### PR TITLE
v1.13 backports 2023-02-28

### DIFF
--- a/.github/workflows/conformance-ingress-shared.yaml
+++ b/.github/workflows/conformance-ingress-shared.yaml
@@ -78,7 +78,7 @@ jobs:
           minikube image load ${{ env.ECHO_SERVER_IMAGE }}
           minikube tunnel &
         env:
-          ECHO_SERVER_IMAGE: k8s.gcr.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
+          ECHO_SERVER_IMAGE: registry.k8s.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
 
       - name: Checkout ingress-controller-conformance
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -78,7 +78,7 @@ jobs:
           minikube image load ${{ env.ECHO_SERVER_IMAGE }}
           minikube tunnel &
         env:
-          ECHO_SERVER_IMAGE: k8s.gcr.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
+          ECHO_SERVER_IMAGE: registry.k8s.io/ingressconformance/echoserver:v0.0.1@sha256:9b34b17f391f87fb2155f01da2f2f90b7a4a5c1110ed84cb5379faa4f570dc52
 
       - name: Checkout ingress-controller-conformance
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0

--- a/Documentation/glossary.rst
+++ b/Documentation/glossary.rst
@@ -52,7 +52,7 @@ with words you expected to see here.
      https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 
    NodeSelector
-     https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 
    Volumes
      https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -106,7 +106,7 @@
      - int
      - ``65536``
    * - bpf.mapDynamicSizeRatio
-     - Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/stable/concepts/ebpf/maps/#ebpf-maps
+     - Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
      - float64
      - ``0.0025``
    * - bpf.masquerade
@@ -162,7 +162,7 @@
      - object
      - ``{}``
    * - certgen.tolerations
-     - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[]``
    * - certgen.ttlSecondsAfterFinished
@@ -226,7 +226,7 @@
      - object
      - ``{"digest":"sha256:f7273ddb4c223e54827d1185d0c8f3b87966b05229358a224cdc3fe11a25fc72","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.13.0","useDigest":true}``
    * - clustermesh.apiserver.nodeSelector
-     - Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
+     - Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object
      - ``{"kubernetes.io/os":"linux"}``
    * - clustermesh.apiserver.podAnnotations
@@ -326,7 +326,7 @@
      - list
      - ``[]``
    * - clustermesh.apiserver.tolerations
-     - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[]``
    * - clustermesh.apiserver.topologySpreadConstraints
@@ -670,7 +670,7 @@
      - bool
      - ``false``
    * - etcd.nodeSelector
-     - Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
+     - Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object
      - ``{"kubernetes.io/os":"linux"}``
    * - etcd.podAnnotations
@@ -698,7 +698,7 @@
      - string
      - ``""``
    * - etcd.resources
-     - cilium-etcd-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/
+     - cilium-etcd-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
      - object
      - ``{}``
    * - etcd.securityContext
@@ -710,7 +710,7 @@
      - bool
      - ``false``
    * - etcd.tolerations
-     - Node tolerations for cilium-etcd-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     - Node tolerations for cilium-etcd-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[{"operator":"Exists"}]``
    * - etcd.topologySpreadConstraints
@@ -814,7 +814,7 @@
      - string
      - ``":4244"``
    * - hubble.metrics
-     - Hubble metrics configuration. See https://docs.cilium.io/en/stable/operations/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics.
+     - Hubble metrics configuration. See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics.
      - object
      - ``{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}``
    * - hubble.metrics.enableOpenMetrics
@@ -838,7 +838,7 @@
      - object
      - ``{}``
    * - hubble.metrics.serviceMonitor.enabled
-     - Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+     - Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
      - bool
      - ``false``
    * - hubble.metrics.serviceMonitor.interval
@@ -902,7 +902,7 @@
      - string
      - ``"4245"``
    * - hubble.relay.nodeSelector
-     - Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
+     - Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object
      - ``{"kubernetes.io/os":"linux"}``
    * - hubble.relay.podAnnotations
@@ -950,7 +950,7 @@
      - object
      - ``{}``
    * - hubble.relay.prometheus.serviceMonitor.enabled
-     - Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+     - Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
      - bool
      - ``false``
    * - hubble.relay.prometheus.serviceMonitor.interval
@@ -1034,7 +1034,7 @@
      - list
      - ``[]``
    * - hubble.relay.tolerations
-     - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[]``
    * - hubble.relay.topologySpreadConstraints
@@ -1078,7 +1078,7 @@
      - string
      - ``"helm"``
    * - hubble.tls.auto.schedule
-     - Schedule for certificates regeneration (regardless of their expiration date). Only used if method is "cronJob". If nil, then no recurring job will be created. Instead, only the one-shot job is deployed to generate the certificates at installation time.  Defaults to midnight of the first day of every fourth month. For syntax, see https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
+     - Schedule for certificates regeneration (regardless of their expiration date). Only used if method is "cronJob". If nil, then no recurring job will be created. Instead, only the one-shot job is deployed to generate the certificates at installation time.  Defaults to midnight of the first day of every fourth month. For syntax, see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax
      - string
      - ``"0 0 1 */4 *"``
    * - hubble.tls.ca
@@ -1150,7 +1150,7 @@
      - object
      - ``{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"tls":[]}``
    * - hubble.ui.nodeSelector
-     - Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
+     - Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object
      - ``{"kubernetes.io/os":"linux"}``
    * - hubble.ui.podAnnotations
@@ -1222,7 +1222,7 @@
      - object
      - ``{"cert":"","key":""}``
    * - hubble.ui.tolerations
-     - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     - Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[]``
    * - hubble.ui.topologySpreadConstraints
@@ -1322,7 +1322,7 @@
      - object
      - ``{"enabled":false}``
    * - ipam.mode
-     - Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/
+     - Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/network/concepts/ipam/
      - string
      - ``"cluster-pool"``
    * - ipam.operator.clusterPoolIPv4MaskSize
@@ -1518,7 +1518,7 @@
      - object
      - ``{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"d69851597ea019af980891a4628fb36b7880ec26"}``
    * - nodeinit.nodeSelector
-     - Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
+     - Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object
      - ``{"kubernetes.io/os":"linux"}``
    * - nodeinit.podAnnotations
@@ -1534,7 +1534,7 @@
      - string
      - ``""``
    * - nodeinit.resources
-     - nodeinit resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/
+     - nodeinit resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
      - object
      - ``{"requests":{"cpu":"100m","memory":"100Mi"}}``
    * - nodeinit.securityContext
@@ -1542,7 +1542,7 @@
      - object
      - ``{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}``
    * - nodeinit.tolerations
-     - Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     - Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[{"operator":"Exists"}]``
    * - nodeinit.updateStrategy
@@ -1602,7 +1602,7 @@
      - string
      - ``"5m0s"``
    * - operator.nodeSelector
-     - Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
+     - Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object
      - ``{"kubernetes.io/os":"linux"}``
    * - operator.podAnnotations
@@ -1650,7 +1650,7 @@
      - object
      - ``{}``
    * - operator.prometheus.serviceMonitor.enabled
-     - Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+     - Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
      - bool
      - ``false``
    * - operator.prometheus.serviceMonitor.interval
@@ -1678,7 +1678,7 @@
      - int
      - ``2``
    * - operator.resources
-     - cilium-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/
+     - cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
      - object
      - ``{}``
    * - operator.rollOutPods
@@ -1702,7 +1702,7 @@
      - bool
      - ``false``
    * - operator.tolerations
-     - Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     - Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[{"operator":"Exists"}]``
    * - operator.topologySpreadConstraints
@@ -1734,7 +1734,7 @@
      - object
      - ``{}``
    * - policyEnforcementMode
-     - The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes
+     - The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
      - string
      - ``"default"``
    * - pprof.address
@@ -1766,7 +1766,7 @@
      - object
      - ``{"digest":"sha256:6544a3441b086a2e09005d3e21d1a4afb216fae19c5a60b35793c8a9438f8f68","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.13.0","useDigest":true}``
    * - preflight.nodeSelector
-     - Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/
+     - Node labels for preflight pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object
      - ``{"kubernetes.io/os":"linux"}``
    * - preflight.podAnnotations
@@ -1794,7 +1794,7 @@
      - string
      - ``""``
    * - preflight.resources
-     - preflight resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/
+     - preflight resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
      - object
      - ``{}``
    * - preflight.securityContext
@@ -1810,7 +1810,7 @@
      - string
      - ``""``
    * - preflight.tolerations
-     - Node tolerations for preflight scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     - Node tolerations for preflight scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[{"effect":"NoSchedule","key":"node.kubernetes.io/not-ready"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized","value":"true"},{"key":"CriticalAddonsOnly","operator":"Exists"}]``
    * - preflight.updateStrategy
@@ -1830,7 +1830,7 @@
      - object
      - ``{"enabled":false,"metrics":null,"port":9962,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}``
    * - prometheus.metrics
-     - Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics
+     - Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/observability/metrics/
      - string
      - ``nil``
    * - prometheus.serviceMonitor.annotations
@@ -1838,7 +1838,7 @@
      - object
      - ``{}``
    * - prometheus.serviceMonitor.enabled
-     - Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+     - Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
      - bool
      - ``false``
    * - prometheus.serviceMonitor.interval
@@ -1886,7 +1886,7 @@
      - object
      - ``{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}``
    * - resources
-     - Agent resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/
+     - Agent resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
      - object
      - ``{}``
    * - rollOutCiliumPods
@@ -1998,7 +1998,7 @@
      - string
      - ``"local"``
    * - tolerations
-     - Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+     - Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[{"operator":"Exists"}]``
    * - tunnel

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -552,8 +552,9 @@ Option Value          Description
 ===================== ===================================================================================
 ``identity``          All Cilium security identity labels
 ``namespace``         Kubernetes namespace name
-``pod``               Kubernetes pod name
-``pod-short``         Deprecated, will be removed in Cilium 1.14 - use ``workload-name|pod`` instead. Short version of the Kubernetes pod name. Typically the deployment/replicaset name.
+``pod``               Kubernetes pod name and namespace name in the form of ``namespace/pod``.
+``pod-short``         Deprecated, will be removed in Cilium 1.14 - use ``workload-name|pod-name`` instead. Short version of the Kubernetes pod name. Typically the deployment/replicaset name.
+``pod-name``          Kubernetes pod name.
 ``dns``               All known DNS names of the source or destination (comma-separated)
 ``ip``                The IPv4 or IPv6 address
 ``reserved-identity`` Reserved identity label.

--- a/Documentation/operations/performance/scalability/report.rst
+++ b/Documentation/operations/performance/scalability/report.rst
@@ -128,7 +128,7 @@ and all metrics were being gathered.
 * Each deployment had 1 replica (125 pods in total).
 
 * To measure **only** the resources consumed by Cilium, all deployments used
-  the same base image ``k8s.gcr.io/pause:3.2``. This image does not have any
+  the same base image ``registry.k8s.io/pause:3.2``. This image does not have any
   CPU or memory overhead.
 
 * We provision a small number of pods in a small cluster to understand the CPU

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -19,7 +19,7 @@ Summary
 When running Cilium using the container image ``cilium/cilium``, the host
 system must meet these requirements:
 
-- `Linux kernel`_ >= 4.19.57 (or equivalent)
+- `Linux kernel`_ >= 4.19.57 or equivalent (e.g., 4.18 on RHEL8)
 
 When running Cilium as a native process on your host (i.e. **not** running the
 ``cilium/cilium`` container image) these additional requirements must be met:
@@ -35,14 +35,14 @@ must be met:
 
 - :ref:`req_kvstore` etcd >= 3.1.0
 
-======================== ========================== ===================
-Requirement              Minimum Version            In cilium container
-======================== ========================== ===================
-`Linux kernel`_          >= 4.19.57                 no
-Key-Value store (etcd)   >= 3.1.0                   no
-clang+LLVM               >= 10.0                    yes
-iproute2                 >= 5.9.0 [#iproute2_foot]_ yes
-======================== ========================== ===================
+======================== ============================== ===================
+Requirement              Minimum Version                In cilium container
+======================== ============================== ===================
+`Linux kernel`_          >= 4.19.57 or >= 4.18 on RHEL8 no
+Key-Value store (etcd)   >= 3.1.0                       no
+clang+LLVM               >= 10.0                        yes
+iproute2                 >= 5.9.0 [#iproute2_foot]_     yes
+======================== ============================== ===================
 
 .. [#iproute2_foot] Requires support for eBPF templating as documented
    :ref:`below <iproute2_requirements>`.
@@ -142,8 +142,8 @@ subsystems which integrate with eBPF. Therefore, host systems are required to
 run a recent Linux kernel to run a Cilium agent. More recent kernels may
 provide additional eBPF functionality that Cilium will automatically detect and
 use on agent start. For this version of Cilium, it is recommended to use kernel
-4.19.57 or later (or equivalent). For a list of features that require newer
-kernels, see :ref:`advanced_features`.
+4.19.57 or later (or equivalent such as 4.18 on RHEL8). For a list of features
+that require newer kernels, see :ref:`advanced_features`.
 
 In order for the eBPF feature to be enabled properly, the following kernel
 configuration options must be enabled. This is typically the case with

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -933,7 +933,7 @@ If you believe to have found an issue in Cilium, please report a
 ensure that developers have the best chance to reproduce the issue.
 
 .. _Slack channel: https://cilium.herokuapp.com
-.. _NodeSelector: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+.. _NodeSelector: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
 .. _RBAC: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 .. _CNI: https://github.com/containernetworking/cni
 .. _Volumes: https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/

--- a/Documentation/security/policy/kubernetes.rst
+++ b/Documentation/security/policy/kubernetes.rst
@@ -115,7 +115,7 @@ ServiceAccounts
 ----------------
 
 Kubernetes `Service Accounts
-<https://kubernetes.io/docs/concepts/configuration/assign-pod-node/>`_ are used
+<https://kubernetes.io/docs/concepts/security/service-accounts/>`_ are used
 to associate an identity to a pod or process managed by Kubernetes and grant
 identities access to Kubernetes resources and secrets. Cilium supports the
 specification of network security policies based on the service account

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -400,10 +400,11 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 				// Also wait for all cluster mesh to be synchronized with the
 				// datapath before proceeding.
 				if d.clustermesh != nil {
-					err := d.clustermesh.ClustersSynced(context.Background())
+					err := d.clustermesh.ClustersSynced(d.ctx)
 					if err != nil {
 						log.WithError(err).Fatal("timeout while waiting for all clusters to be locally synchronized")
 					}
+					log.Debug("all clusters have been correctly synchronized locally")
 				}
 				// Start controller which removes any leftover Kubernetes
 				// services that may have been deleted while Cilium was not

--- a/examples/kubernetes-local-redirect/node-local-dns.yaml
+++ b/examples/kubernetes-local-redirect/node-local-dns.yaml
@@ -114,7 +114,7 @@ spec:
         operator: "Exists"
       containers:
       - name: node-cache
-        image: k8s.gcr.io/dns/k8s-dns-node-cache:1.15.16
+        image: registry.k8s.io/dns/k8s-dns-node-cache:1.15.16
         resources:
           requests:
             cpu: 25m

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -77,7 +77,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.hostLegacyRouting | bool | `false` | Configure whether direct routing mode should route traffic via host stack (true) or directly and more efficiently out of BPF (false) if the kernel supports it. The latter has the implication that it will also bypass netfilter in the host namespace. |
 | bpf.lbExternalClusterIP | bool | `false` | Allow cluster external access to ClusterIP services. |
 | bpf.lbMapMax | int | `65536` | Configure the maximum number of service entries in the load balancer maps. |
-| bpf.mapDynamicSizeRatio | float64 | `0.0025` | Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/stable/concepts/ebpf/maps/#ebpf-maps |
+| bpf.mapDynamicSizeRatio | float64 | `0.0025` | Configure auto-sizing for all BPF maps based on available memory. ref: https://docs.cilium.io/en/stable/network/ebpf/maps/ |
 | bpf.masquerade | bool | `false` | Enable native IP masquerade support in eBPF |
 | bpf.monitorAggregation | string | `"medium"` | Configure the level of aggregation for monitor notifications. Valid options are none, low, medium, maximum. |
 | bpf.monitorFlags | string | `"all"` | Configure which TCP flags trigger notifications when seen for the first time in a connection. |
@@ -91,7 +91,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.vlanBypass | list | `[]` | Configure explicitly allowed VLAN id's for bpf logic bypass. [0] will allow all VLAN id's without any filtering. |
 | certgen | object | `{"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.podLabels | object | `{}` | Labels to be added to hubble-certgen pods |
-| certgen.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| certgen.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | certgen.ttlSecondsAfterFinished | int | `1800` | Seconds after which the completed job pod will be deleted |
 | cgroup | object | `{"autoMount":{"enabled":true,"resources":{}},"hostRoot":"/run/cilium/cgroupv2"}` | Configure cgroup related configuration |
 | cgroup.autoMount.enabled | bool | `true` | Enable auto mount of cgroup2 filesystem. When `autoMount` is enabled, cgroup2 filesystem is mounted at `cgroup.hostRoot` path on the underlying host and inside the cilium agent pod. If users disable `autoMount`, it's expected that users have mounted cgroup2 filesystem at the specified `cgroup.hostRoot` volume, and then the volume will be mounted inside the cilium agent pod at the same path. |
@@ -107,7 +107,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.etcd.resources | object | `{}` | Specifies the resources for etcd container in the apiserver |
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
 | clustermesh.apiserver.image | object | `{"digest":"sha256:f7273ddb4c223e54827d1185d0c8f3b87966b05229358a224cdc3fe11a25fc72","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.13.0","useDigest":true}` | Clustermesh API server image. |
-| clustermesh.apiserver.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| clustermesh.apiserver.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | clustermesh.apiserver.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
@@ -132,7 +132,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.tls.server | object | `{"cert":"","extraDnsNames":[],"extraIpAddresses":[],"key":""}` | base64 encoded PEM values for the clustermesh-apiserver server certificate and private key. Used if 'auto' is not enabled. |
 | clustermesh.apiserver.tls.server.extraDnsNames | list | `[]` | Extra DNS names added to certificate when it's auto generated |
 | clustermesh.apiserver.tls.server.extraIpAddresses | list | `[]` | Extra IP addresses added to certificate when it's auto generated |
-| clustermesh.apiserver.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| clustermesh.apiserver.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | clustermesh.apiserver.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for clustermesh-apiserver |
 | clustermesh.apiserver.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | clustermesh-apiserver update strategy |
 | clustermesh.config | object | `{"clusters":[],"domain":"mesh.cilium.io","enabled":false}` | Clustermesh explicit configuration. |
@@ -218,17 +218,17 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments. |
 | etcd.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc"}` | cilium-etcd-operator image. |
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
-| etcd.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| etcd.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | etcd.podAnnotations | object | `{}` | Annotations to be added to cilium-etcd-operator pods |
 | etcd.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | etcd.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | etcd.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | etcd.podLabels | object | `{}` | Labels to be added to cilium-etcd-operator pods |
 | etcd.priorityClassName | string | `""` | The priority class to use for cilium-etcd-operator |
-| etcd.resources | object | `{}` | cilium-etcd-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| etcd.resources | object | `{}` | cilium-etcd-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | etcd.securityContext | object | `{}` | Security context to be added to cilium-etcd-operator pods |
 | etcd.ssl | bool | `false` | Enable use of TLS/SSL for connectivity to etcd. (auto-enabled if managed=true) |
-| etcd.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-etcd-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| etcd.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-etcd-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | etcd.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for cilium-etcd-operator |
 | etcd.updateStrategy | object | `{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"}` | cilium-etcd-operator update strategy |
 | externalIPs.enabled | bool | `false` | Enable ExternalIPs service support. |
@@ -254,13 +254,13 @@ contributors across the globe, there is almost always someone available to help.
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |
 | hubble.enabled | bool | `true` | Enable Hubble (true by default). |
 | hubble.listenAddress | string | `":4244"` | An additional address for Hubble to listen to. Set this field ":4244" if you are enabling Hubble Relay, as it assumes that Hubble is listening on port 4244. |
-| hubble.metrics | object | `{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/operations/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
+| hubble.metrics | object | `{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
 | hubble.metrics.enableOpenMetrics | bool | `false` | Enables exporting hubble metrics in OpenMetrics format. |
 | hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"  |
 | hubble.metrics.port | int | `9965` | Configure the port the hubble metric server listens on. |
 | hubble.metrics.serviceAnnotations | object | `{}` | Annotations to be added to hubble-metrics service. |
 | hubble.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble |
-| hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
+| hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | hubble.metrics.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
 | hubble.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor hubble |
@@ -276,7 +276,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.image | object | `{"digest":"sha256:bc00f086285d2d287dd662a319d3dbe90e57179515ce8649425916aecaa9ac3c","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.13.0","useDigest":true}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
-| hubble.relay.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| hubble.relay.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | hubble.relay.podAnnotations | object | `{}` | Annotations to be added to hubble-relay pods |
 | hubble.relay.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | hubble.relay.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
@@ -288,7 +288,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.priorityClassName | string | `""` | The priority class to use for hubble-relay |
 | hubble.relay.prometheus | object | `{"enabled":false,"port":9966,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for hubble-relay on the configured port at /metrics |
 | hubble.relay.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble-relay |
-| hubble.relay.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
+| hubble.relay.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | hubble.relay.prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
 | hubble.relay.prometheus.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble-relay |
 | hubble.relay.prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor hubble-relay |
@@ -309,7 +309,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.relay.tls.server | object | `{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":""}` | base64 encoded PEM values for the hubble-relay server certificate and private key |
 | hubble.relay.tls.server.extraDnsNames | list | `[]` | extra DNS names added to certificate when its auto gen |
 | hubble.relay.tls.server.extraIpAddresses | list | `[]` | extra IP addresses added to certificate when its auto gen |
-| hubble.relay.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/  |
+| hubble.relay.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | hubble.relay.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for hubble-relay |
 | hubble.relay.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-relay update strategy |
 | hubble.skipUnknownCGroupIDs | bool | `true` | Skip Hubble events with unknown cgroup ids |
@@ -320,7 +320,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.tls.auto.certValidityDuration | int | `1095` | Generated certificates validity duration in days. |
 | hubble.tls.auto.enabled | bool | `true` | Auto-generate certificates. When set to true, automatically generate a CA and certificates to enable mTLS between Hubble server and Hubble Relay instances. If set to false, the certs for Hubble server need to be provided by setting appropriate values below. |
 | hubble.tls.auto.method | string | `"helm"` | Set the method to auto-generate certificates. Supported values: - helm:         This method uses Helm to generate all certificates. - cronJob:      This method uses a Kubernetes CronJob the generate any                 certificates not provided by the user at installation                 time. - certmanager:  This method use cert-manager to generate & rotate certificates. |
-| hubble.tls.auto.schedule | string | `"0 0 1 */4 *"` | Schedule for certificates regeneration (regardless of their expiration date). Only used if method is "cronJob". If nil, then no recurring job will be created. Instead, only the one-shot job is deployed to generate the certificates at installation time.  Defaults to midnight of the first day of every fourth month. For syntax, see https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule |
+| hubble.tls.auto.schedule | string | `"0 0 1 */4 *"` | Schedule for certificates regeneration (regardless of their expiration date). Only used if method is "cronJob". If nil, then no recurring job will be created. Instead, only the one-shot job is deployed to generate the certificates at installation time.  Defaults to midnight of the first day of every fourth month. For syntax, see https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax |
 | hubble.tls.ca | object | `{"cert":"","key":""}` | Deprecated in favor of tls.ca. To be removed in 1.13. base64 encoded PEM values for the Hubble CA certificate and private key. |
 | hubble.tls.ca.cert | string | `""` | Deprecated in favor of tls.ca.cert. To be removed in 1.13. |
 | hubble.tls.ca.key | string | `""` | Deprecated in favor of tls.ca.key. To be removed in 1.13. The CA private key (optional). If it is provided, then it will be used by hubble.tls.auto.method=cronJob to generate all other certificates. Otherwise, a ephemeral CA is generated if hubble.tls.auto.enabled=true. |
@@ -338,7 +338,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
 | hubble.ui.ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":["chart-example.local"],"tls":[]}` | hubble-ui ingress configuration. |
-| hubble.ui.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/ |
+| hubble.ui.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
 | hubble.ui.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | hubble.ui.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
@@ -356,7 +356,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.standalone.enabled | bool | `false` | When true, it will allow installing the Hubble UI only, without checking dependencies. It is useful if a cluster already has cilium and Hubble relay installed and you just want Hubble UI to be deployed. When installed via helm, installing UI should be done via `helm upgrade` and when installed via the cilium cli, then `cilium hubble enable --ui` |
 | hubble.ui.standalone.tls.certsVolume | object | `{}` | When deploying Hubble UI in standalone, with tls enabled for Hubble relay, it is required to provide a volume for mounting the client certificates. |
 | hubble.ui.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values used to connect to hubble-relay This keypair is presented to Hubble Relay instances for mTLS authentication and is required when hubble.relay.tls.server.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |
-| hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/  |
+| hubble.ui.tolerations | list | `[]` | Node tolerations for pod assignment on nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | hubble.ui.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for hubble-ui |
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
 | identityAllocationMode | string | `"crd"` | Method to use for identity allocation (`crd` or `kvstore`). |
@@ -381,7 +381,7 @@ contributors across the globe, there is almost always someone available to help.
 | installIptablesRules | bool | `true` | Configure whether to install iptables rules to allow for TPROXY (L7 proxy injection), iptables-based masquerading and compatibility with kube-proxy. |
 | installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
 | ipMasqAgent | object | `{"enabled":false}` | Configure the eBPF-based ip-masq-agent |
-| ipam.mode | string | `"cluster-pool"` | Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/ |
+| ipam.mode | string | `"cluster-pool"` | Configure IP Address Management mode. ref: https://docs.cilium.io/en/stable/network/concepts/ipam/ |
 | ipam.operator.clusterPoolIPv4MaskSize | int | `24` | IPv4 CIDR mask size to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv4PodCIDR | string | `"10.0.0.0/8"` | Deprecated in favor of ipam.operator.clusterPoolIPv4PodCIDRList. IPv4 CIDR range to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv4PodCIDRList | list | `[]` | IPv4 CIDR list range to delegate to individual nodes for IPAM. |
@@ -430,13 +430,13 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraEnv | list | `[]` | Additional nodeinit environment variables. |
 | nodeinit.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"d69851597ea019af980891a4628fb36b7880ec26"}` | node-init image. |
-| nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/  |
+| nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
 | nodeinit.priorityClassName | string | `""` | The priority class to use for the nodeinit pod. |
-| nodeinit.resources | object | `{"requests":{"cpu":"100m","memory":"100Mi"}}` | nodeinit resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| nodeinit.resources | object | `{"requests":{"cpu":"100m","memory":"100Mi"}}` | nodeinit resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | nodeinit.securityContext | object | `{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}` | Security context to be added to nodeinit pods. |
-| nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | nodeinit.updateStrategy | object | `{"type":"RollingUpdate"}` | node-init update strategy |
 | operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"io.cilium/app":"operator"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-operator |
 | operator.dnsPolicy | string | `""` | DNS policy for Cilium operator pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
@@ -451,7 +451,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
 | operator.image | object | `{"alibabacloudDigest":"sha256:0332376a4a6f92ff7936d3b52614f8219a10d6fd46aa14fead8426d0e140f79a","awsDigest":"sha256:3cc9ff5bcc57f536427e7059abc916831b368654dfddcbad8a412731984a95e4","azureDigest":"sha256:ec1246bbbf7125998e2f547fc518ae56ae364dbd3f46812fa325c068cc406bd7","genericDigest":"sha256:4b58d5b33e53378355f6e8ceb525ccf938b7b6f5384b35373f1f46787467ebf5","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.13.0","useDigest":true}` | cilium-operator image. |
 | operator.nodeGCInterval | string | `"5m0s"` | Interval for cilium node garbage collection. |
-| operator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/  |
+| operator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
 | operator.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | operator.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
@@ -463,20 +463,20 @@ contributors across the globe, there is almost always someone available to help.
 | operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
 | operator.prometheus | object | `{"enabled":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
 | operator.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-operator |
-| operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
+| operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | operator.prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
 | operator.prometheus.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor cilium-operator |
 | operator.prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor cilium-operator |
 | operator.prometheus.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor cilium-operator |
 | operator.removeNodeTaints | bool | `true` | Remove Cilium node taint from Kubernetes nodes that have a healthy Cilium pod running. |
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |
-| operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{}` | Security context to be added to cilium-operator pods |
 | operator.setNodeNetworkStatus | bool | `true` | Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod. |
 | operator.skipCNPStatusStartupClean | bool | `false` | Skip CNP node status clean up at operator startup. |
 | operator.skipCRDCreation | bool | `false` | Skip CRDs creation for cilium-operator |
-| operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | operator.topologySpreadConstraints | list | `[]` | Pod topology spread constraints for cilium-operator |
 | operator.unmanagedPodWatcher.intervalSeconds | int | `15` | Interval, in seconds, to check if there are any pods that are not managed by Cilium. |
 | operator.unmanagedPodWatcher.restart | bool | `true` | Restart any pod that are not managed by Cilium. |
@@ -484,7 +484,7 @@ contributors across the globe, there is almost always someone available to help.
 | pmtuDiscovery.enabled | bool | `false` | Enable path MTU discovery to send ICMP fragmentation-needed replies to the client. |
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |
-| policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes |
+| policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes |
 | pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-agent |
 | pprof.enabled | bool | `false` | Enable pprof for cilium-agent |
 | pprof.port | int | `6060` | Configure pprof listen port for cilium-agent |
@@ -492,25 +492,25 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.enabled | bool | `false` | Enable Cilium pre-flight resources (required for upgrade) |
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |
 | preflight.image | object | `{"digest":"sha256:6544a3441b086a2e09005d3e21d1a4afb216fae19c5a60b35793c8a9438f8f68","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.13.0","useDigest":true}` | Cilium pre-flight image. |
-| preflight.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/user-guide/node-selection/  |
+| preflight.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
 | preflight.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
 | preflight.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
 | preflight.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
 | preflight.podLabels | object | `{}` | Labels to be added to the preflight pod. |
 | preflight.priorityClassName | string | `""` | The priority class to use for the preflight pod. |
-| preflight.resources | object | `{}` | preflight resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| preflight.resources | object | `{}` | preflight resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | preflight.securityContext | object | `{}` | Security context to be added to preflight pods |
 | preflight.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for preflight Deployment and DaemonSet. |
 | preflight.tofqdnsPreCache | string | `""` | Path to write the `--tofqdns-pre-cache` file to. |
-| preflight.tolerations | list | `[{"effect":"NoSchedule","key":"node.kubernetes.io/not-ready"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized","value":"true"},{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Node tolerations for preflight scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| preflight.tolerations | list | `[{"effect":"NoSchedule","key":"node.kubernetes.io/not-ready"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane"},{"effect":"NoSchedule","key":"node.cloudprovider.kubernetes.io/uninitialized","value":"true"},{"key":"CriticalAddonsOnly","operator":"Exists"}]` | Node tolerations for preflight scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | preflight.updateStrategy | object | `{"type":"RollingUpdate"}` | preflight update strategy |
 | preflight.validateCNPs | bool | `true` | By default we should always validate the installed CNPs before upgrading Cilium. This will make sure the user will have the policies deployed in the cluster with the right schema. |
 | priorityClassName | string | `""` | The priority class to use for cilium-agent. |
 | prometheus | object | `{"enabled":false,"metrics":null,"port":9962,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}` | Configure prometheus metrics on the configured port at /metrics |
-| prometheus.metrics | string | `nil` | Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics |
+| prometheus.metrics | string | `nil` | Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/observability/metrics/ |
 | prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-agent |
-| prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
+| prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
 | prometheus.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor cilium-agent |
 | prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor cilium-agent |
@@ -522,7 +522,7 @@ contributors across the globe, there is almost always someone available to help.
 | readinessProbe.periodSeconds | int | `30` | interval between checks of the readiness probe |
 | remoteNodeIdentity | bool | `true` | Enable use of the remote node identity. ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity |
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
-| resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
+| resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |
 | sctp | object | `{"enabled":false}` | SCTP Configuration Values |
 | sctp.enabled | bool | `false` | Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming. |
@@ -550,7 +550,7 @@ contributors across the globe, there is almost always someone available to help.
 | tls.ca.certValidityDuration | int | `1095` | Generated certificates validity duration in days. This will be used for auto generated CA. |
 | tls.ca.key | string | `""` | Optional CA private key. If it is provided, it will be used by cilium to generate all other certificates. Otherwise, an ephemeral CA is generated. |
 | tls.secretsBackend | string | `"local"` | This configures how the Cilium agent loads the secrets used TLS-aware CiliumNetworkPolicies (namely the secrets referenced by terminatingTLS and originatingTLS). Possible values:   - local   - k8s |
-| tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
+| tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | tunnel | string | `"vxlan"` | Configure the encapsulation configuration for communication between nodes. Possible values:   - disabled   - vxlan (default)   - geneve |
 | tunnelPort | int | Port 8472 for VXLAN, Port 6081 for Geneve | Configure VXLAN and Geneve tunnel port. |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | Cilium agent update strategy |

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -13,6 +13,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: hubble-ui
+  {{- with .Values.hubble.ui.updateStrategy }}
+  strategy:
+    {{- toYaml . | trim | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -18,7 +18,7 @@
 {{/* validate service monitoring CRDs */}}
 {{- if and .Values.prometheus.enabled (or .Values.prometheus.serviceMonitor.enabled .Values.operator.prometheus.serviceMonitor.enabled) }}
   {{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
-      {{ fail "Service Monitor requires monitoring.coreos.com/v1 CRDs. Please refer to https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml" }}
+      {{ fail "Service Monitor requires monitoring.coreos.com/v1 CRDs. Please refer to https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml" }}
   {{- end }}
 {{- end }}
 

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -125,7 +125,7 @@ nodeSelector:
   kubernetes.io/os: linux
 
 # -- Node tolerations for agent scheduling to nodes with taints
-# ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+# ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 tolerations:
 - operator: Exists
   # - key: "key"
@@ -180,7 +180,7 @@ podAnnotations: {}
 podLabels: {}
 
 # -- Agent resource limits & requests
-# ref: https://kubernetes.io/docs/user-guide/compute-resources/
+# ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 resources: {}
   # limits:
   #   cpu: 4000m
@@ -382,7 +382,7 @@ bpf:
   policyMapMax: 16384
 
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
-  # ref: https://docs.cilium.io/en/stable/concepts/ebpf/maps/#ebpf-maps
+  # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
   # @default -- `0.0025`
   mapDynamicSizeRatio: ~
 
@@ -805,7 +805,7 @@ certgen:
   # -- Labels to be added to hubble-certgen pods
   podLabels: {}
   # -- Node tolerations for pod assignment on nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: []
 
 hubble:
@@ -823,7 +823,7 @@ hubble:
   # eventBufferCapacity: "4095"
 
   # -- Hubble metrics configuration.
-  # See https://docs.cilium.io/en/stable/operations/metrics/#hubble-metrics
+  # See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics
   # for more comprehensive documentation about Hubble metrics.
   metrics:
     # -- Configures the list of metrics to collect. If empty or null, metrics
@@ -852,7 +852,7 @@ hubble:
     serviceMonitor:
       # -- Create ServiceMonitor resources for Prometheus Operator.
       # This requires the prometheus CRDs to be available.
-      # ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+      # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
       enabled: false
       # -- Labels to add to ServiceMonitor hubble
       labels: {}
@@ -932,7 +932,7 @@ hubble:
       # installation time.
       #
       # Defaults to midnight of the first day of every fourth month. For syntax, see
-      # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
+      # https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax
       schedule: "0 0 1 */4 *"
 
       # [Example]
@@ -1002,13 +1002,12 @@ hubble:
       #   whenUnsatisfiable: DoNotSchedule
 
     # -- Node labels for pod assignment
-    # ref: https://kubernetes.io/docs/user-guide/node-selection/
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector:
       kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
-    # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-    #
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
     tolerations: []
 
     # -- Additional hubble-relay environment variables.
@@ -1107,7 +1106,7 @@ hubble:
       port: 9966
       serviceMonitor:
         # -- Enable service monitors.
-        # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+        # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
         enabled: false
         # -- Labels to add to ServiceMonitor hubble-relay
         labels: {}
@@ -1245,13 +1244,12 @@ hubble:
       #   whenUnsatisfiable: DoNotSchedule
 
     # -- Node labels for pod assignment
-    # ref: https://kubernetes.io/docs/user-guide/node-selection/
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector:
       kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
-    # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-    #
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
     tolerations: []
 
     # -- The priority class to use for hubble-ui
@@ -1316,7 +1314,7 @@ installNoConntrackIptablesRules: false
 
 ipam:
   # -- Configure IP Address Management mode.
-  # ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/
+  # ref: https://docs.cilium.io/en/stable/network/concepts/ipam/
   mode: "cluster-pool"
   operator:
     # -- Deprecated in favor of ipam.operator.clusterPoolIPv4PodCIDRList.
@@ -1397,7 +1395,7 @@ readinessProbe:
 
 # -- Configure the kube-proxy replacement in Cilium BPF datapath
 # Valid options are "disabled", "partial", "strict".
-# ref: https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/
+# ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/
 #kubeProxyReplacement: "disabled"
 
 # -- healthz server bind address for the kube-proxy replacement.
@@ -1567,7 +1565,7 @@ nodePort:
 
 # -- The agent can be put into one of the three policy enforcement modes:
 # default, always and never.
-# ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes
+# ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
 policyEnforcementMode: "default"
 
 pprof:
@@ -1584,7 +1582,7 @@ prometheus:
   port: 9962
   serviceMonitor:
     # -- Enable service monitors.
-    # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+    # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
     enabled: false
     # -- Labels to add to ServiceMonitor cilium-agent
     labels: {}
@@ -1606,7 +1604,7 @@ prometheus:
   # -- Metrics that should be enabled or disabled from the default metric
   # list. (+metric_foo to enable metric_foo , -metric_bar to disable
   # metric_bar).
-  # ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics
+  # ref: https://docs.cilium.io/en/stable/observability/metrics/
   metrics: ~
 
 # -- Configure Istio proxy options.
@@ -1716,7 +1714,7 @@ etcd:
   extraArgs: []
 
   # -- Node tolerations for cilium-etcd-operator scheduling to nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations:
   - operator: Exists
     # - key: "key"
@@ -1731,7 +1729,7 @@ etcd:
     #   whenUnsatisfiable: DoNotSchedule
 
   # -- Node labels for cilium-etcd-operator pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
 
@@ -1753,7 +1751,7 @@ etcd:
     maxUnavailable: 1
 
   # -- cilium-etcd-operator resource limits & requests
-  # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources: {}
     # limits:
     #   cpu: 4000m
@@ -1846,13 +1844,12 @@ operator:
     #   whenUnsatisfiable: DoNotSchedule
 
   # -- Node labels for cilium-operator pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  #
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
 
   # -- Node tolerations for cilium-operator scheduling to nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations:
   - operator: Exists
     # - key: "key"
@@ -1899,7 +1896,7 @@ operator:
     maxUnavailable: 1
 
   # -- cilium-operator resource limits & requests
-  # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources: {}
     # limits:
     #   cpu: 1000m
@@ -1942,7 +1939,7 @@ operator:
     port: 9963
     serviceMonitor:
       # -- Enable service monitors.
-      # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+      # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
       enabled: false
       # -- Labels to add to ServiceMonitor cilium-operator
       labels: {}
@@ -1998,13 +1995,12 @@ nodeinit:
   affinity: {}
 
   # -- Node labels for nodeinit pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  #
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
 
   # -- Node tolerations for nodeinit scheduling to nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations:
   - operator: Exists
     # - key: "key"
@@ -2019,7 +2015,7 @@ nodeinit:
   podLabels: {}
 
   # -- nodeinit resource limits & requests
-  # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     requests:
       cpu: 100m
@@ -2082,13 +2078,12 @@ preflight:
             k8s-app: cilium
 
   # -- Node labels for preflight pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  #
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
 
   # -- Node tolerations for preflight scheduling to nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations:
   - key: node.kubernetes.io/not-ready
     effect: NoSchedule
@@ -2124,7 +2119,7 @@ preflight:
     maxUnavailable: 1
 
   # -- preflight resource limits & requests
-  # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources: {}
     # limits:
     #   cpu: 4000m
@@ -2297,12 +2292,12 @@ clustermesh:
       #   whenUnsatisfiable: DoNotSchedule
 
     # -- Node labels for pod assignment
-    # ref: https://kubernetes.io/docs/user-guide/node-selection/
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector:
       kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
-    # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
     tolerations: []
 
     # -- clustermesh-apiserver update strategy
@@ -2344,7 +2339,7 @@ clustermesh:
         #
         # Defaults to none. Commented syntax gives midnight of the first day of every
         # fourth month. For syntax, see
-        # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
+        # https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax
         # schedule: "0 0 1 */4 *"
 
         # [Example]

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -122,7 +122,7 @@ nodeSelector:
   kubernetes.io/os: linux
 
 # -- Node tolerations for agent scheduling to nodes with taints
-# ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+# ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 tolerations:
 - operator: Exists
   # - key: "key"
@@ -177,7 +177,7 @@ podAnnotations: {}
 podLabels: {}
 
 # -- Agent resource limits & requests
-# ref: https://kubernetes.io/docs/user-guide/compute-resources/
+# ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 resources: {}
   # limits:
   #   cpu: 4000m
@@ -379,7 +379,7 @@ bpf:
   policyMapMax: 16384
 
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
-  # ref: https://docs.cilium.io/en/stable/concepts/ebpf/maps/#ebpf-maps
+  # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
   # @default -- `0.0025`
   mapDynamicSizeRatio: ~
 
@@ -802,7 +802,7 @@ certgen:
   # -- Labels to be added to hubble-certgen pods
   podLabels: {}
   # -- Node tolerations for pod assignment on nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations: []
 
 hubble:
@@ -820,7 +820,7 @@ hubble:
   # eventBufferCapacity: "4095"
 
   # -- Hubble metrics configuration.
-  # See https://docs.cilium.io/en/stable/operations/metrics/#hubble-metrics
+  # See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics
   # for more comprehensive documentation about Hubble metrics.
   metrics:
     # -- Configures the list of metrics to collect. If empty or null, metrics
@@ -849,7 +849,7 @@ hubble:
     serviceMonitor:
       # -- Create ServiceMonitor resources for Prometheus Operator.
       # This requires the prometheus CRDs to be available.
-      # ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+      # ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
       enabled: false
       # -- Labels to add to ServiceMonitor hubble
       labels: {}
@@ -929,7 +929,7 @@ hubble:
       # installation time.
       #
       # Defaults to midnight of the first day of every fourth month. For syntax, see
-      # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
+      # https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax
       schedule: "0 0 1 */4 *"
 
       # [Example]
@@ -999,13 +999,12 @@ hubble:
       #   whenUnsatisfiable: DoNotSchedule
 
     # -- Node labels for pod assignment
-    # ref: https://kubernetes.io/docs/user-guide/node-selection/
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector:
       kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
-    # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-    #
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
     tolerations: []
 
     # -- Additional hubble-relay environment variables.
@@ -1104,7 +1103,7 @@ hubble:
       port: 9966
       serviceMonitor:
         # -- Enable service monitors.
-        # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+        # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
         enabled: false
         # -- Labels to add to ServiceMonitor hubble-relay
         labels: {}
@@ -1242,13 +1241,12 @@ hubble:
       #   whenUnsatisfiable: DoNotSchedule
 
     # -- Node labels for pod assignment
-    # ref: https://kubernetes.io/docs/user-guide/node-selection/
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector:
       kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
-    # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-    #
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
     tolerations: []
 
     # -- The priority class to use for hubble-ui
@@ -1313,7 +1311,7 @@ installNoConntrackIptablesRules: false
 
 ipam:
   # -- Configure IP Address Management mode.
-  # ref: https://docs.cilium.io/en/stable/concepts/networking/ipam/
+  # ref: https://docs.cilium.io/en/stable/network/concepts/ipam/
   mode: "cluster-pool"
   operator:
     # -- Deprecated in favor of ipam.operator.clusterPoolIPv4PodCIDRList.
@@ -1394,7 +1392,7 @@ readinessProbe:
 
 # -- Configure the kube-proxy replacement in Cilium BPF datapath
 # Valid options are "disabled", "partial", "strict".
-# ref: https://docs.cilium.io/en/stable/gettingstarted/kubeproxy-free/
+# ref: https://docs.cilium.io/en/stable/network/kubernetes/kubeproxy-free/
 #kubeProxyReplacement: "disabled"
 
 # -- healthz server bind address for the kube-proxy replacement.
@@ -1564,7 +1562,7 @@ nodePort:
 
 # -- The agent can be put into one of the three policy enforcement modes:
 # default, always and never.
-# ref: https://docs.cilium.io/en/stable/policy/intro/#policy-enforcement-modes
+# ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
 policyEnforcementMode: "default"
 
 pprof:
@@ -1581,7 +1579,7 @@ prometheus:
   port: 9962
   serviceMonitor:
     # -- Enable service monitors.
-    # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+    # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
     enabled: false
     # -- Labels to add to ServiceMonitor cilium-agent
     labels: {}
@@ -1603,7 +1601,7 @@ prometheus:
   # -- Metrics that should be enabled or disabled from the default metric
   # list. (+metric_foo to enable metric_foo , -metric_bar to disable
   # metric_bar).
-  # ref: https://docs.cilium.io/en/stable/operations/metrics/#exported-metrics
+  # ref: https://docs.cilium.io/en/stable/observability/metrics/
   metrics: ~
 
 # -- Configure Istio proxy options.
@@ -1713,7 +1711,7 @@ etcd:
   extraArgs: []
 
   # -- Node tolerations for cilium-etcd-operator scheduling to nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations:
   - operator: Exists
     # - key: "key"
@@ -1728,7 +1726,7 @@ etcd:
     #   whenUnsatisfiable: DoNotSchedule
 
   # -- Node labels for cilium-etcd-operator pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
 
@@ -1750,7 +1748,7 @@ etcd:
     maxUnavailable: 1
 
   # -- cilium-etcd-operator resource limits & requests
-  # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources: {}
     # limits:
     #   cpu: 4000m
@@ -1843,13 +1841,12 @@ operator:
     #   whenUnsatisfiable: DoNotSchedule
 
   # -- Node labels for cilium-operator pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  #
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
 
   # -- Node tolerations for cilium-operator scheduling to nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations:
   - operator: Exists
     # - key: "key"
@@ -1896,7 +1893,7 @@ operator:
     maxUnavailable: 1
 
   # -- cilium-operator resource limits & requests
-  # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources: {}
     # limits:
     #   cpu: 1000m
@@ -1939,7 +1936,7 @@ operator:
     port: 9963
     serviceMonitor:
       # -- Enable service monitors.
-      # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/master/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+      # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
       enabled: false
       # -- Labels to add to ServiceMonitor cilium-operator
       labels: {}
@@ -1995,13 +1992,12 @@ nodeinit:
   affinity: {}
 
   # -- Node labels for nodeinit pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  #
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
 
   # -- Node tolerations for nodeinit scheduling to nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations:
   - operator: Exists
     # - key: "key"
@@ -2016,7 +2012,7 @@ nodeinit:
   podLabels: {}
 
   # -- nodeinit resource limits & requests
-  # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources:
     requests:
       cpu: 100m
@@ -2079,13 +2075,12 @@ preflight:
             k8s-app: cilium
 
   # -- Node labels for preflight pod assignment
-  # ref: https://kubernetes.io/docs/user-guide/node-selection/
-  #
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
   nodeSelector:
     kubernetes.io/os: linux
 
   # -- Node tolerations for preflight scheduling to nodes with taints
-  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
   tolerations:
   - key: node.kubernetes.io/not-ready
     effect: NoSchedule
@@ -2121,7 +2116,7 @@ preflight:
     maxUnavailable: 1
 
   # -- preflight resource limits & requests
-  # ref: https://kubernetes.io/docs/user-guide/compute-resources/
+  # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources: {}
     # limits:
     #   cpu: 4000m
@@ -2294,12 +2289,12 @@ clustermesh:
       #   whenUnsatisfiable: DoNotSchedule
 
     # -- Node labels for pod assignment
-    # ref: https://kubernetes.io/docs/user-guide/node-selection/
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
     nodeSelector:
       kubernetes.io/os: linux
 
     # -- Node tolerations for pod assignment on nodes with taints
-    # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+    # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
     tolerations: []
 
     # -- clustermesh-apiserver update strategy
@@ -2341,7 +2336,7 @@ clustermesh:
         #
         # Defaults to none. Commented syntax gives midnight of the first day of every
         # fourth month. For syntax, see
-        # https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#schedule
+        # https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#schedule-syntax
         # schedule: "0 0 1 */4 *"
 
         # [Example]

--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -113,7 +113,7 @@ func (c *globalServiceCache) onDelete(svc *serviceStore.ClusterService) {
 
 	c.mutex.Lock()
 	if globalService, ok := c.byName[svc.NamespaceServiceName()]; ok {
-		c.delete(globalService, svc.NamespaceServiceName(), svc.Cluster)
+		c.delete(globalService, svc.Cluster, svc.NamespaceServiceName())
 	} else {
 		scopedLog.Debugf("Ignoring delete request for unknown global service")
 	}
@@ -126,7 +126,7 @@ func (c *globalServiceCache) onClusterDelete(clusterName string) {
 
 	c.mutex.Lock()
 	for serviceName, globalService := range c.byName {
-		c.delete(globalService, serviceName, clusterName)
+		c.delete(globalService, clusterName, serviceName)
 	}
 	c.mutex.Unlock()
 }

--- a/pkg/clustermesh/services.go
+++ b/pkg/clustermesh/services.go
@@ -156,7 +156,6 @@ func (r *remoteServiceObserver) OnUpdate(key store.Key) {
 		mesh.globalServices.onUpdate(svc)
 
 		if merger := mesh.conf.ServiceMerger; merger != nil {
-			r.swg.Add()
 			merger.MergeExternalServiceUpdate(svc, r.swg)
 		} else {
 			scopedLog.Debugf("Ignoring remote service update. Missing merger function")
@@ -176,7 +175,6 @@ func (r *remoteServiceObserver) OnDelete(key store.NamedKey) {
 		mesh.globalServices.onDelete(svc)
 
 		if merger := mesh.conf.ServiceMerger; merger != nil {
-			r.swg.Add()
 			merger.MergeExternalServiceDelete(svc, r.swg)
 		} else {
 			scopedLog.Debugf("Ignoring remote service delete. Missing merger function")

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/pkg/checker"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -28,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/rand"
+	serviceStore "github.com/cilium/cilium/pkg/service/store"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
@@ -328,4 +330,61 @@ func (s *ClusterMeshServicesTestSuite) TestClusterMeshServicesNonGlobal(c *C) {
 		swgSvcs.Wait()
 		return true
 	}, 2*time.Second), IsNil)
+}
+
+type fakeServiceMerger struct {
+	updated map[string]int
+	deleted map[string]int
+}
+
+func (f *fakeServiceMerger) init() {
+	f.updated = make(map[string]int)
+	f.deleted = make(map[string]int)
+}
+
+func (f *fakeServiceMerger) MergeExternalServiceUpdate(service *serviceStore.ClusterService, _ *lock.StoppableWaitGroup) {
+	f.updated[service.String()]++
+}
+
+func (f *fakeServiceMerger) MergeExternalServiceDelete(service *serviceStore.ClusterService, _ *lock.StoppableWaitGroup) {
+	f.deleted[service.String()]++
+}
+
+func (s *ClusterMeshServicesTestSuite) TestRemoteServiceObserver(c *C) {
+	svc1 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name", IncludeExternal: true, Shared: true}
+	cache := newGlobalServiceCache("cluster", "node")
+	merger := fakeServiceMerger{}
+
+	observer := remoteServiceObserver{
+		remoteCluster: &remoteCluster{
+			mesh: &ClusterMesh{
+				globalServices: cache,
+				conf:           Configuration{ServiceMerger: &merger},
+			},
+		},
+		swg: lock.NewStoppableWaitGroup(),
+	}
+
+	// Observe a new service update (for a shared service), and assert it is correctly added to the cache
+	merger.init()
+	observer.OnUpdate(&svc1)
+
+	c.Assert(merger.updated[svc1.String()], Equals, 1)
+	c.Assert(merger.deleted[svc1.String()], Equals, 0)
+
+	c.Assert(cache.byName, HasLen, 1)
+	gs, ok := cache.byName[svc1.NamespaceServiceName()]
+	c.Assert(ok, Equals, true)
+	c.Assert(gs.clusterServices, HasLen, 1)
+	found, ok := gs.clusterServices[svc1.Cluster]
+	c.Assert(ok, Equals, true)
+	c.Assert(found, checker.DeepEquals, &svc1)
+
+	// Observe a new service deletion, and assert it is correctly removed from the cache
+	merger.init()
+	observer.OnDelete(&svc1)
+
+	c.Assert(merger.updated[svc1.String()], Equals, 0)
+	c.Assert(merger.deleted[svc1.String()], Equals, 1)
+	c.Assert(cache.byName, HasLen, 0)
 }

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -27,11 +27,13 @@ const (
 	ContextIdentity
 	// ContextNamespace uses the namespace name for identification purposes
 	ContextNamespace
-	// ContextPod uses the pod name for identification purposes
+	// ContextPod uses the namespace and pod name for identification purposes in the form of namespace/pod-name.
 	ContextPod
 	// ContextPodShort uses a short version of the pod name. It should
-	// typically map to the deployment/replicaset name
+	// typically map to the deployment/replicaset name. Deprecated.
 	ContextPodShort
+	// ContextPodName uses the pod name for identification purposes
+	ContextPodName
 	// ContextDNS uses the DNS name for identification purposes
 	ContextDNS
 	// ContextIP uses the IP address for identification purposes
@@ -51,7 +53,7 @@ const ContextOptionsHelp = `
  sourceContext          ::= identifier , { "|", identifier }
  destinationContext     ::= identifier , { "|", identifier }
  labels                 ::= label , { ",", label }
- identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
+ identifier             ::= identity | namespace | pod | pod-short | pod-name | dns | ip | reserved-identity | workload-name | app
  label                  ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 
@@ -146,6 +148,8 @@ func parseContextIdentifier(s string) (ContextIdentifier, error) {
 		return ContextPod, nil
 	case "pod-short":
 		return ContextPodShort, nil
+	case "pod-name":
+		return ContextPodName, nil
 	case "dns":
 		return ContextDNS, nil
 	case "ip":
@@ -409,6 +413,8 @@ func getContextIDLabelValue(contextID ContextIdentifier, flow *pb.Flow, source b
 		if ep.GetNamespace() != "" {
 			labelValue = ep.GetNamespace() + "/" + labelValue
 		}
+	case ContextPodName:
+		labelValue = ep.GetPodName()
 	case ContextDNS:
 		if source {
 			labelValue = strings.Join(flow.GetSourceNames(), ",")

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -115,6 +115,14 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.Nil(t, err)
 	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-bar-123-123"}}), []string{"foo/bar-bar"})
 
+	opts, err = ParseContextOptions(Options{"sourceContext": "pod-name"})
+	assert.Nil(t, err)
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123"}}), []string{"foo-123"})
+
+	opts, err = ParseContextOptions(Options{"destinationContext": "pod-name"})
+	assert.Nil(t, err)
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "bar-123"}}), []string{"bar-123"})
+
 	opts, err = ParseContextOptions(Options{"sourceContext": "dns"})
 	assert.Nil(t, err)
 	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{SourceNames: []string{"foo", "bar"}}), []string{"foo,bar"})

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -23,7 +23,7 @@ Options:
  sourceContext          ::= identifier , { "|", identifier }
  destinationContext     ::= identifier , { "|", identifier }
  labels                 ::= label , { ",", label }
- identifier             ::= identity | namespace | pod | pod-short | dns | ip | reserved-identity | workload-name | app
+ identifier             ::= identity | namespace | pod | pod-short | pod-name | dns | ip | reserved-identity | workload-name | app
  label                  ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())

--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -304,7 +304,7 @@ func (s *Server) ServerStatus(ctx context.Context, req *observerpb.ServerStatusR
 		resp.SeenFlows += status.SeenFlows
 		// use the oldest uptime as a reference for the uptime as cumulating
 		// values would make little sense
-		if resp.UptimeNs == 0 || resp.UptimeNs > status.UptimeNs {
+		if resp.UptimeNs < status.UptimeNs {
 			resp.UptimeNs = status.UptimeNs
 		}
 	}

--- a/pkg/hubble/relay/observer/server_test.go
+++ b/pkg/hubble/relay/observer/server_test.go
@@ -932,7 +932,7 @@ func TestServerStatus(t *testing.T) {
 					NumFlows:            3333,
 					MaxFlows:            3333,
 					SeenFlows:           3333,
-					UptimeNs:            111111111,
+					UptimeNs:            222222222,
 					NumConnectedNodes:   &wrapperspb.UInt32Value{Value: 2},
 					NumUnavailableNodes: &wrapperspb.UInt32Value{Value: 0},
 				},

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -259,8 +259,8 @@ var nodeSampleJSON = `{
             },
             {
                 "names": [
-                    "k8s.gcr.io/node-problem-detector@sha256:f95cab985c26b2f46e9bd43283e0bfa88860c14e0fb0649266babe8b65e9eb2b",
-                    "k8s.gcr.io/node-problem-detector:v0.4.1"
+                    "registry.k8s.io/node-problem-detector@sha256:f95cab985c26b2f46e9bd43283e0bfa88860c14e0fb0649266babe8b65e9eb2b",
+                    "registry.k8s.io/node-problem-detector:v0.4.1"
                 ],
                 "sizeBytes": 286572743
             },
@@ -280,59 +280,59 @@ var nodeSampleJSON = `{
             },
             {
                 "names": [
-                    "k8s.gcr.io/fluentd-elasticsearch@sha256:a54e7a450c0bdd19f49f56e487427a08c50f99ea8f8846179acf7d4182ce1fc0",
-                    "k8s.gcr.io/fluentd-elasticsearch:v2.2.0"
+                    "registry.k8s.io/fluentd-elasticsearch@sha256:a54e7a450c0bdd19f49f56e487427a08c50f99ea8f8846179acf7d4182ce1fc0",
+                    "registry.k8s.io/fluentd-elasticsearch:v2.2.0"
                 ],
                 "sizeBytes": 138313727
             },
             {
                 "names": [
-                    "k8s.gcr.io/fluentd-gcp-scaler@sha256:457a13df66534b94bab627c4c2dc2df0ee5153a5d0f0afd27502bd46bd8da81d",
-                    "k8s.gcr.io/fluentd-gcp-scaler:0.5"
+                    "registry.k8s.io/fluentd-gcp-scaler@sha256:457a13df66534b94bab627c4c2dc2df0ee5153a5d0f0afd27502bd46bd8da81d",
+                    "registry.k8s.io/fluentd-gcp-scaler:0.5"
                 ],
                 "sizeBytes": 103488147
             },
             {
                 "names": [
-                    "k8s.gcr.io/kubernetes-dashboard-amd64@sha256:dc4026c1b595435ef5527ca598e1e9c4343076926d7d62b365c44831395adbd0",
-                    "k8s.gcr.io/kubernetes-dashboard-amd64:v1.8.3"
+                    "registry.k8s.io/kubernetes-dashboard-amd64@sha256:dc4026c1b595435ef5527ca598e1e9c4343076926d7d62b365c44831395adbd0",
+                    "registry.k8s.io/kubernetes-dashboard-amd64:v1.8.3"
                 ],
                 "sizeBytes": 102319441
             },
             {
                 "names": [
                     "gcr.io/google_containers/kube-proxy:v1.12.5-gke.10",
-                    "k8s.gcr.io/kube-proxy:v1.12.5-gke.10"
+                    "registry.k8s.io/kube-proxy:v1.12.5-gke.10"
                 ],
                 "sizeBytes": 101370340
             },
             {
                 "names": [
-                    "k8s.gcr.io/event-exporter@sha256:7f9cd7cb04d6959b0aa960727d04fa86759008048c785397b7b0d9dff0007516",
-                    "k8s.gcr.io/event-exporter:v0.2.3"
+                    "registry.k8s.io/event-exporter@sha256:7f9cd7cb04d6959b0aa960727d04fa86759008048c785397b7b0d9dff0007516",
+                    "registry.k8s.io/event-exporter:v0.2.3"
                 ],
                 "sizeBytes": 94171943
             },
             {
                 "names": [
                     "gcr.io/google-containers/prometheus-to-sd@sha256:6c0c742475363d537ff059136e5d5e4ab1f512ee0fd9b7ca42ea48bc309d1662",
-                    "k8s.gcr.io/prometheus-to-sd@sha256:6c0c742475363d537ff059136e5d5e4ab1f512ee0fd9b7ca42ea48bc309d1662",
+                    "registry.k8s.io/prometheus-to-sd@sha256:6c0c742475363d537ff059136e5d5e4ab1f512ee0fd9b7ca42ea48bc309d1662",
                     "gcr.io/google-containers/prometheus-to-sd:v0.3.1",
-                    "k8s.gcr.io/prometheus-to-sd:v0.3.1"
+                    "registry.k8s.io/prometheus-to-sd:v0.3.1"
                 ],
                 "sizeBytes": 88077694
             },
             {
                 "names": [
-                    "k8s.gcr.io/heapster-amd64@sha256:9fae0af136ce0cf4f88393b3670f7139ffc464692060c374d2ae748e13144521",
-                    "k8s.gcr.io/heapster-amd64:v1.6.0-beta.1"
+                    "registry.k8s.io/heapster-amd64@sha256:9fae0af136ce0cf4f88393b3670f7139ffc464692060c374d2ae748e13144521",
+                    "registry.k8s.io/heapster-amd64:v1.6.0-beta.1"
                 ],
                 "sizeBytes": 76016169
             },
             {
                 "names": [
-                    "k8s.gcr.io/ingress-gce-glbc-amd64@sha256:14f14351a03038b238232e60850a9cfa0dffbed0590321ef84216a432accc1ca",
-                    "k8s.gcr.io/ingress-gce-glbc-amd64:v1.2.3"
+                    "registry.k8s.io/ingress-gce-glbc-amd64@sha256:14f14351a03038b238232e60850a9cfa0dffbed0590321ef84216a432accc1ca",
+                    "registry.k8s.io/ingress-gce-glbc-amd64:v1.2.3"
                 ],
                 "sizeBytes": 71797285
             },
@@ -345,45 +345,45 @@ var nodeSampleJSON = `{
             },
             {
                 "names": [
-                    "k8s.gcr.io/kube-addon-manager@sha256:d53486c3a0b49ebee019932878dc44232735d5622a51dbbdcec7124199020d09",
-                    "k8s.gcr.io/kube-addon-manager:v8.7"
+                    "registry.k8s.io/kube-addon-manager@sha256:d53486c3a0b49ebee019932878dc44232735d5622a51dbbdcec7124199020d09",
+                    "registry.k8s.io/kube-addon-manager:v8.7"
                 ],
                 "sizeBytes": 63322109
             },
             {
                 "names": [
-                    "k8s.gcr.io/cpvpa-amd64@sha256:cfe7b0a11c9c8e18c87b1eb34fef9a7cbb8480a8da11fc2657f78dbf4739f869",
-                    "k8s.gcr.io/cpvpa-amd64:v0.6.0"
+                    "registry.k8s.io/cpvpa-amd64@sha256:cfe7b0a11c9c8e18c87b1eb34fef9a7cbb8480a8da11fc2657f78dbf4739f869",
+                    "registry.k8s.io/cpvpa-amd64:v0.6.0"
                 ],
                 "sizeBytes": 51785854
             },
             {
                 "names": [
-                    "k8s.gcr.io/k8s-dns-kube-dns-amd64@sha256:618a82fa66cf0c75e4753369a6999032372be7308866fc9afb381789b1e5ad52",
-                    "k8s.gcr.io/k8s-dns-kube-dns@sha256:c54a527a4ba8f1bc15e4796b09bf5d69313c7f42af9911dc437e056c0264a2fe",
-                    "k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13",
-                    "k8s.gcr.io/k8s-dns-kube-dns:1.14.13"
+                    "registry.k8s.io/k8s-dns-kube-dns-amd64@sha256:618a82fa66cf0c75e4753369a6999032372be7308866fc9afb381789b1e5ad52",
+                    "registry.k8s.io/k8s-dns-kube-dns@sha256:c54a527a4ba8f1bc15e4796b09bf5d69313c7f42af9911dc437e056c0264a2fe",
+                    "registry.k8s.io/k8s-dns-kube-dns-amd64:1.14.13",
+                    "registry.k8s.io/k8s-dns-kube-dns:1.14.13"
                 ],
                 "sizeBytes": 51157394
             },
             {
                 "names": [
-                    "k8s.gcr.io/cluster-proportional-autoscaler-amd64@sha256:36359630278b119e7dd78f5437be1c667080108fa59ecba1b81cda3610dcf4d7",
-                    "k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.2.0"
+                    "registry.k8s.io/cluster-proportional-autoscaler-amd64@sha256:36359630278b119e7dd78f5437be1c667080108fa59ecba1b81cda3610dcf4d7",
+                    "registry.k8s.io/cluster-proportional-autoscaler-amd64:1.2.0"
                 ],
                 "sizeBytes": 50258329
             },
             {
                 "names": [
-                    "k8s.gcr.io/cluster-proportional-autoscaler-amd64@sha256:003f98d9f411ddfa6ff6d539196355e03ddd69fa4ed38c7ffb8fec6f729afe2d",
-                    "k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2"
+                    "registry.k8s.io/cluster-proportional-autoscaler-amd64@sha256:003f98d9f411ddfa6ff6d539196355e03ddd69fa4ed38c7ffb8fec6f729afe2d",
+                    "registry.k8s.io/cluster-proportional-autoscaler-amd64:1.1.2-r2"
                 ],
                 "sizeBytes": 49648481
             },
             {
                 "names": [
-                    "k8s.gcr.io/ip-masq-agent-amd64@sha256:1ffda57d87901bc01324c82ceb2145fe6a0448d3f0dd9cb65aa76a867cd62103",
-                    "k8s.gcr.io/ip-masq-agent-amd64:v2.1.1"
+                    "registry.k8s.io/ip-masq-agent-amd64@sha256:1ffda57d87901bc01324c82ceb2145fe6a0448d3f0dd9cb65aa76a867cd62103",
+                    "registry.k8s.io/ip-masq-agent-amd64:v2.1.1"
                 ],
                 "sizeBytes": 49612505
             },

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1018,7 +1018,7 @@ reList:
 		scopedLog.WithField(fieldRev, nextRev).Debug("Starting to watch a prefix")
 
 		e.limiter.Wait(ctx)
-		etcdWatch := e.client.Watch(ctx, w.Prefix,
+		etcdWatch := e.client.Watch(client.WithRequireLeader(ctx), w.Prefix,
 			client.WithPrefix(), client.WithRev(nextRev))
 		for {
 			select {

--- a/test/controlplane/node/ciliumnodes/v1.24/init.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/init.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -219,18 +219,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -239,7 +239,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -248,7 +248,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/node/ciliumnodes/v1.24/state1.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state1.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -220,18 +220,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -240,7 +240,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -249,7 +249,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/node/ciliumnodes/v1.24/state2.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state2.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -219,18 +219,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -239,7 +239,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -248,7 +248,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/node/ciliumnodes/v1.24/state3.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state3.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -220,18 +220,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -240,7 +240,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -249,7 +249,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/node/ciliumnodes/v1.24/state4.yaml
+++ b/test/controlplane/node/ciliumnodes/v1.24/state4.yaml
@@ -89,18 +89,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -108,7 +108,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -117,7 +117,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -220,18 +220,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -240,7 +240,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -249,7 +249,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/services/dualstack/v1.23/init.yaml
+++ b/test/controlplane/services/dualstack/v1.23/init.yaml
@@ -86,22 +86,22 @@ items:
     images:
     - names:
       - docker.io/library/import-2022-09-02@sha256:f27fe306ea3c0e3ef176dda243bcbcc2bd8fa0f9d19f87285b0fb47e96d85f93
-      - k8s.gcr.io/kube-proxy:v1.23.10
+      - registry.k8s.io/kube-proxy:v1.23.10
       sizeBytes: 114214764
     - names:
-      - k8s.gcr.io/etcd:3.5.1-0
+      - registry.k8s.io/etcd:3.5.1-0
       sizeBytes: 98888614
     - names:
       - docker.io/library/import-2022-09-02@sha256:1475e1063b4a6e72ad5429344f40b184db5f400e1ceec1c98cae4ebae6183969
-      - k8s.gcr.io/kube-apiserver:v1.23.10
+      - registry.k8s.io/kube-apiserver:v1.23.10
       sizeBytes: 79616477
     - names:
       - docker.io/library/import-2022-09-02@sha256:55a29e82414b1bfee75b1ad51d83aac0b1cb2dbc9f277005723fa1dc2e9c7974
-      - k8s.gcr.io/kube-controller-manager:v1.23.10
+      - registry.k8s.io/kube-controller-manager:v1.23.10
       sizeBytes: 68167791
     - names:
       - docker.io/library/import-2022-09-02@sha256:b01e3e44037758b7250cb5b7a9e3795099bdcbc22de134029a58f924c2f5a8bf
-      - k8s.gcr.io/kube-scheduler:v1.23.10
+      - registry.k8s.io/kube-scheduler:v1.23.10
       sizeBytes: 54831215
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -110,7 +110,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -215,18 +215,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-02@sha256:f27fe306ea3c0e3ef176dda243bcbcc2bd8fa0f9d19f87285b0fb47e96d85f93
-      - k8s.gcr.io/kube-proxy:v1.23.10
+      - registry.k8s.io/kube-proxy:v1.23.10
       sizeBytes: 114214764
     - names:
-      - k8s.gcr.io/etcd:3.5.1-0
+      - registry.k8s.io/etcd:3.5.1-0
       sizeBytes: 98888614
     - names:
       - docker.io/library/import-2022-09-02@sha256:1475e1063b4a6e72ad5429344f40b184db5f400e1ceec1c98cae4ebae6183969
-      - k8s.gcr.io/kube-apiserver:v1.23.10
+      - registry.k8s.io/kube-apiserver:v1.23.10
       sizeBytes: 79616477
     - names:
       - docker.io/library/import-2022-09-02@sha256:55a29e82414b1bfee75b1ad51d83aac0b1cb2dbc9f277005723fa1dc2e9c7974
-      - k8s.gcr.io/kube-controller-manager:v1.23.10
+      - registry.k8s.io/kube-controller-manager:v1.23.10
       sizeBytes: 68167791
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -234,7 +234,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-02@sha256:b01e3e44037758b7250cb5b7a9e3795099bdcbc22de134029a58f924c2f5a8bf
-      - k8s.gcr.io/kube-scheduler:v1.23.10
+      - registry.k8s.io/kube-scheduler:v1.23.10
       sizeBytes: 54831215
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -243,7 +243,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -348,18 +348,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-02@sha256:f27fe306ea3c0e3ef176dda243bcbcc2bd8fa0f9d19f87285b0fb47e96d85f93
-      - k8s.gcr.io/kube-proxy:v1.23.10
+      - registry.k8s.io/kube-proxy:v1.23.10
       sizeBytes: 114214764
     - names:
-      - k8s.gcr.io/etcd:3.5.1-0
+      - registry.k8s.io/etcd:3.5.1-0
       sizeBytes: 98888614
     - names:
       - docker.io/library/import-2022-09-02@sha256:1475e1063b4a6e72ad5429344f40b184db5f400e1ceec1c98cae4ebae6183969
-      - k8s.gcr.io/kube-apiserver:v1.23.10
+      - registry.k8s.io/kube-apiserver:v1.23.10
       sizeBytes: 79616477
     - names:
       - docker.io/library/import-2022-09-02@sha256:55a29e82414b1bfee75b1ad51d83aac0b1cb2dbc9f277005723fa1dc2e9c7974
-      - k8s.gcr.io/kube-controller-manager:v1.23.10
+      - registry.k8s.io/kube-controller-manager:v1.23.10
       sizeBytes: 68167791
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -367,7 +367,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-02@sha256:b01e3e44037758b7250cb5b7a9e3795099bdcbc22de134029a58f924c2f5a8bf
-      - k8s.gcr.io/kube-scheduler:v1.23.10
+      - registry.k8s.io/kube-scheduler:v1.23.10
       sizeBytes: 54831215
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -376,7 +376,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/services/dualstack/v1.24/init.yaml
+++ b/test/controlplane/services/dualstack/v1.24/init.yaml
@@ -87,22 +87,22 @@ items:
     images:
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -111,7 +111,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -216,18 +216,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -236,7 +236,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -245,7 +245,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -350,18 +350,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-12@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -369,7 +369,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -378,7 +378,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/controlplane/services/nodeport/v1.24/init.yaml
+++ b/test/controlplane/services/nodeport/v1.24/init.yaml
@@ -92,18 +92,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-13@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -111,7 +111,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -120,7 +120,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -225,18 +225,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-13@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -244,7 +244,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -253,7 +253,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a
@@ -358,18 +358,18 @@ items:
       sizeBytes: 459801943
     - names:
       - docker.io/library/import-2022-09-01@sha256:d6e7206df3996420ee00b7f0aaa232e02a8d3cbb5e187c6eef820c91dfcefbc1
-      - k8s.gcr.io/kube-proxy:v1.24.4
+      - registry.k8s.io/kube-proxy:v1.24.4
       sizeBytes: 111859564
     - names:
-      - k8s.gcr.io/etcd:3.5.3-0
+      - registry.k8s.io/etcd:3.5.3-0
       sizeBytes: 102143581
     - names:
       - docker.io/library/import-2022-09-01@sha256:45e51931a7b4a8bf7e1e73880a7f7cf6ef44228fca6668a9f671312208290f03
-      - k8s.gcr.io/kube-apiserver:v1.24.4
+      - registry.k8s.io/kube-apiserver:v1.24.4
       sizeBytes: 77294050
     - names:
       - docker.io/library/import-2022-09-01@sha256:f2b9b2249b15ff427f44927d374e70e1472569368be1622d08c5b4f48b3802a7
-      - k8s.gcr.io/kube-controller-manager:v1.24.4
+      - registry.k8s.io/kube-controller-manager:v1.24.4
       sizeBytes: 65570930
     - names:
       - docker.io/library/import-2022-09-13@sha256:6f761bfdb87a8a1822ef74a627df64d51118b88e66f7ac20ef860b7af9a4e32e
@@ -378,7 +378,7 @@ items:
       sizeBytes: 62955304
     - names:
       - docker.io/library/import-2022-09-01@sha256:d3a5fd050278f04da4c5900e22f2632b628f8bf4fed65beac57fd0db39fc9a3d
-      - k8s.gcr.io/kube-scheduler:v1.24.4
+      - registry.k8s.io/kube-scheduler:v1.24.4
       sizeBytes: 52340852
     - names:
       - docker.io/kindest/kindnetd:v20220726-ed811e41
@@ -387,7 +387,7 @@ items:
       - docker.io/kindest/local-path-provisioner:v0.0.22-kind.0
       sizeBytes: 17375346
     - names:
-      - k8s.gcr.io/coredns/coredns:v1.8.6
+      - registry.k8s.io/coredns/coredns:v1.8.6
       sizeBytes: 13585107
     - names:
       - docker.io/kindest/local-path-helper:v20220607-9a4d8d2a

--- a/test/provision/manifest/1.16/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/coredns_deployment.yaml
@@ -130,7 +130,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.16/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.16/eks/coredns_deployment.yaml
@@ -118,7 +118,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/coredns_deployment.yaml
@@ -132,7 +132,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.17/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.17/eks/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/coredns_deployment.yaml
@@ -132,7 +132,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.18/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.18/eks/coredns_deployment.yaml
@@ -125,7 +125,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.19/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/coredns_deployment.yaml
@@ -146,7 +146,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.19/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.19/eks/coredns_deployment.yaml
@@ -138,7 +138,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.20/coredns_deployment.yaml
+++ b/test/provision/manifest/1.20/coredns_deployment.yaml
@@ -145,7 +145,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.20/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.20/eks/coredns_deployment.yaml
@@ -145,7 +145,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.21/coredns_deployment.yaml
+++ b/test/provision/manifest/1.21/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.21/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.21/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.22/coredns_deployment.yaml
+++ b/test/provision/manifest/1.22/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.22/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.22/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.23/coredns_deployment.yaml
+++ b/test/provision/manifest/1.23/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.23/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.23/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.24/coredns_deployment.yaml
+++ b/test/provision/manifest/1.24/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.24/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.24/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/1.25/eks/coredns_deployment.yaml
+++ b/test/provision/manifest/1.25/eks/coredns_deployment.yaml
@@ -147,7 +147,7 @@ spec:
         kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns/coredns:v1.8.6
+        image: registry.k8s.io/coredns/coredns:v1.8.6
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/test/provision/manifest/coredns_deployment.yaml
+++ b/test/provision/manifest/coredns_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.3
+        image: registry.k8s.io/coredns/coredns:v1.8.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 5

--- a/test/runtime/privileged_tests.go
+++ b/test/runtime/privileged_tests.go
@@ -42,7 +42,7 @@ var _ = Describe("RuntimeDatapathPrivilegedUnitTests", func() {
 		path, _ := filepath.Split(vm.BasePath())
 		ctx, cancel := context.WithTimeout(context.Background(), privilegedUnitTestTimeout)
 		defer cancel()
-		res := vm.ExecContext(ctx, fmt.Sprintf("bash -c 'sudo make -C %s tests-privileged | ts \"[%%H:%%M:%%S]\"; exit \"${PIPESTATUS[0]}\"'", path))
+		res := vm.ExecContext(ctx, fmt.Sprintf("bash -c 'sudo make -C %s tests-privileged NO_COLOR=1 | ts \"[%%H:%%M:%%S]\"; exit \"${PIPESTATUS[0]}\"'", path))
 		res.ExpectSuccess("Failed to run privileged unit tests")
 	})
 })

--- a/test/vtep/README.rst
+++ b/test/vtep/README.rst
@@ -4,7 +4,7 @@ How to test VXLAN Tunnel Endpoint (VTEP) integration
 Requirements
 
 1. One Virtual Machine with Linux distribution (Ubuntu 20.04 tested)
-2. Please reference https://docs.cilium.io/en/stable/gettingstarted/kind/
+2. Please reference https://docs.cilium.io/en/stable/installation/kind/
    for Cilium deployment in kind dependencies
 3. Install python3-scapy package
 

--- a/test/vtep/install.sh
+++ b/test/vtep/install.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 
-#Please refer https://docs.cilium.io/en/stable/gettingstarted/kind/
+#Please refer https://docs.cilium.io/en/stable/installation/kind/
 
 # 1 create kind cluster
 kind create cluster --config=kind-cluster.yaml


### PR DESCRIPTION
 - [x] #23821 -- CI: switch to registry.k8s.io (@ameukam). _Updated: I have double checked this PR :heavy_check_mark:._
 - [x] #23741 -- clustermesh: fix cluster synchronization wait group increment (@giorio94)
 - [x] #23951 -- docs: Clarify basic kernel requirement (@pchaigno)
 - [ ] #23966 -- hubble/relay: fix uptime value in ServerStatus implementation (@rolinh)
 - [x] #23920 -- Fixed broken/deprecated links (@PhilipSchmid)
 - [x] #23151 -- test/runtime: Set NO_COLOR for privileged tests (@joestringer)
 - [x] #23199 -- Add pod-name hubble metrics context for pod name label without namespace (@chancez)
 - [x] #23975 -- fix(helm): add missing updateStrategy to hubble-ui deployment (@mhulscher). _Updated: I have double checked this PR :heavy_check_mark:._
 - [ ] #23590 -- Add leader requirement to watch from Etcd. (@marseel)
 - [x] #23947 -- clustermesh: fix services cache bloat due to incorrect deletion (@giorio94)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 23821 23741 23951 23966 23920 23151 23199 23975 23590 23947; do contrib/backporting/set-labels.py $pr done 1.13; done
```