### PR TITLE
renovate: Add stop updating label

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -48,6 +48,7 @@
     "kind/enhancement",
     "release-note/misc"
   ],
+  "stopUpdatingLabel": "renovate/stop-updating",
   "packageRules": [
     {
       "groupName": "all github action dependencies",


### PR DESCRIPTION
This commit is to add renovate/stop-updating label, so that renovate will not update PR. This is to avoid the case that the PR is force pushed while tests are running, and it's hard for tophat/reviewers to keep track.
