### PR TITLE
v1.11 backport - Enable Google Analytics 4

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         with:
           persist-credentials: false
-      - uses: docker://cilium/docs-builder:2021-06-09@sha256:7126ea9182667ab1961bd8bb71265cbd3ec951e412910a116e24e0e74d7fc653
+      - uses: docker://cilium/docs-builder:2023-03-01-v1.11@sha256:6eb74c197feee068ac726a2baac3a3e1ecc18d05e63cf91b19f68fb06e48492b
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -41,6 +41,7 @@ extensions = ['sphinx.ext.ifconfig',
               'sphinx.ext.extlinks',
               'sphinxcontrib.openapi',
               'sphinx_tabs.tabs',
+              'sphinxcontrib.googleanalytics',
               'sphinxcontrib.spelling',
               'versionwarning.extension']
 
@@ -160,6 +161,7 @@ todo_include_todos = False
 # Add custom filters for spell checks.
 spelling_filters = [cilium_spellfilters.WireGuardFilter]
 
+googleanalytics_id = 'G-V9SYWYG92Y'
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/22220, to enable Google Analytics on the v1.11 branch.


```release-note
docs: Enable Google Analytics for v1.11 documentation
```

Cc @chalin, @joestringer

We'll need a new docs-builder image. Joe, I haven't addressed the automation discussed on the recent PR for `master`, but at least I pushed to the `cilium` repository directly.

---

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 22220; do contrib/backporting/set-labels.py $pr done 1.11; done
```