### PR TITLE
v1.12 backport - Enable Google Analytics 4

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run pre-requisites for validation
         run: |
           make -C Documentation copy-api # necessary for check-build.sh
-      - uses: docker://cilium/docs-builder:2022-04-08@sha256:44f59d844a7e1162080e6fdd62c72a16fc268c893c6cb81e1fbd31cfa189e691
+      - uses: docker://cilium/docs-builder:2023-03-01-v1.12@sha256:febddfe7f9752634c9e23ab585ade795328e0f3cde1c4df51089e798030bd9ac
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -24,6 +24,7 @@ RUN pip install -r /tmp/requirements.txt
 
 ENV HOME=/tmp
 ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION
+ENV MAKE_GIT_REPO_SAFE=1
 
 ## Workaround odd behaviour of sphinx versionwarning extension. It wants to
 ## write runtime data inside a system directory.

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -62,6 +62,24 @@ describe_spelling_errors() {
 }
 
 build_with_spellchecker() {
+    # The spell checker runs some Git commands to retreive the name of authors
+    # and consider them as acceptable words.
+    #
+    # Recent Git versions refuse to work by default if the repository owner is
+    # different from the user. This is the case when we run this script in a
+    # container on macOS, because pass --user "uid:gid", and these values
+    # differ from what Linux is used to (The gid from macOS seems to be 20,
+    # which corresponds to the "dialout" group in the container). We pass
+    # --user "uid:gid" to have the "install" command work in the workaround for
+    # versionwarning above.
+    #
+    # If running in a container, tell Git that the repository is safe.
+    set +o nounset
+    if [[ -n "$MAKE_GIT_REPO_SAFE" ]]; then
+        git config --global --add safe.directory "${script_dir}/.."
+    fi
+    set -o nounset
+
     rm -rf "${spelldir}"
     # Call with -q -W --keep-going: suppresses regular output (keeps warning;
     # -Q would suppress warnings as well including those we write to a file),

--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -12,6 +12,7 @@ set -o pipefail
 # times anyway.
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(dirname "${script_dir}")"
 
 build_dir="${script_dir}/_build"
 warnings="${build_dir}/warnings.txt"
@@ -76,7 +77,7 @@ build_with_spellchecker() {
     # If running in a container, tell Git that the repository is safe.
     set +o nounset
     if [[ -n "$MAKE_GIT_REPO_SAFE" ]]; then
-        git config --global --add safe.directory "${script_dir}/.."
+        git config --global --add safe.directory "${root_dir}"
     fi
     set -o nounset
 

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -42,6 +42,7 @@ extensions = ['myst_parser',
               'sphinx.ext.extlinks',
               'sphinxcontrib.openapi',
               'sphinx_tabs.tabs',
+              'sphinxcontrib.googleanalytics',
               'sphinxcontrib.spelling',
               'versionwarning.extension']
 
@@ -164,6 +165,7 @@ spelling_filters = [cilium_spellfilters.WireGuardFilter]
 # Ignore some warnings from MyST parser
 suppress_warnings = ['myst.header']
 
+googleanalytics_id = 'G-V9SYWYG92Y'
 
 # -- Options for HTML output ----------------------------------------------
 


### PR DESCRIPTION
Backport of https://github.com/cilium/cilium/pull/22220, to enable Google Analytics on the v1.12 branch.


```release-note
docs: Enable Google Analytics for v1.12 documentation
```

Cc @chalin, @joestringer

We'll need a new docs-builder image.

---


Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 21069 21040 22220; do contrib/backporting/set-labels.py $pr done 1.12; done
```