### PR TITLE
workflows: l4lb/verifier: fix skip-test-run job 

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -113,6 +113,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     steps:
+    - name: Set up job variables
+      id: vars
+      run: |
+	if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
+	  PR_API_JSON=$(curl \
+	    -H "Accept: application/vnd.github.v3+json" \
+	    -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+	    ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
+	  SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+	else
+	  SHA=${{ github.sha }}
+	fi
+	echo "sha=${SHA}" >> $GITHUB_OUTPUT
     - name: Set commit status to success
       uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
       with:

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -116,6 +116,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     steps:
+    - name: Set up job variables
+      id: vars
+      run: |
+	if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
+	  PR_API_JSON=$(curl \
+	    -H "Accept: application/vnd.github.v3+json" \
+	    -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+	    ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
+	  SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+	else
+	  SHA=${{ github.sha }}
+	fi
+	echo "sha=${SHA}" >> $GITHUB_OUTPUT
     - name: Set commit status to success
       uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
       with:

--- a/.github/workflows/tests-l4lb-v1.12.yaml
+++ b/.github/workflows/tests-l4lb-v1.12.yaml
@@ -116,6 +116,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     steps:
+    - name: Set up job variables
+      id: vars
+      run: |
+	if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
+	  PR_API_JSON=$(curl \
+	    -H "Accept: application/vnd.github.v3+json" \
+	    -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+	    ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
+	  SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+	else
+	  SHA=${{ github.sha }}
+	fi
+	echo "sha=${SHA}" >> $GITHUB_OUTPUT
     - name: Set commit status to success
       uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
       with:

--- a/.github/workflows/tests-l4lb-v1.13.yaml
+++ b/.github/workflows/tests-l4lb-v1.13.yaml
@@ -116,6 +116,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     steps:
+    - name: Set up job variables
+      id: vars
+      run: |
+	if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
+	  PR_API_JSON=$(curl \
+	    -H "Accept: application/vnd.github.v3+json" \
+	    -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+	    ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
+	  SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+	else
+	  SHA=${{ github.sha }}
+	fi
+	echo "sha=${SHA}" >> $GITHUB_OUTPUT
     - name: Set commit status to success
       uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
       with:

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -119,6 +119,19 @@ jobs:
     runs-on: ubuntu-latest
     needs: check_changes
     steps:
+    - name: Set up job variables
+      id: vars
+      run: |
+	if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
+	  PR_API_JSON=$(curl \
+	    -H "Accept: application/vnd.github.v3+json" \
+	    -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+	    ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
+	  SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+	else
+	  SHA=${{ github.sha }}
+	fi
+	echo "sha=${SHA}" >> $GITHUB_OUTPUT
     - name: Set commit status to success
       uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
       with:


### PR DESCRIPTION
this job is currently failing as the sha parameter of the github-status
action is left unset, as we are skipping the "Retrieve pull request's
base and head" step.

This commit fixes this by setting the appropriate workflow sha variable
in the previous step.