### PR TITLE
daemon: move circular initialization of policy.Repository to hive

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -7,10 +7,12 @@ import (
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
+	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/node"
@@ -78,6 +80,9 @@ var (
 
 		// Auth is responsible for authenticating a request if required by a policy.
 		auth.Cell,
+
+		// IPCache, policy.Repository and CachingIdentityAllocator.
+		cell.Provide(newPolicyTrifecta),
 	)
 
 	// Datapath provides the privileged operations to apply control-plane
@@ -90,5 +95,9 @@ var (
 			newWireguardAgent,
 			newDatapath,
 		),
+
+		cell.Provide(func(dp datapath.Datapath) ipcacheTypes.NodeHandler {
+			return dp.Node()
+		}),
 	)
 )

--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -19,6 +19,10 @@ var goleakOptions = []goleak.Option{
 	// by prior tests or by package init() functions (like the
 	// client-go logger).
 	goleak.IgnoreCurrent(),
+	// Ignore goroutines started by the policy trifecta, see [newPolicyTrifecta].
+	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/identity/cache.(*identityWatcher).watch.func1"),
+	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter"),
+	goleak.IgnoreTopFunction("sync.runtime_notifyListWait"),
 }
 
 // TestAgentCell verifies that the Agent hive can be instantiated with

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -411,6 +411,10 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	nodeLocalStore node.LocalNodeStore,
 	authManager auth.Manager,
 	cacheStatus k8s.CacheStatus,
+	ipc *ipcache.IPCache,
+	identityAllocator CachingIdentityAllocator,
+	pr *policy.Repository,
+	policyUpdater *policy.Updater,
 ) (*Daemon, *endpointRestoreState, error) {
 
 	var (
@@ -555,6 +559,13 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		endpointCreations: newEndpointCreationManager(clientset),
 		apiLimiterSet:     apiLimiterSet,
 		controllers:       controller.NewManager(),
+		// **NOTE** The global identity allocator is not yet initialized here; that
+		// happens below via InitIdentityAllocator(). Only the local identity
+		// allocator is initialized here.
+		identityAllocator: identityAllocator,
+		ipcache:           ipc,
+		policy:            pr,
+		policyUpdater:     policyUpdater,
 	}
 
 	if option.Config.RunMonitorAgent {
@@ -598,27 +609,10 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		ipcachemap.IPCacheMap().Close()
 	}
 
-	// Propagate identity allocator down to packages which themselves do not
-	// have types to which we can add an allocator member.
-	//
-	// **NOTE** The global identity allocator is not yet initialized here; that
-	// happens below vie InitIdentityAllocator(). Only the local identity allocator
-	// is initialized here.
-	//
-	// TODO: convert these package level variables to types for easier unit
-	// testing in the future.
-	d.identityAllocator = NewCachingIdentityAllocator(&d)
-	if err := d.initPolicy(epMgr, certManager, secretManager, authManager); err != nil {
+	if err := d.initPolicy(authManager); err != nil {
 		return nil, nil, fmt.Errorf("error while initializing policy subsystem: %w", err)
 	}
-	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{
-		Context:           ctx,
-		IdentityAllocator: d.identityAllocator,
-		PolicyHandler:     d.policy.GetSelectorCache(),
-		DatapathHandler:   epMgr,
-		NodeHandler:       dp.Node(),
-		CacheStatus:       cacheStatus,
-	})
+
 	// Preallocate IDs for old CIDRs. This must be done before any Identity allocations are
 	// possible so that the old IDs are still available. That is why we do this ASAP after the
 	// new (userspace) ipcache is created above.
@@ -1384,16 +1378,9 @@ func (d *Daemon) ReloadOnDeviceChange(devices []string) {
 
 // Close shuts down a daemon
 func (d *Daemon) Close() {
-	if err := d.ipcache.Shutdown(); err != nil {
-		log.WithError(err).Debug("Failure during ipcache shutdown")
-	}
-	if d.policyUpdater != nil {
-		d.policyUpdater.Shutdown()
-	}
 	if d.datapathRegenTrigger != nil {
 		d.datapathRegenTrigger.Shutdown()
 	}
-	d.identityAllocator.Close()
 	identitymanager.RemoveAll()
 	d.cgroupManager.Close()
 }
@@ -1472,23 +1459,4 @@ func (d *Daemon) SendNotification(notification monitorAPI.AgentNotifyMessage) er
 		return nil
 	}
 	return d.monitorAgent.SendEvent(monitorAPI.MessageTypeAgent, notification)
-}
-
-// GetNodeSuffix returns the suffix to be appended to kvstore keys of this
-// agent
-func (d *Daemon) GetNodeSuffix() string {
-	var ip net.IP
-
-	switch {
-	case option.Config.EnableIPv4:
-		ip = node.GetIPv4()
-	case option.Config.EnableIPv6:
-		ip = node.GetIPv6()
-	}
-
-	if ip == nil {
-		log.Fatal("Node IP not available yet")
-	}
-
-	return ip.String()
 }

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -181,10 +181,6 @@ type Daemon struct {
 	linkCache      *link.LinkCache
 	hubbleObserver *observer.LocalObserverServer
 
-	// k8sCachesSynced is closed when all essential Kubernetes caches have
-	// been fully synchronized
-	k8sCachesSynced <-chan struct{}
-
 	// endpointCreations is a map of all currently ongoing endpoint
 	// creation events
 	endpointCreations *endpointCreationManager
@@ -414,6 +410,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	secretManager certificatemanager.SecretManager,
 	nodeLocalStore node.LocalNodeStore,
 	authManager auth.Manager,
+	cacheStatus k8s.CacheStatus,
 ) (*Daemon, *endpointRestoreState, error) {
 
 	var (
@@ -620,6 +617,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		PolicyHandler:     d.policy.GetSelectorCache(),
 		DatapathHandler:   epMgr,
 		NodeHandler:       dp.Node(),
+		CacheStatus:       cacheStatus,
 	})
 	// Preallocate IDs for old CIDRs. This must be done before any Identity allocations are
 	// possible so that the old IDs are still available. That is why we do this ASAP after the
@@ -693,7 +691,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	d.cgroupManager = manager.NewCgroupManager()
 
 	if option.Config.EnableIPv4EgressGateway {
-		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(&d, d.identityAllocator, option.Config.InstallEgressGatewayRoutes)
+		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(cacheStatus, d.identityAllocator, option.Config.InstallEgressGatewayRoutes)
 	}
 
 	d.k8sWatcher = watchers.NewK8sWatcher(
@@ -714,8 +712,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		sharedResources,
 	)
 	nd.RegisterK8sGetters(d.k8sWatcher)
-
-	d.ipcache.RegisterK8sSyncedChecker(&d)
 
 	d.k8sWatcher.RegisterNodeSubscriber(d.endpointManager)
 	if option.Config.BGPAnnounceLBIP || option.Config.BGPAnnouncePodCIDR {
@@ -1082,15 +1078,12 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	if clientset.IsEnabled() {
 		bootstrapStats.k8sInit.Start()
 
-		// Initialize d.k8sCachesSynced before any k8s watchers are alive, as they may
-		// access it to check the status of k8s initialization
-		cachesSynced := make(chan struct{})
-		d.k8sCachesSynced = cachesSynced
-
 		// Launch the K8s watchers in parallel as we continue to process other
 		// daemon options.
-		d.k8sWatcher.InitK8sSubsystem(d.ctx, cachesSynced)
+		d.k8sWatcher.InitK8sSubsystem(d.ctx, cacheStatus)
 		bootstrapStats.k8sInit.End(true)
+	} else {
+		close(cacheStatus)
 	}
 
 	bootstrapStats.cleanup.Start()
@@ -1498,18 +1491,4 @@ func (d *Daemon) GetNodeSuffix() string {
 	}
 
 	return ip.String()
-}
-
-// K8sCacheIsSynced returns true if the agent has fully synced its k8s cache
-// with the API server
-func (d *Daemon) K8sCacheIsSynced() bool {
-	if !d.clientset.IsEnabled() {
-		return true
-	}
-	select {
-	case <-d.k8sCachesSynced:
-		return true
-	default:
-		return false
-	}
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -1654,20 +1655,24 @@ var daemonCell = cell.Module(
 type daemonParams struct {
 	cell.In
 
-	Lifecycle       hive.Lifecycle
-	Clientset       k8sClient.Clientset
-	Datapath        datapath.Datapath
-	WGAgent         *wg.Agent `optional:"true"`
-	LocalNodeStore  node.LocalNodeStore
-	BGPController   *bgpv1.Controller
-	Shutdowner      hive.Shutdowner
-	SharedResources k8s.SharedResources
-	CacheStatus     k8s.CacheStatus
-	NodeManager     nodeManager.NodeManager
-	EndpointManager endpointmanager.EndpointManager
-	CertManager     certificatemanager.CertificateManager
-	SecretManager   certificatemanager.SecretManager
-	AuthManager     auth.Manager
+	Lifecycle         hive.Lifecycle
+	Clientset         k8sClient.Clientset
+	Datapath          datapath.Datapath
+	WGAgent           *wg.Agent `optional:"true"`
+	LocalNodeStore    node.LocalNodeStore
+	BGPController     *bgpv1.Controller
+	Shutdowner        hive.Shutdowner
+	SharedResources   k8s.SharedResources
+	CacheStatus       k8s.CacheStatus
+	NodeManager       nodeManager.NodeManager
+	EndpointManager   endpointmanager.EndpointManager
+	CertManager       certificatemanager.CertificateManager
+	SecretManager     certificatemanager.SecretManager
+	AuthManager       auth.Manager
+	IdentityAllocator CachingIdentityAllocator
+	Policy            *policy.Repository
+	PolicyUpdater     *policy.Updater
+	IPCache           *ipcache.IPCache
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
@@ -1702,6 +1707,10 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 				params.LocalNodeStore,
 				params.AuthManager,
 				params.CacheStatus,
+				params.IPCache,
+				params.IdentityAllocator,
+				params.Policy,
+				params.PolicyUpdater,
 			)
 			if err != nil {
 				return fmt.Errorf("daemon creation failed: %w", err)

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
-	"github.com/cilium/cilium/pkg/identity/cache"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labelsfilter"
@@ -299,12 +298,4 @@ func (ds *DaemonSuite) GetDNSRules(epID uint16) restore.DNSRules {
 }
 
 func (ds *DaemonSuite) RemoveRestoredDNSRules(epID uint16) {
-}
-
-func (ds *DaemonSuite) GetNodeSuffix() string {
-	return ds.d.GetNodeSuffix()
-}
-
-func (ds *DaemonSuite) UpdateIdentities(added, deleted cache.IdentityCache) {
-	ds.d.UpdateIdentities(added, deleted)
 }

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	identitymodel "github.com/cilium/cilium/pkg/identity/model"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -100,20 +101,13 @@ type CachingIdentityAllocator interface {
 
 type cachingIdentityAllocator struct {
 	*cache.CachingIdentityAllocator
-	d *Daemon
-}
-
-func NewCachingIdentityAllocator(d *Daemon) cachingIdentityAllocator {
-	return cachingIdentityAllocator{
-		CachingIdentityAllocator: cache.NewCachingIdentityAllocator(d),
-		d:                        d,
-	}
+	ipcache *ipcache.IPCache
 }
 
 func (c cachingIdentityAllocator) AllocateCIDRsForIPs(ips []net.IP, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
-	return c.d.ipcache.AllocateCIDRsForIPs(ips, newlyAllocatedIdentities)
+	return c.ipcache.AllocateCIDRsForIPs(ips, newlyAllocatedIdentities)
 }
 
 func (c cachingIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
-	c.d.ipcache.ReleaseCIDRIdentitiesByID(ctx, identities)
+	c.ipcache.ReleaseCIDRIdentitiesByID(ctx, identities)
 }

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -83,6 +84,7 @@ type Configuration struct {
 	ipcacheTypes.PolicyHandler
 	ipcacheTypes.DatapathHandler
 	ipcacheTypes.NodeHandler
+	k8s.CacheStatus
 }
 
 // IPCache is a collection of mappings:
@@ -114,9 +116,7 @@ type IPCache struct {
 	// is then swapped in place while 'mutex' is being held.
 	namedPorts types.NamedPortMultiMap
 
-	// k8sSyncedChecker knows how to check for whether the K8s watcher cache
-	// has been fully synced.
-	k8sSyncedChecker k8sSyncedChecker
+	cacheStatus k8s.CacheStatus
 
 	// Configuration provides pointers towards other agent components that
 	// the IPCache relies upon at runtime.
@@ -783,12 +783,6 @@ func (ipc *IPCache) LookupByHostRLocked(hostIPv4, hostIPv6 net.IP) (cidrs []net.
 	return cidrs
 }
 
-// RegisterK8sWaiter registers the object that checks for wehther the K8s cache
-// has been fully synced.
-func (ipc *IPCache) RegisterK8sSyncedChecker(c k8sSyncedChecker) {
-	ipc.k8sSyncedChecker = c
-}
-
 // Equal returns true if two K8sMetadata pointers contain the same data or are
 // both nil.
 func (m *K8sMetadata) Equal(o *K8sMetadata) bool {
@@ -806,10 +800,4 @@ func (m *K8sMetadata) Equal(o *K8sMetadata) bool {
 		}
 	}
 	return m.Namespace == o.Namespace && m.PodName == o.PodName
-}
-
-// k8sCacheIsSynced is an interface for checking if the K8s watcher cache has
-// been fully synced.
-type k8sSyncedChecker interface {
-	K8sCacheIsSynced() bool
 }

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -162,7 +162,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 		return modifiedPrefixes, ErrLocalIdentityAllocatorUninitialized
 	}
 
-	if ipc.k8sSyncedChecker == nil || !ipc.k8sSyncedChecker.K8sCacheIsSynced() {
+	if !ipc.cacheStatus.Synchronized() {
 		return modifiedPrefixes, errors.New("k8s cache not fully synced")
 	}
 

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -159,7 +159,6 @@ func TestOverrideIdentity(t *testing.T) {
 		PolicyHandler:     &mockUpdater{},
 		DatapathHandler:   &mockTriggerer{},
 	})
-	ipc.k8sSyncedChecker = &mockK8sSyncedChecker{}
 	ctx := context.Background()
 
 	// Create CIDR identity from labels
@@ -245,7 +244,6 @@ func setupTest(t *testing.T) (cleanup func()) {
 		PolicyHandler:     &mockUpdater{},
 		DatapathHandler:   &mockTriggerer{},
 	})
-	IPIdentityCache.k8sSyncedChecker = &mockK8sSyncedChecker{}
 
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "kube-uid", labels.LabelKubeAPIServer)
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.Local, "host-uid", labels.LabelHost)
@@ -255,10 +253,6 @@ func setupTest(t *testing.T) (cleanup func()) {
 		IPIdentityCache.Shutdown()
 	}
 }
-
-type mockK8sSyncedChecker struct{}
-
-func (m *mockK8sSyncedChecker) K8sCacheIsSynced() bool { return true }
 
 type mockUpdater struct{}
 

--- a/pkg/k8s/cache_status.go
+++ b/pkg/k8s/cache_status.go
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+// CacheStatus allows waiting for k8s caches to synchronize.
+type CacheStatus chan struct{}
+
+// Sychronized returns true if caches have been synchronized at least once.
+//
+// Returns true for an uninitialized [CacheStatus].
+func (cs CacheStatus) Synchronized() bool {
+	if cs == nil {
+		return true
+	}
+
+	select {
+	case <-cs:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
IPCache, CachingIdentityAllocator and policy.Repository (really SelectorCache) have a gnarly circular dependency during intialization. Do the simplest possible thing and lift them into hive by providing a constructor that encapsulates the neccessary logic.

This way we can add dependencies on these without having to modularize them first.

Pre-requisite for #23046.