### PR TITLE
auth: define auth handlers as private hive cell

### DIFF
--- a/pkg/auth/monitor/monitor.go
+++ b/pkg/auth/monitor/monitor.go
@@ -24,7 +24,7 @@ type dropMonitor struct {
 	lostEvents  uint64
 }
 
-func AddAuthManager(auth AuthManager) *dropMonitor {
+func New(auth AuthManager) *dropMonitor {
 	return &dropMonitor{authManager: auth}
 }
 

--- a/pkg/auth/null_authhandler.go
+++ b/pkg/auth/null_authhandler.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import "github.com/cilium/cilium/pkg/policy"
+
+type nullAuthHandler struct {
+}
+
+func (r *nullAuthHandler) authenticate() error {
+	// Authentication trivially done
+	return nil
+}
+
+func (r *nullAuthHandler) authType() policy.AuthType {
+	return policy.AuthTypeNull
+}


### PR DESCRIPTION
The "null" auth handler is defined as private hive cell within the auth manager cell. The auth manager collects all provided auth handlers in the value group "authHandlers" - which is a feature provided by hive / uber/dig.

This way, multiple auth handlers can register themselves for a different auth type.

Following auth handlers can depend on other components too, without having the manager as core component to know everything. e.g. `~mtlsAuthHandler` -> `~keyProvider` (which can be implemented by spiffe/spire or something else.

The authentication interface (auth request & response) needs to be defined and implemented once it's clarified.
