### PR TITLE
daemon: Check for leaked goroutines from the agent cell

### DIFF
--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -7,18 +7,28 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/metrics"
 )
+
+var goleakOptions = []goleak.Option{
+	// Ignore all the currently running goroutines spawned
+	// by prior tests or by package init() functions (like the
+	// client-go logger).
+	goleak.IgnoreCurrent(),
+}
 
 // TestAgentCell verifies that the Agent hive can be instantiated with
 // default configuration and thus the Agent hive can be inspected with
 // the hive commands and documentation can be generated from it.
 func TestAgentCell(t *testing.T) {
+	defer goleak.VerifyNone(t, goleakOptions...)
 	defer metrics.ResetMetrics()
 
+	logging.SetLogLevelToDebug()
 	err := hive.New(Agent).Populate()
 	assert.NoError(t, err, "Populate()")
-
 }


### PR DESCRIPTION
This adds a check to the TestAgentCell to make sure none of the constructors spawn goroutines
(they should be spawned from Start() and terminated from Stop() hooks instead).

Second commit fixes few issues that already existed.
