### PR TITLE
operator: Remove duplicated package import

### DIFF
--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/option"
-	pkgOption "github.com/cilium/cilium/pkg/option"
 )
 
 func init() {
@@ -309,7 +308,7 @@ func init() {
 	flags.String(operatorOption.CiliumPodLabels, "k8s-app=cilium", "Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false")
 	option.BindEnv(Vp, operatorOption.CiliumPodLabels)
 
-	flags.Bool(operatorOption.RemoveCiliumNodeTaints, true, fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", pkgOption.Config.AgentNotReadyNodeTaintValue()))
+	flags.Bool(operatorOption.RemoveCiliumNodeTaints, true, fmt.Sprintf("Remove node taint %q from Kubernetes nodes once Cilium is up and running", option.Config.AgentNotReadyNodeTaintValue()))
 	option.BindEnv(Vp, operatorOption.RemoveCiliumNodeTaints)
 
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")


### PR DESCRIPTION
The package "github.com/cilium/cilium/pkg/option" was imported more than once with different aliases in `operator/cmd/flags.go`.
The commit fixes it removing the unnecessary additional import.