### PR TITLE
daemon: fix panic when running with etcd with endpoint crd disabled

### DIFF
--- a/daemon/cmd/ciliumendpoints.go
+++ b/daemon/cmd/ciliumendpoints.go
@@ -31,6 +31,9 @@ func (d *Daemon) cleanStaleCEPs(ctx context.Context, eps localEndpointCache, cil
 		crdType = "ciliumendpointslice"
 	}
 	indexer := d.k8sWatcher.GetIndexer(crdType)
+	if indexer == nil {
+		return fmt.Errorf("%s indexer was nil", crdType)
+	}
 	objs, err := indexer.ByIndex("localNode", node.GetCiliumEndpointNodeIP())
 	if err != nil {
 		return fmt.Errorf("could not get %s objects from localNode indexer: %w", crdType, err)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1784,7 +1784,9 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 			<-restoreComplete
 		}
 
-		if params.Clientset.IsEnabled() && option.Config.EnableStaleCiliumEndpointCleanup {
+		// Only attempt CEP cleanup if cilium endpoint CRD is not disabled, otherwise the cep/ces
+		// watchers/indexers will not be initialized.
+		if params.Clientset.IsEnabled() && option.Config.EnableStaleCiliumEndpointCleanup && !option.Config.DisableCiliumEndpointCRD {
 			// Use restored endpoints to delete local CiliumEndpoints which are not in the restored endpoint cache.
 			// This will clear out any CiliumEndpoints that may be stale.
 			// Likely causes for this are Pods having their init container restarted or the node being restarted.


### PR DESCRIPTION
daemon: fix panic when running with etcd with endpoint crd disabled

When running etcd kvstore, if endpoint CRD is disabled then the stale CEP cleanup init procedure panics due to a nil indexer references returned from k8s watchers.
This is because the cep/ces k8s watchers aren't initialized if this option is set to true.

Fixes: #24366

```release-note
daemon: fix panic when running with etcd with endpoint crd disabled 
```
