### PR TITLE
contrib: Add support for snapshot releases

### DIFF
--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -33,12 +33,12 @@ handle_args() {
 
     if ! echo "$1" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z[-rcW]"
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z[-rc.W|-snapshot.W]"
     fi
 
     if ! echo "$2" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid NEW-VERSION ARG \"$2\"; Expected X.Y.Z[-rcW]"
+        common::exit 1 "Invalid NEW-VERSION ARG \"$2\"; Expected X.Y.Z[-rc.W|-snapshot.W]"
     fi
 
     if [ "$#" -eq 3 ] && ! echo "$3" | grep -q "[0-9]\+\.[0-9]\+"; then

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -109,6 +109,7 @@ main() {
     target_branch=$(echo "$version" | sed "$BRANCH_REGEX")
     if ! git ls-remote --exit-code --heads $REMOTE $target_branch; then
         target_branch=$(echo "$old_version" | sed "$BRANCH_REGEX")
+        old_branch="$target_branch"
     fi
     $DIR/../../Documentation/check-crd-compat-table.sh "$target_branch" --update
     if [ "${old_branch}" != "" ]; then

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -83,8 +83,8 @@ main() {
     git fetch -q $REMOTE
     if [ "$branch" = "master" ]; then
         git checkout -b pr/prepare-$version $REMOTE/$branch
-        if echo "$version" | grep -q 'rc'; then
-            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'snapshot' | sort -V | tail -n 1)"
+        if version_is_prerelease "$version"; then
+            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'rc\|snapshot' | sort -V | tail -n 1)"
         else
             old_version="$(git tag -l "$VERSION_GLOB" | sort -V | tail -n 1)"
         fi
@@ -107,6 +107,9 @@ main() {
     fi
 
     target_branch=$(echo "$version" | sed "$BRANCH_REGEX")
+    if ! git ls-remote --exit-code --heads $REMOTE $target_branch; then
+        target_branch=$(echo "$old_version" | sed "$BRANCH_REGEX")
+    fi
     $DIR/../../Documentation/check-crd-compat-table.sh "$target_branch" --update
     if [ "${old_branch}" != "" ]; then
       $DIR/prep-changelog.sh "$old_version" "$version" "$old_branch"


### PR DESCRIPTION
Some of the scripts already had some 'snapshot' version/tag support already, this fixes up the remaining instances.

- contrib: Support vX.Y.Z-snapshot.W versions
- contrib: Fix incorrect relnotes for snapshots

Used to generate https://github.com/cilium/cilium/pull/24091.
