### PR TITLE
vendor,test: Updated CoverBee to v0.3.1 to resolve panic during testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.74.0
 	github.com/aws/smithy-go v1.13.5
 	github.com/blang/semver/v4 v4.0.0
-	github.com/cilium/coverbee v0.3.0
+	github.com/cilium/coverbee v0.3.1
 	github.com/cilium/customvet v0.0.0-20221207003726-576d50314db5
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,8 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/controller-tools v0.6.2 h1:oIkqAzqncKsm+lQFJVP6n+bqHOVs9nUZ06hgZ4PxlMM=
 github.com/cilium/controller-tools v0.6.2/go.mod h1:oaeGpjXn6+ZSEIQkUe/+3I40PNiDYp9aeawbt3xTgJ8=
-github.com/cilium/coverbee v0.3.0 h1:Jo3aTIQj3cUZ+degKZKJgcsNmXcrmgKOBDLC//ou7Z0=
-github.com/cilium/coverbee v0.3.0/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
+github.com/cilium/coverbee v0.3.1 h1:HfATR8JDy13g7rZp/GIxo91jKUbiYv3CGEZngAPP3KU=
+github.com/cilium/coverbee v0.3.1/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
 github.com/cilium/customvet v0.0.0-20221207003726-576d50314db5 h1:1PZtm6h4KJeLbWncB8X1evfZyJ5W9m6+lxqddWEXBws=
 github.com/cilium/customvet v0.0.0-20221207003726-576d50314db5/go.mod h1:nFj/mLY2y3zQe+DDXgl9rXixkJPVLf23UfRlaljzW6k=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e h1:VZolEtS7AlGDu3IH368iqkvfQQSGPgOnPjNaUx4dS7M=

--- a/vendor/github.com/cilium/coverbee/pkg/verifierlog/verifierlog.go
+++ b/vendor/github.com/cilium/coverbee/pkg/verifierlog/verifierlog.go
@@ -37,6 +37,8 @@ func MergedPerInstruction(log string) []VerifierState {
 	var curState VerifierState
 
 	mergeCurState := func(state VerifierState) {
+		curState.Unknown = false
+
 		for _, reg := range state.Registers {
 			found := false
 			for i, curReg := range curState.Registers {
@@ -68,11 +70,17 @@ func MergedPerInstruction(log string) []VerifierState {
 
 	applyCurState := func(instNum int) {
 		if instNum >= len(states) {
-			states = append(states, make([]VerifierState, 1+instNum-len(states))...)
+			newStates := make([]VerifierState, 1+instNum-len(states))
+			for i := range newStates {
+				newStates[i].Unknown = true
+			}
+			states = append(states, newStates...)
 		}
 
 		// Apply current state to `states`
 		for _, curReg := range curState.Registers {
+			states[instNum].Unknown = false
+
 			found := false
 			for i, reg := range states[instNum].Registers {
 				if reg.Register == curReg.Register {
@@ -470,6 +478,8 @@ type VerifierState struct {
 	FrameNumber int
 	Registers   []RegisterState
 	Stack       []StackState
+	// If true, the struct was initialized as filler, but no actual state info is known
+	Unknown bool
 }
 
 func parseRegisterState(key, value string) (*RegisterState, error) {
@@ -509,7 +519,12 @@ func parseRegisterState(key, value string) (*RegisterState, error) {
 }
 
 func (is *VerifierState) String() string {
+	if is.Unknown {
+		return "unknown"
+	}
+
 	var sb strings.Builder
+
 	if is.FrameNumber != 0 {
 		fmt.Fprintf(&sb, "frame%d: ", is.FrameNumber)
 	}
@@ -1490,10 +1505,11 @@ func parseFunctionCall(firstLine string, scan *bufio.Scanner) VerifierStatement 
 // FunctionCall indicates the verifier is following a bpf-to-bpf function call.
 // For example:
 // caller:
-//   frame1: R6=pkt(id=0,off=54,r=74,imm=0) R7=pkt(id=0,off=0,r=74,imm=0) R8_w=pkt(id=0,off=74,r=74,imm=0) R9=invP6
-//   R10=fp0 fp-8=pkt_end fp-16=mmmmmmmm
-//  callee:
-//   frame2: R1_w=pkt(id=0,off=54,r=74,imm=0) R2_w=invP(id=0) R10=fp0
+//
+//	 frame1: R6=pkt(id=0,off=54,r=74,imm=0) R7=pkt(id=0,off=0,r=74,imm=0) R8_w=pkt(id=0,off=74,r=74,imm=0) R9=invP6
+//	 R10=fp0 fp-8=pkt_end fp-16=mmmmmmmm
+//	callee:
+//	 frame2: R1_w=pkt(id=0,off=54,r=74,imm=0) R2_w=invP(id=0) R10=fp0
 type FunctionCall struct {
 	CallerState *VerifierState
 	CalleeState *VerifierState
@@ -1550,10 +1566,13 @@ func parseReturnFunctionCall(firstLine string, scan *bufio.Scanner) VerifierStat
 // ReturnFunctionCall indicates the verifier is evaluating returning from a function call.
 // Example:
 // returning from callee:
-//  frame2: R0=map_value(id=0,off=0,ks=1,vs=16,imm=0) R1_w=invP(id=0) R6=invP(id=31) R10=fp0 fp-8=m???????
+//
+//	frame2: R0=map_value(id=0,off=0,ks=1,vs=16,imm=0) R1_w=invP(id=0) R6=invP(id=31) R10=fp0 fp-8=m???????
+//
 // to caller at 156:
-//   frame1: R0=map_value(id=0,off=0,ks=1,vs=16,imm=0) R6=pkt(id=0,off=54,r=54,imm=0) R7=pkt(id=0,off=0,r=54,imm=0)
-//   R8=invP14 R9=invP(id=30,umax_value=255,var_off=(0x0; 0xff)) R10=fp0 fp-8=pkt_end fp-16=mmmmmmmm
+//
+//	frame1: R0=map_value(id=0,off=0,ks=1,vs=16,imm=0) R6=pkt(id=0,off=54,r=54,imm=0) R7=pkt(id=0,off=0,r=54,imm=0)
+//	R8=invP14 R9=invP(id=30,umax_value=255,var_off=(0x0; 0xff)) R10=fp0 fp-8=pkt_end fp-16=mmmmmmmm
 type ReturnFunctionCall struct {
 	CallerState *VerifierState
 	CallSite    int

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -168,7 +168,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.1.2
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/cilium/coverbee v0.3.0
+# github.com/cilium/coverbee v0.3.1
 ## explicit; go 1.18
 github.com/cilium/coverbee
 github.com/cilium/coverbee/pkg/cparser


### PR DESCRIPTION
We were getting panics in the CoverBee code when coverage testing certain test programs. It turns out that this was due to "dead code" which the verifier would never evaluate, which CoverBee did not expect to be possible.

This version of CoverBee fixes the issue without additional changes.

Fixes: #24053

```release-note
Fixed panic when generating code coverage report of eBPF tests
```
