### PR TITLE
Documentation: add section to roadmap about modularization

### DIFF
--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -152,7 +152,18 @@ Tetragon provides security observability and runtime enforcement through the JSO
 CLI for things like process execution, file access, network observability, and
 privileged execution.
 
+Codebase modularization
+~~~~~~~~~~~~~~~~~~~~~~~
 
+As the project is growing in complexity it is becoming increasingly important to be able
+to divide it into more manageable chunks. To achieve this, we're working on modularizing the
+codebase and going from a tightly coupled design (one large initialization and configuration)
+to a more loosely coupled design of mostly self-contained modules. This will make Cilium 
+internals easier to comprehend, test and extend. 
+
+Contributions in this area are very welcome. To get started, take a look at the :ref:`guide-to-the-hive`
+documentation and the issues referenced from `modularization meta issue <modularization-issue_>`_.
+If you have any questions or ideas please join us on the #sig-modularization channel on `Cilium Slack <slack_>`_.
 
 .. _rm-influence:
 
@@ -200,3 +211,4 @@ anything other than trivial fixes.
 .. _slack: https://cilium.io/slack
 .. _enterprise: https://cilium.io/enterprise
 .. _CFP design doc: https://github.com/cilium/design-cfps/tree/main
+.. _modularization-issue: https://github.com/cilium/cilium/issues/23425

--- a/Documentation/contributing/development/hive.rst
+++ b/Documentation/contributing/development/hive.rst
@@ -4,7 +4,7 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
-.. _hive:
+.. _guide-to-the-hive:
 
 Guide to the Hive
 =================

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -699,6 +699,7 @@ minikube
 misconfigures
 mlx
 modularity
+modularizing
 monitorAggregation
 monitorFlags
 monitorInterval


### PR DESCRIPTION
To raise community awareness of the modularization effort add a section to roadmap that links to the hive documentation, the meta issue and the slack channel.
