### PR TITLE
egressgw: test: switch to WaitForEgressPolicyEntries

### DIFF
--- a/test/k8s/egress.go
+++ b/test/k8s/egress.go
@@ -320,10 +320,10 @@ var _ = SkipDescribeIf(func() bool {
 					//   - 2 matching endpoints
 					//   - 1 destination CIDR
 
-					err := kubectl.WaitForEgressPolicyEntries(k8s1IP, 6)
+					err := kubectl.WaitForEgressPolicyEntries(helpers.K8s1, 6)
 					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
 
-					err = kubectl.WaitForEgressPolicyEntries(k8s2IP, 6)
+					err = kubectl.WaitForEgressPolicyEntries(helpers.K8s2, 6)
 					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
 				})
 				AfterAll(func() {
@@ -375,10 +375,10 @@ var _ = SkipDescribeIf(func() bool {
 					//   - 1 destination CIDR
 					//   - 1 excluded CIDR
 
-					err := kubectl.WaitForEgressPolicyEntries(k8s1IP, 4)
+					err := kubectl.WaitForEgressPolicyEntries(helpers.K8s1, 4)
 					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
 
-					err = kubectl.WaitForEgressPolicyEntries(k8s2IP, 4)
+					err = kubectl.WaitForEgressPolicyEntries(helpers.K8s2, 4)
 					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
 				})
 				AfterAll(func() {

--- a/test/k8s/egress.go
+++ b/test/k8s/egress.go
@@ -314,11 +314,26 @@ var _ = SkipDescribeIf(func() bool {
 
 				BeforeAll(func() {
 					policyYAML = applyEgressPolicy("egress-gateway-policy.yaml")
-					kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
-					kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
+
+					// Wait for 6 entries:
+					// - 3 policies, each with:
+					//   - 2 matching endpoints
+					//   - 1 destination CIDR
+
+					err := kubectl.WaitForEgressPolicyEntries(k8s1IP, 6)
+					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
+
+					err = kubectl.WaitForEgressPolicyEntries(k8s2IP, 6)
+					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
 				})
 				AfterAll(func() {
 					kubectl.Delete(policyYAML)
+
+					err := kubectl.WaitForEgressPolicyEntries(helpers.K8s1, 0)
+					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
+
+					err = kubectl.WaitForEgressPolicyEntries(helpers.K8s2, 0)
+					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
 				})
 
 				AfterFailed(func() {
@@ -353,11 +368,27 @@ var _ = SkipDescribeIf(func() bool {
 
 				BeforeAll(func() {
 					policyYAML = applyEgressPolicy("egress-gateway-policy-excl-cidr.yaml")
-					kubectl.WaitForEgressPolicyEntry(k8s1IP, outsideIP)
-					kubectl.WaitForEgressPolicyEntry(k8s2IP, outsideIP)
+
+					// Wait for 4 entries:
+					// - 1 policies with:
+					//   - 2 matching endpoints
+					//   - 1 destination CIDR
+					//   - 1 excluded CIDR
+
+					err := kubectl.WaitForEgressPolicyEntries(k8s1IP, 4)
+					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
+
+					err = kubectl.WaitForEgressPolicyEntries(k8s2IP, 4)
+					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
 				})
 				AfterAll(func() {
 					kubectl.Delete(policyYAML)
+
+					err := kubectl.WaitForEgressPolicyEntries(helpers.K8s1, 0)
+					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
+
+					err = kubectl.WaitForEgressPolicyEntries(helpers.K8s2, 0)
+					Expect(err).Should(BeNil(), "Failed waiting for egress policy map entries")
 				})
 
 				AfterFailed(func() {


### PR DESCRIPTION
To wait for a CiliumEgressGatewayPolicy to be effective in a ginkgo test
suite, we rely on the WaitForEgressPolicyEntry helper, which lists the
entries in the bpf egress policy map and makes sure that at least one
entry matches the k8s3 node IP (as that's used as destination CIDR in
one of the policies).

This is not optimal as matching that IP doesn't guarantee that the full
policy/all policies are effective.

With this commit, instead of looking for a particular IP, we just count
the number of entries, since, given a policies manifest, it's easy to
determine how many entries we should expect in the bpf map.