### PR TITLE
docs: Revert Python to 3.7.9 in docs-builder, downgrade a dependency

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run pre-requisites for validation
         run: |
           make -C Documentation copy-api # necessary for check-build.sh
-      - uses: docker://cilium/docs-builder:2023-02-24@sha256:2f5689df73c3e6090c5c83bcd546a35c44e40b1d770dae9044c0b4c2966b45fd
+      - uses: docker://cilium/docs-builder:2023-03-01@sha256:36b233afd73482c2bc7ed43f7a1537f09962015c34679b86c4ca1fa618d67b95
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,4 +1,5 @@
-FROM docker.io/library/python:3.10.4-alpine3.15 AS docs-base
+# Python version should match the one in use in Read The Docs
+FROM docker.io/library/python:3.7.9-alpine3.13 AS docs-base
 
 LABEL maintainer="maintainer@cilium.io"
 
@@ -30,4 +31,4 @@ ENV MAKE_GIT_REPO_SAFE=1
 ## Workaround odd behaviour of sphinx versionwarning extension. It wants to
 ## write runtime data inside a system directory.
 ## We do rely on this extension, so we cannot just drop it.
-RUN install -m 0777 -d /usr/local/lib/python3.10/site-packages/versionwarning/_static/data
+RUN install -m 0777 -d /usr/local/lib/python3.7/site-packages/versionwarning/_static/data

--- a/Documentation/requirements-min/requirements.txt
+++ b/Documentation/requirements-min/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==5.3.0
+sphinx==5.3.0
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -1,5 +1,5 @@
 ## Auto-generated from requirements-min/requirements.txt with "make update-requirements"
-Sphinx==5.3.0
+sphinx==5.3.0
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
@@ -20,7 +20,7 @@ yamllint==1.29.0
 ## The following requirements were added by pip freeze:
 alabaster==0.7.13
 attrs==22.2.0
-Babel==2.11.0
+Babel==2.12.1
 certifi==2022.12.7
 charset-normalizer==3.0.1
 click==8.1.3
@@ -30,6 +30,8 @@ deepmerge==1.1.0
 docutils==0.17.1
 idna==3.4
 imagesize==1.4.1
+importlib-metadata==4.13.0
+importlib-resources==5.12.0
 Jinja2==3.0.3
 jsonschema==4.17.3
 livereload==2.6.3
@@ -41,6 +43,7 @@ mistune==2.0.5
 packaging==23.0
 pathspec==0.11.0
 picobox==2.2.0
+pkgutil-resolve-name==1.3.10
 pydantic==1.10.5
 pyenchant==3.2.2
 Pygments==2.14.0
@@ -53,10 +56,10 @@ rstcheck-core==1.0.3
 shellingham==1.5.0.post1
 six==1.16.0
 snowballstemmer==2.2.0
-sphinx_mdinclude==0.5.3
-sphinxcontrib-applehelp==1.0.4
+sphinx-mdinclude==0.5.3
+sphinxcontrib-applehelp==1.0.2
 sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.0.0
 sphinxcontrib-httpdomain==1.8.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
@@ -64,5 +67,6 @@ sphinxcontrib-serializinghtml==1.1.5
 tornado==6.2
 typer==0.7.0
 types-docutils==0.19.1.6
-typing_extensions==4.5.0
+typing-extensions==4.5.0
 urllib3==1.26.14
+zipp==3.15.0


### PR DESCRIPTION
Some time ago, we updated the version of the Python interpreter in the Dockerfile for the docs-builder image. But we didn't realise that this would introduce a difference with the version in use on the Read The Docs platform. For a long period it didn't cause any issue, but the latest update of Sphinx dependencies bumped sphinxcontrib-applehelp to a version which is no longer compatible with Python 3.7. The build would run fine locally and in CI with Python 3.10, but would fail on Read The Docs where Python 3.7.9 is still in use.

We have two options: revert back to Python 3.7 in the docs-builder image, or make Read The Docs use a newer version. Updating the version on RTD sounds sensible, but there's no concrete advantage at this point, and we would have to introduce a .readthedocs.yaml file at the root of the Cilium repository, which we haven't needed so far. Conversely, there's no apparent drawback to stick to the older Python version in the docs-builder image, so we can just do that.

In addition to the Python version change, we need to regenerate the list of dependencies. Some are updated to their latest version, some seem to be slightly renamed, but note the downgrade for sphinxcontrib-applehelp. This should fix the builds on Read The Docs.

Fixes: 2b3207ed1967 ("docs: update Alpine image for cilium/docs-builder")
Fixes: #19348
Fixes: eb1338a12e63 ("docs: Update build dependencies (Sphinx add-ons etc.)")
Fixes: #24014

```release-note
docs: Revert Python version in docs-builder image to 3.7.9, downgrade sphinxcontrib-applehelp, to fix builds on Read The Docs
```
