### PR TITLE
Allow using predefined MAC addresses for endpoint interfaces

### DIFF
--- a/api/v1/models/daemon_configuration_status.go
+++ b/api/v1/models/daemon_configuration_status.go
@@ -44,6 +44,12 @@ type DaemonConfigurationStatus struct {
 	// Configured compatibility mode for --egress-multi-home-ip-rule-compat
 	EgressMultiHomeIPRuleCompat bool `json:"egress-multi-home-ip-rule-compat,omitempty"`
 
+	// MAC address for host side veth interface
+	EndpointInterfaceHostMAC string `json:"endpointInterfaceHostMAC,omitempty"`
+
+	// MAC address for container side veth interface
+	EndpointInterfaceMAC string `json:"endpointInterfaceMAC,omitempty"`
+
 	// Immutable configuration (read-only)
 	Immutable ConfigurationMap `json:"immutable,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2350,6 +2350,12 @@ definitions:
       routeMTU:
         description: MTU for network facing routes
         type: integer
+      endpointInterfaceHostMAC:
+        description: MAC address for host side veth interface
+        type: string
+      endpointInterfaceMAC:
+        description: MAC address for container side veth interface
+        type: string
       datapathMode:
         "$ref": "#/definitions/DatapathMode"
       ipam-mode:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2087,6 +2087,14 @@ func init() {
           "description": "Configured compatibility mode for --egress-multi-home-ip-rule-compat",
           "type": "boolean"
         },
+        "endpointInterfaceHostMAC": {
+          "description": "MAC address for host side veth interface",
+          "type": "string"
+        },
+        "endpointInterfaceMAC": {
+          "description": "MAC address for container side veth interface",
+          "type": "string"
+        },
         "immutable": {
           "description": "Immutable configuration (read-only)",
           "$ref": "#/definitions/ConfigurationMap"
@@ -6853,6 +6861,14 @@ func init() {
         "egress-multi-home-ip-rule-compat": {
           "description": "Configured compatibility mode for --egress-multi-home-ip-rule-compat",
           "type": "boolean"
+        },
+        "endpointInterfaceHostMAC": {
+          "description": "MAC address for host side veth interface",
+          "type": "string"
+        },
+        "endpointInterfaceMAC": {
+          "description": "MAC address for container side veth interface",
+          "type": "string"
         },
         "immutable": {
           "description": "Immutable configuration (read-only)",

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -199,6 +199,8 @@ func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
 			IPV6: option.Config.EnableIPv6Masquerade,
 		},
 		EgressMultiHomeIPRuleCompat: option.Config.EgressMultiHomeIPRuleCompat,
+		EndpointInterfaceHostMAC:    option.Config.EndpointInterfaceHostMAC,
+		EndpointInterfaceMAC:        option.Config.EndpointInterfaceMAC,
 		GROMaxSize:                  int64(d.bigTCPConfig.GetGROMaxSize()),
 		GSOMaxSize:                  int64(d.bigTCPConfig.GetGSOMaxSize()),
 	}

--- a/pkg/datapath/connector/veth.go
+++ b/pkg/datapath/connector/veth.go
@@ -61,11 +61,19 @@ func SetupVethWithNames(lxcIfName, tmpIfName string, mtu, groMaxSize, gsoMaxSize
 	// explicitly setting MAC addrs for both veth ends. This sets
 	// addr_assign_type for NET_ADDR_SET which prevents systemd from changing
 	// the addrs.
-	epHostMAC, err = mac.GenerateRandMAC()
+	if ep.HostMac != "" {
+		epHostMAC, err = mac.ParseMAC(ep.HostMac)
+	} else {
+		epHostMAC, err = mac.GenerateRandMAC()
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to generate rnd mac addr: %s", err)
 	}
-	epLXCMAC, err = mac.GenerateRandMAC()
+	if ep.Mac != "" {
+		epLXCMAC, _ = mac.ParseMAC(ep.Mac)
+	} else {
+		epLXCMAC, err = mac.GenerateRandMAC()
+	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to generate rnd mac addr: %s", err)
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -335,6 +335,12 @@ const (
 	// LoopbackIPv4 is the default address for service loopback
 	LoopbackIPv4 = "169.254.42.1"
 
+	// EndpointInterfaceHostMAC is set to empty to enable auto generation (default mode)
+	EndpointInterfaceHostMAC = ""
+
+	// EndpointInterfaceMAC is set to empty to enable auto generation (default mode)
+	EndpointInterfaceMAC = ""
+
 	// ForceLocalPolicyEvalAtSource is the default value for
 	// option.ForceLocalPolicyEvalAtSource. It can be enabled to provide
 	// backwards compatibility.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -803,6 +803,12 @@ const (
 	// LocalRouterIPv6 is the link-local IPv6 address to use for Cilium router device
 	LocalRouterIPv6 = "local-router-ipv6"
 
+	// EndpointInterfaceHostMAC defines MAC address for host side veth interface
+	EndpointInterfaceHostMAC = "endpoint-interface-host-mac"
+
+	// EndpointInterfaceMAC defines MAC address for container side veth interface
+	EndpointInterfaceMAC = "endpoint-interface-mac"
+
 	// ForceLocalPolicyEvalAtSource forces a policy decision at the source
 	// endpoint for all local communication
 	ForceLocalPolicyEvalAtSource = "force-local-policy-eval-at-source"
@@ -1855,6 +1861,12 @@ type DaemonConfig struct {
 	// LocalRouterIPv6 is the link-local IPv6 address used for Cilium's router device
 	LocalRouterIPv6 string
 
+	// EndpointInterfaceHostMAC defines MAC address for host side veth interface
+	EndpointInterfaceHostMAC string
+
+	// EndpointInterfaceMAC defines MAC address for container side veth interface
+	EndpointInterfaceMAC string
+
 	// ForceLocalPolicyEvalAtSource forces a policy decision at the source
 	// endpoint for all local communication
 	ForceLocalPolicyEvalAtSource bool
@@ -2348,6 +2360,8 @@ var (
 		KVStoreOpt:                   make(map[string]string),
 		LogOpt:                       make(map[string]string),
 		LoopbackIPv4:                 defaults.LoopbackIPv4,
+		EndpointInterfaceHostMAC:     defaults.EndpointInterfaceHostMAC,
+		EndpointInterfaceMAC:         defaults.EndpointInterfaceMAC,
 		ForceLocalPolicyEvalAtSource: defaults.ForceLocalPolicyEvalAtSource,
 		EnableEndpointRoutes:         defaults.EnableEndpointRoutes,
 		AnnotateK8sNode:              defaults.AnnotateK8sNode,
@@ -2879,6 +2893,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableWireguard = vp.GetBool(EnableWireguard)
 	c.EnableWireguardUserspaceFallback = vp.GetBool(EnableWireguardUserspaceFallback)
 	c.EnableWellKnownIdentities = vp.GetBool(EnableWellKnownIdentities)
+	c.EndpointInterfaceHostMAC = viper.GetString(EndpointInterfaceHostMAC)
+	c.EndpointInterfaceMAC = viper.GetString(EndpointInterfaceMAC)
 	c.EnableXDPPrefilter = vp.GetBool(EnableXDPPrefilter)
 	c.DisableCiliumEndpointCRD = vp.GetBool(DisableCiliumEndpointCRDName)
 	c.EgressMasqueradeInterfaces = vp.GetString(EgressMasqueradeInterfaces)

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -486,6 +486,8 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		K8sPodName:            string(cniArgs.K8S_POD_NAME),
 		K8sNamespace:          string(cniArgs.K8S_POD_NAMESPACE),
 		DatapathConfiguration: &models.EndpointDatapathConfiguration{},
+		Mac:                   conf.EndpointInterfaceMAC,
+		HostMac:               conf.EndpointInterfaceHostMAC,
 	}
 
 	if conf.IpamMode == ipamOption.IPAMDelegatedPlugin {


### PR DESCRIPTION
This PR introduces two new options:

- `--endpoint-interface-mac` which defines MAC address for container side veth interface
- `--endpoint-interface-host-mac` which defines MAC address for host side veth interface

If these options are specified cilium will use them for creating endpoint interfaces.
This might be useful for virtual machines created by kubevirt to ensure seamless live-migration with preserving IP-address over the nodes.

---

Hello, we use this fix in [Deckhouse](https://github.com/deckhouse/deckhouse/tree/main/modules/021-cni-cilium/images/cilium/patches) to provide [KubeVirt](https://github.com/kubevirt/kubevirt) virtual machines a stable MAC address which is not changing during live migration.

This allows to live-migrate virtual machine without reconfiguring network interfaces and routes in it. 

We would like to have this opportunity in upstream, so we are ready to update it according to your recommendations.
If you are interested in this patch to get merged, please guide us for rewriting it in a more correct way.

related issues:
- <s>https://github.com/cilium/cilium/pull/19789</s> (old implementation)
- https://github.com/cilium/cilium/pull/24098
- https://github.com/kubevirt/kubevirt/pull/7768
- https://github.com/kubevirt/community/pull/182

---

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Use predictable MAC-address generation seeded by hash of IP-address
```
