### PR TITLE
docs: Document kernel requirement for L3 devices support

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -277,6 +277,7 @@ VXLAN Tunnel Endpoint (VTEP) Integration               >= 5.2
 Full support for :ref:`session-affinity`               >= 5.7
 BPF-based proxy redirection                            >= 5.7
 Socket-level LB bypass in pod netns                    >= 5.7
+L3 devices                                             >= 5.8
 BPF-based host routing                                 >= 5.10
 IPv6 BIG TCP support                                   >= 5.19
 ====================================================== ===============================


### PR DESCRIPTION
The support for L3 devices requires Linux 5.8 with commit 6f3f65d80d ("net: bpf: Allow TC programs to call BPF_FUNC_skb_change_head"). Let's document that requirement.

Fixes: https://github.com/cilium/cilium/pull/15343.