### PR TITLE
bpf: remove a redundant IPcache lookup in from-host

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -304,7 +304,7 @@ skip_host_firewall:
 	}
 
 #ifdef ENABLE_IPSEC
-	if (info && info->key && info->tunnel_endpoint) {
+	if (info->key && info->tunnel_endpoint) {
 		__u8 key = get_min_encrypt_key(info->key);
 
 		set_encrypt_key_meta(ctx, key, info->node_id);
@@ -601,7 +601,7 @@ skip_vtep:
 	}
 
 #ifdef ENABLE_IPSEC
-	if (info && info->key && info->tunnel_endpoint) {
+	if (info->key && info->tunnel_endpoint) {
 		__u8 key = get_min_encrypt_key(info->key);
 
 		set_encrypt_key_meta(ctx, key, info->node_id);

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -269,9 +269,10 @@ skip_host_firewall:
 	if (!from_host)
 		return CTX_ACT_OK;
 
-#ifdef TUNNEL_MODE
 	dst = (union v6addr *) &ip6->daddr;
 	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN, 0);
+
+#ifdef TUNNEL_MODE
 	if (info != NULL && info->tunnel_endpoint != 0) {
 		/* If IPSEC is needed recirc through ingress to use xfrm stack
 		 * and then result will routed back through bpf_netdev on egress
@@ -285,7 +286,6 @@ skip_host_firewall:
 		struct tunnel_key key = {};
 
 		/* IPv6 lookup key: daddr/96 */
-		dst = (union v6addr *) &ip6->daddr;
 		key.ip6.p1 = dst->p1;
 		key.ip6.p2 = dst->p2;
 		key.ip6.p3 = dst->p3;
@@ -298,8 +298,6 @@ skip_host_firewall:
 	}
 #endif
 
-	dst = (union v6addr *) &ip6->daddr;
-	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN, 0);
 	if (info == NULL || info->sec_label == WORLD_ID) {
 		/* See IPv4 comment. */
 		return DROP_UNROUTABLE;
@@ -567,8 +565,9 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 skip_vtep:
 #endif
 
-#ifdef TUNNEL_MODE
 	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
+
+#ifdef TUNNEL_MODE
 	if (info != NULL && info->tunnel_endpoint != 0) {
 		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
 						      info->key, info->node_id,
@@ -588,7 +587,6 @@ skip_vtep:
 	}
 #endif
 
-	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
 	if (info == NULL || info->sec_label == WORLD_ID) {
 		/* We have received a packet for which no ipcache entry exists,
 		 * we do not know what to do with this packet, drop it.


### PR DESCRIPTION
Two little cleanups for the `from-host` path in bpf_host. We've tried these before, but back then the 4.9 verifier didn't like it.