### PR TITLE
renovate: fix config file format

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -78,7 +78,7 @@
       "postUpdateOptions": [
 	// update source import paths on major updates
         "gomodUpdateImportPaths",
-      ]
+      ],
       "matchUpdateTypes": [
         "major",
         "minor",


### PR DESCRIPTION
Fixes: a6a9a4689a05 ("renovate: update source import paths on Go module major updates")
Reported-by: Sebastian Wicki <sebastian@isovalent.com>
