### PR TITLE
go.mod, golangci-lint: update base Go version to 1.20

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,9 +50,9 @@ linters-settings:
   goimports:
     local-prefixes: github.com/cilium/cilium
   staticcheck:
-    go: "1.19"
+    go: "1.20"
   unused:
-    go: "1.19"
+    go: "1.20"
   goheader:
     values:
       regexp:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cilium/cilium
 
-go 1.19
+go 1.20
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20221118232415-3345c89a7c72


### PR DESCRIPTION
Fixes: d6c423c616bf ("Update Go to 1.20.1")
Fixes: 20c0b7c11983 ("ci, make: update golangci-lint to v1.51.0")