### PR TITLE
Pprof modularization

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -240,7 +240,7 @@ cilium-agent [flags]
       --policy-queue-size int                                   Size of queues for policy-related events (default 100)
       --pprof                                                   Enable serving pprof debugging API
       --pprof-address string                                    Address that pprof listens on (default "localhost")
-      --pprof-port int                                          Port that pprof listens on (default 6060)
+      --pprof-port uint16                                       Port that pprof listens on (default 6060)
       --preallocate-bpf-maps                                    Enable BPF map pre-allocation (default true)
       --prepend-iptables-chains                                 Prepend custom iptables chains instead of appending (default true)
       --procfs string                                           Root's proc filesystem path (default "/proc")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -21,6 +21,9 @@ cilium-agent hive [flags]
       --k8s-heartbeat-timeout duration     Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string         Absolute path of the kubernetes kubeconfig file
       --mesh-auth-monitor-queue-size int   Queue size for the auth monitor (default 1024)
+      --pprof                              Enable serving pprof debugging API
+      --pprof-address string               Address that pprof listens on (default "localhost")
+      --pprof-port uint16                  Port that pprof listens on (default 6060)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -26,6 +26,9 @@ cilium-agent hive dot-graph [flags]
       --k8s-heartbeat-timeout duration     Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string         Absolute path of the kubernetes kubeconfig file
       --mesh-auth-monitor-queue-size int   Queue size for the auth monitor (default 1024)
+      --pprof                              Enable serving pprof debugging API
+      --pprof-address string               Address that pprof listens on (default "localhost")
+      --pprof-port uint16                  Port that pprof listens on (default 6060)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -66,8 +66,9 @@ cilium-operator-alibabacloud [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-pprof                            Enable pprof debugging endpoint
-      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
+      --operator-pprof                            Enable serving pprof debugging API
+      --operator-pprof-address string             Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -23,6 +23,9 @@ cilium-operator-alibabacloud hive [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -28,6 +28,9 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -74,8 +74,9 @@ cilium-operator-aws [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-pprof                            Enable pprof debugging endpoint
-      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
+      --operator-pprof                            Enable serving pprof debugging API
+      --operator-pprof-address string             Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -23,6 +23,9 @@ cilium-operator-aws hive [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -28,6 +28,9 @@ cilium-operator-aws hive dot-graph [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -69,8 +69,9 @@ cilium-operator-azure [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-pprof                            Enable pprof debugging endpoint
-      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
+      --operator-pprof                            Enable serving pprof debugging API
+      --operator-pprof-address string             Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -23,6 +23,9 @@ cilium-operator-azure hive [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -28,6 +28,9 @@ cilium-operator-azure hive dot-graph [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -65,8 +65,9 @@ cilium-operator-generic [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-pprof                            Enable pprof debugging endpoint
-      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
+      --operator-pprof                            Enable serving pprof debugging API
+      --operator-pprof-address string             Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -23,6 +23,9 @@ cilium-operator-generic hive [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -28,6 +28,9 @@ cilium-operator-generic hive dot-graph [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -79,8 +79,9 @@ cilium-operator [flags]
       --log-opt map                               Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --nodes-gc-interval duration                GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string            Address to serve API requests (default "localhost:9234")
-      --operator-pprof                            Enable pprof debugging endpoint
-      --operator-pprof-port int                   Port that the pprof listens on (default 6061)
+      --operator-pprof                            Enable serving pprof debugging API
+      --operator-pprof-address string             Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16                Port that pprof listens on (default 6061)
       --operator-prometheus-serve-addr string     Address to serve Prometheus metrics (default ":9963")
       --parallel-alloc-workers int                Maximum number of parallel IPAM workers (default 50)
       --pod-restart-selector string               cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted (default "k8s-app=kube-dns")

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -23,6 +23,9 @@ cilium-operator hive [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -28,6 +28,9 @@ cilium-operator hive dot-graph [flags]
       --k8s-client-qps float32                Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration        Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string            Absolute path of the kubernetes kubeconfig file
+      --operator-pprof                        Enable serving pprof debugging API
+      --operator-pprof-address string         Address that pprof listens on (default "localhost")
+      --operator-pprof-port uint16            Port that pprof listens on (default 6061)
 ```
 
 ### SEE ALSO

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -22,8 +22,11 @@ import (
 	"github.com/cilium/workerpool"
 	"github.com/spf13/cobra"
 
+	apiserverOption "github.com/cilium/cilium/clustermesh-apiserver/option"
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // BugtoolRootCmd is the top level command for the bugtool.
@@ -87,10 +90,10 @@ func init() {
 	BugtoolRootCmd.Flags().BoolVar(&envoyDump, "envoy-dump", true, "When set, dump envoy configuration from unix socket")
 	BugtoolRootCmd.Flags().BoolVar(&envoyMetrics, "envoy-metrics", true, "When set, dump envoy prometheus metrics from unix socket")
 	BugtoolRootCmd.Flags().IntVar(&pprofPort,
-		"pprof-port", defaults.PprofPortAgent,
+		"pprof-port", option.PprofPortAgent,
 		fmt.Sprintf(
 			"Pprof port to connect to. Known Cilium component ports are agent:%d, operator:%d, apiserver:%d",
-			defaults.PprofPortAgent, defaults.PprofPortOperator, defaults.PprofPortAPIServer,
+			option.PprofPortAgent, operatorOption.PprofPortOperator, apiserverOption.PprofPortAPIServer,
 		),
 	)
 	BugtoolRootCmd.Flags().IntVar(&traceSeconds, "pprof-trace-seconds", 180, "Amount of seconds used for pprof CPU traces")

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
+	apiserverOption "github.com/cilium/cilium/clustermesh-apiserver/option"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
@@ -112,8 +113,8 @@ func init() {
 	rootHive = hive.New(
 		pprof.Cell,
 		cell.Config(pprof.Config{
-			PprofAddress: defaults.PprofAddressAPIServer,
-			PprofPort:    defaults.PprofPortAPIServer,
+			PprofAddress: apiserverOption.PprofAddressAPIServer,
+			PprofPort:    apiserverOption.PprofPortAPIServer,
 		}),
 
 		gops.Cell(defaults.GopsPortApiserver),

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -110,6 +110,12 @@ var (
 
 func init() {
 	rootHive = hive.New(
+		pprof.Cell,
+		cell.Config(pprof.Config{
+			PprofAddress: defaults.PprofAddressAPIServer,
+			PprofPort:    defaults.PprofPortAPIServer,
+		}),
+
 		gops.Cell(defaults.GopsPortApiserver),
 		k8sClient.Cell,
 		k8s.SharedResourcesCell,
@@ -243,15 +249,6 @@ func runApiserver() error {
 
 	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enable support of Kubernetes EndpointSlice")
 	option.BindEnv(vp, option.K8sEnableEndpointSlice)
-
-	flags.Bool(option.PProf, false, "Enable serving the pprof debugging API")
-	option.BindEnv(vp, option.PProf)
-
-	flags.String(option.PProfAddress, defaults.PprofAddressAPIServer, "Address that pprof listens on")
-	option.BindEnv(vp, option.PProfAddress)
-
-	flags.Int(option.PProfPort, defaults.PprofPortAPIServer, "Port that pprof listens on")
-	option.BindEnv(vp, option.PProfPort)
 
 	vp.BindPFlags(flags)
 
@@ -626,10 +623,6 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, servi
 			<-timer.After(kvstore.HeartbeatWriteInterval)
 		}
 	}()
-
-	if option.Config.PProf {
-		pprof.Enable(option.Config.PProfAddress, option.Config.PProfPort)
-	}
 
 	log.Info("Initialization complete")
 }

--- a/clustermesh-apiserver/option/config.go
+++ b/clustermesh-apiserver/option/config.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package option
+
+const (
+	// PprofAddressAPIServer is the default value for pprof in the clustermesh-apiserver
+	PprofAddressAPIServer = "localhost"
+
+	// PprofPortAPIServer is the default value for pprof in the clustermesh-apiserver
+	PprofPortAPIServer = 6063
+)

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -39,8 +39,8 @@ var (
 		// Register the pprof HTTP handlers, to get runtime profiling data.
 		pprof.Cell,
 		cell.Config(pprof.Config{
-			PprofAddress: defaults.PprofAddressAgent,
-			PprofPort:    defaults.PprofPortAgent,
+			PprofAddress: option.PprofAddressAgent,
+			PprofPort:    option.PprofPortAgent,
 		}),
 
 		// Runs the gops agent, a tool to diagnose Go processes.

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/pprof"
 )
 
 var (
@@ -34,6 +35,13 @@ var (
 	Infrastructure = cell.Module(
 		"infra",
 		"Infrastructure",
+
+		// Register the pprof HTTP handlers, to get runtime profiling data.
+		pprof.Cell,
+		cell.Config(pprof.Config{
+			PprofAddress: defaults.PprofAddressAgent,
+			PprofPort:    defaults.PprofPortAgent,
+		}),
 
 		// Runs the gops agent, a tool to diagnose Go processes.
 		gops.Cell(defaults.GopsPortAgent),

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -79,7 +79,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/version"
@@ -760,15 +759,6 @@ func initializeFlags() {
 	flags.Bool(option.Version, false, "Print version information")
 	option.BindEnv(Vp, option.Version)
 
-	flags.Bool(option.PProf, false, "Enable serving pprof debugging API")
-	option.BindEnv(Vp, option.PProf)
-
-	flags.String(option.PProfAddress, defaults.PprofAddressAgent, "Address that pprof listens on")
-	option.BindEnv(Vp, option.PProfAddress)
-
-	flags.Int(option.PProfPort, defaults.PprofPortAgent, "Port that pprof listens on")
-	option.BindEnv(Vp, option.PProfPort)
-
 	flags.Bool(option.EnableXDPPrefilter, false, "Enable XDP prefiltering")
 	option.BindEnv(Vp, option.EnableXDPPrefilter)
 
@@ -1211,10 +1201,6 @@ func initEnv() {
 			log.Fatalf("Envoy version %s does not match with required version %s ,aborting.",
 				envoyVersionArray[2], envoy.RequiredEnvoyVersionSHA)
 		}
-	}
-
-	if option.Config.PProf {
-		pprof.Enable(option.Config.PProfAddress, option.Config.PProfPort)
 	}
 
 	if option.Config.PreAllocateMaps {

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -245,12 +246,6 @@ func init() {
 	flags.String(operatorOption.OperatorAPIServeAddr, "localhost:9234", "Address to serve API requests")
 	option.BindEnv(Vp, operatorOption.OperatorAPIServeAddr)
 
-	flags.Bool(operatorOption.PProf, false, "Enable pprof debugging endpoint")
-	option.BindEnv(Vp, operatorOption.PProf)
-
-	flags.Int(operatorOption.PProfPort, defaults.PprofPortOperator, "Port that the pprof listens on")
-	option.BindEnv(Vp, operatorOption.PProfPort)
-
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
 	option.BindEnv(Vp, operatorOption.SyncK8sServices)
 
@@ -328,4 +323,32 @@ func init() {
 	option.BindEnv(Vp, option.KVstoreLeaseTTL)
 
 	Vp.BindPFlags(flags)
+}
+
+const (
+	// pprofOperator enables pprof debugging endpoint for the operator
+	pprofOperator = "operator-pprof"
+
+	// pprofAddress is the port that the pprof listens on
+	pprofAddress = "operator-pprof-address"
+
+	// pprofPort is the port that the pprof listens on
+	pprofPort = "operator-pprof-port"
+)
+
+// operatorPprofConfig holds the configuration for the operator pprof cell.
+// Differently from the agent and the clustermesh-apiserver, the operator prefixes
+// the pprof related flags with the string "operator-".
+// To reuse the same cell, we need a different config type to map the same fields
+// to the operator-specific pprof flag names.
+type operatorPprofConfig struct {
+	OperatorPprof        bool
+	OperatorPprofAddress string
+	OperatorPprofPort    uint16
+}
+
+func (def operatorPprofConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool(pprofOperator, def.OperatorPprof, "Enable serving pprof debugging API")
+	flags.String(pprofAddress, def.OperatorPprofAddress, "Address that pprof listens on")
+	flags.Uint16(pprofPort, def.OperatorPprofPort, "Port that pprof listens on")
 }

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -158,8 +158,8 @@ func newOperatorHive() *hive.Hive {
 			}
 		}),
 		cell.Config(operatorPprofConfig{
-			OperatorPprofAddress: defaults.PprofAddressOperator,
-			OperatorPprofPort:    defaults.PprofPortOperator,
+			OperatorPprofAddress: operatorOption.PprofAddressOperator,
+			OperatorPprofPort:    operatorOption.PprofPortOperator,
 		}),
 
 		gops.Cell(defaults.GopsPortOperator),

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -149,6 +149,19 @@ func registerOperatorHooks(lc hive.Lifecycle, llc *LeaderLifecycle, clientset k8
 
 func newOperatorHive() *hive.Hive {
 	h := hive.New(
+		pprof.Cell,
+		cell.ProvidePrivate(func(cfg operatorPprofConfig) pprof.Config {
+			return pprof.Config{
+				Pprof:        cfg.OperatorPprof,
+				PprofAddress: cfg.OperatorPprofAddress,
+				PprofPort:    cfg.OperatorPprofPort,
+			}
+		}),
+		cell.Config(operatorPprofConfig{
+			OperatorPprofAddress: defaults.PprofAddressOperator,
+			OperatorPprofPort:    defaults.PprofPortOperator,
+		}),
+
 		gops.Cell(defaults.GopsPortOperator),
 		k8sClient.Cell,
 		OperatorCell,
@@ -266,10 +279,6 @@ func runOperator(lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner 
 
 	if operatorOption.Config.EnableMetrics {
 		operatorMetrics.Register()
-	}
-
-	if operatorOption.Config.PProf {
-		pprof.Enable(operatorOption.Config.PProfAddress, operatorOption.Config.PProfPort)
 	}
 
 	if clientset.IsEnabled() {

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -37,6 +37,12 @@ const (
 
 	// CNPStatusCleanupBurstDefault is the default maximum burst for the CNP NodeStatus updates GC.
 	CNPStatusCleanupBurstDefault = 20
+
+	// PprofAddressOperator is the default value for pprof in the operator
+	PprofAddressOperator = "localhost"
+
+	// PprofPortOperator is the default value for pprof in the operator
+	PprofPortOperator = 6061
 )
 
 const (

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -93,15 +93,6 @@ const (
 	// metrics (pass ":Port" to bind on all interfaces, "" is off).
 	OperatorPrometheusServeAddr = "operator-prometheus-serve-addr"
 
-	// PProf enabled pprof debugging endpoint
-	PProf = "operator-pprof"
-
-	// PProfAddress is the port that the pprof listens on
-	PProfAddress = "operator-pprof-address"
-
-	// PProfPort is the port that the pprof listens on
-	PProfPort = "operator-pprof-port"
-
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices = "synchronize-k8s-services"
 
@@ -349,15 +340,6 @@ type OperatorConfig struct {
 	OperatorAPIServeAddr        string
 	OperatorPrometheusServeAddr string
 
-	// PProf enables pprof debugging endpoint
-	PProf bool
-
-	// PProfAddress is the address that the pprof listens on
-	PProfAddress string
-
-	// PProfPort is the port that the pprof listens on
-	PProfPort int
-
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices bool
 
@@ -585,9 +567,6 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.EndpointGCInterval = vp.GetDuration(EndpointGCInterval)
 	c.OperatorAPIServeAddr = vp.GetString(OperatorAPIServeAddr)
 	c.OperatorPrometheusServeAddr = vp.GetString(OperatorPrometheusServeAddr)
-	c.PProf = vp.GetBool(PProf)
-	c.PProfAddress = vp.GetString(PProfAddress)
-	c.PProfPort = vp.GetInt(PProfPort)
 	c.SyncK8sServices = vp.GetBool(SyncK8sServices)
 	c.SyncK8sNodes = vp.GetBool(SyncK8sNodes)
 	c.UnmanagedPodWatcherInterval = vp.GetInt(UnmanagedPodWatcherInterval)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -20,13 +20,16 @@ const (
 	// PprofAddressAgent is the default value for pprof in the agent
 	PprofAddressAgent = "localhost"
 
+	// PprofAddressOperator is the default value for pprof in the operator
+	PprofAddressOperator = "localhost"
+
 	// PprofAddressAPIServer is the default value for pprof in the clustermesh-apiserver
 	PprofAddressAPIServer = "localhost"
 
 	// PprofPortAgent is the default value for pprof in the agent
 	PprofPortAgent = 6060
 
-	// PprofPortAgent is the default value for pprof in the operator
+	// PprofPortOperator is the default value for pprof in the operator
 	PprofPortOperator = 6061
 
 	// PprofPortAPIServer is the default value for pprof in the clustermesh-apiserver

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -17,24 +17,6 @@ const (
 	// ClusterMeshHealthPort is the default value for option.ClusterMeshHealthPort
 	ClusterMeshHealthPort = 80
 
-	// PprofAddressAgent is the default value for pprof in the agent
-	PprofAddressAgent = "localhost"
-
-	// PprofAddressOperator is the default value for pprof in the operator
-	PprofAddressOperator = "localhost"
-
-	// PprofAddressAPIServer is the default value for pprof in the clustermesh-apiserver
-	PprofAddressAPIServer = "localhost"
-
-	// PprofPortAgent is the default value for pprof in the agent
-	PprofPortAgent = 6060
-
-	// PprofPortOperator is the default value for pprof in the operator
-	PprofPortOperator = 6061
-
-	// PprofPortAPIServer is the default value for pprof in the clustermesh-apiserver
-	PprofPortAPIServer = 6063
-
 	// GopsPortAgent is the default value for option.GopsPort in the agent
 	GopsPortAgent = 9890
 

--- a/pkg/hive/cell/provide.go
+++ b/pkg/hive/cell/provide.go
@@ -91,7 +91,7 @@ func Provide(ctors ...any) Cell {
 	return &provider{ctors: ctors, export: true}
 }
 
-// ProvidePrivate is like Private, but the constructed objects are only
+// ProvidePrivate is like Provide, but the constructed objects are only
 // available within the module it is defined and nested modules.
 func ProvidePrivate(ctors ...any) Cell {
 	return &provider{ctors: ctors, export: false}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1263,6 +1263,12 @@ const (
 
 	// KubeProxyReplacement healthz server bind address
 	KubeProxyReplacementHealthzBindAddr = "kube-proxy-replacement-healthz-bind-address"
+
+	// PprofAddressAgent is the default value for pprof in the agent
+	PprofAddressAgent = "localhost"
+
+	// PprofPortAgent is the default value for pprof in the agent
+	PprofPortAgent = 6060
 )
 
 // GetTunnelModes returns the list of all tunnel modes

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -419,15 +419,6 @@ const (
 	// Version prints the version information
 	Version = "version"
 
-	// PProf enables serving the pprof debugging API
-	PProf = "pprof"
-
-	// PProfAddress is the port that the pprof listens on
-	PProfAddress = "pprof-address"
-
-	// PProfPort is the port that the pprof listens on
-	PProfPort = "pprof-port"
-
 	// EnableXDPPrefilter enables XDP-based prefiltering
 	EnableXDPPrefilter = "enable-xdp-prefilter"
 
@@ -1690,9 +1681,6 @@ type DaemonConfig struct {
 	SocketPath                 string
 	TracePayloadlen            int
 	Version                    string
-	PProf                      bool
-	PProfAddress               string
-	PProfPort                  int
 	PrometheusServeAddr        string
 	ToFQDNsMinTTL              int
 
@@ -2991,9 +2979,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.MonitorAggregationInterval = vp.GetDuration(MonitorAggregationInterval)
 	c.MonitorQueueSize = vp.GetInt(MonitorQueueSizeName)
 	c.MTU = vp.GetInt(MTUName)
-	c.PProf = vp.GetBool(PProf)
-	c.PProfAddress = vp.GetString(PProfAddress)
-	c.PProfPort = vp.GetInt(PProfPort)
 	c.PreAllocateMaps = vp.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = vp.GetBool(PrependIptablesChainsName)
 	c.ProcFs = vp.GetString(ProcFs)

--- a/pkg/pprof/cell.go
+++ b/pkg/pprof/cell.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package pprof
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	_ "net/http/pprof"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+const (
+	// Pprof is the flag to enable the registration of pprof HTTP handlers
+	Pprof = "pprof"
+
+	// PprofAddress is the flag to set the address that pprof listens on
+	PprofAddress = "pprof-address"
+
+	// PprofPort is the flag to set the port that pprof listens on
+	PprofPort = "pprof-port"
+)
+
+type Server interface {
+	// Port returns the port at which the server is listening
+	Port() int
+}
+
+// Cell creates the cell for pprof, that registers its HTTP handlers to serve
+// profiling data in the format expected by the pprof visualization tool.
+var Cell = cell.Module(
+	"pprof",
+	"pprof HTTP server to expose runtime profiling data",
+
+	// We don't call cell.Config directly here, because the operator
+	// uses different flags names for the same pprof config flags.
+	// Therefore, to register each flag with the correct name, we leave
+	// the call to cell.Config to the user of the cell.
+
+	// Provide coupled with Invoke is used to improve cell testability,
+	// namely to allow taking a reference to the Server and call Port() on it.
+	cell.Provide(newServer),
+	cell.Invoke(func(srv Server) {}),
+)
+
+// Config contains the configuration for the pprof cell.
+type Config struct {
+	Pprof        bool
+	PprofAddress string
+	PprofPort    uint16
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool(Pprof, def.Pprof, "Enable serving pprof debugging API")
+	flags.String(PprofAddress, def.PprofAddress, "Address that pprof listens on")
+	flags.Uint16(PprofPort, def.PprofPort, "Port that pprof listens on")
+}
+
+func newServer(lc hive.Lifecycle, log logrus.FieldLogger, cfg Config) Server {
+	if !cfg.Pprof {
+		return nil
+	}
+
+	srv := &server{
+		logger:  log,
+		address: cfg.PprofAddress,
+		port:    cfg.PprofPort,
+	}
+	lc.Append(srv)
+
+	return srv
+}
+
+type server struct {
+	logger logrus.FieldLogger
+
+	address string
+	port    uint16
+
+	httpSrv  *http.Server
+	listener net.Listener
+}
+
+func (s *server) Start(ctx hive.HookContext) error {
+	listener, err := net.Listen("tcp", net.JoinHostPort(s.address, strconv.FormatUint(uint64(s.port), 10)))
+	if err != nil {
+		return err
+	}
+	s.listener = listener
+
+	s.logger = s.logger.WithFields(logrus.Fields{
+		"ip":   s.listener.Addr().(*net.TCPAddr).IP,
+		"port": s.listener.Addr().(*net.TCPAddr).Port,
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	s.httpSrv = &http.Server{
+		Handler: mux,
+	}
+	go func() {
+		if err := s.httpSrv.Serve(s.listener); !errors.Is(err, http.ErrServerClosed) {
+			s.logger.WithError(err).Error("server stopped unexpectedly")
+		}
+	}()
+	s.logger.Info("Started pprof server")
+
+	return nil
+}
+
+func (s *server) Stop(ctx hive.HookContext) error {
+	s.logger.Info("Stopped pprof server")
+	return s.httpSrv.Shutdown(ctx)
+}
+
+func (s *server) Port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}

--- a/pkg/pprof/cell_test.go
+++ b/pkg/pprof/cell_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package pprof
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+func TestPprofDisabled(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var testSrv Server
+
+	hive := hive.New(
+		cell.Provide(newServer),
+		cell.Config(Config{
+			Pprof:        false,
+			PprofAddress: "localhost",
+			PprofPort:    0,
+		}),
+		cell.Invoke(func(srv Server) {
+			testSrv = srv
+		}),
+	)
+
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if testSrv != nil {
+		t.Fatalf("listener unexpectedly started on port %d", testSrv.Port())
+	}
+
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func TestPprofHandlers(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	var testSrv Server
+
+	hive := hive.New(
+		cell.Provide(newServer),
+		cell.Config(Config{
+			Pprof:        true,
+			PprofAddress: "localhost",
+			PprofPort:    0,
+		}),
+		cell.Invoke(func(srv Server) {
+			testSrv = srv
+		}),
+	)
+
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("http://localhost:%d/debug/pprof/heap", testSrv.Port()),
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("failed to create http request: %s", err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http request for profiling data failed: %s", err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected http status code %d, got: %d", http.StatusOK, res.StatusCode)
+	}
+
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -17,6 +17,8 @@ import (
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "pprof")
 
 // Enable runs an HTTP server to serve the pprof API
+//
+// Deprecated: use pprof.Cell() instead.
 func Enable(host string, port int) {
 	var apiAddress = net.JoinHostPort(host, strconv.Itoa(port))
 	go func() {


### PR DESCRIPTION
Modularize the pprof related code into a cell. The cell is used by the agent, the operator and the clustermesh-apiserver to register the pprof HTTP handlers and export runtime profiling data.
    
The already present `pprof.Enable` function is marked as deprecated, but not removed, since hubble-relay still depends on it and that is not yet modularized to use hive and cells.
    
Differently from the agent and the clustermesh-apiserver, the operator prefixes the pprof related flags with `operator-`.  To reuse the same cell, we use an operator specific config type, in order to map the equivalent fields to the operator-specific flag names.  Also, when importing the cell, an additional call to cell.Config is requested to register the default config type (for agent and clustermesh-apiserver) or the operator-specific one.

The PR also adds an integration-style unit test to verify the correct registration of the pprof HTTP handlers when the cell is used.

Fixes: #24048