### PR TITLE
daemon: use the real err instead of a nil one

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -240,7 +240,6 @@ func (l *Loader) ReinitializeXDP(ctx context.Context, o datapath.BaseProgramOwne
 func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
 	var (
 		args []string
-		ret  error
 	)
 
 	args = make([]string, initArgMax)
@@ -272,8 +271,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 		preFilter, err := prefilter.NewPreFilter()
 		if err != nil {
-			scopedLog.WithError(ret).Warn("Unable to init prefilter")
-			return ret
+			scopedLog.WithError(err).Warn("Unable to init prefilter")
+			return err
 		}
 
 		if err := writePreFilterHeader(preFilter, "./"); err != nil {


### PR DESCRIPTION
An incorrect 'nil' error was used instead of the real err returned from NewPreFilter.
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!
