### PR TITLE
cilium: Add TunnelDevice config helper to retrieve tunnel device name

### DIFF
--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -100,9 +100,6 @@ const (
 	// RulePriorityVtep is the priority of the rule used for routing packets to VTEP device
 	RulePriorityVtep = 112
 
-	// TunnelDeviceName the default name of the tunnel device when using vxlan
-	TunnelDeviceName = "cilium_vxlan"
-
 	// IPSec offset value for node rules
 	IPsecMaxKeyVersion = 15
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1316,7 +1316,7 @@ func (n *linuxNodeHandler) createNodeIPSecInRoute(ip *net.IPNet) route.Route {
 	if option.Config.Tunnel == option.TunnelDisabled {
 		device = option.Config.EncryptInterface[0]
 	} else {
-		device = linux_defaults.TunnelDeviceName
+		device = option.Config.TunnelDevice()
 	}
 	return route.Route{
 		Nexthop: nil,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2467,6 +2467,15 @@ func (c *DaemonConfig) TunnelingEnabled() bool {
 	return c.Tunnel != TunnelDisabled
 }
 
+// TunnelDevice returns cilium_{vxlan,geneve} depending on the config or "" if disabled.
+func (c *DaemonConfig) TunnelDevice() string {
+	if c.TunnelingEnabled() {
+		return fmt.Sprintf("cilium_%s", c.Tunnel)
+	} else {
+		return ""
+	}
+}
+
 // TunnelExists returns true if some traffic may go through a tunnel, including
 // if the primary mode is native routing. For example, in the egress gateway,
 // we may send such traffic to a gateway node via a tunnel.


### PR DESCRIPTION
And also remove hard-coded TunnelDeviceName default since tunnel can be either vxlan or geneve. Nothing should use a hard-coded name.

```release-note
Fix bug that would prevent IPsec from working with GENEVE encapsulation.
```