### PR TITLE
ci: Automate generation and update of docs-builder image

### DIFF
--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -1,0 +1,180 @@
+name: Docs-builder Image Build
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths:
+      - Documentation/Dockerfile
+      - Documentation/requirements.txt
+
+permissions:
+  # To be able to access the repository with `actions/checkout`
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    name: Build and push image
+    runs-on: ubuntu-20.04
+    timeout-minutes: 30
+    environment: docs-builder
+    outputs:
+      tag: ${{ steps.docs-builder-tag.outputs.tag }}
+      digest: ${{ steps.docker-build-docs-builder.outputs.digest }}
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1 # v2.9.1
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Generate image tag for docs-builder
+        id: docs-builder-tag
+        run: |
+          echo tag="$(git ls-tree --full-tree HEAD -- ./Documentation | awk '{ print $3 }')" >> $GITHUB_OUTPUT
+
+      - name: Check if tag for docs-builder already exists
+        id: docs-builder-tag-in-repositories
+        shell: bash
+        run: |
+          if docker buildx imagetools inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ steps.docs-builder-tag.outputs.tag }} &>/dev/null; then
+            echo exists="true" >> $GITHUB_OUTPUT
+          else
+            echo exists="false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to quay.io
+        if: ${{ steps.docs-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DOCS_BUILDER_USERNAME }}
+          password: ${{ secrets.QUAY_DOCS_BUILDER_PASSWORD }}
+          logout: true
+
+      - name: Build docs-builder image
+        if: ${{ steps.docs-builder-tag-in-repositories.outputs.exists == 'false' }}
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
+        id: docker-build-docs-builder
+        with:
+          provenance: false
+          context: ./Documentation
+          file: ./Documentation/Dockerfile
+          push: true
+          tags: |
+            quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ steps.docs-builder-tag.outputs.tag }}
+
+  # Use a separate job for the steps below, to ensure we're no longer logged
+  # into Quay.io.
+  update-pr:
+    name: Update Pull Request with new image reference
+    needs: build-and-push
+    if: needs.build-and-push.outputs.digest
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    environment: docs-builder
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up git
+        run: |
+          git config user.name "Cilium Imagebot"
+          git config user.email "noreply@cilium.io"
+
+      - name: Update docs-builder image reference in CI workflow
+        run: |
+          NEW_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ needs.build-and-push.outputs.tag }}@${{ needs.build-and-push.outputs.digest }}"
+          # Run in Docker to prevent the script from accessing the environment.
+          docker run --rm -v $PWD:/cilium -w /cilium "${NEW_IMAGE}" \
+              bash -c "git config --global --add safe.directory /cilium && \
+                       /cilium/Documentation/update-docs-builder-image.sh ${NEW_IMAGE}"
+          git commit -sam "ci: update docs-builder"
+
+      - name: Get token
+        id: get_token
+        uses: cilium/actions-app-token@61a6271ce92ba02f49bf81c755685d59fb25a59a # v0.21.1
+        with:
+          APP_PEM: ${{ secrets.AUTO_COMMITTER_PEM }}
+          APP_ID: ${{ secrets.AUTO_COMMITTER_APP_ID }}
+
+      - name: Push changes into PR
+        env:
+          REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git diff HEAD^
+          git push https://x-access-token:${{ steps.get_token.outputs.app_token }}@github.com/${{ env.QUAY_ORGANIZATION }}/cilium.git HEAD:"$REF"
+
+  image-digest:
+    name: Retrieve and display image digest
+    needs: build-and-push
+    if: needs.build-and-push.outputs.digest
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout default branch (trusted)
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Retrieve image digest
+        shell: bash
+        run: |
+          NEW_IMAGE="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docs-builder:${{ needs.build-and-push.outputs.tag }}@${{ needs.build-and-push.outputs.digest }}"
+          mkdir -p image-digest/
+          echo "## docs-builder" > image-digest/docs-builder.txt
+          echo "" >> image-digest/docs-builder.txt
+          echo "\`${NEW_IMAGE}\`" >> image-digest/docs-builder.txt
+          echo "" >> image-digest/docs-builder.txt
+
+      - name: Upload artifact digests
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: image-digest docs-builder
+          path: image-digest
+          retention-days: 1
+
+      - name: Output image digest
+        shell: bash
+        run: |
+          cd image-digest/
+          find -type f | sort | xargs -d '\n' cat

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           persist-credentials: false
-      - uses: docker://cilium/docs-builder:2023-03-01@sha256:36b233afd73482c2bc7ed43f7a1537f09962015c34679b86c4ca1fa618d67b95
+      - uses: docker://quay.io/cilium/docs-builder:989b89f58d28b46941f8f96e77800aae7f3ea554@sha256:12ac522fe84a65f6e0c8bc47ef7c13d6502fc44fd0e8726777da5655a792fbee
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           persist-credentials: false
-      - uses: docker://quay.io/cilium/docs-builder:989b89f58d28b46941f8f96e77800aae7f3ea554@sha256:12ac522fe84a65f6e0c8bc47ef7c13d6502fc44fd0e8726777da5655a792fbee
+      - uses: docker://quay.io/cilium/docs-builder:fdcc2524f647c6e09534f8813aac3141ae478b5b@sha256:54b57f47904af397c1545c04d1e6a87f41f46966d57d04f661c09130aa853c29
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/update-docs-builder-image.sh
+++ b/Documentation/update-docs-builder-image.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of Cilium
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+image_full=${1}
+image="${image_full%%:*}"
+root_dir="$(git rev-parse --show-toplevel)"
+
+cd "${root_dir}"
+
+# shellcheck disable=SC2207
+used_by=($(git grep -l "${image}:" .github/workflows/))
+
+for i in "${used_by[@]}" ; do
+  sed -E "s#${image}:.*#${image_full}#" "${i}" > "${i}.sedtmp" && mv "${i}.sedtmp" "${i}"
+done
+
+do_check="${CHECK:-false}"
+if [ "${do_check}" = "true" ] ; then
+    git diff --exit-code "${used_by[@]}" || (echo "docs-builder image out of date" && \
+    exit 1)
+fi


### PR DESCRIPTION
The docs-builder image is used for the CI wofkflow for testing documentation. Each time we change the list of requirements (Sphinx dependencies etc.) or the Dockerfile for that image, we have to generate a new image to use in the CI workflow.

So far these images have been generated and pushed to Docker manually (thanks Joe!). But this is not fun or practical [citation needed]. This commit introduces a new CI workflow to generate and push a new image when relevant, and to update the documentation workflow with the new tag and digest.

For Pull Requests from branches of the cilium/cilium repository, we can add a new commit directly to update the image. For branches from external forks, we require an additional step from the PR author to update the image reference.

Fixes: #24019

Status: Currently a draft, because we're missing scripts and docs regarding the update for PRs with branches on external forks. Also, nothing has been tested yet.