### PR TITLE
Docs: Move Maintainers to Committers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,7 @@ Everybody listed is a committer as per governance definition.
 
 Regardless of committer status, any code contribution is subject
 to code review requirements as per [CODEOWNERS](CODEOWNERS) and PRs get merged
-by the "janitor role" which is rotated between all committers.
+by the "tophat role" which is rotated between all committers.
 
 ## Cilium Committers
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,10 +4,6 @@ See [Governance](Documentation/community/governance/commit_access.rst) for
 governance, commit, and vote guidelines as well as committer responsibilities.
 Everybody listed is a committer as per governance definition.
 
-Regardless of committer status, any code contribution is subject
-to code review requirements as per [CODEOWNERS](CODEOWNERS) and PRs get merged
-by the "tophat role" which is rotated between all committers.
-
 ## Cilium Committers
 
  * [Aditi Ghag] (Isovalent)

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,30 +1,18 @@
 # Maintainers
 
 See [Governance](Documentation/community/governance/commit_access.rst) for
-governance, commit, and vote guidelines as well as maintainer responsibilities.
+governance, commit, and vote guidelines as well as committer responsibilities.
 Everybody listed is a committer as per governance definition.
 
-All committers and maintainers have identical voting rights. Maintainers have
-additional administrative and janitorial responsibilities.
-
-Regardless of maintainer or committer status, any code contribution is subject
+Regardless of committer status, any code contribution is subject
 to code review requirements as per [CODEOWNERS](CODEOWNERS) and PRs get merged
 by the "janitor role" which is rotated between all committers.
 
-## Cilium Maintainers
-
- * [André Martins] (Isovalent)
- * [Joe Stringer] (Isovalent)
-
-## Hubble Maintainers
-
- * [Glib Smaga] (Isovalent)
- * [Sebastian Wicki] (Isovalent)
-
-## Cilium & Hubble Committers
+## Cilium Committers
 
  * [Aditi Ghag] (Isovalent)
  * [Alexandre Perrin] (Isovalent)
+ * [André Martins] (Isovalent)
  * [Beatriz Martínez] (Isovalent)
  * [Bill Mulligan] (Isovalent)
  * [Bruno M. Custódio] (Isovalent)
@@ -36,9 +24,11 @@ by the "janitor role" which is rotated between all committers.
  * [Deepesh Pathak]
  * [Eloy Coto] (Red Hat)
  * [Gilberto Bertin] (Isovalent)
+ * [Glib Smaga] (Isovalent)
  * [Hemanth Malla] (Datadog)
  * [Ian Vernon]
  * [Jarno Rajahalme] (Isovalent)
+ * [Joe Stringer] (Isovalent)
  * [John Fastabend] (Isovalent)
  * [Julian Wiedmann] (Isovalent)
  * [Kornilios Kourtis] (Isovalent)
@@ -56,6 +46,7 @@ by the "janitor role" which is rotated between all committers.
  * [Paul Chaignon] (Isovalent)
  * [Quentin Monnet] (Isovalent)
  * [Robin Hahling] (Isovalent)
+ * [Sebastian Wicki] (Isovalent)
  * [Tam Mach] (Isovalent)
  * [Thomas Graf] (Isovalent)
  * [Timo Beckers] (Isovalent)


### PR DESCRIPTION
Maintainers are being tracked in https://github.com/cilium/community/blob/main/roles/Maintainers.md
