### PR TITLE
workflows: Cover IPsec + GENEVE

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -189,7 +189,7 @@ jobs:
             kernel: 'bpf-next-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
-            tunnel: 'vxlan'
+            tunnel: 'geneve'
             encryption: 'ipsec'
             encryption-node: 'false'
             endpoint-routes: 'true'
@@ -227,7 +227,7 @@ jobs:
             --nodes-without-cilium=kind-worker3 \
             --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }} \
             --helm-set=bpf.masquerade=false"
-          TUNNEL="--helm-set-string=tunnel=vxlan"
+          TUNNEL="--helm-set-string=tunnel=${{ matrix.tunnel }}"
           if [ "${{ matrix.tunnel }}" == "disabled" ]; then
             TUNNEL="--helm-set-string=tunnel=disabled --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16"
             TUNNEL="${TUNNEL} --helm-set-string=ipv6NativeRoutingCIDR=fd00:10:244::/56"


### PR DESCRIPTION
Daniel recently reported a bug that might be affecting IPsec + GENEVE. We don't have any coverage for that configuration so let's add some. We can convert one of the two IPsec + VXLAN configurations from the datapath workflow for that.

Passing test: https://github.com/cilium/cilium/actions/runs/4322605721/jobs/7545223283.