### PR TITLE
bpf,test: Define BPF_TEST macro for map-in-map/prog-map initialization

### DIFF
--- a/bpf/tests/common.h
+++ b/bpf/tests/common.h
@@ -10,6 +10,12 @@
 #include <bpf/loader.h>
 #include <bpf/section.h>
 
+/* We can use this macro inside the actual datapath code
+ * to compile-in the code for testing. The primary usecase
+ * is initializing map-in-map or prog-map.
+ */
+#define BPF_TEST
+
 #ifndef ___bpf_concat
 #define ___bpf_concat(a, b) a ## b
 #endif


### PR DESCRIPTION
Please see the commit message for more details.

```release-note
bpf,test: Define BPF_TEST macro for map-in-map/prog-map initialization
```
