### PR TITLE
bpf: Handle tuple collisions on UDP services for inactive backends

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -922,7 +922,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		/* Drain existing connections, but redirect new ones to only
 		 * active backends.
 		 */
-		if (backend && !state->syn)
+		if (backend && tuple->nexthdr == IPPROTO_TCP && !state->syn)
 			goto update_state;
 		key->backend_slot = 0;
 		svc = lb6_lookup_service(key, false, true);
@@ -1625,7 +1625,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		/* Drain existing connections, but redirect new ones to only
 		 * active backends.
 		 */
-		if (backend && !state->syn)
+		if (backend && tuple->nexthdr == IPPROTO_TCP && !state->syn)
 			goto update_state;
 		key->backend_slot = 0;
 		svc = lb4_lookup_service(key, false, true);


### PR DESCRIPTION
Cilium chooses to pick a new active backend in the case when the backend picked from the CT_SERVICE entry is inactive for TCP service (See #20407). However, in such a tuple collision case, it still sends traffic to the inactive backend for the UDP service. This PR fixes this issue by selecting a new active backend for the UDP service.


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #24128
