### PR TITLE
test: gather containerd logs on failure

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3724,6 +3724,7 @@ func (kub *Kubectl) GatherLogs(ctx context.Context) {
 	reportCmds = map[string]string{
 		"journalctl -D /var/log/journal --no-pager -au kubelet":        "kubelet.log",
 		"journalctl -D /var/log/journal --no-pager -au kube-apiserver": "kube-apiserver.log",
+		"journalctl -D /var/log/journal --no-pager -au containerd":     "containerd.log",
 		"top -n 1 -b": "top.log",
 		"ps aux":      "ps.log",
 	}


### PR DESCRIPTION
To aid in debugging.

Sometimes containerd gets sad, and the only way to feel better is to talk about it.
