### PR TITLE
helm: move poststart eni script to agent

### DIFF
--- a/install/kubernetes/cilium/files/agent/poststart-eni.bash
+++ b/install/kubernetes/cilium/files/agent/poststart-eni.bash
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -o errexit
 set -o pipefail
 set -o nounset

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -220,10 +220,13 @@ spec:
           postStart:
             exec:
               command:
-              - "/cni-install.sh"
-              - "--enable-debug={{ .Values.debug.enabled }}"
-              - "--cni-exclusive={{ .Values.cni.exclusive }}"
-              - "--log-file={{ .Values.cni.logFile }}"
+              - "bash"
+              - "-c"
+              - "/cni-install.sh --enable-debug={{ .Values.debug.enabled }} --cni-exclusive={{ .Values.cni.exclusive }} --log-file={{ .Values.cni.logFile }}"
+                {{- if .Values.eni.enabled }}
+              - |
+                {{- tpl (.Files.Get "files/agent/poststart-eni.bash") . | nindent 20 }}
+                {{- end }}
           preStop:
             exec:
               command:

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -46,19 +46,6 @@ spec:
           image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           lifecycle:
-            {{- if .Values.eni.enabled }}
-            postStart:
-              exec:
-                command:
-                  - nsenter
-                  - --target=1
-                  - --mount
-                  - --
-                  - "/bin/bash"
-                  - "-c"
-                  - |
-                    {{- tpl (.Files.Get "files/nodeinit/poststart-eni.bash") . | nindent 20 }}
-            {{- end }}
             {{- if .Values.nodeinit.revertReconfigureKubelet }}
             preStop:
               exec:


### PR DESCRIPTION
We rely on host having certain binaries in nodeinit scripts. They are not always available, so we are moving the eni-specific poststart hook to agent pod so that we can ensure it always runs if needed.

Related: https://github.com/cilium/cilium/issues/19256

```release-note
Move poststart eni script to agent pod from nodeinit pod
```
