### PR TITLE
daemon: initialize datapath before compiling sockops programs

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -281,6 +281,10 @@ func (d *Daemon) init() error {
 			return fmt.Errorf("failed while creating node config header file: %w", err)
 		}
 
+		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
+			return fmt.Errorf("failed while reinitializing datapath: %w", err)
+		}
+
 		if option.Config.SockopsEnable {
 			eppolicymap.CreateEPPolicyMap()
 			if err := sockops.SockmapEnable(); err != nil {
@@ -290,10 +294,6 @@ func (d *Daemon) init() error {
 			} else {
 				sockmap.SockmapCreate()
 			}
-		}
-
-		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
-			return fmt.Errorf("failed while reinitializing datapath: %w", err)
 		}
 	}
 


### PR DESCRIPTION
When egress gateway is enabled, we define the ENABLE_EGRESS_GATEWAY macro in the datapath, which in lib/common.h causes HAVE_ENCAP to be defined as well:

    #if defined(ENCAP_IFINDEX) || defined(ENABLE_EGRESS_GATEWAY)
    #define HAVE_ENCAP
    //..
    #endif

This doesn't work with sockops enabled, as bpf_sockops.c ends up including lib/overloadable_skb.h with HAVE_ENCAP defined and ENCAP_IFINDEX not defined.

This happens since in the daemon we currently:

- create the node_config.h header file with createNodeConfigHeaderfile()
- invoke the logic to compile the sockops programs with the sockops.Sockmap*() methods
- initialize the datapath with Datapath().Loader().Reinitialize(), which is responsible among other things of invoking bpf/init.sh, which in turn is responsible for populating node_config.h with a few missing constants, one of which is ENCAP_IFINDEX

To fix this, simply invoke Datapath().Loader().Reinitialize() before compiling the sockops programs, in order to properly populate node_config.h

Fixes: #24090