### PR TITLE
tools/maptool: correctly build with CGO_ENABLED=0 if not in RACE mode

### DIFF
--- a/tools/maptool/Makefile
+++ b/tools/maptool/Makefile
@@ -11,11 +11,7 @@ all: $(TARGET)
 
 $(TARGET):
 	@$(ECHO_GO)
-ifneq ($(RACE),"")
-	$(QUIET)$(GO_BUILD_WITH_CGO) -o $@
-else
 	$(QUIET)$(GO_BUILD) -o $@
-endif
 
 clean:
 	@$(ECHO_CLEAN)


### PR DESCRIPTION
Makefile.defs already defines $GO_BUILD depending on $RACE, no need to duplicate the logic. Also, the detection of $RACE being set is not working correctly, note that CGO_ENABLED=1 despite $RACE being empty:

    % RACE= make
    CGO_ENABLED=1  go build -mod=vendor -ldflags '-X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.13.90 666d6991d9d0 2023-02-28T10:58:01+00:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=505865fff55aa3e7e3e490044c428651e0fe339c" -X "github.com/cilium/cilium/pkg/datapath/loader.DatapathSHA256=920256b880238047f84e8dd31a10b24c3606c0e071f53fdc6445526b1db81d22" ' -tags=osusergo  -o maptool

After this patch:

    % RACE= make
    CGO_ENABLED=0 go build -mod=vendor -ldflags '-X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.13.90 283254dff59e 2023-03-02T16:55:57+01:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=505865fff55aa3e7e3e490044c428651e0fe339c" -X "github.com/cilium/cilium/pkg/datapath/loader.DatapathSHA256=920256b880238047f84e8dd31a10b24c3606c0e071f53fdc6445526b1db81d22" ' -tags=osusergo  -o maptool

And setting RACE=1 correctly build with CGO_ENABLED=1:

    % RACE=1 make
    CGO_ENABLED=1  go build -mod=vendor -race -ldflags '-X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.13.90 283254dff59e 2023-03-02T16:55:57+01:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=505865fff55aa3e7e3e490044c428651e0fe339c" -X "github.com/cilium/cilium/pkg/datapath/loader.DatapathSHA256=920256b880238047f84e8dd31a10b24c3606c0e071f53fdc6445526b1db81d22" ' -tags=osusergo,lockdebug  -mod=vendor -race -ldflags '-X "github.com/cilium/cilium/pkg/version.ciliumVersion=1.13.90 283254dff59e 2023-03-02T16:55:57+01:00" -s -w -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=505865fff55aa3e7e3e490044c428651e0fe339c" -X "github.com/cilium/cilium/pkg/datapath/loader.DatapathSHA256=920256b880238047f84e8dd31a10b24c3606c0e071f53fdc6445526b1db81d22" ' -tags=osusergo,lockdebug  -o maptool

Fixes: c6d373c34bba ("Makefile: Build maptool with CGO enabled if RACE")