### PR TITLE
Aspsk/pr/make cilium monitor great again

### DIFF
--- a/pkg/datapath/loader/check-sources.sh
+++ b/pkg/datapath/loader/check-sources.sh
@@ -10,9 +10,28 @@ defined_files=$(
 		/return 0/{exit}
 		{if (!found || !/_strcase_/) next}
 		{gsub(/.* |"|\)|;/, "", $1); print $1}
-		' bpf/source_names_to_ids.h
+		' bpf/source_names_to_ids.h | sort -u
 )
 
+#
+# Now let's find all the names defined inside the go source file
+#
+defined_files_go=$(
+	awk '/sourceFileNames/{found=1; next}
+		{if (!found) next}
+		/}/{exit}
+		{if (!/: /) next}
+		{gsub(/"|,/, "", $2); print $2}
+		' pkg/monitor/datapath_drop.go | sort -u
+)
+if [ "$defined_files" != "$defined_files_go" ]; then
+	echo "File lists in bpf/source_names_to_ids.h and pkg/monitor/datapath_drop.go aren't same, please sync" >&2
+	exit 1
+fi
+
+#
+# Both lists should be the same
+#
 
 #
 # Now we need to find all the C files in the bpf/ directory and all header

--- a/pkg/datapath/loader/check-sources.sh
+++ b/pkg/datapath/loader/check-sources.sh
@@ -60,7 +60,6 @@ done
 #
 # Check that all defined files actually use send_drop_notify*
 #
-retval=0
 for f in $defined_files; do
 	if ! grep --silent -w "$f" <<<"$required_files"; then
 		echo "$0: $f is not using send_drop_notify*, please remove it from bpf/source_names_to_ids.h" >&2


### PR DESCRIPTION
Commit https://github.com/cilium/cilium/commit/bb5e3fef6f0ed123a5264063368692693b05757a "improved" the output of 'cilium monitor -t drop'
so that file ids were used since in the report:
```
    xx drop (Invalid packet) flow 0x0 to endpoint 0, ifindex 12, file 101:80, ...
    xx drop (Policy denied) flow 0xeea42740 to endpoint 0, ifindex 14, file 2:1167, ...
```
This turns out to be really inconvenient, so switch back to file names. Now
output looks more readable, like this:
```
    xx drop (Invalid source ip) flow 0x0 to endpoint 0, ifindex 8, file bpf_lxc.c:734, ...
    xx drop (Unknown L3 target address) flow 0x0 to endpoint 0, ifindex 8, file lib/icmp6.h:413, ...
    xx drop (Invalid source ip) flow 0x0 to endpoint 0, ifindex 10, file bpf_lxc.c:734, ...
```
The pkg/datapath/loader/check-sources.sh script was adjusted to check that file
names are synced between C and Go.

```release-note
Improve cilium monitor output for dropped packets: display source file names instead of numerical ids
```