### PR TITLE
test: Enable conformance tests for non-SCTP traffic in conjunction with SCTP policies

### DIFF
--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -93,9 +93,7 @@ ${HOME}/go/bin/kubetest --provider=local --test \
 
 # We currently skip the following tests:
 # - NetworkPolicy between server and client using SCTP
-# - should not allow access by TCP when a policy specifies only SCTP
-# - should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't supportSCTP [Feature:NetworkPolicy]
-#   - Cilium does not support SCTP yet
+#   - Service translation is not yet supported, and the tests rely on Services.
 #   - More info at https://github.com/cilium/cilium/issues/5719
 # - should allow egress access to server in CIDR block and
 # - should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed and
@@ -105,4 +103,4 @@ ${HOME}/go/bin/kubetest --provider=local --test \
 #   - More info at https://github.com/cilium/cilium/issues/9209
 echo "Running upstream NetworkPolicy tests"
 ${HOME}/go/bin/kubetest --provider=local --test \
-  --test_args="--ginkgo.focus=Net.*ol.* --e2e-verify-service-account=false --host ${KUBE_MASTER_URL} --ginkgo.skip=(should.not.allow.access.by.TCP.when.a.policy.specifies.only.SCTP)|(should.allow.egress.access.to.server.in.CIDR.block)|(should.enforce.except.clause.while.egress.access.to.server.in.CIDR.block)|(should.ensure.an.IP.overlapping.both.IPBlock.CIDR.and.IPBlock.Except.is.allowed)|(NetworkPolicy.between.server.and.client.using.SCTP)|(should.properly.isolate.pods.that.are.selected.by.a.policy.allowing.SCTP..even.if.the.plugin.doesn.t.support.SCTP..Feature.NetworkPolicy.)"
+  --test_args="--ginkgo.focus=Net.*ol.* --e2e-verify-service-account=false --host ${KUBE_MASTER_URL} --ginkgo.skip=(should.allow.egress.access.to.server.in.CIDR.block)|(should.enforce.except.clause.while.egress.access.to.server.in.CIDR.block)|(should.ensure.an.IP.overlapping.both.IPBlock.CIDR.and.IPBlock.Except.is.allowed)|(Feature:SCTPConnectivity)"


### PR DESCRIPTION
These tests should now be supported, so enable them.

Fixes: ae046b49a797 ("bpf: Add partial SCTP support.")
Related: https://github.com/cilium/cilium/pull/20033