### PR TITLE
fix: Remove the duplicate ENABLE_SIP_VERIFICATION in ep_config.h

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -445,6 +445,16 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		return d.errorDuringCreation(ep, fmt.Errorf("unable to insert endpoint into manager: %s", err))
 	}
 
+	// We need to make sure DatapathConfiguration.DisableSipVerification value is same as
+	// the value of SourceIPVerification option in the endpoint.
+	if epTemplate.DatapathConfiguration != nil {
+		if epTemplate.DatapathConfiguration.DisableSipVerification {
+			ep.GetOptions().SetBool(option.SourceIPVerification, false)
+		} else {
+			ep.GetOptions().SetBool(option.SourceIPVerification, true)
+		}
+	}
+
 	// We need to update the the visibility policy after adding the endpoint in
 	// the endpoint manager because the endpoint manager create the endpoint
 	// queue of the endpoint. If we execute this function before the endpoint

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -894,10 +894,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
 	}
 
-	if !e.DisableSIPVerification() {
-		fmt.Fprintf(fw, "#define ENABLE_SIP_VERIFICATION 1\n")
-	}
-
 	if !option.Config.EnableHostLegacyRouting && option.Config.DirectRoutingDevice != "" {
 		directRoutingIface := option.Config.DirectRoutingDevice
 		directRoutingIfIndex, err := link.GetIfIndex(directRoutingIface)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -964,6 +964,14 @@ func (e *Endpoint) Update(cfg *models.EndpointConfigurationSpec) error {
 
 	e.getLogger().WithField("configuration-options", cfg).Debug("updating endpoint configuration options")
 
+	// We need to make sure DatapathConfiguration.DisableSipVerification value is same as
+	// the value of SourceIPVerification option in the endpoint.
+	if e.GetOptions().IsEnabled(option.SourceIPVerification) {
+		e.DatapathConfiguration.DisableSipVerification = false
+	} else {
+		e.DatapathConfiguration.DisableSipVerification = true
+	}
+
 	// CurrentStatus will be not OK when we have an uncleared error in BPF,
 	// policy or Other. We should keep trying to regenerate in the hopes of
 	// succeeding.


### PR DESCRIPTION
Either DatapathConfiguration.DisableSipVerification or SourceIPVerification option in endpoint can trigger macro ENABLE_SIP_VERIFICATION update in the ep_config.h. If DatapathConfiguration.DisableSipVerification value is not synced with SourceIPVerification, two value of macro ENABLE_SIP_VERIFICATION in ep_config.h may conflict.

This patch is to sync the value of DatapathConfiguration.DisableSipVerification and SourceIPVerification, remove one duplicate entry of ENABLE_SIP_VERIFICATION in ep_config.h
