### PR TITLE
bpf: Fix VTEP compilation error

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -244,13 +244,13 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx, __u32 *identity)
 #ifdef ENABLE_VTEP
 		{
 			struct vtep_key vkey = {};
-			struct vtep_value *info;
+			struct vtep_value *vtep;
 
 			vkey.vtep_ip = ip4->saddr & VTEP_MASK;
-			info = map_lookup_elem(&VTEP_MAP, &vkey);
-			if (!info)
+			vtep = map_lookup_elem(&VTEP_MAP, &vkey);
+			if (!vtep)
 				goto skip_vtep;
-			if (info->tunnel_endpoint) {
+			if (vtep->tunnel_endpoint) {
 				if (*identity != WORLD_ID)
 					return DROP_INVALID_VNI;
 			}


### PR DESCRIPTION
Compilation fails when VTEP is enabled because two variables conflicts (have the same name). `struct vtep_value *info` conflicts with `struct remote_endpoint_info *info`. This pull request fixes it.

The compilation tests will be extended in a separate pull request (cf. https://github.com/cilium/cilium/pull/24122) to cover this.

The compilation error didn't make it into any release.

Fixes: https://github.com/cilium/cilium/pull/24030.