### PR TITLE
examples: setup HUBBLE_SERVER for the Hubble CLI Deployment

### DIFF
--- a/examples/hubble/hubble-cli.yaml
+++ b/examples/hubble/hubble-cli.yaml
@@ -19,6 +19,9 @@ spec:
       - name: hubble-cli
         image: quay.io/cilium/hubble:v0.11.2@sha256:706e819ab74e6812faea48067c5a7df56c2c2ab4a9088e05fbc5fe150cd09848
         imagePullPolicy: IfNotPresent
+        env:
+          - name: HUBBLE_SERVER
+            value: "$(HUBBLE_RELAY_SERVICE_HOST):$(HUBBLE_RELAY_SERVICE_PORT)"
         command:
           - tail
         args:


### PR DESCRIPTION
Before this patch, the Hubble CLI Deployment example would use the CLI's default `HUBBLE_SERVER` (i.e. `localhost:4245`) which doesn't work in a kubernetes context.

This patch set `HUBBLE_SERVER` based on the `HUBBLE_RELAY_SERVICE` env variables, to make `hubble observe` work out-of-the-box.