### PR TITLE
pkg/k8s: set the ciliumNodeStore as nil when connecting to KVStore

### DIFF
--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -133,9 +133,17 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 		go ciliumNodeInformer.Run(isConnected)
 
 		<-kvstore.Connected()
-		close(isConnected)
-
 		log.Info("Connected to key-value store, stopping CiliumNode watcher")
+
+		// Set the ciliumNodeStore as nil so that any attempts of getting the
+		// CiliumNode are performed with a request sent to kube-apiserver
+		// directly instead of relying on an outdated version of the CiliumNode
+		// in this cache.
+		k.ciliumNodeStoreMU.Lock()
+		k.ciliumNodeStore = nil
+		k.ciliumNodeStoreMU.Unlock()
+
+		close(isConnected)
 
 		k.cancelWaitGroupToSyncResources(apiGroup)
 		k.k8sAPIGroups.RemoveAPI(apiGroup)


### PR DESCRIPTION
When connecting to the KVStore the CiliumNodeStore will stop receiving any updates from kube-apiserver since we stop the kubernetes informer.

This will cause any "Gets" done into this store cache to potentially return CiliumNodes out-of-sync. Thus we will be setting the CiliumNodeStore as nil to avoid reading from it and fetch the state directly from kube-apiserver.

Fixes: 76cc93eb7975 ("k8s: optimize API calls made to kube-apiserver")

```release-note
Avoid k8s CiliumNode initialization problems when Cilium connects to the KVStore
```
