### PR TITLE
Service Mesh mTLS: auth request & response

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -226,6 +226,7 @@ cilium-agent [flags]
       --log-driver strings                                      Logging endpoints to use for example syslog
       --log-opt map                                             Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
       --log-system-load                                         Enable periodic logging of system load
+      --mesh-auth-monitor-queue-size int                        Queue size for the auth monitor (default 1024)
       --metrics strings                                         Metrics that should be enabled or disabled from the default metric list. The list is expected to be separated by a space. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
       --monitor-aggregation string                              Level of monitor aggregation for traces from the datapath (default "None")
       --monitor-aggregation-flags strings                       TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -11,15 +11,16 @@ cilium-agent hive [flags]
 ### Options
 
 ```
-      --certificates-directory string    Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --enable-k8s-api-discovery         Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                 Port for gops server to listen on (default 9890)
-  -h, --help                             help for hive
-      --k8s-api-server string            Kubernetes API server URL
-      --k8s-client-burst int             Burst value allowed for the K8s client
-      --k8s-client-qps float32           Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string       Absolute path of the kubernetes kubeconfig file
+      --certificates-directory string      Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --enable-k8s-api-discovery           Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                   Port for gops server to listen on (default 9890)
+  -h, --help                               help for hive
+      --k8s-api-server string              Kubernetes API server URL
+      --k8s-client-burst int               Burst value allowed for the K8s client
+      --k8s-client-qps float32             Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration     Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string         Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int   Queue size for the auth monitor (default 1024)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -17,14 +17,15 @@ cilium-agent hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --certificates-directory string    Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --enable-k8s-api-discovery         Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                 Port for gops server to listen on (default 9890)
-      --k8s-api-server string            Kubernetes API server URL
-      --k8s-client-burst int             Burst value allowed for the K8s client
-      --k8s-client-qps float32           Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string       Absolute path of the kubernetes kubeconfig file
+      --certificates-directory string      Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --enable-k8s-api-discovery           Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                   Port for gops server to listen on (default 9890)
+      --k8s-api-server string              Kubernetes API server URL
+      --k8s-client-burst int               Burst value allowed for the K8s client
+      --k8s-client-qps float32             Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration     Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string         Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int   Queue size for the auth monitor (default 1024)
 ```
 
 ### SEE ALSO

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -649,6 +649,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		}
 	}
 	nodeMngr.SetIPCache(d.ipcache)
+	authManager.SetIPCache(d.ipcache)
 
 	proxy.Allocator = d.identityAllocator
 

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -44,7 +44,7 @@ type Manager interface {
 }
 
 func newManager(params authManagerParams) (Manager, error) {
-	mgr, err := newAuthManager(params.AuthHandlers, params.DatapathAuthenticator)
+	mgr, err := newAuthManager(params.AuthHandlers, params.DatapathAuthenticator, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create auth manager: %w", err)
 	}

--- a/pkg/auth/ctmap_authenticator.go
+++ b/pkg/auth/ctmap_authenticator.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/ctmap"
+	"github.com/cilium/cilium/pkg/monitor"
+	"github.com/cilium/cilium/pkg/u8proto"
+)
+
+type ctMapAuthenticator struct {
+	endpointManager endpointmanager.EndpointsLookup
+}
+
+func newCtMapAuthenticator(endpointManager endpointmanager.EndpointsLookup) datapathAuthenticator {
+	return &ctMapAuthenticator{
+		endpointManager: endpointManager,
+	}
+}
+
+func (r *ctMapAuthenticator) markAuthenticated(dn *monitor.DropNotify, ci *monitor.ConnectionInfo, resp *authResponse) error {
+	ep := r.endpointManager.LookupCiliumID(dn.Source)
+	if ep == nil {
+		// Maybe endpoint was deleted?
+		log.WithField(logfields.EndpointID, dn.Source).Debug("auth: Cannot find Endpoint")
+		return nil
+	}
+
+	srcAddr := ci.SrcIP.String() + ":" + strconv.FormatUint(uint64(ci.SrcPort), 10)
+	dstAddr := ci.DstIP.String() + ":" + strconv.FormatUint(uint64(ci.DstPort), 10)
+
+	proto, err := u8proto.ParseProtocol(ci.Proto)
+	if err != nil {
+		return fmt.Errorf("cannot parse protocol: %w", err)
+	}
+
+	/* Update CT flags as authorized. */
+	if err := ctmap.Update(ep.ConntrackName(), srcAddr, dstAddr, proto, isIngress(dn),
+		func(entry *ctmap.CtEntry) error {
+			before := entry.Flags
+			if entry.Flags&ctmap.AuthRequired != 0 {
+				entry.Flags = entry.Flags &^ ctmap.AuthRequired
+				log.Debugf("auth: Cleared auth flag for %v->%v (%v), before %v after %v",
+					srcAddr, dstAddr, proto, before&ctmap.AuthRequired, entry.Flags&ctmap.AuthRequired)
+			}
+			return nil
+		}); err != nil {
+		return fmt.Errorf("conntrack map update failed: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/auth/ctmap_authenticator.go
+++ b/pkg/auth/ctmap_authenticator.go
@@ -24,7 +24,7 @@ func newCtMapAuthenticator(endpointManager endpointmanager.EndpointsLookup) data
 	}
 }
 
-func (r *ctMapAuthenticator) markAuthenticated(dn *monitor.DropNotify, ci *monitor.ConnectionInfo, resp *authResponse) error {
+func (r *ctMapAuthenticator) markAuthenticated(dn *monitor.DropNotify, ci *monitor.ConnectionInfo, _ *authResult) error {
 	ep := r.endpointManager.LookupCiliumID(dn.Source)
 	if ep == nil {
 		// Maybe endpoint was deleted?

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -21,6 +21,12 @@ import (
 type authManager struct {
 	endpointManager endpointmanager.EndpointsLookup
 	authHandlers    map[policy.AuthType]authHandler
+	ipCache         ipCache
+}
+
+// ipCache is the set of interactions the auth manager performs with the IPCache
+type ipCache interface {
+	GetHostIP(ip string) net.IP
 }
 
 // authHandler is responsible to handle authentication for a specific auth type

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import (
+	"net"
+	"testing"
+
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/monitor"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/policy"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_newAuthManager_clashingAuthHandlers(t *testing.T) {
+	authHandlers := []authHandler{
+		&nullAuthHandler{},
+		&nullAuthHandler{},
+	}
+
+	am, err := newAuthManager(authHandlers, nil, nil)
+	assert.ErrorContains(t, err, "multiple handlers for auth type: null")
+	assert.Nil(t, am)
+}
+
+func Test_newAuthManager(t *testing.T) {
+	authHandlers := []authHandler{
+		&nullAuthHandler{},
+		&fakeAuthHandler{},
+	}
+
+	am, err := newAuthManager(authHandlers, nil, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, am)
+
+	assert.Len(t, am.authHandlers, 2)
+}
+
+func Test_authManager_authRequired(t *testing.T) {
+	type args struct {
+		dn *monitor.DropNotify
+		ci *monitor.ConnectionInfo
+	}
+	tests := []struct {
+		name              string
+		args              args
+		wantErr           assert.ErrorAssertionFunc
+		wantAuthenticated bool
+	}{
+		{
+			name: "missing handler for auth type",
+			args: args{
+				dn: testDropNotify(0),
+				ci: testConnInfo("10.244.1.1", "10.244.2.1"),
+			},
+			wantErr: assertErrorString("unknown requested auth type: none"),
+		},
+		{
+			name: "missing node IP for source IP",
+			args: args{
+				dn: testDropNotify(1),
+				ci: testConnInfo("10.244.1.2", "10.244.2.1"),
+			},
+			wantErr: assertErrorString("failed to gather auth request information: failed to get host IP of connection source IP 10.244.1.2"),
+		},
+		{
+			name: "missing node IP for destination IP",
+			args: args{
+				dn: testDropNotify(1),
+				ci: testConnInfo("10.244.1.1", "10.244.2.2"),
+			},
+			wantErr: assertErrorString("failed to gather auth request information: failed to get host IP of connection destination IP 10.244.2.2"),
+		},
+		{
+			name: "successful auth",
+			args: args{
+				dn: testDropNotify(1),
+				ci: testConnInfo("10.244.1.1", "10.244.2.1"),
+			},
+			wantErr:           assert.NoError,
+			wantAuthenticated: true,
+		},
+		{
+			name: "successful auth with lookup of cilium host IP v4 with /32 when getting host IP",
+			args: args{
+				dn: testDropNotify(1),
+				ci: testConnInfo("10.244.1.170", "10.244.2.1"),
+			},
+			wantErr:           assert.NoError,
+			wantAuthenticated: true,
+		},
+		{
+			name: "successful auth with lookup of cilium host IP v6 with /128 when getting host IP",
+			args: args{
+				dn: testDropNotify(1),
+				ci: testConnInfo("ff00::101", "10.244.2.1"),
+			},
+			wantErr:           assert.NoError,
+			wantAuthenticated: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dpAuth := &fakeDatapathAuthenticator{}
+			am, err := newAuthManager(
+				[]authHandler{&nullAuthHandler{}},
+				dpAuth,
+				newFakeIPCache(map[string]string{
+					"10.244.1.1":      "172.18.0.2",
+					"10.244.2.1":      "172.18.0.3",
+					"10.244.1.170/32": "172.18.0.3",
+					"ff00::101/128":   "172.18.0.3",
+				}),
+			)
+			assert.NoError(t, err)
+
+			err = am.authRequired(tt.args.dn, tt.args.ci)
+			tt.wantErr(t, err)
+
+			assert.Equal(t, tt.wantAuthenticated, dpAuth.authenticated)
+		})
+	}
+}
+
+// Fake IPCache
+type fakeIPCache struct {
+	ipHostMappings map[string]net.IP
+}
+
+func newFakeIPCache(mappings map[string]string) *fakeIPCache {
+	m := map[string]net.IP{}
+	for ip, hostIP := range mappings {
+		m[ip] = net.ParseIP(hostIP)
+	}
+
+	return &fakeIPCache{
+		ipHostMappings: m,
+	}
+}
+
+func (r *fakeIPCache) GetHostIP(ip string) net.IP {
+	return r.ipHostMappings[ip]
+}
+
+// Fake AuthHandler
+
+type fakeAuthHandler struct {
+}
+
+func (r *fakeAuthHandler) authenticate(authReq *authRequest) (*authResponse, error) {
+
+	return &authResponse{}, nil
+}
+
+func (r *fakeAuthHandler) authType() policy.AuthType {
+	return policy.AuthType(255)
+}
+
+// Fake DatapathAuthenticator
+type fakeDatapathAuthenticator struct {
+	authenticated bool
+}
+
+func (r *fakeDatapathAuthenticator) markAuthenticated(dn *monitor.DropNotify, ci *monitor.ConnectionInfo, resp *authResponse) error {
+	r.authenticated = true
+	return nil
+}
+func testConnInfo(srcIP string, dstIP string) *monitor.ConnectionInfo {
+	return &monitor.ConnectionInfo{
+		SrcIP: net.ParseIP(srcIP),
+		DstIP: net.ParseIP(dstIP),
+	}
+}
+
+func testDropNotify(authType int8) *monitor.DropNotify {
+	return &monitor.DropNotify{
+		Type:     monitorAPI.MessageTypeDrop,
+		SubType:  uint8(flow.DropReason_AUTH_REQUIRED),
+		Source:   1,
+		SrcLabel: 1,
+		DstLabel: 2,
+		DstID:    2,
+		ExtError: authType, // Auth Type
+	}
+}
+
+func assertErrorString(errString string) assert.ErrorAssertionFunc {
+	return func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
+		return assert.EqualError(t, err, errString, msgAndArgs)
+	}
+}

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -164,7 +164,7 @@ type fakeDatapathAuthenticator struct {
 	authenticated bool
 }
 
-func (r *fakeDatapathAuthenticator) markAuthenticated(dn *monitor.DropNotify, ci *monitor.ConnectionInfo, resp *authResponse) error {
+func (r *fakeDatapathAuthenticator) markAuthenticated(dn *monitor.DropNotify, ci *monitor.ConnectionInfo, result *authResult) error {
 	r.authenticated = true
 	return nil
 }

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -7,12 +7,12 @@ import (
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_newAuthManager_clashingAuthHandlers(t *testing.T) {
@@ -164,7 +164,7 @@ type fakeDatapathAuthenticator struct {
 	authenticated bool
 }
 
-func (r *fakeDatapathAuthenticator) markAuthenticated(dn *monitor.DropNotify, ci *monitor.ConnectionInfo, result *authResult) error {
+func (r *fakeDatapathAuthenticator) markAuthenticated(result *authResult) error {
 	r.authenticated = true
 	return nil
 }

--- a/pkg/auth/monitor/monitor_test.go
+++ b/pkg/auth/monitor/monitor_test.go
@@ -70,7 +70,14 @@ func Test_dropMonitor_NotifyPerfEvent_AuthenticateDroppedPacketsWithAuthRequired
 
 	mockAuthManager := &fakeAuthManager{}
 
-	dm := &dropMonitor{authManager: mockAuthManager}
+	dm := &dropMonitor{
+		authManager: mockAuthManager,
+		queue:       make(chan dropEvent, 1),
+		shutdown:    make(chan struct{}),
+	}
+
+	dm.startEventProcessing()
+	t.Cleanup(dm.stopEventProcessing)
 
 	buffer := bytes.NewBuffer([]byte{})
 	err := binary.Write(buffer, byteorder.Native, dn)

--- a/pkg/auth/monitor/monitor_test.go
+++ b/pkg/auth/monitor/monitor_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package monitor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/monitor"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_dropMonitor_NotifyPerfEventLost(t *testing.T) {
+	dm := &dropMonitor{}
+	assert.Equal(t, uint64(0), dm.lostEvents)
+
+	dm.NotifyPerfEventLost(1, 0)
+	assert.Equal(t, uint64(1), dm.lostEvents)
+
+	dm.NotifyPerfEventLost(5, 0)
+	assert.Equal(t, uint64(6), dm.lostEvents)
+}
+
+func Test_dropMonitor_NotifyPerfEvent_DontHandleOtherNotificationTypes(t *testing.T) {
+	dm := &dropMonitor{}
+
+	dn := &monitor.DropNotify{
+		Type: monitorAPI.MessageTypeCapture,
+	}
+
+	buffer := bytes.NewBuffer([]byte{})
+	err := binary.Write(buffer, byteorder.Native, dn)
+	assert.NoError(t, err)
+
+	dm.NotifyPerfEvent(buffer.Bytes(), 0)
+}
+
+func Test_dropMonitor_NotifyPerfEvent_DontHandleOtherDropSubTypes(t *testing.T) {
+	dm := &dropMonitor{}
+
+	dn := &monitor.DropNotify{
+		Type:    monitorAPI.MessageTypeDrop,
+		SubType: uint8(flow.DropReason_CT_MAP_INSERTION_FAILED),
+	}
+
+	buffer := bytes.NewBuffer([]byte{})
+	err := binary.Write(buffer, byteorder.Native, dn)
+	assert.NoError(t, err)
+
+	dm.NotifyPerfEvent(buffer.Bytes(), 0)
+}
+
+func Test_dropMonitor_NotifyPerfEvent_AuthenticateDroppedPacketsWithAuthRequired(t *testing.T) {
+	dn := &monitor.DropNotify{
+		Type:     monitorAPI.MessageTypeDrop,
+		SubType:  uint8(flow.DropReason_AUTH_REQUIRED),
+		Source:   1,
+		SrcLabel: identity.NumericIdentity(1),
+		DstLabel: identity.NumericIdentity(2),
+		DstID:    2,
+		ExtError: 0, // Auth Type
+	}
+
+	mockAuthManager := &fakeAuthManager{}
+
+	dm := &dropMonitor{authManager: mockAuthManager}
+
+	buffer := bytes.NewBuffer([]byte{})
+	err := binary.Write(buffer, byteorder.Native, dn)
+	assert.NoError(t, err)
+
+	dm.NotifyPerfEvent(buffer.Bytes(), 0)
+}
+
+type fakeAuthManager struct {
+}
+
+func (r *fakeAuthManager) AuthRequired(*monitor.DropNotify, *monitor.ConnectionInfo) {
+}

--- a/pkg/auth/null_authhandler.go
+++ b/pkg/auth/null_authhandler.go
@@ -18,7 +18,7 @@ func (r *nullAuthHandler) authenticate(authReq *authRequest) (*authResponse, err
 	log.Debugf("auth: Successfully authenticated request")
 
 	return &authResponse{
-		expiryTime: time.Now().Add(1 * time.Minute),
+		expirationTime: time.Now().Add(1 * time.Minute),
 	}, nil
 }
 

--- a/pkg/auth/null_authhandler.go
+++ b/pkg/auth/null_authhandler.go
@@ -3,14 +3,23 @@
 
 package auth
 
-import "github.com/cilium/cilium/pkg/policy"
+import (
+	"time"
 
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+// nullAuthHandler implements an authHandler for auth type null by just authenticate every request.
 type nullAuthHandler struct {
 }
 
-func (r *nullAuthHandler) authenticate() error {
+func (r *nullAuthHandler) authenticate(authReq *authRequest) (*authResponse, error) {
 	// Authentication trivially done
-	return nil
+	log.Debugf("auth: Successfully authenticated request")
+
+	return &authResponse{
+		expiryTime: time.Now().Add(1 * time.Minute),
+	}, nil
 }
 
 func (r *nullAuthHandler) authType() policy.AuthType {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -215,6 +215,14 @@ func endpointIPToCIDR(ip net.IP) *net.IPNet {
 	}
 }
 
+// GetHostIP returns the host IP for the given IP address.
+func (ipc *IPCache) GetHostIP(ip string) net.IP {
+	ipc.mutex.RLock()
+	defer ipc.mutex.RUnlock()
+	hostIP, _ := ipc.getHostIPCache(ip)
+	return hostIP
+}
+
 func (ipc *IPCache) getHostIPCache(ip string) (net.IP, uint8) {
 	ipKeyPair := ipc.ipToHostIPCache[ip]
 	return ipKeyPair.IP, ipKeyPair.Key


### PR DESCRIPTION
These changes are defining an initial version of the auth request & response as interaction between the auth manager and an auth handler.

* request: `localIdentity`, `remoteIdentity` & `remoteHostIP`
* response: `expirationTime`

The host IP of the remote/peer endpoint is retrieved from the `IPCache`.

For the time being the `IPCache` needs to be injected via setter. Once https://github.com/cilium/cilium/pull/24073 is merged we can change this to a properly injected injection.

In general, this PR refactors the auth manager into different methods / components which allows better testing of the manager. It might be better to have a look at the sourcecode directly.