### PR TITLE
feat: optional bpf mount

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -81,6 +81,10 @@
      - Enables the BGP control plane.
      - bool
      - ``false``
+   * - bpf.autoMount.enabled
+     - Enable automatic mount of BPF filesystem When ``autoMount`` is enabled, the BPF filesystem is mounted at ``bpf.root`` path on the underlying host and inside the cilium agent pod. If users disable ``autoMount``\ , it's expected that users have mounted bpffs filesystem at the specified ``bpf.root`` volume, and then the volume will be mounted inside the cilium agent pod at the same path.
+     - bool
+     - ``true``
    * - bpf.clockProbe
      - Enable BPF clock source probing for more efficient tick retrieval.
      - bool
@@ -438,11 +442,11 @@
      - string
      - ``"0s"``
    * - containerRuntime
-     - Configure container runtime specific integration.
+     - Configure container runtime specific integration. Deprecated in favor of bpf.autoMount.enabled. To be removed in 1.15.
      - object
      - ``{"integration":"none"}``
    * - containerRuntime.integration
-     - Enables specific integrations for container runtimes. Supported values: - containerd - crio - docker - none - auto (automatically detect the container runtime)
+     - Enables specific integrations for container runtimes. Supported values: - crio - none
      - string
      - ``"none"``
    * - crdWaitTimeout

--- a/Documentation/network/kubernetes/configuration.rst
+++ b/Documentation/network/kubernetes/configuration.rst
@@ -340,7 +340,7 @@ If you want to use CRIO, generate the YAML using:
 
 .. note::
 
-   The helm ``--set containerRuntime.integration=crio`` might not be
+   The helm ``--set bpf.autoMount.enabled=false`` might not be
    required for your setup. For more info see :ref:`crio-known-issues`.
 
 .. parsed-literal::
@@ -374,7 +374,7 @@ Common CRIO issues
 
 Some CRI-O environments automatically mount the bpf filesystem in the pods,
 which is something that Cilium avoids doing when
-``--set containerRuntime.integration=crio`` is set. However, some
+``--set bpf.autoMount.enabled=false`` is set. However, some
 CRI-O environments do not mount the bpf filesystem automatically which causes
 Cilium to print the following message::
 
@@ -387,5 +387,5 @@ Cilium to print the following message::
         level=info msg="Mounting BPF filesystem at /sys/fs/bpf" subsys=bpf
 
 If you see this warning in the Cilium pod logs with your CRI-O environment,
-please remove the flag ``--set containerRuntime.integration=crio`` from
+please remove the flag ``--set bpf.autoMount.enabled=false`` from
 your helm setup and redeploy Cilium.

--- a/Documentation/network/kubernetes/kata.rst
+++ b/Documentation/network/kubernetes/kata.rst
@@ -65,7 +65,7 @@ Deploy Cilium release via Helm:
 
            helm install cilium |CHART_RELEASE| \\
              --namespace kube-system \\
-             --set containerRuntime.integration=crio
+             --set bpf.autoMount.enabled=false
 
      .. group-tab:: Using CRI-containerd
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -334,6 +334,7 @@ Helm Options
   ``podSecurityContext``.
 * The ``securityContext`` for Hubble Relay now defaults to drop all
   capabilities and run as non-root user.
+* The ``containerRuntime.integration`` value is being deprecated in favor of ``bpf.autoMount.enabled``.
 
 .. _earlier_upgrade_notes:
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -71,6 +71,7 @@ contributors across the globe, there is almost always someone available to help.
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |
 | bgpControlPlane | object | `{"enabled":false}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
+| bpf.autoMount.enabled | bool | `true` | Enable automatic mount of BPF filesystem When `autoMount` is enabled, the BPF filesystem is mounted at `bpf.root` path on the underlying host and inside the cilium agent pod. If users disable `autoMount`, it's expected that users have mounted bpffs filesystem at the specified `bpf.root` volume, and then the volume will be mounted inside the cilium agent pod at the same path. |
 | bpf.clockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
 | bpf.ctAnyMax | int | `262144` | Configure the maximum number of entries for the non-TCP connection tracking table. |
 | bpf.ctTcpMax | int | `524288` | Configure the maximum number of entries in the TCP connection tracking table. |
@@ -160,8 +161,8 @@ contributors across the globe, there is almost always someone available to help.
 | cni.logFile | string | `"/var/run/cilium/cilium-cni.log"` | Configure the log file for CNI logging with retention policy of 7 days. Disable CNI file logging by setting this field to empty explicitly. |
 | cni.uninstall | bool | `true` | Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable. |
 | conntrackGCInterval | string | `"0s"` | Configure how frequently garbage collection should occur for the datapath connection tracking table. |
-| containerRuntime | object | `{"integration":"none"}` | Configure container runtime specific integration. |
-| containerRuntime.integration | string | `"none"` | Enables specific integrations for container runtimes. Supported values: - containerd - crio - docker - none - auto (automatically detect the container runtime) |
+| containerRuntime | object | `{"integration":"none"}` | Configure container runtime specific integration. Deprecated in favor of bpf.autoMount.enabled. To be removed in 1.15. |
+| containerRuntime.integration | string | `"none"` | Enables specific integrations for container runtimes. Supported values: - crio - none |
 | crdWaitTimeout | string | `"5m"` | Configure timeout in which Cilium will exit if CRDs are not available |
 | customCalls | object | `{"enabled":false}` | Tail call hooks for custom eBPF programs. |
 | customCalls.enabled | bool | `false` | Enable tail call hooks for custom eBPF programs. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -289,7 +289,7 @@ spec:
           name: host-proc-sys-kernel
         {{- end}}
         {{- /* CRI-O already mounts the BPF filesystem */ -}}
-        {{- if not (eq .Values.containerRuntime.integration "crio") }}
+        {{- if and .Values.bpf.autoMount.enabled (not (eq .Values.containerRuntime.integration "crio")) }}
         - name: bpf-maps
           mountPath: /sys/fs/bpf
           {{- if .Values.securityContext.privileged }}
@@ -532,7 +532,7 @@ spec:
               - ALL
           {{- end}}
       {{- end }}
-      {{- if not .Values.securityContext.privileged }}
+      {{- if and .Values.bpf.autoMount.enabled (not .Values.securityContext.privileged) }}
       # Mount the bpf fs if it is not mounted. We will perform this task
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
@@ -549,7 +549,7 @@ spec:
         securityContext:
           privileged: true
       {{- /* CRI-O already mounts the BPF filesystem */ -}}
-      {{- if not (eq .Values.containerRuntime.integration "crio") }}
+      {{- if and .Values.bpf.autoMount.enabled (not (eq .Values.containerRuntime.integration "crio")) }}
         volumeMounts:
         - name: bpf-maps
           mountPath: /sys/fs/bpf
@@ -621,7 +621,7 @@ spec:
           {{- end}}
         volumeMounts:
         {{- /* CRI-O already mounts the BPF filesystem */ -}}
-        {{- if not (eq .Values.containerRuntime.integration "crio") }}
+        {{- if and .Values.bpf.autoMount.enabled (not (eq .Values.containerRuntime.integration "crio")) }}
         - name: bpf-maps
           mountPath: /sys/fs/bpf
         {{- end }}
@@ -713,7 +713,7 @@ spec:
           path: {{ .Values.daemon.runPath }}
           type: DirectoryOrCreate
       {{- /* CRI-O already mounts the BPF filesystem */ -}}
-      {{- if not (eq .Values.containerRuntime.integration "crio") }}
+      {{- if and .Values.bpf.autoMount.enabled (not (eq .Values.containerRuntime.integration "crio")) }}
         # To keep state between restarts / upgrades for bpf maps
       - name: bpf-maps
         hostPath:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -358,6 +358,14 @@ pmtuDiscovery:
   enabled: false
 
 bpf:
+  autoMount:
+    # -- Enable automatic mount of BPF filesystem
+    # When `autoMount` is enabled, the BPF filesystem is mounted at
+    # `bpf.root` path on the underlying host and inside the cilium agent pod.
+    # If users disable `autoMount`, it's expected that users have mounted
+    # bpffs filesystem at the specified `bpf.root` volume, and then the
+    # volume will be mounted inside the cilium agent pod at the same path.
+    enabled: true
   # -- Configure the mount point for the BPF filesystem
   root: /sys/fs/bpf
 
@@ -518,17 +526,13 @@ cni:
 conntrackGCInterval: ""
 
 # -- Configure container runtime specific integration.
+# Deprecated in favor of bpf.autoMount.enabled. To be removed in 1.15.
 containerRuntime:
   # -- Enables specific integrations for container runtimes.
   # Supported values:
-  # - containerd
   # - crio
-  # - docker
   # - none
-  # - auto (automatically detect the container runtime)
   integration: none
-  # -- Configure the path to the container runtime control socket.
-  # socketPath: /path/to/runtime.sock
 
 # -- (string) Configure timeout in which Cilium will exit if CRDs are not available
 # @default -- `"5m"`

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -355,6 +355,14 @@ pmtuDiscovery:
   enabled: false
 
 bpf:
+  autoMount:
+    # -- Enable automatic mount of BPF filesystem
+    # When `autoMount` is enabled, the BPF filesystem is mounted at
+    # `bpf.root` path on the underlying host and inside the cilium agent pod.
+    # If users disable `autoMount`, it's expected that users have mounted
+    # bpffs filesystem at the specified `bpf.root` volume, and then the
+    # volume will be mounted inside the cilium agent pod at the same path.
+    enabled: true
   # -- Configure the mount point for the BPF filesystem
   root: /sys/fs/bpf
 
@@ -515,17 +523,13 @@ cni:
 conntrackGCInterval: ""
 
 # -- Configure container runtime specific integration.
+# Deprecated in favor of bpf.autoMount.enabled. To be removed in 1.15.
 containerRuntime:
   # -- Enables specific integrations for container runtimes.
   # Supported values:
-  # - containerd
   # - crio
-  # - docker
   # - none
-  # - auto (automatically detect the container runtime)
   integration: none
-  # -- Configure the path to the container runtime control socket.
-  # socketPath: /path/to/runtime.sock
 
 # -- (string) Configure timeout in which Cilium will exit if CRDs are not available
 # @default -- `"5m"`


### PR DESCRIPTION
On distributions that already mount the `bpffs` filesystem at `/sys/fs/bpf` this is a good way to optionally disable the bpf mount init container and have no pods running with `securityContext.privilged` and also reduced the number of init containers that needs to be run.

This option was previously used when `containerRuntime.integration=crio`
helm value was set, since this is not just only specific to crio,
deprecate the `containerRuntime.integration=crio` option to skip
mounting `bpffs` filesystem in favour of `bpf.autoMount.enabled` which
is similar to how `cgroupv2` mounts are disabled (`cgroup.autoMount.enabled`).

Eg: On [Talos](https://www.talos.dev/) both `cgroupv2` and `bpffs` filesystems are already mounted and using a values yaml like below helps reduce the number of init containers by a factor of two.

`partial-values.yaml`

```yaml
cgroup:
  autoMount:
    enabled: false
  hostRoot: /sys/fs/cgroup
bpf:
  autoMount:
    enabled: false
```
