### PR TITLE
Improve Hubble decoding performance for trace events

### DIFF
--- a/pkg/monitor/datapath_trace.go
+++ b/pkg/monitor/datapath_trace.go
@@ -125,11 +125,15 @@ func DecodeTraceNotify(data []byte, tn *TraceNotify) error {
 
 	switch version {
 	case TraceNotifyVersion0:
-		return binary.Read(bytes.NewReader(data), byteorder.Native, &tn.TraceNotifyV0)
+		return decodeTraceNotifyVersion0(data, &tn.TraceNotifyV0)
 	case TraceNotifyVersion1:
 		return binary.Read(bytes.NewReader(data), byteorder.Native, tn)
 	}
 	return fmt.Errorf("Unrecognized trace event (version %d)", version)
+}
+
+func decodeTraceNotifyVersion0(data []byte, tn *TraceNotifyV0) error {
+	return binary.Read(bytes.NewReader(data), byteorder.Native, tn)
 }
 
 // dumpIdentity dumps the source and destination identities in numeric or

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -6,6 +6,7 @@ package monitor
 import (
 	"bytes"
 	"encoding/binary"
+	"testing"
 
 	. "github.com/cilium/checkmate"
 
@@ -120,4 +121,22 @@ func (s *MonitorSuite) TestDecodeTraceNotifyErrors(c *C) {
 	err = DecodeTraceNotify(ev, &tn)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "Unrecognized trace event (version 255)")
+}
+
+func BenchmarkDecodeTraceNotifyVersion0(b *testing.B) {
+	input := TraceNotifyV0{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tn := &TraceNotifyV0{}
+		if err := decodeTraceNotifyVersion0(buf.Bytes(), tn); err != nil {
+			b.Fatal(err)
+		}
+	}
 }

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -4,48 +4,120 @@
 package monitor
 
 import (
+	"bytes"
+	"encoding/binary"
+
 	. "github.com/cilium/checkmate"
+
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/types"
 )
 
-func (s *MonitorSuite) TestDecodeTraceNotify(c *C) {
-	tn := &TraceNotify{}
-	err := DecodeTraceNotify([]byte{}, tn)
-	c.Assert(err, NotNil)
+func (s *MonitorSuite) TestDecodeTraceNotifyV0(c *C) {
+	// This check on the struct length constant is there to ensure that this
+	// test is updated when the struct changes.
+	c.Assert(traceNotifyV0Len, Equals, 32)
 
-	data := []byte{
-		0x00,       // Type
-		0x00,       // ObsPoint
-		0x00, 0x00, // Source
-		0x00, 0x00, 0x00, 0x00, // Hash
-		0x00, 0x00, 0x00, 0x00, // OrigLen
-		0x00, 0x00, // CapLen
-		0x00, 0x00, // Version
-		0x00, 0x00, 0x00, 0x00, // SrcLabel
-		0x00, 0x00, 0x00, 0x00, // DstLabel
-		0x00, 0x00, // DstID
-		0x00,                   // Reason
-		0x00,                   // Flags
-		0x02, 0x00, 0x00, 0x00, // Ifindex
+	input := TraceNotifyV0{
+		Type:     0x00,
+		ObsPoint: 0x02,
+		Source:   0x03_04,
+		Hash:     0x05_06_07_08,
+		OrigLen:  0x09_0a_0b_0c,
+		CapLen:   0x0d_0e,
+		Version:  TraceNotifyVersion0,
+		SrcLabel: identity.NumericIdentity(0x_11_12_13_14),
+		DstLabel: identity.NumericIdentity(0x_15_16_17_18),
+		DstID:    0x19_1a,
+		Reason:   0x1b,
+		Flags:    0x1c,
+		Ifindex:  0x1d_1e_1f_20,
 	}
-
-	err = DecodeTraceNotify(data, tn)
+	buf := bytes.NewBuffer(nil)
+	err := binary.Write(buf, byteorder.Native, input)
 	c.Assert(err, IsNil)
-	c.Assert(tn.Version, Equals, uint16(TraceNotifyVersion0))
-	c.Assert(tn.Ifindex, Equals, uint32(2))
 
-	// add buffer space for OrigIP field
-	data = append(data, make([]byte, len(tn.OrigIP))...)
-	// set version to TraceNotifyVersion1
-	data[14] = 0x01
-
-	err = DecodeTraceNotify(data, tn)
+	output := TraceNotify{}
+	err = DecodeTraceNotify(buf.Bytes(), &output)
 	c.Assert(err, IsNil)
-	c.Assert(tn.Version, Equals, uint16(TraceNotifyVersion1))
-	c.Assert(tn.Ifindex, Equals, uint32(2))
+	c.Assert(output.Type, Equals, input.Type)
+	c.Assert(output.ObsPoint, Equals, input.ObsPoint)
+	c.Assert(output.Source, Equals, input.Source)
+	c.Assert(output.Hash, Equals, input.Hash)
+	c.Assert(output.OrigLen, Equals, input.OrigLen)
+	c.Assert(output.CapLen, Equals, input.CapLen)
+	c.Assert(output.Version, Equals, input.Version)
+	c.Assert(output.SrcLabel, Equals, input.SrcLabel)
+	c.Assert(output.DstLabel, Equals, input.DstLabel)
+	c.Assert(output.DstID, Equals, input.DstID)
+	c.Assert(output.Reason, Equals, input.Reason)
+	c.Assert(output.Flags, Equals, input.Flags)
+	c.Assert(output.Ifindex, Equals, input.Ifindex)
+}
 
-	// set invalid version
-	data[14] = 0xff
-	err = DecodeTraceNotify(data, tn)
+func (s *MonitorSuite) TestDecodeTraceNotifyV1(c *C) {
+	// This check on the struct length constant is there to ensure that this
+	// test is updated when the struct changes.
+	c.Assert(traceNotifyV1Len, Equals, 48)
+
+	in := TraceNotifyV1{
+		TraceNotifyV0: TraceNotifyV0{
+			Type:     0x00,
+			ObsPoint: 0x02,
+			Source:   0x03_04,
+			Hash:     0x05_06_07_08,
+			OrigLen:  0x09_0a_0b_0c,
+			CapLen:   0x0d_0e,
+			Version:  TraceNotifyVersion1,
+			SrcLabel: identity.NumericIdentity(0x_11_12_13_14),
+			DstLabel: identity.NumericIdentity(0x_15_16_17_18),
+			DstID:    0x19_1a,
+			Reason:   0x1b,
+			Flags:    0x1c,
+			Ifindex:  0x1d_1e_1f_20,
+		},
+		OrigIP: types.IPv6{
+			0x21, 0x22,
+			0x23, 0x24,
+			0x25, 0x26,
+			0x27, 0x28,
+			0x29, 0x2a,
+		},
+	}
+	buf := bytes.NewBuffer(nil)
+	err := binary.Write(buf, byteorder.Native, in)
+	c.Assert(err, IsNil)
+
+	out := TraceNotify{}
+	err = DecodeTraceNotify(buf.Bytes(), &out)
+	c.Assert(err, IsNil)
+	c.Assert(out.Type, Equals, in.Type)
+	c.Assert(out.ObsPoint, Equals, in.ObsPoint)
+	c.Assert(out.Source, Equals, in.Source)
+	c.Assert(out.Hash, Equals, in.Hash)
+	c.Assert(out.OrigLen, Equals, in.OrigLen)
+	c.Assert(out.CapLen, Equals, in.CapLen)
+	c.Assert(out.Version, Equals, in.Version)
+	c.Assert(out.SrcLabel, Equals, in.SrcLabel)
+	c.Assert(out.DstLabel, Equals, in.DstLabel)
+	c.Assert(out.DstID, Equals, in.DstID)
+	c.Assert(out.Reason, Equals, in.Reason)
+	c.Assert(out.Flags, Equals, in.Flags)
+	c.Assert(out.Ifindex, Equals, in.Ifindex)
+	c.Assert(out.OrigIP, Equals, in.OrigIP)
+}
+
+func (s *MonitorSuite) TestDecodeTraceNotifyErrors(c *C) {
+	tn := TraceNotify{}
+	err := DecodeTraceNotify([]byte{}, &tn)
 	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "Unknown trace event")
 
+	// invalid version
+	ev := make([]byte, traceNotifyV1Len)
+	ev[14] = 0xff
+	err = DecodeTraceNotify(ev, &tn)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "Unrecognized trace event (version 255)")
 }

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -141,3 +141,22 @@ func BenchmarkDecodeTraceNotifyVersion0(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkDecodeTraceNotifyVersion1(b *testing.B) {
+	input := TraceNotifyV1{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tn := &TraceNotifyV1{}
+		if err := tn.decodeTraceNotifyVersion1(buf.Bytes()); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/monitor/datapath_trace_test.go
+++ b/pkg/monitor/datapath_trace_test.go
@@ -131,11 +131,12 @@ func BenchmarkDecodeTraceNotifyVersion0(b *testing.B) {
 		b.Fatal(err)
 	}
 
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
 		tn := &TraceNotifyV0{}
-		if err := decodeTraceNotifyVersion0(buf.Bytes(), tn); err != nil {
+		if err := tn.decodeTraceNotifyVersion0(buf.Bytes()); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

See each commit message for the detailed description, but these patches reduce the baseline CPU usage of Cilium Agents by 3-4%, by removing allocations. The decode functions themselves improved in runtime by 92-95%.

```release-note
Improve Hubble decoding performance for trace events
```
