### PR TITLE
agent: rework clustermesh config watcher for increased robustness

### DIFF
--- a/pkg/clustermesh/logfields.go
+++ b/pkg/clustermesh/logfields.go
@@ -13,6 +13,8 @@ var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "clustermesh")
 const (
 	fieldClusterName   = "clusterName"
 	fieldConfig        = "config"
+	fieldConfigDir     = "configDir"
+	fieldEvent         = "event"
 	fieldKVStoreStatus = "kvstoreStatus"
 	fieldKVStoreErr    = "kvstoreErr"
 )


### PR DESCRIPTION
The agent leverages an fsnotify watcher to detect file changes in the directory containing the etcd configurations for remote clusters (as well as the associated keys/certs), triggering a reconfiguration as appropriate.

This PR reworks the above logic to address two main issues:
* Due to how Kubernetes mounts ConfigMaps and Secrets within pods, and in particular the usage of symbolic links to handle atomic updates, changes in existing files were not detected (since the watched file itself was a symbolic link, which doesn't change during such operation). Now, an explicit watch operation is started for each configuration file (i.e., watching the actual target), causing a notification to be properly emitted when that is changed.
* Prevent possible spurious notifications even if the configuration is not actually modified. This is achieved through hash comparison.

Integration tests are updated to cover the above two aspects.

<!-- Description of change -->

Fixes: #23273

```release-note
agent: rework clustermesh config watcher for increased robustness
```
