### PR TITLE
Update clustermesh requirements to mention node InternalIP explicitly

### DIFF
--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -29,9 +29,9 @@ Cluster Addressing Requirements
 * PodCIDR ranges in all clusters and all nodes must be non-conflicting and
   unique IP addresses.
 
-* Nodes in all clusters must have IP connectivity between each other. This
-  requirement is typically met by establishing peering or VPN tunnels between
-  the networks of the nodes of each cluster.
+* Nodes in all clusters must have IP connectivity between each other using the 
+  configured InternalIP for each node. This requirement is typically met by establishing 
+  peering or VPN tunnels between the networks of the nodes of each cluster.
 
 * The network between clusters must allow the inter-cluster communication. The
   exact ports are documented in the :ref:`firewall_requirements` section.


### PR DESCRIPTION
This is a one-line clustermesh documentation fix-up to be more explicit about what is required for clustermesh.

Discovered in a community slack discussion that k8s node ExternalIP isn't used by clustermesh.  
Slack discussion reference:
https://cilium.slack.com/archives/C1MATJ5U5/p1677861317308659


```release-note
docs: Update Cluster Mesh requirements to mention node InternalIP explicitly
```