### PR TITLE
gha: Skip flaky test HTTPRouteHeaderMatching in GatewayAPI

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -140,7 +140,8 @@ jobs:
             -v ./operator/pkg/gateway-api \
             --gateway-class cilium \
             --supported-features ReferenceGrant,TLSRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,RouteDestinationPortMatching,GatewayClassObservedGenerationBump \
-            -test.run "TestConformance"
+            -test.run "TestConformance" \
+            -test.skip "TestConformance/HTTPRouteHeaderMatching" # Enable once #23999 is fixed
 
       - name: Post-test information gathering
         if: ${{ !success() }}


### PR DESCRIPTION
Will enable it back again once below issue is fixed.

Relates: #23999
