### PR TITLE
Release restrictions for BPFHostrouting when using the IPAMDelegatedPlugin

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -147,6 +147,7 @@ cilium-agent [flags]
       --envoy-config-timeout duration                           Timeout duration for Envoy Config acknowledgements (default 2m0s)
       --envoy-log string                                        Path to a separate Envoy log file, if any
       --exclude-local-address strings                           Exclude CIDR from being recognized as local address
+      --externally-managed-endpoint-routes                      Use external system management route when IPAM mode is delegated-plugin
       --fixed-identity-mapping map                              Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns
       --gops-port uint16                                        Port for gops server to listen on (default 9890)
   -h, --help                                                    help for cilium-agent

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -237,6 +237,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableEndpointRoutes, defaults.EnableEndpointRoutes, "Use per endpoint routes instead of routing via cilium_host")
 	option.BindEnv(Vp, option.EnableEndpointRoutes)
 
+	flags.Bool(option.ExternallyManagedEndpointRoutes, defaults.ExternallyManagedEndpointRoutes, "Use external system management route when IPAM mode is delegated-plugin")
+	option.BindEnv(Vp, option.ExternallyManagedEndpointRoutes)
+
 	flags.Bool(option.EnableHealthChecking, defaults.EnableHealthChecking, "Enable connectivity health checking")
 	option.BindEnv(Vp, option.EnableHealthChecking)
 
@@ -1468,13 +1471,8 @@ func initEnv() {
 		}
 		// Release restrictions for BPFHostrouting when using the IPAMDelegatedPlugin
 		// Cloud providers can manage local routes by themselves
-		if !option.Config.EnableEndpointRoutes {
-			if option.Config.IPAM == ipamOption.IPAMDelegatedPlugin {
-				log.Warnf("use ipam mode %s without %s, cilium will not manage local endpoint routes.",
-					ipamOption.IPAMDelegatedPlugin, option.EnableEndpointRoutes)
-			} else {
-				log.Fatalf("Cannot specify %s or %s without %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableEndpointRoutes)
-			}
+		if !option.Config.EnableEndpointRoutes && !option.Config.ExternallyManagedEndpointRoutes {
+			log.Fatalf("Cannot specify %s or %s without %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableEndpointRoutes)
 		}
 		if option.Config.EnableIPSec {
 			log.Fatalf("Cannot specify %s or %s with %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableIPSecName)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1473,7 +1473,7 @@ func initEnv() {
 				log.Warnf("use ipam mode %s without %s, cilium will not manage local endpoint routes.",
 					ipamOption.IPAMDelegatedPlugin, option.EnableEndpointRoutes)
 			} else {
-				log.Fatalf("Cannot specify %s or %s  without %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableEndpointRoutes)
+				log.Fatalf("Cannot specify %s or %s without %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableEndpointRoutes)
 			}
 		}
 		if option.Config.EnableIPSec {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1466,8 +1466,15 @@ func initEnv() {
 		if option.Config.TunnelingEnabled() {
 			log.Fatalf("Cannot specify %s or %s in tunnel mode.", option.LocalRouterIPv4, option.LocalRouterIPv6)
 		}
+		// Release restrictions for BPFHostrouting when using the IPAMDelegatedPlugin
+		// Cloud providers can manage local routes by themselves
 		if !option.Config.EnableEndpointRoutes {
-			log.Fatalf("Cannot specify %s or %s  without %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableEndpointRoutes)
+			if option.Config.IPAM == ipamOption.IPAMDelegatedPlugin {
+				log.Warnf("use ipam mode %s without %s, cilium will not manage local endpoint routes.",
+					ipamOption.IPAMDelegatedPlugin, option.EnableEndpointRoutes)
+			} else {
+				log.Fatalf("Cannot specify %s or %s  without %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableEndpointRoutes)
+			}
 		}
 		if option.Config.EnableIPSec {
 			log.Fatalf("Cannot specify %s or %s with %s.", option.LocalRouterIPv4, option.LocalRouterIPv6, option.EnableIPSecName)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -344,6 +344,10 @@ const (
 	// It is disabled by default for backwards compatibility.
 	EnableEndpointRoutes = false
 
+	// ExternallyManagedEndpointRoutes indicate that the routes are managed by some external system
+	// Note that this option can only be used with IPAMDelegatedPlugin
+	ExternallyManagedEndpointRoutes = false
+
 	// AnnotateK8sNode is the default value for option.AnnotateK8sNode. It is
 	// disabled by default to annotate kubernetes node and can be enabled using
 	// the provided option.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -814,6 +814,10 @@ const (
 	// EnableEndpointRoutes enables use of per endpoint routes
 	EnableEndpointRoutes = "enable-endpoint-routes"
 
+	// ExternallyManagedEndpointRoutes indicate that the routes are managed by some external system
+	// Note that this option can only be used with IPAMDelegatedPlugin
+	ExternallyManagedEndpointRoutes = "externally-managed-endpoint-routes"
+
 	// ExcludeLocalAddress excludes certain addresses to be recognized as a
 	// local address
 	ExcludeLocalAddress = "exclude-local-address"
@@ -1862,6 +1866,10 @@ type DaemonConfig struct {
 	// EnableEndpointRoutes enables use of per endpoint routes
 	EnableEndpointRoutes bool
 
+	// ExternallyManagedEndpointRoutes indicate that the routes are managed by some external system
+	// Note that this option should only be used with IPAMDelegatedPlugin
+	ExternallyManagedEndpointRoutes bool
+
 	// Specifies wheather to annotate the kubernetes nodes or not
 	AnnotateK8sNode bool
 
@@ -2322,43 +2330,44 @@ type DaemonConfig struct {
 var (
 	// Config represents the daemon configuration
 	Config = &DaemonConfig{
-		CreationTime:                 time.Now(),
-		Opts:                         NewIntOptions(&DaemonOptionLibrary),
-		Monitor:                      &models.MonitorStatus{Cpus: int64(runtime.NumCPU()), Npages: 64, Pagesize: int64(os.Getpagesize()), Lost: 0, Unknown: 0},
-		IPv6ClusterAllocCIDR:         defaults.IPv6ClusterAllocCIDR,
-		IPv6ClusterAllocCIDRBase:     defaults.IPv6ClusterAllocCIDRBase,
-		EnableHostIPRestore:          defaults.EnableHostIPRestore,
-		EnableHealthChecking:         defaults.EnableHealthChecking,
-		EnableEndpointHealthChecking: defaults.EnableEndpointHealthChecking,
-		EnableHealthCheckNodePort:    defaults.EnableHealthCheckNodePort,
-		EnableIPv4:                   defaults.EnableIPv4,
-		EnableIPv6:                   defaults.EnableIPv6,
-		EnableIPv6NDP:                defaults.EnableIPv6NDP,
-		EnableSCTP:                   defaults.EnableSCTP,
-		EnableL7Proxy:                defaults.EnableL7Proxy,
-		EndpointStatus:               make(map[string]struct{}),
-		DNSMaxIPsPerRestoredRule:     defaults.DNSMaxIPsPerRestoredRule,
-		ToFQDNsMaxIPsPerHost:         defaults.ToFQDNsMaxIPsPerHost,
-		KVstorePeriodicSync:          defaults.KVstorePeriodicSync,
-		KVstoreConnectivityTimeout:   defaults.KVstoreConnectivityTimeout,
-		IPAllocationTimeout:          defaults.IPAllocationTimeout,
-		IdentityChangeGracePeriod:    defaults.IdentityChangeGracePeriod,
-		IdentityRestoreGracePeriod:   defaults.IdentityRestoreGracePeriod,
-		FixedIdentityMapping:         make(map[string]string),
-		KVStoreOpt:                   make(map[string]string),
-		LogOpt:                       make(map[string]string),
-		LoopbackIPv4:                 defaults.LoopbackIPv4,
-		ForceLocalPolicyEvalAtSource: defaults.ForceLocalPolicyEvalAtSource,
-		EnableEndpointRoutes:         defaults.EnableEndpointRoutes,
-		AnnotateK8sNode:              defaults.AnnotateK8sNode,
-		K8sServiceCacheSize:          defaults.K8sServiceCacheSize,
-		AutoCreateCiliumNodeResource: defaults.AutoCreateCiliumNodeResource,
-		IdentityAllocationMode:       IdentityAllocationModeKVstore,
-		AllowICMPFragNeeded:          defaults.AllowICMPFragNeeded,
-		EnableWellKnownIdentities:    defaults.EnableWellKnownIdentities,
-		K8sEnableK8sEndpointSlice:    defaults.K8sEnableEndpointSlice,
-		AllocatorListTimeout:         defaults.AllocatorListTimeout,
-		EnableICMPRules:              defaults.EnableICMPRules,
+		CreationTime:                    time.Now(),
+		Opts:                            NewIntOptions(&DaemonOptionLibrary),
+		Monitor:                         &models.MonitorStatus{Cpus: int64(runtime.NumCPU()), Npages: 64, Pagesize: int64(os.Getpagesize()), Lost: 0, Unknown: 0},
+		IPv6ClusterAllocCIDR:            defaults.IPv6ClusterAllocCIDR,
+		IPv6ClusterAllocCIDRBase:        defaults.IPv6ClusterAllocCIDRBase,
+		EnableHostIPRestore:             defaults.EnableHostIPRestore,
+		EnableHealthChecking:            defaults.EnableHealthChecking,
+		EnableEndpointHealthChecking:    defaults.EnableEndpointHealthChecking,
+		EnableHealthCheckNodePort:       defaults.EnableHealthCheckNodePort,
+		EnableIPv4:                      defaults.EnableIPv4,
+		EnableIPv6:                      defaults.EnableIPv6,
+		EnableIPv6NDP:                   defaults.EnableIPv6NDP,
+		EnableSCTP:                      defaults.EnableSCTP,
+		EnableL7Proxy:                   defaults.EnableL7Proxy,
+		EndpointStatus:                  make(map[string]struct{}),
+		DNSMaxIPsPerRestoredRule:        defaults.DNSMaxIPsPerRestoredRule,
+		ToFQDNsMaxIPsPerHost:            defaults.ToFQDNsMaxIPsPerHost,
+		KVstorePeriodicSync:             defaults.KVstorePeriodicSync,
+		KVstoreConnectivityTimeout:      defaults.KVstoreConnectivityTimeout,
+		IPAllocationTimeout:             defaults.IPAllocationTimeout,
+		IdentityChangeGracePeriod:       defaults.IdentityChangeGracePeriod,
+		IdentityRestoreGracePeriod:      defaults.IdentityRestoreGracePeriod,
+		FixedIdentityMapping:            make(map[string]string),
+		KVStoreOpt:                      make(map[string]string),
+		LogOpt:                          make(map[string]string),
+		LoopbackIPv4:                    defaults.LoopbackIPv4,
+		ForceLocalPolicyEvalAtSource:    defaults.ForceLocalPolicyEvalAtSource,
+		EnableEndpointRoutes:            defaults.EnableEndpointRoutes,
+		ExternallyManagedEndpointRoutes: defaults.ExternallyManagedEndpointRoutes,
+		AnnotateK8sNode:                 defaults.AnnotateK8sNode,
+		K8sServiceCacheSize:             defaults.K8sServiceCacheSize,
+		AutoCreateCiliumNodeResource:    defaults.AutoCreateCiliumNodeResource,
+		IdentityAllocationMode:          IdentityAllocationModeKVstore,
+		AllowICMPFragNeeded:             defaults.AllowICMPFragNeeded,
+		EnableWellKnownIdentities:       defaults.EnableWellKnownIdentities,
+		K8sEnableK8sEndpointSlice:       defaults.K8sEnableEndpointSlice,
+		AllocatorListTimeout:            defaults.AllocatorListTimeout,
+		EnableICMPRules:                 defaults.EnableICMPRules,
 
 		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 		APIRateLimit:                     make(map[string]string),
@@ -2899,6 +2908,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableXTSocketFallback = vp.GetBool(EnableXTSocketFallbackName)
 	c.EnableAutoDirectRouting = vp.GetBool(EnableAutoDirectRoutingName)
 	c.EnableEndpointRoutes = vp.GetBool(EnableEndpointRoutes)
+	c.ExternallyManagedEndpointRoutes = vp.GetBool(ExternallyManagedEndpointRoutes)
 	c.EnableHealthChecking = vp.GetBool(EnableHealthChecking)
 	c.EnableEndpointHealthChecking = vp.GetBool(EnableEndpointHealthChecking)
 	c.EnableHealthCheckNodePort = vp.GetBool(EnableHealthCheckNodePort)
@@ -3601,6 +3611,11 @@ func (c *DaemonConfig) checkIPAMDelegatedPlugin() error {
 		if c.EnableEndpointHealthChecking {
 			return fmt.Errorf("--%s must be disabled with --%s=%s", EnableEndpointHealthChecking, IPAM, ipamOption.IPAMDelegatedPlugin)
 		}
+	} else if c.ExternallyManagedEndpointRoutes {
+		// ExternallyManagedEndpointRoutes should only be used with IPAMDelegatedPlugin.
+		// It indicates that in IPAM delegate mode, Endpoints routes are all managed by external systems
+		// which have routing management capability.
+		return fmt.Errorf("--%s must be %s when --%s is enabled", IPAM, ipamOption.IPAMDelegatedPlugin, ExternallyManagedEndpointRoutes)
 	}
 	return nil
 }


### PR DESCRIPTION
The IPAMDelegatedPlugin plugin makes it possible not to write 
the code of the cloud vendor into the core code of Cilium. 
This mode is conducive to the scalability of Cilium. 
However:

1. DaemonConfig check requires that 
`LocalRouterIPv4`/`LocalRouterIPv6` must be set when 
IPAMDelegatedPlugin is used.
2. When `LocalRouterIPv6`/`LocalRouterIPv6` is set, 
the verifier requires that the `EnableEndpointRoutes=true` 
option must be set.
3. which is equivalent to prohibiting the use of BPFHostrouting by DelegateIPAM.

After turning off the `EnableEndpointRoutes` option, cloud providers 
actually have the opportunity to set their own routes. 

For example, in the cni plugin chain, the private cni plugin of the 
cloud provider manages the local routing, and cooperates with `cilium-cni `
to implement BPFHostRouting to accelerate the container network.