### PR TITLE
chore: Update json-mock image

### DIFF
--- a/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster1.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: x-wing-container
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
         livenessProbe:
           exec:
             command:

--- a/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
+++ b/examples/kubernetes/clustermesh/global-service-example/cluster2.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
       - name: x-wing-container
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
         livenessProbe:
           exec:
             command:

--- a/examples/policies/kubernetes/namespace/demo-pods.yaml
+++ b/examples/policies/kubernetes/namespace/demo-pods.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: leia-container
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
 ---
 apiVersion: v1
 kind: Service
@@ -50,7 +50,7 @@ metadata:
 spec:
   containers:
   - name: luke-container
-    image: docker.io/cilium/json-mock:1.2
+    image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
 ---
 apiVersion: v1
 kind: Pod
@@ -62,4 +62,4 @@ metadata:
 spec:
   containers:
   - name: vader-container
-    image: docker.io/cilium/json-mock:1.2
+    image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0

--- a/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
+++ b/examples/policies/kubernetes/serviceaccount/demo-pods.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: leia
       containers:
       - name: leia-container
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
 ---
 apiVersion: v1
 kind: Service
@@ -51,7 +51,7 @@ spec:
   serviceAccountName: luke
   containers:
   - name: luke-container
-    image: docker.io/cilium/json-mock:1.2
+    image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
 ---
 apiVersion: v1
 kind: Pod
@@ -61,4 +61,4 @@ spec:
   serviceAccountName: vader
   containers:
   - name: vader-container
-    image: docker.io/cilium/json-mock:1.2
+    image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0

--- a/test/controlplane/services/dualstack/manifests/echo-dpl.yaml
+++ b/test/controlplane/services/dualstack/manifests/echo-dpl.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
         livenessProbe:
           exec:
             command:

--- a/test/controlplane/services/nodeport/manifests/nodeport.yaml
+++ b/test/controlplane/services/nodeport/manifests/nodeport.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
         ports:
         - containerPort: 80
           hostPort: 8080

--- a/test/controlplane/services/nodeport/v1.24/state1.yaml
+++ b/test/controlplane/services/nodeport/v1.24/state1.yaml
@@ -211,7 +211,7 @@ items:
     uid: 7620eeb9-aa91-466a-b409-a0df5b79c8f9
   spec:
     containers:
-    - image: docker.io/cilium/json-mock:1.2
+    - image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
       imagePullPolicy: IfNotPresent
       name: echo-container
       ports:
@@ -293,8 +293,8 @@ items:
       type: PodScheduled
     containerStatuses:
     - containerID: containerd://cc84c3c87f6ccacbe724ee0fad740dd250e65b224273bcb9591927a6d0ed6987
-      image: docker.io/cilium/json-mock:1.2
-      imageID: docker.io/cilium/json-mock@sha256:941e03da57551dd4a71f351b35650c152a1192ac1df717e43ee58b5aa2b8e241
+      image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+      imageID: quay.io/cilium/json-mock@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
       lastState: {}
       name: echo-container
       ready: true

--- a/test/controlplane/services/nodeport/v1.25/state1.yaml
+++ b/test/controlplane/services/nodeport/v1.25/state1.yaml
@@ -211,7 +211,7 @@ items:
     uid: 88542b9d-6369-4ec3-a5eb-fd53720013e8
   spec:
     containers:
-    - image: docker.io/cilium/json-mock:1.2
+    - image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
       imagePullPolicy: IfNotPresent
       name: echo-container
       ports:
@@ -293,8 +293,8 @@ items:
       type: PodScheduled
     containerStatuses:
     - containerID: containerd://9fe24338688e8c3e12e4ae626afe44567585648743a6c7fcf28cace496ee8f6b
-      image: docker.io/cilium/json-mock:1.2
-      imageID: docker.io/cilium/json-mock@sha256:941e03da57551dd4a71f351b35650c152a1192ac1df717e43ee58b5aa2b8e241
+      image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+      imageID: quay.io/cilium/json-mock@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
       lastState: {}
       name: echo-container
       ready: true

--- a/test/controlplane/services/nodeport/v1.26/state1.yaml
+++ b/test/controlplane/services/nodeport/v1.26/state1.yaml
@@ -211,7 +211,7 @@ items:
     uid: 88542b9d-6369-4ec3-a5eb-fd53720013e8
   spec:
     containers:
-    - image: docker.io/cilium/json-mock:1.2
+    - image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
       imagePullPolicy: IfNotPresent
       name: echo-container
       ports:
@@ -293,8 +293,8 @@ items:
       type: PodScheduled
     containerStatuses:
     - containerID: containerd://9fe24338688e8c3e12e4ae626afe44567585648743a6c7fcf28cace496ee8f6b
-      image: docker.io/cilium/json-mock:1.2
-      imageID: docker.io/cilium/json-mock@sha256:941e03da57551dd4a71f351b35650c152a1192ac1df717e43ee58b5aa2b8e241
+      image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
+      imageID: quay.io/cilium/json-mock@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
       lastState: {}
       name: echo-container
       ready: true

--- a/test/k8s/manifests/echo-svc.yaml
+++ b/test/k8s/manifests/echo-svc.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: echo-container
-        image: docker.io/cilium/json-mock:1.2
+        image: quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0
         livenessProbe:
           exec:
             command:


### PR DESCRIPTION
Just replace docker.io/cilium/json-mock.* to quay.io/cilium/json-mock:v1.3.3@sha256:f26044a2b8085fcaa8146b6b8bb73556134d7ec3d5782c6a04a058c945924ca0

Fixes: #24170
