### PR TITLE
EndpointSlice Conditions semantics: Ready, Serving and Terminating

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1200,6 +1200,11 @@ gracefully. The endpoint state is fully removed when the agent receives
 a Kubernetes delete event for the endpoint. The `Kubernetes
 pod termination <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination>`_
 documentation contains more background on the behavior and configuration using ``terminationGracePeriodSeconds``.
+There are some special cases, like zero disruption during rolling updates, that require to be able to send traffic
+to Terminating Pods that are still Serving traffic during the Terminating period, the Kubernetes blog
+`Advancements in Kubernetes Traffic Engineering
+<https://kubernetes.io/blog/2022/12/30/advancements-in-kubernetes-traffic-engineering/#traffic-loss-from-load-balancers-during-rolling-updates>`_
+explains it in detail.
 
 .. admonition:: Video
   :class: attention

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -293,32 +293,45 @@ func ParseEndpointSliceV1(ep *slim_discovery_v1.EndpointSlice) (EndpointSliceID,
 		return ParseEndpointSliceID(ep), endpoints
 	}
 
+	log.Debugf("Processing %d endpoints for EndpointSlice %s", len(ep.Endpoints), ep.Name)
 	for _, sub := range ep.Endpoints {
-		skipEndpoint := false
 		// ready indicates that this endpoint is prepared to receive traffic,
 		// according to whatever system is managing the endpoint. A nil value
 		// indicates an unknown state. In most cases consumers should interpret this
 		// unknown state as ready.
 		// More info: vendor/k8s.io/api/discovery/v1/types.go
-		if sub.Conditions.Ready != nil && !*sub.Conditions.Ready {
-			skipEndpoint = true
-			if option.Config.EnableK8sTerminatingEndpoint {
-				// Terminating indicates that the endpoint is getting terminated. A
-				// nil values indicates an unknown state. Ready is never true when
-				// an endpoint is terminating. Propagate the terminating endpoint
-				// state so that we can gracefully remove those endpoints.
-				// More details : vendor/k8s.io/api/discovery/v1/types.go
-				if sub.Conditions.Terminating != nil && *sub.Conditions.Terminating {
-					skipEndpoint = false
-				}
+		isReady := sub.Conditions.Ready == nil || *sub.Conditions.Ready
+		// serving is identical to ready except that it is set regardless of the
+		// terminating state of endpoints. This condition should be set to true for
+		// a ready endpoint that is terminating. If nil, consumers should defer to
+		// the ready condition.
+		// More info: vendor/k8s.io/api/discovery/v1/types.go
+		isServing := (sub.Conditions.Serving == nil && isReady) || (sub.Conditions.Serving != nil && *sub.Conditions.Serving)
+		// Terminating indicates that the endpoint is getting terminated. A
+		// nil values indicates an unknown state. Ready is never true when
+		// an endpoint is terminating. Propagate the terminating endpoint
+		// state so that we can gracefully remove those endpoints.
+		// More info: vendor/k8s.io/api/discovery/v1/types.go
+		isTerminating := sub.Conditions.Terminating != nil && *sub.Conditions.Terminating
+
+		// if is not Ready and EnableK8sTerminatingEndpoint is set
+		// allow endpoints that are Serving and Terminating
+		if !isReady {
+			if !option.Config.EnableK8sTerminatingEndpoint {
+				log.Debugf("discarding Endpoint on EndpointSlice %s: not Ready and EnableK8sTerminatingEndpoint %v", ep.Name, option.Config.EnableK8sTerminatingEndpoint)
+				continue
+			}
+			// filter not Serving endpoints since those can not receive traffic
+			if !isServing {
+				log.Debugf("discarding Endpoint on EndpointSlice %s: not Serving and EnableK8sTerminatingEndpoint %v", ep.Name, option.Config.EnableK8sTerminatingEndpoint)
+				continue
 			}
 		}
-		if skipEndpoint {
-			continue
-		}
+
 		for _, addr := range sub.Addresses {
 			addrCluster, err := cmtypes.ParseAddrCluster(addr)
 			if err != nil {
+				log.WithError(err).Infof("Unable to parse address %s for EndpointSlices %s", addr, ep.Name)
 				continue
 			}
 
@@ -333,11 +346,12 @@ func ParseEndpointSliceV1(ep *slim_discovery_v1.EndpointSlice) (EndpointSliceID,
 						backend.NodeName = nodeName
 					}
 				}
-				if option.Config.EnableK8sTerminatingEndpoint {
-					if sub.Conditions.Terminating != nil && *sub.Conditions.Terminating {
-						backend.Terminating = true
-						metrics.TerminatingEndpointsEvents.Inc()
-					}
+				// If is not ready check if is serving and terminating
+				if !isReady && option.Config.EnableK8sTerminatingEndpoint &&
+					isServing && isTerminating {
+					log.Debugf("Endpoint address %s on EndpointSlice %s is Terminating", addr, ep.Name)
+					backend.Terminating = true
+					metrics.TerminatingEndpointsEvents.Inc()
 				}
 			}
 
@@ -357,6 +371,7 @@ func ParseEndpointSliceV1(ep *slim_discovery_v1.EndpointSlice) (EndpointSliceID,
 		}
 	}
 
+	log.Debugf("EndpointSlice %s has %d backends", ep.Name, len(endpoints.Backends))
 	return ParseEndpointSliceID(ep), endpoints
 }
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -696,10 +696,17 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 	// only contain local backends (i.e. it has externalTrafficPolicy=Local)
 	if option.Config.EnableHealthCheckNodePort {
 		if svc.isExtLocal() && filterBackends {
-			_, activeBackends, _ := segregateBackends(backendsCopy)
-
+			// HealthCheckNodePort is used by external systems to poll the state of the Service,
+			// it should never take into consideration Terminating backends, even when there are only
+			// Terminating backends.
+			activeBackends := 0
+			for _, b := range backendsCopy {
+				if b.State == lb.BackendStateActive {
+					activeBackends++
+				}
+			}
 			s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcName.Namespace, svc.svcName.Name,
-				len(activeBackends), svc.svcHealthCheckNodePort)
+				activeBackends, svc.svcHealthCheckNodePort)
 		} else if svc.svcHealthCheckNodePort == 0 {
 			// Remove the health check server in case this service used to have
 			// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
@@ -1679,6 +1686,9 @@ func isWildcardAddr(frontend lb.L3n4AddrID) bool {
 	return cmtypes.MustParseAddrCluster("0.0.0.0").Equal(frontend.AddrCluster)
 }
 
+// segregateBackends returns the list of active, preferred and nonActive backends to be
+// added to the lbmaps. If EnableK8sTerminatingEndpoint and there are no active backends,
+// segregateBackends will return all terminating backends as active.
 func segregateBackends(backends []*lb.Backend) (preferredBackends map[string]*lb.Backend,
 	activeBackends map[string]*lb.Backend, nonActiveBackends []lb.BackendID) {
 	preferredBackends = make(map[string]*lb.Backend)
@@ -1698,6 +1708,21 @@ func segregateBackends(backends []*lb.Backend) (preferredBackends map[string]*lb
 			}
 		} else {
 			nonActiveBackends = append(nonActiveBackends, b.ID)
+		}
+	}
+	// To avoid connections drops during rolling updates, Kubernetes defines a Terminating state on the EndpointSlices
+	// that can be used to identify Pods that, despite being terminated, still can serve traffic.
+	// In case that there are no Active backends, use the Backends in TerminatingState to answer new requests
+	// and avoid traffic disruption until new active backends are created.
+	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1669-proxy-terminating-endpoints
+	if option.Config.EnableK8sTerminatingEndpoint && len(activeBackends) == 0 {
+		nonActiveBackends = []lb.BackendID{}
+		for _, b := range backends {
+			if b.State == lb.BackendStateTerminating {
+				activeBackends[b.String()] = b
+			} else {
+				nonActiveBackends = append(nonActiveBackends, b.ID)
+			}
 		}
 	}
 	return preferredBackends, activeBackends, nonActiveBackends


### PR DESCRIPTION
Fix the usage of the EndpointSlice Conditions semantics: Ready, Serving and Terminating.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

The EndpointSlice conditions describe 3 states for an Endpoint: Ready, Service and Terminating.

If the Endpoint is Ready it must leverage that value, independently of the other Conditions, this is the reason why the Kubernetes test mentioned in #18241 fails, since using `service.Spec.publishNotReadyAddresses` force this Ready state in the Endpoint.

In addition, Terminating endpoints must be included only of they are Serving, since that indicates that the Endpoint is valid, this state has to be introduced in the API for handling backward compatibility between versions adding an undesired complexity to consumers, so apologize for that 😄 

In KEP https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1669-proxy-terminating-endpoints  we describe the behavior for Terminating Endpoints in case there are no existing Ready endpoints, to allow to implement zero downtime strategies during rolling updates.

Add a job to run Kubernetes sig-network tests, to guarantee that there is no regression and also benefit Cilium of these tests, that should guarantee a standard and conformance behavior with Kubernetes sig-network defined behaviors.

Fixes: #18241

```release-note
Services backends with publishNotReadyAddresses are able to receive traffic independently if they are Terminating, since is the user intent to make them reachable despite its state.
```
