### PR TITLE
bpf_tests: Bumped CoverBee to v0.3.2 blank state value fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.74.0
 	github.com/aws/smithy-go v1.13.5
 	github.com/blang/semver/v4 v4.0.0
-	github.com/cilium/coverbee v0.3.1
+	github.com/cilium/coverbee v0.3.2
 	github.com/cilium/customvet v0.0.0-20221207181232-aa8731fa2d27
 	github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e
 	github.com/cilium/ebpf v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -164,10 +164,10 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/controller-tools v0.6.2 h1:oIkqAzqncKsm+lQFJVP6n+bqHOVs9nUZ06hgZ4PxlMM=
 github.com/cilium/controller-tools v0.6.2/go.mod h1:oaeGpjXn6+ZSEIQkUe/+3I40PNiDYp9aeawbt3xTgJ8=
-github.com/cilium/coverbee v0.3.1 h1:HfATR8JDy13g7rZp/GIxo91jKUbiYv3CGEZngAPP3KU=
-github.com/cilium/coverbee v0.3.1/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
 github.com/cilium/customvet v0.0.0-20221207181232-aa8731fa2d27 h1:X99IJC9BVwnZiPv3XTuMRf5HlCYUL7rlNEZU/zWVtOo=
 github.com/cilium/customvet v0.0.0-20221207181232-aa8731fa2d27/go.mod h1:nFj/mLY2y3zQe+DDXgl9rXixkJPVLf23UfRlaljzW6k=
+github.com/cilium/coverbee v0.3.2 h1:RaJN5OaHf/M8tmeLemHmdO0H5bFUhvtTAoYbStDIX14=
+github.com/cilium/coverbee v0.3.2/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e h1:VZolEtS7AlGDu3IH368iqkvfQQSGPgOnPjNaUx4dS7M=
 github.com/cilium/deepequal-gen v0.0.0-20200406125435-ad6a9003139e/go.mod h1:c4R5wxGyXhbM6zyKeRKNIc9aab5EZi4z4oOSZvUMvZA=
 github.com/cilium/dns v1.1.51-0.20220729113855-5b94b11b46fc h1:tNEOByqRaBwlf1ANK/U/sd5oOIkxkPkpCVqaabxvU84=

--- a/vendor/github.com/cilium/coverbee/cover.go
+++ b/vendor/github.com/cilium/coverbee/cover.go
@@ -360,16 +360,23 @@ func BlockListFilePaths(blockList [][]CoverBlock) []string {
 
 // Check for:
 // aaaaa
-//   bbbbb
+//
+//	bbbbb
+//
 // -----
-//    aaaa
+//
+//	aaaa
+//
 // bbbb
 // -----
-//   aaa
+//
+//	aaa
+//
 // bbbbbbb
 // -----
 // aaaaaaa
-//   bbb
+//
+//	bbb
 func blocksOverlap(a, b cover.ProfileBlock) bool {
 	return (blockLTE(a.StartLine, a.StartCol, b.EndLine, b.EndCol) &&
 		blockGTE(a.EndLine, a.EndCol, b.EndLine, b.EndCol)) ||

--- a/vendor/github.com/cilium/coverbee/pkg/verifierlog/verifierlog.go
+++ b/vendor/github.com/cilium/coverbee/pkg/verifierlog/verifierlog.go
@@ -418,34 +418,34 @@ func parseVerifierState(line string) (*VerifierState, error) {
 		var value string
 
 		line = line[equal+1:]
-		if len(line) == 0 {
-			break
-		}
+		// If there are chars left after '=' find the end of the current value.
+		// If not, the current key may not have a value (R1=) which is also valid.
+		if len(line) > 1 {
+			bktDepth := 0
+			i := 0
+			for {
+				i++
+				if i >= len(line) {
+					value = line
+					line = line[i:]
+					break
+				}
 
-		bktDepth := 0
-		i := 0
-		for {
-			i++
-			if i >= len(line) {
-				value = line
-				line = line[i:]
-				break
-			}
+				if line[i] == '(' {
+					bktDepth++
+					continue
+				}
 
-			if line[i] == '(' {
-				bktDepth++
-				continue
-			}
+				if line[i] == ')' {
+					bktDepth--
+					continue
+				}
 
-			if line[i] == ')' {
-				bktDepth--
-				continue
-			}
-
-			if line[i] == ' ' && bktDepth == 0 {
-				value = line[:i]
-				line = line[i+1:]
-				break
+				if line[i] == ' ' && bktDepth == 0 {
+					value = line[:i]
+					line = line[i+1:]
+					break
+				}
 			}
 		}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -168,7 +168,7 @@ github.com/census-instrumentation/opencensus-proto/gen-go/trace/v1
 # github.com/cespare/xxhash/v2 v2.2.0
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/cilium/coverbee v0.3.1
+# github.com/cilium/coverbee v0.3.2
 ## explicit; go 1.18
 github.com/cilium/coverbee
 github.com/cilium/coverbee/pkg/cparser


### PR DESCRIPTION
There was a bug in CoverBee which caused instrumentation to fail on some programs if the verifier log contained frame pointer dumps at the end of a log line without a value.

This fixes a bug reported by @jspaleta and @jschwinger233 

```release-note
Bumped CoverBee version to v0.3.2
```
