### PR TITLE
bpf: use skb->ifindex for FIB lookup in handle_*_from_lxc()

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -605,7 +605,7 @@ ct_recreate6:
 		int oif = 0;
 
 		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, ext_err,
-				      ctx->ingress_ifindex, &oif);
+				      ctx_get_ifindex(ctx), &oif);
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,
@@ -1109,7 +1109,7 @@ skip_vtep:
 		int oif = 0;
 
 		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, ext_err,
-				      ctx->ingress_ifindex, &oif);
+				      ctx_get_ifindex(ctx), &oif);
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,


### PR DESCRIPTION
L7 LB traffic is first redirected to envoy for load-balancing. The corresponding local packet by envoy is then sent back to handle_policy_egress() by the cilium_from_host program via tail-call.

In a config with ENABLE_HOST_ROUTING and multiple devices, it then potentially requires a in-BPF FIB lookup. For this lookup, we currently use ctx->ingress_ifindex (aka skb->skb_iif).

For the normal veth->veth transition, the skb->skb_iif would be set by the __netif_receive_skb() in process_backlog(). But for a local packet (as generated by envoy for L7 LB) skb->skb_iif is not set. Consequently such a FIB lookup for ctx->ingress_ifindex 0 will fail, and the packet gets dropped with DROP_NO_FIB.

Use ctx->ifindex instead. This changes nothing for normal from-pod traffic, but allows L7 LB traffic to perform a FIB lookup.

Note that for the L7 LB case, ctx->ifindex will point at cilium_host (rather than the pod's veth interface).

```release-note
Fix FIB lookup for traffic to a L7 service backend, when BPF host-routing is enabled and multiple external devices are configured.
```