### PR TITLE
v1.12 backport: fix cgroup program detachment and 1.14 downgrade

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -267,10 +267,10 @@ function bpf_load_cgroups()
 	NAME=$9
 
 	OPTS="${OPTS} -DCALLS_MAP=${CALLS_MAP}"
-	bpf_compile $IN $OUT obj "$OPTS"
+	bpf_compile "$IN" "$OUT" obj "$OPTS"
 
 	TMP_FILE="$BPFMNT/tc/globals/cilium_cgroups_$WHERE"
-	rm -f $TMP_FILE
+	rm -f "$TMP_FILE"
 
 	cilium bpf migrate-maps -s "$OUT"
 
@@ -284,11 +284,24 @@ function bpf_load_cgroups()
 	rm -f "$BPFFS_ROOT/cilium/socketlb/links/cgroup/$NAME"
 	set -e
 
-	if ! bpftool cgroup attach "$CGRP" "$WHERE" pinned "$TMP_FILE"; then
+	if bpftool cgroup attach "$CGRP" "$WHERE" pinned "$TMP_FILE"; then
 		rm -f "$TMP_FILE"
-		cilium bpf migrate-maps -e "$OUT" -r 1
-		return 1
+		return 0
 	fi
+
+	# Program might've been attached in multi-mode by a newer version of Cilium or
+	# by another tool. This means 'bpftool cgroup attach' won't succeed unless
+	# any/all attached programs are removed.
+	bpf_clear_cgroups "$CGRP" "$WHERE" "$NAME"
+
+	if bpftool cgroup attach "$CGRP" "$WHERE" pinned "$TMP_FILE"; then
+		rm -f "$TMP_FILE"
+		return 0
+	fi
+
+	rm -f "$TMP_FILE"
+	cilium bpf migrate-maps -e "$OUT" -r 1
+	return 1
 }
 
 function bpf_clear_cgroups()


### PR DESCRIPTION
This is a manual backport of the following PRs:

 * [ ] #23537 (@ti-mo)
 * [ ] #24118 (@ti-mo)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 23537 24118; do contrib/backporting/set-labels.py $pr done 1.12; done
```