### PR TITLE
v1.13 backport: fix cgroup program detachment and 1.14 downgrade

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -263,6 +263,7 @@ function bpf_load_cgroups()
 	CALLS_MAP=$6
 	CGRP=$7
 	BPFMNT=$8
+	NAME=$9
 
 	OPTS="${OPTS} -DCALLS_MAP=${CALLS_MAP}"
 	bpf_compile $IN $OUT obj "$OPTS"
@@ -277,6 +278,11 @@ function bpf_load_cgroups()
 		return 1
 	fi
 
+	set +e
+	bpftool link detach pinned "$BPFFS_ROOT/cilium/socketlb/links/cgroup/$NAME" || true
+	rm -f "$BPFFS_ROOT/cilium/socketlb/links/cgroup/$NAME"
+	set -e
+
 	if ! bpftool cgroup attach "$CGRP" "$WHERE" pinned "$TMP_FILE"; then
 		rm -f "$TMP_FILE"
 		cilium bpf migrate-maps -e "$OUT" -r 1
@@ -288,10 +294,15 @@ function bpf_clear_cgroups()
 {
 	CGRP=$1
 	HOOK=$2
+	NAME=$3
 
 	set +e
+	bpftool link detach pinned "$BPFFS_ROOT/cilium/socketlb/links/cgroup/$NAME" || true
+	rm -f "$BPFFS_ROOT/cilium/socketlb/links/cgroup/$NAME"
+
 	ID=$(bpftool cgroup show $CGRP | grep -w $HOOK | awk '{print $1}')
 	set -e
+	
 	if [ -n "$ID" ]; then
 		bpftool cgroup detach $CGRP $HOOK id $ID
 	fi
@@ -501,57 +512,57 @@ if [ "$SOCKETLB" = "true" ]; then
 	CALLS_MAP="cilium_calls_lb"
 	COPTS=""
 	if [ "$IP6_HOST" != "<nil>" ] || [ "$IP4_HOST" != "<nil>" ] && [ -f "${PROCSYSNETDIR}/ipv6/conf/all/forwarding" ]; then
-		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr connect6 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr connect6 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock6_connect
 		if [ "$SOCKETLB_PEER" = "true" ]; then
-			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr getpeername6 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr getpeername6 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock6_getpeername
 		fi
 		if [ "$NODE_PORT" = "true" ] && [ "$NODE_PORT_BIND" = "true" ]; then
-			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sock post_bind6 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sock post_bind6 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock6_post_bind
 		else
-			bpf_clear_cgroups $CGROUP_ROOT post_bind6
+			bpf_clear_cgroups "$CGROUP_ROOT" post_bind6 cil_sock6_post_bind
 		fi
 		if [ "$MODE" = "ipip" ]; then
-			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr bind6 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr bind6 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock6_pre_bind
 		else
-			bpf_clear_cgroups $CGROUP_ROOT bind6
+			bpf_clear_cgroups "$CGROUP_ROOT" bind6 cil_sock6_pre_bind
 		fi
-		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr sendmsg6 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
-		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr recvmsg6 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr sendmsg6 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock6_sendmsg
+		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr recvmsg6 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock6_recvmsg
 	fi
 	if [ "$IP4_HOST" != "<nil>" ]; then
-		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr connect4 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr connect4 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock4_connect
 		if [ "$SOCKETLB_PEER" = "true" ]; then
-			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr getpeername4 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr getpeername4 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock4_getpeername
 		fi
 		if [ "$NODE_PORT" = "true" ] && [ "$NODE_PORT_BIND" = "true" ]; then
-			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sock post_bind4 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sock post_bind4 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock4_post_bind
 		else
-			bpf_clear_cgroups $CGROUP_ROOT post_bind4
+			bpf_clear_cgroups "$CGROUP_ROOT" post_bind4 cil_sock4_post_bind
 		fi
 		if [ "$MODE" = "ipip" ]; then
-			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr bind4 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+			bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr bind4 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock4_pre_bind
 		else
-			bpf_clear_cgroups $CGROUP_ROOT bind4
+			bpf_clear_cgroups "$CGROUP_ROOT" bind4 cil_sock4_pre_bind
 		fi
-		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr sendmsg4 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
-		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr recvmsg4 $CALLS_MAP $CGROUP_ROOT $BPFFS_ROOT
+		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr sendmsg4 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock4_sendmsg
+		bpf_load_cgroups "$COPTS" bpf_sock.c bpf_sock.o sockaddr recvmsg4 "$CALLS_MAP" "$CGROUP_ROOT" "$BPFFS_ROOT" cil_sock4_recvmsg
 	fi
 
 	cilium bpf migrate-maps -e bpf_sock.o -r 0
 
 else
-	bpf_clear_cgroups $CGROUP_ROOT bind4
-	bpf_clear_cgroups $CGROUP_ROOT bind6
-	bpf_clear_cgroups $CGROUP_ROOT post_bind4
-	bpf_clear_cgroups $CGROUP_ROOT post_bind6
-	bpf_clear_cgroups $CGROUP_ROOT connect4
-	bpf_clear_cgroups $CGROUP_ROOT connect6
-	bpf_clear_cgroups $CGROUP_ROOT sendmsg4
-	bpf_clear_cgroups $CGROUP_ROOT sendmsg6
-	bpf_clear_cgroups $CGROUP_ROOT recvmsg4
-	bpf_clear_cgroups $CGROUP_ROOT recvmsg6
-	bpf_clear_cgroups $CGROUP_ROOT getpeername4
-	bpf_clear_cgroups $CGROUP_ROOT getpeername6
+	bpf_clear_cgroups "$CGROUP_ROOT" bind4 cil_sock4_pre_bind
+	bpf_clear_cgroups "$CGROUP_ROOT" bind6 cil_sock6_pre_bind
+	bpf_clear_cgroups "$CGROUP_ROOT" post_bind4 cil_sock4_post_bind
+	bpf_clear_cgroups "$CGROUP_ROOT" post_bind6 cil_sock6_post_bind
+	bpf_clear_cgroups "$CGROUP_ROOT" connect4 cil_sock4_connect
+	bpf_clear_cgroups "$CGROUP_ROOT" connect6 cil_sock6_connect
+	bpf_clear_cgroups "$CGROUP_ROOT" sendmsg4 cil_sock4_sendmsg
+	bpf_clear_cgroups "$CGROUP_ROOT" sendmsg6 cil_sock6_sendmsg
+	bpf_clear_cgroups "$CGROUP_ROOT" recvmsg4 cil_sock4_recvmsg
+	bpf_clear_cgroups "$CGROUP_ROOT" recvmsg6 cil_sock6_recvmsg
+	bpf_clear_cgroups "$CGROUP_ROOT" getpeername4 cil_sock4_getpeername
+	bpf_clear_cgroups "$CGROUP_ROOT" getpeername6 cil_sock6_getpeername
 fi
 
 if [ "$HOST_DEV1" != "$HOST_DEV2" ]; then

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -296,16 +296,45 @@ function bpf_clear_cgroups()
 	HOOK=$2
 	NAME=$3
 
+	# Since Linux commit 1ba5ad36e00f ("bpftool: Use libbpf_bpf_attach_type_str"),
+	# bpftool uses the libbpf_bpf_attach_type_str() format in 'bpftool cgroup
+	# show' output. Perform a naive translation to ensure compatibility with prior
+	# bpftool versions and to avoid updating the hook name at all call sites. The
+	# transformed string can be used in a suffix match against the new format.
+
+	# Examples: (old -> transformed, new)
+	# connect4 -> 4_connect, cgroup_inet4_connect
+	# post_bind6 -> 6_post_bind, cgroup_inet6_post_bind
+	# sendmsg4 -> 4_sendmsg, cgroup_udp4_sendmsg
+
+	# There is no inet4/6 variant of e.g. sendmsg, so it's safe to assume the
+	# intended udp4/6 hook is selected.
+	newhook=$(echo "$HOOK" | sed -E 's/([a-z_]+)([0-9])/\2_\1/')
+
 	set +e
 	bpftool link detach pinned "$BPFFS_ROOT/cilium/socketlb/links/cgroup/$NAME" || true
 	rm -f "$BPFFS_ROOT/cilium/socketlb/links/cgroup/$NAME"
-
-	ID=$(bpftool cgroup show $CGRP | grep -w $HOOK | awk '{print $1}')
 	set -e
-	
-	if [ -n "$ID" ]; then
-		bpftool cgroup detach $CGRP $HOOK id $ID
-	fi
+
+	# Get all programs attached to the given cgroup and store their ids in a
+	# newline-separated string. Perform a full match on the 'legacy' hook name
+	# appearing in older versions of bpftool, but perform a suffix match using the
+	# 'new' hook name.
+	ids=$(bpftool cgroup show "$CGRP" -j |
+		jq --arg legacy "$HOOK" --arg new "$newhook" '.[] |
+			select(
+				.attach_type == $legacy or
+				(.attach_type | endswith($new))
+			) | .id')
+
+	# Cilium versions 1.14 and later use ebpf-go to attach cgroup programs, which
+	# potentially attaches programs using the 'multi' flag if the kernel is recent
+	# enough to support the flag, but too old to support bpf_link. Detach all
+	# programs at the given hook since we can't reliably determine which ones
+	# Cilium owns.
+	for id in $ids; do
+		bpftool cgroup detach "$CGRP" "$HOOK" id "$id"
+	done
 }
 
 function create_encap_dev()


### PR DESCRIPTION
This is a manual backport of the following PRs:

 * [ ] #23537 (@ti-mo)
 * [ ] #24118 (@ti-mo)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 23537 24118; do contrib/backporting/set-labels.py $pr done 1.13; done
```