### PR TITLE
[v1.13] bpf: use skb->ifindex for FIB lookup in handle_*_from_lxc()

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -513,7 +513,7 @@ ct_recreate6:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif;
 
-		ret = redirect_direct_v6(ctx, ETH_HLEN, ip6, &oif);
+		ret = redirect_direct_v6(ctx, ETH_HLEN, ip6, ctx_get_ifindex(ctx), &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,
@@ -1093,7 +1093,7 @@ skip_vtep:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif;
 
-		ret = redirect_direct_v4(ctx, ETH_HLEN, ip4, &oif);
+		ret = redirect_direct_v4(ctx, ETH_HLEN, ip4, ctx_get_ifindex(ctx), &oif);
 		if (likely(ret == CTX_ACT_REDIRECT))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_id, 0, oif,

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -14,7 +14,8 @@
 static __always_inline int
 redirect_direct_v6(struct __ctx_buff *ctx __maybe_unused,
 		   int l3_off __maybe_unused,
-		   struct ipv6hdr *ip6 __maybe_unused, int *oif)
+		   struct ipv6hdr *ip6 __maybe_unused,
+		   int iif __maybe_unused, int *oif)
 {
 	bool no_neigh = is_defined(ENABLE_SKIP_FIB);
 	int ret;
@@ -23,7 +24,7 @@ redirect_direct_v6(struct __ctx_buff *ctx __maybe_unused,
 	struct bpf_redir_neigh nh_params;
 	struct bpf_fib_lookup fib_params = {
 		.family		= AF_INET6,
-		.ifindex	= ctx->ingress_ifindex,
+		.ifindex	= iif,
 	};
 
 	ipv6_addr_copy((union v6addr *)&fib_params.ipv6_src,
@@ -76,7 +77,8 @@ redirect_direct_v6(struct __ctx_buff *ctx __maybe_unused,
 static __always_inline int
 redirect_direct_v4(struct __ctx_buff *ctx __maybe_unused,
 		   int l3_off __maybe_unused,
-		   struct iphdr *ip4 __maybe_unused, int *oif)
+		   struct iphdr *ip4 __maybe_unused,
+		   int iif __maybe_unused, int *oif)
 {
 	/* For deployments with just single external dev, redirect_neigh()
 	 * will resolve the GW and do L2 resolution for us. For multi-device
@@ -91,7 +93,7 @@ redirect_direct_v4(struct __ctx_buff *ctx __maybe_unused,
 	struct bpf_redir_neigh nh_params;
 	struct bpf_fib_lookup fib_params = {
 		.family		= AF_INET,
-		.ifindex	= ctx->ingress_ifindex,
+		.ifindex	= iif,
 		.ipv4_src	= ip4->saddr,
 		.ipv4_dst	= ip4->daddr,
 	};


### PR DESCRIPTION
 * [ ] #24182 (@julianwiedmann )

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 24182; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=24182
```
