### PR TITLE
v1.11 Backports 2023-03-06

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -321,6 +321,10 @@
      - Install the CNI configuration and binary files into the filesystem.
      - bool
      - ``true``
+   * - cni.uninstall
+     - Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable.
+     - bool
+     - ``true``
    * - containerRuntime
      - Configure container runtime specific integration.
      - object

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -173,6 +173,7 @@ linked, either choice is valid.
         CONFIG_CRYPTO_USER_API_HASH=y
         CONFIG_CGROUPS=y
         CONFIG_CGROUP_BPF=y
+        CONFIG_PERF_EVENTS=y
 
 .. note::
 

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -250,7 +250,8 @@ func tcInterfaceCommands() ([]string, error) {
 	commands := []string{}
 	for _, iface := range ifaces {
 		commands = append(commands,
-			fmt.Sprintf("tc filter show dev %s", iface.Name),
+			fmt.Sprintf("tc filter show dev %s ingress", iface.Name),
+			fmt.Sprintf("tc filter show dev %s egress", iface.Name),
 			fmt.Sprintf("tc chain show dev %s", iface.Name),
 			fmt.Sprintf("tc class show dev %s", iface.Name))
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -131,6 +131,7 @@ contributors across the globe, there is almost always someone available to help.
 | cni.exclusive | bool | `true` | Make Cilium take ownership over the `/etc/cni/net.d` directory on the node, renaming all non-Cilium CNI configurations to `*.cilium_bak`. This ensures no Pods can be scheduled using other CNI plugins during Cilium agent downtime. |
 | cni.hostConfDirMountPath | string | `"/host/etc/cni/net.d"` | Configure the path to where the CNI configuration directory is mounted inside the agent pod. |
 | cni.install | bool | `true` | Install the CNI configuration and binary files into the filesystem. |
+| cni.uninstall | bool | `true` | Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable. |
 | containerRuntime | object | `{"integration":"none"}` | Configure container runtime specific integration. |
 | containerRuntime.integration | string | `"none"` | Enables specific integrations for container runtimes. Supported values: - containerd - crio - docker - none - auto (automatically detect the container runtime) |
 | customCalls | object | `{"enabled":false}` | Tail call hooks for custom eBPF programs. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -641,6 +641,9 @@ data:
 {{- else if .Values.cni.readCniConf }}
   read-cni-conf: {{ .Values.cni.readCniConf }}
 {{- end }}
+{{- if .Values.cni.uninstall }}
+  cni-uninstall: {{ .Values.cni.uninstall | quote }}
+{{- end }}
 {{- if .Values.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.kubeConfigPath | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -350,6 +350,12 @@ cni:
   # -- Install the CNI configuration and binary files into the filesystem.
   install: true
 
+  # -- Remove the CNI configuration and binary files on agent shutdown. Enable this
+  # if you're removing Cilium from the cluster. Disable this to prevent the CNI
+  # configuration file from being removed during agent upgrade, which can cause
+  # nodes to go unmanageable.
+  uninstall: true
+
   # -- Configure chaining on top of other CNI plugins. Possible values:
   #  - none
   #  - generic-veth

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -347,6 +347,12 @@ cni:
   # -- Install the CNI configuration and binary files into the filesystem.
   install: true
 
+  # -- Remove the CNI configuration and binary files on agent shutdown. Enable this
+  # if you're removing Cilium from the cluster. Disable this to prevent the CNI
+  # configuration file from being removed during agent upgrade, which can cause
+  # nodes to go unmanageable.
+  uninstall: true
+
   # -- Configure chaining on top of other CNI plugins. Possible values:
   #  - none
   #  - generic-veth

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -8,6 +8,11 @@ CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
 CNI_CONF_DIR=${CNI_CONF_DIR:-${HOST_PREFIX}/etc/cni/net.d}
 CILIUM_CUSTOM_CNI_CONF=${CILIUM_CUSTOM_CNI_CONF:-false}
 
+if [[ "$(cat /tmp/cilium/config-map/cni-uninstall 2>/dev/null || true)" != "true" ]]; then
+    echo "cni-uninstall disabled, not removing CNI configuration"
+    exit
+fi
+
 # Do not interact with the host's CNI directory when the user specified they
 # are managing CNI configs externally.
 if [ "${CILIUM_CUSTOM_CNI_CONF}" != "true" ]; then


### PR DESCRIPTION
v1.11 backports 2023-03-06

 - [x] #24057 -- bugtool: Add ingress/egress tc filter dump (@joestringer)
 - [x] #24055 -- docs: Document CONFIG_PERF_EVENTS requirement (@joestringer)
 - [x] #24009 -- cni: add option to keep CNI configuration file on agent shutdown (@squeed)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 24057 24055 24009; do contrib/backporting/set-labels.py $pr done 1.11; done
```