### PR TITLE
service cache should handle duplicate endpoints addresses

### DIFF
--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -414,7 +414,21 @@ func (es *EndpointSlices) GetEndpoints() *Endpoints {
 	allEps := newEndpoints()
 	for _, eps := range es.epSlices {
 		for backend, ep := range eps.Backends {
-			allEps.Backends[backend] = ep
+			// EndpointSlices may have duplicate addresses on different slices.
+			// kubectl get endpointslices -n endpointslicemirroring-4896
+			// NAME                             ADDRESSTYPE   PORTS   ENDPOINTS     AGE
+			// example-custom-endpoints-f6z84   IPv4          9090    10.244.1.49   28s
+			// example-custom-endpoints-g6r6v   IPv4          8090    10.244.1.49   28s
+			b, ok := allEps.Backends[backend]
+			if !ok {
+				allEps.Backends[backend] = ep
+			} else {
+				clone := b.DeepCopy()
+				for k, v := range ep.Ports {
+					clone.Ports[k] = v
+				}
+				allEps.Backends[backend] = clone
+			}
 		}
 	}
 	return allEps


### PR DESCRIPTION
In some corner cases, a group of endpointslices may have the same address duplicate in different slices.

Since the Endpoints are cached by address, when aggregating the endpoints, we should merge the content instead of overwriting.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Thanks for contributing!

<!-- Description of change -->

Kubernetes e2e test now passes

```
e2e.test -kubeconfig /tmp/kindkind -ginkgo.v --ginkgo.focus="should.mirror.a.custom.Endpoint.with.multiple.subsets.and.same.IP.address"
```

Fixes: #22446

```release-note
Solved an issue failing to forward traffic to Services if the Endpoint Slices had the same Address on different Slices
```
