### PR TITLE
Defer deletion of service backends to pod deletion.

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -906,6 +906,7 @@ func (k *K8sWatcher) deletePodHostData(pod *slim_corev1.Pod) (bool, error) {
 		}
 
 		k.ipcache.DeleteOnMetadataMatch(podIP, source.Kubernetes, pod.Namespace, pod.Name)
+		k.svcManager.DeleteBackendsByIP(podIP)
 	}
 
 	if len(errs) != 0 {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -145,6 +145,7 @@ type svcManager interface {
 	RegisterL7LBService(serviceName, resourceName loadbalancer.ServiceName, ports []string, proxyPort uint16) error
 	RegisterL7LBServiceBackendSync(serviceName, resourceName loadbalancer.ServiceName, ports []string) error
 	RemoveL7LBService(serviceName, resourceName loadbalancer.ServiceName) error
+	DeleteBackendsByIP(string) error
 }
 
 type redirectPolicyManager interface {


### PR DESCRIPTION
(Will need to add/fix tests here, but just wanted to open the PR for initial feedback on the proposed approach)

Currently backend entries are deleted from the map as soon
as the service refCount for a backend goes down to 0. This behavior has
the consequence of causing conntrack for any long-lived connections pointing
to those backends to break. There are valid uses cases to persist and
drain already established connections to backends, past when any services
actively point to them--such as changing the label-selector on a service
for blue-green rollouts, etc.

This commit defers the deletion of the backend map entries to when the
associated pod is deleted, thus allowing for long-lived connections to
any service backends to be drained.

Fixes: #23761

Signed-off-by: Yash Shetty <yashshetty@google.com>