### PR TITLE
helm: simplify TLS configuration of clustermesh peers 

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -785,11 +785,27 @@ spec:
       {{- end }}
         # To read the clustermesh configuration
       - name: clustermesh-secrets
-        secret:
-          secretName: cilium-clustermesh
+        projected:
           # note: the leading zero means this number is in octal representation: do not remove it
           defaultMode: 0400
-          optional: true
+          sources:
+          - secret:
+              name: cilium-clustermesh
+              optional: true
+              # note: items are not explicitly listed here, since the entries of this secret
+              # depend on the peers configured, and that would cause a restart of all agents
+              # at every addition/removal. Leaving the field empty makes each secret entry
+              # to be automatically projected into the volume as a file whose name is the key.
+          - secret:
+              name: clustermesh-apiserver-remote-cert
+              optional: true
+              items:
+              - key: tls.key
+                path: common-etcd-client.key
+              - key: tls.crt
+                path: common-etcd-client.crt
+              - key: ca.crt
+                path: common-etcd-client-ca.crt
       {{- if and .Values.ipMasqAgent .Values.ipMasqAgent.enabled }}
       - name: ip-masq-agent
         configMap:

--- a/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
@@ -1,14 +1,16 @@
 {{- define "clustermesh-config-generate-etcd-cfg" }}
 {{- $cluster := index . 0 -}}
 {{- $domain := index . 1 -}}
+{{- /* The parenthesis around $cluster.tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
+{{- $prefix := ternary "common-" (printf "%s." $cluster.name) (or (empty ($cluster.tls).cert) (empty ($cluster.tls).key)) -}}
 
 endpoints:
 {{- if $cluster.ips }}
 - https://{{ $cluster.name }}.{{ $domain }}:{{ $cluster.port }}
-{{ else }}
+{{- else }}
 - https://{{ $cluster.address | required "missing clustermesh.apiserver.config.clusters.address" }}:{{ $cluster.port }}
 {{- end }}
-trusted-ca-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client-ca.crt
-key-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client.key
-cert-file: /var/lib/cilium/clustermesh/{{ $cluster.name }}.etcd-client.crt
+trusted-ca-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client-ca.crt
+key-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client.key
+cert-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client.crt
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -10,7 +10,7 @@ data:
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
   {{- if and (.tls).cert (.tls).key }}
-  {{ .name }}.etcd-client-ca.crt: {{ $.Values.clustermesh.apiserver.tls.ca.cert }}
+  {{ .name }}.etcd-client-ca.crt: {{ .tls.caCert | default $.Values.clustermesh.apiserver.tls.ca.cert }}
   {{ .name }}.etcd-client.key: {{ .tls.key }}
   {{ .name }}.etcd-client.crt: {{ .tls.cert }}
   {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -8,8 +8,11 @@ metadata:
 data:
   {{- range .Values.clustermesh.config.clusters }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain) | b64enc }}
+  {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
+  {{- if and (.tls).cert (.tls).key }}
   {{ .name }}.etcd-client-ca.crt: {{ $.Values.clustermesh.apiserver.tls.ca.cert }}
   {{ .name }}.etcd-client.key: {{ .tls.key }}
   {{ .name }}.etcd-client.crt: {{ .tls.cert }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2289,6 +2289,7 @@ clustermesh:
     #   tls:
     #     cert: ""
     #     key: ""
+    #     caCert: ""
 
   apiserver:
     # -- Clustermesh API server image.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2284,6 +2284,8 @@ clustermesh:
     #   ips:
     #   - 172.18.255.201
     # # -- base64 encoded PEM values for the cluster client certificate, private key and certificate authority.
+    # # These fields can (and should) be omitted in case the CA is shared across clusters. In that case, the
+    # # "remote" private key and certificate available in the local cluster are automatically used instead.
     #   tls:
     #     cert: ""
     #     key: ""

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2286,6 +2286,7 @@ clustermesh:
     #   tls:
     #     cert: ""
     #     key: ""
+    #     caCert: ""
 
   apiserver:
     # -- Clustermesh API server image.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2281,6 +2281,8 @@ clustermesh:
     #   ips:
     #   - 172.18.255.201
     # # -- base64 encoded PEM values for the cluster client certificate, private key and certificate authority.
+    # # These fields can (and should) be omitted in case the CA is shared across clusters. In that case, the
+    # # "remote" private key and certificate available in the local cluster are automatically used instead.
     #   tls:
     #     cert: ""
     #     key: ""


### PR DESCRIPTION
This PR introduces two main changes
1. Avoid the need to specify the TLS config for clustermesh peers in case of shared CA
2. Allow to override the CA on a per-peer basis, required in case of non-shared CA

Please, refer to the individual commits for more details.

<!-- Description of change -->

```release-note
helm: simplify TLS configuration of clustermesh peers 
```
