### PR TITLE
Operator api server modularization

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -115,6 +115,7 @@ cilium-agent [flags]
       --enable-ipv6-big-tcp                                     Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits
       --enable-ipv6-masquerade                                  Masquerade IPv6 traffic from endpoints leaving the host (default true)
       --enable-ipv6-ndp                                         Enable IPv6 NDP support
+      --enable-k8s                                              Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                                Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                               Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                               Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -15,6 +15,7 @@ cilium-agent hive [flags]
       --cni-chaining-mode string               Enable CNI chaining with the specified plugin (default "none")
       --cni-exclusive                          Whether to remove other CNI configurations
       --cni-log-file string                    Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
+      --enable-k8s                             Enable the k8s clientset (default true)
       --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                       Port for gops server to listen on (default 9890)
   -h, --help                                   help for hive

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -21,6 +21,7 @@ cilium-agent hive dot-graph [flags]
       --cni-chaining-mode string               Enable CNI chaining with the specified plugin (default "none")
       --cni-exclusive                          Whether to remove other CNI configurations
       --cni-log-file string                    Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
+      --enable-k8s                             Enable the k8s clientset (default true)
       --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                       Port for gops server to listen on (default 9890)
       --install-egress-gateway-routes          Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -33,7 +33,7 @@ cilium-operator-alibabacloud [flags]
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -28,6 +28,7 @@ cilium-operator-alibabacloud hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -11,6 +11,7 @@ cilium-operator-alibabacloud hive [flags]
 ### Options
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -33,6 +33,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -37,7 +37,7 @@ cilium-operator-aws [flags]
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -28,6 +28,7 @@ cilium-operator-aws hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -11,6 +11,7 @@ cilium-operator-aws hive [flags]
 ### Options
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -33,6 +33,7 @@ cilium-operator-aws hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator-aws hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -36,7 +36,7 @@ cilium-operator-azure [flags]
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -28,6 +28,7 @@ cilium-operator-azure hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -11,6 +11,7 @@ cilium-operator-azure hive [flags]
 ### Options
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator-azure hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -33,6 +33,7 @@ cilium-operator-azure hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -32,7 +32,7 @@ cilium-operator-generic [flags]
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -28,6 +28,7 @@ cilium-operator-generic hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -11,6 +11,7 @@ cilium-operator-generic hive [flags]
 ### Options
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -33,6 +33,7 @@ cilium-operator-generic hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator-generic hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -42,7 +42,7 @@ cilium-operator [flags]
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
-      --enable-k8s                                           Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes (default true)
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature into Cilium-Operator if the k8s cluster supports it (default true)
       --enable-k8s-event-handover                            Enable k8s event handover to kvstore for improved scalability

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -28,6 +28,7 @@ cilium-operator hive [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -11,6 +11,7 @@ cilium-operator hive [flags]
 ### Options
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -33,6 +33,7 @@ cilium-operator hive dot-graph [flags]
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)

--- a/Documentation/cmdref/cilium_build-config.md
+++ b/Documentation/cmdref/cilium_build-config.md
@@ -14,6 +14,7 @@ cilium build-config --node-name $K8S_NODE_NAME [flags]
       --allow-config-keys strings        List of configuration keys that are allowed to be overridden (e.g. set from not the first source. Takes precedence over deny-config-keys
       --deny-config-keys strings         List of configuration keys that are not allowed to be overridden (e.g. set from not the first source. If allow-config-keys is set, this field is ignored
       --dest string                      Destination directory to write the fully-resolved configuration. (default "/tmp/cilium/config-map")
+      --enable-k8s                       Enable the k8s clientset (default true)
       --enable-k8s-api-discovery         Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                             help for build-config
       --k8s-api-server string            Kubernetes API server URL

--- a/Documentation/cmdref/cilium_preflight_migrate-identity.md
+++ b/Documentation/cmdref/cilium_preflight_migrate-identity.md
@@ -22,6 +22,7 @@ cilium preflight migrate-identity [flags]
 ### Options
 
 ```
+      --enable-k8s                       Enable the k8s clientset (default true)
       --enable-k8s-api-discovery         Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                             help for migrate-identity
       --k8s-api-server string            Kubernetes API server URL

--- a/Documentation/cmdref/cilium_preflight_validate-cnp.md
+++ b/Documentation/cmdref/cilium_preflight_validate-cnp.md
@@ -18,6 +18,7 @@ cilium preflight validate-cnp [flags]
 ### Options
 
 ```
+      --enable-k8s                       Enable the k8s clientset (default true)
       --enable-k8s-api-discovery         Enable discovery of Kubernetes API groups and resources with the discovery API
   -h, --help                             help for validate-cnp
       --k8s-api-server string            Kubernetes API server URL

--- a/api/v1/operator/client/operator/get_healthz_responses.go
+++ b/api/v1/operator/client/operator/get_healthz_responses.go
@@ -36,6 +36,12 @@ func (o *GetHealthzReader) ReadResponse(response runtime.ClientResponse, consume
 			return nil, err
 		}
 		return nil, result
+	case 501:
+		result := NewGetHealthzNotImplemented()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	default:
 		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
 	}
@@ -154,6 +160,67 @@ func (o *GetHealthzInternalServerError) GetPayload() string {
 }
 
 func (o *GetHealthzInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	// response payload
+	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewGetHealthzNotImplemented creates a GetHealthzNotImplemented with default headers values
+func NewGetHealthzNotImplemented() *GetHealthzNotImplemented {
+	return &GetHealthzNotImplemented{}
+}
+
+/*
+GetHealthzNotImplemented describes a response with status code 501, with default header values.
+
+Cilium operator health status not available
+*/
+type GetHealthzNotImplemented struct {
+	Payload string
+}
+
+// IsSuccess returns true when this get healthz not implemented response has a 2xx status code
+func (o *GetHealthzNotImplemented) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this get healthz not implemented response has a 3xx status code
+func (o *GetHealthzNotImplemented) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this get healthz not implemented response has a 4xx status code
+func (o *GetHealthzNotImplemented) IsClientError() bool {
+	return false
+}
+
+// IsServerError returns true when this get healthz not implemented response has a 5xx status code
+func (o *GetHealthzNotImplemented) IsServerError() bool {
+	return true
+}
+
+// IsCode returns true when this get healthz not implemented response a status code equal to that given
+func (o *GetHealthzNotImplemented) IsCode(code int) bool {
+	return code == 501
+}
+
+func (o *GetHealthzNotImplemented) Error() string {
+	return fmt.Sprintf("[GET /healthz][%d] getHealthzNotImplemented  %+v", 501, o.Payload)
+}
+
+func (o *GetHealthzNotImplemented) String() string {
+	return fmt.Sprintf("[GET /healthz][%d] getHealthzNotImplemented  %+v", 501, o.Payload)
+}
+
+func (o *GetHealthzNotImplemented) GetPayload() string {
+	return o.Payload
+}
+
+func (o *GetHealthzNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {

--- a/api/v1/operator/openapi.yaml
+++ b/api/v1/operator/openapi.yaml
@@ -46,3 +46,7 @@ paths:
           description: Cilium operator is not healthy
           schema:
             type: string
+        '501':
+          description: Cilium operator health status not available
+          schema:
+            type: string

--- a/api/v1/operator/server/embedded_spec.go
+++ b/api/v1/operator/server/embedded_spec.go
@@ -57,6 +57,12 @@ func init() {
             "schema": {
               "type": "string"
             }
+          },
+          "501": {
+            "description": "Cilium operator health status not available",
+            "schema": {
+              "type": "string"
+            }
           }
         }
       }
@@ -123,6 +129,12 @@ func init() {
           },
           "500": {
             "description": "Cilium operator is not healthy",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "501": {
+            "description": "Cilium operator health status not available",
             "schema": {
               "type": "string"
             }

--- a/api/v1/operator/server/restapi/operator/get_healthz_responses.go
+++ b/api/v1/operator/server/restapi/operator/get_healthz_responses.go
@@ -99,3 +99,46 @@ func (o *GetHealthzInternalServerError) WriteResponse(rw http.ResponseWriter, pr
 		panic(err) // let the recovery middleware deal with this
 	}
 }
+
+// GetHealthzNotImplementedCode is the HTTP code returned for type GetHealthzNotImplemented
+const GetHealthzNotImplementedCode int = 501
+
+/*
+GetHealthzNotImplemented Cilium operator health status not available
+
+swagger:response getHealthzNotImplemented
+*/
+type GetHealthzNotImplemented struct {
+
+	/*
+	  In: Body
+	*/
+	Payload string `json:"body,omitempty"`
+}
+
+// NewGetHealthzNotImplemented creates GetHealthzNotImplemented with default headers values
+func NewGetHealthzNotImplemented() *GetHealthzNotImplemented {
+
+	return &GetHealthzNotImplemented{}
+}
+
+// WithPayload adds the payload to the get healthz not implemented response
+func (o *GetHealthzNotImplemented) WithPayload(payload string) *GetHealthzNotImplemented {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the get healthz not implemented response
+func (o *GetHealthzNotImplemented) SetPayload(payload string) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *GetHealthzNotImplemented) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(501)
+	payload := o.Payload
+	if err := producer.Produce(rw, payload); err != nil {
+		panic(err) // let the recovery middleware deal with this
+	}
+}

--- a/operator/api/cell.go
+++ b/operator/api/cell.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+// SharedConfig contains the configuration that is shared between
+// this module and others.
+// This is done to avoid polluting this module with a direct dependency
+// on global operator configuration.
+type SharedConfig struct {
+	EnableK8s bool
+}

--- a/operator/api/cell.go
+++ b/operator/api/cell.go
@@ -39,11 +39,3 @@ type Config struct {
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.String(OperatorAPIServeAddr, OperatorAPIServeAddrDefault, "Address to serve API requests")
 }
-
-// SharedConfig contains the configuration that is shared between
-// this module and others.
-// This is done to avoid polluting this module with a direct dependency
-// on global operator configuration.
-type SharedConfig struct {
-	EnableK8s bool
-}

--- a/operator/api/cell.go
+++ b/operator/api/cell.go
@@ -3,6 +3,43 @@
 
 package api
 
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+const (
+	// OperatorAPIServeAddr is the "<ip>:<port>" on which to serve api requests
+	// from the operator.
+	// Use ":<port>" to bind on all interfaces.
+	// Use an empty string to bind on both "127.0.0.1:0" and "[::1]:0".
+	OperatorAPIServeAddr = "operator-api-serve-addr"
+)
+
+const (
+	// OperatorAPIServeAddrDefault is the default "<ip>:<port>" value on which to serve
+	// api requests from the operator.
+	OperatorAPIServeAddrDefault = "localhost:9234"
+)
+
+var ServerCell = cell.Module(
+	"cilium-operator-api",
+	"Cilium Operator API Server",
+
+	cell.Config(Config{}),
+	cell.Provide(newServer),
+	cell.Invoke(func(Server) {}),
+)
+
+type Config struct {
+	OperatorAPIServeAddr string
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.String(OperatorAPIServeAddr, OperatorAPIServeAddrDefault, "Address to serve API requests")
+}
+
 // SharedConfig contains the configuration that is shared between
 // this module and others.
 // This is done to avoid polluting this module with a direct dependency

--- a/operator/api/health.go
+++ b/operator/api/health.go
@@ -30,9 +30,8 @@ func HealthHandlerCell(
 		cell.Provide(func(
 			clientset k8sClient.Clientset,
 			logger logrus.FieldLogger,
-			cfg SharedConfig,
 		) operator.GetHealthzHandler {
-			if !cfg.EnableK8s || !clientset.IsEnabled() {
+			if !clientset.IsEnabled() {
 				return &healthHandler{
 					enabled: false,
 				}

--- a/operator/api/health.go
+++ b/operator/api/health.go
@@ -16,31 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 )
 
-type getHealthz struct {
-	*Server
-}
-
-// NewGetHealthzHandler handles health requests.
-func NewGetHealthzHandler(s *Server) operator.GetHealthzHandler {
-	return &getHealthz{Server: s}
-}
-
-// Handle handles GET requests for /healthz .
-func (h *getHealthz) Handle(params operator.GetHealthzParams) middleware.Responder {
-	select {
-	// only start serving the real health check once all systems all up and running
-	case <-h.Server.allSystemsGo:
-		if err := h.Server.checkStatus(); err != nil {
-			log.WithError(err).Warn("Health check status")
-
-			return operator.NewGetHealthzInternalServerError().WithPayload(err.Error())
-		}
-	default:
-	}
-
-	return operator.NewGetHealthzOK().WithPayload("ok")
-}
-
 type kvstoreEnabledFunc func() bool
 
 func HealthHandlerCell(kvstoreEnabled kvstoreEnabledFunc) cell.Cell {

--- a/operator/api/health.go
+++ b/operator/api/health.go
@@ -4,9 +4,16 @@
 package api
 
 import (
+	"errors"
+
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/discovery"
 
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/kvstore"
 )
 
 type getHealthz struct {
@@ -32,4 +39,68 @@ func (h *getHealthz) Handle(params operator.GetHealthzParams) middleware.Respond
 	}
 
 	return operator.NewGetHealthzOK().WithPayload("ok")
+}
+
+type kvstoreEnabledFunc func() bool
+
+func HealthHandlerCell(kvstoreEnabled kvstoreEnabledFunc) cell.Cell {
+	return cell.Module(
+		"health-handler",
+		"Operator health HTTP handler",
+
+		cell.Provide(func(
+			clientset k8sClient.Clientset,
+			logger logrus.FieldLogger,
+			cfg SharedConfig,
+		) operator.GetHealthzHandler {
+			if !cfg.EnableK8s || !clientset.IsEnabled() {
+				return &healthHandler{
+					enabled: false,
+				}
+			}
+
+			return &healthHandler{
+				enabled:        true,
+				kvstoreEnabled: kvstoreEnabled,
+				discovery:      clientset.Discovery(),
+				log:            logger,
+			}
+		}),
+	)
+}
+
+type healthHandler struct {
+	enabled        bool
+	discovery      discovery.DiscoveryInterface
+	kvstoreEnabled kvstoreEnabledFunc
+	log            logrus.FieldLogger
+}
+
+func (h *healthHandler) Handle(params operator.GetHealthzParams) middleware.Responder {
+	if !h.enabled {
+		return operator.NewGetHealthzNotImplemented()
+	}
+
+	if err := h.checkStatus(); err != nil {
+		h.log.WithError(err).Warn("Health check status")
+		return operator.NewGetHealthzInternalServerError().WithPayload(err.Error())
+	}
+
+	return operator.NewGetHealthzOK().WithPayload("ok")
+}
+
+// checkStatus verifies the connection status to the kvstore and the
+// k8s apiserver and returns an error if any of them is unhealthy
+func (h *healthHandler) checkStatus() error {
+	if h.kvstoreEnabled() {
+		client := kvstore.Client()
+		if client == nil {
+			return errors.New("kvstore client not configured")
+		}
+		if _, err := client.Status(); err != nil {
+			return err
+		}
+	}
+	_, err := h.discovery.ServerVersion()
+	return err
 }

--- a/operator/api/health_test.go
+++ b/operator/api/health_test.go
@@ -40,6 +40,9 @@ func TestHealthHandlerK8sDisabled(t *testing.T) {
 			func() bool {
 				return false
 			},
+			func() bool {
+				return false
+			},
 		),
 
 		// transform GetHealthzHandler in a http.HandlerFunc to use
@@ -88,6 +91,9 @@ func TestHealthHandlerK8sEnabled(t *testing.T) {
 		}),
 
 		HealthHandlerCell(
+			func() bool {
+				return false
+			},
 			func() bool {
 				return false
 			},

--- a/operator/api/health_test.go
+++ b/operator/api/health_test.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/safeio"
+)
+
+func TestHealthHandlerK8sDisabled(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
+		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
+		goleak.IgnoreTopFunction("time.Sleep"),
+	)
+
+	rr := httptest.NewRecorder()
+
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		cell.Provide(func() SharedConfig {
+			return SharedConfig{
+				EnableK8s: false,
+			}
+		}),
+
+		HealthHandlerCell(
+			func() bool {
+				return false
+			},
+		),
+
+		// transform GetHealthzHandler in a http.HandlerFunc to use
+		// the http package testing facilities
+		cell.Provide(func(h operator.GetHealthzHandler) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				res := h.Handle(operator.GetHealthzParams{})
+				res.WriteResponse(w, runtime.TextProducer())
+			}
+		}),
+
+		cell.Invoke(func(hf http.HandlerFunc) {
+			req := httptest.NewRequest(http.MethodGet, "http://localhost/healthz", nil)
+			hf.ServeHTTP(rr, req)
+		}),
+	)
+
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if rr.Result().StatusCode != http.StatusNotImplemented {
+		t.Fatalf("expected http status code %d, got %d", http.StatusNotImplemented, rr.Result().StatusCode)
+	}
+
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func TestHealthHandlerK8sEnabled(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
+		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
+		goleak.IgnoreTopFunction("time.Sleep"),
+	)
+
+	rr := httptest.NewRecorder()
+
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		cell.Provide(func() SharedConfig {
+			return SharedConfig{
+				EnableK8s: true,
+			}
+		}),
+
+		HealthHandlerCell(
+			func() bool {
+				return false
+			},
+		),
+
+		// transform GetHealthzHandler in a http.HandlerFunc to use
+		// the http package testing facilities
+		cell.Provide(func(h operator.GetHealthzHandler) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				res := h.Handle(operator.GetHealthzParams{})
+				res.WriteResponse(w, runtime.TextProducer())
+			}
+		}),
+
+		cell.Invoke(func(hf http.HandlerFunc) {
+			req := httptest.NewRequest(http.MethodGet, "http://localhost/healthz", nil)
+			hf.ServeHTTP(rr, req)
+		}),
+	)
+
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected http status code %d, got %d", http.StatusOK, rr.Result().StatusCode)
+	}
+
+	body, err := safeio.ReadAllLimit(rr.Result().Body, safeio.KB)
+	if err != nil {
+		t.Fatalf("error while reading response body: %s", err)
+	}
+	rr.Result().Body.Close()
+
+	if string(body) != "ok" {
+		t.Fatalf("expected response body %q, got: %q", "ok", string(body))
+	}
+
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}

--- a/operator/api/health_test.go
+++ b/operator/api/health_test.go
@@ -30,10 +30,8 @@ func TestHealthHandlerK8sDisabled(t *testing.T) {
 
 	hive := hive.New(
 		k8sClient.FakeClientCell,
-		cell.Provide(func() SharedConfig {
-			return SharedConfig{
-				EnableK8s: false,
-			}
+		cell.Invoke(func(cs *k8sClient.FakeClientset) {
+			cs.Disable()
 		}),
 
 		HealthHandlerCell(
@@ -84,11 +82,6 @@ func TestHealthHandlerK8sEnabled(t *testing.T) {
 
 	hive := hive.New(
 		k8sClient.FakeClientCell,
-		cell.Provide(func() SharedConfig {
-			return SharedConfig{
-				EnableK8s: true,
-			}
-		}),
 
 		HealthHandlerCell(
 			func() bool {

--- a/operator/api/metrics.go
+++ b/operator/api/metrics.go
@@ -11,25 +11,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 )
 
-type getMetrics struct {
-	*Server
-}
-
-// NewGetMetricsHandler handles metrics requests.
-func NewGetMetricsHandler(s *Server) metrics.GetMetricsHandler {
-	return &getMetrics{Server: s}
-}
-
-// Handle handles GET requests for /metrics/ .
-func (h *getMetrics) Handle(params metrics.GetMetricsParams) middleware.Responder {
-	m, err := opMetrics.DumpMetrics()
-	if err != nil {
-		return metrics.NewGetMetricsFailed()
-	}
-
-	return metrics.NewGetMetricsOK().WithPayload(m)
-}
-
 var MetricsHandlerCell = cell.Module(
 	"metrics-handler",
 	"Operator metrics HTTP handler",

--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/api/v1/operator/models"
+	"github.com/cilium/cilium/api/v1/operator/server/restapi/metrics"
+	operatorMetrics "github.com/cilium/cilium/operator/metrics"
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/safeio"
+)
+
+func TestMetricsHandlerWithoutMetrics(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
+		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
+		goleak.IgnoreTopFunction("time.Sleep"),
+	)
+
+	rr := httptest.NewRecorder()
+
+	hive := hive.New(
+		MetricsHandlerCell,
+
+		// transform GetMetricsHandler in a http.HandlerFunc to use
+		// the http package testing facilities
+		cell.Provide(func(h metrics.GetMetricsHandler) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				res := h.Handle(metrics.GetMetricsParams{})
+				res.WriteResponse(w, runtime.TextProducer())
+			}
+		}),
+
+		cell.Invoke(func(hf http.HandlerFunc) {
+			req := httptest.NewRequest(http.MethodGet, "http://localhost/metrics", nil)
+			hf.ServeHTTP(rr, req)
+		}),
+	)
+
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected http status code %d, got %d", http.StatusOK, rr.Result().StatusCode)
+	}
+
+	body, err := safeio.ReadAllLimit(rr.Result().Body, safeio.KB)
+	if err != nil {
+		t.Fatalf("error while reading response body: %s", err)
+	}
+	rr.Result().Body.Close()
+
+	var metrics []models.Metric
+	if err := json.Unmarshal(body, &metrics); err != nil {
+		t.Fatalf("error while unmarshaling response body: %s", err)
+	}
+
+	if len(metrics) != 0 {
+		t.Fatalf("no metrics expected, found %v", metrics)
+	}
+
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func TestMetricsHandlerWithMetrics(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
+		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
+		goleak.IgnoreTopFunction("time.Sleep"),
+	)
+
+	rr := httptest.NewRecorder()
+
+	hive := hive.New(
+		MetricsHandlerCell,
+
+		// transform GetMetricsHandler in a http.HandlerFunc to use
+		// the http package testing facilities
+		cell.Provide(func(h metrics.GetMetricsHandler) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				res := h.Handle(metrics.GetMetricsParams{})
+				res.WriteResponse(w, runtime.TextProducer())
+			}
+		}),
+
+		cell.Invoke(func(lc hive.Lifecycle, hf http.HandlerFunc) {
+			lc.Append(hive.Hook{
+				OnStart: func(hive.HookContext) error {
+					// registering the metrics for the operator will start the
+					// prometheus server. To avoid port clashing while testing,
+					// let the kernel pick an available port.
+					operatorOption.Config.OperatorPrometheusServeAddr = "localhost:0"
+
+					// registers metrics for the cilium-operator
+					operatorMetrics.Register()
+
+					// set values for some operator metrics
+					operatorMetrics.IdentityGCSize.
+						WithLabelValues(operatorMetrics.LabelValueOutcomeAlive).
+						Set(float64(12))
+					operatorMetrics.IdentityGCRuns.
+						WithLabelValues(operatorMetrics.LabelValueOutcomeSuccess).
+						Set(float64(15))
+					operatorMetrics.EndpointGCObjects.
+						WithLabelValues(operatorMetrics.LabelValueOutcomeSuccess).
+						Inc()
+
+					req := httptest.NewRequest(http.MethodGet, "http://localhost/metrics", nil)
+					hf.ServeHTTP(rr, req)
+
+					return nil
+				},
+				OnStop: func(ctx hive.HookContext) error {
+					// unregister metrics for cilium-operator
+					operatorMetrics.Unregister()
+
+					return nil
+				},
+			})
+		}),
+	)
+
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Fatalf("expected http status code %d, got %d", http.StatusOK, rr.Result().StatusCode)
+	}
+
+	body, err := safeio.ReadAllLimit(rr.Result().Body, safeio.MB)
+	if err != nil {
+		t.Fatalf("error while reading response body: %s", err)
+	}
+	rr.Result().Body.Close()
+
+	var metrics []models.Metric
+	if err := json.Unmarshal(body, &metrics); err != nil {
+		t.Fatalf("error while unmarshaling response body: %s", err)
+	}
+
+	if err := testMetric(
+		metrics,
+		"cilium_operator_identity_gc_entries",
+		float64(12),
+		map[string]string{
+			operatorMetrics.LabelStatus: operatorMetrics.LabelValueOutcomeAlive,
+		},
+	); err != nil {
+		t.Fatalf("error while inspecting metric: %s", err)
+	}
+	if err := testMetric(
+		metrics,
+		"cilium_operator_identity_gc_runs",
+		float64(15),
+		map[string]string{
+			operatorMetrics.LabelOutcome: operatorMetrics.LabelValueOutcomeSuccess,
+		},
+	); err != nil {
+		t.Fatalf("error while inspecting metric: %s", err)
+	}
+	if err := testMetric(
+		metrics,
+		"cilium_operator_endpoint_gc_objects",
+		float64(1),
+		map[string]string{
+			operatorMetrics.LabelOutcome: operatorMetrics.LabelValueOutcomeSuccess,
+		},
+	); err != nil {
+		t.Fatalf("error while inspecting metric: %s", err)
+	}
+
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func testMetric(metrics []models.Metric, name string, value float64, labels map[string]string,
+) error {
+	for _, metric := range metrics {
+		if metric.Name == name {
+			if metric.Value != value {
+				return fmt.Errorf("expected value %f for %q, got %f", value, name, metric.Value)
+			}
+			if !reflect.DeepEqual(metric.Labels, labels) {
+				return fmt.Errorf("expected labels map %v for %q, got %v", labels, name, metric.Labels)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("%q not found", name)
+}

--- a/operator/api/server.go
+++ b/operator/api/server.go
@@ -33,8 +33,7 @@ type Server interface {
 type params struct {
 	cell.In
 
-	Cfg       Config
-	SharedCfg SharedConfig
+	Cfg Config
 
 	HealthHandler  operator.GetHealthzHandler
 	MetricsHandler metrics.GetMetricsHandler
@@ -66,10 +65,6 @@ type httpServer struct {
 func newServer(
 	p params,
 ) (Server, error) {
-	if !p.SharedCfg.EnableK8s {
-		return nil, nil
-	}
-
 	server := &server{
 		logger:         p.Logger,
 		shutdowner:     p.Shutdowner,

--- a/operator/api/server.go
+++ b/operator/api/server.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -13,161 +12,158 @@ import (
 
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
 	operatorApi "github.com/cilium/cilium/api/v1/operator/server"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi"
+	"github.com/cilium/cilium/api/v1/operator/server/restapi/metrics"
 	"github.com/cilium/cilium/api/v1/operator/server/restapi/operator"
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
 )
 
-var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "cilium-operator-api")
+type Server interface {
+	// Ports returns the ports at which the server is listening
+	Ports() []int
+}
 
-	noOpFunc = func() error {
-		return nil
-	}
-)
+// params contains all the dependencies for the api server.
+// They will be provided through dependency injection.
+type params struct {
+	cell.In
 
-// Server is the type corresponding to cilium-operator apiserver.
-type Server struct {
+	Cfg       Config
+	SharedCfg SharedConfig
+
+	HealthHandler  operator.GetHealthzHandler
+	MetricsHandler metrics.GetMetricsHandler
+
+	Logger     logrus.FieldLogger
+	Lifecycle  hive.Lifecycle
+	Shutdowner hive.Shutdowner
+}
+
+type server struct {
 	operatorApi.Server
 
-	shutdownSignal <-chan struct{}
-	allSystemsGo   <-chan struct{}
+	logger     logrus.FieldLogger
+	shutdowner hive.Shutdowner
 
-	checkStatus func() error
+	address  string
+	httpSrvs []httpServer
 
-	// This is the /healthz handler outside of the open-api spec.
-	healthzHandler *getHealthz
-
-	listenAddrs []string
+	healthHandler  operator.GetHealthzHandler
+	metricsHandler metrics.GetMetricsHandler
 }
 
-// newServer instantiates a new instance of the cilium-operator API server.
-func (s *Server) newServer(spec *loads.Document) *operatorApi.Server {
-	api := restapi.NewCiliumOperatorAPI(spec)
-	api.Logger = log.Debugf
-
-	// Register API handlers for the operator apiserver
-	api.OperatorGetHealthzHandler = NewGetHealthzHandler(s)
-	api.MetricsGetMetricsHandler = NewGetMetricsHandler(s)
-
-	srv := operatorApi.NewServer(api)
-	srv.EnabledListeners = []string{"http"}
-
-	srv.ConfigureAPI()
-
-	return srv
+type httpServer struct {
+	address  string
+	listener net.Listener
+	server   *http.Server
 }
 
-// NewServer creates a server to handle cilium-operator requests.
-func NewServer(shutdownSignal <-chan struct{}, allSystemsGo <-chan struct{}, addrs ...string) (*Server, error) {
-	server := &Server{
-		listenAddrs: addrs,
-
-		shutdownSignal: shutdownSignal,
-		allSystemsGo:   allSystemsGo,
-
-		checkStatus: noOpFunc,
+func newServer(
+	p params,
+) (Server, error) {
+	if !p.SharedCfg.EnableK8s {
+		return nil, nil
 	}
 
-	server.healthzHandler = &getHealthz{Server: server}
-
-	swaggerSpec, err := loads.Analyzed(operatorApi.SwaggerJSON, "")
-	if err != nil {
-		return nil, err
+	server := &server{
+		logger:         p.Logger,
+		shutdowner:     p.Shutdowner,
+		address:        p.Cfg.OperatorAPIServeAddr,
+		healthHandler:  p.HealthHandler,
+		metricsHandler: p.MetricsHandler,
 	}
+	p.Lifecycle.Append(server)
 
-	server.Server = *server.newServer(swaggerSpec)
 	return server, nil
 }
 
-// WithStatusCheckFunc returns the server configuring the check status function
-// to return the health of the operator.
-func (s *Server) WithStatusCheckFunc(f func() error) *Server {
-	s.checkStatus = f
-	return s
-}
-
-// StartServer starts the HTTP listeners for the apiserver.
-func (s *Server) StartServer() error {
-	errs := make(chan error, 1)
-	nServers := 0
-
-	// Since we are opening this on localhost only, we need to make sure
-	// we can open for both v4 and v6 localhost. In case the user is running
-	// v4-only or v6-only.
-	for _, addr := range s.listenAddrs {
-		if addr == "" {
-			continue
-		}
-		nServers++
-
-		mux := http.NewServeMux()
-
-		// Index handler is the the handler for Open-API router.
-		mux.Handle("/", s.Server.GetHandler())
-		// Create a custom handler for /healthz as an alias to /v1/healthz. A http mux
-		// is required for this because open-api spec does not allow multiple base paths
-		// to be specified.
-		mux.HandleFunc("/healthz", func(rw http.ResponseWriter, _ *http.Request) {
-			resp := s.healthzHandler.Handle(operator.GetHealthzParams{})
-			resp.WriteResponse(rw, runtime.TextProducer())
-		})
-
-		srv := &http.Server{
-			Addr:    addr,
-			Handler: mux,
-		}
-		errCh := make(chan error, 1)
-
-		lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
-		ln, err := lc.Listen(context.Background(), "tcp", addr)
-		if err != nil {
-			log.WithError(err).Fatalf("Unable to listen on %s for healthz apiserver", addr)
-		}
-
-		go func() {
-			err := srv.Serve(ln)
-			if err != nil {
-				// If the error is due to the server being shutdown, then send nil to
-				// the server errors channel.
-				if errors.Is(err, http.ErrServerClosed) {
-					log.WithField("address", addr).Debug("Operator API server closed")
-					errs <- nil
-				} else {
-					errCh <- err
-					errs <- err
-				}
-			}
-		}()
-
-		go func() {
-			select {
-			case <-s.shutdownSignal:
-				if err := srv.Shutdown(context.Background()); err != nil {
-					log.WithError(err).Error("apiserver shutdown")
-				}
-			case err := <-errCh:
-				log.WithError(err).Warn("Unable to start operator API server")
-			}
-		}()
-
-		log.Infof("Starting apiserver on address %s", addr)
+func (s *server) Start(ctx hive.HookContext) error {
+	spec, err := loads.Analyzed(operatorApi.SwaggerJSON, "")
+	if err != nil {
+		return err
 	}
 
-	var retErr error
-	for err := range errs {
-		if err != nil {
-			retErr = err
-		}
+	api := restapi.NewCiliumOperatorAPI(spec)
+	api.Logger = s.logger.Debugf
+	api.OperatorGetHealthzHandler = s.healthHandler
+	api.MetricsGetMetricsHandler = s.metricsHandler
 
-		nServers--
-		if nServers == 0 {
-			return retErr
+	srv := operatorApi.NewServer(api)
+	srv.EnabledListeners = []string{"http"}
+	srv.ConfigureAPI()
+	s.Server = *srv
+
+	mux := http.NewServeMux()
+
+	// Index handler is the the handler for Open-API router.
+	mux.Handle("/", s.Server.GetHandler())
+	// Create a custom handler for /healthz as an alias to /v1/healthz. A http mux
+	// is required for this because open-api spec does not allow multiple base paths
+	// to be specified.
+	mux.HandleFunc("/healthz", func(rw http.ResponseWriter, _ *http.Request) {
+		resp := s.healthHandler.Handle(operator.GetHealthzParams{})
+		resp.WriteResponse(rw, runtime.TextProducer())
+	})
+
+	if s.address == "" {
+		// Since we are opening this on localhost only, we need to make sure
+		// we can open for both v4 and v6 localhost, in case the user is running
+		// v4-only or v6-only.
+		s.httpSrvs = make([]httpServer, 2)
+		s.httpSrvs[0].address = "127.0.0.1:0"
+		s.httpSrvs[1].address = "[::1]:0"
+	} else {
+		s.httpSrvs = make([]httpServer, 1)
+		s.httpSrvs[0].address = s.address
+	}
+
+	var errs []error
+	for i := range s.httpSrvs {
+		lc := net.ListenConfig{Control: setsockoptReuseAddrAndPort}
+		ln, err := lc.Listen(ctx, "tcp", s.httpSrvs[i].address)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("unable to listen on %s: %w", s.httpSrvs[i].address, err))
+			continue
 		}
+		s.httpSrvs[i].listener = ln
+
+		s.logger.WithFields(logrus.Fields{
+			fmt.Sprintf("address-%d", i): ln.Addr().String(),
+		})
+
+		s.httpSrvs[i].server = &http.Server{
+			Addr:    s.httpSrvs[i].address,
+			Handler: mux,
+		}
+	}
+
+	// if no apiserver can be started, we stop the cell
+	if (len(s.httpSrvs) == 1 && s.httpSrvs[0].server == nil) ||
+		(len(s.httpSrvs) == 2 && s.httpSrvs[0].server == nil && s.httpSrvs[1].server == nil) {
+		s.shutdowner.Shutdown()
+		return errors.Join(errs...)
+	}
+
+	// otherwise just log any possible error and continue
+	for _, err := range errs {
+		s.logger.WithError(err).Error("apiserver start failed")
+	}
+
+	for _, srv := range s.httpSrvs {
+		if srv.server == nil {
+			continue
+		}
+		go func(srv httpServer) {
+			if err := srv.server.Serve(srv.listener); !errors.Is(err, http.ErrServerClosed) {
+				s.logger.WithError(err).Error("server stopped unexpectedly")
+				s.shutdowner.Shutdown()
+			}
+		}(srv)
 	}
 
 	return nil
@@ -176,6 +172,30 @@ func (s *Server) StartServer() error {
 // setsockoptReuseAddrAndPort sets the SO_REUSEADDR and SO_REUSEPORT socket options on c's
 // underlying socket in order to improve the chance to re-bind to the same address and port
 // upon restart.
+func (s *server) Stop(ctx hive.HookContext) error {
+	for _, srv := range s.httpSrvs {
+		if srv.server == nil {
+			continue
+		}
+		if err := srv.server.Shutdown(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *server) Ports() []int {
+	ports := make([]int, 0, len(s.httpSrvs))
+	for _, srv := range s.httpSrvs {
+		if srv.server == nil {
+			continue
+		}
+		ports = append(ports, srv.listener.Addr().(*net.TCPAddr).Port)
+	}
+	return ports
+}
+
+// setsockoptReuseAddrAndPort sets SO_REUSEADDR and SO_REUSEPORT
 func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) error {
 	var soerr error
 	if err := c.Control(func(su uintptr) {
@@ -187,11 +207,10 @@ func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) erro
 			soerr = fmt.Errorf("failed to setsockopt(SO_REUSEADDR): %w", err)
 			return
 		}
-		// Allow reuse of recently-used ports. This gives the agent a
+
+		// Allow reuse of recently-used ports. This gives the operator a
 		// better chance to re-bind upon restarts.
-		if err := unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
-			soerr = fmt.Errorf("failed to Setsockopt(SO_REUSEPORT): %w", err)
-		}
+		soerr = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
 	}); err != nil {
 		return err
 	}

--- a/operator/api/server_test.go
+++ b/operator/api/server_test.go
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+)
+
+func TestAPIServerDisabled(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
+		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
+		goleak.IgnoreTopFunction("time.Sleep"),
+	)
+
+	var testSrv Server
+
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		MetricsHandlerCell,
+		HealthHandlerCell(func() bool {
+			return false
+		}),
+		cell.Provide(func() SharedConfig {
+			return SharedConfig{
+				EnableK8s: false,
+			}
+		}),
+		cell.Provide(func() Config {
+			return Config{
+				OperatorAPIServeAddr: "localhost:0",
+			}
+		}),
+
+		cell.Provide(newServer),
+
+		cell.Invoke(func(srv Server) {
+			testSrv = srv
+		}),
+	)
+
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if testSrv != nil {
+		t.Fatalf("listeners unexpectedly started on ports %v", testSrv.Ports())
+	}
+
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func TestAPIServerEnabled(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
+		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
+		goleak.IgnoreTopFunction("time.Sleep"),
+	)
+
+	var testSrv Server
+
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		MetricsHandlerCell,
+		HealthHandlerCell(func() bool {
+			return false
+		}),
+		cell.Provide(func() SharedConfig {
+			return SharedConfig{
+				EnableK8s: true,
+			}
+		}),
+		cell.Provide(func() Config {
+			return Config{
+				OperatorAPIServeAddr: "localhost:0",
+			}
+		}),
+
+		cell.Provide(newServer),
+
+		cell.Invoke(func(srv Server) {
+			testSrv = srv
+		}),
+	)
+
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if len(testSrv.Ports()) != 1 {
+		t.Fatalf("expected a single opened port, got: %v", len(testSrv.Ports()))
+	}
+	port := testSrv.Ports()[0]
+
+	if err := testEndpoint(t, port, "/v1/healthz"); err != nil {
+		t.Fatalf("failed to query endpoint: %s", err)
+	}
+	if err := testEndpoint(t, port, "/v1/metrics"); err != nil {
+		t.Fatalf("failed to query endpoint: %s", err)
+	}
+	if err := testEndpoint(t, port, "/healthz"); err != nil {
+		t.Fatalf("failed to query endpoint: %s", err)
+	}
+
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func testEndpoint(t *testing.T, port int, path string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		fmt.Sprintf("http://localhost:%d%s", port, path),
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create http request: %s", err)
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request for healthz failed: %s", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("expected http status code %d, got: %d", http.StatusOK, res.StatusCode)
+	}
+
+	return nil
+}

--- a/operator/api/server_test.go
+++ b/operator/api/server_test.go
@@ -29,9 +29,14 @@ func TestAPIServerDisabled(t *testing.T) {
 	hive := hive.New(
 		k8sClient.FakeClientCell,
 		MetricsHandlerCell,
-		HealthHandlerCell(func() bool {
-			return false
-		}),
+		HealthHandlerCell(
+			func() bool {
+				return false
+			},
+			func() bool {
+				return true
+			},
+		),
 		cell.Provide(func() SharedConfig {
 			return SharedConfig{
 				EnableK8s: false,
@@ -75,9 +80,14 @@ func TestAPIServerEnabled(t *testing.T) {
 	hive := hive.New(
 		k8sClient.FakeClientCell,
 		MetricsHandlerCell,
-		HealthHandlerCell(func() bool {
-			return false
-		}),
+		HealthHandlerCell(
+			func() bool {
+				return false
+			},
+			func() bool {
+				return true
+			},
+		),
 		cell.Provide(func() SharedConfig {
 			return SharedConfig{
 				EnableK8s: true,

--- a/operator/api/server_test.go
+++ b/operator/api/server_test.go
@@ -17,7 +17,7 @@ import (
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 )
 
-func TestAPIServerDisabled(t *testing.T) {
+func TestAPIServerK8sDisabled(t *testing.T) {
 	defer goleak.VerifyNone(
 		t,
 		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
@@ -28,6 +28,9 @@ func TestAPIServerDisabled(t *testing.T) {
 
 	hive := hive.New(
 		k8sClient.FakeClientCell,
+		cell.Invoke(func(cs *k8sClient.FakeClientset) {
+			cs.Disable()
+		}),
 		MetricsHandlerCell,
 		HealthHandlerCell(
 			func() bool {
@@ -37,62 +40,6 @@ func TestAPIServerDisabled(t *testing.T) {
 				return true
 			},
 		),
-		cell.Provide(func() SharedConfig {
-			return SharedConfig{
-				EnableK8s: false,
-			}
-		}),
-		cell.Provide(func() Config {
-			return Config{
-				OperatorAPIServeAddr: "localhost:0",
-			}
-		}),
-
-		cell.Provide(newServer),
-
-		cell.Invoke(func(srv Server) {
-			testSrv = srv
-		}),
-	)
-
-	if err := hive.Start(context.Background()); err != nil {
-		t.Fatalf("failed to start: %s", err)
-	}
-
-	if testSrv != nil {
-		t.Fatalf("listeners unexpectedly started on ports %v", testSrv.Ports())
-	}
-
-	if err := hive.Stop(context.Background()); err != nil {
-		t.Fatalf("failed to stop: %s", err)
-	}
-}
-
-func TestAPIServerEnabled(t *testing.T) {
-	defer goleak.VerifyNone(
-		t,
-		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
-		goleak.IgnoreTopFunction("time.Sleep"),
-	)
-
-	var testSrv Server
-
-	hive := hive.New(
-		k8sClient.FakeClientCell,
-		MetricsHandlerCell,
-		HealthHandlerCell(
-			func() bool {
-				return false
-			},
-			func() bool {
-				return true
-			},
-		),
-		cell.Provide(func() SharedConfig {
-			return SharedConfig{
-				EnableK8s: true,
-			}
-		}),
 		cell.Provide(func() Config {
 			return Config{
 				OperatorAPIServeAddr: "localhost:0",
@@ -115,13 +62,13 @@ func TestAPIServerEnabled(t *testing.T) {
 	}
 	port := testSrv.Ports()[0]
 
-	if err := testEndpoint(t, port, "/v1/healthz"); err != nil {
+	if err := testEndpoint(t, port, "/v1/metrics", http.StatusOK); err != nil {
 		t.Fatalf("failed to query endpoint: %s", err)
 	}
-	if err := testEndpoint(t, port, "/v1/metrics"); err != nil {
+	if err := testEndpoint(t, port, "/v1/healthz", http.StatusNotImplemented); err != nil {
 		t.Fatalf("failed to query endpoint: %s", err)
 	}
-	if err := testEndpoint(t, port, "/healthz"); err != nil {
+	if err := testEndpoint(t, port, "/healthz", http.StatusNotImplemented); err != nil {
 		t.Fatalf("failed to query endpoint: %s", err)
 	}
 
@@ -130,7 +77,64 @@ func TestAPIServerEnabled(t *testing.T) {
 	}
 }
 
-func testEndpoint(t *testing.T, port int, path string) error {
+func TestAPIServerK8sEnabled(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
+		// ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go init function
+		goleak.IgnoreTopFunction("time.Sleep"),
+	)
+
+	var testSrv Server
+
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		MetricsHandlerCell,
+		HealthHandlerCell(
+			func() bool {
+				return false
+			},
+			func() bool {
+				return true
+			},
+		),
+		cell.Provide(func() Config {
+			return Config{
+				OperatorAPIServeAddr: "localhost:0",
+			}
+		}),
+
+		cell.Provide(newServer),
+
+		cell.Invoke(func(srv Server) {
+			testSrv = srv
+		}),
+	)
+
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+
+	if len(testSrv.Ports()) != 1 {
+		t.Fatalf("expected a single opened port, got: %v", len(testSrv.Ports()))
+	}
+	port := testSrv.Ports()[0]
+
+	if err := testEndpoint(t, port, "/v1/metrics", http.StatusOK); err != nil {
+		t.Fatalf("failed to query endpoint: %s", err)
+	}
+	if err := testEndpoint(t, port, "/v1/healthz", http.StatusOK); err != nil {
+		t.Fatalf("failed to query endpoint: %s", err)
+	}
+	if err := testEndpoint(t, port, "/healthz", http.StatusOK); err != nil {
+		t.Fatalf("failed to query endpoint: %s", err)
+	}
+
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func testEndpoint(t *testing.T, port int, path string, statusCode int) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -146,12 +150,12 @@ func testEndpoint(t *testing.T, port int, path string) error {
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("http request for healthz failed: %s", err)
+		return fmt.Errorf("http request for %s failed: %s", path, err)
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("expected http status code %d, got: %d", http.StatusOK, res.StatusCode)
+	if res.StatusCode != statusCode {
+		return fmt.Errorf("expected http status code %d, got: %d", statusCode, res.StatusCode)
 	}
 
 	return nil

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -243,9 +243,6 @@ func init() {
 	flags.String(operatorOption.OperatorPrometheusServeAddr, operatorOption.PrometheusServeAddr, "Address to serve Prometheus metrics")
 	option.BindEnv(Vp, operatorOption.OperatorPrometheusServeAddr)
 
-	flags.String(operatorOption.OperatorAPIServeAddr, "localhost:9234", "Address to serve API requests")
-	option.BindEnv(Vp, operatorOption.OperatorAPIServeAddr)
-
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
 	option.BindEnv(Vp, operatorOption.SyncK8sServices)
 

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -309,9 +309,6 @@ func init() {
 	flags.StringSlice(operatorOption.IngressLBAnnotationPrefixes, operatorOption.IngressLBAnnotationsDefault, "Annotation prefixes for propagating from Ingress to the Load Balancer service")
 	option.BindEnv(Vp, operatorOption.IngressLBAnnotationPrefixes)
 
-	flags.Bool(operatorOption.EnableK8s, true, `Enable operation of Kubernetes-related services/controllers when using Cilium with Kubernetes`)
-	option.BindEnv(Vp, operatorOption.EnableK8s)
-
 	flags.String(operatorOption.PodRestartSelector, "k8s-app=kube-dns", "cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted")
 	option.BindEnv(Vp, operatorOption.PodRestartSelector)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -108,14 +108,6 @@ var (
 			}
 		}),
 
-		cell.Provide(func(
-			operatorCfg *operatorOption.OperatorConfig,
-		) api.SharedConfig {
-			return api.SharedConfig{
-				EnableK8s: operatorCfg.EnableK8s,
-			}
-		}),
-
 		api.HealthHandlerCell(
 			kvstoreEnabled,
 			isLeader.Load,

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -68,7 +68,8 @@ var (
 
 	// Use a Go context so we can tell the leaderelection code when we
 	// want to step down
-	leaderElectionCtx, leaderElectionCtxCancel = context.WithCancel(context.Background())
+	leaderElectionCtx       context.Context
+	leaderElectionCtxCancel context.CancelFunc
 
 	operatorAddr string
 
@@ -225,7 +226,7 @@ func initEnv() {
 func doCleanup() {
 	IsLeader.Store(false)
 
-	// Cancelling this conext here makes sure that if the operator hold the
+	// Cancelling this context here makes sure that if the operator hold the
 	// leader lease, it will be released.
 	leaderElectionCtxCancel()
 }
@@ -270,6 +271,7 @@ func runOperator(lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner 
 
 	allSystemsGo := make(chan struct{})
 	IsLeader.Store(false)
+	leaderElectionCtx, leaderElectionCtxCancel = context.WithCancel(context.Background())
 
 	// Configure API server for the operator.
 	srv, err := api.NewServer(apiServerShutdownSignal, allSystemsGo, getAPIServerAddr()...)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -87,10 +87,6 @@ const (
 	// NodesGCInterval is the duration for which the cilium nodes are GC.
 	NodesGCInterval = "nodes-gc-interval"
 
-	// OperatorAPIServeAddr IP:Port on which to serve api requests in
-	// operator (pass ":Port" to bind on all interfaces, "" is off)
-	OperatorAPIServeAddr = "operator-api-serve-addr"
-
 	// OperatorPrometheusServeAddr IP:Port on which to serve prometheus
 	// metrics (pass ":Port" to bind on all interfaces, "" is off).
 	OperatorPrometheusServeAddr = "operator-prometheus-serve-addr"
@@ -343,7 +339,6 @@ type OperatorConfig struct {
 	// will simply return.
 	EndpointGCInterval time.Duration
 
-	OperatorAPIServeAddr        string
 	OperatorPrometheusServeAddr string
 
 	// SyncK8sServices synchronizes k8s services into the kvstore
@@ -571,7 +566,6 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.CNPStatusCleanupBurst = vp.GetInt(CNPStatusCleanupBurst)
 	c.EnableMetrics = vp.GetBool(EnableMetrics)
 	c.EndpointGCInterval = vp.GetDuration(EndpointGCInterval)
-	c.OperatorAPIServeAddr = vp.GetString(OperatorAPIServeAddr)
 	c.OperatorPrometheusServeAddr = vp.GetString(OperatorPrometheusServeAddr)
 	c.SyncK8sServices = vp.GetBool(SyncK8sServices)
 	c.SyncK8sNodes = vp.GetBool(SyncK8sNodes)

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -293,11 +293,6 @@ const (
 	// Applicable values: dedicated, shared
 	IngressDefaultLoadbalancerMode = "ingress-default-lb-mode"
 
-	// EnableK8s operation of Kubernet-related services/controllers.
-	// Intended for operating cilium with CNI-compatible orchestrators
-	// other than Kubernetes. (default is true)
-	EnableK8s = "enable-k8s"
-
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	// default values: k8s-app=kube-dns
 	PodRestartSelector = "pod-restart-selector"
@@ -547,11 +542,6 @@ type OperatorConfig struct {
 	// Applicable values: dedicated, shared
 	IngressDefaultLoadbalancerMode string
 
-	// Enables/Disables operation of kubernet-related services/controllers.
-	// Intended for operating cilium with CNI-compatible orquestrators
-	// othern than Kubernetes. (default is true)
-	EnableK8s bool
-
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	PodRestartSelector string
 }
@@ -596,7 +586,6 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.IngressLBAnnotationPrefixes = vp.GetStringSlice(IngressLBAnnotationPrefixes)
 	c.IngressSharedLBServiceName = vp.GetString(IngressSharedLBServiceName)
 	c.IngressDefaultLoadbalancerMode = vp.GetString(IngressDefaultLoadbalancerMode)
-	c.EnableK8s = vp.GetBool(EnableK8s)
 	c.PodRestartSelector = vp.GetString(PodRestartSelector)
 
 	c.CiliumK8sNamespace = vp.GetString(CiliumK8sNamespace)

--- a/pkg/k8s/client/config.go
+++ b/pkg/k8s/client/config.go
@@ -14,6 +14,10 @@ import (
 )
 
 type Config struct {
+	// EnableK8s is a flag that, when set to false, forcibly disables the clientset, to let cilium
+	// operates with CNI-compatible orchestrators other than Kubernetes. Default to true.
+	EnableK8s bool
+
 	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
 	K8sAPIServer string
 
@@ -34,6 +38,7 @@ type Config struct {
 }
 
 var defaultConfig = Config{
+	EnableK8s:             true,
 	K8sAPIServer:          "",
 	K8sKubeConfigPath:     "",
 	K8sClientQPS:          defaults.K8sClientQPSLimit,
@@ -43,6 +48,7 @@ var defaultConfig = Config{
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool(option.EnableK8s, def.EnableK8s, "Enable the k8s clientset")
 	flags.String(option.K8sAPIServer, def.K8sAPIServer, "Kubernetes API server URL")
 	flags.String(option.K8sKubeConfigPath, def.K8sKubeConfigPath, "Absolute path of the kubernetes kubeconfig file")
 	flags.Float32(option.K8sClientQPSLimit, def.K8sClientQPS, "Queries per second limit for the K8s client")
@@ -52,6 +58,9 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 }
 
 func (cfg Config) isEnabled() bool {
+	if !cfg.EnableK8s {
+		return false
+	}
 	return cfg.K8sAPIServer != "" ||
 		cfg.K8sKubeConfigPath != "" ||
 		(os.Getenv("KUBERNETES_SERVICE_HOST") != "" &&

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -198,6 +198,10 @@ const (
 	// should watch for.
 	K8sWatcherEndpointSelector = "k8s-watcher-endpoint-selector"
 
+	// EnableK8s operation of Kubernetes-related services/controllers.
+	// Intended for operating cilium with CNI-compatible orchestrators other than Kubernetes. (default is true)
+	EnableK8s = "enable-k8s"
+
 	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
 	K8sAPIServer = "k8s-api-server"
 

--- a/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
+++ b/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
@@ -28,54 +28,6 @@ import (
 )
 
 var (
-	initialObjects = []k8sRuntime.Object{
-		&corev1.Node{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Node",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "cnp-status-update-control-plane",
-				Labels: map[string]string{"kubernetes.io/hostname": "cnp-status-update-control-plane"},
-			},
-			Spec: corev1.NodeSpec{
-				PodCIDR:  cidr.MustParseCIDR("10.244.0.0/24").String(),
-				PodCIDRs: []string{cidr.MustParseCIDR("10.244.0.0/24").String()},
-				Taints: []corev1.Taint{
-					{Effect: corev1.TaintEffectNoSchedule, Key: "node-role.kubernetes.io/control-plane"},
-				},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{},
-				Addresses: []corev1.NodeAddress{
-					{Type: corev1.NodeInternalIP, Address: "172.18.0.3"},
-					{Type: corev1.NodeHostName, Address: "cnp-status-update-control-plane"},
-				},
-			},
-		},
-		&corev1.Node{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Node",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   "cnp-status-update-worker",
-				Labels: map[string]string{"kubernetes.io/hostname": "cnp-status-update-worker"},
-			},
-			Spec: corev1.NodeSpec{
-				PodCIDR:  cidr.MustParseCIDR("10.244.1.0/24").String(),
-				PodCIDRs: []string{cidr.MustParseCIDR("10.244.1.0/24").String()},
-			},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{},
-				Addresses: []corev1.NodeAddress{
-					{Type: corev1.NodeInternalIP, Address: "172.18.0.2"},
-					{Type: corev1.NodeHostName, Address: "cnp-status-update-worker"},
-				},
-			},
-		},
-	}
-
 	dummyCNP = &v2.CiliumNetworkPolicy{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cilium.io/v2",
@@ -148,6 +100,56 @@ var (
 			},
 		},
 	}
+
+	initialObjects = []k8sRuntime.Object{
+		&corev1.Node{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Node",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "cnp-status-update-control-plane",
+				Labels: map[string]string{"kubernetes.io/hostname": "cnp-status-update-control-plane"},
+			},
+			Spec: corev1.NodeSpec{
+				PodCIDR:  cidr.MustParseCIDR("10.244.0.0/24").String(),
+				PodCIDRs: []string{cidr.MustParseCIDR("10.244.0.0/24").String()},
+				Taints: []corev1.Taint{
+					{Effect: corev1.TaintEffectNoSchedule, Key: "node-role.kubernetes.io/control-plane"},
+				},
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{},
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "172.18.0.3"},
+					{Type: corev1.NodeHostName, Address: "cnp-status-update-control-plane"},
+				},
+			},
+		},
+		&corev1.Node{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Node",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "cnp-status-update-worker",
+				Labels: map[string]string{"kubernetes.io/hostname": "cnp-status-update-worker"},
+			},
+			Spec: corev1.NodeSpec{
+				PodCIDR:  cidr.MustParseCIDR("10.244.1.0/24").String(),
+				PodCIDRs: []string{cidr.MustParseCIDR("10.244.1.0/24").String()},
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{},
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeInternalIP, Address: "172.18.0.2"},
+					{Type: corev1.NodeHostName, Address: "cnp-status-update-worker"},
+				},
+			},
+		},
+		dummyCNP,
+		dummyCCNP,
+	}
 )
 
 func getDummyCNP(test *suite.ControlPlaneTest) (*v2.CiliumNetworkPolicy, error) {
@@ -206,15 +208,6 @@ func validateCNPs(test *suite.ControlPlaneTest) error {
 	return nil
 }
 
-func applyDummyCNPs(test *suite.ControlPlaneTest) error {
-	test.UpdateObjects(dummyCNP)
-	test.UpdateObjects(dummyCCNP)
-
-	// validate CNPs before starting the controlplane test,
-	// to be sure that they have been correctly stored.
-	return validateCNPs(test)
-}
-
 func validateCNPsAfterGC(test *suite.ControlPlaneTest) error {
 	cnp, err := getDummyCNP(test)
 	if err != nil {
@@ -256,16 +249,17 @@ func init() {
 			SetupEnvironment(func(_ *option.DaemonConfig, operatorCfg *operatorOption.OperatorConfig) {
 				operatorCfg.SkipCNPStatusStartupClean = true
 			}).
+			// check that CNPs contain status updates info before starting agent and operator
+			Eventually(func() error { return validateCNPs(test) }).
 			StartAgent().
 			StartOperator(func(vp *viper.Viper) {
 				vp.Set(operatorApi.OperatorAPIServeAddr, "localhost:0")
 			}).
-			Execute(func() error { return applyDummyCNPs(test) }).
 			Eventually(func() error { return validateCNPs(test) })
 
 		test.StopAgent()
 		test.StopOperator()
-		test.DeleteObjects()
+		test.DeleteObjects(initialObjects...)
 
 		// When running with GC enabled, the Nodes Status updates should eventually be deleted.
 		test.
@@ -273,11 +267,12 @@ func init() {
 			SetupEnvironment(func(_ *option.DaemonConfig, operatorCfg *operatorOption.OperatorConfig) {
 				operatorCfg.SkipCNPStatusStartupClean = false
 			}).
+			// check that CNPs contain status updates info before starting agent and operator
+			Eventually(func() error { return validateCNPs(test) }).
 			StartAgent().
 			StartOperator(func(vp *viper.Viper) {
 				vp.Set(operatorApi.OperatorAPIServeAddr, "localhost:0")
 			}).
-			Execute(func() error { return applyDummyCNPs(test) }).
 			Eventually(func() error { return validateCNPsAfterGC(test) })
 
 		test.StopAgent()

--- a/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
+++ b/test/controlplane/ciliumnetworkpolicies/status_updates_gc.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
+	operatorApi "github.com/cilium/cilium/operator/api"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/cidr"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -256,7 +257,9 @@ func init() {
 				operatorCfg.SkipCNPStatusStartupClean = true
 			}).
 			StartAgent().
-			StartOperator(func(_ *viper.Viper) {}).
+			StartOperator(func(vp *viper.Viper) {
+				vp.Set(operatorApi.OperatorAPIServeAddr, "localhost:0")
+			}).
 			Execute(func() error { return applyDummyCNPs(test) }).
 			Eventually(func() error { return validateCNPs(test) })
 
@@ -271,7 +274,9 @@ func init() {
 				operatorCfg.SkipCNPStatusStartupClean = false
 			}).
 			StartAgent().
-			StartOperator(func(_ *viper.Viper) {}).
+			StartOperator(func(vp *viper.Viper) {
+				vp.Set(operatorApi.OperatorAPIServeAddr, "localhost:0")
+			}).
 			Execute(func() error { return applyDummyCNPs(test) }).
 			Eventually(func() error { return validateCNPsAfterGC(test) })
 


### PR DESCRIPTION
Modularize the operator api server into its own independent cell.  The refactoring aims to keep the same behavior of the previous implementation. The refactored server:

- adds a custom handler for /healthz as an alias to /v1/healthz
- in case of an empty server address option, it starts two HTTP servers, one listening on "127.0.0.1:0" and the other on "[::1]:0", in case the user is running ipv4 or ipv6 only, respectively

To answer the health checks, the operator api server should always be up and running, whether the operator has been elected leader or not.
Therefore, the health handler behavior should change based on the operator instance being elected leader or not, so it is refactored to accept a function that returns the current leading status of the operator instance.

Integration style unit tests have been added for both the handlers and the server.

Fixes: https://github.com/cilium/cilium/issues/24064