### PR TITLE
Avoid clearing objects in conversion funcs

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -559,8 +559,6 @@ func ConvertToK8sService(obj interface{}) interface{} {
 // *types.SlimCNP, also without the Status field of the given CNP, in its Obj.
 // If the given obj can't be cast into either *cilium_v2.CiliumClusterwideNetworkPolicy
 // nor cache.DeletedFinalStateUnknown, the original obj is returned.
-// WARNING calling this function will set *all* fields of the given CNP as
-// empty.
 func ConvertToCCNP(obj interface{}) interface{} {
 	switch concreteObj := obj.(type) {
 	case *cilium_v2.CiliumClusterwideNetworkPolicy:
@@ -572,7 +570,6 @@ func ConvertToCCNP(obj interface{}) interface{} {
 				Specs:      concreteObj.Specs,
 			},
 		}
-		*concreteObj = cilium_v2.CiliumClusterwideNetworkPolicy{}
 		return ccnp
 
 	case cache.DeletedFinalStateUnknown:
@@ -592,7 +589,6 @@ func ConvertToCCNP(obj interface{}) interface{} {
 			Key: concreteObj.Key,
 			Obj: slimCNP,
 		}
-		*ccnp = cilium_v2.CiliumClusterwideNetworkPolicy{}
 		return dfsu
 
 	default:
@@ -606,8 +602,6 @@ func ConvertToCCNP(obj interface{}) interface{} {
 // *types.SlimCNP, also without the Status field of the given CNP, in its Obj.
 // If the given obj can't be cast into either *cilium_v2.CiliumNetworkPolicy
 // nor cache.DeletedFinalStateUnknown, the original obj is returned.
-// WARNING calling this function will set *all* fields of the given CNP as
-// empty.
 func ConvertToCNP(obj interface{}) interface{} {
 	switch concreteObj := obj.(type) {
 	case *cilium_v2.CiliumNetworkPolicy:
@@ -619,7 +613,6 @@ func ConvertToCNP(obj interface{}) interface{} {
 				Specs:      concreteObj.Specs,
 			},
 		}
-		*concreteObj = cilium_v2.CiliumNetworkPolicy{}
 		return cnp
 	case cache.DeletedFinalStateUnknown:
 		cnp, ok := concreteObj.Obj.(*cilium_v2.CiliumNetworkPolicy)
@@ -637,7 +630,6 @@ func ConvertToCNP(obj interface{}) interface{} {
 				},
 			},
 		}
-		*cnp = cilium_v2.CiliumNetworkPolicy{}
 		return dfsu
 	default:
 		return obj
@@ -692,8 +684,6 @@ func convertToTaints(v1Taints []v1.Taint) []slim_corev1.Taint {
 // a cache.DeletedFinalStateUnknown with a *types.Node in its Obj.
 // If the given obj can't be cast into either *v1.Node
 // nor cache.DeletedFinalStateUnknown, the original obj is returned.
-// WARNING calling this function will set *all* fields of the given Node as
-// empty.
 func ConvertToNode(obj interface{}) interface{} {
 	switch concreteObj := obj.(type) {
 	case *v1.Node:
@@ -719,7 +709,6 @@ func ConvertToNode(obj interface{}) interface{} {
 				Addresses: convertToAddress(concreteObj.Status.Addresses),
 			},
 		}
-		*concreteObj = v1.Node{}
 		return p
 	case cache.DeletedFinalStateUnknown:
 		node, ok := concreteObj.Obj.(*v1.Node)
@@ -751,7 +740,6 @@ func ConvertToNode(obj interface{}) interface{} {
 				},
 			},
 		}
-		*node = v1.Node{}
 		return dfsu
 	default:
 		return obj


### PR DESCRIPTION
This removes the behavior of mutating the objects received from the client-go library. To begin with there isn't really any benefit from doing so, given we don't store the object afterwards, and it will be ready for gc when it leaves the scope inside client-go. client-go can possibly return the same pointer twice here, to trigger eg. both an object update delta and then a DeletedFinalStateUnknown delta with the same pointer.

For more info, see the issue 115658 in the kubernetes/kubernetes repo on github. (avoiding to link directly since it spamms the original issue).

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [ ] Thanks for contributing!