### PR TITLE
Prepare Cilium API for IPAM pools

### DIFF
--- a/api/v1/client/ipam/delete_ipam_ip_parameters.go
+++ b/api/v1/client/ipam/delete_ipam_ip_parameters.go
@@ -70,6 +70,9 @@ type DeleteIpamIPParams struct {
 	*/
 	IP string
 
+	// Pool.
+	Pool *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -134,6 +137,17 @@ func (o *DeleteIpamIPParams) SetIP(ip string) {
 	o.IP = ip
 }
 
+// WithPool adds the pool to the delete ipam IP params
+func (o *DeleteIpamIPParams) WithPool(pool *string) *DeleteIpamIPParams {
+	o.SetPool(pool)
+	return o
+}
+
+// SetPool adds the pool to the delete ipam IP params
+func (o *DeleteIpamIPParams) SetPool(pool *string) {
+	o.Pool = pool
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteIpamIPParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -145,6 +159,23 @@ func (o *DeleteIpamIPParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.
 	// path param ip
 	if err := r.SetPathParam("ip", o.IP); err != nil {
 		return err
+	}
+
+	if o.Pool != nil {
+
+		// query param pool
+		var qrPool string
+
+		if o.Pool != nil {
+			qrPool = *o.Pool
+		}
+		qPool := qrPool
+		if qPool != "" {
+
+			if err := r.SetQueryParam("pool", qPool); err != nil {
+				return err
+			}
+		}
 	}
 
 	if len(res) > 0 {

--- a/api/v1/client/ipam/post_ipam_ip_parameters.go
+++ b/api/v1/client/ipam/post_ipam_ip_parameters.go
@@ -73,6 +73,9 @@ type PostIpamIPParams struct {
 	// Owner.
 	Owner *string
 
+	// Pool.
+	Pool *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -148,6 +151,17 @@ func (o *PostIpamIPParams) SetOwner(owner *string) {
 	o.Owner = owner
 }
 
+// WithPool adds the pool to the post ipam IP params
+func (o *PostIpamIPParams) WithPool(pool *string) *PostIpamIPParams {
+	o.SetPool(pool)
+	return o
+}
+
+// SetPool adds the pool to the post ipam IP params
+func (o *PostIpamIPParams) SetPool(pool *string) {
+	o.Pool = pool
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PostIpamIPParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -173,6 +187,23 @@ func (o *PostIpamIPParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Re
 		if qOwner != "" {
 
 			if err := r.SetQueryParam("owner", qOwner); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Pool != nil {
+
+		// query param pool
+		var qrPool string
+
+		if o.Pool != nil {
+			qrPool = *o.Pool
+		}
+		qPool := qrPool
+		if qPool != "" {
+
+			if err := r.SetQueryParam("pool", qPool); err != nil {
 				return err
 			}
 		}

--- a/api/v1/client/ipam/post_ipam_parameters.go
+++ b/api/v1/client/ipam/post_ipam_parameters.go
@@ -74,6 +74,9 @@ type PostIpamParams struct {
 	// Owner.
 	Owner *string
 
+	// Pool.
+	Pool *string
+
 	timeout    time.Duration
 	Context    context.Context
 	HTTPClient *http.Client
@@ -160,6 +163,17 @@ func (o *PostIpamParams) SetOwner(owner *string) {
 	o.Owner = owner
 }
 
+// WithPool adds the pool to the post ipam params
+func (o *PostIpamParams) WithPool(pool *string) *PostIpamParams {
+	o.SetPool(pool)
+	return o
+}
+
+// SetPool adds the pool to the post ipam params
+func (o *PostIpamParams) SetPool(pool *string) {
+	o.Pool = pool
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PostIpamParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -205,6 +219,23 @@ func (o *PostIpamParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Regi
 		if qOwner != "" {
 
 			if err := r.SetQueryParam("owner", qOwner); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.Pool != nil {
+
+		// query param pool
+		var qrPool string
+
+		if o.Pool != nil {
+			qrPool = *o.Pool
+		}
+		qPool := qrPool
+		if qPool != "" {
+
+			if err := r.SetQueryParam("pool", qPool); err != nil {
 				return err
 			}
 		}

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -426,6 +426,7 @@ paths:
       parameters:
       - "$ref": "#/parameters/ipam-family"
       - "$ref": "#/parameters/ipam-owner"
+      - "$ref": "#/parameters/ipam-pool"
       - "$ref": "#/parameters/ipam-expiration"
       responses:
         '201':
@@ -445,6 +446,7 @@ paths:
       parameters:
       - "$ref": "#/parameters/ipam-ip"
       - "$ref": "#/parameters/ipam-owner"
+      - "$ref": "#/parameters/ipam-pool"
       responses:
         '200':
           description: Success
@@ -468,6 +470,7 @@ paths:
       - ipam
       parameters:
       - "$ref": "#/parameters/ipam-release-arg"
+      - "$ref": "#/parameters/ipam-pool"
       responses:
         '200':
           description: Success
@@ -1113,6 +1116,10 @@ parameters:
     name: owner
     in: query
     type: string
+  ipam-pool:
+    name: pool
+    in: query
+    type: string
   ipam-expiration:
     name: expiration
     in: header
@@ -1147,7 +1154,6 @@ parameters:
     required: false
     in: query
     type: string
-
 
 definitions:
   Endpoint:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -846,6 +846,9 @@ func init() {
             "$ref": "#/parameters/ipam-owner"
           },
           {
+            "$ref": "#/parameters/ipam-pool"
+          },
+          {
             "$ref": "#/parameters/ipam-expiration"
           }
         ],
@@ -878,6 +881,9 @@ func init() {
           },
           {
             "$ref": "#/parameters/ipam-owner"
+          },
+          {
+            "$ref": "#/parameters/ipam-pool"
           }
         ],
         "responses": {
@@ -913,6 +919,9 @@ func init() {
         "parameters": [
           {
             "$ref": "#/parameters/ipam-release-arg"
+          },
+          {
+            "$ref": "#/parameters/ipam-pool"
           }
         ],
         "responses": {
@@ -4446,6 +4455,11 @@ func init() {
       "name": "owner",
       "in": "query"
     },
+    "ipam-pool": {
+      "type": "string",
+      "name": "pool",
+      "in": "query"
+    },
     "ipam-release-arg": {
       "type": "string",
       "description": "IP address or owner name",
@@ -5484,6 +5498,11 @@ func init() {
             "in": "query"
           },
           {
+            "type": "string",
+            "name": "pool",
+            "in": "query"
+          },
+          {
             "type": "boolean",
             "name": "expiration",
             "in": "header"
@@ -5524,6 +5543,11 @@ func init() {
             "type": "string",
             "name": "owner",
             "in": "query"
+          },
+          {
+            "type": "string",
+            "name": "pool",
+            "in": "query"
           }
         ],
         "responses": {
@@ -5563,6 +5587,11 @@ func init() {
             "name": "ip",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "name": "pool",
+            "in": "query"
           }
         ],
         "responses": {
@@ -9670,6 +9699,11 @@ func init() {
     "ipam-owner": {
       "type": "string",
       "name": "owner",
+      "in": "query"
+    },
+    "ipam-pool": {
+      "type": "string",
+      "name": "pool",
       "in": "query"
     },
     "ipam-release-arg": {

--- a/api/v1/server/restapi/ipam/delete_ipam_ip_parameters.go
+++ b/api/v1/server/restapi/ipam/delete_ipam_ip_parameters.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/errors"
+	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 )
@@ -38,6 +39,10 @@ type DeleteIpamIPParams struct {
 	  In: path
 	*/
 	IP string
+	/*
+	  In: query
+	*/
+	Pool *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -49,8 +54,15 @@ func (o *DeleteIpamIPParams) BindRequest(r *http.Request, route *middleware.Matc
 
 	o.HTTPRequest = r
 
+	qs := runtime.Values(r.URL.Query())
+
 	rIP, rhkIP, _ := route.Params.GetOK("ip")
 	if err := o.bindIP(rIP, rhkIP, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPool, qhkPool, _ := qs.GetOK("pool")
+	if err := o.bindPool(qPool, qhkPool, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -69,6 +81,24 @@ func (o *DeleteIpamIPParams) bindIP(rawData []string, hasKey bool, formats strfm
 	// Required: true
 	// Parameter is provided by construction from the route
 	o.IP = raw
+
+	return nil
+}
+
+// bindPool binds and validates parameter Pool from query.
+func (o *DeleteIpamIPParams) bindPool(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Pool = &raw
 
 	return nil
 }

--- a/api/v1/server/restapi/ipam/post_ipam_ip_parameters.go
+++ b/api/v1/server/restapi/ipam/post_ipam_ip_parameters.go
@@ -43,6 +43,10 @@ type PostIpamIPParams struct {
 	  In: query
 	*/
 	Owner *string
+	/*
+	  In: query
+	*/
+	Pool *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -63,6 +67,11 @@ func (o *PostIpamIPParams) BindRequest(r *http.Request, route *middleware.Matche
 
 	qOwner, qhkOwner, _ := qs.GetOK("owner")
 	if err := o.bindOwner(qOwner, qhkOwner, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPool, qhkPool, _ := qs.GetOK("pool")
+	if err := o.bindPool(qPool, qhkPool, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -99,6 +108,24 @@ func (o *PostIpamIPParams) bindOwner(rawData []string, hasKey bool, formats strf
 		return nil
 	}
 	o.Owner = &raw
+
+	return nil
+}
+
+// bindPool binds and validates parameter Pool from query.
+func (o *PostIpamIPParams) bindPool(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Pool = &raw
 
 	return nil
 }

--- a/api/v1/server/restapi/ipam/post_ipam_parameters.go
+++ b/api/v1/server/restapi/ipam/post_ipam_parameters.go
@@ -48,6 +48,10 @@ type PostIpamParams struct {
 	  In: query
 	*/
 	Owner *string
+	/*
+	  In: query
+	*/
+	Pool *string
 }
 
 // BindRequest both binds and validates a request, it assumes that complex things implement a Validatable(strfmt.Registry) error interface
@@ -72,6 +76,11 @@ func (o *PostIpamParams) BindRequest(r *http.Request, route *middleware.MatchedR
 
 	qOwner, qhkOwner, _ := qs.GetOK("owner")
 	if err := o.bindOwner(qOwner, qhkOwner, route.Formats); err != nil {
+		res = append(res, err)
+	}
+
+	qPool, qhkPool, _ := qs.GetOK("pool")
+	if err := o.bindPool(qPool, qhkPool, route.Formats); err != nil {
 		res = append(res, err)
 	}
 	if len(res) > 0 {
@@ -148,6 +157,24 @@ func (o *PostIpamParams) bindOwner(rawData []string, hasKey bool, formats strfmt
 		return nil
 	}
 	o.Owner = &raw
+
+	return nil
+}
+
+// bindPool binds and validates parameter Pool from query.
+func (o *PostIpamParams) bindPool(rawData []string, hasKey bool, formats strfmt.Registry) error {
+	var raw string
+	if len(rawData) > 0 {
+		raw = rawData[len(rawData)-1]
+	}
+
+	// Required: false
+	// AllowEmptyValue: false
+
+	if raw == "" { // empty values pass all other validations
+		return nil
+	}
+	o.Pool = &raw
 
 	return nil
 }

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -25,6 +25,7 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -509,14 +510,14 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	if addressing := epTemplate.Addressing; addressing != nil {
 		if uuid := addressing.IPV4ExpirationUUID; uuid != "" {
 			if ip := net.ParseIP(addressing.IPV4); ip != nil {
-				if err := d.ipam.StopExpirationTimer(ip, uuid); err != nil {
+				if err := d.ipam.StopExpirationTimer(ip, ipam.PoolDefault, uuid); err != nil {
 					return d.errorDuringCreation(ep, err)
 				}
 			}
 		}
 		if uuid := addressing.IPV6ExpirationUUID; uuid != "" {
 			if ip := net.ParseIP(addressing.IPV6); ip != nil {
-				if err := d.ipam.StopExpirationTimer(ip, uuid); err != nil {
+				if err := d.ipam.StopExpirationTimer(ip, ipam.PoolDefault, uuid); err != nil {
 					return d.errorDuringCreation(ep, err)
 				}
 			}
@@ -726,13 +727,13 @@ func (d *Daemon) EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConf
 
 	if !conf.NoIPRelease {
 		if option.Config.EnableIPv4 {
-			if err := d.ipam.ReleaseIP(ep.IPv4.AsSlice()); err != nil {
+			if err := d.ipam.ReleaseIP(ep.IPv4.AsSlice(), ipam.PoolDefault); err != nil {
 				scopedLog := ep.Logger(daemonSubsys).WithError(err)
 				scopedLog.Warning("Unable to release IPv4 address during endpoint deletion")
 			}
 		}
 		if option.Config.EnableIPv6 {
-			if err := d.ipam.ReleaseIP(ep.IPv6.AsSlice()); err != nil {
+			if err := d.ipam.ReleaseIP(ep.IPv6.AsSlice(), ipam.PoolDefault); err != nil {
 				scopedLog := ep.Logger(daemonSubsys).WithError(err)
 				scopedLog.Warning("Unable to release IPv6 address during endpoint deletion")
 			}

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -18,13 +18,14 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
 func getEPTemplate(c *C, d *Daemon) *models.EndpointChangeRequest {
-	ip4, ip6, err := d.ipam.AllocateNext("", "test")
+	ip4, ip6, err := d.ipam.AllocateNext("", "test", ipam.PoolDefault)
 	c.Assert(err, Equals, nil)
 	c.Assert(ip4, Not(IsNil))
 	c.Assert(ip6, Not(IsNil))

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -41,11 +41,12 @@ func NewPostIPAMHandler(d *Daemon) ipamapi.PostIpamHandler {
 func (h *postIPAM) Handle(params ipamapi.PostIpamParams) middleware.Responder {
 	family := strings.ToLower(swag.StringValue(params.Family))
 	owner := swag.StringValue(params.Owner)
+	pool := ipam.PoolOrDefault(swag.StringValue(params.Pool))
 	var expirationTimeout time.Duration
 	if swag.BoolValue(params.Expiration) {
 		expirationTimeout = defaults.IPAMExpiration
 	}
-	ipv4Result, ipv6Result, err := h.daemon.ipam.AllocateNextWithExpiration(family, owner, expirationTimeout)
+	ipv4Result, ipv6Result, err := h.daemon.ipam.AllocateNextWithExpiration(family, owner, pool, expirationTimeout)
 	if err != nil {
 		return api.Error(ipamapi.PostIpamFailureCode, err)
 	}
@@ -96,7 +97,8 @@ func NewPostIPAMIPHandler(d *Daemon) ipamapi.PostIpamIPHandler {
 // Handle incoming requests address allocation requests for the daemon.
 func (h *postIPAMIP) Handle(params ipamapi.PostIpamIPParams) middleware.Responder {
 	owner := swag.StringValue(params.Owner)
-	if err := h.daemon.ipam.AllocateIPString(params.IP, owner); err != nil {
+	pool := ipam.PoolOrDefault(swag.StringValue(params.Pool))
+	if err := h.daemon.ipam.AllocateIPString(params.IP, owner, pool); err != nil {
 		return api.Error(ipamapi.PostIpamIPFailureCode, err)
 	}
 
@@ -121,7 +123,8 @@ func (h *deleteIPAMIP) Handle(params ipamapi.DeleteIpamIPParams) middleware.Resp
 		return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
 	}
 
-	if err := h.daemon.ipam.ReleaseIPString(params.IP); err != nil {
+	pool := ipam.PoolOrDefault(swag.StringValue(params.Pool))
+	if err := h.daemon.ipam.ReleaseIPString(params.IP, pool); err != nil {
 		return api.Error(ipamapi.DeleteIpamIPFailureCode, err)
 	}
 
@@ -212,7 +215,7 @@ func coalesceCIDRs(rCIDRs []string) (result []string) {
 
 func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerIP net.IP, err error) {
 	// Avoid allocating external IP
-	d.ipam.ExcludeIP(family.PrimaryExternal(), "node-ip")
+	d.ipam.ExcludeIP(family.PrimaryExternal(), "node-ip", ipam.PoolDefault)
 
 	// (Re-)allocate the router IP. If not possible, allocate a fresh IP.
 	// In that case, removal and re-creation of the cilium_host is
@@ -221,7 +224,7 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerI
 	var result *ipam.AllocationResult
 	routerIP = family.Router()
 	if routerIP != nil {
-		result, err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, "router")
+		result, err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, "router", ipam.PoolDefault)
 		if err != nil {
 			log.Warn("Router IP could not be re-allocated. Need to re-allocate. This will cause brief network disruption")
 
@@ -236,7 +239,7 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerI
 
 	if routerIP == nil {
 		family := ipam.DeriveFamily(family.PrimaryExternal())
-		result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(family, "router")
+		result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(family, "router", ipam.PoolDefault)
 		if err != nil {
 			err = fmt.Errorf("Unable to allocate router IP for family %s: %s", family, err)
 			return
@@ -273,7 +276,7 @@ func (d *Daemon) allocateHealthIPs() error {
 	bootstrapStats.healthCheck.Start()
 	if option.Config.EnableHealthChecking && option.Config.EnableEndpointHealthChecking {
 		if option.Config.EnableIPv4 {
-			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "health")
+			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "health", ipam.PoolDefault)
 			if err != nil {
 				return fmt.Errorf("unable to allocate health IPs: %s, see https://cilium.link/ipam-range-full", err)
 			}
@@ -301,10 +304,10 @@ func (d *Daemon) allocateHealthIPs() error {
 		}
 
 		if option.Config.EnableIPv6 {
-			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "health")
+			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "health", ipam.PoolDefault)
 			if err != nil {
 				if healthIPv4 := node.GetEndpointHealthIPv4(); healthIPv4 != nil {
-					d.ipam.ReleaseIP(healthIPv4)
+					d.ipam.ReleaseIP(healthIPv4, ipam.PoolDefault)
 					node.SetEndpointHealthIPv4(nil)
 				}
 				return fmt.Errorf("unable to allocate health IPs: %s, see https://cilium.link/ipam-range-full", err)
@@ -336,7 +339,7 @@ func (d *Daemon) allocateIngressIPs() error {
 			// Reallocate the same address as before, if possible
 			ingressIPv4 := node.GetIngressIPv4()
 			if ingressIPv4 != nil {
-				result, err = d.ipam.AllocateIPWithoutSyncUpstream(ingressIPv4, "ingress")
+				result, err = d.ipam.AllocateIPWithoutSyncUpstream(ingressIPv4, "ingress", ipam.PoolDefault)
 				if err != nil {
 					log.WithError(err).WithField(logfields.SourceIP, ingressIPv4).Warn("unable to re-allocate ingress IPv4.")
 					result = nil
@@ -346,7 +349,7 @@ func (d *Daemon) allocateIngressIPs() error {
 			// Allocate a fresh IP if not restored, or the reallocation of the restored
 			// IP failed
 			if result == nil {
-				result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "ingress")
+				result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "ingress", ipam.PoolDefault)
 				if err != nil {
 					return fmt.Errorf("unable to allocate ingress IPs: %s, see https://cilium.link/ipam-range-full", err)
 				}
@@ -389,7 +392,7 @@ func (d *Daemon) allocateIngressIPs() error {
 			// Reallocate the same address as before, if possible
 			ingressIPv6 := node.GetIngressIPv6()
 			if ingressIPv6 != nil {
-				result, err = d.ipam.AllocateIPWithoutSyncUpstream(ingressIPv6, "ingress")
+				result, err = d.ipam.AllocateIPWithoutSyncUpstream(ingressIPv6, "ingress", ipam.PoolDefault)
 				if err != nil {
 					log.WithError(err).WithField(logfields.SourceIP, ingressIPv6).Warn("unable to re-allocate ingress IPv6.")
 					result = nil
@@ -399,10 +402,10 @@ func (d *Daemon) allocateIngressIPs() error {
 			// Allocate a fresh IP if not restored, or the reallocation of the restored
 			// IP failed
 			if result == nil {
-				result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "ingress")
+				result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "ingress", ipam.PoolDefault)
 				if err != nil {
 					if ingressIPv4 := node.GetIngressIPv4(); ingressIPv4 != nil {
-						d.ipam.ReleaseIP(ingressIPv4)
+						d.ipam.ReleaseIP(ingressIPv4, ipam.PoolDefault)
 						node.SetIngressIPv4(nil)
 					}
 					return fmt.Errorf("unable to allocate ingress IPs: %s, see https://cilium.link/ipam-range-full", err)

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -339,20 +339,20 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	var err error
 
 	if option.Config.EnableIPv6 && ep.IPv6.IsValid() {
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanStringLocked()+" [restored]")
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanStringLocked()+" [restored]", ipam.PoolDefault)
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6, err)
 		}
 
 		defer func() {
 			if err != nil {
-				d.ipam.ReleaseIP(ep.IPv6.AsSlice())
+				d.ipam.ReleaseIP(ep.IPv6.AsSlice(), ipam.PoolDefault)
 			}
 		}()
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4.IsValid() {
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanStringLocked()+"[restored]")
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanStringLocked()+" [restored]", ipam.PoolDefault)
 		switch {
 		// We only check for BypassIPAllocUponRestore for IPv4 because we
 		// assume that this flag is only turned on for IPv4-only IPAM modes

--- a/pkg/client/ipam.go
+++ b/pkg/client/ipam.go
@@ -15,17 +15,18 @@ const (
 )
 
 // IPAMAllocate allocates an IP address out of address family specific pool.
-func (c *Client) IPAMAllocate(family, owner string, expiration bool) (*models.IPAMResponse, error) {
+func (c *Client) IPAMAllocate(family, owner, pool string, expiration bool) (*models.IPAMResponse, error) {
 	params := ipam.NewPostIpamParams().WithTimeout(api.ClientTimeout)
 
 	if family != "" {
 		params.SetFamily(&family)
 	}
-
 	if owner != "" {
 		params.SetOwner(&owner)
 	}
-
+	if pool != "" {
+		params.SetPool(&pool)
+	}
 	params.SetExpiration(&expiration)
 
 	resp, err := c.Ipam.PostIpam(params)
@@ -36,15 +37,21 @@ func (c *Client) IPAMAllocate(family, owner string, expiration bool) (*models.IP
 }
 
 // IPAMAllocateIP tries to allocate a particular IP address.
-func (c *Client) IPAMAllocateIP(ip, owner string) error {
+func (c *Client) IPAMAllocateIP(ip, owner, pool string) error {
 	params := ipam.NewPostIpamIPParams().WithIP(ip).WithOwner(&owner).WithTimeout(api.ClientTimeout)
+	if pool != "" {
+		params.SetPool(&pool)
+	}
 	_, err := c.Ipam.PostIpamIP(params)
 	return Hint(err)
 }
 
 // IPAMReleaseIP releases a IP address back to the pool.
-func (c *Client) IPAMReleaseIP(ip string) error {
+func (c *Client) IPAMReleaseIP(ip, pool string) error {
 	params := ipam.NewDeleteIpamIPParams().WithIP(ip).WithTimeout(api.ClientTimeout)
+	if pool != "" {
+		params.SetPool(&pool)
+	}
 	_, err := c.Ipam.DeleteIpamIP(params)
 	return Hint(err)
 }

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -71,7 +71,7 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
-	if ownedBy, ok := ipam.isIPExcluded(ip); ok {
+	if ownedBy, ok := ipam.isIPExcluded(ip, pool); ok {
 		err = fmt.Errorf("IP %s is excluded, owned by %s", ip, ownedBy)
 		return
 	}
@@ -148,9 +148,10 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 			return
 		}
 
-		if _, ok := ipam.isIPExcluded(result.IP); !ok {
+		if _, ok := ipam.isIPExcluded(result.IP, pool); !ok {
 			log.WithFields(logrus.Fields{
 				"ip":    result.IP.String(),
+				"pool":  pool.String(),
 				"owner": owner,
 			}).Debugf("Allocated random IP")
 			ipam.owner[result.IP.String()] = owner

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -46,29 +46,28 @@ func (ipam *IPAM) lookupIPsByOwner(owner string) (ips []net.IP) {
 }
 
 // AllocateIP allocates a IP address.
-func (ipam *IPAM) AllocateIP(ip net.IP, owner string) (err error) {
+func (ipam *IPAM) AllocateIP(ip net.IP, owner string, pool Pool) error {
 	needSyncUpstream := true
-	_, err = ipam.allocateIP(ip, owner, needSyncUpstream)
-	return
+	_, err := ipam.allocateIP(ip, owner, pool, needSyncUpstream)
+	return err
 }
 
 // AllocateIPWithoutSyncUpstream allocates a IP address without syncing upstream.
-func (ipam *IPAM) AllocateIPWithoutSyncUpstream(ip net.IP, owner string) (result *AllocationResult, err error) {
+func (ipam *IPAM) AllocateIPWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	needSyncUpstream := false
-	return ipam.allocateIP(ip, owner, needSyncUpstream)
+	return ipam.allocateIP(ip, owner, pool, needSyncUpstream)
 }
 
 // AllocateIPString is identical to AllocateIP but takes a string
-func (ipam *IPAM) AllocateIPString(ipAddr, owner string) error {
+func (ipam *IPAM) AllocateIPString(ipAddr, owner string, pool Pool) error {
 	ip := net.ParseIP(ipAddr)
 	if ip == nil {
 		return fmt.Errorf("Invalid IP address: %s", ipAddr)
 	}
-
-	return ipam.AllocateIP(ip, owner)
+	return ipam.AllocateIP(ip, owner, pool)
 }
 
-func (ipam *IPAM) allocateIP(ip net.IP, owner string, needSyncUpstream bool) (result *AllocationResult, err error) {
+func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstream bool) (result *AllocationResult, err error) {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
@@ -85,11 +84,11 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, needSyncUpstream bool) (re
 		}
 
 		if needSyncUpstream {
-			if result, err = ipam.IPv4Allocator.Allocate(ip, owner); err != nil {
+			if result, err = ipam.IPv4Allocator.Allocate(ip, owner, pool); err != nil {
 				return
 			}
 		} else {
-			if result, err = ipam.IPv4Allocator.AllocateWithoutSyncUpstream(ip, owner); err != nil {
+			if result, err = ipam.IPv4Allocator.AllocateWithoutSyncUpstream(ip, owner, pool); err != nil {
 				return
 			}
 		}
@@ -101,11 +100,11 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, needSyncUpstream bool) (re
 		}
 
 		if needSyncUpstream {
-			if _, err = ipam.IPv6Allocator.Allocate(ip, owner); err != nil {
+			if _, err = ipam.IPv6Allocator.Allocate(ip, owner, pool); err != nil {
 				return
 			}
 		} else {
-			if _, err = ipam.IPv6Allocator.AllocateWithoutSyncUpstream(ip, owner); err != nil {
+			if _, err = ipam.IPv6Allocator.AllocateWithoutSyncUpstream(ip, owner, pool); err != nil {
 				return
 			}
 		}
@@ -121,7 +120,7 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, needSyncUpstream bool) (re
 	return
 }
 
-func (ipam *IPAM) allocateNextFamily(family Family, owner string, needSyncUpstream bool) (result *AllocationResult, err error) {
+func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, needSyncUpstream bool) (result *AllocationResult, err error) {
 	var allocator Allocator
 	switch family {
 	case IPv6:
@@ -141,9 +140,9 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, needSyncUpstre
 
 	for {
 		if needSyncUpstream {
-			result, err = allocator.AllocateNext(owner)
+			result, err = allocator.AllocateNext(owner, pool)
 		} else {
-			result, err = allocator.AllocateNextWithoutSyncUpstream(owner)
+			result, err = allocator.AllocateNextWithoutSyncUpstream(owner, pool)
 		}
 		if err != nil {
 			return
@@ -167,33 +166,33 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, needSyncUpstre
 }
 
 // AllocateNextFamily allocates the next IP of the requested address family
-func (ipam *IPAM) AllocateNextFamily(family Family, owner string) (result *AllocationResult, err error) {
+func (ipam *IPAM) AllocateNextFamily(family Family, owner string, pool Pool) (result *AllocationResult, err error) {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
 	needSyncUpstream := true
 
-	return ipam.allocateNextFamily(family, owner, needSyncUpstream)
+	return ipam.allocateNextFamily(family, owner, pool, needSyncUpstream)
 }
 
 // AllocateNextFamilyWithoutSyncUpstream allocates the next IP of the requested address family
 // without syncing upstream
-func (ipam *IPAM) AllocateNextFamilyWithoutSyncUpstream(family Family, owner string) (result *AllocationResult, err error) {
+func (ipam *IPAM) AllocateNextFamilyWithoutSyncUpstream(family Family, owner string, pool Pool) (result *AllocationResult, err error) {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
 	needSyncUpstream := false
 
-	return ipam.allocateNextFamily(family, owner, needSyncUpstream)
+	return ipam.allocateNextFamily(family, owner, pool, needSyncUpstream)
 }
 
 // AllocateNext allocates the next available IPv4 and IPv6 address out of the
 // configured address pool. If family is set to "ipv4" or "ipv6", then
 // allocation is limited to the specified address family. If the pool has been
 // drained of addresses, an error will be returned.
-func (ipam *IPAM) AllocateNext(family, owner string) (ipv4Result, ipv6Result *AllocationResult, err error) {
+func (ipam *IPAM) AllocateNext(family, owner string, pool Pool) (ipv4Result, ipv6Result *AllocationResult, err error) {
 	if (family == "ipv6" || family == "") && ipam.IPv6Allocator != nil {
-		ipv6Result, err = ipam.AllocateNextFamily(IPv6, owner)
+		ipv6Result, err = ipam.AllocateNextFamily(IPv6, owner, pool)
 		if err != nil {
 			return
 		}
@@ -201,10 +200,10 @@ func (ipam *IPAM) AllocateNext(family, owner string) (ipv4Result, ipv6Result *Al
 	}
 
 	if (family == "ipv4" || family == "") && ipam.IPv4Allocator != nil {
-		ipv4Result, err = ipam.AllocateNextFamily(IPv4, owner)
+		ipv4Result, err = ipam.AllocateNextFamily(IPv4, owner, pool)
 		if err != nil {
 			if ipv6Result != nil {
-				ipam.ReleaseIP(ipv6Result.IP)
+				ipam.ReleaseIP(ipv6Result.IP, pool)
 			}
 			return
 		}
@@ -216,8 +215,8 @@ func (ipam *IPAM) AllocateNext(family, owner string) (ipv4Result, ipv6Result *Al
 // AllocateNextWithExpiration is identical to AllocateNext but registers an
 // expiration timer as well. This is identical to using AllocateNext() in
 // combination with StartExpirationTimer()
-func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, timeout time.Duration) (ipv4Result, ipv6Result *AllocationResult, err error) {
-	ipv4Result, ipv6Result, err = ipam.AllocateNext(family, owner)
+func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, pool Pool, timeout time.Duration) (ipv4Result, ipv6Result *AllocationResult, err error) {
+	ipv4Result, ipv6Result, err = ipam.AllocateNext(family, owner, pool)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -225,13 +224,13 @@ func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, timeout time.
 	if timeout != time.Duration(0) {
 		for _, result := range []*AllocationResult{ipv4Result, ipv6Result} {
 			if result != nil {
-				result.ExpirationUUID, err = ipam.StartExpirationTimer(result.IP, timeout)
+				result.ExpirationUUID, err = ipam.StartExpirationTimer(result.IP, pool, timeout)
 				if err != nil {
 					if ipv4Result != nil {
-						ipam.ReleaseIP(ipv4Result.IP)
+						ipam.ReleaseIP(ipv4Result.IP, pool)
 					}
 					if ipv6Result != nil {
-						ipam.ReleaseIP(ipv6Result.IP)
+						ipam.ReleaseIP(ipv6Result.IP, pool)
 					}
 					return
 				}
@@ -242,14 +241,14 @@ func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, timeout time.
 	return
 }
 
-func (ipam *IPAM) releaseIPLocked(ip net.IP) error {
+func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 	family := IPv4
 	if ip.To4() != nil {
 		if ipam.IPv4Allocator == nil {
 			return ErrIPv4Disabled
 		}
 
-		if err := ipam.IPv4Allocator.Release(ip); err != nil {
+		if err := ipam.IPv4Allocator.Release(ip, pool); err != nil {
 			return err
 		}
 	} else {
@@ -258,7 +257,7 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP) error {
 			return ErrIPv6Disabled
 		}
 
-		if err := ipam.IPv6Allocator.Release(ip); err != nil {
+		if err := ipam.IPv6Allocator.Release(ip, pool); err != nil {
 			return err
 		}
 	}
@@ -276,17 +275,17 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP) error {
 }
 
 // ReleaseIP release a IP address.
-func (ipam *IPAM) ReleaseIP(ip net.IP) error {
+func (ipam *IPAM) ReleaseIP(ip net.IP, pool Pool) error {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
-	return ipam.releaseIPLocked(ip)
+	return ipam.releaseIPLocked(ip, pool)
 }
 
 // ReleaseIPString is identical to ReleaseIP but takes a string and supports
 // referring to the IPs to be released with the IP itself or the owner name
 // used during allocation. If the owner can be referred to multiple IPs, then
 // all IPs are being released.
-func (ipam *IPAM) ReleaseIPString(releaseArg string) (err error) {
+func (ipam *IPAM) ReleaseIPString(releaseArg string, pool Pool) (err error) {
 	var ips []net.IP
 
 	ip := net.ParseIP(releaseArg)
@@ -301,7 +300,7 @@ func (ipam *IPAM) ReleaseIPString(releaseArg string) (err error) {
 
 	for _, parsedIP := range ips {
 		// If any of the releases fail, report the failure
-		if err2 := ipam.ReleaseIP(parsedIP); err2 != nil {
+		if err2 := ipam.ReleaseIP(parsedIP, pool); err2 != nil {
 			err = err2
 		}
 	}
@@ -353,7 +352,7 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 // by an external entity and that external entity can disappear. Therefore such
 // users should register an expiration timer before returning the IP and then
 // stop the expiration timer when the IP has been used.
-func (ipam *IPAM) StartExpirationTimer(ip net.IP, timeout time.Duration) (string, error) {
+func (ipam *IPAM) StartExpirationTimer(ip net.IP, pool Pool, timeout time.Duration) (string, error) {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
@@ -375,7 +374,7 @@ func (ipam *IPAM) StartExpirationTimer(ip net.IP, timeout time.Duration) (string
 		if currentUUID, ok := ipam.expirationTimers[ipString]; ok {
 			if currentUUID == allocationUUID {
 				scopedLog := log.WithFields(logrus.Fields{"ip": ipString, "uuid": allocationUUID})
-				if err := ipam.releaseIPLocked(ip); err != nil {
+				if err := ipam.releaseIPLocked(ip, pool); err != nil {
 					scopedLog.WithError(err).Warning("Unable to release IP after expiration")
 				} else {
 					scopedLog.Warning("Released IP after expiration")
@@ -397,7 +396,7 @@ func (ipam *IPAM) StartExpirationTimer(ip net.IP, timeout time.Duration) (string
 // The UUID returned by the symmetric StartExpirationTimer must be provided.
 // The expiration timer will only be removed if the UUIDs match. Releasing an
 // IP will also stop the expiration timer.
-func (ipam *IPAM) StopExpirationTimer(ip net.IP, allocationUUID string) error {
+func (ipam *IPAM) StopExpirationTimer(ip net.IP, pool Pool, allocationUUID string) error {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -71,7 +71,7 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
 
-	if ownedBy, ok := ipam.excludedIPs[ip.String()]; ok {
+	if ownedBy, ok := ipam.isIPExcluded(ip); ok {
 		err = fmt.Errorf("IP %s is excluded, owned by %s", ip, ownedBy)
 		return
 	}
@@ -148,7 +148,7 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 			return
 		}
 
-		if !ipam.isIPExcluded(result.IP) {
+		if _, ok := ipam.isIPExcluded(result.IP); !ok {
 			log.WithFields(logrus.Fields{
 				"ip":    result.IP.String(),
 				"owner": owner,

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -50,64 +50,63 @@ func (s *IPAMSuite) TestExpirationTimer(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
 
-	err := ipam.AllocateIP(ip, "foo")
+	err := ipam.AllocateIP(ip, "foo", PoolDefault)
 	c.Assert(err, IsNil)
 
-	uuid, err := ipam.StartExpirationTimer(ip, timeout)
+	uuid, err := ipam.StartExpirationTimer(ip, PoolDefault, timeout)
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Not(Equals), "")
 	// must fail, already registered
-	uuid, err = ipam.StartExpirationTimer(ip, timeout)
+	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault, timeout)
 	c.Assert(err, Not(IsNil))
 	c.Assert(uuid, Equals, "")
 	// must fail, already in use
-	err = ipam.AllocateIP(ip, "foo")
+	err = ipam.AllocateIP(ip, "foo", PoolDefault)
 	c.Assert(err, Not(IsNil))
 	// Let expiration timer expire
 	time.Sleep(2 * timeout)
 	// Must succeed, IP must be released again
-	err = ipam.AllocateIP(ip, "foo")
+	err = ipam.AllocateIP(ip, "foo", PoolDefault)
 	c.Assert(err, IsNil)
 	// register new expiration timer
-	uuid, err = ipam.StartExpirationTimer(ip, timeout)
+	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault, timeout)
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Not(Equals), "")
 	// attempt to stop with an invalid uuid, must fail
-	err = ipam.StopExpirationTimer(ip, "unknown-uuid")
+	err = ipam.StopExpirationTimer(ip, PoolDefault, "unknown-uuid")
 	c.Assert(err, Not(IsNil))
 	// stop expiration with valid uuid
-	err = ipam.StopExpirationTimer(ip, uuid)
+	err = ipam.StopExpirationTimer(ip, PoolDefault, uuid)
 	c.Assert(err, IsNil)
 	// Let expiration timer expire
 	time.Sleep(2 * timeout)
 	// must fail as IP is properly in use now
-	err = ipam.AllocateIP(ip, "foo")
+	err = ipam.AllocateIP(ip, "foo", PoolDefault)
 	c.Assert(err, Not(IsNil))
 	// release IP for real
-	err = ipam.ReleaseIP(ip)
+	err = ipam.ReleaseIP(ip, PoolDefault)
 	c.Assert(err, IsNil)
 
 	// allocate IP again
-	err = ipam.AllocateIP(ip, "foo")
+	err = ipam.AllocateIP(ip, "foo", PoolDefault)
 	c.Assert(err, IsNil)
 	// register expiration timer
-	uuid, err = ipam.StartExpirationTimer(ip, timeout)
+	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault, timeout)
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Not(Equals), "")
 	// release IP, must also stop expiration timer
-	err = ipam.ReleaseIP(ip)
+	err = ipam.ReleaseIP(ip, PoolDefault)
 	c.Assert(err, IsNil)
 	// allocate same IP again
-	err = ipam.AllocateIP(ip, "foo")
+	err = ipam.AllocateIP(ip, "foo", PoolDefault)
 	c.Assert(err, IsNil)
 	// register expiration timer must succeed even though stop was never called
-	uuid, err = ipam.StartExpirationTimer(ip, timeout)
+	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault, timeout)
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Not(Equals), "")
 	// release IP
-	err = ipam.ReleaseIP(ip)
+	err = ipam.ReleaseIP(ip, PoolDefault)
 	c.Assert(err, IsNil)
-
 }
 
 func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
@@ -116,47 +115,47 @@ func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
 
-	ipv4, ipv6, err := ipam.AllocateNextWithExpiration("", "foo", timeout)
+	ipv4, ipv6, err := ipam.AllocateNextWithExpiration("", "foo", PoolDefault, timeout)
 	c.Assert(err, IsNil)
 
 	// IPv4 address must be in use
-	err = ipam.AllocateIP(ipv4.IP, "foo")
+	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault)
 	c.Assert(err, Not(IsNil))
 	// IPv6 address must be in use
-	err = ipam.AllocateIP(ipv6.IP, "foo")
+	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault)
 	c.Assert(err, Not(IsNil))
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be available again
-	err = ipam.AllocateIP(ipv4.IP, "foo")
+	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault)
 	c.Assert(err, IsNil)
 	// IPv6 address must be available again
-	err = ipam.AllocateIP(ipv6.IP, "foo")
+	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault)
 	c.Assert(err, IsNil)
 	// Release IPs
-	err = ipam.ReleaseIP(ipv4.IP)
+	err = ipam.ReleaseIP(ipv4.IP, PoolDefault)
 	c.Assert(err, IsNil)
-	err = ipam.ReleaseIP(ipv6.IP)
+	err = ipam.ReleaseIP(ipv6.IP, PoolDefault)
 	c.Assert(err, IsNil)
 
 	// Allocate IPs again and test stopping the expiration timer
-	ipv4, ipv6, err = ipam.AllocateNextWithExpiration("", "foo", timeout)
+	ipv4, ipv6, err = ipam.AllocateNextWithExpiration("", "foo", PoolDefault, timeout)
 	c.Assert(err, IsNil)
 
 	// Stop expiration timer for IPv4 address
-	err = ipam.StopExpirationTimer(ipv4.IP, ipv4.ExpirationUUID)
+	err = ipam.StopExpirationTimer(ipv4.IP, PoolDefault, ipv4.ExpirationUUID)
 	c.Assert(err, IsNil)
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be in use
-	err = ipam.AllocateIP(ipv4.IP, "foo")
+	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault)
 	c.Assert(err, Not(IsNil))
 	// IPv6 address must be available again
-	err = ipam.AllocateIP(ipv6.IP, "foo")
+	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault)
 	c.Assert(err, IsNil)
 	// Release IPv4 address
-	err = ipam.ReleaseIP(ipv4.IP)
+	err = ipam.ReleaseIP(ipv4.IP, PoolDefault)
 	c.Assert(err, IsNil)
 }

--- a/pkg/ipam/clusterpool.go
+++ b/pkg/ipam/clusterpool.go
@@ -708,12 +708,12 @@ func newClusterPoolAllocator(family Family, conf Configuration, owner Owner, k8s
 	}
 }
 
-func (c *clusterPoolAllocator) Allocate(ip net.IP, owner string) (*AllocationResult, error) {
+func (c *clusterPoolAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	defer sharedCRDWatcher.triggerWithReason("allocation of IP")
-	return c.AllocateWithoutSyncUpstream(ip, owner)
+	return c.AllocateWithoutSyncUpstream(ip, owner, pool)
 }
 
-func (c *clusterPoolAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string) (*AllocationResult, error) {
+func (c *clusterPoolAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	if err := c.pool.allocate(ip); err != nil {
 		return nil, err
 	}
@@ -721,12 +721,12 @@ func (c *clusterPoolAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner stri
 	return &AllocationResult{IP: ip}, nil
 }
 
-func (c *clusterPoolAllocator) AllocateNext(owner string) (*AllocationResult, error) {
+func (c *clusterPoolAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {
 	defer sharedCRDWatcher.triggerWithReason("allocation of next IP")
-	return c.AllocateNextWithoutSyncUpstream(owner)
+	return c.AllocateNextWithoutSyncUpstream(owner, pool)
 }
 
-func (c *clusterPoolAllocator) AllocateNextWithoutSyncUpstream(owner string) (*AllocationResult, error) {
+func (c *clusterPoolAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error) {
 	ip, err := c.pool.allocateNext()
 	if err != nil {
 		return nil, err
@@ -735,7 +735,7 @@ func (c *clusterPoolAllocator) AllocateNextWithoutSyncUpstream(owner string) (*A
 	return &AllocationResult{IP: ip}, nil
 }
 
-func (c *clusterPoolAllocator) Release(ip net.IP) error {
+func (c *clusterPoolAllocator) Release(ip net.IP, pool Pool) error {
 	defer sharedCRDWatcher.triggerWithReason("release of IP")
 	return c.pool.release(ip)
 }

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -746,7 +746,7 @@ func (a *crdAllocator) buildAllocationResult(ip net.IP, ipInfo *ipamTypes.Alloca
 // allocate it if it is available. If the IP is unavailable or already
 // allocated, an error is returned. The custom resource will be updated to
 // reflect the newly allocated IP.
-func (a *crdAllocator) Allocate(ip net.IP, owner string) (*AllocationResult, error) {
+func (a *crdAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
@@ -775,7 +775,7 @@ func (a *crdAllocator) Allocate(ip net.IP, owner string) (*AllocationResult, err
 // custom resource and allocate it if it is available. If the IP is
 // unavailable or already allocated, an error is returned. The custom resource
 // will not be updated.
-func (a *crdAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string) (*AllocationResult, error) {
+func (a *crdAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
@@ -801,7 +801,7 @@ func (a *crdAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string) (*Al
 // Release will release the specified IP or return an error if the IP has not
 // been allocated before. The custom resource will be updated to reflect the
 // released IP.
-func (a *crdAllocator) Release(ip net.IP) error {
+func (a *crdAllocator) Release(ip net.IP, pool Pool) error {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
@@ -825,7 +825,7 @@ func (a *crdAllocator) markAllocated(ip net.IP, owner string, ipInfo ipamTypes.A
 // AllocateNext allocates the next available IP as offered by the custom
 // resource or return an error if no IP is available. The custom resource will
 // be updated to reflect the newly allocated IP.
-func (a *crdAllocator) AllocateNext(owner string) (*AllocationResult, error) {
+func (a *crdAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 
@@ -849,7 +849,7 @@ func (a *crdAllocator) AllocateNext(owner string) (*AllocationResult, error) {
 // AllocateNextWithoutSyncUpstream allocates the next available IP as offered
 // by the custom resource or return an error if no IP is available. The custom
 // resource will not be updated.
-func (a *crdAllocator) AllocateNextWithoutSyncUpstream(owner string) (*AllocationResult, error) {
+func (a *crdAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error) {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -106,7 +106,7 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 	// Allocate the first 3 IPs
 	for i := 1; i <= 3; i++ {
 		epipv4 := netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))
-		_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), fmt.Sprintf("test%d", i))
+		_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), fmt.Sprintf("test%d", i), PoolDefault)
 		c.Assert(err, IsNil)
 	}
 
@@ -114,7 +114,7 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 	cn.Status.IPAM.ReleaseIPs["1.1.1.4"] = ipamOption.IPAMMarkForRelease
 	// Attempts to allocate 1.1.1.4 should fail, since it's already marked for release
 	epipv4 := netip.MustParseAddr("1.1.1.4")
-	_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), "test")
+	_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), "test", PoolDefault)
 	c.Assert(err, NotNil)
 	// Call agent's CRD update function. status for 1.1.1.4 should change from marked for release to ready for release
 	sharedNodeStore.updateLocalNodeResource(cn)

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -31,7 +31,7 @@ func newHostScopeAllocator(n *net.IPNet) Allocator {
 	return a
 }
 
-func (h *hostScopeAllocator) Allocate(ip net.IP, owner string) (*AllocationResult, error) {
+func (h *hostScopeAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	if err := h.allocator.Allocate(ip); err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func (h *hostScopeAllocator) Allocate(ip net.IP, owner string) (*AllocationResul
 	return &AllocationResult{IP: ip}, nil
 }
 
-func (h *hostScopeAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string) (*AllocationResult, error) {
+func (h *hostScopeAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	if err := h.allocator.Allocate(ip); err != nil {
 		return nil, err
 	}
@@ -47,11 +47,11 @@ func (h *hostScopeAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string
 	return &AllocationResult{IP: ip}, nil
 }
 
-func (h *hostScopeAllocator) Release(ip net.IP) error {
+func (h *hostScopeAllocator) Release(ip net.IP, pool Pool) error {
 	return h.allocator.Release(ip)
 }
 
-func (h *hostScopeAllocator) AllocateNext(owner string) (*AllocationResult, error) {
+func (h *hostScopeAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {
 	ip, err := h.allocator.AllocateNext()
 	if err != nil {
 		return nil, err
@@ -60,7 +60,7 @@ func (h *hostScopeAllocator) AllocateNext(owner string) (*AllocationResult, erro
 	return &AllocationResult{IP: ip}, nil
 }
 
-func (h *hostScopeAllocator) AllocateNextWithoutSyncUpstream(owner string) (*AllocationResult, error) {
+func (h *hostScopeAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error) {
 	ip, err := h.allocator.AllocateNext()
 	if err != nil {
 		return nil, err

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -164,13 +164,13 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 // change and suddenly cover the IP to be excluded.
 func (ipam *IPAM) ExcludeIP(ip net.IP, owner string, pool Pool) {
 	ipam.allocatorMutex.Lock()
-	ipam.excludedIPs[ip.String()] = owner
+	ipam.excludedIPs[pool.String()+":"+ip.String()] = owner
 	ipam.allocatorMutex.Unlock()
 }
 
 // isIPExcluded is used to check if a particular IP is excluded from being allocated.
-func (ipam *IPAM) isIPExcluded(ip net.IP) (string, bool) {
-	owner, ok := ipam.excludedIPs[ip.String()]
+func (ipam *IPAM) isIPExcluded(ip net.IP, pool Pool) (string, bool) {
+	owner, ok := ipam.excludedIPs[pool.String()+":"+ip.String()]
 	return owner, ok
 }
 

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -169,9 +169,9 @@ func (ipam *IPAM) ExcludeIP(ip net.IP, owner string, pool Pool) {
 }
 
 // isIPExcluded is used to check if a particular IP is excluded from being allocated.
-func (ipam *IPAM) isIPExcluded(ip net.IP) bool {
-	_, ok := ipam.excludedIPs[ip.String()]
-	return ok
+func (ipam *IPAM) isIPExcluded(ip net.IP) (string, bool) {
+	owner, ok := ipam.excludedIPs[ip.String()]
+	return owner, ok
 }
 
 // PoolOrDefault returns the default pool if no pool is specified.

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -162,7 +162,7 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 // ExcludeIP ensures that a certain IP is never allocated. It is preferred to
 // use this method instead of allocating the IP as the allocation block can
 // change and suddenly cover the IP to be excluded.
-func (ipam *IPAM) ExcludeIP(ip net.IP, owner string) {
+func (ipam *IPAM) ExcludeIP(ip net.IP, owner string, pool Pool) {
 	ipam.allocatorMutex.Lock()
 	ipam.excludedIPs[ip.String()] = owner
 	ipam.allocatorMutex.Unlock()
@@ -172,4 +172,12 @@ func (ipam *IPAM) ExcludeIP(ip net.IP, owner string) {
 func (ipam *IPAM) isIPExcluded(ip net.IP) bool {
 	_, ok := ipam.excludedIPs[ip.String()]
 	return ok
+}
+
+// PoolOrDefault returns the default pool if no pool is specified.
+func PoolOrDefault(pool string) Pool {
+	if pool == "" {
+		return PoolDefault
+	}
+	return Pool(pool)
 }

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -56,17 +56,17 @@ func (s *IPAMSuite) TestLock(c *C) {
 	ipv6 = ipv6.Next()
 
 	// Forcefully release possible allocated IPs
-	err := ipam.IPv4Allocator.Release(ipv4.AsSlice())
+	err := ipam.IPv4Allocator.Release(ipv4.AsSlice(), PoolDefault)
 	c.Assert(err, IsNil)
-	err = ipam.IPv6Allocator.Release(ipv6.AsSlice())
+	err = ipam.IPv6Allocator.Release(ipv6.AsSlice(), PoolDefault)
 	c.Assert(err, IsNil)
 
 	// Let's allocate the IP first so we can see the tests failing
-	result, err := ipam.IPv4Allocator.Allocate(ipv4.AsSlice(), "test")
+	result, err := ipam.IPv4Allocator.Allocate(ipv4.AsSlice(), "test", PoolDefault)
 	c.Assert(err, IsNil)
 	c.Assert(result.IP, checker.DeepEquals, net.IP(ipv4.AsSlice()))
 
-	err = ipam.IPv4Allocator.Release(ipv4.AsSlice())
+	err = ipam.IPv4Allocator.Release(ipv4.AsSlice(), PoolDefault)
 	c.Assert(err, IsNil)
 }
 
@@ -77,22 +77,22 @@ func (s *IPAMSuite) TestExcludeIP(c *C) {
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
 
-	ipam.ExcludeIP(ipv4.AsSlice(), "test-foo")
-	err := ipam.AllocateIP(ipv4.AsSlice(), "test-bar")
+	ipam.ExcludeIP(ipv4.AsSlice(), "test-foo", PoolDefault)
+	err := ipam.AllocateIP(ipv4.AsSlice(), "test-bar", PoolDefault)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, ".* owned by test-foo")
-	err = ipam.ReleaseIP(ipv4.AsSlice())
+	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault)
 	c.Assert(err, IsNil)
 
 	ipv6 := fakeIPv6AllocCIDRIP(fakeAddressing)
 	ipv6 = ipv6.Next()
 
-	ipam.ExcludeIP(ipv6.AsSlice(), "test-foo")
-	err = ipam.AllocateIP(ipv6.AsSlice(), "test-bar")
+	ipam.ExcludeIP(ipv6.AsSlice(), "test-foo", PoolDefault)
+	err = ipam.AllocateIP(ipv6.AsSlice(), "test-bar", PoolDefault)
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, ".* owned by test-foo")
-	ipam.ReleaseIP(ipv6.AsSlice())
-	err = ipam.ReleaseIP(ipv4.AsSlice())
+	ipam.ReleaseIP(ipv6.AsSlice(), PoolDefault)
+	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault)
 	c.Assert(err, IsNil)
 }
 
@@ -107,21 +107,21 @@ func (s *IPAMSuite) TestOwnerRelease(c *C) {
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
-	err := ipam.AllocateIP(ipv4.AsSlice(), "default/test")
+	err := ipam.AllocateIP(ipv4.AsSlice(), "default/test", PoolDefault)
 	c.Assert(err, IsNil)
 
 	ipv6 := fakeIPv6AllocCIDRIP(fakeAddressing)
 	ipv6 = ipv6.Next()
-	err = ipam.AllocateIP(ipv6.AsSlice(), "default/test")
+	err = ipam.AllocateIP(ipv6.AsSlice(), "default/test", PoolDefault)
 	c.Assert(err, IsNil)
 
 	// unknown owner, must fail
-	err = ipam.ReleaseIPString("default/test2")
+	err = ipam.ReleaseIPString("default/test2", PoolDefault)
 	c.Assert(err, Not(IsNil))
 	// 1st release by correct owner, must succeed
-	err = ipam.ReleaseIPString("default/test")
+	err = ipam.ReleaseIPString("default/test", PoolDefault)
 	c.Assert(err, IsNil)
 	// 2nd release by owner, must now fail
-	err = ipam.ReleaseIPString("default/test")
+	err = ipam.ReleaseIPString("default/test", PoolDefault)
 	c.Assert(err, Not(IsNil))
 }

--- a/pkg/ipam/noop_allocator.go
+++ b/pkg/ipam/noop_allocator.go
@@ -15,23 +15,23 @@ var errNotSupported = errors.New("Operation not supported")
 // without relying on the cilium daemon or operator.
 type noOpAllocator struct{}
 
-func (n *noOpAllocator) Allocate(ip net.IP, owner string) (*AllocationResult, error) {
+func (n *noOpAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	return nil, errNotSupported
 }
 
-func (n *noOpAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string) (*AllocationResult, error) {
+func (n *noOpAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
 	return nil, errNotSupported
 }
 
-func (n *noOpAllocator) Release(ip net.IP) error {
+func (n *noOpAllocator) Release(ip net.IP, pool Pool) error {
 	return errNotSupported
 }
 
-func (n *noOpAllocator) AllocateNext(owner string) (*AllocationResult, error) {
+func (n *noOpAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {
 	return nil, errNotSupported
 }
 
-func (n *noOpAllocator) AllocateNextWithoutSyncUpstream(owner string) (*AllocationResult, error) {
+func (n *noOpAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error) {
 	return nil, errNotSupported
 }
 

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -46,3 +46,6 @@ const (
 // prefixes. Every /28 prefix contains 16 IP addresses.
 // See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html#ec2-prefix-basics for more details
 const ENIPDBlockSizeIPv4 = 16
+
+// PoolDefault is the default IP pool from which to allocate.
+const PoolDefault = "default"

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -83,8 +83,8 @@ type IPAM struct {
 	IPv6Allocator Allocator
 	IPv4Allocator Allocator
 
-	// owner maps an IP to the owner
-	owner map[string]string
+	// owner maps an IP to the owner per pool.
+	owner map[Pool]map[string]string
 
 	// expirationTimers is a map of all expiration timers. Each entry
 	// represents a IP allocation which is protected by an expiration

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -94,7 +94,8 @@ type IPAM struct {
 	// mutex covers access to all members of this struct
 	allocatorMutex lock.RWMutex
 
-	// excludedIPS contains excluded IPs and their respective owners.
+	// excludedIPS contains excluded IPs and their respective owners per pool. The key is a
+	// combination pool:ip to avoid having to maintain a map of maps.
 	excludedIPs map[string]string
 }
 

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/types"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -47,22 +48,22 @@ type AllocationResult struct {
 // Allocator is the interface for an IP allocator implementation
 type Allocator interface {
 	// Allocate allocates a specific IP or fails
-	Allocate(ip net.IP, owner string) (*AllocationResult, error)
+	Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error)
 
 	// AllocateWithoutSyncUpstream allocates a specific IP without syncing
 	// upstream or fails
-	AllocateWithoutSyncUpstream(ip net.IP, owner string) (*AllocationResult, error)
+	AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error)
 
 	// Release releases a previously allocated IP or fails
-	Release(ip net.IP) error
+	Release(ip net.IP, pool Pool) error
 
 	// AllocateNext allocates the next available IP or fails if no more IPs
 	// are available
-	AllocateNext(owner string) (*AllocationResult, error)
+	AllocateNext(owner string, pool Pool) (*AllocationResult, error)
 
 	// AllocateNextWithoutSyncUpstream allocates the next available IP without syncing
 	// upstream or fails if no more IPs are available
-	AllocateNextWithoutSyncUpstream(owner string) (*AllocationResult, error)
+	AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error)
 
 	// Dump returns a map of all allocated IPs with the IP represented as
 	// key in the map. Dump must also provide a status one-liner to
@@ -125,3 +126,14 @@ func (ipam *IPAM) GetVpcCIDRs() (vpcCIDRs []*cidr.CIDR) {
 	}
 	return append(secondary, primary)
 }
+
+// Pool is the the IP pool from which to allocate.
+type Pool string
+
+func (p Pool) String() string {
+	return string(p)
+}
+
+const (
+	PoolDefault Pool = ipamOption.PoolDefault
+)

--- a/plugins/cilium-docker/driver/ipam.go
+++ b/plugins/cilium-docker/driver/ipam.go
@@ -105,7 +105,7 @@ func (driver *driver) requestAddress(w http.ResponseWriter, r *http.Request) {
 		family = client.AddressFamilyIPv6
 	}
 
-	ipam, err := driver.client.IPAMAllocate(family, "docker-ipam", false)
+	ipam, err := driver.client.IPAMAllocate(family, "docker-ipam", "", false)
 	if err != nil {
 		sendError(w, fmt.Sprintf("Could not allocate IP address: %s", err), http.StatusBadRequest)
 		return
@@ -145,7 +145,7 @@ func (driver *driver) releaseAddress(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.WithField(logfields.Request, logfields.Repr(&release)).Debug("Release Address request")
-	if err := driver.client.IPAMReleaseIP(release.Address); err != nil {
+	if err := driver.client.IPAMReleaseIP(release.Address, ""); err != nil {
 		sendError(w, fmt.Sprintf("Could not release IP address: %s", err), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
Pass an optional pool parameter to all IPAM API methods. Keep track of owners and excluded IPs per pool. For now only the default pool is used, so no functional change. This is in preparation for IPAM pools, split out of #22762 to ease reviews.

See individual commit messages for more details.

Joint work with @gandro.