### PR TITLE
endpoint: correctly log IPv6 addresses

### DIFF
--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -113,7 +113,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 		logfields.DatapathPolicyRevision: e.policyRevision,
 		logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 		logfields.IPv4:                   e.GetIPv4Address(),
-		logfields.IPv6:                   e.GetIPv4Address(),
+		logfields.IPv6:                   e.GetIPv6Address(),
 		logfields.K8sPodName:             e.getK8sNamespaceAndPodName(),
 	})
 
@@ -171,7 +171,7 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
 			logfields.DatapathPolicyRevision: e.policyRevision,
 			logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 			logfields.IPv4:                   e.GetIPv4Address(),
-			logfields.IPv6:                   e.GetIPv4Address(),
+			logfields.IPv6:                   e.GetIPv6Address(),
 			logfields.K8sPodName:             e.getK8sNamespaceAndPodName(),
 		})
 


### PR DESCRIPTION
Reference: https://github.com/cilium/cilium/commit/f3a4c4d204cf84af3d40f4782aa68e7c2da98440#r103598930
Fixes: f3a4c4d204cf ("endpoint: convert Endpoint from addressing.CiliumIPv{4,6} to netip.Addr")
Reported-by: Joe Stringer <joe@cilium.io>