### PR TITLE
Service Mesh mTLS: Inject IPCache into auth manager via hive

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -641,7 +641,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		}
 	}
 	nodeMngr.SetIPCache(d.ipcache)
-	authManager.SetIPCache(d.ipcache)
 
 	proxy.Allocator = d.identityAllocator
 


### PR DESCRIPTION
Injecting the IPCache via hive instead of setting it explicitly.

This is possible since the `IPCache` itself is now provided via cell. https://github.com/cilium/cilium/pull/24073
