### PR TITLE
nodemanager: inject ipcache into nodemanager via hive

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -640,7 +640,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 			}
 		}
 	}
-	nodeMngr.SetIPCache(d.ipcache)
 
 	proxy.Allocator = d.identityAllocator
 

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -35,7 +35,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.New("", &fakeConfig.Config{})
+	nm, err = manager.New("", &fakeConfig.Config{}, nil)
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -38,7 +39,7 @@ type Notifier interface {
 type NodeManager interface {
 	Notifier
 
-	// GetNodes returns a copy of all of the nodes as a map from Identity to Node.
+	// GetNodes returns a copy of all the nodes as a map from Identity to Node.
 	GetNodes() map[types.Identity]types.Node
 
 	// GetNodeIdentities returns a list of all node identities store in node
@@ -52,22 +53,19 @@ type NodeManager interface {
 	// NodeDeleted is called when the store detects a deletion of a node
 	NodeDeleted(n types.Node)
 
-	// ClusterSizeDependantInterval returns a time.Duration that is dependant on
+	// ClusterSizeDependantInterval returns a time.Duration that is dependent on
 	// the cluster size, i.e. the number of nodes that have been discovered. This
 	// can be used to control sync intervals of shared or centralized resources to
 	// avoid overloading these resources as the cluster grows.
 	ClusterSizeDependantInterval(baseInterval time.Duration) time.Duration
-
-	// SetIPCache sets the ipcache field in the Manager.
-	SetIPCache(ipc IPCache)
 
 	// StartNeighborRefresh spawns a controller which refreshes neighbor table
 	// by sending arping periodically.
 	StartNeighborRefresh(nh datapath.NodeHandler)
 }
 
-func newAllNodeManager(lc hive.Lifecycle) (NodeManager, error) {
-	mngr, err := New("all", option.Config)
+func newAllNodeManager(lc hive.Lifecycle, ipCache *ipcache.IPCache) (NodeManager, error) {
+	mngr, err := New("all", option.Config, ipCache)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -169,13 +169,14 @@ func (m *manager) Iter(f func(nh datapath.NodeHandler)) {
 }
 
 // New returns a new node manager
-func New(name string, c Configuration) (*manager, error) {
+func New(name string, c Configuration, ipCache IPCache) (*manager, error) {
 	m := &manager{
 		name:              name,
 		nodes:             map[nodeTypes.Identity]*nodeEntry{},
 		conf:              c,
 		controllerManager: controller.NewManager(),
 		nodeHandlers:      map[datapath.NodeHandler]struct{}{},
+		ipcache:           ipCache,
 	}
 
 	m.metricEventsReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
@@ -205,11 +206,6 @@ func New(name string, c Configuration) (*manager, error) {
 	}
 
 	return m, nil
-}
-
-// SetIPCache sets the ipcache field in the Manager.
-func (m *manager) SetIPCache(ipc IPCache) {
-	m.ipcache = ipc
 }
 
 func (m *manager) Start(hive.HookContext) error {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -194,8 +194,7 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New("test", &configMock{})
-	mngr.SetIPCache(ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock)
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)
 
@@ -257,9 +256,8 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New("test", &configMock{})
+	mngr, err := New("test", &configMock{}, ipcacheMock)
 	c.Assert(err, check.IsNil)
-	mngr.SetIPCache(ipcacheMock)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
@@ -330,9 +328,8 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New("test", &configMock{})
+	mngr, err := New("test", &configMock{}, ipcacheMock)
 	c.Assert(err, check.IsNil)
-	mngr.SetIPCache(ipcacheMock)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
@@ -352,9 +349,8 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New("test", &configMock{})
+	mngr, err := New("test", &configMock{}, ipcacheMock)
 	c.Assert(err, check.IsNil)
-	mngr.SetIPCache(ipcacheMock)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
@@ -380,8 +376,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New("test", &configMock{})
-	mngr.SetIPCache(ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock)
 	mngr.Subscribe(signalNodeHandler)
 	c.Assert(err, check.IsNil)
 	defer mngr.Stop(context.TODO())
@@ -420,9 +415,8 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 func (s *managerTestSuite) TestIpcache(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{})
+	mngr, err := New("test", &configMock{}, ipcacheMock)
 	c.Assert(err, check.IsNil)
-	mngr.SetIPCache(ipcacheMock)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
@@ -469,9 +463,8 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{})
+	mngr, err := New("test", &configMock{}, ipcacheMock)
 	c.Assert(err, check.IsNil)
-	mngr.SetIPCache(ipcacheMock)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
@@ -546,9 +539,8 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{RemoteNodeIdentity: true})
+	mngr, err := New("test", &configMock{RemoteNodeIdentity: true}, ipcacheMock)
 	c.Assert(err, check.IsNil)
-	mngr.SetIPCache(ipcacheMock)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
@@ -623,9 +615,8 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{NodeEncryption: true, Encryption: true})
+	mngr, err := New("test", &configMock{NodeEncryption: true, Encryption: true}, ipcacheMock)
 	c.Assert(err, check.IsNil)
-	mngr.SetIPCache(ipcacheMock)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 
@@ -715,9 +706,8 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := New("test", &configMock{})
+	mngr, err := New("test", &configMock{}, ipcacheMock)
 	c.Assert(err, check.IsNil)
-	mngr.SetIPCache(ipcacheMock)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
 


### PR DESCRIPTION
Injecting the IPCache into the nodemanager via hive instead of setting it explicitly from within the daemon.

This is possible since the IPCache itself is now provided via cell. https://github.com/cilium/cilium/pull/24073