### PR TITLE
fuzzing: modify oss-fuzz build script

### DIFF
--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -20,4 +20,6 @@ compile_go_fuzzer github.com/cilium/cilium/test/fuzzing Fuzz fuzz gofuzz
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/monitor/format FuzzFormatEvent FuzzFormatEvent
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumNetworkPolicyParse FuzzCiliumNetworkPolicyParse
 compile_native_go_fuzzer github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2 FuzzCiliumClusterwideNetworkPolicyParse FuzzCiliumClusterwideNetworkPolicyParse
-compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzTest FuzzResolveEgressPolicy
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzResolveEgressPolicy FuzzResolveEgressPolicy
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzDenyPreferredInsert FuzzDenyPreferredInsert
+compile_native_go_fuzzer github.com/cilium/cilium/pkg/policy FuzzAccumulateMapChange FuzzAccumulateMapChange


### PR DESCRIPTION
Modifies the name of a fuzzer in the build script. Builds two more fuzzers.

