### PR TITLE
Service mesh: add mTLS auth method

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -228,6 +228,9 @@ cilium-agent [flags]
       --log-opt map                                             Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
       --log-system-load                                         Enable periodic logging of system load
       --mesh-auth-monitor-queue-size int                        Queue size for the auth monitor (default 1024)
+      --mesh-auth-mtls-listener-port int                        Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spire-admin-socket string                     The path for the SPIRE admin agent Unix socket.
       --metrics strings                                         Metrics that should be enabled or disabled from the default metric list. The list is expected to be separated by a space. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
       --monitor-aggregation string                              Level of monitor aggregation for traces from the datapath (default "None")
       --monitor-aggregation-flags strings                       TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -11,19 +11,22 @@ cilium-agent hive [flags]
 ### Options
 
 ```
-      --certificates-directory string      Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --enable-k8s-api-discovery           Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                   Port for gops server to listen on (default 9890)
-  -h, --help                               help for hive
-      --k8s-api-server string              Kubernetes API server URL
-      --k8s-client-burst int               Burst value allowed for the K8s client
-      --k8s-client-qps float32             Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration     Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string         Absolute path of the kubernetes kubeconfig file
-      --mesh-auth-monitor-queue-size int   Queue size for the auth monitor (default 1024)
-      --pprof                              Enable serving pprof debugging API
-      --pprof-address string               Address that pprof listens on (default "localhost")
-      --pprof-port uint16                  Port that pprof listens on (default 6060)
+      --certificates-directory string          Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                       Port for gops server to listen on (default 9890)
+  -h, --help                                   help for hive
+      --k8s-api-server string                  Kubernetes API server URL
+      --k8s-client-burst int                   Burst value allowed for the K8s client
+      --k8s-client-qps float32                 Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration         Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int       Queue size for the auth monitor (default 1024)
+      --mesh-auth-mtls-listener-port int       Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spire-admin-socket string    The path for the SPIRE admin agent Unix socket.
+      --pprof                                  Enable serving pprof debugging API
+      --pprof-address string                   Address that pprof listens on (default "localhost")
+      --pprof-port uint16                      Port that pprof listens on (default 6060)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -17,18 +17,21 @@ cilium-agent hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --certificates-directory string      Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --enable-k8s-api-discovery           Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                   Port for gops server to listen on (default 9890)
-      --k8s-api-server string              Kubernetes API server URL
-      --k8s-client-burst int               Burst value allowed for the K8s client
-      --k8s-client-qps float32             Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration     Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string         Absolute path of the kubernetes kubeconfig file
-      --mesh-auth-monitor-queue-size int   Queue size for the auth monitor (default 1024)
-      --pprof                              Enable serving pprof debugging API
-      --pprof-address string               Address that pprof listens on (default "localhost")
-      --pprof-port uint16                  Port that pprof listens on (default 6060)
+      --certificates-directory string          Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                       Port for gops server to listen on (default 9890)
+      --k8s-api-server string                  Kubernetes API server URL
+      --k8s-client-burst int                   Burst value allowed for the K8s client
+      --k8s-client-qps float32                 Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration         Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int       Queue size for the auth monitor (default 1024)
+      --mesh-auth-mtls-listener-port int       Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spire-admin-socket string    The path for the SPIRE admin agent Unix socket.
+      --pprof                                  Enable serving pprof debugging API
+      --pprof-address string                   Address that pprof listens on (default "localhost")
+      --pprof-port uint16                      Port that pprof listens on (default 6060)
 ```
 
 ### SEE ALSO

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -37,6 +37,22 @@
      - Annotate k8s node upon initialization with Cilium's metadata.
      - bool
      - ``false``
+   * - auth.mTLS.enabled
+     - Enable mtls-spiffe authentication method in CiliumNetworkPolicy
+     - bool
+     - ``false``
+   * - auth.mTLS.port
+     - port on the agent which is used to mTLS handshakes on
+     - int
+     - ``4250``
+   * - auth.mTLS.spiffeTrustDomain
+     - SPIFFE trust domain to use for fetching certificates
+     - string
+     - ``"spiffe.cilium.io"``
+   * - auth.mTLS.spireAdminSocketPath
+     - SPIRE socket path where the SPIRE delegated api agent is listening
+     - string
+     - ``"/run/spire/sockets/admin.sock"``
    * - autoDirectNodeRoutes
      - Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -188,9 +188,9 @@ asm
 assignees
 au
 auth
+authenticator
 authMapMax
 authMapMin
-authenticator
 autoDirectNodeRoutes
 autoMount
 autoProtectPortRange
@@ -710,6 +710,7 @@ monitorInterval
 mountCgroup
 mountPath
 mov
+mtls
 mul
 multi
 multicore
@@ -947,6 +948,9 @@ sockops
 sortBufferDrainTimeout
 sortBufferLenMax
 sourceContext
+spiffe
+spiffeTrustDomain
+spireAdminSocketPath
 src
 srv
 ssl

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -60,6 +60,10 @@ contributors across the globe, there is almost always someone available to help.
 | aksbyocni.enabled | bool | `false` | Enable AKS BYOCNI integration. Note that this is incompatible with AKS clusters not created in BYOCNI mode: use Azure integration (`azure.enabled`) instead. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
+| auth.mTLS.enabled | bool | `false` | Enable mtls-spiffe authentication method in CiliumNetworkPolicy |
+| auth.mTLS.port | int | `4250` | port on the agent which is used to mTLS handshakes on |
+| auth.mTLS.spiffeTrustDomain | string | `"spiffe.cilium.io"` | SPIFFE trust domain to use for fetching certificates |
+| auth.mTLS.spireAdminSocketPath | string | `"/run/spire/sockets/admin.sock"` | SPIRE socket path where the SPIRE delegated api agent is listening |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |
 | azure.enabled | bool | `false` | Enable Azure integration. Note that this is incompatible with AKS clusters created in BYOCNI mode: use AKS BYOCNI integration (`aksbyocni.enabled`) instead. |
 | bandwidthManager | object | `{"bbr":false,"enabled":false}` | Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -281,6 +281,11 @@ spec:
           {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
+        {{- if .Values.auth.mTLS.enabled }}
+        - name: spire-agent-socket
+          mountPath: {{ dir .Values.auth.mTLS.spireAdminSocketPath }}
+          readOnly: false
+        {{- end }}
         {{- if not .Values.securityContext.privileged }}
         # Unprivileged containers need to mount /proc/sys/net from the host
         # to have write access
@@ -776,6 +781,12 @@ spec:
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
+      {{- if .Values.auth.mTLS.enabled }}
+      - name: spire-agent-socket
+        hostPath:
+          path: {{ dir .Values.auth.mTLS.spireAdminSocketPath }}
+          type: DirectoryOrCreate
+      {{- end }}
       {{- if .Values.kubeConfigPath }}
       - name: kube-config
         hostPath:

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -999,6 +999,12 @@ data:
 
 {{- end }}
 
+{{- if .Values.auth.mTLS.enabled }}
+  mesh-auth-mtls-listener-port: {{ .Values.auth.mTLS.port | quote }}
+  mesh-auth-spire-admin-socket: {{ .Values.auth.mTLS.spireAdminSocketPath }}
+  mesh-auth-spiffe-trust-domain: {{ .Values.auth.mTLS.spiffeTrustDomain }}
+{{- end }}
+
 ---
 {{- if and .Values.ipMasqAgent.enabled .Values.ipMasqAgent.config }}
 apiVersion: v1

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2607,3 +2607,14 @@ dnsProxy:
 sctp:
   # -- Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming.
   enabled: false
+
+auth:
+  mTLS:
+    # -- Enable mtls-spiffe authentication method in CiliumNetworkPolicy
+    enabled: false
+    # -- SPIRE socket path where the SPIRE delegated api agent is listening
+    spireAdminSocketPath: /run/spire/sockets/admin.sock
+    # -- SPIFFE trust domain to use for fetching certificates
+    spiffeTrustDomain: spiffe.cilium.io
+    # -- port on the agent which is used to mTLS handshakes on
+    port: 4250

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2604,3 +2604,14 @@ dnsProxy:
 sctp:
   # -- Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming.
   enabled: false
+
+auth:
+  mTLS:
+    # -- Enable mtls-spiffe authentication method in CiliumNetworkPolicy
+    enabled: false
+    # -- SPIRE socket path where the SPIRE delegated api agent is listening
+    spireAdminSocketPath: /run/spire/sockets/admin.sock
+    # -- SPIFFE trust domain to use for fetching certificates
+    spiffeTrustDomain: spiffe.cilium.io
+    # -- port on the agent which is used to mTLS handshakes on
+    port: 4250

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/auth/monitor"
+	"github.com/cilium/cilium/pkg/auth/spire"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -24,6 +25,8 @@ var Cell = cell.Module(
 	"auth-manager",
 	"Authenticates requests as demanded by policy",
 
+	spire.Cell,
+
 	// The manager is the main entry point which gets registered to the agent monitor and receives auth requests.
 	cell.Provide(newManager),
 	cell.ProvidePrivate(
@@ -31,8 +34,11 @@ var Cell = cell.Module(
 		newNullAuthHandler,
 		// CT map authenticator provides support to write authentication information into the eBPF conntrack map
 		newCtMapAuthenticator,
+		// MTLS auth handler provides support for auth type "mtls-*" - which performs mTLS authentication.
+		newMTLSAuthHandler,
 	),
 	cell.Config(config{MeshAuthMonitorQueueSize: 1024}),
+	cell.Config(MTLSConfig{}),
 )
 
 type config struct {

--- a/pkg/auth/certs/provider.go
+++ b/pkg/auth/certs/provider.go
@@ -6,6 +6,8 @@ package certs
 import (
 	"crypto/tls"
 	"crypto/x509"
+
+	"github.com/cilium/cilium/pkg/identity"
 )
 
 type CertificateProvider interface {
@@ -15,10 +17,16 @@ type CertificateProvider interface {
 
 	// GetCertificateForIdentity gives the certificate and intermediates required
 	// to send as trust chain for a certain identity as well as a private key
-	GetCertificateForIdentity(identity string) (*tls.Certificate, error)
+	GetCertificateForIdentity(id identity.NumericIdentity) (*tls.Certificate, error)
 
 	// ValidateIdentity will check if the SANs or other identity methods are valid
 	// for the given Cilium identity this function is needed as SPIFFE encodes the
 	// full ID in the URI SAN.
-	ValidateIdentity(identity string, cert *x509.Certificate) (bool, error)
+	ValidateIdentity(id identity.NumericIdentity, cert *x509.Certificate) (bool, error)
+
+	// NumericIdentityToSNI will return the SNI that should be used for a given Cilium Identity
+	NumericIdentityToSNI(id identity.NumericIdentity) string
+
+	// SNIToNumericIdentity will return the Cilium Identity for a given SNI
+	SNIToNumericIdentity(sni string) (identity.NumericIdentity, error)
 }

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -60,6 +60,9 @@ type authResult struct {
 func newAuthManager(authHandlers []authHandler, dpAuthenticator datapathAuthenticator, ipCache ipCache) (*authManager, error) {
 	ahs := map[policy.AuthType]authHandler{}
 	for _, ah := range authHandlers {
+		if ah == nil {
+			continue
+		}
 		if _, ok := ahs[ah.authType()]; ok {
 			return nil, fmt.Errorf("multiple handlers for auth type: %s", ah.authType())
 		}

--- a/pkg/auth/mtls_authhandler.go
+++ b/pkg/auth/mtls_authhandler.go
@@ -1,0 +1,274 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/auth/certs"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+type mtlsParams struct {
+	cell.In
+
+	CertificateProvider certs.CertificateProvider
+}
+
+func newMTLSAuthHandler(lc hive.Lifecycle, cfg MTLSConfig, params mtlsParams, log logrus.FieldLogger) authHandlerResult {
+	if cfg.MTLSListenerPort == 0 {
+		log.Info("mTLS Auth Handler is disabled as no port is configured")
+		return authHandlerResult{}
+	}
+	if params.CertificateProvider == nil {
+		log.Fatal("No certificate provider configured, but one is required. Please check if the spire flags are configured.")
+	}
+
+	mtls := &mtlsAuthHandler{
+		cfg:  cfg,
+		log:  log.WithField(logfields.LogSubsys, "mtls-auth-handler"),
+		cert: params.CertificateProvider,
+	}
+
+	lc.Append(hive.Hook{OnStart: mtls.onStart, OnStop: mtls.onStop})
+
+	return authHandlerResult{
+		AuthHandler: mtls,
+	}
+}
+
+type MTLSConfig struct {
+	MTLSListenerPort int `mapstructure:"mesh-auth-mtls-listener-port"`
+}
+
+func (cfg MTLSConfig) Flags(flags *pflag.FlagSet) {
+	flags.IntVar(&cfg.MTLSListenerPort, "mesh-auth-mtls-listener-port", 0, "Port on which the Cilium Agent will perfom mTLS handshakes between other Agents")
+}
+
+type mtlsAuthHandler struct {
+	cell.In
+
+	cfg MTLSConfig
+	log logrus.FieldLogger
+
+	cert certs.CertificateProvider
+
+	cancelSocketListen context.CancelFunc
+}
+
+func (m *mtlsAuthHandler) authenticate(ar *authRequest) (*authResponse, error) {
+	if ar == nil {
+		return nil, errors.New("authRequest is nil")
+	}
+	clientCert, err := m.cert.GetCertificateForIdentity(ar.localIdentity)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get certificate for local identity %s: %w", ar.localIdentity.String(), err)
+	}
+
+	caBundle, err := m.cert.GetTrustBundle()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get CA bundle: %w", err)
+	}
+
+	// set up TCP connection
+	conn, err := net.Dial("tcp", net.JoinHostPort(ar.remoteHostIP.String(), strconv.Itoa(m.cfg.MTLSListenerPort)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial %s:%d: %w", ar.remoteHostIP.String(), m.cfg.MTLSListenerPort, err)
+	}
+	defer conn.Close()
+
+	var expirationTime *time.Time = &clientCert.Leaf.NotAfter
+
+	// set up TLS socket
+
+	//nolint:gosec // InsecureSkipVerify is not insecure as we do the verification in VerifyPeerCertificate
+	tlsConn := tls.Client(conn, &tls.Config{
+		ServerName: m.cert.NumericIdentityToSNI(ar.remoteIdentity),
+		GetClientCertificate: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return clientCert, nil
+		},
+		MinVersion:         tls.VersionTLS13,
+		InsecureSkipVerify: true, // not insecure as we do the verification in VerifyPeerCertificate
+		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+			// verifiedChains will be nil as we set InsecureSkipVerify to true
+
+			chain := make([]*x509.Certificate, len(rawCerts))
+			for i, rawCert := range rawCerts {
+				cert, err := x509.ParseCertificate(rawCert)
+				if err != nil {
+					return fmt.Errorf("failed to parse certificate: %w", err)
+				}
+				chain[i] = cert
+			}
+
+			peerExpirationTime, err := m.verifyPeerCertificate(&ar.remoteIdentity, caBundle, [][]*x509.Certificate{chain})
+			if peerExpirationTime != nil && peerExpirationTime.Before(*expirationTime) {
+				expirationTime = peerExpirationTime // send down the lowest expiration time of the two certificates
+			}
+			return err
+		},
+		ClientCAs: caBundle,
+		RootCAs:   caBundle,
+	})
+	defer tlsConn.Close()
+
+	if err := tlsConn.Handshake(); err != nil {
+		return nil, fmt.Errorf("failed to perform TLS handshake: %w", err)
+	}
+
+	if expirationTime == nil {
+		return nil, fmt.Errorf("failed to get expiration time of peer certificate")
+	}
+
+	return &authResponse{
+		expirationTime: *expirationTime,
+	}, nil
+}
+
+func (m *mtlsAuthHandler) authType() policy.AuthType {
+	return policy.AuthTypeMTLSSpiffe
+}
+
+func (m *mtlsAuthHandler) listenForConnections(upstreamCtx context.Context, ready chan<- struct{}) {
+	// set up TCP listener
+
+	ctx, cancel := context.WithCancel(upstreamCtx)
+	defer cancel()
+
+	var lc net.ListenConfig
+	l, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", m.cfg.MTLSListenerPort))
+	if err != nil {
+		m.log.WithError(err).Fatal("Failed to start mTLS listener")
+	}
+	go func() { // shutdown socket goroutine
+		<-ctx.Done()
+		l.Close()
+	}()
+
+	m.log.WithField(logfields.Port, m.cfg.MTLSListenerPort).Info("Started mTLS listener")
+	ready <- struct{}{} // signal to hive that we are ready to accept connections
+
+	for {
+		conn, err := l.Accept()
+		if err != nil {
+			m.log.WithError(err).Error("Failed to accept connection")
+			if errors.Is(err, net.ErrClosed) {
+				m.log.Info("mTLS listener socket got closed")
+				return
+			}
+			continue
+		}
+		go m.handleConnection(ctx, conn)
+	}
+}
+
+func (m *mtlsAuthHandler) handleConnection(ctx context.Context, conn net.Conn) {
+	defer conn.Close()
+
+	caBundle, err := m.cert.GetTrustBundle()
+	if err != nil {
+		m.log.WithError(err).Error("failed to get CA bundle")
+		return
+	}
+
+	tlsConn := tls.Server(conn, &tls.Config{
+		ClientAuth:     tls.RequireAndVerifyClientCert,
+		GetCertificate: m.GetCertificateForIncomingConnection,
+		MinVersion:     tls.VersionTLS13,
+		ClientCAs:      caBundle,
+	})
+	defer tlsConn.Close()
+
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		m.log.WithError(err).Error("failed to perform TLS handshake")
+	}
+}
+
+func (m *mtlsAuthHandler) GetCertificateForIncomingConnection(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	m.log.WithField("SNI", info.ServerName).Debug("Got new TLS connection")
+	id, err := m.cert.SNIToNumericIdentity(info.ServerName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get identity for SNI %s: %w", info.ServerName, err)
+	}
+
+	return m.cert.GetCertificateForIdentity(id)
+}
+
+func (m *mtlsAuthHandler) onStart(ctx hive.HookContext) error {
+	m.log.Info("Starting mTLS auth handler")
+
+	listenCtx, cancel := context.WithCancel(context.Background())
+	m.cancelSocketListen = cancel
+
+	ready := make(chan struct{})
+	go m.listenForConnections(listenCtx, ready)
+	<-ready // wait for the socket to be ready
+	return nil
+}
+
+func (m *mtlsAuthHandler) onStop(ctx hive.HookContext) error {
+	m.log.Info("Stopping mTLS auth handler")
+	m.cancelSocketListen()
+	return nil
+}
+
+// verifyPeerCertificate is used for Go's TLS library to verify certificates
+func (m *mtlsAuthHandler) verifyPeerCertificate(id *identity.NumericIdentity, caBundle *x509.CertPool, certChains [][]*x509.Certificate) (*time.Time, error) {
+	if len(certChains) == 0 {
+		return nil, fmt.Errorf("no certificate chains found")
+	}
+
+	var expirationTime *time.Time
+
+	for _, chain := range certChains {
+		opts := x509.VerifyOptions{
+			Roots:         caBundle,
+			Intermediates: x509.NewCertPool(),
+		}
+
+		var leaf *x509.Certificate
+		for _, cert := range chain {
+			if cert.IsCA {
+				opts.Intermediates.AddCert(cert)
+			} else {
+				leaf = cert
+			}
+		}
+		if leaf == nil {
+			return nil, fmt.Errorf("no leaf certificate found")
+		}
+		if _, err := leaf.Verify(opts); err != nil {
+			return nil, fmt.Errorf("failed to verify certificate: %w", err)
+		}
+
+		if id != nil { // this will be empty in the peer connection
+			m.log.WithField("SNI ID", id.String()).Debug("Validating Server SNI")
+			if valid, err := m.cert.ValidateIdentity(*id, leaf); err != nil {
+				return nil, fmt.Errorf("failed to validate SAN: %w", err)
+			} else if !valid {
+				return nil, fmt.Errorf("unable to validate SAN")
+			}
+		}
+
+		expirationTime = &leaf.NotAfter
+
+		m.log.WithField("uri-san", leaf.URIs).Debug("Validated certificate")
+	}
+
+	return expirationTime, nil
+}

--- a/pkg/auth/mtls_authhandler_test.go
+++ b/pkg/auth/mtls_authhandler_test.go
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"math/big"
+	"net"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/identity"
+)
+
+var (
+	id1000 = identity.NumericIdentity(1000)
+	id1001 = identity.NumericIdentity(1001)
+	idbad1 = identity.NumericIdentity(9999)
+)
+
+type fakeCertificateProvider struct {
+	certMap    map[string]*x509.Certificate
+	privkeyMap map[string]*ecdsa.PrivateKey
+	caPool     *x509.CertPool
+}
+
+func (f *fakeCertificateProvider) GetTrustBundle() (*x509.CertPool, error) {
+	return f.caPool, nil
+}
+
+func (f *fakeCertificateProvider) GetCertificateForIdentity(id identity.NumericIdentity) (*tls.Certificate, error) {
+	uriSAN := "spiffe://spiffe.cilium.io/cilium-id/" + id.String()
+	cert, ok := f.certMap[uriSAN]
+	if !ok {
+		return nil, fmt.Errorf("no certificate for %s", uriSAN)
+	}
+
+	// convert the x509 cert to tls cert
+	certBytes := cert.Raw
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{certBytes},
+		PrivateKey:  f.privkeyMap[uriSAN],
+		Leaf:        cert,
+	}
+	return &tlsCert, nil
+}
+
+func (f *fakeCertificateProvider) ValidateIdentity(id identity.NumericIdentity, cert *x509.Certificate) (bool, error) {
+	for _, uri := range cert.URIs {
+		if uri.String() == fmt.Sprintf("spiffe://spiffe.cilium.io/cilium-id/%d", id) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *fakeCertificateProvider) NumericIdentityToSNI(id identity.NumericIdentity) string {
+	return id.String() + "." + "spiffe.cilium.io"
+}
+
+func (f *fakeCertificateProvider) SNIToNumericIdentity(sni string) (identity.NumericIdentity, error) {
+	suffix := "." + "spiffe.cilium.io"
+	if !strings.HasSuffix(sni, suffix) {
+		return 0, fmt.Errorf("SNI %s does not belong to our trust domain", sni)
+	}
+
+	idStr := strings.TrimSuffix(sni, suffix)
+	return identity.ParseNumericIdentity(idStr)
+}
+
+func generateTestCertificates(t *testing.T) (map[string]*x509.Certificate, map[string]*ecdsa.PrivateKey, *x509.CertPool) {
+	caPool := x509.NewCertPool()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	caCert := &x509.Certificate{
+		Subject:               pkix.Name{CommonName: "ca"},
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		SerialNumber:          big.NewInt(1),
+		BasicConstraintsValid: true,
+	}
+	// sign the CA certificate
+	caCertBytes, err := x509.CreateCertificate(rand.Reader, caCert, caCert, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to sign CA certificate: %v", err)
+	}
+	caCert, err = x509.ParseCertificate(caCertBytes)
+	if err != nil {
+		t.Fatalf("failed to parse CA certificate: %v", err)
+	}
+	caPool.AddCert(caCert)
+
+	// sign two SPIFFE like certificates
+	leafCerts := make(map[string]*x509.Certificate)
+	leafPrivKeys := make(map[string]*ecdsa.PrivateKey)
+
+	for i := 1000; i <= 1001; i++ {
+		certURL, err := url.Parse(fmt.Sprintf("spiffe://spiffe.cilium.io/cilium-id/%d", i))
+		if err != nil {
+			t.Fatalf("failed to parse URL: %v", err)
+		}
+		leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatalf("failed to generate leaf key: %v", err)
+		}
+		leafCert := &x509.Certificate{
+			NotAfter:     time.Now().Add(time.Hour),
+			URIs:         []*url.URL{certURL},
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+			SerialNumber: big.NewInt(int64(i)),
+		}
+		leafCertBytes, err := x509.CreateCertificate(rand.Reader, leafCert, caCert, &leafKey.PublicKey, caKey)
+		if err != nil {
+			t.Fatalf("failed to sign leaf certificate: %v", err)
+		}
+		leafCert, err = x509.ParseCertificate(leafCertBytes)
+		if err != nil {
+			t.Fatalf("failed to parse leaf certificate: %v", err)
+		}
+		leafCerts[certURL.String()] = leafCert
+		leafPrivKeys[certURL.String()] = leafKey
+	}
+
+	return leafCerts, leafPrivKeys, caPool
+}
+
+func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
+	certMap, keyMap, caPool := generateTestCertificates(t)
+	certMapOtherCA, _, _ := generateTestCertificates(t)
+	type args struct {
+		id             *identity.NumericIdentity
+		caBundle       *x509.CertPool
+		verifiedChains [][]*x509.Certificate
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *time.Time
+		wantErr bool
+	}{
+		{
+			name: "valid certificate with SNI to match identity",
+			args: args{
+				id:             &id1000,
+				caBundle:       caPool,
+				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+			},
+			want:    &certMap["spiffe://spiffe.cilium.io/cilium-id/1000"].NotAfter,
+			wantErr: false,
+		},
+		{
+			name: "valid certificate with no identity provided",
+			args: args{
+				id:             nil,
+				caBundle:       caPool,
+				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+			},
+			want:    &certMap["spiffe://spiffe.cilium.io/cilium-id/1000"].NotAfter,
+			wantErr: false,
+		},
+		{
+			name: "error on invalid certificate because incorrect identity provided",
+			args: args{
+				id:             &id1001,
+				caBundle:       caPool,
+				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error on invalid certificate signed by other CA",
+			args: args{
+				id:             &id1000,
+				caBundle:       caPool,
+				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error on invalid certificate signed by other CA with no identity provided",
+			args: args{
+				id:             nil,
+				caBundle:       caPool,
+				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+			},
+			want:    nil,
+			wantErr: true,
+		}, {
+			name: "error on no certificates in verifiedChains",
+			args: args{
+				id:             nil,
+				caBundle:       caPool,
+				verifiedChains: [][]*x509.Certificate{},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error on empty caBundle provided",
+			args: args{
+				id:             nil,
+				caBundle:       x509.NewCertPool(),
+				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mtlsAuthHandler{
+				cfg:  MTLSConfig{MTLSListenerPort: 1234},
+				log:  log,
+				cert: &fakeCertificateProvider{certMap: certMap, caPool: caPool, privkeyMap: keyMap},
+			}
+			got, err := m.verifyPeerCertificate(tt.args.id, tt.args.caBundle, tt.args.verifiedChains)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mtlsAuthHandler.verifyPeerCertificate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mtlsAuthHandler.verifyPeerCertificate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mtlsAuthHandler_GetCertificateForIncomingConnection(t *testing.T) {
+	certMap, keyMap, caPool := generateTestCertificates(t)
+	type args struct {
+		info *tls.ClientHelloInfo
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantURI string
+		wantErr bool
+	}{
+		{
+			name: "valid certificate with SNI to match identity",
+			args: args{
+				info: &tls.ClientHelloInfo{
+					ServerName: "1000.spiffe.cilium.io",
+				},
+			},
+			wantURI: "spiffe://spiffe.cilium.io/cilium-id/1000",
+			wantErr: false,
+		},
+		{
+			name: "no certificate for non existing identity",
+			args: args{
+				info: &tls.ClientHelloInfo{
+					ServerName: "9999.spiffe.cilium.io",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "no certificate for random non existing domain",
+			args: args{
+				info: &tls.ClientHelloInfo{
+					ServerName: "www.example.com",
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mtlsAuthHandler{
+				cfg:  MTLSConfig{MTLSListenerPort: 1234},
+				log:  log,
+				cert: &fakeCertificateProvider{certMap: certMap, caPool: caPool, privkeyMap: keyMap},
+			}
+			got, err := m.GetCertificateForIncomingConnection(tt.args.info)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mtlsAuthHandler.GetCertificateForIncomingConnection() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if got.Leaf == nil {
+					t.Errorf("mtlsAuthHandler.GetCertificateForIncomingConnection() leaf certificate is nil")
+				}
+				if len(got.Leaf.URIs) == 0 {
+					t.Errorf("mtlsAuthHandler.GetCertificateForIncomingConnection() leaf certificate has no URIs")
+				}
+				gotURI := got.Leaf.URIs[0].String()
+				if !reflect.DeepEqual(gotURI, tt.wantURI) {
+					t.Errorf("mtlsAuthHandler.GetCertificateForIncomingConnection() = %v, want %v", got, tt.wantURI)
+				}
+			}
+
+		})
+	}
+}
+
+func Test_mtlsAuthHandler_authenticate(t *testing.T) {
+	certMap, keyMap, caPool := generateTestCertificates(t)
+
+	tls := &mtlsAuthHandler{
+		cfg:  MTLSConfig{MTLSListenerPort: getRandomOpenPort(t)},
+		log:  log,
+		cert: &fakeCertificateProvider{certMap: certMap, caPool: caPool, privkeyMap: keyMap},
+	}
+	tls.onStart(context.Background())
+	defer tls.onStop(context.Background())
+
+	var lowestExpirationTime time.Time
+	for _, cert := range certMap {
+		if lowestExpirationTime.IsZero() || cert.NotAfter.Before(lowestExpirationTime) {
+			lowestExpirationTime = cert.NotAfter
+		}
+	}
+
+	type args struct {
+		ar *authRequest
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *authResponse
+		wantErr bool
+	}{
+		{
+			name: "authenticate two valid identities",
+			args: args{
+				ar: &authRequest{
+					localIdentity:  id1000,
+					remoteIdentity: id1001,
+					remoteHostIP:   GetLoopBackIP(t),
+				},
+			},
+			want: &authResponse{
+				expirationTime: lowestExpirationTime,
+			},
+		},
+		{
+			name: "error on authenticate when remote identity is not valid",
+			args: args{
+				ar: &authRequest{
+					localIdentity:  id1000,
+					remoteIdentity: idbad1,
+					remoteHostIP:   GetLoopBackIP(t),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error on  authenticate when local identity is not valid",
+			args: args{
+				ar: &authRequest{
+					localIdentity:  idbad1,
+					remoteIdentity: id1001,
+					remoteHostIP:   GetLoopBackIP(t),
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error on authenticate when auth request is bad",
+			args: args{
+				ar: &authRequest{
+					localIdentity: id1000,
+					// all other fields are intentionally left blank
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tls.authenticate(tt.args.ar)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mtlsAuthHandler.authenticate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mtlsAuthHandler.authenticate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func getRandomOpenPort(t *testing.T) int {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("failed to get random open port: %v", err)
+	}
+	defer l.Close()
+	addr := l.Addr().(*net.TCPAddr)
+	return addr.Port
+}
+
+func GetLoopBackIP(t *testing.T) net.IP {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		t.Fatalf("failed to get interface addresses: %v", err)
+	}
+	for _, address := range addrs {
+		if ipnet, ok := address.(*net.IPNet); ok && ipnet.IP.IsLoopback() {
+			return ipnet.IP
+		}
+	}
+
+	t.Fatalf("failed to get loopback IP")
+	return nil
+}

--- a/pkg/auth/spire/certificate_provider_test.go
+++ b/pkg/auth/spire/certificate_provider_test.go
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package spire
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
+	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "spire") // just to avoid nil errors as well as debugging tests
+
+func TestSpireDelegateClient_NumericIdentityToSNI(t *testing.T) {
+	type args struct {
+		id identity.NumericIdentity
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "convert valid numeric identity",
+			args: args{
+				id: 1234,
+			},
+			want: "1234.test.cilium.io",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SpireDelegateClient{
+				cfg: SpireDelegateConfig{
+					SpiffeTrustDomain: "test.cilium.io",
+				},
+				log: log,
+			}
+			if got := s.NumericIdentityToSNI(tt.args.id); got != tt.want {
+				t.Errorf("SpireDelegateClient.NumericIdentityToSNI() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpireDelegateClient_SNIToNumericIdentity(t *testing.T) {
+	type args struct {
+		sni string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    identity.NumericIdentity
+		wantErr bool
+	}{
+		{
+			name: "convert valid SNI",
+			args: args{
+				sni: "1234.test.cilium.io",
+			},
+			want:    1234,
+			wantErr: false,
+		},
+		{
+			name: "error on convert invalid SNI under trust domain",
+			args: args{
+				sni: "hacker.test.cilium.io",
+			},
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "error on convert invalid SNI outside trust domain",
+			args: args{
+				sni: "1234.cilium.example.com",
+			},
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SpireDelegateClient{
+				cfg: SpireDelegateConfig{
+					SpiffeTrustDomain: "test.cilium.io",
+				},
+				log: log,
+			}
+			got, err := s.SNIToNumericIdentity(tt.args.sni)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SpireDelegateClient.SNIToNumericIdentity() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SpireDelegateClient.SNIToNumericIdentity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpireDelegateClient_sniToSPIFFEID(t *testing.T) {
+	type args struct {
+		id identity.NumericIdentity
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "convert valid numeric identity",
+			args: args{
+				id: 1234,
+			},
+			want: "spiffe://test.cilium.io/cilium-id/1234",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SpireDelegateClient{
+				cfg: SpireDelegateConfig{
+					SpiffeTrustDomain: "test.cilium.io",
+				},
+				log: log,
+			}
+			if got := s.sniToSPIFFEID(tt.args.id); got != tt.want {
+				t.Errorf("SpireDelegateClient.sniToSPIFFEID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpireDelegateClient_ValidateIdentity(t *testing.T) {
+	urlFor1234, _ := url.Parse("spiffe://test.cilium.io/cilium-id/1234")
+	urlFor9999, _ := url.Parse("spiffe://test.cilium.io/cilium-id/9999")
+
+	type args struct {
+		id   identity.NumericIdentity
+		cert *x509.Certificate
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "validate with correct SPIFFE ID",
+			args: args{
+				id: 1234,
+				cert: &x509.Certificate{
+					URIs: []*url.URL{urlFor1234},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "not validate with incorrect SPIFFE ID",
+			args: args{
+				id: 1234,
+				cert: &x509.Certificate{
+					URIs: []*url.URL{urlFor9999},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "error on validate with incorrect SPIFFE cert",
+			args: args{
+				id: 1234,
+				cert: &x509.Certificate{
+					URIs: []*url.URL{urlFor1234, urlFor9999},
+				},
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "error on validate with non SPIFFE cert",
+			args: args{
+				id: 1234,
+				cert: &x509.Certificate{
+					DNSNames: []string{"test.cilium.io"},
+				},
+			},
+			want:    false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SpireDelegateClient{
+				cfg: SpireDelegateConfig{
+					SpiffeTrustDomain: "test.cilium.io",
+				},
+				log: log,
+			}
+			got, err := s.ValidateIdentity(tt.args.id, tt.args.cert)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SpireDelegateClient.ValidateIdentity() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SpireDelegateClient.ValidateIdentity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpireDelegateClient_GetTrustBundle(t *testing.T) {
+	someTrustBundle := x509.NewCertPool()
+	someTrustBundle.AddCert(&x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "test.cilium.io",
+		},
+		IsCA: true,
+	})
+
+	tests := []struct {
+		name        string
+		trustBundle *x509.CertPool
+		want        *x509.CertPool
+		wantErr     bool
+	}{
+		{
+			name:        "get trust bundle",
+			trustBundle: someTrustBundle,
+			want:        someTrustBundle,
+		},
+		{
+			name:        "error on no trust bundle",
+			trustBundle: nil,
+			want:        nil,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SpireDelegateClient{
+				cfg: SpireDelegateConfig{
+					SpiffeTrustDomain: "test.cilium.io",
+				},
+				log:         log,
+				trustBundle: tt.trustBundle,
+			}
+			got, err := s.GetTrustBundle()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SpireDelegateClient.GetTrustBundle() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SpireDelegateClient.GetTrustBundle() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSpireDelegateClient_GetCertificateForIdentity(t *testing.T) {
+	certURL, err := url.Parse("spiffe://spiffe.cilium.io/cilium-id/1234")
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+	leafKey, err := rsa.GenerateKey(rand.Reader, 512)
+	if err != nil {
+		t.Fatalf("failed to generate leaf key: %v", err)
+	}
+	leafCert := &x509.Certificate{
+		NotAfter:     time.Now().Add(time.Hour),
+		URIs:         []*url.URL{certURL},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		SerialNumber: big.NewInt(1),
+	}
+	leafCertBytes, err := x509.CreateCertificate(rand.Reader, leafCert, leafCert, &leafKey.PublicKey, leafKey)
+	if err != nil {
+		t.Fatalf("failed to sign leaf certificate: %v", err)
+	}
+	leafCert, err = x509.ParseCertificate(leafCertBytes)
+	if err != nil {
+		t.Fatalf("failed to parse leaf certificate: %v", err)
+	}
+	leafPKCS8Key, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	if err != nil {
+		t.Fatalf("failed to marshal leaf key: %v", err)
+	}
+
+	svidStore := map[string]*delegatedidentityv1.X509SVIDWithKey{
+		"spiffe://test.cilium.io/cilium-id/1234": {
+			X509Svid: &types.X509SVID{
+				Id: &types.SPIFFEID{
+					TrustDomain: "test.cilium.io",
+					Path:        "/cilium-id/1234",
+				},
+				CertChain: [][]byte{leafCertBytes},
+			},
+			X509SvidKey: leafPKCS8Key,
+		},
+		"spiffe://test.cilium.io/cilium-id/2222": {
+			X509Svid: &types.X509SVID{
+				Id: &types.SPIFFEID{
+					TrustDomain: "test.cilium.io",
+					Path:        "/cilium-id/2222",
+				},
+				CertChain: [][]byte{},
+			},
+			X509SvidKey: leafPKCS8Key,
+		},
+		"spiffe://test.cilium.io/cilium-id/3333": {
+			X509Svid: &types.X509SVID{
+				Id: &types.SPIFFEID{
+					TrustDomain: "test.cilium.io",
+					Path:        "/cilium-id/3333",
+				},
+				CertChain: [][]byte{leafCertBytes},
+			},
+		},
+	}
+
+	type args struct {
+		id identity.NumericIdentity
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *tls.Certificate
+		wantErr bool
+	}{
+		{
+			name: "get certificate for numeric identity",
+			args: args{
+				id: 1234,
+			},
+			want: &tls.Certificate{
+				Certificate: [][]byte{leafCertBytes},
+				PrivateKey:  leafKey,
+				Leaf:        leafCert,
+			},
+		},
+		{
+			name: "error on no certificate for numeric identity",
+			args: args{
+				id: 9999,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error on no certchain for numeric identity",
+			args: args{
+				id: 2222,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "error on no private key for numeric identity",
+			args: args{
+				id: 3333,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SpireDelegateClient{
+				cfg: SpireDelegateConfig{
+					SpiffeTrustDomain: "test.cilium.io",
+				},
+				log:       log,
+				svidStore: svidStore,
+			}
+			got, err := s.GetCertificateForIdentity(tt.args.id)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SpireDelegateClient.GetCertificateForIdentity() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SpireDelegateClient.GetCertificateForIdentity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -83,6 +83,7 @@ spec:
                             the allowed traffic, if any.
                           enum:
                           - "null"
+                          - mtls-spiffe
                           type: string
                       required:
                       - type
@@ -1437,6 +1438,7 @@ spec:
                             the allowed traffic, if any.
                           enum:
                           - "null"
+                          - mtls-spiffe
                           type: string
                       required:
                       - type
@@ -2556,6 +2558,7 @@ spec:
                               for the allowed traffic, if any.
                             enum:
                             - "null"
+                            - mtls-spiffe
                             type: string
                         required:
                         - type
@@ -3932,6 +3935,7 @@ spec:
                               for the allowed traffic, if any.
                             enum:
                             - "null"
+                            - mtls-spiffe
                             type: string
                         required:
                         - type

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -87,6 +87,7 @@ spec:
                             the allowed traffic, if any.
                           enum:
                           - "null"
+                          - mtls-spiffe
                           type: string
                       required:
                       - type
@@ -1441,6 +1442,7 @@ spec:
                             the allowed traffic, if any.
                           enum:
                           - "null"
+                          - mtls-spiffe
                           type: string
                       required:
                       - type
@@ -2560,6 +2562,7 @@ spec:
                               for the allowed traffic, if any.
                             enum:
                             - "null"
+                            - mtls-spiffe
                             type: string
                         required:
                         - type
@@ -3936,6 +3939,7 @@ spec:
                               for the allowed traffic, if any.
                             enum:
                             - "null"
+                            - mtls-spiffe
                             type: string
                         required:
                         - type

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -14,7 +14,8 @@ import (
 type AuthType string
 
 const (
-	AuthTypeNull AuthType = "null" // Always succeeds
+	AuthTypeNull       AuthType = "null"        // Always succeeds
+	AuthTypeMTLSSpiffe AuthType = "mtls-spiffe" // Mutual TLS with SPIFFE as certificate provider
 )
 
 // Auth specifies the kind of cryptographic authentication required for the traffic to
@@ -22,7 +23,7 @@ const (
 type Auth struct {
 	// Type is the required authentication type for the allowed traffic, if any.
 	//
-	// +kubebuilder:validation:Enum=null
+	// +kubebuilder:validation:Enum=null;mtls-spiffe
 	// +kubebuilder:validation:Required
 	Type AuthType `json:"type"`
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -222,6 +222,8 @@ const (
 	AuthTypeNone AuthType = iota
 	// AuthTypeNull is a simple auth type that always succeeds
 	AuthTypeNull
+	// AuthTypeMTLSSpiffe is a mTLS auth type that uses SPIFFE identities with a SPIRE server
+	AuthTypeMTLSSpiffe
 )
 
 // GetAuthType returns the AuthType of the L4Filter.
@@ -232,6 +234,8 @@ func (a *PerSelectorPolicy) GetAuthType() AuthType {
 	switch a.Auth.Type {
 	case "null":
 		return AuthTypeNull
+	case "mtls-spiffe":
+		return AuthTypeMTLSSpiffe
 	}
 	return AuthTypeNone
 }
@@ -248,6 +252,8 @@ func (a AuthType) String() string {
 		return "none"
 	case AuthTypeNull:
 		return "null"
+	case AuthTypeMTLSSpiffe:
+		return "mtls-spiffe"
 	}
 	return fmt.Sprintf("Unknown-auth-type-%d", a.Uint8())
 }


### PR DESCRIPTION
This adds an mTLS auth handler to the Serice Mesh auth package.
It will listen on a given port and does a mutual TLS handshake with
SPIFFE IDs it received. This will assure the both sides got the needed
certificates.

In order to integrate with the datapath tables it also improves the SPIFFE
interface to use the Cilium Numeric Identities. And convert them from and
to valid SNI fields. As well as implement code to validate the URI SANS
inside the certificates.

This can be enabled in the  in the Helm chart.

Fixes: #23807

```release-note
Add mtls-spiffe as auth mode in the CiliumNetworkPolicy
```
