### PR TITLE
Move leader election to a separate Kubernetes client

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -326,16 +326,18 @@ func runOperator(lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner 
 		ns = metav1.NamespaceDefault
 	}
 
-	leResourceLock := &resourcelock.LeaseLock{
-		LeaseMeta: metav1.ObjectMeta{
-			Name:      leaderElectionResourceLockName,
-			Namespace: ns,
-		},
-		Client: clientset.CoordinationV1(),
-		LockConfig: resourcelock.ResourceLockConfig{
+	leResourceLock, err := resourcelock.NewFromKubeconfig(
+		resourcelock.LeasesResourceLock,
+		ns,
+		leaderElectionResourceLockName,
+		resourcelock.ResourceLockConfig{
 			// Identity name of the lock holder
 			Identity: operatorID,
 		},
+		clientset.RestConfig(),
+		operatorOption.Config.LeaderElectionRenewDeadline)
+	if err != nil {
+		log.WithError(err).Fatal("Failed to create resource lock for leader election")
 	}
 
 	// Start the leader election for running cilium-operators

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -86,6 +86,9 @@ type Clientset interface {
 
 	// Config returns the configuration used to create this client.
 	Config() Config
+
+	// RestConfig returns the deep copy of rest configuration.
+	RestConfig() *rest.Config
 }
 
 // compositeClientset implements the Clientset using real clients.
@@ -200,6 +203,10 @@ func (c *compositeClientset) Disable() {
 
 func (c *compositeClientset) Config() Config {
 	return c.config
+}
+
+func (c *compositeClientset) RestConfig() *rest.Config {
+	return rest.CopyConfig(c.restConfig)
 }
 
 func (c *compositeClientset) onStart(startCtx hive.HookContext) error {
@@ -457,6 +464,10 @@ func (c *FakeClientset) Disable() {
 
 func (c *FakeClientset) Config() Config {
 	return Config{}
+}
+
+func (c *FakeClientset) RestConfig() *rest.Config {
+	return &rest.Config{}
 }
 
 func NewFakeClientset() (*FakeClientset, Clientset) {


### PR DESCRIPTION
Move leader election to a separate Kubernetes client. This is needed to prevent possible crashlooping if there are a lot of requests to kube-apiserver at scale.

Fixes: #24266

```release-note
Operator: Move leader election to a separate Kubernetes client
```
