### PR TITLE
bpf: Use per-CPU LRU for conntrack hashmaps

### DIFF
--- a/bpf/lib/conntrack_map.h
+++ b/bpf/lib/conntrack_map.h
@@ -16,6 +16,7 @@ struct {
 	__type(value, struct ct_entry);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CT_MAP_SIZE_TCP);
+	__uint(map_flags, BPF_F_NO_COMMON_LRU);
 } CT_MAP_TCP6 __section_maps_btf;
 
 struct {
@@ -24,6 +25,7 @@ struct {
 	__type(value, struct ct_entry);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CT_MAP_SIZE_ANY);
+	__uint(map_flags, BPF_F_NO_COMMON_LRU);
 } CT_MAP_ANY6 __section_maps_btf;
 
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
@@ -50,6 +52,7 @@ struct {
 		__type(key, struct ipv6_ct_tuple);
 		__type(value, struct ct_entry);
 		__uint(max_entries, CT_MAP_SIZE_TCP);
+		__uint(map_flags, BPF_F_NO_COMMON_LRU);
 	});
 } PER_CLUSTER_CT_TCP6 __section_maps_btf;
 
@@ -64,6 +67,7 @@ struct {
 		__type(key, struct ipv6_ct_tuple);
 		__type(value, struct ct_entry);
 		__uint(max_entries, CT_MAP_SIZE_ANY);
+		__uint(map_flags, BPF_F_NO_COMMON_LRU);
 	});
 } PER_CLUSTER_CT_ANY6 __section_maps_btf;
 #endif
@@ -85,6 +89,7 @@ struct {
 	__type(value, struct ct_entry);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CT_MAP_SIZE_TCP);
+	__uint(map_flags, BPF_F_NO_COMMON_LRU);
 } CT_MAP_TCP4 __section_maps_btf;
 
 struct {
@@ -93,6 +98,7 @@ struct {
 	__type(value, struct ct_entry);
 	__uint(pinning, LIBBPF_PIN_BY_NAME);
 	__uint(max_entries, CT_MAP_SIZE_ANY);
+	__uint(map_flags, BPF_F_NO_COMMON_LRU);
 } CT_MAP_ANY4 __section_maps_btf;
 
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
@@ -107,6 +113,7 @@ struct {
 		__type(key, struct ipv4_ct_tuple);
 		__type(value, struct ct_entry);
 		__uint(max_entries, CT_MAP_SIZE_TCP);
+		__uint(map_flags, BPF_F_NO_COMMON_LRU);
 	});
 } PER_CLUSTER_CT_TCP4 __section_maps_btf;
 
@@ -121,6 +128,7 @@ struct {
 		__type(key, struct ipv4_ct_tuple);
 		__type(value, struct ct_entry);
 		__uint(max_entries, CT_MAP_SIZE_ANY);
+		__uint(map_flags, BPF_F_NO_COMMON_LRU);
 	});
 } PER_CLUSTER_CT_ANY4 __section_maps_btf;
 #endif


### PR DESCRIPTION
Pass the BPF_F_NO_COMMON_LRU flag to BPF_MAP_TYPE_LRU_HASH conntrack maps to reduce the chance of getting -EBUSY from map_update_elem that happens when multiple CPUs contend over the same hash bucket. The locking used in this type of a map doesn't wait until the lock is released, but instead fails immediately.

TODO: commit message.

```release-note
TODO
```
