### PR TITLE
Check IP Family for LB source range

### DIFF
--- a/pkg/testutils/mockmaps/lbmap.go
+++ b/pkg/testutils/mockmaps/lbmap.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	datapathTypes "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/ip"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -222,7 +223,14 @@ func (m *LBMockMap) UpdateSourceRanges(revNATID uint16, prevRanges []*cidr.CIDR,
 	if len(prevRanges) != len(m.SourceRanges[revNATID]) {
 		return fmt.Errorf("Inconsistent view of source ranges")
 	}
-	m.SourceRanges[revNATID] = ranges
+	srcRanges := []*cidr.CIDR{}
+	for _, cidr := range ranges {
+		if ip.IsIPv6(cidr.IP) == !ipv6 {
+			continue
+		}
+		srcRanges = append(srcRanges, cidr)
+	}
+	m.SourceRanges[revNATID] = srcRanges
 
 	return nil
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
This PR adds IP family check for LB's source range.  Before the fix, if we add IPv6 addresses to IPv4 LB's source, api-server would not catch it, and the IPv6 addresses may collide with the IPv4 entries. See details in the issue. 
Fixes: #22658 

Add loadbalancer source range IP family check to drop mismatched source ranges. 
