### PR TITLE
pkg/ipcache: add ipcacher interface

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -65,7 +65,7 @@ type Configuration struct {
 	// remote cluster.
 	RemoteIdentityWatcher RemoteIdentityWatcher
 
-	IPCache *ipcache.IPCache
+	IPCache ipcache.IPCacher
 }
 
 func SetClusterConfig(clusterName string, config *cmtypes.CiliumClusterConfig, backend kvstore.BackendOperations) error {
@@ -144,7 +144,7 @@ type ClusterMesh struct {
 	controllers   *controller.Manager
 	configWatcher *configDirectoryWatcher
 
-	ipcache *ipcache.IPCache
+	ipcache ipcache.IPCacher
 
 	// globalServices is a list of all global services. The datastructure
 	// is protected by its own mutex inside the structure.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -809,3 +809,11 @@ func (m *K8sMetadata) Equal(o *K8sMetadata) bool {
 	}
 	return m.Namespace == o.Namespace && m.PodName == o.PodName
 }
+
+func (ipc *IPCache) ForEachListener(f func(listener IPIdentityMappingListener)) {
+	ipc.mutex.Lock()
+	defer ipc.mutex.Unlock()
+	for _, listener := range ipc.listeners {
+		f(listener)
+	}
+}

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -35,7 +35,7 @@ const (
 
 var (
 	// IPIdentitiesPath is the path to where endpoint IPs are stored in the key-value
-	//store.
+	// store.
 	IPIdentitiesPath = path.Join(kvstore.BaseKeyPrefix, "state", "ip", "v1")
 
 	// AddressSpace is the address space (cluster, etc.) in which policy is
@@ -201,12 +201,18 @@ type IPIdentityWatcher struct {
 
 	clusterID uint32
 
-	ipcache *IPCache
+	ipcache IPCacher
+}
+
+type IPCacher interface {
+	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *K8sMetadata, newIdentity Identity) (bool, error)
+	ForEachListener(f func(listener IPIdentityMappingListener))
+	Delete(IP string, source source.Source) (namedPortsChanged bool)
 }
 
 // NewIPIdentityWatcher creates a new IPIdentityWatcher using the specified
 // kvstore backend.
-func NewIPIdentityWatcher(ipc *IPCache, backend kvstore.BackendOperations) *IPIdentityWatcher {
+func NewIPIdentityWatcher(ipc IPCacher, backend kvstore.BackendOperations) *IPIdentityWatcher {
 	return NewClusterIPIdentityWatcher(0, ipc, backend)
 }
 
@@ -215,7 +221,7 @@ func NewIPIdentityWatcher(ipc *IPCache, backend kvstore.BackendOperations) *IPId
 // is that each IP <=> Identity mapping will be annotated with ClusterID. Thus, it
 // can be used for watching the kvstore of the remote cluster with overlapping PodCIDR.
 // Calling this function with clusterID = 0 is identical to calling NewIPIdentityWatcher.
-func NewClusterIPIdentityWatcher(clusterID uint32, ipc *IPCache, backend kvstore.BackendOperations) *IPIdentityWatcher {
+func NewClusterIPIdentityWatcher(clusterID uint32, ipc IPCacher, backend kvstore.BackendOperations) *IPIdentityWatcher {
 	watcher := &IPIdentityWatcher{
 		clusterID: clusterID,
 		backend:   backend,
@@ -275,11 +281,9 @@ restart:
 			//   the deletion event.
 			switch event.Typ {
 			case kvstore.EventTypeListDone:
-				iw.ipcache.Lock()
-				for _, listener := range iw.ipcache.listeners {
+				iw.ipcache.ForEachListener(func(listener IPIdentityMappingListener) {
 					listener.OnIPIdentityCacheGC()
-				}
-				iw.ipcache.Unlock()
+				})
 				iw.closeSynced()
 
 			case kvstore.EventTypeCreate, kvstore.EventTypeModify:


### PR DESCRIPTION
With an interface it will be possible to reuse certain code without requiring a real implementation of the ipcache. This can be proven useful when mocking some aspects of the controlplane.