### PR TITLE
pkg/k8s: set user-agent in k8s client

### DIFF
--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -306,9 +306,20 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 		config = &rest.Config{Host: apiServerURL, UserAgent: userAgent}
 	}
 
-	config.QPS = qps
-	config.Burst = burst
+	setConfig(config, userAgent, qps, burst)
 	return config, nil
+}
+
+func setConfig(config *rest.Config, userAgent string, qps float32, burst int) {
+	if userAgent != "" {
+		config.UserAgent = userAgent
+	}
+	if qps != 0.0 {
+		config.QPS = qps
+	}
+	if burst != 0 {
+		config.Burst = burst
+	}
 }
 
 func (c *compositeClientset) waitForConn(ctx context.Context) error {


### PR DESCRIPTION
The user agent for the k8s client was never set and it was defaulting to some non-specific which would make it difficult to distinguish the Cilium requests in the kube-apiserver logs.

This looks a regression introduced in fc41aeb6152c and, similarly to the user-agent, we should make sure we are not overwriting any default QPS nor Burt values with '0'.

Fixes: fc41aeb6152c ("k8s: Add k8s-client cell")

```release-note
Set user-agent for k8s client with Cilium's version
```
