### PR TITLE
Add IPAM modes comparison table

### DIFF
--- a/Documentation/network/concepts/ipam/index.rst
+++ b/Documentation/network/concepts/ipam/index.rst
@@ -14,6 +14,19 @@ IP Address Management (IPAM) is responsible for the allocation and management
 of IP addresses used by network endpoints (container and others) managed by
 Cilium. Various IPAM modes are supported to meet the needs of different users:
 
+
+============================ ======================= ========================= ================== ============ =============== ================= =============
+Feature                      Kubernetes Host Scope   Cluster Scope (default)   Cluster Scope v2   CRD-backed   AWS ENI         Azure IPAM         GKE
+============================ ======================= ========================= ================== ============ =============== ================= =============
+Tunnel routing               ✅                      ✅                        ❌                 ❌           ❌              ❌                ❌
+Direct routing               ✅                      ✅                        ✅                 ✅           ✅              ✅                ✅
+CIDR Configuration           Kubernetes              Cilium                    Cilium             External     External (AWS)  External (Azure)  External (GCP)
+Multiple CIDRs per cluster   ❌                      ✅                        ✅                 N/A          N/A             N/A               N/A
+Multiple CIDRs per node      ❌                      ❌                        ✅                 N/A          N/A             N/A               N/A
+Dynamic CIDR/IP allocation   ❌                      ❌                        ✅                 ✅           ✅              ✅                ❌
+============================ ======================= ========================= ================== ============ =============== ================= =============
+
+
 .. toctree::
    :maxdepth: 1
    :glob:


### PR DESCRIPTION
Signed-off-by: Raphaël Pinson <raphael@isovalent.com>


```release-note
docs: Add a comparison table for IPAM modes
```
