### PR TITLE
versioncheck: fix parsing of snapshot release versions

### DIFF
--- a/pkg/versioncheck/check.go
+++ b/pkg/versioncheck/check.go
@@ -56,8 +56,8 @@ func Version(version string) (semver.Version, error) {
 	for _, pre := range ver.Pre {
 		if strings.Contains(pre.VersionStr, "rc") ||
 			strings.Contains(pre.VersionStr, "beta") ||
-			strings.Contains(pre.VersionStr, "alpha") {
-
+			strings.Contains(pre.VersionStr, "alpha") ||
+			strings.Contains(pre.VersionStr, "snapshot") {
 			return ver, nil
 		}
 	}

--- a/pkg/versioncheck/check_test.go
+++ b/pkg/versioncheck/check_test.go
@@ -101,6 +101,21 @@ func (vc *VersionCheckTestSuite) TestMustCompile(c *C) {
 			constraint: ">=1.17.0-alpha.1",
 			want:       true,
 		},
+		{
+			version:    "1.14.0-snapshot.0",
+			constraint: ">=1.13.0",
+			want:       true,
+		},
+		{
+			version:    "1.14.0-snapshot.1",
+			constraint: ">=1.14.0-snapshot.0",
+			want:       true,
+		},
+		{
+			version:    "1.14.0-snapshot.0",
+			constraint: ">=1.14.0",
+			want:       false,
+		},
 	}
 	for _, t := range tests {
 		ver, err := Version(t.version)

--- a/pkg/versioncheck/check_test.go
+++ b/pkg/versioncheck/check_test.go
@@ -22,97 +22,81 @@ var _ = Suite(&VersionCheckTestSuite{})
 
 func (vc *VersionCheckTestSuite) TestMustCompile(c *C) {
 	tests := []struct {
-		name       string
 		version    string
 		constraint string
 		want       bool
 	}{
 		{
-			name:       "1",
 			version:    "1.17.0-alpha.2",
 			constraint: ">=1.17.0",
 			want:       false,
 		},
 		{
-			name:       "2",
 			version:    "1.14.7-eks-e9b1d0",
 			constraint: ">=1.11.0",
 			want:       true,
 		},
 		{
-			name:       "3",
 			version:    "1.17.0-alpha.2",
 			constraint: ">=1.11.0",
 			want:       true,
 		},
 		{
-			name:       "4",
 			version:    "1.16.3-beta.0",
 			constraint: ">=1.11.0",
 			want:       true,
 		},
 		{
-			name:       "5",
 			version:    "1.17.0-alpha.2",
 			constraint: ">=1.11.0",
 			want:       true,
 		},
 		{
-			name:       "6",
 			version:    "1.16.3-beta.0",
 			constraint: ">=1.11.0",
 			want:       true,
 		},
 		{
-			name:       "7",
 			version:    "1.17.0",
 			constraint: ">=1.17.0",
 			want:       true,
 		},
 		{
-			name:       "8",
 			version:    "1.14.7-eks-e9b1d0",
 			constraint: ">=1.14.7",
 			want:       true,
 		},
 		{
-			name:       "9",
 			version:    "1.14.7-eks-e9b1d0",
 			constraint: ">=1.14.6",
 			want:       true,
 		},
 		{
-			name:       "10",
 			version:    "1.14.7-eks-e9b1d0",
 			constraint: ">=1.14.8",
 			want:       false,
 		},
 		{
-			name:       "11",
 			version:    "1.14.7-eks-e9b1d0",
 			constraint: ">=1.13.0",
 			want:       true,
 		},
 		{
-			name:       "12",
 			version:    "1.17.0-alpha.2",
 			constraint: ">=1.13.0",
 			want:       true,
 		},
 		{
-			name:       "13",
 			version:    "1.16.3-beta.0",
 			constraint: ">=1.13.0",
 			want:       true,
 		},
 		{
-			name:       "14",
 			version:    "1.16.0-rc.2",
 			constraint: ">=1.16.0",
 			want:       false,
 		},
 		{
-			name:       "15",
 			version:    "1.17.0-alpha.2",
 			constraint: ">=1.17.0-alpha.1",
 			want:       true,
@@ -120,9 +104,9 @@ func (vc *VersionCheckTestSuite) TestMustCompile(c *C) {
 	}
 	for _, t := range tests {
 		ver, err := Version(t.version)
-		c.Assert(err, IsNil, Commentf("Test Name %s", t.name))
+		c.Assert(err, IsNil, Commentf("version %s, constraint %s", t.version, t.constraint))
 		constraint, err := Compile(t.constraint)
-		c.Assert(err, IsNil, Commentf("Test Name %s", t.name))
-		c.Assert(constraint(ver), checker.Equals, t.want, Commentf("Test Name %s", t.name))
+		c.Assert(err, IsNil, Commentf("version %s, constraint", t.version, t.constraint))
+		c.Assert(constraint(ver), checker.Equals, t.want, Commentf("version %s, constraint %s", t.version, t.constraint))
 	}
 }


### PR DESCRIPTION
For the Cilium v1.14 release cycle we started doing snapshot releases which are tagged in the format vX.Y.Z-snapshotN. Let `versioncheck.Version` accept this version format.

For https://github.com/cilium/cilium-cli/issues/1448

First commit cleans up the test failure reporting in the versioncheck package. Second commit fixes parsing of the version.