### PR TITLE
add better errors for our calls to Setsockopt()

### DIFF
--- a/daemon/cmd/sockopt.go
+++ b/daemon/cmd/sockopt.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"fmt"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -11,7 +12,7 @@ import (
 
 // setsockoptReuseAddrAndPort sets the SO_REUSEADDR and SO_REUSEPORT socket options on c's
 // underlying socket in order to improve the chance to re-bind to the same address and port
-// upon agent restart.
+// upon restart.
 func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) error {
 	var soerr error
 	if err := c.Control(func(su uintptr) {
@@ -19,13 +20,15 @@ func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) erro
 		// Allow reuse of recently-used addresses. This socket option is
 		// set by default on listeners in Go's net package, see
 		// net setDefaultListenerSockopts
-		soerr = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
-		if soerr != nil {
+		if err := unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil {
+			soerr = fmt.Errorf("failed to setsockopt(SO_REUSEADDR): %w", err)
 			return
 		}
 		// Allow reuse of recently-used ports. This gives the agent a
 		// better chance to re-bind upon restarts.
-		soerr = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+		if err := unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
+			soerr = fmt.Errorf("failed to setsockopt(SO_REUSEPORT): %w", err)
+		}
 	}); err != nil {
 		return err
 	}

--- a/operator/api/server.go
+++ b/operator/api/server.go
@@ -6,6 +6,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"syscall"
@@ -172,7 +173,9 @@ func (s *Server) StartServer() error {
 	return nil
 }
 
-// setsockoptReuseAddrAndPort sets SO_REUSEADDR and SO_REUSEPORT
+// setsockoptReuseAddrAndPort sets the SO_REUSEADDR and SO_REUSEPORT socket options on c's
+// underlying socket in order to improve the chance to re-bind to the same address and port
+// upon restart.
 func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) error {
 	var soerr error
 	if err := c.Control(func(su uintptr) {
@@ -180,13 +183,15 @@ func setsockoptReuseAddrAndPort(network, address string, c syscall.RawConn) erro
 		// Allow reuse of recently-used addresses. This socket option is
 		// set by default on listeners in Go's net package, see
 		// net setDefaultListenerSockopts
-		soerr = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
-		if soerr != nil {
+		if err := unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEADDR, 1); err != nil {
+			soerr = fmt.Errorf("failed to setsockopt(SO_REUSEADDR): %w", err)
 			return
 		}
-		// Allow reuse of recently-used ports. This gives the operator a
-		// better change to re-bind upon restarts.
-		soerr = unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+		// Allow reuse of recently-used ports. This gives the agent a
+		// better chance to re-bind upon restarts.
+		if err := unix.SetsockoptInt(s, unix.SOL_SOCKET, unix.SO_REUSEPORT, 1); err != nil {
+			soerr = fmt.Errorf("failed to Setsockopt(SO_REUSEPORT): %w", err)
+		}
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Some users reported this failing, but we don't have enough logging to figure out what, exactly, is failing.
