### PR TITLE
.gitattributes: Mark install/kubernetes/cilium/README.md as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /install/kubernetes/cilium/values.yaml.tmpl linguist-language=yml
 /install/kubernetes/cilium/values.yaml linguist-generated
+/install/kubernetes/cilium/README.md linguist-generated
 *.Jenkinsfile linguist-language=Groovy
 go.sum linguist-generated
 examples/kubernetes/connectivity-check/connectivity-*.yaml linguist-generated


### PR DESCRIPTION
The `README.md` file inside of the `install/kubernetes/cilium/` directory has been generated with `helm-docs` ever since its introduction in commit 72958796e2b6, using `README.md.gotmpl` as a template, and other files such as `values.yaml` (in turn generated from `values.yaml.tmpl`). It should not be edited by hand. Pull Requests on GitHub usually display changes on this `README.md`, but instead we want to focus on the source files from which the changes are generated. Let's mark the file as generated, so that the GitHub interface hides the related diff, and reviewers don't lose time looking at it.
