### PR TITLE
gh/workflows: Split ci-dp encrypt tests into separate matrix configs

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -118,33 +118,28 @@ jobs:
       github.event_name == 'pull_request'
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         include:
           # See https://github.com/cilium/cilium/issues/20606 for configuration table
+
           - name: '1'
             kernel: '4.19-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'
-            encryption: 'ipsec'
-            encryption-node: 'false'
-            ipv6: 'false' # until https://github.com/cilium/cilium/issues/23461 has been fixed
 
           - name: '2'
             kernel: '5.4-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
-            encryption: 'ipsec'
-            encryption-node: 'false'
 
           - name: '3'
             kernel: '5.10-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
-            encryption: 'ipsec'
-            encryption-node: 'false'
             endpoint-routes: 'true'
 
           - name: '4'
@@ -152,8 +147,6 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
-            encryption: 'wireguard'
-            encryption-node: 'false'
             lb-mode: 'snat'
             endpoint-routes: 'true'
             egress-gateway: 'true'
@@ -163,9 +156,7 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
-            encryption: 'wireguard'
-            encryption-node: 'false'
-            lb-mode: 'snat'
+            lb-mode: 'dsr'
             endpoint-routes: 'true'
             egress-gateway: 'true'
 
@@ -174,12 +165,83 @@ jobs:
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'vxlan'
-            encryption: 'wireguard'
-            encryption-node: 'true'
             lb-mode: 'snat'
             egress-gateway: 'true'
 
           - name: '7'
+            kernel: 'bpf-next-main'
+            kube-proxy: 'none'
+            kpr: 'strict'
+            tunnel: 'disabled'
+            lb-mode: 'snat'
+            egress-gateway: 'true'
+
+          - name: '8'
+            kernel: 'bpf-next-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'geneve'
+            endpoint-routes: 'true'
+
+          - name: '9'
+            kernel: '4.19-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'vxlan'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            ipv6: 'false' # until https://github.com/cilium/cilium/issues/23461 has been fixed
+
+          - name: '10'
+            kernel: '5.4-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+
+          - name: '11'
+            kernel: '5.10-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            endpoint-routes: 'true'
+
+          - name: '12'
+            kernel: '5.10-main'
+            kube-proxy: 'iptables'
+            kpr: 'strict'
+            tunnel: 'vxlan'
+            encryption: 'wireguard'
+            encryption-node: 'false'
+            lb-mode: 'snat'
+            endpoint-routes: 'true'
+            egress-gateway: 'true'
+
+          - name: '13'
+            kernel: '5.15-main'
+            kube-proxy: 'iptables'
+            kpr: 'strict'
+            tunnel: 'disabled'
+            encryption: 'wireguard'
+            encryption-node: 'false'
+            lb-mode: 'snat' # https://github.com/cilium/cilium/issues/23328
+            endpoint-routes: 'true'
+            egress-gateway: 'true'
+
+          - name: '14'
+            kernel: '6.0-main'
+            kube-proxy: 'none'
+            kpr: 'strict'
+            tunnel: 'vxlan'
+            encryption: 'wireguard'
+            encryption-node: 'true'
+            lb-mode: 'snat' # https://github.com/cilium/cilium/issues/23328
+            egress-gateway: 'true'
+
+          - name: '15'
             kernel: 'bpf-next-main'
             kube-proxy: 'none'
             kpr: 'strict'
@@ -189,7 +251,7 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
 
-          - name: '8'
+          - name: '16'
             kernel: 'bpf-next-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
@@ -257,7 +319,15 @@ jobs:
             EGRESS_GATEWAY+=" --helm-set=egressGateway.enabled=true"
           fi
 
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${EGRESS_GATEWAY}"
+          ENCRYPT=""
+          if [ "${{ matrix.encryption }}" != "" ]; then
+            ENCRYPT="--encryption=${{ matrix.encryption }}"
+            if [ "${{ matrix.encryption-node }}" != "" ]; then
+              ENCRYPT+=" --node-encryption=${{ matrix.encryption-node }}"
+            fi
+          fi
+
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${EGRESS_GATEWAY} ${ENCRYPT}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
       - name: Set commit status to pending
@@ -303,7 +373,7 @@ jobs:
             until docker manifest inspect quay.io/${{ github.repository_owner }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
-      - name: Run kube-proxy tests
+      - name: Run tests
         uses: cilium/little-vm-helper@0b7d7157dae56a44dc531c852e7756dc671071af # v0.0.3
         with:
           provision: 'false'
@@ -313,28 +383,13 @@ jobs:
             ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
 
             ./cilium-cli status --wait
+            kubectl -n kube-system exec -it daemonset/cilium  -- cilium status
+
             ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./cilium-cli connectivity test --collect-sysdump-on-failure \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             kind delete cluster
-
-      - name: Run encryption tests
-        if: ${{ matrix.encryption != 'disabled' }}
-        uses: cilium/little-vm-helper@0b7d7157dae56a44dc531c852e7756dc671071af # v0.0.3
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
-            ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }} \
-              --encryption=${{ matrix.encryption }} --node-encryption=${{ matrix.encryption-node }}
-
-            ./cilium-cli status --wait
-            ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
-            ./cilium-cli connectivity test --collect-sysdump-on-failure \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
 
       - name: Fetch artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
This commit creates separate matrix configs for the encryption tests, so that they can be run in separately jobs. The main motivation for that is that previously, some configurations were not possible. E.g., DSR with WireGuard due to \[1\]. The whole job had to disable the DSR.

Next, this commit undoes the encryption limitation changes for non-encryption jobs (IPsec with IPv6 and WireGuard with DSR).

Afterwards, the commit adds Cilium configuration reporting via the "cilium status", as it's not clear which features are enabled (some might get auto-disabled by the cilium-agent).

Finally, do not allow more than 8 parallel jobs to avoid starving the runners.

\[1\]:  https://github.com/cilium/cilium/issues/23328

**UPDATED** configuration table - https://github.com/cilium/cilium/issues/20606.

Successful run - https://github.com/cilium/cilium/actions/runs/4385479640/jobs/7678266839.

Fix #23327