### PR TITLE
Add SubscribeToRotatedIdentities interface 

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -234,6 +234,7 @@ cilium-agent [flags]
       --log-system-load                                         Enable periodic logging of system load
       --mesh-auth-monitor-queue-size int                        Queue size for the auth monitor (default 1024)
       --mesh-auth-mtls-listener-port int                        Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-rotated-identities-queue-size int             The size of the queue for signaling rotated identities. (default 1024)
       --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-admin-socket string                     The path for the SPIRE admin agent Unix socket.
       --metrics strings                                         Metrics that should be enabled or disabled from the default metric list. The list is expected to be separated by a space. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -11,29 +11,30 @@ cilium-agent hive [flags]
 ### Options
 
 ```
-      --certificates-directory string          Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cni-chaining-mode string               Enable CNI chaining with the specified plugin (default "none")
-      --cni-exclusive                          Whether to remove other CNI configurations
-      --cni-log-file string                    Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
-      --enable-k8s                             Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                       Port for gops server to listen on (default 9890)
-  -h, --help                                   help for hive
-      --install-egress-gateway-routes          Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
-      --k8s-api-server string                  Kubernetes API server URL
-      --k8s-client-burst int                   Burst value allowed for the K8s client
-      --k8s-client-qps float32                 Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration         Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file
-      --mesh-auth-monitor-queue-size int       Queue size for the auth monitor (default 1024)
-      --mesh-auth-mtls-listener-port int       Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
-      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-admin-socket string    The path for the SPIRE admin agent Unix socket.
-      --pprof                                  Enable serving pprof debugging API
-      --pprof-address string                   Address that pprof listens on (default "localhost")
-      --pprof-port uint16                      Port that pprof listens on (default 6060)
-      --read-cni-conf string                   CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
-      --write-cni-conf-when-ready string       Write the CNI configuration to the specified path when agent is ready
+      --certificates-directory string                 Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cni-chaining-mode string                      Enable CNI chaining with the specified plugin (default "none")
+      --cni-exclusive                                 Whether to remove other CNI configurations
+      --cni-log-file string                           Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
+      --enable-k8s                                    Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                      Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                              Port for gops server to listen on (default 9890)
+  -h, --help                                          help for hive
+      --install-egress-gateway-routes                 Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
+      --k8s-api-server string                         Kubernetes API server URL
+      --k8s-client-burst int                          Burst value allowed for the K8s client
+      --k8s-client-qps float32                        Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                    Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int              Queue size for the auth monitor (default 1024)
+      --mesh-auth-mtls-listener-port int              Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-rotated-identities-queue-size int   The size of the queue for signaling rotated identities. (default 1024)
+      --mesh-auth-spiffe-trust-domain string          The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-admin-socket string           The path for the SPIRE admin agent Unix socket.
+      --pprof                                         Enable serving pprof debugging API
+      --pprof-address string                          Address that pprof listens on (default "localhost")
+      --pprof-port uint16                             Port that pprof listens on (default 6060)
+      --read-cni-conf string                          CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --write-cni-conf-when-ready string              Write the CNI configuration to the specified path when agent is ready
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -17,28 +17,29 @@ cilium-agent hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --certificates-directory string          Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cni-chaining-mode string               Enable CNI chaining with the specified plugin (default "none")
-      --cni-exclusive                          Whether to remove other CNI configurations
-      --cni-log-file string                    Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
-      --enable-k8s                             Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                       Port for gops server to listen on (default 9890)
-      --install-egress-gateway-routes          Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
-      --k8s-api-server string                  Kubernetes API server URL
-      --k8s-client-burst int                   Burst value allowed for the K8s client
-      --k8s-client-qps float32                 Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration         Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file
-      --mesh-auth-monitor-queue-size int       Queue size for the auth monitor (default 1024)
-      --mesh-auth-mtls-listener-port int       Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
-      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-admin-socket string    The path for the SPIRE admin agent Unix socket.
-      --pprof                                  Enable serving pprof debugging API
-      --pprof-address string                   Address that pprof listens on (default "localhost")
-      --pprof-port uint16                      Port that pprof listens on (default 6060)
-      --read-cni-conf string                   CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
-      --write-cni-conf-when-ready string       Write the CNI configuration to the specified path when agent is ready
+      --certificates-directory string                 Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cni-chaining-mode string                      Enable CNI chaining with the specified plugin (default "none")
+      --cni-exclusive                                 Whether to remove other CNI configurations
+      --cni-log-file string                           Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
+      --enable-k8s                                    Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                      Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                              Port for gops server to listen on (default 9890)
+      --install-egress-gateway-routes                 Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
+      --k8s-api-server string                         Kubernetes API server URL
+      --k8s-client-burst int                          Burst value allowed for the K8s client
+      --k8s-client-qps float32                        Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                    Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int              Queue size for the auth monitor (default 1024)
+      --mesh-auth-mtls-listener-port int              Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-rotated-identities-queue-size int   The size of the queue for signaling rotated identities. (default 1024)
+      --mesh-auth-spiffe-trust-domain string          The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-admin-socket string           The path for the SPIRE admin agent Unix socket.
+      --pprof                                         Enable serving pprof debugging API
+      --pprof-address string                          Address that pprof listens on (default "localhost")
+      --pprof-port uint16                             Port that pprof listens on (default 6060)
+      --read-cni-conf string                          CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --write-cni-conf-when-ready string              Write the CNI configuration to the specified path when agent is ready
 ```
 
 ### SEE ALSO

--- a/pkg/auth/always_fail_authhandler.go
+++ b/pkg/auth/always_fail_authhandler.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"errors"
 
+	"github.com/cilium/cilium/pkg/auth/certs"
 	"github.com/cilium/cilium/pkg/policy"
 )
 
@@ -25,4 +26,8 @@ func (r *alwaysFailAuthHandler) authenticate(authReq *authRequest) (*authRespons
 
 func (r *alwaysFailAuthHandler) authType() policy.AuthType {
 	return policy.AuthTypeAlwaysFail
+}
+
+func (r *alwaysFailAuthHandler) subscribeToRotatedIdentities() <-chan certs.CertificateRotationEvent {
+	return nil
 }

--- a/pkg/auth/certs/provider.go
+++ b/pkg/auth/certs/provider.go
@@ -10,6 +10,10 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 )
 
+type CertificateRotationEvent struct {
+	Identity identity.NumericIdentity
+}
+
 type CertificateProvider interface {
 	// GetTrustBundle gives the CA trust bundle for the certificate provider
 	// this is then used to verify the certificates given by the peer in the handshake
@@ -29,4 +33,7 @@ type CertificateProvider interface {
 
 	// SNIToNumericIdentity will return the Cilium Identity for a given SNI
 	SNIToNumericIdentity(sni string) (identity.NumericIdentity, error)
+
+	// SubscribeToRotatedIdentities will return a channel with the identities that have rotated certificates
+	SubscribeToRotatedIdentities() <-chan CertificateRotationEvent
 }

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/cilium/cilium/pkg/auth/certs"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/monitor"
@@ -30,6 +31,7 @@ type ipCache interface {
 type authHandler interface {
 	authenticate(*authRequest) (*authResponse, error)
 	authType() policy.AuthType
+	subscribeToRotatedIdentities() <-chan certs.CertificateRotationEvent
 }
 
 type authRequest struct {

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/auth/certs"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
@@ -161,6 +162,10 @@ func (r *fakeAuthHandler) authenticate(authReq *authRequest) (*authResponse, err
 
 func (r *fakeAuthHandler) authType() policy.AuthType {
 	return policy.AuthType(255)
+}
+
+func (r *fakeAuthHandler) subscribeToRotatedIdentities() <-chan certs.CertificateRotationEvent {
+	return nil
 }
 
 // Fake DatapathAuthenticator

--- a/pkg/auth/mtls_authhandler.go
+++ b/pkg/auth/mtls_authhandler.go
@@ -272,3 +272,7 @@ func (m *mtlsAuthHandler) verifyPeerCertificate(id *identity.NumericIdentity, ca
 
 	return expirationTime, nil
 }
+
+func (m *mtlsAuthHandler) subscribeToRotatedIdentities() <-chan certs.CertificateRotationEvent {
+	return m.cert.SubscribeToRotatedIdentities()
+}

--- a/pkg/auth/mtls_authhandler_test.go
+++ b/pkg/auth/mtls_authhandler_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cilium/cilium/pkg/auth/certs"
 	"github.com/cilium/cilium/pkg/identity"
 )
 
@@ -77,6 +78,10 @@ func (f *fakeCertificateProvider) SNIToNumericIdentity(sni string) (identity.Num
 
 	idStr := strings.TrimSuffix(sni, suffix)
 	return identity.ParseNumericIdentity(idStr)
+}
+
+func (f *fakeCertificateProvider) SubscribeToRotatedIdentities() <-chan certs.CertificateRotationEvent {
+	return nil
 }
 
 func generateTestCertificates(t *testing.T) (map[string]*x509.Certificate, map[string]*ecdsa.PrivateKey, *x509.CertPool) {

--- a/pkg/auth/null_authhandler.go
+++ b/pkg/auth/null_authhandler.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"time"
 
+	"github.com/cilium/cilium/pkg/auth/certs"
 	"github.com/cilium/cilium/pkg/policy"
 )
 
@@ -24,4 +25,8 @@ func (r *nullAuthHandler) authenticate(authReq *authRequest) (*authResponse, err
 
 func (r *nullAuthHandler) authType() policy.AuthType {
 	return policy.AuthTypeNull
+}
+
+func (r *nullAuthHandler) subscribeToRotatedIdentities() <-chan certs.CertificateRotationEvent {
+	return nil
 }

--- a/pkg/auth/spire/delegate.go
+++ b/pkg/auth/spire/delegate.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -43,11 +44,16 @@ type SpireDelegateClient struct {
 	trustBundle    *x509.CertPool
 
 	cancelListenForUpdates context.CancelFunc
+
+	rotatedIdentitiesChan chan certs.CertificateRotationEvent
+
+	logLimiter logging.Limiter
 }
 
 type SpireDelegateConfig struct {
 	SpireAdminSocketPath string `mapstructure:"mesh-auth-spire-admin-socket"`
 	SpiffeTrustDomain    string `mapstructure:"mesh-auth-spiffe-trust-domain"`
+	RotatedQueueSize     int    `mapstructure:"mesh-auth-rotated-identities-queue-size"`
 }
 
 var Cell = cell.Module(
@@ -63,9 +69,11 @@ func newSpireDelegateClient(lc hive.Lifecycle, cfg SpireDelegateConfig, log logr
 		return nil
 	}
 	client := &SpireDelegateClient{
-		cfg:       cfg,
-		log:       log.WithField(logfields.LogSubsys, "spire-delegate"),
-		svidStore: map[string]*delegatedidentityv1.X509SVIDWithKey{},
+		cfg:                   cfg,
+		log:                   log.WithField(logfields.LogSubsys, "spire-delegate"),
+		svidStore:             map[string]*delegatedidentityv1.X509SVIDWithKey{},
+		rotatedIdentitiesChan: make(chan certs.CertificateRotationEvent, cfg.RotatedQueueSize),
+		logLimiter:            logging.NewLimiter(10*time.Second, 3),
 	}
 
 	lc.Append(hive.Hook{OnStart: client.onStart, OnStop: client.onStop})
@@ -76,6 +84,7 @@ func newSpireDelegateClient(lc hive.Lifecycle, cfg SpireDelegateConfig, log logr
 func (cfg SpireDelegateConfig) Flags(flags *pflag.FlagSet) {
 	flags.StringVar(&cfg.SpireAdminSocketPath, "mesh-auth-spire-admin-socket", "", "The path for the SPIRE admin agent Unix socket.") // default is /run/spire/sockets/admin.sock
 	flags.StringVar(&cfg.SpiffeTrustDomain, "mesh-auth-spiffe-trust-domain", "spiffe.cilium", "The trust domain for the SPIFFE identity.")
+	flags.IntVar(&cfg.RotatedQueueSize, "mesh-auth-rotated-identities-queue-size", 1024, "The size of the queue for signaling rotated identities.")
 }
 
 func (s *SpireDelegateClient) onStart(ctx hive.HookContext) error {
@@ -167,6 +176,8 @@ func (s *SpireDelegateClient) handleX509SVIDUpdate(svids []*delegatedidentityv1.
 	newSvidStore := map[string]*delegatedidentityv1.X509SVIDWithKey{}
 
 	s.svidStoreMutex.RLock()
+	updatedKeys := []string{}
+
 	for _, svid := range svids {
 
 		if svid.X509Svid.Id.TrustDomain != s.cfg.SpiffeTrustDomain {
@@ -180,8 +191,7 @@ func (s *SpireDelegateClient) handleX509SVIDUpdate(svids []*delegatedidentityv1.
 		if _, exists := s.svidStore[key]; exists {
 			old := s.svidStore[key]
 			if old.X509Svid.ExpiresAt != svid.X509Svid.ExpiresAt || !equalCertChains(old.X509Svid.CertChain, svid.X509Svid.CertChain) {
-				s.log.Debugf("X509-SVID for %s has changed, updating", key)
-				// this is a good point to in the future send a trigger for a new handshake
+				updatedKeys = append(updatedKeys, key)
 			}
 		} else {
 			s.log.Debugf("X509-SVID for %s is new, adding", key)
@@ -194,6 +204,23 @@ func (s *SpireDelegateClient) handleX509SVIDUpdate(svids []*delegatedidentityv1.
 	s.svidStoreMutex.Lock()
 	s.svidStore = newSvidStore
 	s.svidStoreMutex.Unlock()
+
+	for _, key := range updatedKeys {
+		// we send an update event to re-trigger a handshake if needed
+		id, err := s.spiffeIDToNumericIdentity(key)
+		if err != nil {
+			s.log.WithError(err).Errorf("failed to convert spiffe ID %s to numeric identity", key)
+			continue
+		}
+		select {
+		case s.rotatedIdentitiesChan <- certs.CertificateRotationEvent{Identity: id}:
+			s.log.Debugf("X509-SVID for %s has changed, signaling this", key)
+		default:
+			if s.logLimiter.Allow() {
+				s.log.Warnf("skipping sending rotated identity %d as channel is full", id)
+			}
+		}
+	}
 }
 
 func (s *SpireDelegateClient) handleX509BundleUpdate(bundles map[string][]byte) {


### PR DESCRIPTION
This change adds a SubscribeToRotatedIdentities function.
This gives a channel which is used to pass identity updates
back from the certificate proider to the auth manager.
In the auth manager there can better be acted upon to
receive the IDs and re-trigger a mTLS handshake if needed.

```release-note
Add a mechanism for the SPIRE server to signal rotated certificates for re-authenticating connections
```
