### PR TITLE
bgpv1: Clear announcement vars after server recreation

### DIFF
--- a/pkg/bgpv1/gobgp/reconcile.go
+++ b/pkg/bgpv1/gobgp/reconcile.go
@@ -169,6 +169,10 @@ func preflightReconciler(ctx context.Context, _ *BGPRouterManager, sc *ServerWit
 	// actions as if this is a new BgpServer.
 	sc.Config = nil
 
+	// Clear the shadow state since any advertisements will be gone now that the server has been recreated.
+	sc.PodCIDRAnnouncements = nil
+	sc.ServiceAnnouncements = nil
+
 	return nil
 }
 


### PR DESCRIPTION
We maintain a cache/shadow map for all advertisements we have made. During reconciliation we check the desired state against this shadow state which lives in the `PodCIDRAnnouncements` and `ServiceAnnouncements` variables.

This works until the `preflightReconciler` decides to recreate the server, which happens if the router-id or the listen port changes. At this point the GoBGP route server is recreated which also clears the tables. But we forget to clear our shadow state as well. This causes any existing routes to not be added since the reconcilers think they are already there.

Fixes: #24069

```release-note
Fix bug in BGP CP where changing the route-id of an existing router would cause announcements to disappear
```
