### PR TITLE
Add new logging format option,  'json-ts',  for JSON formatted logs with timestamps

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/klog/v2"
@@ -26,8 +27,9 @@ const (
 	LevelOpt  = "level"
 	FormatOpt = "format"
 
-	LogFormatText LogFormat = "text"
-	LogFormatJSON LogFormat = "json"
+	LogFormatText          LogFormat = "text"
+	LogFormatJSON          LogFormat = "json"
+	LogFormatJSONTimestamp LogFormat = "json-ts"
 
 	// DefaultLogFormat is the string representation of the default logrus.Formatter
 	// we want to use (possible values: text or json)
@@ -105,10 +107,10 @@ func (o LogOptions) GetLogFormat() LogFormat {
 	}
 
 	formatOpt = strings.ToLower(formatOpt)
-	re := regexp.MustCompile(`^(text|json)$`)
+	re := regexp.MustCompile(`^(text|json|json-ts)$`)
 	if !re.MatchString(formatOpt) {
 		logrus.WithError(
-			fmt.Errorf("incorrect log format configured '%s', expected 'text' or 'json'", formatOpt),
+			fmt.Errorf("incorrect log format configured '%s', expected 'text', 'json' or 'json-ts'", formatOpt),
 		).Warning("Ignoring user-configured log format")
 		return DefaultLogFormat
 	}
@@ -202,6 +204,11 @@ func GetFormatter(format LogFormat) logrus.Formatter {
 	case LogFormatJSON:
 		return &logrus.JSONFormatter{
 			DisableTimestamp: true,
+		}
+	case LogFormatJSONTimestamp:
+		return &logrus.JSONFormatter{
+			DisableTimestamp: false,
+			TimestampFormat:  time.RFC3339Nano,
 		}
 	}
 

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -6,6 +6,7 @@ package logging
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
@@ -40,6 +41,9 @@ func (s *LoggingSuite) TestGetLogFormat(c *C) {
 
 	opts[FormatOpt] = "Invalid"
 	c.Assert(opts.GetLogFormat(), Equals, DefaultLogFormat)
+
+	opts[FormatOpt] = "JSON-TS"
+	c.Assert(opts.GetLogFormat(), Equals, LogFormatJSONTimestamp)
 }
 
 func (s *LoggingSuite) TestSetLogLevel(c *C) {
@@ -64,6 +68,11 @@ func (s *LoggingSuite) TestSetLogFormat(c *C) {
 
 	SetLogFormat(LogFormatJSON)
 	c.Assert(reflect.TypeOf(DefaultLogger.Formatter).String(), Equals, "*logrus.JSONFormatter")
+
+	SetLogFormat(LogFormatJSONTimestamp)
+	c.Assert(reflect.TypeOf(DefaultLogger.Formatter).String(), Equals, "*logrus.JSONFormatter")
+	c.Assert(DefaultLogger.Formatter.(*logrus.JSONFormatter).DisableTimestamp, Equals, false)
+	c.Assert(DefaultLogger.Formatter.(*logrus.JSONFormatter).TimestampFormat, Equals, time.RFC3339Nano)
 }
 
 func (s *LoggingSuite) TestSetDefaultLogFormat(c *C) {


### PR DESCRIPTION
This commit adds a new log formatter named 'json-ts', which can be used to enable json logs that include timestamps. Normally, timestamps for logs can be collected through the use of k8s container logging system, ie by passing `--timestamps` to `kubectl logs`. Relying on k8s for log timestamps is not always available however, therefore it is useful to have the ability to add timestamps if needed in special cases.

One case in which this is useful is for programmatically parsing through the `cilium-cni` log file, in order to observe and record CNI events.

Correct me if I'm wrong, but I'm pretty sure this needs the following labels:

* `release-note/misc`
* `area/misc`

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!
