### PR TITLE
bpf: fix ipv6 extension header parsing error

### DIFF
--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -60,11 +60,12 @@ static __always_inline int ipv6_hdrlen_offset(struct __ctx_buff *ctx, __u8 *next
 			if (ctx_load_bytes(ctx, l3_off + len, &opthdr, sizeof(opthdr)) < 0)
 				return DROP_INVALID;
 
-			nh = opthdr.nexthdr;
 			if (nh == NEXTHDR_AUTH)
 				len += ipv6_authlen(&opthdr);
 			else
 				len += ipv6_optlen(&opthdr);
+
+			nh = opthdr.nexthdr;
 			break;
 
 		default:

--- a/bpf/tests/ipv6_test.c
+++ b/bpf/tests/ipv6_test.c
@@ -3,8 +3,9 @@
 
 #include "common.h"
 
-#include <bpf/ctx/skb.h>
+#include <bpf/ctx/xdp.h>
 
+#include "pktgen.h"
 #include "node_config.h"
 
 #include "lib/common.h"
@@ -29,6 +30,178 @@ LPM_LOOKUP_FN(lpm4_lookup31, __be32, PREFIX31, dummy_map, match_dummy_prefix)
 LPM_LOOKUP_FN(lpm4_lookup22, __be32, PREFIX22, dummy_map, match_dummy_prefix)
 LPM_LOOKUP_FN(lpm4_lookup11, __be32, PREFIX11, dummy_map, match_dummy_prefix)
 LPM_LOOKUP_FN(lpm4_lookup0, __be32, PREFIX0, dummy_map, match_dummy_prefix)
+
+PKTGEN("xdp", "ipv6_without_extension_header")
+int ipv6_without_extension_header_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	memcpy(&l3->saddr, (__u8 *)v6_node_one, sizeof(l3->saddr));
+	memcpy(&l3->daddr, (__u8 *)v6_node_two, sizeof(l3->daddr));
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = tcp_src_one;
+	l4->dest = tcp_svc_one;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("xdp", "ipv6_without_extension_header")
+int ipv6_without_extension_header_setup(__maybe_unused struct __ctx_buff *ctx)
+{
+	return 123;
+}
+
+CHECK("xdp", "ipv6_without_extension_header")
+int ipv6_without_extension_header_check(struct __ctx_buff *ctx)
+{
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	__u32 *status_code;
+	__u8 nexthdr;
+
+	test_init();
+
+	if (ctx_data(ctx) + sizeof(__u32) > ctx_data_end(ctx))
+		test_fatal("status code out of bounds");
+
+	status_code = ctx_data(ctx);
+	assert(*status_code == 123);
+
+	xdp_adjust_head(ctx, 4);
+	l2 = ctx_data(ctx);
+	if ((void *)(l2 + 1) > ctx_data_end(ctx))
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == __bpf_htons(ETH_P_IPV6));
+
+	l3 = (void *)l2 + ETH_HLEN;
+	if ((void *)(l3 + 1) > ctx_data_end(ctx))
+		test_fatal("l3 out of bounds");
+
+	nexthdr = l3->nexthdr;
+	assert(ipv6_hdrlen(ctx, &nexthdr) > 0);
+	assert(nexthdr == IPPROTO_TCP);
+
+	test_finish();
+}
+
+struct ipv6_authhdr {
+	struct ipv6_opt_hdr opt;
+	__u16 reserved;
+	int spi;
+	int seq;
+	char icv[];
+};
+
+PKTGEN("xdp", "ipv6_with_auth_hop_tcp")
+int ipv6_with_hop_auth_tcp_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct ipv6_authhdr *authhdr;
+	struct ipv6_opt_hdr *l3_next;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	memcpy(&l3->saddr, (__u8 *)v6_node_one, sizeof(l3->saddr));
+	memcpy(&l3->daddr, (__u8 *)v6_node_two, sizeof(l3->daddr));
+
+	l3_next = pktgen__append_ipv6_extension_header(&builder, NEXTHDR_AUTH);
+	if (!l3_next)
+		return TEST_ERROR;
+
+	authhdr = (struct ipv6_authhdr *)l3_next;
+	authhdr->spi = 0x222;
+	authhdr->seq = 1;
+
+	l3_next = pktgen__append_ipv6_extension_header(&builder, NEXTHDR_HOP);
+	if (!l3_next)
+		return TEST_ERROR;
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = tcp_src_one;
+	l4->dest = tcp_svc_one;
+
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("xdp", "ipv6_with_auth_hop_tcp")
+int ipv6_with_hop_auth_tcp_setup(__maybe_unused struct __ctx_buff *ctx)
+{
+	return 1234;
+}
+
+CHECK("xdp", "ipv6_with_auth_hop_tcp")
+int ipv6_with_hop_auth_tcp_check(struct __ctx_buff *ctx)
+{
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	__u32 *status_code;
+	__u8 nexthdr;
+
+	test_init();
+
+	if (ctx_data(ctx) + sizeof(__u32) > ctx_data_end(ctx))
+		test_fatal("status code out of bounds");
+
+	status_code = ctx_data(ctx);
+	assert(*status_code == 1234);
+
+	xdp_adjust_head(ctx, 4);
+	l2 = ctx_data(ctx);
+	if ((void *)(l2 + 1) > ctx_data_end(ctx))
+		test_fatal("l2 out of bounds");
+
+	assert(l2->h_proto == __bpf_htons(ETH_P_IPV6));
+
+	l3 = (void *)l2 + ETH_HLEN;
+	if ((void *)(l3 + 1) > ctx_data_end(ctx))
+		test_fatal("l3 out of bounds");
+
+	nexthdr = l3->nexthdr;
+	assert(ipv6_hdrlen(ctx, &nexthdr) > 0);
+	assert(nexthdr == IPPROTO_TCP);
+
+	test_finish();
+}
 
 CHECK("xdp", "ipv6")
 int bpf_test(__maybe_unused struct xdp_md *ctx)

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -67,6 +67,14 @@ static volatile const __u8 v6_pod_two[] = {0xfd, 0x04, 0, 0, 0, 0, 0, 0,
 static volatile const __u8 v6_pod_three[] = {0xfd, 0x04, 0, 0, 0, 0, 0, 0,
 					   0, 0, 0, 0, 0, 0, 0, 3};
 
+/* IPv6 addresses for nodes in the cluster */
+static volatile const __u8 v6_node_one[] = {0xfd, 0x05, 0, 0, 0, 0, 0, 0,
+					   0, 0, 0, 0, 0, 0, 0, 1};
+static volatile const __u8 v6_node_two[] = {0xfd, 0x06, 0, 0, 0, 0, 0, 0,
+					   0, 0, 0, 0, 0, 0, 0, 2};
+static volatile const __u8 v6_node_three[] = {0xfd, 0x07, 0, 0, 0, 0, 0, 0,
+					   0, 0, 0, 0, 0, 0, 0, 3};
+
 /* Source port to be used by a client */
 #define tcp_src_one	__bpf_htons(22334)
 #define tcp_src_two	__bpf_htons(33445)
@@ -77,6 +85,23 @@ static volatile const __u8 v6_pod_three[] = {0xfd, 0x04, 0, 0, 0, 0, 0, 0,
 #define tcp_svc_three	__bpf_htons(53)
 
 #define default_data "Should not change!!"
+
+#define NEXTHDR_HOP             0       /* Hop-by-hop option header. */
+#define NEXTHDR_TCP             6       /* TCP segment. */
+#define NEXTHDR_UDP             17      /* UDP message. */
+#define NEXTHDR_IPV6            41      /* IPv6 in IPv6 */
+#define NEXTHDR_ROUTING         43      /* Routing header. */
+#define NEXTHDR_FRAGMENT        44      /* Fragmentation/reassembly header. */
+#define NEXTHDR_GRE             47      /* GRE header. */
+#define NEXTHDR_ESP             50      /* Encapsulating security payload. */
+#define NEXTHDR_AUTH            51      /* Authentication header. */
+#define NEXTHDR_ICMP            58      /* ICMP for IPv6. */
+#define NEXTHDR_NONE            59      /* No next header */
+#define NEXTHDR_DEST            60      /* Destination options header. */
+#define NEXTHDR_SCTP            132     /* SCTP message. */
+#define NEXTHDR_MOBILITY        135     /* Mobility header. */
+
+#define NEXTHDR_MAX             255
 
 /* Define SCTP header here because this is all we need. */
 struct sctphdr {
@@ -97,7 +122,10 @@ enum pkt_layer {
 	PKT_LAYER_IPV4,
 	PKT_LAYER_IPV6,
 	PKT_LAYER_ARP,
-	/* TODO IPv6 extension headers */
+
+	/* IPv6 extension headers */
+	PKT_LAYER_IPV6_HOP_BY_HOP,
+	PKT_LAYER_IPV6_AUTH,
 
 	/* L4 layers */
 	PKT_LAYER_TCP,
@@ -109,6 +137,8 @@ enum pkt_layer {
 	/* Packet data*/
 	PKT_LAYER_DATA,
 };
+
+#define IPV6_DEFAULT_HOPLIMIT 64
 
 #define PKT_BUILDER_LAYERS 6
 
@@ -144,6 +174,29 @@ int pktgen__free_layer(const struct pktgen *builder)
 	}
 
 	return -1;
+}
+
+static __always_inline
+__attribute__((warn_unused_result))
+int ctx_data_valid(const struct __ctx_buff *ctx, __maybe_unused __u16 off)
+{
+	int ret = 0;
+
+	/* try to open up a range on the pkt reg */
+	asm volatile("r1 = *(u32 *)(%[ctx] +0)\n\t"
+		     "r2 = *(u32 *)(%[ctx] +4)\n\t"
+		     "%[off] &= %[offmax]\n\t"
+		     "r1 += %[off]\n\t"
+		     "if r1 > r2 goto +2\n\t"
+		     "%[ret] = 0\n\t"
+		     "goto +1\n\t"
+		     "%[ret] = %[errno]\n\t"
+		     : [ret]"=r"(ret)
+		     : [ctx]"r"(ctx), [off]"r"(off),
+		       [offmax]"i"(0xff), [errno]"i"(-EINVAL)
+		     : "r1", "r2");
+
+	return ret;
 }
 
 /* Push an empty ethernet header onto the packet */
@@ -291,16 +344,88 @@ struct iphdr *pktgen__push_default_iphdr(struct pktgen *builder)
 	return pktgen__push_default_iphdr_with_options(builder, 0);
 }
 
-/* Push an IPv6 header with sane defaults onto the packet */
-struct ipv6hdr *pktgen__push_default_ipv6hdr(struct pktgen *builder)
+static __always_inline
+__attribute__((warn_unused_result))
+void *pktgen__push_rawhdr(struct pktgen *builder, __u16 hdrsize, enum pkt_layer type)
 {
-	struct ipv6hdr *hdr = pktgen__push_ipv6hdr(builder);
+	struct __ctx_buff *ctx = builder->ctx;
+	void *layer = NULL;
+	int layer_idx;
+
+	ctx_adjust_troom(ctx, builder->cur_off + hdrsize - ctx_full_len(ctx));
+	if (ctx_data(ctx) + builder->cur_off + hdrsize > ctx_data_end(ctx))
+		return NULL;
+
+	if (builder->cur_off >= MAX_PACKET_OFF - hdrsize)
+		return NULL;
+
+	layer = ctx_data(ctx) + builder->cur_off;
+	layer_idx = pktgen__free_layer(builder);
+
+	if (layer_idx < 0)
+		return NULL;
+
+	builder->layers[layer_idx] = type;
+	builder->layer_offsets[layer_idx] = builder->cur_off;
+	builder->cur_off += hdrsize;
+
+	return layer;
+}
+
+static __always_inline
+__attribute__((warn_unused_result))
+struct ipv6_opt_hdr *pktgen__append_ipv6_extension_header(struct pktgen *builder,
+							  __maybe_unused __u8 nexthdr)
+{
+	struct ipv6_opt_hdr *hdr = NULL;
+	__u8 hdrlen = 0;
+	__u8 length = 0;
+	/* TODO improve */
+	switch (nexthdr) {
+	case NEXTHDR_HOP:
+		length = (0 + 1) << 3;
+		hdr = pktgen__push_rawhdr(builder, length, PKT_LAYER_IPV6_HOP_BY_HOP);
+		break;
+	case NEXTHDR_AUTH:
+		length = (2 + 2) << 2;
+		hdr = pktgen__push_rawhdr(builder, length, PKT_LAYER_IPV6_AUTH);
+		hdrlen = 2;
+		break;
+	default:
+		break;
+	}
 
 	if (!hdr)
-		return 0;
+		return NULL;
 
+	/* after multiple extension headers are added, LLVM tends to generate
+	 * code that verifier doesn't understand. try to open up a range on
+	 * the pkt reg
+	 */
+	if (ctx_data_valid(builder->ctx, builder->cur_off))
+		return NULL;
+
+	hdr->hdrlen = hdrlen;
+
+	return hdr;
+}
+
+static __always_inline
+__attribute__((warn_unused_result))
+struct ipv6hdr *pktgen__push_default_ipv6hdr(struct pktgen *builder)
+{
+	struct ipv6hdr *hdr = pktgen__push_rawhdr(builder,
+			sizeof(struct ipv6hdr), PKT_LAYER_IPV6);
+
+	if (!hdr)
+		return NULL;
+
+	if ((void *) hdr + sizeof(struct ipv6hdr) > ctx_data_end(builder->ctx))
+		return NULL;
+
+	memset(hdr, 0, sizeof(struct ipv6hdr));
 	hdr->version = 6;
-	hdr->hop_limit = 255;
+	hdr->hop_limit = IPV6_DEFAULT_HOPLIMIT;
 
 	return hdr;
 }
@@ -454,6 +579,7 @@ void pktgen__finish(const struct pktgen *builder)
 	struct ethhdr *eth_layer;
 	struct iphdr *ipv4_layer;
 	struct ipv6hdr *ipv6_layer;
+	struct ipv6_opt_hdr *ipv6_opt_layer;
 	struct tcphdr *tcp_layer;
 	__u16 layer_off;
 	__u16 v4len;
@@ -558,6 +684,12 @@ void pktgen__finish(const struct pktgen *builder)
 				return;
 
 			switch (builder->layers[i + 1]) {
+			case PKT_LAYER_IPV6_HOP_BY_HOP:
+				ipv6_layer->nexthdr = NEXTHDR_HOP;
+				break;
+			case PKT_LAYER_IPV6_AUTH:
+				ipv6_layer->nexthdr = NEXTHDR_AUTH;
+				break;
 			case PKT_LAYER_TCP:
 				ipv6_layer->nexthdr = IPPROTO_TCP;
 				break;
@@ -579,6 +711,44 @@ void pktgen__finish(const struct pktgen *builder)
 
 			/* Calculate payload length, which doesn't include the header size */
 			ipv6_layer->payload_len = __bpf_htons(v6len);
+
+			break;
+
+		case PKT_LAYER_IPV6_HOP_BY_HOP:
+		case PKT_LAYER_IPV6_AUTH:
+			layer_off = builder->layer_offsets[i];
+			if (layer_off >= MAX_PACKET_OFF - sizeof(struct ipv6_opt_hdr))
+				return;
+
+			ipv6_opt_layer = ctx_data(builder->ctx) + layer_off;
+			if ((void *)(ipv6_opt_layer + 1) > ctx_data_end(builder->ctx))
+				return;
+
+			if (i + 1 >= PKT_BUILDER_LAYERS)
+				return;
+
+			switch (builder->layers[i + 1]) {
+			case PKT_LAYER_IPV6_HOP_BY_HOP:
+				ipv6_opt_layer->nexthdr = NEXTHDR_HOP;
+				break;
+			case PKT_LAYER_IPV6_AUTH:
+				ipv6_opt_layer->nexthdr = NEXTHDR_AUTH;
+				break;
+			case PKT_LAYER_TCP:
+				ipv6_opt_layer->nexthdr = IPPROTO_TCP;
+				break;
+			case PKT_LAYER_UDP:
+				ipv6_opt_layer->nexthdr = IPPROTO_UDP;
+				break;
+			case PKT_LAYER_ICMPV6:
+				ipv6_opt_layer->nexthdr = IPPROTO_ICMPV6;
+				break;
+			case PKT_LAYER_SCTP:
+				ipv6_opt_layer->nexthdr = IPPROTO_SCTP;
+				break;
+			default:
+				break;
+			}
 
 			break;
 


### PR DESCRIPTION
The ipv6_hdrlen function incorrectly sets the length of the extension header
during parsing, causing cilum to obtain the wrong next header and resulting
in packet loss.
    
This issue will affect the parsing of IPv6 packets that carry both the "auth"
and other extension headers, such as `ipv6/auth/hopbyhop/tcp`.
    
Fixes: 1ce3c7f6a4745bb6c420fb59106cfe0587ff18fa ("bpf: Skip over IPv6 extension headers")
Fixes: #24187

Signed-off-by: chenyuezhou <zcy.chenyue.zhou@gmail.com>