### PR TITLE
bpf: nodeport: don't track L2 addr for connection to local backend

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -930,13 +930,14 @@ redo:
 			return DROP_UNKNOWN_CT;
 		}
 
-		ret = neigh_record_ip6(ctx);
-		if (ret < 0)
-			return ret;
 		if (backend_local) {
 			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 			return CTX_ACT_OK;
 		}
+
+		ret = neigh_record_ip6(ctx);
+		if (ret < 0)
+			return ret;
 	}
 
 	/* TX request to remote backend: */
@@ -2078,13 +2079,14 @@ redo:
 			return DROP_UNKNOWN_CT;
 		}
 
-		ret = neigh_record_ip4(ctx);
-		if (ret < 0)
-			return ret;
 		if (backend_local) {
 			ctx_set_xfer(ctx, XFER_PKT_NO_SVC);
 			return CTX_ACT_OK;
 		}
+
+		ret = neigh_record_ip4(ctx);
+		if (ret < 0)
+			return ret;
 	}
 
 	/* TX request to remote backend: */


### PR DESCRIPTION
Replies by a local backend either get their L2 resolution by the stack, or (when bpf_lxc uses bpf-host-routing) by bpf_redirect_neigh(). But fib_redirect_*() will never fall through to the L2 neigh cache to get the client's MAC address.