### PR TITLE
policy: lazily start SelectorCache.handleUserNotifications

### DIFF
--- a/daemon/cmd/cells_test.go
+++ b/daemon/cmd/cells_test.go
@@ -22,7 +22,6 @@ var goleakOptions = []goleak.Option{
 	// Ignore goroutines started by the policy trifecta, see [newPolicyTrifecta].
 	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/identity/cache.(*identityWatcher).watch.func1"),
 	goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/trigger.(*Trigger).waiter"),
-	goleak.IgnoreTopFunction("sync.runtime_notifyListWait"),
 }
 
 // TestAgentCell verifies that the Agent hive can be instantiated with


### PR DESCRIPTION
Hive wants components to not start any goroutines during startup. Change SelectorCache so that handleUserNotifications is started when the first notification is queued, not when SelectorCache is created.