### PR TITLE
v1.11 - Backport initContainer change

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -61,6 +61,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
 
 COPY images/cilium/init-container.sh \
      plugins/cilium-cni/cni-install.sh \
+     plugins/cilium-cni/install-plugin.sh \
      plugins/cilium-cni/cni-uninstall.sh \
        /tmp/install/${TARGETOS}/${TARGETARCH}
 

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -265,8 +265,6 @@ spec:
         {{- end}}
         - name: cilium-run
           mountPath: /var/run/cilium
-        - name: cni-path
-          mountPath: /host/opt/cni/bin
         - name: etc-cni-netd
           mountPath: {{ .Values.cni.hostConfDirMountPath }}
         {{- if .Values.etcd.enabled }}
@@ -512,6 +510,30 @@ spec:
             done
         terminationMessagePolicy: FallbackToLogsOnError
       {{- end }} # wait-for-kube-proxy
+      # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
+      - name: install-cni-binaries
+        image: {{ include "cilium.image" .Values.image | quote }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - "/install-plugin.sh"
+        resources:
+          requests:
+            cpu: 100m
+            memory: 10Mi
+        securityContext:
+          {{- if not .Values.securityContext.privileged }}
+          seLinuxOptions:
+            {{- with .Values.securityContext.seLinuxOptions }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          capabilities:
+            drop:
+              - ALL
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+          - name: cni-path
+            mountPath: /host/opt/cni/bin
       restartPolicy: Always
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.priorityClassName "system-node-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.cilium.name | quote }}

--- a/plugins/cilium-cni/cni-install.sh
+++ b/plugins/cilium-cni/cni-install.sh
@@ -42,34 +42,9 @@ while test $# -gt 0; do
   esac
 done
 
-BIN_NAME=cilium-cni
-CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
 CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 CNI_CONF_DIR="$(dirname "$CILIUM_CNI_CONF")"
 CILIUM_CUSTOM_CNI_CONF=${CILIUM_CUSTOM_CNI_CONF:-false}
-
-if [ ! -d "${CNI_DIR}/bin" ]; then
-	mkdir -p "${CNI_DIR}/bin"
-fi
-
-# Install the CNI loopback driver if not installed already
-if [ ! -f "${CNI_DIR}/bin/loopback" ]; then
-	echo "Installing loopback driver..."
-
-	# Don't fail hard if this fails as it is usually not required
-	cp /cni/loopback "${CNI_DIR}/bin/" || true
-fi
-
-echo "Installing ${BIN_NAME} to ${CNI_DIR}/bin/ ..."
-
-# Move an eventual old existing binary out of the way, we can't delete it
-# as it might be in use right now.
-if [ -f "${CNI_DIR}/bin/${BIN_NAME}" ]; then
-	rm -f "${CNI_DIR}/bin/${BIN_NAME}.old" || true
-	mv "${CNI_DIR}/bin/${BIN_NAME}" "${CNI_DIR}/bin/${BIN_NAME}.old"
-fi
-
-cp "/opt/cni/bin/${BIN_NAME}" "${CNI_DIR}/bin/"
 
 # The CILIUM_CUSTOM_CNI_CONF env is set by the `cni.customConf` Helm option.
 # It stops this script from touching the host's CNI config directory.

--- a/plugins/cilium-cni/cni-uninstall.sh
+++ b/plugins/cilium-cni/cni-uninstall.sh
@@ -27,7 +27,3 @@ if [ "${CILIUM_CUSTOM_CNI_CONF}" != "true" ]; then
         -name '*.conflist' \
     \) -delete
 fi
-
-echo "Removing ${CNI_DIR}/bin/cilium-cni..."
-rm -f "${CNI_DIR}/bin/${BIN_NAME}"
-rm -f "${CNI_DIR}/bin/${BIN_NAME}.old"

--- a/plugins/cilium-cni/install-plugin.sh
+++ b/plugins/cilium-cni/install-plugin.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Copy the cilium-cni plugin binary to the host
+
+set -e
+
+HOST_PREFIX=${HOST_PREFIX:-/host}
+
+BIN_NAME=cilium-cni
+CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
+CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
+
+if [ ! -d "${CNI_DIR}/bin" ]; then
+	mkdir -p "${CNI_DIR}/bin"
+fi
+
+# Install the CNI loopback driver if not installed already
+if [ ! -f "${CNI_DIR}/bin/loopback" ]; then
+	echo "Installing loopback driver..."
+
+	# Don't fail hard if this fails as it is usually not required
+	cp /cni/loopback "${CNI_DIR}/bin/" || true
+fi
+
+echo "Installing ${BIN_NAME} to ${CNI_DIR}/bin/ ..."
+
+# Copy the binary, then do a rename
+# so the move is atomic
+rm -f "${CNI_DIR}/bin/${BIN_NAME}.new" || true
+cp "/opt/cni/bin/${BIN_NAME}" "${CNI_DIR}/bin/.${BIN_NAME}.new"
+mv "${CNI_DIR}/bin/.${BIN_NAME}.new" "${CNI_DIR}/bin/${BIN_NAME}"
+
+echo "wrote ${CNI_DIR}/bin/${BIN_NAME}"


### PR DESCRIPTION
[ upstream commit e1a46216b4dfba98a13f5b32b1272c137b2cc923 ]

This reduces the potential security surface of the agent by removing the bind-mount of /opt/cni/bin. Instead, write the binaries once in an initContainer.

There is no currently known vulnerability exploiting this, but it's good practice to remove as many long-running host mounts as possible. This could be a potential further exploit vector if an agent were to be compromized.

This is backport of https://github.com/cilium/cilium/pull/24075
