### PR TITLE
egressgateway: provide a very basic Cell

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -15,6 +15,7 @@ cilium-agent hive [flags]
       --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                       Port for gops server to listen on (default 9890)
   -h, --help                                   help for hive
+      --install-egress-gateway-routes          Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
       --k8s-api-server string                  Kubernetes API server URL
       --k8s-client-burst int                   Burst value allowed for the K8s client
       --k8s-client-qps float32                 Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -20,6 +20,7 @@ cilium-agent hive dot-graph [flags]
       --certificates-directory string          Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                       Port for gops server to listen on (default 9890)
+      --install-egress-gateway-routes          Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
       --k8s-api-server string                  Kubernetes API server URL
       --k8s-client-burst int                   Burst value allowed for the K8s client
       --k8s-client-qps float32                 Queries per second limit for the K8s client

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -90,5 +91,8 @@ var (
 
 		// IPCache, policy.Repository and CachingIdentityAllocator.
 		cell.Provide(newPolicyTrifecta),
+
+		// Egress Gateway allows originating traffic from specific IPv4 addresses.
+		egressgateway.Cell,
 	)
 )

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -419,6 +419,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 	identityAllocator CachingIdentityAllocator,
 	pr *policy.Repository,
 	policyUpdater *policy.Updater,
+	egressGatewayManager *egressgateway.Manager,
 ) (*Daemon, *endpointRestoreState, error) {
 
 	var (
@@ -566,10 +567,11 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		// **NOTE** The global identity allocator is not yet initialized here; that
 		// happens below via InitIdentityAllocator(). Only the local identity
 		// allocator is initialized here.
-		identityAllocator: identityAllocator,
-		ipcache:           ipc,
-		policy:            pr,
-		policyUpdater:     policyUpdater,
+		identityAllocator:    identityAllocator,
+		ipcache:              ipc,
+		policy:               pr,
+		policyUpdater:        policyUpdater,
+		egressGatewayManager: egressGatewayManager,
 	}
 
 	if option.Config.RunMonitorAgent {
@@ -687,8 +689,9 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 
 	d.cgroupManager = manager.NewCgroupManager()
 
-	if option.Config.EnableIPv4EgressGateway {
-		d.egressGatewayManager = egressgateway.NewEgressGatewayManager(cacheStatus, d.identityAllocator, option.Config.InstallEgressGatewayRoutes)
+	var egressGatewayWatcher watchers.EgressGatewayManager
+	if d.egressGatewayManager != nil {
+		egressGatewayWatcher = d.egressGatewayManager
 	}
 
 	d.k8sWatcher = watchers.NewK8sWatcher(
@@ -701,7 +704,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		d.datapath,
 		d.redirectPolicyManager,
 		d.bgpSpeaker,
-		d.egressGatewayManager,
+		egressGatewayWatcher,
 		d.l7Proxy,
 		option.Config,
 		d.ipcache,
@@ -1007,11 +1010,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup,
 		}
 	}
 	if option.Config.EnableIPv4EgressGateway {
-		if probes.HaveLargeInstructionLimit() != nil {
-			log.WithError(err).Error("egress gateway needs kernel 5.2 or newer")
-			return nil, nil, fmt.Errorf("egress gateway needs kernel 5.2 or newer")
-		}
-
 		// datapath code depends on remote node identities to distinguish between cluser-local and
 		// cluster-egress traffic
 		if !option.Config.EnableRemoteNodeIdentity {

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -80,10 +80,11 @@ type policyParams struct {
 type policyOut struct {
 	cell.Out
 
-	IdentityAllocator CachingIdentityAllocator
-	Repository        *policy.Repository
-	Updater           *policy.Updater
-	IPCache           *ipcache.IPCache
+	IdentityAllocator      CachingIdentityAllocator
+	CacheIdentityAllocator cache.IdentityAllocator
+	Repository             *policy.Repository
+	Updater                *policy.Updater
+	IPCache                *ipcache.IPCache
 }
 
 // newPolicyTrifecta instantiates CachingIdentityAllocator, Repository and IPCache.
@@ -142,10 +143,11 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 	})
 
 	return policyOut{
-		IdentityAllocator: idAlloc,
-		Repository:        iao.policy,
-		Updater:           policyUpdater,
-		IPCache:           ipc,
+		IdentityAllocator:      idAlloc,
+		CacheIdentityAllocator: idAlloc,
+		Repository:             iao.policy,
+		Updater:                policyUpdater,
+		IPCache:                ipc,
 	}, nil
 }
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -8,12 +8,15 @@ import (
 	"fmt"
 	"net"
 	"sort"
-	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/identity"
 	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -32,6 +35,14 @@ var (
 	zeroIPv4 = net.ParseIP("0.0.0.0")
 )
 
+// Cell provides a [Manager] for consumption with hive.
+var Cell = cell.Module(
+	"egressgateway",
+	"Egress Gateway allows originating traffic from specific IPv4 addresses",
+	cell.Config(defaultConfig),
+	cell.Provide(NewEgressGatewayManager),
+)
+
 type eventType int
 
 const (
@@ -44,6 +55,20 @@ const (
 	eventUpdateEndpoint
 	eventDeleteEndpoint
 )
+
+type Config struct {
+	// Install egress gateway IP rules and routes in order to properly steer
+	// egress gateway traffic to the correct ENI interface
+	InstallEgressGatewayRoutes bool
+}
+
+var defaultConfig = Config{
+	InstallEgressGatewayRoutes: false,
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.Bool("install-egress-gateway-routes", def.InstallEgressGatewayRoutes, "Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface")
+}
 
 // The egressgateway manager stores the internal data tracking the node, policy,
 // endpoint, and lease mappings. It also hooks up all the callbacks to update
@@ -80,19 +105,47 @@ type Manager struct {
 	installRoutes bool
 }
 
-// NewEgressGatewayManager returns a new Egress Gateway Manager.
-func NewEgressGatewayManager(cacheStatus k8s.CacheStatus, identityAlocator identityCache.IdentityAllocator, installRoutes bool) *Manager {
+type Params struct {
+	cell.In
+
+	Config            Config
+	DaemonConfig      *option.DaemonConfig
+	CacheStatus       k8s.CacheStatus
+	IdentityAllocator identityCache.IdentityAllocator
+
+	Lifecycle hive.Lifecycle
+}
+
+func NewEgressGatewayManager(p Params) *Manager {
+	if !p.DaemonConfig.EnableIPv4EgressGateway {
+		return nil
+	}
+
 	manager := &Manager{
-		cacheStatus:             cacheStatus,
+		cacheStatus:             p.CacheStatus,
 		nodeDataStore:           make(map[string]nodeTypes.Node),
 		policyConfigs:           make(map[policyID]*PolicyConfig),
 		policyConfigsBySourceIP: make(map[string][]*PolicyConfig),
 		epDataStore:             make(map[endpointID]*endpointMetadata),
-		identityAllocator:       identityAlocator,
-		installRoutes:           installRoutes,
+		identityAllocator:       p.IdentityAllocator,
+		installRoutes:           p.Config.InstallEgressGatewayRoutes,
 	}
 
-	manager.runReconciliationAfterK8sSync()
+	ctx, cancel := context.WithCancel(context.Background())
+	p.Lifecycle.Append(hive.Hook{
+		OnStart: func(hc hive.HookContext) error {
+			if probes.HaveLargeInstructionLimit() != nil {
+				return fmt.Errorf("egress gateway needs kernel 5.2 or newer")
+			}
+
+			manager.runReconciliationAfterK8sSync(ctx)
+			return nil
+		},
+		OnStop: func(hc hive.HookContext) error {
+			cancel()
+			return nil
+		},
+	})
 
 	return manager
 }
@@ -115,19 +168,15 @@ func (manager *Manager) getIdentityLabels(securityIdentity uint32) (labels.Label
 
 // runReconciliationAfterK8sSync spawns a goroutine that waits for the agent to
 // sync with k8s and then runs the first reconciliation.
-func (manager *Manager) runReconciliationAfterK8sSync() {
+func (manager *Manager) runReconciliationAfterK8sSync(ctx context.Context) {
 	go func() {
-		for {
-			if manager.cacheStatus.Synchronized() {
-				break
-			}
-
-			time.Sleep(1 * time.Second)
+		select {
+		case <-manager.cacheStatus:
+			manager.Lock()
+			manager.reconcile(eventK8sSyncDone)
+			manager.Unlock()
+		case <-ctx.Done():
 		}
-
-		manager.Lock()
-		manager.reconcile(eventK8sSyncDone)
-		manager.Unlock()
 	}()
 }
 

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	ciliumTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -209,7 +208,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 		}
 	}
 
-	if option.Config.EnableIPv4EgressGateway {
+	if k.egressGatewayManager != nil {
 		k.egressGatewayManager.OnUpdateEndpoint(endpoint)
 	}
 }
@@ -236,7 +235,7 @@ func (k *K8sWatcher) endpointDeleted(endpoint *types.CiliumEndpoint) {
 			k.policyManager.TriggerPolicyUpdates(true, "Named ports deleted")
 		}
 	}
-	if option.Config.EnableIPv4EgressGateway {
+	if k.egressGatewayManager != nil {
 		k.egressGatewayManager.OnDeleteEndpoint(endpoint)
 	}
 }

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 // RegisterCiliumNodeSubscriber allows registration of subscriber.CiliumNode implementations.
@@ -52,7 +51,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 						valid = true
 						n := nodeTypes.ParseCiliumNode(ciliumNode)
 						errs := k.CiliumNodeChain.OnAddCiliumNode(ciliumNode, swgNodes)
-						if option.Config.EnableIPv4EgressGateway {
+						if k.egressGatewayManager != nil {
 							k.egressGatewayManager.OnUpdateNode(n)
 						}
 						if n.IsLocal() {
@@ -83,7 +82,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 							}
 							n := nodeTypes.ParseCiliumNode(ciliumNode)
 							errs := k.CiliumNodeChain.OnUpdateCiliumNode(oldCN, ciliumNode, swgNodes)
-							if option.Config.EnableIPv4EgressGateway {
+							if k.egressGatewayManager != nil {
 								k.egressGatewayManager.OnUpdateNode(n)
 							}
 							if isLocal {
@@ -103,7 +102,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 					}
 					valid = true
 					n := nodeTypes.ParseCiliumNode(ciliumNode)
-					if option.Config.EnableIPv4EgressGateway {
+					if k.egressGatewayManager != nil {
 						k.egressGatewayManager.OnDeleteNode(n)
 					}
 					errs := k.CiliumNodeChain.OnDeleteCiliumNode(ciliumNode, swgNodes)

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -165,7 +165,7 @@ type bgpSpeakerManager interface {
 	OnUpdateEndpointSliceV1(eps *slim_discover_v1.EndpointSlice) error
 	OnUpdateEndpointSliceV1Beta1(eps *slim_discover_v1beta1.EndpointSlice) error
 }
-type egressGatewayManager interface {
+type EgressGatewayManager interface {
 	OnAddEgressPolicy(config egressgateway.PolicyConfig)
 	OnDeleteEgressPolicy(configID types.NamespacedName)
 	OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint)
@@ -240,7 +240,7 @@ type K8sWatcher struct {
 	svcManager            svcManager
 	redirectPolicyManager redirectPolicyManager
 	bgpSpeakerManager     bgpSpeakerManager
-	egressGatewayManager  egressGatewayManager
+	egressGatewayManager  EgressGatewayManager
 	ipcache               ipcacheManager
 	envoyConfigManager    envoyConfigManager
 	cgroupManager         cgroupManager
@@ -290,7 +290,7 @@ func NewK8sWatcher(
 	datapath datapath.Datapath,
 	redirectPolicyManager redirectPolicyManager,
 	bgpSpeakerManager bgpSpeakerManager,
-	egressGatewayManager egressGatewayManager,
+	egressGatewayManager EgressGatewayManager,
 	envoyConfigManager envoyConfigManager,
 	cfg WatcherConfiguration,
 	ipcache ipcacheManager,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -365,9 +365,6 @@ const (
 	// EnableIPv4EgressGateway enables the IPv4 egress gateway
 	EnableIPv4EgressGateway = "enable-ipv4-egress-gateway"
 
-	// InstallEgressGatewayRoutes installs IP rules and routes required to steer traffic to the correct network interface
-	InstallEgressGatewayRoutes = "install-egress-gateway-routes"
-
 	// EnableIngressController enables Ingress Controller
 	EnableIngressController = "enable-ingress-controller"
 
@@ -1693,7 +1690,6 @@ type DaemonConfig struct {
 	EnableBPFClockProbe        bool
 	EnableIPMasqAgent          bool
 	EnableIPv4EgressGateway    bool
-	InstallEgressGatewayRoutes bool
 	EnableEnvoyConfig          bool
 	EnableIngressController    bool
 	EnableGatewayAPI           bool
@@ -2990,7 +2986,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableBPFClockProbe = vp.GetBool(EnableBPFClockProbe)
 	c.EnableIPMasqAgent = vp.GetBool(EnableIPMasqAgent)
 	c.EnableIPv4EgressGateway = vp.GetBool(EnableIPv4EgressGateway)
-	c.InstallEgressGatewayRoutes = vp.GetBool(InstallEgressGatewayRoutes)
 	c.EgressGatewayPolicyMapEntries = vp.GetInt(EgressGatewayPolicyMapEntriesName)
 	c.EnableEnvoyConfig = vp.GetBool(EnableEnvoyConfig)
 	c.EnableIngressController = vp.GetBool(EnableIngressController)


### PR DESCRIPTION
These are the minimal changes needed to get the EGW into a hive Cell. The hacky part is that enabling the EGW is gated on the global option.Config.EnableIPv4EgressGateway which is references from a bunch of places. It's not entirely clear to me how to migrate that toggle yet, and it'll probably require a bunch of changes. I've kept the PR simple in the interests of making this easier to review.