### PR TITLE
test/verifier: Temporarily reenable complexity tests on K8sDatapathVerifier

### DIFF
--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -534,6 +534,17 @@ func DoesNotRunOn419OrLaterKernel() bool {
 	return !RunsOn419OrLaterKernel()
 }
 
+// RunsOn419OrNetNextKernel checks whether a test case is running on 4.19.x (x > 57) or net-next kernel.
+func RunsOn419OrNetNextKernel() bool {
+	return RunsOnNetNextKernel() || RunsOn419Kernel()
+}
+
+// DoesNotRunOn419OrNetNextKernel is the complement function of
+// RunsOn419OrNetNextKernel.
+func DoesNotRunOn419OrNetNextKernel() bool {
+	return !RunsOn419OrNetNextKernel()
+}
+
 // RunsOn54OrLaterKernel checks whether a test case is running on 5.4 or later kernel
 func RunsOn54OrLaterKernel() bool {
 	return RunsOnNetNextKernel() || RunsOn54Kernel()

--- a/test/k8s/verifier.go
+++ b/test/k8s/verifier.go
@@ -74,7 +74,10 @@ var (
 //
 // The test is skipped on all but 4.19 kernels. These are already covered in the GHA datapath
 // verifier workflow, see .github/workflows/tests-datapath-verifier.yaml.
-var _ = SkipDescribeIf(helpers.DoesNotRunOn419Kernel, "K8sDatapathVerifier", func() {
+//
+// The test is temporarily not skipped on net-next kernels, because of a bug in
+// the implementation of the GitHub Actions workflow that affects these kernels.
+var _ = SkipDescribeIf(helpers.DoesNotRunOn419OrNetNextKernel, "K8sDatapathVerifier", func() {
 	var kubectl *helpers.Kubectl
 
 	collectObjectFiles := func() {


### PR DESCRIPTION
While the GitHub Actions workflow is broken for bpf-next kernels, temporarily reenable the old test.