### PR TITLE
bpf,init.sh: make netdev bpf filter cleanup less eager

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -537,9 +537,11 @@ for iface in $(ip -o -a l | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep 
 	done
 	$found && continue
 	for where in ingress egress; do
-		# Filters created Go bpf loader are of format 'cilium-<iface>'.
-		# iproute2 would use the filename and section, e.g. bpf_overlay.o:[from-overlay].
-		if tc filter show dev "$iface" "$where" | grep -q "bpf_netdev\|bpf_host\|cilium"; then
+		# iproute2 uses the filename and section (bpf_overlay.o:[from-overlay]) as
+		# the filter name. Filters created by the Go bpf loader contain the bpf
+		# function and interface name, like cil_from_netdev-eth0.
+		# Only detach programs known to be attached to 'physical' network devices.
+		if tc filter show dev "$iface" "$where" | grep -qE "\b(bpf_host|cil_from_netdev|cil_to_netdev)"; then
 			echo "Removing $where TC filter from interface $iface"
 			tc filter del dev "$iface" "$where" || true
 		fi

--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -507,14 +507,16 @@ func getTCFilters(link netlink.Link) ([]*netlink.BpfFilter, error) {
 		}
 		for _, f := range filters {
 			if bpfFilter, ok := f.(*netlink.BpfFilter); ok {
-				// Filters created Go bpf loader are of format 'cilium-<iface>'.
-				// iproute2 would use the filename and section, e.g. bpf_overlay.o:[from-overlay].
+				// iproute2 uses the filename and section (bpf_overlay.o:[from-overlay])
+				// as the filter name.
 				if strings.Contains(bpfFilter.Name, "bpf_netdev") ||
 					strings.Contains(bpfFilter.Name, "bpf_network") ||
 					strings.Contains(bpfFilter.Name, "bpf_host") ||
 					strings.Contains(bpfFilter.Name, "bpf_lxc") ||
 					strings.Contains(bpfFilter.Name, "bpf_overlay") ||
-					strings.Contains(bpfFilter.Name, "cilium") {
+					// Filters created by the Go bpf loader contain the bpf function and
+					// interface name, like cil_from_netdev-eth0.
+					strings.Contains(bpfFilter.Name, "cil_") {
 					allFilters = append(allFilters, bpfFilter)
 				}
 			}


### PR DESCRIPTION
Due to an oversight when updating init.sh to deal with the new tc filter names for bpf progs after the introduction of Go-based loader/netlink attach, all interfaces in the host namespace that didn't contain the word 'cilium' would have their egress and ingress filters stripped. This included lxc interfaces and many others. lxc programs in particular would only be reattached when the endpoint got regenerated, which can take a while on nodes with many Pods. This caused connectivity interruptions in the meantime.

This commit changes the tc filter naming convention to converge on the changes introduced in 2e40d67ec9 ("bpf: Finish rename of BPF programs to cil_ prefix"), using the bpf program (function) name containing the 'cil_' prefix. The 'cilium_' prefix is no longer included explicitly, instead opting for the program name suffixed by the interface name, e.g. cil_from_netdev-eth0.

init.sh no longer uses the term 'cilium' to trigger a removal of the interface's tc filters.

Fixes commit 2a7cef4bb3 ("init,cleanup: remove TC filters containing 'cilium' in their names").

```release-note
Fix Pod connectivity interruption during agent restart
```

Fixes: https://github.com/cilium/cilium/issues/24191