### PR TITLE
Correctly configure extra SANs for the clustermesh API server certificate when generated through certgen

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -1,5 +1,9 @@
 {{- define "clustermesh-apiserver-generate-certs.job.spec" }}
 {{- $certValiditySecondsStr := printf "%ds" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24 60 60) -}}
+{{- $clustermeshServerSANs := concat (list "*.mesh.cilium.io")
+  .Values.clustermesh.apiserver.tls.server.extraDnsNames
+  .Values.clustermesh.apiserver.tls.server.extraIpAddresses
+-}}
 spec:
   template:
     metadata:
@@ -31,6 +35,7 @@ spec:
             {{- end }}
             - "--clustermesh-apiserver-server-cert-generate"
             - "--clustermesh-apiserver-server-cert-validity-duration={{ $certValiditySecondsStr }}"
+            - "--clustermesh-apiserver-server-cert-sans={{ join "," $clustermeshServerSANs }}"
             - "--clustermesh-apiserver-admin-cert-generate"
             - "--clustermesh-apiserver-admin-cert-validity-duration={{ $certValiditySecondsStr }}"
             {{- if .Values.externalWorkloads.enabled }}


### PR DESCRIPTION
This PR extends the Helm chart, to respect the extra DNS names and IP addresses specified for the clustermesh API server TLS certificate, when it is generated through the Cilium's certgen tool. The same fields are already considered when helm or cert-manager are used for generating that certificate.

<!-- Description of change -->

```release-note
Correctly configure extra SANs for the clustermesh API server certificate when generated through certgen
```
