### PR TITLE
bpf: Use builtin memcpy for copying addresses

### DIFF
--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -80,8 +80,7 @@ static __always_inline int ipv6_hdrlen(struct __ctx_buff *ctx, __u8 *nexthdr)
 static __always_inline void ipv6_addr_copy(union v6addr *dst,
 					   const union v6addr *src)
 {
-	dst->d1 = src->d1;
-	dst->d2 = src->d2;
+	memcpy(dst, src, sizeof(*dst));
 }
 
 static __always_inline __u64 ipv6_addrcmp(const union v6addr *a,


### PR DESCRIPTION
TODO:
- [ ] there are 16 `git grep -n " = ip4->s"`
- [ ] there are 18 `git grep -n " = ip4->d"`
  - For both of these, I'll add ipv4_addr_copy