### PR TITLE
Fix panic in hubble http v2 metrics

### DIFF
--- a/pkg/hubble/metrics/http/handler_test.go
+++ b/pkg/hubble/metrics/http/handler_test.go
@@ -198,3 +198,23 @@ func Test_httpHandlerV2_ProcessFlow(t *testing.T) {
 	`
 	require.NoError(t, testutil.CollectAndCompare(handler.(*httpHandler).duration, strings.NewReader(durationExpected)))
 }
+
+func Test_httpHandler_ListMetricVec(t *testing.T) {
+	plugin := httpPlugin{}
+	handler := plugin.NewHandler()
+	require.NoError(t, handler.Init(prometheus.NewRegistry(), nil))
+	assert.Len(t, handler.ListMetricVec(), 3, "expecting 3 metrics, requests, responses and duration")
+	for _, vec := range handler.ListMetricVec() {
+		require.NotNil(t, vec, "ListMetricVec should not nil metrics vectors")
+	}
+}
+
+func Test_httpV2Handler_ListMetricVec(t *testing.T) {
+	plugin := httpV2Plugin{}
+	handler := plugin.NewHandler()
+	require.NoError(t, handler.Init(prometheus.NewRegistry(), nil))
+	assert.Len(t, handler.ListMetricVec(), 2, "expecting 2 metrics, requests and duration")
+	for _, vec := range handler.ListMetricVec() {
+		require.NotNil(t, vec, "ListMetricVec should not nil metrics vectors")
+	}
+}


### PR DESCRIPTION
@kaworu found a bug when testing another PR based on master when using httpV2 metrics:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x23a666e]

goroutine 1271 [running]:
github.com/cilium/cilium/pkg/hubble/metrics/http.(*httpHandler).ListMetricVec(0xc00079c150)
	/go/src/github.com/cilium/cilium/pkg/hubble/metrics/http/handler.go:85 +0x4e
github.com/cilium/cilium/pkg/hubble/metrics/api.Handlers.ProcessPodDeletion({{0xc000748680, 0x6, 0x8}, {0xc000748700, 0x6, 0x8}}, 0xc001f56820)
	/go/src/github.com/cilium/cilium/pkg/hubble/metrics/api/api.go:134 +0xad
github.com/cilium/cilium/pkg/hubble/metrics.initPodDeletionHandler.func1()
	/go/src/github.com/cilium/cilium/pkg/hubble/metrics/metrics.go:90 +0x45
created by github.com/cilium/cilium/pkg/hubble/metrics.initPodDeletionHandler
	/go/src/github.com/cilium/cilium/pkg/hubble/metrics/metrics.go:84 +0x9d
```

This was introduced in #23385 which seems to have handled all the other metrics correctly, but http is a bit special and it didn't handle the v2 metrics option. 

I wrote a new test (second commit) which reproduces the panic:

```
 (⎈|kind-kind:N/A) ~/g/s/g/c/cilium ❯❯❯ go test -v ./pkg/hubble/metrics/http                                                                                                                                                                                                             master ⬆ ✭
=== RUN   Test_httpHandler_Status
--- PASS: Test_httpHandler_Status (0.00s)
=== RUN   Test_httpHandler_ProcessFlow
--- PASS: Test_httpHandler_ProcessFlow (0.00s)
=== RUN   Test_httpHandlerV2_ProcessFlow
--- PASS: Test_httpHandlerV2_ProcessFlow (0.00s)
=== RUN   Test_httpHandler_ListMetricVec
--- PASS: Test_httpHandler_ListMetricVec (0.00s)
=== RUN   Test_httpV2Handler_ListMetricVec
--- FAIL: Test_httpV2Handler_ListMetricVec (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x100c6e650]

goroutine 65 [running]:
testing.tRunner.func1.2({0x100e115c0, 0x10136d580})
	/Users/chancezibolski/.asdf/installs/golang/1.19.5/go/src/testing/testing.go:1396 +0x1c8
testing.tRunner.func1()
	/Users/chancezibolski/.asdf/installs/golang/1.19.5/go/src/testing/testing.go:1399 +0x378
panic({0x100e115c0, 0x10136d580})
	/Users/chancezibolski/.asdf/installs/golang/1.19.5/go/src/runtime/panic.go:884 +0x204
github.com/cilium/cilium/pkg/hubble/metrics/http.(*httpHandler).ListMetricVec(0x14000078f30)
	/Users/chancezibolski/go/src/github.com/cilium/cilium/pkg/hubble/metrics/http/handler.go:85 +0x60
github.com/cilium/cilium/pkg/hubble/metrics/http.Test_httpV2Handler_ListMetricVec(0x0?)
	/Users/chancezibolski/go/src/github.com/cilium/cilium/pkg/hubble/metrics/http/handler_test.go:216 +0x10c
testing.tRunner(0x140002fe820, 0x100ed4100)
	/Users/chancezibolski/.asdf/installs/golang/1.19.5/go/src/testing/testing.go:1446 +0x10c
created by testing.(*T).Run
	/Users/chancezibolski/.asdf/installs/golang/1.19.5/go/src/testing/testing.go:1493 +0x300
FAIL	github.com/cilium/cilium/pkg/hubble/metrics/http	0.204s
```

And the first commit fixes this by properly handling the difference between http v2 metrics and v1.

```release-note
Fix panic in hubble http v2 metrics
```
