### PR TITLE
ipam: add method to get IP owner per pool

### DIFF
--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -319,7 +319,7 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 		st4 = "IPv4: " + st4
 		for ip := range allocv4 {
 			// XXX: only consider default pool for now
-			owner, _ := ipam.owner[PoolDefault][ip]
+			owner := ipam.getIPOwner(ip, PoolDefault)
 			// If owner is not available, report IP but leave owner empty
 			allocv4[ip] = owner
 		}
@@ -330,7 +330,7 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 		st6 = "IPv6: " + st6
 		for ip := range allocv6 {
 			// XXX: only consider default pool for now
-			owner, _ := ipam.owner[PoolDefault][ip]
+			owner := ipam.getIPOwner(ip, PoolDefault)
 			// If owner is not available, report IP but leave owner empty
 			allocv6[ip] = owner
 		}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -159,6 +159,15 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 	return ipam
 }
 
+// getIPOwner returns the owner for an IP in a particular pool or the empty
+// string in case the pool or IP is not registered.
+func (ipam *IPAM) getIPOwner(ip string, pool Pool) string {
+	if p, ok := ipam.owner[pool]; ok {
+		return p[ip]
+	}
+	return ""
+}
+
 // registerIPOwner registers a new owner for an IP in a particular pool.
 func (ipam *IPAM) registerIPOwner(ip net.IP, owner string, pool Pool) {
 	if _, ok := ipam.owner[pool]; !ok {


### PR DESCRIPTION
Avoid accessing a nil map once we use more than just the default pool.

Fixes: e3f1a22ef7d3 ("ipam: track IP owner per pool")
