### PR TITLE
kvstore/etcd: don't use atomic type for version check timeout

### DIFF
--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -155,9 +154,9 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 	}
 
 	// short timeout for tests
-	atomic.StoreInt64(&versionCheckTimeout, int64(time.Second))
+	timeout := time.Second
 
-	c.Assert(client.checkMinVersion(context.TODO()), IsNil)
+	c.Assert(client.checkMinVersion(context.TODO(), timeout), IsNil)
 
 	// One endpoint has a bad version and should fail
 	cfg.Endpoints = []string{"http://127.0.0.1:4003", "http://127.0.0.1:4004", "http://127.0.0.1:4005"}
@@ -168,7 +167,7 @@ func (s *EtcdSuite) TestETCDVersionCheck(c *C) {
 		client: cli,
 	}
 
-	c.Assert(client.checkMinVersion(context.TODO()), Not(IsNil))
+	c.Assert(client.checkMinVersion(context.TODO(), timeout), Not(IsNil))
 }
 
 type EtcdHelpersSuite struct{}


### PR DESCRIPTION
Commit 441759e44dfb ("pkg/kvstore: fix concurrent access of var in testing") changed versionCheckTimeout to be accessed atomically to fix a race in tests. Instead, pass the timeout value to the function it is used in. This allows to drop the use of an atomic type.
