### PR TITLE
ipcache: Simplify implementation with guaranteed LPM support

### DIFF
--- a/bpf/lib/eps.h
+++ b/bpf/lib/eps.h
@@ -97,4 +97,5 @@ ipcache_lookup4(const void *map, __be32 addr, __u32 prefix, __u8 cluster_id)
 	ipcache_lookup6(&IPCACHE_MAP, addr, V6_CACHE_KEY_LEN, cluster_id)
 #define lookup_ip4_remote_endpoint(addr, cluster_id) \
 	ipcache_lookup4(&IPCACHE_MAP, addr, V4_CACHE_KEY_LEN, cluster_id)
+
 #endif /* __LIB_EPS_H_ */

--- a/bpf/tests/ipv6_test.c
+++ b/bpf/tests/ipv6_test.c
@@ -11,25 +11,6 @@
 #include "lib/ipv6.h"
 #include "lib/maps.h"
 
-static __be32 *dummy_map;
-static __be32 match_dummy_prefix(__maybe_unused const void *map, __be32 addr,
-				 __u32 prefix)
-{
-	return (addr & GET_PREFIX(prefix)) == *dummy_map;
-}
-
-#define PREFIX32 32,
-#define PREFIX31 31,
-#define PREFIX22 22,
-#define PREFIX11 11,
-#define PREFIX0  0,
-
-LPM_LOOKUP_FN(lpm4_lookup32, __be32, PREFIX32, dummy_map, match_dummy_prefix)
-LPM_LOOKUP_FN(lpm4_lookup31, __be32, PREFIX31, dummy_map, match_dummy_prefix)
-LPM_LOOKUP_FN(lpm4_lookup22, __be32, PREFIX22, dummy_map, match_dummy_prefix)
-LPM_LOOKUP_FN(lpm4_lookup11, __be32, PREFIX11, dummy_map, match_dummy_prefix)
-LPM_LOOKUP_FN(lpm4_lookup0, __be32, PREFIX0, dummy_map, match_dummy_prefix)
-
 CHECK("xdp", "ipv6")
 int bpf_test(__maybe_unused struct xdp_md *ctx)
 {
@@ -72,33 +53,6 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 		assert(bpf_ntohl(v6.p2) == 0x00000000);
 		assert(bpf_ntohl(v6.p3) == 0x00000000);
 		assert(bpf_ntohl(v6.p4) == 0x00000000);
-	});
-
-	TEST("test_lpm_lookup", {
-		__be32 addr;
-
-		dummy_map = &addr;
-
-		addr = bpf_htonl(0xFFFFFFFF);
-		assert(__lpm4_lookup32(bpf_htonl(0xFFFFFFFF)));
-		assert(!__lpm4_lookup32(bpf_htonl(0xFFF00000)));
-		addr = bpf_htonl(0xFFFFFFFE);
-		assert(__lpm4_lookup31(bpf_htonl(0xFFFFFFFE)));
-		assert(__lpm4_lookup31(bpf_htonl(0xFFFFFFFF)));
-		assert(!__lpm4_lookup31(bpf_htonl(0xFFF00000)));
-		addr = bpf_htonl(0xFFFFFC00);
-		assert(__lpm4_lookup22(bpf_htonl(0xFFFFFC00)));
-		assert(__lpm4_lookup22(bpf_htonl(0xFFFFFFFF)));
-		assert(!__lpm4_lookup22(bpf_htonl(0xFFF00000)));
-		addr = bpf_htonl(0xFFE00000);
-		assert(__lpm4_lookup11(bpf_htonl(0xFFE00000)));
-		assert(__lpm4_lookup11(bpf_htonl(0xFFFFFFFF)));
-		assert(__lpm4_lookup11(bpf_htonl(0xFFF00000)));
-		addr = bpf_htonl(0xF0000000);
-		assert(__lpm4_lookup11(bpf_htonl(0xF0000000)));
-		addr = bpf_htonl(0x00000000);
-		assert(__lpm4_lookup0(addr));
-		assert(__lpm4_lookup0(bpf_htonl(0xFFFFFFFF)));
 	});
 
 	test_finish();

--- a/cilium/cmd/bpf_ipcache_get.go
+++ b/cilium/cmd/bpf_ipcache_get.go
@@ -67,7 +67,7 @@ func init() {
 func dumpIPCache() map[string][]string {
 	bpfIPCache := make(map[string][]string)
 
-	if err := ipcache.IPCacheMap().Dump(bpfIPCache); err != nil {
+	if err := ipcache.NewMap().Dump(bpfIPCache); err != nil {
 		Fatalf("unable to dump IPCache: %s\n", err)
 	}
 

--- a/cilium/cmd/bpf_ipcache_list.go
+++ b/cilium/cmd/bpf_ipcache_list.go
@@ -32,7 +32,7 @@ var bpfIPCacheListCmd = &cobra.Command{
 		common.RequireRootPrivilege("cilium bpf ipcache list")
 
 		bpfIPCacheList := make(map[string][]string)
-		if err := ipcache.IPCacheMap().Dump(bpfIPCacheList); err != nil {
+		if err := ipcache.NewMap().Dump(bpfIPCacheList); err != nil {
 			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)
 			os.Exit(1)
 		}

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
@@ -90,5 +91,12 @@ var (
 
 		// IPCache, policy.Repository and CachingIdentityAllocator.
 		cell.Provide(newPolicyTrifecta),
+
+		// IPCache initializer, handles restoring of IPCache state from the datapath and setting the local node ingress
+		// IPs.
+		cell.Provide(newIPCacheInitializer),
+
+		// Monitor agent distributes monitor events
+		agent.Cell,
 	)
 )

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/controller"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	datapathIpcache "github.com/cilium/cilium/pkg/datapath/ipcache"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
@@ -146,6 +147,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 			},
 			func() datapath.Datapath { return fakeDatapath.NewDatapath() },
 			func() *option.DaemonConfig { return option.Config },
+			datapathIpcache.NewMockListener,
 		),
 		ControlPlane,
 		cell.Invoke(func(p promise.Promise[*Daemon]) {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -392,7 +392,6 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 		restoreComplete = d.regenerateRestoredEndpoints(restoredEndpoints)
 		go func() {
 			<-restoreComplete
-			endParallelMapMode()
 		}()
 
 		go func() {
@@ -425,9 +424,6 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 		}()
 	} else {
 		log.Info("State restore is disabled. Existing endpoints on node are ignored")
-
-		// No restore happened, end parallel map mode immediately
-		endParallelMapMode()
 	}
 	bootstrapStats.restore.End(true)
 

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -210,13 +210,11 @@ func (s *BPFPrivilegedTestSuite) TestOpenParallel(c *C) {
 		BPF_F_NO_PREALLOC,
 		0,
 		ConvertKeyValue).WithCache()
-	isNew, err := parallelMap.OpenParallel()
+	err := parallelMap.Recreate()
 	defer parallelMap.Close()
 	c.Assert(err, IsNil)
-	c.Assert(isNew, Equals, true)
 
-	isNew, err = parallelMap.OpenParallel()
-	c.Assert(isNew, Equals, false)
+	err = parallelMap.Recreate()
 	c.Assert(err, Not(IsNil))
 
 	// Check OpenMap warning section
@@ -245,8 +243,6 @@ func (s *BPFPrivilegedTestSuite) TestOpenParallel(c *C) {
 	value, err = parallelMap.Lookup(key2)
 	c.Assert(err, IsNil)
 	c.Assert(value, checker.DeepEquals, value2)
-
-	parallelMap.EndParallelMode()
 }
 
 func (s *BPFPrivilegedTestSuite) TestBasicManipulation(c *C) {

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"path/filepath"
 
+	ipcacheDatapath "github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
@@ -15,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/maps"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -30,6 +32,13 @@ var Cell = cell.Module(
 		newWireguardAgent,
 		newDatapath,
 	),
+
+	// Provide BPF maps
+	maps.Cell,
+
+	// The IPCache datapath component, subscribes to the agent component, updates the map, and reloads the
+	// datapath when necessary.
+	ipcacheDatapath.Cell,
 
 	cell.Provide(func(dp types.Datapath) ipcache.NodeHandler {
 		return dp.Node()

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -206,11 +206,10 @@ func (l *BPFListener) updateStaleEntriesFunction(keysToRemove map[string]*ipcach
 	}
 }
 
-// garbageCollect implements GC of the ipcache map in the following way:
-//
-//	Periodically sweep through every element in the BPF map and check it
-//	against the in-memory copy of the map. If it doesn't exist in memory,
-//	delete the entry.
+// garbageCollect implements GC of the ipcache map in the form of a
+// periodically sweep through every element in the BPF map and check it
+// against the in-memory copy of the map. If it doesn't exist in memory,
+// delete the entry.
 //
 // Returns an error if garbage collection failed to occur.
 func (l *BPFListener) garbageCollect(ctx context.Context) (*sync.WaitGroup, error) {
@@ -236,6 +235,7 @@ func (l *BPFListener) garbageCollect(ctx context.Context) (*sync.WaitGroup, erro
 			return nil, fmt.Errorf("error deleting key %s from ipcache BPF map: %s", k, err)
 		}
 	}
+
 	return nil, nil
 }
 

--- a/pkg/datapath/ipcache/mock.go
+++ b/pkg/datapath/ipcache/mock.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipcache
+
+import (
+	"net"
+	"net/netip"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache"
+)
+
+type mockListener struct{}
+
+func (ml *mockListener) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrCluster cmtypes.PrefixCluster,
+	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
+	encryptKey uint8, nodeID uint16, k8sMeta *ipcache.K8sMetadata) {
+}
+func (ml *mockListener) OnIPIdentityCacheGC()                   {}
+func (ml *mockListener) GetOldNIDs() []identity.NumericIdentity { return nil }
+func (ml *mockListener) GetOldCIDRs() []netip.Prefix            { return nil }
+func (ml *mockListener) GetOldIngressIPs() []*net.IPNet         { return nil }
+
+func NewMockListener() BPFListenerInterface {
+	return &mockListener{}
+}

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -141,8 +141,7 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 			lbmap.Affinity6MapName,
 			lbmap.SourceRange6MapName,
 			lbmap.HealthProbe6MapName,
-			cidrmap.MapName + "v6_dyn",
-			cidrmap.MapName + "v6_fix",
+			cidrmap.MapName + "v6",
 		}...)
 	}
 
@@ -165,8 +164,7 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 			lbmap.SourceRange4MapName,
 			lbmap.HealthProbe4MapName,
 			ipmasq.MapName,
-			cidrmap.MapName + "v4_dyn",
-			cidrmap.MapName + "v4_fix",
+			cidrmap.MapName + "v4",
 		}...)
 	}
 
@@ -209,10 +207,8 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 
 	if !option.Config.EnableXDPPrefilter {
 		maps = append(maps, []string{
-			cidrmap.MapName + "v4_dyn",
-			cidrmap.MapName + "v4_fix",
-			cidrmap.MapName + "v6_dyn",
-			cidrmap.MapName + "v6_fix",
+			cidrmap.MapName + "v4",
+			cidrmap.MapName + "v6",
 		}...)
 	}
 

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package maps
+
+import (
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/maps/ipcache"
+)
+
+var Cell = cell.Module("maps", "Maps",
+	ipcache.Cell,
+)

--- a/pkg/proxy/logger/logger_test.go
+++ b/pkg/proxy/logger/logger_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/monitor/agent/listener"
 	"github.com/cilium/cilium/pkg/monitor/api"
@@ -121,7 +122,9 @@ type MockLogNotifier struct {
 
 // NewMockLogNotifier returns a MockLogNotifier ready to be used in the benchmarks below.
 func NewMockLogNotifier() *MockLogNotifier {
-	return &MockLogNotifier{agent.NewAgent(context.Background())}
+	return &MockLogNotifier{agent.NewAgent(&hive.DefaultLifecycle{}, &option.DaemonConfig{
+		DryMode: true,
+	})}
 }
 
 // NewProxyLogRecord sends the event to the monitor agent to notify the listeners.

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/daemon/cmd"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/datapath/ipcache"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -66,6 +67,7 @@ func startCiliumAgent(t *testing.T, nodeName string, clientset k8sClient.Clients
 			func() k8sClient.Clientset { return clientset },
 			func() datapath.Datapath { return fdp },
 			func() *option.DaemonConfig { return option.Config },
+			ipcache.NewMockListener,
 		),
 		cmd.ControlPlane,
 		cell.Invoke(func(p promise.Promise[*cmd.Daemon]) {


### PR DESCRIPTION
This PR modularizes the IPCache map, the first map in `pkg/datapath/maps` to become a module. This process moved the initialization logic of the IPCache map from the daemon into seperate components and made a clean seperation between datapath and the agent.

During this process I noticed a lot of "legacy" code that deals with kernels without LPM support. Cilium v1.13 and above has a minium kernel version requirement of v4.19.57 or above (or with equal feature support). This means that we can assume that we always have full LPM map support including iterating over the map and deleting elements from the map.

This allows us to considerably simplify our IPCache logic. This PR drops all fallback code for non-LPM maps or LPM maps without delete functionality.

```release-note
Removed legacy fallbacks for LPM maps
```
