### PR TITLE
alignchecker: fully parse structures

### DIFF
--- a/pkg/alignchecker/alignchecker_test.go
+++ b/pkg/alignchecker/alignchecker_test.go
@@ -22,6 +22,25 @@ func TestAlignChecker(t *testing.T) {
 		_ foo
 	}
 
+	type foo3 struct {
+		_ [4]uint32 `align:"$union0.ip6"`
+		_ uint32    `align:"$union1.p2"`
+		_ uint8     `align:"family"`
+		_ uint8     `align:"pad4"`
+		_ uint16    `align:"pad5"`
+	}
+
+	type foo4 struct {
+		_ uint32 `align:"$union0.$struct0.ip4"`
+		_ uint32 `align:"$union0.$struct0.pad1"`
+		_ uint32 `align:"$union0.$struct0.pad2"`
+		_ uint32 `align:"$union0.$struct0.pad3"`
+		_ uint32 `align:"$union1.p1"`
+		_ uint8  `align:"family"`
+		_ uint8  `align:"pad4"`
+		_ uint16 `align:"pad5"`
+	}
+
 	type fooInvalidSize struct {
 		_ uint32
 	}
@@ -60,6 +79,20 @@ func TestAlignChecker(t *testing.T) {
 			[]reflect.Type{
 				reflect.TypeOf(foo{}),
 				reflect.TypeOf(foo2{}),
+			},
+			"",
+		},
+		{
+			"foo",
+			[]reflect.Type{
+				reflect.TypeOf(foo3{}),
+			},
+			"",
+		},
+		{
+			"foo",
+			[]reflect.Type{
+				reflect.TypeOf(foo4{}),
 			},
 			"",
 		},

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -341,7 +341,7 @@ func (k *Service4Key) ToHost() ServiceKey {
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
 type Service4Value struct {
-	BackendID uint32    `align:"backend_id"`
+	BackendID uint32    `align:"$union0"`
 	Count     uint16    `align:"count"`
 	RevNat    uint16    `align:"rev_nat_index"`
 	Flags     uint8     `align:"flags"`

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -195,7 +195,7 @@ func (k *Service6Key) ToHost() ServiceKey {
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
 type Service6Value struct {
-	BackendID uint32    `align:"backend_id"`
+	BackendID uint32    `align:"$union0"`
 	Count     uint16    `align:"count"`
 	RevNat    uint16    `align:"rev_nat_index"`
 	Flags     uint8     `align:"flags"`


### PR DESCRIPTION
The alignchecker package takes BTF descriptions of structures and creates a map with offsets. For example,

    struct x {
        u64 a;
        u32 b;
        u8 c;
        u8 d;
    };

will be converted to

    {a: 0, b: 8, c: 12, d: 13}

These names are later used in Go struct definitions, so that we can check if they are properly aligned, e.g.:

    type X struct {
        A uint64 `align:"a"`
        B uint32 `align:"b"`
        C uint8 `align:"c"`
        D uint8 `align:"d"`
       }

If there are anonymous unions present, then their offsets will be stored as $union0, $union1, etc., e.g.,

    struct x {
        union { u32 a; u32 b; };
        union { u32 c; u32 d; };
        u32 f;
    };

will be converted to

    {$union0: 0, $union1: 4, f: 8}

However, there's no way to refer to inner fields of unions, or to fields of structures. Fix this by parsing BTFs recursively. After this change, e.g., the following structure

    struct x {
        u32 a;
        struct {
            union {
                u32 a;
                u32 b;
            };
            u32 c;
        };
        u32 d;
    };

will be converted to

    {
        a: 0,
        $struct0: 4,
        $struct0.$union0: 4,
        $struct0.$union0.a: 4,
        $struct0.$union0.b: 4,
        $struct0.c: 8,
        d: 12
    }

Also fix a minor bug: previous code didn't check if an offset exists or not (it was set to 0 by default). Patch two occurrences in code which were referencing non-existing offset (it happened that the corresponding offsets were indeed 0).