### PR TITLE
checker: Fix incorrect checker for ExportedEqual()

### DIFF
--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -163,7 +163,7 @@ func (checker *cmpExportedChecker) Check(params []interface{}, _ []string) (resu
 // deeply equal, then the second return value includes a json representation of
 // the difference between the parameters.
 func ExportedEqual(params ...interface{}) (bool, string) {
-	return Equals.Check(params, cmpParams)
+	return ExportedEquals.Check(params, cmpParams)
 }
 
 func DeepIgnoreUnexported(vs ...interface{}) cmp.Option {


### PR DESCRIPTION
When using checker.ExportedEqual(), it was using the standard Equals
checker under-the-hood, but this is incorrect. Fix it to use the correct
checker.

In the commit introducing the bug, there was no direct usage of
checker.ExportedEqual(), but rather checker.ExportedEqual (note the
plural). Subtle!

Discovered while working on improving policy unit tests.

Fixes: f4407e7c8f9 ("checker: Add ExportedEquals checker")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
