### PR TITLE
helm chart: add helm option to customize nodeinit scripts

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1669,6 +1669,10 @@
      - Labels to be added to node-init pods.
      - object
      - ``{}``
+   * - nodeinit.prestop
+     - prestop offers way to customize prestop nodeinit script (pre and post position)
+     - object
+     - ``{"postScript":"","preScript":""}``
    * - nodeinit.priorityClassName
      - The priority class to use for the nodeinit pod.
      - string
@@ -1681,6 +1685,10 @@
      - Security context to be added to nodeinit pods.
      - object
      - ``{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}``
+   * - nodeinit.startup
+     - startup offers way to customize startup nodeinit script (pre and post position)
+     - object
+     - ``{"postScript":"","preScript":""}``
    * - nodeinit.tolerations
      - Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -822,6 +822,7 @@ prepend
 prepended
 prepulls
 prerequirement
+prestop
 printf
 priori
 priorityClassName

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -468,9 +468,11 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
+| nodeinit.prestop | object | `{"postScript":"","preScript":""}` | prestop offers way to customize prestop nodeinit script (pre and post position) |
 | nodeinit.priorityClassName | string | `""` | The priority class to use for the nodeinit pod. |
 | nodeinit.resources | object | `{"requests":{"cpu":"100m","memory":"100Mi"}}` | nodeinit resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | nodeinit.securityContext | object | `{"capabilities":{"add":["SYS_MODULE","NET_ADMIN","SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}}` | Security context to be added to nodeinit pods. |
+| nodeinit.startup | object | `{"postScript":"","preScript":""}` | startup offers way to customize startup nodeinit script (pre and post position) |
 | nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | nodeinit.updateStrategy | object | `{"type":"RollingUpdate"}` | node-init update strategy |
 | operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"io.cilium/app":"operator"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-operator |

--- a/install/kubernetes/cilium/files/nodeinit/prestop.bash
+++ b/install/kubernetes/cilium/files/nodeinit/prestop.bash
@@ -4,6 +4,8 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
+{{ .Values.nodeinit.prestop.preScript }}
+
 if stat /tmp/node-deinit.cilium.io > /dev/null 2>&1; then
   exit 0
 fi
@@ -52,5 +54,7 @@ if iptables -w -t nat -L IP-MASQ > /dev/null; then
   iptables -w -t nat -A POSTROUTING -m comment --comment "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain" -m addrtype ! --dst-type LOCAL -j IP-MASQ
 fi
 {{- end }}
+
+{{ .Values.nodeinit.prestop.postScript }}
 
 echo "Node de-initialization complete"

--- a/install/kubernetes/cilium/files/nodeinit/startup.bash
+++ b/install/kubernetes/cilium/files/nodeinit/startup.bash
@@ -14,6 +14,8 @@ echo "Addressing:"
 ip -4 a
 ip -6 a
 
+{{ .Values.nodeinit.startup.preScript }}
+
 {{- if .Values.nodeinit.removeCbrBridge }}
 if ip link show cbr0; then
   echo "Detected cbr0 bridge. Deleting interface..."
@@ -199,4 +201,7 @@ fi
 {{- if .Values.nodeinit.revertReconfigureKubelet }}
 rm -f /tmp/node-deinit.cilium.io
 {{- end }}
+
+{{ .Values.nodeinit.startup.postScript }}
+
 echo "Node initialization complete"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2174,6 +2174,15 @@ nodeinit:
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is
   # written by the node-init DaemonSet
   bootstrapFile: "/tmp/cilium-bootstrap.d/cilium-bootstrap-time"
+  
+  # -- startup offers way to customize startup nodeinit script (pre and post position)
+  startup:
+   preScript: ""
+   postScript: ""
+  # -- prestop offers way to customize prestop nodeinit script (pre and post position)
+  prestop:
+   preScript: ""
+   postScript: ""
 
 preflight:
   # -- Enable Cilium pre-flight resources (required for upgrade)

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2171,6 +2171,15 @@ nodeinit:
   # -- bootstrapFile is the location of the file where the bootstrap timestamp is
   # written by the node-init DaemonSet
   bootstrapFile: "/tmp/cilium-bootstrap.d/cilium-bootstrap-time"
+  
+  # -- startup offers way to customize startup nodeinit script (pre and post position)
+  startup:
+   preScript: ""
+   postScript: ""
+  # -- prestop offers way to customize prestop nodeinit script (pre and post position)
+  prestop:
+   preScript: ""
+   postScript: ""
 
 preflight:
   # -- Enable Cilium pre-flight resources (required for upgrade)


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [ ] Thanks for contributing! 🎉 

<!-- Description of change -->

implement a way to customize cilium nodeinit script to be able to adapt it to different environments before cilium is started. might be a possible way for workaround in #18706

```release-note
add helm option to customize nodeinit scripts
```
