### PR TITLE
datapath: DSR+UDP+IPV4, there is no need for advertising a lower MTU

### DIFF
--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -271,6 +271,8 @@ ctx_adjust_hroom(struct xdp_md *ctx, const __s32 len_diff, const __u32 mode,
 			else
 				ret = -EFAULT;
 			break;
+		case -8:  /* __u32 opt[2] */
+			break;
 		case 48: /* struct {ipv6hdr + icmp6hdr} */
 			break;
 		case 40: /* struct ipv6hdr */


### PR DESCRIPTION
1. when UDP has multiple IPv4 fragments, the IPv4 option extension header is only added to the first fragment.
2. The backends receives the IPv4 option, deletes it, and passes it to the pod(Pod doesn't need to know about svc addr:port).

Another possible solution is: 
When using DSR mode, adjust MRU and MTU in pkg/mtu:GetDeviceMTU() and pkg/mtu:GetRouteMTU(),
increase MRU by 8 bytes and keep MTU unchanged (for example: MRU1508, MTU1500).Thanks @joestringer 
But the current solution removes the option field, reducing the impact of DSR mode on the application layer, so it may be better. welcome discussion here~

Fixes: #24359 

```release-note
In DSR IPv4 UDP, can choose the client decrease its MTU by 8bytes or the node's increasing its MTU by 8bytes
```
