### PR TITLE
Increase logging verbosity of Kubernetes API Server in kind

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -130,6 +130,14 @@ networking:
   ipFamily: ${ipfamily}
   ${pod_subnet:+"podSubnet: "$pod_subnet}
   ${service_subnet:+"serviceSubnet: "$service_subnet}
+kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    metadata:
+      name: config
+    apiServer:
+      extraArgs:
+        "v": "3"
 containerdConfigPatches:
 - |-
   [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${reg_port}"]


### PR DESCRIPTION
This will allow us to see what requests are made by Cilium components against k8s apiserver.

Example:
```
kubectl logs -n kube-system kube-apiserver-kind-control-plane
```

