### PR TITLE
[CI] Make ingress conformance ready timeout 60s

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -223,7 +223,7 @@ jobs:
         timeout-minutes: 30
         run: |
           cd ingress-controller-conformance
-          ./ingress-controller-conformance -ingress-class cilium -wait-time-for-ingress-status 10s -wait-time-for-ready 30s
+          ./ingress-controller-conformance -ingress-class cilium -wait-time-for-ingress-status 10s -wait-time-for-ready 60s
 
       - name: Post-test information gathering
         if: ${{ !success() }}


### PR DESCRIPTION
Early draft PR to test multiple runs in actual CI environment

This doubles the timeout that the ingress conformance will wait on pods becoming ready.
In a kind cluster that has a lot of scheduling going on the 30s timeout caused flakes by 1 container still being created when it timed out. The default is 5 minutes in the code, this is still less to fail faster.

Fixes: https://github.com/cilium/cilium/issues/24355

```release-note
Increase timeout waiting for resources in Ingress conformance test
```
