### PR TITLE
Turn off CNP node status GC when CNP status updates are disabled.

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -833,9 +833,10 @@ data:
 {{- end }}
 
 {{- if .Values.enableCnpStatusUpdates }}
-  disable-cnp-status-updates: {{ (not .Values.enableCnpStatusUpdates) | quote }}
+  disable-cnp-status-updates: "false"
 {{- else if (eq $defaultEnableCnpStatusUpdates "false") }}
   disable-cnp-status-updates: "true"
+  cnp-node-status-gc-interval: "0s"
 {{- end }}
 
 {{- if .Values.egressGateway.enabled }}


### PR DESCRIPTION
CNP Node Status GC was still running in cilium-operator even though by default CNP Node Status updates were disabled.
This GC periodically made unnecessary API calls (one call per 10 policies) to k8s apiserver, which were going directly to underlying Etcd. 

```release-note
Disable by default CNP Node Status GC in cilium-operator.
```
