### PR TITLE
Fix execution of coccinelle checks

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           persist-credentials: false
-      - uses: docker://cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a
+      - uses: docker://cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -113,7 +113,7 @@ skip_service_lookup:
 	/* Store state to be picked up on the continuation tail call. */
 	lb4_ctx_store_state(ctx, &ct_state_new, proxy_port);
 	ep_tail_call(ctx, CILIUM_CALL_IPV4_CT_EGRESS);
-	return ret;
+	return DROP_MISSED_TAIL_CALL;
 }
 #endif /* ENABLE_IPV4 */
 
@@ -163,7 +163,7 @@ skip_service_lookup:
 	/* Store state to be picked up on the continuation tail call. */
 	lb6_ctx_store_state(ctx, &ct_state_new, proxy_port);
 	ep_tail_call(ctx, CILIUM_CALL_IPV6_CT_EGRESS);
-	return ret;
+	return DROP_MISSED_TAIL_CALL;
 }
 #endif /* ENABLE_IPV6 */
 

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1131,7 +1131,7 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 }
 
 static __always_inline void
-lb4_fill_key(struct lb4_key *key, struct ipv4_ct_tuple *tuple)
+lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
 {
 	/* FIXME: set after adding support for different L4 protocols in LB */
 	key->proto = 0;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -515,7 +515,8 @@ snat_v4_rev_nat_can_skip(const struct ipv4_nat_target *target, const struct ipv4
  * - on CT_NEW (ie. the tuple is reversed)
  */
 static __always_inline __maybe_unused int
-snat_v4_create_dsr(struct ipv4_ct_tuple *tuple, __be32 to_saddr, __be16 to_sport)
+snat_v4_create_dsr(const struct ipv4_ct_tuple *tuple,
+		   __be32 to_saddr, __be16 to_sport)
 {
 	struct ipv4_ct_tuple tmp = *tuple;
 	struct ipv4_nat_entry state = {};
@@ -1248,7 +1249,7 @@ snat_v6_rev_nat_can_skip(const struct ipv6_nat_target *target, const struct ipv6
 }
 
 static __always_inline __maybe_unused int
-snat_v6_create_dsr(struct ipv6_ct_tuple *tuple, union v6addr *to_saddr,
+snat_v6_create_dsr(const struct ipv6_ct_tuple *tuple, union v6addr *to_saddr,
 		   __be16 to_sport)
 {
 	struct ipv6_ct_tuple tmp = *tuple;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -292,7 +292,7 @@ static __always_inline int find_dsr_v6(struct __ctx_buff *ctx, __u8 nexthdr,
 
 static __always_inline int
 nodeport_extract_dsr_v6(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
-			struct ipv6_ct_tuple *tuple, int l4_off,
+			const struct ipv6_ct_tuple *tuple, int l4_off,
 			union v6addr *addr, __be16 *port, bool *dsr)
 {
 	struct dsr_opt_v6 opt __align_stack_8 = {};
@@ -1406,9 +1406,9 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 #endif /* DSR_ENCAP_MODE */
 
 static __always_inline int
-nodeport_extract_dsr_v4(struct __ctx_buff *ctx, struct iphdr *ip4,
-			struct ipv4_ct_tuple *tuple, int l4_off, __be32 *addr,
-			__be16 *port, bool *dsr)
+nodeport_extract_dsr_v4(struct __ctx_buff *ctx, const struct iphdr *ip4,
+			const struct ipv4_ct_tuple *tuple, int l4_off,
+			__be32 *addr, __be16 *port, bool *dsr)
 {
 	struct ipv4_ct_tuple tmp = *tuple;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -882,7 +882,7 @@ skip_service_lookup:
 				ctx_store_meta(ctx, CB_ADDR_V6_3, key.address.p3);
 				ctx_store_meta(ctx, CB_ADDR_V6_4, key.address.p4);
 				ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_DSR_INGRESS);
-				ret = DROP_MISSED_TAIL_CALL;
+				return DROP_MISSED_TAIL_CALL;
 			}
 
 			if (IS_ERR(ret))
@@ -1985,7 +1985,7 @@ skip_service_lookup:
 				ctx_store_meta(ctx, CB_PORT, key.dport);
 				ctx_store_meta(ctx, CB_ADDR_V4, key.address);
 				ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_DSR_INGRESS);
-				ret = DROP_MISSED_TAIL_CALL;
+				return DROP_MISSED_TAIL_CALL;
 			}
 
 			if (IS_ERR(ret))

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -160,7 +160,7 @@ static __always_inline void ctx_snat_done_set(struct __sk_buff *ctx)
 	ctx->mark |= MARK_MAGIC_SNAT_DONE;
 }
 
-static __always_inline bool ctx_snat_done(struct __sk_buff *ctx)
+static __always_inline bool ctx_snat_done(const struct __sk_buff *ctx)
 {
 	return (ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_SNAT_DONE;
 }

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -368,7 +368,7 @@ int tc_drop_no_backend_setup(struct __ctx_buff *ctx)
 }
 
 CHECK("tc", "tc_drop_no_backend")
-int tc_drop_no_backend_check(struct __ctx_buff *ctx)
+int tc_drop_no_backend_check(const struct __ctx_buff *ctx)
 {
 	__u32 expected_status = TC_ACT_SHOT;
 	__u32 *status_code;

--- a/bpf/tests/wildcard_lookup.c
+++ b/bpf/tests/wildcard_lookup.c
@@ -274,7 +274,7 @@ int test_v4_check(__maybe_unused struct xdp_md *ctx)
 	test_finish();
 }
 
-static inline void __setup_v6_ipcache(union v6addr *HOST_IP6)
+static inline void __setup_v6_ipcache(const union v6addr *HOST_IP6)
 {
 	struct remote_endpoint_info cache_value = {};
 	struct ipcache_key cache_key = {};
@@ -286,7 +286,7 @@ static inline void __setup_v6_ipcache(union v6addr *HOST_IP6)
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 }
 
-static inline void __setup_v6_nodeport(union v6addr *HOST_IP6)
+static inline void __setup_v6_nodeport(const union v6addr *HOST_IP6)
 {
 	union v6addr ZERO = {};
 	struct { struct lb6_key key; struct lb6_service value; } services[] = {
@@ -301,7 +301,7 @@ static inline void __setup_v6_nodeport(union v6addr *HOST_IP6)
 				BPF_ANY);
 }
 
-static inline void __setup_v6_hostport(union v6addr *HOST_IP6)
+static inline void __setup_v6_hostport(const union v6addr *HOST_IP6)
 {
 	union v6addr ZERO = {};
 	struct { struct lb6_key key; struct lb6_service value; } services[] = {

--- a/contrib/coccinelle/aligned.cocci
+++ b/contrib/coccinelle/aligned.cocci
@@ -64,6 +64,6 @@ cnt += 1
 if cnt > 0:
   print("""Use the following command to fix the above issues:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                  \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a spatch --sp-file contrib/coccinelle/aligned.cocci \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b spatch --sp-file contrib/coccinelle/aligned.cocci \\
     --include-headers --very-quiet --in-place bpf/\n
 """)

--- a/contrib/coccinelle/check-cocci.sh
+++ b/contrib/coccinelle/check-cocci.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+set -o errexit
+set -o pipefail
+
 make -C bpf coccicheck | tee /tmp/stdout
 exit $(grep -c "^* file " /tmp/stdout)

--- a/contrib/coccinelle/const.cocci
+++ b/contrib/coccinelle/const.cocci
@@ -65,6 +65,6 @@ cnt += 1
 if cnt > 0:
   print("""Use the following command to fix the above issues:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a spatch --sp-file contrib/coccinelle/const.cocci \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b spatch --sp-file contrib/coccinelle/const.cocci \\
     --include-headers --very-quiet --in-place bpf/\n
 """)

--- a/contrib/coccinelle/identity_is_node.cocci
+++ b/contrib/coccinelle/identity_is_node.cocci
@@ -61,6 +61,6 @@ if len(p2) > 0:
 if cnt > 0:
   print("""Use the following command to fix the above issues:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                           \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a spatch --sp-file contrib/coccinelle/identity_is_node.cocci \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b spatch --sp-file contrib/coccinelle/identity_is_node.cocci \\
     --include-headers --very-quiet --in-place bpf/\n
 """)

--- a/contrib/coccinelle/tail_calls.cocci
+++ b/contrib/coccinelle/tail_calls.cocci
@@ -109,5 +109,5 @@ cnt += 1
 if cnt > 0:
   print("""Unlogged tail calls found. Please fix and use the following command to check:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a make -C bpf coccicheck\n
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b make -C bpf coccicheck\n
 """)

--- a/contrib/coccinelle/zero_trace_reason.cocci
+++ b/contrib/coccinelle/zero_trace_reason.cocci
@@ -85,6 +85,6 @@ cnt += 1
 if cnt > 0:
   print("""Use the following command to fix the above issues:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                           \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a spatch --sp-file contrib/coccinelle/zero_trace_reason.cocci \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b spatch --sp-file contrib/coccinelle/zero_trace_reason.cocci \\
     --include-headers --very-quiet --in-place bpf/\n
 """)


### PR DESCRIPTION
Coccinelle checks have apparently been failing silently (locally and in CI) for a while :scream: . The root cause for the breakage has not been identified at this time, but we can trivially fix the Dockerfile to at least be able to run the checks again.

[EDIT: Dockerfile fix moved to a separate PR and merged as 0dad1577d3146433b8ee6c0b3f52fc31f71f39e8 already]

We can also make sure that such issues in the future are not silent, and that we catch them in the CI.

We will need a new coccicheck image for the CI, incorporating the change from this PR.
[EDIT: We have the image now]

Any insight on what caused Python to suddenly fail to find the coccilib module is welcome.
