### PR TITLE
Add encrypt-node status to cilium status

### DIFF
--- a/api/v1/models/wireguard_status.go
+++ b/api/v1/models/wireguard_status.go
@@ -26,6 +26,9 @@ type WireguardStatus struct {
 
 	// Wireguard interfaces managed by this Cilium instance
 	Interfaces []*WireguardInterface `json:"interfaces"`
+
+	// Node Encryption status
+	NodeEncryption string `json:"node-encryption,omitempty"`
 }
 
 // Validate validates this wireguard status

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3392,6 +3392,9 @@ definitions:
 
       +k8s:deepcopy-gen=true
     properties:
+      node-encryption:
+        description: Node Encryption status
+        type: string
       interfaces:
         description: Wireguard interfaces managed by this Cilium instance
         type: array

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -4403,6 +4403,10 @@ func init() {
           "items": {
             "$ref": "#/definitions/WireguardInterface"
           }
+        },
+        "node-encryption": {
+          "description": "Node Encryption status",
+          "type": "string"
         }
       }
     }
@@ -9662,6 +9666,10 @@ func init() {
           "items": {
             "$ref": "#/definitions/WireguardInterface"
           }
+        },
+        "node-encryption": {
+          "description": "Node Encryption status",
+          "type": "string"
         }
       }
     }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -682,20 +682,21 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 	}
 
 	if sr.Encryption != nil {
-		fields := []string{sr.Encryption.Mode}
+		var fields []string
 
 		if sr.Encryption.Msg != "" {
 			fields = append(fields, sr.Encryption.Msg)
 		} else if wg := sr.Encryption.Wireguard; wg != nil {
+			fields = append(fields, fmt.Sprintf("[NodeEncryption: %s", wg.NodeEncryption))
 			ifaces := make([]string, 0, len(wg.Interfaces))
 			for _, i := range wg.Interfaces {
 				iface := fmt.Sprintf("%s (Pubkey: %s, Port: %d, Peers: %d)",
 					i.Name, i.PublicKey, i.ListenPort, i.PeerCount)
 				ifaces = append(ifaces, iface)
 			}
-			fields = append(fields, fmt.Sprintf("[%s]", strings.Join(ifaces, ", ")))
+			fields = append(fields, fmt.Sprintf("%s]", strings.Join(ifaces, ", ")))
 		}
 
-		fmt.Fprintf(w, "Encryption:\t%s\n", strings.Join(fields, "\t"))
+		fmt.Fprintf(w, "Encryption:\t%s\t%s\n", sr.Encryption.Mode, strings.Join(fields, ", "))
 	}
 }

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -594,7 +594,17 @@ func (a *Agent) Status(withPeers bool) (*models.WireguardStatus, error) {
 		}
 	}
 
+	var nodeEncryptionStatus = "Disabled"
+	if option.Config.EncryptNode {
+		if node.GetOptOutNodeEncryption() {
+			nodeEncryptionStatus = "OptedOut"
+		} else {
+			nodeEncryptionStatus = "Enabled"
+		}
+	}
+
 	status := &models.WireguardStatus{
+		NodeEncryption: nodeEncryptionStatus,
 		Interfaces: []*models.WireguardInterface{{
 			Name:       dev.Name,
 			ListenPort: int64(dev.ListenPort),


### PR DESCRIPTION
This patch adds param "NodeEncryption" to the cilium status

$ cilium status
[...]
Encryption:   Wireguard [NodeEncryption: true, cilium_wg0 (Pubkey: UzRSJUmRqsxl82xvFG0joBheaiqOnM3BCgpByYjVtCE=, Port: 51871, Peers: 3)]

Fixes: #24239

```release-note
cmd: Add NodeEncryption status to the cilium status command
```
