### PR TITLE
docs: Update the documentation for the `--conntrack-gc-interval` flag

### DIFF
--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -399,10 +399,21 @@ Handling drop (CT: Map insertion failed)
 If connectivity fails and ``cilium monitor --type drop`` shows ``xx drop (CT:
 Map insertion failed)``, then it is likely that the connection tracking table
 is filling up and the automatic adjustment of the garbage collector interval is
-insufficient. Set ``--conntrack-gc-interval`` to an interval lower than the
-default. The default starting interval is 5 minutes. Alternatively, the value
-for ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` can be increased.
-Setting both of these options will be a trade-off of CPU for ``conntrack-gc-interval``, and for
+insufficient.
+
+Setting ``--conntrack-gc-interval`` to an interval lower than the current value
+may help. This controls the time interval between two garbage collection runs.
+
+By default ``--contrack-gc-interval`` is set to 0 which translates to
+using a dynamic interval. In that case, the interval is updated after each
+garbage collection run depending on how many entries where garbage collected.
+If very few or no entries were garbage collected, the interval will increase;
+if many entries were garbage collected, it will decrease. The current interval
+value is reported in the Cilium agent logs.
+
+Alternatively, the value for ``bpf-ct-global-any-max`` and
+``bpf-ct-global-tcp-max`` can be increased. Setting both of these options will
+be a trade-off of CPU for ``conntrack-gc-interval``, and for
 ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
 consumed. You can track conntrack garbage collection related metrics such as
 ``datapath_conntrack_gc_runs_total`` and ``datapath_conntrack_gc_entries`` to


### PR DESCRIPTION
The current documentation is incorrect as the default value is 0 and not 5 minutes. 0 implies a dynamic interval value, which this commit now documents.