### PR TITLE
policy: Utilize the DistillPolicy() code path in tests

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -5,9 +5,9 @@ package policy
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
-	stdlog "log"
 	"net/netip"
 	"strings"
 	"testing"
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labels/cidr"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -305,6 +306,7 @@ var (
 
 	// Misc other bpf key fields for convenience / readability.
 	dirIngress = trafficdirection.Ingress.Uint8()
+	dirEgress  = trafficdirection.Egress.Uint8()
 	// Desired map keys for L3, L3-dependent L4, L4
 	mapKeyAllowFoo__ = Key{identityFoo, 0, 0, dirIngress}
 	mapKeyAllowBar__ = Key{identityBar, 0, 0, dirIngress}
@@ -314,6 +316,7 @@ var (
 	mapKeyAllow___L4 = Key{0, 80, 6, dirIngress}
 	mapKeyDeny____L4 = mapKeyAllow___L4
 	mapKeyAllowAll__ = Key{0, 0, 0, dirIngress}
+	mapKeyAllowAllE_ = Key{0, 0, 0, dirEgress}
 	// Desired map entries for no L7 redirect / redirect to Proxy
 	mapEntryL7None_ = func(lbls ...labels.LabelArray) MapStateEntry {
 		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false, AuthTypeNone).WithOwners()
@@ -322,7 +325,9 @@ var (
 		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, true, AuthTypeNone).WithOwners()
 	}
 	mapEntryL7Proxy = func(lbls ...labels.LabelArray) MapStateEntry {
-		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false, AuthTypeNone).WithOwners()
+		entry := NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), true, false, AuthTypeNone).WithOwners()
+		entry.ProxyPort = 4242
+		return entry
 	}
 )
 
@@ -364,95 +369,34 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 
 // distillPolicy distills the policy repository into a set of bpf map state
 // entries for an endpoint with the specified labels.
-func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.LabelArray) (MapState, error) {
-	result := make(MapState)
-	selectorCache := d.Repository.GetSelectorCache()
-	endpointSelected, _ := d.Repository.GetRulesMatching(epLabels)
-	io.WriteString(d.log, fmt.Sprintf("[distill] Endpoint selected by policy: %t\n", endpointSelected))
-	if !endpointSelected {
-		allowAllIngress := true
-		allowAllEgress := false // Skip egress
-		result.AllowAllIdentities(allowAllIngress, allowAllEgress)
-		result.clearCaches()
-		return result, nil
-	}
-
-	// Prepare the L4 policy so we know whether L4 policy may apply
-	ingressL4 := SearchContext{
-		To:    epLabels,
-		Trace: TRACE_VERBOSE,
-	}
-	ingressL4.Logging = stdlog.New(d.log, "", 0)
-	io.WriteString(d.log, fmt.Sprintf("[distill] Evaluating L4 Ingress -> %s", epLabels))
-	l4IngressPolicy, err := d.Repository.ResolveL4IngressPolicy(&ingressL4)
+func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.LabelArray, identity *identity.Identity) (MapState, error) {
+	sp, err := d.Repository.resolvePolicyLocked(identity)
 	if err != nil {
 		return nil, err
 	}
 
-	// Handle L4 ingress from each identity in the cache to the endpoint.
-	io.WriteString(d.log, "[distill] Producing L4 ingress filter keys\n")
-	for _, l4 := range l4IngressPolicy {
-		io.WriteString(d.log, fmt.Sprintf("[distill] Processing ingress L4Filter (l4: %d/%s), (l3/7: %+v)\n", l4.Port, l4.Protocol, l4.PerSelectorPolicies))
-		for key, entry := range l4.ToMapState(owner, 0, selectorCache) {
-			var policyStr string
-			if entry.IsDeny {
-				policyStr = "deny"
-			} else {
-				policyStr = "allow"
-			}
-			io.WriteString(d.log, fmt.Sprintf("[distill] L4 ingress %s %+v (parser=%s, redirect=%t)\n", policyStr, key, l4.L7Parser, entry.IsRedirectEntry()))
-			result.DenyPreferredInsert(key, entry, selectorCache)
-		}
-	}
-	l4IngressPolicy.Detach(selectorCache)
-	result.clearCaches()
-
-	// Prepare the L4 policy so we know whether L4 policy may apply
-	egressL4 := SearchContext{
-		From:  epLabels,
-		Trace: TRACE_VERBOSE,
-	}
-	egressL4.Logging = stdlog.New(d.log, "", 0)
-	io.WriteString(d.log, fmt.Sprintf("[distill] Evaluating L4 Egress -> %s", epLabels))
-	l4EgressPolicy, err := d.Repository.ResolveL4EgressPolicy(&egressL4)
-	if err != nil {
-		return nil, err
+	epp := sp.DistillPolicy(DummyOwner{}, false)
+	if epp == nil {
+		return nil, errors.New("policy distillation failure")
 	}
 
-	// Handle L4 egress from each identity in the cache to the endpoint.
-	io.WriteString(d.log, "[distill] Producing L4 egress filter keys\n")
-	for _, l4 := range l4EgressPolicy {
-		io.WriteString(d.log, fmt.Sprintf("[distill] Processing egress L4Filter (l4: %d/%s), (l3/7: %+v)\n", l4.Port, l4.Protocol, l4.PerSelectorPolicies))
-		for key, entry := range l4.ToMapState(owner, 1, selectorCache) {
-			var policyStr string
-			if entry.IsDeny {
-				policyStr = "deny"
-			} else {
-				policyStr = "allow"
-			}
-			io.WriteString(d.log, fmt.Sprintf("[distill] L4 egress %s %+v (parser=%s, redirect=%t)\n", policyStr, key, l4.L7Parser, entry.IsRedirectEntry()))
-			result.DenyPreferredInsert(key, entry, selectorCache)
-		}
-	}
-	l4EgressPolicy.Detach(selectorCache)
-	result.clearCaches()
-	return result, nil
-}
+	// Remove the allow-all egress entry that's generated by default. This is
+	// because this test suite doesn't have a notion of traffic direction, so
+	// the extra egress allow-all is technically correct, but omitted from the
+	// expected output that's asserted against for the sake of brevity.
+	delete(epp.PolicyMapState, mapKeyAllowAllE_)
 
-// clearCaches removes CachedSelectors and CachedNets from MapStateEntries
-// for testing purposes.  Table-driven testing pattern used for these
-// tests does not allow expected MapStateEntries to contain actual
-// CachedSelectors as those have not been inserted to the selector
-// cache at the time when the expectations are created.
-func (m MapState) clearCaches() {
-	for k, v := range m {
-		v.owners = make(map[MapStateOwner]struct{})
-		v.cachedNets = nil
-		m[k] = v
-	}
+	return epp.PolicyMapState, nil
 }
 
 func Test_MergeL3(t *testing.T) {
+	// Cache policy enforcement value from when test was ran to avoid pollution
+	// across tests.
+	oldPolicyEnable := GetPolicyEnabled()
+	defer SetPolicyEnabled(oldPolicyEnable)
+
+	SetPolicyEnabled(option.DefaultEnforcement)
+
 	identityCache := cache.IdentityCache{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.NumericIdentity(identityBar): labelsBar,
@@ -468,6 +412,7 @@ func Test_MergeL3(t *testing.T) {
 		{1, api.Rules{rule__L3AllowFoo, ruleL3L4__Allow}, MapState{mapKeyAllowFoo__: mapEntryL7None_(lbls__L3AllowFoo), mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)}},
 	}
 
+	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 	for _, tt := range tests {
 		repo := newPolicyDistillery(selectorCache)
 		for _, r := range tt.rules {
@@ -479,11 +424,11 @@ func Test_MergeL3(t *testing.T) {
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
-			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo)
+			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
 			}
-			if equal, err := checker.DeepEqual(mapstate, tt.result); !equal {
+			if equal, err := checker.ExportedEqual(mapstate, tt.result); !equal {
 				t.Logf("Rules:\n%s\n\n", tt.rules.String())
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 				t.Errorf("Policy obtained didn't match expected for endpoint %s:\n%s", labelsFoo, err)
@@ -936,10 +881,18 @@ func generateRule(testCase int) api.Rules {
 }
 
 func Test_MergeRules(t *testing.T) {
+	// Cache policy enforcement value from when test was ran to avoid pollution
+	// across tests.
+	oldPolicyEnable := GetPolicyEnabled()
+	defer SetPolicyEnabled(oldPolicyEnable)
+
+	SetPolicyEnabled(option.DefaultEnforcement)
+
 	identityCache := cache.IdentityCache{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
+	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	tests := []struct {
 		test   int
@@ -1012,14 +965,14 @@ func Test_MergeRules(t *testing.T) {
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
-			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo)
+			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
 			}
 			// Ignore generated rules as they lap LabelArrayList which would
 			// make the tests fail.
 			if i < generatedIdx {
-				if equal, err := checker.DeepEqual(mapstate, tt.result); !equal {
+				if equal, err := checker.ExportedEqual(mapstate, tt.result); !equal {
 					t.Logf("Rules:\n%s\n\n", tt.rules.String())
 					t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 					t.Errorf("Policy obtained didn't match expected for endpoint %s:\n%s", labelsFoo, err)
@@ -1036,10 +989,10 @@ func Test_MergeRules(t *testing.T) {
 				v.DerivedFromRules = labels.LabelArrayList(nil).Sort()
 				mapstate[k] = v
 			}
-			if equal, err := checker.DeepEqual(mapstate, expectedMapState[tt.test]); !equal {
+			if equal, err := checker.ExportedEqual(mapstate, expectedMapState[tt.test]); !equal {
 				t.Errorf("Policy obtained didn't match expected for endpoint:\n%s", err)
 			}
-			if equal, err := checker.DeepEqual(generatedRule, tt.rules); !equal {
+			if equal, err := checker.ExportedEqual(generatedRule, tt.rules); !equal {
 				t.Logf("Rules:\n%s\n\n", tt.rules.String())
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 				t.Errorf("Generated rules didn't match manual rules:\n%s", err)
@@ -1049,10 +1002,18 @@ func Test_MergeRules(t *testing.T) {
 }
 
 func Test_MergeRulesWithNamedPorts(t *testing.T) {
+	// Cache policy enforcement value from when test was ran to avoid pollution
+	// across tests.
+	oldPolicyEnable := GetPolicyEnabled()
+	defer SetPolicyEnabled(oldPolicyEnable)
+
+	SetPolicyEnabled(option.DefaultEnforcement)
+
 	identityCache := cache.IdentityCache{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
+	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	tests := []struct {
 		test   int
@@ -1107,11 +1068,11 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
-			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo)
+			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
 			}
-			if equal, err := checker.DeepEqual(mapstate, tt.result); !equal {
+			if equal, err := checker.ExportedEqual(mapstate, tt.result); !equal {
 				t.Logf("Rules:\n%s\n\n", tt.rules.String())
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 				t.Errorf("Policy obtained didn't match expected for endpoint %s:\n%s", labelsFoo, err)
@@ -1121,11 +1082,19 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 }
 
 func Test_AllowAll(t *testing.T) {
+	// Cache policy enforcement value from when test was ran to avoid pollution
+	// across tests.
+	oldPolicyEnable := GetPolicyEnabled()
+	defer SetPolicyEnabled(oldPolicyEnable)
+
+	SetPolicyEnabled(option.DefaultEnforcement)
+
 	identityCache := cache.IdentityCache{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.NumericIdentity(identityBar): labelsBar,
 	}
 	selectorCache := testNewSelectorCache(identityCache)
+	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	tests := []struct {
 		test     int
@@ -1148,11 +1117,11 @@ func Test_AllowAll(t *testing.T) {
 		t.Run(fmt.Sprintf("permutation_%d", tt.test), func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
-			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo)
+			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
 			}
-			if equal, err := checker.DeepEqual(mapstate, tt.result); !equal {
+			if equal, err := checker.ExportedEqual(mapstate, tt.result); !equal {
 				t.Logf("Rules:\n%s\n\n", tt.rules.String())
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 				t.Errorf("Policy obtained didn't match expected for endpoint %s:\n%s", labelsFoo, err)
@@ -1369,6 +1338,13 @@ var (
 )
 
 func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
+	// Cache policy enforcement value from when test was ran to avoid pollution
+	// across tests.
+	oldPolicyEnable := GetPolicyEnabled()
+	defer SetPolicyEnabled(oldPolicyEnable)
+
+	SetPolicyEnabled(option.DefaultEnforcement)
+
 	identityCache := cache.IdentityCache{
 		identity.NumericIdentity(identityFoo): labelsFoo,
 		identity.ReservedIdentityWorld:        labels.LabelWorld.LabelArray(),
@@ -1376,6 +1352,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 		worldSubnetIdentity:                   lblWorldSubnet.LabelArray(), // "192.0.2.0/24"
 	}
 	selectorCache := testNewSelectorCache(identityCache)
+	identity := identity.NewIdentityFromLabelArray(identity.NumericIdentity(identityFoo), labelsFoo)
 
 	tests := []struct {
 		test   string
@@ -1441,11 +1418,11 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 		t.Run(tt.test, func(t *testing.T) {
 			logBuffer := new(bytes.Buffer)
 			repo = repo.WithLogBuffer(logBuffer)
-			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo)
+			mapstate, err := repo.distillPolicy(DummyOwner{}, labelsFoo, identity)
 			if err != nil {
 				t.Errorf("Policy resolution failure: %s", err)
 			}
-			if equal, err := checker.DeepEqual(mapstate, tt.result); !equal {
+			if equal, err := checker.ExportedEqual(mapstate, tt.result); !equal {
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
 				t.Errorf("Policy test, %q, obtained didn't match expected for endpoint %s:\n%s", tt.test, labelsFoo, err)
 			}


### PR DESCRIPTION
Previously, the DistillPolicy() was mocked in by defining a test mock
called distillPolicy(). Over time, this code path can rot and introduce
regressions into the code if the test implementation differs from the
real implementation.

Fix it by moving the test code to use the real implementation.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
