### PR TITLE
bpf: Fix verifier issue in fib_redirect

### DIFF
--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -83,7 +83,6 @@ fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 skip_oif:
 #else
 	*oif = DIRECT_ROUTING_DEV_IFINDEX;
-	nh_params.nh_family = fib_params->l.family;
 #endif /* ENABLE_SKIP_FIB */
 	if (needs_l2_check) {
 		bool l2_hdr_required = true;
@@ -112,7 +111,7 @@ skip_oif:
 			 * inbound client traffic on the load-balancer where we
 			 * know that replies need to go back to them.
 			 */
-			dmac = nh_params.nh_family == AF_INET ?
+			dmac = fib_params->l.family == AF_INET ?
 			       neigh_lookup_ip4(&fib_params->l.ipv4_dst) :
 			       neigh_lookup_ip6((void *)&fib_params->l.ipv6_dst);
 			if (!dmac) {


### PR DESCRIPTION
(see commit msg)

This fixes a verifier issue in CI for bpf-next inside the fib_redirect helper code.

```release-note
Fix failure to load the datapath for new pods on latest kernel when (almost) all datapath features are enabled.
```