### PR TITLE
Service Mesh mTLS: BPF map auth provided by hive cell

### DIFF
--- a/cilium/cmd/bpf_auth_list.go
+++ b/cilium/cmd/bpf_auth_list.go
@@ -35,13 +35,14 @@ var bpfAuthListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf auth list")
 
-		if err := authmap.OpenAuthMap(); err != nil {
+		authMap, err := authmap.LoadAuthMap()
+		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				fmt.Fprintln(os.Stderr, "Cannot find auth bpf map")
 				return
 			}
 
-			Fatalf("Cannot open auth bpf map: %s", err)
+			Fatalf("Cannot load auth bpf map: %s", err)
 		}
 
 		var bpfAuthList []authEntry
@@ -56,7 +57,7 @@ var bpfAuthListCmd = &cobra.Command{
 			})
 		}
 
-		if err := authmap.AuthMap().IterateWithCallback(parse); err != nil {
+		if err := authMap.IterateWithCallback(parse); err != nil {
 			Fatalf("Error dumping contents of the auth map: %s\n", err)
 		}
 

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/maps/authmap"
+	fakeauthmap "github.com/cilium/cilium/pkg/maps/authmap/fake"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
@@ -149,6 +151,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 			func() datapath.Datapath { return fakeDatapath.NewDatapath() },
 			func() *option.DaemonConfig { return option.Config },
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
+			func() authmap.Map { return fakeauthmap.NewFakeAuthMap() },
 		),
 		ControlPlane,
 		cell.Invoke(func(p promise.Promise[*Daemon]) {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
@@ -359,10 +358,6 @@ func (d *Daemon) initMaps() error {
 	}
 
 	if err := nodemap.NodeMap().OpenOrCreate(); err != nil {
-		return err
-	}
-
-	if err := authmap.InitAuthMap(option.Config.AuthMapEntries); err != nil {
 		return err
 	}
 

--- a/pkg/auth/authmap_authenticator.go
+++ b/pkg/auth/authmap_authenticator.go
@@ -6,21 +6,15 @@ package auth
 import (
 	"github.com/cilium/cilium/pkg/datapath/linux/utime"
 	"github.com/cilium/cilium/pkg/maps/authmap"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 type authMapAuthenticator struct {
-	authMap *authmap.Map
+	authMap authmap.Map
 }
 
-func newAuthMapAuthenticator() datapathAuthenticator {
-	// Make sure authmap is initialized. This will fail in non-privileged unit tests,
-	// but as we are not exercising this authenticator in nonprivileged unit tests yet,
-	// we'll just ignore the error for now.
-	authmap.InitAuthMap(option.Config.AuthMapEntries)
-
+func newAuthMapAuthenticator(authMap authmap.Map) datapathAuthenticator {
 	return &authMapAuthenticator{
-		authMap: authmap.AuthMap(),
+		authMap: authMap,
 	}
 }
 

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -30,6 +31,9 @@ var Cell = cell.Module(
 		newWireguardAgent,
 		newDatapath,
 	),
+
+	// Provides the auth.Map which contains the authentication state between Cilium security identities.
+	authmap.Cell,
 
 	cell.Provide(func(dp types.Datapath) ipcache.NodeHandler {
 		return dp.Node()

--- a/pkg/maps/authmap/auth_map_privileged_test.go
+++ b/pkg/maps/authmap/auth_map_privileged_test.go
@@ -37,9 +37,10 @@ func (k *AuthMapTestSuite) SetUpSuite(c *C) {
 }
 
 func (k *AuthMapTestSuite) TestAuthMap(c *C) {
-	err := initMap(10, true)
+	authMap := newMap(10)
+	err := authMap.init()
 	c.Assert(err, IsNil)
-	defer authMap.Unpin()
+	defer authMap.bpfMap.Unpin()
 
 	_, err = authMap.Lookup(identity.NumericIdentity(1), identity.NumericIdentity(2), 1, policy.AuthTypeNull)
 	c.Assert(errors.Is(err, ebpf.ErrKeyNotExist), Equals, true)

--- a/pkg/maps/authmap/cell.go
+++ b/pkg/maps/authmap/cell.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package authmap
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+// Cell provides the auth.Map which contains the authentication state between Cilium security identities.
+// Datapath checks the map for a valid authentication entry whenever authentication is demanded by a policy.
+// If no or an expired entry is found the packet gets dropped and an authentication gets requested via
+// auth.Manager.
+var Cell = cell.Module(
+	"auth-map",
+	"eBPF map which manages authenticated connections between identities",
+
+	cell.Provide(newAuthMap),
+)
+
+func newAuthMap(lifecycle hive.Lifecycle) (Map, error) {
+	authMap := newMap(option.Config.AuthMapEntries)
+
+	lifecycle.Append(hive.Hook{
+		OnStart: func(context hive.HookContext) error {
+			return authMap.init()
+		},
+		OnStop: func(context hive.HookContext) error {
+			return authMap.close()
+		},
+	})
+
+	return authMap, nil
+}

--- a/pkg/maps/authmap/fake/auth_map.go
+++ b/pkg/maps/authmap/fake/auth_map.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fake
+
+import (
+	"github.com/cilium/cilium/pkg/datapath/linux/utime"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/maps/authmap"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+type fakeAuthMap struct {
+	Entries map[authmap.AuthKey]authmap.AuthInfo
+}
+
+func NewFakeAuthMap() *fakeAuthMap {
+	return &fakeAuthMap{
+		Entries: map[authmap.AuthKey]authmap.AuthInfo{},
+	}
+}
+
+func (f fakeAuthMap) Lookup(localIdentity identity.NumericIdentity, remoteIdentity identity.NumericIdentity, remoteNodeID uint16, authType policy.AuthType) (*authmap.AuthInfo, error) {
+	key := &authmap.AuthKey{
+		LocalIdentity:  localIdentity.Uint32(),
+		RemoteIdentity: remoteIdentity.Uint32(),
+		RemoteNodeID:   remoteNodeID,
+		AuthType:       authType.Uint8(),
+	}
+
+	info := f.Entries[*key]
+	return &info, nil
+}
+
+func (f fakeAuthMap) Update(localIdentity identity.NumericIdentity, remoteIdentity identity.NumericIdentity, remoteNodeID uint16, authType policy.AuthType, expiration utime.UTime) error {
+	key := &authmap.AuthKey{
+		LocalIdentity:  localIdentity.Uint32(),
+		RemoteIdentity: remoteIdentity.Uint32(),
+		RemoteNodeID:   remoteNodeID,
+		AuthType:       authType.Uint8(),
+	}
+	value := &authmap.AuthInfo{
+		Expiration: expiration,
+	}
+
+	f.Entries[*key] = *value
+
+	return nil
+}
+
+func (f fakeAuthMap) Delete(localIdentity identity.NumericIdentity, remoteIdentity identity.NumericIdentity, remoteNodeID uint16, authType policy.AuthType) error {
+	key := &authmap.AuthKey{
+		LocalIdentity:  localIdentity.Uint32(),
+		RemoteIdentity: remoteIdentity.Uint32(),
+		RemoteNodeID:   remoteNodeID,
+		AuthType:       authType.Uint8(),
+	}
+	delete(f.Entries, *key)
+
+	return nil
+}
+
+func (f fakeAuthMap) IterateWithCallback(cb authmap.IterateCallback) error {
+	for key, info := range f.Entries {
+		cb(&key, &info)
+	}
+	return nil
+}

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -17,6 +17,8 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/maps/authmap"
+	fakeauthmap "github.com/cilium/cilium/pkg/maps/authmap/fake"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	agentOption "github.com/cilium/cilium/pkg/option"
@@ -51,7 +53,7 @@ func (h *agentHandle) tearDown() {
 	node.Uninitialize()
 }
 
-func startCiliumAgent(t *testing.T, nodeName string, clientset k8sClient.Clientset) (*fakeDatapath.FakeDatapath, agentHandle, error) {
+func startCiliumAgent(t *testing.T, clientset k8sClient.Clientset) (*fakeDatapath.FakeDatapath, agentHandle, error) {
 	var (
 		err           error
 		handle        agentHandle
@@ -69,6 +71,7 @@ func startCiliumAgent(t *testing.T, nodeName string, clientset k8sClient.Clients
 			func() datapath.Datapath { return fdp },
 			func() *option.DaemonConfig { return option.Config },
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
+			func() authmap.Map { return fakeauthmap.NewFakeAuthMap() },
 		),
 		cmd.ControlPlane,
 		cell.Invoke(func(p promise.Promise[*cmd.Daemon]) {

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -138,7 +138,7 @@ func (cpt *ControlPlaneTest) StartAgent() *ControlPlaneTest {
 	if cpt.agentHandle != nil {
 		cpt.t.Fatal("StartAgent() already called")
 	}
-	datapath, agentHandle, err := startCiliumAgent(cpt.t, cpt.nodeName, cpt.clients)
+	datapath, agentHandle, err := startCiliumAgent(cpt.t, cpt.clients)
 	if err != nil {
 		cpt.t.Fatalf("Failed to start cilium agent: %s", err)
 	}


### PR DESCRIPTION
This change enables the possibility to use the eBPF map "auth" as dependency in another hive cell, without having to access a global variable.

The cell itself initializes the BPF map. Therefore, dependent cells can rely on a pre-initialized map - even in their OnCreate Lifecycle hook.

Access from the Cilium CLI "cilium bpf auth list" still uses a global function to access the map.

for https://github.com/cilium/cilium/issues/23805