### PR TITLE
test/verifier: Fix compilation command

### DIFF
--- a/test/verifier/verifier_test.go
+++ b/test/verifier/verifier_test.go
@@ -122,14 +122,12 @@ func TestVerifier(t *testing.T) {
 				}
 
 				t.Logf("Building %s object file", bpfProgram.name)
-				cmd = exec.Command("make", "-C", "bpf",
-					fmt.Sprintf("%s.o", bpfProgram.name),
-					fmt.Sprintf("KERNEL=%s %s=%q",
-						kernelVersion,
-						bpfProgram.macroName,
-						datapathConfig),
-				)
+				cmd = exec.Command("make", "-C", "bpf", fmt.Sprintf("%s.o", bpfProgram.name))
 				cmd.Dir = *ciliumBasePath
+				cmd.Env = append(cmd.Env,
+					fmt.Sprintf("%s=%s", bpfProgram.macroName, datapathConfig),
+					fmt.Sprintf("KERNEL=%s", kernelVersion),
+				)
 				if err := cmd.Run(); err != nil {
 					t.Fatalf("Failed to compile %s bpf objects: %v", bpfProgram.name, err)
 				}


### PR DESCRIPTION
As part of the verifier tests, we first compile the datapath then attempt to load it. We do that for a set of kernels and datapath
configurations. We compile e.g. `bpf_lxc` with: 

    make -C bpf KERNEL=[kernel] MAX_LXC_OPTIONS=[config]

We however pass those two environment variable as the same exec.Command parameter, which causes it to escape them as `KERNEL="[kernel] MAX_LXC_OPTIONS=[config]"` and the `MAX_LXC_OPTIONS` is therefore undefined. The default `MAX_LXC_OPTIONS` value is used instead.

That means the verifier test has been covering a subset of the expected datapath configurations. The 4.19 kernel is not affected because it was kept in the previous K8sVerifier ginkgo test.

This pull request fixes it by using `cmd.Env` instead to pass the environment variables. Note we also need to switch from `%q` to `%s` for the datapath config as we don't want it to be quoted. If quoted, it will be passed quoted to the Clang command and Clang will fail to recognize the macro definitions.

Passing CI run with test commit: https://github.com/cilium/cilium/actions/runs/4437216413.

Fixes: https://github.com/cilium/cilium/pull/22754.