### PR TITLE
Fix for disabled cloud provider rate limiting

### DIFF
--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -427,7 +427,7 @@ type OperatorConfig struct {
 	// ENIGarbageCollectionInterval defines the interval of ENI GC
 	ENIGarbageCollectionInterval time.Duration
 
-	// ParallelAllocWorkers specifies the number of parallel workers to be used in ENI mode.
+	// ParallelAllocWorkers specifies the number of parallel workers to be used for accessing cloud provider APIs .
 	ParallelAllocWorkers int64
 
 	// AWSInstanceLimitMapping allows overwriting AWS instance limits defined in
@@ -620,6 +620,12 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 		log.Infof("Auto-set %q to `true` because BGP support requires synchronizing services.",
 			SyncK8sServices)
 	}
+
+	// IPAM options
+
+	c.IPAMAPIQPSLimit = vp.GetFloat64(IPAMAPIQPSLimit)
+	c.IPAMAPIBurst = vp.GetInt(IPAMAPIBurst)
+	c.ParallelAllocWorkers = vp.GetInt64(ParallelAllocWorkers)
 
 	// AWS options
 


### PR DESCRIPTION
Earlier versions of these flags had a prefix of ENI and were later renamed with a prefix of IPAM to be consistent across cloud providers. While removing the deprecated old flags, #12676 also removed lines needed for setting OperatorConfig struct fields from the values read in. This resulted in fields having golang defaults, which caused the rate limiter to be completely bypassed.