### PR TITLE
bug: Fix Potential Nil Reference in GetLabels Implementation

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -209,7 +209,10 @@ type policyIdentitiesLabelLookup struct {
 // an Endpoint's policy map.
 func (p *policyIdentitiesLabelLookup) GetLabels(id identity.NumericIdentity) labels.LabelArray {
 	ident := p.allocator.LookupIdentityByID(context.Background(), id)
-	return ident.LabelArray
+	if ident != nil {
+		return ident.LabelArray
+	}
+	return nil
 }
 
 // addNewRedirectsFromDesiredPolicy must be called while holding the endpoint lock for


### PR DESCRIPTION
The policyIdentityLabelLookup wrapper for Endpoint implements the GetLabels interface method. This is necessary for constructing the MapState of the policy engine. This implementation incorrectly did not check if the identity returned by LookupIdentityByID was nil. This fixes this bug, which heretofore has not caused any issues.

