### PR TITLE
Revert "docs: fix Rule spec document typos"

### DIFF
--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -64,7 +64,7 @@ type Rule struct {
 	Ingress []IngressRule `json:"ingress,omitempty"`
 
 	// IngressDeny is a list of IngressDenyRule which are enforced at ingress.
-	// Any rule inserted here will be denied regardless of the allowed ingress
+	// Any rule inserted here will by denied regardless of the allowed ingress
 	// rules in the 'ingress' field.
 	// If omitted or empty, this rule does not apply at ingress.
 	//
@@ -78,7 +78,7 @@ type Rule struct {
 	Egress []EgressRule `json:"egress,omitempty"`
 
 	// EgressDeny is a list of EgressDenyRule which are enforced at egress.
-	// Any rule inserted here will be denied regardless of the allowed egress
+	// Any rule inserted here will by denied regardless of the allowed egress
 	// rules in the 'egress' field.
 	// If omitted or empty, this rule does not apply at egress.
 	//


### PR DESCRIPTION
This reverts commit a97f1f493202db44c3ae43ab15d338b2286ab32a.

The linters should have failed on the PR, but for some reason they didn't. 

/cc @nrnrk Please run `make generate-k8s-api` locally before submitting the changes.

See the failure on other runs - https://github.com/cilium/cilium/actions/runs/4440944264/jobs/7795725126?pr=23831