### PR TITLE
operator, hive, k8s: don't call workerpool.New from hive constructors

### DIFF
--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -90,7 +90,6 @@ func registerGC(p params) {
 		heartbeatTimeout: p.Cfg.HeartbeatTimeout,
 		gcRateInterval:   p.Cfg.RateInterval,
 		gcRateLimit:      p.Cfg.RateLimit,
-		wp:               workerpool.New(1),
 		heartbeatStore: newHeartbeatStore(
 			p.Cfg.HeartbeatTimeout,
 		),
@@ -106,6 +105,8 @@ func registerGC(p params) {
 	}
 	p.Lifecycle.Append(hive.Hook{
 		OnStart: func(ctx hive.HookContext) error {
+			gc.wp = workerpool.New(1)
+
 			switch gc.allocationMode {
 			case option.IdentityAllocationModeCRD:
 				return gc.startCRDModeGC(ctx)

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -29,16 +29,14 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(
-		m,
+func TestIdentitiesGC(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
 		// To ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go
 		// init function
 		goleak.IgnoreTopFunction("time.Sleep"),
 	)
-}
 
-func TestIdentitiesGC(t *testing.T) {
 	var clientset k8sClient.Clientset
 
 	hive := hive.New(

--- a/pkg/hive/example/events.go
+++ b/pkg/hive/example/events.go
@@ -51,6 +51,7 @@ func (es *exampleEventSource) Events(ctx context.Context) <-chan ExampleEvent {
 }
 
 func (es *exampleEventSource) Start(hive.HookContext) error {
+	es.wp = workerpool.New(1)
 	// Start the emitter
 	return es.wp.Submit("emitter", es.emitter)
 }
@@ -97,9 +98,7 @@ func makeEvent() ExampleEvent {
 }
 
 func newExampleEvents(lc hive.Lifecycle) ExampleEvents {
-	es := &exampleEventSource{
-		wp: workerpool.New(1),
-	}
+	es := &exampleEventSource{}
 	// Multicast() constructs a one-to-many observable to which items can be emitted.
 	es.src, es.emit, es.complete = stream.Multicast[ExampleEvent]()
 	lc.Append(es)

--- a/pkg/k8s/resource/example/main.go
+++ b/pkg/k8s/resource/example/main.go
@@ -103,13 +103,13 @@ func newPrintServices(p printServicesParams) (*PrintServices, error) {
 	ps := &PrintServices{
 		pods:     p.Pods,
 		services: p.Services,
-		wp:       workerpool.New(1),
 	}
 	p.Lifecycle.Append(ps)
 	return ps, nil
 }
 
 func (ps *PrintServices) Start(startCtx hive.HookContext) error {
+	ps.wp = workerpool.New(1)
 	ps.wp.Submit("processLoop", ps.processLoop)
 
 	// Using the start context, do a blocking dump of all


### PR DESCRIPTION
`workerpool.New` spawns a goroutine [1]. Per the hive guidelines [2], spawning of goroutines must not be performed from constructors, but rather via the Start hook. Fix three occurrences of this anti-pattern. See commits for details.

[1] https://github.com/cilium/workerpool/blob/054fdc524a07dfe6cc4123aba9bd76186605d960/workerpool.go#L68
[2] https://docs.cilium.io/en/latest/contributing/development/hive/#guidelines
