### PR TITLE
cocci: Fix Python path for coccilib

### DIFF
--- a/contrib/coccinelle/Dockerfile
+++ b/contrib/coccinelle/Dockerfile
@@ -3,6 +3,7 @@ FROM docker.io/library/alpine:3.16.0@sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eea
 LABEL maintainer="maintainer@cilium.io"
 
 ENV COCCINELLE_VERSION 1.1.1
+ENV PYTHONPATH /usr/local/lib/coccinelle/python
 
 RUN apk add -t .build_apks curl autoconf automake gcc libc-dev ocaml ocaml-dev ocaml-ocamldoc ocaml-findlib && \
     apk add make python3 bash && \


### PR DESCRIPTION
Trying to run the coccinelle checks locally (with the coccicheck image from DockerHub, or by rebuilding it locally) fails with the current error:

    Python error: No module named 'coccilib'

It so happens that it has also been failing silently in the CI for a while! Logging in to the container, we can see:

    bash-5.1$ python3
    Python 3.10.4 (main, Apr 30 2022, 16:49:16) [GCC 11.2.1 20220219] on linux
    Type "help", "copyright", "credits" or "license" for more information.
    >>> import sys
    >>> print(sys.path)
    ['', '/usr/lib/python310.zip', '/usr/lib/python3.10', '/usr/lib/python3.10/lib-dynload', '/usr/lib/python3.10/site-packages']

    bash-5.1$ find /usr -name 'coccilib'
    /usr/local/lib/coccinelle/python/coccilib

This can be trivially addressed by adding the relevant module path to the `$PYTHONPATH` environment variable in the Dockerfile.

The coccinelle checks used to work, but now fail on multiple branches. The root cause for the issue is unknown at this time.

This commit was split off of https://github.com/cilium/cilium/pull/24392, so we can merge the Dockerfile change, then generate a new image from the repo, and at last fix the script and coccinelle reports and update the image references (see initial PR). See also that PR as proof that setting `$PYTHONPATH` does fix the issue.
