### PR TITLE
operator/cmd: add goleak check to TestOperatorHive

### DIFF
--- a/operator/cmd/root_test.go
+++ b/operator/cmd/root_test.go
@@ -7,12 +7,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
 )
 
 // TestOperatorHive verifies that the Operator hive can be instantiated with
 // default configuration and thus the Operator hive can be inspected with
 // the hive commands and documentation can be generated from it.
 func TestOperatorHive(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		// Ignore all the currently running goroutines spawned
+		// by prior tests or by package init() functions (like the
+		// client-go logger).
+		goleak.IgnoreCurrent(),
+	)
+
 	err := operatorHive.Populate()
 	assert.NoError(t, err, "Populate()")
 }


### PR DESCRIPTION
Add a goleak check the same way as in the daemon's TestAgentCell.

Reference: https://github.com/cilium/cilium/pull/24419#pullrequestreview-1345786274
Suggested-by: Jussi Maki <jussi@isovalent.com>