### PR TITLE
.github: Rename failure step in actions

### DIFF
--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -116,7 +116,7 @@ jobs:
         working-directory: test/k8s/manifests/netpol-cyclonus
         run: ./test-cyclonus.sh
 
-      - name: Capture cilium-sysdump
+      - name: Report cluster failure status and capture cilium-sysdump
         if: ${{ failure() }}
         run: |
           echo "=== Install Cilium CLI ==="

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -147,7 +147,7 @@ jobs:
           kubectl apply -f ${{ env.CONFORMANCE_TEMPLATE }}
           kubectl wait --for=condition=Available --all deployment --timeout=${{ env.TIMEOUT }}
 
-      - name: Capture cilium-sysdump
+      - name: Report cluster failure status and capture cilium-sysdump
         if: ${{ failure() }}
         # The following is needed to prevent hubble from receiving an empty
         # file (EOF) on stdin and displaying no flows.

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -179,7 +179,7 @@ jobs:
           sudo mv prometheus-${PROM_VERSION}.linux-amd64/promtool /usr/bin
           cat metrics.prom | promtool check metrics
 
-      - name: Capture cilium-sysdump
+      - name: Report cluster failure status and capture cilium-sysdump
         if: ${{ failure() }}
         # The following is needed to prevent hubble from receiving an empty
         # file (EOF) on stdin and displaying no flows.


### PR DESCRIPTION
Currently, the way that GitHub renders failing jobs here is that the
"Install cilium chart" step will fail, then the "Capture cilium-sysdump"
step will be collapsed. Recently we added `cilium status` output into
this step, but unless developers know to click on this step and expand
the output to investigate the cluster status, it's not obvious whether
the failure is a random CI issue or whether there is some cause related
to their changes.

Renaming the failure step here will hopefully give a slightly better
signal to developers when a failure is caused by their changes, and that
they should take a closer look at the sysdump to confirm the failure
condition.
