### PR TITLE
ingress: Avoid potential nil pointer during cleanup

### DIFF
--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -654,16 +654,22 @@ func (ic *Controller) garbageCollectOwnedResources(ing *slim_networkingv1.Ingres
 		return err
 	}
 
-	if err := deleteObjectIfExists(cec, ic.envoyConfigManager.getByKey, ic.clientset.CiliumV2().CiliumEnvoyConfigs(cec.GetNamespace()).Delete); err != nil {
-		return err
+	if cec != nil {
+		if err := deleteObjectIfExists(cec, ic.envoyConfigManager.getByKey, ic.clientset.CiliumV2().CiliumEnvoyConfigs(cec.GetNamespace()).Delete); err != nil {
+			return err
+		}
 	}
 
-	if err := deleteObjectIfExists(svc, ic.serviceManager.getByKey, ic.clientset.CoreV1().Services(svc.GetNamespace()).Delete); err != nil {
-		return err
+	if svc != nil {
+		if err := deleteObjectIfExists(svc, ic.serviceManager.getByKey, ic.clientset.CoreV1().Services(svc.GetNamespace()).Delete); err != nil {
+			return err
+		}
 	}
 
-	if err := deleteObjectIfExists(ep, ic.endpointManager.getByKey, ic.clientset.CoreV1().Endpoints(ep.GetNamespace()).Delete); err != nil {
-		return err
+	if ep != nil {
+		if err := deleteObjectIfExists(ep, ic.endpointManager.getByKey, ic.clientset.CoreV1().Endpoints(ep.GetNamespace()).Delete); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Description

As part of garbage collected steps in default Ingress class changes, the garbage collection process kicks off based on our translation logic. However, depending on which load-balancer mode is used, the translated service or endpoint might be nil. This commit is to make sure that we only performs GC if applicable. Ideally, only Service and Endpoint objs should be checked, but for readability, nil check for CEC object is also done.

Fixes: 85671ad3
Fixes: #24347

### Notes

This is only happening in master branch but not 1.13 branch, so backport is not required.
