### PR TITLE
docs: fix typo in operations/troubleshooting.rst

### DIFF
--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -404,7 +404,7 @@ insufficient.
 Setting ``--conntrack-gc-interval`` to an interval lower than the current value
 may help. This controls the time interval between two garbage collection runs.
 
-By default ``--contrack-gc-interval`` is set to 0 which translates to
+By default ``--conntrack-gc-interval`` is set to 0 which translates to
 using a dynamic interval. In that case, the interval is updated after each
 garbage collection run depending on how many entries where garbage collected.
 If very few or no entries were garbage collected, the interval will increase;


### PR DESCRIPTION
contrack -> conntrack

Fixes: 93ebeb3bae11 ("docs: Update the documentation for the conntrack-gc-interval flag")