### PR TITLE
Services API: fix a broken backend pointer ref after consecutive upsertService calls

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1634,6 +1634,7 @@ func (s *Service) updateBackendsCacheLocked(svc *svcInfo, backends []*lb.Backend
 			if s.backendRefCount.Add(hash) {
 				id, err := AcquireBackendID(backend.L3n4Addr)
 				if err != nil {
+					s.backendRefCount.Delete(hash)
 					return nil, nil, nil, fmt.Errorf("Unable to acquire backend ID for %q: %s",
 						backend.L3n4Addr, err)
 				}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -84,9 +84,10 @@ type envoyCache interface {
 }
 
 type svcInfo struct {
-	hash          string
-	frontend      lb.L3n4AddrID
-	backends      []*lb.Backend
+	hash     string
+	frontend lb.L3n4AddrID
+	backends []*lb.Backend
+	// Hashed `backends`; pointing to the same objects.
 	backendByHash map[string]*lb.Backend
 
 	svcType                   lb.SVCType
@@ -239,7 +240,9 @@ type Service struct {
 	svcByID   map[lb.ID]*svcInfo
 
 	backendRefCount counter.StringCounter
-	backendByHash   map[string]*lb.Backend
+	// only used to keep track of the existing hash->ID mapping,
+	// not for loadbalancing decisions.
+	backendByHash map[string]*lb.Backend
 
 	healthServer  healthServer
 	monitorNotify monitorNotify
@@ -1642,7 +1645,6 @@ func (s *Service) updateBackendsCacheLocked(svc *svcInfo, backends []*lb.Backend
 			} else {
 				backends[i].ID = s.backendByHash[hash].ID
 			}
-			svc.backendByHash[hash] = backends[i]
 		} else {
 			backends[i].ID = b.ID
 			// Backend state can either be updated via kubernetes events,
@@ -1672,6 +1674,7 @@ func (s *Service) updateBackendsCacheLocked(svc *svcInfo, backends []*lb.Backend
 				backends[i].State = b.State
 			}
 		}
+		svc.backendByHash[hash] = backends[i]
 	}
 
 	for hash, backend := range svc.backendByHash {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -807,9 +807,6 @@ func (s *Service) UpdateBackendsState(backends []*lb.Backend) error {
 			// possible to receive an API call for a backend that's already deleted.
 			continue
 		}
-		if be.State == updatedB.State {
-			continue
-		}
 		if !lb.IsValidStateTransition(be.State, updatedB.State) {
 			currentState, _ := be.State.String()
 			newState, _ := updatedB.State.String()
@@ -826,6 +823,9 @@ func (s *Service) UpdateBackendsState(backends []*lb.Backend) error {
 			for i, b := range info.backends {
 				if b.L3n4Addr.String() != updatedB.L3n4Addr.String() {
 					continue
+				}
+				if b.State == updatedB.State {
+					break
 				}
 				info.backends[i].State = updatedB.State
 				info.backends[i].Preferred = updatedB.Preferred

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1640,8 +1640,7 @@ func (s *Service) updateBackendsCacheLocked(svc *svcInfo, backends []*lb.Backend
 				backends[i].ID = id
 				backends[i].Weight = backend.Weight
 				newBackends = append(newBackends, backends[i])
-				// TODO make backendByHash by value not by ref
-				s.backendByHash[hash] = backends[i]
+				s.backendByHash[hash] = backends[i].DeepCopy()
 			} else {
 				backends[i].ID = s.backendByHash[hash].ID
 			}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1477,8 +1477,10 @@ func (m *ManagerTestSuite) TestUpsertServiceWithZeroWeightBackends(c *C) {
 	c.Assert(len(m.lbmap.BackendByID), Equals, 3)
 	hash := backends[1].L3n4Addr.Hash()
 	c.Assert(m.svc.backendByHash[hash].State, Equals, lb.BackendStateMaintenance)
-	hash = backends[2].L3n4Addr.Hash()
-	c.Assert(m.svc.backendByHash[hash].State, Equals, lb.BackendStateActive)
+	c.Assert(m.svc.svcByID[id1].backendByHash[hash].State, Equals, lb.BackendStateMaintenance)
+	hash2 := backends[2].L3n4Addr.Hash()
+	c.Assert(m.svc.backendByHash[hash2].State, Equals, lb.BackendStateActive)
+	c.Assert(m.svc.svcByID[id1].backendByHash[hash2].State, Equals, lb.BackendStateActive)
 	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, 2)
 
 	// Update existing backend weight
@@ -1491,7 +1493,7 @@ func (m *ManagerTestSuite) TestUpsertServiceWithZeroWeightBackends(c *C) {
 	c.Assert(created, Equals, false)
 	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 3)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 3)
-	c.Assert(m.svc.backendByHash[hash].State, Equals, lb.BackendStateMaintenance)
+	c.Assert(m.svc.svcByID[id1].backendByHash[hash2].State, Equals, lb.BackendStateMaintenance)
 	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, 1)
 
 	// Delete backends with weight 0

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1102,9 +1102,15 @@ func (m *ManagerTestSuite) TestUpsertServiceWithOnlyTerminatingBackends(c *C) {
 func (m *ManagerTestSuite) TestUpsertServiceWithExternalClusterIP(c *C) {
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	option.Config.ExternalClusterIP = true
+	backends := make([]*lb.Backend, 0, len(backends1))
+	for _, b := range backends1 {
+		backends = append(backends, b.DeepCopy())
+	}
+	backends[0].State = lb.BackendStateActive
+	backends[1].State = lb.BackendStateActive
 	p := &lb.SVC{
 		Frontend:         frontend1,
-		Backends:         backends1,
+		Backends:         backends,
 		Type:             lb.SVCTypeClusterIP,
 		ExtTrafficPolicy: lb.SVCTrafficPolicyCluster,
 		IntTrafficPolicy: lb.SVCTrafficPolicyCluster,
@@ -1120,7 +1126,7 @@ func (m *ManagerTestSuite) TestUpsertServiceWithExternalClusterIP(c *C) {
 	c.Assert(len(m.lbmap.BackendByID), Equals, 2)
 	c.Assert(m.svc.svcByID[id1].svcName.Name, Equals, "svc1")
 	c.Assert(m.svc.svcByID[id1].svcName.Namespace, Equals, "ns1")
-	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, len(backends1))
+	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, len(backends))
 }
 
 // Tests whether upsert service doesn't provision the Maglev LUT for ClusterIP,
@@ -1297,7 +1303,12 @@ func (m *ManagerTestSuite) TestL7LoadBalancerServiceOverride(c *C) {
 // Tests that services with the given backends are updated with the new backend
 // state.
 func (m *ManagerTestSuite) TestUpdateBackendsState(c *C) {
-	backends := backends1
+	backends := make([]*lb.Backend, 0, len(backends1))
+	for _, b := range backends1 {
+		backends = append(backends, b.DeepCopy())
+	}
+	backends[0].State = lb.BackendStateActive
+	backends[1].State = lb.BackendStateActive
 	p1 := &lb.SVC{
 		Frontend: frontend1,
 		Backends: backends,
@@ -1377,7 +1388,15 @@ func (m *ManagerTestSuite) TestUpdateBackendsState(c *C) {
 // Tests that backend states are restored.
 func (m *ManagerTestSuite) TestRestoreServiceWithBackendStates(c *C) {
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
-	backends := append(backends1, backends4...)
+	bs := append(backends1, backends4...)
+	backends := make([]*lb.Backend, 0, len(bs))
+	for _, b := range bs {
+		backends = append(backends, b.DeepCopy())
+	}
+	backends[0].State = lb.BackendStateActive
+	backends[1].State = lb.BackendStateActive
+	backends[2].State = lb.BackendStateActive
+
 	p1 := &lb.SVC{
 		Frontend:                  frontend1,
 		Backends:                  backends,


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
Consecutive service upserts for same backend(s) break cache state-keeping, since the expected "linking" (multiple pointers pointing to the same Backend object) is broken.
___
Here's my POC unittest in [pastebin](https://pastebin.com/ZYNTxamJ) (ready to drop into `pkg/service/service_test.go`).

TLDR;
There are 3 important structures here (numbers used later as a reference):
1. the "global" backends cache; [backendByHash](https://github.com/cilium/cilium/blob/1823afbe09a43cd3c464dd12adae242a3339daf8/pkg/service/service.go#L242)
2. per-service [backends](https://github.com/cilium/cilium/blob/1823afbe09a43cd3c464dd12adae242a3339daf8/pkg/service/service.go#L89)
3. per-service [backendByHash](https://github.com/cilium/cilium/blob/1823afbe09a43cd3c464dd12adae242a3339daf8/pkg/service/service.go#L90)

As seen in POC, on initial upsert, for a single set of backends, those would all point to a single set of [Backend](https://github.com/cilium/cilium/blob/188c1121ffd52da65662abc223449ef48d36daae/pkg/loadbalancer/loadbalancer.go#L360) objects. 
These are all the states upsertService can cause:
- a service is upserted with  backend already existing in 3.
  - `1.` and `3`. stil point to the same objects, but `2.` [changes](https://github.com/cilium/cilium/blob/1823afbe09a43cd3c464dd12adae242a3339daf8/pkg/service/service.go#L1618) (the bug)
- a service is upserted with backends not in `1.` nor in `3.`
  - all `1.` `2.` `3.` point to the same objects
- a service is upserted with backends in `1.` but not in `3.`
  - `2.` and `3.` are updated to a new (same) reference but `1.` is unchanged (pointing to a different object than the rest)
___
As far as I understand, the `1.` is only ever the same with the `2.` and `3.` for saving some memory (possibly hinted [here](https://github.com/cilium/cilium/blob/1823afbe09a43cd3c464dd12adae242a3339daf8/pkg/service/service.go#L1569)) and only the state is required to keep up to date with the [UpdateBackendsState](https://github.com/cilium/cilium/blob/1823afbe09a43cd3c464dd12adae242a3339daf8/pkg/service/service.go#L778) calls (which it is). Other than that, the `1.` is not used to make loadbalancing decisions and mainly only kept for keeping the hash->BackendID mapping, which I'm adding as a comment to this field.

The `2.` and `3.` o the other hand absolutely need to always point to the same object.

Fixes: 22f5b525ebe1 ("service: Improve memory usage when handling update of a big service.")
cc @alan-kut


```release-note
Fix issue where Cilium ServiceAPI would ignore backend changes to services with backends that were used in several services and updated at least once
```
