### PR TITLE
ci: quarantine `K8sAgentIstioTest`

### DIFF
--- a/test/k8s/istio.go
+++ b/test/k8s/istio.go
@@ -19,7 +19,9 @@ import (
 // Documentation/gettingstarted/istio.rst.
 // The 5.4 CI job is intended to catch BPF complexity regressions and as such
 // doesn't need to execute this test suite.
-var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sAgentIstioTest", func() {
+// QUARANTINED: The test is consistently failing since on Kernel 4.19 pipelines
+// for K8s 1.17 - 1.24 with the following issue: https://github.com/cilium/cilium/issues/24475
+var _ = SkipDescribeIf(func() bool { return helpers.RunsOn54Kernel() || helpers.SkipQuarantined() }, "K8sAgentIstioTest", func() {
 
 	var (
 		// istioSystemNamespace is the default namespace into which Istio is


### PR DESCRIPTION
This test has been consistently failing since March 10 on Kernel 4.19 pipelines for K8s 1.17 - 1.24.

Since we are considering deprecating the Istio integration (https://github.com/cilium/cilium/issues/24204), we quarantine the test as it's unclear if we should invest in understanding the issue and fixing it.