### PR TITLE
renovate: Fix Hubble release digest regex

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -227,6 +227,8 @@
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_version=\"(?<currentValue>.*)\"",
         // The digestVersion in this regex is required for Renovate to be able
         // to match the digest to the pinned version. It will not work without it.
+        // Note that for GitHub release artifact digests, you likely want to use
+        // github-release-attachments as the datasource here.
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?) digestVersion=(?<currentValue>.*)\\s+.+_sha256.*=\"(?<currentDigest>.*)\""
       ]
     },

--- a/images/cilium/download-hubble.sh
+++ b/images/cilium/download-hubble.sh
@@ -8,13 +8,13 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-# renovate: datasource=github-releases depName=cilium/hubble
+# renovate: datasource=github-release-attachments depName=cilium/hubble
 hubble_version="v0.11.2"
 
 declare -A hubble_sha256
-# renovate: datasource=github-releases depName=cilium/hubble digestVersion=v0.11.2
+# renovate: datasource=github-release-attachments depName=cilium/hubble digestVersion=v0.11.2
 hubble_sha256[amd64]="fa2b5a1468f17957899063ad2ff1b51c68aae955a2b5d09390174a7b36a80bdb"
-# renovate: datasource=github-releases depName=cilium/hubble digestVersion=v0.11.2
+# renovate: datasource=github-release-attachments depName=cilium/hubble digestVersion=v0.11.2
 hubble_sha256[arm64]="7e1496bdc937dcf34de2f282edf62f91edc7ed1435ad78401035dc04e6b66f90"
 
 for arch in amd64 arm64 ; do


### PR DESCRIPTION
Renovate v35 had a breaking change in how it computes the digest of GitHub releases. Previously, it would use the digest of the release attachements, but now it's just using a git sha as the "digest". This commit changes the data source for the Hubble artifacts to use the data source which preserves the old behavior.

Ref: https://github.com/renovatebot/renovate/pull/20178

---

~Note: It might makes sense to merge the outstanding renovate PRs on this file first to not confuse Renovate further.~

- ~https://github.com/cilium/cilium/pull/24490~
- ~https://github.com/cilium/cilium/pull/24468~
- ~https://github.com/cilium/cilium/pull/24452~