### PR TITLE
Fix misleading use of bpf_ntohl

### DIFF
--- a/bpf/sockops/bpf_redir.c
+++ b/bpf/sockops/bpf_redir.c
@@ -29,7 +29,7 @@ static __always_inline void sk_msg_extract4_key(const struct sk_msg_md *msg,
 	key->sip4 = msg->local_ip4;
 	key->family = ENDPOINT_KEY_IPV4;
 
-	key->sport = (bpf_ntohl(msg->local_port) >> 16);
+	key->sport = (bpf_htonl(msg->local_port) >> 16);
 	/* clang-7.1 or higher seems to think it can do a 16-bit read here
 	 * which unfortunately most kernels (as of October 2019) do not
 	 * support, which leads to verifier failures. Insert a READ_ONCE

--- a/bpf/sockops/bpf_sockops.c
+++ b/bpf/sockops/bpf_sockops.c
@@ -30,7 +30,7 @@ static __always_inline void sk_extract4_key(const struct bpf_sock_ops *ops,
 	key->sip4 = ops->local_ip4;
 	key->family = ENDPOINT_KEY_IPV4;
 
-	key->sport = (bpf_ntohl(ops->local_port) >> 16);
+	key->sport = (bpf_htonl(ops->local_port) >> 16);
 	/* clang-7.1 or higher seems to think it can do a 16-bit read here
 	 * which unfortunately most kernels (as of October 2019) do not
 	 * support, which leads to verifier failures. Insert a READ_ONCE


### PR DESCRIPTION
`local_port` in `struct bpf_sock_ops` and `struct sk_msg_md` is stored in host byte order. The use of `bpf_ntohl` is kind of misleading.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

