### PR TITLE
bpf, datapath: unconditionally assume support for direct access to map values

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -301,8 +301,8 @@ struct {
 static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *dst_id,
 						__s8 *ext_err)
 {
-	struct ct_state ct_state_on_stack __maybe_unused, *ct_state, ct_state_new = {};
-	struct ipv6_ct_tuple tuple_on_stack __maybe_unused, *tuple;
+	struct ct_state *ct_state, ct_state_new = {};
+	struct ipv6_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
 	union macaddr router_mac = NODE_MAC;
 #endif
@@ -367,15 +367,8 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		/* The map value is zeroed so the map update didn't happen somehow. */
 		return DROP_INVALID_TC_BUFFER;
 
-#if HAVE_DIRECT_ACCESS_TO_MAP_VALUES
 	tuple = (struct ipv6_ct_tuple *)&ct_buffer->tuple;
 	ct_state = (struct ct_state *)&ct_buffer->ct_state;
-#else
-	memcpy(&tuple_on_stack, &ct_buffer->tuple, sizeof(tuple_on_stack));
-	tuple = &tuple_on_stack;
-	memcpy(&ct_state_on_stack, &ct_buffer->ct_state, sizeof(ct_state_on_stack));
-	ct_state = &ct_state_on_stack;
-#endif /* HAVE_DIRECT_ACCESS_TO_MAP_VALUES */
 	trace.monitor = ct_buffer->monitor;
 	ret = ct_buffer->ret;
 	ct_status = (enum ct_status)ret;
@@ -757,8 +750,8 @@ struct {
 static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *dst_id,
 						__s8 *ext_err)
 {
-	struct ct_state ct_state_on_stack __maybe_unused, *ct_state, ct_state_new = {};
-	struct ipv4_ct_tuple tuple_on_stack __maybe_unused, *tuple;
+	struct ct_state *ct_state, ct_state_new = {};
+	struct ipv4_ct_tuple *tuple;
 #ifdef ENABLE_ROUTING
 	union macaddr router_mac = NODE_MAC;
 #endif
@@ -819,15 +812,8 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 		/* The map value is zeroed so the map update didn't happen somehow. */
 		return DROP_INVALID_TC_BUFFER;
 
-#if HAVE_DIRECT_ACCESS_TO_MAP_VALUES
 	tuple = (struct ipv4_ct_tuple *)&ct_buffer->tuple;
 	ct_state = (struct ct_state *)&ct_buffer->ct_state;
-#else
-	memcpy(&tuple_on_stack, &ct_buffer->tuple, sizeof(tuple_on_stack));
-	tuple = &tuple_on_stack;
-	memcpy(&ct_state_on_stack, &ct_buffer->ct_state, sizeof(ct_state_on_stack));
-	ct_state = &ct_state_on_stack;
-#endif /* HAVE_DIRECT_ACCESS_TO_MAP_VALUES */
 	trace.monitor = ct_buffer->monitor;
 	ret = ct_buffer->ret;
 	ct_status = (enum ct_status)ret;
@@ -1334,8 +1320,8 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 	    enum ct_status *ct_status, struct ipv6_ct_tuple *tuple_out,
 	    __s8 *ext_err, __u16 *proxy_port, bool from_host __maybe_unused)
 {
-	struct ct_state ct_state_on_stack __maybe_unused, *ct_state, ct_state_new = {};
-	struct ipv6_ct_tuple tuple_on_stack __maybe_unused, *tuple;
+	struct ct_state *ct_state, ct_state_new = {};
+	struct ipv6_ct_tuple *tuple;
 	int ret, verdict = CTX_ACT_OK, hdrlen, zero = 0;
 	struct ct_buffer6 *ct_buffer;
 	void *data, *data_end;
@@ -1366,15 +1352,8 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 		/* The map value is zeroed so the map update didn't happen somehow. */
 		return DROP_INVALID_TC_BUFFER;
 
-#if HAVE_DIRECT_ACCESS_TO_MAP_VALUES
 	tuple = (struct ipv6_ct_tuple *)&ct_buffer->tuple;
 	ct_state = (struct ct_state *)&ct_buffer->ct_state;
-#else
-	memcpy(&tuple_on_stack, &ct_buffer->tuple, sizeof(tuple_on_stack));
-	tuple = &tuple_on_stack;
-	memcpy(&ct_state_on_stack, &ct_buffer->ct_state, sizeof(ct_state_on_stack));
-	ct_state = &ct_state_on_stack;
-#endif /* HAVE_DIRECT_ACCESS_TO_MAP_VALUES */
 	monitor = ct_buffer->monitor;
 	ret = ct_buffer->ret;
 	*ct_status = (enum ct_status)ret;
@@ -1641,8 +1620,8 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, enum ct_status
 	    struct ipv4_ct_tuple *tuple_out, __s8 *ext_err, __u16 *proxy_port,
 	    bool from_host __maybe_unused)
 {
-	struct ct_state ct_state_on_stack __maybe_unused, *ct_state, ct_state_new = {};
-	struct ipv4_ct_tuple tuple_on_stack __maybe_unused, *tuple;
+	struct ct_state *ct_state, ct_state_new = {};
+	struct ipv4_ct_tuple *tuple;
 	void *data, *data_end;
 	struct iphdr *ip4;
 	bool skip_ingress_proxy = false;
@@ -1681,15 +1660,8 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, enum ct_status
 		/* The map value is zeroed so the map update didn't happen somehow. */
 		return DROP_INVALID_TC_BUFFER;
 
-#if HAVE_DIRECT_ACCESS_TO_MAP_VALUES
 	tuple = (struct ipv4_ct_tuple *)&ct_buffer->tuple;
 	ct_state = (struct ct_state *)&ct_buffer->ct_state;
-#else
-	memcpy(&tuple_on_stack, &ct_buffer->tuple, sizeof(tuple_on_stack));
-	tuple = &tuple_on_stack;
-	memcpy(&ct_state_on_stack, &ct_buffer->ct_state, sizeof(ct_state_on_stack));
-	ct_state = &ct_state_on_stack;
-#endif /* HAVE_DIRECT_ACCESS_TO_MAP_VALUES */
 	monitor = ct_buffer->monitor;
 	ret = ct_buffer->ret;
 	*ct_status = (enum ct_status)ret;

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -523,16 +523,10 @@ func writeCommonHeader(writer io.Writer, probes *FeatureProbes) error {
 			probes.ProgramHelpers[ProgramHelper{ebpf.XDP, asm.FnJiffies64}],
 		"HAVE_SOCKET_LOOKUP": probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSockAddr, asm.FnSkLookupTcp}] &&
 			probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSockAddr, asm.FnSkLookupUdp}],
-		"HAVE_CGROUP_ID": probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSockAddr, asm.FnGetCurrentCgroupId}],
-		// Before upstream commit d71962f3e627 (4.18), map helpers were not
-		// allowed to access map values directly. So for those older kernels,
-		// we need to copy the data to the stack first.
-		// We don't have a probe for that, but the bpf_fib_lookup helper was
-		// introduced in the same release.
-		"HAVE_DIRECT_ACCESS_TO_MAP_VALUES": probes.ProgramHelpers[ProgramHelper{ebpf.SchedCLS, asm.FnFibLookup}],
-		"HAVE_LARGE_INSN_LIMIT":            probes.Misc.HaveLargeInsnLimit,
-		"HAVE_SET_RETVAL":                  probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSock, asm.FnSetRetval}],
-		"HAVE_FIB_NEIGH":                   probes.ProgramHelpers[ProgramHelper{ebpf.SchedCLS, asm.FnRedirectNeigh}],
+		"HAVE_CGROUP_ID":        probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSockAddr, asm.FnGetCurrentCgroupId}],
+		"HAVE_LARGE_INSN_LIMIT": probes.Misc.HaveLargeInsnLimit,
+		"HAVE_SET_RETVAL":       probes.ProgramHelpers[ProgramHelper{ebpf.CGroupSock, asm.FnSetRetval}],
+		"HAVE_FIB_NEIGH":        probes.ProgramHelpers[ProgramHelper{ebpf.SchedCLS, asm.FnRedirectNeigh}],
 		// Check if kernel has d1c362e1dd68 ("bpf: Always return target ifindex
 		// in bpf_fib_lookup") which is 5.10+. This got merged in the same kernel
 		// as the new redirect helpers.


### PR DESCRIPTION
Map helpers are allowed to access map values directly since kernel version 4.18 [1], [2].

For Cilium v1.14, the minimum required kernel version is 4.19.57 [4]. Thus we can now unconditionally assume support for direct access to map values.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d71962f3e627b5941804036755c844fabfb65ff5
[2] https://github.com/iovisor/bcc/blob/master/docs/kernel-versions.md#main-features
[3] https://docs.cilium.io/en/latest/operations/system_requirements/#base-requirements

For #22116