### PR TITLE
datapath: write full verifier log to stderr and endpoint directory

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -127,11 +128,12 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 	}
 	var ve *ebpf.VerifierError
 	if errors.As(err, &ve) {
-		//TODO: Write this to a file in endpoint directory instead.
-		l.Debugf("Got verifier error: %+v", ve)
+		if _, err := fmt.Fprintf(os.Stderr, "Verifier error: %s\nVerifier log: %+v\n", err, ve); err != nil {
+			return nil, fmt.Errorf("writing verifier log to stderr: %w", err)
+		}
 	}
 	if err != nil {
-		return nil, fmt.Errorf("error loading eBPF collection into the kernel: %w", err)
+		return nil, fmt.Errorf("loading eBPF collection into the kernel: %w", err)
 	}
 	defer coll.Close()
 


### PR DESCRIPTION
Follow-up to e5e44a9973 ("bpf: grow verifier log buffer to 10MiB, log as debug").

This commit removes the call to Debug from replaceDatapath and handles it in
regenerate() instead, where it writes a 'verifier.log' file containing the full
verifier log to the endpoint directory as well as to standard error.

This results in output similar to this:
```
Verifier error: program cil_to_host: load program: invalid argument: unreachable insn 68 (1 line(s) omi
Verifier log: load program: invalid argument:
        unreachable insn 68
        processed 0 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read
level=warning msg="JoinEP: Failed to load program for host endpoint (cil_to_host)" ...
  error="loading eBPF collection ..." file-path=628_next/bpf_host.o identity=1 ipv4= ipv6=
  k8sPodName=/ subsys=datapath-loader veth=cilium_host
```

```release-note
Emit full verifier logs to agent logs and verifier.log in the endpoint directory
```
