### PR TITLE
k8s api: remove status documentation from CRD CiliumIdentity

### DIFF
--- a/cilium/cmd/preflight_identity_crd_migrate.go
+++ b/cilium/cmd/preflight_identity_crd_migrate.go
@@ -216,10 +216,9 @@ func initK8s(ctx context.Context, clientset k8sClient.Clientset) (crdBackend all
 
 	// Create a CRD Backend
 	crdBackend, err := identitybackend.NewCRDBackend(identitybackend.CRDBackendConfiguration{
-		NodeName: "cilium-preflight",
-		Store:    nil,
-		Client:   clientset,
-		KeyFunc:  (&cacheKey.GlobalIdentity{}).PutKeyFromMap,
+		Store:   nil,
+		Client:  clientset,
+		KeyFunc: (&cacheKey.GlobalIdentity{}).PutKeyFromMap,
 	})
 	if err != nil {
 		log.WithError(err).Fatal("Cannot create CRD identity backend")

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -184,10 +184,9 @@ func (m *CachingIdentityAllocator) InitIdentityAllocator(client clientset.Interf
 				log.Warnf("Ignoring provided identityStore")
 			}
 			backend, err = identitybackend.NewCRDBackend(identitybackend.CRDBackendConfiguration{
-				NodeName: owner.GetNodeSuffix(),
-				Store:    nil,
-				Client:   client,
-				KeyFunc:  (&key.GlobalIdentity{}).PutKeyFromMap,
+				Store:   nil,
+				Client:  client,
+				KeyFunc: (&key.GlobalIdentity{}).PutKeyFromMap,
 			})
 			if err != nil {
 				log.WithError(err).Fatal("Unable to initialize Kubernetes CRD backend for identity allocation")

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumidentities.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumidentities.yaml
@@ -36,18 +36,14 @@ spec:
           by Cilium. It is intended as a backing store for identity allocation, acting
           as the global coordination backend, and can be used in place of a KVStore
           (such as etcd). The name of the CRD is the numeric identity and the labels
-          on the CRD object are the the kubernetes sourced labels seen by cilium.
-          This is currently the only label source possible when running under kubernetes.
+          on the CRD object are the kubernetes sourced labels seen by cilium. This
+          is currently the only label source possible when running under kubernetes.
           Non-kubernetes labels are filtered but all labels, from all sources, are
           places in the SecurityLabels field. These also include the source and are
           used to define the identity. The labels under metav1.ObjectMeta can be used
           when searching for CiliumIdentity instances that include particular labels.
           This can be done with invocations such as: \n \tkubectl get ciliumid -l
-          'foo=bar' \n Each node using a ciliumidentity updates the status field with
-          it's name and a timestamp when it first allocates or uses an identity, and
-          periodically after that. It deletes its entry when no longer using this
-          identity. cilium-operator uses the list of nodes in status to reference
-          count users of this identity, and to expire stale usage."
+          'foo=bar'"
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -221,7 +221,7 @@ type EndpointIdentity struct {
 // global coordination backend, and can be used in place of a KVStore (such as
 // etcd).
 // The name of the CRD is the numeric identity and the labels on the CRD object
-// are the the kubernetes sourced labels seen by cilium. This is currently the
+// are the kubernetes sourced labels seen by cilium. This is currently the
 // only label source possible when running under kubernetes. Non-kubernetes
 // labels are filtered but all labels, from all sources, are places in the
 // SecurityLabels field. These also include the source and are used to define
@@ -231,12 +231,6 @@ type EndpointIdentity struct {
 // with invocations such as:
 //
 //	kubectl get ciliumid -l 'foo=bar'
-//
-// Each node using a ciliumidentity updates the status field with it's name and
-// a timestamp when it first allocates or uses an identity, and periodically
-// after that. It deletes its entry when no longer using this identity.
-// cilium-operator uses the list of nodes in status to reference count
-// users of this identity, and to expire stale usage.
 type CiliumIdentity struct {
 	// +deepequal-gen=false
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/k8s/identitybackend/identity.go
+++ b/pkg/k8s/identitybackend/identity.go
@@ -50,10 +50,9 @@ func NewCRDBackend(c CRDBackendConfiguration) (allocator.Backend, error) {
 }
 
 type CRDBackendConfiguration struct {
-	NodeName string
-	Store    cache.Indexer
-	Client   clientset.Interface
-	KeyFunc  func(map[string]string) allocator.AllocatorKey
+	Store   cache.Indexer
+	Client  clientset.Interface
+	KeyFunc func(map[string]string) allocator.AllocatorKey
 }
 
 type crdBackend struct {

--- a/pkg/k8s/identitybackend/identity_test.go
+++ b/pkg/k8s/identitybackend/identity_test.go
@@ -186,10 +186,9 @@ func TestGetIdentity(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			_, client := k8sClient.NewFakeClientset()
 			backend, err := NewCRDBackend(CRDBackendConfiguration{
-				NodeName: "some-node",
-				Store:    nil,
-				Client:   client,
-				KeyFunc:  (&key.GlobalIdentity{}).PutKeyFromMap,
+				Store:   nil,
+				Client:  client,
+				KeyFunc: (&key.GlobalIdentity{}).PutKeyFromMap,
 			})
 			ctx := context.Background()
 			stopChan := make(chan struct{}, 1)


### PR DESCRIPTION
The status has been deleted on the CRD CiliumIdentity for quite some time (https://github.com/cilium/cilium/pull/11275). This commit removes the corresponding documentation and other leftovers too.