### PR TITLE
README.rst: Fix timezones in details for community meeting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -267,7 +267,9 @@ Weekly Developer meeting
 ------------------------
 * The developer community is hanging out on zoom on a weekly basis to chat.
   Everybody is welcome.
-* Weekly, Wednesday, 8:00 am PT, 11:00 am ET, 5:00 pm CEST
+* Weekly, Wednesday,
+  5:00 pm `Europe/Zurich time <https://time.is/Canton_of_Zurich>`__ (CET/CEST),
+  usually equivalent to 8:00 am PT, or 11:00 am ET.
 * `Join zoom <https://zoom.us/j/596609673>`_
 
 eBPF & Cilium Office Hours livestream


### PR DESCRIPTION
The weekly community meeting is aligned to the Europe/Zurich time zone.

The current time indication, "8:00 am PT, 11:00 am ET, 5:00 pm CEST", has two issues. Contrarily to PT or ET, which are not static but switch between standard and daylight time, CEST is fixed at UTC+02. So the current indication is incorrect during half the year, when most Europe switches to CET instead of CEST, and the meeting follows. Another issue is that the USA and Europe don't switch to/from daylight times on the same dates, and during the few weeks when they're "out of sync", it is unclear what time zone should be the reference.

Let's make it clear that the meeting is aligned on European time.
