### PR TITLE
bpf: dsr: don't track L2 addresses for DSR traffic

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -779,10 +779,6 @@ create_ct:
 		goto drop_err;
 	}
 
-	ret = neigh_record_ip6(ctx);
-	if (ret < 0)
-		goto drop_err;
-
 	ctx_skip_nodeport_set(ctx);
 	ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
 	ret = DROP_MISSED_TAIL_CALL;
@@ -1870,10 +1866,6 @@ create_ct:
 		ret = DROP_UNKNOWN_CT;
 		goto drop_err;
 	}
-
-	ret = neigh_record_ip4(ctx);
-	if (ret < 0)
-		goto drop_err;
 
 	/* Recircle, so packet can continue on its way to the local backend: */
 	ctx_skip_nodeport_set(ctx);


### PR DESCRIPTION
When DSR traffic arrives at a backend node, don't bother tracking its L2 source address. Its the LB's MAC address, but the replies need to go straight to the client.