### PR TITLE
.github/workflows: remove ip binary workaround in datapath complexity tests

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -202,8 +202,6 @@ jobs:
         with:
           provision: 'false'
           cmd: |
-            # workaround to use correct ip binary. TODO: this should be fixed in the complexity-test image.
-            rm /usr/bin/ip
             cd /host/
             make -C bpf/ clean V=0
             make -C tools/maptool/

--- a/test/verifier/verifier_test.go
+++ b/test/verifier/verifier_test.go
@@ -117,8 +117,8 @@ func TestVerifier(t *testing.T) {
 				t.Logf("Cleaning %s build files", bpfProgram.name)
 				cmd := exec.Command("make", "-C", "bpf/", "clean")
 				cmd.Dir = *ciliumBasePath
-				if err := cmd.Run(); err != nil {
-					t.Fatalf("Failed to clean bpf objects: %v", err)
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("Failed to clean bpf objects: %v\ncommand output: %s", err, out)
 				}
 
 				t.Logf("Building %s object file", bpfProgram.name)
@@ -128,8 +128,8 @@ func TestVerifier(t *testing.T) {
 					fmt.Sprintf("%s=%s", bpfProgram.macroName, datapathConfig),
 					fmt.Sprintf("KERNEL=%s", kernelVersion),
 				)
-				if err := cmd.Run(); err != nil {
-					t.Fatalf("Failed to compile %s bpf objects: %v", bpfProgram.name, err)
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("Failed to compile %s bpf objects: %v\ncommand output: %s", bpfProgram.name, err, out)
 				}
 
 				t.Logf("Running the verifier test script with %s", bpfProgram.name)


### PR DESCRIPTION
Follow-up for #24117 now that the complexity-test image correctly replaces the ip binary with the one from the Cilium image, see https://github.com/cilium/little-vm-helper-images/pull/50