### PR TITLE
ci: fix datapath complexity workflow

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -111,7 +111,7 @@ jobs:
     needs: check_changes
     name: Set commit status
     outputs:
-      sha: ${{ steaps.vars.outputs.sha }}
+      sha: ${{ steps.vars.outputs.sha }}
     steps:
       - name: Set up job variables
         id: vars


### PR DESCRIPTION
Due to a typo introduced in commit 683b101822be ("ci: only report status after matrix jobs are done") the workflow is currently not run and fails with an error, see e.g.
https://github.com/cilium/cilium/actions/runs/4491935023

Fixes: 683b101822be ("ci: only report status after matrix jobs are done")
