### PR TITLE
ci: fix missing timeout in Cyclonus test

### DIFF
--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -105,8 +105,8 @@ jobs:
              --set hubble.enabled=true \
              --set hubble.metrics.enabled="{dns,drop,tcp,flow,port-distribution,icmp,http}"
 
-          kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=${{ env.timeout }}
-          kubectl rollout -n kube-system status deploy/coredns --timeout=${{ env.timeout }}
+          kubectl wait -n kube-system --for=condition=Ready -l app.kubernetes.io/part-of=cilium pod --timeout=5m
+          kubectl rollout -n kube-system status deploy/coredns --timeout=5m
 
           # To make sure that cilium CRD is available (default timeout is 5m)
           # https://github.com/cilium/cilium/blob/master/operator/crd.go#L34


### PR DESCRIPTION
We addressed a CoreDNS flake in
a2b56059cc55d8a12adf227d5f1e7b10736b6d36 but did not notice that the timeout environment variable was missing in this specific workflow, and instead should stick to the hardcoded 5m value as previously.