### PR TITLE
Fix some test failures for bpf_nat_test.c

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -153,7 +153,7 @@ jobs:
         env:
           # Disable coverage report for these test cases since they are hitting
           # https://github.com/cilium/coverbee/issues/7
-          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o"
+          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o|bpf_nat_tests.o"
         run: |
           make -C test run_bpf_tests COVER=1 NOCOVER="$NOCOVER_PATTERN" || (echo "Run 'make -C test run_bpf_tests COVER=1 NOCOVER=\"$NOCOVER_PATTERN\"' locally to investigate failures"; exit 1)
       - name: Archive code coverage results

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -53,7 +53,7 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 	memcpy(dst, &l3, sizeof(struct iphdr));
 	dst += sizeof(struct iphdr);
 
-	struct icmphdr icmphdr = {
+	struct icmphdr icmphdr __align_stack_8 = {
 		.type           = ICMP_DEST_UNREACH,
 		.code           = ICMP_FRAG_NEEDED,
 		.un = {
@@ -111,7 +111,7 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 	}
 		break;
 	case IPPROTO_ICMP: {
-		struct icmphdr inner_l4 = {
+		struct icmphdr inner_l4 __align_stack_8 = {
 			.type = ICMP_ECHO,
 			.un = {
 				.echo = {
@@ -428,7 +428,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	int in_l3_off;
 	int in_l4_off;
 	struct iphdr in_ip4;
-	struct icmphdr in_l4hdr;
+	struct icmphdr in_l4hdr __align_stack_8;
 
 	in_l3_off = l4_off + sizeof(icmphdr);
 	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,


### PR DESCRIPTION
This PR fixes two test failures on the latest master.

**BPF Unit Test failure for bpf_nat_test.c**
https://github.com/cilium/cilium/pull/24212 introduces a known bug of Coverbee into the code base (https://github.com/cilium/coverbee/issues/7). This only becomes a problem when we run the test with the affected code (the code includes `nat.h` or `conntrack_map.h`). We introduced the feature to disable coverage report per file to prevent CI from failing. The latest exclusion pattern is also introduced in https://github.com/cilium/cilium/pull/24212 (https://github.com/cilium/cilium/pull/24212/commits/9a274dbe7f07a97b2a1749f067c75e91eecd4276).

Yesterday, we merged the PR that introduces a new test file affected by the bug https://github.com/cilium/cilium/pull/18414 (https://github.com/cilium/cilium/pull/18414/commits/07edf550cab7f865ef83522061256183a803109e), but we couldn't notice that because the BPF Unit test CI ran without the change introduced in https://github.com/cilium/cilium/pull/24212.

**Coccicheck failure for bpf_nat_test.c**
https://github.com/cilium/cilium/pull/24392 "fixed" the Coccicheck, which was not running correctly for a while. This was merged on May 21st. https://github.com/cilium/cilium/pull/18414 introduced the code which fails with Coccicheck but ran the check on May 20th, which was before the fix merged. That's why we couldn't notice the failure before the merge.

```release-note
Fix some test failures for bpf_nat_test.c
```
