### PR TITLE
bpf: port verifier test to Go

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -205,9 +205,9 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host/
-            make -C bpf/ clean V=0
             make -C tools/maptool/
-            go test -c ./test/verifier
+            # Run with cgo disabled, LVH images don't ship with gcc.
+            CGO_ENABLED=0 go test -c ./test/verifier
             docker run -t --privileged \
               -v /sys/fs/bpf:/sys/fs/bpf \
               -v "\$PWD:/cilium" \

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -127,8 +127,17 @@ func LoadCollection(spec *ebpf.CollectionSpec, opts ebpf.CollectionOptions) (*eb
 	}
 
 	// Set initial size of verifier log buffer.
+	//
+	// Up until kernel 5.1, the maximum log size is (2^24)-1. In 5.2, this was
+	// increased to (2^30)-1 by 7a9f5c65abcc ("bpf: increase verifier log limit").
+	//
+	// The default value of (2^22)-1 was chosen to be large enough to fit the log
+	// of most Cilium programs, while falling just within the 5.1 maximum size in
+	// one of the steps of the multiplication loop below. Without the -1, it would
+	// overshoot the cap to 2^24, making e.g. verifier tests unable to load the
+	// program if the previous size (2^22) was too small to fit the log.
 	if opts.Programs.LogSize == 0 {
-		opts.Programs.LogSize = 4_194_304
+		opts.Programs.LogSize = 4_194_303
 	}
 
 	attempt := 1

--- a/test/verifier/verifier_test.go
+++ b/test/verifier/verifier_test.go
@@ -5,15 +5,25 @@ package verifier_test
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
+	"github.com/cilium/ebpf/rlimit"
 	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 var (
@@ -58,6 +68,10 @@ func getDatapathConfigFile(t *testing.T, ciKernelVersion, bpfProgram string) str
 	return filepath.Join(*ciliumBasePath, "bpf", "complexity-tests", ciKernelVersion, fmt.Sprintf("%s.txt", bpfProgram))
 }
 
+// This test tries to compile BPF programs with a set of options that maximize
+// size & complexity (as defined in bpf/complexity-tests). Programs are then
+// loaded into the kernel to detect complexity & other verifier-related
+// regressions.
 func TestVerifier(t *testing.T) {
 	flag.Parse()
 
@@ -66,60 +80,55 @@ func TestVerifier(t *testing.T) {
 	}
 	t.Logf("Cilium checkout base path: %s", *ciliumBasePath)
 
+	if err := rlimit.RemoveMemlock(); err != nil {
+		t.Fatal(err)
+	}
+
 	kernelVersion, source := getCIKernelVersion(t)
 	t.Logf("CI kernel version: %s (%s)", kernelVersion, source)
 
-	const (
-		HookTC     = "TC"
-		HookCgroup = "CG"
-		HookXDP    = "XDP"
-	)
-
 	for _, bpfProgram := range []struct {
 		name      string
-		hook      string
 		macroName string
 	}{
 		{
 			name:      "bpf_lxc",
-			hook:      HookTC,
 			macroName: "MAX_LXC_OPTIONS",
 		},
 		{
 			name:      "bpf_host",
-			hook:      HookTC,
 			macroName: "MAX_HOST_OPTIONS",
 		},
 		{
 			name:      "bpf_xdp",
-			hook:      HookXDP,
 			macroName: "MAX_XDP_OPTIONS",
 		},
 		{
 			name:      "bpf_overlay",
-			hook:      HookTC,
 			macroName: "MAX_OVERLAY_OPTIONS",
 		},
+		{
+			name:      "bpf_sock",
+			macroName: "MAX_LB_OPTIONS",
+		},
 	} {
-		t.Run(bpfProgram.name, func(t *testing.T) {
-			file, err := os.Open(getDatapathConfigFile(t, kernelVersion, bpfProgram.name))
-			if err != nil {
-				t.Fatalf("Unable to open list of datapath configurations for %s: %v", bpfProgram.name, err)
-			}
-			defer file.Close()
+		file, err := os.Open(getDatapathConfigFile(t, kernelVersion, bpfProgram.name))
+		if err != nil {
+			t.Fatalf("Unable to open list of datapath configurations for %s: %v", bpfProgram.name, err)
+		}
+		defer file.Close()
 
-			scanner := bufio.NewScanner(file)
-			for scanner.Scan() {
-				datapathConfig := scanner.Text()
+		scanner := bufio.NewScanner(file)
+		for i := 1; scanner.Scan(); i++ {
+			datapathConfig := scanner.Text()
 
-				t.Logf("Cleaning %s build files", bpfProgram.name)
+			t.Run(fmt.Sprintf("%s_%d", bpfProgram.name, i), func(t *testing.T) {
 				cmd := exec.Command("make", "-C", "bpf/", "clean")
 				cmd.Dir = *ciliumBasePath
 				if out, err := cmd.CombinedOutput(); err != nil {
 					t.Fatalf("Failed to clean bpf objects: %v\ncommand output: %s", err, out)
 				}
 
-				t.Logf("Building %s object file", bpfProgram.name)
 				cmd = exec.Command("make", "-C", "bpf", fmt.Sprintf("%s.o", bpfProgram.name))
 				cmd.Dir = *ciliumBasePath
 				cmd.Env = append(cmd.Env,
@@ -130,23 +139,122 @@ func TestVerifier(t *testing.T) {
 					t.Fatalf("Failed to compile %s bpf objects: %v\ncommand output: %s", bpfProgram.name, err, out)
 				}
 
-				t.Logf("Running the verifier test script with %s", bpfProgram.name)
-				cmd = exec.Command("./test/bpf/verifier-test.sh")
-				cmd.Dir = *ciliumBasePath
-				cmd.Env = append(cmd.Env,
-					"TC_PROGS=",
-					"XDP_PROGS=",
-					"CG_PROGS=",
-					fmt.Sprintf("%s_PROGS=%s", bpfProgram.hook, bpfProgram.name),
-				)
-				if out, err := cmd.CombinedOutput(); err != nil {
-					t.Errorf("Failed to load BPF program %s: %v\ndatapath configuration: %s\ncommand output: %s", bpfProgram.name, err, datapathConfig, out)
+				// Parse the compiled object into a CollectionSpec.
+				spec, err := bpf.LoadCollectionSpec(path.Join(*ciliumBasePath, "bpf", fmt.Sprintf("%s.o", bpfProgram.name)))
+				if err != nil {
+					t.Fatal(err)
 				}
-			}
+
+				// Delete unsupported programs from the spec.
+				for n, p := range spec.Programs {
+					err := haveAttachType(p.Type, p.AttachType)
+					if errors.Is(err, ebpf.ErrNotSupported) {
+						t.Logf("%s: skipped unsupported program/attach type (%s/%s)", n, p.Type, p.AttachType)
+						delete(spec.Programs, n)
+						continue
+					}
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+
+				// Strip all pinning flags so we don't need to specify a pin path.
+				// This creates new maps for every Collection.
+				for _, m := range spec.Maps {
+					m.Pinning = ebpf.PinNone
+				}
+
+				coll, err := bpf.LoadCollection(spec, ebpf.CollectionOptions{
+					// Enable verifier logs for successful loads.
+					// Use log level 1 since it's known by all target kernels.
+					Programs: ebpf.ProgramOptions{
+						// Maximum log size for kernels <5.2. Some programs generate a
+						// verifier log of over 8MiB, so avoid retries due to the initial
+						// size being too small. This saves a lot of time as retrying means
+						// reloading all maps and progs in the collection.
+						LogSize:  (math.MaxUint32 >> 8), // 16MiB
+						LogLevel: ebpf.LogLevelBranch,
+					},
+				})
+				var ve *ebpf.VerifierError
+				if errors.As(err, &ve) {
+					t.Fatalf("Verifier error: %s\nVerifier log: %+v\n\nDatapath build config: %s", err, ve, datapathConfig)
+				}
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer coll.Close()
+
+				// Print verifier stats appearing on the last line of the log, e.g.
+				// 'processed 12248 insns (limit 1000000) ...'.
+				for n, p := range coll.Programs {
+					p.VerifierLog = strings.TrimRight(p.VerifierLog, "\n")
+					// Offset points at the last newline, increment by 1 to skip it.
+					// Turn a -1 into a 0 if there are no newlines in the log.
+					lastOff := strings.LastIndex(p.VerifierLog, "\n") + 1
+					t.Logf("%s: %v", n, p.VerifierLog[lastOff:])
+				}
+			})
 
 			if err = scanner.Err(); err != nil {
-				t.Fatalf("Error while reading list of datapath configuration for %s: %v", bpfProgram.name, err)
+				t.Fatalf("Error while reading list of datapath configurations for %s: %v", bpfProgram.name, err)
 			}
-		})
+		}
 	}
 }
+
+// haveAttachType returns nil if the given program/attach type combination is
+// supported by the underlying kernel. Returns ErrNotSupported if loading a
+// program with the given Program/AttachType fails.
+func haveAttachType(pt ebpf.ProgramType, at ebpf.AttachType) (err error) {
+	if err := features.HaveProgramType(pt); err != nil {
+		return err
+	}
+
+	probesMu.Lock()
+	defer probesMu.Unlock()
+	if err, ok := probes[probe{pt, at}]; ok {
+		return err
+	}
+
+	defer func() {
+		// Closes over named return variable err to cache any returned errors.
+		probes[probe{pt, at}] = err
+	}()
+
+	spec := &ebpf.ProgramSpec{
+		Type:       pt,
+		AttachType: at,
+		Instructions: asm.Instructions{
+			// recvmsg and peername require a return value of 1, use it for all probes.
+			asm.LoadImm(asm.R0, 1, asm.DWord),
+			asm.Return(),
+		},
+	}
+
+	prog, err := ebpf.NewProgramWithOptions(spec, ebpf.ProgramOptions{
+		LogDisabled: true,
+	})
+	if err == nil {
+		prog.Close()
+	}
+
+	switch {
+	// EINVAL occurs when attempting to create a program with an unknown type.
+	// E2BIG occurs when ProgLoadAttr contains non-zero bytes past the end
+	// of the struct known by the running kernel, meaning the kernel is too old
+	// to support the given prog type.
+	case errors.Is(err, unix.EINVAL), errors.Is(err, unix.E2BIG):
+		err = ebpf.ErrNotSupported
+	}
+
+	return err
+}
+
+type probe struct {
+	pt ebpf.ProgramType
+	at ebpf.AttachType
+}
+
+var probesMu lock.Mutex
+var probes map[probe]error = make(map[probe]error)


### PR DESCRIPTION
Supersedes https://github.com/cilium/cilium/pull/24526.

Description taken from the main commit:

```
This commit switches package test/verifier over from running verifier-test.sh
to loading programs using Go natively.

A few modifications are made to the CollectionSpec before loading:
- Remove map pinning flags so each ELF gets its own copies of maps that would
  normally be shared across multiple ELFs by pinning them.
- Run some probes over ProgramType/AttachType combinations to make sure we
  don't try to load cgroup programs on kernels that don't support specific
  attach types.

verifier_test.go now tests bpf_sock as well.

Also converted each line in bpf/complexity-tests/*/*.txt to run its own
subtest so it's easier to spot which configuration in the list caused an
error, and specific subtests can be run using go test -run=...
```

Closes #24522

```release-note
Port verifier tests to Go
```
