### PR TITLE
images: install ccache in builder.

### DIFF
--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -43,6 +43,7 @@ RUN \
       gcc \
       git \
       libc6-dev \
+      ccache \
       make && \
     apt-get purge --auto-remove && \
     apt-get clean && \


### PR DESCRIPTION
I'd like to cache bpf builds in development environments.