### PR TITLE
contrib/kind: no longer create local docker registry

### DIFF
--- a/contrib/scripts/kind-down.sh
+++ b/contrib/scripts/kind-down.sh
@@ -9,10 +9,5 @@ if ! have_kind; then
     echo "  https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
 fi
 
-if [ "${1:-}" != "--keep-registry" ]; then
-    docker kill kind-registry && \
-        docker rm kind-registry
-fi
-
 kind delete clusters kind && \
     docker network rm kind-cilium

--- a/contrib/testing/kind-clustermesh1.yaml
+++ b/contrib/testing/kind-clustermesh1.yaml
@@ -5,9 +5,11 @@ debug:
   enabled: true
 image:
   override: "localhost:5000/cilium/cilium-dev:local"
+  pullPolicy: Never
 operator:
   image:
     override: "localhost:5000/cilium/operator-generic:local"
+    pullPolicy: Never
     suffix: ""
 ipam:
   mode: kubernetes

--- a/contrib/testing/kind-clustermesh2.yaml
+++ b/contrib/testing/kind-clustermesh2.yaml
@@ -5,9 +5,11 @@ debug:
   enabled: true
 image:
   override: "localhost:5000/cilium/cilium-dev:local"
+  pullPolicy: Never
 operator:
   image:
     override: "localhost:5000/cilium/operator-generic:local"
+    pullPolicy: Never
     suffix: ""
 ipam:
   mode: kubernetes

--- a/contrib/testing/kind-values.yaml
+++ b/contrib/testing/kind-values.yaml
@@ -2,9 +2,11 @@ debug:
   enabled: true
 image:
   override: "localhost:5000/cilium/cilium-dev:local"
+  pullPolicy: Never
 operator:
   image:
     override: "localhost:5000/cilium/operator-generic:local"
+    pullPolicy: Never
     suffix: ""
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
Now that we use `kind load docker-image`, it's not necessary to push images to a local registry as well.
