### PR TITLE
bpf: Fix nat test lint

### DIFF
--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -53,7 +53,7 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 	memcpy(dst, &l3, sizeof(struct iphdr));
 	dst += sizeof(struct iphdr);
 
-	struct icmphdr icmphdr = {
+	struct icmphdr icmphdr __align_stack_8 = {
 		.type           = ICMP_DEST_UNREACH,
 		.code           = ICMP_FRAG_NEEDED,
 		.un = {
@@ -111,7 +111,7 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 	}
 		break;
 	case IPPROTO_ICMP: {
-		struct icmphdr inner_l4 = {
+		struct icmphdr inner_l4 __align_stack_8 = {
 			.type = ICMP_ECHO,
 			.un = {
 				.echo = {
@@ -428,7 +428,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	int in_l3_off;
 	int in_l4_off;
 	struct iphdr in_ip4;
-	struct icmphdr in_l4hdr;
+	struct icmphdr in_l4hdr __align_stack_8;
 
 	in_l3_off = l4_off + sizeof(icmphdr);
 	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,


### PR DESCRIPTION
Fix coccicheck lint errors in bpf/tests/bpf_nat_tests.c:
```
* file bpf/tests/bpf_nat_tests.c: missing __align_stack_8 on icmphdr on line 56
* file bpf/tests/bpf_nat_tests.c: missing __align_stack_8 on inner_l4 on line 114
* file bpf/tests/bpf_nat_tests.c: missing __align_stack_8 on in_l4hdr on line 431 diff -u -p a/tests/bpf_nat_tests.c b/tests/bpf_nat_tests.c --- a/tests/bpf_nat_tests.c
+++ b/tests/bpf_nat_tests.c
@@ -53,7 +53,7 @@
 	memcpy(dst, &l3, sizeof(struct iphdr));
 	dst += sizeof(struct iphdr);
 
-	struct icmphdr icmphdr = {
+	struct icmphdr icmphdr __align_stack_8 = {
 		.type           = ICMP_DEST_UNREACH,
 		.code           = ICMP_FRAG_NEEDED,
 		.un = {
@@ -111,7 +111,7 @@
 	}
 		break;
 	case IPPROTO_ICMP: {
-		struct icmphdr inner_l4 = {
+		struct icmphdr inner_l4 __align_stack_8 = {
 			.type = ICMP_ECHO,
 			.un = {
 				.echo = {
@@ -428,7 +428,7 @@
 	int in_l3_off;
 	int in_l4_off;
 	struct iphdr in_ip4;
-	struct icmphdr in_l4hdr;
+	struct icmphdr in_l4hdr __align_stack_8;
 
 	in_l3_off = l4_off + sizeof(icmphdr); if (ctx_load_bytes(ctx, in_l3_off, &in_ip4, Use the following command to fix the above issues:
docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                  \
    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b spatch --sp-file contrib/coccinelle/aligned.cocci \
    --include-headers --very-quiet --in-place bpf/
```
