### PR TITLE
build: enable ccache for development builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -530,7 +530,7 @@ kind-ready:
 
 $(eval $(call KIND_ENV,kind-build-image-agent))
 kind-build-image-agent: ## Build cilium-dev docker image
-	$(QUIET)$(MAKE) dev-docker-image$(DEBUGGER_SUFFIX) DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
+	$(QUIET)$(MAKE) CCACHE=1 dev-docker-image$(DEBUGGER_SUFFIX) DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
 	@echo "  DEPLOY image to kind ($(LOCAL_AGENT_IMAGE))"
 	$(QUIET)$(CONTAINER_ENGINE) push $(LOCAL_AGENT_IMAGE)
 

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -98,6 +98,7 @@ endif
 		--build-arg CILIUM_SHA=$(firstword $(GIT_VERSION)) \
 		--build-arg OPERATOR_VARIANT=$(IMAGE_NAME) \
 		--build-arg DEBUG_HOLD=$(DEBUG_HOLD) \
+		--build-arg CCACHE=${CCACHE}\
 		--target $(5) \
 		-t $(IMAGE_REPOSITORY)/$(IMAGE_NAME)$${UNSTRIPPED}$(DOCKER_IMAGE_SUFFIX):$(4) .
 ifneq ($(KIND_LOAD),)

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -30,6 +30,10 @@ BPF_ASM := $(patsubst %.o,%.s,$(BPF))
 CLANG ?= clang
 LLC   ?= llc
 
+ifeq ($(CCACHE),1)
+  CLANG := ccache $(CLANG)
+endif
+
 HOST_CC    ?= gcc
 HOST_STRIP ?= strip
 

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -43,6 +43,7 @@ RUN \
       gcc \
       git \
       libc6-dev \
+      ccache \
       make && \
     apt-get purge --auto-remove && \
     apt-get clean && \

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -39,6 +39,7 @@ ARG LOCKDEBUG
 ARG RACE
 ARG V
 ARG LIBNETWORK_PLUGIN
+ARG CCACHE
 
 #
 # Please do not add any dependency updates before the 'make install' here,
@@ -54,7 +55,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=
     # fine to run this with same architecture as BUILDARCH since the output of
     # bash_completion is the same for both architectures.
     make GOARCH=${BUILDARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} PKG_BUILD=1 V=${V} LIBNETWORK_PLUGIN=${LIBNETWORK_PLUGIN} \
-    DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} install-bash-completion licenses-all && \
+    CCACHE=${CCACHE} DESTDIR=/tmp/install/${TARGETOS}/${TARGETARCH} install-bash-completion licenses-all && \
     mv LICENSE.all /tmp/install/${TARGETOS}/${TARGETARCH}/LICENSE.all
 
 COPY images/cilium/init-container.sh \


### PR DESCRIPTION
This has two commits:
1 - Install ccache in the builder image
2 - Configure `make kind-image` to use ccache for bpf builds

Since we already set `/root/.cache` to be a cache directory in the Dockerfile, this saves a lot of time when doing a `make kind-image` for the second time.

### Results
_ note: all builds are second builds_
- go build cached, clang not cached: **57 seconds**
- go build cached, clang cached: **45 seconds**

And, if we can get `llc` support in to ccache, this should be even faster.