### PR TITLE
v1.13 Backports 2023-03-22

### DIFF
--- a/Documentation/bpf/progtypes.rst
+++ b/Documentation/bpf/progtypes.rst
@@ -323,64 +323,62 @@ talked about XDP this mode is typically implied.
   production environment either the native or offloaded mode is better
   suited and the recommended way to run XDP.
 
-..
+.. _xdp_drivers:
 
 **Driver support**
 
-Since BPF and XDP is evolving quickly in terms of feature and driver support,
-the following lists native and offloaded XDP drivers as of kernel 4.17.
-
 **Drivers supporting native XDP**
 
-* **Broadcom**
+A list of drivers supporting native XDP can be found in the table below. The
+corresponding network driver name of an interface can be determined as follows:
 
-  * bnxt
+.. code-block:: shell-session
 
-..
+    # ethtool -i eth0
+    driver: nfp
+    [...]
 
-* **Cavium**
-
-  * thunderx
-
-..
-
-* **Intel**
-
-  * ixgbe
-  * ixgbevf
-  * i40e
-
-..
-
-* **Mellanox**
-
-  * mlx4
-  * mlx5
-
-..
-
-* **Netronome**
-
-  * nfp
-
-..
-
-* **Others**
-
-  * tun
-  * virtio_net
-
-..
-
-* **Qlogic**
-
-  * qede
-
-..
-
-* **Solarflare**
-
-  * sfc [1]_
++-------------------+------------+-------------+
+| Vendor            | Driver     | XDP Support |
++===================+============+=============+
+| Amazon            | ena        | >= 5.6      |
++-------------------+------------+-------------+
+| Broadcom          | bnxt_en    | >= 4.11     |
++-------------------+------------+-------------+
+| Cavium            | thunderx   | >= 4.12     |
++-------------------+------------+-------------+
+| Freescale         | dpaa2      | >= 5.0      |
++-------------------+------------+-------------+
+| Intel             | ixgbe      | >= 4.12     |
+|                   +------------+-------------+
+|                   | ixgbevf    | >= 4.17     |
+|                   +------------+-------------+
+|                   | i40e       | >= 4.13     |
+|                   +------------+-------------+
+|                   | ice        | >= 5.5      |
++-------------------+------------+-------------+
+| Marvell           | mvneta     | >= 5.5      |
++-------------------+------------+-------------+
+| Mellanox          | mlx4       | >= 4.8      |
+|                   +------------+-------------+
+|                   | mlx5       | >= 4.9      |
++-------------------+------------+-------------+
+| Microsoft         | hv_netvsc  | >= 5.6      |
++-------------------+------------+-------------+
+| Netronome         | nfp        | >= 4.10     |
++-------------------+------------+-------------+
+| Others            | virtio_net | >= 4.10     |
+|                   +------------+-------------+
+|                   | tun/tap    | >= 4.14     |
++-------------------+------------+-------------+
+| Qlogic            | qede       | >= 4.10     |
++-------------------+------------+-------------+
+| Socionext         | netsec     | >= 5.3      |
++-------------------+------------+-------------+
+| Solarflare        | sfc        | >= 5.5      |
++-------------------+------------+-------------+
+| Texas Instruments | cpsw       | >= 5.3      |
++-------------------+------------+-------------+
 
 **Drivers supporting offloaded XDP**
 
@@ -392,8 +390,6 @@ the following lists native and offloaded XDP drivers as of kernel 4.17.
 
     Examples for writing and loading XDP programs are included in the `bpf_dev` section under the respective tools.
 
-.. [1] XDP for sfc available via out of tree driver as of kernel 4.17, but
-   will be upstreamed soon.
 .. [2] Some BPF helper functions such as retrieving the current CPU number
    will not be available in an offloaded setting.
 

--- a/Documentation/bpf/progtypes.rst
+++ b/Documentation/bpf/progtypes.rst
@@ -370,6 +370,8 @@ corresponding network driver name of an interface can be determined as follows:
 | Others            | virtio_net | >= 4.10     |
 |                   +------------+-------------+
 |                   | tun/tap    | >= 4.14     |
+|                   +------------+-------------+
+|                   | bond       | >= 5.15     |
 +-------------------+------------+-------------+
 | Qlogic            | qede       | >= 4.10     |
 +-------------------+------------+-------------+

--- a/Documentation/community/community.rst
+++ b/Documentation/community/community.rst
@@ -86,7 +86,7 @@ and meeting links.
 ====================== ===================================== ============= ================================================================================
 SIG                    Meeting                               Slack         Description
 ====================== ===================================== ============= ================================================================================
-Datapath               Thursdays, 08:00 PT                   #sig-datapath Development discussions for Linux and eBPF code used in Cilium.
+Datapath               On demand                             #sig-datapath Development discussions for Linux and eBPF code used in Cilium.
 Documentation          None                                  #sig-docs     Documentation, Helm references, and translations.
 Envoy                  On demand                             #sig-envoy    Envoy, Istio and maintenance of all L7 protocol parsers.
 Hubble                 During community meeting              #sig-hubble   All Hubble-related code: Server, UI, CLI and Relay.

--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -29,9 +29,9 @@ Cluster Addressing Requirements
 * PodCIDR ranges in all clusters and all nodes must be non-conflicting and
   unique IP addresses.
 
-* Nodes in all clusters must have IP connectivity between each other. This
-  requirement is typically met by establishing peering or VPN tunnels between
-  the networks of the nodes of each cluster.
+* Nodes in all clusters must have IP connectivity between each other using the 
+  configured InternalIP for each node. This requirement is typically met by establishing 
+  peering or VPN tunnels between the networks of the nodes of each cluster.
 
 * The network between clusters must allow the inter-cluster communication. The
   exact ports are documented in the :ref:`firewall_requirements` section.

--- a/Documentation/network/concepts/ipam/cluster-pool.rst
+++ b/Documentation/network/concepts/ipam/cluster-pool.rst
@@ -28,14 +28,14 @@ Architecture
 This is useful if Kubernetes cannot be configured to hand out PodCIDRs or if
 more control is needed.
 
-In this mode, the Cilium agent will wait on startup until the ``PodCIDRs`` range
+In this mode, the Cilium agent will wait on startup until the ``podCIDRs`` range
 are made available via the Cilium Node ``v2.CiliumNode`` object for all enabled
 address families via the resource field set in the ``v2.CiliumNode``:
 
 ====================== ==============================
 Field                  Description
 ====================== ==============================
-``Spec.IPAM.PodCIDRs`` IPv4 and/or IPv6 PodCIDR range
+``spec.ipam.podCIDRs`` IPv4 and/or IPv6 PodCIDR range
 ====================== ==============================
 
 *************
@@ -52,11 +52,11 @@ Troubleshooting
 Look for allocation errors
 ==========================
 
-Check the ``Error`` field in the ``Status.Operator`` field:
+Check the ``Error`` field in the ``status.ipam.operator-status`` field:
 
 .. code-block:: shell-session
 
-    kubectl get ciliumnodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.operator.error}{"\n"}{end}'
+    kubectl get ciliumnodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.ipam.operator-status}{"\n"}{end}'
     
 Check for conflicting node CIDRs
 ================================
@@ -90,9 +90,9 @@ PodCIDR status section:
 +-------------------------+----------------------------------------------------+
 |Field                    | Description                                        |
 +=========================+====================================================+
-|``Spec.IPAM.PodCIDRs``   | List of assigned IPv4 and/or IPv6 PodCIDRs         |
+|``spec.ipam.podCIDRs``   | List of assigned IPv4 and/or IPv6 PodCIDRs         |
 +-------------------------+----------------------------------------------------+
-|``Status.IPAM.PodCIDRs`` | PodCIDR utilization                                |
+|``status.ipam.pod-cidrs``| PodCIDR utilization                                |
 |                         | (one of: ``in-use``, ``depleted``, or ``released``)|
 +-------------------------+----------------------------------------------------+
 
@@ -120,9 +120,9 @@ Helm options. The CIDR pool used in Cluster Pool v2 mode are configured the same
 way as regular cluster pool (see :ref:`gsg_ipam_crd_cluster_pool`).
 
 In addition, the thresholds for when a PodCIDR should be allocated or released
-can be configured per node via the following ``CiliumNode.Spec.IPAM`` fields:
+can be configured per node via the following ``CiliumNode.spec.ipam`` fields:
 
-``Spec.IPAM.PodCIDRAllocationThreshold``
+``spec.ipam.pod-cidr-allocation-threshold``
   Defines the minimum number of free IPs which must be available to this node
   via its PodCIDR pool.
 
@@ -136,7 +136,7 @@ can be configured per node via the following ``CiliumNode.Spec.IPAM`` fields:
   If unspecified, defaults to 8.
 
 
-``Spec.IPAM.PodCIDRReleaseThreshold``
+``spec.ipam.pod-cidr-release-threshold``
   Defines the maximum number of free IPs which may be available to this node via
   its PodCIDR pool.
 

--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -55,17 +55,16 @@ Additionally, the enablement of the egress gateway feature requires that both
 BPF masquerading and the kube-proxy replacement are enabled, which may not be
 possible in all environments (due to, e.g., incompatible kernel versions).
 
-Compatibility with other features
-=================================
-
-L7 policies
------------
+Incompatibility with other features
+-----------------------------------
 
 Egress gateway is currently partially incompatible with L7 policies.
 Specifically, when an egress gateway policy and an L7 policy both select the same
 endpoint, traffic from that endpoint will not go through egress gateway, even if
 the policy allows it. Full support will be added in an upcoming release once
 :gh-issue:`19642` is resolved.
+
+Egress gateway is not supported for IPv6 traffic.
 
 Enable egress gateway
 =====================

--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -55,6 +55,15 @@ Additionally, the enablement of the egress gateway feature requires that both
 BPF masquerading and the kube-proxy replacement are enabled, which may not be
 possible in all environments (due to, e.g., incompatible kernel versions).
 
+Delay for enforcement of egress policies on new pods
+----------------------------------------------------
+
+When new pods are started, there is a delay before egress gateway policies are
+applied for those pods. That means traffic from those pods may leave the
+cluster with a source IP address (pod IP or node IP) that doesn't match the
+egress gateway IP. That egressing traffic will also not be redirected through
+the gateway node.
+
 Incompatibility with other features
 -----------------------------------
 

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -617,56 +617,7 @@ the multi-device XDP acceleration.
 NodePort acceleration can be used with either direct routing (``tunnel=disabled``)
 or tunnel mode. Direct routing is recommended to achieve optimal performance.
 
-A list of drivers supporting native XDP can be found in the table below. The
-corresponding network driver name of an interface can be determined as follows:
-
-.. code-block:: shell-session
-
-    # ethtool -i eth0
-    driver: nfp
-    [...]
-
-+-------------------+------------+-------------+
-| Vendor            | Driver     | XDP Support |
-+===================+============+=============+
-| Amazon            | ena        | >= 5.6      |
-+-------------------+------------+-------------+
-| Broadcom          | bnxt_en    | >= 4.11     |
-+-------------------+------------+-------------+
-| Cavium            | thunderx   | >= 4.12     |
-+-------------------+------------+-------------+
-| Freescale         | dpaa2      | >= 5.0      |
-+-------------------+------------+-------------+
-| Intel             | ixgbe      | >= 4.12     |
-|                   +------------+-------------+
-|                   | ixgbevf    | >= 4.17     |
-|                   +------------+-------------+
-|                   | i40e       | >= 4.13     |
-|                   +------------+-------------+
-|                   | ice        | >= 5.5      |
-+-------------------+------------+-------------+
-| Marvell           | mvneta     | >= 5.5      |
-+-------------------+------------+-------------+
-| Mellanox          | mlx4       | >= 4.8      |
-|                   +------------+-------------+
-|                   | mlx5       | >= 4.9      |
-+-------------------+------------+-------------+
-| Microsoft         | hv_netvsc  | >= 5.6      |
-+-------------------+------------+-------------+
-| Netronome         | nfp        | >= 4.10     |
-+-------------------+------------+-------------+
-| Others            | virtio_net | >= 4.10     |
-|                   +------------+-------------+
-|                   | tun/tap    | >= 4.14     |
-+-------------------+------------+-------------+
-| Qlogic            | qede       | >= 4.10     |
-+-------------------+------------+-------------+
-| Socionext         | netsec     | >= 5.3      |
-+-------------------+------------+-------------+
-| Solarflare        | sfc        | >= 5.5      |
-+-------------------+------------+-------------+
-| Texas Instruments | cpsw       | >= 5.3      |
-+-------------------+------------+-------------+
+A list of drivers supporting XDP can be found in :ref:`the documentation for XDP<xdp_drivers>`.
 
 The current Cilium kube-proxy XDP acceleration mode can also be introspected through
 the ``cilium status`` CLI command. If it has been enabled successfully, ``Native``

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1200,6 +1200,11 @@ gracefully. The endpoint state is fully removed when the agent receives
 a Kubernetes delete event for the endpoint. The `Kubernetes
 pod termination <https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination>`_
 documentation contains more background on the behavior and configuration using ``terminationGracePeriodSeconds``.
+There are some special cases, like zero disruption during rolling updates, that require to be able to send traffic
+to Terminating Pods that are still Serving traffic during the Terminating period, the Kubernetes blog
+`Advancements in Kubernetes Traffic Engineering
+<https://kubernetes.io/blog/2022/12/30/advancements-in-kubernetes-traffic-engineering/#traffic-loss-from-load-balancers-during-rolling-updates>`_
+explains it in detail.
 
 .. admonition:: Video
   :class: attention

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1094,11 +1094,15 @@ issue.
 
 This section elaborates on the various ``kubeProxyReplacement`` options:
 
-- ``kubeProxyReplacement=strict``: This option expects a kube-proxy-free
-  Kubernetes setup where Cilium is expected to fully replace all kube-proxy
-  functionality. Once the Cilium agent is up and running, it takes care of handling
-  Kubernetes services of type ClusterIP, NodePort, LoadBalancer, services with externalIPs
-  as well as HostPort. If the underlying kernel version requirements are not met
+- ``kubeProxyReplacement=strict``: When using this option, it's highly recommended
+  to run a kube-proxy-free Kubernetes setup where Cilium is expected to fully replace
+  all kube-proxy functionality. However, if it's not possible to remove kube-proxy for
+  specific reasons (e.g. Kubernetes distribution limitations), it's also acceptable to
+  leave it deployed in the background. Just be aware of the potential side effects on
+  existing nodes as mentioned above when running kube-proxy in co-existence. Once the
+  Cilium agent is up and running, it takes care of handling Kubernetes services of type
+  ClusterIP, NodePort, LoadBalancer, services with externalIPs as well as HostPort.
+  If the underlying kernel version requirements are not met
   (see :ref:`kubeproxy-free` note), then the Cilium agent will bail out on start-up
   with an error message.
 

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -399,10 +399,21 @@ Handling drop (CT: Map insertion failed)
 If connectivity fails and ``cilium monitor --type drop`` shows ``xx drop (CT:
 Map insertion failed)``, then it is likely that the connection tracking table
 is filling up and the automatic adjustment of the garbage collector interval is
-insufficient. Set ``--conntrack-gc-interval`` to an interval lower than the
-default. The default starting interval is 5 minutes. Alternatively, the value
-for ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` can be increased.
-Setting both of these options will be a trade-off of CPU for ``conntrack-gc-interval``, and for
+insufficient.
+
+Setting ``--conntrack-gc-interval`` to an interval lower than the current value
+may help. This controls the time interval between two garbage collection runs.
+
+By default ``--contrack-gc-interval`` is set to 0 which translates to
+using a dynamic interval. In that case, the interval is updated after each
+garbage collection run depending on how many entries where garbage collected.
+If very few or no entries were garbage collected, the interval will increase;
+if many entries were garbage collected, it will decrease. The current interval
+value is reported in the Cilium agent logs.
+
+Alternatively, the value for ``bpf-ct-global-any-max`` and
+``bpf-ct-global-tcp-max`` can be increased. Setting both of these options will
+be a trade-off of CPU for ``conntrack-gc-interval``, and for
 ``bpf-ct-global-any-max`` and ``bpf-ct-global-tcp-max`` the amount of memory
 consumed. You can track conntrack garbage collection related metrics such as
 ``datapath_conntrack_gc_runs_total`` and ``datapath_conntrack_gc_entries`` to

--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -404,7 +404,7 @@ insufficient.
 Setting ``--conntrack-gc-interval`` to an interval lower than the current value
 may help. This controls the time interval between two garbage collection runs.
 
-By default ``--contrack-gc-interval`` is set to 0 which translates to
+By default ``--conntrack-gc-interval`` is set to 0 which translates to
 using a dynamic interval. In that case, the interval is updated after each
 garbage collection run depending on how many entries where garbage collected.
 If very few or no entries were garbage collected, the interval will increase;

--- a/Documentation/overview/component-overview.rst
+++ b/Documentation/overview/component-overview.rst
@@ -38,6 +38,15 @@ Client (CLI)
   status of the local agent. It also provides tooling to directly access the
   eBPF maps to validate their state.
 
+  .. note::
+
+     The in-agent Cilium CLI client described here should not be confused with
+     the `command line tool for quick-installing, managing and troubleshooting
+     Cilium on Kubernetes clusters <https://github.com/cilium/cilium-cli>`_,
+     which also has the name ``cilium``. That tool is typically installed
+     remote from the cluster, and uses ``kubeconfig`` information to access
+     Cilium running on the cluster via the Kubernetes API.
+
 Operator
   The Cilium Operator is responsible for managing duties in the cluster which
   should logically be handled once for the entire cluster, rather than once for

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -32,8 +32,7 @@ redirect_direct_v6(struct __ctx_buff *ctx __maybe_unused,
 	ipv6_addr_copy((union v6addr *)&fib_params.ipv6_dst,
 		       (union v6addr *)&ip6->daddr);
 
-	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
-			 BPF_FIB_LOOKUP_DIRECT);
+	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params), 0);
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
 		break;
@@ -98,8 +97,7 @@ redirect_direct_v4(struct __ctx_buff *ctx __maybe_unused,
 		.ipv4_dst	= ip4->daddr,
 	};
 
-	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params),
-			 BPF_FIB_LOOKUP_DIRECT);
+	ret = fib_lookup(ctx, &fib_params, sizeof(fib_params), 0);
 	switch (ret) {
 	case BPF_FIB_LKUP_RET_SUCCESS:
 		break;

--- a/images/cilium/download-hubble.sh
+++ b/images/cilium/download-hubble.sh
@@ -8,13 +8,13 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-# renovate: datasource=github-releases depName=cilium/hubble
+# renovate: datasource=github-release-attachments depName=cilium/hubble
 hubble_version="v0.11.2"
 
 declare -A hubble_sha256
-# renovate: datasource=github-releases depName=cilium/hubble digestVersion=v0.11.2
+# renovate: datasource=github-release-attachments depName=cilium/hubble digestVersion=v0.11.2
 hubble_sha256[amd64]="fa2b5a1468f17957899063ad2ff1b51c68aae955a2b5d09390174a7b36a80bdb"
-# renovate: datasource=github-releases depName=cilium/hubble digestVersion=v0.11.2
+# renovate: datasource=github-release-attachments depName=cilium/hubble digestVersion=v0.11.2
 hubble_sha256[arm64]="7e1496bdc937dcf34de2f282edf62f91edc7ed1435ad78401035dc04e6b66f90"
 
 for arch in amd64 arm64 ; do

--- a/install/kubernetes/cilium/files/agent/poststart-eni.bash
+++ b/install/kubernetes/cilium/files/agent/poststart-eni.bash
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 set -o errexit
 set -o pipefail
 set -o nounset

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -220,10 +220,13 @@ spec:
           postStart:
             exec:
               command:
-              - "/cni-install.sh"
-              - "--enable-debug={{ .Values.debug.enabled }}"
-              - "--cni-exclusive={{ .Values.cni.exclusive }}"
-              - "--log-file={{ .Values.cni.logFile }}"
+              - "bash"
+              - "-c"
+              - "/cni-install.sh --enable-debug={{ .Values.debug.enabled }} --cni-exclusive={{ .Values.cni.exclusive }} --log-file={{ .Values.cni.logFile }}"
+                {{- if .Values.eni.enabled }}
+              - |
+                {{- tpl (.Files.Get "files/agent/poststart-eni.bash") . | nindent 20 }}
+                {{- end }}
           preStop:
             exec:
               command:

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -46,19 +46,6 @@ spec:
           image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           lifecycle:
-            {{- if .Values.eni.enabled }}
-            postStart:
-              exec:
-                command:
-                  - nsenter
-                  - --target=1
-                  - --mount
-                  - --
-                  - "/bin/bash"
-                  - "-c"
-                  - |
-                    {{- tpl (.Files.Get "files/nodeinit/poststart-eni.bash") . | nindent 20 }}
-            {{- end }}
             {{- if .Values.nodeinit.revertReconfigureKubelet }}
             preStop:
               exec:

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -465,7 +465,7 @@ type OperatorConfig struct {
 	// ENIGarbageCollectionInterval defines the interval of ENI GC
 	ENIGarbageCollectionInterval time.Duration
 
-	// ParallelAllocWorkers specifies the number of parallel workers to be used in ENI mode.
+	// ParallelAllocWorkers specifies the number of parallel workers to be used for accessing cloud provider APIs .
 	ParallelAllocWorkers int64
 
 	// AWSInstanceLimitMapping allows overwriting AWS instance limits defined in
@@ -661,6 +661,12 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 		log.Infof("Auto-set %q to `true` because BGP support requires synchronizing services.",
 			SyncK8sServices)
 	}
+
+	// IPAM options
+
+	c.IPAMAPIQPSLimit = vp.GetFloat64(IPAMAPIQPSLimit)
+	c.IPAMAPIBurst = vp.GetInt(IPAMAPIBurst)
+	c.ParallelAllocWorkers = vp.GetInt64(ParallelAllocWorkers)
 
 	// AWS options
 

--- a/pkg/bgpv1/gobgp/reconcile.go
+++ b/pkg/bgpv1/gobgp/reconcile.go
@@ -169,6 +169,10 @@ func preflightReconciler(ctx context.Context, _ *BGPRouterManager, sc *ServerWit
 	// actions as if this is a new BgpServer.
 	sc.Config = nil
 
+	// Clear the shadow state since any advertisements will be gone now that the server has been recreated.
+	sc.PodCIDRAnnouncements = nil
+	sc.ServiceAnnouncements = nil
+
 	return nil
 }
 

--- a/pkg/checker/checker.go
+++ b/pkg/checker/checker.go
@@ -163,7 +163,7 @@ func (checker *cmpExportedChecker) Check(params []interface{}, _ []string) (resu
 // deeply equal, then the second return value includes a json representation of
 // the difference between the parameters.
 func ExportedEqual(params ...interface{}) (bool, string) {
-	return Equals.Check(params, cmpParams)
+	return ExportedEquals.Check(params, cmpParams)
 }
 
 func DeepIgnoreUnexported(vs ...interface{}) cmp.Option {

--- a/pkg/clustermesh/logfields.go
+++ b/pkg/clustermesh/logfields.go
@@ -13,6 +13,8 @@ var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "clustermesh")
 const (
 	fieldClusterName   = "clusterName"
 	fieldConfig        = "config"
+	fieldConfigDir     = "configDir"
+	fieldEvent         = "event"
 	fieldKVStoreStatus = "kvstoreStatus"
 	fieldKVStoreErr    = "kvstoreErr"
 )

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -270,6 +270,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				rc.getLogger().Info("All resources of remote cluster cleaned up")
 				return nil
 			},
+			CancelDoFuncOnUpdate: true,
 		},
 	)
 }

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -118,7 +118,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 		logfields.DatapathPolicyRevision: e.policyRevision,
 		logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 		logfields.IPv4:                   e.GetIPv4Address(),
-		logfields.IPv6:                   e.GetIPv4Address(),
+		logfields.IPv6:                   e.GetIPv6Address(),
 		logfields.K8sPodName:             e.getK8sNamespaceAndPodName(),
 	})
 
@@ -177,7 +177,7 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
 			logfields.DatapathPolicyRevision: e.policyRevision,
 			logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 			logfields.IPv4:                   e.GetIPv4Address(),
-			logfields.IPv6:                   e.GetIPv4Address(),
+			logfields.IPv6:                   e.GetIPv6Address(),
 			logfields.K8sPodName:             e.getK8sNamespaceAndPodName(),
 		})
 

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -22,6 +22,7 @@ import (
 var (
 	worldPrefix     = netip.MustParsePrefix("1.1.1.1/32")
 	inClusterPrefix = netip.MustParsePrefix("10.0.0.4/32")
+	aPrefix         = netip.MustParsePrefix("100.4.16.32/32")
 )
 
 func TestInjectLabels(t *testing.T) {
@@ -56,6 +57,23 @@ func TestInjectLabels(t *testing.T) {
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 2)
 	assert.False(t, IPIdentityCache.ipToIdentityCache["10.0.0.4/32"].ID.HasLocalScope())
+
+	// Assert that a CIDR identity can be overridden automatically (without
+	// overrideIdentity=true) when the prefix becomes associated with an entity
+	// within the cluster.
+	IPIdentityCache.metadata.upsertLocked(aPrefix, source.Generated, "cnp-uid", labels.LabelWorld)
+	assert.Len(t, IPIdentityCache.metadata.m, 3)
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{aPrefix})
+	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
+	assert.Len(t, IPIdentityCache.ipToIdentityCache, 3)
+	assert.True(t, IPIdentityCache.ipToIdentityCache["100.4.16.32/32"].ID.HasLocalScope())
+	IPIdentityCache.metadata.upsertLocked(aPrefix, source.CustomResource, "node-uid", labels.LabelRemoteNode)
+	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{aPrefix})
+	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
+	assert.Len(t, IPIdentityCache.ipToIdentityCache, 3)
+	assert.False(t, IPIdentityCache.ipToIdentityCache["100.4.16.32/32"].ID.HasLocalScope())
 }
 
 func TestFilterMetadataByLabels(t *testing.T) {

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -86,6 +86,9 @@ type Clientset interface {
 
 	// Config returns the configuration used to create this client.
 	Config() Config
+
+	// RestConfig returns the deep copy of rest configuration.
+	RestConfig() *rest.Config
 }
 
 // compositeClientset implements the Clientset using real clients.
@@ -200,6 +203,10 @@ func (c *compositeClientset) Disable() {
 
 func (c *compositeClientset) Config() Config {
 	return c.config
+}
+
+func (c *compositeClientset) RestConfig() *rest.Config {
+	return rest.CopyConfig(c.restConfig)
 }
 
 func (c *compositeClientset) onStart(startCtx hive.HookContext) error {
@@ -457,6 +464,10 @@ func (c *FakeClientset) Disable() {
 
 func (c *FakeClientset) Config() Config {
 	return Config{}
+}
+
+func (c *FakeClientset) RestConfig() *rest.Config {
+	return &rest.Config{}
 }
 
 func NewFakeClientset() (*FakeClientset, Clientset) {

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -306,9 +306,20 @@ func createConfig(apiServerURL, kubeCfgPath string, qps float32, burst int) (*re
 		config = &rest.Config{Host: apiServerURL, UserAgent: userAgent}
 	}
 
-	config.QPS = qps
-	config.Burst = burst
+	setConfig(config, userAgent, qps, burst)
 	return config, nil
+}
+
+func setConfig(config *rest.Config, userAgent string, qps float32, burst int) {
+	if userAgent != "" {
+		config.UserAgent = userAgent
+	}
+	if qps != 0.0 {
+		config.QPS = qps
+	}
+	if burst != 0 {
+		config.Burst = burst
+	}
 }
 
 func (c *compositeClientset) waitForConn(ctx context.Context) error {

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -293,32 +293,45 @@ func ParseEndpointSliceV1(ep *slim_discovery_v1.EndpointSlice) (EndpointSliceID,
 		return ParseEndpointSliceID(ep), endpoints
 	}
 
+	log.Debugf("Processing %d endpoints for EndpointSlice %s", len(ep.Endpoints), ep.Name)
 	for _, sub := range ep.Endpoints {
-		skipEndpoint := false
 		// ready indicates that this endpoint is prepared to receive traffic,
 		// according to whatever system is managing the endpoint. A nil value
 		// indicates an unknown state. In most cases consumers should interpret this
 		// unknown state as ready.
 		// More info: vendor/k8s.io/api/discovery/v1/types.go
-		if sub.Conditions.Ready != nil && !*sub.Conditions.Ready {
-			skipEndpoint = true
-			if option.Config.EnableK8sTerminatingEndpoint {
-				// Terminating indicates that the endpoint is getting terminated. A
-				// nil values indicates an unknown state. Ready is never true when
-				// an endpoint is terminating. Propagate the terminating endpoint
-				// state so that we can gracefully remove those endpoints.
-				// More details : vendor/k8s.io/api/discovery/v1/types.go
-				if sub.Conditions.Terminating != nil && *sub.Conditions.Terminating {
-					skipEndpoint = false
-				}
+		isReady := sub.Conditions.Ready == nil || *sub.Conditions.Ready
+		// serving is identical to ready except that it is set regardless of the
+		// terminating state of endpoints. This condition should be set to true for
+		// a ready endpoint that is terminating. If nil, consumers should defer to
+		// the ready condition.
+		// More info: vendor/k8s.io/api/discovery/v1/types.go
+		isServing := (sub.Conditions.Serving == nil && isReady) || (sub.Conditions.Serving != nil && *sub.Conditions.Serving)
+		// Terminating indicates that the endpoint is getting terminated. A
+		// nil values indicates an unknown state. Ready is never true when
+		// an endpoint is terminating. Propagate the terminating endpoint
+		// state so that we can gracefully remove those endpoints.
+		// More info: vendor/k8s.io/api/discovery/v1/types.go
+		isTerminating := sub.Conditions.Terminating != nil && *sub.Conditions.Terminating
+
+		// if is not Ready and EnableK8sTerminatingEndpoint is set
+		// allow endpoints that are Serving and Terminating
+		if !isReady {
+			if !option.Config.EnableK8sTerminatingEndpoint {
+				log.Debugf("discarding Endpoint on EndpointSlice %s: not Ready and EnableK8sTerminatingEndpoint %v", ep.Name, option.Config.EnableK8sTerminatingEndpoint)
+				continue
+			}
+			// filter not Serving endpoints since those can not receive traffic
+			if !isServing {
+				log.Debugf("discarding Endpoint on EndpointSlice %s: not Serving and EnableK8sTerminatingEndpoint %v", ep.Name, option.Config.EnableK8sTerminatingEndpoint)
+				continue
 			}
 		}
-		if skipEndpoint {
-			continue
-		}
+
 		for _, addr := range sub.Addresses {
 			addrCluster, err := cmtypes.ParseAddrCluster(addr)
 			if err != nil {
+				log.WithError(err).Infof("Unable to parse address %s for EndpointSlices %s", addr, ep.Name)
 				continue
 			}
 
@@ -333,11 +346,12 @@ func ParseEndpointSliceV1(ep *slim_discovery_v1.EndpointSlice) (EndpointSliceID,
 						backend.NodeName = nodeName
 					}
 				}
-				if option.Config.EnableK8sTerminatingEndpoint {
-					if sub.Conditions.Terminating != nil && *sub.Conditions.Terminating {
-						backend.Terminating = true
-						metrics.TerminatingEndpointsEvents.Inc()
-					}
+				// If is not ready check if is serving and terminating
+				if !isReady && option.Config.EnableK8sTerminatingEndpoint &&
+					isServing && isTerminating {
+					log.Debugf("Endpoint address %s on EndpointSlice %s is Terminating", addr, ep.Name)
+					backend.Terminating = true
+					metrics.TerminatingEndpointsEvents.Inc()
 				}
 			}
 
@@ -357,6 +371,7 @@ func ParseEndpointSliceV1(ep *slim_discovery_v1.EndpointSlice) (EndpointSliceID,
 		}
 	}
 
+	log.Debugf("EndpointSlice %s has %d backends", ep.Name, len(endpoints.Backends))
 	return ParseEndpointSliceID(ep), endpoints
 }
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -671,6 +671,8 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		shuffleEndpoints(config.Endpoints)
 	}
 
+	// Set client context so that client can be cancelled from outside
+	config.Context = ctx
 	// Set DialTimeout to 0, otherwise the creation of a new client will
 	// block until DialTimeout is reached or a connection to the server
 	// is made.
@@ -785,6 +787,8 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 				ec.lastHeartbeat = time.Now()
 				ec.RWMutex.Unlock()
 				log.Debug("Received update notification of heartbeat")
+			case <-ctx.Done():
+				return
 			}
 		}
 	}()
@@ -932,6 +936,19 @@ func (e *etcdClient) Watch(ctx context.Context, w *Watcher) {
 	localCache := watcherCache{}
 	listSignalSent := false
 
+	defer func() {
+		close(w.Events)
+		w.stopWait.Done()
+
+		// The watch might be aborted by closing
+		// the context instead of calling
+		// w.Stop() from outside. In that case
+		// we make sure to close everything and
+		// as this uses sync.Once it can be
+		// run multiple times (if that's the case).
+		w.Stop()
+	}()
+
 	scopedLog := e.getLogger().WithFields(logrus.Fields{
 		fieldWatcher: w,
 		fieldPrefix:  w.Prefix,
@@ -1039,10 +1056,7 @@ reList:
 			case <-ctx.Done():
 				return
 			case <-w.stopWatch:
-				close(w.Events)
-				w.stopWait.Done()
 				return
-
 			case r, ok := <-etcdWatch:
 				if !ok {
 					time.Sleep(50 * time.Millisecond)

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -696,10 +696,17 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 	// only contain local backends (i.e. it has externalTrafficPolicy=Local)
 	if option.Config.EnableHealthCheckNodePort {
 		if svc.isExtLocal() && filterBackends {
-			_, activeBackends, _ := segregateBackends(backendsCopy)
-
+			// HealthCheckNodePort is used by external systems to poll the state of the Service,
+			// it should never take into consideration Terminating backends, even when there are only
+			// Terminating backends.
+			activeBackends := 0
+			for _, b := range backendsCopy {
+				if b.State == lb.BackendStateActive {
+					activeBackends++
+				}
+			}
 			s.healthServer.UpsertService(lb.ID(svc.frontend.ID), svc.svcName.Namespace, svc.svcName.Name,
-				len(activeBackends), svc.svcHealthCheckNodePort)
+				activeBackends, svc.svcHealthCheckNodePort)
 		} else if svc.svcHealthCheckNodePort == 0 {
 			// Remove the health check server in case this service used to have
 			// externalTrafficPolicy=Local with HealthCheckNodePort in the previous
@@ -1717,6 +1724,9 @@ func isWildcardAddr(frontend lb.L3n4AddrID) bool {
 	return cmtypes.MustParseAddrCluster("0.0.0.0").Equal(frontend.AddrCluster)
 }
 
+// segregateBackends returns the list of active, preferred and nonActive backends to be
+// added to the lbmaps. If EnableK8sTerminatingEndpoint and there are no active backends,
+// segregateBackends will return all terminating backends as active.
 func segregateBackends(backends []*lb.Backend) (preferredBackends map[string]*lb.Backend,
 	activeBackends map[string]*lb.Backend, nonActiveBackends []lb.BackendID) {
 	preferredBackends = make(map[string]*lb.Backend)
@@ -1736,6 +1746,21 @@ func segregateBackends(backends []*lb.Backend) (preferredBackends map[string]*lb
 			}
 		} else {
 			nonActiveBackends = append(nonActiveBackends, b.ID)
+		}
+	}
+	// To avoid connections drops during rolling updates, Kubernetes defines a Terminating state on the EndpointSlices
+	// that can be used to identify Pods that, despite being terminated, still can serve traffic.
+	// In case that there are no Active backends, use the Backends in TerminatingState to answer new requests
+	// and avoid traffic disruption until new active backends are created.
+	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1669-proxy-terminating-endpoints
+	if option.Config.EnableK8sTerminatingEndpoint && len(activeBackends) == 0 {
+		nonActiveBackends = []lb.BackendID{}
+		for _, b := range backends {
+			if b.State == lb.BackendStateTerminating {
+				activeBackends[b.String()] = b
+			} else {
+				nonActiveBackends = append(nonActiveBackends, b.ID)
+			}
 		}
 	}
 	return preferredBackends, activeBackends, nonActiveBackends

--- a/proxylib/proxylib/instance.go
+++ b/proxylib/proxylib/instance.go
@@ -183,7 +183,7 @@ func (ins *Instance) PolicyUpdate(resp *envoy_service_discovery.DiscoveryRespons
 			return fmt.Errorf("NPDS: Policy has no endpoint_ips")
 		}
 		for _, ip := range ips {
-			logrus.Infof("NPDS: Endpoint IP: %s", ip)
+			logrus.Debugf("NPDS: Endpoint IP: %s", ip)
 		}
 		// Locate the old version, if any
 		oldPolicy, found := oldMap[ips[0]]

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4269,7 +4269,7 @@ func (kub *Kubectl) reportMapHost(ctx context.Context, path string, reportCmds m
 		wg.Add(1)
 		go func(cmd, logfile string) {
 			defer wg.Done()
-			res := kub.ExecContext(ctx, cmd)
+			res := kub.ExecContext(ctx, cmd, ExecOptions{SkipLog: true})
 
 			if !res.WasSuccessful() {
 				log.WithError(res.GetErr("reportMapHost")).Errorf("command %s failed", cmd)

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -4,7 +4,6 @@
 package k8sTest
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"regexp"
@@ -143,22 +142,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	SkipContextIf(helpers.SkipQuarantined, "Encapsulation", func() {
-		validateBPFTunnelMap := func() {
-			By("Checking that BPF tunnels are in place")
-			ciliumPod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
-			ExpectWithOffset(1, err).Should(BeNil(), "Unable to determine cilium pod on node %s", helpers.K8s1)
-			status := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPod, "cilium bpf tunnel list | wc -l")
-
-			// ipv4+ipv6: 2 entries for each remote node + 1 header row
-			numEntries := (kubectl.GetNumCiliumNodes()-1)*2 + 1
-			if value := helpers.HelmOverride("ipv6.enabled"); value == "false" {
-				// ipv4 only: 1 entry for each remote node + 1 header row
-				numEntries = (kubectl.GetNumCiliumNodes() - 1) + 1
-			}
-
-			Expect(status.IntOutput()).Should(Equal(numEntries), "Did not find expected number of entries in BPF tunnel map")
-		}
-
 		enableVXLANTunneling := func(options map[string]string) {
 			options["tunnel"] = "vxlan"
 			if helpers.RunsOnGKE() {
@@ -167,38 +150,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				options["endpointRoutes.enabled"] = "true"
 			}
 		}
-
-		It("Check connectivity with VXLAN encapsulation", func() {
-			options := map[string]string{}
-			enableVXLANTunneling(options)
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
-			validateBPFTunnelMap()
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-		}, 600)
-
-		// Geneve is currently not supported on GKE
-		SkipItIf(helpers.RunsOnGKE, "Check connectivity with Geneve encapsulation", func() {
-			deploymentManager.DeployCilium(map[string]string{
-				"tunnel": "geneve",
-			}, DeployCiliumOptionsAndDNS)
-			validateBPFTunnelMap()
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-		})
-
-		It("Check vxlan connectivity with per-endpoint routes", func() {
-			options := map[string]string{
-				"endpointRoutes.enabled": "true",
-			}
-			enableVXLANTunneling(options)
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-
-			if helpers.RunsOn419OrLaterKernel() {
-				By("Test BPF masquerade")
-				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, false)).
-					Should(BeTrue(), "Connectivity test to http://google.com failed")
-			}
-		})
 
 		It("Check iptables masquerading with random-fully", func() {
 			options := map[string]string{
@@ -217,6 +168,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				Should(BeTrue(), "IPv6 connectivity test to http://google.com failed")
 		})
 
+		// TODO(brb) Enable IPv6 masq in ci-datapath, and then drop this test case
 		It("Check iptables masquerading without random-fully", func() {
 			options := map[string]string{
 				"bpf.masquerade":       "false",

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -186,38 +186,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
-	Context("AutoDirectNodeRoutes", func() {
-		BeforeEach(func() {
-			SkipIfIntegration(helpers.CIIntegrationGKE)
-			SkipIfIntegration(helpers.CIIntegrationAKS)
-		})
-
-		It("Check connectivity with automatic direct nodes routes", func() {
-			deploymentManager.DeployCilium(map[string]string{
-				"tunnel":               "disabled",
-				"autoDirectNodeRoutes": "true",
-			}, DeployCiliumOptionsAndDNS)
-
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-			if helpers.RunsOn419OrLaterKernel() {
-				By("Test BPF masquerade")
-				Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, false)).
-					Should(BeTrue(), "Connectivity test to http://google.com failed")
-			}
-		})
-
-		It("Check direct connectivity with per endpoint routes", func() {
-			deploymentManager.DeployCilium(map[string]string{
-				"tunnel":                 "disabled",
-				"autoDirectNodeRoutes":   "true",
-				"endpointRoutes.enabled": "true",
-				"ipv6.enabled":           "false",
-			}, DeployCiliumOptionsAndDNS)
-
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-		})
-	})
-
 	SkipContextIf(func() bool {
 		return helpers.RunsWithKubeProxyReplacement() || helpers.GetCurrentIntegration() != "" || helpers.SkipQuarantined()
 	}, "IPv6 masquerading", func() {

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -234,29 +234,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
-	// DirectRouting without AutoDirectNodeRoutes not supported outside of GKE.
-	SkipContextIf(helpers.DoesNotRunOnGKE, "DirectRouting", func() {
-		It("Check connectivity with direct routing", func() {
-			deploymentManager.DeployCilium(map[string]string{
-				"tunnel":                 "disabled",
-				"k8s.requireIPv4PodCIDR": "true",
-				"endpointRoutes.enabled": "false",
-			}, DeployCiliumOptionsAndDNS)
-
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-		})
-
-		It("Check connectivity with direct routing and endpointRoutes", func() {
-			deploymentManager.DeployCilium(map[string]string{
-				"tunnel":                 "disabled",
-				"k8s.requireIPv4PodCIDR": "true",
-				"endpointRoutes.enabled": "true",
-			}, DeployCiliumOptionsAndDNS)
-
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-		})
-	})
-
 	Context("AutoDirectNodeRoutes", func() {
 		BeforeEach(func() {
 			SkipIfIntegration(helpers.CIIntegrationGKE)

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -57,16 +57,6 @@ func ciliumDelService(kubectl *helpers.Kubectl, id int64) {
 	}
 }
 
-func ciliumHasServiceIP(kubectl *helpers.Kubectl, pod, vip string) bool {
-	service := kubectl.CiliumExecMustSucceed(context.TODO(), pod, "cilium service list", "Cannot retrieve services on cilium Pod")
-	vip4 := fmt.Sprintf(" %s:", vip)
-	if strings.Contains(service.Stdout(), vip4) {
-		return true
-	}
-	vip6 := fmt.Sprintf(" [%s]:", vip)
-	return strings.Contains(service.Stdout(), vip6)
-}
-
 var newlineRegexp = regexp.MustCompile(`\n[ \t\n]*`)
 
 func trimNewlines(script string) string {

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -18,11 +18,9 @@ import (
 )
 
 const (
-	appServiceName     = "app1-service"
-	appServiceNameIPv6 = "app1-service-ipv6"
-	echoServiceName    = "echo"
-	echoPodLabel       = "name=echo"
-	app2PodLabel       = "id=app2"
+	appServiceName  = "app1-service"
+	echoServiceName = "echo"
+	echoPodLabel    = "name=echo"
 	// echoServiceNameIPv6 = "echo-ipv6"
 
 	testDSClient = "zgroup=testDSClient"
@@ -95,49 +93,6 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 				kubectl.Delete(yaml)
 			}
 			ExpectAllPodsTerminated(kubectl)
-		})
-
-		// This is testing bpf_lxc LB (= KPR=disabled) when both client and
-		// server are running on the same node. Thus, skipping when running with
-		// KPR.
-		SkipItIf(func() bool {
-			return helpers.RunsWithKubeProxyReplacement()
-		}, "Checks service on same node", func() {
-			serviceNames := []string{appServiceName}
-			if helpers.DualStackSupported() {
-				serviceNames = append(serviceNames, appServiceNameIPv6)
-			}
-
-			ciliumPods, err := kubectl.GetCiliumPods()
-			Expect(err).To(BeNil(), "Cannot get cilium pods")
-
-			for _, svcName := range serviceNames {
-				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, svcName)
-				Expect(err).Should(BeNil(), "Cannot get service %s", svcName)
-				Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
-
-				By("testing connectivity via cluster IP %s", clusterIP)
-
-				httpSVCURL := fmt.Sprintf("http://%s/", net.JoinHostPort(clusterIP, "80"))
-				tftpSVCURL := fmt.Sprintf("tftp://%s/hello", net.JoinHostPort(clusterIP, "69"))
-
-				status := kubectl.ExecInHostNetNS(context.TODO(), ni.K8s1NodeName,
-					helpers.CurlFail(httpSVCURL))
-				Expect(status).Should(helpers.CMDSuccess(), "cannot curl to service IP from host: %s", status.CombineOutput())
-
-				status = kubectl.ExecInHostNetNS(context.TODO(), ni.K8s1NodeName,
-					helpers.CurlFail(tftpSVCURL))
-				Expect(status).Should(helpers.CMDSuccess(), "cannot curl to service IP from host: %s", status.CombineOutput())
-
-				for _, pod := range ciliumPods {
-					Expect(ciliumHasServiceIP(kubectl, pod, clusterIP)).Should(BeTrue(),
-						"ClusterIP is not present in the cilium service list")
-				}
-				// Send requests from "app2" pod which runs on the same node as
-				// "app1" pods
-				testCurlFromPods(kubectl, app2PodLabel, httpSVCURL, 10, 0)
-				testCurlFromPods(kubectl, app2PodLabel, tftpSVCURL, 10, 0)
-			}
 		})
 
 		SkipContextIf(helpers.DoesNotRunWithKubeProxyReplacement, "Checks in-cluster KPR", func() {

--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -93,9 +93,7 @@ ${HOME}/go/bin/kubetest --provider=local --test \
 
 # We currently skip the following tests:
 # - NetworkPolicy between server and client using SCTP
-# - should not allow access by TCP when a policy specifies only SCTP
-# - should properly isolate pods that are selected by a policy allowing SCTP, even if the plugin doesn't supportSCTP [Feature:NetworkPolicy]
-#   - Cilium does not support SCTP yet
+#   - Service translation is not yet supported, and the tests rely on Services.
 #   - More info at https://github.com/cilium/cilium/issues/5719
 # - should allow egress access to server in CIDR block and
 # - should ensure an IP overlapping both IPBlock.CIDR and IPBlock.Except is allowed and
@@ -105,4 +103,4 @@ ${HOME}/go/bin/kubetest --provider=local --test \
 #   - More info at https://github.com/cilium/cilium/issues/9209
 echo "Running upstream NetworkPolicy tests"
 ${HOME}/go/bin/kubetest --provider=local --test \
-  --test_args="--ginkgo.focus=Net.*ol.* --e2e-verify-service-account=false --host ${KUBE_MASTER_URL} --ginkgo.skip=(should.not.allow.access.by.TCP.when.a.policy.specifies.only.SCTP)|(should.allow.egress.access.to.server.in.CIDR.block)|(should.enforce.except.clause.while.egress.access.to.server.in.CIDR.block)|(should.ensure.an.IP.overlapping.both.IPBlock.CIDR.and.IPBlock.Except.is.allowed)|(NetworkPolicy.between.server.and.client.using.SCTP)|(should.properly.isolate.pods.that.are.selected.by.a.policy.allowing.SCTP..even.if.the.plugin.doesn.t.support.SCTP..Feature.NetworkPolicy.)"
+  --test_args="--ginkgo.focus=Net.*ol.* --e2e-verify-service-account=false --host ${KUBE_MASTER_URL} --ginkgo.skip=(should.allow.egress.access.to.server.in.CIDR.block)|(should.enforce.except.clause.while.egress.access.to.server.in.CIDR.block)|(should.ensure.an.IP.overlapping.both.IPBlock.CIDR.and.IPBlock.Except.is.allowed)|(Feature:SCTPConnectivity)"


### PR DESCRIPTION
 * [x] #22848 (@christarazi)
 * [x] #24205 (@borkmann)
 * [x] #24174 (@aojea)
 * [x] #24171 (@romanspb80)
 * [x] #24255 (@tklauser)
 * [x] #24144 (@joestringer)
 * [x] #24140 (@jibi)
 * [x] #24164 (@jspaleta)
 * [x] #24271 (@borkmann)
 * [x] #24275 (@aanm)
 * [x] #24244 (@pchaigno)
 * [x] #24134 (@nebril)
 * [x] #24163 (@giorio94)
 * [x] #24304 (@dylandreimerink)
 * [x] #24223 (@brb)
 * [x] #24189 (@forgems)
 * [x] #24046 (@oblazek)
 * [x] #24373 (@christarazi)
 * [x] #24267 (@alexkats)
 * [x] #24407 (@PhilipSchmid)
 * [x] #24400 (@pchaigno)
 * [x] #24398 (@pchaigno)
 * [x] #23764 (@christarazi)
 * [x] #24413 (@hemanthmalla)
 * [x] #24460 (@NikAleksandrov)
 * [x] #24428 (@PhilipSchmid)
 * [x] #24477 (@gandro)
 * [x] #24435 (@lizrice)
 * [x] #23297 (@dylandreimerink)

PRs skipped due to conflicts:

 * #24296 (@brb)
 * #24350 (@chancez)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 22848 24205 24174 24171 24255 24144 24140 24164 24271 24275 24244 24134 24163 24304 24223 24189 24046 24373 24267 24407 24400 24398 23764 24413 24460 24428 24477 24435 23297; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=22848,24205,24174,24171,24255,24144,24140,24164,24271,24275,24244,24134,24163,24304,24223,24189,24046,24373,24267,24407,24400,24398,23764,24413,24460,24428,24477,24435,23297
```
