### PR TITLE
pkg: add missing xfrm-no-track rules from ipv6

### DIFF
--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1640,9 +1640,14 @@ func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
 	return nil
 }
 
-func (m *IptablesManager) addCiliumNoTrackXfrmRules() error {
+func (m *IptablesManager) addCiliumNoTrackXfrmRules() (err error) {
 	if option.Config.EnableIPv4 {
-		return m.ciliumNoTrackXfrmRules(ip4tables, "-I")
+		if err = m.ciliumNoTrackXfrmRules(ip4tables, "-I"); err != nil {
+			return
+		}
+	}
+	if option.Config.EnableIPv6 {
+		return m.ciliumNoTrackXfrmRules(ip6tables, "-I")
 	}
 	return nil
 }

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -155,7 +155,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 					// has been fixed, we need to disable IPv6 masq
 					"enableIPv6Masquerade": "false",
 				})
-				testExternalTrafficPolicyLocal(kubectl, ni, true)
+				testExternalTrafficPolicyLocal(kubectl, ni)
 				deploymentManager.DeleteAll()
 				deploymentManager.DeleteCilium()
 			})
@@ -164,12 +164,12 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 					"hostFirewall.enabled": "true",
 				})
-				testExternalTrafficPolicyLocal(kubectl, ni, false)
+				testExternalTrafficPolicyLocal(kubectl, ni)
 			})
 
 			It("with externalTrafficPolicy=Local", func() {
 				DeployCiliumAndDNS(kubectl, ciliumFilename)
-				testExternalTrafficPolicyLocal(kubectl, ni, false)
+				testExternalTrafficPolicyLocal(kubectl, ni)
 			})
 
 			It("", func() {


### PR DESCRIPTION
By right there should be a rule to let ipsec skb bypass conntrack:

-A CILIUM_PRE_raw -m mark --mark 0xd00/0xf00 -m comment --comment "cilium-xfrm-notrack:" -j CT --notrack

However ipv6 missed it and this commit adds the rule back.

Fixes: #23481


```release-note
Add missing xfrm-no-track rules for IPv6 IPSec. This fixes a connectivity issue for IPv6 IPSec with externalTrafficPolicy=local.
```
