### PR TITLE
Feature/job groups

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -114,6 +115,9 @@ var (
 		),
 		api.MetricsHandlerCell,
 		api.ServerCell,
+
+		// Provides a global job registry which cells can use to spawn job groups.
+		job.Cell,
 
 		// These cells are started only after the operator is elected leader.
 		WithLeaderLifecycle(

--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -29,8 +30,9 @@ type LBIPAMParams struct {
 
 	Logger logrus.FieldLogger
 
-	LC         hive.Lifecycle
-	Shutdowner hive.Shutdowner
+	LC          hive.Lifecycle
+	Shutdowner  hive.Shutdowner
+	JobRegistry job.Registry
 
 	Clientset    k8sClient.Clientset
 	PoolResource resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]

--- a/operator/pkg/lbipam/lbipam_fixture_test.go
+++ b/operator/pkg/lbipam/lbipam_fixture_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	cilium_fake "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
@@ -151,6 +152,8 @@ func mkTestFixture(pools []*cilium_api_v2alpha1.CiliumLoadBalancerIPPool, ipv4, 
 				lbIPAM.RegisterOnReady(initDone)
 			}
 		}),
+
+		job.Cell,
 
 		// Add the actual LB-IPAM cell under test.
 		Cell,

--- a/pkg/hive/job/job.go
+++ b/pkg/hive/job/job.go
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package job
+
+import (
+	"context"
+	"fmt"
+	"runtime/pprof"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/internal"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/stream"
+)
+
+// Cell provides job.Registry which constructs job.Group-s. Job groups automate a lot of the logic involved with
+// lifecycle management of goroutines within a Hive Cell. Providing a context that is canceled on shutdown and making
+// sure multiple goroutines properly shutdown takes a lot of boilerplate. Job groups make it easy to queue, spawn, and
+// collect jobs with minimal boilerplate. The registry maintains references to all groups which will allow us to add
+// automatic metrics collection and/or status reporting in the future.
+var Cell = cell.Provide(newRegistry)
+
+// A Registry creates Groups, it maintains references to these groups for the purposes of collecting information
+// centralized like metrics.
+type Registry interface {
+	NewGroup(opts ...groupOpt) Group
+}
+
+type registry struct {
+	logger     logrus.FieldLogger
+	shutdowner hive.Shutdowner
+
+	mu     lock.Mutex
+	groups []Group
+}
+
+func newRegistry(logger logrus.FieldLogger, shutdowner hive.Shutdowner) Registry {
+	return &registry{
+		logger:     logger,
+		shutdowner: shutdowner,
+	}
+}
+
+// NewGroup creates a new Group with the given `opts` options, which allows you to customize the behavior for the
+// group as a whole. For example by allowing you to add pprof labels to the group or by customizing the logger.
+func (c *registry) NewGroup(opts ...groupOpt) Group {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var options options
+	options.logger = c.logger
+	options.shutdowner = c.shutdowner
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	g := &group{
+		options: options,
+		wg:      &sync.WaitGroup{},
+	}
+
+	c.groups = append(c.groups, g)
+
+	return g
+}
+
+// Group aims to streamline the management of work within a cell. Group implements hive.HookInterface and takes care
+// of proper start and stop behavior as expected by hive. A group allows you to add multiple types of jobs which
+// different kinds of logic. No matter the job type, the function provided to is always called with a context which
+// is bound to the lifecycle of the cell.
+type Group interface {
+	Add(...Job)
+	hive.HookInterface
+}
+
+// Job in an interface that describes a unit of work which can be added to a Group. This interface contains unexported
+// methods and thus can only be implemented by functions in this package such as OneShot, Timer, or Observer.
+type Job interface {
+	start(ctx context.Context, wg *sync.WaitGroup, options options)
+}
+
+type group struct {
+	options options
+
+	wg *sync.WaitGroup
+
+	mu         lock.Mutex
+	ctx        context.Context
+	cancel     context.CancelFunc
+	queuedJobs []Job
+}
+
+type options struct {
+	pprofLabels pprof.LabelSet
+	logger      logrus.FieldLogger
+	shutdowner  hive.Shutdowner
+}
+
+type groupOpt func(o *options)
+
+// WithLogger replaces the default logger with the given logger, useful if you want to add certain fields to the logs
+// created by the group/jobs.
+func WithLogger(logger logrus.FieldLogger) groupOpt {
+	return func(o *options) {
+		o.logger = logger
+	}
+}
+
+// WithPprofLabels adds pprof labels which will be added to the goroutines spawned for the jobs and thus included in
+// the pprof profiles.
+func WithPprofLabels(pprofLabels pprof.LabelSet) groupOpt {
+	return func(o *options) {
+		o.pprofLabels = pprofLabels
+	}
+}
+
+var _ hive.HookInterface = (*group)(nil)
+
+// Start implements the hive.HookInterface interface
+func (jg *group) Start(_ hive.HookContext) error {
+	jg.mu.Lock()
+	defer jg.mu.Unlock()
+
+	jg.ctx, jg.cancel = context.WithCancel(context.Background())
+
+	jg.wg.Add(len(jg.queuedJobs))
+	for _, job := range jg.queuedJobs {
+		pprof.Do(jg.ctx, jg.options.pprofLabels, func(ctx context.Context) {
+			go job.start(ctx, jg.wg, jg.options)
+		})
+	}
+	// Nil the queue once we start so it can be GC'ed
+	jg.queuedJobs = nil
+
+	return nil
+}
+
+// Stop implements the hive.HookInterface interface
+func (jg *group) Stop(stopCtx hive.HookContext) error {
+	jg.mu.Lock()
+	defer jg.mu.Unlock()
+
+	done := make(chan struct{})
+	go func() {
+		jg.wg.Wait()
+		close(done)
+	}()
+
+	jg.cancel()
+
+	select {
+	case <-stopCtx.Done():
+		jg.options.logger.Error("Stop hook context expired before job group was done")
+	case <-done:
+	}
+
+	return nil
+}
+
+func (jg *group) Add(jobs ...Job) {
+	jg.mu.Lock()
+	defer jg.mu.Unlock()
+
+	for _, j := range jobs {
+		// The context is only set once the group has been started. If we have not yet started, queue the job.
+		if jg.ctx == nil {
+			jg.queuedJobs = append(jg.queuedJobs, j)
+			return
+		}
+
+		jg.wg.Add(1)
+		pprof.Do(jg.ctx, jg.options.pprofLabels, func(ctx context.Context) {
+			go j.start(ctx, jg.wg, jg.options)
+		})
+	}
+}
+
+// OneShot creates a "One shot" job which can be added to a Group. The function passed to a one shot job is invoked
+// once at startup. It can live for the entire lifetime of the group or exit early depending on its task.
+// If it returns an error, it can optionally be retried if the WithRetry option. If retries are not configured or
+// all retries failed as well, a shutdown of the hive can be triggered by specifying the WithShutdown option.
+//
+// The given function is expected to exit as soon as the context given to it expires, this is especially important for
+// blocking or long running jobs.
+func OneShot(name string, fn OneShotFunc, opts ...jobOneShotOpt) Job {
+	job := &jobOneShot{
+		name: name,
+		fn:   fn,
+		opts: opts,
+	}
+
+	return job
+}
+
+type jobOneShotOpt func(*jobOneShot)
+
+// WithRetry option configures a one shot job to retry `times` amount of times. Each retry attempt the `backoff`
+// ratelimiter is consulted to check how long the job should wait before making another attempt.
+func WithRetry(times int, backoff workqueue.RateLimiter) jobOneShotOpt {
+	return func(jos *jobOneShot) {
+		jos.retry = times
+		jos.backoff = backoff
+	}
+}
+
+// WithShutdown option configures a one shot job to shutdown the whole hive if the job returns an error. If the
+// WithRetry option is also configured, all retries must be exhausted before we trigger the shutdown.
+func WithShutdown() jobOneShotOpt {
+	return func(jos *jobOneShot) {
+		jos.shutdownOnError = true
+	}
+}
+
+// OneShotFunc is the function type which is invoked by a one shot job. The given function is expected to exit as soon
+// as the context given to it expires, this is especially important for blocking or long running jobs.
+type OneShotFunc func(ctx context.Context) error
+
+type jobOneShot struct {
+	name string
+	fn   OneShotFunc
+	opts []jobOneShotOpt
+
+	// If retry > 0, retry on error x times.
+	retry           int
+	backoff         workqueue.RateLimiter
+	shutdownOnError bool
+}
+
+func (jos *jobOneShot) start(ctx context.Context, wg *sync.WaitGroup, options options) {
+	defer wg.Done()
+
+	for _, opt := range jos.opts {
+		opt(jos)
+	}
+
+	l := options.logger.WithFields(logrus.Fields{
+		"name": jos.name,
+		"func": internal.FuncNameAndLocation(jos.fn),
+	})
+
+	if jos.fn == nil {
+		l.Error("can't start a nil one shot job")
+		return
+	}
+
+	var err error
+	for i := 0; i <= jos.retry; i++ {
+		if i != 0 {
+			timeout := jos.backoff.When(jos)
+			l.WithFields(logrus.Fields{
+				"backoff":     timeout,
+				"retry-count": i,
+			}).Debug("Delaying retry attempt")
+			time.Sleep(timeout)
+		}
+
+		l.Debug("Starting one-shot job")
+
+		err = jos.fn(ctx)
+
+		if err == nil {
+			l.Debug("one-shot job finished")
+			return
+		} else {
+			l.WithError(err).Error("one-shot job errored")
+		}
+	}
+
+	if options.shutdowner != nil && jos.shutdownOnError {
+		options.shutdowner.Shutdown(hive.ShutdownWithError(err))
+	}
+
+	return
+}
+
+// Timer creates a timer job which can be added to a Group. Timer jobs invoke the given function at the specified
+// interval. Timer jobs are particularly useful to implement periodic syncs and cleanup actions.
+// Timer jobs can optionally be triggered by an external Trigger with the WithTrigger option.
+// This trigger can for example be passed between cells or between jobs in the same cell to allow for an additional
+// invocation of the function.
+//
+// The interval between invocations is counted from the start of the last invocation. If the `fn` takes longer than the
+// interval, its next invocation is not delayed. The `fn` is expected to stop as soon as the context passed to it
+// expires. This is especially important for long running functions. The signal created by a Trigger is coalesced so
+// multiple calls to trigger before the invocation takes place can result in just a single invocation.
+func Timer(name string, fn TimerFunc, interval time.Duration, opts ...timerOpt) Job {
+	job := &jobTimer{
+		name:     name,
+		fn:       fn,
+		interval: interval,
+		opts:     opts,
+	}
+
+	return job
+}
+
+// TimerFunc is the func type invoked by a timer job. A TimerFunc is expected to return as soon as the ctx expires.
+type TimerFunc func(ctx context.Context) error
+
+type timerOpt func(*jobTimer)
+
+// Trigger which can be used to trigger a timer job, trigger events are coalesced.
+type Trigger interface {
+	_trigger()
+	Trigger()
+}
+
+// NewTrigger creates a new trigger, which can be used to trigger a timer job.
+func NewTrigger() *trigger {
+	return &trigger{
+		c: make(chan struct{}, 1),
+	}
+}
+
+type trigger struct {
+	c chan struct{}
+}
+
+func (t *trigger) _trigger() {}
+
+func (t *trigger) Trigger() {
+	select {
+	case t.c <- struct{}{}:
+	default:
+	}
+}
+
+// WithTrigger option allows a user to specify a trigger, which if triggered will invoke the function of a timer
+// before the configured interval has expired.
+func WithTrigger(trig Trigger) timerOpt {
+	return func(jt *jobTimer) {
+		jt.trigger = trig.(*trigger)
+	}
+}
+
+type jobTimer struct {
+	name string
+	fn   TimerFunc
+	opts []timerOpt
+
+	interval time.Duration
+	trigger  *trigger
+
+	// If not nil, call the shutdowner on error
+	shutdown hive.Shutdowner
+}
+
+func (jt *jobTimer) start(ctx context.Context, wg *sync.WaitGroup, options options) {
+	defer wg.Done()
+
+	for _, opt := range jt.opts {
+		opt(jt)
+	}
+
+	l := options.logger.WithFields(logrus.Fields{
+		"name": jt.name,
+		"func": internal.FuncNameAndLocation(jt.fn),
+	})
+
+	if jt.fn == nil {
+		l.Error(fmt.Errorf("can't start a nil one timer job"))
+		return
+	}
+
+	timer := time.NewTicker(jt.interval)
+	defer timer.Stop()
+
+	var triggerChan chan struct{}
+	if jt.trigger != nil {
+		triggerChan = jt.trigger.c
+	}
+
+	l.Debug("Starting timer job")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		case <-triggerChan:
+		}
+
+		l.Debug("Timer job triggered")
+
+		err := jt.fn(ctx)
+
+		if err == nil {
+			l.Debug("Timer job finished")
+		} else {
+			l.WithError(err).Error("Timer job errored")
+			if jt.shutdown != nil {
+				jt.shutdown.Shutdown(hive.ShutdownWithError(err))
+			}
+		}
+	}
+}
+
+// AddObserver adds an observer job to the group. Observer jobs invoke the given `fn` for each item observed on
+// `observable`. If the `observable` completes, the job stops. The context given to the observable is also canceled
+// once the group stops.
+func Observer[T any](name string, fn ObserverFunc[T], observable stream.Observable[T], opts ...observerOpt[T]) Job {
+	job := &jobObserver[T]{
+		name:       name,
+		fn:         fn,
+		observable: observable,
+		opts:       opts,
+	}
+
+	return job
+}
+
+// ObserverFunc is the func type invoked by observer jobs.
+// A ObserverFunc is expected to return as soon as ctx is canceled.
+type ObserverFunc[T any] func(ctx context.Context, event T) error
+
+type observerOpt[T any] func(*jobObserver[T])
+
+type jobObserver[T any] struct {
+	name string
+	fn   ObserverFunc[T]
+	opts []observerOpt[T]
+
+	observable stream.Observable[T]
+
+	// If not nil, call the shutdowner on error
+	shutdown hive.Shutdowner
+}
+
+func (jo *jobObserver[T]) start(ctx context.Context, wg *sync.WaitGroup, options options) {
+	defer wg.Done()
+
+	for _, opt := range jo.opts {
+		opt(jo)
+	}
+
+	l := options.logger.WithFields(logrus.Fields{
+		"name": jo.name,
+		"func": internal.FuncNameAndLocation(jo.fn),
+	})
+
+	if jo.fn == nil {
+		l.Error("can't start a nil observer job")
+		return
+	}
+
+	l.Debug("Observer job started")
+
+	done := make(chan struct{})
+
+	var err error
+	jo.observable.Observe(ctx, func(t T) {
+		err := jo.fn(ctx, t)
+		if err != nil {
+			l.WithError(err).Error("Observer job errored")
+			if jo.shutdown != nil {
+				jo.shutdown.Shutdown(hive.ShutdownWithError(
+					err,
+				))
+			}
+		}
+	}, func(e error) {
+		err = e
+		close(done)
+	})
+
+	<-done
+
+	if err != nil {
+		l.WithError(err).Error("Observer job stopped with an error")
+	} else {
+		l.WithError(err).Debug("Observer job stopped")
+	}
+
+	return
+}

--- a/pkg/hive/job/job_test.go
+++ b/pkg/hive/job/job_test.go
@@ -1,0 +1,774 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package job
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/stream"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+	"k8s.io/client-go/util/workqueue"
+)
+
+func TestMain(m *testing.M) {
+	cleanup := func(exitCode int) {
+		// Force garbage-collection to force finalizers to run and catch
+		// missing Event.Done() calls.
+		runtime.GC()
+	}
+	goleak.VerifyTestMain(m, goleak.Cleanup(cleanup))
+}
+
+func fixture(fn func(Registry, hive.Lifecycle)) *hive.Hive {
+	logging.SetLogLevel(logrus.DebugLevel)
+	return hive.New(
+		Cell,
+		cell.Invoke(fn),
+	)
+}
+
+// This test asserts that a OneShot jobs is started and completes. This test will timeout on failure
+func TestOneShot_ShortRun(t *testing.T) {
+	stop := make(chan struct{})
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			OneShot("short", func(ctx context.Context) error {
+				defer close(stop)
+				return nil
+			}),
+		)
+
+		l.Append(g)
+	})
+
+	if assert.NoError(t, h.Start(context.Background())) {
+		<-stop
+		assert.NoError(t, h.Stop(context.Background()))
+	}
+}
+
+// This test asserts that the context given to a one shot job cancels when the lifecycle of the group ends.
+func TestOneShot_LongRun(t *testing.T) {
+	started := make(chan struct{})
+	stopped := make(chan struct{})
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			OneShot("long", func(ctx context.Context) error {
+				close(started)
+				<-ctx.Done()
+				defer close(stopped)
+				return nil
+			}),
+		)
+
+		l.Append(g)
+	})
+
+	if assert.NoError(t, h.Start(context.Background())) {
+		<-started
+		assert.NoError(t, h.Stop(context.Background()))
+		<-stopped
+	}
+}
+
+// This test asserts that we will stop retrying after the retry limit
+func TestOneShot_RetryFail(t *testing.T) {
+	var (
+		g Group
+		i int
+	)
+
+	const retries = 3
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g = r.NewGroup()
+
+		g.Add(
+			OneShot("retry-fail", func(ctx context.Context) error {
+				defer func() { i++ }()
+				return errors.New("Always error")
+			}, WithRetry(retries, workqueue.DefaultControllerRateLimiter())),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Continue as soon as all jobs stopped
+	g.(*group).wg.Wait()
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1 for the initial run, and 3 retries
+	if i != retries+1 {
+		t.Fatalf("Retries = %d, Ran = %d", retries, i)
+	}
+}
+
+// Run the actual test multiple times, as long as 1 out of 5 is good, we accept it, only fail if we are consistently
+// broken. This is due to the time based nature of the test which is unreliable in certain CI environments.
+func TestOneShot_RetryBackoff(t *testing.T) {
+	ok := 0
+	for i := 0; i < 5; i++ {
+		failed, err := testOneShot_RetryBackoff()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !failed {
+			ok++
+		}
+	}
+
+	if ok == 0 {
+		t.Fatal("0/5 retry backoff tests succeeded")
+	}
+}
+
+// This test asserts that the one shot jobs have a delay equal to the expected behavior of the passed in ratelimiter.
+func testOneShot_RetryBackoff() (bool, error) {
+	var (
+		g     Group
+		i     int
+		times []time.Time
+	)
+
+	failed := false
+
+	const retries = 6
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g = r.NewGroup()
+
+		g.Add(
+			OneShot("retry-backoff", func(ctx context.Context) error {
+				defer func() { i++ }()
+				times = append(times, time.Now())
+				return errors.New("Always error")
+			}, WithRetry(retries, workqueue.NewItemExponentialFailureRateLimiter(50*time.Millisecond, 10*time.Second))),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		return true, err
+	}
+
+	// Continue as soon as all jobs stopped
+	g.(*group).wg.Wait()
+
+	if err := h.Stop(context.Background()); err != nil {
+		return true, err
+	}
+
+	var last time.Duration
+	for i := 1; i < len(times); i++ {
+		diff := times[i].Sub(times[i-1])
+		if i > 2 {
+			// Test that the rate of change is 2 +- 50%, the 50% to account for CI time dilation.
+			// The 10 factor is to add avoid integer rounding.
+			fract := uint64(diff * 10 / last * 10)
+			if fract < 150 || fract > 250 {
+				failed = true
+			}
+		}
+		last = diff
+	}
+
+	return failed, nil
+}
+
+// This test asserts that we do not keep retrying after the job function has recovered
+func TestOneShot_RetryRecover(t *testing.T) {
+	var (
+		g Group
+		i int
+	)
+
+	const retries = 3
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g = r.NewGroup()
+
+		g.Add(
+			OneShot("retry-recover", func(ctx context.Context) error {
+				defer func() { i++ }()
+				if i == 0 {
+					return errors.New("Sometimes error")
+				}
+
+				return nil
+			}, WithRetry(retries, workqueue.DefaultControllerRateLimiter())),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Continue as soon as all jobs stopped
+	g.(*group).wg.Wait()
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if i != 2 {
+		t.Fatal("One shot was invoked after the recovery")
+	}
+}
+
+// This tests asserts that returning an error on a one shot job with the WithShutdown option will shutdown the hive.
+func TestOneShot_Shutdown(t *testing.T) {
+	targetErr := errors.New("Always error")
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			OneShot("shutdown", func(ctx context.Context) error {
+				return targetErr
+			}, WithShutdown()),
+		)
+
+		l.Append(g)
+	})
+
+	err := h.Run()
+	if !errors.Is(err, targetErr) {
+		t.Fail()
+	}
+}
+
+// This test asserts that when the retry and shutdown options are used, the hive is only shutdown after all retries
+// failed
+func TestOneShot_RetryFailShutdown(t *testing.T) {
+	var i int
+
+	const retries = 3
+
+	targetErr := errors.New("Always error")
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			OneShot("retry-fail-shutdown", func(ctx context.Context) error {
+				defer func() { i++ }()
+				return targetErr
+			}, WithRetry(retries, workqueue.DefaultControllerRateLimiter()), WithShutdown()),
+		)
+
+		l.Append(g)
+	})
+
+	err := h.Run()
+	if !errors.Is(err, targetErr) {
+		t.Fail()
+	}
+
+	if i != retries+1 {
+		t.Fail()
+	}
+}
+
+// This test asserts that when both the WithRetry and WithShutdown options are used, and the one shot function recovers
+// that the hive does not shutdown.
+func TestOneShot_RetryRecoverNoShutdown(t *testing.T) {
+	var (
+		g Group
+		i int
+	)
+
+	started := make(chan struct{})
+
+	const retries = 5
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g = r.NewGroup()
+
+		g.Add(
+			OneShot("retry-recover-no-shutdown", func(ctx context.Context) error {
+				defer func() { i++ }()
+				if started != nil {
+					close(started)
+					started = nil
+				}
+
+				if i == 0 {
+					return errors.New("First try error")
+				}
+
+				return nil
+			}, WithRetry(retries, workqueue.DefaultControllerRateLimiter()), WithShutdown()),
+		)
+
+		l.Append(g)
+	})
+
+	shutdown := make(chan struct{})
+
+	// Manually trigger a shutdown after the group has no more running jobs, will exit the hive with a nil
+	go func() {
+		<-started
+		g.(*group).wg.Wait()
+		h.Shutdown()
+		close(shutdown)
+	}()
+
+	err := h.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if i != 2 {
+		t.Fail()
+	}
+
+	<-shutdown
+}
+
+// This test asserts that the timer invokes the function a the given interval.
+func TestTimer_OnInterval(t *testing.T) {
+	stop := make(chan struct{})
+
+	var (
+		times []time.Time
+		i     int
+	)
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			Timer("on-interval", func(ctx context.Context) error {
+				defer func() { i++ }()
+				if i == 5 {
+					defer close(stop)
+				}
+				times = append(times, time.Now())
+				return nil
+			}, 100*time.Millisecond),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	<-stop
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the difference is 100 ms +- 50% to account for CI time distortion
+	for i := 1; i < len(times); i++ {
+		diff := times[i].Sub(times[i-1])
+		if diff < 50*time.Millisecond || diff > 150*time.Millisecond {
+			t.Fatal()
+		}
+	}
+}
+
+// This test asserts that, when the timer func is lower than the interval, the timer will not sleep in between calls.
+func TestTimer_ExceedInterval(t *testing.T) {
+	stop := make(chan struct{})
+
+	var (
+		times []time.Time
+		i     int
+	)
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			Timer("on-interval", func(ctx context.Context) error {
+				defer func() { i++ }()
+				if i == 5 {
+					defer close(stop)
+				}
+
+				times = append(times, time.Now())
+
+				time.Sleep(100 * time.Millisecond)
+
+				return nil
+			}, 50*time.Millisecond),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	<-stop
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the difference is 100 ms +- 50% to account for CI time distortion
+	for i := 1; i < len(times); i++ {
+		diff := times[i].Sub(times[i-1])
+		if diff < 50*time.Millisecond || diff > 150*time.Millisecond {
+			t.Fatal()
+		}
+	}
+}
+
+// This test asserts that a timer will run when triggered, even when its interval has not yet expired
+func TestTimer_Trigger(t *testing.T) {
+	ran := make(chan struct{})
+
+	var i int
+
+	trigger := NewTrigger()
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			Timer("on-interval", func(ctx context.Context) error {
+				defer func() { ran <- struct{}{} }()
+
+				i++
+
+				return nil
+			}, 1*time.Hour, WithTrigger(trigger)),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	trigger.Trigger()
+	<-ran
+
+	trigger.Trigger()
+	<-ran
+
+	trigger.Trigger()
+	<-ran
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if i != 3 {
+		t.Fail()
+	}
+}
+
+// This test asserts that, if a trigger is called multiple times before a job is finished, that the events will coalesce
+func TestTimer_DoubleTrigger(t *testing.T) {
+	ran := make(chan struct{})
+
+	var i int
+
+	trigger := NewTrigger()
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			Timer("on-interval", func(ctx context.Context) error {
+				defer func() { close(ran) }()
+
+				i++
+
+				time.Sleep(100 * time.Millisecond)
+
+				return nil
+			}, 1*time.Hour, WithTrigger(trigger)),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	trigger.Trigger()
+	trigger.Trigger()
+	trigger.Trigger()
+	<-ran
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if i != 1 {
+		t.Fail()
+	}
+}
+
+// This test asserts that the timer will stop as soon as the lifecycle has stopped, when waiting for an interval pulse
+func TestTimer_ExitOnClose(t *testing.T) {
+	var i int
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			Timer("on-interval", func(ctx context.Context) error {
+				i++
+				return nil
+			}, 1*time.Hour),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if i != 0 {
+		t.Fail()
+	}
+}
+
+// This test asserts that the context given to the timer closes when the lifecycle ends, and that the timer stops
+// after the fn return.
+func TestTimer_ExitOnCloseFnCtx(t *testing.T) {
+	var i int
+	started := make(chan struct{})
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			Timer("on-interval", func(ctx context.Context) error {
+				i++
+				close(started)
+				<-ctx.Done()
+				return nil
+			}, 1*time.Millisecond),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	<-started
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if i != 1 {
+		t.Fail()
+	}
+}
+
+// This test asserts that an observer job will stop after a stream has been completed.
+func TestObserver_ShortStream(t *testing.T) {
+	var (
+		g Group
+		i int
+	)
+
+	streamSlice := []string{"a", "b", "c"}
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g = r.NewGroup()
+
+		g.Add(
+			Observer("retry-fail", func(ctx context.Context, event string) error {
+				i++
+				return nil
+			}, stream.FromSlice(streamSlice)),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Continue as soon as all jobs stopped
+	g.(*group).wg.Wait()
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if i != len(streamSlice) {
+		t.Fatal()
+	}
+}
+
+// This test asserts that the observer will stop without errors when the lifecycle ends, even if the stream has not
+// gone away.
+func TestObserver_LongStream(t *testing.T) {
+	var (
+		g Group
+		i int
+	)
+
+	inChan := make(chan struct{})
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g = r.NewGroup()
+
+		g.Add(
+			Observer("retry-fail", func(ctx context.Context, _ struct{}) error {
+				i++
+				return nil
+			}, stream.FromChannel(inChan)),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if i != 0 {
+		t.Fatal()
+	}
+}
+
+// This test asserts that the context given to the observer fn is closed when the lifecycle ends and the observer
+// stops even if there are still pending items in the stream.
+func TestObserver_CtxClose(t *testing.T) {
+	started := make(chan struct{})
+	streamSlice := []string{"a", "b", "c"}
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+
+		g.Add(
+			Observer("retry-fail", func(ctx context.Context, event string) error {
+				if started != nil {
+					close(started)
+					started = nil
+				}
+				<-ctx.Done()
+				return nil
+			}, stream.FromSlice(streamSlice)),
+		)
+
+		l.Append(g)
+	})
+
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	<-started
+
+	if err := h.Stop(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// This test asserts that the test registry hold on to references to its groups
+func TestRegistry(t *testing.T) {
+	var (
+		r1 Registry
+		g1 Group
+		g2 Group
+	)
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		r1 = r
+		g1 = r.NewGroup()
+		g2 = r.NewGroup()
+	})
+	h.Populate()
+
+	if r1.(*registry).groups[0] != g1 {
+		t.Fail()
+	}
+	if r1.(*registry).groups[1] != g2 {
+		t.Fail()
+	}
+}
+
+// This test asserts that jobs are queued, until the hive has been started
+func TestGroup_JobQueue(t *testing.T) {
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g := r.NewGroup()
+		g.Add(OneShot("queued", func(ctx context.Context) error {
+			return nil
+		}))
+		if len(g.(*group).queuedJobs) != 1 {
+			t.Fatal()
+		}
+		l.Append(g)
+	})
+
+	h.Populate()
+}
+
+// This test asserts that jobs can be added at runtime.
+func TestGroup_JobRuntime(t *testing.T) {
+	var (
+		g Group
+		i int
+	)
+
+	h := fixture(func(r Registry, l hive.Lifecycle) {
+		g = r.NewGroup()
+		l.Append(g)
+	})
+
+	h.Start(context.Background())
+
+	done := make(chan struct{})
+	g.Add(OneShot("runtime", func(ctx context.Context) error {
+		i++
+		close(done)
+		return nil
+	}))
+
+	h.Stop(context.Background())
+
+	if i != 1 {
+		t.Fatal()
+	}
+}


### PR DESCRIPTION
This PR introduces a new job group system. Up to this point we did not have a "good" way to manage jobs/work/routines in hive cells. While the lifecycle Start and Stop hook methods are really great for guaranteeing ordered startup and shutdown, they are not great on the usage side. Most code expect to have a context and just stop when it cancels, which is reasonable. However converting between the two paradigms takes a lot of boilerplate code: a waitgroup, context and cancel function. 

Until now we have been using `cilium/workerpool` to reduce the manual work, however, workerpool requires you to specify the amount of goroutines upfront, and submitting more work than workers will queue work. It is simply not designed for what we are doing with it. This job system is designed to replace both of these older methods.

In the pre-hive code it is common to see the pkg/controller used. It did what lifecycles do for us now but with some extra features such as retries, periodic invocation and triggers. It also monitors the controllers and makes that info available as metrics. In anticipation of replacing the current controller system with this new job group system, I have added a few features which are present in pkg/controllers so future migration of code that uses controllers is easier.

```release-note
Added a new job group system to manage the lifecycle of jobs within cells
```
