### PR TITLE
Services API: do not change backend state when weight is changed in upsertService

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1664,9 +1664,6 @@ func (s *Service) updateBackendsCacheLocked(svc *svcInfo, backends []*lb.Backend
 			case backends[i].Weight != b.Weight:
 				// Update the cached weight as weight has changed
 				b.Weight = backends[i].Weight
-				// Update but do not persist the state as backend might be set as active
-				// only temporarily for specific service
-				b.State = backends[i].State
 			default:
 				// Set the backend state to the saved state.
 				backends[i].State = b.State

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -1472,7 +1472,6 @@ func (m *ManagerTestSuite) TestUpsertServiceWithZeroWeightBackends(c *C) {
 	c.Assert(created, Equals, false)
 	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, 3)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 3)
-	c.Assert(m.svc.backendByHash[hash].State, Equals, lb.BackendStateMaintenance)
 	c.Assert(m.lbmap.DummyMaglevTable[uint16(id1)], Equals, 1)
 
 	// Delete backends with weight 0


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [ ] Thanks for contributing!

The API currently allows update/change of the backend state of a service through upsertService, but ONLY when a weight is changed. Otherwise the change is ignored ([code](https://github.com/cilium/cilium/blob/fa485ad5e404e452e421e7cf84406de4cae75ec0/pkg/service/service.go#L1666)).

This is prety counterintuitive as the API usage goes.

~Also, in case a user does update his service, changing both a backend's state and weight, at this point, if a [UpdateBackendsState](https://github.com/cilium/cilium/blob/master/pkg/service/service.go#L778) would be called, updating the same backend to a state it originally was ( the state that would still be in [here](https://github.com/cilium/cilium/blob/acbfb5dab49d0261811d8dda7abc16d09f50d786/pkg/service/service.go#L242)), this [condition](https://github.com/cilium/cilium/blob/acbfb5dab49d0261811d8dda7abc16d09f50d786/pkg/service/service.go#L808) would make the backend be skipped in the update of all services selecting the backend, therefore leaving it's state as is, which I believe would not be expected.~

Fixes: #issue-number

```release-note
Backend state changes for a single service are no longer permitted ( use the updateServices API flag or CLI equivalent)
```
