### PR TITLE
helm: fix poststart-eni.bash execution in agent DS

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -212,7 +212,7 @@ spec:
               - "bash"
               - "-c"
               - |
-                {{- tpl (.Files.Get "files/agent/poststart-eni.bash") . | nindent 20 }}
+                {{- tpl (.Files.Get "files/agent/poststart-eni.bash") . | nindent 16 }}
           {{- end }}
           preStop:
             exec:


### PR DESCRIPTION
This change fixes malformed `bash -c` call in postStart agent hook, which caused the script to not be executed.

This fixes a bug introduced in https://github.com/cilium/cilium/pull/24134