### PR TITLE
Enable update-ec2-adapter-limit-via-api by default

### DIFF
--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -95,7 +95,7 @@ cilium-operator-aws [flags]
       --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-adapter-limit-via-api                     Use the EC2 API to update the instance type to adapter limits
+      --update-ec2-adapter-limit-via-api                     Use the EC2 API to update the instance type to adapter limits (default true)
       --version                                              Print version information
 ```
 

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -100,7 +100,7 @@ cilium-operator [flags]
       --synchronize-k8s-nodes                                Synchronize Kubernetes nodes to kvstore and perform CNP GC (default true)
       --synchronize-k8s-services                             Synchronize Kubernetes services to kvstore (default true)
       --unmanaged-pod-watcher-interval int                   Interval to check for unmanaged kube-dns pods (0 to disable) (default 15)
-      --update-ec2-adapter-limit-via-api                     Use the EC2 API to update the instance type to adapter limits
+      --update-ec2-adapter-limit-via-api                     Use the EC2 API to update the instance type to adapter limits (default true)
       --version                                              Print version information
 ```
 

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -735,7 +735,7 @@
    * - eni.updateEC2AdapterLimitViaAPI
      - Update ENI Adapter limits from the EC2 API
      - bool
-     - ``false``
+     - ``true``
    * - etcd.clusterDomain
      - Cluster domain for cilium-etcd-operator.
      - string

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -314,6 +314,16 @@ Annotations:
   DNS server is expired.
 * Cilium now writes its CNI configuration file to ``05-cilium.conflist`` in
   all cases, rather than the previous default of ``05-cilium.conf``.
+* The default value of ``--update-ec2-adapter-limit-via-api`` has changed from
+  ``false`` to ``true``. This means that the Cilium Operator will fetch the
+  most up-to-date EC2 adapter limits from the AWS API. This now requires
+  updated IAM permissions for Cilium to have ``ec2:DescribeInstances``. In EKS,
+  nodes usually have ``AmazonEKSWorkerNodePolicy`` which includes this
+  permission, so it should work in most cases. If your nodes don't have this
+  policy, then consider adding it to your IAM permissions. Explicitly configure
+  ``--update-ec2-adapter-limit-via-api`` to ``false`` if you want to avoid this
+  additional IAM permission. Beware that if your EC2 instance type that Cilium
+  is running on is not known to Cilium, it may cause a crash.
 
 Removed Options
 ~~~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -233,7 +233,7 @@ contributors across the globe, there is almost always someone available to help.
 | eni.instanceTagsFilter | list | `[]` | Filter via AWS EC2 Instance tags (k=v) which will dictate which AWS EC2 Instances are going to be used to create new ENIs |
 | eni.subnetIDsFilter | list | `[]` | Filter via subnet IDs which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead. |
 | eni.subnetTagsFilter | list | `[]` | Filter via tags (k=v) which will dictate which subnets are going to be used to create new ENIs Important note: This requires that each instance has an ENI with a matching subnet attached when Cilium is deployed. If you only want to control subnets for ENIs attached by Cilium, use the CNI configuration file settings (cni.customConf) instead. |
-| eni.updateEC2AdapterLimitViaAPI | bool | `false` | Update ENI Adapter limits from the EC2 API |
+| eni.updateEC2AdapterLimitViaAPI | bool | `true` | Update ENI Adapter limits from the EC2 API |
 | etcd.clusterDomain | string | `"cluster.local"` | Cluster domain for cilium-etcd-operator. |
 | etcd.enabled | bool | `false` | Enable etcd mode for the agent. |
 | etcd.endpoints | list | `["https://CHANGE-ME:2379"]` | List of etcd endpoints (not needed when using managed=true). |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -760,7 +760,7 @@ eni:
   # -- Enable Elastic Network Interface (ENI) integration.
   enabled: false
   # -- Update ENI Adapter limits from the EC2 API
-  updateEC2AdapterLimitViaAPI: false
+  updateEC2AdapterLimitViaAPI: true
   # -- Release IPs not used from the ENI
   awsReleaseExcessIPs: false
   # -- Enable ENI prefix delegation

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -757,7 +757,7 @@ eni:
   # -- Enable Elastic Network Interface (ENI) integration.
   enabled: false
   # -- Update ENI Adapter limits from the EC2 API
-  updateEC2AdapterLimitViaAPI: false
+  updateEC2AdapterLimitViaAPI: true
   # -- Release IPs not used from the ENI
   awsReleaseExcessIPs: false
   # -- Enable ENI prefix delegation

--- a/operator/cmd/provider_aws_flags.go
+++ b/operator/cmd/provider_aws_flags.go
@@ -45,7 +45,7 @@ func init() {
 		"Interval for garbage collection of unattached ENIs. Set to 0 to disable")
 	option.BindEnv(Vp, operatorOption.ENIGarbageCollectionInterval)
 
-	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, false, "Use the EC2 API to update the instance type to adapter limits")
+	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, true, "Use the EC2 API to update the instance type to adapter limits")
 	option.BindEnv(Vp, operatorOption.UpdateEC2AdapterLimitViaAPI)
 
 	flags.Bool(operatorOption.AWSUsePrimaryAddress, false, "Allows for using primary address of the ENI for allocations on the node")


### PR DESCRIPTION
This prevents reports of crashes of the Operator because the instance
type limits are not up-to-date.

Related: https://github.com/cilium/cilium/issues/18197

Signed-off-by: Chris Tarazi <chris@isovalent.com>
