### PR TITLE
bugtool: simplify `removeIfEmpty` with more efficient `os.ReadDir`

### DIFF
--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -140,14 +140,7 @@ func getVerifyCiliumPods() (k8sPods []string) {
 }
 
 func removeIfEmpty(dir string) {
-	d, err := os.Open(dir)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to open directory %s\n", err)
-		return
-	}
-	defer d.Close()
-
-	files, err := d.Readdir(-1)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to read directory %s\n", err)
 		return

--- a/bugtool/cmd/root_test.go
+++ b/bugtool/cmd/root_test.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_removeIfEmpty(t *testing.T) {
+	t.Run("directory is empty", func(t *testing.T) {
+		tempdir := t.TempDir()
+
+		removeIfEmpty(tempdir)
+
+		if _, err := os.Stat(tempdir); !os.IsNotExist(err) {
+			t.Fatalf("%s should be removed", tempdir)
+		}
+	})
+
+	t.Run("directory is not empty", func(t *testing.T) {
+		tempdir := t.TempDir()
+
+		if _, err := os.MkdirTemp(tempdir, ""); err != nil {
+			t.Fatal(err)
+		}
+
+		removeIfEmpty(tempdir)
+
+		if _, err := os.Stat(tempdir); os.IsNotExist(err) {
+			t.Fatalf("%s should not be removed", tempdir)
+		}
+	})
+}


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
We can simplify the following code

```go
dir, err := os.Open(dirname)
if err != nil {
	return err
}
defer dir.Close()

dirs, err := dir.Readdir(-1)
```

with just `os.ReadDir(dirname)`. `os.ReadDir` is recommended over `Readdir()`, as stated in the official doc [^1]


```release-note
bugtool: simplify `removeIfEmpty` with more effiicient `os.ReadDir`
```

[^1]: https://pkg.go.dev/os#File.Readdir
