### PR TITLE
test: Update 1.26 k8s version

### DIFF
--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -542,7 +542,7 @@ case $K8S_VERSION in
         sudo apt-get install -y conntrack
         KUBERNETES_CNI_VERSION="1.1.1"
         KUBERNETES_CNI_OS="-linux"
-        K8S_FULL_VERSION="1.26.0-rc.0"
+        K8S_FULL_VERSION="1.26.3"
         KUBEADM_OPTIONS="--ignore-preflight-errors=cri,swap"
         KUBEADM_WORKER_OPTIONS="--config=/tmp/config.yaml"
         sudo ln -sf $COREDNS_DEPLOYMENT $DNS_DEPLOYMENT


### PR DESCRIPTION
It's better to run official release in our tests, either v1.26.0 or the latest release of v1.26.x.

Relates: 70252f41
