### PR TITLE
Expose bpf-lb-sock-hostns-only in cilium status

### DIFF
--- a/api/v1/models/kube_proxy_replacement.go
+++ b/api/v1/models/kube_proxy_replacement.go
@@ -283,6 +283,9 @@ func (m *KubeProxyReplacementDeviceListItems0) UnmarshalBinary(b []byte) error {
 // swagger:model KubeProxyReplacementFeatures
 type KubeProxyReplacementFeatures struct {
 
+	// flag bpf-lb-sock-hostns-only
+	BpfSocketLBHostnsOnly bool `json:"bpfSocketLBHostnsOnly,omitempty"`
+
 	// external i ps
 	ExternalIPs *KubeProxyReplacementFeaturesExternalIPs `json:"externalIPs,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2173,6 +2173,9 @@ definitions:
             properties:
               enabled:
                 type: boolean
+          bpfSocketLBHostnsOnly:
+            description: flag bpf-lb-sock-hostns-only
+            type: boolean
   AllocationMap:
     description: |
       Map of allocated IPs

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3087,6 +3087,10 @@ func init() {
           "description": "\n\n+k8s:deepcopy-gen=true",
           "type": "object",
           "properties": {
+            "bpfSocketLBHostnsOnly": {
+              "description": "flag bpf-lb-sock-hostns-only",
+              "type": "boolean"
+            },
             "externalIPs": {
               "description": "\n\n+k8s:deepcopy-gen=true",
               "type": "object",
@@ -7936,6 +7940,10 @@ func init() {
           "description": "\n\n+k8s:deepcopy-gen=true",
           "type": "object",
           "properties": {
+            "bpfSocketLBHostnsOnly": {
+              "description": "flag bpf-lb-sock-hostns-only",
+              "type": "boolean"
+            },
             "externalIPs": {
               "description": "\n\n+k8s:deepcopy-gen=true",
               "type": "object",
@@ -8112,6 +8120,10 @@ func init() {
       "description": "\n\n+k8s:deepcopy-gen=true",
       "type": "object",
       "properties": {
+        "bpfSocketLBHostnsOnly": {
+          "description": "flag bpf-lb-sock-hostns-only",
+          "type": "boolean"
+        },
         "externalIPs": {
           "description": "\n\n+k8s:deepcopy-gen=true",
           "type": "object",

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -241,14 +241,15 @@ func (d *Daemon) getKubeProxyReplacementStatus() *models.KubeProxyReplacement {
 	}
 
 	features := &models.KubeProxyReplacementFeatures{
-		NodePort:            &models.KubeProxyReplacementFeaturesNodePort{},
-		HostPort:            &models.KubeProxyReplacementFeaturesHostPort{},
-		ExternalIPs:         &models.KubeProxyReplacementFeaturesExternalIPs{},
-		SocketLB:            &models.KubeProxyReplacementFeaturesSocketLB{},
-		SocketLBTracing:     &models.KubeProxyReplacementFeaturesSocketLBTracing{},
-		SessionAffinity:     &models.KubeProxyReplacementFeaturesSessionAffinity{},
-		GracefulTermination: &models.KubeProxyReplacementFeaturesGracefulTermination{},
-		Nat46X64:            &models.KubeProxyReplacementFeaturesNat46X64{},
+		NodePort:              &models.KubeProxyReplacementFeaturesNodePort{},
+		HostPort:              &models.KubeProxyReplacementFeaturesHostPort{},
+		ExternalIPs:           &models.KubeProxyReplacementFeaturesExternalIPs{},
+		SocketLB:              &models.KubeProxyReplacementFeaturesSocketLB{},
+		SocketLBTracing:       &models.KubeProxyReplacementFeaturesSocketLBTracing{},
+		SessionAffinity:       &models.KubeProxyReplacementFeaturesSessionAffinity{},
+		GracefulTermination:   &models.KubeProxyReplacementFeaturesGracefulTermination{},
+		Nat46X64:              &models.KubeProxyReplacementFeaturesNat46X64{},
+		BpfSocketLBHostnsOnly: option.Config.BPFSocketLBHostnsOnly,
 	}
 	if option.Config.EnableNodePort {
 		features.NodePort.Enabled = true

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -608,6 +608,11 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 			socketLBTracing = "Enabled"
 		}
 
+		socketLBCoverage := "Full"
+		if sr.KubeProxyReplacement.Features.BpfSocketLBHostnsOnly {
+			socketLBCoverage = "Hostns-only"
+		}
+
 		gracefulTerm := "Disabled"
 		if sr.KubeProxyReplacement.Features.GracefulTermination.Enabled {
 			gracefulTerm = "Enabled"
@@ -633,6 +638,7 @@ func FormatStatusResponse(w io.Writer, sr *models.StatusResponse, sd StatusDetai
 		fmt.Fprintf(tab, "  Status:\t%s\n", sr.KubeProxyReplacement.Mode)
 		fmt.Fprintf(tab, "  Socket LB:\t%s\n", socketLB)
 		fmt.Fprintf(tab, "  Socket LB Tracing:\t%s\n", socketLBTracing)
+		fmt.Fprintf(tab, "  Socket LB Coverage:\t%s\n", socketLBCoverage)
 		if kubeProxyDevices != "" {
 			fmt.Fprintf(tab, "  Devices:\t%s\n", kubeProxyDevices)
 		}


### PR DESCRIPTION
BPFSocketLBHostnsOnly is outputted in the Kube Proxy Replacement section in cilium status --verbose:

$ cilium status --verbose
[...]
KubeProxyReplacement Details:
  [...]
  BPFSocketLBHostnsOnly:   Enabled
  [...]

Fixes: #24160

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
