### PR TITLE
endpoint: fix k8sNamespace log field when ep gets deleted

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -702,14 +702,14 @@ func (d *Daemon) DeleteEndpoint(id string) (int, error) {
 				logfields.IPv6:         ep.GetIPv6Address(),
 				logfields.EndpointID:   ep.ID,
 				logfields.K8sPodName:   ep.GetK8sPodName(),
-				logfields.K8sNamespace: ep.GetK8sPodName(),
+				logfields.K8sNamespace: ep.GetK8sNamespace(),
 			}).Info(msg)
 		default:
 			log.WithFields(logrus.Fields{
 				logfields.ContainerID:  containerID,
 				logfields.EndpointID:   ep.ID,
 				logfields.K8sPodName:   ep.GetK8sPodName(),
-				logfields.K8sNamespace: ep.GetK8sPodName(),
+				logfields.K8sNamespace: ep.GetK8sNamespace(),
 			}).Info(msg)
 		}
 		return d.deleteEndpoint(ep), nil


### PR DESCRIPTION
Currently, the log field k8sNamespace contains the name of the pod instead of the actual namespace when an endpoint gets deleted. This commit fixes this and adds the k8s namespace.