### PR TITLE
datapath/linux/route: fix CI expectations for rule string format

### DIFF
--- a/pkg/datapath/linux/route/route_linux_test.go
+++ b/pkg/datapath/linux/route/route_linux_test.go
@@ -185,21 +185,21 @@ func (p *RouteSuitePrivileged) TestRule_String(c *C) {
 				From: fakeIP,
 				To:   fakeIP2,
 			},
-			wantStr: "0: from 10.10.10.10/32 to 1.1.1.1/32 lookup 0",
+			wantStr: "0: from 10.10.10.10/32 to 1.1.1.1/32 lookup 0 proto unspec",
 		},
 		{
 			name: "contains priority",
 			rule: Rule{
 				Priority: 1,
 			},
-			wantStr: "1: from all to all lookup 0",
+			wantStr: "1: from all to all lookup 0 proto unspec",
 		},
 		{
 			name: "contains table",
 			rule: Rule{
 				Table: 1,
 			},
-			wantStr: "0: from all to all lookup 1",
+			wantStr: "0: from all to all lookup 1 proto unspec",
 		},
 		{
 			name: "contains mark and mask",
@@ -207,14 +207,14 @@ func (p *RouteSuitePrivileged) TestRule_String(c *C) {
 				Mark: 1,
 				Mask: 1,
 			},
-			wantStr: "0: from all to all lookup 0 mark 0x1 mask 0x1",
+			wantStr: "0: from all to all lookup 0 mark 0x1 mask 0x1 proto unspec",
 		},
 		{
 			name: "main table",
 			rule: Rule{
 				Table: unix.RT_TABLE_MAIN,
 			},
-			wantStr: "0: from all to all lookup main",
+			wantStr: "0: from all to all lookup main proto unspec",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
When CI is running it expects the fib rule format without the new protocol, so it breaks when matching the string formats with the expected ones. Fix it by adding the protocol.

Fixes: d0cca9d61d85 ("datapath/linux/route: add support for rule protocol")
