### PR TITLE
endpoint, proxy: Fix deadlock in writeHeaderfile

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2101,11 +2101,22 @@ func (e *Endpoint) syncEndpointHeaderFile(reasons []string) {
 	e.buildMutex.Lock()
 	defer e.buildMutex.Unlock()
 
+	// The following GetDNSRules call will acquire a read-lock on the IPCache.
+	// Because IPCache itself will potentially acquire endpoint locks in its
+	// critical section, it is important to _not_ hold any endpoint lock
+	// while calling GetDNSRules, to avoid a deadlock between IPCache and the
+	// endpoint.
+	rules := e.owner.GetDNSRules(e.ID)
+
 	if err := e.lockAlive(); err != nil {
 		// endpoint was removed in the meanwhile, return
 		return
 	}
 	defer e.unlock()
+
+	// Update DNSRules if any. This is needed because DNSRules also encode allowed destination IPs
+	// and those can change anytime we have identity updates in the cluster.
+	e.OnDNSPolicyUpdateLocked(rules)
 
 	if err := e.writeHeaderfile(e.StateDirectoryPath()); err != nil {
 		e.getLogger().WithFields(logrus.Fields{

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -35,6 +35,7 @@ type Owner interface {
 
 	// GetDNSRules creates a fresh copy of DNS rules that can be used when
 	// endpoint is restored on a restart.
+	// No endpoint lock must be held while calling this function.
 	GetDNSRules(epID uint16) restore.DNSRules
 
 	// RemoveRestoredDNSRules removes any restored DNS rules for


### PR DESCRIPTION
This fixes a deadlock with the IPCache and the endpoint mutex where writeHeaderfile calls into the proxy to fetch the endpoint's DNSRules while holding on to the endpoint mutex. That pattern causes a deadlock, because the proxy code itself then calls into IPCache while the endpoint mutex is held. This violates the assumed lock ordering, as we require that the IPCache mutex is always acquired _before_ any endpoint mutex.

We fix this deadlock by hoisting call to update the endpoint's DNSRules out of writeHeaderfile and into the syncEndpointHeaderFile function, which is triggered whenever there is a change in DNSRules.

Fixes: cilium/cilium#23836
Ref: cilium/cilium#20915