### PR TITLE
Fix CODEOWNERS update hint

### DIFF
--- a/Documentation/check-codeowners.sh
+++ b/Documentation/check-codeowners.sh
@@ -10,6 +10,6 @@ target_file="${script_dir}/codeowners.rst"
 
 if ! git diff --quiet -- "$target_file" ; then
     git --no-pager diff -- "$target_file"
-    echo "HINT: to fix this, run 'make -C Documentation update-owners'"
+    echo "HINT: to fix this, run 'make -C Documentation update-codeowners'"
     exit 1
 fi


### PR DESCRIPTION
The suggested target doesn't exist

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [x] Thanks for contributing!

```release-note
docs: Fix Makefile target name in CODEOWNERS update hint
```
