### PR TITLE
bpf/wireguard: Skip encryption for cluster-external traffic

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -92,6 +92,15 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 		goto out;
 #endif /* ENABLE_NODE_ENCRYPTION */
 
+	/* We don't want to encrypt any traffic that originates from outside
+	 * the cluster.
+	 * Without this check, that may happen for the egress gateway, when
+	 * reply traffic arrives from the cluster-external server and goes to
+	 * the client pod.
+	 */
+	if (!src || !identity_is_cluster(src->sec_label))
+		goto out;
+
 	/* Redirect to the WireGuard tunnel device if the encryption is
 	 * required.
 	 */


### PR DESCRIPTION
Egress gateway traffic travels from a client pod to a gateway node via the overlay to be SNATed at the gateway node's native device. The reply traffic should then take the same path back to the client pod.

When WireGuard is also enabled, however, we observe that the reply traffic goes through the WireGuard device instead of the overlay device. More specifically, after being reverse SNATed in bpf_host's handle_ipv4, this reply traffic goes through `encap_and_redirect_with_nodeid` to be redirected to the overlay device. There, it runs through `wg_maybe_redirect_to_encrypt`, which was never taught to skip traffic from outside the cluster.

Without the egress gateway, this scenario doesn't happen for WireGuard because all traffic coming from outside the cluster is either:
- destined to the local node and not subject to WireGuard encryption, or
- destined to a service with a remote backend, but redirected in the BPF NodePort logic.

This pull request fixes this bug by adding a new case in `wg_maybe_redirect_to_encrypt`, to skip encryption for any traffic that originates from outside the cluster.

Fixes: 29479334c19 ("datapath: Change WG integration to support host2host case")
Fixes: https://github.com/cilium/cilium/issues/24450.

This bug didn't make it into any release, hence the `release-note/misc` label.
```
Fix bug that causes egress gateway traffic to be dropped when WireGuard is enabled.
```