### PR TITLE
clustermesh: fix client usage when setting the cluster configuration

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -79,7 +79,7 @@ func SetClusterConfig(clusterName string, config *cmtypes.CiliumClusterConfig, b
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	_, err = kvstore.Client().UpdateIfDifferent(ctx, key, val, true)
+	_, err = backend.UpdateIfDifferent(ctx, key, val, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Previously, the SetClusterConfig function always used the default kvstore client to update the cluster configuration, neglecting the one specified as parameter. This PR fixes it.

I've not currently marked this PR for backport, since this is not a user-facing bug. Indeed, all callers of that function specify the default client as parameter. 

<!-- Description of change -->

```release-note
clustermesh: fix client usage when setting the cluster configuration
```
