### PR TITLE
More coccinelle fixes

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -69,6 +69,12 @@ jobs:
       - uses: docker://cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
+        # Note: Setting COCCINELLE_HOME can be removed, here and in the
+        # messages in the .cocci files, next time we upgrade coccinelle.
+        # The issue was fixed, after v1.1.1 that we're using, in
+        # https://gitlab.inria.fr/coccinelle/coccinelle/-/commit/540888ff426e.
+        env:
+          COCCINELLE_HOME: /usr/local/lib/coccinelle
 
   set_clang_dir:
     name: Set clang directory

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -260,7 +260,7 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 		return CT_ESTABLISHED;
 	}
 
-ct_new: __maybe_unused
+ct_new: __maybe_unused;
 	*monitor = TRACE_PAYLOAD_LEN;
 	return CT_NEW;
 }

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -313,7 +313,7 @@ srv6_decapsulation(struct __ctx_buff *ctx)
 	}
 #endif /* ENABLE_SRV6_SRH_ENCAP */
 	case IPPROTO_IPIP:
-parse_outer_ipv4: __maybe_unused
+parse_outer_ipv4: __maybe_unused;
 		if (ctx_change_proto(ctx, new_proto, 0) < 0)
 			return DROP_WRITE_ERROR;
 		if (ctx_store_bytes(ctx, offsetof(struct ethhdr, h_proto),
@@ -327,7 +327,7 @@ parse_outer_ipv4: __maybe_unused
 		shrink += sizeof(struct iphdr);
 		break;
 	case IPPROTO_IPV6:
-parse_outer_ipv6: __maybe_unused
+parse_outer_ipv6: __maybe_unused;
 		shrink += sizeof(struct ipv6hdr);
 		break;
 	default:

--- a/bpf/lib/icmp6.h
+++ b/bpf/lib/icmp6.h
@@ -168,8 +168,9 @@ static __always_inline int icmp6_send_echo_reply(struct __ctx_buff *ctx,
  *
  * Send an ICMPv6 nadv reply in return to an ICMPv6 ndisc.
  */
-static __always_inline int send_icmp6_ndisc_adv(struct __ctx_buff *ctx,
-						int nh_off, union macaddr *mac, bool to_router)
+static __always_inline int
+send_icmp6_ndisc_adv(struct __ctx_buff *ctx, int nh_off,
+		     const union macaddr *mac, bool to_router)
 {
 	struct icmp6hdr icmp6hdr __align_stack_8 = {}, icmp6hdr_old __align_stack_8;
 	__u8 opts[8], opts_old[8];

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -351,12 +351,12 @@ ctx_redirect_to_proxy_first(struct __ctx_buff *ctx, __be16 proxy_port)
 	}
 #endif /* ENABLE_TPROXY */
 
-mark: __maybe_unused
+mark: __maybe_unused;
 	cilium_dbg(ctx, DBG_CAPTURE_PROXY_POST, proxy_port, 0);
 	ctx->mark = MARK_MAGIC_TO_PROXY | (proxy_port << 16);
 	ctx_change_type(ctx, PACKET_HOST);
 
-out: __maybe_unused
+out: __maybe_unused;
 	return ret;
 }
 

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -107,7 +107,8 @@ combine_ports(__u16 dport, __u16 sport)
  * ingress. Will modify 'tuple'!						\
  */										\
 static __always_inline int							\
-NAME(struct __ctx_buff *ctx, CT_TUPLE_TYPE * ct_tuple, __be16 proxy_port, void *tproxy_addr)	\
+NAME(struct __ctx_buff *ctx, const CT_TUPLE_TYPE * ct_tuple,			\
+     __be16 proxy_port, void *tproxy_addr)					\
 {										\
 	struct bpf_sock_tuple *tuple = (struct bpf_sock_tuple *)ct_tuple;	\
 	__u8 nexthdr = ct_tuple->nexthdr;					\

--- a/contrib/coccinelle/aligned.cocci
+++ b/contrib/coccinelle/aligned.cocci
@@ -63,7 +63,9 @@ cnt += 1
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                  \\
-    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b spatch --sp-file contrib/coccinelle/aligned.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/aligned.cocci\n
 """)

--- a/contrib/coccinelle/const.cocci
+++ b/contrib/coccinelle/const.cocci
@@ -64,7 +64,9 @@ cnt += 1
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                \\
-    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b spatch --sp-file contrib/coccinelle/const.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/const.cocci\n
 """)

--- a/contrib/coccinelle/identity_is_node.cocci
+++ b/contrib/coccinelle/identity_is_node.cocci
@@ -60,7 +60,9 @@ if len(p2) > 0:
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                           \\
-    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b spatch --sp-file contrib/coccinelle/identity_is_node.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/identity_is_node.cocci\n
 """)

--- a/contrib/coccinelle/tail_calls.cocci
+++ b/contrib/coccinelle/tail_calls.cocci
@@ -109,5 +109,8 @@ cnt += 1
 if cnt > 0:
   print("""Unlogged tail calls found. Please fix and use the following command to check:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
-    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b make -C bpf coccicheck\n
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/tail_calls.cocci\n
 """)

--- a/contrib/coccinelle/zero_trace_reason.cocci
+++ b/contrib/coccinelle/zero_trace_reason.cocci
@@ -84,7 +84,9 @@ cnt += 1
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                           \\
-    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b spatch --sp-file contrib/coccinelle/zero_trace_reason.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/zero_trace_reason.cocci\n
 """)


### PR DESCRIPTION
- bpf: Add semi-colons after __maybe_unused label attributes
- bpf: Add some missing const qualifiers
- cocci: Set COCCINELLE_HOME to fix path for isomorphisms and macros files

Please look at commit descriptions for details.

```release-note
cocci: Work around a bug in coccinelle to better check files, add a few missing `const` qualifiers to BPF code
```