### PR TITLE
devices: allow local route entries in device mngr

### DIFF
--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -265,11 +265,8 @@ func (dm *DeviceManager) updateDevicesFromRoutes(l3DevOK bool, routes []netlink.
 	// Collect all link indices mentioned in the route update batch
 	for _, route := range routes {
 		// Only consider devices that have global unicast routes,
-		// e.g. skip loopback, multicast and link local routes.
+		// e.g. skip loopback, multicast.
 		if route.Dst != nil && !route.Dst.IP.IsGlobalUnicast() {
-			continue
-		}
-		if route.Table == unix.RT_TABLE_LOCAL {
 			continue
 		}
 		linkInfo := linkInfos[route.LinkIndex]

--- a/pkg/datapath/linux/devices_test.go
+++ b/pkg/datapath/linux/devices_test.go
@@ -561,9 +561,6 @@ func delRoutes(iface string) error {
 	}
 
 	for _, r := range routes {
-		if r.Table == unix.RT_TABLE_LOCAL {
-			continue
-		}
 		if err := netlink.RouteDel(&r); err != nil {
 			return err
 		}


### PR DESCRIPTION
Related slack thread: https://cilium.slack.com/archives/C2B917YHE/p1679920009513589

Previously when `--enable-runtime-device-detection` was enabled the code skipped local route table.
This means if device route was only present in the local table it was skipped and no datapath program
was attached. 

In case of a dummy device with e.g. anycast IP it would be necessary to remove this check. 
Known unwanted links are still filtered out and the rest can be narrowed down by using `--devices` flag.
This PR fixes that.
    
Signed-off-by: Ondrej Blazek <ondrej.blazek@firma.seznam.cz>

```release-note
Allow devices from local route table to be used for datapath programs. 
```