### PR TITLE
Add always-fail auth handler

### DIFF
--- a/pkg/auth/always_fail_authhandler.go
+++ b/pkg/auth/always_fail_authhandler.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import (
+	"errors"
+
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+func newAlwaysFailAuthHandler() authHandlerResult {
+	return authHandlerResult{
+		AuthHandler: &alwaysFailAuthHandler{},
+	}
+}
+
+// alwaysFailAuthHandler implements an authHandler for auth type always-fail to deny every request.
+type alwaysFailAuthHandler struct {
+}
+
+func (r *alwaysFailAuthHandler) authenticate(authReq *authRequest) (*authResponse, error) {
+	return nil, errors.New("authenticating failed by the always-fail auth handler")
+}
+
+func (r *alwaysFailAuthHandler) authType() policy.AuthType {
+	return policy.AuthTypeAlwaysFail
+}

--- a/pkg/auth/always_fail_authhandler_test.go
+++ b/pkg/auth/always_fail_authhandler_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func Test_alwaysFailAuthHandler_authenticate(t *testing.T) {
+	tests := []struct {
+		name    string
+		want    *authResponse
+		wantErr bool
+	}{
+		{
+			name:    "Always fail",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &alwaysFailAuthHandler{}
+			got, err := r.authenticate(&authRequest{
+				localIdentity:  1000,
+				remoteIdentity: 1001,
+				remoteHostIP:   net.ParseIP("::1"),
+			})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("alwaysFailAuthHandler.authenticate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("alwaysFailAuthHandler.authenticate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -36,6 +36,8 @@ var Cell = cell.Module(
 		newCtMapAuthenticator,
 		// MTLS auth handler provides support for auth type "mtls-*" - which performs mTLS authentication.
 		newMTLSAuthHandler,
+		// Always fail auth handler provides support for auth type "always-fail" - which always fails.
+		newAlwaysFailAuthHandler,
 	),
 	cell.Config(config{MeshAuthMonitorQueueSize: 1024}),
 	cell.Config(MTLSConfig{}),

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -84,6 +84,7 @@ spec:
                           enum:
                           - "null"
                           - mtls-spiffe
+                          - always-fail
                           type: string
                       required:
                       - type
@@ -1439,6 +1440,7 @@ spec:
                           enum:
                           - "null"
                           - mtls-spiffe
+                          - always-fail
                           type: string
                       required:
                       - type
@@ -2559,6 +2561,7 @@ spec:
                             enum:
                             - "null"
                             - mtls-spiffe
+                            - always-fail
                             type: string
                         required:
                         - type
@@ -3936,6 +3939,7 @@ spec:
                             enum:
                             - "null"
                             - mtls-spiffe
+                            - always-fail
                             type: string
                         required:
                         - type

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -88,6 +88,7 @@ spec:
                           enum:
                           - "null"
                           - mtls-spiffe
+                          - always-fail
                           type: string
                       required:
                       - type
@@ -1443,6 +1444,7 @@ spec:
                           enum:
                           - "null"
                           - mtls-spiffe
+                          - always-fail
                           type: string
                       required:
                       - type
@@ -2563,6 +2565,7 @@ spec:
                             enum:
                             - "null"
                             - mtls-spiffe
+                            - always-fail
                             type: string
                         required:
                         - type
@@ -3940,6 +3943,7 @@ spec:
                             enum:
                             - "null"
                             - mtls-spiffe
+                            - always-fail
                             type: string
                         required:
                         - type

--- a/pkg/policy/api/rule.go
+++ b/pkg/policy/api/rule.go
@@ -16,6 +16,7 @@ type AuthType string
 const (
 	AuthTypeNull       AuthType = "null"        // Always succeeds
 	AuthTypeMTLSSpiffe AuthType = "mtls-spiffe" // Mutual TLS with SPIFFE as certificate provider
+	AuthTypeAlwaysFail AuthType = "always-fail"
 )
 
 // Auth specifies the kind of cryptographic authentication required for the traffic to
@@ -23,7 +24,7 @@ const (
 type Auth struct {
 	// Type is the required authentication type for the allowed traffic, if any.
 	//
-	// +kubebuilder:validation:Enum=null;mtls-spiffe
+	// +kubebuilder:validation:Enum=null;mtls-spiffe;always-fail
 	// +kubebuilder:validation:Required
 	Type AuthType `json:"type"`
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -226,6 +226,8 @@ const (
 	AuthTypeNull
 	// AuthTypeMTLSSpiffe is a mTLS auth type that uses SPIFFE identities with a SPIRE server
 	AuthTypeMTLSSpiffe
+	// AuthTypeAlwaysFail is a simple auth type that always denies the request
+	AuthTypeAlwaysFail
 )
 
 // GetAuthType returns the AuthType of the L4Filter.
@@ -238,6 +240,8 @@ func (a *PerSelectorPolicy) GetAuthType() AuthType {
 		return AuthTypeNull
 	case "mtls-spiffe":
 		return AuthTypeMTLSSpiffe
+	case "always-fail":
+		return AuthTypeAlwaysFail
 	}
 	return AuthTypeNone
 }
@@ -256,6 +260,8 @@ func (a AuthType) String() string {
 		return "null"
 	case AuthTypeMTLSSpiffe:
 		return "mtls-spiffe"
+	case AuthTypeAlwaysFail:
+		return "always-fail"
 	}
 	return fmt.Sprintf("Unknown-auth-type-%d", a.Uint8())
 }


### PR DESCRIPTION
Part of https://github.com/cilium/cilium/issues/24600



This adds an always fail auth handler that will always deny auth requests.
This is useful for testing policies and to use in end-to-end testing to
ensure the auth mechanism in the datapath is functional.

```release-note
Add network policy auth method "always-fail"
```
