### PR TITLE
bpf: fixes for IPv6 revNAT

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1740,7 +1740,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target)
 			ipv6_addr_copy(&tuple.saddr, (union v6addr *)&iphdr.daddr);
 			ipv6_addr_copy(&tuple.daddr, (union v6addr *)&iphdr.saddr);
 
-			hdrlen = ipv6_hdrlen_offset(ctx, &iphdr.nexthdr, icmpoff);
+			hdrlen = ipv6_hdrlen_offset(ctx, &tuple.nexthdr, icmpoff);
 			if (hdrlen < 0)
 				return hdrlen;
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1775,7 +1775,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target)
 				tuple.dport = identifier;
 				break;
 			default:
-				return DROP_INVALID;
+				return DROP_UNKNOWN_L4;
 			}
 			state = snat_v6_lookup(&tuple);
 			if (!state)

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1740,7 +1740,12 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target)
 			ipv6_addr_copy(&tuple.saddr, (union v6addr *)&iphdr.daddr);
 			ipv6_addr_copy(&tuple.daddr, (union v6addr *)&iphdr.saddr);
 
-			icmpoff += ipv6_hdrlen_offset(ctx, &iphdr.nexthdr, icmpoff);
+			hdrlen = ipv6_hdrlen_offset(ctx, &iphdr.nexthdr, icmpoff);
+			if (hdrlen < 0)
+				return hdrlen;
+
+			icmpoff += hdrlen;
+
 			switch (tuple.nexthdr) {
 			case IPPROTO_TCP:
 			case IPPROTO_UDP:


### PR DESCRIPTION
Fix some minor fallout from https://github.com/cilium/cilium/pull/18414.