### PR TITLE
ci: don't use ./contrib/scripts/kind.sh --xdp in 1.13 workflow

### DIFF
--- a/.github/workflows/conformance-datapath-v1.13.yaml
+++ b/.github/workflows/conformance-datapath-v1.13.yaml
@@ -286,7 +286,7 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host/
-            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
+            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
             ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
 
             ./cilium-cli status --wait
@@ -294,7 +294,7 @@ jobs:
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./cilium-cli connectivity test --collect-sysdump-on-failure \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
-            ./contrib/scripts/kind-down.sh --keep-registry
+            kind delete cluster
 
       - name: Run encryption tests
         if: ${{ matrix.encryption != 'disabled' }}
@@ -303,7 +303,7 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host/
-            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
+            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
             ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }} \
               --encryption=${{ matrix.encryption }}
 


### PR DESCRIPTION
The corresponding changes introducing the --xdp flag haven't been backported to v1.13. Don't use it in 1.13 workflows for now.

Partially reverts commit 4310b5e5c4a1 ("contrib/kind: enable XDP_TX from pod veth").

See https://github.com/cilium/cilium/actions/runs/4544793510 for a failure on a 1.13 backport PR.