### PR TITLE
Refactor CRD generation in Makefile

### DIFF
--- a/Documentation/contributing/development/introducing_new_crds.rst
+++ b/Documentation/contributing/development/introducing_new_crds.rst
@@ -258,7 +258,7 @@ client.
                    synced.CRDResourceName(k8sconstv2alpha1.CESName):  createCESCRD,
    +               synced.CRDResourceName(k8sconstv2alpha1.BGPPName): createCESCRD,
            }
-           for _, r := range synced.AllCRDResourceNames() {
+           for _, r := range synced.AllCiliumCRDResourceNames() {
                    fn, ok := resourceToCreateFnMapping[r]
    @@ -127,6 +134,12 @@ var (
     

--- a/Documentation/contributing/development/introducing_new_crds.rst
+++ b/Documentation/contributing/development/introducing_new_crds.rst
@@ -127,9 +127,9 @@ Generating CRD YAML
 To simply generate the CRDs and copy them into the correct location you
 must perform two tasks:
 
-* Update the ``Makefile`` to copy your generated CRD from a ``tmp`` directory to 
-  the correct location in Cilium repository. Edit the following 
-  `location <https://github.com/cilium/cilium/blob/89ca3eddf3dae9ac5fc6c343a2cd26cf3aa405fa/Makefile#L303-L311>`__
+* Update the ``Makefile`` to edit the ``CRDS_CILIUM_V2`` or
+  ``CRDS_CILIUM_V2ALPHA1`` variable (depending on the version of your new CRD)
+  to contain the plural name of your new CRD.
 * Run ``make manifests``
 
 This will generate your Golang structs into CRD manifests and copy them

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,8 @@ GIT_VERSION: force
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 CRD_PATHS := "$(PWD)/pkg/k8s/apis/cilium.io/v2;\
               $(PWD)/pkg/k8s/apis/cilium.io/v2alpha1;"
+CRDS_CILIUM_PATHS := $(PWD)/pkg/k8s/apis/cilium.io/client/crds/v2\
+                     $(PWD)/pkg/k8s/apis/cilium.io/client/crds/v2alpha1
 CRDS_CILIUM_V2 := ciliumnetworkpolicies \
                   ciliumclusterwidenetworkpolicies \
                   ciliumendpoints \
@@ -208,6 +210,10 @@ manifests: ## Generate K8s manifests e.g. CRD, RBAC etc.
 	$(eval TMPDIR := $(shell mktemp -d))
 	$(QUIET)$(GO) run sigs.k8s.io/controller-tools/cmd/controller-gen $(CRD_OPTIONS) paths=$(CRD_PATHS) output:crd:artifacts:config="$(TMPDIR)"
 	$(QUIET)$(GO) run ./tools/crdcheck "$(TMPDIR)"
+
+	# Clean up old CRD state and start with a blank state.
+	for path in $(CRDS_CILIUM_PATHS); do rm -rf $${path} && mkdir $${path}; done
+
 	for file in $(CRDS_CILIUM_V2); do mv ${TMPDIR}/cilium.io_$${file}.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/$${file}.yaml; done
 	for file in $(CRDS_CILIUM_V2ALPHA1); do mv ${TMPDIR}/cilium.io_$${file}.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2alpha1/$${file}.yaml; done
 	rm -rf $(TMPDIR)

--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,8 @@ github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1beta1
 github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/util/intstr
 endef
 
+GEN_CRD_GROUPS := "cilium.io:v2\
+                   cilium.io:v2alpha1"
 generate-k8s-api: ## Generate Cilium k8s API client, deepcopy and deepequal Go sources.
 	$(ASSERT_CILIUM_MODULE)
 
@@ -333,7 +335,7 @@ generate-k8s-api: ## Generate Cilium k8s API client, deepcopy and deepequal Go s
 
 	$(QUIET) $(call generate_k8s_api,client,github.com/cilium/cilium/pkg/k8s/slim/k8s/client,github.com/cilium/cilium/pkg/k8s/slim/k8s/api,"discovery:v1beta1 discovery:v1 networking:v1 core:v1","$(TMPDIR)")
 	$(QUIET) $(call generate_k8s_api,client,github.com/cilium/cilium/pkg/k8s/slim/k8s/apiextensions-client,github.com/cilium/cilium/pkg/k8s/slim/k8s/apis,"apiextensions:v1","$(TMPDIR)")
-	$(QUIET) $(call generate_k8s_api,client$(comma)lister$(comma)informer,github.com/cilium/cilium/pkg/k8s/client,github.com/cilium/cilium/pkg/k8s/apis,"cilium.io:v2 cilium.io:v2alpha1","$(TMPDIR)")
+	$(QUIET) $(call generate_k8s_api,client$(comma)lister$(comma)informer,github.com/cilium/cilium/pkg/k8s/client,github.com/cilium/cilium/pkg/k8s/apis,$(GEN_CRD_GROUPS),"$(TMPDIR)")
 
 	$(QUIET) cp -r "$(TMPDIR)/github.com/cilium/cilium/." ./
 	$(QUIET) rm -rf "$(TMPDIR)"

--- a/Makefile
+++ b/Makefile
@@ -188,9 +188,11 @@ GIT_VERSION: force
 
 ##@ API targets
 CRD_OPTIONS ?= "crd:crdVersions=v1"
+CRD_PATHS := "$(PWD)/pkg/k8s/apis/cilium.io/v2;\
+              $(PWD)/pkg/k8s/apis/cilium.io/v2alpha1;"
 manifests: ## Generate K8s manifests e.g. CRD, RBAC etc.
 	$(eval TMPDIR := $(shell mktemp -d))
-	$(QUIET)$(GO) run sigs.k8s.io/controller-tools/cmd/controller-gen $(CRD_OPTIONS) paths="$(PWD)/pkg/k8s/apis/cilium.io/v2;$(PWD)/pkg/k8s/apis/cilium.io/v2alpha1" output:crd:artifacts:config="$(TMPDIR)"
+	$(QUIET)$(GO) run sigs.k8s.io/controller-tools/cmd/controller-gen $(CRD_OPTIONS) paths=$(CRD_PATHS) output:crd:artifacts:config="$(TMPDIR)"
 	$(QUIET)$(GO) run ./tools/crdcheck "$(TMPDIR)"
 	mv ${TMPDIR}/cilium.io_ciliumnetworkpolicies.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
 	mv ${TMPDIR}/cilium.io_ciliumclusterwidenetworkpolicies.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml

--- a/Makefile
+++ b/Makefile
@@ -190,24 +190,26 @@ GIT_VERSION: force
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 CRD_PATHS := "$(PWD)/pkg/k8s/apis/cilium.io/v2;\
               $(PWD)/pkg/k8s/apis/cilium.io/v2alpha1;"
+CRDS_CILIUM_V2 := ciliumnetworkpolicies \
+                  ciliumclusterwidenetworkpolicies \
+                  ciliumendpoints \
+                  ciliumidentities \
+                  ciliumnodes \
+                  ciliumexternalworkloads \
+                  ciliumlocalredirectpolicies \
+                  ciliumegressgatewaypolicies \
+                  ciliumenvoyconfigs \
+                  ciliumclusterwideenvoyconfigs
+CRDS_CILIUM_V2ALPHA1 := ciliumendpointslices \
+                        ciliumbgppeeringpolicies \
+                        ciliumloadbalancerippools \
+                        ciliumnodeconfigs
 manifests: ## Generate K8s manifests e.g. CRD, RBAC etc.
 	$(eval TMPDIR := $(shell mktemp -d))
 	$(QUIET)$(GO) run sigs.k8s.io/controller-tools/cmd/controller-gen $(CRD_OPTIONS) paths=$(CRD_PATHS) output:crd:artifacts:config="$(TMPDIR)"
 	$(QUIET)$(GO) run ./tools/crdcheck "$(TMPDIR)"
-	mv ${TMPDIR}/cilium.io_ciliumnetworkpolicies.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
-	mv ${TMPDIR}/cilium.io_ciliumclusterwidenetworkpolicies.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
-	mv ${TMPDIR}/cilium.io_ciliumendpoints.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
-	mv ${TMPDIR}/cilium.io_ciliumidentities.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumidentities.yaml
-	mv ${TMPDIR}/cilium.io_ciliumnodes.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnodes.yaml
-	mv ${TMPDIR}/cilium.io_ciliumexternalworkloads.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumexternalworkloads.yaml
-	mv ${TMPDIR}/cilium.io_ciliumlocalredirectpolicies.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumlocalredirectpolicies.yaml
-	mv ${TMPDIR}/cilium.io_ciliumegressgatewaypolicies.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml
-	mv ${TMPDIR}/cilium.io_ciliumendpointslices.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml
-	mv ${TMPDIR}/cilium.io_ciliumclusterwideenvoyconfigs.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwideenvoyconfigs.yaml
-	mv ${TMPDIR}/cilium.io_ciliumenvoyconfigs.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/ciliumenvoyconfigs.yaml
-	mv ${TMPDIR}/cilium.io_ciliumbgppeeringpolicies.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
-	mv ${TMPDIR}/cilium.io_ciliumloadbalancerippools.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumloadbalancerippools.yaml
-	mv ${TMPDIR}/cilium.io_ciliumnodeconfigs.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumnodeconfigs.yaml
+	for file in $(CRDS_CILIUM_V2); do mv ${TMPDIR}/cilium.io_$${file}.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2/$${file}.yaml; done
+	for file in $(CRDS_CILIUM_V2ALPHA1); do mv ${TMPDIR}/cilium.io_$${file}.yaml ./pkg/k8s/apis/cilium.io/client/crds/v2alpha1/$${file}.yaml; done
 	rm -rf $(TMPDIR)
 
 generate-api: api/v1/openapi.yaml ## Generate cilium-agent client, model and server code from openapi spec.

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -565,7 +565,7 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, servi
 	}).Info("Starting clustermesh-apiserver...")
 
 	if mockFile == "" {
-		synced.SyncCRDs(startCtx, clientset, synced.AllCRDResourceNames(), &synced.Resources{}, &synced.APIGroups{})
+		synced.SyncCRDs(startCtx, clientset, synced.AllCiliumCRDResourceNames(), &synced.Resources{}, &synced.APIGroups{})
 	}
 
 	mgr := NewVMManager(clientset)

--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -106,7 +106,7 @@ func CreateCustomResourceDefinitions(clientset apiextensionsclient.Interface) er
 		synced.CRDResourceName(k8sconstv2alpha1.LBIPPoolName): createCRD(LBIPPoolCRDName, k8sconstv2alpha1.LBIPPoolName),
 		synced.CRDResourceName(k8sconstv2alpha1.CNCName):      createCRD(CNCCRDName, k8sconstv2alpha1.CNCName),
 	}
-	for _, r := range synced.AllCRDResourceNames() {
+	for _, r := range synced.AllCiliumCRDResourceNames() {
 		fn, ok := resourceToCreateFnMapping[r]
 		if !ok {
 			log.Fatalf("Unknown resource %s. Please update pkg/k8s/apis/cilium.io/client to understand this type.", r)

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -78,10 +78,13 @@ func AgentCRDResourceNames() []string {
 	return agentCRDResourceNames()
 }
 
-// AllCRDResourceNames returns a list of all CRD resource names that the
-// clustermesh-apiserver or testsuite may register.
-func AllCRDResourceNames() []string {
-	return append(agentCRDResourceNames(), CRDResourceName(v2.CEWName))
+// AllCiliumCRDResourceNames returns a list of all Cilium CRD resource names
+// that the clustermesh-apiserver or testsuite may register.
+func AllCiliumCRDResourceNames() []string {
+	return append(
+		AgentCRDResourceNames(),
+		CRDResourceName(v2.CEWName),
+	)
 }
 
 // SyncCRDs will sync Cilium CRDs to ensure that they have all been

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -4668,7 +4668,7 @@ func (kub *Kubectl) CleanupCiliumComponents() {
 			"resourcequota":      "cilium-resource-quota cilium-operator-resource-quota",
 		}
 
-		crdsToDelete = synced.AllCRDResourceNames()
+		crdsToDelete = synced.AllCiliumCRDResourceNames()
 	)
 
 	wg.Add(len(resourcesToDelete))


### PR DESCRIPTION
- Clarify function for all Cilium CRDs
- Makefile: Extract paths for CRD into variable
- Makefile: Extract CRD groups from generate-k8s-api
- Makefile: Refactor CRD generation to avoid copy-paste pattern
- Makefile: Clean up old CRD state, ensure blank slate
