### PR TITLE
service-cache: fix memory leak and missed updates on scale to zero events in rare circumstances

### DIFF
--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -496,8 +496,10 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 		}
 	}
 
+	var hasExternalEndpoints bool
 	if svcFound && svc.IncludeExternal {
-		externalEndpoints, hasExternalEndpoints := s.externalEndpoints[id]
+		externalEndpoints, ok := s.externalEndpoints[id]
+		hasExternalEndpoints = ok && len(externalEndpoints.endpoints) > 0
 		if hasExternalEndpoints {
 			// remote cluster endpoints already contain all Endpoints from all
 			// EndpointSlices so no need to search the endpoints of a particular
@@ -522,7 +524,7 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 
 	// Report the service as ready if a local endpoints object exists or if
 	// external endpoints have been identified
-	return endpoints, hasLocalEndpoints || len(endpoints.Backends) > 0
+	return endpoints, hasLocalEndpoints || hasExternalEndpoints
 }
 
 // MergeExternalServiceUpdate merges a cluster service of a remote cluster into

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -608,6 +608,9 @@ func (s *ServiceCache) MergeExternalServiceDelete(service *serviceStore.ClusterS
 		scopedLog.Debug("Deleting external endpoints")
 
 		delete(externalEndpoints.endpoints, service.Cluster)
+		if len(externalEndpoints.endpoints) == 0 {
+			delete(s.externalEndpoints, id)
+		}
 
 		svc, ok := s.services[id]
 
@@ -625,6 +628,7 @@ func (s *ServiceCache) MergeExternalServiceDelete(service *serviceStore.ClusterS
 			}
 
 			if !serviceReady {
+				delete(s.services, id)
 				event.Action = DeleteService
 			}
 
@@ -670,6 +674,9 @@ func (s *ServiceCache) MergeClusterServiceDelete(service *serviceStore.ClusterSe
 	if ok {
 		scopedLog.Debug("Deleting cluster endpoints")
 		delete(externalEndpoints.endpoints, service.Cluster)
+		if len(externalEndpoints.endpoints) == 0 {
+			delete(s.externalEndpoints, id)
+		}
 	}
 
 	svc, ok := s.services[id]


### PR DESCRIPTION
This PR fixes two issues which could affect the endpoints handling in the service cache, concerning remote services:
* Prevents that an update could be missed in case of scale to zero events in very specific scenarios.
* Ensures the deletion of a map entry which was previously leaked;

Please, refer to the respective commit messages for more details.

<!-- Description of change -->

```release-note
Fix a memory leak in the service cache, and possible missed service updates on scale to zero events in rare circumstances
```
