### PR TITLE
Add a hint about using Vagrant on Apple Silicon

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -300,6 +300,12 @@ to enable NFS.
 
 .. note::
 
+   Although providing a Developer preview for macOS/arm64 (M1/M2) hosts, 
+   Oracle is not going to offer official support for ARM64 on Mac. As of VirtualBox 7.0.6
+   the developer preview is *not* working with the Cilium Vagrant Setup.
+   
+.. note::
+
    OSX file system is by default case insensitive, which can confuse
    git.  At the writing of this Cilium repo has no file names that
    would be considered referring to the same file on a case


### PR DESCRIPTION
According to [official information](https://forums.virtualbox.org/viewtopic.php?f=8&t=107344), Oracle won't provide official support for Apple M1/M2, so I've added a minor hint in order to raise awareness on this topic for contributors working on Apple silicon. 
