### PR TITLE
operator: fix deadlock when running in kvstore mode

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -110,9 +110,16 @@ var (
 		WithLeaderLifecycle(
 			k8s.SharedResourcesCell,
 			lbipam.Cell,
-			identitygc.Cell,
 
 			legacyCell,
+
+			// When running in kvstore mode, the start hook of the identity GC
+			// cell blocks until the kvstore client has been initialized, which
+			// is performed by the legacyCell start hook. Hence, the identity GC
+			// cell is registered afterwards, to ensure the ordering of the
+			// setup operations. This is a hacky workaround until the kvstore is
+			// refactored into a proper cell.
+			identitygc.Cell,
 		),
 	)
 


### PR DESCRIPTION
When running in kvstore mode, the start hook of the identity GC cell blocks until the kvstore client has been initialized, which is performed by the legacyCell start hook. Given that the identity GC cell was registered first, and there are no explicit dependencies among the two, its start hook was also executed first, causing a deadlock.

This PR changes the order in which the cells are registered as a workaround, until the kvstore is refactored into a proper cell.

No backport is required, since the original commit is not present in any stable branch.

<!-- Description of change -->

```release-note
operator: fix deadlock when running in kvstore mode
```
