### PR TITLE
Add IPSec remark for upgrade to v1.11.15

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -340,6 +340,13 @@ Annotations:
   gateway nodes. Once the connectivity is restored, clients will need to
   reconnect.
 
+* In upgrades to Cilium v1.11.15 with IPSec enabled, the IPSec state is not refreshed, which causes dropped connections in 
+  the cluster. As such, we recommend staying at v1.11.14. This issue can be mitigated by
+  either replacing workload nodes in the cluster (to get a fresh IPSec state) or by
+  flushing the current state by running the following command on each node:
+  ``ip xfrm state flush``.
+
+
 Removed Metrics/Labels
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Cilium upgrades to v1.11.15 can cause severe problems when IPSec is enabled. This adds a remark to the docs.