### PR TITLE
renovate: Add packageRule group for Hubble CLI

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -207,6 +207,14 @@
         "golang.zx2c4.com/wireguard",
       ],
       "versioning": "regex:^v0.0.0-(<patch>\\d+)-.*$",
+    },
+    {
+      "groupName": "Hubble CLI",
+      "groupSlug": "hubble-cli",
+      "matchDepNames": [
+        "cilium/hubble",
+        "quay.io/cilium/hubble"
+      ],
     }
   ],
   "kubernetes": {


### PR DESCRIPTION
This commit adds a new packageRule group for the two Hubble CLI dependencies we have: The GitHub release on `cilium/hubble` and the Docker image on `quay.io/cilium/hubble`.

With this commit, the two dependencies will be updated together in a single PR instead of separate PRs if there is a new Hubble CLI version.

I have tested this on a fork here: 
- https://github.com/gandro/cilium/pull/131

Note that the Hubble github-release digests are currently not updated due to a bug in Renovate, but the upstream fix is in progress. See https://github.com/cilium/cilium/pull/24477#issuecomment-1488625438 for details