### PR TITLE
daemon: ignore EEXIST on NodeEnsureLocalIPRule

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sync/semaphore"
+	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/models"
 	health "github.com/cilium/cilium/cilium-health/launch"
@@ -285,7 +286,9 @@ func (d *Daemon) init() error {
 			return fmt.Errorf("failed while reinitializing datapath: %w", err)
 		}
 
-		if err := linuxdatapath.NodeEnsureLocalIPRule(); err != nil {
+		if err := linuxdatapath.NodeEnsureLocalIPRule(); errors.Is(err, unix.EEXIST) {
+			log.WithError(err).Warn("Failed to ensure local IP rules")
+		} else if err != nil {
 			return fmt.Errorf("failed to ensure local IP rules: %w", err)
 		}
 


### PR DESCRIPTION
According to Nik, some Kernel versions (namely 4.9 which is still supported in v1.13) doesn't support the fib rule protocol attribute. The call fails with the following error:

    daemon creation failed: error while initializing daemon: failed to ensure local IP rules: could not replace IPv4 local rule: file exists"

See https://github.com/cilium/cilium/pull/24607#issuecomment-1488485253

In order to ease backporting, let's also apply this change on master even though 4.9 is no longer supported (ref. #22116). The EEXIST case should not occur on kernels which support the fib rule protocol attribute.

Fixes: 291852afc80a ("datapath/linux: make sure we have a local rule with proto kernel")