### PR TITLE
egressgw: init gatewayIP to 0.0.0.0

### DIFF
--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -100,7 +100,8 @@ func (config *policyGatewayConfig) selectsNodeAsGateway(node nodeTypes.Node) boo
 
 func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 	gwc := gatewayConfig{
-		egressIP: net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 0)},
+		egressIP:  net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 0)},
+		gatewayIP: zeroIPv4,
 	}
 
 	policyGwc := config.policyGwConfig


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
Always init gatewayIP to 0.0.0.0 by default instead of the previous nil value. Before this commit the rules that didn't match any node where added in addMissingEgressRules and removed right after in removeUnusedEgressRules. The egressmap auto convert nil to 0.0.0.0 and removeUnusedEgressRules doesn't do anything to match nil and 0.0.0.0.

```release-note
Prevent egress gateway from adding and then immediately removing BPF policy entries for policies that don't match any gateway node 
```