### PR TITLE
bpf: init.sh: clean up stale encap device after change of tunnel proto

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -500,10 +500,14 @@ if [ "${TUNNEL_MODE}" != "<nil>" ]; then
 	bpf_load "$ENCAP_DEV" "$COPTS" egress bpf_overlay.c bpf_overlay.o to-overlay "$CALLS_MAP"
 
 	cilium bpf migrate-maps -e bpf_overlay.o -r 0
+fi
 
-else
-	# Remove eventual existing encapsulation device from previous run
+# Remove stale encapsulation device from a previous run:
+if [ "${TUNNEL_MODE}" != "vxlan" ]; then
 	ip link del cilium_vxlan 2> /dev/null || true
+fi
+
+if [ "${TUNNEL_MODE}" != "geneve" ]; then
 	ip link del cilium_geneve 2> /dev/null || true
 fi
 


### PR DESCRIPTION
Currently we only clean up stale encap devices when TUNNEL_MODE is not set (ie. when in direct-routing mode without an ad-hoc tunnel). So if the `--tunnel` protocol is switched from vxlan to geneve (or vice-versa), the old encap device doesn't get cleaned up.

This is obviously a rather exotic scenario. I noticed it while looking at some jenkins e2e datapath tests, where we do switch between vxlan and geneve tunneling.