### PR TITLE
Tracks agent goroutines scheduling latency

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -257,6 +257,7 @@ cilium-agent [flags]
       --read-cni-conf string                                    CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --restore                                                 Restores state, if possible, from previous daemon (default true)
       --route-metric int                                        Overwrite the metric used by cilium when adding routes to its 'cilium_host' device
+      --runtime-check-interval duration                         runtime check interval (default 5m0s)
       --sidecar-istio-proxy-image string                        Regular expression matching compatible Istio sidecar istio-proxy container image names (default "cilium/istio_proxy")
       --single-cluster-route                                    Use a single cluster route instead of per node routes
       --socket-path string                                      Sets daemon's socket path to listen for connections (default "/var/run/cilium/cilium.sock")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -28,6 +28,7 @@ cilium-agent hive [flags]
       --pprof                                  Enable serving pprof debugging API
       --pprof-address string                   Address that pprof listens on (default "localhost")
       --pprof-port uint16                      Port that pprof listens on (default 6060)
+      --runtime-check-interval duration        runtime check interval (default 5m0s)
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -33,6 +33,7 @@ cilium-agent hive dot-graph [flags]
       --pprof                                  Enable serving pprof debugging API
       --pprof-address string                   Address that pprof listens on (default "localhost")
       --pprof-port uint16                      Port that pprof listens on (default 6060)
+      --runtime-check-interval duration        runtime check interval (default 5m0s)
 ```
 
 ### SEE ALSO

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -19,6 +19,7 @@ import (
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pprof"
+	"github.com/cilium/cilium/pkg/runtime"
 )
 
 var (
@@ -47,6 +48,9 @@ var (
 
 		// Runs the gops agent, a tool to diagnose Go processes.
 		gops.Cell(defaults.GopsPortAgent),
+
+		// Runs agent runtime monitor.
+		runtime.Cell(defaults.RuntimeCheckInterval),
 
 		// Provides Clientset, API for accessing Kubernetes objects.
 		k8sClient.Cell,

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -523,6 +523,9 @@ const (
 
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy = true
+
+	// RuntimeCheckInterval tracks agent monitor heartbeat.
+	RuntimeCheckInterval = 5 * time.Minute
 )
 
 var (

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1278,6 +1278,9 @@ const (
 
 	// PprofPortAgent is the default value for pprof in the agent
 	PprofPortAgent = 6060
+
+	// RuntimeCheckInterval tracks rutime monitor chack intervals.
+	RuntimeCheckInterval = "runtime-check-interval"
 )
 
 // GetTunnelModes returns the list of all tunnel modes
@@ -2328,6 +2331,9 @@ type DaemonConfig struct {
 
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy bool
+
+	// RuntimeCheckInterval tracks runtime monitor check interfals.
+	RuntimeCheckInterval time.Duration
 }
 
 var (
@@ -2378,6 +2384,8 @@ var (
 		EnableVTEP:             defaults.EnableVTEP,
 		EnableBGPControlPlane:  defaults.EnableBGPControlPlane,
 		EnableK8sNetworkPolicy: defaults.EnableK8sNetworkPolicy,
+
+		RuntimeCheckInterval: defaults.RuntimeCheckInterval,
 	}
 )
 

--- a/pkg/runtime/cell.go
+++ b/pkg/runtime/cell.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runtime
+
+import (
+	"context"
+	"runtime/metrics"
+	"time"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/inctimer"
+	cmx "github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+)
+
+// RuntimeMetrics tracks go runtime metrics.
+type RuntimeMetrics interface {
+	// GetSchedulerLatency fetch scheduler GOR latency.
+	GetSchedulerLatency() *metrics.Float64Histogram
+}
+
+// Config tracks the cell configuration.
+type Config struct {
+	// RuntimeCheckInterval tracks process metrics check interval.
+	RuntimeCheckInterval time.Duration `mapstructure:"runtime-check-interval"`
+}
+
+// Flags hydrates cell config from cli args.
+func (c Config) Flags(flags *pflag.FlagSet) {
+	flags.Duration(option.RuntimeCheckInterval, c.RuntimeCheckInterval, "runtime check interval")
+}
+
+// Cell creates a cell for an agent runtime perf checks.
+func Cell(d time.Duration) cell.Cell {
+	return cell.Module(
+		"runtime",
+		"Agent runtime performance",
+
+		cell.Config(Config{RuntimeCheckInterval: d}),
+		cell.Invoke(registerSchedLatencyHooks),
+	)
+}
+
+func registerSchedLatencyHooks(lc hive.Lifecycle, log logrus.FieldLogger, cfg Config) {
+	ctx, cancel := context.WithCancel(context.Background())
+	log = rtLogger(log)
+
+	lc.Append(hive.Hook{
+		OnStart: _start(ctx, log, cfg, newGORuntimeMetrics()),
+		OnStop:  _stop(cancel, log),
+	})
+}
+
+func _start(ctx context.Context, log logrus.FieldLogger, cfg Config, mx RuntimeMetrics) func(hive.HookContext) error {
+	return func(hive.HookContext) error {
+		log.Infof("Starting runtime monitor [%v]", cfg.RuntimeCheckInterval)
+		go run(ctx, log, cfg, mx)
+		return nil
+	}
+}
+
+func run(ctx context.Context, log logrus.FieldLogger, cfg Config, mx RuntimeMetrics) {
+	collect(log, mx)
+	timer, stopFn := inctimer.New()
+	for {
+		select {
+		case <-timer.After(cfg.RuntimeCheckInterval):
+			collect(log, mx)
+		case <-ctx.Done():
+			log.Info("Runtime monitor canceled!")
+			stopFn()
+			return
+		}
+	}
+}
+
+func collect(log logrus.FieldLogger, mx RuntimeMetrics) {
+	h := mx.GetSchedulerLatency()
+	if h == nil {
+		return
+	}
+	if m := computeMedian(h); m > 0 {
+		cmx.RuntimeSchedulerLatency.WithLabelValues("latency").Set(m)
+	}
+}
+
+func _stop(cancel context.CancelFunc, log logrus.FieldLogger) func(hive.HookContext) error {
+	return func(hive.HookContext) error {
+		cancel()
+		log.Info("Runtime monitor stopped")
+		return nil
+	}
+}

--- a/pkg/runtime/cell_test.go
+++ b/pkg/runtime/cell_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runtime
+
+import (
+	"context"
+	"runtime/metrics"
+	"testing"
+	"time"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/inctimer"
+	cmx "github.com/cilium/cilium/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOnStart(t *testing.T) {
+	var (
+		logger, _ = test.NewNullLogger()
+		cfg       = Config{RuntimeCheckInterval: 100 * time.Millisecond}
+	)
+
+	uu := map[string]struct {
+		hits      int
+		collected float64
+		metrics   RuntimeMetrics
+	}{
+		"none": {
+			hits:      1,
+			collected: 0,
+			metrics:   newTestRTMetrics(nil),
+		},
+
+		"empty": {
+			hits:      1,
+			collected: 0,
+			metrics: newTestRTMetrics(&metrics.Float64Histogram{
+				Counts:  []uint64{},
+				Buckets: []float64{},
+			}),
+		},
+
+		"sparse": {
+			hits:      1,
+			collected: 10,
+			metrics: newTestRTMetrics(&metrics.Float64Histogram{
+				Counts:  []uint64{50, 0},
+				Buckets: []float64{10},
+			}),
+		},
+
+		"full": {
+			hits:      1,
+			collected: 20,
+			metrics: newTestRTMetrics(&metrics.Float64Histogram{
+				Counts:  []uint64{50, 100, 10, 60},
+				Buckets: []float64{10, 20, 30, 40},
+			}),
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			cmx.RuntimeSchedulerLatency = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: cmx.Namespace,
+				Name:      cmx.RuntimeSchedLatencyMX,
+			}, []string{"kind"})
+
+			var (
+				ctx, cancel = context.WithCancel(context.Background())
+				hctx        = hive.HookContext(context.Background())
+			)
+			f := _start(ctx, logger, cfg, u.metrics)
+			assert.NoError(t, f(hctx))
+
+			<-inctimer.After(2 * time.Millisecond)
+			sf := _stop(cancel, logger)
+			sf(hctx)
+
+			assert.Equal(t, u.hits, u.hits)
+			assert.Equal(t, u.collected, getMetricValue(cmx.RuntimeSchedulerLatency))
+		})
+	}
+}

--- a/pkg/runtime/helpers.go
+++ b/pkg/runtime/helpers.go
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runtime
+
+import (
+	"runtime/metrics"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	cmx "github.com/cilium/cilium/pkg/metrics"
+	"github.com/sirupsen/logrus"
+)
+
+func rtLogger(log logrus.FieldLogger) logrus.FieldLogger {
+	return log.WithFields(logrus.Fields{
+		logfields.LogSubsys: cmx.SubsystemRuntime,
+	})
+}
+
+func compact(h *metrics.Float64Histogram) {
+	nc, nb := make([]uint64, 0, len(h.Counts)), make([]float64, 0, len(h.Counts))
+	for i, c := range h.Counts {
+		if c == 0 {
+			continue
+		}
+		if i >= len(h.Buckets) {
+			break
+		}
+		if h.Buckets[i] > 0 {
+			nc, nb = append(nc, c), append(nb, h.Buckets[i])
+		}
+	}
+	h.Counts, h.Buckets = nc, nb
+}
+
+func computeMedian(h *metrics.Float64Histogram) float64 {
+	compact(h)
+	var total uint64
+	for _, c := range h.Counts {
+		total += c
+	}
+	m, total := total/2, 0
+	if m == 0 {
+		return 0
+	}
+	for i, c := range h.Counts {
+		total += c
+		if total >= m {
+			return h.Buckets[i]
+		}
+	}
+
+	return 0
+}

--- a/pkg/runtime/helpers_test.go
+++ b/pkg/runtime/helpers_test.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runtime
+
+import (
+	"runtime/metrics"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeMedian(t *testing.T) {
+	uu := map[string]struct {
+		h metrics.Float64Histogram
+		e float64
+	}{
+		"empty": {},
+
+		"zeros": {
+			h: metrics.Float64Histogram{
+				Buckets: []float64{10, 0, 30},
+				Counts:  []uint64{10, 0, 30},
+			},
+			e: 30,
+		},
+
+		"plain": {
+			h: metrics.Float64Histogram{
+				Buckets: []float64{10, 20, 30},
+				Counts:  []uint64{10, 20, 30},
+			},
+			e: 20,
+		},
+
+		"sparse": {
+			h: metrics.Float64Histogram{
+				Buckets: []float64{0.000000, 0.000001, 0.000002, 0.000003, 0.000004, 0.000006, 0.000007, 0.000008, 0.000010, 0.000012, 0.000014, 0.000016, 0.000020, 0.000025, 0.000029, 0.000033, 0.000041, 0.000049, 0.000057, 0.000066, 0.000082, 0.000098, 0.000115, 0.000131, 0.000164, 0.000197, 0.000229, 0.000262, 0.000328, 0.000393},
+				Counts:  []uint64{257, 1, 0, 2, 2, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 4, 2, 2, 1, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1},
+			},
+			e: 0.000041,
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, computeMedian(&u.h))
+		})
+	}
+}
+
+func TestCompact(t *testing.T) {
+	uu := map[string]struct {
+		h, e metrics.Float64Histogram
+	}{
+		"empty": {
+			e: metrics.Float64Histogram{
+				Buckets: []float64{},
+				Counts:  []uint64{},
+			},
+		},
+
+		"zeros": {
+			h: metrics.Float64Histogram{
+				Buckets: []float64{10, 0, 30},
+				Counts:  []uint64{10, 0, 30},
+			},
+			e: metrics.Float64Histogram{
+				Buckets: []float64{10, 30},
+				Counts:  []uint64{10, 30},
+			},
+		},
+
+		"plain": {
+			h: metrics.Float64Histogram{
+				Buckets: []float64{10, 20, 30},
+				Counts:  []uint64{10, 20, 30},
+			},
+			e: metrics.Float64Histogram{
+				Buckets: []float64{10, 20, 30},
+				Counts:  []uint64{10, 20, 30},
+			},
+		},
+
+		"sparse": {
+			h: metrics.Float64Histogram{
+				Buckets: []float64{0.000000, 0.000001, 0.000002, 0.000003, 0.000004, 0.000006, 0.000007, 0.000008, 0.000010, 0.000012, 0.000014, 0.000016, 0.000020, 0.000025, 0.000029, 0.000033, 0.000041, 0.000049, 0.000057, 0.000066, 0.000082, 0.000098, 0.000115, 0.000131, 0.000164, 0.000197, 0.000229, 0.000262, 0.000328, 0.000393},
+				Counts:  []uint64{257, 1, 0, 2, 2, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 4, 2, 2, 1, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1},
+			},
+			e: metrics.Float64Histogram{
+				Buckets: []float64{0.000001, 0.000003, 0.000004, 0.000012, 0.000025, 0.000029, 0.000033, 0.000041, 0.000049, 0.000057, 0.000066, 0.000082, 0.000164},
+				Counts:  []uint64{1, 2, 2, 1, 1, 1, 1, 4, 2, 2, 1, 2, 1},
+			},
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			compact(&u.h)
+			assert.Equal(t, u.e, u.h)
+		})
+	}
+}

--- a/pkg/runtime/metrics.go
+++ b/pkg/runtime/metrics.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runtime
+
+import "runtime/metrics"
+
+const schedLatencyMX = "/sched/latencies:seconds"
+
+type goRuntimeMetrics struct {
+	samples []metrics.Sample
+}
+
+func newGORuntimeMetrics() *goRuntimeMetrics {
+	return &goRuntimeMetrics{
+		samples: []metrics.Sample{
+			{Name: schedLatencyMX},
+		},
+	}
+}
+
+// GetSchedulerLatency fetches GORs scheduling latencies from GO runtime.
+func (g goRuntimeMetrics) GetSchedulerLatency() *metrics.Float64Histogram {
+	metrics.Read(g.samples)
+	for _, s := range g.samples {
+		if s.Name == schedLatencyMX {
+			return s.Value.Float64Histogram()
+		}
+	}
+
+	return nil
+}

--- a/pkg/runtime/test_helpers_test.go
+++ b/pkg/runtime/test_helpers_test.go
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package runtime
+
+import (
+	"runtime/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+type testRTMetrics struct {
+	hits int
+	hist *metrics.Float64Histogram
+}
+
+func newTestRTMetrics(h *metrics.Float64Histogram) *testRTMetrics {
+	return &testRTMetrics{hist: h}
+}
+
+// GetSchedulerLatency fetch GORs scheduling latencies from GO runtime.
+func (tmx *testRTMetrics) GetSchedulerLatency() *metrics.Float64Histogram {
+	tmx.hits++
+
+	return tmx.hist
+}
+
+func getMetricValue(col prometheus.Collector) float64 {
+	var acc float64
+	gather(col, func(m dto.Metric) {
+		switch {
+		case m.GetHistogram() != nil:
+			acc += float64(m.GetHistogram().GetSampleCount())
+		case m.GetSummary() != nil:
+			acc += float64(m.GetSummary().GetSampleCount())
+		case m.GetGauge() != nil:
+			acc += m.GetGauge().GetValue()
+		case m.GetCounter() != nil:
+			acc += m.GetCounter().GetValue()
+		}
+	})
+
+	return acc
+}
+
+func gather(c prometheus.Collector, f func(dto.Metric)) {
+	out := make(chan prometheus.Metric)
+	go func(c prometheus.Collector, out chan prometheus.Metric) {
+		c.Collect(out)
+		close(out)
+	}(c, out)
+
+	for x := range out {
+		var m dto.Metric
+		if err := x.Write(&m); err == nil {
+			f(m)
+		}
+	}
+}


### PR DESCRIPTION
The Agent/Controller largely depends on various goroutines being scheduled on time to perform critical control plane tasks (i.e. like controllers, etc...)

We want to be able to detect/alert goroutine scheduling latency, specifically when CPU contention is so great that things may not be running on time.

Taps into runtime to monitor GO scheduler latency for GORs waiting to run
- Add cell to monitor GO scheduler latencies (default: every 5mins)
- Add prom metric to report on agent scheduler latency

> NOTE: This is no way full proof ie if the agent is already in trouble
likely the RT monitor will lag. That is if the heatlh probe did not catch it earlier and restarts the pod.

Please ensure your pull request adheres to the following guidelines:

- [x ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Monitors GO scheduler runtime latency and expose agent's latencies as prometheus
metric `cilium_runtime_scheduler_latency_duration_seconds`
```

Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>