### PR TITLE
Add flag to administratively enable APIs on bootstrap

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -91,6 +91,7 @@ cilium-agent [flags]
       --enable-bpf-clock-probe                                  Enable BPF clock source probing for more efficient tick retrieval
       --enable-bpf-masquerade                                   Masquerade packets from endpoints leaving the host with BPF instead of iptables
       --enable-bpf-tproxy                                       Enable BPF-based proxy redirection, if support available
+      --enable-cilium-api-server-access strings                 List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-endpoint-slice                            Enable the CiliumEndpointSlice watcher in place of the CiliumEndpoint watcher (beta)
       --enable-custom-calls                                     Enable tail call hooks for custom eBPF programs
       --enable-endpoint-health-checking                         Enable connectivity health checking between virtual endpoints (default true)

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -93,6 +93,7 @@ cilium-agent [flags]
       --enable-bpf-tproxy                                       Enable BPF-based proxy redirection, if support available
       --enable-cilium-api-server-access strings                 List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-cilium-endpoint-slice                            Enable the CiliumEndpointSlice watcher in place of the CiliumEndpoint watcher (beta)
+      --enable-cilium-health-api-server-access strings          List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-custom-calls                                     Enable tail call hooks for custom eBPF programs
       --enable-endpoint-health-checking                         Enable connectivity health checking between virtual endpoints (default true)
       --enable-endpoint-routes                                  Use per endpoint routes instead of routing via cilium_host

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -11,29 +11,30 @@ cilium-agent hive [flags]
 ### Options
 
 ```
-      --certificates-directory string          Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cni-chaining-mode string               Enable CNI chaining with the specified plugin (default "none")
-      --cni-exclusive                          Whether to remove other CNI configurations
-      --cni-log-file string                    Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
-      --enable-k8s                             Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                       Port for gops server to listen on (default 9890)
-  -h, --help                                   help for hive
-      --install-egress-gateway-routes          Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
-      --k8s-api-server string                  Kubernetes API server URL
-      --k8s-client-burst int                   Burst value allowed for the K8s client
-      --k8s-client-qps float32                 Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration         Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file
-      --mesh-auth-monitor-queue-size int       Queue size for the auth monitor (default 1024)
-      --mesh-auth-mtls-listener-port int       Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
-      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-admin-socket string    The path for the SPIRE admin agent Unix socket.
-      --pprof                                  Enable serving pprof debugging API
-      --pprof-address string                   Address that pprof listens on (default "localhost")
-      --pprof-port uint16                      Port that pprof listens on (default 6060)
-      --read-cni-conf string                   CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
-      --write-cni-conf-when-ready string       Write the CNI configuration to the specified path when agent is ready
+      --certificates-directory string             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cni-chaining-mode string                  Enable CNI chaining with the specified plugin (default "none")
+      --cni-exclusive                             Whether to remove other CNI configurations
+      --cni-log-file string                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
+      --enable-cilium-api-server-access strings   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-k8s                                Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                          Port for gops server to listen on (default 9890)
+  -h, --help                                      help for hive
+      --install-egress-gateway-routes             Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
+      --k8s-api-server string                     Kubernetes API server URL
+      --k8s-client-burst int                      Burst value allowed for the K8s client
+      --k8s-client-qps float32                    Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int          Queue size for the auth monitor (default 1024)
+      --mesh-auth-mtls-listener-port int          Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-spiffe-trust-domain string      The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-admin-socket string       The path for the SPIRE admin agent Unix socket.
+      --pprof                                     Enable serving pprof debugging API
+      --pprof-address string                      Address that pprof listens on (default "localhost")
+      --pprof-port uint16                         Port that pprof listens on (default 6060)
+      --read-cni-conf string                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --write-cni-conf-when-ready string          Write the CNI configuration to the specified path when agent is ready
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -11,30 +11,31 @@ cilium-agent hive [flags]
 ### Options
 
 ```
-      --certificates-directory string             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cni-chaining-mode string                  Enable CNI chaining with the specified plugin (default "none")
-      --cni-exclusive                             Whether to remove other CNI configurations
-      --cni-log-file string                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
-      --enable-cilium-api-server-access strings   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-k8s                                Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                          Port for gops server to listen on (default 9890)
-  -h, --help                                      help for hive
-      --install-egress-gateway-routes             Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
-      --k8s-api-server string                     Kubernetes API server URL
-      --k8s-client-burst int                      Burst value allowed for the K8s client
-      --k8s-client-qps float32                    Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
-      --mesh-auth-monitor-queue-size int          Queue size for the auth monitor (default 1024)
-      --mesh-auth-mtls-listener-port int          Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
-      --mesh-auth-spiffe-trust-domain string      The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-admin-socket string       The path for the SPIRE admin agent Unix socket.
-      --pprof                                     Enable serving pprof debugging API
-      --pprof-address string                      Address that pprof listens on (default "localhost")
-      --pprof-port uint16                         Port that pprof listens on (default 6060)
-      --read-cni-conf string                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
-      --write-cni-conf-when-ready string          Write the CNI configuration to the specified path when agent is ready
+      --certificates-directory string                    Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cni-chaining-mode string                         Enable CNI chaining with the specified plugin (default "none")
+      --cni-exclusive                                    Whether to remove other CNI configurations
+      --cni-log-file string                              Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
+      --enable-cilium-api-server-access strings          List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-cilium-health-api-server-access strings   List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-k8s                                       Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                         Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                                 Port for gops server to listen on (default 9890)
+  -h, --help                                             help for hive
+      --install-egress-gateway-routes                    Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
+      --k8s-api-server string                            Kubernetes API server URL
+      --k8s-client-burst int                             Burst value allowed for the K8s client
+      --k8s-client-qps float32                           Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int                 Queue size for the auth monitor (default 1024)
+      --mesh-auth-mtls-listener-port int                 Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-spiffe-trust-domain string             The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-admin-socket string              The path for the SPIRE admin agent Unix socket.
+      --pprof                                            Enable serving pprof debugging API
+      --pprof-address string                             Address that pprof listens on (default "localhost")
+      --pprof-port uint16                                Port that pprof listens on (default 6060)
+      --read-cni-conf string                             CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --write-cni-conf-when-ready string                 Write the CNI configuration to the specified path when agent is ready
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -17,28 +17,29 @@ cilium-agent hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --certificates-directory string          Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cni-chaining-mode string               Enable CNI chaining with the specified plugin (default "none")
-      --cni-exclusive                          Whether to remove other CNI configurations
-      --cni-log-file string                    Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
-      --enable-k8s                             Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery               Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                       Port for gops server to listen on (default 9890)
-      --install-egress-gateway-routes          Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
-      --k8s-api-server string                  Kubernetes API server URL
-      --k8s-client-burst int                   Burst value allowed for the K8s client
-      --k8s-client-qps float32                 Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration         Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file
-      --mesh-auth-monitor-queue-size int       Queue size for the auth monitor (default 1024)
-      --mesh-auth-mtls-listener-port int       Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
-      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-admin-socket string    The path for the SPIRE admin agent Unix socket.
-      --pprof                                  Enable serving pprof debugging API
-      --pprof-address string                   Address that pprof listens on (default "localhost")
-      --pprof-port uint16                      Port that pprof listens on (default 6060)
-      --read-cni-conf string                   CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
-      --write-cni-conf-when-ready string       Write the CNI configuration to the specified path when agent is ready
+      --certificates-directory string             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cni-chaining-mode string                  Enable CNI chaining with the specified plugin (default "none")
+      --cni-exclusive                             Whether to remove other CNI configurations
+      --cni-log-file string                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
+      --enable-cilium-api-server-access strings   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-k8s                                Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                          Port for gops server to listen on (default 9890)
+      --install-egress-gateway-routes             Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
+      --k8s-api-server string                     Kubernetes API server URL
+      --k8s-client-burst int                      Burst value allowed for the K8s client
+      --k8s-client-qps float32                    Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int          Queue size for the auth monitor (default 1024)
+      --mesh-auth-mtls-listener-port int          Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-spiffe-trust-domain string      The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-admin-socket string       The path for the SPIRE admin agent Unix socket.
+      --pprof                                     Enable serving pprof debugging API
+      --pprof-address string                      Address that pprof listens on (default "localhost")
+      --pprof-port uint16                         Port that pprof listens on (default 6060)
+      --read-cni-conf string                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --write-cni-conf-when-ready string          Write the CNI configuration to the specified path when agent is ready
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -17,29 +17,30 @@ cilium-agent hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
-      --certificates-directory string             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
-      --cni-chaining-mode string                  Enable CNI chaining with the specified plugin (default "none")
-      --cni-exclusive                             Whether to remove other CNI configurations
-      --cni-log-file string                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
-      --enable-cilium-api-server-access strings   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
-      --enable-k8s                                Enable the k8s clientset (default true)
-      --enable-k8s-api-discovery                  Enable discovery of Kubernetes API groups and resources with the discovery API
-      --gops-port uint16                          Port for gops server to listen on (default 9890)
-      --install-egress-gateway-routes             Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
-      --k8s-api-server string                     Kubernetes API server URL
-      --k8s-client-burst int                      Burst value allowed for the K8s client
-      --k8s-client-qps float32                    Queries per second limit for the K8s client
-      --k8s-heartbeat-timeout duration            Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
-      --k8s-kubeconfig-path string                Absolute path of the kubernetes kubeconfig file
-      --mesh-auth-monitor-queue-size int          Queue size for the auth monitor (default 1024)
-      --mesh-auth-mtls-listener-port int          Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
-      --mesh-auth-spiffe-trust-domain string      The trust domain for the SPIFFE identity. (default "spiffe.cilium")
-      --mesh-auth-spire-admin-socket string       The path for the SPIRE admin agent Unix socket.
-      --pprof                                     Enable serving pprof debugging API
-      --pprof-address string                      Address that pprof listens on (default "localhost")
-      --pprof-port uint16                         Port that pprof listens on (default 6060)
-      --read-cni-conf string                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
-      --write-cni-conf-when-ready string          Write the CNI configuration to the specified path when agent is ready
+      --certificates-directory string                    Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cni-chaining-mode string                         Enable CNI chaining with the specified plugin (default "none")
+      --cni-exclusive                                    Whether to remove other CNI configurations
+      --cni-log-file string                              Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
+      --enable-cilium-api-server-access strings          List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-cilium-health-api-server-access strings   List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
+      --enable-k8s                                       Enable the k8s clientset (default true)
+      --enable-k8s-api-discovery                         Enable discovery of Kubernetes API groups and resources with the discovery API
+      --gops-port uint16                                 Port for gops server to listen on (default 9890)
+      --install-egress-gateway-routes                    Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
+      --k8s-api-server string                            Kubernetes API server URL
+      --k8s-client-burst int                             Burst value allowed for the K8s client
+      --k8s-client-qps float32                           Queries per second limit for the K8s client
+      --k8s-heartbeat-timeout duration                   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
+      --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-monitor-queue-size int                 Queue size for the auth monitor (default 1024)
+      --mesh-auth-mtls-listener-port int                 Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
+      --mesh-auth-spiffe-trust-domain string             The trust domain for the SPIFFE identity. (default "spiffe.cilium")
+      --mesh-auth-spire-admin-socket string              The path for the SPIRE admin agent Unix socket.
+      --pprof                                            Enable serving pprof debugging API
+      --pprof-address string                             Address that pprof listens on (default "localhost")
+      --pprof-port uint16                                Port that pprof listens on (default 6060)
+      --read-cni-conf string                             CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
+      --write-cni-conf-when-ready string                 Write the CNI configuration to the specified path when agent is ready
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -31,6 +31,7 @@ cilium-operator-alibabacloud [flags]
       --config-dir string                                    Configuration directory that contains a file for each option
   -D, --debug                                                Enable debugging mode
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -11,6 +11,7 @@ cilium-operator-alibabacloud hive [flags]
 ### Options
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -35,6 +35,7 @@ cilium-operator-aws [flags]
   -D, --debug                                                Enable debugging mode
       --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -11,6 +11,7 @@ cilium-operator-aws hive [flags]
 ### Options
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator-aws hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -34,6 +34,7 @@ cilium-operator-azure [flags]
       --config-dir string                                    Configuration directory that contains a file for each option
   -D, --debug                                                Enable debugging mode
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -11,6 +11,7 @@ cilium-operator-azure hive [flags]
 ### Options
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator-azure hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -30,6 +30,7 @@ cilium-operator-generic [flags]
       --config-dir string                                    Configuration directory that contains a file for each option
   -D, --debug                                                Enable debugging mode
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -11,6 +11,7 @@ cilium-operator-generic hive [flags]
 ### Options
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator-generic hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -40,6 +40,7 @@ cilium-operator [flags]
   -D, --debug                                                Enable debugging mode
       --ec2-api-endpoint string                              AWS API endpoint for the EC2 service
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -11,6 +11,7 @@ cilium-operator hive [flags]
 ### Options
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -17,6 +17,7 @@ cilium-operator hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --gops-port uint16                                     Port for gops server to listen on (default 9891)

--- a/api/v1/health/server/server.go
+++ b/api/v1/health/server/server.go
@@ -113,6 +113,28 @@ var (
 	tlsCACertificate  string
 )
 
+var SpecCell = cell.Module(
+	"cilium-health-api-spec",
+	"cilium health API Specification",
+
+	cell.Provide(newSpec),
+)
+
+type Spec struct {
+	*loads.Document
+}
+
+func newSpec() (*Spec, error) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load swagger spec: %w", err)
+	}
+
+	return &Spec{
+		Document: swaggerSpec,
+	}, nil
+}
+
 // NewServer creates a new api cilium health API server but does not configure it
 func NewServer(api *restapi.CiliumHealthAPIAPI) *Server {
 	s := new(Server)

--- a/api/v1/operator/server/server.go
+++ b/api/v1/operator/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/swag"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
 	"golang.org/x/net/netutil"
 
 	"github.com/cilium/cilium/api/v1/operator/server/restapi"
@@ -113,25 +114,52 @@ var (
 	tlsCACertificate  string
 )
 
+type SpecConfig struct {
+	EnableCiliumOperatorServerAccess []string
+}
+
+var (
+	defaultSpecConfig = SpecConfig{
+		EnableCiliumOperatorServerAccess: []string{"*"},
+	}
+	AdminEnableFlag = "enable-cilium-operator-server-access"
+)
+
+func (cfg SpecConfig) Flags(flags *pflag.FlagSet) {
+	flags.StringSlice(AdminEnableFlag, cfg.EnableCiliumOperatorServerAccess,
+		"List of cilium operator APIs which are administratively enabled. Supports '*'.")
+}
+
 var SpecCell = cell.Module(
 	"cilium-operator-spec",
 	"cilium operator Specification",
 
+	cell.Config(defaultSpecConfig),
 	cell.Provide(newSpec),
 )
 
 type Spec struct {
 	*loads.Document
+
+	// DeniedAPIs is a set of APIs that are administratively disabled.
+	DeniedAPIs api.PathSet
 }
 
-func newSpec() (*Spec, error) {
+func newSpec(cfg SpecConfig) (*Spec, error) {
 	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to load swagger spec: %w", err)
 	}
 
+	deniedAPIs, err := api.AllowedFlagsToDeniedPaths(swaggerSpec, cfg.EnableCiliumOperatorServerAccess)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %q flag: %w",
+			AdminEnableFlag, err)
+	}
+
 	return &Spec{
-		Document: swaggerSpec,
+		Document:   swaggerSpec,
+		DeniedAPIs: deniedAPIs,
 	}, nil
 }
 

--- a/api/v1/operator/server/server.go
+++ b/api/v1/operator/server/server.go
@@ -113,6 +113,28 @@ var (
 	tlsCACertificate  string
 )
 
+var SpecCell = cell.Module(
+	"cilium-operator-spec",
+	"cilium operator Specification",
+
+	cell.Provide(newSpec),
+)
+
+type Spec struct {
+	*loads.Document
+}
+
+func newSpec() (*Spec, error) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load swagger spec: %w", err)
+	}
+
+	return &Spec{
+		Document: swaggerSpec,
+	}, nil
+}
+
 // NewServer creates a new api cilium operator server but does not configure it
 func NewServer(api *restapi.CiliumOperatorAPI) *Server {
 	s := new(Server)

--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-openapi/loads"
   "github.com/go-openapi/swag"
   {{ if .UsePFlags }}flag "github.com/spf13/pflag"
   {{ end -}}
@@ -121,6 +122,28 @@ var (
   tlsCertificateKey string
   tlsCACertificate  string
 )
+
+var SpecCell = cell.Module(
+	"{{ dasherize .Name }}-spec",
+	"{{ humanize .Name }} Specification",
+
+	cell.Provide(newSpec),
+)
+
+type Spec struct {
+	*loads.Document
+}
+
+func newSpec() (*Spec, error) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load swagger spec: %w", err)
+	}
+
+	return &Spec{
+		Document:   swaggerSpec,
+	}, nil
+}
 
 // NewServer creates a new api {{ humanize .Name }} server but does not configure it
 func NewServer(api *{{ .Package }}.{{ pascalize .Name }}API) *Server {

--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -123,25 +123,52 @@ var (
   tlsCACertificate  string
 )
 
+type SpecConfig struct {
+	Enable{{ pascalize .Name }}ServerAccess []string
+}
+
+var (
+	defaultSpecConfig = SpecConfig{
+		Enable{{ pascalize .Name }}ServerAccess: []string{"*"},
+	}
+	AdminEnableFlag = "enable-{{ dasherize .Name }}-server-access"
+)
+
+func (cfg SpecConfig) Flags(flags *pflag.FlagSet) {
+	flags.StringSlice(AdminEnableFlag, cfg.Enable{{ pascalize .Name }}ServerAccess,
+		"List of {{ humanize .Name }} APIs which are administratively enabled. Supports '*'.")
+}
+
 var SpecCell = cell.Module(
 	"{{ dasherize .Name }}-spec",
 	"{{ humanize .Name }} Specification",
 
+	cell.Config(defaultSpecConfig),
 	cell.Provide(newSpec),
 )
 
 type Spec struct {
 	*loads.Document
+
+	// DeniedAPIs is a set of APIs that are administratively disabled.
+	DeniedAPIs api.PathSet
 }
 
-func newSpec() (*Spec, error) {
+func newSpec(cfg SpecConfig) (*Spec, error) {
 	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to load swagger spec: %w", err)
 	}
 
+	deniedAPIs, err := api.AllowedFlagsToDeniedPaths(swaggerSpec, cfg.Enable{{ pascalize .Name }}ServerAccess)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse %q flag: %w",
+				       AdminEnableFlag, err)
+	}
+
 	return &Spec{
 		Document:   swaggerSpec,
+		DeniedAPIs: deniedAPIs,
 	}, nil
 }
 

--- a/api/v1/server/server.go
+++ b/api/v1/server/server.go
@@ -217,6 +217,28 @@ var (
 	tlsCACertificate  string
 )
 
+var SpecCell = cell.Module(
+	"cilium-api-spec",
+	"cilium API Specification",
+
+	cell.Provide(newSpec),
+)
+
+type Spec struct {
+	*loads.Document
+}
+
+func newSpec() (*Spec, error) {
+	swaggerSpec, err := loads.Analyzed(SwaggerJSON, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to load swagger spec: %w", err)
+	}
+
+	return &Spec{
+		Document: swaggerSpec,
+	}, nil
+}
+
 // NewServer creates a new api cilium API server but does not configure it
 func NewServer(api *restapi.CiliumAPIAPI) *Server {
 	s := new(Server)

--- a/cilium-health/launch/launcher.go
+++ b/cilium-health/launch/launcher.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/api"
 	ciliumPkg "github.com/cilium/cilium/pkg/client"
@@ -38,7 +39,7 @@ const (
 )
 
 // Launch starts the cilium-health server and returns a handle to obtain its status
-func Launch() (*CiliumHealth, error) {
+func Launch(spec *healthApi.Spec) (*CiliumHealth, error) {
 	var (
 		err error
 		ch  = &CiliumHealth{}
@@ -49,6 +50,7 @@ func Launch() (*CiliumHealth, error) {
 		ProbeInterval: serverProbeInterval,
 		ProbeDeadline: serverProbeDeadline,
 		HTTPPathPort:  option.Config.ClusterHealthPort,
+		HealthAPISpec: spec,
 	}
 
 	ch.server, err = server.NewServer(config)

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/auth"
@@ -86,6 +87,9 @@ var (
 
 		// Cilium API specification cell makes the swagger model available for reuse
 		server.SpecCell,
+
+		// cilium-health connectivity probe API specification cell makes the swagger model available for reuse
+		healthApi.SpecCell,
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -4,6 +4,7 @@
 package cmd
 
 import (
+	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bgpv1"
@@ -82,6 +83,9 @@ var (
 
 		// Certificate manager provides an API for retrieving secrets and certificate in the form of TLS contexts.
 		certificatemanager.Cell,
+
+		// Cilium API specification cell makes the swagger model available for reuse
+		server.SpecCell,
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	"github.com/cilium/cilium/daemon/cmd/cni"
+	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/aws/eni"
 	bgpv1 "github.com/cilium/cilium/pkg/bgpv1/agent"
@@ -1978,6 +1979,8 @@ func (d *Daemon) instantiateAPI(swaggerSpec *server.Spec) *restapi.CiliumAPIAPI 
 
 	// /bgp/peers
 	restAPI.BgpGetBgpPeersHandler = NewGetBGPHandler(d.bgpControlPlaneController)
+
+	api.DisableAPIs(swaggerSpec.DeniedAPIs, restAPI.AddMiddlewareFor)
 
 	return restAPI
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
+	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/api/v1/server/restapi"
 	"github.com/cilium/cilium/daemon/cmd/cni"
@@ -1593,6 +1594,7 @@ type daemonParams struct {
 	EgressGatewayManager *egressgateway.Manager
 	CNIConfigManager     cni.CNIConfigManager
 	SwaggerSpec          *server.Spec
+	HealthAPISpec        *healthApi.Spec
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
@@ -1774,7 +1776,7 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 
 	bootstrapStats.healthCheck.Start()
 	if option.Config.EnableHealthChecking {
-		d.initHealth(cleaner)
+		d.initHealth(params.HealthAPISpec, cleaner)
 	}
 	bootstrapStats.healthCheck.End(true)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1980,6 +1980,23 @@ func (d *Daemon) instantiateAPI(swaggerSpec *server.Spec) *restapi.CiliumAPIAPI 
 	// /bgp/peers
 	restAPI.BgpGetBgpPeersHandler = NewGetBGPHandler(d.bgpControlPlaneController)
 
+	msg := "Required API option %s is disabled. This may prevent Cilium from operating correctly"
+	hint := "Consider enabling this API in " + server.AdminEnableFlag
+	for _, requiredAPI := range []string{
+		"GetConfig",
+		"GetHealthz",
+		"PutEndpointID",
+		"DeleteEndpointID",
+		"PostIPAM",
+		"DeleteIPAMIP",
+	} {
+		if _, denied := swaggerSpec.DeniedAPIs[requiredAPI]; denied {
+			log.WithFields(logrus.Fields{
+				logfields.Hint:   hint,
+				logfields.Params: requiredAPI,
+			}).Warning(msg)
+		}
+	}
 	api.DisableAPIs(swaggerSpec.DeniedAPIs, restAPI.AddMiddlewareFor)
 
 	return restAPI

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	health "github.com/cilium/cilium/cilium-health/launch"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -19,10 +20,10 @@ import (
 	"github.com/cilium/cilium/pkg/pidfile"
 )
 
-func (d *Daemon) initHealth(cleaner *daemonCleanup) {
+func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup) {
 	// Launch cilium-health in the same process (and namespace) as cilium.
 	log.Info("Launching Cilium health daemon")
-	if ch, err := health.Launch(); err != nil {
+	if ch, err := health.Launch(spec); err != nil {
 		log.WithError(err).Fatal("Failed to launch cilium-health")
 	} else {
 		d.ciliumHealth = ch

--- a/operator/api/server.go
+++ b/operator/api/server.go
@@ -83,12 +83,12 @@ func (s *server) Start(ctx hive.HookContext) error {
 		return err
 	}
 
-	api := restapi.NewCiliumOperatorAPI(spec)
-	api.Logger = s.logger.Debugf
-	api.OperatorGetHealthzHandler = s.healthHandler
-	api.MetricsGetMetricsHandler = s.metricsHandler
+	restAPI := restapi.NewCiliumOperatorAPI(spec)
+	restAPI.Logger = s.logger.Debugf
+	restAPI.OperatorGetHealthzHandler = s.healthHandler
+	restAPI.MetricsGetMetricsHandler = s.metricsHandler
 
-	srv := operatorApi.NewServer(api)
+	srv := operatorApi.NewServer(restAPI)
 	srv.EnabledListeners = []string{"http"}
 	srv.ConfigureAPI()
 	s.Server = srv

--- a/operator/api/server_test.go
+++ b/operator/api/server_test.go
@@ -12,6 +12,7 @@ import (
 
 	"go.uber.org/goleak"
 
+	operatorApi "github.com/cilium/cilium/api/v1/operator/server"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -46,6 +47,7 @@ func TestAPIServerK8sDisabled(t *testing.T) {
 			}
 		}),
 
+		operatorApi.SpecCell,
 		cell.Provide(newServer),
 
 		cell.Invoke(func(srv Server) {
@@ -103,6 +105,7 @@ func TestAPIServerK8sEnabled(t *testing.T) {
 			}
 		}),
 
+		operatorApi.SpecCell,
 		cell.Provide(newServer),
 
 		cell.Invoke(func(srv Server) {

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 
+	operatorApi "github.com/cilium/cilium/api/v1/operator/server"
 	"github.com/cilium/cilium/operator/api"
 	"github.com/cilium/cilium/operator/auth"
 	"github.com/cilium/cilium/operator/identitygc"
@@ -113,6 +114,7 @@ var (
 			isLeader.Load,
 		),
 		api.MetricsHandlerCell,
+		operatorApi.SpecCell,
 		api.ServerCell,
 
 		// These cells are started only after the operator is elected leader.

--- a/pkg/api/apidisable.go
+++ b/pkg/api/apidisable.go
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+type AdminDisableHandler struct {
+	name string
+}
+
+func NewAdminDisableHandler(name string) *AdminDisableHandler {
+	return &AdminDisableHandler{
+		name: name,
+	}
+}
+
+func (a *AdminDisableHandler) ServeHTTP(wr http.ResponseWriter, req *http.Request) {
+	wr.WriteHeader(http.StatusForbidden)
+	log.WithFields(logrus.Fields{
+		logfields.Endpoint: a.name,
+	}).Info("Denied API request on admininstratively disabled API endpoint")
+	_, _ = wr.Write([]byte("This API is administratively disabled. Contact your administrator for more details."))
+}
+
+// DisableAPIs configures the API middleware for all of the paths in the
+// provided PathSet such that those APIs will be administratively disabled at
+// runtime.
+func DisableAPIs(paths PathSet, addMiddleware func(method, path string, builder middleware.Builder)) {
+	for k, pm := range paths {
+		addMiddleware(pm.Method, pm.Path, func(_ http.Handler) http.Handler {
+			return NewAdminDisableHandler(k)
+		})
+	}
+}

--- a/pkg/health/server/server.go
+++ b/pkg/health/server/server.go
@@ -383,15 +383,15 @@ func (s *Server) Shutdown() {
 // newServer instantiates a new instance of the health API server on the
 // defaults unix socket.
 func (s *Server) newServer(spec *loads.Document) *healthApi.Server {
-	api := restapi.NewCiliumHealthAPIAPI(spec)
-	api.Logger = log.Printf
+	restAPI := restapi.NewCiliumHealthAPIAPI(spec)
+	restAPI.Logger = log.Printf
 
 	// Admin API
-	api.GetHealthzHandler = NewGetHealthzHandler(s)
-	api.ConnectivityGetStatusHandler = NewGetStatusHandler(s)
-	api.ConnectivityPutStatusProbeHandler = NewPutStatusProbeHandler(s)
+	restAPI.GetHealthzHandler = NewGetHealthzHandler(s)
+	restAPI.ConnectivityGetStatusHandler = NewGetStatusHandler(s)
+	restAPI.ConnectivityPutStatusProbeHandler = NewPutStatusProbeHandler(s)
 
-	srv := healthApi.NewServer(api)
+	srv := healthApi.NewServer(restAPI)
 	srv.EnabledListeners = []string{"unix"}
 	srv.SocketPath = defaults.SockPath
 


### PR DESCRIPTION
Depends on https://github.com/cilium/cilium/pull/24967 .

Add a new (hidden) flag, `enable-cilium-api-server-access`, which accepts a list of APIs
that the daemon should allow REST API clients to mutate.

This flag can be useful to restrict the sorts of changes that can be
made locally directly from the node or from users with access to the
Cilium container. Many of these have been added over time to assist
development and debugging purposes, and may not be necessary in
production environments.

Set the default to allow "all" API modifications (`*`) so that there is no
change in behaviour for existing deployments.

In order to successfully use this flag, it is likely that at least the following options must be configured in order to allow cilium-cni to provision pods, and to ensure that the health of the agent can be assessed by Kubernetes:

- `GetConfig`
- `GetHealthz`
- `PutEndpointID`
- `DeleteEndpointID`
- `PostIPAM`
- `DeleteIPAMIP`

Users may additionally see benefit in providing `Get*` as a wildcard in order to allow any read-only APIs to be accessed, which can be very useful for debugging. Occasionally, additional flush APIs can also be very useful in order to mitigate issues at runtime, so this option should not be used unless you have a pretty strong understanding of the APIs you are likely to rely upon.

For completeness, similar flags are also added for the cilium-health and operator APIs, though the usefulness there is more limited.