### PR TITLE
bpf: inline test functions with ctx as input

### DIFF
--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -277,7 +277,7 @@ int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 	test_finish();
 }
 
-int build_reply(struct __ctx_buff *ctx)
+static __always_inline int build_reply(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -321,7 +321,7 @@ int build_reply(struct __ctx_buff *ctx)
 	return 0;
 }
 
-int check_reply(const struct __ctx_buff *ctx)
+static __always_inline int check_reply(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -540,7 +540,7 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-int build_reply(struct __ctx_buff *ctx)
+static __always_inline int build_reply(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -584,7 +584,7 @@ int build_reply(struct __ctx_buff *ctx)
 	return 0;
 }
 
-int check_reply(const struct __ctx_buff *ctx)
+static __always_inline int check_reply(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -52,7 +52,7 @@ struct {
  *            \---------------------------/
  */
 
-int build_packet(struct __ctx_buff *ctx)
+static __always_inline int build_packet(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	volatile const __u8 *src = mac_one;

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -436,7 +436,7 @@ int nodeport_nat_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
-int build_reply(struct __ctx_buff *ctx)
+static __always_inline int build_reply(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -480,7 +480,7 @@ int build_reply(struct __ctx_buff *ctx)
 	return 0;
 }
 
-int check_reply(const struct __ctx_buff *ctx)
+static __always_inline int check_reply(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -43,7 +43,7 @@ struct {
 
 static long (*bpf_xdp_adjust_tail)(struct xdp_md *xdp_md, int delta) = (void *)65;
 
-static int build_packet(struct __ctx_buff *ctx)
+static __always_inline int build_packet(struct __ctx_buff *ctx)
 {
 	/* Create room for our packet to be crafted */
 	unsigned int data_len = ctx->data_end - ctx->data;


### PR DESCRIPTION
Run ebpf test on kernel v5.11 will raise the following error:

```
  Validating build_packet() func#1...
  btf_vmlinux is malformed
  Arg#0 type PTR in build_packet() is not supported yet.
```
It's due to missing kernel patch e5069b9c "bpf: Support pointers in global func args". Inline those functions so the ebpf test can also run on v5.11 and older kernels.

Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes. n/a

