### PR TITLE
renovate: automate golangci-lint upgrades

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,7 +10,8 @@
     "images/**",
     "examples/hubble/*",
     "go.mod",
-    "go.sum"
+    "go.sum",
+    "Makefile.defs"
   ],
   postUpdateOptions: [
     "gomodTidy"
@@ -215,6 +216,18 @@
         "cilium/hubble",
         "quay.io/cilium/hubble"
       ],
+    },
+    {
+      // Do not allow any updates into stable branches.
+      "enabled": false,
+      "matchDepNames": [
+        "golangci/golangci-lint"
+      ],
+      "matchBaseBranches": [
+        "v1.13",
+        "v1.12",
+        "v1.11"
+      ]
     }
   ],
   "kubernetes": {
@@ -248,7 +261,18 @@
       // similar to the examples shown here:
       //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_version: (?<currentValue>.*)",
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+version: (?<currentValue>.*)",
+      ]
+    },
+    {
+      "fileMatch": [
+        "^Makefile\\.defs$"
+      ],
+      // This regex manages version strings in the Makefile.defs file,
+      // similar to the examples shown here:
+      //   https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION = (?<currentValue>.*)\\s+.+_SHA = (?<currentDigest>sha256:[a-f0-9]+)"
       ]
     }
   ]

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:
+          # renovate: datasource=docker depName=golangci/golangci-lint
           version: v1.51.2
           skip-cache: true
 

--- a/Makefile
+++ b/Makefile
@@ -420,7 +420,7 @@ ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION),$(GOLANGCILINT_VERSION)))
 	@$(ECHO_CHECK) golangci-lint $(GOLANGCI_LINT_ARGS)
 	$(QUIET) golangci-lint run $(GOLANGCI_LINT_ARGS)
 else
-	$(QUIET) $(CONTAINER_ENGINE) run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:v$(GOLANGCILINT_WANT_VERSION)@$(GOLANGCILINT_IMAGE_SHA) golangci-lint run $(GOLANGCI_LINT_ARGS)
+	$(QUIET) $(CONTAINER_ENGINE) run --rm -v `pwd`:/app -w /app docker.io/golangci/golangci-lint:$(GOLANGCILINT_WANT_VERSION)@$(GOLANGCILINT_IMAGE_SHA) golangci-lint run $(GOLANGCI_LINT_ARGS)
 endif
 
 golangci-lint-fix: ## Run golangci-lint to automatically fix warnings

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -87,7 +87,8 @@ ifneq ($(V),0)
 endif
 endif
 
-GOLANGCILINT_WANT_VERSION = 1.51.2
+# renovate: datasource=docker depName=golangci/golangci-lint
+GOLANGCILINT_WANT_VERSION = v1.51.2
 GOLANGCILINT_IMAGE_SHA = sha256:be42f5df32011553183947c2b2502718bde485f566e15bbd2541f38a077e4d29
 GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
 


### PR DESCRIPTION
This commit introduces automated upgrades of golangci-lint with renovate.

Only activated on the master branch.