### PR TITLE
k8s: api: clean up CRD versioning

### DIFF
--- a/Documentation/contributing/development/introducing_new_crds.rst
+++ b/Documentation/contributing/development/introducing_new_crds.rst
@@ -221,10 +221,8 @@ scheme.
            metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 
 You should also bump the ``CustomResourceDefinitionSchemaVersion``
-variable in the correct ``{api_version}/register.go`` to instruct Cilium
-that new CRDs have been added to the system. For example, bump this line if
-adding a CRD to the ``v2`` group:
-`register.go <https://github.com/cilium/cilium/blob/ea9fd6f97b6e7b0d115067dc9f69ba461055530f/pkg/k8s/apis/cilium.io/v2/register.go#L21-L27>`__
+variable in ``register.go`` to instruct Cilium
+that new CRDs have been added to the system.
 
 Register With Client
 ~~~~~~~~~~~~~~~~~~~~

--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/yaml"
 
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sconstv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -287,7 +288,7 @@ func constructV1CRD(
 			},
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
-			Group: k8sconstv2.CustomResourceDefinitionGroup,
+			Group: k8sconst.CustomResourceDefinitionGroup,
 			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Kind:       template.Spec.Names.Kind,
 				Plural:     template.Spec.Names.Plural,

--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -81,7 +81,7 @@ var (
 	// log is the k8s package logger object.
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsysK8s)
 
-	comparableCRDSchemaVersion = versioncheck.MustVersion(k8sconstv2.CustomResourceDefinitionSchemaVersion)
+	comparableCRDSchemaVersion = versioncheck.MustVersion(k8sconst.CustomResourceDefinitionSchemaVersion)
 )
 
 type crdCreationFn func(clientset apiextensionsclient.Interface) error
@@ -284,7 +284,7 @@ func constructV1CRD(
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				k8sconst.CustomResourceDefinitionSchemaVersionKey: k8sconstv2.CustomResourceDefinitionSchemaVersion,
+				k8sconst.CustomResourceDefinitionSchemaVersionKey: k8sconst.CustomResourceDefinitionSchemaVersion,
 			},
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{

--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -284,7 +284,7 @@ func constructV1CRD(
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				k8sconstv2.CustomResourceDefinitionSchemaVersionKey: k8sconstv2.CustomResourceDefinitionSchemaVersion,
+				k8sconst.CustomResourceDefinitionSchemaVersionKey: k8sconstv2.CustomResourceDefinitionSchemaVersion,
 			},
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -306,7 +306,7 @@ func needsUpdateV1(clusterCRD *apiextensionsv1.CustomResourceDefinition) bool {
 		// no validation detected
 		return true
 	}
-	v, ok := clusterCRD.Labels[k8sconstv2.CustomResourceDefinitionSchemaVersionKey]
+	v, ok := clusterCRD.Labels[k8sconst.CustomResourceDefinitionSchemaVersionKey]
 	if !ok {
 		// no schema version detected
 		return true

--- a/pkg/k8s/apis/cilium.io/client/register_test.go
+++ b/pkg/k8s/apis/cilium.io/client/register_test.go
@@ -19,7 +19,6 @@ import (
 	fakediscovery "k8s.io/client-go/discovery/fake"
 
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -36,7 +35,7 @@ func (s *CiliumV2RegisterSuite) getV1TestCRD() *apiextensionsv1.CustomResourceDe
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo-v1",
 			Labels: map[string]string{
-				k8sconst.CustomResourceDefinitionSchemaVersionKey: ciliumv2.CustomResourceDefinitionSchemaVersion,
+				k8sconst.CustomResourceDefinitionSchemaVersionKey: k8sconst.CustomResourceDefinitionSchemaVersion,
 			},
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -59,7 +58,7 @@ func (s *CiliumV2RegisterSuite) getV1beta1TestCRD() *apiextensionsv1beta1.Custom
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo-v1beta1",
 			Labels: map[string]string{
-				k8sconst.CustomResourceDefinitionSchemaVersionKey: ciliumv2.CustomResourceDefinitionSchemaVersion,
+				k8sconst.CustomResourceDefinitionSchemaVersionKey: k8sconst.CustomResourceDefinitionSchemaVersion,
 			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{

--- a/pkg/k8s/apis/cilium.io/client/register_test.go
+++ b/pkg/k8s/apis/cilium.io/client/register_test.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -35,7 +36,7 @@ func (s *CiliumV2RegisterSuite) getV1TestCRD() *apiextensionsv1.CustomResourceDe
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo-v1",
 			Labels: map[string]string{
-				ciliumv2.CustomResourceDefinitionSchemaVersionKey: ciliumv2.CustomResourceDefinitionSchemaVersion,
+				k8sconst.CustomResourceDefinitionSchemaVersionKey: ciliumv2.CustomResourceDefinitionSchemaVersion,
 			},
 		},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
@@ -58,7 +59,7 @@ func (s *CiliumV2RegisterSuite) getV1beta1TestCRD() *apiextensionsv1beta1.Custom
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "foo-v1beta1",
 			Labels: map[string]string{
-				ciliumv2.CustomResourceDefinitionSchemaVersionKey: ciliumv2.CustomResourceDefinitionSchemaVersion,
+				k8sconst.CustomResourceDefinitionSchemaVersionKey: ciliumv2.CustomResourceDefinitionSchemaVersion,
 			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
@@ -200,13 +201,13 @@ func (s *CiliumV2RegisterSuite) TestNeedsUpdateNoVersionLabel(c *C) {
 
 func (s *CiliumV2RegisterSuite) TestNeedsUpdateOlderVersion(c *C) {
 	v1CRD := s.getV1TestCRD()
-	v1CRD.Labels[ciliumv2.CustomResourceDefinitionSchemaVersionKey] = "0.9"
+	v1CRD.Labels[k8sconst.CustomResourceDefinitionSchemaVersionKey] = "0.9"
 	c.Assert(needsUpdateV1(v1CRD), Equals, true)
 }
 
 func (s *CiliumV2RegisterSuite) TestNeedsUpdateCorruptedVersion(c *C) {
 	v1CRD := s.getV1TestCRD()
-	v1CRD.Labels[ciliumv2.CustomResourceDefinitionSchemaVersionKey] = "totally-not-semver"
+	v1CRD.Labels[k8sconst.CustomResourceDefinitionSchemaVersionKey] = "totally-not-semver"
 	c.Assert(needsUpdateV1(v1CRD), Equals, true)
 }
 

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -6,4 +6,7 @@ package ciliumio
 const (
 	// CustomResourceDefinitionGroup is the name of the third party resource group
 	CustomResourceDefinitionGroup = "cilium.io"
+
+	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
+	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
 )

--- a/pkg/k8s/apis/cilium.io/register.go
+++ b/pkg/k8s/apis/cilium.io/register.go
@@ -9,4 +9,11 @@ const (
 
 	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
 	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
+
+	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
+	// Used to determine if CRD needs to be updated in cluster
+	//
+	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
+	// Developers: Bump patch for each change in the CRD schema.
+	CustomResourceDefinitionSchemaVersion = "1.26.7"
 )

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -18,13 +18,6 @@ const (
 	// CustomResourceDefinitionVersion is the current version of the resource
 	CustomResourceDefinitionVersion = "v2"
 
-	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
-	// Used to determine if CRD needs to be updated in cluster
-	//
-	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
-	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.26.7"
-
 	// Cilium Network Policy (CNP)
 
 	// CNPSingularName is the singular name of Cilium Network Policy

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -25,9 +25,6 @@ const (
 	// Developers: Bump patch for each change in the CRD schema.
 	CustomResourceDefinitionSchemaVersion = "1.26.7"
 
-	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
-	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
-
 	// Cilium Network Policy (CNP)
 
 	// CNPSingularName is the singular name of Cilium Network Policy

--- a/pkg/k8s/apis/cilium.io/v2alpha1/register.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/register.go
@@ -18,13 +18,6 @@ const (
 	// CustomResourceDefinitionVersion is the current version of the resource
 	CustomResourceDefinitionVersion = "v2alpha1"
 
-	// CustomResourceDefinitionSchemaVersion is semver-conformant version of CRD schema
-	// Used to determine if CRD needs to be updated in cluster
-	//
-	// Maintainers: Run ./Documentation/check-crd-compat-table.sh for each release
-	// Developers: Bump patch for each change in the CRD schema.
-	CustomResourceDefinitionSchemaVersion = "1.27.0"
-
 	// Cilium Endpoint Slice (CES)
 
 	// CESSingularName is the singular name of Cilium Endpoint Slice

--- a/pkg/k8s/apis/cilium.io/v2alpha1/register.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/register.go
@@ -25,9 +25,6 @@ const (
 	// Developers: Bump patch for each change in the CRD schema.
 	CustomResourceDefinitionSchemaVersion = "1.27.0"
 
-	// CustomResourceDefinitionSchemaVersionKey is key to label which holds the CRD schema version
-	CustomResourceDefinitionSchemaVersionKey = "io.cilium.k8s.crd.schema.version"
-
 	// Cilium Endpoint Slice (CES)
 
 	// CESSingularName is the singular name of Cilium Endpoint Slice


### PR DESCRIPTION
Clean up some confusion in the `v2` / `v2alpha1` versioning for CRDs. Turns out the `CustomResourceDefinitionSchemaVersion` for `v2alpha1` isn't actually used anymore.