### PR TITLE
Three fixes for deadlocks

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2101,11 +2101,22 @@ func (e *Endpoint) syncEndpointHeaderFile(reasons []string) {
 	e.buildMutex.Lock()
 	defer e.buildMutex.Unlock()
 
+	// The following GetDNSRules call will acquire a read-lock on the IPCache.
+	// Because IPCache itself will potentially acquire endpoint locks in its
+	// critical section, we must _not_ hold endpoint.mutex while calling
+	// GetDNSRules, to avoid a deadlock between IPCache and the endpoint. It is
+	// okay to hold endpoint.buildMutex, however.
+	rules := e.owner.GetDNSRules(e.ID)
+
 	if err := e.lockAlive(); err != nil {
 		// endpoint was removed in the meanwhile, return
 		return
 	}
 	defer e.unlock()
+
+	// Update DNSRules if any. This is needed because DNSRules also encode allowed destination IPs
+	// and those can change anytime we have identity updates in the cluster.
+	e.OnDNSPolicyUpdateLocked(rules)
 
 	if err := e.writeHeaderfile(e.StateDirectoryPath()); err != nil {
 		e.getLogger().WithFields(logrus.Fields{

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -35,6 +35,7 @@ type Owner interface {
 
 	// GetDNSRules creates a fresh copy of DNS rules that can be used when
 	// endpoint is restored on a restart.
+	// The endpoint lock must not be held while calling this function.
 	GetDNSRules(epID uint16) restore.DNSRules
 
 	// RemoveRestoredDNSRules removes any restored DNS rules for

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -218,50 +218,88 @@ func (p *DNSProxy) checkRestored(endpointID uint64, destPort uint16, destIP stri
 	return false
 }
 
+// skipIPInRestorationRLocked skips IPs that are allowed but have never been used,
+// but only if at least one server has been used so far.
+// Requires the RLock to be held.
+func (p *DNSProxy) skipIPInRestorationRLocked(ip string) bool {
+	if len(p.usedServers) > 0 {
+		if _, used := p.usedServers[ip]; !used {
+			return true
+		}
+	}
+	return false
+}
+
 // GetRules creates a fresh copy of EP's DNS rules to be stored
 // for later restoration.
 func (p *DNSProxy) GetRules(endpointID uint16) (restore.DNSRules, error) {
+	// Lock ordering note: Acquiring the IPCache read lock (as LookupIPsBySecID does) while holding
+	// the proxy lock can lead to a deadlock. Avoid this by reading the state from DNSProxy while
+	// holding the read lock, then perform the IPCache lookups.
+	// Note that IPCache state may change in between calls to LookupIPsBySecID.
 	p.RLock()
-	defer p.RUnlock()
+
+	type selRegex struct {
+		re *regexp.Regexp
+		cs policy.CachedSelector
+	}
+
+	portToSelRegex := make(map[uint16][]selRegex)
+	for port, entries := range p.allowed[uint64(endpointID)] {
+		var nidRules = make([]selRegex, 0, len(entries))
+		// Copy the entries to avoid racy map accesses after we release the lock. We don't need
+		// constant time access, hence a preallocated slice instead of another map.
+		for cs, regex := range entries {
+			nidRules = append(nidRules, selRegex{cs: cs, re: regex})
+		}
+		portToSelRegex[port] = nidRules
+	}
+
+	// We've read what we need from the proxy. The following IPCache lookups _must_ occur outside of
+	// the critical section.
+	p.RUnlock()
 
 	restored := make(restore.DNSRules)
-	for port, entries := range p.allowed[uint64(endpointID)] {
+	for port, selRegexes := range portToSelRegex {
 		var ipRules restore.IPRules
-		for cs, regex := range entries {
-			var IPs map[string]struct{}
-			if !cs.IsWildcard() {
-				IPs = make(map[string]struct{})
-				count := 0
-			Loop:
-				for _, nid := range cs.GetSelections() {
-					nidIPs := p.LookupIPsBySecID(nid)
-					for _, ip := range nidIPs {
-						// Skip IPs that are allowed but have never been used,
-						// but only if at least one server has been used so far.
-						if len(p.usedServers) > 0 {
-							if _, used := p.usedServers[ip]; !used {
-								continue
-							}
-						}
-						IPs[ip] = struct{}{}
-						count++
-						if count > p.maxIPsPerRestoredDNSRule {
-							log.WithFields(logrus.Fields{
-								logfields.EndpointID:            endpointID,
-								logfields.Port:                  port,
-								logfields.EndpointLabelSelector: cs,
-								logfields.Limit:                 p.maxIPsPerRestoredDNSRule,
-								logfields.Count:                 len(nidIPs),
-							}).Warning("Too many IPs for a DNS rule, skipping the rest")
-							break Loop
-						}
+		for _, selRegex := range selRegexes {
+			if selRegex.cs.IsWildcard() {
+				ipRules = append(ipRules, asIPRule(selRegex.re, nil))
+				continue
+			}
+			ips := make(map[string]struct{})
+			count := 0
+			nids := selRegex.cs.GetSelections()
+		Loop:
+			for _, nid := range nids {
+				// Note: p.RLock must not be held during this call to IPCache
+				nidIPs := p.LookupIPsBySecID(nid)
+				p.RLock()
+				for _, ip := range nidIPs {
+					if p.skipIPInRestorationRLocked(ip) {
+						continue
+					}
+					ips[ip] = struct{}{}
+					count++
+					if count > p.maxIPsPerRestoredDNSRule {
+						log.WithFields(logrus.Fields{
+							logfields.EndpointID:            endpointID,
+							logfields.Port:                  port,
+							logfields.EndpointLabelSelector: selRegex.cs,
+							logfields.Limit:                 p.maxIPsPerRestoredDNSRule,
+							logfields.Count:                 len(nidIPs),
+						}).Warning("Too many IPs for a DNS rule, skipping the rest")
+						p.RUnlock()
+						break Loop
 					}
 				}
+				p.RUnlock()
 			}
-			ipRules = append(ipRules, asIPRule(regex, IPs))
+			ipRules = append(ipRules, asIPRule(selRegex.re, ips))
 		}
 		restored[port] = ipRules
 	}
+
 	return restored, nil
 }
 

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"net/netip"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -103,18 +104,17 @@ type IPCache struct {
 	// controllers manages the async controllers for this IPCache
 	controllers *controller.Manager
 
-	// needNamedPorts is initially 'false', but will be changd to 'true' when the
-	// clusterwide named port mappings are needed for network policy computation
-	// for the first time. This avoids the overhead of maintaining 'namedPorts' map
-	// when it is known not to be needed.
-	// Protected by 'mutex'.
-	needNamedPorts bool
+	// needNamedPorts is initially 'false', but will atomically be changed to 'true'
+	// when the clusterwide named port mappings are needed for network policy
+	// computation for the first time. This avoids the overhead of unnecessarily
+	// triggering policy updates when it is known not to be needed.
+	needNamedPorts atomic.Bool
 
 	// namedPorts is a collection of all named ports in the cluster. This is needed
 	// only if an egress policy refers to a port by name.
 	// This map is returned to users so all updates must be made into a fresh map that
-	// is then swapped in place while 'mutex' is being held.
-	namedPorts types.NamedPortMultiMap
+	// is then swapped in place atomically.
+	namedPorts atomic.Pointer[types.NamedPortMultiMap]
 
 	cacheStatus k8s.CacheStatus
 
@@ -141,7 +141,7 @@ func NewIPCache(c *Configuration) *IPCache {
 		ipToHostIPCache:   map[string]IPKeyPair{},
 		ipToK8sMetadata:   map[string]K8sMetadata{},
 		controllers:       controller.NewManager(),
-		namedPorts:        nil,
+		namedPorts:        atomic.Pointer[types.NamedPortMultiMap]{},
 		metadata:          newMetadata(),
 		Configuration:     c,
 	}
@@ -244,13 +244,19 @@ func (ipc *IPCache) getK8sMetadata(ip string) *K8sMetadata {
 	return nil
 }
 
-// updateNamedPorts accumulates named ports from all K8sMetadata entries to a single map
-func (ipc *IPCache) updateNamedPorts() (namedPortsChanged bool) {
-	if !ipc.needNamedPorts {
-		return false
-	}
+// updateNamedPortsRLocked accumulates named ports from all K8sMetadata entries
+// to a single map. It is required to hold _at least_ the read lock when calling
+// this function, holding the write lock is also allowed.
+func (ipc *IPCache) updateNamedPortsRLocked() (namedPortsChanged bool) {
 	// Collect new named Ports
-	npm := make(types.NamedPortMultiMap, len(ipc.namedPorts))
+	var oldLen = 0
+	var old types.NamedPortMultiMap
+	if m := ipc.namedPorts.Load(); m != nil {
+		old = *m
+		oldLen = len(old)
+	}
+
+	npm := make(types.NamedPortMultiMap, oldLen)
 	for _, km := range ipc.ipToK8sMetadata {
 		for name, port := range km.NamedPorts {
 			if npm[name] == nil {
@@ -259,15 +265,20 @@ func (ipc *IPCache) updateNamedPorts() (namedPortsChanged bool) {
 			npm[name][port] = struct{}{}
 		}
 	}
-	namedPortsChanged = !npm.Equal(ipc.namedPorts)
+	namedPortsChanged = !npm.Equal(old)
 	if namedPortsChanged {
-		// swap the new map in
-		if len(npm) == 0 {
-			ipc.namedPorts = nil
-		} else {
-			ipc.namedPorts = npm
-		}
+		// atomically swap the new map in
+		ipc.namedPorts.Store(&npm)
 	}
+
+	// Set namedPortsChanged to false if they have not (yet) been requested.
+	// This avoids triggering policy updates if named ports changed, but no
+	// policy actually needs them. We still pre-compute the namedPorts map,
+	// so we don't have to acquire the IPCache lock in GetNamedPorts
+	if !ipc.needNamedPorts.Load() {
+		namedPortsChanged = false
+	}
+
 	return namedPortsChanged
 }
 
@@ -465,7 +476,7 @@ func (ipc *IPCache) upsertLocked(
 		if namedPortsChanged {
 			// It is possible that some other POD defines same values, check if
 			// anything changes over all the PODs.
-			namedPortsChanged = ipc.updateNamedPorts()
+			namedPortsChanged = ipc.updateNamedPortsRLocked()
 		}
 	}
 
@@ -658,7 +669,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	// Update named ports
 	namedPortsChanged = false
 	if oldK8sMeta != nil && len(oldK8sMeta.NamedPorts) > 0 {
-		namedPortsChanged = ipc.updateNamedPorts()
+		namedPortsChanged = ipc.updateNamedPortsRLocked()
 	}
 
 	if newHostIP != nil {
@@ -680,15 +691,23 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 
 // GetNamedPorts returns a copy of the named ports map. May return nil.
 func (ipc *IPCache) GetNamedPorts() (npm types.NamedPortMultiMap) {
-	ipc.mutex.Lock()
-	if !ipc.needNamedPorts {
-		ipc.needNamedPorts = true
-		ipc.updateNamedPorts()
-	}
+	// We must not acquire the IPCache mutex here, as that would establish a lock ordering of
+	// Endpoint > IPCache (as endpoint.mutex can be held while calling GetNamedPorts)
+	// Since InjectLabels requires IPCache > Endpoint, a deadlock can occur otherwise.
+
+	// needNamedPorts is initially set to 'false'. This means that we will not trigger
+	// policy updates upon changes to named ports. Once this is set to 'true' though,
+	// Upsert and Delete will start to return 'namedPortsChanged = true' if the upsert
+	// or delete changed a named port, enabling the caller to trigger a policy update.
+	// Note that at the moment, this will never be set back to false, even if no policy
+	// uses named ports anymore.
+	ipc.needNamedPorts.Store(true)
+
 	// Caller can keep using the map after the lock is released, as the map is never changed
 	// once published.
-	npm = ipc.namedPorts
-	ipc.mutex.Unlock()
+	if ptr := ipc.namedPorts.Load(); ptr != nil {
+		npm = *ptr
+	}
 	return npm
 }
 

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -550,7 +550,7 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	namedPortsChanged = IPIdentityCache.Delete(endpointIP2, source.Kubernetes)
 	c.Assert(namedPortsChanged, Equals, true)
 	npm = IPIdentityCache.GetNamedPorts()
-	c.Assert(npm, IsNil)
+	c.Assert(npm, HasLen, 0)
 }
 
 type dummyListener struct {


### PR DESCRIPTION
This PR collects three commits with deadlock fixes:
1. Fixes a deadlock involving `writeHeaderFile`. See #24582 for details
2. Removes the lock ordering constraint of DNSProxy > IPCache by hoisting IPCache access out of the DNSProxy critical section in `GetRules`
3. Resolves a potential deadlock involving IPCache and Endpoint by avoiding to hold the IPCache mutex in `GetNamedPorts`. `IPCache.InjectLabels` holds the ipcache mutex while calling into `endpointManager.UpdatePolicyMaps`, which holds each EP lock in turn. On the other hand, `GetNamedPorts` holds an EP lock and calls into IPCache.

Please review commit by commit, and carefully - all changes are subtle.

Could use some help in word-smithing the release note.

[Marking this as backport/author, `atomic.Bool` and friends aren't available in Go 1.18 for v1.12]

- v1.13 backport is #24814
- v1.12 backport is #24669

Fixes: #23836
Ref: #20915

```release-note
Solve control-plane deadlock issues leading to outages. A typical log line indicative of this issue is `probe=l7-proxy msg="No response from probe within 15 seconds"`
```

cc @gandro @joestringer @christarazi 