### PR TITLE
Add link to threat model in security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,14 @@ We strongly encourage you to report security vulnerabilities to
 our private security mailing list: security@cilium.io - first, before
 disclosing them in any public forums.
 
+A threat model for Cilium and recommendations for running Cilium in production
+environments can be found [here][threat-model]. Please ensure that you have
+taken this threat model into consideration before making a report, including
+considering the feasibility of an attack against a correctly secured
+environment.
+
 This is a private mailing list where members of Cilium's
 [Security Team](https://github.com/cilium/community/blob/main/roles/Security-Team.md)
 are subscribed to, and is treated as top priority.
+
+[threat-model]: https://docs.cilium.io/en/latest/security/threat-model/


### PR DESCRIPTION
Reference the threat model from within our Security Policy, which should allow potential vulnerability reporters to assess their reports against the threat model before submitting their reports.