### PR TITLE
Decouple CES work queue and k8s client rate limiting

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -15,6 +15,10 @@ cilium-operator-alibabacloud [flags]
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -18,6 +18,10 @@ cilium-operator-aws [flags]
       --aws-use-primary-address                              Allows for using primary address of the ENI for allocations on the node
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -18,6 +18,10 @@ cilium-operator-azure [flags]
       --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -14,6 +14,10 @@ cilium-operator-generic [flags]
       --auto-create-cilium-pod-ip-pools map                  Automatically create CiliumPodIPPool resources on startup. Specify pools in the form of <pool>=ipv4-cidrs:<cidr>,[<cidr>...];ipv4-mask-size:<size> (multiple pools can also be passed by repeating the CLI flag)
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -23,6 +23,10 @@ cilium-operator [flags]
       --azure-user-assigned-identity-id string               ID of the user assigned identity used to auth with the Azure API
       --bgp-announce-lb-ip                                   Announces service IPs of type LoadBalancer via BGP
       --bgp-config-path string                               Path to file containing the BGP configuration (default "/var/lib/cilium/bgp/config.yaml")
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cilium-endpoint-gc-interval duration                 GC interval for cilium endpoints (default 5m0s)
       --cilium-pod-labels string                             Cilium Pod's labels. Used to detect if a Cilium pod is running to remove the node taints where its running and set NetworkUnavailable to false (default "k8s-app=cilium")
       --cilium-pod-namespace string                          Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in k8s-namespace

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -288,16 +288,32 @@ func init() {
 	flags.String(option.BGPConfigPath, "/var/lib/cilium/bgp/config.yaml", "Path to file containing the BGP configuration")
 	option.BindEnv(Vp, option.BGPConfigPath)
 
-	flags.Bool(option.EnableCiliumEndpointSlice, false, "If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.")
+	enableCES := flags.Bool(option.EnableCiliumEndpointSlice, false, "If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.")
 	option.BindEnv(Vp, option.EnableCiliumEndpointSlice)
 
 	flags.Int(operatorOption.CESMaxCEPsInCES, operatorOption.CESMaxCEPsInCESDefault, "Maximum number of CiliumEndpoints allowed in a CES")
-	flags.MarkHidden(operatorOption.CESMaxCEPsInCES)
+	if *enableCES {
+		flags.MarkHidden(operatorOption.CESMaxCEPsInCES)
+	}
 	option.BindEnv(Vp, operatorOption.CESMaxCEPsInCES)
 
 	flags.String(operatorOption.CESSlicingMode, operatorOption.CESSlicingModeDefault, "Slicing mode define how ceps are grouped into a CES")
-	flags.MarkHidden(operatorOption.CESSlicingMode)
+	if *enableCES {
+		flags.MarkHidden(operatorOption.CESSlicingMode)
+	}
 	option.BindEnv(Vp, operatorOption.CESSlicingMode)
+
+	flags.Float64(operatorOption.CESWriteQPSLimit, operatorOption.CESWriteQPSLimitDefault, "CES work queue rate limit")
+	if *enableCES {
+		flags.MarkHidden(operatorOption.CESWriteQPSLimit)
+	}
+	option.BindEnv(Vp, operatorOption.CESWriteQPSLimit)
+
+	flags.Int(operatorOption.CESWriteQPSBurst, operatorOption.CESWriteQPSBurstDefault, "CES work queue burst rate")
+	if *enableCES {
+		flags.MarkHidden(operatorOption.CESWriteQPSBurst)
+	}
+	option.BindEnv(Vp, operatorOption.CESWriteQPSBurst)
 
 	flags.String(operatorOption.CiliumK8sNamespace, "", fmt.Sprintf("Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in %s", option.K8sNamespaceName))
 	option.BindEnv(Vp, operatorOption.CiliumK8sNamespace)

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -405,8 +405,8 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 			legacy.clientset,
 			operatorOption.Config.CESMaxCEPsInCES,
 			operatorOption.Config.CESSlicingMode,
-			float64(legacy.clientset.Config().K8sClientQPS),
-			legacy.clientset.Config().K8sClientBurst)
+			operatorOption.Config.CESWriteQPSLimit,
+			operatorOption.Config.CESWriteQPSBurst)
 		// Start CEP watcher
 		operatorWatchers.CiliumEndpointsSliceInit(legacy.ctx, &legacy.wg, legacy.clientset, cesController)
 		// Start the CES controller, after current CEPs are synced locally in cache.

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -32,6 +32,20 @@ const (
 	// CESSlicingModeDefault is default method for grouping CEP in a CES.
 	CESSlicingModeDefault = "cesSliceModeIdentity"
 
+	// CESWriteQPSLimitDefault is the default rate limit for the CES work queue.
+	CESWriteQPSLimitDefault = 10
+
+	// CESWriteQPSLimitMax is the maximum rate limit for the CES work queue.
+	// CES work queue QPS limit cannot exceed this value, regardless of other config.
+	CESWriteQPSLimitMax = 50
+
+	// CESWriteQPSBurstDefault is the default burst rate for the CES work queue.
+	CESWriteQPSBurstDefault = 20
+
+	// CESWriteQPSBurstMax is the maximum burst rate for the CES work queue.
+	// CES work queue QPS burst cannot exceed this value, regardless of other config.
+	CESWriteQPSBurstMax = 100
+
 	// CNPStatusCleanupQPSDefault is the default rate for the CNP NodeStatus updates GC.
 	CNPStatusCleanupQPSDefault = 10
 
@@ -233,6 +247,16 @@ const (
 
 	// CESSlicingMode instructs how CEPs are grouped in a CES.
 	CESSlicingMode = "ces-slice-mode"
+
+	// CESWriteQPSLimit is the rate limit per second for the CES work queue to
+	// process  CES events that result in CES write (Create, Update, Delete)
+	// requests to the kube-apiserver.
+	CESWriteQPSLimit = "ces-write-qps-limit"
+
+	// CESWriteQPSBurst is the burst rate per second used with CESWriteQPSLimit
+	// for the CES work queue to process CES events that result in CES write
+	// (Create, Update, Delete) requests to the kube-apiserver.
+	CESWriteQPSBurst = "ces-write-qps-burst"
 
 	// LoadBalancerL7 enables loadbalancer capabilities for services via envoy proxy
 	LoadBalancerL7 = "loadbalancer-l7"
@@ -500,6 +524,16 @@ type OperatorConfig struct {
 	// CESSlicingMode instructs how CEPs are grouped in a CES.
 	CESSlicingMode string
 
+	// CESWriteQPSLimit is the rate limit per second for the CES work queue to
+	// process  CES events that result in CES write (Create, Update, Delete)
+	// requests to the kube-apiserver.
+	CESWriteQPSLimit float64
+
+	// CESWriteQPSBurst is the burst rate per second used with CESWriteQPSLimit
+	// for the CES work queue to process CES events that result in CES write
+	// (Create, Update, Delete) requests to the kube-apiserver.
+	CESWriteQPSBurst int
+
 	// LoadBalancerL7 enables loadbalancer capabilities for services.
 	LoadBalancerL7 string
 
@@ -668,6 +702,8 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	// CiliumEndpointSlice options
 	c.CESMaxCEPsInCES = vp.GetInt(CESMaxCEPsInCES)
 	c.CESSlicingMode = vp.GetString(CESSlicingMode)
+	c.CESWriteQPSLimit = vp.GetFloat64(CESWriteQPSLimit)
+	c.CESWriteQPSBurst = vp.GetInt(CESWriteQPSBurst)
 
 	// Option maps and slices
 

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -113,10 +113,14 @@ func NewCESController(
 ) *CiliumEndpointSliceController {
 	if qpsLimit == 0 {
 		qpsLimit = CESControllerWorkQueueQPSLimit
+	} else if qpsLimit > operatorOption.CESWriteQPSLimitMax {
+		qpsLimit = operatorOption.CESWriteQPSLimitMax
 	}
 
 	if burstLimit == 0 {
 		burstLimit = CESControllerWorkQueueBurstLimit
+	} else if burstLimit > operatorOption.CESWriteQPSBurstMax {
+		burstLimit = operatorOption.CESWriteQPSBurstMax
 	}
 
 	log.WithFields(logrus.Fields{


### PR DESCRIPTION
Decouple CES work queue and k8s client rate limiting

Currently CiliumEndpointSlice (CES) work queue uses rate limiting values specified for the k8s client.

Changes:

```release-note
1. Add a new set of flags for CES work queue limit and burst rates,  `CESWriteQPSLimit` to ` and `CESWriteQPSBurst`.

  The processed work queue items always trigger a single CES create, update or write request to the kube-apiserver.
  The work queue rate limiting effectively limits the rate of writes to the kube-apiserver for CES api objects.

2. Set the default `CESWriteQPSLimit` to `10` and `CESWriteQPSBurst` to `20`.

3. Set the maximums for qps `50` and burst `100`. These values cannot be exceeded regardless of any configuration.

4. Unhide `CESMaxCEPsInCES` and `CESSlicingMode` flags from appearing in logs when `CES` is enabled.
```

Signed-off-by: Dorde Lapcevic <[dordel@google.com](mailto:dordel@google.com)>
