### PR TITLE
datapath: Devices table and controller

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -78,9 +78,6 @@ var (
 		// Provide option.Config via hive so cells can depend on the agent config.
 		cell.Provide(func() *option.DaemonConfig { return option.Config }),
 
-		// Provides an in-memory transactional database for internal state
-		statedb.Cell,
-
 		// Provides a global job registry which cells can use to spawn job groups.
 		job.Cell,
 
@@ -95,6 +92,10 @@ var (
 		// This starts before the API server as ciliumAPIHandlers() depends on
 		// the 'deletionQueue' provided by this cell.
 		deletionQueueCell,
+
+		// DB provides an extendable in-memory database with rich transactions
+		// and multi-version concurrency control through immutable radix trees.
+		statedb.Cell,
 	)
 
 	// ControlPlane implement the per-node control functions. These are pure

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -506,11 +506,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	nd := nodediscovery.NewNodeDiscovery(params.NodeManager, params.Clientset, mtuConfig, params.CNIConfigManager.GetCustomNetConf())
 
-	devMngr, err := linuxdatapath.NewDeviceManager()
-	if err != nil {
-		return nil, nil, err
-	}
-
 	d := Daemon{
 		ctx:               ctx,
 		clientset:         params.Clientset,
@@ -519,7 +514,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		compilationMutex:  new(lock.RWMutex),
 		mtuConfig:         mtuConfig,
 		datapath:          params.Datapath,
-		deviceManager:     devMngr,
+		deviceManager:     params.DeviceManager,
 		nodeDiscovery:     nd,
 		nodeLocalStore:    params.LocalNodeStore,
 		endpointCreations: newEndpointCreationManager(params.Clientset),
@@ -905,14 +900,16 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	// This is because the device detection requires self (Cilium)Node object,
 	// and the k8s service watcher depends on option.Config.EnableNodePort flag
 	// which can be modified after the device detection.
-	devices, err := d.deviceManager.Detect(params.Clientset.IsEnabled())
-	if err != nil {
-		if option.Config.AreDevicesRequired() {
-			// Fail hard if devices are required to function.
-			return nil, nil, fmt.Errorf("failed to detect devices: %w", err)
+	var devices []string
+	if d.deviceManager != nil {
+		if _, err := d.deviceManager.Detect(params.Clientset.IsEnabled()); err != nil {
+			if option.Config.AreDevicesRequired() {
+				// Fail hard if devices are required to function.
+				return nil, nil, fmt.Errorf("failed to detect devices: %w", err)
+			}
+			log.WithError(err).Warn("failed to detect devices, disabling BPF NodePort")
+			disableNodePort()
 		}
-		log.WithError(err).Warn("failed to detect devices, disabling BPF NodePort")
-		disableNodePort()
 	}
 
 	if d.l2announcer != nil {
@@ -1210,7 +1207,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	identitymanager.Subscribe(d.policy)
 
 	// Start listening to changed devices if requested.
-	if option.Config.EnableRuntimeDeviceDetection {
+	if option.Config.EnableRuntimeDeviceDetection && d.deviceManager != nil {
 		if option.Config.AreDevicesRequired() {
 			devicesChan, err := d.deviceManager.Listen(ctx)
 			if err != nil {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1643,6 +1643,7 @@ type daemonParams struct {
 	Settings             cellSettings
 	HealthProvider       cell.Health
 	HealthReporter       cell.HealthReporter
+	DeviceManager        *linuxdatapath.DeviceManager `optional:"true"`
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -71,6 +71,15 @@ var Cell = cell.Module(
 	cell.Provide(func(dp types.Datapath) types.NodeIDHandler {
 		return dp.NodeIDs()
 	}),
+
+	// DevicesController manages the devices and routes tables
+	linuxdatapath.DevicesControllerCell,
+	cell.Provide(func(cfg *option.DaemonConfig) linuxdatapath.DevicesConfig {
+		// Provide the configured devices to the devices controller.
+		// This is temporary until DevicesController takes ownership of the
+		// device-related configuration options.
+		return linuxdatapath.DevicesConfig{Devices: cfg.GetDevices()}
+	}),
 )
 
 func newWireguardAgent(lc hive.Lifecycle, localNodeStore *node.LocalNodeStore) *wg.Agent {
@@ -143,4 +152,9 @@ type datapathParams struct {
 	BpfMaps []bpf.BpfMap `group:"bpf-maps"`
 
 	NodeMap nodemap.Map
+
+	// Depend on DeviceManager to ensure devices have been resolved.
+	// This is required until option.Config.GetDevices() has been removed and
+	// uses of it converted to Table[Device].
+	DeviceManager *linuxdatapath.DeviceManager
 }

--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -1,527 +1,140 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-// This module implements Cilium's network device detection.
-
 package linux
 
 import (
 	"context"
 	"fmt"
 	"net"
-	"sort"
 	"strings"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/asm"
-	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netns"
-	"golang.org/x/sys/unix"
+	"golang.org/x/exp/slices"
 
-	"github.com/cilium/cilium/pkg/cidr"
-	"github.com/cilium/cilium/pkg/datapath/linux/probes"
-	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 )
 
-var (
-	// Route filter to look at all routing tables.
-	routeFilter = netlink.Route{
-		Table: unix.RT_TABLE_UNSPEC,
-	}
-	routeFilterMask = netlink.RT_FILTER_TABLE
-)
-
-type DeviceManager struct {
-	lock.Mutex
-	devices map[string]struct{}
-	filter  deviceFilter
-	handle  *netlink.Handle
-	netns   netns.NsHandle
-}
-
-func NewDeviceManager() (*DeviceManager, error) {
-	return NewDeviceManagerAt(netns.None())
-}
-
-func NewDeviceManagerAt(netns netns.NsHandle) (*DeviceManager, error) {
-	handle, err := netlink.NewHandleAt(netns)
-	if err != nil {
-		return nil, fmt.Errorf("unable to setup device manager: %w", err)
-	}
-	return &DeviceManager{
-		devices: make(map[string]struct{}),
-		filter:  deviceFilter(option.Config.GetDevices()),
-		handle:  handle,
-		netns:   netns,
-	}, nil
-}
-
-// Detect tries to detect devices to which BPF programs may be loaded.
-// See AreDevicesRequired() for features that require the device information.
+// DeviceManager is a temporary compatibility bridge to keep DeviceManager uses as is and reuse its tests
+// against DevicesController and the devices table.
 //
-// The devices are detected by looking at all the configured global unicast
-// routes in the system.
+// This will be refactored away in follow-up PRs that convert code over to the devices table.
+// The DirectRoutingDevice and IPv6MCastDevice would computed from the devices table as necessary.
+type DeviceManager struct {
+	params         devicesControllerParams
+	initialDevices []string
+	hive           *hive.Hive
+}
+
 func (dm *DeviceManager) Detect(k8sEnabled bool) ([]string, error) {
-	dm.Lock()
-	defer dm.Unlock()
-	dm.devices = make(map[string]struct{})
-
-	if err := dm.expandDevices(); err != nil {
-		return nil, err
+	hasWildcard := false
+	userDevices := option.Config.GetDevices()
+	for _, name := range userDevices {
+		hasWildcard = hasWildcard || strings.HasSuffix(name, "+")
 	}
 
-	if err := dm.expandDirectRoutingDevice(); err != nil {
-		return nil, err
+	devs, _ := tables.SelectedDevices(dm.params.DeviceTable.Reader(dm.params.DB.ReadTxn()))
+	names := tables.DeviceNames(devs)
+
+	if len(names) == 0 && hasWildcard {
+		// Fail if user provided a device wildcard which didn't match anything.
+		return nil, fmt.Errorf("No device found matching %v", userDevices)
 	}
 
-	l3DevOK := true
-	if !option.Config.EnableHostLegacyRouting && !option.Config.DryMode {
-		// Probe whether BPF host routing is supported for L3 devices. This will
-		// invoke bpftool and requires root privileges, so we're only probing
-		// when necessary.
-		l3DevOK = supportL3Dev()
-	}
+	option.Config.SetDevices(names)
+	dm.initialDevices = names
 
-	if len(option.Config.GetDevices()) == 0 && option.Config.AreDevicesRequired() {
-		// Detect the devices from the system routing table by finding the devices
-		// which have global unicast routes.
-		family := netlink.FAMILY_ALL
-		if option.Config.EnableIPv4 && !option.Config.EnableIPv6 {
-			family = netlink.FAMILY_V4
-		} else if !option.Config.EnableIPv4 && option.Config.EnableIPv6 {
-			family = netlink.FAMILY_V6
-		}
-
-		routes, err := dm.handle.RouteListFiltered(family, &routeFilter, routeFilterMask)
-		if err != nil {
-			return nil, fmt.Errorf("cannot retrieve routes for device detection: %w", err)
-		}
-		dm.updateDevicesFromRoutes(l3DevOK, routes)
-	} else {
-		for _, dev := range option.Config.GetDevices() {
-			dm.devices[dev] = struct{}{}
+	// Look up the device that holds the node IP. Used as fallback for direct-routing
+	// and multicast devices.
+	var nodeDevice *tables.Device
+	if k8sEnabled {
+		nodeIP := node.GetK8sNodeIP()
+		for _, dev := range devs {
+			if dev.HasIP(nodeIP) {
+				nodeDevice = dev
+				break
+			}
 		}
 	}
 
-	detectDirectRoutingDev := option.Config.DirectRoutingDeviceRequired()
-	if option.Config.DirectRoutingDeviceRequired() && option.Config.DirectRoutingDevice != "" {
-		dm.devices[option.Config.DirectRoutingDevice] = struct{}{}
-		detectDirectRoutingDev = false
-	}
-
-	detectIPv6MCastDev := option.Config.EnableIPv6NDP
-	if option.Config.IPv6MCastDevice != "" {
-		dm.devices[option.Config.IPv6MCastDevice] = struct{}{}
-		detectIPv6MCastDev = false
-	}
-
-	if detectDirectRoutingDev || detectIPv6MCastDev {
-		k8sNodeDev := ""
-		k8sNodeLink, err := findK8SNodeIPLink()
-		if err == nil {
-			k8sNodeDev = k8sNodeLink.Attrs().Name
-			dm.devices[k8sNodeDev] = struct{}{}
-		} else if k8sEnabled {
-			return nil, fmt.Errorf("k8s is enabled, but still failed to find node IP: %w", err)
+	if option.Config.DirectRoutingDeviceRequired() {
+		var filter deviceFilter
+		if option.Config.DirectRoutingDevice != "" {
+			filter = deviceFilter(strings.Split(option.Config.DirectRoutingDevice, ","))
 		}
-
-		if detectDirectRoutingDev {
-			// If only one device found, use that one. Otherwise use the device with k8s node IP.
-			if len(dm.devices) == 1 {
-				for dev := range dm.devices {
-					option.Config.DirectRoutingDevice = dev
+		option.Config.DirectRoutingDevice = ""
+		if filter.nonEmpty() {
+			// User has defined a direct-routing device. Try to find the first matching
+			// device.
+			for _, dev := range devs {
+				if filter.match(dev.Name) {
+					option.Config.DirectRoutingDevice = dev.Name
 					break
 				}
-			} else if k8sNodeDev != "" {
-				option.Config.DirectRoutingDevice = k8sNodeDev
-			} else {
-				return nil, fmt.Errorf("unable to determine direct routing device. Use --%s to specify it",
-					option.DirectRoutingDevice)
 			}
-			log.WithField(option.DirectRoutingDevice, option.Config.DirectRoutingDevice).
-				Info("Direct routing device detected")
+		} else if len(devs) == 1 {
+			option.Config.DirectRoutingDevice = devs[0].Name
+		} else if nodeDevice != nil {
+			option.Config.DirectRoutingDevice = nodeDevice.Name
 		}
-
-		if detectIPv6MCastDev {
-			if k8sNodeLink != nil && k8sNodeLink.Attrs().Flags&net.FlagMulticast != 0 {
-				option.Config.IPv6MCastDevice = k8sNodeDev
-				log.WithField(option.IPv6MCastDevice, option.Config.IPv6MCastDevice).Info("IPv6 multicast device detected")
-			} else {
-				return nil, fmt.Errorf("unable to determine Multicast device. Use --%s to specify it",
-					option.IPv6MCastDevice)
-			}
+		if option.Config.DirectRoutingDevice == "" {
+			return nil, fmt.Errorf("unable to determine direct routing device. Use --%s to specify it",
+				option.DirectRoutingDevice)
 		}
+		log.WithField(option.DirectRoutingDevice, option.Config.DirectRoutingDevice).
+			Info("Direct routing device detected")
 	}
 
-	deviceList := dm.getDeviceList()
-	option.Config.SetDevices(deviceList)
-	log.WithField(logfields.Devices, deviceList).Info("Detected devices")
-	return deviceList, nil
-}
-
-func (dm *DeviceManager) getDeviceList() []string {
-	devs := make([]string, 0, len(dm.devices))
-	for dev := range dm.devices {
-		devs = append(devs, dev)
-	}
-	sort.Strings(devs)
-	return devs
-}
-
-// Exclude devices that have one or more of these flags set.
-var excludedIfFlagsMask uint32 = unix.IFF_SLAVE | unix.IFF_LOOPBACK
-
-// isViableDevice returns true if the given link is usable and Cilium should attach
-// programs to it.
-func (dm *DeviceManager) isViableDevice(l3DevOK, hasDefaultRoute bool, link netlink.Link) bool {
-	name := link.Attrs().Name
-
-	// Do not consider any of the excluded devices.
-	for _, p := range defaults.ExcludedDevicePrefixes {
-		if strings.HasPrefix(name, p) {
-			log.WithField(logfields.Device, name).
-				Debugf("Skipping device as it has excluded prefix '%s'", p)
-			return false
-		}
-	}
-
-	// Skip devices that have an excluded interface flag set.
-	if link.Attrs().RawFlags&excludedIfFlagsMask != 0 {
-		log.WithField(logfields.Device, name).Debugf("Skipping device as it has excluded flag (%x)", link.Attrs().RawFlags)
-		return false
-	}
-
-	// Ignore L3 devices if we cannot support them.
-	if !l3DevOK && !mac.LinkHasMacAddr(link) {
-		log.WithField(logfields.Device, name).
-			Info("Ignoring L3 device; >= 5.8 kernel is required.")
-		return false
-	}
-
-	// If user specified devices or wildcards, then skip the device if it doesn't match.
-	if !dm.filter.match(name) {
-		return false
-	}
-
-	switch link.Type() {
-	case "veth":
-		// Skip veth devices that don't have a default route.
-		// This is a workaround for kubernetes-in-docker. We want to avoid
-		// veth devices in general as they may be leftovers from another CNI.
-		if !hasDefaultRoute {
-			log.WithField(logfields.Device, name).
-				Debug("Ignoring veth device as it has no default route")
-			return false
-		}
-
-	case "bridge", "openvswitch":
-		// Skip bridge devices as they're very unlikely to be used for K8s
-		// purposes. In the rare cases where a user wants to load datapath
-		// programs onto them they can override device detection with --devices.
-		log.WithField(logfields.Device, name).Debug("Ignoring bridge-like device")
-		return false
-
-	}
-
-	if link.Attrs().MasterIndex > 0 {
-		if master, err := dm.handle.LinkByIndex(link.Attrs().MasterIndex); err == nil {
-			switch master.Type() {
-			case "bridge", "openvswitch":
-				log.WithField(logfields.Device, name).Debug("Ignoring device attached to bridge")
-				return false
-
-			case "bond", "team":
-				log.WithField(logfields.Device, name).Debug("Ignoring bonded device")
-				return false
-			}
-
-		}
-	}
-
-	return true
-}
-
-type linkInfo struct {
-	hasDefaultRoute bool
-}
-
-func genZeroNet(family int) *net.IPNet {
-	switch family {
-	case netlink.FAMILY_V4:
-		return &net.IPNet{
-			IP:   net.IPv4zero,
-			Mask: net.CIDRMask(0, 8*net.IPv4len),
-		}
-	case netlink.FAMILY_V6:
-		return &net.IPNet{
-			IP:   net.IPv6zero,
-			Mask: net.CIDRMask(0, 8*net.IPv6len),
-		}
-	}
-	return nil
-}
-
-// updateDevicesFromRoutes processes a batch of routes and updates the set of
-// devices. Returns true if devices changed.
-func (dm *DeviceManager) updateDevicesFromRoutes(l3DevOK bool, routes []netlink.Route) bool {
-	linkInfos := make(map[int]linkInfo)
-
-	// Collect all link indices mentioned in the route update batch
-	for _, route := range routes {
-		// Only consider devices that have global unicast routes,
-		// e.g. skip loopback, multicast.
-		if !cidr.Equal(route.Dst, genZeroNet(route.Family)) && !route.Dst.IP.IsGlobalUnicast() {
-			continue
-		}
-		linkInfo := linkInfos[route.LinkIndex]
-		linkInfo.hasDefaultRoute = linkInfo.hasDefaultRoute || cidr.Equal(route.Dst, genZeroNet(route.Family))
-		linkInfos[route.LinkIndex] = linkInfo
-	}
-
-	changed := false
-	for index, info := range linkInfos {
-		link, err := dm.handle.LinkByIndex(index)
-		if err != nil {
-			log.WithError(err).WithField(logfields.LinkIndex, index).
-				Warn("Failed to get link by index")
-			continue
-		}
-		name := link.Attrs().Name
-
-		// Skip devices we already know.
-		if _, exists := dm.devices[name]; exists {
-			continue
-		}
-
-		viable := dm.isViableDevice(l3DevOK, info.hasDefaultRoute, link)
-		if viable {
-			dm.devices[name] = struct{}{}
-			changed = true
+	if option.Config.EnableIPv6NDP && option.Config.IPv6MCastDevice == "" {
+		if nodeDevice != nil && nodeDevice.Flags&net.FlagMulticast != 0 {
+			option.Config.IPv6MCastDevice = nodeDevice.Name
 		} else {
-			log.WithField(logfields.Device, name).Debug("Skipping unviable device")
+			return nil, fmt.Errorf("unable to determine Multicast device. Use --%s to specify it",
+				option.IPv6MCastDevice)
 		}
 	}
-	return changed
+
+	return names, nil
 }
 
-// Listen starts listening to changes to network devices. When devices change the new set
-// of devices is sent on the returned channel.
 func (dm *DeviceManager) Listen(ctx context.Context) (chan []string, error) {
-	l3DevOK := supportL3Dev()
-	routeChan := make(chan netlink.RouteUpdate)
-	closeChan := make(chan struct{})
-
-	err := netlink.RouteSubscribeWithOptions(routeChan, closeChan,
-		netlink.RouteSubscribeOptions{
-			// List existing routes to make sure we did not miss changes that happened after Detect().
-			ListExisting: true,
-			Namespace:    &dm.netns,
-		})
-	if err != nil {
-		return nil, err
-	}
-
-	linkChan := make(chan netlink.LinkUpdate)
-
-	err = netlink.LinkSubscribeWithOptions(linkChan, closeChan, netlink.LinkSubscribeOptions{
-		ListExisting: false,
-		Namespace:    &dm.netns,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	devicesChan := make(chan []string, 1)
-
-	// Find links deleted after Detect()
-	if allLinks, err := dm.handle.LinkList(); err == nil {
-		changed := false
-		linksByName := map[string]struct{}{}
-		for _, link := range allLinks {
-			linksByName[link.Attrs().Name] = struct{}{}
-		}
-		dm.Lock()
-		for name := range dm.devices {
-			if _, exists := linksByName[name]; !exists {
-				delete(dm.devices, name)
-				changed = true
-			}
-		}
-		devices := dm.getDeviceList()
-		dm.Unlock()
-
-		if changed {
-			log.WithField(logfields.Devices, devices).Info("Devices changed")
-			devicesChan <- devices
-		}
-	}
-
+	devs := make(chan []string)
 	go func() {
-		log.Info("Listening for device changes")
+		defer close(devs)
 
+		prevDevices := dm.initialDevices
 		for {
-			devicesChanged := false
-			var devices []string
-
+			iter, invalidated := tables.SelectedDevices(dm.params.DeviceTable.Reader(dm.params.DB.ReadTxn()))
+			newDevices := tables.DeviceNames(iter)
+			if slices.Equal(prevDevices, newDevices) {
+				continue
+			}
 			select {
+			case devs <- newDevices:
 			case <-ctx.Done():
-				log.Debug("context closed, Listen() stopping")
-				close(closeChan)
-				close(devicesChan)
-				// drain the route and link channels
-				for range routeChan {
-				}
-				for range linkChan {
-				}
 				return
-
-			case update := <-routeChan:
-				if update.Type == unix.RTM_NEWROUTE {
-					dm.Lock()
-					devicesChanged = dm.updateDevicesFromRoutes(l3DevOK, []netlink.Route{update.Route})
-					devices = dm.getDeviceList()
-					dm.Unlock()
-				}
-
-			case update := <-linkChan:
-				if update.Header.Type == unix.RTM_DELLINK {
-					name := update.Attrs().Name
-					dm.Lock()
-					if _, ok := dm.devices[name]; ok {
-						delete(dm.devices, name)
-						devicesChanged = true
-					}
-					devices = dm.getDeviceList()
-					dm.Unlock()
-				}
 			}
-
-			if devicesChanged {
-				log.WithField(logfields.Devices, devices).Info("Devices changed")
-				devicesChan <- devices
+			select {
+			case <-invalidated:
+			case <-ctx.Done():
+				return
 			}
+			prevDevices = newDevices
 		}
 	}()
-	return devicesChan, nil
+	return devs, nil
 }
 
-// expandDevices expands all wildcard device names to concrete devices.
-// e.g. device "eth+" expands to "eth0,eth1" etc. Non-matching wildcards are ignored.
-func (dm *DeviceManager) expandDevices() error {
-	expandedDevices, err := dm.expandDeviceWildcards(option.Config.GetDevices(), option.Devices)
-	if err != nil {
-		return err
-	}
-	option.Config.SetDevices(expandedDevices)
-	return nil
+// newDeviceManager constructs a DeviceManager that implements the old DeviceManager API.
+// Dummy dependency to *devicesController to make sure devices table is populated.
+func newDeviceManager(p devicesControllerParams, _ *devicesController) *DeviceManager {
+	return &DeviceManager{params: p, hive: nil}
 }
 
-// expandDirectRoutingDevice expands all wildcard device names to concrete devices and picks a first one.
-func (dm *DeviceManager) expandDirectRoutingDevice() error {
-	if option.Config.DirectRoutingDevice == "" {
-		return nil
+func (dm *DeviceManager) Stop() {
+	if dm.hive != nil {
+		dm.hive.Stop(context.TODO())
 	}
-	expandedDevices, err := dm.expandDeviceWildcards([]string{option.Config.DirectRoutingDevice}, option.DirectRoutingDevice)
-	if err != nil {
-		return err
-	}
-	option.Config.DirectRoutingDevice = expandedDevices[0]
-	return nil
-}
-
-func (dm *DeviceManager) expandDeviceWildcards(devices []string, option string) ([]string, error) {
-	allLinks, err := dm.handle.LinkList()
-	if err != nil {
-		return nil, fmt.Errorf("device wildcard expansion failed to fetch devices: %w", err)
-	}
-	expandedDevicesMap := make(map[string]struct{})
-	for _, iface := range devices {
-		if strings.HasSuffix(iface, "+") {
-			prefix := strings.TrimRight(iface, "+")
-			for _, link := range allLinks {
-				attrs := link.Attrs()
-				if strings.HasPrefix(attrs.Name, prefix) {
-					expandedDevicesMap[attrs.Name] = struct{}{}
-				}
-			}
-		} else {
-			expandedDevicesMap[iface] = struct{}{}
-		}
-	}
-	if len(devices) > 0 && len(expandedDevicesMap) == 0 {
-		// User defined devices, but expansion yielded no devices. Fail here to not
-		// surprise with auto-detection.
-		return nil, fmt.Errorf("device wildcard expansion failed to detect devices. Please verify --%s option.",
-			option)
-	}
-
-	expandedDevices := make([]string, 0, len(expandedDevicesMap))
-	for dev := range expandedDevicesMap {
-		expandedDevices = append(expandedDevices, dev)
-	}
-	sort.Strings(expandedDevices)
-	return expandedDevices, nil
-}
-
-func findK8SNodeIPLink() (netlink.Link, error) {
-	nodeIP := node.GetK8sNodeIP()
-
-	if nodeIP == nil {
-		return nil, fmt.Errorf("failed to find K8s node device as node IP is not known")
-	}
-
-	var family int
-	if nodeIP.To4() != nil {
-		family = netlink.FAMILY_V4
-	} else {
-		family = netlink.FAMILY_V6
-	}
-
-	if addrs, err := netlink.AddrList(nil, family); err == nil {
-		for _, a := range addrs {
-			if a.IP.Equal(nodeIP) {
-				link, err := netlink.LinkByIndex(a.LinkIndex)
-				if err != nil {
-					return nil, err
-				}
-
-				// When IPv6 is enabled and the node has an IPv6 address, the 'cilium_host'
-				// interface is assigned the same IP of the node itself. Let's skip it here.
-				if link.Attrs().Name == defaults.HostDevice {
-					continue
-				}
-
-				return link, nil
-			}
-		}
-	}
-	return nil, fmt.Errorf("K8s node device not found")
-}
-
-// supportL3Dev returns true if the kernel is new enough to support BPF host routing of
-// packets coming from L3 devices using bpf_skb_redirect_peer.
-func supportL3Dev() bool {
-	return probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnSkbChangeHead) == nil
-}
-
-type deviceFilter []string
-
-func (lst deviceFilter) match(dev string) bool {
-	if len(lst) == 0 {
-		return true
-	}
-	for _, entry := range lst {
-		if strings.HasSuffix(entry, "+") {
-			prefix := strings.TrimRight(entry, "+")
-			return strings.HasPrefix(dev, prefix)
-		} else if dev == entry {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -1,0 +1,644 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netns"
+	"golang.org/x/exp/slices"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/statedb"
+)
+
+// DevicesControllerCell registers a controller that subscribes to network devices
+// and routes via netlink and populates the devices and routes devices.
+var DevicesControllerCell = cell.Module(
+	"devices-controller",
+	"Synchronizes the device and route tables with the kernel",
+
+	cell.Provide(
+		newDevicesController,
+		newDeviceManager,
+	),
+	cell.Invoke(func(*devicesController) {}),
+)
+
+var (
+	// batchingDuration is the amount of time to wait for more
+	// addr/route/link updates before processing the batch.
+	batchingDuration = 100 * time.Millisecond
+
+	// restartWaitDuration is the amount of time to wait after
+	// a netlink failure before restarting from scratch.
+	restartWaitDuration = time.Second
+
+	// Route filter to look at all routing tables.
+	routeFilter = netlink.Route{
+		Table: unix.RT_TABLE_UNSPEC,
+	}
+	routeFilterMask = netlink.RT_FILTER_TABLE
+)
+
+type DevicesConfig struct {
+	// Devices is the user-specified devices to use. This can be
+	// either concrete devices ("eth0,eth1"), or a wildcard "eth+".
+	// If empty the devices are auto-detected according to rules defined
+	// by isSelectedDevice().
+	Devices []string
+}
+
+type devicesControllerParams struct {
+	cell.In
+
+	Config      DevicesConfig
+	Log         logrus.FieldLogger
+	DB          statedb.DB
+	DeviceTable statedb.Table[*tables.Device]
+	RouteTable  statedb.Table[*tables.Route]
+
+	// netlinkFuncs is optional and used by tests to verify error handling behavior.
+	NetlinkFuncs *netlinkFuncs `optional:"true"`
+}
+
+type devicesController struct {
+	params devicesControllerParams
+	log    logrus.FieldLogger
+
+	initialized    chan struct{}
+	filter         deviceFilter
+	l3DevSupported bool
+
+	cancel context.CancelFunc // controller's context is cancelled when stopped.
+}
+
+func newDevicesController(lc hive.Lifecycle, p devicesControllerParams) *devicesController {
+	dc := &devicesController{
+		params:      p,
+		initialized: make(chan struct{}),
+		filter:      deviceFilter(p.Config.Devices),
+		log:         p.Log,
+	}
+	lc.Append(dc)
+	return dc
+}
+
+func (dc *devicesController) Start(startCtx hive.HookContext) error {
+	if dc.params.NetlinkFuncs == nil {
+		var err error
+		dc.params.NetlinkFuncs, err = makeNetlinkFuncs(netns.None())
+		if err != nil {
+			return err
+		}
+
+		// Only probe for L3 device support when netlink isn't mocked by tests.
+		dc.l3DevSupported = probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnSkbChangeHead) == nil
+	}
+
+	var ctx context.Context
+	ctx, dc.cancel = context.WithCancel(context.Background())
+
+	go dc.run(ctx)
+
+	// Wait until the initial population of the tables has finished
+	// successfully or the start has been aborted.
+	select {
+	case <-dc.initialized:
+	case <-startCtx.Done():
+		dc.cancel()
+	}
+
+	return nil
+}
+
+func (dc *devicesController) run(ctx context.Context) {
+	defer dc.params.NetlinkFuncs.Close()
+
+	// Run the controller in a loop and restarting on failures until stopped.
+	// We're doing this as netlink is an unreliable protocol that may drop
+	// messages if the socket buffer is filled (recvmsg returns ENOBUFS).
+	for ctx.Err() == nil {
+		dc.subscribeAndProcess(ctx)
+
+		t, stop := inctimer.New()
+
+		select {
+		case <-ctx.Done():
+			stop()
+			return
+		case <-t.After(restartWaitDuration):
+		}
+	}
+}
+
+func (dc *devicesController) subscribeAndProcess(ctx context.Context) {
+	// Wrap the controller context to allow cancelling it on failures.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Callback for logging errors from the netlink subscriptions.
+	// It cancels the context to unsubscribe from netlink updates
+	// which stops the processing.
+	errorCallback := func(err error) {
+		dc.log.WithError(err).Warn("Netlink error received, restarting")
+
+		// Cancel the context to stop the subscriptions.
+		cancel()
+	}
+
+	addrUpdates := make(chan netlink.AddrUpdate)
+	if err := dc.params.NetlinkFuncs.AddrSubscribe(addrUpdates, ctx.Done(), errorCallback); err != nil {
+		dc.log.WithError(err).Warn("AddrSubscribe failed, restarting")
+		return
+	}
+	routeUpdates := make(chan netlink.RouteUpdate)
+	err := dc.params.NetlinkFuncs.RouteSubscribe(routeUpdates, ctx.Done(), errorCallback)
+	if err != nil {
+		dc.log.WithError(err).Warn("RouteSubscribe failed, restarting")
+		return
+	}
+	linkUpdates := make(chan netlink.LinkUpdate)
+	err = dc.params.NetlinkFuncs.LinkSubscribe(linkUpdates, ctx.Done(), errorCallback)
+	if err != nil {
+		dc.log.WithError(err).Warn("LinkSubscribe failed, restarting", err)
+		return
+	}
+
+	// Initialize the tables by listing links, routes and addresses.
+	// Preferably we'd just subscribe to updates with listing enabled, but
+	// unfortunately netlink Go library does not mark where the initial list
+	// ends and updates begin.
+	err = dc.initialize()
+	if err != nil {
+		dc.log.WithError(err).Warn("Initialization failed, restarting")
+		return
+	}
+
+	// Start processing the incremental updates until we're stopping or
+	// a failure is encountered.
+	dc.processUpdates(addrUpdates, routeUpdates, linkUpdates)
+}
+
+func (dc *devicesController) Stop(hive.HookContext) error {
+	dc.cancel()
+
+	// Unfortunately vishvananda/netlink is buggy and does not return from Recvfrom even
+	// though the stop channel given to AddrSubscribeWithOptions or RouteSubscribeWithOptions
+	// is closed. This is fixed by https://github.com/vishvananda/netlink/pull/793, which
+	// isn't yet merged.
+	// Due to this, we're currently not waiting here for run() to exit and thus leaving around
+	// couple goroutines until some address or route change arrive.
+	return nil
+}
+
+func (dc *devicesController) initialize() error {
+	// Do initial listing for each address, routes and links. We cannot use
+	// the 'ListExisting' option as it does not provide a mechanism to know when
+	// the listing is done and the updates begin. Netlink does send a NLMSG_DONE,
+	// but this is not exposed by the library.
+	batch := map[int][]any{}
+	links, err := dc.params.NetlinkFuncs.LinkList()
+	if err != nil {
+		return fmt.Errorf("LinkList failed: %w", err)
+	}
+	for _, link := range links {
+		batch[link.Attrs().Index] = append(batch[link.Attrs().Index], netlink.LinkUpdate{
+			Header: unix.NlMsghdr{Type: unix.RTM_NEWLINK},
+			Link:   link,
+		})
+	}
+	addrs, err := dc.params.NetlinkFuncs.AddrList(nil, netlink.FAMILY_ALL)
+	if err != nil {
+		return fmt.Errorf("AddrList failed: %w", err)
+	}
+	for _, addr := range addrs {
+		var ipnet net.IPNet
+		if addr.IPNet != nil {
+			ipnet = *addr.IPNet
+		}
+		batch[addr.LinkIndex] = append(batch[addr.LinkIndex], netlink.AddrUpdate{
+			LinkAddress: ipnet,
+			LinkIndex:   addr.LinkIndex,
+			Flags:       addr.Flags,
+			Scope:       addr.Scope,
+			PreferedLft: addr.PreferedLft,
+			ValidLft:    addr.ValidLft,
+			NewAddr:     true,
+		})
+	}
+	routes, err := dc.params.NetlinkFuncs.RouteListFiltered(netlink.FAMILY_ALL, &routeFilter, routeFilterMask)
+	if err != nil {
+		return fmt.Errorf("RouteList failed: %w", err)
+	}
+	for _, route := range routes {
+		batch[route.LinkIndex] = append(batch[route.LinkIndex], netlink.RouteUpdate{
+			Type:  unix.RTM_NEWROUTE,
+			Route: route,
+		})
+	}
+
+	txn := dc.params.DB.WriteTxn()
+
+	// Flush existing data from potential prior run.
+	dc.params.DeviceTable.Writer(txn).DeleteAll(statedb.All)
+	dc.params.RouteTable.Writer(txn).DeleteAll(statedb.All)
+
+	// Process the initial batch.
+	dc.processBatch(txn, batch)
+
+	iter, _ := tables.SelectedDevices(dc.params.DeviceTable.Reader(txn))
+	names := tables.DeviceNames(iter)
+	dc.log.WithField(logfields.Devices, names).Info("Detected initial devices")
+
+	if err := txn.Commit(); err != nil {
+		return fmt.Errorf("failed to commit initial batch: %w", err)
+	}
+
+	select {
+	case <-dc.initialized:
+	default:
+		close(dc.initialized)
+	}
+
+	return nil
+}
+
+func (dc *devicesController) processUpdates(
+	addrUpdates chan netlink.AddrUpdate,
+	routeUpdates chan netlink.RouteUpdate,
+	linkUpdates chan netlink.LinkUpdate,
+) {
+	// Use a ticker to periodically commit the batch of updates to the device and route tables.
+	// We do this to reduce the number of write transactions to the state in cases like large
+	// routing tables and to reduce churn in other components that observe the devices by
+	// avoiding intermediate states (e.g. devices without addresses).
+	ticker := time.NewTicker(batchingDuration)
+	defer ticker.Stop()
+
+	batch := map[int][]any{}
+	appendUpdate := func(index int, u any) {
+		batch[index] = append(batch[index], u)
+	}
+
+	// Gather address, route and link updates into a batch and
+	// periodically commit it. We loop until all channels have
+	// been closed in order to release the netlink subscriptions
+	// when being stopped.
+	for addrUpdates != nil || routeUpdates != nil || linkUpdates != nil {
+		select {
+		case u, ok := <-addrUpdates:
+			if !ok {
+				addrUpdates = nil
+			} else {
+				appendUpdate(u.LinkIndex, u)
+			}
+
+		case r, ok := <-routeUpdates:
+			if !ok {
+				routeUpdates = nil
+			} else {
+				appendUpdate(r.LinkIndex, r)
+			}
+
+		case l, ok := <-linkUpdates:
+			if !ok {
+				linkUpdates = nil
+			} else {
+				appendUpdate(int(l.Index), l)
+			}
+
+		case <-ticker.C:
+			if len(batch) > 0 {
+				txn := dc.params.DB.WriteTxn()
+				dc.processBatch(txn, batch)
+				if err := txn.Commit(); err != nil {
+					dc.log.WithError(err).Warnf("Failed to commit devices and routes, retrying later")
+				} else {
+					batch = map[int][]any{}
+				}
+			}
+		}
+	}
+}
+
+func deviceAddressFromAddrUpdate(upd netlink.AddrUpdate) tables.DeviceAddress {
+	return tables.DeviceAddress{
+		Addr: ip.MustAddrFromIP(upd.LinkAddress.IP),
+
+		// ifaddrmsg.ifa_scope is uint8, vishvananda/netlink has wrong type
+		Scope: uint8(upd.Scope),
+	}
+}
+
+func populateFromLink(d *tables.Device, link netlink.Link) {
+	a := link.Attrs()
+	d.Index = a.Index
+	d.MTU = a.MTU
+	d.Name = a.Name
+	d.HardwareAddr = a.HardwareAddr
+	d.Flags = a.Flags
+	d.RawFlags = a.RawFlags
+	d.MasterIndex = a.MasterIndex
+	d.Type = link.Type()
+}
+
+// processBatch processes a batch of address, link and route updates.
+// The address and link updates are merged into a device object and upserted
+// into the device table.
+func (dc *devicesController) processBatch(txn statedb.WriteTransaction, batch map[int][]any) {
+	devicesWriter := dc.params.DeviceTable.Writer(txn)
+	routesWriter := dc.params.RouteTable.Writer(txn)
+
+	for index, updates := range batch {
+		d, err := devicesWriter.First(tables.DeviceByIndex(index))
+		if err != nil {
+			panic("BUG: DeviceByIndex is broken")
+		}
+		if d == nil {
+			// Unseen device. We may receive address updates before link updates
+			// and thus the only thing we know at this point is the index.
+			d = &tables.Device{}
+			d.Index = index
+		} else {
+			d = d.DeepCopy()
+		}
+		deviceDeleted := false
+
+		for _, u := range updates {
+			switch u := u.(type) {
+			case netlink.AddrUpdate:
+				if u.Scope == unix.RT_SCOPE_LINK {
+					// Ignore link local addresses.
+					continue
+				}
+				addr := deviceAddressFromAddrUpdate(u)
+				if u.NewAddr {
+					d.Addrs = append(d.Addrs, addr)
+				} else {
+					i := slices.Index(d.Addrs, addr)
+					if i >= 0 {
+						d.Addrs = slices.Delete(d.Addrs, i, i+1)
+					}
+				}
+			case netlink.RouteUpdate:
+				r := tables.Route{
+					Table:     u.Table,
+					LinkIndex: index,
+					Scope:     uint8(u.Scope),
+					Dst:       ipnetToPrefix(u.Family, u.Dst),
+				}
+				r.Src, _ = netip.AddrFromSlice(u.Src)
+				r.Gw, _ = netip.AddrFromSlice(u.Gw)
+
+				if u.Type == unix.RTM_NEWROUTE {
+					routesWriter.Insert(&r)
+				} else {
+					routesWriter.Delete(&r)
+				}
+			case netlink.LinkUpdate:
+				if u.Header.Type == unix.RTM_DELLINK {
+					// Mark for deletion. This may be undone if
+					// the ifindex is reused.
+					deviceDeleted = true
+				} else {
+					deviceDeleted = false
+					populateFromLink(d, u.Link)
+				}
+			}
+		}
+
+		if deviceDeleted {
+			// Remove the deleted device. The routes table will be cleaned up from the
+			// route updates.
+			devicesWriter.DeleteAll(tables.DeviceByIndex(index))
+		} else {
+			// Recheck the viability of the device after the updates have been applied.
+			d.Selected = dc.isSelectedDevice(d, routesWriter) && len(d.Addrs) > 0
+
+			// Create or update the device.
+			devicesWriter.Insert(d)
+		}
+	}
+}
+
+const (
+	// Exclude devices that have one or more of these flags set.
+	excludedIfFlagsMask uint32 = unix.IFF_SLAVE | unix.IFF_LOOPBACK
+
+	// Require these flags to be set.
+	requiredIfFlagsMask uint32 = unix.IFF_UP
+)
+
+// isSelectedDevice checks if the device is selected or not. We still maintain its state in
+// case it later becomes selected.
+func (dc *devicesController) isSelectedDevice(d *tables.Device, routes statedb.TableReader[*tables.Route]) bool {
+	if d.Name == "" {
+		// Looks like we have seen the addresses for this device before the initial link update,
+		// hence it has no name. Definitely not selected yet!
+		return false
+	}
+
+	log := dc.log.WithField(logfields.Device, d.Name)
+
+	// Skip devices that have an excluded interface flag set.
+	if d.RawFlags&excludedIfFlagsMask != 0 {
+		log.Debugf("Not selecting device as it has an excluded flag set (mask=0x%x, flags=0x%x)", excludedIfFlagsMask, d.RawFlags)
+		return false
+	}
+
+	// Skip devices that don't have the required flags set.
+	if d.RawFlags&requiredIfFlagsMask == 0 {
+		log.Debugf("Not selecting device as it is missing required flag (mask=0x%x, flags=0x%x)", requiredIfFlagsMask, d.RawFlags)
+		return false
+	}
+
+	// Ignore bridge and bonding slave devices
+	if d.MasterIndex != 0 {
+		log.Debugf("Not selecting enslaved device (master %d)", d.MasterIndex)
+		return false
+	}
+
+	// Ignore L3 devices if we cannot support them.
+	hasMacAddr := len(d.HardwareAddr) != 0
+	if !dc.l3DevSupported && !hasMacAddr {
+		log.Info("Not selecting L3 device; >= 5.8 kernel is required.")
+		return false
+	}
+
+	// If user specified devices or wildcards, then skip the device if it doesn't match.
+	if !dc.filter.match(d.Name) {
+		log.WithField("filter", dc.filter).Info("Not selecting non-matching device")
+		return false
+	}
+
+	// Always choose a device that the user has specified, regardless of its
+	// properties.
+	if dc.filter.nonEmpty() {
+		return true
+	}
+
+	// Never consider devices with any of the excluded devices.
+	for _, p := range defaults.ExcludedDevicePrefixes {
+		if strings.HasPrefix(d.Name, p) {
+			log.Debugf("Not selecting device as it has excluded prefix '%s'", p)
+			return false
+		}
+	}
+	switch d.Type {
+	case "veth":
+		// Skip veth devices that don't have a default route (unless user has specified
+		// the device manually).
+		// This is a workaround for kubernetes-in-docker. We want to avoid
+		// veth devices in general as they may be leftovers from another CNI.
+		if !dc.filter.nonEmpty() && !tables.HasDefaultRoute(routes, d.Index) {
+			log.Debug("Not selecting veth device as it has no default route")
+			return false
+		}
+
+	case "bridge", "openvswitch":
+		// Skip bridge devices as they're very unlikely to be used for K8s
+		// purposes. In the rare cases where a user wants to load datapath
+		// programs onto them they can override device detection with --devices.
+		log.Debug("Not selecting bridge-like device")
+		return false
+	}
+
+	if !hasGlobalRoute(d.Index, routes) {
+		log.Debug("Not selecting device as it has no global unicast routes")
+		return false
+	}
+
+	log.Debug("Selected this device")
+
+	return true
+}
+
+func hasGlobalRoute(devIndex int, routes statedb.TableReader[*tables.Route]) bool {
+	iter, err := routes.Get(tables.RouteByLinkIndex(devIndex))
+	if err != nil {
+		panic("BUG: RouteByLinkIndex is broken")
+	}
+	for route, ok := iter.Next(); ok; route, ok = iter.Next() {
+		if route.Dst.Addr().IsGlobalUnicast() {
+			return true
+		}
+	}
+	return false
+}
+
+// deviceFilter implements filtering device names either by
+// concrete name ("eth0") or by iptables-like wildcard ("eth+").
+type deviceFilter []string
+
+// nonEmpty returns true if the filter has been defined
+// (i.e. user has specified --devices).
+func (lst deviceFilter) nonEmpty() bool {
+	return len(lst) > 0
+}
+
+// match checks whether the given device name passes the filter
+func (lst deviceFilter) match(dev string) bool {
+	if len(lst) == 0 {
+		return true
+	}
+	for _, entry := range lst {
+		if strings.HasSuffix(entry, "+") {
+			prefix := strings.TrimRight(entry, "+")
+			if strings.HasPrefix(dev, prefix) {
+				return true
+			}
+		} else if dev == entry {
+			return true
+		}
+	}
+	return false
+}
+
+// netlinkFuncs wraps the netlink subscribe functions into a simpler interface to facilitate
+// testing of the error handling paths.
+type netlinkFuncs struct {
+	RouteSubscribe    func(ch chan<- netlink.RouteUpdate, done <-chan struct{}, errorCallback func(error)) error
+	AddrSubscribe     func(ch chan<- netlink.AddrUpdate, done <-chan struct{}, errorCallback func(error)) error
+	LinkSubscribe     func(ch chan<- netlink.LinkUpdate, done <-chan struct{}, errorCallback func(error)) error
+	Close             func()
+	LinkList          func() ([]netlink.Link, error)
+	AddrList          func(link netlink.Link, family int) ([]netlink.Addr, error)
+	RouteListFiltered func(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error)
+}
+
+func makeNetlinkFuncs(netns netns.NsHandle) (*netlinkFuncs, error) {
+	h, err := netlink.NewHandleAt(netns)
+	if err != nil {
+		return nil, fmt.Errorf("NewHandleAt failed: %w", err)
+	}
+
+	return &netlinkFuncs{
+		RouteSubscribe: func(ch chan<- netlink.RouteUpdate, done <-chan struct{}, errorCallback func(error)) error {
+			return netlink.RouteSubscribeWithOptions(ch, done,
+				netlink.RouteSubscribeOptions{
+					ListExisting:  false,
+					Namespace:     &netns,
+					ErrorCallback: errorCallback,
+				})
+		},
+		AddrSubscribe: func(ch chan<- netlink.AddrUpdate, done <-chan struct{}, errorCallback func(error)) error {
+			return netlink.AddrSubscribeWithOptions(ch, done,
+				netlink.AddrSubscribeOptions{
+					ListExisting:  false,
+					Namespace:     &netns,
+					ErrorCallback: errorCallback,
+				})
+		},
+		LinkSubscribe: func(ch chan<- netlink.LinkUpdate, done <-chan struct{}, errorCallback func(error)) error {
+			return netlink.LinkSubscribeWithOptions(ch, done,
+				netlink.LinkSubscribeOptions{
+					ListExisting:  false,
+					Namespace:     &netns,
+					ErrorCallback: errorCallback,
+				})
+		},
+		Close:             h.Close,
+		LinkList:          h.LinkList,
+		AddrList:          h.AddrList,
+		RouteListFiltered: h.RouteListFiltered,
+	}, nil
+}
+
+func ipnetToPrefix(family int, ipn *net.IPNet) netip.Prefix {
+	if ipn != nil {
+		cidr, _ := ipn.Mask.Size()
+		return netip.PrefixFrom(ip.MustAddrFromIP(ipn.IP), cidr)
+	}
+	return netip.PrefixFrom(zeroAddr(family), 0)
+}
+
+func zeroAddr(family int) netip.Addr {
+	if family == nl.FAMILY_V4 {
+		return netip.IPv4Unspecified()
+	} else {
+		return netip.IPv6Unspecified()
+	}
+}

--- a/pkg/datapath/linux/devices_controller_test.go
+++ b/pkg/datapath/linux/devices_controller_test.go
@@ -1,0 +1,474 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/netip"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"github.com/vishvananda/netns"
+	"go.uber.org/goleak"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func withFreshNetNS(t *testing.T, test func(netns.NsHandle)) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	oldNetNS, err := netns.Get()
+	assert.NoError(t, err)
+	testNetNS, err := netns.New()
+	assert.NoError(t, err)
+	defer func() { assert.NoError(t, testNetNS.Close()) }()
+	defer func() { assert.NoError(t, netns.Set(oldNetNS)) }()
+	test(testNetNS)
+}
+
+func devicesControllerTestSetup(t *testing.T) {
+	t.Cleanup(func() {
+		goleak.VerifyNone(
+			t,
+			goleak.IgnoreCurrent(),
+			// Ignore loop() and the netlink goroutines. These are left behind as netlink library has a bug
+			// that causes it to be stuck in Recvfrom even after stop channel closes.
+			// This is fixed by https://github.com/vishvananda/netlink/pull/793, but that has not been merged.
+			// These goroutines will terminate after any route or address update.
+			goleak.IgnoreTopFunction("github.com/cilium/cilium/pkg/datapath/linux.(*devicesController).loop"),
+			goleak.IgnoreTopFunction("syscall.Syscall6"), // Recvfrom
+		)
+	})
+}
+
+func TestDevicesController(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	testutils.PrivilegedTest(t)
+	devicesControllerTestSetup(t)
+
+	logging.SetLogLevelToDebug()
+
+	routeExists := func(routes []*tables.Route, linkIndex int, dst, src string) bool {
+		for _, r := range routes {
+			if r.LinkIndex == linkIndex && r.Dst.String() == dst && r.Src.String() == src {
+				return true
+			}
+		}
+		return false
+	}
+
+	// The test steps perform an action, wait for devices table to change
+	// and then validate the change. Since we may see intermediate states
+	// in the devices table (as there's multiple netlink updates that may
+	// be processed at different times) the check function is repeated
+	// until the desired state is reached or [ctx] times out.
+	testSteps := []struct {
+		name    string
+		prepare func(*testing.T)
+		check   func(*testing.T, []*tables.Device, []*tables.Route) bool
+	}{
+		{
+			"initial",
+			func(*testing.T) {},
+			func(t *testing.T, devs []*tables.Device, routes []*tables.Route) bool {
+				return len(devs) == 1 &&
+					devs[0].Name == "dummy0" &&
+					devs[0].Index > 0 &&
+					devs[0].Selected &&
+					routeExists(routes, devs[0].Index, "192.168.0.0/24", "192.168.0.1")
+			},
+		},
+		{
+			"add dummy1",
+			func(t *testing.T) {
+				// Create another dummy to check that the table updates.
+				require.NoError(t, createDummy("dummy1", "192.168.1.1/24", false))
+			},
+			func(t *testing.T, devs []*tables.Device, routes []*tables.Route) bool {
+				// Since we're indexing by ifindex, we expect these to be in the order
+				// they were added.
+				return len(devs) == 2 &&
+					"dummy0" == devs[0].Name &&
+					routeExists(routes, devs[0].Index, "192.168.0.0/24", "192.168.0.1") &&
+					devs[0].Selected &&
+					"dummy1" == devs[1].Name &&
+					devs[1].Selected &&
+					routeExists(routes, devs[1].Index, "192.168.1.0/24", "192.168.1.1")
+			},
+		},
+
+		{ // Only consider veth devices when they have a default route.
+			"veth-without-default-gw",
+			func(t *testing.T) {
+				require.NoError(t, createVeth("veth0", "192.168.4.1/24", false))
+			},
+			func(t *testing.T, devs []*tables.Device, routes []*tables.Route) bool {
+				// No changes expected to previous step.
+				return len(devs) == 2 &&
+					"dummy0" == devs[0].Name &&
+					"dummy1" == devs[1].Name
+			},
+		},
+
+		{
+			"delete-dummy0",
+			func(t *testing.T) {
+				require.NoError(t, deleteLink("dummy0"))
+			},
+			func(t *testing.T, devs []*tables.Device, routes []*tables.Route) bool {
+				return len(devs) == 1 &&
+					"dummy1" == devs[0].Name &&
+					len(devs[0].Addrs) == 1 &&
+					devs[0].Addrs[0].Addr == netip.MustParseAddr("192.168.1.1")
+			},
+		},
+
+		{
+			"veth-with-default-gw",
+			func(t *testing.T) {
+				assert.NoError(t,
+					addRoute(addRouteParams{iface: "veth0", gw: "192.168.4.254", table: unix.RT_TABLE_MAIN}))
+			},
+			func(t *testing.T, devs []*tables.Device, routes []*tables.Route) bool {
+				return len(devs) == 2 &&
+					devs[0].Name == "dummy1" &&
+					devs[0].Selected &&
+					devs[1].Name == "veth0" &&
+					len(devs[1].Addrs) == 1 &&
+					devs[1].Addrs[0].Addr == netip.MustParseAddr("192.168.4.1") &&
+					devs[1].Selected
+			},
+		},
+		{
+			"bond-is-selected",
+			func(t *testing.T) {
+				require.NoError(t, deleteLink("veth0"))
+				require.NoError(t, createBond("bond0", "192.168.6.1/24", false))
+				require.NoError(t, setBondMaster("dummy1", "bond0"))
+			},
+			func(t *testing.T, devs []*tables.Device, routes []*tables.Route) bool {
+				// Slaved devices are ignored, so we should only see bond0.
+				return len(devs) == 1 &&
+					devs[0].Name == "bond0" &&
+					devs[0].Selected
+			},
+		},
+		{
+			"dummy1-restored",
+			func(t *testing.T) {
+				// Deleting the bond device restores dummy1 as a selected device
+				// as it is no longer a slave device.
+				assert.NoError(t, deleteLink("bond0"))
+				assert.NoError(t, setLinkUp("dummy1"))
+			},
+			func(t *testing.T, devs []*tables.Device, routes []*tables.Route) bool {
+				return len(devs) == 1 &&
+					devs[0].Name == "dummy1" &&
+					devs[0].Selected
+			},
+		},
+		{
+			"skip-bridge-devices",
+			func(t *testing.T) {
+				require.NoError(t, createBridge("br0", "192.168.5.1/24", false))
+				require.NoError(t, setMaster("dummy1", "br0"))
+			},
+			func(t *testing.T, devs []*tables.Device, routes []*tables.Route) bool {
+				return len(devs) == 0
+			},
+		},
+	}
+
+	withFreshNetNS(t, func(ns netns.NsHandle) {
+
+		var (
+			db           statedb.DB
+			devicesTable statedb.Table[*tables.Device]
+			routesTable  statedb.Table[*tables.Route]
+		)
+		h := hive.New(
+			statedb.Cell,
+			tables.Cell,
+			DevicesControllerCell,
+			cell.Provide(func() (*netlinkFuncs, error) {
+				// Provide the normal netlink interface, but restrict it to the test network
+				// namespace.
+				return makeNetlinkFuncs(ns)
+			}),
+
+			cell.Provide(func() DevicesConfig {
+				return DevicesConfig{}
+			}),
+
+			cell.Invoke(func(db_ statedb.DB, devicesTable_ statedb.Table[*tables.Device], routesTable_ statedb.Table[*tables.Route]) {
+				db = db_
+				devicesTable = devicesTable_
+				routesTable = routesTable_
+			}))
+
+		// Create a dummy device before starting to exercise initialize()
+		require.NoError(t, createDummy("dummy0", "192.168.0.1/24", false))
+
+		err := h.Start(ctx)
+		require.NoError(t, err)
+
+		for _, step := range testSteps {
+			step.prepare(t)
+
+			// Get the new set of devices
+			for {
+				txn := db.ReadTxn()
+				devs, devsInvalidated := tables.SelectedDevices(devicesTable.Reader(txn))
+
+				routesIter, err := routesTable.Reader(txn).Get(statedb.All)
+				require.NoError(t, err)
+				routes := statedb.Collect[*tables.Route](routesIter)
+
+				if step.check(t, devs, routes) {
+					break
+				}
+
+				// Wait for a changes and try again.
+				select {
+				case <-routesIter.Invalidated():
+				case <-devsInvalidated:
+				case <-ctx.Done():
+					db.WriteJSON(os.Stdout)
+					t.Fatalf("Test case %q timed out while waiting for devices. Last devices seen: %+v", step.name, devs)
+				}
+			}
+
+			if t.Failed() {
+				break
+			}
+		}
+
+		err = h.Stop(ctx)
+		require.NoError(t, err)
+	})
+}
+
+// Test that if the user specifies a device wildcard, then all devices not matching the wildcard
+// will be marked as non-selected.
+func TestDevicesController_Wildcards(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	testutils.PrivilegedTest(t)
+	devicesControllerTestSetup(t)
+
+	withFreshNetNS(t, func(ns netns.NsHandle) {
+
+		var (
+			db           statedb.DB
+			devicesTable statedb.Table[*tables.Device]
+		)
+		h := hive.New(
+			statedb.Cell,
+			tables.Cell,
+			DevicesControllerCell,
+			cell.Provide(func() DevicesConfig {
+				return DevicesConfig{
+					Devices: []string{"dummy+"},
+				}
+			}),
+			cell.Provide(func() (*netlinkFuncs, error) { return makeNetlinkFuncs(ns) }),
+			cell.Invoke(func(db_ statedb.DB, devicesTable_ statedb.Table[*tables.Device]) {
+				db = db_
+				devicesTable = devicesTable_
+			}))
+
+		err := h.Start(ctx)
+		require.NoError(t, err)
+		require.NoError(t, createDummy("dummy0", "192.168.0.1/24", false))
+		require.NoError(t, createDummy("nonviable", "192.168.1.1/24", false))
+
+		for {
+			devices := devicesTable.Reader(db.ReadTxn())
+			devs, invalidated := tables.SelectedDevices(devices)
+
+			if len(devs) == 1 && devs[0].Name == "dummy0" {
+				break
+			}
+
+			// Not yet what we expected, wait for changes and try again.
+			select {
+			case <-ctx.Done():
+				t.Fatalf("Test timed out while waiting for devices, last seen: %v", devs)
+			case <-invalidated:
+			}
+		}
+
+		err = h.Stop(context.TODO())
+		assert.NoError(t, err)
+	})
+}
+
+func TestDevicesController_Restarts(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var (
+		db           statedb.DB
+		devicesTable statedb.Table[*tables.Device]
+	)
+
+	logging.SetLogLevelToDebug()
+
+	// Is this the first subscription?
+	var first atomic.Bool
+	first.Store(true)
+
+	funcs := netlinkFuncs{
+		AddrList: func(link netlink.Link, family int) ([]netlink.Addr, error) {
+			return nil, nil
+		},
+
+		Close: func() {},
+
+		LinkList: func() ([]netlink.Link, error) {
+			if first.Load() {
+				// On first round we create a stale device that should get flushed
+				// from the devices table.
+				return []netlink.Link{&netlink.Dummy{
+					LinkAttrs: netlink.LinkAttrs{
+						Index:        2,
+						Name:         "stale",
+						HardwareAddr: []byte{2, 3, 4, 5, 6, 7},
+					},
+				}}, nil
+			}
+			return nil, nil
+		},
+
+		RouteListFiltered: func(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error) {
+			return nil, nil
+		},
+
+		RouteSubscribe: func(ch chan<- netlink.RouteUpdate, done <-chan struct{}, errorCallback func(error)) error {
+			go func() {
+				defer close(ch)
+				if !first.Load() {
+					_, ipn, _ := net.ParseCIDR("1.2.3.0/24")
+					select {
+					case <-done:
+					case ch <- netlink.RouteUpdate{
+						Type: unix.RTM_NEWROUTE,
+						Route: netlink.Route{
+							LinkIndex: 1,
+							Table:     unix.RT_TABLE_DEFAULT,
+							Scope:     unix.RT_SCOPE_SITE,
+							Dst:       ipn,
+						},
+					}:
+					}
+				}
+				<-done
+			}()
+			return nil
+		},
+		AddrSubscribe: func(ch chan<- netlink.AddrUpdate, done <-chan struct{}, errorCallback func(error)) error {
+			go func() {
+				defer close(ch)
+				if !first.Load() {
+					_, ipn, _ := net.ParseCIDR("1.2.3.4/24")
+					select {
+					case <-done:
+					case ch <- netlink.AddrUpdate{
+						LinkAddress: *ipn,
+						LinkIndex:   1,
+						NewAddr:     true,
+					}:
+					}
+				}
+				<-done
+			}()
+			return nil
+		},
+		LinkSubscribe: func(ch chan<- netlink.LinkUpdate, done <-chan struct{}, errorCallback func(error)) error {
+			go func() {
+				defer close(ch)
+				if first.Load() {
+					// Simulate a netlink socket failure on the first subscription round
+					errorCallback(errors.New("first"))
+					first.Store(false)
+				} else {
+					select {
+					case <-done:
+					case ch <- netlink.LinkUpdate{
+						IfInfomsg: nl.IfInfomsg{IfInfomsg: unix.IfInfomsg{Index: 1}},
+						Header:    unix.NlMsghdr{Type: unix.RTM_NEWLINK},
+						Link: &netlink.Dummy{
+							LinkAttrs: netlink.LinkAttrs{
+								Index:        1,
+								Name:         "dummy",
+								HardwareAddr: []byte{1, 2, 3, 4, 5, 6},
+							},
+						},
+					}:
+					}
+				}
+				<-done
+			}()
+			return nil
+		},
+	}
+
+	h := hive.New(
+		statedb.Cell,
+		tables.Cell,
+		DevicesControllerCell,
+		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
+		cell.Provide(func() *netlinkFuncs { return &funcs }),
+		cell.Invoke(func(db_ statedb.DB, devicesTable_ statedb.Table[*tables.Device]) {
+			db = db_
+			devicesTable = devicesTable_
+		}))
+
+	err := h.Start(ctx)
+	assert.NoError(t, err)
+
+	for {
+		iter, err := devicesTable.Reader(db.ReadTxn()).Get(statedb.All)
+		require.NoError(t, err)
+		devs := statedb.Collect[*tables.Device](iter)
+
+		// We expect the 'stale' device to have been flushed by the restart
+		// and for the 'dummy' to have appeared.
+		if len(devs) == 1 && devs[0].Name == "dummy" {
+			break
+		}
+
+		select {
+		case <-ctx.Done():
+			db.WriteJSON(os.Stdout)
+			t.Fatalf("Test timed out while waiting for device, last seen: %v", devs)
+		case <-iter.Invalidated():
+		}
+	}
+
+	err = h.Stop(ctx)
+	assert.NoError(t, err)
+
+}

--- a/pkg/datapath/linux/devices_test.go
+++ b/pkg/datapath/linux/devices_test.go
@@ -14,11 +14,17 @@ import (
 	. "github.com/cilium/checkmate"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -75,28 +81,32 @@ func (s *DevicesSuite) TearDownTest(c *C) {
 
 func (s *DevicesSuite) TestDetect(c *C) {
 	s.withFixture(c, func() {
-		dm, err := NewDeviceManager()
-		c.Assert(err, IsNil)
-
 		option.Config.SetDevices([]string{})
 		option.Config.DirectRoutingDevice = ""
 		option.Config.NodePortAcceleration = option.NodePortAccelerationDisabled
 
 		// No devices, nothing to detect.
+		dm, err := newDeviceManagerForTests()
+		c.Assert(err, IsNil)
+
 		devices, err := dm.Detect(false)
 		c.Assert(err, IsNil)
 		c.Assert(devices, checker.DeepEquals, []string{})
+		dm.Stop()
 
 		// Node IP not set, can still detect. Direct routing device shouldn't be detected.
 		option.Config.EnableNodePort = true
 		c.Assert(createDummy("dummy0", "192.168.0.1/24", false), IsNil)
 		nodeSetIP(nil)
 
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
 		c.Assert(devices, checker.DeepEquals, []string{"dummy0"})
 		c.Assert(option.Config.GetDevices(), checker.DeepEquals, devices)
 		c.Assert(option.Config.DirectRoutingDevice, Equals, "")
+		dm.Stop()
 
 		// Manually specified devices, no detection is performed
 		option.Config.EnableNodePort = true
@@ -104,6 +114,8 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		c.Assert(createDummy("dummy1", "192.168.1.1/24", false), IsNil)
 		option.Config.SetDevices([]string{"dummy0"})
 
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
 		c.Assert(devices, checker.DeepEquals, []string{"dummy0"})
@@ -120,6 +132,8 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		option.Config.EnableIPv4 = true
 		option.Config.EnableIPv6 = false
 		option.Config.RoutingMode = option.RoutingModeNative
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
 		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1", "dummy2"})
@@ -127,6 +141,7 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy1")
 		option.Config.DirectRoutingDevice = ""
 		option.Config.SetDevices([]string{})
+		dm.Stop()
 
 		// Tunnel routing mode with XDP, should find all devices and set direct
 		// routing device to the one with k8s node ip.
@@ -137,6 +152,8 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		option.Config.EnableNodePort = true
 		option.Config.NodePortAcceleration = option.NodePortAccelerationNative
 
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
 		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1", "dummy2"})
@@ -147,68 +164,89 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		option.Config.SetDevices([]string{})
 		option.Config.NodePortAcceleration = option.NodePortAccelerationDisabled
 		option.Config.RoutingMode = option.RoutingModeNative
+		dm.Stop()
 
 		// Use IPv6 node IP and enable IPv6NDP and check that multicast device is detected.
-		// Use an excluded device name to verify that device with NodeIP is still picked.
 		option.Config.EnableIPv6 = true
 		option.Config.EnableIPv6NDP = true
-		c.Assert(createDummy("cilium_foo", "2001:db8::face/64", true), IsNil)
+		c.Assert(createDummy("dummy_v6", "2001:db8::face/64", true), IsNil)
 		nodeSetIP(nil)
 		nodeSetIP(net.ParseIP("2001:db8::face"))
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
-		c.Assert(devices, checker.DeepEquals, []string{"cilium_foo", "dummy0", "dummy1", "dummy2"})
+		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1", "dummy2", "dummy_v6"})
 		c.Assert(option.Config.GetDevices(), checker.DeepEquals, devices)
-		c.Assert(option.Config.DirectRoutingDevice, checker.Equals, "cilium_foo")
-		c.Assert(option.Config.IPv6MCastDevice, checker.DeepEquals, "cilium_foo")
+		c.Assert(option.Config.DirectRoutingDevice, checker.Equals, "dummy_v6")
+		c.Assert(option.Config.IPv6MCastDevice, checker.DeepEquals, "dummy_v6")
 		option.Config.DirectRoutingDevice = ""
 		option.Config.SetDevices([]string{})
+		dm.Stop()
 
 		// Only consider veth devices if they have a default route.
 		c.Assert(createVeth("veth0", "192.168.4.1/24", false), IsNil)
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
-		c.Assert(devices, checker.DeepEquals, []string{"cilium_foo", "dummy0", "dummy1", "dummy2"})
+		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1", "dummy2", "dummy_v6"})
 		c.Assert(option.Config.GetDevices(), checker.DeepEquals, devices)
 		option.Config.SetDevices([]string{})
+		dm.Stop()
 
 		c.Assert(addRoute(addRouteParams{iface: "veth0", gw: "192.168.4.254", table: unix.RT_TABLE_MAIN}), IsNil)
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
-		c.Assert(devices, checker.DeepEquals, []string{"cilium_foo", "dummy0", "dummy1", "dummy2", "veth0"})
+		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1", "dummy2", "dummy_v6", "veth0"})
 		c.Assert(option.Config.GetDevices(), checker.DeepEquals, devices)
 		option.Config.SetDevices([]string{})
+		dm.Stop()
 
 		// Detect devices that only have routes in non-main tables
 		c.Assert(addRoute(addRouteParams{iface: "dummy3", dst: "192.168.3.1/24", scope: unix.RT_SCOPE_LINK, table: 11}), IsNil)
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
-		c.Assert(devices, checker.DeepEquals, []string{"cilium_foo", "dummy0", "dummy1", "dummy2", "dummy3", "veth0"})
+		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1", "dummy2", "dummy3", "dummy_v6", "veth0"})
 		c.Assert(option.Config.GetDevices(), checker.DeepEquals, devices)
 		option.Config.SetDevices([]string{})
+		dm.Stop()
 
 		// Skip bridge devices, and devices added to the bridge
 		c.Assert(createBridge("br0", "192.168.5.1/24", false), IsNil)
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
-		c.Assert(devices, checker.DeepEquals, []string{"cilium_foo", "dummy0", "dummy1", "dummy2", "dummy3", "veth0"})
+		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1", "dummy2", "dummy3", "dummy_v6", "veth0"})
 		c.Assert(option.Config.GetDevices(), checker.DeepEquals, devices)
 		option.Config.SetDevices([]string{})
+		dm.Stop()
 
 		c.Assert(setMaster("dummy3", "br0"), IsNil)
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
-		c.Assert(devices, checker.DeepEquals, []string{"cilium_foo", "dummy0", "dummy1", "dummy2", "veth0"})
+		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1", "dummy2", "dummy_v6", "veth0"})
 		c.Assert(option.Config.GetDevices(), checker.DeepEquals, devices)
 		option.Config.SetDevices([]string{})
+		dm.Stop()
 
 		// Don't skip bond devices, but do skip bond slaves.
 		c.Assert(createBond("bond0", "192.168.6.1/24", false), IsNil)
 		c.Assert(setBondMaster("dummy2", "bond0"), IsNil)
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
 		devices, err = dm.Detect(true)
 		c.Assert(err, IsNil)
-		c.Assert(devices, checker.DeepEquals, []string{"bond0", "cilium_foo", "dummy0", "dummy1", "veth0"})
+		c.Assert(devices, checker.DeepEquals, []string{"bond0", "dummy0", "dummy1", "dummy_v6", "veth0"})
 		option.Config.SetDevices([]string{})
+		dm.Stop()
 	})
 }
 
@@ -220,37 +258,52 @@ func (s *DevicesSuite) TestExpandDevices(c *C) {
 		c.Assert(createDummy("other1", "192.168.3.4/24", false), IsNil)
 		c.Assert(createDummy("unmatched", "192.168.4.5/24", false), IsNil)
 
-		dm, err := NewDeviceManager()
-		c.Assert(err, IsNil)
-
 		// 1. Check expansion works and non-matching prefixes are ignored
 		option.Config.SetDevices([]string{"dummy+", "missing+", "other0+" /* duplicates: */, "dum+", "other0", "other1"})
-		c.Assert(dm.expandDevices(), IsNil)
-		c.Assert(option.Config.GetDevices(), checker.DeepEquals, []string{"dummy0", "dummy1", "other0", "other1"})
+		dm, err := newDeviceManagerForTests()
+		c.Assert(err, IsNil)
+		devs, err := dm.Detect(true)
+		c.Assert(err, IsNil)
+		c.Assert(devs, checker.DeepEquals, []string{"dummy0", "dummy1", "other0", "other1"})
+		dm.Stop()
 
 		// 2. Check that expansion fails if devices are specified but yields empty expansion
 		option.Config.SetDevices([]string{"none+"})
-		c.Assert(dm.expandDevices(), NotNil)
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
+		_, err = dm.Detect(true)
+		c.Assert(err, NotNil)
+		dm.Stop()
 	})
 }
 
 func (s *DevicesSuite) TestExpandDirectRoutingDevice(c *C) {
 	s.withFixture(c, func() {
+		option.Config.EnableNodePort = true
+		option.Config.RoutingMode = option.RoutingModeNative
+
 		c.Assert(createDummy("dummy0", "192.168.0.1/24", false), IsNil)
 		c.Assert(createDummy("dummy1", "192.168.1.2/24", false), IsNil)
 		c.Assert(createDummy("unmatched", "192.168.4.5/24", false), IsNil)
-
-		dm, err := NewDeviceManager()
-		c.Assert(err, IsNil)
+		nodeSetIP(net.ParseIP("192.168.0.1"))
 
 		// 1. Check expansion works and non-matching prefixes are ignored
 		option.Config.DirectRoutingDevice = "dummy+"
-		c.Assert(dm.expandDirectRoutingDevice(), IsNil)
+		dm, err := newDeviceManagerForTests()
+		c.Assert(err, IsNil)
+		_, err = dm.Detect(true)
+		c.Assert(err, IsNil)
 		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
+		dm.Stop()
 
 		// 2. Check that expansion fails if directRoutingDevice is specified but yields empty expansion
 		option.Config.DirectRoutingDevice = "none+"
-		c.Assert(dm.expandDirectRoutingDevice(), NotNil)
+		dm, err = newDeviceManagerForTests()
+		c.Assert(err, IsNil)
+		_, err = dm.Detect(true)
+		c.Assert(err, NotNil)
+		c.Assert(option.Config.DirectRoutingDevice, Equals, "")
+		dm.Stop()
 	})
 }
 
@@ -259,23 +312,29 @@ func (s *DevicesSuite) TestListenForNewDevices(c *C) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		timeout := time.After(time.Second)
+		timeout := time.After(10 * time.Second)
 
 		option.Config.SetDevices([]string{})
-		dm, err := NewDeviceManager()
+		c.Assert(createDummy("dummy0", "192.168.1.2/24", false), IsNil)
+
+		dm, err := newDeviceManagerForTests()
 		c.Assert(err, IsNil)
+		defer dm.Stop()
+
+		initialDevices, err := dm.Detect(false)
+		c.Assert(err, IsNil)
+		c.Assert(initialDevices, checker.DeepEquals, []string{"dummy0"})
 
 		devicesChan, err := dm.Listen(ctx)
 		c.Assert(err, IsNil)
 
 		// Create the IPv4 & IPv6 devices that should be detected.
-		c.Assert(createDummy("dummy0", "192.168.1.2/24", false), IsNil)
 		c.Assert(createDummy("dummy1", "2001:db8::face/64", true), IsNil)
 
 		// Create another device without an IP address or routes. This should be ignored.
 		c.Assert(createDummy("dummy2", "", false), IsNil)
 
-		// Create a veth device which should be detected. veth devices are used in test
+		// Create a veth device with default route that should be detected. veth devices are used in test
 		// setups.
 		c.Assert(createVeth("veth0", "192.168.2.2/24", false), IsNil)
 		c.Assert(addRoute(addRouteParams{iface: "veth0", gw: "192.168.2.254", table: unix.RT_TABLE_MAIN}), IsNil)
@@ -288,10 +347,14 @@ func (s *DevicesSuite) TestListenForNewDevices(c *C) {
 		// this may span multiple callbacks.
 		passed := false
 		for !passed {
+			var devices []string
 			select {
 			case <-timeout:
-				c.Fatal("Test timed out")
-			case devices := <-devicesChan:
+				c.Fatalf("Test timed out, last devices seen: %v", devices)
+			case devices = <-devicesChan:
+				if slices.Equal(devices, initialDevices) {
+					c.Fatalf("Expected Listen() to not emit the initial devices")
+				}
 				passed, _ = checker.DeepEqual(devices, []string{"dummy0", "dummy1", "veth0"})
 			}
 		}
@@ -303,11 +366,12 @@ func (s *DevicesSuite) TestListenForNewDevices(c *C) {
 		c.Assert(err, IsNil)
 
 		for !passed {
+			var devices []string
 			select {
 			case <-timeout:
-				c.Fatal("Test timed out")
-			case devices := <-devicesChan:
-				passed, _ = checker.DeepEqual(devices, []string{"dummy1"})
+				c.Fatalf("Test timed out, last devices seen: %v", devices)
+			case devices = <-devicesChan:
+				passed, _ = checker.DeepEqual(devices, []string{"dummy1", "veth0"})
 			}
 		}
 	})
@@ -318,11 +382,12 @@ func (s *DevicesSuite) TestListenForNewDevicesFiltered(c *C) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		timeout := time.After(time.Second)
+		timeout := time.After(5 * time.Second)
 
 		option.Config.SetDevices([]string{"dummy+"})
-		dm, err := NewDeviceManager()
+		dm, err := newDeviceManagerForTests()
 		c.Assert(err, IsNil)
+		defer dm.Stop()
 
 		devicesChan, err := dm.Listen(ctx)
 		c.Assert(err, IsNil)
@@ -353,16 +418,16 @@ func (s *DevicesSuite) TestListenAfterDelete(c *C) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		timeout := time.After(time.Second)
+		timeout := time.After(time.Second * 5)
 
 		option.Config.SetDevices([]string{"dummy+"})
-		dm, err := NewDeviceManager()
-		c.Assert(err, IsNil)
-
 		c.Assert(createDummy("dummy0", "192.168.1.2/24", false), IsNil)
 		c.Assert(createDummy("dummy1", "2001:db8::face/64", true), IsNil)
 
 		// Detect the devices
+		dm, err := newDeviceManagerForTests()
+		c.Assert(err, IsNil)
+		defer dm.Stop()
 		devices, err := dm.Detect(true)
 		c.Assert(err, IsNil)
 		c.Assert(devices, checker.DeepEquals, []string{"dummy0", "dummy1"})
@@ -380,9 +445,10 @@ func (s *DevicesSuite) TestListenAfterDelete(c *C) {
 
 		passed := false
 		for !passed {
+			var devices []string
 			select {
 			case <-timeout:
-				c.Fatal("Test timed out")
+				c.Fatalf("Test timed out, last seen devices: %v", devices)
 			case devices := <-devicesChan:
 				passed, _ = checker.DeepEqual(devices, []string{"dummy0"})
 			}
@@ -393,6 +459,8 @@ func (s *DevicesSuite) TestListenAfterDelete(c *C) {
 func (s *DevicesSuite) withFixture(c *C, test func()) {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
+
+	logging.SetLogLevelToDebug()
 
 	testNetNS, err := netns.New() // creates netns, and sets it to current
 	c.Assert(err, IsNil)
@@ -434,6 +502,14 @@ func createLink(linkTemplate netlink.Link, iface, ipAddr string, flagMulticast b
 	return nil
 }
 
+func deleteLink(name string) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkDel(link)
+}
+
 func createDummy(iface, ipAddr string, flagMulticast bool) error {
 	return createLink(&netlink.Dummy{}, iface, ipAddr, flagMulticast)
 }
@@ -450,6 +526,14 @@ func createBond(iface, ipAddr string, flagMulticast bool) error {
 	bond := netlink.NewLinkBond(netlink.LinkAttrs{})
 	bond.Mode = netlink.BOND_MODE_BALANCE_RR
 	return createLink(bond, iface, ipAddr, flagMulticast)
+}
+
+func setLinkUp(iface string) error {
+	link, err := netlink.LinkByName(iface)
+	if err != nil {
+		return err
+	}
+	return netlink.LinkSetUp(link)
 }
 
 func setMaster(iface string, master string) error {
@@ -473,8 +557,8 @@ func setBondMaster(iface string, master string) error {
 	if err != nil {
 		return err
 	}
-
 	netlink.LinkSetDown(link)
+	defer netlink.LinkSetUp(link)
 	return netlink.LinkSetBondSlave(link, masterLink.(*netlink.Bond))
 }
 
@@ -567,4 +651,22 @@ func delRoutes(iface string) error {
 	}
 
 	return nil
+}
+
+func newDeviceManagerForTests() (dm *DeviceManager, err error) {
+	ns, _ := netns.Get()
+	h := hive.New(
+		statedb.Cell,
+		tables.Cell,
+		DevicesControllerCell,
+		cell.Provide(func() DevicesConfig {
+			return DevicesConfig{Devices: option.Config.GetDevices()}
+		}),
+		cell.Provide(func() (*netlinkFuncs, error) { return makeNetlinkFuncs(ns) }),
+		cell.Invoke(func(dm_ *DeviceManager) {
+			dm = dm_
+		}))
+	err = h.Start(context.TODO())
+	dm.hive = h
+	return
 }

--- a/pkg/datapath/tables/cells.go
+++ b/pkg/datapath/tables/cells.go
@@ -5,10 +5,14 @@ package tables
 
 import (
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/statedb"
 )
 
 var Cell = cell.Module(
 	"datapath-tables",
-	"Datapath tables",
-	L2AnnouncementTableCell,
+	"Datapath state tables",
+
+	statedb.NewTableCell[*L2AnnounceEntry](l2AnnounceTableSchema),
+	statedb.NewTableCell[*Device](deviceTableSchema),
+	statedb.NewTableCell[*Route](routeTableSchema),
 )

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tables
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+
+	"github.com/hashicorp/go-memdb"
+	"golang.org/x/exp/slices"
+
+	"github.com/cilium/cilium/pkg/statedb"
+)
+
+const (
+	DeviceNameIndex statedb.Index = "Name"
+)
+
+// deviceTableSchema defines the table schema for the device table.
+//
+// It contains all the network devices on the local node. The
+// ones used by Cilium have 'Selected' set to true. We track all
+// devices to collect address and route information while the device
+// is perhaps not yet selected.
+//
+// Use the SelectedDevices() query function to look up and watch
+// the devices that should be used.
+var deviceTableSchema = &memdb.TableSchema{
+	Name: "devices",
+	Indexes: map[string]*memdb.IndexSchema{
+		string(statedb.IDIndex): {
+			Name:         string(statedb.IDIndex),
+			AllowMissing: false,
+			Unique:       true,
+			Indexer:      &memdb.IntFieldIndex{Field: "Index"},
+		},
+		string(DeviceNameIndex): {
+			Name: string(DeviceNameIndex),
+			// Name can be temporarily missing if we create the device
+			// from an address update.
+			AllowMissing: true,
+			Unique:       true,
+			Indexer:      &memdb.StringFieldIndex{Field: "Name"},
+		},
+	},
+}
+
+// Device is a local network device along with addresses associated with it.
+type Device struct {
+	Index        int              // positive integer that starts at one, zero is never used
+	MTU          int              // maximum transmission unit
+	Name         string           // e.g., "en0", "lo0", "eth0.100"
+	HardwareAddr net.HardwareAddr // IEEE MAC-48, EUI-48 and EUI-64 form
+	Flags        net.Flags        // e.g. net.FlagUp, net.eFlagLoopback, net.FlagMulticast
+
+	Selected    bool            // If true this device can be used by Cilium
+	Addrs       []DeviceAddress // Addresses assigned to the device
+	RawFlags    uint32          // Raw interface flags
+	Type        string          // Device type, e.g. "veth" etc.
+	MasterIndex int             // Index of the master device (e.g. bridge or bonding device)
+}
+
+func (d *Device) String() string {
+	return fmt.Sprintf("Device{Index:%d, Name:%s, len(Addrs):%d}", d.Index, d.Name, len(d.Addrs))
+}
+
+func (d *Device) DeepCopy() *Device {
+	copy := *d
+	copy.Addrs = slices.Clone(d.Addrs)
+	return &copy
+}
+
+func (d *Device) HasIP(ip net.IP) bool {
+	for _, addr := range d.Addrs {
+		if addr.AsIP().Equal(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+type DeviceAddress struct {
+	Addr  netip.Addr
+	Scope uint8 // Routing table scope
+}
+
+func (d *DeviceAddress) AsIP() net.IP {
+	return d.Addr.AsSlice()
+}
+
+// DeviceByIndex constructs a query to find a device by its
+// interface index.
+func DeviceByIndex(index int) statedb.Query {
+	return statedb.Query{Index: statedb.IDIndex, Args: []any{index}}
+}
+
+// DeviceByName constructs a query to find a device by its
+// name.
+func DeviceByName(name string) statedb.Query {
+	return statedb.Query{Index: DeviceNameIndex, Args: []any{name}}
+}
+
+// SelectedDevices returns the network devices selected for
+// Cilium use.
+//
+// The invalidated channel is closed when devices have changed and
+// should be requeried with a new transaction.
+func SelectedDevices(r statedb.TableReader[*Device]) (devs []*Device, invalidated <-chan struct{}) {
+	iter, err := r.Get(statedb.Query{Index: DeviceNameIndex})
+	if err != nil {
+		// table schema is malformed?
+		panic(err)
+	}
+	for dev, ok := iter.Next(); ok; dev, ok = iter.Next() {
+		if !dev.Selected {
+			continue
+		}
+		devs = append(devs, dev)
+	}
+	return devs, iter.Invalidated()
+}
+
+// DeviceNames extracts the device names from a slice of devices.
+func DeviceNames(devs []*Device) (names []string) {
+	names = make([]string, len(devs))
+	for i := range devs {
+		names[i] = devs[i].Name
+	}
+	return
+}

--- a/pkg/datapath/tables/l2_announce.go
+++ b/pkg/datapath/tables/l2_announce.go
@@ -61,7 +61,7 @@ var (
 				Unique: true,
 				Indexer: &memdb.CompoundIndex{
 					Indexes: []memdb.Indexer{
-						&statedb.IPIndexer{Field: "IP"},
+						&statedb.IPFieldIndex{Field: "IP"},
 						&memdb.StringFieldIndex{Field: "NetworkInterface"},
 					},
 				},

--- a/pkg/datapath/tables/l2_announce.go
+++ b/pkg/datapath/tables/l2_announce.go
@@ -34,11 +34,9 @@ func (pne *L2AnnounceEntry) DeepCopy() *L2AnnounceEntry {
 	return &n
 }
 
-var L2AnnouncementTableCell = statedb.NewTableCell[*L2AnnounceEntry](schema)
-
 func ByProxyIPAndInterface(ip net.IP, iface string) statedb.Query {
 	return statedb.Query{
-		Index: idIndex,
+		Index: statedb.IDIndex,
 		Args:  []any{ip, iface},
 	}
 }
@@ -51,13 +49,13 @@ func ByProxyOrigin(originKey resource.Key) statedb.Query {
 }
 
 var (
-	idIndex     = statedb.Index("id")
-	originIndex = statedb.Index("byOrigin")
-	schema      = &memdb.TableSchema{
+	originIndex = statedb.Index("Origins")
+
+	l2AnnounceTableSchema = &memdb.TableSchema{
 		Name: "l2-announce-entries",
 		Indexes: map[string]*memdb.IndexSchema{
-			string(idIndex): {
-				Name:   string(idIndex),
+			string(statedb.IDIndex): {
+				Name:   string(statedb.IDIndex),
 				Unique: true,
 				Indexer: &memdb.CompoundIndex{
 					Indexes: []memdb.Indexer{

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tables
+
+import (
+	"fmt"
+	"net/netip"
+
+	"github.com/hashicorp/go-memdb"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/statedb"
+)
+
+type Route struct {
+	Table     int
+	LinkIndex int
+
+	Scope uint8
+	Dst   netip.Prefix
+	Src   netip.Addr
+	Gw    netip.Addr
+}
+
+func (r *Route) DeepCopy() *Route {
+	r2 := *r
+	return &r2
+}
+
+func (r *Route) String() string {
+	return fmt.Sprintf("Route{Dst: %s, Src: %s, Table: %d, LinkIndex: %d}",
+		r.Dst, r.Src, r.Table, r.LinkIndex)
+}
+
+const (
+	linkIndexIndex statedb.Index = "LinkIndex"
+)
+
+var (
+	routeTableSchema = &memdb.TableSchema{
+		Name: "routes",
+		Indexes: map[string]*memdb.IndexSchema{
+			"id": {
+				Name:         "id",
+				AllowMissing: false,
+				Unique:       true,
+				Indexer: &memdb.CompoundIndex{
+					Indexes: []memdb.Indexer{
+						&memdb.IntFieldIndex{Field: "Table"},
+						&memdb.IntFieldIndex{Field: "LinkIndex"},
+						&statedb.NetIPPrefixFieldIndex{Field: "Dst"},
+					},
+				},
+			},
+			string(linkIndexIndex): {
+				Name:         string(linkIndexIndex),
+				AllowMissing: false,
+				Unique:       false,
+				Indexer:      &memdb.IntFieldIndex{Field: "LinkIndex"},
+			}},
+	}
+)
+
+func RouteByLinkIndex(index int) statedb.Query {
+	return statedb.Query{Index: linkIndexIndex, Args: []any{index}}
+}
+
+func HasDefaultRoute(reader statedb.TableReader[*Route], linkIndex int) bool {
+	// Device has a default route when a route exists in the main table
+	// with a zero destination.
+	for _, prefix := range []netip.Prefix{zeroPrefixV4, zeroPrefixV6} {
+		q := statedb.Query{
+			Index: "id",
+			Args: []any{
+				unix.RT_TABLE_MAIN,
+				linkIndex,
+				prefix,
+			},
+		}
+		r, err := reader.First(q)
+		if err != nil {
+			panic(fmt.Sprintf("Internal error: Query %+v is malformed (%s)", q, err))
+		}
+		if r != nil {
+			return true
+		}
+	}
+	return false
+}
+
+var (
+	zeroPrefixV4 = netip.PrefixFrom(netip.IPv4Unspecified(), 0)
+	zeroPrefixV6 = netip.PrefixFrom(netip.IPv6Unspecified(), 0)
+)

--- a/pkg/statedb/index_test.go
+++ b/pkg/statedb/index_test.go
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb_test
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/statedb"
+)
+
+type prefixFieldTest struct {
+	Prefix netip.Prefix
+}
+
+func TestNetIPPrefixFieldIndex(t *testing.T) {
+	testPrefix, err := netip.ParsePrefix("1.2.3.0/24")
+	require.NoError(t, err)
+	checkBytes := func(bs []byte) {
+		var out netip.Prefix
+		out.UnmarshalBinary(bs)
+		require.Equal(t, testPrefix, out)
+	}
+
+	idx := statedb.NetIPPrefixFieldIndex{Field: "Prefix"}
+
+	ok, bs, err := idx.FromObject(prefixFieldTest{testPrefix})
+	require.NoError(t, err)
+	require.True(t, ok, "FromObject succeeds")
+	checkBytes(bs)
+
+	bs, err = idx.FromArgs("foo")
+	require.Error(t, err, "Expected FromArgs to fail with bad type")
+	require.Nil(t, bs)
+
+	bs, err = idx.FromArgs(testPrefix)
+	require.NoError(t, err, "Expected FromArgs to succeed with 'netip.Prefix'")
+	checkBytes(bs)
+
+	bs, err = idx.FromArgs(&testPrefix)
+	require.NoError(t, err, "Expected FromArgs to succeed with '*netip.Prefix'")
+	checkBytes(bs)
+}
+
+type ipnetFieldTest struct {
+	IPNet net.IPNet
+}
+
+func TestIPNetFieldIndex(t *testing.T) {
+	_, testIPNet, err := net.ParseCIDR("1.2.3.0/24")
+	require.NoError(t, err)
+
+	idx := statedb.IPNetFieldIndex{Field: "IPNet"}
+
+	ok, bs, err := idx.FromObject(ipnetFieldTest{*testIPNet})
+	require.NoError(t, err)
+	require.True(t, ok, "FromObject succeeds")
+	require.NotEmpty(t, bs)
+
+	bs, err = idx.FromArgs("foo")
+	require.Error(t, err, "Expected FromArgs to fail with bad type")
+	require.Nil(t, bs)
+
+	bs, err = idx.FromArgs(*testIPNet)
+	require.NoError(t, err, "Expected FromArgs to succeed with 'net.IPNet'")
+	require.NotEmpty(t, bs)
+
+	bs, err = idx.FromArgs(testIPNet)
+	require.NoError(t, err, "Expected FromArgs to succeed with '*net.IPNet'")
+	require.NotEmpty(t, bs)
+}
+
+type ipFieldTest struct {
+	IP net.IP
+}
+
+func TestIPFieldIndex(t *testing.T) {
+	testIP := net.ParseIP("1.2.3.4")
+	require.NotNil(t, testIP)
+
+	idx := statedb.IPFieldIndex{Field: "IP"}
+
+	ok, bs, err := idx.FromObject(ipFieldTest{testIP})
+	require.NoError(t, err)
+	require.True(t, ok, "FromObject succeeds")
+	require.NotEmpty(t, bs)
+
+	bs, err = idx.FromArgs(1234)
+	require.Error(t, err, "Expected FromArgs to fail with bad type")
+	require.Nil(t, bs)
+
+	bs, err = idx.FromArgs("not-proper-ip")
+	require.Error(t, err, "Expected FromArgs to fail with bad IP string")
+	require.Nil(t, bs)
+
+	bs, err = idx.FromArgs(testIP.String())
+	require.NoError(t, err, "Expected FromArgs to succeed with 'string'")
+	require.NotEmpty(t, bs)
+
+	bs, err = idx.FromArgs(testIP)
+	require.NoError(t, err, "Expected FromArgs to succeed with 'net.IP'")
+	require.NotEmpty(t, bs)
+}

--- a/pkg/statedb/schema.go
+++ b/pkg/statedb/schema.go
@@ -17,6 +17,8 @@ var (
 		Indexer:      &memdb.UUIDFieldIndex{Field: "UUID"},
 	}
 
+	IDIndex = Index("id")
+
 	RevisionIndex       = Index("revision")
 	RevisionIndexSchema = &memdb.IndexSchema{
 		Name:         string(RevisionIndex),

--- a/pkg/statedb/schema.go
+++ b/pkg/statedb/schema.go
@@ -30,6 +30,6 @@ var (
 		Name:         string(IPIndex),
 		AllowMissing: false,
 		Unique:       false,
-		Indexer:      &IPIndexer{Field: "IP"},
+		Indexer:      &IPFieldIndex{Field: "IP"},
 	}
 )


### PR DESCRIPTION
This PR adds the following new tables to pkg/datapath/tables:
```
// Device is a local network device along with addresses associated with it.
type Device struct {
	Index        int              // positive integer that starts at one, zero is never used
	MTU          int              // maximum transmission unit
	Name         string           // e.g., "en0", "lo0", "eth0.100"
	HardwareAddr net.HardwareAddr // IEEE MAC-48, EUI-48 and EUI-64 form
	Flags        net.Flags        // e.g. net.FlagUp, net.eFlagLoopback, net.FlagMulticast

	Selected    bool            // If true this device can be used by Cilium
	Addrs       []DeviceAddress // Addresses assigned to the device
	RawFlags    uint32          // Raw interface flags
	Type        string          // Device type, e.g. "veth" etc.
	MasterIndex int             // Index of the master device (e.g. bridge or bonding device)
}

var deviceTableSchema = &memdb.TableSchema{
	Name: "devices",
	Indexes: map[string]*memdb.IndexSchema{
		string(statedb.IDIndex): {
			Name:         string(statedb.IDIndex),
			AllowMissing: false,
			Unique:       true,
			Indexer:      &memdb.IntFieldIndex{Field: "Index"},
		},
		string(DeviceNameIndex): {
			Name: string(DeviceNameIndex),
			// Name can be temporarily missing if we create the device
			// from an address update.
			AllowMissing: true,
			Unique:       true,
			Indexer:      &memdb.StringFieldIndex{Field: "Name"},
		},
	},
}

type Route struct {
	Table     int
	LinkIndex int

	Scope uint8
	Dst   netip.Prefix
	Src   netip.Addr
	Gw    netip.Addr
}

var (
	routeTableSchema = &memdb.TableSchema{
		Name: "routes",
		Indexes: map[string]*memdb.IndexSchema{
			"id": {
				Name:         "id",
				AllowMissing: false,
				Unique:       true,
				Indexer: &memdb.CompoundIndex{
					Indexes: []memdb.Indexer{
						&memdb.IntFieldIndex{Field: "Table"},
						&memdb.IntFieldIndex{Field: "LinkIndex"},
						&statedb.NetIPPrefixFieldIndex{Field: "Dst"},
					},
				},
			},
			string(linkIndexIndex): {
				Name:         string(linkIndexIndex),
				AllowMissing: false,
				Unique:       false,
				Indexer:      &memdb.IntFieldIndex{Field: "LinkIndex"},
			}},
	}
)

```

The tables are populated by the DevicesController by subscribing to links, addresses and routes using netlink.
To avoid large changes to existing code, this PR keeps the existing DeviceManager API and validates the
new implementation using the old existing test suite.

Follow-up PRs will incrementally switch uses of `option.Config.GetDevices()` to querying and watching the devices table.
