### PR TITLE
pkg/service: Handle leaked backends

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -953,21 +953,26 @@ func (s *Service) GetDeepCopyServicesByName(name, namespace string) (svcs []*lb.
 
 // RestoreServices restores services from BPF maps.
 //
+// It first restores all the service entries, followed by backend entries.
+// In the process, it deletes any duplicate backend entries that were leaked, and
+// are not referenced by any service entries.
+//
 // The method should be called once before establishing a connectivity
 // to kube-apiserver.
 func (s *Service) RestoreServices() error {
 	s.Lock()
 	defer s.Unlock()
 	var errs error
+	backendsById := make(map[lb.BackendID]struct{})
 
 	// Restore service cache from BPF maps
-	if err := s.restoreServicesLocked(); err != nil {
+	if err := s.restoreServicesLocked(backendsById); err != nil {
 		errs = multierr.Append(errs,
 			fmt.Errorf("error while restoring services: %w", err))
 	}
 
 	// Restore backend IDs
-	if err := s.restoreBackendsLocked(); err != nil {
+	if err := s.restoreBackendsLocked(backendsById); err != nil {
 		errs = multierr.Append(errs,
 			fmt.Errorf("error while restoring backends: %w", err))
 	}
@@ -1355,7 +1360,7 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 	return nil
 }
 
-func (s *Service) restoreBackendsLocked() error {
+func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{}) error {
 	failed, restored := 0, 0
 	backends, err := s.lbmap.DumpBackendMaps()
 	if err != nil {
@@ -1369,6 +1374,35 @@ func (s *Service) restoreBackendsLocked() error {
 			logfields.BackendState:     b.State,
 			logfields.BackendPreferred: b.Preferred,
 		}).Debug("Restoring backend")
+		if _, ok := svcBackendsById[b.ID]; !ok && s.backendRefCount[b.L3n4Addr.Hash()] != 0 {
+			// If a backend by id isn't referenced by any of the service entries,
+			// it's likely to be a duplicate backend. This can happen when agent
+			// leaked backend entries in the backends map prior to restart, and created
+			// duplicate with different IDs but same L3n4Addr (hash).
+			// As none of the service entries have a reference to these backends
+			// in the services map, the duplicate backends were not available for
+			// load-balancing new traffic. While there is a slim chance that the
+			// duplicate backends could have previously established active connections,
+			// and these connections can get disrupted. However, the leaks likely
+			// happened when service entries were deleted, so those connections
+			// were also expected to be terminated.
+			// Regardless, delete the duplicates as this can affect restoration of current
+			// active backends, and may prevent new backends getting added as map
+			// size is limited, which can result in connectivity issues.
+			id := b.ID
+			DeleteBackendID(id)
+			if err := s.lbmap.DeleteBackendByID(id); err != nil {
+				log.Errorf("unable to delete duplicate backend: %v", id)
+			}
+			log.WithFields(logrus.Fields{
+				logfields.BackendID:        b.ID,
+				logfields.L3n4Addr:         b.L3n4Addr,
+				logfields.BackendState:     b.State,
+				logfields.BackendPreferred: b.Preferred,
+			}).Debug("Duplicate backend entry not restored")
+			failed++
+			continue
+		}
 		if err := RestoreBackendID(b.L3n4Addr, b.ID); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				logfields.BackendID:        b.ID,
@@ -1408,7 +1442,7 @@ func (s *Service) deleteOrphanBackends() error {
 	return nil
 }
 
-func (s *Service) restoreServicesLocked() error {
+func (s *Service) restoreServicesLocked(svcBackendsById map[lb.BackendID]struct{}) error {
 	failed, restored := 0, 0
 
 	svcs, errors := s.lbmap.DumpServiceMaps()
@@ -1458,6 +1492,7 @@ func (s *Service) restoreServicesLocked() error {
 			hash := backend.L3n4Addr.Hash()
 			s.backendRefCount.Add(hash)
 			newSVC.backendByHash[hash] = svc.Backends[j]
+			svcBackendsById[backend.ID] = struct{}{}
 		}
 
 		// Recalculate Maglev lookup tables if the maps were removed due to

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -958,15 +958,18 @@ func (s *Service) GetDeepCopyServicesByName(name, namespace string) (svcs []*lb.
 func (s *Service) RestoreServices() error {
 	s.Lock()
 	defer s.Unlock()
+	var errs error
 
 	// Restore backend IDs
 	if err := s.restoreBackendsLocked(); err != nil {
-		return err
+		errs = multierr.Append(errs,
+			fmt.Errorf("error while restoring backends: %w", err))
 	}
 
 	// Restore service cache from BPF maps
 	if err := s.restoreServicesLocked(); err != nil {
-		return err
+		errs = multierr.Append(errs,
+			fmt.Errorf("error while restoring services: %w", err))
 	}
 
 	// Remove LB source ranges for no longer existing services
@@ -976,7 +979,7 @@ func (s *Service) RestoreServices() error {
 		}
 	}
 
-	return nil
+	return errs
 }
 
 // deleteOrphanAffinityMatchesLocked removes affinity matches which point to

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -960,16 +960,16 @@ func (s *Service) RestoreServices() error {
 	defer s.Unlock()
 	var errs error
 
-	// Restore backend IDs
-	if err := s.restoreBackendsLocked(); err != nil {
-		errs = multierr.Append(errs,
-			fmt.Errorf("error while restoring backends: %w", err))
-	}
-
 	// Restore service cache from BPF maps
 	if err := s.restoreServicesLocked(); err != nil {
 		errs = multierr.Append(errs,
 			fmt.Errorf("error while restoring services: %w", err))
+	}
+
+	// Restore backend IDs
+	if err := s.restoreBackendsLocked(); err != nil {
+		errs = multierr.Append(errs,
+			fmt.Errorf("error while restoring backends: %w", err))
 	}
 
 	// Remove LB source ranges for no longer existing services


### PR DESCRIPTION
The current logic to restore backends is brittle, and doesn't account for failure scenarios effectively. 

pkg/service: Handle duplicate backends
   
    In certain error scenarios, backends can be leaked, where
    they were deleted from the userspace state, but left in the
    datapath backends map. To reconcile datapath and userspace,
    identify such backends that were created with different IDs
    but same L3n4Addr hash.
    This commit builds up on previous commits that don't bail out
    on such error conditions (e.g., backend IDs mismatch during restore),
    and tracks backends that are currently referenced in service entries
    restored from the lb4_services map to restore backend entries.
    Furthermore, it uses the tracked state to delete any duplicate backends
    that were previously leaked.
    
    Fixes: b79a4a53 (pkg/service: Gracefully terminate service backends)

pkg/service: Restore services prior to backends

    The restore logic attempts to reconcile datapath state
    with the userspace post agent restart.
    Previously, it first restored backends from the `lb4_backends`
    map before restoring service entries from the `lb4_services`
    map. If there were error scenarios prior to agent restart (for
    example, backend map full because of leaked backends), the logic
    would fail to restore backends currently referenced in the services
    map (and as a result, selected for load-balancing traffic).
    
    This commit prioritizes restoring service entries followed by
    backend entries. Follow-up commit handles error cases such as leaked
    backends by keeping track of backends retrieved from restoration of
    service entries, and then using that to subsequently restore backends.

pkg/service: Don't bail out on failures
    
    The restore code attempts to reconcile datapath state with
    the userspace state post agent restart. Bailing out early
    on failures prevents any remediation from happening, so
    log any errors. Follow-up commits will try to handle leaked
    backends in the cluster if any.

```release-note
Handle leaked service backends that may lead to filling up of `lb4_backends` map and thereby connectivity issues.
```

Relates: https://github.com/cilium/cilium/issues/23551

Signed-off-by: Aditi Ghag <aditi@cilium.io>