### PR TITLE
Log error message on unhealthy /healthz check

### DIFF
--- a/daemon/cmd/agenthealth.go
+++ b/daemon/cmd/agenthealth.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -42,6 +43,10 @@ func (d *Daemon) startAgentHealthHTTPService() {
 		statusCode := http.StatusOK
 		sr := d.getStatus(true)
 		if isUnhealthy(&sr) {
+			log.WithError(errors.New(sr.Cilium.Msg)).WithFields(logrus.Fields{
+				logfields.State: sr.Cilium.State,
+			},
+			).Warn("/healthz returning unhealthy")
 			statusCode = http.StatusServiceUnavailable
 		}
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -646,13 +646,13 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case d.statusResponse.Kvstore != nil && d.statusResponse.Kvstore.State != models.StatusStateOk:
-		msg := "Kvstore service is not ready"
+		msg := "Kvstore service is not ready: " + d.statusResponse.Kvstore.Msg
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.Kvstore.State,
 			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case d.statusResponse.ContainerRuntime != nil && d.statusResponse.ContainerRuntime.State != models.StatusStateOk:
-		msg := "Container runtime is not ready"
+		msg := "Container runtime is not ready: " + d.statusResponse.ContainerRuntime.Msg
 		if d.statusResponse.ContainerRuntime.State == models.StatusStateDisabled {
 			msg = "Container runtime is disabled"
 		}
@@ -661,13 +661,13 @@ func (d *Daemon) getStatus(brief bool) models.StatusResponse {
 			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case d.clientset.IsEnabled() && d.statusResponse.Kubernetes != nil && d.statusResponse.Kubernetes.State != models.StatusStateOk:
-		msg := "Kubernetes service is not ready"
+		msg := "Kubernetes service is not ready: " + d.statusResponse.Kubernetes.Msg
 		sr.Cilium = &models.Status{
 			State: d.statusResponse.Kubernetes.State,
 			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),
 		}
 	case d.statusResponse.CniFile != nil && d.statusResponse.CniFile.State == models.StatusStateFailure:
-		msg := "Could not write CNI config file"
+		msg := "Could not write CNI config file: " + d.statusResponse.CniFile.Msg
 		sr.Cilium = &models.Status{
 			State: models.StatusStateFailure,
 			Msg:   fmt.Sprintf("%s    %s", ciliumVer, msg),

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -729,4 +729,7 @@ const (
 
 	// Value identifies a generic value (e.g., of a key/value pair).
 	Value = "value"
+
+	// State is the state of an individual component (apiserver, kvstore etc)
+	State = "state"
 )


### PR DESCRIPTION
I was looking into kubelet liveness checks returning HTTP 503 response codes recently and noticed that there was not any logging in the agent that indicated the issue.

The logging I'm adding in this PR allowed me to track down why the liveness checks were failing by giving the error message associated with the current subsystem's unhealthy state. For example:

```
WARN  [<timestamp>] cilium.io/agent: 1.11.13 (v1.11.13-e4e51408f9) /healthz returning unhealthy: Kvstore service is not ready: Err: not able to connect to any etcd endpoints (state: Failure, subsys: daemon)
```
