### PR TITLE
bpf: small CT cleanups

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -729,7 +729,6 @@ enum {
 #define CB_CLUSTER_ID_EGRESS	CB_IFINDEX	/* Alias, non-overlapping */
 	CB_POLICY,
 #define	CB_ADDR_V6_2		CB_POLICY	/* Alias, non-overlapping */
-#define	CB_BACKEND_ID		CB_POLICY	/* Alias, non-overlapping */
 #define CB_SRV6_SID_3		CB_POLICY	/* Alias, non-overlapping */
 #define CB_ENCAP_DSTID		CB_POLICY	/* XDP */
 #define	CB_CLUSTER_ID_INGRESS	CB_POLICY	/* Alias, non-overlapping */

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -198,18 +198,19 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 			*monitor = ct_update_timeout(entry, is_tcp, dir, seen_flags);
 		if (ct_state) {
 			ct_state->rev_nat_index = entry->rev_nat_index;
-			ct_state->loopback = entry->lb_loopback;
-			ct_state->node_port = entry->node_port;
-			ct_state->ifindex = entry->ifindex;
-			ct_state->dsr = entry->dsr;
 			ct_state->proxy_redirect = entry->proxy_redirect;
 			ct_state->from_l7lb = entry->from_l7lb;
 			ct_state->auth_required = entry->auth_required;
 			if (dir == CT_SERVICE) {
 				ct_state->backend_id = entry->backend_id;
 				ct_state->syn = syn;
-			} else if (dir == CT_INGRESS || dir == CT_EGRESS)
+			} else if (dir == CT_INGRESS || dir == CT_EGRESS) {
+				ct_state->loopback = entry->lb_loopback;
+				ct_state->node_port = entry->node_port;
+				ct_state->dsr = entry->dsr;
 				ct_state->from_tunnel = entry->from_tunnel;
+				ct_state->ifindex = entry->ifindex;
+			}
 		}
 #ifdef CONNTRACK_ACCOUNTING
 		/* FIXME: This is slow, per-cpu counters? */
@@ -846,14 +847,14 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 	entry.from_l7lb = from_l7lb;
 	entry.auth_required = auth_required;
 
-	if (dir == CT_SERVICE)
+	if (dir == CT_SERVICE) {
 		entry.backend_id = ct_state->backend_id;
-
-	entry.lb_loopback = ct_state->loopback;
-	entry.node_port = ct_state->node_port;
-	relax_verifier();
-	entry.dsr = ct_state->dsr;
-	entry.ifindex = ct_state->ifindex;
+	} else if (dir == CT_INGRESS || dir == CT_EGRESS) {
+		entry.lb_loopback = ct_state->loopback;
+		entry.node_port = ct_state->node_port;
+		entry.dsr = ct_state->dsr;
+		entry.ifindex = ct_state->ifindex;
+	}
 
 	entry.rev_nat_index = ct_state->rev_nat_index;
 	seen_flags.value |= is_tcp ? TCP_FLAG_SYN : 0;
@@ -917,16 +918,15 @@ static __always_inline int ct_create4(const void *map_main,
 	entry.from_l7lb = from_l7lb;
 	entry.auth_required = auth_required;
 
-	entry.lb_loopback = ct_state->loopback;
-	entry.node_port = ct_state->node_port;
-	relax_verifier();
-	entry.dsr = ct_state->dsr;
-	entry.ifindex = ct_state->ifindex;
-
-	if (dir == CT_SERVICE)
+	if (dir == CT_SERVICE) {
 		entry.backend_id = ct_state->backend_id;
-	else if (dir == CT_INGRESS || dir == CT_EGRESS)
+	} else if (dir == CT_INGRESS || dir == CT_EGRESS) {
+		entry.lb_loopback = ct_state->loopback;
+		entry.node_port = ct_state->node_port;
+		entry.dsr = ct_state->dsr;
 		entry.from_tunnel = ct_state->from_tunnel;
+		entry.ifindex = ct_state->ifindex;
+	}
 
 	entry.rev_nat_index = ct_state->rev_nat_index;
 	seen_flags.value |= is_tcp ? TCP_FLAG_SYN : 0;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -198,9 +198,6 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 			*monitor = ct_update_timeout(entry, is_tcp, dir, seen_flags);
 		if (ct_state) {
 			ct_state->rev_nat_index = entry->rev_nat_index;
-			ct_state->proxy_redirect = entry->proxy_redirect;
-			ct_state->from_l7lb = entry->from_l7lb;
-			ct_state->auth_required = entry->auth_required;
 			if (dir == CT_SERVICE) {
 				ct_state->backend_id = entry->backend_id;
 				ct_state->syn = syn;
@@ -208,6 +205,9 @@ static __always_inline __u8 __ct_lookup(const void *map, struct __ctx_buff *ctx,
 				ct_state->loopback = entry->lb_loopback;
 				ct_state->node_port = entry->node_port;
 				ct_state->dsr = entry->dsr;
+				ct_state->proxy_redirect = entry->proxy_redirect;
+				ct_state->from_l7lb = entry->from_l7lb;
+				ct_state->auth_required = entry->auth_required;
 				ct_state->from_tunnel = entry->from_tunnel;
 				ct_state->ifindex = entry->ifindex;
 			}
@@ -840,13 +840,6 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
 	union tcp_flags seen_flags = { .value = 0 };
 
-	/* Note if this is a proxy connection so that replies can be redirected
-	 * back to the proxy.
-	 */
-	entry.proxy_redirect = proxy_redirect;
-	entry.from_l7lb = from_l7lb;
-	entry.auth_required = auth_required;
-
 	if (dir == CT_SERVICE) {
 		entry.backend_id = ct_state->backend_id;
 	} else if (dir == CT_INGRESS || dir == CT_EGRESS) {
@@ -854,6 +847,13 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 		entry.node_port = ct_state->node_port;
 		entry.dsr = ct_state->dsr;
 		entry.ifindex = ct_state->ifindex;
+
+		/* Note if this is a proxy connection so that replies can be redirected
+		 * back to the proxy.
+		 */
+		entry.proxy_redirect = proxy_redirect;
+		entry.from_l7lb = from_l7lb;
+		entry.auth_required = auth_required;
 	}
 
 	entry.rev_nat_index = ct_state->rev_nat_index;
@@ -911,13 +911,6 @@ static __always_inline int ct_create4(const void *map_main,
 	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
 	union tcp_flags seen_flags = { .value = 0 };
 
-	/* Note if this is a proxy connection so that replies can be redirected
-	 * back to the proxy.
-	 */
-	entry.proxy_redirect = proxy_redirect;
-	entry.from_l7lb = from_l7lb;
-	entry.auth_required = auth_required;
-
 	if (dir == CT_SERVICE) {
 		entry.backend_id = ct_state->backend_id;
 	} else if (dir == CT_INGRESS || dir == CT_EGRESS) {
@@ -926,6 +919,13 @@ static __always_inline int ct_create4(const void *map_main,
 		entry.dsr = ct_state->dsr;
 		entry.from_tunnel = ct_state->from_tunnel;
 		entry.ifindex = ct_state->ifindex;
+
+		/* Note if this is a proxy connection so that replies can be redirected
+		 * back to the proxy.
+		 */
+		entry.proxy_redirect = proxy_redirect;
+		entry.from_l7lb = from_l7lb;
+		entry.auth_required = auth_required;
 	}
 
 	entry.rev_nat_index = ct_state->rev_nat_index;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -977,7 +977,6 @@ static __always_inline void lb6_ctx_store_state(struct __ctx_buff *ctx,
 					       __u16 proxy_port)
 {
 	ctx_store_meta(ctx, CB_PROXY_MAGIC, (__u32)proxy_port << 16);
-	ctx_store_meta(ctx, CB_BACKEND_ID, state->backend_id);
 	ctx_store_meta(ctx, CB_CT_STATE, (__u32)state->rev_nat_index);
 }
 
@@ -995,10 +994,6 @@ static __always_inline void lb6_ctx_restore_state(struct __ctx_buff *ctx,
 	ctx_store_meta(ctx, CB_CT_STATE, 0);
 
 	/* No loopback support for IPv6, see lb6_local() above. */
-
-	state->backend_id = ctx_load_meta(ctx, CB_BACKEND_ID);
-	/* Must clear to avoid policy bypass as CB_BACKEND_ID aliases CB_POLICY. */
-	ctx_store_meta(ctx, CB_BACKEND_ID, 0);
 
 	*proxy_port = ctx_load_meta(ctx, CB_PROXY_MAGIC) >> 16;
 	ctx_store_meta(ctx, CB_PROXY_MAGIC, 0);
@@ -1709,7 +1704,6 @@ static __always_inline void lb4_ctx_store_state(struct __ctx_buff *ctx,
 					       __u16 proxy_port, __u32 cluster_id)
 {
 	ctx_store_meta(ctx, CB_PROXY_MAGIC, (__u32)proxy_port << 16);
-	ctx_store_meta(ctx, CB_BACKEND_ID, state->backend_id);
 	ctx_store_meta(ctx, CB_CT_STATE, (__u32)state->rev_nat_index << 16 |
 		       state->loopback);
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, cluster_id);
@@ -1737,10 +1731,6 @@ lb4_ctx_restore_state(struct __ctx_buff *ctx, struct ct_state *state,
 
 	/* Clear to not leak state to later stages of the datapath. */
 	ctx_store_meta(ctx, CB_CT_STATE, 0);
-
-	state->backend_id = ctx_load_meta(ctx, CB_BACKEND_ID);
-	/* must clear to avoid policy bypass as CB_BACKEND_ID aliases CB_POLICY. */
-	ctx_store_meta(ctx, CB_BACKEND_ID, 0);
 
 	*proxy_port = ctx_load_meta(ctx, CB_PROXY_MAGIC) >> 16;
 	ctx_store_meta(ctx, CB_PROXY_MAGIC, 0);


### PR DESCRIPTION
Clarify the semantics of some field in the ct_entry / ct_state struct. Callers of lb_local() re-use the result of the `CT_SERVICE` lookup (or parts of it), so it's important to understand which fields are relevant and which ones are guaranteed to be 0.

We started to pay more attention to this in https://github.com/cilium/cilium/pull/24212, let's now also clean up the backlog of existing fields.

