### PR TITLE
renovate: group golangci-lint updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -218,6 +218,14 @@
       ],
     },
     {
+      // Group golangci-lint updates to overrule grouping of version updates in the GHA files.
+      // Without this, golangci-lint updates are not in sync for GHA files and other usages.
+      "groupName": "golangci-lint",
+      "matchDepNames": [
+        "golangci/golangci-lint"
+      ]
+    },
+    {
       // Do not allow any updates into stable branches.
       "enabled": false,
       "matchDepNames": [


### PR DESCRIPTION
Currently, the golangci-lint update does not contain the update in the GH action files. The reason is a packageRule which combines and schedules all GH action version updates.

This commit introduces the necessary grouping packageRule which combines all golangci-lint updates over all files.

Being further down in the list of package rules, this one gets selected.

the result of a dry-run results in the following result

```
DEBUG: 2 file(s) to commit (repository=mhofstetter/cilium, baseBranch=master, branch=renovate/master-golangci-lint)
 INFO: DRY-RUN: Would commit files to branch renovate/master-golangci-lint (repository=mhofstetter/cilium, baseBranch=master, branch=renovate/master-golangci-lint)
```

Initial PR: https://github.com/cilium/cilium/pull/24664
Automated Renovate PR (with missing update in GH action): https://github.com/cilium/cilium/pull/24682