### PR TITLE
contrib/kind: adapt clustermesh related make targets to recent changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -458,7 +458,7 @@ kind-clustermesh-images: kind-clustermesh-ready kind-build-clustermesh-apiserver
 	$(QUIET)kind load docker-image $(LOCAL_OPERATOR_IMAGE) --name clustermesh1
 	$(QUIET)kind load docker-image $(LOCAL_OPERATOR_IMAGE) --name clustermesh2
 
-.PHONY: kind-install-cilium-clustermesh
+$(eval $(call KIND_ENV,kind-install-cilium-clustermesh))
 kind-install-cilium-clustermesh: kind-clustermesh-ready ## Install a local Cilium version into the clustermesh clusters and enable clustermesh.
 	@echo "  INSTALL cilium on clustermesh1 cluster"
 	kubectl config use kind-clustermesh1

--- a/Makefile
+++ b/Makefile
@@ -429,8 +429,7 @@ kind-clustermesh: ## Create two kind clusters for clustermesh development.
 
 .PHONY: kind-clustermesh-down
 kind-clustermesh-down: ## Destroy kind clusters for clustermesh development.
-	kind delete clusters clustermesh1
-	kind delete clusters clustermesh2
+	$(QUIET)./contrib/scripts/kind-down.sh clustermesh1 clustermesh2
 
 .PHONY: kind-clustermesh-ready
 kind-clustermesh-ready: ## Check if both kind clustermesh clusters exist

--- a/contrib/scripts/kind-down.sh
+++ b/contrib/scripts/kind-down.sh
@@ -9,5 +9,11 @@ if ! have_kind; then
     echo "  https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
 fi
 
-kind delete clusters kind && \
-    docker network rm kind-cilium
+default_cluster_name="kind"
+default_network="kind-cilium"
+
+for cluster in "${@:-${default_cluster_name}}"; do
+    kind delete cluster --name "$cluster"
+done
+
+docker network rm ${default_network}

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -112,11 +112,14 @@ echo "${kind_cmd}"
 
 # create a custom network so we can control the name of the bridge device.
 # Inspired by https://github.com/kubernetes-sigs/kind/blob/6b58c9dfcbdb1b3a0d48754d043d59ca7073589b/pkg/cluster/internal/providers/docker/network.go#L149-L161
-docker network create -d=bridge \
-  -o "com.docker.network.bridge.enable_ip_masquerade=true" \
-  -o "com.docker.network.bridge.name=${bridge_dev}" \
-  --ipv6 --subnet "${v6_prefix}" \
-  "${default_network}"
+# This operation is skipped if the network is already present (most notably in case of "make kind-clustermesh")
+if ! docker network inspect "${default_network}" >/dev/null 2>&1; then
+  docker network create -d=bridge \
+    -o "com.docker.network.bridge.enable_ip_masquerade=true" \
+    -o "com.docker.network.bridge.name=${bridge_dev}" \
+    --ipv6 --subnet "${v6_prefix}" \
+    "${default_network}"
+fi
 
 export KIND_EXPERIMENTAL_DOCKER_NETWORK="${default_network}"
 


### PR DESCRIPTION
This PR fixes two issues concerning the clustermesh related make targets introduced by recent modifications:

* `make kind-clustermesh`: do not fail if the `kind-cilium` docker network already exists
* `make kind-install-cilium-clustermesh`: initialize the `LOCAL_CLUSTERMESH_IMAGE` variable

Additionally, it extends the kind-down.sh script and makes the `kind-clustermesh-down` target use it, ensuring that the `kind-cilium` network gets deleted also in that case.

More details are provided in the respective commit messages.

<!-- Description of change -->

```release-note
contrib/kind: adapt clustermesh related make targets to recent changes
```
