### PR TITLE
identity/cache: don't panic in CachingIdentityAllocator.Close()

### DIFF
--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -257,7 +257,8 @@ func (m *CachingIdentityAllocator) Close() {
 		// This means the channel was closed and therefore the IdentityAllocator == nil will never be true
 	default:
 		if m.IdentityAllocator == nil {
-			log.Panic("Close() called without calling InitIdentityAllocator() first")
+			log.Error("Close() called without calling InitIdentityAllocator() first")
+			return
 		}
 	}
 


### PR DESCRIPTION
Closing a CachingIdentityAllocator currently panics if InitIdentityAllocator() has not been called. With the ongoing hiveification this causes a problem:

    level=panic msg="Close() called without calling InitIdentityAllocator() first" subsys=identity-cache
    panic: (*logrus.Entry) 0xc000666b60

The reason this happens is that we now create a CachingIdentityAllocator using hive, before newDaemon is invoked. Essentially:

* Create a new CachingIdentityAllocator using hive
* Call newDaemon(allocator)
  * Do a bunch of unrelated initialisation
  * Call allocator.InitIdentityAllocator

If any of the unrelated initialization fails, hive executes the stop hooks of all objects it has created. In the case of the allocator this invokes CachingIdentityAllocator.Close(). That function panics since we haven't reached InitIdentityAllocator in the initialization order yet.

Fix this by allowing to close an uninitialized allocator.

Fixes: d6503fa75b ("daemon: move circular initialization of policy.Repository to hive")
