### PR TITLE
v1.12: docs: Fix mitigation for IPsec upgrade issue

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -356,7 +356,7 @@ Annotations:
   the cluster. As such, we recommend staying at v1.12.7. This issue can be mitigated by
   either replacing workload nodes in the cluster (to get a fresh IPSec state) or by
   flushing the current state by running the following command on each node:
-  ``ip xfrm state flush``.  
+  ``ip xfrm state flush && ip xfrm policy flush``.  
 
 New Options
 ~~~~~~~~~~~


### PR DESCRIPTION
The mitigation documented in commit https://github.com/cilium/cilium/commit/bab91dc73177188493a06ae1089ee1922d42e11d ("Add IPSec remark for upgrade to v1.12.8") is actually incomplete. The XFRM policies also need to be flushed.

Fixes: https://github.com/cilium/cilium/pull/24630.