### PR TITLE
contrib: detect pre-release version correctly

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -83,7 +83,7 @@ main() {
     git fetch -q $REMOTE
     if [ "$branch" = "master" ]; then
         git checkout -b pr/prepare-$version $REMOTE/$branch
-        if version_is_prerelease "$version"; then
+        if ! version_is_prerelease "$version"; then
             old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'rc\|snapshot' | sort -V | tail -n 1)"
         else
             old_version="$(git tag -l "$VERSION_GLOB" | sort -V | tail -n 1)"


### PR DESCRIPTION
The script was not detecting the pre-release of a version correctly. This commit fixes it by negating the return value of 'version_is_prerelease'

Fixes: 4ba5d9441588 ("contrib: Support vX.Y.Z-snapshot.W versions")