### PR TITLE
docs: Fix upgradeCompatibility references

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -163,12 +163,7 @@ file.
 
 To minimize datapath disruption during the upgrade, the
 ``upgradeCompatibility`` option should be set to the initial Cilium
-version which was installed in this cluster. Valid options are:
-
-* ``1.7`` if the initial install was Cilium 1.7.x or earlier.
-* ``1.8`` if the initial install was Cilium 1.8.x.
-* ``1.9`` if the initial install was Cilium 1.9.x.
-* ``1.10`` if the initial install was Cilium 1.10.x.
+version which was installed in this cluster.
 
 .. tabs::
   .. group-tab:: kubectl


### PR DESCRIPTION
The upgradeCompatability should always be set to the first version that
the user installed in order to assume the Helm defaults that were in
place during that release.

Tracking each version here initially would provide confirmation for
users in order to pick a valid version. Except that we forgot to keep it
up to date with each release.

Drop the examples to reduce user confusion.
