### PR TITLE
Aspsk/fix dns resolution on kind

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -311,13 +311,7 @@ jobs:
           if [ "${{ matrix.ipv6 }}" != "false" ]; then
             IPV6="--helm-set=ipv6.enabled=true"
           fi
-          # We need to enable BPF masquerading for EGW so we keep the default
-          # here. masq is off due to https://github.com/cilium/cilium/issues/23283
-          EGRESS_GATEWAY="--helm-set=bpf.masquerade=false"
           if [ "${{ matrix.egress-gateway }}" == "true" ]; then
-            EGRESS_GATEWAY="--helm-set=bpf.masquerade=true --helm-set=enableIPv6Masquerade=false"
-            # Force legacy host routing to work around #23283 with masq on.
-            EGRESS_GATEWAY+=" --helm-set=bpf.hostLegacyRouting=true"
             EGRESS_GATEWAY+=" --helm-set=egressGateway.enabled=true"
           fi
 

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -161,6 +161,12 @@ if [ "${xdp}" = true ]; then
   done
 fi
 
+# Replace "forward . /etc/resolv.conf" in the coredns cm with "forward . 8.8.8.8".
+# This is required because in case of BPF Host Routing we bypass iptables thus
+# breaking DNS. See https://github.com/cilium/cilium/issues/23330
+NewCoreFile=$(kubectl get cm -n kube-system coredns -o jsonpath='{.data.Corefile}' | sed 's,forward . /etc/resolv.conf,forward . 8.8.8.8,' | sed -z 's/\n/\\n/g')
+kubectl patch configmap/coredns -n kube-system --type merge -p '{"data":{"Corefile": "'"$NewCoreFile"'"}}'
+
 set +e
 kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 set -e


### PR DESCRIPTION
Patch `coredns` configmap to bypass docker DNS resolver in kind and use 8.8.8.8. Re-enable masquerading and fast routing for the EGW test.

Fixes: #23283 
Fixes: #23330 