### PR TITLE
pkg/bandwidth: add error for bandwidth manager not being enabled

### DIFF
--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -53,7 +53,7 @@ func ProbeBandwidthManager() {
 		return
 	}
 	if _, err := sysctl.Read("net.core.default_qdisc"); err != nil {
-		log.Warn("BPF bandwidth manager could not read procfs. Disabling the feature.")
+		log.WithError(err).Warn("BPF bandwidth manager could not read procfs. Disabling the feature.")
 		option.Config.EnableBandwidthManager = false
 		return
 	}


### PR DESCRIPTION
If we can read "procfs" the user will not the reason for it. We should log the error as well.