### PR TITLE
Pass error codes from map_update_elem (ct_create) to drop notifications

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -194,7 +194,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
 		if (!ctx_skip_nodeport(ctx)) {
-			ret = nodeport_lb6(ctx, secctx);
+			ret = nodeport_lb6(ctx, secctx, ext_err);
 			/* nodeport_lb6() returns with TC_ACT_REDIRECT for
 			 * traffic to L7 LB. Policy enforcement needs to take
 			 * place after L7 LB has processed the packet, so we
@@ -216,7 +216,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		if (IS_ERR(ret))
 			return ret;
 	} else if (!ctx_skip_host_fw(ctx)) {
-		ret = ipv6_host_policy_ingress(ctx, &remote_id, &trace);
+		ret = ipv6_host_policy_ingress(ctx, &remote_id, &trace, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -480,7 +480,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
 		if (!ctx_skip_nodeport(ctx)) {
-			ret = nodeport_lb4(ctx, secctx);
+			ret = nodeport_lb4(ctx, secctx, ext_err);
 			if (ret == NAT_46X64_RECIRC) {
 				ctx_store_meta(ctx, CB_SRC_LABEL, secctx);
 				ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_NETDEV);
@@ -514,7 +514,7 @@ handle_ipv4(struct __ctx_buff *ctx, __u32 secctx,
 			return ret;
 	} else if (!ctx_skip_host_fw(ctx)) {
 		/* We're on the ingress path of the native device. */
-		ret = ipv4_host_policy_ingress(ctx, &remote_id, &trace);
+		ret = ipv4_host_policy_ingress(ctx, &remote_id, &trace, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -1259,6 +1259,7 @@ int cil_to_host(struct __ctx_buff *ctx)
 	int ret = CTX_ACT_OK;
 	bool traced = false;
 	__u32 src_id = 0;
+	__s8 ext_err = 0;
 
 	if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
 		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
@@ -1301,12 +1302,12 @@ int cil_to_host(struct __ctx_buff *ctx)
 # endif
 # ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		ret = ipv6_host_policy_ingress(ctx, &src_id, &trace);
+		ret = ipv6_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
 		break;
 # endif
 # ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		ret = ipv4_host_policy_ingress(ctx, &src_id, &trace);
+		ret = ipv4_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
 		break;
 # endif
 	default:
@@ -1319,8 +1320,8 @@ int cil_to_host(struct __ctx_buff *ctx)
 
 out:
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
-					      METRIC_INGRESS);
+		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_INGRESS);
 
 	if (!traced)
 		send_trace_notify(ctx, TRACE_TO_STACK, src_id, 0, 0,
@@ -1341,11 +1342,12 @@ int tail_ipv6_host_policy_ingress(struct __ctx_buff *ctx)
 	};
 	__u32 src_id = 0;
 	int ret;
+	__s8 ext_err = 0;
 
-	ret = ipv6_host_policy_ingress(ctx, &src_id, &trace);
+	ret = ipv6_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
-					      METRIC_INGRESS);
+		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_INGRESS);
 	return ret;
 }
 #endif /* ENABLE_IPV6 */
@@ -1361,11 +1363,12 @@ int tail_ipv4_host_policy_ingress(struct __ctx_buff *ctx)
 	};
 	__u32 src_id = 0;
 	int ret;
+	__s8 ext_err = 0;
 
-	ret = ipv4_host_policy_ingress(ctx, &src_id, &trace);
+	ret = ipv4_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
-					      METRIC_INGRESS);
+		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_INGRESS);
 	return ret;
 }
 #endif /* ENABLE_IPV4 */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -463,7 +463,8 @@ ct_recreate6:
 		 */
 		ct_state_new.src_sec_id = SECLABEL;
 		ret = ct_create6(get_ct_map6(tuple), &CT_MAP_ANY6, tuple, ctx,
-				 CT_EGRESS, &ct_state_new, proxy_port > 0, from_l7lb);
+				 CT_EGRESS, &ct_state_new, proxy_port > 0, from_l7lb,
+				 NULL);
 		if (IS_ERR(ret))
 			return ret;
 		trace.monitor = TRACE_PAYLOAD_LEN;
@@ -918,7 +919,8 @@ ct_recreate4:
 		 * handling here, but turns out that verifier cannot handle it.
 		 */
 		ret = ct_create4(ct_map, ct_related_map, tuple, ctx,
-				 CT_EGRESS, &ct_state_new, proxy_port > 0, from_l7lb);
+				 CT_EGRESS, &ct_state_new, proxy_port > 0, from_l7lb,
+				 NULL);
 		if (IS_ERR(ret))
 			return ret;
 		break;
@@ -1506,7 +1508,7 @@ skip_policy_enforcement:
 	if (ret == CT_NEW) {
 		ct_state_new.src_sec_id = src_label;
 		ret = ct_create6(get_ct_map6(tuple), &CT_MAP_ANY6, tuple, ctx, CT_INGRESS,
-				 &ct_state_new, *proxy_port > 0, false);
+				 &ct_state_new, *proxy_port > 0, false, NULL);
 		if (IS_ERR(ret))
 			return ret;
 
@@ -1827,7 +1829,7 @@ skip_policy_enforcement:
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.from_tunnel = from_tunnel;
 		ret = ct_create4(get_ct_map4(tuple), &CT_MAP_ANY4, tuple, ctx, CT_INGRESS,
-				 &ct_state_new, *proxy_port > 0, false);
+				 &ct_state_new, *proxy_port > 0, false, NULL);
 		if (IS_ERR(ret))
 			return ret;
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -75,7 +75,8 @@
 #ifdef ENABLE_PER_PACKET_LB
 
 #ifdef ENABLE_IPV4
-static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *ip4)
+static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *ip4,
+						       __s8 *ext_err)
 {
 	struct ipv4_ct_tuple tuple = {};
 	struct ct_state ct_state_new = {};
@@ -109,7 +110,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 #endif /* ENABLE_L7_LB */
 		ret = lb4_local(get_ct_map4(&tuple), ctx, ETH_HLEN, l4_off,
 				&key, &tuple, svc, &ct_state_new,
-				has_l4_header, false, &cluster_id);
+				has_l4_header, false, &cluster_id, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -122,7 +123,8 @@ skip_service_lookup:
 #endif /* ENABLE_IPV4 */
 
 #ifdef ENABLE_IPV6
-static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr *ip6)
+static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr *ip6,
+						       __s8 *ext_err)
 {
 	struct ipv6_ct_tuple tuple = {};
 	struct ct_state ct_state_new = {};
@@ -158,7 +160,7 @@ static __always_inline int __per_packet_lb_svc_xlate_6(void *ctx, struct ipv6hdr
 		}
 #endif /* ENABLE_L7_LB */
 		ret = lb6_local(get_ct_map6(&tuple), ctx, ETH_HLEN, l4_off,
-				&key, &tuple, svc, &ct_state_new, false);
+				&key, &tuple, svc, &ct_state_new, false, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -464,7 +466,7 @@ ct_recreate6:
 		ct_state_new.src_sec_id = SECLABEL;
 		ret = ct_create6(get_ct_map6(tuple), &CT_MAP_ANY6, tuple, ctx,
 				 CT_EGRESS, &ct_state_new, proxy_port > 0, from_l7lb,
-				 NULL);
+				 ext_err);
 		if (IS_ERR(ret))
 			return ret;
 		trace.monitor = TRACE_PAYLOAD_LEN;
@@ -704,7 +706,8 @@ TAIL_CT_LOOKUP6(CILIUM_CALL_IPV6_CT_EGRESS, tail_ipv6_ct_egress, CT_EGRESS,
 		is_defined(ENABLE_PER_PACKET_LB),
 		CILIUM_CALL_IPV6_FROM_LXC_CONT, tail_handle_ipv6_cont)
 
-static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx)
+static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
+					      __s8 *ext_err __maybe_unused)
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -731,7 +734,7 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx)
 
 #ifdef ENABLE_PER_PACKET_LB
 	/* will tailcall internally or return error */
-	return __per_packet_lb_svc_xlate_6(ctx, ip6);
+	return __per_packet_lb_svc_xlate_6(ctx, ip6, ext_err);
 #else
 	/* won't be a tailcall, see TAIL_CT_LOOKUP6 */
 	return tail_ipv6_ct_egress(ctx);
@@ -741,11 +744,12 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx)
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_FROM_LXC)
 int tail_handle_ipv6(struct __ctx_buff *ctx)
 {
-	int ret = __tail_handle_ipv6(ctx);
+	__s8 ext_err = 0;
+	int ret = __tail_handle_ipv6(ctx, &ext_err);
 
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, SECLABEL, ret,
-		    CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error_ext(ctx, SECLABEL, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_EGRESS);
 	return ret;
 }
 #endif /* ENABLE_IPV6 */
@@ -920,7 +924,7 @@ ct_recreate4:
 		 */
 		ret = ct_create4(ct_map, ct_related_map, tuple, ctx,
 				 CT_EGRESS, &ct_state_new, proxy_port > 0, from_l7lb,
-				 NULL);
+				 ext_err);
 		if (IS_ERR(ret))
 			return ret;
 		break;
@@ -1246,7 +1250,8 @@ TAIL_CT_LOOKUP4(CILIUM_CALL_IPV4_CT_EGRESS, tail_ipv4_ct_egress, CT_EGRESS,
 		is_defined(ENABLE_PER_PACKET_LB),
 		CILIUM_CALL_IPV4_FROM_LXC_CONT, tail_handle_ipv4_cont)
 
-static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx)
+static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx,
+					      __s8 *ext_err __maybe_unused)
 {
 	void *data, *data_end;
 	struct iphdr *ip4;
@@ -1268,7 +1273,7 @@ static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx)
 
 #ifdef ENABLE_PER_PACKET_LB
 	/* will tailcall internally or return error */
-	return __per_packet_lb_svc_xlate_4(ctx, ip4);
+	return __per_packet_lb_svc_xlate_4(ctx, ip4, ext_err);
 #else
 	/* won't be a tailcall, see TAIL_CT_LOOKUP4 */
 	return tail_ipv4_ct_egress(ctx);
@@ -1278,11 +1283,12 @@ static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx)
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_FROM_LXC)
 int tail_handle_ipv4(struct __ctx_buff *ctx)
 {
-	int ret = __tail_handle_ipv4(ctx);
+	__s8 ext_err = 0;
+	int ret = __tail_handle_ipv4(ctx, &ext_err);
 
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, SECLABEL, ret,
-		    CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error_ext(ctx, SECLABEL, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_EGRESS);
 	return ret;
 }
 
@@ -1507,8 +1513,14 @@ skip_policy_enforcement:
 
 	if (ret == CT_NEW) {
 		ct_state_new.src_sec_id = src_label;
+		/* ext_err may contain a value from __policy_can_access, and
+		 * ct_create6 overwrites it only if it returns an error itself.
+		 * As the error from __policy_can_access is dropped in that
+		 * case, it's OK to return ext_err from ct_create6 along with
+		 * its error code.
+		 */
 		ret = ct_create6(get_ct_map6(tuple), &CT_MAP_ANY6, tuple, ctx, CT_INGRESS,
-				 &ct_state_new, *proxy_port > 0, false, NULL);
+				 &ct_state_new, *proxy_port > 0, false, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 
@@ -1828,8 +1840,14 @@ skip_policy_enforcement:
 	if (ret == CT_NEW) {
 		ct_state_new.src_sec_id = src_label;
 		ct_state_new.from_tunnel = from_tunnel;
+		/* ext_err may contain a value from __policy_can_access, and
+		 * ct_create4 overwrites it only if it returns an error itself.
+		 * As the error from __policy_can_access is dropped in that
+		 * case, it's OK to return ext_err from ct_create4 along with
+		 * its error code.
+		 */
 		ret = ct_create4(get_ct_map4(tuple), &CT_MAP_ANY4, tuple, ctx, CT_INGRESS,
-				 &ct_state_new, *proxy_port > 0, false, NULL);
+				 &ct_state_new, *proxy_port > 0, false, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -76,7 +76,8 @@ ipv6_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	if (ret == CT_NEW && verdict == CTX_ACT_OK) {
 		ct_state_new.src_sec_id = HOST_ID;
 		ret = ct_create6(get_ct_map6(&tuple), &CT_MAP_ANY6, &tuple,
-				 ctx, CT_EGRESS, &ct_state_new, proxy_port > 0, false);
+				 ctx, CT_EGRESS, &ct_state_new, proxy_port > 0, false,
+				 NULL);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -161,7 +162,8 @@ ipv6_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id,
 		ct_state_new.src_sec_id = *src_id;
 		ct_state_new.node_port = ct_state.node_port;
 		ret = ct_create6(get_ct_map6(&tuple), &CT_MAP_ANY6, &tuple,
-				 ctx, CT_INGRESS, &ct_state_new, proxy_port > 0, false);
+				 ctx, CT_INGRESS, &ct_state_new, proxy_port > 0, false,
+				 NULL);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -220,7 +222,7 @@ whitelist_snated_egress_connections(struct __ctx_buff *ctx, __u32 ipcache_srcid,
 		if (ret == CT_NEW) {
 			ret = ct_create4(get_ct_map4(&tuple), &CT_MAP_ANY4,
 					 &tuple, ctx, CT_EGRESS, &ct_state_new,
-					 false, false);
+					 false, false, NULL);
 			if (IS_ERR(ret))
 				return ret;
 		}
@@ -295,7 +297,8 @@ ipv4_host_policy_egress(struct __ctx_buff *ctx, __u32 src_id,
 	if (ret == CT_NEW && verdict == CTX_ACT_OK) {
 		ct_state_new.src_sec_id = HOST_ID;
 		ret = ct_create4(get_ct_map4(&tuple), &CT_MAP_ANY4, &tuple,
-				 ctx, CT_EGRESS, &ct_state_new, proxy_port > 0, false);
+				 ctx, CT_EGRESS, &ct_state_new, proxy_port > 0, false,
+				 NULL);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -385,7 +388,8 @@ ipv4_host_policy_ingress(struct __ctx_buff *ctx, __u32 *src_id,
 		ct_state_new.src_sec_id = *src_id;
 		ct_state_new.node_port = ct_state.node_port;
 		ret = ct_create4(get_ct_map4(&tuple), &CT_MAP_ANY4, &tuple,
-				 ctx, CT_INGRESS, &ct_state_new, proxy_port > 0, false);
+				 ctx, CT_INGRESS, &ct_state_new, proxy_port > 0, false,
+				 NULL);
 		if (IS_ERR(ret))
 			return ret;
 	}

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -838,7 +838,8 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 				     struct ipv6_ct_tuple *tuple,
 				     const struct lb6_service *svc,
 				     struct ct_state *state,
-				     const bool skip_l3_xlate)
+				     const bool skip_l3_xlate,
+				     __s8 *ext_err)
 {
 	__u32 monitor; /* Deliberately ignored; regular CT will determine monitoring. */
 	__u8 flags = tuple->flags;
@@ -877,7 +878,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		state->backend_id = backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
 
-		ret = ct_create6(map, NULL, tuple, ctx, CT_SERVICE, state, false, false, NULL);
+		ret = ct_create6(map, NULL, tuple, ctx, CT_SERVICE, state, false, false, ext_err);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */
@@ -1528,7 +1529,8 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 				     struct ct_state *state,
 				     bool has_l4_header,
 				     const bool skip_l3_xlate,
-				     __u32 *cluster_id __maybe_unused)
+				     __u32 *cluster_id __maybe_unused,
+				     __s8 *ext_err)
 {
 	__u32 monitor; /* Deliberately ignored; regular CT will determine monitoring. */
 	__be32 saddr = tuple->saddr;
@@ -1570,7 +1572,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		state->backend_id = backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
 
-		ret = ct_create4(map, NULL, tuple, ctx, CT_SERVICE, state, false, false, NULL);
+		ret = ct_create4(map, NULL, tuple, ctx, CT_SERVICE, state, false, false, ext_err);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -877,7 +877,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		state->backend_id = backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
 
-		ret = ct_create6(map, NULL, tuple, ctx, CT_SERVICE, state, false, false);
+		ret = ct_create6(map, NULL, tuple, ctx, CT_SERVICE, state, false, false, NULL);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */
@@ -1570,7 +1570,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		state->backend_id = backend_id;
 		state->rev_nat_index = svc->rev_nat_index;
 
-		ret = ct_create4(map, NULL, tuple, ctx, CT_SERVICE, state, false, false);
+		ret = ct_create4(map, NULL, tuple, ctx, CT_SERVICE, state, false, false, NULL);
 		/* Fail closed, if the conntrack entry create fails drop
 		 * service lookup.
 		 */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -344,7 +344,7 @@ static __always_inline int snat_v4_track_connection(struct __ctx_buff *ctx,
 		return ret;
 	} else if (ret == CT_NEW) {
 		ret = ct_create4(get_ct_map4(&tmp), NULL, &tmp, ctx,
-				 where, &ct_state, false, false);
+				 where, &ct_state, false, false, NULL);
 		if (IS_ERR(ret))
 			return ret;
 	}
@@ -1284,7 +1284,7 @@ static __always_inline int snat_v6_track_connection(struct __ctx_buff *ctx,
 		return ret;
 	} else if (ret == CT_NEW) {
 		ret = ct_create6(get_ct_map6(&tmp), NULL, &tmp, ctx, where,
-				 &ct_state, false, false);
+				 &ct_state, false, false, NULL);
 		if (IS_ERR(ret))
 			return ret;
 	}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -99,7 +99,8 @@ static __always_inline bool nodeport_uses_dsr6(const struct ipv6_ct_tuple *tuple
 }
 
 static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
-						  const union v6addr *addr)
+						  const union v6addr *addr,
+						  __s8 *ext_err)
 {
 	struct ipv6_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
@@ -110,7 +111,7 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 	ipv6_addr_copy(&target.addr, addr);
 
 	ret = snat_v6_needed(ctx, addr) ?
-	      snat_v6_nat(ctx, &target) : CTX_ACT_OK;
+	      snat_v6_nat(ctx, &target, ext_err) : CTX_ACT_OK;
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
 	return ret;
@@ -626,6 +627,7 @@ int tail_nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx)
 	bool dsr = false;
 	int ret, l4_off;
 	__be16 port = 0;
+	__s8 ext_err = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 		ret = DROP_INVALID;
@@ -659,7 +661,7 @@ create_ct:
 		ct_state_new.dsr = 1;
 		ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 		ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
-				 CT_EGRESS, &ct_state_new, false, false, NULL);
+				 CT_EGRESS, &ct_state_new, false, false, &ext_err);
 		if (!IS_ERR(ret))
 			ret = snat_v6_create_dsr(&tuple, &addr, port);
 
@@ -683,7 +685,7 @@ create_ct:
 	ret = DROP_MISSED_TAIL_CALL;
 
 drop_err:
-	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
+	return send_drop_notify_error_ext(ctx, 0, ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
 }
 #endif /* ENABLE_DSR */
 
@@ -764,7 +766,8 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 	};
 	int ret;
 
-	ret = snat_v6_rev_nat(ctx, &target);
+	/* ext_err is NULL because errors don't survive the tailcall anyway. */
+	ret = snat_v6_rev_nat(ctx, &target, NULL);
 	if (IS_ERR(ret)) {
 		/* In case of no mapping, recircle back to main path. SNAT is very
 		 * expensive in terms of instructions (since we don't have BPF to
@@ -844,7 +847,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 		verdict = ret;
 	}
 #endif
-	ret = snat_v6_nat(ctx, &target);
+	ret = snat_v6_nat(ctx, &target, &ext_err);
 	if (IS_ERR(ret) && ret != NAT_PUNT_TO_STACK)
 		goto drop_err;
 
@@ -893,7 +896,8 @@ drop_err:
 
 /* See nodeport_lb4(). */
 static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
-					__u32 src_identity)
+					__u32 src_identity,
+					__s8 *ext_err)
 {
 	int ret, l3_off = ETH_HLEN, l4_off;
 	struct ipv6_ct_tuple tuple = {};
@@ -944,7 +948,7 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 #endif
 		ret = lb6_local(get_ct_map6(&tuple), ctx, l3_off, l4_off,
 				&key, &tuple, svc, &ct_state_new,
-				skip_l3_xlate);
+				skip_l3_xlate, ext_err);
 		if (IS_ERR(ret))
 			return ret;
 
@@ -1013,7 +1017,7 @@ redo:
 			ct_state_new.node_port = 1;
 			ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 			ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
-					 CT_EGRESS, &ct_state_new, false, false, NULL);
+					 CT_EGRESS, &ct_state_new, false, false, ext_err);
 			if (IS_ERR(ret))
 				return ret;
 			break;
@@ -1242,10 +1246,10 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 	};
 	__u32 src_id = 0;
 
-	ret = ipv6_host_policy_ingress(ctx, &src_id, &trace);
+	ret = ipv6_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
-					      METRIC_INGRESS);
+		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_INGRESS);
 	/* We don't want to enforce host policies a second time if we jump back to
 	 * bpf_host's handle_ipv6.
 	 */
@@ -1269,6 +1273,7 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 {
 	enum trace_point obs_point;
 	int ret;
+	__s8 ext_err = 0;
 #if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
 	union v6addr addr = { .p1 = 0 };
 
@@ -1280,9 +1285,10 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 	obs_point = TRACE_TO_NETWORK;
 #endif
 
-	ret = nodeport_snat_fwd_ipv6(ctx, &addr);
+	ret = nodeport_snat_fwd_ipv6(ctx, &addr, &ext_err);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_EGRESS);
 
 	send_trace_notify(ctx, obs_point, 0, 0, 0, 0, TRACE_REASON_UNKNOWN, 0);
 
@@ -1354,7 +1360,8 @@ static __always_inline bool nodeport_uses_dsr4(const struct ipv4_ct_tuple *tuple
 }
 
 static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
-						  __u32 cluster_id __maybe_unused)
+						  __u32 cluster_id __maybe_unused,
+						  __s8 *ext_err)
 {
 	struct ipv4_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
@@ -1370,7 +1377,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 
 	snat_needed = snat_v4_prepare_state(ctx, &target);
 	if (snat_needed)
-		ret = snat_v4_nat(ctx, &target);
+		ret = snat_v4_nat(ctx, &target, ext_err);
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
 
@@ -1861,6 +1868,7 @@ int tail_nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx)
 	int ret, l4_off;
 	__be32 addr = 0;
 	__be16 port = 0;
+	__s8 ext_err = 0;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
 		ret = DROP_INVALID;
@@ -1906,7 +1914,7 @@ create_ct:
 		ct_state_new.dsr = 1;
 		ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 		ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
-				 CT_EGRESS, &ct_state_new, false, false, NULL);
+				 CT_EGRESS, &ct_state_new, false, false, &ext_err);
 		if (!IS_ERR(ret))
 			ret = snat_v4_create_dsr(&tuple, addr, port);
 
@@ -1940,7 +1948,7 @@ create_ct:
 	ret = DROP_MISSED_TAIL_CALL;
 
 drop_err:
-	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
+	return send_drop_notify_error_ext(ctx, 0, ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
 }
 #endif /* ENABLE_DSR */
 
@@ -1960,7 +1968,8 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	};
 	int ret;
 
-	ret = snat_v4_rev_nat(ctx, &target);
+	/* ext_err is NULL because errors don't survive the tailcall anyway. */
+	ret = snat_v4_rev_nat(ctx, &target, NULL);
 	if (IS_ERR(ret)) {
 		/* In case of no mapping, recircle back to main path. SNAT is very
 		 * expensive in terms of instructions (since we don't have BPF to
@@ -2050,7 +2059,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		verdict = ret;
 	}
 #endif
-	ret = snat_v4_nat(ctx, &target);
+	ret = snat_v4_nat(ctx, &target, &ext_err);
 	if (IS_ERR(ret) && ret != NAT_PUNT_TO_STACK)
 		goto drop_err;
 
@@ -2085,7 +2094,8 @@ drop_err:
  * iii) reply from remote backend EP.
  */
 static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
-					__u32 src_identity)
+					__u32 src_identity,
+					__s8 *ext_err)
 {
 	bool backend_local, l4_ports, has_l4_header;
 	struct ipv4_ct_tuple tuple = {};
@@ -2147,7 +2157,8 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 		} else {
 			ret = lb4_local(get_ct_map4(&tuple), ctx, l3_off, l4_off,
 					&key, &tuple, svc, &ct_state_new,
-					has_l4_header, skip_l3_xlate, &cluster_id);
+					has_l4_header, skip_l3_xlate, &cluster_id,
+					ext_err);
 		}
 		if (IS_ERR(ret))
 			return ret;
@@ -2251,7 +2262,7 @@ redo:
 			ct_state_new.node_port = 1;
 			ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 			ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
-					 CT_EGRESS, &ct_state_new, false, false, NULL);
+					 CT_EGRESS, &ct_state_new, false, false, ext_err);
 			if (IS_ERR(ret))
 				return ret;
 			break;
@@ -2464,10 +2475,10 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 	};
 	__u32 src_id = 0;
 
-	ret = ipv4_host_policy_ingress(ctx, &src_id, &trace);
+	ret = ipv4_host_policy_ingress(ctx, &src_id, &trace, &ext_err);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
-					      METRIC_INGRESS);
+		return send_drop_notify_error_ext(ctx, src_id, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_INGRESS);
 	/* We don't want to enforce host policies a second time if we jump back to
 	 * bpf_host's handle_ipv6.
 	 */
@@ -2491,6 +2502,7 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 	__u32 cluster_id = ctx_load_meta(ctx, CB_CLUSTER_ID_EGRESS);
 	enum trace_point obs_point;
 	int ret;
+	__s8 ext_err = 0;
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, 0);
 
@@ -2500,9 +2512,10 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 	obs_point = TRACE_TO_NETWORK;
 #endif
 
-	ret = nodeport_snat_fwd_ipv4(ctx, cluster_id);
+	ret = nodeport_snat_fwd_ipv4(ctx, cluster_id, &ext_err);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_EGRESS);
 
 	send_trace_notify(ctx, obs_point, 0, 0, 0, 0, TRACE_REASON_UNKNOWN, 0);
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -659,7 +659,7 @@ create_ct:
 		ct_state_new.dsr = 1;
 		ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 		ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
-				 CT_EGRESS, &ct_state_new, false, false);
+				 CT_EGRESS, &ct_state_new, false, false, NULL);
 		if (!IS_ERR(ret))
 			ret = snat_v6_create_dsr(&tuple, &addr, port);
 
@@ -1013,7 +1013,7 @@ redo:
 			ct_state_new.node_port = 1;
 			ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 			ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
-					 CT_EGRESS, &ct_state_new, false, false);
+					 CT_EGRESS, &ct_state_new, false, false, NULL);
 			if (IS_ERR(ret))
 				return ret;
 			break;
@@ -1906,7 +1906,7 @@ create_ct:
 		ct_state_new.dsr = 1;
 		ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 		ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
-				 CT_EGRESS, &ct_state_new, false, false);
+				 CT_EGRESS, &ct_state_new, false, false, NULL);
 		if (!IS_ERR(ret))
 			ret = snat_v4_create_dsr(&tuple, addr, port);
 
@@ -2251,7 +2251,7 @@ redo:
 			ct_state_new.node_port = 1;
 			ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 			ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
-					 CT_EGRESS, &ct_state_new, false, false);
+					 CT_EGRESS, &ct_state_new, false, false, NULL);
 			if (IS_ERR(ret))
 				return ret;
 			break;

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -133,7 +133,7 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 			ct_state_new.node_port = ct_state.node_port;
 			ct_state_new.ifindex = ct_state.ifindex;
 			ret = ct_create4(get_ct_map4(&tuple), &CT_MAP_ANY4, &tuple, ctx,
-					 CT_EGRESS, &ct_state_new, false, false);
+					 CT_EGRESS, &ct_state_new, false, false, NULL);
 			break;
 
 		default:

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -180,7 +180,7 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target);
+	ret = snat_v4_rev_nat(ctx, &target, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -288,7 +288,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target);
+	ret = snat_v4_rev_nat(ctx, &target, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -395,7 +395,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target);
+	ret = snat_v4_rev_nat(ctx, &target, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -491,7 +491,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target);
+	ret = snat_v4_rev_nat(ctx, &target, NULL);
 	assert(ret == 0);
 
 	/* nothing really change with udp/tcp */

--- a/bpf/tests/nat_test.c
+++ b/bpf/tests/nat_test.c
@@ -74,7 +74,8 @@ static __always_inline int mock_ct_create4(__maybe_unused const void *map_main,
 					   __maybe_unused const int dir,
 					   __maybe_unused const struct ct_state *ct_state,
 					   __maybe_unused bool proxy_redirect,
-					   __maybe_unused bool from_l7lb)
+					   __maybe_unused bool from_l7lb,
+					   __maybe_unused __s8 *ext_err)
 {
 	return mock_ct_create4_response;
 }

--- a/bpf/tests/nat_test.c
+++ b/bpf/tests/nat_test.c
@@ -114,8 +114,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return exactly the same value which means */
 	/* an error occurs when snat_v4_track_connection is looking for the ipv4_ct_tuple. */
 	TEST("return -1 on error", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS, 0, &target)
-		    != -1){
+		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS,
+					     0, &target, NULL) != -1) {
 			test_fail();
 		}
 	});
@@ -127,8 +127,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return 0 which means snat_v4_track_connection */
 	/* successfully tracks ipv4_ct_tuple. */
 	TEST("return 0 on track", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS, 0, &target)
-		    != 0){
+		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS,
+					     0, &target, NULL) != 0) {
 			test_fail();
 		}
 	});
@@ -143,8 +143,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return that value which means an error occurs */
 	/* when snat_v4_track_connection is trying to create the ipv4_ct_tuple. */
 	TEST("return -1 on create error", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS, 0, &target)
-		    != -1){
+		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS,
+					     0, &target, NULL) != -1) {
 			test_fail();
 		}
 	});
@@ -158,8 +158,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return 0 which means snat_v4_track_connection */
 	/* successfully creates the ipv4_ct_tuple. */
 	TEST("return 0 on create success", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS, 0, &target)
-		    != 0) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS,
+					     0, &target, NULL) != 0) {
 			test_fail();
 		}
 	});


### PR DESCRIPTION
```release-note
Report the kernel error code in case of packet drops due to failures to create conntrack map entries.
```