### PR TITLE
contrib: Fix codegen script to avoid double make

### DIFF
--- a/contrib/scripts/check-api-code-gen.sh
+++ b/contrib/scripts/check-api-code-gen.sh
@@ -40,7 +40,7 @@ diff="$(git diff)"
 if [ -n "$diff" ]; then
 	echo "Ungenerated api source code:"
 	echo "$diff"
-	echo "Please run `make generate-api generate-health-api generate-hubble-api generate-operator-api` and submit your changes"
+	echo "Please run 'make generate-api generate-health-api generate-hubble-api generate-operator-api' and submit your changes"
 	exit 1
 fi
 


### PR DESCRIPTION
This error message was running the command that it should have told the
developer to run. Fix it by avoiding grave accents in the message.
