### PR TITLE
helm: Ignore .github folder in .helmignore

### DIFF
--- a/install/kubernetes/cilium/.helmignore
+++ b/install/kubernetes/cilium/.helmignore
@@ -4,6 +4,7 @@
 .DS_Store
 # Common VCS dirs
 .git/
+.github/
 .gitignore
 .bzr/
 .bzrignore


### PR DESCRIPTION
This commit ignores the .github folder in .helmignore, which causes issues in code scanning tools.

