### PR TITLE
egressgw: policy: set namespace in policy ID

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -188,7 +188,7 @@ func (manager *Manager) OnAddEgressPolicy(config PolicyConfig) {
 	manager.Lock()
 	defer manager.Unlock()
 
-	logger := log.WithField(logfields.CiliumEgressGatewayPolicyName, config.id.Name)
+	logger := log.WithField(logfields.CiliumEgressGatewayPolicyName, config.id)
 
 	if _, ok := manager.policyConfigs[config.id]; !ok {
 		logger.Debug("Added CiliumEgressGatewayPolicy")

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -331,7 +331,8 @@ func ParseCEGP(cegp *v2.CiliumEgressGatewayPolicy) (*PolicyConfig, error) {
 		matchedEndpoints:  make(map[endpointID]*endpointMetadata),
 		policyGwConfig:    policyGwc,
 		id: types.NamespacedName{
-			Name: name,
+			Name:      name,
+			Namespace: cegp.Namespace,
 		},
 	}, nil
 }


### PR DESCRIPTION
when parsing a CEGP into a PolicyConfig, in addition to the policy name, set also the policy namespace in the config ID, as otherwise 2 policies sharing the same name on different namespaces can overwrite each other.