### PR TITLE
renovate: add packageRule group for cilium-cli

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -210,6 +210,13 @@
       "versioning": "regex:^v0.0.0-(<patch>\\d+)-.*$",
     },
     {
+      "groupName": "Cilium CLI",
+      "groupSlug": "cilium-cli",
+      "matchDepNames": [
+        "cilium/cilium-cli"
+      ]
+    },
+    {
       "groupName": "Hubble CLI",
       "groupSlug": "hubble-cli",
       "matchDepNames": [


### PR DESCRIPTION
Add a new packageRule group for the cilium-cli dependency. This makes sure cilium-cli updates occur in a dedicated PR rather than being grouped with other GitHub action dependency updates. This is useful to allow manual testing by the reviewer.

Example PR: https://github.com/tklauser/cilium/pull/501

/cc @nbusseneau