### PR TITLE
endpoint: omit pre-1.11 compatibility restoration symlink

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -47,11 +47,6 @@ const (
 	// EndpointGenerationTimeout specifies timeout for proxy completion context
 	EndpointGenerationTimeout = 330 * time.Second
 
-	// OldCHeaderFileName is the previous name of the C header file for BPF
-	// programs for a particular endpoint. It can be removed once Cilium v1.11
-	// is the oldest supported version.
-	oldCHeaderFileName = "lxc_config.h"
-
 	// ciliumCHeaderPrefix is the prefix using when printing/writing an endpoint in a
 	// base64 form.
 	ciliumCHeaderPrefix = "CILIUM_BASE64_"
@@ -176,25 +171,7 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 		return err
 	}
 
-	err = f.CloseAtomicallyReplace()
-
-	// Create symlink with old header filename, to allow downgrade to pre-1.11
-	// Cilium. Can be removed once v1.11 is the oldest supported release.
-	// The symlink is not needed for the host endpoint because we check the new
-	// header filename for that special endpoint. To avoid linking to a
-	// nonexistent file, only create the symlink if the header file
-	// creation/replacement file succeeded above.
-	if !e.IsHost() && err == nil {
-		oldHeaderPath := filepath.Join(prefix, oldCHeaderFileName)
-		if _, err := os.Stat(oldHeaderPath); err != nil {
-			// The symlink doesn't already exists.
-			if err := renameio.Symlink(common.CHeaderFileName, oldHeaderPath); err != nil {
-				e.getLogger().WithError(err).Error("Failed to create C header file symlink")
-			}
-		}
-	}
-
-	return err
+	return f.CloseAtomicallyReplace()
 }
 
 // policyIdentitiesLabelLookup is an implementation of the policy.Identities interface.

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -118,22 +118,6 @@ func ReadEPsFromDirNames(ctx context.Context, owner regeneration.Owner, policyGe
 			continue
 		}
 
-		// This symlink is only needed when upgrading from a pre-1.11 Cilium
-		// and we can thus remove it once Cilium v1.11 is the oldest supported
-		// version.
-		oldCHeaderFile := filepath.Join(epDir, oldCHeaderFileName)
-		if _, err := os.Stat(oldCHeaderFile); err != nil {
-			if !os.IsNotExist(err) {
-				scopedLog.WithError(err).Warn("Failed to check if old C header exists. Ignoring endpoint")
-				continue
-			}
-			if err := os.Symlink(common.CHeaderFileName, oldCHeaderFile); err != nil {
-				scopedLog.WithError(err).Warn("Failed to create symlink for C header. Ignoring endpoint")
-				continue
-			}
-			scopedLog.Debug("Created symlink for endpoint C header file")
-		}
-
 		scopedLog.Debug("Found endpoint C header file")
 
 		bEp, err := getCiliumVersionString(cHeaderFile)


### PR DESCRIPTION
With the release of 1.13, Cilium 1.11 is the oldest supported release. There is now no risk that a user tries to downgrade to a version of Cilium that uses the old lxc_config.h file/symlink for endpoint restoration and we can safely omit the compatibility symlink.

Ref. 9faa347acb76 ("endpoint: Remove outdated code for endpoint restoration")