### PR TITLE
CI: enable load balancer acceleration for some datapath conformance cases

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -169,6 +169,7 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
             host-fw: 'true'
+            lb-acceleration: 'testing-only'
 
           - name: '7'
             kernel: 'bpf-next-main'
@@ -177,6 +178,7 @@ jobs:
             tunnel: 'disabled'
             lb-mode: 'snat'
             egress-gateway: 'true'
+            lb-acceleration: 'testing-only'
 
           - name: '8'
             kernel: 'bpf-next-main'
@@ -317,6 +319,10 @@ jobs:
           if [ "${{ matrix.egress-gateway }}" == "true" ]; then
             EGRESS_GATEWAY="--helm-set=egressGateway.enabled=true"
           fi
+          LB_ACCELERATION=""
+          if [ "${{ matrix.lb-acceleration }}" != "" ]; then
+            LB_ACCELERATION="--helm-set=loadBalancer.acceleration=${{ matrix.lb-acceleration }}"
+          fi
 
           ENCRYPT=""
           if [ "${{ matrix.encryption }}" != "" ]; then
@@ -331,7 +337,7 @@ jobs:
             HOST_FW="--helm-set=hostFirewall.enabled=true"
           fi
 
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW}"
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
       - name: Set commit status to pending

--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -313,8 +313,9 @@ jobs:
           if [ "${{ matrix.ipv6 }}" != "false" ]; then
             IPV6="--helm-set=ipv6.enabled=true"
           fi
+          EGRESS_GATEWAY=""
           if [ "${{ matrix.egress-gateway }}" == "true" ]; then
-            EGRESS_GATEWAY+=" --helm-set=egressGateway.enabled=true"
+            EGRESS_GATEWAY="--helm-set=egressGateway.enabled=true"
           fi
 
           ENCRYPT=""


### PR DESCRIPTION
gh/workflows: enable loadBalancer acceleration for some suites
    
    Set loadBalancer.acceleration=testing-only in two datapath
    conformance tests. I had originally planned to modify 12-15 but
    those have encryption enabled. Instead, enable it on 6-7. Compared
    to Jenkins we drop  testing for (EP routes=true,
    acceleration=testing-only) from the matrix.
    
    Updates #24151
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

gh/workflows: fix initialization of EGRESS_GATEWAY
    
    Use the same logic for EGRESS_GATEWAY as for other features.
    
    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

```release-note
Enable loadBalancer.acceleration=testing-only in some datapath conformance cases
```
