### PR TITLE
renovate: Add explicit gitAuthor

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,8 @@
     ":gitSignOff",
     "helpers:pinGitHubActionDigests"
   ],
+  // This ensures that the gitAuthor and gitSignOff fields match
+  "gitAuthor": "renovate[bot] <bot@renovateapp.com>",
   "includePaths": [
     ".github/workflows/**",
     "images/**",

--- a/.mailmap
+++ b/.mailmap
@@ -103,6 +103,7 @@ Qifeng Guo <qifeng.guo@daocloud.io>
 Raam <ram29@bskyb.com>
 Raphael Campos <raphael@accuknox.com>
 Rei Shimizu <Shikugawa@gmail.com>
+renovate[bot] <bot@renovateapp.com> <29139614+renovate[bot]@users.noreply.github.com>
 Roman Ptitcyn <romanspb@yahoo.com>
 Sachin Maurya <sachin.maurya7666@gmail.com>
 Sadik Kuzu <sadikkuzu@hotmail.com>


### PR DESCRIPTION
This commit adds an explicit gitAuthor to Renovate. The intent behind this is that it will match the author line in the `Signed-off-by` field:

 https://docs.renovatebot.com/presets-default/#gitsignoff

This fixes an issue where previously checkpatch failed with the following error:
```
Error: ERROR:NO_AUTHOR_SIGN_OFF: Missing Signed-off-by: line by nominal patch author '"renovate[bot]" <29139614+renovate[bot]@users.noreply.github.com>'
```

Manually tested here:
 - https://github.com/gandro/cilium/pull/133/commits/f73ad382eee043dcc82d11796a044fdb6a3abfb1

:warning: Note that this changes the Renovate git commit author, meaning Renovate updates before and after this PR is merged will have a different commit author (old: `renovate[bot]" <29139614+renovate[bot]@users.noreply.github.com>`, new: `Renovate Bot <bot@renovateapp.com>`