### PR TITLE
Add go runtime scheduler latency metrics

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -325,6 +325,7 @@ Added Metrics
 
 * ``cilium_operator_ces_sync_total``
 * ``cilium_policy_change_total``
+* ``go_sched_latencies_seconds``
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,6 +12,7 @@ package metrics
 
 import (
 	"net/http"
+	"regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -219,6 +220,9 @@ const (
 )
 
 var (
+	// goCustomCollectorsRX tracks enabled go runtime metrics.
+	goCustomCollectorsRX = regexp.MustCompile(`^/sched/latencies:seconds`)
+
 	registry = prometheus.NewPedanticRegistry()
 
 	// BootstrapTimes is the durations of cilium-agent bootstrap sequence.
@@ -1561,7 +1565,10 @@ func init() {
 
 func registerDefaultMetrics() {
 	MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{Namespace: Namespace}))
-	MustRegister(collectors.NewGoCollector())
+	MustRegister(collectors.NewGoCollector(
+		collectors.WithGoCollectorRuntimeMetrics(
+			collectors.GoRuntimeMetricsRule{Matcher: goCustomCollectorsRX},
+		)))
 	MustRegister(newStatusCollector())
 	MustRegister(newbpfCollector())
 }


### PR DESCRIPTION
The Agent/Controller largely depends on various goroutines being scheduled on time to perform critical control plane tasks (i.e. like controllers, etc...)

We want to be able to detect/alert goroutine scheduling latency, specifically when CPU contention is so great that things may not be running on time.

- Added GOR scheduler latency metric to the default GO metrics collector

Signed-off-by: Fernand Galiana fernand.galiana@isovalent.com

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [x] Thanks for contributing!

```release-note
Expose Cilium agent go runtime scheduler latency prometheus metric `go_sched_latencies_seconds`
```