### PR TITLE
envoy: Support more envoy image tag formats

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -119,7 +119,7 @@ endif
 
 ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/images/cilium/Dockerfile),)
     CILIUM_ENVOY_REF=$(shell sed -E -e 's/^FROM (--[^ ]* )*([^ ]*) as cilium-envoy/\2/p;d' < $(ROOT_DIR)/images/cilium/Dockerfile)
-    CILIUM_ENVOY_SHA=$(shell echo $(CILIUM_ENVOY_REF) | sed -E -e 's/[^/]*\/[^:]*:([^:@-]*).*/\1/p;d')
+    CILIUM_ENVOY_SHA=$(shell echo $(CILIUM_ENVOY_REF) | sed -E -e 's/[^/]*\/[^:]*:([^:@]*).*/\1/p;d' | sed -E -e 's/.*-([^-]*)$/\1/')
     GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/envoy.RequiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
 endif
 


### PR DESCRIPTION
This commit is to add the support for the below image tags

Different envoy image tag formats:

```
quay.io/cilium/cilium-envoy:f195a0a836629ceca5d7561f758c9505d9ebaebfa262647a2d4
quay.io/cilium/cilium-envoy:v1.23-f195a0a836629ceca5d7561f758c9505d9ebaebfa262647a2d4
```

Testing was done as per below, kindly note the existing format should be working as usual.

```bash
$ test=quay.io/cilium/cilium-envoy:014ceeb312a4d18dcf0ea219143f099fa91f2f28@sha256:1a3020822e8fb10b5f96bf45554690c411c2f48d8ca8fcf33da871dad1ce6b53
$ echo $test | sed -E -e 's/[^/]*\/[^:]*:([^:@]*).*/\1/p;d' | sed -E -e 's/.*-([^-]*)$/\1/'
014ceeb312a4d18dcf0ea219143f099fa91f2f28
$ test=quay.io/cilium/cilium-envoy:v1.24-014ceeb312a4d18dcf0ea219143f099fa91f2f28@sha256:1a3020822e8fb10b5f96bf45554690c411c2f48d8ca8fcf33da871dad1ce6b53
$ echo $test | sed -E -e 's/[^/]*\/[^:]*:([^:@]*).*/\1/p;d' | sed -E -e 's/.*-([^-]*)$/\1/'
014ceeb312a4d18dcf0ea219143f099fa91f2f28
```

Fixes: #24749 
