### PR TITLE
Mitigate GKE workflow flake

### DIFF
--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -287,12 +287,14 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy --test-namespace cilium-test-tunnel 
+        # --test-namespace cilium-test-tunnel added for mitigating test flake until the issue is solved https://github.com/cilium/cilium/issues/22368
 
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
-          cilium uninstall --chart-directory=install/kubernetes/cilium --wait
+          cilium uninstall --chart-directory=install/kubernetes/cilium --test-namespace cilium-test-tunnel
+        # --wait removed and --test-namespace cilium-test-tunnel added for mitigating test flake until the issue is solved https://github.com/cilium/cilium/issues/22368
 
       - name: Create custom IPsec secret
         run: |

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -287,12 +287,14 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy --test-namespace cilium-test-tunnel
+        # --test-namespace cilium-test-tunnel added for mitigating test flake until the issue is solved https://github.com/cilium/cilium/issues/22368
 
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
-          cilium uninstall --chart-directory=install/kubernetes/cilium --wait
+          cilium uninstall --chart-directory=install/kubernetes/cilium --test-namespace cilium-test-tunnel
+        # --wait removed and --test-namespace cilium-test-tunnel added for mitigating test flake until the issue is solved https://github.com/cilium/cilium/issues/22368
 
       - name: Create custom IPsec secret
         run: |

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -288,12 +288,14 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy --test-namespace cilium-test-tunnel 
+        # --test-namespace cilium-test-tunnel added for mitigating test flake until the issue is solved https://github.com/cilium/cilium/issues/22368
 
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
-          cilium uninstall --chart-directory=install/kubernetes/cilium --wait
+          cilium uninstall --chart-directory=install/kubernetes/cilium --test-namespace cilium-test-tunnel
+        # --wait removed and --test-namespace cilium-test-tunnel added for mitigating test flake until the issue is solved https://github.com/cilium/cilium/issues/22368
 
       - name: Create custom IPsec secret
         run: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -293,12 +293,14 @@ jobs:
 
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy --test-namespace cilium-test-tunnel 
+        # --test-namespace cilium-test-tunnel added for mitigating test flake until the issue is solved https://github.com/cilium/cilium/issues/22368
 
       - name: Clean up Cilium
         run: |
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
-          cilium uninstall --chart-directory=install/kubernetes/cilium --wait
+          cilium uninstall --chart-directory=install/kubernetes/cilium --test-namespace cilium-test-tunnel
+        # --wait removed and --test-namespace cilium-test-tunnel added for mitigating test flake until the issue is solved https://github.com/cilium/cilium/issues/22368
 
       - name: Create custom IPsec secret
         run: |


### PR DESCRIPTION
This commit mitigates workflow flake on GKE with tunnel installation until issue #22368 is fixed.
For the test with tunnel test namespace is added and for uninstall `--wait` option is removed.
