### PR TITLE
bpf: lb: deal with stale rev_nat_index after svc lookup in fallback path

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -935,6 +935,8 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 			goto drop_no_service;
 		state->backend_id = backend_id;
 		ct_update_backend_id(map, tuple, state);
+		state->rev_nat_index = svc->rev_nat_index;
+		ct_update_rev_nat_index(map, tuple, state);
 	}
 update_state:
 	/* Restore flags so that SERVICE flag is only used in used when the
@@ -1618,6 +1620,8 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 			goto drop_no_service;
 		state->backend_id = backend_id;
 		ct_update_backend_id(map, tuple, state);
+		state->rev_nat_index = svc->rev_nat_index;
+		ct_update_rev_nat_index(map, tuple, state);
 	}
 update_state:
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -941,7 +941,6 @@ update_state:
 	 * service lookup happens and future lookups use EGRESS or INGRESS.
 	 */
 	tuple->flags = flags;
-	state->rev_nat_index = svc->rev_nat_index;
 #ifdef ENABLE_SESSION_AFFINITY
 	if (lb6_svc_is_affinity(svc))
 		lb6_update_affinity_by_addr(svc, &client_id,
@@ -1629,7 +1628,6 @@ update_state:
 	 * service lookup happens and future lookups use EGRESS or INGRESS.
 	 */
 	tuple->flags = flags;
-	state->rev_nat_index = svc->rev_nat_index;
 	state->addr = backend->address;
 #ifdef ENABLE_SESSION_AFFINITY
 	if (lb4_svc_is_affinity(svc))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1028,7 +1028,7 @@ redo:
 		case CT_REOPENED:
 		case CT_ESTABLISHED:
 			if (unlikely(ct_state.rev_nat_index !=
-				     svc->rev_nat_index))
+				     ct_state_new.rev_nat_index))
 				goto redo;
 			break;
 		default:
@@ -2279,7 +2279,7 @@ redo:
 			 * belongs to a flow which target a different svc.
 			 */
 			if (unlikely(ct_state.rev_nat_index !=
-				     svc->rev_nat_index))
+				     ct_state_new.rev_nat_index))
 				goto redo;
 			break;
 		default:


### PR DESCRIPTION
Fix two corner-case bugs in the fallback path for `lb_local()`, when a previously selected backend is unavailable. In this case we perform a fresh svc lookup, and thus need to handle that the new svc entry is associated with a different `rev_nat_index`.