### PR TITLE
mtls: SPIRE server and agent installation

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -232,7 +232,7 @@ cilium-agent [flags]
       --log-system-load                                         Enable periodic logging of system load
       --mesh-auth-monitor-queue-size int                        Queue size for the auth monitor (default 1024)
       --mesh-auth-mtls-listener-port int                        Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
-      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                    The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-admin-socket string                     The path for the SPIRE admin agent Unix socket.
       --metrics strings                                         Metrics that should be enabled or disabled from the default metric list. The list is expected to be separated by a space. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)
       --monitor-aggregation string                              Level of monitor aggregation for traces from the datapath (default "None")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -27,7 +27,7 @@ cilium-agent hive [flags]
       --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file
       --mesh-auth-monitor-queue-size int       Queue size for the auth monitor (default 1024)
       --mesh-auth-mtls-listener-port int       Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
-      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-admin-socket string    The path for the SPIRE admin agent Unix socket.
       --pprof                                  Enable serving pprof debugging API
       --pprof-address string                   Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -32,7 +32,7 @@ cilium-agent hive dot-graph [flags]
       --k8s-kubeconfig-path string             Absolute path of the kubernetes kubeconfig file
       --mesh-auth-monitor-queue-size int       Queue size for the auth monitor (default 1024)
       --mesh-auth-mtls-listener-port int       Port on which the Cilium Agent will perfom mTLS handshakes between other Agents
-      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string   The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-admin-socket string    The path for the SPIRE admin agent Unix socket.
       --pprof                                  Enable serving pprof debugging API
       --pprof-address string                   Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -65,7 +65,7 @@ cilium-operator-alibabacloud [flags]
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -25,7 +25,7 @@ cilium-operator-alibabacloud hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -30,7 +30,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -73,7 +73,7 @@ cilium-operator-aws [flags]
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -25,7 +25,7 @@ cilium-operator-aws hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -30,7 +30,7 @@ cilium-operator-aws hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -68,7 +68,7 @@ cilium-operator-azure [flags]
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -25,7 +25,7 @@ cilium-operator-azure hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -30,7 +30,7 @@ cilium-operator-azure hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -64,7 +64,7 @@ cilium-operator-generic [flags]
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -25,7 +25,7 @@ cilium-operator-generic hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -30,7 +30,7 @@ cilium-operator-generic hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -78,7 +78,7 @@ cilium-operator [flags]
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -25,7 +25,7 @@ cilium-operator hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -30,7 +30,7 @@ cilium-operator hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --mesh-auth-mtls-enabled                               The flag to enable mTLS for the SPIRE server.
-      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium.io")
+      --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
       --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
       --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -40,34 +40,46 @@
      - Annotate k8s node upon initialization with Cilium's metadata.
      - bool
      - ``false``
-   * - auth.mTLS.enabled
-     - Enable mtls-spiffe authentication method in CiliumNetworkPolicy
-     - bool
-     - ``false``
    * - auth.mTLS.port
-     - port on the agent which is used to mTLS handshakes on
+     - Port on the agent where mTLS handshakes between agents will be performed
      - int
      - ``4250``
-   * - auth.mTLS.spiffeTrustDomain
-     - SPIFFE trust domain to use for fetching certificates
-     - string
-     - ``"spiffe.cilium"``
-   * - auth.mTLS.spireAdminSocketPath
+   * - auth.mTLS.spire.adminSocketPath
      - SPIRE socket path where the SPIRE delegated api agent is listening
      - string
      - ``"/run/spire/sockets/admin.sock"``
-   * - auth.mTLS.spireAgentSocketPath
-     - SPIRE agent socket path where the SPIRE agent is listening
+   * - auth.mTLS.spire.agentSocketPath
+     - SPIRE socket path where the SPIRE workload agent is listening. Applies to both the Cilium Agent and Operator
      - string
      - ``"/run/spire/sockets/agent/agent.sock"``
-   * - auth.mTLS.spireServerAddress
-     - SPIRE server endpoint This endpoint will be automatically injected later once embedded SPIRE installation is done.
+   * - auth.mTLS.spire.connectionTimeout
+     - SPIRE connection timeout
      - string
-     - ``"spire-server.spire.svc.cluster.local:8081"``
-   * - auth.mTLS.spireServerConnectionTimeout
-     - SPIRE server connection timeout
+     - ``"30s"``
+   * - auth.mTLS.spire.enabled
+     - Enable SPIRE integration
+     - bool
+     - ``false``
+   * - auth.mTLS.spire.install
+     - Settings to control the SPIRE installation and configuration
+     - object
+     - ``{"enabled":false,"namespace":"cilium-spire"}``
+   * - auth.mTLS.spire.install.enabled
+     - Enable SPIRE installation. This will only take effect only if auth.mTLS.spire.enabled is true
+     - bool
+     - ``false``
+   * - auth.mTLS.spire.install.namespace
+     - SPIRE namespace to install into
      - string
-     - ``"10s"``
+     - ``"cilium-spire"``
+   * - auth.mTLS.spire.serverAddress
+     - SPIRE server address
+     - string
+     - ``"spire-server.cilium-spire.svc.cluster.local:8081"``
+   * - auth.mTLS.spire.trustDomain
+     - SPIFFE trust domain to use for fetching certificates
+     - string
+     - ``"spiffe.cilium"``
    * - autoDirectNodeRoutes
      - Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment.
      - bool
@@ -249,7 +261,7 @@
      - int
      - ``0``
    * - cluster.name
-     - Name of the cluster. Only required for Cluster Mesh.
+     - Name of the cluster. Only required for Cluster Mesh and mTLS auth with SPIRE.
      - string
      - ``"default"``
    * - clustermesh.apiserver.affinity

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -51,7 +51,7 @@
    * - auth.mTLS.spiffeTrustDomain
      - SPIFFE trust domain to use for fetching certificates
      - string
-     - ``"spiffe.cilium.io"``
+     - ``"spiffe.cilium"``
    * - auth.mTLS.spireAdminSocketPath
      - SPIRE socket path where the SPIRE delegated api agent is listening
      - string

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -63,7 +63,35 @@
    * - auth.mTLS.spire.install
      - Settings to control the SPIRE installation and configuration
      - object
-     - ``{"enabled":false,"namespace":"cilium-spire"}``
+     - ``{"agent":{"annotations":{},"image":"ghcr.io/spiffe/spire-agent:1.5.1@sha256:40228af4d9a094f0fef2d7a303a3b6a689c4b4eba2fa9f7da5125b81d2d68ec8","initContainers":[{"args":["-t","30","spire-server:8081"],"image":"cgr.dev/chainguard/wait-for-it@sha256:ecb58e3a2ffbdb732bb9049987e06eaf826d945410e167f31d6ffe28fab259f4","name":"init"}],"labels":{},"serviceAccount":{"create":true,"name":"spire-agent"},"skipKubeletVerification":false},"enabled":false,"namespace":"cilium-spire","server":{"annotations":{},"ca":{"keyType":"rsa-4096","subject":{"commonName":"","country":"US","organization":"SPIRE"}},"dataStorage":{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":null},"image":"ghcr.io/spiffe/spire-server:1.5.1@sha256:4851ec8c71a8fbe230d87be78dfed0e908800c2342cf192289c7885bb2f7a870","initContainers":[],"labels":{},"service":{"annotations":{},"labels":{},"type":"ClusterIP"},"serviceAccount":{"create":true,"name":"spire-server"}}}``
+   * - auth.mTLS.spire.install.agent
+     - SPIRE agent configuration
+     - object
+     - ``{"annotations":{},"image":"ghcr.io/spiffe/spire-agent:1.5.1@sha256:40228af4d9a094f0fef2d7a303a3b6a689c4b4eba2fa9f7da5125b81d2d68ec8","initContainers":[{"args":["-t","30","spire-server:8081"],"image":"cgr.dev/chainguard/wait-for-it@sha256:ecb58e3a2ffbdb732bb9049987e06eaf826d945410e167f31d6ffe28fab259f4","name":"init"}],"labels":{},"serviceAccount":{"create":true,"name":"spire-agent"},"skipKubeletVerification":false}``
+   * - auth.mTLS.spire.install.agent.annotations
+     - SPIRE agent annotations
+     - object
+     - ``{}``
+   * - auth.mTLS.spire.install.agent.image
+     - SPIRE agent image
+     - string
+     - ``"ghcr.io/spiffe/spire-agent:1.5.1@sha256:40228af4d9a094f0fef2d7a303a3b6a689c4b4eba2fa9f7da5125b81d2d68ec8"``
+   * - auth.mTLS.spire.install.agent.initContainers
+     - SPIRE agent init containers
+     - list
+     - ``[{"args":["-t","30","spire-server:8081"],"image":"cgr.dev/chainguard/wait-for-it@sha256:ecb58e3a2ffbdb732bb9049987e06eaf826d945410e167f31d6ffe28fab259f4","name":"init"}]``
+   * - auth.mTLS.spire.install.agent.labels
+     - SPIRE agent labels
+     - object
+     - ``{}``
+   * - auth.mTLS.spire.install.agent.serviceAccount
+     - SPIRE agent service account
+     - object
+     - ``{"create":true,"name":"spire-agent"}``
+   * - auth.mTLS.spire.install.agent.skipKubeletVerification
+     - SPIRE Workload Attestor kubelet verification.
+     - bool
+     - ``false``
    * - auth.mTLS.spire.install.enabled
      - Enable SPIRE installation. This will only take effect only if auth.mTLS.spire.enabled is true
      - bool
@@ -72,6 +100,46 @@
      - SPIRE namespace to install into
      - string
      - ``"cilium-spire"``
+   * - auth.mTLS.spire.install.server.annotations
+     - SPIRE server annotations
+     - object
+     - ``{}``
+   * - auth.mTLS.spire.install.server.ca
+     - SPIRE CA configuration
+     - object
+     - ``{"keyType":"rsa-4096","subject":{"commonName":"","country":"US","organization":"SPIRE"}}``
+   * - auth.mTLS.spire.install.server.ca.keyType
+     - SPIRE CA key type AWS requires the use of RSA. EC cryptography is not supported
+     - string
+     - ``"rsa-4096"``
+   * - auth.mTLS.spire.install.server.ca.subject
+     - SPIRE CA Subject
+     - object
+     - ``{"commonName":"","country":"US","organization":"SPIRE"}``
+   * - auth.mTLS.spire.install.server.dataStorage
+     - SPIRE server datastorage configuration
+     - object
+     - ``{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":null}``
+   * - auth.mTLS.spire.install.server.image
+     - SPIRE server image
+     - string
+     - ``"ghcr.io/spiffe/spire-server:1.5.1@sha256:4851ec8c71a8fbe230d87be78dfed0e908800c2342cf192289c7885bb2f7a870"``
+   * - auth.mTLS.spire.install.server.initContainers
+     - SPIRE server init containers
+     - list
+     - ``[]``
+   * - auth.mTLS.spire.install.server.labels
+     - SPIRE server labels
+     - object
+     - ``{}``
+   * - auth.mTLS.spire.install.server.service
+     - SPIRE server service configuration
+     - object
+     - ``{"annotations":{},"labels":{},"type":"ClusterIP"}``
+   * - auth.mTLS.spire.install.server.serviceAccount
+     - SPIRE server service account
+     - object
+     - ``{"create":true,"name":"spire-server"}``
    * - auth.mTLS.spire.serverAddress
      - SPIRE server address
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -5,6 +5,7 @@ AdapterLimitViaAPI
 Alemayhu
 Alibaba
 Anthos
+Attestor
 Automount
 BIGTCP
 BPF
@@ -338,10 +339,12 @@ curl
 customCalls
 customConf
 daemonset
+dataStorage
 datacenter
 datagrams
 datapath
 datapathMode
+datastorage
 datastore
 datastream
 datastreams
@@ -554,6 +557,7 @@ ingressLBAnnotationPrefixes
 ingressing
 init
 initContainer
+initContainers
 inline
 inlined
 inlines
@@ -610,6 +614,7 @@ kata
 keepDeprecatedLabels
 keepDeprecatedProbes
 keyFile
+keyType
 keyless
 keypair
 keyspace
@@ -932,6 +937,7 @@ securityContext
 selftest
 selftests
 sendmsg
+serverAddress
 serviceAccount
 serviceAccountName
 serviceAccounts
@@ -953,6 +959,7 @@ sig
 skb
 skipCNPStatusStartupClean
 skipCRDCreation
+skipKubeletVerification
 skipUnknownCGroupIDs
 skipteardown
 sleepAfterInit

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -165,7 +165,9 @@ Zhou
 Zookeeper
 aarch
 admin
+adminSocketPath
 agentNotReadyTaintKey
+agentSocketPath
 aksbyocni
 alibabacloud
 allocator
@@ -271,6 +273,7 @@ cidr
 cidrs
 ciliumAgent
 ciliumNodeUpdateRate
+ciliumOperator
 ciliumnode
 classful
 classid
@@ -309,6 +312,7 @@ configSources
 configmap
 configs
 conformant
+connectionTimeout
 conntrack
 conntrackGCInterval
 containerRuntime
@@ -350,6 +354,7 @@ decapsulation
 decrypt
 decrypted
 deepcopy
+delegatedClient
 deletetopic
 demux
 dependant
@@ -959,11 +964,6 @@ sortBufferLenMax
 sourceContext
 spiffe
 spiffeTrustDomain
-spireAdminSocketPath
-spireAgentSocketPath
-spireServerAddress
-spireServerConnectionTimeout
-spireServerSocketPath
 src
 srv
 ssl
@@ -1042,6 +1042,7 @@ tracepoint
 tracepoints
 transpiling
 triaged
+trustDomain
 ttlSecondsAfterFinished
 tunnelPort
 tunnelProtocol

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -62,7 +62,7 @@ contributors across the globe, there is almost always someone available to help.
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
 | auth.mTLS.enabled | bool | `false` | Enable mtls-spiffe authentication method in CiliumNetworkPolicy |
 | auth.mTLS.port | int | `4250` | port on the agent which is used to mTLS handshakes on |
-| auth.mTLS.spiffeTrustDomain | string | `"spiffe.cilium.io"` | SPIFFE trust domain to use for fetching certificates |
+| auth.mTLS.spiffeTrustDomain | string | `"spiffe.cilium"` | SPIFFE trust domain to use for fetching certificates |
 | auth.mTLS.spireAdminSocketPath | string | `"/run/spire/sockets/admin.sock"` | SPIRE socket path where the SPIRE delegated api agent is listening |
 | auth.mTLS.spireAgentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE agent socket path where the SPIRE agent is listening |
 | auth.mTLS.spireServerAddress | string | `"spire-server.spire.svc.cluster.local:8081"` | SPIRE server endpoint This endpoint will be automatically injected later once embedded SPIRE installation is done. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -60,13 +60,16 @@ contributors across the globe, there is almost always someone available to help.
 | aksbyocni.enabled | bool | `false` | Enable AKS BYOCNI integration. Note that this is incompatible with AKS clusters not created in BYOCNI mode: use Azure integration (`azure.enabled`) instead. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
-| auth.mTLS.enabled | bool | `false` | Enable mtls-spiffe authentication method in CiliumNetworkPolicy |
-| auth.mTLS.port | int | `4250` | port on the agent which is used to mTLS handshakes on |
-| auth.mTLS.spiffeTrustDomain | string | `"spiffe.cilium"` | SPIFFE trust domain to use for fetching certificates |
-| auth.mTLS.spireAdminSocketPath | string | `"/run/spire/sockets/admin.sock"` | SPIRE socket path where the SPIRE delegated api agent is listening |
-| auth.mTLS.spireAgentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE agent socket path where the SPIRE agent is listening |
-| auth.mTLS.spireServerAddress | string | `"spire-server.spire.svc.cluster.local:8081"` | SPIRE server endpoint This endpoint will be automatically injected later once embedded SPIRE installation is done. |
-| auth.mTLS.spireServerConnectionTimeout | string | `"10s"` | SPIRE server connection timeout |
+| auth.mTLS.port | int | `4250` | Port on the agent where mTLS handshakes between agents will be performed |
+| auth.mTLS.spire.adminSocketPath | string | `"/run/spire/sockets/admin.sock"` | SPIRE socket path where the SPIRE delegated api agent is listening |
+| auth.mTLS.spire.agentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE socket path where the SPIRE workload agent is listening. Applies to both the Cilium Agent and Operator |
+| auth.mTLS.spire.connectionTimeout | string | `"30s"` | SPIRE connection timeout |
+| auth.mTLS.spire.enabled | bool | `false` | Enable SPIRE integration |
+| auth.mTLS.spire.install | object | `{"enabled":false,"namespace":"cilium-spire"}` | Settings to control the SPIRE installation and configuration |
+| auth.mTLS.spire.install.enabled | bool | `false` | Enable SPIRE installation. This will only take effect only if auth.mTLS.spire.enabled is true |
+| auth.mTLS.spire.install.namespace | string | `"cilium-spire"` | SPIRE namespace to install into |
+| auth.mTLS.spire.serverAddress | string | `"spire-server.cilium-spire.svc.cluster.local:8081"` | SPIRE server address |
+| auth.mTLS.spire.trustDomain | string | `"spiffe.cilium"` | SPIFFE trust domain to use for fetching certificates |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |
 | azure.enabled | bool | `false` | Enable Azure integration. Note that this is incompatible with AKS clusters created in BYOCNI mode: use AKS BYOCNI integration (`aksbyocni.enabled`) instead. |
 | bandwidthManager | object | `{"bbr":false,"enabled":false}` | Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |
@@ -112,7 +115,7 @@ contributors across the globe, there is almost always someone available to help.
 | cleanBpfState | bool | `false` | Clean all eBPF datapath state from the initContainer of the cilium-agent DaemonSet.  WARNING: Use with care! |
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true.  WARNING: Use with care! |
 | cluster.id | int | `0` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh, may be 0 if Cluster Mesh is not used. |
-| cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh. |
+| cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh and mTLS auth with SPIRE. |
 | clustermesh.apiserver.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for clustermesh.apiserver |
 | clustermesh.apiserver.etcd.image | object | `{"digest":"sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3","override":null,"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.5.4","useDigest":true}` | Clustermesh API server etcd image. |
 | clustermesh.apiserver.etcd.init.resources | object | `{}` | Specifies the resources for etcd init container in the apiserver |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -65,9 +65,26 @@ contributors across the globe, there is almost always someone available to help.
 | auth.mTLS.spire.agentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE socket path where the SPIRE workload agent is listening. Applies to both the Cilium Agent and Operator |
 | auth.mTLS.spire.connectionTimeout | string | `"30s"` | SPIRE connection timeout |
 | auth.mTLS.spire.enabled | bool | `false` | Enable SPIRE integration |
-| auth.mTLS.spire.install | object | `{"enabled":false,"namespace":"cilium-spire"}` | Settings to control the SPIRE installation and configuration |
+| auth.mTLS.spire.install | object | `{"agent":{"annotations":{},"image":"ghcr.io/spiffe/spire-agent:1.5.1@sha256:40228af4d9a094f0fef2d7a303a3b6a689c4b4eba2fa9f7da5125b81d2d68ec8","initContainers":[{"args":["-t","30","spire-server:8081"],"image":"cgr.dev/chainguard/wait-for-it@sha256:ecb58e3a2ffbdb732bb9049987e06eaf826d945410e167f31d6ffe28fab259f4","name":"init"}],"labels":{},"serviceAccount":{"create":true,"name":"spire-agent"},"skipKubeletVerification":false},"enabled":false,"namespace":"cilium-spire","server":{"annotations":{},"ca":{"keyType":"rsa-4096","subject":{"commonName":"","country":"US","organization":"SPIRE"}},"dataStorage":{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":null},"image":"ghcr.io/spiffe/spire-server:1.5.1@sha256:4851ec8c71a8fbe230d87be78dfed0e908800c2342cf192289c7885bb2f7a870","initContainers":[],"labels":{},"service":{"annotations":{},"labels":{},"type":"ClusterIP"},"serviceAccount":{"create":true,"name":"spire-server"}}}` | Settings to control the SPIRE installation and configuration |
+| auth.mTLS.spire.install.agent | object | `{"annotations":{},"image":"ghcr.io/spiffe/spire-agent:1.5.1@sha256:40228af4d9a094f0fef2d7a303a3b6a689c4b4eba2fa9f7da5125b81d2d68ec8","initContainers":[{"args":["-t","30","spire-server:8081"],"image":"cgr.dev/chainguard/wait-for-it@sha256:ecb58e3a2ffbdb732bb9049987e06eaf826d945410e167f31d6ffe28fab259f4","name":"init"}],"labels":{},"serviceAccount":{"create":true,"name":"spire-agent"},"skipKubeletVerification":false}` | SPIRE agent configuration |
+| auth.mTLS.spire.install.agent.annotations | object | `{}` | SPIRE agent annotations |
+| auth.mTLS.spire.install.agent.image | string | `"ghcr.io/spiffe/spire-agent:1.5.1@sha256:40228af4d9a094f0fef2d7a303a3b6a689c4b4eba2fa9f7da5125b81d2d68ec8"` | SPIRE agent image |
+| auth.mTLS.spire.install.agent.initContainers | list | `[{"args":["-t","30","spire-server:8081"],"image":"cgr.dev/chainguard/wait-for-it@sha256:ecb58e3a2ffbdb732bb9049987e06eaf826d945410e167f31d6ffe28fab259f4","name":"init"}]` | SPIRE agent init containers |
+| auth.mTLS.spire.install.agent.labels | object | `{}` | SPIRE agent labels |
+| auth.mTLS.spire.install.agent.serviceAccount | object | `{"create":true,"name":"spire-agent"}` | SPIRE agent service account |
+| auth.mTLS.spire.install.agent.skipKubeletVerification | bool | `false` | SPIRE Workload Attestor kubelet verification. |
 | auth.mTLS.spire.install.enabled | bool | `false` | Enable SPIRE installation. This will only take effect only if auth.mTLS.spire.enabled is true |
 | auth.mTLS.spire.install.namespace | string | `"cilium-spire"` | SPIRE namespace to install into |
+| auth.mTLS.spire.install.server.annotations | object | `{}` | SPIRE server annotations |
+| auth.mTLS.spire.install.server.ca | object | `{"keyType":"rsa-4096","subject":{"commonName":"","country":"US","organization":"SPIRE"}}` | SPIRE CA configuration |
+| auth.mTLS.spire.install.server.ca.keyType | string | `"rsa-4096"` | SPIRE CA key type AWS requires the use of RSA. EC cryptography is not supported |
+| auth.mTLS.spire.install.server.ca.subject | object | `{"commonName":"","country":"US","organization":"SPIRE"}` | SPIRE CA Subject |
+| auth.mTLS.spire.install.server.dataStorage | object | `{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":null}` | SPIRE server datastorage configuration |
+| auth.mTLS.spire.install.server.image | string | `"ghcr.io/spiffe/spire-server:1.5.1@sha256:4851ec8c71a8fbe230d87be78dfed0e908800c2342cf192289c7885bb2f7a870"` | SPIRE server image |
+| auth.mTLS.spire.install.server.initContainers | list | `[]` | SPIRE server init containers |
+| auth.mTLS.spire.install.server.labels | object | `{}` | SPIRE server labels |
+| auth.mTLS.spire.install.server.service | object | `{"annotations":{},"labels":{},"type":"ClusterIP"}` | SPIRE server service configuration |
+| auth.mTLS.spire.install.server.serviceAccount | object | `{"create":true,"name":"spire-server"}` | SPIRE server service account |
 | auth.mTLS.spire.serverAddress | string | `"spire-server.cilium-spire.svc.cluster.local:8081"` | SPIRE server address |
 | auth.mTLS.spire.trustDomain | string | `"spiffe.cilium"` | SPIFFE trust domain to use for fetching certificates |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |

--- a/install/kubernetes/cilium/files/spire/init.bash
+++ b/install/kubernetes/cilium/files/spire/init.bash
@@ -1,0 +1,48 @@
+# shellcheck disable=SC2086
+# shellcheck disable=SC2139
+set -e
+
+echo "Waiting for spire process to start"
+while ! pgrep spire-server > /dev/null; do sleep 5; done
+
+SPIRE_SERVER_ROOT_PATH="/proc/$(pgrep spire-server)/root"
+
+alias spire_server="${SPIRE_SERVER_ROOT_PATH}/opt/spire/bin/spire-server"
+SOCKET_PATH="${SPIRE_SERVER_ROOT_PATH}/tmp/spire-server/private/api.sock"
+SOCKET_FLAG="-socketPath ${SOCKET_PATH}"
+
+echo "Checking spire-server status"
+while ! spire_server entry show ${SOCKET_FLAG} &> /dev/null; do
+  echo "Waiting for spire-server to start..."
+  sleep 5
+done
+
+echo "Spire Server is up, initializing cilium spire entries..."
+
+AGENT_SPIFFE_ID="spiffe://{{ .Values.auth.mTLS.spire.trustDomain }}/ns/{{ .Values.auth.mTLS.spire.install.namespace }}/sa/spire-agent"
+AGENT_SELECTORS="-selector k8s_psat:agent_ns:{{ .Values.auth.mTLS.spire.install.namespace }} -selector k8s_psat:agent_sa:spire-agent"
+CILIUM_AGENT_SPIFFE_ID="spiffe://{{ .Values.auth.mTLS.spire.trustDomain }}/cilium-agent"
+CILIUM_AGENT_SELECTORS="-selector k8s:ns:{{ .Release.Namespace }} -selector k8s:sa:{{ .Values.serviceAccounts.cilium.name }}"
+CILIUM_OPERATOR_SPIFFE_ID="spiffe://{{ .Values.auth.mTLS.spire.trustDomain }}/cilium-operator"
+CILIUM_OPERATOR_SELECTORS="-selector k8s:ns:{{ .Release.Namespace }} -selector k8s:sa:{{ .Values.serviceAccounts.operator.name }}"
+
+while pgrep spire-server > /dev/null;
+do
+  echo "Ensuring agent entry"
+  if spire_server entry show ${SOCKET_FLAG} -spiffeID $AGENT_SPIFFE_ID $AGENT_SELECTORS | grep -q "Found 0 entries" &> /dev/null; then
+    spire_server entry create ${SOCKET_FLAG} -spiffeID $AGENT_SPIFFE_ID $AGENT_SELECTORS -node
+  fi
+
+  echo "Ensuring cilium-agent entry (required for the delegated identity to work)"
+  if spire_server entry show ${SOCKET_FLAG} -spiffeID $CILIUM_AGENT_SPIFFE_ID $CILIUM_AGENT_SELECTORS | grep -q "Found 0 entries" &> /dev/null; then
+    spire_server entry create ${SOCKET_FLAG} -spiffeID $CILIUM_AGENT_SPIFFE_ID -parentID $AGENT_SPIFFE_ID $CILIUM_AGENT_SELECTORS
+  fi
+
+  echo "Ensuring cilium-operator entry (required for creating SPIFFE identities)"
+  if spire_server entry show ${SOCKET_FLAG} -spiffeID $CILIUM_OPERATOR_SPIFFE_ID $CILIUM_OPERATOR_SELECTORS | grep -q "Found 0 entries" &> /dev/null; then
+    spire_server entry create ${SOCKET_FLAG} -spiffeID $CILIUM_OPERATOR_SPIFFE_ID -parentID $AGENT_SPIFFE_ID $CILIUM_OPERATOR_SELECTORS
+  fi
+
+  echo "Cilium Spire entries are initialized successfully or already in-sync"
+  sleep 30;
+done

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -268,9 +268,9 @@ spec:
           {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        {{- if .Values.auth.mTLS.enabled }}
+        {{- if .Values.auth.mTLS.spire.enabled }}
         - name: spire-agent-socket
-          mountPath: {{ dir .Values.auth.mTLS.spireAdminSocketPath }}
+          mountPath: {{ dir .Values.auth.mTLS.spire.adminSocketPath }}
           readOnly: false
         {{- end }}
         {{- if not .Values.securityContext.privileged }}
@@ -768,10 +768,10 @@ spec:
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
-      {{- if .Values.auth.mTLS.enabled }}
+      {{- if .Values.auth.mTLS.spire.enabled }}
       - name: spire-agent-socket
         hostPath:
-          path: {{ dir .Values.auth.mTLS.spireAdminSocketPath }}
+          path: {{ dir .Values.auth.mTLS.spire.adminSocketPath }}
           type: DirectoryOrCreate
       {{- end }}
       {{- if .Values.kubeConfigPath }}

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1032,14 +1032,14 @@ data:
 
 {{- end }}
 
-{{- if .Values.auth.mTLS.enabled }}
+{{- if .Values.auth.mTLS.spire.enabled }}
   mesh-auth-mtls-enabled: "true"
   mesh-auth-mtls-listener-port: {{ .Values.auth.mTLS.port | quote }}
-  mesh-auth-spire-agent-socket: {{ .Values.auth.mTLS.spireAgentSocketPath }}
-  mesh-auth-spire-server-address: {{ .Values.auth.mTLS.spireServerAddress }}
-  mesh-auth-spire-server-connection-timeout: {{ .Values.auth.mTLS.spireServerConnectionTimeout }}
-  mesh-auth-spire-admin-socket: {{ .Values.auth.mTLS.spireAdminSocketPath }}
-  mesh-auth-spiffe-trust-domain: {{ .Values.auth.mTLS.spiffeTrustDomain }}
+  mesh-auth-spire-agent-socket: {{ .Values.auth.mTLS.spire.agentSocketPath | quote }}
+  mesh-auth-spire-server-address: {{ .Values.auth.mTLS.spire.serverAddress | quote }}
+  mesh-auth-spire-server-connection-timeout: {{ .Values.auth.mTLS.spire.connectionTimeout }}
+  mesh-auth-spire-admin-socket: {{ .Values.auth.mTLS.spire.adminSocketPath | quote }}
+  mesh-auth-spiffe-trust-domain: {{ .Values.auth.mTLS.spire.trustDomain | quote }}
 {{- end }}
 
 ---

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -208,9 +208,9 @@ spec:
           mountPath: {{ .Values.kubeConfigPath }}
           readOnly: true
         {{- end }}
-        {{- if .Values.auth.mTLS.enabled }}
+        {{- if .Values.auth.mTLS.spire.enabled }}
         - name: spire-agent-socket
-          mountPath: {{ dir .Values.auth.mTLS.spireAgentSocketPath }}
+          mountPath: {{ dir .Values.auth.mTLS.spire.agentSocketPath }}
           readOnly: true
         {{- end }}
         {{- range .Values.operator.extraHostPathMounts }}
@@ -239,7 +239,7 @@ spec:
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
-      {{- if or (and .Values.etcd.managed (not .Values.etcd.k8sService)) .Values.auth.mTLS.enabled }}
+      {{- if or (and .Values.etcd.managed (not .Values.etcd.k8sService)) .Values.auth.mTLS.spire.enabled }}
       # Cilium must be able to resolve the DNS name of the etcd service in managed etcd mode,
       # and the DNS name of the SPIRE server in mTLS mode.
       dnsPolicy: ClusterFirstWithHostNet
@@ -321,10 +321,10 @@ spec:
         configMap:
           name: bgp-config
       {{- end }}
-      {{- if .Values.auth.mTLS.enabled }}
+      {{- if .Values.auth.mTLS.spire.enabled }}
       - name: spire-agent-socket
         hostPath:
-          path: {{ dir .Values.auth.mTLS.spireAgentSocketPath }}
+          path: {{ dir .Values.auth.mTLS.spire.agentSocketPath }}
           type: DirectoryOrCreate
       {{- end }}
       {{- with .Values.operator.extraVolumes }}

--- a/install/kubernetes/cilium/templates/spire/agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/clusterrole.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled .Values.auth.mTLS.spire.install.agent.serviceAccount.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.agent.serviceAccount.name }}
+rules:
+# Required cluster role to allow spire-agent to query k8s API server
+- apiGroups: [ "" ]
+  resources: [ "pods","nodes","nodes/proxy" ]
+  verbs: [ "get" ]
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/agent/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled .Values.auth.mTLS.spire.install.agent.serviceAccount.create -}}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.agent.serviceAccount.name }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Values.auth.mTLS.spire.install.agent.serviceAccount.name }}
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.auth.mTLS.spire.install.agent.serviceAccount.name }}
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/agent/configmap.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/configmap.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-agent
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+data:
+  agent.conf: |
+    agent {
+      data_dir = "/run/spire"
+      log_level = "ERROR"
+      server_address = "spire-server"
+      server_port = "8081"
+      socket_path = {{ .Values.auth.mTLS.spire.agentSocketPath | quote }}
+      admin_socket_path = {{ .Values.auth.mTLS.spire.adminSocketPath | quote }}
+      trust_bundle_path = "/run/spire/bundle/bundle.crt"
+      trust_domain = {{ .Values.auth.mTLS.spire.trustDomain | quote }}
+      authorized_delegates = [
+        "spiffe://{{ .Values.auth.mTLS.spire.trustDomain }}/cilium-agent",
+      ]
+    }
+
+    plugins {
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          cluster = {{ .Values.cluster.name | quote }}
+        }
+      }
+
+      KeyManager "memory" {
+        plugin_data {
+        }
+      }
+
+      WorkloadAttestor "k8s" {
+        plugin_data {
+          skip_kubelet_verification = {{ .Values.auth.mTLS.spire.install.agent.skipKubeletVerification }}
+        }
+      }
+    }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
@@ -1,0 +1,81 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: spire-agent
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+  {{- with .Values.auth.mTLS.spire.install.server.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  labels:
+    app: spire-agent
+  {{- with .Values.auth.mTLS.spire.install.server.labels }}
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: spire-agent
+  template:
+    metadata:
+      namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+      labels:
+        app: spire-agent
+    spec:
+      hostPID: true
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: {{ .Values.auth.mTLS.spire.install.agent.serviceAccount.name }}
+      {{- if gt (len .Values.auth.mTLS.spire.install.agent.initContainers) 0 }}
+      initContainers:
+        {{- toYaml .Values.auth.mTLS.spire.install.agent.initContainers | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: spire-agent
+          image: {{ .Values.auth.mTLS.spire.install.agent.image }}
+          args: ["-config", "/run/spire/config/agent.conf"]
+          volumeMounts:
+            - name: spire-config
+              mountPath: /run/spire/config
+              readOnly: true
+            - name: spire-bundle
+              mountPath: /run/spire/bundle
+            - name: spire-agent-socket
+              mountPath: /run/spire/sockets
+              readOnly: false
+            - name: spire-agent
+              mountPath: /var/run/secrets/tokens
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: 8080
+            failureThreshold: 2
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: spire-config
+          configMap:
+            name: spire-agent
+        - name: spire-bundle
+          configMap:
+            name: spire-bundle
+        - name: spire-agent-socket
+          hostPath:
+            path: /run/spire/sockets
+            type: DirectoryOrCreate
+        - name: spire-agent
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: spire-agent
+                expirationSeconds: 600
+                audience: spire-server
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/agent/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled .Values.auth.mTLS.spire.install.agent.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.agent.serviceAccount.name }}
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/bundle-configmap.yaml
+++ b/install/kubernetes/cilium/templates/spire/bundle-configmap.yaml
@@ -1,0 +1,7 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-bundle
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/namespace.yaml
+++ b/install/kubernetes/cilium/templates/spire/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/server/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/clusterrole.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled .Values.auth.mTLS.spire.install.server.serviceAccount.create -}}
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+rules:
+# ClusterRole to allow spire-server node attestor to query Token Review API
+- apiGroups: [ "authentication.k8s.io" ]
+  resources: [ "tokenreviews" ]
+  verbs: [ "create" ]
+# Required cluster role to allow spire-server to query k8s API server
+# for pods for psat attestation
+- apiGroups: [ "" ]
+  resources: [ "pods" ]
+  verbs: [ "get" ]
+# Required cluster role to allow spire-server to query k8s API server
+# for nodes for psat attestation
+- apiGroups: [ "" ]
+  resources: [ "nodes","nodes/proxy" ]
+  verbs: [ "get" ]
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/server/clusterrolebinding.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled .Values.auth.mTLS.spire.install.server.serviceAccount.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+roleRef:
+  kind: ClusterRole
+  name: spire-server
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/server/configmap.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/configmap.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spire-server
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+data:
+  server.conf: |
+    server {
+      bind_address = "0.0.0.0"
+      bind_port = "8081"
+      socket_path = "/tmp/spire-server/private/api.sock"
+      trust_domain = {{ .Values.auth.mTLS.spire.trustDomain | quote }}
+      data_dir = "/run/spire/data"
+      log_level = "INFO"
+      ca_key_type = {{ .Values.auth.mTLS.spire.install.server.ca.keyType | quote }}
+
+      ca_subject = {
+        country = [{{ .Values.auth.mTLS.spire.install.server.ca.subject.country | quote }}],
+        organization = [{{ .Values.auth.mTLS.spire.install.server.ca.subject.organization | quote }}],
+        common_name = {{ .Values.auth.mTLS.spire.install.server.ca.subject.commonName | quote }},
+      }
+
+      admin_ids = [
+        "spiffe://{{ .Values.auth.mTLS.spire.trustDomain }}/cilium-operator",
+      ]
+    }
+
+    plugins {
+      DataStore "sql" {
+        plugin_data {
+          database_type = "sqlite3"
+          connection_string = "/run/spire/data/datastore.sqlite3"
+        }
+      }
+
+      NodeAttestor "k8s_psat" {
+        plugin_data {
+          clusters = {
+            {{ .Values.cluster.name | quote }} = {
+              use_token_review_api_validation = true
+              service_account_allow_list = ["{{ .Values.auth.mTLS.spire.install.namespace}}:{{ .Values.auth.mTLS.spire.install.agent.serviceAccount.name }}"]
+            }
+          }
+        }
+      }
+
+      KeyManager "disk" {
+        plugin_data {
+          keys_path = "/run/spire/data/keys.json"
+        }
+      }
+
+      Notifier "k8sbundle" {
+        plugin_data {
+          namespace = {{ .Values.auth.mTLS.spire.install.namespace | quote }}
+        }
+      }
+    }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/server/role.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/role.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled .Values.auth.mTLS.spire.install.server.serviceAccount.create -}}
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+rules:
+# Role (namespace scoped) to be able to push certificate bundles to a configmap
+- apiGroups: [ "" ]
+  resources: [ "configmaps" ]
+  verbs: [ "patch", "get", "list" ]
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/server/rolebinding.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/rolebinding.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spire-server
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}-pod
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}-pod
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/server/service.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/service.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: spire-server
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+  {{- with .Values.auth.mTLS.spire.install.server.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.auth.mTLS.spire.install.server.service.labels }}
+  labels:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+spec:
+  type: {{ .Values.auth.mTLS.spire.install.server.service.type }}
+  ports:
+  - name: grpc
+    port: 8081
+    targetPort: grpc
+    protocol: TCP
+  selector:
+    app: spire-server
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/server/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled .Values.auth.mTLS.spire.install.server.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -25,6 +25,7 @@ spec:
         app: spire-server
     spec:
       serviceAccountName: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+      shareProcessNamespace: true
       {{- if gt (len .Values.auth.mTLS.spire.install.server.initContainers) 0 }}
       initContainers:
         {{- toYaml .Values.auth.mTLS.spire.install.server.initContainers | nindent 8 }}

--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -1,0 +1,94 @@
+{{- if and .Values.auth.mTLS.spire.enabled .Values.auth.mTLS.spire.install.enabled -}}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: spire-server
+  namespace: {{ .Values.auth.mTLS.spire.install.namespace }}
+  {{- with .Values.auth.mTLS.spire.install.server.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  labels:
+    app: spire-server
+  {{- with .Values.auth.mTLS.spire.install.server.labels }}
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: spire-server
+  serviceName: spire-server
+  template:
+    metadata:
+      labels:
+        app: spire-server
+    spec:
+      serviceAccountName: {{ .Values.auth.mTLS.spire.install.server.serviceAccount.name }}
+      {{- if gt (len .Values.auth.mTLS.spire.install.server.initContainers) 0 }}
+      initContainers:
+        {{- toYaml .Values.auth.mTLS.spire.install.server.initContainers | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: cilium-init
+        image: docker.io/library/busybox:1.35.0@sha256:223ae047b1065bd069aac01ae3ac8088b3ca4a527827e283b85112f29385fb1b
+        command:
+          - /bin/sh
+          - -c
+          - |
+            {{- tpl (.Files.Get "files/spire/init.bash") . | nindent 12 }}
+      - name: spire-server
+        image: ghcr.io/spiffe/spire-server:1.5.1
+        args:
+        - -config
+        - /run/spire/config/server.conf
+        ports:
+        - name: grpc
+          containerPort: 8081
+        volumeMounts:
+        - name: spire-config
+          mountPath: /run/spire/config
+          readOnly: true
+        {{- if .Values.auth.mTLS.spire.install.server.dataStorage.enabled }}
+        - name: spire-data
+          mountPath: /run/spire/data
+          readOnly: false
+        {{- end }}
+        - name: spire-server-socket
+          mountPath: /tmp/spire-server/private
+          readOnly: false
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 8080
+          failureThreshold: 2
+          initialDelaySeconds: 15
+          periodSeconds: 60
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+      volumes:
+      - name: spire-config
+        configMap:
+          name: spire-server
+      - name: spire-server-socket
+        hostPath:
+          path: /var/run/spire-server/sockets
+          type: DirectoryOrCreate
+  {{- if .Values.auth.mTLS.spire.install.server.dataStorage.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: spire-data
+    spec:
+      accessModes:
+      - {{ .Values.auth.mTLS.spire.install.server.dataStorage.accessMode | default "ReadWriteOnce" }}
+      resources:
+        requests:
+          storage: {{ .Values.auth.mTLS.spire.install.server.dataStorage.size }}
+      storageClassName: {{ .Values.auth.mTLS.spire.install.server.dataStorage.storageClass }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -55,3 +55,9 @@
     {{ fail "Ingress/Gateway API controller requires .Values.kubeProxyReplacement to be set to either 'partial' or 'strict'" }}
   {{- end }}
 {{- end }}
+
+{{- if .Values.auth.mTLS.spire.install.enabled }}
+  {{- if not .Values.auth.mTLS.spire.enabled }}
+    {{ fail "SPIRE installation requires .Values.auth.mTLS.enabled=true and .Values.auth.mTLS.spire.enabled=true" }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2661,6 +2661,6 @@ auth:
     # -- SPIRE socket path where the SPIRE delegated api agent is listening
     spireAdminSocketPath: /run/spire/sockets/admin.sock
     # -- SPIFFE trust domain to use for fetching certificates
-    spiffeTrustDomain: spiffe.cilium.io
+    spiffeTrustDomain: spiffe.cilium
     # -- port on the agent which is used to mTLS handshakes on
     port: 4250

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -40,7 +40,7 @@ k8sServiceHost: ""
 k8sServicePort: ""
 
 cluster:
-  # -- Name of the cluster. Only required for Cluster Mesh.
+  # -- Name of the cluster. Only required for Cluster Mesh and mTLS auth with SPIRE.
   name: default
   # -- (int) Unique ID of the cluster. Must be unique across all connected
   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
@@ -2649,18 +2649,27 @@ sctp:
 
 auth:
   mTLS:
-    # -- Enable mtls-spiffe authentication method in CiliumNetworkPolicy
-    enabled: false
-    # -- SPIRE server endpoint
-    # This endpoint will be automatically injected later once embedded SPIRE installation is done.
-    spireServerAddress: spire-server.spire.svc.cluster.local:8081
-    # -- SPIRE server connection timeout
-    spireServerConnectionTimeout: 10s
-    # -- SPIRE agent socket path where the SPIRE agent is listening
-    spireAgentSocketPath: /run/spire/sockets/agent/agent.sock
-    # -- SPIRE socket path where the SPIRE delegated api agent is listening
-    spireAdminSocketPath: /run/spire/sockets/admin.sock
-    # -- SPIFFE trust domain to use for fetching certificates
-    spiffeTrustDomain: spiffe.cilium
-    # -- port on the agent which is used to mTLS handshakes on
+    # -- Port on the agent where mTLS handshakes between agents will be performed
     port: 4250
+    # Settings for SPIRE
+    spire:
+      # -- Enable SPIRE integration
+      enabled: false
+      # -- Settings to control the SPIRE installation and configuration
+      install:
+        # -- Enable SPIRE installation.
+        # This will only take effect only if auth.mTLS.spire.enabled is true
+        enabled: false
+        # -- SPIRE namespace to install into
+        namespace: cilium-spire
+      # -- SPIRE server address
+      serverAddress: spire-server.cilium-spire.svc.cluster.local:8081
+      # -- SPIFFE trust domain to use for fetching certificates
+      trustDomain: spiffe.cilium
+      # -- SPIRE socket path where the SPIRE delegated api agent is listening
+      adminSocketPath: /run/spire/sockets/admin.sock
+      # -- SPIRE socket path where the SPIRE workload agent is listening.
+      # Applies to both the Cilium Agent and Operator
+      agentSocketPath: /run/spire/sockets/agent/agent.sock
+      # -- SPIRE connection timeout
+      connectionTimeout: 30s

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2662,6 +2662,59 @@ auth:
         enabled: false
         # -- SPIRE namespace to install into
         namespace: cilium-spire
+        # -- SPIRE agent configuration
+        agent:
+          # -- SPIRE agent image
+          image: ghcr.io/spiffe/spire-agent:1.5.1@sha256:40228af4d9a094f0fef2d7a303a3b6a689c4b4eba2fa9f7da5125b81d2d68ec8
+          # -- SPIRE agent service account
+          serviceAccount:
+            create: true
+            name: spire-agent
+          # -- SPIRE agent init containers
+          initContainers:
+          - name: init
+            image: cgr.dev/chainguard/wait-for-it@sha256:ecb58e3a2ffbdb732bb9049987e06eaf826d945410e167f31d6ffe28fab259f4
+            args: [ "-t", "30", "spire-server:8081" ]
+          # -- SPIRE agent annotations
+          annotations: { }
+          # -- SPIRE agent labels
+          labels: { }
+          # -- SPIRE Workload Attestor kubelet verification.
+          skipKubeletVerification: false
+        server:
+          # -- SPIRE server image
+          image: ghcr.io/spiffe/spire-server:1.5.1@sha256:4851ec8c71a8fbe230d87be78dfed0e908800c2342cf192289c7885bb2f7a870
+          # -- SPIRE server service account
+          serviceAccount:
+            create: true
+            name: spire-server
+          # -- SPIRE server init containers
+          initContainers: []
+          # -- SPIRE server annotations
+          annotations: {}
+          # -- SPIRE server labels
+          labels: {}
+          # -- SPIRE server service configuration
+          service:
+            type: ClusterIP
+            annotations: {}
+            labels: {}
+          # -- SPIRE server datastorage configuration
+          dataStorage:
+            enabled: true
+            size: 1Gi
+            accessMode: ReadWriteOnce
+            storageClass: null
+          # -- SPIRE CA configuration
+          ca:
+            # -- SPIRE CA key type
+            # AWS requires the use of RSA. EC cryptography is not supported
+            keyType: "rsa-4096"
+            # -- SPIRE CA Subject
+            subject:
+              country: "US"
+              organization: "SPIRE"
+              commonName: ""
       # -- SPIRE server address
       serverAddress: spire-server.cilium-spire.svc.cluster.local:8081
       # -- SPIFFE trust domain to use for fetching certificates

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2659,6 +2659,59 @@ auth:
         enabled: false
         # -- SPIRE namespace to install into
         namespace: cilium-spire
+        # -- SPIRE agent configuration
+        agent:
+          # -- SPIRE agent image
+          image: ghcr.io/spiffe/spire-agent:1.5.1@sha256:40228af4d9a094f0fef2d7a303a3b6a689c4b4eba2fa9f7da5125b81d2d68ec8
+          # -- SPIRE agent service account
+          serviceAccount:
+            create: true
+            name: spire-agent
+          # -- SPIRE agent init containers
+          initContainers:
+          - name: init
+            image: cgr.dev/chainguard/wait-for-it@sha256:ecb58e3a2ffbdb732bb9049987e06eaf826d945410e167f31d6ffe28fab259f4
+            args: [ "-t", "30", "spire-server:8081" ]
+          # -- SPIRE agent annotations
+          annotations: { }
+          # -- SPIRE agent labels
+          labels: { }
+          # -- SPIRE Workload Attestor kubelet verification.
+          skipKubeletVerification: false
+        server:
+          # -- SPIRE server image
+          image: ghcr.io/spiffe/spire-server:1.5.1@sha256:4851ec8c71a8fbe230d87be78dfed0e908800c2342cf192289c7885bb2f7a870
+          # -- SPIRE server service account
+          serviceAccount:
+            create: true
+            name: spire-server
+          # -- SPIRE server init containers
+          initContainers: []
+          # -- SPIRE server annotations
+          annotations: {}
+          # -- SPIRE server labels
+          labels: {}
+          # -- SPIRE server service configuration
+          service:
+            type: ClusterIP
+            annotations: {}
+            labels: {}
+          # -- SPIRE server datastorage configuration
+          dataStorage:
+            enabled: true
+            size: 1Gi
+            accessMode: ReadWriteOnce
+            storageClass: null
+          # -- SPIRE CA configuration
+          ca:
+            # -- SPIRE CA key type
+            # AWS requires the use of RSA. EC cryptography is not supported
+            keyType: "rsa-4096"
+            # -- SPIRE CA Subject
+            subject:
+              country: "US"
+              organization: "SPIRE"
+              commonName: ""
       # -- SPIRE server address
       serverAddress: spire-server.cilium-spire.svc.cluster.local:8081
       # -- SPIFFE trust domain to use for fetching certificates

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -37,7 +37,7 @@ k8sServiceHost: ""
 k8sServicePort: ""
 
 cluster:
-  # -- Name of the cluster. Only required for Cluster Mesh.
+  # -- Name of the cluster. Only required for Cluster Mesh and mTLS auth with SPIRE.
   name: default
   # -- (int) Unique ID of the cluster. Must be unique across all connected
   # clusters and in the range of 1 to 255. Only required for Cluster Mesh,
@@ -2646,18 +2646,27 @@ sctp:
 
 auth:
   mTLS:
-    # -- Enable mtls-spiffe authentication method in CiliumNetworkPolicy
-    enabled: false
-    # -- SPIRE server endpoint
-    # This endpoint will be automatically injected later once embedded SPIRE installation is done.
-    spireServerAddress: spire-server.spire.svc.cluster.local:8081
-    # -- SPIRE server connection timeout
-    spireServerConnectionTimeout: 10s
-    # -- SPIRE agent socket path where the SPIRE agent is listening
-    spireAgentSocketPath: /run/spire/sockets/agent/agent.sock
-    # -- SPIRE socket path where the SPIRE delegated api agent is listening
-    spireAdminSocketPath: /run/spire/sockets/admin.sock
-    # -- SPIFFE trust domain to use for fetching certificates
-    spiffeTrustDomain: spiffe.cilium
-    # -- port on the agent which is used to mTLS handshakes on
+    # -- Port on the agent where mTLS handshakes between agents will be performed
     port: 4250
+    # Settings for SPIRE
+    spire:
+      # -- Enable SPIRE integration
+      enabled: false
+      # -- Settings to control the SPIRE installation and configuration
+      install:
+        # -- Enable SPIRE installation.
+        # This will only take effect only if auth.mTLS.spire.enabled is true
+        enabled: false
+        # -- SPIRE namespace to install into
+        namespace: cilium-spire
+      # -- SPIRE server address
+      serverAddress: spire-server.cilium-spire.svc.cluster.local:8081
+      # -- SPIFFE trust domain to use for fetching certificates
+      trustDomain: spiffe.cilium
+      # -- SPIRE socket path where the SPIRE delegated api agent is listening
+      adminSocketPath: /run/spire/sockets/admin.sock
+      # -- SPIRE socket path where the SPIRE workload agent is listening.
+      # Applies to both the Cilium Agent and Operator
+      agentSocketPath: /run/spire/sockets/agent/agent.sock
+      # -- SPIRE connection timeout
+      connectionTimeout: 30s

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2658,6 +2658,6 @@ auth:
     # -- SPIRE socket path where the SPIRE delegated api agent is listening
     spireAdminSocketPath: /run/spire/sockets/admin.sock
     # -- SPIFFE trust domain to use for fetching certificates
-    spiffeTrustDomain: spiffe.cilium.io
+    spiffeTrustDomain: spiffe.cilium
     # -- port on the agent which is used to mTLS handshakes on
     port: 4250

--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -29,7 +29,7 @@ import (
 const (
 	notFoundError   = "NotFound"
 	defaultParentID = "/dclient"
-	pathPrefix      = "/cilium-id"
+	pathPrefix      = "/identity"
 )
 
 var defaultSelectors = []*types.Selector{
@@ -154,7 +154,7 @@ func (c *Client) connect(ctx context.Context) (*grpc.ClientConn, error) {
 }
 
 // Upsert creates or updates the SPIFFE ID for the given ID.
-// The SPIFFE ID is in the form of spiffe://<trust-domain>/cilium-id/<id>.
+// The SPIFFE ID is in the form of spiffe://<trust-domain>/identity/<id>.
 func (c *Client) Upsert(ctx context.Context, id string) error {
 	if c.entry == nil {
 		return fmt.Errorf("unable to connect to SPIRE server %s", c.cfg.SpireServerAddress)
@@ -191,7 +191,7 @@ func (c *Client) Upsert(ctx context.Context, id string) error {
 }
 
 // Delete deletes the SPIFFE ID for the given ID.
-// The SPIFFE ID is in the form of spiffe://<trust-domain>/cilium-id/<id>.
+// The SPIFFE ID is in the form of spiffe://<trust-domain>/identity/<id>.
 func (c *Client) Delete(ctx context.Context, id string) error {
 	if c.entry == nil {
 		return fmt.Errorf("unable to connect to SPIRE server %s", c.cfg.SpireServerAddress)

--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	notFoundError   = "NotFound"
-	defaultParentID = "/dclient"
+	defaultParentID = "/cilium-operator"
 	pathPrefix      = "/identity"
 )
 

--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -76,7 +76,7 @@ func (cfg ClientConfig) Flags(flags *pflag.FlagSet) {
 		"SPIRE server endpoint.")
 	flags.StringVar(&cfg.SpiffeTrustDomain,
 		"mesh-auth-spiffe-trust-domain",
-		"spiffe.cilium.io",
+		"spiffe.cilium",
 		"The trust domain for the SPIFFE identity.")
 }
 

--- a/operator/auth/spire/client_test.go
+++ b/operator/auth/spire/client_test.go
@@ -81,7 +81,7 @@ func TestClient_Upsert(t *testing.T) {
 							Filter: &entryv1.ListEntriesRequest_Filter{
 								BySpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/cilium-id/dummy-id",
+									Path:        "/identity/dummy-id",
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
@@ -116,7 +116,7 @@ func TestClient_Upsert(t *testing.T) {
 							Filter: &entryv1.ListEntriesRequest_Filter{
 								BySpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/cilium-id/dummy-id",
+									Path:        "/identity/dummy-id",
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
@@ -140,7 +140,7 @@ func TestClient_Upsert(t *testing.T) {
 							{
 								SpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/cilium-id/dummy-id",
+									Path:        "/identity/dummy-id",
 								},
 								ParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
@@ -166,7 +166,7 @@ func TestClient_Upsert(t *testing.T) {
 							Filter: &entryv1.ListEntriesRequest_Filter{
 								BySpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/cilium-id/dummy-id",
+									Path:        "/identity/dummy-id",
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
@@ -192,7 +192,7 @@ func TestClient_Upsert(t *testing.T) {
 							{
 								SpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/cilium-id/dummy-id",
+									Path:        "/identity/dummy-id",
 								},
 								ParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
@@ -252,7 +252,7 @@ func TestClient_Delete(t *testing.T) {
 							Filter: &entryv1.ListEntriesRequest_Filter{
 								BySpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/cilium-id/dummy-id",
+									Path:        "/identity/dummy-id",
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
@@ -287,7 +287,7 @@ func TestClient_Delete(t *testing.T) {
 							Filter: &entryv1.ListEntriesRequest_Filter{
 								BySpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/cilium-id/dummy-id",
+									Path:        "/identity/dummy-id",
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
@@ -321,7 +321,7 @@ func TestClient_Delete(t *testing.T) {
 							Filter: &entryv1.ListEntriesRequest_Filter{
 								BySpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/cilium-id/dummy-id",
+									Path:        "/identity/dummy-id",
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
@@ -355,7 +355,7 @@ func TestClient_Delete(t *testing.T) {
 							Filter: &entryv1.ListEntriesRequest_Filter{
 								BySpiffeId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/cilium-id/dummy-id",
+									Path:        "/identity/dummy-id",
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",

--- a/operator/auth/spire/client_test.go
+++ b/operator/auth/spire/client_test.go
@@ -85,7 +85,7 @@ func TestClient_Upsert(t *testing.T) {
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/dclient",
+									Path:        "/cilium-operator",
 								},
 								BySelectors: &types.SelectorMatch{
 									Selectors: []*types.Selector{
@@ -120,7 +120,7 @@ func TestClient_Upsert(t *testing.T) {
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/dclient",
+									Path:        "/cilium-operator",
 								},
 								BySelectors: &types.SelectorMatch{
 									Selectors: []*types.Selector{
@@ -144,7 +144,7 @@ func TestClient_Upsert(t *testing.T) {
 								},
 								ParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/dclient",
+									Path:        "/cilium-operator",
 								},
 								Selectors: defaultSelectors,
 							},
@@ -170,7 +170,7 @@ func TestClient_Upsert(t *testing.T) {
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/dclient",
+									Path:        "/cilium-operator",
 								},
 								BySelectors: &types.SelectorMatch{
 									Selectors: []*types.Selector{
@@ -196,7 +196,7 @@ func TestClient_Upsert(t *testing.T) {
 								},
 								ParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/dclient",
+									Path:        "/cilium-operator",
 								},
 								Selectors: defaultSelectors,
 							},
@@ -256,7 +256,7 @@ func TestClient_Delete(t *testing.T) {
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/dclient",
+									Path:        "/cilium-operator",
 								},
 								BySelectors: &types.SelectorMatch{
 									Selectors: []*types.Selector{
@@ -291,7 +291,7 @@ func TestClient_Delete(t *testing.T) {
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/dclient",
+									Path:        "/cilium-operator",
 								},
 								BySelectors: &types.SelectorMatch{
 									Selectors: []*types.Selector{
@@ -325,7 +325,7 @@ func TestClient_Delete(t *testing.T) {
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/dclient",
+									Path:        "/cilium-operator",
 								},
 								BySelectors: &types.SelectorMatch{
 									Selectors: []*types.Selector{
@@ -359,7 +359,7 @@ func TestClient_Delete(t *testing.T) {
 								},
 								ByParentId: &types.SPIFFEID{
 									TrustDomain: "dummy.trusted.domain",
-									Path:        "/dclient",
+									Path:        "/cilium-operator",
 								},
 								BySelectors: &types.SelectorMatch{
 									Selectors: []*types.Selector{

--- a/pkg/auth/mtls_authhandler_test.go
+++ b/pkg/auth/mtls_authhandler_test.go
@@ -40,7 +40,7 @@ func (f *fakeCertificateProvider) GetTrustBundle() (*x509.CertPool, error) {
 }
 
 func (f *fakeCertificateProvider) GetCertificateForIdentity(id identity.NumericIdentity) (*tls.Certificate, error) {
-	uriSAN := "spiffe://spiffe.cilium.io/identity/" + id.String()
+	uriSAN := "spiffe://spiffe.cilium/identity/" + id.String()
 	cert, ok := f.certMap[uriSAN]
 	if !ok {
 		return nil, fmt.Errorf("no certificate for %s", uriSAN)
@@ -58,7 +58,7 @@ func (f *fakeCertificateProvider) GetCertificateForIdentity(id identity.NumericI
 
 func (f *fakeCertificateProvider) ValidateIdentity(id identity.NumericIdentity, cert *x509.Certificate) (bool, error) {
 	for _, uri := range cert.URIs {
-		if uri.String() == fmt.Sprintf("spiffe://spiffe.cilium.io/identity/%d", id) {
+		if uri.String() == fmt.Sprintf("spiffe://spiffe.cilium/identity/%d", id) {
 			return true, nil
 		}
 	}
@@ -66,11 +66,11 @@ func (f *fakeCertificateProvider) ValidateIdentity(id identity.NumericIdentity, 
 }
 
 func (f *fakeCertificateProvider) NumericIdentityToSNI(id identity.NumericIdentity) string {
-	return id.String() + "." + "spiffe.cilium.io"
+	return id.String() + "." + "spiffe.cilium"
 }
 
 func (f *fakeCertificateProvider) SNIToNumericIdentity(sni string) (identity.NumericIdentity, error) {
-	suffix := "." + "spiffe.cilium.io"
+	suffix := "." + "spiffe.cilium"
 	if !strings.HasSuffix(sni, suffix) {
 		return 0, fmt.Errorf("SNI %s does not belong to our trust domain", sni)
 	}
@@ -110,7 +110,7 @@ func generateTestCertificates(t *testing.T) (map[string]*x509.Certificate, map[s
 	leafPrivKeys := make(map[string]*ecdsa.PrivateKey)
 
 	for i := 1000; i <= 1001; i++ {
-		certURL, err := url.Parse(fmt.Sprintf("spiffe://spiffe.cilium.io/identity/%d", i))
+		certURL, err := url.Parse(fmt.Sprintf("spiffe://spiffe.cilium/identity/%d", i))
 		if err != nil {
 			t.Fatalf("failed to parse URL: %v", err)
 		}
@@ -159,9 +159,9 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             &id1000,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/identity/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium/identity/1000"]}},
 			},
-			want:    &certMap["spiffe://spiffe.cilium.io/identity/1000"].NotAfter,
+			want:    &certMap["spiffe://spiffe.cilium/identity/1000"].NotAfter,
 			wantErr: false,
 		},
 		{
@@ -169,9 +169,9 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             nil,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/identity/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium/identity/1000"]}},
 			},
-			want:    &certMap["spiffe://spiffe.cilium.io/identity/1000"].NotAfter,
+			want:    &certMap["spiffe://spiffe.cilium/identity/1000"].NotAfter,
 			wantErr: false,
 		},
 		{
@@ -179,7 +179,7 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             &id1001,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/identity/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium/identity/1000"]}},
 			},
 			want:    nil,
 			wantErr: true,
@@ -189,7 +189,7 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             &id1000,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/identity/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium/identity/1000"]}},
 			},
 			want:    nil,
 			wantErr: true,
@@ -199,7 +199,7 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             nil,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/identity/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium/identity/1000"]}},
 			},
 			want:    nil,
 			wantErr: true,
@@ -218,7 +218,7 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             nil,
 				caBundle:       x509.NewCertPool(),
-				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/identity/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium/identity/1000"]}},
 			},
 			want:    nil,
 			wantErr: true,
@@ -258,17 +258,17 @@ func Test_mtlsAuthHandler_GetCertificateForIncomingConnection(t *testing.T) {
 			name: "valid certificate with SNI to match identity",
 			args: args{
 				info: &tls.ClientHelloInfo{
-					ServerName: "1000.spiffe.cilium.io",
+					ServerName: "1000.spiffe.cilium",
 				},
 			},
-			wantURI: "spiffe://spiffe.cilium.io/identity/1000",
+			wantURI: "spiffe://spiffe.cilium/identity/1000",
 			wantErr: false,
 		},
 		{
 			name: "no certificate for non existing identity",
 			args: args{
 				info: &tls.ClientHelloInfo{
-					ServerName: "9999.spiffe.cilium.io",
+					ServerName: "9999.spiffe.cilium",
 				},
 			},
 			wantErr: true,

--- a/pkg/auth/mtls_authhandler_test.go
+++ b/pkg/auth/mtls_authhandler_test.go
@@ -40,7 +40,7 @@ func (f *fakeCertificateProvider) GetTrustBundle() (*x509.CertPool, error) {
 }
 
 func (f *fakeCertificateProvider) GetCertificateForIdentity(id identity.NumericIdentity) (*tls.Certificate, error) {
-	uriSAN := "spiffe://spiffe.cilium.io/cilium-id/" + id.String()
+	uriSAN := "spiffe://spiffe.cilium.io/identity/" + id.String()
 	cert, ok := f.certMap[uriSAN]
 	if !ok {
 		return nil, fmt.Errorf("no certificate for %s", uriSAN)
@@ -58,7 +58,7 @@ func (f *fakeCertificateProvider) GetCertificateForIdentity(id identity.NumericI
 
 func (f *fakeCertificateProvider) ValidateIdentity(id identity.NumericIdentity, cert *x509.Certificate) (bool, error) {
 	for _, uri := range cert.URIs {
-		if uri.String() == fmt.Sprintf("spiffe://spiffe.cilium.io/cilium-id/%d", id) {
+		if uri.String() == fmt.Sprintf("spiffe://spiffe.cilium.io/identity/%d", id) {
 			return true, nil
 		}
 	}
@@ -110,7 +110,7 @@ func generateTestCertificates(t *testing.T) (map[string]*x509.Certificate, map[s
 	leafPrivKeys := make(map[string]*ecdsa.PrivateKey)
 
 	for i := 1000; i <= 1001; i++ {
-		certURL, err := url.Parse(fmt.Sprintf("spiffe://spiffe.cilium.io/cilium-id/%d", i))
+		certURL, err := url.Parse(fmt.Sprintf("spiffe://spiffe.cilium.io/identity/%d", i))
 		if err != nil {
 			t.Fatalf("failed to parse URL: %v", err)
 		}
@@ -159,9 +159,9 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             &id1000,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/identity/1000"]}},
 			},
-			want:    &certMap["spiffe://spiffe.cilium.io/cilium-id/1000"].NotAfter,
+			want:    &certMap["spiffe://spiffe.cilium.io/identity/1000"].NotAfter,
 			wantErr: false,
 		},
 		{
@@ -169,9 +169,9 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             nil,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/identity/1000"]}},
 			},
-			want:    &certMap["spiffe://spiffe.cilium.io/cilium-id/1000"].NotAfter,
+			want:    &certMap["spiffe://spiffe.cilium.io/identity/1000"].NotAfter,
 			wantErr: false,
 		},
 		{
@@ -179,7 +179,7 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             &id1001,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMap["spiffe://spiffe.cilium.io/identity/1000"]}},
 			},
 			want:    nil,
 			wantErr: true,
@@ -189,7 +189,7 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             &id1000,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/identity/1000"]}},
 			},
 			want:    nil,
 			wantErr: true,
@@ -199,7 +199,7 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             nil,
 				caBundle:       caPool,
-				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/identity/1000"]}},
 			},
 			want:    nil,
 			wantErr: true,
@@ -218,7 +218,7 @@ func Test_mtlsAuthHandler_verifyPeerCertificate(t *testing.T) {
 			args: args{
 				id:             nil,
 				caBundle:       x509.NewCertPool(),
-				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/cilium-id/1000"]}},
+				verifiedChains: [][]*x509.Certificate{{certMapOtherCA["spiffe://spiffe.cilium.io/identity/1000"]}},
 			},
 			want:    nil,
 			wantErr: true,
@@ -261,7 +261,7 @@ func Test_mtlsAuthHandler_GetCertificateForIncomingConnection(t *testing.T) {
 					ServerName: "1000.spiffe.cilium.io",
 				},
 			},
-			wantURI: "spiffe://spiffe.cilium.io/cilium-id/1000",
+			wantURI: "spiffe://spiffe.cilium.io/identity/1000",
 			wantErr: false,
 		},
 		{

--- a/pkg/auth/spire/certificate_provider.go
+++ b/pkg/auth/spire/certificate_provider.go
@@ -64,7 +64,7 @@ func (s *SpireDelegateClient) GetCertificateForIdentity(id identity.NumericIdent
 }
 
 func (s *SpireDelegateClient) sniToSPIFFEID(id identity.NumericIdentity) string {
-	return "spiffe://" + s.cfg.SpiffeTrustDomain + "/cilium-id/" + id.String()
+	return "spiffe://" + s.cfg.SpiffeTrustDomain + "/identity/" + id.String()
 }
 
 func (s *SpireDelegateClient) ValidateIdentity(id identity.NumericIdentity, cert *x509.Certificate) (bool, error) {

--- a/pkg/auth/spire/certificate_provider_test.go
+++ b/pkg/auth/spire/certificate_provider_test.go
@@ -126,7 +126,7 @@ func TestSpireDelegateClient_sniToSPIFFEID(t *testing.T) {
 			args: args{
 				id: 1234,
 			},
-			want: "spiffe://test.cilium.io/cilium-id/1234",
+			want: "spiffe://test.cilium.io/identity/1234",
 		},
 	}
 	for _, tt := range tests {
@@ -145,8 +145,8 @@ func TestSpireDelegateClient_sniToSPIFFEID(t *testing.T) {
 }
 
 func TestSpireDelegateClient_ValidateIdentity(t *testing.T) {
-	urlFor1234, _ := url.Parse("spiffe://test.cilium.io/cilium-id/1234")
-	urlFor9999, _ := url.Parse("spiffe://test.cilium.io/cilium-id/9999")
+	urlFor1234, _ := url.Parse("spiffe://test.cilium.io/identity/1234")
+	urlFor9999, _ := url.Parse("spiffe://test.cilium.io/identity/9999")
 
 	type args struct {
 		id   identity.NumericIdentity
@@ -271,7 +271,7 @@ func TestSpireDelegateClient_GetTrustBundle(t *testing.T) {
 }
 
 func TestSpireDelegateClient_GetCertificateForIdentity(t *testing.T) {
-	certURL, err := url.Parse("spiffe://spiffe.cilium.io/cilium-id/1234")
+	certURL, err := url.Parse("spiffe://spiffe.cilium.io/identity/1234")
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
 	}
@@ -300,31 +300,31 @@ func TestSpireDelegateClient_GetCertificateForIdentity(t *testing.T) {
 	}
 
 	svidStore := map[string]*delegatedidentityv1.X509SVIDWithKey{
-		"spiffe://test.cilium.io/cilium-id/1234": {
+		"spiffe://test.cilium.io/identity/1234": {
 			X509Svid: &types.X509SVID{
 				Id: &types.SPIFFEID{
 					TrustDomain: "test.cilium.io",
-					Path:        "/cilium-id/1234",
+					Path:        "/identity/1234",
 				},
 				CertChain: [][]byte{leafCertBytes},
 			},
 			X509SvidKey: leafPKCS8Key,
 		},
-		"spiffe://test.cilium.io/cilium-id/2222": {
+		"spiffe://test.cilium.io/identity/2222": {
 			X509Svid: &types.X509SVID{
 				Id: &types.SPIFFEID{
 					TrustDomain: "test.cilium.io",
-					Path:        "/cilium-id/2222",
+					Path:        "/identity/2222",
 				},
 				CertChain: [][]byte{},
 			},
 			X509SvidKey: leafPKCS8Key,
 		},
-		"spiffe://test.cilium.io/cilium-id/3333": {
+		"spiffe://test.cilium.io/identity/3333": {
 			X509Svid: &types.X509SVID{
 				Id: &types.SPIFFEID{
 					TrustDomain: "test.cilium.io",
-					Path:        "/cilium-id/3333",
+					Path:        "/identity/3333",
 				},
 				CertChain: [][]byte{leafCertBytes},
 			},

--- a/pkg/auth/spire/certificate_provider_test.go
+++ b/pkg/auth/spire/certificate_provider_test.go
@@ -271,7 +271,7 @@ func TestSpireDelegateClient_GetTrustBundle(t *testing.T) {
 }
 
 func TestSpireDelegateClient_GetCertificateForIdentity(t *testing.T) {
-	certURL, err := url.Parse("spiffe://spiffe.cilium.io/identity/1234")
+	certURL, err := url.Parse("spiffe://spiffe.cilium/identity/1234")
 	if err != nil {
 		t.Fatalf("failed to parse URL: %v", err)
 	}

--- a/pkg/auth/spire/delegate.go
+++ b/pkg/auth/spire/delegate.go
@@ -75,7 +75,7 @@ func newSpireDelegateClient(lc hive.Lifecycle, cfg SpireDelegateConfig, log logr
 
 func (cfg SpireDelegateConfig) Flags(flags *pflag.FlagSet) {
 	flags.StringVar(&cfg.SpireAdminSocketPath, "mesh-auth-spire-admin-socket", "", "The path for the SPIRE admin agent Unix socket.") // default is /run/spire/sockets/admin.sock
-	flags.StringVar(&cfg.SpiffeTrustDomain, "mesh-auth-spiffe-trust-domain", "spiffe.cilium.io", "The trust domain for the SPIFFE identity.")
+	flags.StringVar(&cfg.SpiffeTrustDomain, "mesh-auth-spiffe-trust-domain", "spiffe.cilium", "The trust domain for the SPIFFE identity.")
 }
 
 func (s *SpireDelegateClient) onStart(ctx hive.HookContext) error {


### PR DESCRIPTION
### Description

This is to install SPIRE server and agent for cilium mTLS.

### TODO

- [x] Figure out the way to register the below identities as part of the installation
    - [x] init sidecar

<details>
<summary>Temp script</summary>

```
kubectl exec -n cilium-spire spire-server-0 -- \
  /opt/spire/bin/spire-server entry create \
  -spiffeID spiffe://spiffe.cilium/ns/spire/sa/spire-agent \
  -selector k8s_psat:agent_ns:cilium-spire \
  -selector k8s_psat:agent_sa:spire-agent \
  -node

# Then add the cilium-agent identity to the server (required for the delegated identity to work)
kubectl exec -n cilium-spire spire-server-0 -- \
  /opt/spire/bin/spire-server entry create \
  -spiffeID spiffe://spiffe.cilium/cilium-agent \
  -parentID spiffe://spiffe.cilium/ns/spire/sa/spire-agent \
  -selector k8s:ns:kube-system \
  -selector k8s:label:k8s-app:spiffetest

kubectl exec -n cilium-spire spire-server-0 -- \
  /opt/spire/bin/spire-server entry create \
  -spiffeID spiffe://spiffe.cilium/dclient \
  -parentID spiffe://spiffe.cilium/ns/spire/sa/spire-agent \
  -selector k8s:ns:kube-system \
  -selector k8s:sa:cilium

kubectl exec -n cilium-spire spire-server-0 -- \
  /opt/spire/bin/spire-server entry create \
  -spiffeID spiffe://spiffe.cilium/cilium-operator \
  -parentID spiffe://spiffe.cilium/ns/spire/sa/spire-agent \
  -selector k8s:ns:kube-system \
  -selector k8s:sa:cilium-operator

```

</details>

Fixes: https://github.com/cilium/cilium/issues/23806

### Testing

Testing was done with fresh cilium installation with mTLS enabled.
- auth.mTLS.spire.enabled=true
- auth.mTLS.spire.install.enabled=true

```
$ cilium connectivity test --test auth
ℹ️  Single-node environment detected, enabling single-node connectivity test
ℹ️  Monitor aggregation detected, will skip some flow validation steps
...
[=] Skipping Test [client-egress-l7-set-header]
[=] Test [echo-ingress-auth-always-fail]
........
[=] Test [echo-ingress-auth-mtls-spiffe]
........
✅ All 2 tests (16 actions) successful, 35 tests skipped, 0 scenarios skipped.
```

```release-note
mtls: SPIRE server and agent installation
```
