### PR TITLE
loader: Don't compile `.asm` files by default

### DIFF
--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -345,19 +345,21 @@ func compileDatapath(ctx context.Context, dirs *directoryInfo, isHost bool, logg
 		linker:   string(linkerVersion),
 	}).Debug("Compiling datapath")
 
-	// Write out assembly and preprocessing files for debugging purposes
-	progs := debugProgs
-	if isHost {
-		progs = debugHostProgs
-	}
-	for _, p := range progs {
-		if err := compile(ctx, p, dirs); err != nil {
-			// Only log an error here if the context was not canceled. This log message
-			// should only represent failures with respect to compiling the program.
-			if !errors.Is(err, context.Canceled) {
-				scopedLog.WithField(logfields.Params, logfields.Repr(p)).WithError(err).Debug("JoinEP: Failed to compile")
+	if option.Config.Debug {
+		// Write out assembly and preprocessing files for debugging purposes
+		progs := debugProgs
+		if isHost {
+			progs = debugHostProgs
+		}
+		for _, p := range progs {
+			if err := compile(ctx, p, dirs); err != nil {
+				// Only log an error here if the context was not canceled. This log message
+				// should only represent failures with respect to compiling the program.
+				if !errors.Is(err, context.Canceled) {
+					scopedLog.WithField(logfields.Params, logfields.Repr(p)).WithError(err).Debug("JoinEP: Failed to compile")
+				}
+				return err
 			}
-			return err
 		}
 	}
 


### PR DESCRIPTION
Today, we always compile a `.asm` files for endpoints, even though we rarely use them. They take a lot of space in the sysdumps and increase the overall compile time.

This pull request changes it to only compile those files if debugging mode is enabled.

Marking for backports to all branches because the change here is unlikely to conflict and should help with sysdump collection.

```
Don't generate `.asm` files for BPF programs unless debugging mode is enabled. 
```