### PR TITLE
pkg/service: Backends leak follow ups with revised fixes, debugging improvements and unit tests

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1550,6 +1550,28 @@ For more information, ensure that you have the fix `Pull Request <https://github
     48498    getpeername4
     48494    getpeername6
 
+Known Issues
+############
+
+For clusters deployed with Cilium version 1.11.14 or earlier, service backend entries could
+be leaked in the BPF maps in some instances. The known cases that could lead
+to such leaks are due to race conditions between deletion of a service backend
+while it's terminating, and simultaneous deletion of the service the backend is
+associated with. This could lead to duplicate backend entries that could eventually
+fill up the ``cilium_lb4_backends_v2`` map.
+In such cases, you might see error messages like these in the Cilium agent logs::
+
+    Unable to update element for cilium_lb4_backends_v2 map with file descriptor 15: the map is full, please consider resizing it. argument list too long
+
+While the leak was fixed in Cilium version 1.11.15, in some cases, any affected clusters upgrading
+from the problematic cilium versions 1.11.14 or earlier to any subsequent versions may not
+see the leaked backends cleaned up from the BPF maps after the Cilium agent restarts.
+The fixes to clean up leaked duplicate backend entries were backported to older
+releases, and are available as part of Cilium versions v1.11.16, v1.12.9 and v1.13.2.
+Fresh clusters deploying Cilium versions 1.11.15 or later don't experience this leak issue.
+
+For more information, see `this GitHub issue <https://github.com/cilium/cilium/issues/235514>`__.
+
 Limitations
 ###########
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -652,6 +652,10 @@ const (
 	// Number of Backends failed while restoration.
 	FailedBackends = "failedBackends"
 
+	// SkippedBackends is the number of Backends that were skipped during restore
+	// as duplicates.
+	SkippedBackends = "skippedBackends"
+
 	// Number of Services failed while restoration.
 	RestoredSVCs = "restoredServices"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -656,6 +656,9 @@ const (
 	// as duplicates.
 	SkippedBackends = "skippedBackends"
 
+	// OrphanBackends is the number Backends that are not associated with any services.
+	OrphanBackends = "orphanBackends"
+
 	// Number of Services failed while restoration.
 	RestoredSVCs = "restoredServices"
 

--- a/pkg/service/id.go
+++ b/pkg/service/id.go
@@ -61,7 +61,8 @@ func RestoreBackendID(l3n4Addr loadbalancer.L3n4Addr, id loadbalancer.BackendID)
 	// TODO(brb) This shouldn't happen (otherwise, there is a bug in the code).
 	//           But maybe it makes sense to delete all svc v2 in this case.
 	if newID != id {
-		DeleteBackendID(newID)
+		// The newID belongs to another backend that was previously restored,
+		// so don't release the ID here in case of conflicts.
 		return fmt.Errorf("restored backend ID for %+v does not match (%d != %d)",
 			l3n4Addr, newID, id)
 	}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1367,6 +1367,7 @@ func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{
 		return fmt.Errorf("Unable to dump backend maps: %s", err)
 	}
 
+	svcBackendsCount := len(svcBackendsById)
 	for _, b := range backends {
 		log.WithFields(logrus.Fields{
 			logfields.BackendID:        b.ID,
@@ -1374,32 +1375,54 @@ func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{
 			logfields.BackendState:     b.State,
 			logfields.BackendPreferred: b.Preferred,
 		}).Debug("Restoring backend")
-		if _, ok := svcBackendsById[b.ID]; !ok && s.backendRefCount[b.L3n4Addr.Hash()] != 0 {
-			// If a backend by id isn't referenced by any of the service entries,
-			// it's likely to be a duplicate backend. This can happen when agent
-			// leaked backend entries in the backends map prior to restart, and created
-			// duplicate with different IDs but same L3n4Addr (hash).
+		if _, ok := svcBackendsById[b.ID]; !ok && (svcBackendsCount != 0) {
+			// If a backend by ID isn't referenced by any of the services, it's
+			// likely a leaked backend. In case of duplicate leaked backends,
+			// there would be multiple IDs allocated for the same backend resource
+			// identified by its L3nL4Addr hash. The second check for service
+			// backends count is added for unusual cases where there might've been
+			// a problem with reading entries from the services map. In such cases,
+			// the agent should not wipe out the backends map, as this can disrupt
+			// existing connections. SyncWithK8sFinished will later sync the backends
+			// map with the latest state.
+			// Leaked backend scenarios:
+			// 1) Backend entries leaked, no duplicates
+			// 2) Backend entries leaked with duplicates:
+			// 	a) backend with overlapping L3nL4Addr hash is associated with service(s)
+			//     Sequence of events:
+			//     Backends were leaked prior to agent restart, but there was at least
+			//     one service that the backend by hash is associated with.
+			//     s.backendByHash will have a non-zero reference count for the
+			//     overlapping L3nL4Addr hash.
+			// 	b) none of the backends are associated with services
+			//     Sequence of events:
+			// 	   All the services these backends were associated with were deleted
+			//     prior to agent restart.
+			//     s.backendByHash will not have an entry for the backends hash.
 			// As none of the service entries have a reference to these backends
-			// in the services map, the duplicate backends were not available for
+			// in the services map, the backends were likely not available for
 			// load-balancing new traffic. While there is a slim chance that the
-			// duplicate backends could have previously established active connections,
+			// backends could have previously established active connections,
 			// and these connections can get disrupted. However, the leaks likely
 			// happened when service entries were deleted, so those connections
 			// were also expected to be terminated.
 			// Regardless, delete the duplicates as this can affect restoration of current
 			// active backends, and may prevent new backends getting added as map
-			// size is limited, which can result in connectivity issues.
+			// size is limited, which can lead to connectivity disruptions.
 			id := b.ID
 			DeleteBackendID(id)
 			if err := s.lbmap.DeleteBackendByID(id); err != nil {
-				log.Errorf("unable to delete duplicate backend: %v", id)
+				// As the backends map is not expected to be updated during restore,
+				// the deletion call shouldn't fail. But log the error, just
+				// in case...
+				log.Errorf("unable to delete leaked backend: %v", id)
 			}
 			log.WithFields(logrus.Fields{
 				logfields.BackendID:        b.ID,
 				logfields.L3n4Addr:         b.L3n4Addr,
 				logfields.BackendState:     b.State,
 				logfields.BackendPreferred: b.Preferred,
-			}).Debug("Duplicate backend entry not restored")
+			}).Debug("Leaked backend entry not restored")
 			skipped++
 			continue
 		}

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1428,6 +1428,8 @@ func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{
 }
 
 func (s *Service) deleteOrphanBackends() error {
+	orphanBackends := 0
+
 	for hash, b := range s.backendByHash {
 		if s.backendRefCount[hash] == 0 {
 			log.WithField(logfields.BackendID, b.ID).
@@ -1437,8 +1439,12 @@ func (s *Service) deleteOrphanBackends() error {
 			DeleteBackendID(b.ID)
 			s.lbmap.DeleteBackendByID(b.ID)
 			delete(s.backendByHash, hash)
+			orphanBackends++
 		}
 	}
+	log.WithFields(logrus.Fields{
+		logfields.OrphanBackends: orphanBackends,
+	}).Info("Deleted orphan backends")
 
 	return nil
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1361,7 +1361,7 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 }
 
 func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{}) error {
-	failed, restored := 0, 0
+	failed, restored, skipped := 0, 0, 0
 	backends, err := s.lbmap.DumpBackendMaps()
 	if err != nil {
 		return fmt.Errorf("Unable to dump backend maps: %s", err)
@@ -1400,7 +1400,7 @@ func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{
 				logfields.BackendState:     b.State,
 				logfields.BackendPreferred: b.Preferred,
 			}).Debug("Duplicate backend entry not restored")
-			failed++
+			skipped++
 			continue
 		}
 		if err := RestoreBackendID(b.L3n4Addr, b.ID); err != nil {
@@ -1421,6 +1421,7 @@ func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{
 	log.WithFields(logrus.Fields{
 		logfields.RestoredBackends: restored,
 		logfields.FailedBackends:   failed,
+		logfields.SkippedBackends:  skipped,
 	}).Info("Restored backends from maps")
 
 	return nil

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -195,6 +195,9 @@ var (
 		lb.NewBackend(0, lb.TCP, cmtypes.MustParseAddrCluster("10.0.0.5"), 8080),
 		lb.NewBackend(0, lb.TCP, cmtypes.MustParseAddrCluster("10.0.0.6"), 8080),
 	}
+	backends6 = []*lb.Backend{
+		lb.NewBackend(0, lb.TCP, cmtypes.MustParseAddrCluster("10.0.0.7"), 8080),
+	}
 )
 
 func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
@@ -1852,4 +1855,50 @@ func (m *ManagerTestSuite) TestDeleteServiceWithTerminatingBackends(c *C) {
 	c.Assert(found, Equals, true)
 	c.Assert(len(m.lbmap.ServiceByID), Equals, 0)
 	c.Assert(len(m.lbmap.BackendByID), Equals, 0)
+}
+
+func (m *ManagerTestSuite) TestRestoreServicesWithLeakedBackends(c *C) {
+	backends := make([]*lb.Backend, len(backends1))
+	backends[0] = backends1[0].DeepCopy()
+	backends[1] = backends1[1].DeepCopy()
+	p1 := &lb.SVC{
+		Frontend: frontend1,
+		Backends: backends,
+		Type:     lb.SVCTypeClusterIP,
+		Name:     lb.ServiceName{Name: "svc1", Namespace: "ns1"},
+	}
+
+	_, id1, err1 := m.svc.UpsertService(p1)
+
+	c.Assert(err1, IsNil)
+	c.Assert(id1, Equals, lb.ID(1))
+	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
+	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
+
+	// Simulate leaked backends with various leaked scenarios.
+	// Backend2 is a duplicate leaked backend with the same L3nL4Addr as backends[0]
+	// that's associated with the service.
+	// Backend3 is a leaked backend with no associated service.
+	// Backend4 and Backend5 are duplicate leaked backends with no associated service.
+	backend2 := backends[0].DeepCopy()
+	backend2.ID = lb.BackendID(10)
+	backend3 := backends2[0].DeepCopy()
+	backend4 := backends6[0].DeepCopy()
+	backend4.ID = lb.BackendID(20)
+	backend5 := backends6[0].DeepCopy()
+	backend5.ID = lb.BackendID(30)
+	m.svc.lbmap.AddBackend(backend2, backend2.L3n4Addr.IsIPv6())
+	m.svc.lbmap.AddBackend(backend3, backend3.L3n4Addr.IsIPv6())
+	m.svc.lbmap.AddBackend(backend4, backend4.L3n4Addr.IsIPv6())
+	m.svc.lbmap.AddBackend(backend5, backend5.L3n4Addr.IsIPv6())
+	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends)+4)
+	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
+	m.svc = NewService(nil, nil, lbmap)
+
+	// Restore services from lbmap
+	err := m.svc.RestoreServices()
+	c.Assert(err, IsNil)
+	c.Assert(len(m.lbmap.ServiceByID[uint16(id1)].Backends), Equals, len(backends))
+	// Leaked backends should be deleted.
+	c.Assert(len(m.lbmap.BackendByID), Equals, len(backends))
 }


### PR DESCRIPTION
This is a follow-up PR with revised fixes along with debugging improvements, and test coverage for fixes merged in - https://github.com/cilium/cilium/pull/24681.

pkg/service: Extend logic to handle leaked backends

```
This commit revises the logic to handle all the leaked backend scenarios in one place.
Consider the following leaked backend scenarios where (1) and
(2a) were previously handled:
(1) Backend entries leaked, no duplicates: previously, such
      backends would be deleted as orphan backends after sync with
      kubernetes api server.
(2) Backend entries leaked with duplicates:
    (a) backend with overlapping L3nL4Addr hash is associated with service(s)
          Sequence of events:
          Backends were leaked prior to agent restart, but there was at least
          one service that the backend by hash is associated with.
          s.backendByHash will have a non-zero reference count for the
          overlapping L3nL4Addr hash.
    (b) none of the backends are associated with services
          Sequence of events:
          All the services these backends were associated with were deleted
          prior to agent restart.
          s.backendByHash will not have an entry for the backends hash.
```

pkg/service: Fix premature release of backend ID

```
(See commit description)
Fixes: 51b62f5684
```

pkg/service: Log skipped backends count during restore
pkg/service: Log orphan backends count

`Debugging improvements`
 
pkg/service: Unit test for handling of leaked backends in various scenarios described above
 
docs: Document backends leak issue 

` Document the issue along with affected Cilium versions. `

Relates: https://github.com/cilium/cilium/issues/23551

Signed-off-by: Aditi Ghag <aditi@cilium.io>