### PR TITLE
ipsec: Clean up stale XFRM policies and states

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -94,6 +94,27 @@ var (
 		IP:   wildcardIPv6,
 		Mask: net.CIDRMask(128, 128),
 	}
+
+	defaultDropMark = &netlink.XfrmMark{
+		Value: linux_defaults.RouteMarkEncrypt,
+		Mask:  linux_defaults.IPsecMarkMaskIn,
+	}
+	defaultDropPolicyIPv4 = &netlink.XfrmPolicy{
+		Dir:      netlink.XFRM_DIR_OUT,
+		Src:      wildcardCIDRv4,
+		Dst:      wildcardCIDRv4,
+		Mark:     defaultDropMark,
+		Action:   netlink.XFRM_POLICY_BLOCK,
+		Priority: 1,
+	}
+	defaultDropPolicyIPv6 = &netlink.XfrmPolicy{
+		Dir:      netlink.XFRM_DIR_OUT,
+		Src:      wildcardCIDRv6,
+		Dst:      wildcardCIDRv6,
+		Mark:     defaultDropMark,
+		Action:   netlink.XFRM_POLICY_BLOCK,
+		Priority: 1,
+	}
 )
 
 func getIPSecKeys(ip net.IP) *ipSecKey {
@@ -340,6 +361,23 @@ func ipSecReplacePolicyIn(src, dst *net.IPNet, tmplSrc, tmplDst net.IP) error {
 func IpSecReplacePolicyFwd(dst *net.IPNet, tmplDst net.IP) error {
 	// The source CIDR and IP aren't used in the case of FWD policies.
 	return _ipSecReplacePolicyInFwd(nil, dst, net.IP{}, tmplDst, false, netlink.XFRM_DIR_FWD)
+}
+
+// Installs a catch-all policy for outgoing traffic that has the encryption
+// bit. The goal here is to catch any traffic that may passthrough our
+// encryption while we are replacing XFRM policies & states. Those operations
+// cannot always be performed atomically so we may have brief moments where
+// there is no XFRM policy to encrypt a subset of traffic. This policy ensures
+// we drop such traffic and don't let it flow in plain text.
+//
+// We do need to match on the mark because there is also traffic flowing
+// through XFRM that we don't want to encrypt (e.g., hostns traffic).
+func IPsecDefaultDropPolicy(ipv6 bool) error {
+	defaultDropPolicy := defaultDropPolicyIPv4
+	if ipv6 {
+		defaultDropPolicy = defaultDropPolicyIPv6
+	}
+	return netlink.XfrmPolicyUpdate(defaultDropPolicy)
 }
 
 // ipSecXfrmMarkSetSPI takes a XfrmMark base value, an SPI, returns the mark
@@ -896,6 +934,10 @@ func deleteStaleXfrmPolicies(reclaimTimestamp time.Time) {
 			continue
 		}
 
+		if isDefaultDropPolicy(&p) {
+			continue
+		}
+
 		scopedLog = log.WithField(logfields.OldSPI, policySPI)
 
 		scopedLog.Info("Deleting stale XFRM policy")
@@ -903,6 +945,20 @@ func deleteStaleXfrmPolicies(reclaimTimestamp time.Time) {
 			scopedLog.WithError(err).Warning("Deleting stale XFRM policy failed")
 		}
 	}
+}
+
+func isDefaultDropPolicy(p *netlink.XfrmPolicy) bool {
+	return equalDefaultDropPolicy(defaultDropPolicyIPv4, p) ||
+		equalDefaultDropPolicy(defaultDropPolicyIPv6, p)
+}
+
+func equalDefaultDropPolicy(defaultDropPolicy, p *netlink.XfrmPolicy) bool {
+	return p.Priority == defaultDropPolicy.Priority &&
+		p.Action == defaultDropPolicy.Action &&
+		p.Dir == defaultDropPolicy.Dir &&
+		xfrmMarkEqual(p.Mark, defaultDropPolicy.Mark) &&
+		p.Src.String() == defaultDropPolicy.Src.String() &&
+		p.Dst.String() == defaultDropPolicy.Dst.String()
 }
 
 func doReclaimStaleKeys() {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -83,6 +83,17 @@ var (
 	// replaced with a newer one, allowing to reclaim old keys only after
 	// enough time has passed since their replacement
 	ipSecKeysRemovalTime = make(map[uint8]time.Time)
+
+	wildcardIPv4   = net.ParseIP("0.0.0.0")
+	wildcardCIDRv4 = &net.IPNet{
+		IP:   wildcardIPv4,
+		Mask: net.IPv4Mask(0, 0, 0, 0),
+	}
+	wildcardIPv6   = net.ParseIP("0::0")
+	wildcardCIDRv6 = &net.IPNet{
+		IP:   wildcardIPv6,
+		Mask: net.CIDRMask(128, 128),
+	}
 )
 
 func getIPSecKeys(ip net.IP) *ipSecKey {
@@ -279,9 +290,7 @@ func ipSecReplacePolicyOut(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, nodeID 
 
 	policy := ipSecNewPolicy()
 	if dir == IPSecDirOutNode {
-		wildcardIP := net.ParseIP("0.0.0.0")
-		wildcardMask := net.IPv4Mask(0, 0, 0, 0)
-		policy.Src = &net.IPNet{IP: wildcardIP, Mask: wildcardMask}
+		policy.Src = wildcardCIDRv4
 	} else {
 		policy.Src = src
 	}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -115,6 +116,10 @@ var (
 		Action:   netlink.XFRM_POLICY_BLOCK,
 		Priority: 1,
 	}
+
+	// To attempt to remove any stale XFRM configs once at startup, after
+	// we've added the catch-all default-drop policy.
+	removeStaleXFRMOnce sync.Once
 )
 
 func getIPSecKeys(ip net.IP) *ipSecKey {
@@ -372,12 +377,102 @@ func IpSecReplacePolicyFwd(dst *net.IPNet, tmplDst net.IP) error {
 //
 // We do need to match on the mark because there is also traffic flowing
 // through XFRM that we don't want to encrypt (e.g., hostns traffic).
-func IPsecDefaultDropPolicy(ipv6 bool) error {
+func IPsecDefaultDropPolicy(ipv6 bool) (err error) {
 	defaultDropPolicy := defaultDropPolicyIPv4
+	family := netlink.FAMILY_V4
 	if ipv6 {
 		defaultDropPolicy = defaultDropPolicyIPv6
+		family = netlink.FAMILY_V6
 	}
+
+	// We call removeStaleStatesAndPolicies only if the catch-all default-drop
+	// policy was successfully installed. If it was not installed, then there's
+	// a danger of letting plain-text traffic leave the node if we remove stale
+	// XFRM configs.
+	// This code can be removed in Cilium v1.15.
+	defer func() {
+		if err == nil {
+			removeStaleStatesAndPolicies(family)
+		}
+	}()
+
 	return netlink.XfrmPolicyUpdate(defaultDropPolicy)
+}
+
+// Removes XFRM states and policies that are identified as installed by a
+// previous version of Cilium. We rely mainly on the mark mask to identify if
+// it was installed in a previous version. These states and policies need to be
+// removed for cross-node connectivity to work.
+func removeStaleStatesAndPolicies(family int) {
+	removeStaleXFRMOnce.Do(func() {
+		removeStalePolicies(family)
+		removeStaleStates(family)
+	})
+}
+
+func removeStalePolicies(family int) {
+	policies, err := netlink.XfrmPolicyList(family)
+	if err != nil {
+		log.WithError(err).Error("Cannot get XFRM policies")
+	}
+	for _, p := range policies {
+		switch p.Dir {
+		case netlink.XFRM_DIR_OUT:
+			if isDefaultDropPolicy(&p) {
+				continue
+			}
+			if p.Mark.Mask != linux_defaults.IPsecOldMarkMaskOut {
+				// This XFRM OUT policy was not installed by a previous version of Cilium.
+				continue
+			}
+		case netlink.XFRM_DIR_IN:
+			if p.Src.String() != wildcardCIDRv4.String() ||
+				p.Mark.Mask != linux_defaults.IPsecMarkMaskIn {
+				// This XFRM IN policy was not installed by a previous version of Cilium.
+				continue
+			}
+		default:
+			continue
+		}
+		if err := netlink.XfrmPolicyDel(&p); err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.SourceCIDR:      p.Src,
+				logfields.DestinationCIDR: p.Dst,
+			}).Error("Failed to remove stale XFRM policy")
+		}
+	}
+}
+
+func removeStaleStates(family int) {
+	states, err := netlink.XfrmStateList(family)
+	if err != nil {
+		log.WithError(err).Error("Cannot get XFRM states")
+	}
+	for _, s := range states {
+		scopedLog := log.WithFields(logrus.Fields{
+			logfields.SPI:           s.Spi,
+			logfields.SourceIP:      s.Src,
+			logfields.DestinationIP: s.Dst,
+		})
+
+		if s.Mark.Mask == linux_defaults.IPsecOldMarkMaskOut &&
+			s.Mark.Value == ipSecXfrmMarkSetSPI(linux_defaults.RouteMarkEncrypt, uint8(s.Spi)) {
+			// This XFRM state was installed by Cilium.
+			if err := netlink.XfrmStateDel(&s); err == nil {
+				scopedLog.Info("Removed stale XFRM OUT state")
+			} else {
+				scopedLog.WithError(err).Error("Failed to remove stale XFRM OUT state")
+			}
+		} else if s.Mark.Mask == linux_defaults.IPsecMarkMaskIn &&
+			s.Mark.Value == linux_defaults.RouteMarkDecrypt {
+			// This XFRM state was installed by Cilium.
+			if err := netlink.XfrmStateDel(&s); err == nil {
+				scopedLog.Info("Removed stale XFRM IN state")
+			} else {
+				scopedLog.WithError(err).Error("Failed to remove stale XFRM IN state")
+			}
+		}
+	}
 }
 
 // ipSecXfrmMarkSetSPI takes a XfrmMark base value, an SPI, returns the mark

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -106,8 +106,12 @@ const (
 	// IPsecMarkMaskNodeID is the mask used for the node ID.
 	IPsecMarkMaskNodeID = 0xFFFF0000
 
+	// IPsecOldMarkMaskOut is the mask that was previously used. It can be
+	// removed in Cilium v1.15.
+	IPsecOldMarkMaskOut = 0xFF00
+
 	// IPsecMarkMask is the mask required for the IPsec SPI, node ID, and encrypt/decrypt bits
-	IPsecMarkMaskOut = 0xFF00 | IPsecMarkMaskNodeID
+	IPsecMarkMaskOut = IPsecOldMarkMaskOut | IPsecMarkMaskNodeID
 
 	// IPsecMarkMaskIn is the mask required for IPsec to lookup encrypt/decrypt bits
 	IPsecMarkMaskIn = 0x0F00

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -948,6 +948,9 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new4Net)
 
+			err = ipsec.IPsecDefaultDropPolicy(false)
+			upsertIPsecLog(err, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi)
+
 			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
 				if n.subnetEncryption() {
 					for _, cidr := range n.nodeConfig.IPv4PodSubnets {
@@ -998,6 +1001,10 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new6Net)
+
+			err = ipsec.IPsecDefaultDropPolicy(true)
+			upsertIPsecLog(err, "default-drop IPv6", wildcardCIDR, wildcardCIDR, spi)
+
 			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
 				if n.subnetEncryption() {
 					for _, cidr := range n.nodeConfig.IPv6PodSubnets {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -630,6 +630,8 @@ const (
 	// SourceIP is a source IP
 	SourceIP = "sourceIP"
 
+	DestinationIP = "destinationIP"
+
 	// DestinationCIDR is a destination CIDR
 	DestinationCIDR = "destinationCIDR"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -632,6 +632,8 @@ const (
 
 	DestinationIP = "destinationIP"
 
+	SourceCIDR = "sourceCIDR"
+
 	// DestinationCIDR is a destination CIDR
 	DestinationCIDR = "destinationCIDR"
 


### PR DESCRIPTION
First commit is a bit of refactoring. Second implements a proper function to update XFRM states. Third adds a catch-all default-drop policy to avoid leaking plain-text traffic during the cleanup. Fourth commit implements the cleanup itself.
See commit descriptions for details.

Fixes: https://github.com/cilium/cilium/pull/24030.
Fixes: https://github.com/cilium/cilium/issues/24780.
Updates: https://github.com/cilium/cilium/issues/24010.

```
Fix IPsec bug that causes connectivity issues across nodes when upgrading from a previous version of Cilium.
```