### PR TITLE
ipam: add metrics to track per node capacity

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -508,6 +508,9 @@ Name                                     Labels                                 
 ``ipam_resync_total``                                                                                      Enabled    Number of synchronization operations with external IPAM API
 ``ipam_api_duration_seconds``            ``operation``, ``response_code``                                  Enabled    Duration of interactions with external IPAM API.
 ``ipam_api_rate_limit_duration_seconds`` ``operation``                                                     Enabled    Duration of rate limiting while accessing external IPAM API
+``ipam_available_ips``                   ``target_node``                                                   Enabled    Number of available IPs on a node (taking into account plugin specific NIC/Address limits).
+``ipam_used_ips``                        ``target_node``                                                   Enabled    Number of currently used IPs on a node.
+``ipam_needed_ips``                      ``target_node``                                                   Enabled    Number of IPs needed to satisfy allocation on a node.
 ======================================== ================================================================= ========== ========================================================
 
 Hubble

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -357,6 +357,9 @@ Added Metrics
 * ``cilium_operator_ces_sync_total``
 * ``cilium_policy_change_total``
 * ``go_sched_latencies_seconds``
+* ``cilium_operator_ipam_available_ips``
+* ``cilium_operator_ipam_used_ips``
+* ``cilium_operator_ipam_needed_ips``
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~
@@ -365,6 +368,7 @@ Deprecated Metrics
 * ``cilium_policy_import_errors_total`` is deprecated. Please use
   ``cilium_policy_change_total``, which counts all policy changes (Add, Update, Delete)
   based on outcome ("success" or "failure").
+* ``cilium_operator_ipam_ips`` is deprecated. Use ``cilium_operator_ipam_{available,used,needed}_ips`` instead.
 
 Changed Metrics
 ~~~~~~~~~~~~~~~

--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -41,9 +41,13 @@ const (
 	maxENIPerNode = 50
 )
 
+type ipamNodeActions interface {
+	InstanceID() string
+}
+
 type Node struct {
 	// node contains the general purpose fields of a node
-	node *ipam.Node
+	node ipamNodeActions
 
 	// mutex protects members below this field
 	mutex lock.RWMutex

--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/alibabacloud/utils"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/ipam/stats"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
@@ -187,11 +188,16 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 
 // ResyncInterfacesAndIPs is called to retrieve and ENIs and IPs as known to
 // the AlibabaCloud API and return them
-func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (available ipamTypes.AllocationMap, remainAvailableENIsCount int, err error) {
+func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (available ipamTypes.AllocationMap, stats stats.InterfaceStats, err error) {
 	limits, limitsAvailable := n.getLimits()
 	if !limitsAvailable {
-		return nil, -1, fmt.Errorf(errUnableToDetermineLimits)
+		return nil, stats, fmt.Errorf(errUnableToDetermineLimits)
 	}
+
+	// During preparation of IP allocations, the primary NIC is not considered
+	// for allocation, so we don't need to consider it for capacity calculation.
+	stats.NodeCapacity = limits.IPv4 * (limits.Adapters - 1)
+
 	instanceID := n.node.InstanceID()
 	available = ipamTypes.AllocationMap{}
 
@@ -211,9 +217,18 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 				return nil
 			}
 
+			// We exclude all "primary" IPs from the capacity.
+			primaryAllocated := 0
+			for _, ip := range e.PrivateIPSets {
+				if ip.Primary {
+					primaryAllocated++
+				}
+			}
+			stats.NodeCapacity -= primaryAllocated
+
 			availableOnENI := math.IntMax(limits.IPv4-len(e.PrivateIPSets), 0)
 			if availableOnENI > 0 {
-				remainAvailableENIsCount++
+				stats.RemainingAvailableInterfaceCount++
 			}
 
 			for _, ip := range e.PrivateIPSets {
@@ -226,11 +241,11 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 	// An ECS instance has at least one ENI attached, no ENI found implies instance not found.
 	if enis == 0 {
 		scopedLog.Warning("Instance not found! Please delete corresponding ciliumnode if instance has already been deleted.")
-		return nil, -1, fmt.Errorf("unable to retrieve ENIs")
+		return nil, stats, fmt.Errorf("unable to retrieve ENIs")
 	}
 
-	remainAvailableENIsCount += limits.Adapters - len(n.enis)
-	return available, remainAvailableENIsCount, nil
+	stats.RemainingAvailableInterfaceCount += limits.Adapters - len(n.enis)
+	return available, stats, nil
 }
 
 // PrepareIPAllocation returns the number of ENI IPs and interfaces that can be
@@ -255,6 +270,7 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (*ipam.AllocationAct
 			"allocated": len(e.PrivateIPSets),
 		}).Debug("Considering ENI for allocation")
 
+		// limit
 		availableOnENI := math.IntMax(l.IPv4-len(e.PrivateIPSets), 0)
 		if availableOnENI <= 0 {
 			continue

--- a/pkg/alibabacloud/eni/node_stat_test.go
+++ b/pkg/alibabacloud/eni/node_stat_test.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package eni
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/alibabacloud/eni/limits"
+	eniTypes "github.com/cilium/cilium/pkg/alibabacloud/eni/types"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+func TestENIIPAMCapacityAccounting(t *testing.T) {
+	assert := assert.New(t)
+	limits.Update(map[string]ipamTypes.Limits{
+		"ecs.g6.large": {
+			IPv4:     10,
+			Adapters: 3,
+		},
+	})
+	m := ipamTypes.NewInstanceMap()
+	resource := &eniTypes.ENI{
+		NetworkInterfaceID: "eni-1",
+		PrivateIPSets: []eniTypes.PrivateIPSet{
+			{
+				Primary: true, // one primary IP
+			},
+		},
+	}
+	m.Update("vm1", ipamTypes.InterfaceRevision{
+		Resource: resource.DeepCopy(),
+	})
+
+	n := &Node{
+		node: mockIPAMNode("vm1"),
+		manager: &InstancesManager{
+			instances: m,
+		},
+		k8sObj: &v2.CiliumNode{
+			Spec: v2.NodeSpec{
+				AlibabaCloud: eniTypes.Spec{
+					InstanceType: "ecs.g6.large",
+				},
+			},
+		},
+	}
+	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), log)
+	assert.NoError(err)
+	// 3 ENIs, 10 IPs per ENI, 1 primary IP and one ENI is primary.
+	assert.Equal(19, stats.NodeCapacity)
+}
+
+type mockIPAMNode string
+
+func (m mockIPAMNode) InstanceID() string {
+	return string(m)
+}

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -222,7 +222,7 @@ func (m *InstancesManager) UpdateENI(instanceID string, eni *eniTypes.ENI) {
 	m.mutex.Unlock()
 }
 
-// ForeachInstance will iterate over each interface for a particular instance inside `instances`,
+// ForeachInstance will iterate over each interface for a particular instance inside `instances`
 // and call `fn`.
 // This function is read-locked for the entire execution.
 func (m *InstancesManager) ForeachInstance(instanceID string, fn ipamTypes.InterfaceIterator) {

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -222,8 +222,9 @@ func (m *InstancesManager) UpdateENI(instanceID string, eni *eniTypes.ENI) {
 	m.mutex.Unlock()
 }
 
-// ForeachInstance will iterate over each instance inside `instances`, and call
-// `fn`. This function is read-locked for the entire execution.
+// ForeachInstance will iterate over each interface for a particular instance inside `instances`,
+// and call `fn`.
+// This function is read-locked for the entire execution.
 func (m *InstancesManager) ForeachInstance(instanceID string, fn ipamTypes.InterfaceIterator) {
 	// This is a safety net in case the InstanceID is not known for some
 	// reason. If we don't know the instanceID, we also can't derive the

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -40,11 +40,19 @@ const (
 		" this could lead to ip allocation overflows if the max-allocate flag is not set"
 )
 
+type ipamNodeActions interface {
+	IsPrefixDelegationEnabled() bool
+	InstanceID() string
+	Ops() ipam.NodeOperations
+	SetRunning(bool)
+	UpdatedResource(*v2.CiliumNode) bool
+}
+
 // Node represents a Kubernetes node running Cilium with an associated
 // CiliumNode custom resource
 type Node struct {
 	// node contains the general purpose fields of a node
-	node *ipam.Node
+	node ipamNodeActions
 
 	// mutex protects members below this field
 	mutex lock.RWMutex

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/ipam/stats"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
@@ -229,7 +230,7 @@ func (n *Node) PrepareIPAllocation(scopedLog *logrus.Entry) (a *ipam.AllocationA
 			continue
 		}
 
-		effectiveLimits := n.getEffectiveIPLimits(&e, limits.IPv4)
+		_, effectiveLimits := n.getEffectiveIPLimits(&e, limits.IPv4)
 		availableOnENI := math.IntMax(effectiveLimits-len(e.Addresses), 0)
 		if availableOnENI <= 0 {
 			continue
@@ -539,11 +540,15 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 
 // ResyncInterfacesAndIPs is called to retrieve and ENIs and IPs as known to
 // the EC2 API and return them
-func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (available ipamTypes.AllocationMap, remainAvailableENIsCount int, err error) {
+func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (
+	available ipamTypes.AllocationMap,
+	stats stats.InterfaceStats,
+	err error) {
 	limits, limitsAvailable := n.getLimits()
 	if !limitsAvailable {
-		return nil, -1, fmt.Errorf(errUnableToDetermineLimits)
+		return nil, stats, fmt.Errorf(errUnableToDetermineLimits)
 	}
+
 	// n.node does not need to be protected by n.mutex as it is only written to
 	// upon creation of `n`
 	instanceID := n.node.InstanceID()
@@ -551,6 +556,19 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 
 	n.mutex.Lock()
 	n.enis = map[string]eniTypes.ENI{}
+
+	// 1. This calculates the base interface effective limit on this Node, given:
+	// 		* IPAM Prefix Delegation
+	// 		* Node Spec usePrimaryAddress being enabled
+	//
+	_, stats.NodeCapacity = n.getEffectiveIPLimits(nil, limits.IPv4)
+
+	// 2. The base node limit is the number of adapters multiplied by the instances IP limit.
+	//
+	// Note: This may be modified in step(s) 3, where:
+	// * Any leftover additional prefix delegated room will be added to this total.
+	// * Any excluded interfaces will be subtracted from this total.
+	stats.NodeCapacity *= limits.Adapters
 
 	n.manager.ForeachInstance(instanceID,
 		func(instanceID, interfaceID string, rev ipamTypes.InterfaceRevision) error {
@@ -560,14 +578,22 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 			}
 
 			n.enis[e.ID] = *e
+
+			// 3. Finally, we iterate any already existing interfaces and add on any extra
+			//		capacity to account for leftover prefix delegated /28 ip slots.
+			leftoverPrefixCapcity, effectiveLimits := n.getEffectiveIPLimits(e, limits.IPv4)
 			if e.IsExcludedBySpec(n.k8sObj.Spec.ENI) {
+				// If this ENI is excluded by the CN Spec, we remove it from the total
+				// capacity.
+				stats.NodeCapacity -= effectiveLimits
 				return nil
+			} else {
+				stats.NodeCapacity += leftoverPrefixCapcity
 			}
 
-			effectiveLimits := n.getEffectiveIPLimits(e, limits.IPv4)
 			availableOnENI := math.IntMax(effectiveLimits-len(e.Addresses), 0)
 			if availableOnENI > 0 {
-				remainAvailableENIsCount++
+				stats.RemainingAvailableInterfaceCount++
 			}
 
 			for _, ip := range e.Addresses {
@@ -581,11 +607,11 @@ func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Ent
 	// An ec2 instance has at least one ENI attached, no ENI found implies instance not found.
 	if enis == 0 {
 		scopedLog.Warning("Instance not found! Please delete corresponding ciliumnode if instance has already been deleted.")
-		return nil, -1, fmt.Errorf("unable to retrieve ENIs")
+		return nil, stats, fmt.Errorf("unable to retrieve ENIs")
 	}
 
-	remainAvailableENIsCount += limits.Adapters - len(n.enis)
-	return available, remainAvailableENIsCount, nil
+	stats.RemainingAvailableInterfaceCount += limits.Adapters - len(n.enis)
+	return available, stats, nil
 }
 
 // GetMaximumAllocatableIPv4 returns the maximum amount of IPv4 addresses
@@ -788,8 +814,9 @@ func (n *Node) GetUsedIPWithPrefixes() int {
 }
 
 // getEffectiveIPLimits computing the effective number of available addresses on the ENI
-// based on limits
-func (n *Node) getEffectiveIPLimits(eni *eniTypes.ENI, limits int) (effectiveLimits int) {
+// based on limits (which includes any left over prefix delegation capacity), as well as
+// just the left over prefix delegation capacity.
+func (n *Node) getEffectiveIPLimits(eni *eniTypes.ENI, limits int) (leftoverPrefixCapacity, effectiveLimits int) {
 	// The limits include the primary IP, so we need to take it into account
 	// when computing the effective number of available addresses on the ENI.
 	effectiveLimits = limits - 1
@@ -798,13 +825,15 @@ func (n *Node) getEffectiveIPLimits(eni *eniTypes.ENI, limits int) (effectiveLim
 	if n.k8sObj.Spec.ENI.UsePrimaryAddress != nil && *n.k8sObj.Spec.ENI.UsePrimaryAddress {
 		effectiveLimits++
 	}
-	if n.node.Ops().IsPrefixDelegated() {
+
+	if n.IsPrefixDelegated() {
 		effectiveLimits = effectiveLimits * option.ENIPDBlockSizeIPv4
-	} else if len(eni.Prefixes) > 0 {
+	} else if eni != nil && len(eni.Prefixes) > 0 {
 		// If prefix delegation was previously enabled on this node, account for IPs from prefixes
-		effectiveLimits += len(eni.Prefixes) * (option.ENIPDBlockSizeIPv4 - 1)
+		leftoverPrefixCapacity = len(eni.Prefixes) * (option.ENIPDBlockSizeIPv4 - 1)
+		effectiveLimits += leftoverPrefixCapacity
 	}
-	return effectiveLimits
+	return leftoverPrefixCapacity, effectiveLimits
 }
 
 // findSuitableSubnet attempts to find a subnet to allocate an ENI in according to the following heuristic.

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -728,11 +728,18 @@ func (n *Node) GetMinimumAllocatableIPv4() int {
 	return math.IntMin(minimum, (limits.Adapters-index)*maxPerInterface)
 }
 
+func (n *Node) isPrefixDelegationEnabled() bool {
+	if n.node == nil {
+		return false
+	}
+	return n.node.IsPrefixDelegationEnabled()
+}
+
 // IsPrefixDelegated indicates whether prefix delegation can be enabled on a node.
 // Currently, mixed usage of secondary IPs and prefixes is not supported. n.mutex
 // read lock must be held before calling this method.
 func (n *Node) IsPrefixDelegated() bool {
-	if !n.node.IsPrefixDelegationEnabled() {
+	if !n.isPrefixDelegationEnabled() {
 		return false
 	}
 	// Verify if this node is nitro based

--- a/pkg/aws/eni/node_stat_test.go
+++ b/pkg/aws/eni/node_stat_test.go
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package eni
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
+	"github.com/cilium/cilium/pkg/ipam"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+func TestENIIPAMCapacityAccounting(t *testing.T) {
+	assert := assert.New(t)
+	instanceID := "i-000"
+	cn := newCiliumNode("node1", withInstanceType("m5a.large"),
+		func(cn *v2.CiliumNode) {
+			cn.Spec.InstanceID = instanceID
+		},
+	)
+	im := ipamTypes.NewInstanceMap()
+	im.Update(instanceID, ipamTypes.InterfaceRevision{
+		Resource: &eniTypes.ENI{},
+	})
+
+	ipamNode := &mockIPAMNode{
+		instanceID: "i-000",
+	}
+	n := &Node{
+		node:   ipamNode,
+		k8sObj: cn,
+		manager: &InstancesManager{
+			instances: im,
+		},
+		enis: map[string]eniTypes.ENI{"eni-a": {}},
+	}
+
+	ipamNode.SetOpts(n)
+	ipamNode.SetPoolMaintainer(&mockMaintainer{})
+	n.node = ipamNode
+
+	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), log)
+	assert.NoError(err)
+	// m5a.large = 10 IPs per ENI, 3 ENIs.
+	// Accounting for primary ENI IPs, we should be able to allocate (10-1)*3=27 IPs.
+	assert.Equal(27, stats.NodeCapacity)
+
+	cn.Spec.ENI.UsePrimaryAddress = new(bool)
+	*cn.Spec.ENI.UsePrimaryAddress = true
+	_, stats, err = n.ResyncInterfacesAndIPs(context.Background(), log)
+	assert.NoError(err)
+	// In this case, we disable using allocated primary IP,
+	// so we should be able to allocate 10*3=30 IPs.
+	assert.Equal(30, stats.NodeCapacity)
+
+	ipamNode.prefixDelegation = true
+	// Note: m5a.large is a nitro instance, so it supports prefix delegation.
+	_, stats, err = n.ResyncInterfacesAndIPs(context.Background(), log)
+	assert.NoError(err)
+	// m5a.large = 10 IPs per ENI, 3 ENIs.
+	// Accounting for primary ENI IPs, we should be able to allocate (10-1)*3=27 IPs.
+	//
+	// In this case, we have prefix delegation enabled.
+	// Thus we have 16 addr * 10 addr * 3 ENIs = 480 IPs.
+	assert.Equal(480, stats.NodeCapacity)
+
+	// Lets turn off UsePrimaryAddress.
+	*cn.Spec.ENI.UsePrimaryAddress = false
+	_, stats, err = n.ResyncInterfacesAndIPs(context.Background(), log)
+	assert.NoError(err)
+	// In this case, we have prefix delegation enabled.
+	// Thus we have 16 addr * 9 addr * 3 ENIs = 432 IPs.
+	assert.Equal(432, stats.NodeCapacity)
+
+	// Finally, lets disable prefix delegation and simulate the case of
+	// leftover delegated IPs.
+	ipamNode.prefixDelegation = false
+	n.enis["eni-a"] = eniTypes.ENI{
+		ID:       "eni-a",
+		Prefixes: []string{"10.0.0.1/28"},
+	}
+	n.manager.instances.Update("i-000", ipamTypes.InterfaceRevision{
+		Resource: &eniTypes.ENI{
+			ID:       "eni-a",
+			Prefixes: []string{"10.0.0.1/28"},
+		},
+	})
+
+	// Finally, we have the case where an eni has a leftover prefix available.
+	// Thus, we add an additional 16 IPs to the capacity.
+	_, stats, err = n.ResyncInterfacesAndIPs(context.Background(), log)
+	assert.NoError(err)
+	assert.Equal(27+16-1, stats.NodeCapacity)
+}
+
+// mocks ipamNodeActions interface
+type mockIPAMNode struct {
+	instanceID       string
+	prefixDelegation bool
+}
+
+func (m *mockIPAMNode) SetOpts(ipam.NodeOperations)           {}
+func (m *mockIPAMNode) SetPoolMaintainer(ipam.PoolMaintainer) {}
+func (m *mockIPAMNode) UpdatedResource(*v2.CiliumNode) bool   { panic("not impl") }
+func (m *mockIPAMNode) Update(*v2.CiliumNode)                 {}
+func (m *mockIPAMNode) InstanceID() string                    { return m.instanceID }
+func (m *mockIPAMNode) IsPrefixDelegationEnabled() bool       { return m.prefixDelegation }
+func (m *mockIPAMNode) Ops() ipam.NodeOperations              { panic("not impl") }
+func (m *mockIPAMNode) SetRunning(_ bool)                     { panic("not impl") }
+
+var _ ipamNodeActions = (*mockIPAMNode)(nil)
+
+type mockMaintainer struct{}
+
+func (m *mockMaintainer) Trigger()  {}
+func (m *mockMaintainer) Shutdown() {}

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -136,7 +136,7 @@ func (n *Node) CreateInterface(ctx context.Context, allocation *ipam.AllocationA
 	return 0, "", fmt.Errorf("not implemented")
 }
 
-// ResyncInterfacesAndIPs is called to retrieve and interfaces and IPs as known
+// ResyncInterfacesAndIPs is called to retrieve interfaces and IPs known
 // to the Azure API and return them
 func (n *Node) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (
 	available ipamTypes.AllocationMap,

--- a/pkg/azure/ipam/node.go
+++ b/pkg/azure/ipam/node.go
@@ -17,13 +17,17 @@ import (
 	"github.com/cilium/cilium/pkg/math"
 )
 
+type ipamNodeActions interface {
+	InstanceID() string
+}
+
 // Node represents a node representing an Azure instance
 type Node struct {
 	// k8sObj is the CiliumNode custom resource representing the node
 	k8sObj *v2.CiliumNode
 
 	// node contains the general purpose fields of a node
-	node *ipam.Node
+	node ipamNodeActions
 
 	// manager is the Azure node manager responsible for this node
 	manager *InstancesManager

--- a/pkg/azure/ipam/node_stats_test.go
+++ b/pkg/azure/ipam/node_stats_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ipam
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/azure/types"
+	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+)
+
+func TestENIIPAMCapacityAccounting(t *testing.T) {
+	assert := assert.New(t)
+	m := ipamTypes.NewInstanceMap()
+	resource := &types.AzureInterface{
+		Name:          "eth0",
+		SecurityGroup: "sg1",
+		Addresses: []types.AzureAddress{
+			{
+				IP:     "1.1.1.1",
+				Subnet: "subnet-1",
+				State:  types.StateSucceeded,
+			},
+		},
+		State: types.StateSucceeded,
+	}
+	resource.SetID("/subscriptions/xxx/resourceGroups/g1/providers/Microsoft.Compute/virtualMachineScaleSets/vmss11/virtualMachines/vm1/networkInterfaces/vmss11")
+	m.Update("vm1", ipamTypes.InterfaceRevision{
+		Resource: resource.DeepCopy(),
+	})
+
+	n := &Node{
+		node: mockIPAMNode("vm1"),
+		manager: &InstancesManager{
+			instances: m,
+		},
+		k8sObj: &v2.CiliumNode{
+			Spec: v2.NodeSpec{
+				Azure: types.AzureSpec{
+					InterfaceName: "eth0",
+				},
+			},
+		},
+	}
+	_, stats, err := n.ResyncInterfacesAndIPs(context.Background(), log)
+	assert.NoError(err)
+	assert.Equal(255, stats.NodeCapacity)
+}
+
+type mockIPAMNode string
+
+func (m mockIPAMNode) InstanceID() string {
+	return string(m)
+}

--- a/pkg/ipam/metrics/mock/mock.go
+++ b/pkg/ipam/metrics/mock/mock.go
@@ -45,6 +45,9 @@ func NewMockMetrics() *mockMetrics {
 		allocatedIPs:          map[string]int{},
 		nodes:                 map[string]int{},
 		availableIPsPerSubnet: map[string]int{},
+		nodeIPAvailable:       map[string]int{},
+		nodeIPUsed:            map[string]int{},
+		nodeIPNeeded:          map[string]int{},
 	}
 }
 
@@ -173,6 +176,24 @@ func (m *mockMetrics) ResyncCount() int64 {
 func (m *mockMetrics) IncResyncCount() {
 	m.mutex.Lock()
 	m.resyncCount++
+	m.mutex.Unlock()
+}
+
+func (m *mockMetrics) SetIPAvailable(s string, n int) {
+	m.mutex.Lock()
+	m.nodeIPAvailable[s] = n
+	m.mutex.Unlock()
+}
+
+func (m *mockMetrics) SetIPUsed(s string, n int) {
+	m.mutex.Lock()
+	m.nodeIPUsed[s] = n
+	m.mutex.Unlock()
+}
+
+func (m *mockMetrics) SetIPNeeded(s string, n int) {
+	m.mutex.Lock()
+	m.nodeIPNeeded[s] = n
 	m.mutex.Unlock()
 }
 

--- a/pkg/ipam/metrics/mock/mock.go
+++ b/pkg/ipam/metrics/mock/mock.go
@@ -24,6 +24,9 @@ type mockMetrics struct {
 	availableIPsPerSubnet map[string]int
 	nodes                 map[string]int
 	resyncCount           int64
+	nodeIPAvailable       map[string]int
+	nodeIPUsed            map[string]int
+	nodeIPNeeded          map[string]int
 }
 
 type histogram struct {

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -205,9 +205,6 @@ func (n *Node) Ops() NodeOperations {
 }
 
 func (n *Node) IsPrefixDelegationEnabled() bool {
-	if n == nil || n.manager == nil {
-		return false
-	}
 	return n.manager.prefixDelegation
 }
 

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -16,6 +16,7 @@ import (
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	metricsmock "github.com/cilium/cilium/pkg/ipam/metrics/mock"
+	ipamStats "github.com/cilium/cilium/pkg/ipam/stats"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
@@ -85,14 +86,18 @@ func (n *nodeOperationsMock) CreateInterface(ctx context.Context, allocation *Al
 	return 0, "operation not supported", fmt.Errorf("operation not supported")
 }
 
-func (n *nodeOperationsMock) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (ipamTypes.AllocationMap, int, error) {
+func (n *nodeOperationsMock) ResyncInterfacesAndIPs(ctx context.Context, scopedLog *logrus.Entry) (
+	ipamTypes.AllocationMap,
+	ipamStats.InterfaceStats,
+	error) {
+	var stats ipamStats.InterfaceStats
 	available := ipamTypes.AllocationMap{}
 	n.mutex.RLock()
 	for _, ip := range n.allocatedIPs {
 		available[ip] = ipamTypes.AllocationIP{}
 	}
 	n.mutex.RUnlock()
-	return available, 0, nil
+	return available, stats, nil
 }
 
 func (n *nodeOperationsMock) PrepareIPAllocation(scopedLog *logrus.Entry) (*AllocationAction, error) {

--- a/pkg/ipam/stats/stats.go
+++ b/pkg/ipam/stats/stats.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package stats
+
+// InterfaceStats contains stats about the current state of an individual IPAM node.
+// This is used while performing a resync to determine if the node is able to
+// allocate more addresses.
+type InterfaceStats struct {
+	// NodeCapacity is the current inferred total capacity for a Node to schedule
+	// addresses.
+	//
+	// This does not account for currently used addresses.
+	NodeCapacity int
+
+	// RemainingAvailableInterfaceCount is the number of interfaces currently available.
+	RemainingAvailableInterfaceCount int
+}

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -397,7 +397,7 @@ func (m *InstanceMap) ForeachAddress(instanceID string, fn AddressIterator) erro
 		if instance := m.data[instanceID]; instance != nil {
 			return foreachAddress(instanceID, instance, fn)
 		}
-		return fmt.Errorf("instance does not exist")
+		return fmt.Errorf("instance does not exist: %q", instanceID)
 	}
 
 	for instanceID, instance := range m.data {
@@ -438,7 +438,7 @@ func (m *InstanceMap) ForeachInterface(instanceID string, fn InterfaceIterator) 
 		if instance := m.data[instanceID]; instance != nil {
 			return foreachInterface(instanceID, instance, fn)
 		}
-		return fmt.Errorf("instance does not exist")
+		return fmt.Errorf("instance does not exist: %q", instanceID)
 	}
 	for instanceID, instance := range m.data {
 		if err := foreachInterface(instanceID, instance, fn); err != nil {


### PR DESCRIPTION
This PR adds metrics to help track IPAM Node capacity with more granularity.
Specifically, the goal is to help add alerting/dashboards for such questions such as:

* How many IPs are left on my node/cluster?
* How many/what Nodes have capacity?
* What is the capacity of any particular node?
 
This adds three new Operator metrics:

```
cilium_operator_ipam_available_ips
cilium_operator_ipam_used_ips
cilium_operator_ipam_needed_ips
```
As well, this seeks to deprecate the : `cilium_operator_ipam_ips` metric, aside from it being redundant it also is very confusing - the `type=available` does not track what you expect it to track.  

Which are all labelled by "target_node" (i.e. the name of the CiliumNode).

## How does this differ from the existing IPAM metrics?

There's a bit of a blind spot in the current set of metrics:
*  cilium_operator_ipam_ips: this metric is confusing, as well it should probably be separate metrics rather than a single one with classifying labels (CC: @chancez).
* empty_interface_slots/interface_candidates: These two metrics can answer whether there _is_ capacity left in the cluster but they aren't able to give any more detail about how much capacity is left, what nodes are full etc?
    * As well, they may be misleading.  For example: if you have 3 nodes each with 1 slot + 0 interface_candidates then its possible you might have: _3 possible ENIs X 10 Ips = 30 ... but if the nodes with the capacity have a different IP per interface limit then it could also be 10 x 50 = 500._   

```release-note
operator/ipam/metrics: Add new, more accurate, per-node available/used/needed metrics to deprecated existing ipam_ips metric.
```