### PR TITLE
Fix connectivity issue if nodes share the same name across the clustermesh and wireguard is enabled

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1104,9 +1104,9 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 	}
 
 	if option.Config.EnableWireguard && newNode.WireguardPubKey != "" {
-		if err := n.wgAgent.UpdatePeer(newNode.Name, newNode.WireguardPubKey, newIP4, newIP6); err != nil {
+		if err := n.wgAgent.UpdatePeer(newNode.Fullname(), newNode.WireguardPubKey, newIP4, newIP6); err != nil {
 			log.WithError(err).
-				WithField(logfields.NodeName, newNode.Name).
+				WithField(logfields.NodeName, newNode.Fullname()).
 				Warning("Failed to update wireguard configuration for peer")
 		}
 	}
@@ -1222,7 +1222,7 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 	}
 
 	if option.Config.EnableWireguard {
-		if err := n.wgAgent.DeletePeer(oldNode.Name); err != nil {
+		if err := n.wgAgent.DeletePeer(oldNode.Fullname()); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Currently, the wireguard subsystem in the cilium agent caches information about the known peers by node name only. This can lead to conflicts in case of clustermesh, if nodes in different clusters have the same name, causing in turn connectivity issues. Hence, let's switch to identify peers by full name (i.e., cluster-name/node-name) to ensure uniqueness.

Fixes: #24227
Reported-by: @oulinbao

<!-- Description of change -->

```release-note
Fix connectivity issue if nodes share the same name across the clustermesh and wireguard is enabled
```
