### PR TITLE
policy: Do not share same policy for multiple cached selectors

### DIFF
--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -649,18 +649,19 @@ func (l4 *L4Filter) cacheFQDNSelector(sel api.FQDNSelector, selectorCache *Selec
 
 // add L7 rules for all endpoints in the L7DataMap
 func (l7 L7DataMap) addPolicyForSelector(rules *api.L7Rules, terminatingTLS, originatingTLS *TLSContext, auth *api.Auth, deny bool, sni []string, forceRedirect bool) {
-	l7policy := &PerSelectorPolicy{
-		TerminatingTLS: terminatingTLS,
-		OriginatingTLS: originatingTLS,
-		Auth:           auth,
-		IsDeny:         deny,
-		ServerNames:    NewStringSet(sni),
-		isRedirect:     !deny && (forceRedirect || terminatingTLS != nil || originatingTLS != nil || len(sni) > 0 || !rules.IsEmpty()),
-	}
-	if rules != nil {
-		l7policy.L7Rules = *rules
-	}
+	isRedirect := !deny && (forceRedirect || terminatingTLS != nil || originatingTLS != nil || len(sni) > 0 || !rules.IsEmpty())
 	for epsel := range l7 {
+		l7policy := &PerSelectorPolicy{
+			TerminatingTLS: terminatingTLS,
+			OriginatingTLS: originatingTLS,
+			Auth:           auth,
+			IsDeny:         deny,
+			ServerNames:    NewStringSet(sni),
+			isRedirect:     isRedirect,
+		}
+		if rules != nil {
+			l7policy.L7Rules = *rules
+		}
 		l7[epsel] = l7policy
 	}
 }


### PR DESCRIPTION
Do not share the same PerSelectorPolicy object between multiple cached selectors. This makes sure that when rules are merged only the rules for the intended selectors are affected by the merging process.

Fixes: #9486

```release-note
Fixed bug where L7 rules would be incorrectly merged between rules for the same (remote) endpoint. This bug could have caused L7 rules to be bypassed via a wildcard header rule being improperly appended to the set of HTTP rules when both a policy with HTTP header rules applying to multiple endpoints and an allow-all rule for only one of those endpoints are specified.
```
