### PR TITLE
helm: fix poststart-eni.bash execution in agent DS

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -222,10 +222,10 @@ spec:
               command:
               - "bash"
               - "-c"
-              - "/cni-install.sh --enable-debug={{ .Values.debug.enabled }} --cni-exclusive={{ .Values.cni.exclusive }} --log-file={{ .Values.cni.logFile }}"
-                {{- if .Values.eni.enabled }}
               - |
-                {{- tpl (.Files.Get "files/agent/poststart-eni.bash") . | nindent 20 }}
+                /cni-install.sh --enable-debug={{ .Values.debug.enabled }} --cni-exclusive={{ .Values.cni.exclusive }} --log-file={{ .Values.cni.logFile }}
+                {{- if .Values.eni.enabled }}
+                {{- tpl (.Files.Get "files/agent/poststart-eni.bash") . | nindent 16 }}
                 {{- end }}
           preStop:
             exec:


### PR DESCRIPTION
This change fixes malformed yaml that caused poststart-eni to not be executed. The original change was made in https://github.com/cilium/cilium/pull/24134 and backported in https://github.com/cilium/cilium/pull/24547. Master branch is already fixed by https://github.com/cilium/cilium/pull/24389 , which was not marked for backporting.

