### PR TITLE
bpf: dsr: fix parsing of IPv6 AUTH extension header

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -347,11 +347,12 @@ static __always_inline int find_dsr_v6(struct __ctx_buff *ctx, __u8 nexthdr,
 				}
 			}
 
-			nh = opthdr.nexthdr;
 			if (nh == NEXTHDR_AUTH)
 				len += ipv6_authlen(&opthdr);
 			else
 				len += ipv6_optlen(&opthdr);
+
+			nh = opthdr.nexthdr;
 			break;
 
 		default:


### PR DESCRIPTION
When walking an IPv6 packet's extension headers to find a DSR extension, only advance the `nh` variable _after_ calculating the current extension header's length. For AUTH headers we otherwise fail to determine the correct header length.

We recently fixed the same issue in the generic IPv6 code with commit e76d07496f16 ("bpf: fix ipv6 extension header parsing error"), but missed that the nodeport code has its own IPv6 extension header parsing logic.

Fixes: 5fbf127e661b ("datapath: Support multiple IPv6 extensions with DSR")