### PR TITLE
bpf: policy: fix handling of ICMPv6 packet with extension headers

### DIFF
--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -82,10 +82,13 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		struct ipv6hdr *ip6;
 		__u32 off;
 		__u8 icmp_type;
+		__u8 nexthdr;
 
 		if (!revalidate_data(ctx, &data, &data_end, &ip6))
 			return DROP_INVALID;
-		off = ((void *)ip6 - data) + ipv6_hdrlen(ctx, &ip6->nexthdr);
+
+		nexthdr = ip6->nexthdr;
+		off = ((void *)ip6 - data) + ipv6_hdrlen(ctx, &nexthdr);
 		if (ctx_load_bytes(ctx, off, &icmp_type, sizeof(icmp_type)) < 0)
 			return DROP_INVALID;
 


### PR DESCRIPTION
After walking the IPv6 extension headers, ipv6_hdrlen() returns the L4 proto type in `nexthdr` parameter. If we pass in a pointer to the IPv6 header's nexthdr field, then the actual packet content is changed and subsequent processing of the packet is broken (because we treat the first IPv6 extension header as an ICMPv6 header).

So even if we don't care about the L4 proto type (because we already know that it's ICMPv6), we still need to provide some stack space to store the `nexthdr`.

This only becomes relevant when ENABLE_ICMP_RULE is set, which is currently controlled by a hidden agent flag.

Fixes: d49311ccecc9 ("policy: Add bpf ICMP policy support with the "ENABLE_ICMP_POLICY" flag")