### PR TITLE
ci: Disable wireguard in v1.13 conformance datapath

### DIFF
--- a/.github/workflows/conformance-datapath-v1.13.yaml
+++ b/.github/workflows/conformance-datapath-v1.13.yaml
@@ -146,7 +146,7 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
-            encryption: 'wireguard'
+            encryption: 'disabled'
             lb-mode: 'snat'
             endpoint-routes: 'true'
 
@@ -155,7 +155,7 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
-            encryption: 'wireguard'
+            encryption: 'disabled'
             lb-mode: 'snat'
             endpoint-routes: 'true'
 
@@ -164,7 +164,7 @@ jobs:
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'vxlan'
-            encryption: 'wireguard'
+            encryption: 'disabled'
             lb-mode: 'snat'
 
           - name: '7'
@@ -172,7 +172,7 @@ jobs:
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'disabled'
-            encryption: 'wireguard'
+            encryption: 'disabled'
             lb-mode: 'snat'
 
           - name: '8'


### PR DESCRIPTION
ci-datapath-1.13 workflow is failing in the configs with wireguard enable due to an incompatibility with the L7 proxy:

`level=fatal msg="Wireguard (--enable-wireguard) is not compatible with L7 proxy (--enable-l7-proxy)" subsys=daemon`

An example of that failure can be found here: https://github.com/cilium/cilium/actions/runs/4620306511/jobs/8170228050

All the workflow configs with wireguard enabled are changed to disable encryption.
