### PR TITLE
datapath: Remove 2005 route table for IPv4

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -103,8 +103,7 @@ function move_local_rules()
 
 function setup_proxy_rules()
 {
-	# Any packet from an ingress proxy uses a separate routing table that routes
-	# the packet back to the cilium host device.
+	# TODO(brb): remove $PROXY_RT_TABLE -related code in v1.15
 	from_ingress_rulespec="fwmark 0xA00/0xF00 pref 10 lookup $PROXY_RT_TABLE"
 
 	# Any packet to an ingress or egress proxy uses a separate routing table
@@ -118,27 +117,16 @@ function setup_proxy_rules()
 			if [ -z "$(ip -4 rule list $to_proxy_rulespec)" ]; then
 				ip -4 rule add $to_proxy_rulespec
 			fi
-			if [ "$ENDPOINT_ROUTES" = "true" ]; then
-				if [ ! -z "$(ip -4 rule list $from_ingress_rulespec)" ]; then
-					ip -4 rule delete $from_ingress_rulespec
-				fi
-			else
-				if [ -z "$(ip -4 rule list $from_ingress_rulespec)" ]; then
-					ip -4 rule add $from_ingress_rulespec
-				fi
-			fi
+
+			ip -4 rule delete $from_ingress_rulespec || true
 		fi
 
 		# Traffic to the host proxy is local
 		ip route replace table $TO_PROXY_RT_TABLE local 0.0.0.0/0 dev lo
-		# Traffic from ingress proxy goes to Cilium address space via the cilium host device
-		if [ "$ENDPOINT_ROUTES" = "true" ]; then
-			ip route delete table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1 2>/dev/null || true
-			ip route delete table $PROXY_RT_TABLE default via $IP4_HOST 2>/dev/null || true
-		else
-			ip route replace table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1
-			ip route replace table $PROXY_RT_TABLE default via $IP4_HOST
-		fi
+
+		# The $PROXY_RT_TABLE is no longer in use, so delete it
+		ip route delete table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1 2>/dev/null || true
+		ip route delete table $PROXY_RT_TABLE default via $IP4_HOST 2>/dev/null || true
 	else
 		ip -4 rule del $to_proxy_rulespec 2> /dev/null || true
 		ip -4 rule del $from_ingress_rulespec 2> /dev/null || true

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -492,17 +492,6 @@ func testNodePort(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, bpfNodePort, 
 			getHTTPLink(ni.K8s2IP, data.Spec.Ports[0].NodePort),
 			getTFTPLink(ni.K8s2IP, data.Spec.Ports[1].NodePort),
 		}
-
-		if helpers.DualStackSupported() {
-			testURLsFromOutside = append(testURLsFromOutside,
-				getHTTPLink(ni.PrimaryK8s1IPv6, v6Data.Spec.Ports[0].NodePort),
-				getTFTPLink(ni.PrimaryK8s1IPv6, v6Data.Spec.Ports[1].NodePort),
-
-				getHTTPLink(ni.PrimaryK8s2IPv6, v6Data.Spec.Ports[0].NodePort),
-				getTFTPLink(ni.PrimaryK8s2IPv6, v6Data.Spec.Ports[1].NodePort),
-			)
-		}
-
 	}
 
 	count := 10

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -644,6 +644,28 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			})
 		})
 
+		SkipContextIf(func() bool {
+			return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.RunsOnAKS() || helpers.DoesNotExistNodeWithoutCilium()
+		}, "with L7 policy", func() {
+			var demoPolicyL7 string
+
+			BeforeAll(func() {
+				demoPolicyL7 = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-demo.yaml")
+			})
+
+			AfterAll(func() {
+				kubectl.Delete(demoPolicyL7)
+				// Same reason as in other L7 test above
+				kubectl.CiliumExecMustSucceedOnAll(context.TODO(),
+					"cilium bpf ct flush global", "Unable to flush CT maps")
+			})
+
+			It("Tests NodePort with L7 Policy from outside", func() {
+				applyPolicy(kubectl, demoPolicyL7)
+				testNodePort(kubectl, ni, false, true, 0)
+			})
+		})
+
 		It("ClusterIP cannot be accessed externally when access is disabled",
 			func() {
 				Expect(curlClusterIPFromExternalHost(kubectl, ni)).


### PR DESCRIPTION
This reverts 3ed62d51d5ac27bbe2c60372850d4ec78c17bb6e for IPv4 part only, as issue #21954 has been resolved by #24208.

Another PR #24882 removes 2005 route table for IPv6.

Signed-off-by: Zhichuan Liang <gray.isovalent.com>

```release-note
Fix broken IPv4 connectivity from outside to NodePort service when using L7 ingress policy, by removing PROXY_RT route table.
```