### PR TITLE
Use cilium-cli latest stable version in conformance-datapath workflows

### DIFF
--- a/.github/workflows/conformance-datapath-v1.13.yaml
+++ b/.github/workflows/conformance-datapath-v1.13.yaml
@@ -61,6 +61,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # renovate: datasource=github-releases depName=cilium/cilium-cli
+  cilium_cli_version: v0.13.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -256,9 +258,14 @@ jobs:
       - name: Install cilium-cli
         shell: bash
         run: |
-          cid=$(docker create quay.io/cilium/cilium-cli-ci:latest ls)
-          docker cp $cid:/usr/local/bin/cilium ./cilium-cli
-          docker rm $cid
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          mkdir cilium-cli-tmp
+          tar xzvfC cilium-linux-amd64.tar.gz cilium-cli-tmp
+          mv ./cilium-cli-tmp/cilium cilium-cli
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          rmdir cilium-cli-tmp
+          ./cilium-cli version
 
       - name: Provision LVH VMs
         uses: cilium/little-vm-helper@0b7d7157dae56a44dc531c852e7756dc671071af # v0.0.3

--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -64,6 +64,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # renovate: datasource=github-releases depName=cilium/cilium-cli
+  cilium_cli_version: v0.13.2
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -359,9 +361,14 @@ jobs:
       - name: Install cilium-cli
         shell: bash
         run: |
-          cid=$(docker create quay.io/cilium/cilium-cli-ci:latest ls)
-          docker cp $cid:/usr/local/bin/cilium ./cilium-cli
-          docker rm $cid
+          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
+          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+          mkdir cilium-cli-tmp
+          tar xzvfC cilium-linux-amd64.tar.gz cilium-cli-tmp
+          mv ./cilium-cli-tmp/cilium cilium-cli
+          rm cilium-linux-amd64.tar.gz{,.sha256sum}
+          rmdir cilium-cli-tmp
+          ./cilium-cli version
 
       - name: Provision LVH VMs
         uses: cilium/little-vm-helper@0b7d7157dae56a44dc531c852e7756dc671071af # v0.0.3


### PR DESCRIPTION
Currently, both conformance-datapath workflows are using the latest cilium-cli-ci images, built from the master branch.  This recent cilium-cli commit:

https://github.com/cilium/cilium-cli/commit/0c03922cf3dee829f1224fd08fd5a70d52504906

seems to be the culprit of the failures in the conformance workflows:

```
Error from server (BadRequest): error when creating "tmpl.yaml": DaemonSet in version "v1" cannot be handled as a DaemonSet: json: cannot unmarshal bool into Go struct field NodeSelectorRequirement.spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms.matchExpressions.values of type string
```

Since there is no need to use the cilium-cli built from the master branch, the version is changed to be the latest stable one.

This will serve as a temporary fix for the workflows until the issue is addressed in the cilium-cli repository.

Also, renovate is enabled in order to update cilium-cli version in the workflows as soon as a new stable version is released.