### PR TITLE
v1.11 backports 2023-04-12

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -163,12 +163,7 @@ file.
 
 To minimize datapath disruption during the upgrade, the
 ``upgradeCompatibility`` option should be set to the initial Cilium
-version which was installed in this cluster. Valid options are:
-
-* ``1.7`` if the initial install was Cilium 1.7.x or earlier.
-* ``1.8`` if the initial install was Cilium 1.8.x.
-* ``1.9`` if the initial install was Cilium 1.9.x.
-* ``1.10`` if the initial install was Cilium 1.10.x.
+version which was installed in this cluster.
 
 .. tabs::
   .. group-tab:: kubectl

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.1
 	go.etcd.io/etcd/client/v3 v3.5.1
 	go.uber.org/goleak v1.1.12
+	go.uber.org/multierr v1.7.0
 	go.universe.tf/metallb v0.11.0
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/net v0.7.0
@@ -202,7 +203,6 @@ require (
 	gitlab.com/golang-commonmark/puny v0.0.0-20191124015043-9f83538fa04f // indirect
 	go.mongodb.org/mongo-driver v1.7.4 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.19.1 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/oauth2 v0.0.0-20211028175245-ba495a64dcb5 // indirect

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -54,7 +54,7 @@ func ProbeBandwidthManager() {
 		return
 	}
 	if _, err := sysctl.Read("net.core.default_qdisc"); err != nil {
-		log.Warn("BPF bandwidth manager could not read procfs. Disabling the feature.")
+		log.WithError(err).Warn("BPF bandwidth manager could not read procfs. Disabling the feature.")
 		option.Config.EnableBandwidthManager = false
 		return
 	}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -70,6 +70,17 @@ var (
 	// replaced with a newer one, allowing to reclaim old keys only after
 	// enough time has passed since their replacement
 	ipSecKeysRemovalTime = make(map[uint8]time.Time)
+
+	wildcardIPv4   = net.ParseIP("0.0.0.0")
+	wildcardCIDRv4 = &net.IPNet{
+		IP:   wildcardIPv4,
+		Mask: net.IPv4Mask(0, 0, 0, 0),
+	}
+	wildcardIPv6   = net.ParseIP("0::0")
+	wildcardCIDRv6 = &net.IPNet{
+		IP:   wildcardIPv6,
+		Mask: net.CIDRMask(128, 128),
+	}
 )
 
 func getIPSecKeys(ip net.IP) *ipSecKey {
@@ -266,9 +277,7 @@ func ipSecReplacePolicyOut(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, nodeID 
 
 	policy := ipSecNewPolicy()
 	if dir == IPSecDirOutNode {
-		wildcardIP := net.ParseIP("0.0.0.0")
-		wildcardMask := net.IPv4Mask(0, 0, 0, 0)
-		policy.Src = &net.IPNet{IP: wildcardIP, Mask: wildcardMask}
+		policy.Src = wildcardCIDRv4
 	} else {
 		policy.Src = src
 	}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -136,6 +136,96 @@ func ipSecJoinState(state *netlink.XfrmState, keys *ipSecKey) {
 	state.Reqid = keys.ReqID
 }
 
+// xfrmStateReplace attempts to add a new XFRM state only if one doesn't
+// already exist. If it doesn't but some other XFRM state conflicts, then
+// we attempt to remove the conflicting state before trying to add again.
+func xfrmStateReplace(new *netlink.XfrmState) error {
+	states, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	if err != nil {
+		return fmt.Errorf("Cannot get XFRM state: %s", err)
+	}
+
+	// Check if the XFRM state already exists
+	for _, s := range states {
+		if xfrmIPEqual(s.Src, new.Src) && xfrmIPEqual(s.Dst, new.Dst) &&
+			xfrmMarkEqual(s.OutputMark, new.OutputMark) &&
+			xfrmMarkEqual(s.Mark, new.Mark) && s.Spi == new.Spi {
+			return nil
+		}
+	}
+
+	// It doesn't exist so let's attempt to add it.
+	firstAttemptErr := netlink.XfrmStateAdd(new)
+	if !os.IsExist(firstAttemptErr) {
+		return firstAttemptErr
+	}
+	log.WithFields(logrus.Fields{
+		logfields.SPI:           new.Spi,
+		logfields.SourceIP:      new.Src,
+		logfields.DestinationIP: new.Dst,
+	}).Warn("Failed to add XFRM state due to conflicting state")
+
+	// An existing state conflicts with this one. We need to remove the
+	// existing one first.
+	deletedSomething, err := xfrmDeleteConflictingState(states, new)
+	if err != nil {
+		return err
+	}
+
+	// If no conflicting state was found and deleted, there's no point in
+	// attempting to add again.
+	if !deletedSomething {
+		return firstAttemptErr
+	}
+	return netlink.XfrmStateAdd(new)
+}
+
+// Attempt to remove any XFRM state that conflicts with the state we just tried
+// to add. To find those conflicting states, we need to use the same logic that
+// the kernel used to reject our check with EEXIST. That logic is upstream in
+// __xfrm_state_lookup.
+func xfrmDeleteConflictingState(states []netlink.XfrmState, new *netlink.XfrmState) (bool, error) {
+	deletedSomething := false
+	for _, s := range states {
+		if new.Spi == s.Spi && (new.Mark == nil) == (s.Mark == nil) &&
+			(new.Mark == nil || new.Mark.Value&new.Mark.Mask&s.Mark.Mask == s.Mark.Value) &&
+			xfrmIPEqual(new.Src, s.Src) && xfrmIPEqual(new.Dst, s.Dst) {
+			err := netlink.XfrmStateDel(&s)
+			if err == nil {
+				deletedSomething = true
+				log.WithFields(logrus.Fields{
+					logfields.SPI:           s.Spi,
+					logfields.SourceIP:      s.Src,
+					logfields.DestinationIP: s.Dst,
+				}).Info("Removed a conflicting XFRM state")
+			} else {
+				return deletedSomething, fmt.Errorf("Failed to remove a conflicting XFRM state: %w", err)
+			}
+		}
+	}
+	return deletedSomething, nil
+}
+
+// This function compares two IP addresses and returns true if they are equal.
+// This is unfortunately necessary because our netlink library returns nil IPv6
+// addresses as nil IPv4 addresses and net.IP.Equal rightfully considers those
+// are different.
+func xfrmIPEqual(ip1, ip2 net.IP) bool {
+	if ip1.IsUnspecified() && ip2.IsUnspecified() {
+		return true
+	}
+	return ip1.Equal(ip2)
+}
+
+// Returns true if two XFRM marks are identical. They should be either both nil
+// or have the same mark value and mask.
+func xfrmMarkEqual(mark1, mark2 *netlink.XfrmMark) bool {
+	if (mark1 == nil) != (mark2 == nil) {
+		return false
+	}
+	return mark1 == nil || (mark1.Value == mark2.Value && mark1.Mask == mark2.Mask)
+}
+
 func ipSecReplaceStateIn(localIP, remoteIP net.IP, zeroMark bool) (uint8, error) {
 	key := getIPSecKeys(remoteIP)
 	if key == nil {
@@ -161,7 +251,7 @@ func ipSecReplaceStateIn(localIP, remoteIP net.IP, zeroMark bool) (uint8, error)
 		}
 	}
 
-	return key.Spi, netlink.XfrmStateAdd(state)
+	return key.Spi, xfrmStateReplace(state)
 }
 
 func ipSecReplaceStateOut(localIP, remoteIP net.IP, nodeID uint16) (uint8, error) {
@@ -178,7 +268,7 @@ func ipSecReplaceStateOut(localIP, remoteIP net.IP, nodeID uint16) (uint8, error
 		Value: linux_defaults.RouteMarkEncrypt,
 		Mask:  linux_defaults.RouteMarkMask,
 	}
-	return key.Spi, netlink.XfrmStateAdd(state)
+	return key.Spi, xfrmStateReplace(state)
 }
 
 func _ipSecReplacePolicyInFwd(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, proxyMark bool, dir netlink.Dir) error {
@@ -380,9 +470,7 @@ func UpsertIPsecEndpoint(local, remote *net.IPNet, outerLocal, outerRemote net.I
 	if !outerLocal.Equal(outerRemote) {
 		if dir == IPSecDirIn || dir == IPSecDirBoth {
 			if spi, err = ipSecReplaceStateIn(outerLocal, outerRemote, outputMark); err != nil {
-				if !os.IsExist(err) {
-					return 0, fmt.Errorf("unable to replace local state: %s", err)
-				}
+				return 0, fmt.Errorf("unable to replace local state: %s", err)
 			}
 			if err = ipSecReplacePolicyIn(remote, local, outerRemote, outerLocal); err != nil {
 				if !os.IsExist(err) {
@@ -398,9 +486,7 @@ func UpsertIPsecEndpoint(local, remote *net.IPNet, outerLocal, outerRemote net.I
 
 		if dir == IPSecDirOut || dir == IPSecDirOutNode || dir == IPSecDirBoth {
 			if spi, err = ipSecReplaceStateOut(outerLocal, outerRemote, remoteNodeID); err != nil {
-				if !os.IsExist(err) {
-					return 0, fmt.Errorf("unable to replace remote state: %s", err)
-				}
+				return 0, fmt.Errorf("unable to replace remote state: %s", err)
 			}
 
 			if err = ipSecReplacePolicyOut(local, remote, outerLocal, outerRemote, remoteNodeID, dir); err != nil {

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -90,8 +90,12 @@ const (
 	// IPsecMarkMaskNodeID is the mask used for the node ID.
 	IPsecMarkMaskNodeID = 0xFFFF0000
 
+	// IPsecOldMarkMaskOut is the mask that was previously used. It can be
+	// removed in Cilium v1.15.
+	IPsecOldMarkMaskOut = 0xFF00
+
 	// IPsecMarkMask is the mask required for the IPsec SPI, node ID, and encrypt/decrypt bits
-	IPsecMarkMaskOut = 0xFF00 | IPsecMarkMaskNodeID
+	IPsecMarkMaskOut = IPsecOldMarkMaskOut | IPsecMarkMaskNodeID
 
 	// IPsecMarkMaskIn is the mask required for IPsec to lookup encrypt/decrypt bits
 	IPsecMarkMaskIn = 0x0F00

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -921,6 +921,9 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new4Net)
 
+			err = ipsec.IPsecDefaultDropPolicy(false)
+			upsertIPsecLog(err, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi)
+
 			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
 				if n.subnetEncryption() {
 					for _, cidr := range n.nodeConfig.IPv4PodSubnets {
@@ -971,6 +974,10 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new6Net)
+
+			err = ipsec.IPsecDefaultDropPolicy(true)
+			upsertIPsecLog(err, "default-drop IPv6", wildcardCIDR, wildcardCIDR, spi)
+
 			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
 				if n.subnetEncryption() {
 					for _, cidr := range n.nodeConfig.IPv6PodSubnets {

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -345,21 +345,22 @@ func compileDatapath(ctx context.Context, dirs *directoryInfo, isHost bool, logg
 		linker:   string(linkerVersion),
 	}).Debug("Compiling datapath")
 
-	// Write out assembly and preprocessing files for debugging purposes
-	progs := debugProgs
-	if isHost {
-		progs = debugHostProgs
-	}
-	for _, p := range progs {
-		if err := compile(ctx, p, dirs); err != nil {
-			// Only log an error here if the context was not canceled or not
-			// timed out; this log message should only represent failures
-			// with respect to compiling the program.
-			if ctx.Err() == nil {
-				scopedLog.WithField(logfields.Params, logfields.Repr(p)).
-					WithError(err).Debug("JoinEP: Failed to compile")
+	if option.Config.Debug {
+		// Write out assembly and preprocessing files for debugging purposes
+		progs := debugProgs
+		if isHost {
+			progs = debugHostProgs
+		}
+		for _, p := range progs {
+			if err := compile(ctx, p, dirs); err != nil {
+				// Only log an error here if the context was not canceled or not
+				// timed out; this log message should only represent failures
+				// with respect to compiling the program.
+				if ctx.Err() == nil {
+					scopedLog.WithField(logfields.Params, logfields.Repr(p)).
+						WithError(err).Debug("JoinEP: Failed to compile")
+				}
 			}
-			return err
 		}
 	}
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -577,6 +577,8 @@ const (
 
 	DestinationIP = "destinationIP"
 
+	SourceCIDR = "sourceCIDR"
+
 	// DestinationCIDR is a destination CIDR
 	DestinationCIDR = "destinationCIDR"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -575,6 +575,8 @@ const (
 	// SourceIP is a source IP
 	SourceIP = "sourceIP"
 
+	DestinationIP = "destinationIP"
+
 	// DestinationCIDR is a destination CIDR
 	DestinationCIDR = "destinationCIDR"
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -480,21 +480,26 @@ func (s *Service) GetDeepCopyServices() []*lb.SVC {
 
 // RestoreServices restores services from BPF maps.
 //
+// It first restores all the service entries, followed by backend entries.
+// In the process, it deletes any duplicate backend entries that were leaked, and
+// are not referenced by any service entries.
+//
 // The method should be called once before establishing a connectivity
 // to kube-apiserver.
 func (s *Service) RestoreServices() error {
 	s.Lock()
 	defer s.Unlock()
 	var errs error
+	backendsById := make(map[lb.BackendID]struct{})
 
 	// Restore service cache from BPF maps
-	if err := s.restoreServicesLocked(); err != nil {
+	if err := s.restoreServicesLocked(backendsById); err != nil {
 		errs = multierr.Append(errs,
 			fmt.Errorf("error while restoring services: %w", err))
 	}
 
 	// Restore backend IDs
-	if err := s.restoreBackendsLocked(); err != nil {
+	if err := s.restoreBackendsLocked(backendsById); err != nil {
 		errs = multierr.Append(errs,
 			fmt.Errorf("error while restoring backends: %w", err))
 	}
@@ -853,7 +858,7 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, onlyLocalBackends bool,
 	return nil
 }
 
-func (s *Service) restoreBackendsLocked() error {
+func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{}) error {
 	failed, restored := 0, 0
 	backends, err := s.lbmap.DumpBackendMaps()
 	if err != nil {
@@ -865,6 +870,33 @@ func (s *Service) restoreBackendsLocked() error {
 			logfields.BackendID: b.ID,
 			logfields.L3n4Addr:  b.L3n4Addr.String(),
 		}).Debug("Restoring backend")
+		if _, ok := svcBackendsById[b.ID]; !ok && s.backendRefCount[b.L3n4Addr.Hash()] != 0 {
+			// If a backend by id isn't referenced by any of the service entries,
+			// it's likely to be a duplicate backend. This can happen when agent
+			// leaked backend entries in the backends map prior to restart, and created
+			// duplicate with different IDs but same L3n4Addr (hash).
+			// As none of the service entries have a reference to these backends
+			// in the services map, the duplicate backends were not available for
+			// load-balancing new traffic. While there is a slim chance that the
+			// duplicate backends could have previously established active connections,
+			// and these connections can get disrupted. However, the leaks likely
+			// happened when service entries were deleted, so those connections
+			// were also expected to be terminated.
+			// Regardless, delete the duplicates as this can affect restoration of current
+			// active backends, and may prevent new backends getting added as map
+			// size is limited, which can result in connectivity issues.
+			id := b.ID
+			DeleteBackendID(id)
+			if err := s.lbmap.DeleteBackendByID(id, b.L3n4Addr.IsIPv6()); err != nil {
+				log.Errorf("unable to delete duplicate backend: %v", id)
+			}
+			log.WithFields(logrus.Fields{
+				logfields.BackendID: b.ID,
+				logfields.L3n4Addr:  b.L3n4Addr,
+			}).Debug("Duplicate backend entry not restored")
+			failed++
+			continue
+		}
 		if err := RestoreBackendID(b.L3n4Addr, b.ID); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				logfields.BackendID: b.ID,
@@ -903,7 +935,7 @@ func (s *Service) deleteOrphanBackends() error {
 	return nil
 }
 
-func (s *Service) restoreServicesLocked() error {
+func (s *Service) restoreServicesLocked(svcBackendsById map[lb.BackendID]struct{}) error {
 	failed, restored := 0, 0
 
 	svcs, errors := s.lbmap.DumpServiceMaps()
@@ -946,6 +978,7 @@ func (s *Service) restoreServicesLocked() error {
 			hash := backend.L3n4Addr.Hash()
 			s.backendRefCount.Add(hash)
 			newSVC.backendByHash[hash] = &svc.Backends[j]
+			svcBackendsById[backend.ID] = struct{}{}
 		}
 
 		// Recalculate Maglev lookup tables if the maps were removed due to

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -487,16 +487,16 @@ func (s *Service) RestoreServices() error {
 	defer s.Unlock()
 	var errs error
 
-	// Restore backend IDs
-	if err := s.restoreBackendsLocked(); err != nil {
-		errs = multierr.Append(errs,
-			fmt.Errorf("error while restoring backends: %w", err))
-	}
-
 	// Restore service cache from BPF maps
 	if err := s.restoreServicesLocked(); err != nil {
 		errs = multierr.Append(errs,
 			fmt.Errorf("error while restoring services: %w", err))
+	}
+
+	// Restore backend IDs
+	if err := s.restoreBackendsLocked(); err != nil {
+		errs = multierr.Append(errs,
+			fmt.Errorf("error while restoring backends: %w", err))
 	}
 
 	// Remove LB source ranges for no longer existing services

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/service/healthserver"
 
 	"github.com/sirupsen/logrus"
+	"go.uber.org/multierr"
 )
 
 var (
@@ -484,15 +485,18 @@ func (s *Service) GetDeepCopyServices() []*lb.SVC {
 func (s *Service) RestoreServices() error {
 	s.Lock()
 	defer s.Unlock()
+	var errs error
 
 	// Restore backend IDs
 	if err := s.restoreBackendsLocked(); err != nil {
-		return err
+		errs = multierr.Append(errs,
+			fmt.Errorf("error while restoring backends: %w", err))
 	}
 
 	// Restore service cache from BPF maps
 	if err := s.restoreServicesLocked(); err != nil {
-		return err
+		errs = multierr.Append(errs,
+			fmt.Errorf("error while restoring services: %w", err))
 	}
 
 	// Remove LB source ranges for no longer existing services
@@ -502,7 +506,7 @@ func (s *Service) RestoreServices() error {
 		}
 	}
 
-	return nil
+	return errs
 }
 
 // deleteOrphanAffinityMatchesLocked removes affinity matches which point to

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -235,15 +235,17 @@ const (
 	emptyIPNodeIDAlloc  = "Attempt to allocate a node ID for an empty node IP address"
 
 	// ...and their exceptions.
-	lrpExists                    = "local-redirect service exists for frontend"                         // cf. https://github.com/cilium/cilium/issues/16400
-	opCantBeFulfilled            = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
-	initLeaderElection           = "error initially creating leader election record: leases."           // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-861544964
-	globalDataSupport            = "kernel doesn't support global data"                                 // cf. https://github.com/cilium/cilium/issues/16418
-	removeInexistentID           = "removing identity not added to the identity manager!"               // cf. https://github.com/cilium/cilium/issues/16419
-	failedToListCRDs             = "the server could not find the requested resource"                   // cf. https://github.com/cilium/cilium/issues/16425
-	retrieveResLock              = "retrieving resource lock kube-system/cilium-operator-resource-lock" // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-871155492
-	failedToRelLockEmptyName     = "Failed to release lock: resource name may not be empty"             // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-985819560
-	failedToUpdateLockReqTimeout = "Failed to update lock: etcdserver: request timed out"
+	lrpExists                  = "local-redirect service exists for frontend"                         // cf. https://github.com/cilium/cilium/issues/16400
+	opCantBeFulfilled          = "Operation cannot be fulfilled on leases.coordination.k8s.io"        // cf. https://github.com/cilium/cilium/issues/16402
+	initLeaderElection         = "error initially creating leader election record: leases."           // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-861544964
+	globalDataSupport          = "kernel doesn't support global data"                                 // cf. https://github.com/cilium/cilium/issues/16418
+	removeInexistentID         = "removing identity not added to the identity manager!"               // cf. https://github.com/cilium/cilium/issues/16419
+	failedToListCRDs           = "the server could not find the requested resource"                   // cf. https://github.com/cilium/cilium/issues/16425
+	retrieveResLock            = "retrieving resource lock kube-system/cilium-operator-resource-lock" // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-871155492
+	failedToRelLockEmptyName   = "Failed to release lock: resource name may not be empty"             // cf. https://github.com/cilium/cilium/issues/16402#issuecomment-985819560
+	failedToUpdateLock         = "Failed to update lock:"
+	failedToReleaseLock        = "Failed to release lock:"
+	errorCreatingInitialLeader = "error initially creating leader election record:"
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -312,7 +314,7 @@ var badLogMessages = map[string][]string{
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
-	"level=error": {lrpExists, opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLockReqTimeout},
+	"level=error": {lrpExists, opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader},
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
 - [x] #24715 -- pkg/bandwidth: add error for bandwidth manager not being enabled (@aanm)
 - [x] #24711 -- docs: Fix upgradeCompatibility references (@joestringer)
 - [x] #24723 -- tests: add exceptions for lease errors due to etcd (@jibi)
     - Trivial conflicts.
 - [x] #24681 -- pkg/service: Handle leaked backends (@aditighag)
     - Several compilation errors due to silent conflicts.
     - I had to add some missing logfields.
 - [x] #24769 -- loader: Don't compile `.asm` files by default (@pchaigno)
     - Trivial conflict.
 - [x] #24773 -- ipsec: Clean up stale XFRM policies and states (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 24715 24711 24723 24681 24769 24773; do contrib/backporting/set-labels.py $pr done 1.11; done
```