### PR TITLE
node/manager: Remove ipset config from previous node state

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -484,6 +484,9 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		// Delete the old node IP addresses if they have changed in this node.
 		var oldNodeIPAddrs []string
 		for _, address := range oldNode.IPAddresses {
+			if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+				iptables.RemoveFromNodeIpset(address.IP)
+			}
 			if skipIPCache(address) {
 				continue
 			}


### PR DESCRIPTION
Found by code inspection from
https://github.com/cilium/cilium/pull/23208#discussion_r1139462540,
thanks to Joe.

Fix this discrepancy so that we can potentially backport this fix if
needed to older branches. The surrounding logic will get refactored in
the aforementioned PR.

This affects users that are running with the following:
  - --tunnel=disabled (native routing)
  - --enable-bpf-masquerade=false
  - --enable-ipv{4,6}-masquerade=true

Fixes: 49cb220626b ("iptables: Don't masquerade traffic to cluster nodes")
Suggested-by: Joe Stringer <joe@cilium.io>
Signed-off-by: Chris Tarazi <chris@isovalent.com>

```release-note
Fix bug where Cilium configurations running with tunneling disabled, BPF-masq disabled, but with masquerading enabled, do not clean up ipset configuration when a node IP changes. This can lead to a lack of masquerading on those node IPs.
```

---

cc @pchaigno 