### PR TITLE
Ingress: Use partial KPR instead of strict

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -61,6 +61,8 @@ jobs:
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
           CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+            --helm-set=debug.enabled=true \
+            --helm-set=debug.verbose=envoy \
             --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \
             --helm-set=image.tag=${SHA} \

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -68,7 +68,7 @@ jobs:
             --helm-set=operator.image.suffix=-ci \
             --helm-set=operator.image.tag=${SHA} \
             --helm-set=operator.image.useDigest=false \
-            --helm-set kubeProxyReplacement=strict \
+            --helm-set kubeProxyReplacement=partial \
             --helm-set=securityContext.privileged=true \
             --helm-set=gatewayAPI.enabled=true \
             --rollback=false \

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -81,6 +81,8 @@ jobs:
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
           CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+            --helm-set=debug.enabled=true \
+            --helm-set=debug.verbose=envoy \
             --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \
             --helm-set=image.tag=${SHA} \

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -89,7 +89,7 @@ jobs:
             --helm-set=operator.image.tag=${SHA} \
             --helm-set=operator.image.useDigest=false \
             --helm-set=securityContext.privileged=true \
-            --helm-set kubeProxyReplacement=strict \
+            --helm-set kubeProxyReplacement=partial \
             --helm-set=ingressController.enabled=true \
             --helm-set=ingressController.loadbalancerMode=${{ matrix.loadbalancer-mode }} \
             --helm-set=ingressController.default=${{ matrix.default-ingress-controller }} \

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -61,7 +61,7 @@ Installation
         .. code-block:: shell-session
 
             $ cilium install \\
-                --kube-proxy-replacement=strict \\
+                --kube-proxy-replacement=partial \\
                 --helm-set gatewayAPI.enabled=true
 
         Next you can check the status of the Cilium agent and operator:

--- a/Documentation/network/servicemesh/installation.rst
+++ b/Documentation/network/servicemesh/installation.rst
@@ -61,7 +61,7 @@ Installation
         .. code-block:: shell-session
 
             $ cilium install \\
-                --kube-proxy-replacement=strict \\
+                --kube-proxy-replacement=partial \\
                 --helm-set ingressController.enabled=true \\
                 --helm-set ingressController.loadbalancerMode=dedicated
 
@@ -75,7 +75,7 @@ Installation
         .. code-block:: shell-session
 
             $ cilium install \\
-                --kube-proxy-replacement=strict \\
+                --kube-proxy-replacement=partial \\
                 --helm-set-string extraConfig.enable-envoy-config=true
 
         Additionally, the proxy load-balancing feature can be configured with the ``loadBalancer.l7.backend=envoy`` flag.
@@ -83,7 +83,7 @@ Installation
         .. code-block:: shell-session
 
             $ cilium install \\
-                --kube-proxy-replacement=strict \\
+                --kube-proxy-replacement=partial \\
                 --helm-set-string extraConfig.enable-envoy-config=true \\
                 --helm-set loadBalancer.l7.backend=envoy
 


### PR DESCRIPTION
Recommend partial kube proxy replacement, as it is easier to operate. When KPR=strict is used, Cilium agents will not be able to reach kube-apiserver via the well known service IP, rather kube-apiserver address has to be explicitly configured with the --k8s-api-server option.
