### PR TITLE
hubble: Add `--hubble-monitor-events` flag 

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -170,6 +170,7 @@ cilium-agent [flags]
       --hubble-listen-address string                            An additional address for Hubble server to listen to, e.g. ":4244"
       --hubble-metrics strings                                  List of Hubble metrics to enable.
       --hubble-metrics-server string                            Address to serve Hubble metrics on.
+      --hubble-monitor-events strings                           Cilium monitor events for Hubble to observe: [drop debug capture trace policy-verdict recorder trace-sock l7 agent]. By default, Hubble observes all monitor events.
       --hubble-prefer-ipv6                                      Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-recorder-sink-queue-size int                     Queue size of each Hubble recorder sink (default 1024)
       --hubble-recorder-storage-path string                     Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -948,6 +948,14 @@ func initializeFlags() {
 	flags.Bool(option.HubbleSkipUnknownCGroupIDs, true, "Skip Hubble events with unknown cgroup ids")
 	option.BindEnv(Vp, option.HubbleSkipUnknownCGroupIDs)
 
+	flags.StringSlice(option.HubbleMonitorEvents, []string{},
+		fmt.Sprintf(
+			"Cilium monitor events for Hubble to observe: [%s]. By default, Hubble observes all monitor events.",
+			strings.Join(monitorAPI.AllMessageTypeNames(), " "),
+		),
+	)
+	option.BindEnv(Vp, option.HubbleMonitorEvents)
+
 	flags.StringSlice(option.DisableIptablesFeederRules, []string{}, "Chains to ignore when installing feeder rules.")
 	option.BindEnv(Vp, option.DisableIptablesFeederRules)
 

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -99,6 +99,15 @@ func (d *Daemon) launchHubble() {
 		localSrvOpts []serveroption.Option
 	)
 
+	if len(option.Config.HubbleMonitorEvents) > 0 {
+		monitorFilter, err := monitor.NewMonitorFilter(logger, option.Config.HubbleMonitorEvents)
+		if err != nil {
+			logger.WithError(err).Warn("Failed to initialize Hubble monitor event filter")
+		} else {
+			observerOpts = append(observerOpts, observeroption.WithOnMonitorEvent(monitorFilter))
+		}
+	}
+
 	if option.Config.HubbleMetricsServer != "" {
 		logger.WithFields(logrus.Fields{
 			"address": option.Config.HubbleMetricsServer,

--- a/pkg/hubble/monitor/filter.go
+++ b/pkg/hubble/monitor/filter.go
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package monitor
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
+	"github.com/cilium/cilium/pkg/hubble/parser/errors"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+)
+
+// monitorFilter is an implementation of OnMonitorEvent interface that filters monitor events.
+type monitorFilter struct {
+	logger logrus.FieldLogger
+
+	drop          bool
+	debug         bool
+	capture       bool
+	trace         bool
+	l7            bool
+	agent         bool
+	policyVerdict bool
+	recCapture    bool
+	traceSock     bool
+}
+
+// NewMonitorFilter creates a new monitor filter.
+// If monitorEventFilters is empty, no events are allowed.
+func NewMonitorFilter(logger logrus.FieldLogger, monitorEventFilters []string) (*monitorFilter, error) {
+	monitorFilter := monitorFilter{logger: logger}
+
+	for _, filter := range monitorEventFilters {
+		switch filter {
+		case monitorAPI.MessageTypeNameDrop:
+			monitorFilter.drop = true
+		case monitorAPI.MessageTypeNameDebug:
+			monitorFilter.debug = true
+		case monitorAPI.MessageTypeNameCapture:
+			monitorFilter.capture = true
+		case monitorAPI.MessageTypeNameTrace:
+			monitorFilter.trace = true
+		case monitorAPI.MessageTypeNameL7:
+			monitorFilter.l7 = true
+		case monitorAPI.MessageTypeNameAgent:
+			monitorFilter.agent = true
+		case monitorAPI.MessageTypeNamePolicyVerdict:
+			monitorFilter.policyVerdict = true
+		case monitorAPI.MessageTypeNameRecCapture:
+			monitorFilter.recCapture = true
+		case monitorAPI.MessageTypeNameTraceSock:
+			monitorFilter.traceSock = true
+		default:
+			return nil, fmt.Errorf("unknown monitor event type: %s", filter)
+		}
+	}
+
+	logger.WithField("filters", monitorEventFilters).Info("Configured Hubble with monitor event filters")
+	return &monitorFilter, nil
+}
+
+func (m *monitorFilter) OnMonitorEvent(ctx context.Context, event *observerTypes.MonitorEvent) (bool, error) {
+	switch payload := event.Payload.(type) {
+	case *observerTypes.PerfEvent:
+		if len(payload.Data) == 0 {
+			return false, errors.ErrEmptyData
+		}
+
+		switch payload.Data[0] {
+		case monitorAPI.MessageTypeDrop:
+			return m.drop, nil
+		case monitorAPI.MessageTypeDebug:
+			return m.debug, nil
+		case monitorAPI.MessageTypeCapture:
+			return m.capture, nil
+		case monitorAPI.MessageTypeTrace:
+			return m.trace, nil
+		case monitorAPI.MessageTypeAccessLog: // MessageTypeAccessLog maps to MessageTypeNameL7
+			return m.l7, nil
+		case monitorAPI.MessageTypePolicyVerdict:
+			return m.policyVerdict, nil
+		case monitorAPI.MessageTypeRecCapture:
+			return m.recCapture, nil
+		case monitorAPI.MessageTypeTraceSock:
+			return m.traceSock, nil
+		default:
+			return false, errors.ErrUnknownEventType
+		}
+	case *observerTypes.AgentEvent:
+		return m.agent, nil
+	case nil:
+		return false, errors.ErrEmptyData
+	default:
+		return false, errors.ErrUnknownEventType
+	}
+}

--- a/pkg/hubble/monitor/filter_test.go
+++ b/pkg/hubble/monitor/filter_test.go
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package monitor
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+
+	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
+	"github.com/cilium/cilium/pkg/hubble/parser/errors"
+	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+)
+
+func TestNewMonitorFilter(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+
+	tests := []struct {
+		name        string
+		filters     []string
+		expectedErr error
+		expectedMF  *monitorFilter
+	}{
+		{
+			name:        "unknown filter",
+			filters:     []string{"unknown"},
+			expectedErr: fmt.Errorf("unknown monitor event type: unknown"),
+			expectedMF:  nil,
+		},
+		{
+			name: "valid filters",
+			filters: []string{
+				monitorAPI.MessageTypeNameDrop,
+				monitorAPI.MessageTypeNameDebug,
+				monitorAPI.MessageTypeNameCapture,
+				monitorAPI.MessageTypeNameTrace,
+				monitorAPI.MessageTypeNameL7,
+				monitorAPI.MessageTypeNameAgent,
+				monitorAPI.MessageTypeNamePolicyVerdict,
+				monitorAPI.MessageTypeNameRecCapture,
+				monitorAPI.MessageTypeNameTraceSock,
+			},
+			expectedErr: nil,
+			expectedMF: &monitorFilter{
+				logger: logger,
+
+				drop:          true,
+				debug:         true,
+				capture:       true,
+				trace:         true,
+				l7:            true,
+				agent:         true,
+				policyVerdict: true,
+				recCapture:    true,
+				traceSock:     true,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mf, err := NewMonitorFilter(logger, tc.filters)
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expectedMF, mf)
+
+			if tc.expectedMF != nil {
+				assert.Equal(t, 1, len(hook.Entries))
+				assert.Equal(t, logrus.InfoLevel, hook.LastEntry().Level)
+				assert.Equal(t, "Configured Hubble with monitor event filters", hook.LastEntry().Message)
+				assert.Equal(t, tc.filters, hook.LastEntry().Data["filters"])
+			}
+
+			hook.Reset()
+		})
+	}
+}
+
+type testEvent struct {
+	event       *observerTypes.MonitorEvent
+	allowed     bool
+	expectedErr error
+}
+
+func Test_OnMonitorEvent(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	tt := []struct {
+		name    string
+		filters []string
+		events  []testEvent
+	}{
+		{
+			name:    "nil payload",
+			filters: []string{},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: nil,
+					},
+					allowed:     false,
+					expectedErr: errors.ErrEmptyData,
+				},
+			},
+		},
+		{
+			name:    "unknown event type",
+			filters: []string{},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &struct{}{},
+					},
+					allowed:     false,
+					expectedErr: errors.ErrUnknownEventType,
+				},
+			},
+		},
+		{
+			name:    "unknown observerTypes.AgentEvent",
+			filters: []string{},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{0xff},
+						},
+					},
+					allowed:     false,
+					expectedErr: errors.ErrUnknownEventType,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypeAgent",
+			filters: []string{monitorAPI.MessageTypeNameAgent},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.AgentEvent{
+							Type: monitorAPI.MessageTypeAgent,
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypeAccessLog",
+			filters: []string{monitorAPI.MessageTypeNameL7},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeAccessLog},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    "empty observerTypes.PerfEvent",
+			filters: []string{},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{},
+						},
+					},
+					allowed:     false,
+					expectedErr: errors.ErrEmptyData,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypeDrop",
+			filters: []string{monitorAPI.MessageTypeNameDrop},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeDrop},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypeDebug",
+			filters: []string{monitorAPI.MessageTypeNameDebug},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeDebug},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypeCapture",
+			filters: []string{monitorAPI.MessageTypeNameCapture},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeCapture},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypeTrace",
+			filters: []string{monitorAPI.MessageTypeNameTrace},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeTrace},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypePolicyVerdict",
+			filters: []string{monitorAPI.MessageTypeNamePolicyVerdict},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypePolicyVerdict},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypeRecCapture",
+			filters: []string{monitorAPI.MessageTypeNameRecCapture},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeRecCapture},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypeTraceSock",
+			filters: []string{monitorAPI.MessageTypeNameTraceSock},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeTraceSock},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    fmt.Sprintf("composite filter with %s,%s", monitorAPI.MessageTypeNameDebug, monitorAPI.MessageTypeNameTrace),
+			filters: []string{monitorAPI.MessageTypeNameDebug, monitorAPI.MessageTypeNameTrace},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeTrace},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeDebug},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeCapture},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    fmt.Sprintf("composite filter with %s,%s", monitorAPI.MessageTypeNameDebug, monitorAPI.MessageTypeNamePolicyVerdict),
+			filters: []string{monitorAPI.MessageTypeNameDebug, monitorAPI.MessageTypeNamePolicyVerdict},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeDebug},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypePolicyVerdict},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeTrace},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeDrop},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    fmt.Sprintf("composite filter with %s,%s", monitorAPI.MessageTypeNameCapture, monitorAPI.MessageTypeNameTrace),
+			filters: []string{monitorAPI.MessageTypeNameCapture, monitorAPI.MessageTypeNameTrace},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeCapture},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeTrace},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeDrop},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeDebug},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+			},
+		},
+		{
+			name:    "monitorAPI.MessageTypeNamePolicyVerdict should drop everything else except monitorAPI.MessageTypePolicyVerdict",
+			filters: []string{monitorAPI.MessageTypeNamePolicyVerdict},
+			events: []testEvent{
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeDrop},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeDebug},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeCapture},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeTrace},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypePolicyVerdict},
+						},
+					},
+					allowed:     true,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.PerfEvent{
+							Data: []byte{monitorAPI.MessageTypeTraceSock},
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.AgentEvent{
+							Type: monitorAPI.MessageTypeAccessLog,
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+				{
+					event: &observerTypes.MonitorEvent{
+						Payload: &observerTypes.AgentEvent{
+							Type: monitorAPI.MessageTypeAgent,
+						},
+					},
+					allowed:     false,
+					expectedErr: nil,
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mf, err := NewMonitorFilter(logger, tc.filters)
+			assert.NoError(t, err)
+
+			for _, event := range tc.events {
+				allowed, err := mf.OnMonitorEvent(context.Background(), event.event)
+				assert.Equal(t, event.expectedErr, err)
+				assert.Equal(t, event.allowed, allowed)
+			}
+		})
+	}
+}

--- a/pkg/monitor/api/types.go
+++ b/pkg/monitor/api/types.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -84,6 +85,21 @@ var (
 		MessageTypeNameTraceSock:     MessageTypeTraceSock,
 	}
 )
+
+// AllMessageTypeNames returns a slice of MessageTypeNames
+func AllMessageTypeNames() []string {
+	names := make([]string, 0, len(MessageTypeNames))
+	for name := range MessageTypeNames {
+		names = append(names, name)
+	}
+
+	// Sort by the underlying MessageType
+	sort.SliceStable(names, func(i, j int) bool {
+		return MessageTypeNames[names[i]] < MessageTypeNames[names[j]]
+	})
+
+	return names
+}
 
 // MessageTypeName returns the name for a message type or the numeric value if
 // the name can't be found

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -980,6 +980,10 @@ const (
 	// HubbleSkipUnknownCGroupIDs specifies if events with unknown cgroup ids should be skipped
 	HubbleSkipUnknownCGroupIDs = "hubble-skip-unknown-cgroup-ids"
 
+	// HubbleMonitorEvents specifies Cilium monitor events for Hubble to observe.
+	// By default, Hubble observes all monitor events.
+	HubbleMonitorEvents = "hubble-monitor-events"
+
 	// DisableIptablesFeederRules specifies which chains will be excluded
 	// when installing the feeder rules
 	DisableIptablesFeederRules = "disable-iptables-feeder-rules"
@@ -2152,6 +2156,10 @@ type DaemonConfig struct {
 
 	// HubbleSkipUnknownCGroupIDs specifies if events with unknown cgroup ids should be skipped
 	HubbleSkipUnknownCGroupIDs bool
+
+	// HubbleMonitorEvents specifies Cilium monitor events for Hubble to observe.
+	// By default, Hubble observes all monitor events.
+	HubbleMonitorEvents []string
 
 	// EndpointStatus enables population of information in the
 	// CiliumEndpoint.Status resource
@@ -3373,6 +3381,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.HubbleRecorderStoragePath = vp.GetString(HubbleRecorderStoragePath)
 	c.HubbleRecorderSinkQueueSize = vp.GetInt(HubbleRecorderSinkQueueSize)
 	c.HubbleSkipUnknownCGroupIDs = vp.GetBool(HubbleSkipUnknownCGroupIDs)
+	c.HubbleMonitorEvents = vp.GetStringSlice(HubbleMonitorEvents)
 
 	c.DisableIptablesFeederRules = vp.GetStringSlice(DisableIptablesFeederRules)
 	c.EnableCiliumEndpointSlice = vp.GetBool(EnableCiliumEndpointSlice)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Related https://github.com/cilium/cilium/issues/19929

Adds a `--hubble-monitor-events` flag that let's a user control the event types that get to the hubble subsystem. 


```release-note
Add `--hubble-monitor-events` flag, to control the event types that get to the hubble subsystem.
```


#### Why

Nodes with traffic heavy workloads are doing 30k+ flows per second. This causes very high CPU utilization for the cilium-agent container. We'd like to be able to only monitor drop and other events and ignore the normal flows.

Flame graph showing that most of the CPU time is spent in the hubble subsystem decoding the events:

![image](https://user-images.githubusercontent.com/9075816/231541019-ed138d8b-7db7-483e-a84f-7c02e798d789.png)



cc @michi-covalent 