### PR TITLE
configmap & utime sync: provide via hive cell

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
-	"github.com/cilium/cilium/pkg/datapath/linux/utime"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -29,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/maps/eventsmap"
@@ -332,12 +330,6 @@ func (d *Daemon) initMaps() error {
 	if option.Config.DryMode {
 		return nil
 	}
-
-	if err := configmap.InitMap(); err != nil {
-		return err
-	}
-	// start configmap users after configmap.InitMap() above
-	utime.InitUTime(d.ctx, d.controllers, time.Minute)
 
 	if _, err := lxcmap.LXCMap().OpenOrCreate(); err != nil {
 		return err

--- a/pkg/bpf/bpfmap.go
+++ b/pkg/bpf/bpfmap.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bpf
+
+// BpfMap defines the base interface every BPF map needs to implement.
+//
+// Its main purpose is to register a BPF map via value group `bpf-maps`.
+//
+// Example:
+//
+//	type MapOut struct {
+//		 cell.Out
+//
+//		 BpfMap  bpf.BpfMap `group:"bpf-maps"`
+//	}
+type BpfMap interface{}

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/maps"
-	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -32,9 +31,6 @@ var Cell = cell.Module(
 
 	// Provides all BPF Map which are already provided by via hive cell.
 	maps.Cell,
-
-	// ConfigMap stores runtime configuration state for the Cilium datapath.
-	configmap.Cell,
 
 	// Utime synchronizes utime from userspace to datapath via configmap.Map.
 	utime.Cell,

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"path/filepath"
 
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
@@ -16,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/maps"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/option"
@@ -29,10 +31,8 @@ var Cell = cell.Module(
 	"datapath",
 	"Datapath",
 
-	cell.Provide(
-		newWireguardAgent,
-		newDatapath,
-	),
+	// Provides all BPF Map which are already provided by via hive cell.
+	maps.Cell,
 
 	// Provides the auth.Map which contains the authentication state between Cilium security identities.
 	authmap.Cell,
@@ -42,6 +42,11 @@ var Cell = cell.Module(
 
 	// Utime synchronizes utime from userspace to datapath via configmap.Map.
 	utime.Cell,
+
+	cell.Provide(
+		newWireguardAgent,
+		newDatapath,
+	),
 
 	cell.Provide(func(dp types.Datapath) ipcache.NodeHandler {
 		return dp.Node()
@@ -76,7 +81,7 @@ func newWireguardAgent(lc hive.Lifecycle) *wg.Agent {
 	return wgAgent
 }
 
-func newDatapath(lc hive.Lifecycle, wgAgent *wg.Agent) types.Datapath {
+func newDatapath(params datapathParams) types.Datapath {
 	datapathConfig := linuxdatapath.DatapathConfiguration{
 		HostDevice: defaults.HostDevice,
 		ProcFs:     option.Config.ProcFs,
@@ -84,7 +89,7 @@ func newDatapath(lc hive.Lifecycle, wgAgent *wg.Agent) types.Datapath {
 
 	iptablesManager := &iptables.IptablesManager{}
 
-	lc.Append(hive.Hook{
+	params.LC.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
 			// FIXME enableIPForwarding should not live here
 			if err := enableIPForwarding(); err != nil {
@@ -95,5 +100,15 @@ func newDatapath(lc hive.Lifecycle, wgAgent *wg.Agent) types.Datapath {
 			return nil
 		}})
 
-	return linuxdatapath.NewDatapath(datapathConfig, iptablesManager, wgAgent)
+	return linuxdatapath.NewDatapath(datapathConfig, iptablesManager, params.WgAgent)
+}
+
+type datapathParams struct {
+	cell.In
+
+	LC      hive.Lifecycle
+	WgAgent *wg.Agent
+
+	// Force map initialisation before loader
+	BpfMaps []bpf.BpfMap `group:"bpf-maps"`
 }

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -10,12 +10,14 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/utime"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/maps/authmap"
+	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -34,6 +36,12 @@ var Cell = cell.Module(
 
 	// Provides the auth.Map which contains the authentication state between Cilium security identities.
 	authmap.Cell,
+
+	// ConfigMap stores runtime configuration state for the Cilium datapath.
+	configmap.Cell,
+
+	// Utime synchronizes utime from userspace to datapath via configmap.Map.
+	utime.Cell,
 
 	cell.Provide(func(dp types.Datapath) ipcache.NodeHandler {
 		return dp.Node()

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/maps"
-	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
@@ -33,9 +32,6 @@ var Cell = cell.Module(
 
 	// Provides all BPF Map which are already provided by via hive cell.
 	maps.Cell,
-
-	// Provides the auth.Map which contains the authentication state between Cilium security identities.
-	authmap.Cell,
 
 	// ConfigMap stores runtime configuration state for the Cilium datapath.
 	configmap.Cell,

--- a/pkg/datapath/linux/utime/cell.go
+++ b/pkg/datapath/linux/utime/cell.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package utime
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/maps/configmap"
+)
+
+const (
+	syncControllerName     = "sync-utime"
+	syncControllerInterval = 1 * time.Minute
+)
+
+// Cell initializes and manages the utime offset synchronization.
+var Cell = cell.Module(
+	"utime",
+	"Synchronizes utime offset between userspace and datapath",
+
+	cell.Invoke(initUtimeSync),
+)
+
+func initUtimeSync(lifecycle hive.Lifecycle, configMap configmap.Map) {
+	controllerManager := controller.NewManager()
+
+	lifecycle.Append(hive.Hook{
+		OnStart: func(startCtx hive.HookContext) error {
+			ctrl := &utimeController{configMap: configMap}
+
+			// Add controller for keeping clock in sync for NTP time jumps and any difference
+			// between monotonic and boottime clocks.
+			controllerManager.UpdateController(syncControllerName,
+				controller.ControllerParams{
+					DoFunc: func(ctx context.Context) error {
+						return ctrl.sync()
+					},
+					RunInterval: syncControllerInterval,
+				},
+			)
+			return nil
+		},
+		OnStop: func(stopCtx hive.HookContext) error {
+			if err := controllerManager.RemoveController(syncControllerName); err != nil {
+				return fmt.Errorf("failed to remove controller: %w", err)
+			}
+			return nil
+		},
+	})
+}

--- a/pkg/maps/authmap/cell.go
+++ b/pkg/maps/authmap/cell.go
@@ -4,6 +4,7 @@
 package authmap
 
 import (
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/option"
@@ -20,7 +21,7 @@ var Cell = cell.Module(
 	cell.Provide(newAuthMap),
 )
 
-func newAuthMap(lifecycle hive.Lifecycle) (Map, error) {
+func newAuthMap(lifecycle hive.Lifecycle) MapOut {
 	authMap := newMap(option.Config.AuthMapEntries)
 
 	lifecycle.Append(hive.Hook{
@@ -32,5 +33,15 @@ func newAuthMap(lifecycle hive.Lifecycle) (Map, error) {
 		},
 	})
 
-	return authMap, nil
+	return MapOut{
+		AuthMap: authMap,
+		BpfMap:  authMap,
+	}
+}
+
+type MapOut struct {
+	cell.Out
+
+	AuthMap Map
+	BpfMap  bpf.BpfMap `group:"bpf-maps"`
 }

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -5,10 +5,14 @@ package maps
 
 import (
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/maps/authmap"
 )
 
 // Cell contains all cells which are providing BPF Maps.
 var Cell = cell.Module(
 	"maps",
 	"BPF Maps",
+
+	// Provides the auth.Map which contains the authentication state between Cilium security identities.
+	authmap.Cell,
 )

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package maps
+
+import (
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+// Cell contains all cells which are providing BPF Maps.
+var Cell = cell.Module(
+	"maps",
+	"BPF Maps",
+)

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -6,6 +6,7 @@ package maps
 import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/maps/authmap"
+	"github.com/cilium/cilium/pkg/maps/configmap"
 )
 
 // Cell contains all cells which are providing BPF Maps.
@@ -15,4 +16,7 @@ var Cell = cell.Module(
 
 	// Provides the auth.Map which contains the authentication state between Cilium security identities.
 	authmap.Cell,
+
+	// ConfigMap stores runtime configuration state for the Cilium datapath.
+	configmap.Cell,
 )

--- a/pkg/maps/configmap/cell.go
+++ b/pkg/maps/configmap/cell.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package configmap
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+// Cell initializes and manages the config map.
+var Cell = cell.Module(
+	"config-map",
+	"eBPF map config contains runtime configuration state for the Cilium datapath",
+
+	cell.Provide(newMap),
+	cell.Invoke(func(Map) {}),
+)
+
+func newMap(lifecycle hive.Lifecycle) Map {
+	configmap := newConfigMap()
+
+	lifecycle.Append(hive.Hook{
+		OnStart: func(startCtx hive.HookContext) error {
+			return configmap.init()
+		},
+		OnStop: func(stopCtx hive.HookContext) error {
+			return configmap.close()
+		},
+	})
+
+	return configmap
+}

--- a/pkg/maps/configmap/cell.go
+++ b/pkg/maps/configmap/cell.go
@@ -4,6 +4,7 @@
 package configmap
 
 import (
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 )
@@ -14,10 +15,9 @@ var Cell = cell.Module(
 	"eBPF map config contains runtime configuration state for the Cilium datapath",
 
 	cell.Provide(newMap),
-	cell.Invoke(func(Map) {}),
 )
 
-func newMap(lifecycle hive.Lifecycle) Map {
+func newMap(lifecycle hive.Lifecycle) MapOut {
 	configmap := newConfigMap()
 
 	lifecycle.Append(hive.Hook{
@@ -29,5 +29,15 @@ func newMap(lifecycle hive.Lifecycle) Map {
 		},
 	})
 
-	return configmap
+	return MapOut{
+		ConfigMap: configmap,
+		BpfMap:    configmap,
+	}
+}
+
+type MapOut struct {
+	cell.Out
+
+	ConfigMap Map
+	BpfMap    bpf.BpfMap `group:"bpf-maps"`
 }

--- a/pkg/maps/configmap/config_map.go
+++ b/pkg/maps/configmap/config_map.go
@@ -5,7 +5,6 @@ package configmap
 
 import (
 	"fmt"
-	"sync"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -43,7 +42,7 @@ func (k *Index) String() string {
 // GetKeyPtr returns the unsafe pointer to the BPF key
 func (k *Index) GetKeyPtr() unsafe.Pointer { return unsafe.Pointer(k) }
 
-// NewValue returns a new empty instance of the structure represeting the BPF
+// NewValue returns a new empty instance of the structure representing the BPF
 // map value
 func (k *Index) NewValue() bpf.MapValue {
 	var value Value
@@ -70,40 +69,51 @@ func (v *Value) DeepCopyMapValue() bpf.MapValue {
 	return &value
 }
 
-type ConfigMap struct {
-	*bpf.Map
+// Map provides access to the eBPF map configmap.
+type Map interface {
+	// Update writes the given uint64 value to the bpf map at the given index.
+	Update(index Index, val uint64) error
 }
 
-var (
-	once      sync.Once
-	configMap ConfigMap
-)
-
-// MapCreate will create an config map
-func InitMap() error {
-	once.Do(func() {
-		var index Index
-		var value Value
-		configMap = ConfigMap{
-			Map: bpf.NewMap(MapName,
-				bpf.MapTypeArray,
-				&index,
-				int(unsafe.Sizeof(index)),
-				&value,
-				int(unsafe.Sizeof(value)),
-				MaxEntries,
-				0, 0,
-				bpf.ConvertKeyValue,
-			),
-		}
-	})
-
-	_, err := configMap.OpenOrCreate()
-	return err
+type configMap struct {
+	bpfMap *bpf.Map
 }
 
-// Update writes the given uint64 value to the bpf map at the given index.
-func Update(index Index, val uint64) error {
+func newConfigMap() *configMap {
+	var index Index
+	var value Value
+
+	return &configMap{
+		bpfMap: bpf.NewMap(MapName,
+			bpf.MapTypeArray,
+			&index,
+			int(unsafe.Sizeof(index)),
+			&value,
+			int(unsafe.Sizeof(value)),
+			MaxEntries,
+			0, 0,
+			bpf.ConvertKeyValue,
+		),
+	}
+}
+
+func (m *configMap) init() error {
+	if _, err := m.bpfMap.OpenOrCreate(); err != nil {
+		return fmt.Errorf("failed to init bpf map: %w", err)
+	}
+
+	return nil
+}
+
+func (m *configMap) close() error {
+	if err := m.bpfMap.Close(); err != nil {
+		return fmt.Errorf("failed to close bpf map: %w", err)
+	}
+
+	return nil
+}
+
+func (m *configMap) Update(index Index, val uint64) error {
 	value := Value(val)
-	return configMap.Update(&index, &value)
+	return m.bpfMap.Update(&index, &value)
 }


### PR DESCRIPTION
Currently, the interaction with the BPF map configmap and the corresponding utime sync is mainly via global accessors.

This commit refactors this, by introducing hive cells for the configmap and the utime sync.