### PR TITLE
helm: Add SA to nodeinit ds

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1728,6 +1728,14 @@
      - Additional nodeinit environment variables.
      - list
      - ``[]``
+   * - nodeinit.extraVolumeMounts
+     - Additional nodeinit volumeMounts.
+     - list
+     - ``[]``
+   * - nodeinit.extraVolumes
+     - Additional nodeinit volumes.
+     - list
+     - ``[]``
    * - nodeinit.image
      - node-init image.
      - object
@@ -2192,6 +2200,10 @@
      - Hubblecertgen is used if hubble.tls.auto.method=cronJob
      - object
      - ``{"annotations":{},"automount":true,"create":true,"name":"hubble-generate-certs"}``
+   * - serviceAccounts.nodeinit.enabled
+     - Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented. Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by this issue. Name and automount can be configured, if enabled is set to true.  Otherwise, they are ignored. Enabled can be removed once the issue is fixed. Cilium-nodeinit DS must also be fixed.
+     - bool
+     - ``false``
    * - sleepAfterInit
      - Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -202,6 +202,7 @@ autoMount
 autoProtectPortRange
 autocompletion
 autoload
+automount
 autoscaler
 awk
 aws

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -482,6 +482,8 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap.d/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraEnv | list | `[]` | Additional nodeinit environment variables. |
+| nodeinit.extraVolumeMounts | list | `[]` | Additional nodeinit volumeMounts. |
+| nodeinit.extraVolumes | list | `[]` | Additional nodeinit volumes. |
 | nodeinit.image | object | `{"override":null,"pullPolicy":"Always","repository":"quay.io/cilium/startup-script","tag":"d69851597ea019af980891a4628fb36b7880ec26"}` | node-init image. |
 | nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
@@ -598,6 +600,7 @@ contributors across the globe, there is almost always someone available to help.
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"automount":true,"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"automount":true,"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |
+| serviceAccounts.nodeinit.enabled | bool | `false` | Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented. Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by this issue. Name and automount can be configured, if enabled is set to true.  Otherwise, they are ignored. Enabled can be removed once the issue is fixed. Cilium-nodeinit DS must also be fixed.  |
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | socketLB | object | `{"enabled":false}` | Configure socket LB |
 | socketLB.enabled | bool | `false` | Enable socket LB |

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -79,6 +79,10 @@ spec:
             {{- toYaml . | trim | nindent 12 }}
           {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
+          {{- with .Values.nodeinit.extraVolumeMounts }}
+          volumeMounts:
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       {{- with .Values.nodeinit.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -94,4 +98,13 @@ spec:
       hostPID: true
       hostNetwork: true
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.nodeinit.priorityClassName "system-node-critical") }}
+      {{- if .Values.serviceAccounts.nodeinit.enabled }}
+      serviceAccount: {{ .Values.serviceAccounts.nodeinit.name | quote }}
+      serviceAccountName: {{ .Values.serviceAccounts.nodeinit.name | quote }}
+      automountServiceAccountToken: {{ .Values.serviceAccounts.nodeinit.automount }}
+      {{- end }}
+      {{- with .Values.nodeinit.extraVolumes }}
+      volumes:
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.nodeinit.enabled .Values.serviceAccounts.nodeinit.enabled  .Values.serviceAccounts.nodeinit.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccounts.nodeinit.name | quote }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceAccounts.nodeinit.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccounts.nodeinit.annotations | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -55,6 +55,17 @@ serviceAccounts:
     name: cilium
     automount: true
     annotations: {}
+  nodeinit:
+    create: true
+    # -- Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented.
+    # Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by
+    # this issue. Name and automount can be configured, if enabled is set to true. 
+    # Otherwise, they are ignored. Enabled can be removed once the issue is fixed.
+    # Cilium-nodeinit DS must also be fixed. 
+    enabled: false
+    name: cilium-nodeinit
+    automount: true
+    annotations: {}
   etcd:
     create: true
     name: cilium-etcd-operator
@@ -1374,7 +1385,6 @@ hubble:
       #    hosts:
       #      - chart-example.local
 
-
 # -- Method to use for identity allocation (`crd` or `kvstore`).
 identityAllocationMode: "crd"
 
@@ -1497,7 +1507,6 @@ localRedirectPolicy: false
 
 # -- Enables periodic logging of system load
 logSystemLoad: false
-
 
 # -- Configure maglev consistent hashing
 maglev: {}
@@ -2106,6 +2115,12 @@ nodeinit:
 
   # -- Additional nodeinit environment variables.
   extraEnv: []
+
+  # -- Additional nodeinit volumes.
+  extraVolumes: []
+
+  # -- Additional nodeinit volumeMounts.
+  extraVolumeMounts: []
 
   # -- Affinity for cilium-nodeinit
   affinity: {}

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -52,6 +52,17 @@ serviceAccounts:
     name: cilium
     automount: true
     annotations: {}
+  nodeinit:
+    create: true
+    # -- Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented.
+    # Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by
+    # this issue. Name and automount can be configured, if enabled is set to true. 
+    # Otherwise, they are ignored. Enabled can be removed once the issue is fixed.
+    # Cilium-nodeinit DS must also be fixed. 
+    enabled: false
+    name: cilium-nodeinit
+    automount: true
+    annotations: {}
   etcd:
     create: true
     name: cilium-etcd-operator
@@ -1371,7 +1382,6 @@ hubble:
       #    hosts:
       #      - chart-example.local
 
-
 # -- Method to use for identity allocation (`crd` or `kvstore`).
 identityAllocationMode: "crd"
 
@@ -1494,7 +1504,6 @@ localRedirectPolicy: false
 
 # -- Enables periodic logging of system load
 logSystemLoad: false
-
 
 # -- Configure maglev consistent hashing
 maglev: {}
@@ -2103,6 +2112,12 @@ nodeinit:
 
   # -- Additional nodeinit environment variables.
   extraEnv: []
+
+  # -- Additional nodeinit volumes.
+  extraVolumes: []
+
+  # -- Additional nodeinit volumeMounts.
+  extraVolumeMounts: []
 
   # -- Affinity for cilium-nodeinit
   affinity: {}


### PR DESCRIPTION
This commit is to make sure that users can enable/disable SA token auto
mount, which is recommended in NSA security hardening guide. This PR is for the cilium-nodeinit daemonset. 

https://media.defense.gov/2022/Aug/29/2003066362/-1/-1/0/CTR_KUBERNETES_HARDENING_GUIDANCE_1.2_20220829.PDF