### PR TITLE
docs: Note that CiliumEndpointSlice and K8s' EndpointSlice are distinct

### DIFF
--- a/Documentation/network/kubernetes/ciliumendpointslice_beta.rst
+++ b/Documentation/network/kubernetes/ciliumendpointslice_beta.rst
@@ -29,6 +29,26 @@ propagation should be reduced in this case, allowing for better scalability,
 at the cost of potentially longer delay before identity of new endpoint is
 recognized throughout the cluster.
 
+.. note::
+
+   CiliumEndpointSlice is a concept that is specific to Cilium and is not
+   related to `Kubernetes' EndpointSlice`_. Although the names are similar, and
+   even though the concept of slices in each feature brings similar
+   improvements for scalability, they address different problems.
+
+   Kubernetes' Endpoints and EndpointSlices allow Cilium to make load-balancing
+   decisions for a particular Service object; Kubernetes' EndpointSlices offer
+   a scalable way to track Service back-ends within a cluster.
+
+   By contrast, CiliumEndpoints and CiliumEndpointSlices are used to make
+   network routing and policy decisions. So CiliumEndpointSlices focus on
+   tracking Pods, batching CEPs to reduce the number of updates to propagate
+   through the API-server on large clusters.
+
+   Enabling one does not affect the other.
+
+.. _Kubernetes' EndpointSlice: https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/
+
 Deploy Cilium with CES
 =======================
 The CES feature relies on use of CEP. This feature is disabled by default


### PR DESCRIPTION
In an attempt to lift some confusing about the similar naming of CiliumEndpointSlices and Kubernetes' EndpointSlices, and to avoid users to activate one when they only want the other, add a note to the documentation to clarify that CiliumEndpointSlice is a concept specific to Cilium, and unrelated to the Kubernetes feature.
