### PR TITLE
v1.13 Backports 2023-04-12

### DIFF
--- a/pkg/cgroups/manager/manager.go
+++ b/pkg/cgroups/manager/manager.go
@@ -371,18 +371,12 @@ func (m *CgroupManager) deletePodMetadata(pod *v1.Pod) {
 func (m *CgroupManager) getPodMetadata(cgroupId uint64, podMetadataOut chan *PodMetadata) {
 	cm, ok := m.containerMetadataByCgrpId[cgroupId]
 	if !ok {
-		log.WithFields(logrus.Fields{
-			"container-cgroup-id": cgroupId,
-		}).Debugf("Metadata not found")
 		close(podMetadataOut)
 		return
 	}
 
 	pm, ok := m.podMetadataById[cm.podId]
 	if !ok {
-		log.WithFields(logrus.Fields{
-			"container-cgroup-id": cgroupId,
-		}).Debugf("Pod metadata not found")
 		close(podMetadataOut)
 		return
 	}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -634,18 +634,19 @@ func (l4 *L4Filter) cacheFQDNSelector(sel api.FQDNSelector, selectorCache *Selec
 
 // add L7 rules for all endpoints in the L7DataMap
 func (l7 L7DataMap) addPolicyForSelector(rules *api.L7Rules, terminatingTLS, originatingTLS *TLSContext, auth *api.Auth, deny bool, sni []string, forceRedirect bool) {
-	l7policy := &PerSelectorPolicy{
-		TerminatingTLS: terminatingTLS,
-		OriginatingTLS: originatingTLS,
-		Auth:           auth,
-		IsDeny:         deny,
-		ServerNames:    NewStringSet(sni),
-		isRedirect:     !deny && (forceRedirect || terminatingTLS != nil || originatingTLS != nil || len(sni) > 0 || !rules.IsEmpty()),
-	}
-	if rules != nil {
-		l7policy.L7Rules = *rules
-	}
+	isRedirect := !deny && (forceRedirect || terminatingTLS != nil || originatingTLS != nil || len(sni) > 0 || !rules.IsEmpty())
 	for epsel := range l7 {
+		l7policy := &PerSelectorPolicy{
+			TerminatingTLS: terminatingTLS,
+			OriginatingTLS: originatingTLS,
+			Auth:           auth,
+			IsDeny:         deny,
+			ServerNames:    NewStringSet(sni),
+			isRedirect:     isRedirect,
+		}
+		if rules != nil {
+			l7policy.L7Rules = *rules
+		}
 		l7[epsel] = l7policy
 	}
 }

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2645,3 +2645,91 @@ func BenchmarkRuleString(b *testing.B) {
 		_ = r.String()
 	}
 }
+
+// Test merging of L7 rules when the same rules apply to multiple selectors.
+// This was added to prevent regression of a bug where the merging of l7 rules for "foo"
+// also affected the rules for "baz".
+func (ds *PolicyTestSuite) TestMergeL7PolicyEgressWithMultipleSelectors(c *C) {
+	fromBar := &SearchContext{From: labels.ParseSelectLabelArray("bar")}
+	fromFoo := &SearchContext{From: labels.ParseSelectLabelArray("foo")}
+
+	fooSelector := []api.EndpointSelector{
+		api.NewESFromLabels(labels.ParseSelectLabel("foo")),
+	}
+	foobazSelector := []api.EndpointSelector{
+		api.NewESFromLabels(labels.ParseSelectLabel("foo")),
+		api.NewESFromLabels(labels.ParseSelectLabel("baz")),
+	}
+
+	rule1 := &rule{
+		Rule: api.Rule{
+			EndpointSelector: api.NewESFromLabels(labels.ParseSelectLabel("bar")),
+			Egress: []api.EgressRule{
+				{
+					EgressCommonRule: api.EgressCommonRule{
+						ToEndpoints: fooSelector,
+					},
+					// Note that this allows all on 80, so the result should wildcard HTTP to "foo"
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+					}},
+				},
+				{
+					EgressCommonRule: api.EgressCommonRule{
+						ToEndpoints: foobazSelector,
+					},
+					ToPorts: []api.PortRule{{
+						Ports: []api.PortProtocol{
+							{Port: "80", Protocol: api.ProtoTCP},
+						},
+						Rules: &api.L7Rules{
+							HTTP: []api.PortRuleHTTP{
+								{Method: "GET"},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	expected := L4PolicyMap{"80/TCP": &L4Filter{
+		Port: 80, Protocol: api.ProtoTCP, U8Proto: 6,
+		L7Parser: ParserTypeHTTP,
+		PerSelectorPolicies: L7DataMap{
+			cachedFooSelector: &PerSelectorPolicy{
+				L7Rules: api.L7Rules{
+					HTTP: []api.PortRuleHTTP{{Method: "GET"}, {}},
+				},
+				isRedirect: true,
+			},
+			cachedBazSelector: &PerSelectorPolicy{
+				L7Rules: api.L7Rules{
+					HTTP: []api.PortRuleHTTP{{Method: "GET"}},
+				},
+				isRedirect: true,
+			},
+		},
+		Ingress:          false,
+		DerivedFromRules: labels.LabelArrayList{nil},
+	}}
+
+	state := traceState{}
+	res, err := rule1.resolveEgressPolicy(testPolicyContext, fromBar, &state, L4PolicyMap{}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(res, Not(IsNil))
+	c.Assert(res, checker.DeepEquals, expected)
+	c.Assert(state.selectedRules, Equals, 1)
+	c.Assert(state.matchedRules, Equals, 1)
+	res.Detach(testSelectorCache)
+	expected.Detach(testSelectorCache)
+
+	state = traceState{}
+	res, err = rule1.resolveEgressPolicy(testPolicyContext, fromFoo, &state, L4PolicyMap{}, nil, nil)
+	c.Assert(err, IsNil)
+	c.Assert(res, IsNil)
+	c.Assert(state.selectedRules, Equals, 0)
+	c.Assert(state.matchedRules, Equals, 0)
+}


### PR DESCRIPTION
 * [x] #24788 (@jrajahalme)
   * :warning: @jrajahalme Had to fix a conflict in the unit tests around `RulesOrigin` vs `DerivedFromRules`
 * [x] #24815 (@aditighag)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 24788 24815; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=24788,24815
```
