### PR TITLE
renovate: Update builder and runtime images once a week

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -140,6 +140,9 @@
       "matchFiles": [
         "images/builder/Dockerfile",
         "images/runtime/Dockerfile"
+      ],
+      "schedule": [
+        "on friday"
       ]
     },
     {


### PR DESCRIPTION
The golang image SHAs keep changing even for the same patch version, and renovate keeps opening pull requests like this one:

https://github.com/cilium/cilium/pull/24831

Let's try limiting these updates to once a week. It should be enough since we only release patch versions once a month.