### PR TITLE
endpoint: add endpoint SetDefaultOpts unit test

### DIFF
--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	. "gopkg.in/check.v1"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -762,4 +763,22 @@ func (e *Endpoint) getK8sPodLabels() labels.Labels {
 		}
 	}
 	return k8sEPPodLabels
+}
+
+func TestSetDefaultOpts(t *testing.T) {
+	opts := option.NewIntOptions(&option.DaemonMutableOptionLibrary)
+
+	// this is the default set in daemon
+	opts.SetBool(option.SourceIPVerification, true)
+
+	// this datapath option should override the above
+	e := Endpoint{DatapathConfiguration: models.EndpointDatapathConfiguration{
+		DisableSipVerification: true,
+	}}
+
+	e.SetDefaultOpts(opts)
+	gotOpt := e.Options.GetValue(option.SourceIPVerification)
+	if gotOpt != option.OptionDisabled {
+		t.Errorf("SourceIPVerification option should be %v, got %v", option.OptionDisabled, gotOpt)
+	}
 }


### PR DESCRIPTION
Add unit test to test SetDefaultOpts which makes sure the SourceIPVerification option can always be overriden by endpoint specific datapath configuration.

Related slack thread https://cilium.slack.com/archives/C2B917YHE/p1680518197957369

Needs this to be fixed/merged https://github.com/cilium/cilium/pull/24150

```release-note
Add a unit test to test endpoint SetDefaultOpts function for possible override by endpoint datapath config
```
