### PR TITLE
v1.13 egress gateway tests sync

### DIFF
--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#define HAVE_LPM_TRIE_MAP_TYPE
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+#define LXC_IPV4 (__be32)v4_pod_one
+#include "config_replacement.h"
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_EGRESS_GATEWAY
+#define ENABLE_MASQUERADE
+#define ENCAP_IFINDEX 0
+
+#define CLIENT_IP		v4_pod_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define EXTERNAL_SVC_IP		v4_ext_one
+#define EXTERNAL_SVC_PORT	__bpf_htons(1234)
+
+#define NODE_IP			v4_node_one
+
+#define SECCTX_FROM_IPCACHE 1
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *ext_svc_mac = mac_two;
+
+#include "bpf_lxc.c"
+
+#define FROM_CONTAINER 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+/* Test that a packet matching an egress gateway policy on the from-container
+ * program gets redirected to the gateway node.
+ */
+PKTGEN("tc", "tc_egressgw_redirect")
+int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = EXTERNAL_SVC_IP;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = EXTERNAL_SVC_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_egressgw_redirect")
+int egressgw_redirect_setup(struct __ctx_buff *ctx)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
+		.saddr   = CLIENT_IP,
+		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
+	};
+
+	struct egress_gw_policy_entry in_val = {
+		.egress_ip  = 0,
+		.gateway_ip = NODE_IP,
+	};
+
+	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+
+	struct policy_key policy_key = {
+		.egress = 1,
+	};
+	struct policy_entry policy_value = {
+		.deny = 0,
+	};
+
+	/* Avoid policy drop */
+	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_egressgw_redirect")
+int egressgw_redirect_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	test_finish();
+}

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -52,7 +52,7 @@ struct {
  * gets correctly SNATed with the egress IP of the policy.
  */
 PKTGEN("tc", "tc_egressgw_snat")
-int egressgw_pktgen(struct __ctx_buff *ctx)
+int egressgw_snat_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -97,10 +97,10 @@ int egressgw_pktgen(struct __ctx_buff *ctx)
 }
 
 SETUP("tc", "tc_egressgw_snat")
-int egressgw_setup(struct __ctx_buff *ctx)
+int egressgw_snat_setup(struct __ctx_buff *ctx)
 {
 	struct egress_gw_policy_key in_key = {
-		.lpm_key = { 32 + 24, {} },
+		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
 		.saddr   = CLIENT_IP,
 		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
 	};
@@ -119,7 +119,7 @@ int egressgw_setup(struct __ctx_buff *ctx)
 }
 
 CHECK("tc", "tc_egressgw_snat")
-int egressgw_check(const struct __ctx_buff *ctx)
+int egressgw_snat_check(const struct __ctx_buff *ctx)
 {
 	void *data, *data_end;
 	__u32 *status_code;


### PR DESCRIPTION
This PR syncs the v1.13 branch with master with regard to egress gateway bpf and Ginkgo tests.

Most of these changes are from https://github.com/cilium/cilium/pull/23448, as this feature has not been backported to v1.13.

This should help with the number of conflicts we have to deal with next time we need to backport something to v1.13