### PR TITLE
Introduce the support for specifying a CA bundle in the helm chart

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2239,7 +2239,7 @@
    * - tls
      - Configure TLS configuration in the agent.
      - object
-     - ``{"ca":{"cert":"","certValidityDuration":1095,"key":""},"secretsBackend":"local"}``
+     - ``{"ca":{"cert":"","certValidityDuration":1095,"key":""},"caBundle":{"enabled":false,"key":"ca.crt","name":"cilium-root-ca.crt"},"secretsBackend":"local"}``
    * - tls.ca
      - Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components. It is neither required nor used when cert-manager is used to generate the certificates.
      - object
@@ -2256,6 +2256,22 @@
      - Optional CA private key. If it is provided, it will be used by cilium to generate all other certificates. Otherwise, an ephemeral CA is generated.
      - string
      - ``""``
+   * - tls.caBundle
+     - Configure the CA trust bundle used for the validation of the certificates leveraged by hubble and clustermesh. When enabled, it overrides the content of the 'ca.crt' field of the respective certificates, allowing for CA rotation with no down-time.
+     - object
+     - ``{"enabled":false,"key":"ca.crt","name":"cilium-root-ca.crt"}``
+   * - tls.caBundle.enabled
+     - Enable the use of the CA trust bundle.
+     - bool
+     - ``false``
+   * - tls.caBundle.key
+     - Entry of the ConfigMap containing the CA trust bundle.
+     - string
+     - ``"ca.crt"``
+   * - tls.caBundle.name
+     - Name of the ConfigMap containing the CA trust bundle.
+     - string
+     - ``"cilium-root-ca.crt"``
    * - tls.secretsBackend
      - This configures how the Cilium agent loads the secrets used TLS-aware CiliumNetworkPolicies (namely the secrets referenced by terminatingTLS and originatingTLS). Possible values:   - local   - k8s
      - string

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2241,7 +2241,7 @@
      - object
      - ``{"ca":{"cert":"","certValidityDuration":1095,"key":""},"secretsBackend":"local"}``
    * - tls.ca
-     - Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components
+     - Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components. It is neither required nor used when cert-manager is used to generate the certificates.
      - object
      - ``{"cert":"","certValidityDuration":1095,"key":""}``
    * - tls.ca.cert

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -253,6 +253,7 @@ buildx
 busybox
 bytecode
 cBPF
+caBundle
 callee
 cancelled
 cardinality

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -609,11 +609,15 @@ contributors across the globe, there is almost always someone available to help.
 | svcSourceRangeCheck | bool | `true` | Enable check of service source ranges (currently, only for LoadBalancer). |
 | synchronizeK8sNodes | bool | `true` | Synchronize Kubernetes nodes to kvstore and perform CNP GC. |
 | terminationGracePeriodSeconds | int | `1` | Configure termination grace period for cilium-agent DaemonSet. |
-| tls | object | `{"ca":{"cert":"","certValidityDuration":1095,"key":""},"secretsBackend":"local"}` | Configure TLS configuration in the agent. |
+| tls | object | `{"ca":{"cert":"","certValidityDuration":1095,"key":""},"caBundle":{"enabled":false,"key":"ca.crt","name":"cilium-root-ca.crt"},"secretsBackend":"local"}` | Configure TLS configuration in the agent. |
 | tls.ca | object | `{"cert":"","certValidityDuration":1095,"key":""}` | Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components. It is neither required nor used when cert-manager is used to generate the certificates. |
 | tls.ca.cert | string | `""` | Optional CA cert. If it is provided, it will be used by cilium to generate all other certificates. Otherwise, an ephemeral CA is generated. |
 | tls.ca.certValidityDuration | int | `1095` | Generated certificates validity duration in days. This will be used for auto generated CA. |
 | tls.ca.key | string | `""` | Optional CA private key. If it is provided, it will be used by cilium to generate all other certificates. Otherwise, an ephemeral CA is generated. |
+| tls.caBundle | object | `{"enabled":false,"key":"ca.crt","name":"cilium-root-ca.crt"}` | Configure the CA trust bundle used for the validation of the certificates leveraged by hubble and clustermesh. When enabled, it overrides the content of the 'ca.crt' field of the respective certificates, allowing for CA rotation with no down-time. |
+| tls.caBundle.enabled | bool | `false` | Enable the use of the CA trust bundle. |
+| tls.caBundle.key | string | `"ca.crt"` | Entry of the ConfigMap containing the CA trust bundle. |
+| tls.caBundle.name | string | `"cilium-root-ca.crt"` | Name of the ConfigMap containing the CA trust bundle. |
 | tls.secretsBackend | string | `"local"` | This configures how the Cilium agent loads the secrets used TLS-aware CiliumNetworkPolicies (namely the secrets referenced by terminatingTLS and originatingTLS). Possible values:   - local   - k8s |
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | tunnel | string | `""` | Configure the encapsulation configuration for communication between nodes. Possible values:   - disabled   - vxlan (default)   - geneve |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -610,7 +610,7 @@ contributors across the globe, there is almost always someone available to help.
 | synchronizeK8sNodes | bool | `true` | Synchronize Kubernetes nodes to kvstore and perform CNP GC. |
 | terminationGracePeriodSeconds | int | `1` | Configure termination grace period for cilium-agent DaemonSet. |
 | tls | object | `{"ca":{"cert":"","certValidityDuration":1095,"key":""},"secretsBackend":"local"}` | Configure TLS configuration in the agent. |
-| tls.ca | object | `{"cert":"","certValidityDuration":1095,"key":""}` | Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components |
+| tls.ca | object | `{"cert":"","certValidityDuration":1095,"key":""}` | Base64 encoded PEM values for the CA certificate and private key. This can be used as common CA to generate certificates used by hubble and clustermesh components. It is neither required nor used when cert-manager is used to generate the certificates. |
 | tls.ca.cert | string | `""` | Optional CA cert. If it is provided, it will be used by cilium to generate all other certificates. Otherwise, an ephemeral CA is generated. |
 | tls.ca.certValidityDuration | int | `1095` | Generated certificates validity duration in days. This will be used for auto generated CA. |
 | tls.ca.key | string | `""` | Optional CA private key. If it is provided, it will be used by cilium to generate all other certificates. Otherwise, an ephemeral CA is generated. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -825,8 +825,17 @@ spec:
                 path: common-etcd-client.key
               - key: tls.crt
                 path: common-etcd-client.crt
+          {{- if not .Values.tls.caBundle.enabled }}
               - key: ca.crt
                 path: common-etcd-client-ca.crt
+          {{- else }}
+          - configMap:
+              name: {{ .Values.tls.caBundle.name }}
+              optional: true
+              items:
+              - key: {{ .Values.tls.caBundle.key }}
+                path: common-etcd-client-ca.crt
+          {{- end }}
       {{- if and .Values.ipMasqAgent .Values.ipMasqAgent.enabled }}
       - name: ip-masq-agent
         configMap:
@@ -871,12 +880,21 @@ spec:
               name: hubble-server-certs
               optional: true
               items:
-              - key: ca.crt
-                path: client-ca.crt
               - key: tls.crt
                 path: server.crt
               - key: tls.key
                 path: server.key
+          {{- if not .Values.tls.caBundle.enabled }}
+              - key: ca.crt
+                path: client-ca.crt
+          {{- else }}
+          - configMap:
+              name: {{ .Values.tls.caBundle.name }}
+              optional: true
+              items:
+              - key: {{ .Values.tls.caBundle.key }}
+                path: client-ca.crt
+          {{- end }}
       {{- end }}
       {{- range .Values.extraHostPathMounts }}
       - name: {{ .name }}

--- a/install/kubernetes/cilium/templates/cilium-ca-bundle-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ca-bundle-configmap.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.tls.caBundle.enabled .Values.tls.caBundle.content -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.tls.caBundle.name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  {{ .Values.tls.caBundle.key }}: |
+    {{- .Values.tls.caBundle.content | nindent 4 }}
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -189,15 +189,49 @@ spec:
         {{- end }}
       volumes:
       - name: etcd-server-secrets
-        secret:
-          secretName: clustermesh-apiserver-server-cert
+        projected:
           # note: the leading zero means this number is in octal representation: do not remove it
           defaultMode: 0400
+          sources:
+          - secret:
+              name: clustermesh-apiserver-server-cert
+              items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+          {{- if not .Values.tls.caBundle.enabled }}
+              - key: ca.crt
+                path: ca.crt
+          {{- else }}
+          - configMap:
+              name: {{ .Values.tls.caBundle.name }}
+              items:
+              - key: {{ .Values.tls.caBundle.key }}
+                path: ca.crt
+          {{- end }}
       - name: etcd-admin-client
-        secret:
-          secretName: clustermesh-apiserver-admin-cert
+        projected:
           # note: the leading zero means this number is in octal representation: do not remove it
           defaultMode: 0400
+          sources:
+          - secret:
+              name: clustermesh-apiserver-admin-cert
+              items:
+              - key: tls.crt
+                path: tls.crt
+              - key: tls.key
+                path: tls.key
+          {{- if not .Values.tls.caBundle.enabled }}
+              - key: ca.crt
+                path: ca.crt
+          {{- else }}
+          - configMap:
+              name: {{ .Values.tls.caBundle.name }}
+              items:
+              - key: {{ .Values.tls.caBundle.key }}
+                path: ca.crt
+          {{- end }}
       {{- if ne .Values.clustermesh.apiserver.tls.authMode "legacy" }}
       - name: etcd-users-config
         configMap:

--- a/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
@@ -1,6 +1,7 @@
 {{- define "clustermesh-config-generate-etcd-cfg" }}
 {{- $cluster := index . 0 -}}
 {{- $domain := index . 1 -}}
+{{- $hasCustomCACert := index . 2 -}}
 {{- /* The parenthesis around $cluster.tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
 {{- $prefix := ternary "common-" (printf "%s." $cluster.name) (or (empty ($cluster.tls).cert) (empty ($cluster.tls).key)) -}}
 
@@ -10,7 +11,12 @@ endpoints:
 {{- else }}
 - https://{{ $cluster.address | required "missing clustermesh.apiserver.config.clusters.address" }}:{{ $cluster.port }}
 {{- end }}
+{{- if $hasCustomCACert }}
+{{- /* The custom CA configuration takes effect only if a custom certificate and key are also set */}}
 trusted-ca-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client-ca.crt
+{{- else }}
+trusted-ca-file: /var/lib/cilium/clustermesh/common-etcd-client-ca.crt
+{{- end }}
 key-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client.key
 cert-file: /var/lib/cilium/clustermesh/{{ $prefix }}etcd-client.crt
 {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -7,10 +7,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   {{- range .Values.clustermesh.config.clusters }}
-  {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain) | b64enc }}
+  {{- $hasCustomCACert := or (.tls).caCert $.Values.clustermesh.apiserver.tls.ca.cert }}
+  {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $hasCustomCACert) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
   {{- if and (.tls).cert (.tls).key }}
+  {{- if $hasCustomCACert }}
   {{ .name }}.etcd-client-ca.crt: {{ .tls.caCert | default $.Values.clustermesh.apiserver.tls.ca.cert }}
+  {{- end }}
   {{ .name }}.etcd-client.key: {{ .tls.key }}
   {{ .name }}.etcd-client.crt: {{ .tls.cert }}
   {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -135,12 +135,20 @@ spec:
           - secret:
               name: hubble-relay-client-certs
               items:
-                - key: ca.crt
-                  path: hubble-server-ca.crt
                 - key: tls.crt
                   path: client.crt
                 - key: tls.key
                   path: client.key
+          {{- if not .Values.tls.caBundle.enabled }}
+                - key: ca.crt
+                  path: hubble-server-ca.crt
+          {{- else }}
+          - configMap:
+              name: {{ .Values.tls.caBundle.name }}
+              items:
+                - key: {{ .Values.tls.caBundle.key }}
+                  path: hubble-server-ca.crt
+          {{- end }}
           {{- if .Values.hubble.relay.tls.server.enabled }}
           - secret:
               name: hubble-relay-server-certs

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -167,12 +167,20 @@ spec:
           - secret:
               name: hubble-ui-client-certs
               items:
-                - key: ca.crt
-                  path: hubble-relay-ca.crt
                 - key: tls.crt
                   path: client.crt
                 - key: tls.key
                   path: client.key
+          {{- if not .Values.tls.caBundle.enabled }}
+                - key: ca.crt
+                  path: hubble-relay-ca.crt
+          {{- else }}
+          - configMap:
+              name: {{ .Values.tls.caBundle.name }}
+              items:
+                - key: {{ .Values.tls.caBundle.key }}
+                  path: hubble-relay-ca.crt
+          {{- end }}
       {{- end }}
       {{- end }}
       {{- with .Values.hubble.ui.frontend.extraVolumes }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1764,6 +1764,30 @@ tls:
     # -- Generated certificates validity duration in days. This will be used for auto generated CA.
     certValidityDuration: 1095
 
+  # -- Configure the CA trust bundle used for the validation of the certificates
+  # leveraged by hubble and clustermesh. When enabled, it overrides the content of the
+  # 'ca.crt' field of the respective certificates, allowing for CA rotation with no down-time.
+  caBundle:
+    # -- Enable the use of the CA trust bundle.
+    enabled: false
+
+    # -- Name of the ConfigMap containing the CA trust bundle.
+    name: cilium-root-ca.crt
+
+    # -- Entry of the ConfigMap containing the CA trust bundle.
+    key: ca.crt
+
+    # If uncommented, creates the ConfigMap and fills it with the specified content.
+    # Otherwise, the ConfigMap is assumed to be already present in .Release.Namespace.
+    #
+    # content: |
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+
 # -- Configure the encapsulation configuration for communication between nodes.
 # Possible values:
 #   - disabled

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1750,7 +1750,8 @@ tls:
   secretsBackend: local
 
   # -- Base64 encoded PEM values for the CA certificate and private key.
-  # This can be used as common CA to generate certificates used by hubble and clustermesh components
+  # This can be used as common CA to generate certificates used by hubble and clustermesh components.
+  # It is neither required nor used when cert-manager is used to generate the certificates.
   ca:
     # -- Optional CA cert. If it is provided, it will be used by cilium to
     # generate all other certificates. Otherwise, an ephemeral CA is generated.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1747,7 +1747,8 @@ tls:
   secretsBackend: local
 
   # -- Base64 encoded PEM values for the CA certificate and private key.
-  # This can be used as common CA to generate certificates used by hubble and clustermesh components
+  # This can be used as common CA to generate certificates used by hubble and clustermesh components.
+  # It is neither required nor used when cert-manager is used to generate the certificates.
   ca:
     # -- Optional CA cert. If it is provided, it will be used by cilium to
     # generate all other certificates. Otherwise, an ephemeral CA is generated.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1761,6 +1761,30 @@ tls:
     # -- Generated certificates validity duration in days. This will be used for auto generated CA.
     certValidityDuration: 1095
 
+  # -- Configure the CA trust bundle used for the validation of the certificates
+  # leveraged by hubble and clustermesh. When enabled, it overrides the content of the
+  # 'ca.crt' field of the respective certificates, allowing for CA rotation with no down-time.
+  caBundle:
+    # -- Enable the use of the CA trust bundle.
+    enabled: false
+
+    # -- Name of the ConfigMap containing the CA trust bundle.
+    name: cilium-root-ca.crt
+
+    # -- Entry of the ConfigMap containing the CA trust bundle.
+    key: ca.crt
+
+    # If uncommented, creates the ConfigMap and fills it with the specified content.
+    # Otherwise, the ConfigMap is assumed to be already present in .Release.Namespace.
+    #
+    # content: |
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+    #   -----BEGIN CERTIFICATE-----
+    #   ...
+    #   -----END CERTIFICATE-----
+
 # -- Configure the encapsulation configuration for communication between nodes.
 # Possible values:
 #   - disabled


### PR DESCRIPTION
This PR extends the helm chart to introduce the support for the specification of a CA trust bundle used for the validation of the certificates leveraged by hubble and clustermesh. If enabled, it overrides the content of the `ca.crt` field of the respective certificates, allowing for CA rotation with no down-time. The bundle can be either provided out-of-band, or created through Helm.

<!-- Description of change -->

```release-note
Introduce the support for specifying a CA bundle in the helm chart
```
