### PR TITLE
Add Lorenz Bauer to committers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -30,6 +30,7 @@ Everybody listed is a committer as per governance definition.
  * [Kornilios Kourtis] (Isovalent)
  * [Laurent Bernaille] (Datadog)
  * [Liz Rice] (Isovalent)
+ * [Lorenz Bauer] (Isovalent)
  * [Louis DeLosSantos] (Isovalent)
  * [Maciej Kwiek] (Isovalent)
  * [Martynas Pumputis] (Isovalent)
@@ -90,6 +91,7 @@ project.
 [Kornilios Kourtis]: https://github.com/kkourt
 [Laurent Bernaille]: https://github.com/lbernail
 [Liz Rice]: https://github.com/lizrice
+[Lorenz Bauer]: https://github.com/lmb
 [Louis DeLosSantos]: https://github.com/ldelossa
 [Maciej Kwiek]: https://github.com/nebril
 [Martynas Pumputis]: https://github.com/brb


### PR DESCRIPTION
The voting period for granting to commit access to  Lorenz Bauer (@lmb)
 initiated on 2023-03-29 is now closed with the following results:
YES: 26 (58%)
NO: 0 (0%)
ABSTAIN: 9 (20%)
With the company block vote limit applied:
YES: (24 / (24/6)) + 2 = 8 votes
NO: 0 votes
Based on these results committer status is granted and Lorenz will be added to the list of Cilium maintainers at the CNCF
