### PR TITLE
Document known kube-apiserver policy bug

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1209,6 +1209,14 @@ Deny policies do not support: policy enforcement at L7, i.e., specifically
 denying an URL and ``toFQDNs``, i.e., specifically denying traffic to a specific
 domain name.
 
+
+Known issues
+------------
+
+There is currently a known issue (:gh-issue:`24502`) that makes the ``kube-apiserver``
+entity unreliable. Until this is resolved, it is recommended to grant access to the apiserver
+by CIDR or by the special ``world`` entity.
+
 Previous limitations and known issues
 -------------------------------------
 


### PR DESCRIPTION
There is a known issue (#24502) that makes the `kube-apiserver` policy entity unreliable. Until we have a fix, document the workaround.
