### PR TITLE
agent, defaults: enable remote node identity by default

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -130,7 +130,7 @@ cilium-agent [flags]
       --enable-pmtu-discovery                                   Enable path MTU discovery to send ICMP fragmentation-needed replies to the client
       --enable-policy string                                    Enable policy enforcement (default "default")
       --enable-recorder                                         Enable BPF datapath pcap recorder
-      --enable-remote-node-identity                             Enable use of remote node identity
+      --enable-remote-node-identity                             Enable use of remote node identity (default true)
       --enable-runtime-device-detection                         Enable runtime device detection and datapath reconfiguration (experimental)
       --enable-sctp                                             Enable SCTP support (beta)
       --enable-service-topology                                 Enable support for service topology aware hints

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -452,7 +452,7 @@ const (
 	CertsDirectory = RuntimePath + "/certs"
 
 	// EnableRemoteNodeIdentity is the default value for option.EnableRemoteNodeIdentity
-	EnableRemoteNodeIdentity = false
+	EnableRemoteNodeIdentity = true
 
 	// IPAMExpiration is the timeout after which an IP subject to expiratio
 	// is being released again if no endpoint is being created in time.


### PR DESCRIPTION
We already set enable-remote-node-identity: true in the Helm charts [1] since it was introduced for Cilium 1.7, see commit 0b27e79340af ("helm: Enable remote-node identity for all new deployments by default").

Update the default value for the agent flag as well, so it is reflected in the flag usage.

[1] https://github.com/cilium/cilium/blob/95e091935d1b1d21925090858aa2cabfc239b1b3/install/kubernetes/cilium/values.yaml#L1726-L1728

```release-note
Remote node identities are enabled by default in the Cilium agent. They have already been enabled by default in the Helm charts since Cilium version 1.7.
```