### PR TITLE
init.sh,loader: load overlay programs in Go

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 # Copyright Authors of Cilium
 
-LIB=${1}
+# LIB=${1}
 RUNDIR=${2}
 PROCSYSNETDIR=${3}
 SYSCLASSNETDIR=${4}
@@ -23,13 +23,11 @@ MTU=${13}
 # BPFFS_ROOT=${17}
 NODE_PORT=${18}
 # NODE_PORT_BIND=${19}
-MCPU=${20}
-NR_CPUS=${21}
+# MCPU=${20}
+# NR_CPUS=${21}
 ENDPOINT_ROUTES=${22}
 PROXY_RULE=${23}
-FILTER_PRIO=${24}
-
-ID_WORLD=2
+# FILTER_PRIO=${24}
 
 # If the value below is changed, be sure to update bugtool/cmd/configuration.go
 # as well when dumping the routing table in bugtool. See GH-5828.
@@ -42,9 +40,6 @@ set -o pipefail
 
 # Remove old legacy files
 rm $RUNDIR/encap.state 2> /dev/null || true
-
-# This directory was created by the daemon and contains the per container header file
-DIR="$PWD/globals"
 
 function setup_dev()
 {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -18,7 +17,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command/exec"
-	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/ethtool"
@@ -315,7 +313,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		o.SetPrefilter(preFilter)
 	}
 
-	args[initArgLib] = option.Config.BpfDir
+	args[initArgLib] = "<nil>"
 	args[initArgRundir] = option.Config.StateDir
 
 	if option.Config.EnableIPv4 {
@@ -392,8 +390,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	args[initArgNodePortBind] = "<nil>"
 
-	args[initBPFCPU] = GetBPFCPU()
-	args[initArgNrCPUs] = fmt.Sprintf("%d", common.GetNumPossibleCPUs(log))
+	args[initBPFCPU] = "<nil>"
+	args[initArgNrCPUs] = "<nil>"
 
 	if option.Config.EnableEndpointRoutes {
 		args[initArgEndpointRoutes] = "true"
@@ -430,7 +428,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		args[initArgProxyRule] = "false"
 	}
 
-	args[initTCFilterPriority] = strconv.Itoa(int(option.Config.TCFilterPriority))
+	args[initTCFilterPriority] = "<nil>"
 
 	// "Legacy" datapath inizialization with the init.sh script
 	// TODO(mrostecki): Rewrite the whole init.sh in Go, step by step.

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -57,6 +57,10 @@ const (
 	xdpPrefix = "bpf_xdp"
 	xdpProg   = xdpPrefix + "." + string(outputSource)
 	xdpObj    = xdpPrefix + ".o"
+
+	overlayPrefix = "bpf_overlay"
+	overlayProg   = overlayPrefix + "." + string(outputSource)
+	overlayObj    = overlayPrefix + ".o"
 )
 
 var (
@@ -442,6 +446,46 @@ func compileNetwork(ctx context.Context) error {
 	// Write out assembly and preprocessing files for debugging purposes
 	if err := compile(ctx, networkTcProg, &dirs); err != nil {
 		scopedLog.WithField(logfields.Params, logfields.Repr(networkTcProg)).
+			WithError(err).Warn("Failed to compile")
+		return err
+	}
+	return nil
+}
+
+// compileOverlay compiles BPF programs in bpf_overlay.c.
+func compileOverlay(ctx context.Context, opts []string) error {
+	dirs := &directoryInfo{
+		Library: option.Config.BpfDir,
+		Runtime: option.Config.StateDir,
+		Output:  option.Config.StateDir,
+		State:   option.Config.StateDir,
+	}
+	scopedLog := log.WithField(logfields.Debug, true)
+
+	versionCmd := exec.CommandContext(ctx, compiler, "--version")
+	compilerVersion, err := versionCmd.CombinedOutput(scopedLog, true)
+	if err != nil {
+		return err
+	}
+	versionCmd = exec.CommandContext(ctx, linker, "--version")
+	linkerVersion, err := versionCmd.CombinedOutput(scopedLog, true)
+	if err != nil {
+		return err
+	}
+	scopedLog.WithFields(logrus.Fields{
+		compiler: string(compilerVersion),
+		linker:   string(linkerVersion),
+	}).Debug("Compiling overlay programs")
+
+	prog := &progInfo{
+		Source:     overlayProg,
+		Output:     overlayObj,
+		OutputType: outputObject,
+		Options:    opts,
+	}
+	// Write out assembly and preprocessing files for debugging purposes
+	if err := compile(ctx, prog, dirs); err != nil {
+		scopedLog.WithField(logfields.Params, logfields.Repr(prog)).
 			WithError(err).Warn("Failed to compile")
 		return err
 	}


### PR DESCRIPTION
```
With this commit we remove code from init.sh that compiles and loads 
programs from bpf_overlay.c. Without it init.sh isn't responsible for 
loading bpf programs anymore, therefore none of the remaining commands 
should depend on ciliums iproute2 fork.
```

Fixes: #20699
