### PR TITLE
renovate: Update Dockerfiles that use golang image weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -146,6 +146,19 @@
       ]
     },
     {
+      // Images that directly use docker.io/library/golang for building.
+      "groupName": "golang-images",
+      "matchFiles": [
+        "images/cilium-docker-plugin/Dockerfile",
+        "images/clustermesh-apiserver/Dockerfile",
+        "images/hubble-relay/Dockerfile",
+        "images/operator/Dockerfile"
+      ],
+      "schedule": [
+        "on friday"
+      ]
+    },
+    {
       "matchPackageNames": [
         "docker.io/library/ubuntu"
       ],


### PR DESCRIPTION
We added weekly schedule for the builder and runtime images in #24846. There are other Dockerfiles that directly use docker.io/library/golang for building (see #24861). Let's do the same weekly update for these images.