### PR TITLE
datapath: Remove 2005 route table for IPv6

### DIFF
--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -492,6 +492,16 @@ func testNodePort(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, bpfNodePort, 
 			getHTTPLink(ni.K8s2IP, data.Spec.Ports[0].NodePort),
 			getTFTPLink(ni.K8s2IP, data.Spec.Ports[1].NodePort),
 		}
+
+		if helpers.DualStackSupported() {
+			testURLsFromOutside = append(testURLsFromOutside,
+				getHTTPLink(ni.PrimaryK8s1IPv6, v6Data.Spec.Ports[0].NodePort),
+				getTFTPLink(ni.PrimaryK8s1IPv6, v6Data.Spec.Ports[1].NodePort),
+
+				getHTTPLink(ni.PrimaryK8s2IPv6, v6Data.Spec.Ports[0].NodePort),
+				getTFTPLink(ni.PrimaryK8s2IPv6, v6Data.Spec.Ports[1].NodePort),
+			)
+		}
 	}
 
 	count := 10


### PR DESCRIPTION
This reverts 3ed62d51d5ac27bbe2c60372850d4ec78c17bb6e for IPv6 part only, as issue #21954 has been resolved by #24208.

Another PR #24807  removes 2005 route table for IPv4.

Signed-off-by: Zhichuan Liang <gray.isovalent.com>

```release-note
Fix broken IPv6 connectivity from outside to NodePort service when L7 ingress policy applied by removing PROXY_RT route table.
```