### PR TITLE
bpf: nodeport: fix up trace point in to-overlay NAT paths

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1272,11 +1272,14 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 #if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
 	union v6addr addr = { .p1 = 0 };
 
-	obs_point = TRACE_TO_OVERLAY;
 	BPF_V6(addr, ROUTER_IP);
 #else
 	union v6addr addr = IPV6_DIRECT_ROUTING;
+#endif
 
+#ifdef IS_BPF_OVERLAY
+	obs_point = TRACE_TO_OVERLAY;
+#else
 	obs_point = TRACE_TO_NETWORK;
 #endif
 
@@ -1330,7 +1333,7 @@ int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 	int ret;
 	enum trace_point obs_point;
 
-#if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
+#ifdef IS_BPF_OVERLAY
 	obs_point = TRACE_TO_OVERLAY;
 #else
 	obs_point = TRACE_TO_NETWORK;
@@ -2494,7 +2497,7 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, 0);
 
-#if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
+#ifdef IS_BPF_OVERLAY
 	obs_point = TRACE_TO_OVERLAY;
 #else
 	obs_point = TRACE_TO_NETWORK;
@@ -2563,7 +2566,7 @@ int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, 0);
 
-#if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
+#ifdef IS_BPF_OVERLAY
 	obs_point = TRACE_TO_OVERLAY;
 #else
 	obs_point = TRACE_TO_NETWORK;


### PR DESCRIPTION
We have a number of cases (EgressGW, DSR-GENEVE) where the `to-overlay` program is used even when the cluster is in native routing mode.

But the trace points inside `handle_nat_fwd()` currently only report `TRACE_TO_OVERLAY` iff called from `IS_BPF_OVERLAY` *and* `routing-mode=tunnel`. Thus when in native routing mode, we get misleading trace notifications from inside `to-overlay` that report `TRACE_TO_NETWORK`.

Fix this by only checking for IS_BPF_OVERLAY when selecting the obs_point.