### PR TITLE
Fix permission issue when copying cni plugins onto host path

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -670,7 +670,9 @@ spec:
             cpu: 100m
             memory: 10Mi
         securityContext:
-          {{- if not .Values.securityContext.privileged }}
+          {{- if .Values.securityContext.privileged }}
+          privileged: true
+          {{- else }}
           seLinuxOptions:
             {{- with .Values.securityContext.seLinuxOptions }}
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Fix permission issue when copying cni plugins onto host path.

The root cause is that the init container 'install-cni-binaries' didn't have securityContext.privileged settings inside the yaml like other init containers do. It leads to that it failed to copy cni binaries onto the hostpath which has no root permisison.

Fixes: https://github.com/cilium/cilium/issues/24889

Signed-off-by: Joseph Sheng [jiajun.sheng@microfocus.com](mailto:jiajun.sheng@microfocus.com)