### PR TITLE
Backport warning about known policy bug to v1.13

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -314,6 +314,11 @@ Annotations:
   flushing the current state by running the following command on each node:
   ``ip xfrm state flush && ip xfrm policy flush``.
 
+* There is a known issue (:gh-issue:`24502`) with CiliumNetworkPolicies that
+  makes the ``kube-apiserver`` entity unreliable. Until this is resolved, 
+  it is recommended to grant access to the apiserver by CIDR or by the 
+  special ``world`` entity.
+
 1.13 Upgrade Notes
 ------------------
 * The code for the deprecated ``spec.eni.min-allocate``, ``spec.eni.pre-allocate``

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1279,6 +1279,11 @@ considered external to the cluster.
       - toFQDNs:
           - matchName: "www.google.com"
 
+
+There is currently a known issue (:gh-issue:`24502`) that makes the ``kube-apiserver``
+entity unreliable. Until this is resolved, it is recommended to grant access to the apiserver
+by CIDR or by the special ``world`` entity.
+
 .. _HostPolicies:
 
 Host Policies


### PR DESCRIPTION
This backports the warning from https://github.com/cilium/cilium/pull/24868, as well as adding it to the upgrade notes.