### PR TITLE
egressgw: policy: stop iterating through nodes after first match

### DIFF
--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -125,6 +125,8 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 				logger.WithError(err).Error("Failed to derive policy gateway configuration")
 			}
 		}
+
+		break
 	}
 
 	config.gatewayConfig = gwc


### PR DESCRIPTION
in regenerateGatewayConfig(), once a node that matches the given policy is found, there's no need to keep iterating through the rest of the nodes, so let's just return to the caller