### PR TITLE
docs: Add APAC timezone meeting to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -288,14 +288,14 @@ Special Interest Groups (SIG)
 See `Special Interest groups
 <https://docs.cilium.io/en/stable/community/community/#special-interest-groups>`_ for a list of all SIGs and their meeting times.
 
-Weekly Developer meeting
-------------------------
-* The developer community is hanging out on zoom on a weekly basis to chat.
-  Everybody is welcome.
+Developer meetings
+------------------
+The Cilium developer community hangs out on Zoom to chat. Everybody is welcome.
+
 * Weekly, Wednesday,
   5:00 pm `Europe/Zurich time <https://time.is/Canton_of_Zurich>`__ (CET/CEST),
-  usually equivalent to 8:00 am PT, or 11:00 am ET.
-* `Join zoom <https://zoom.us/j/596609673>`_
+  usually equivalent to 8:00 am PT, or 11:00 am ET. `Join zoom <https://zoom.us/j/596609673>`_
+* Third Wednesday of each month, 9:00 am `Japan time <https://time.is/Tokyo>`__ (JST). `Join zoom <https://zoom.us/j/596609673>`_
 
 eBPF & Cilium Office Hours livestream
 -------------------------------------


### PR DESCRIPTION
Per [this Slack discussion](https://cilium.slack.com/archives/C2B917YHE/p1680632495766459)