### PR TITLE
bpf/wireguard: always lookup src identity

### DIFF
--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -48,9 +48,7 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 		}
 #endif
 		dst = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
-#ifndef ENABLE_NODE_ENCRYPTION
 		src = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
-#endif /* ENABLE_NODE_ENCRYPTION */
 		break;
 #endif
 #ifdef ENABLE_IPV4
@@ -58,9 +56,7 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
 		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
-#ifndef ENABLE_NODE_ENCRYPTION
 		src = lookup_ip4_remote_endpoint(ip4->saddr, 0);
-#endif /* ENABLE_NODE_ENCRYPTION */
 		break;
 #endif
 	default:


### PR DESCRIPTION
When WireGuard node encryption is enabled, src is never set. Therefore, the unguarded check in line 97 always evaluates to true and no traffic is encrypted.

This commit fixes this bug by always looking up the src identity, independent of if WireGuard node encryption is enabled or not.

Fixes: 17419c9 ("bpf/wireguard: Skip encryption for cluster-external traffic")

<!-- Description of change -->

When WireGuard node encryption is enabled, src is never set. Therefore, the unguarded check in line 97 always evaluates to true and no traffic is encrypted.

This commit fixes this bug by always looking up the src identity, independent of if WireGuard node encryption is enabled or not.

I didn't (re-) add any tests, since they only recently were moved from `test/k8s` into the ci. Note, that the deleted WireGuard Pod2pod ecryption tests (in `test/k8s/datapath_configuration`) successfully find the issue by additionally enabling node encryption in the helm values.

Note that this bug didn't make it into any release.
```release-note
Fix bug that causes traffic not to be encrypted when WireGuard node encryption is enabled.
```
