### PR TITLE
feat: use bgp router annotations from node when creating cilium node

### DIFF
--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -115,6 +115,10 @@ const (
 	// traffic to that node.
 	WireguardPubKey      = NetworkPrefix + "/wg-pub-key"
 	WireguardPubKeyAlias = Prefix + ".network.wg-pub-key"
+
+	// BGPVRouterAnnoPrefix is the prefix used for all Virtual Router annotations
+	// Its just a prefix, because the ASN of the Router is part of the annotation itself
+	BGPVRouterAnnoPrefix = "cilium.io/bgp-virtual-router."
 )
 
 // Get returns the annotation value associated with the given key, or any of

--- a/pkg/bgpv1/agent/annotations.go
+++ b/pkg/bgpv1/agent/annotations.go
@@ -9,10 +9,8 @@ import (
 	"net"
 	"strconv"
 	"strings"
-)
 
-const (
-	BGPVRouterAnnoPrefix = "cilium.io/bgp-virtual-router."
+	"github.com/cilium/cilium/pkg/annotation"
 )
 
 // ErrNotVRouterAnno is an error returned from parseAnnotation() when the
@@ -137,7 +135,7 @@ func NewAnnotationMap(a map[string]string) (AnnotationMap, error) {
 func parseAnnotation(key string, value string) (int, Attributes, error) {
 	var out Attributes
 	// is this an annotation we care about?
-	if !strings.HasPrefix(key, BGPVRouterAnnoPrefix) {
+	if !strings.HasPrefix(key, annotation.BGPVRouterAnnoPrefix) {
 		return 0, out, ErrNotVRouterAnno{key}
 	}
 

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net"
 	"path"
+	"strings"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -127,6 +128,13 @@ func (n *Node) ToCiliumNode() *ciliumv2.CiliumNode {
 
 	if n.WireguardPubKey != "" {
 		annotations[annotation.WireguardPubKey] = n.WireguardPubKey
+	}
+
+	// if we use a cilium node instead of a node, we also need the BGP Control Plane annotations in the cilium node instead of the main node
+	for k, a := range n.Annotations {
+		if strings.HasPrefix(k, "cilium.io/bgp-virtual-router.") {
+			annotations[k] = a
+		}
 	}
 
 	return &ciliumv2.CiliumNode{

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -132,7 +132,7 @@ func (n *Node) ToCiliumNode() *ciliumv2.CiliumNode {
 
 	// if we use a cilium node instead of a node, we also need the BGP Control Plane annotations in the cilium node instead of the main node
 	for k, a := range n.Annotations {
-		if strings.HasPrefix(k, "cilium.io/bgp-virtual-router.") {
+		if strings.HasPrefix(k, annotation.BGPVRouterAnnoPrefix) {
 			annotations[k] = a
 		}
 	}

--- a/pkg/node/types/node_test.go
+++ b/pkg/node/types/node_test.go
@@ -197,6 +197,9 @@ func (s *NodeSuite) TestNode_ToCiliumNode(c *C) {
 		IPv6IngressIP:           net.ParseIP("c0de::2"),
 		NodeIdentity:            uint32(12345),
 		WireguardPubKey:         "6kiIGGPvMiadJ1brWTVfSGXheE3e3k5GjDTxfjMLYx8=",
+		Annotations: map[string]string{
+			"cilium.io/bgp-virtual-router.64512": "router-id=172.0.0.3",
+		},
 	}
 
 	n := nodeResource.ToCiliumNode()
@@ -205,7 +208,8 @@ func (s *NodeSuite) TestNode_ToCiliumNode(c *C) {
 			Name:      "foo",
 			Namespace: "",
 			Annotations: map[string]string{
-				annotation.WireguardPubKey: "6kiIGGPvMiadJ1brWTVfSGXheE3e3k5GjDTxfjMLYx8=",
+				annotation.WireguardPubKey:           "6kiIGGPvMiadJ1brWTVfSGXheE3e3k5GjDTxfjMLYx8=",
+				"cilium.io/bgp-virtual-router.64512": "router-id=172.0.0.3",
 			},
 		},
 		Spec: ciliumv2.NodeSpec{

--- a/pkg/node/types/node_test.go
+++ b/pkg/node/types/node_test.go
@@ -198,7 +198,7 @@ func (s *NodeSuite) TestNode_ToCiliumNode(c *C) {
 		NodeIdentity:            uint32(12345),
 		WireguardPubKey:         "6kiIGGPvMiadJ1brWTVfSGXheE3e3k5GjDTxfjMLYx8=",
 		Annotations: map[string]string{
-			"cilium.io/bgp-virtual-router.64512": "router-id=172.0.0.3",
+			annotation.BGPVRouterAnnoPrefix + "64512": "router-id=172.0.0.3",
 		},
 	}
 
@@ -208,8 +208,8 @@ func (s *NodeSuite) TestNode_ToCiliumNode(c *C) {
 			Name:      "foo",
 			Namespace: "",
 			Annotations: map[string]string{
-				annotation.WireguardPubKey:           "6kiIGGPvMiadJ1brWTVfSGXheE3e3k5GjDTxfjMLYx8=",
-				"cilium.io/bgp-virtual-router.64512": "router-id=172.0.0.3",
+				annotation.WireguardPubKey:                "6kiIGGPvMiadJ1brWTVfSGXheE3e3k5GjDTxfjMLYx8=",
+				annotation.BGPVRouterAnnoPrefix + "64512": "router-id=172.0.0.3",
 			},
 		},
 		Spec: ciliumv2.NodeSpec{


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

When using cluster-pool, a new CiliumNode Resource is created. This also needs the BGP Control Plane Annotations if present. This PR copies the annotation from the Node to the CiliumNode at creation time.

```release-note
Use BGP Control Plane annotations from Node Resource for creation of CiliumNode Resource
```
