### PR TITLE
workflows/datapath: Fix always-passing step

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -434,7 +434,7 @@ jobs:
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./cilium-cli connectivity test --collect-sysdump-on-failure \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
-            ./contrib/scripts/kind-down.sh --keep-registry
+            ./contrib/scripts/kind-down.sh
 
       - name: Fetch artifacts
         if: ${{ !success() }}

--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -428,7 +428,7 @@ jobs:
             ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
 
             ./cilium-cli status --wait
-            kubectl -n kube-system exec -it daemonset/cilium  -- cilium status
+            kubectl -n kube-system exec daemonset/cilium -- cilium status
 
             ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"


### PR DESCRIPTION
First commit fixes an incorrect flag in the ConformanceDatapath workflow. Second commit fixes an always-passing step in the same workflow. See commits for details.

Passing run with test commit: https://github.com/cilium/cilium/actions/runs/4730060326/jobs/8393311157.

Fixes: https://github.com/cilium/cilium/pull/24296.