### PR TITLE
datapath: pass IPv6 NDP traffic to stack without policy check

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -743,7 +743,6 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	int ret;
 
 	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
@@ -751,11 +750,8 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
 	/* Handle special ICMPv6 NDP messages, and all remaining packets
 	 * are subjected to forwarding into the container.
 	 */
-	if (unlikely(is_icmp6_ndp(ctx, ip6, ETH_HLEN))) {
-		ret = icmp6_ndp_handle(ctx, ETH_HLEN, METRIC_EGRESS);
-		if (IS_ERR(ret))
-			return ret;
-	}
+	if (unlikely(is_icmp6_ndp(ctx, ip6, ETH_HLEN)))
+		return icmp6_ndp_handle(ctx, ETH_HLEN, METRIC_EGRESS);
 
 	if (unlikely(!is_valid_lxc_src_ip(ip6)))
 		return DROP_INVALID_SIP;
@@ -1636,6 +1632,11 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
 		ret = DROP_INVALID;
+		goto out;
+	}
+
+	if (unlikely(is_icmp6_ndp(ctx, ip6, ETH_HLEN))) {
+		ret = CTX_ACT_OK;
 		goto out;
 	}
 


### PR DESCRIPTION
Previously, our policy check for IPv6 NDP traffic caused issues such as #23852 and #23910 because this traffic was identified as WORLD_ID, which would be given a verdict of drop when CiliumNetworkPolicy is applied for per-endpoint routing.

To resolve this issue, we pass all IPv6 NDP traffic to the stack without policy check.

This change aligns with how we handle IPv4 ARP: the cilium bpf never performs policy check for ARP, regardless of whether we enable `ENABLE_ARP_PASSTHROUGH` or `ENABLE_ARP_RESPONDER`.

Fixes: #23852
Fixes: #23910

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>

```release-note
Bypassing policy check for IPv6 NDP to fix broken pod-to-pod connectivity when per-endpoint route is enabled with policy.
```
