### PR TITLE
bpf: remove special handle for ICMPv6 echo targeting router IPv6

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -25,11 +25,6 @@
 /* CB_PROXY_MAGIC overlaps with CB_ENCRYPT_MAGIC */
 #define ENCRYPT_OR_PROXY_MAGIC 0
 
-/* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_ECHO_REPLY section in
- * the bpf_lxc object file.
- */
-#define SKIP_ICMPV6_ECHO_HANDLING
-
 #ifndef VLAN_FILTER
 # define VLAN_FILTER(ifindex, vlan_id) return false;
 #endif

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -713,15 +713,11 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
 	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
-	/* Handle special ICMPv6 messages. This includes echo requests to the
-	 * logical router address, neighbour advertisements to the router.
-	 * All remaining packets are subjected to forwarding into the container.
+	/* Handle special ICMPv6 NDP messages, and all remaining packets
+	 * are subjected to forwarding into the container.
 	 */
-	if (unlikely(ip6->nexthdr == IPPROTO_ICMPV6)) {
-		if (data + sizeof(*ip6) + ETH_HLEN + sizeof(struct icmp6hdr) > data_end)
-			return DROP_INVALID;
-
-		ret = icmp6_handle(ctx, ETH_HLEN, ip6, METRIC_EGRESS);
+	if (unlikely(is_icmp6_ndp(ctx, ip6, ETH_HLEN))) {
+		ret = icmp6_ndp_handle(ctx, ETH_HLEN, METRIC_EGRESS);
 		if (IS_ERR(ret))
 			return ret;
 	}

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -14,11 +14,6 @@
  */
 #define SKIP_ICMPV6_NS_HANDLING
 
-/* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_ECHO_REPLY section in
- * the bpf_lxc object file.
- */
-#define SKIP_ICMPV6_ECHO_HANDLING
-
 /* Controls the inclusion of the CILIUM_CALL_SRV6 section in the object file.
  */
 #define SKIP_SRV6_HANDLING

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -21,11 +21,6 @@
  */
 #define SKIP_ICMPV6_HOPLIMIT_HANDLING
 
-/* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_ECHO_REPLY section in
- * the bpf_lxc object file.
- */
-#define SKIP_ICMPV6_ECHO_HANDLING
-
 /* Controls the inclusion of the CILIUM_CALL_SRV6 section in the object file.
  */
 #define SKIP_SRV6_HANDLING

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -78,7 +78,11 @@ enum {
 
 #define CILIUM_CALL_DROP_NOTIFY			1
 #define CILIUM_CALL_ERROR_NOTIFY		2
-#define CILIUM_CALL_SEND_ICMP6_ECHO_REPLY	3
+/*
+ * A gap in the macro numbering sequence was created by #24921.
+ * It can be reused for a new macro in the future, but caution is needed when
+ * backporting changes as it may conflict with older versions of the code.
+ */
 #define CILIUM_CALL_HANDLE_ICMP6_NS		4
 #define CILIUM_CALL_SEND_ICMP6_TIME_EXCEEDED	5
 #define CILIUM_CALL_ARP				6


### PR DESCRIPTION
Previously we don't have any network interface whose ipv6 is set to router ipv6, so the special handle for icmp6 echo whose destination address is router ipv6 was required, as kernel couldn't handle such icmp6 echo; but it's no more the case since PR #24208 was merged, now cilium_host has router ipv6 instead of native ipv6, making kernel capable of dealing with this icmp6.

Therefore, this commit removes code relevant to this special handle, including several functions such as icmp6_send_echo_reply, tail_icmp6_send_echo_reply, __icmp6_send_echo_reply.

Macro SKIP_ICMPV6_ECHO_HANDLING and CILIUM_CALL_SEND_ICMP6_ECHO_REPLY are also redundant and deleted.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>