### PR TITLE
ci: Mark skipped matrix workflows as successful

### DIFF
--- a/.github/workflows/conformance-datapath-v1.13.yaml
+++ b/.github/workflows/conformance-datapath-v1.13.yaml
@@ -135,6 +135,24 @@ jobs:
           state: pending
           target_url: ${{ env.check_url }}
 
+  skip-test-run:
+    # If the modified files are not relevant for this test then we can skip
+    # this test and mark it as successful.
+    if: github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'false'
+    runs-on: ubuntu-latest
+    needs: setup-report
+    name: Set commit status to success (skipped)
+    steps:
+      - name: Set commit status to success
+        uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ needs.setup-report.outputs.sha }}
+          context: ${{ github.workflow }}
+          description: Datapath tests skipped
+          state: success
+          target_url: ${{ env.check_url }}
+
   setup-and-test:
     runs-on: ubuntu-latest-4cores-16gb
     needs: setup-report

--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -138,6 +138,24 @@ jobs:
           state: pending
           target_url: ${{ env.check_url }}
 
+  skip-test-run:
+    # If the modified files are not relevant for this test then we can skip
+    # this test and mark it as successful.
+    if: github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'false'
+    runs-on: ubuntu-latest
+    needs: setup-report
+    name: Set commit status to success (skipped)
+    steps:
+      - name: Set commit status to success
+        uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+        with:
+          authToken: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ needs.setup-report.outputs.sha }}
+          context: ${{ github.workflow }}
+          description: Datapath tests skipped
+          state: success
+          target_url: ${{ env.check_url }}
+
   setup-and-test:
     runs-on: ubuntu-latest-4cores-16gb
     needs: setup-report


### PR DESCRIPTION
The ConformanceDatapath workflow did not properly set its status on GitHub if the test is skipped. This commit fixes that issue by copying over the `skip-test-run` job from ci-verifier and ci-clustermesh, which was missed when we introduced the separate status reporting jobs.

Fixes: https://github.com/cilium/cilium/issues/24915

Note that this cannot easily be tested with a `pull_request` target since it relies on the issue comment body, which will only be available once this PR has been merged to master.