### PR TITLE
Fix missed deletion events when reconnecting to/disconnecting from remote clusters

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -113,7 +113,7 @@ func (f *FakeRefcountingIdentityAllocator) Close() {
 func (f *FakeRefcountingIdentityAllocator) InitIdentityAllocator(versioned.Interface, k8sCache.Store) <-chan struct{} {
 	return nil
 }
-func (f *FakeRefcountingIdentityAllocator) WatchRemoteIdentities(string, kvstore.BackendOperations) (*allocator.RemoteCache, error) {
+func (f *FakeRefcountingIdentityAllocator) WatchRemoteIdentities(context.Context, string, kvstore.BackendOperations) (*allocator.RemoteCache, error) {
 	return nil, nil
 }
 

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -200,6 +200,19 @@ func (c *cache) stop() {
 	c.stopWatchWg.Wait()
 }
 
+// drain emits a deletion event for all known IDs. It must be called after the
+// cache has been stopped, to ensure that no new events can be received afterwards.
+func (c *cache) drain() {
+	// Make sure we wait until the watch loop has been properly stopped.
+	c.stopWatchWg.Wait()
+
+	c.mutex.Lock()
+	for id, key := range c.nextCache {
+		c.onDeleteLocked(id, key)
+	}
+	c.mutex.Unlock()
+}
+
 // drainIf emits a deletion event for all known IDs that are stale according to
 // the isStale function. It must be called after the cache has been stopped, to
 // ensure that no new events can be received afterwards.

--- a/pkg/allocator/logfields.go
+++ b/pkg/allocator/logfields.go
@@ -7,4 +7,5 @@ const (
 	fieldID     = "id"
 	fieldKey    = "key"
 	fieldRefCnt = "refcnt"
+	fieldRemote = "remote"
 )

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -116,7 +116,7 @@ type RemoteIdentityWatcher interface {
 	// WatchRemoteIdentities starts watching for identities in another kvstore and
 	// syncs all identities to the local identity cache. RemoteName should be unique
 	// unless replacing an existing remote's backend.
-	WatchRemoteIdentities(remoteName string, backend kvstore.BackendOperations) (*allocator.RemoteCache, error)
+	WatchRemoteIdentities(ctx context.Context, remoteName string, backend kvstore.BackendOperations) (*allocator.RemoteCache, error)
 
 	// RemoveRemoteIdentities removes any reference to a remote identity source.
 	RemoveRemoteIdentities(name string)

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -263,6 +263,8 @@ func (cm *ClusterMesh) newRemoteCluster(name, path string) *remoteCluster {
 		changed:     make(chan bool, configNotificationsChannelSize),
 		controllers: controller.NewManager(),
 		swg:         lock.NewStoppableWaitGroup(),
+
+		ipCacheWatcher: ipcache.NewIPIdentityWatcher(name, cm.ipcache),
 	}
 
 	return rc

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -120,8 +120,10 @@ func (rc *remoteCluster) releaseOldConnection() {
 	remoteNodes := rc.remoteNodes
 	rc.remoteNodes = nil
 
-	remoteIdentityCache := rc.remoteIdentityCache
-	rc.remoteIdentityCache = nil
+	if rc.remoteIdentityCache != nil {
+		rc.remoteIdentityCache.Close()
+		rc.remoteIdentityCache = nil
+	}
 
 	remoteServices := rc.remoteServices
 	rc.remoteServices = nil
@@ -145,9 +147,6 @@ func (rc *remoteCluster) releaseOldConnection() {
 		}
 		if remoteNodes != nil {
 			remoteNodes.Close(context.TODO())
-		}
-		if remoteIdentityCache != nil {
-			remoteIdentityCache.Close()
 		}
 		if remoteServices != nil {
 			remoteServices.Close(context.TODO())
@@ -236,7 +235,7 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				}
 				rc.swg.Stop()
 
-				remoteIdentityCache, err := allocator.WatchRemoteIdentities(rc.name, backend)
+				remoteIdentityCache, err := allocator.WatchRemoteIdentities(ctx, rc.name, backend)
 				if err != nil {
 					remoteServices.Close(ctx)
 					remoteNodes.Close(ctx)

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -444,7 +444,7 @@ func (m *CachingIdentityAllocator) ReleaseSlice(ctx context.Context, identities 
 // WatchRemoteIdentities starts watching for identities in another kvstore and
 // syncs all identities to the local identity cache. remoteName must be unique,
 // unless replacing the kvstore for an existing remote.
-func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, backend kvstore.BackendOperations) (*allocator.RemoteCache, error) {
+func (m *CachingIdentityAllocator) WatchRemoteIdentities(ctx context.Context, remoteName string, backend kvstore.BackendOperations) (*allocator.RemoteCache, error) {
 	<-m.globalIdentityAllocatorInitialized
 
 	remoteAllocatorBackend, err := kvstoreallocator.NewKVStoreBackend(m.identitiesPath, m.owner.GetNodeSuffix(), &key.GlobalIdentity{}, backend)
@@ -457,7 +457,7 @@ func (m *CachingIdentityAllocator) WatchRemoteIdentities(remoteName string, back
 		return nil, fmt.Errorf("unable to initialize remote Identity Allocator: %s", err)
 	}
 
-	return m.IdentityAllocator.WatchRemoteKVStore(remoteName, remoteAlloc), nil
+	return m.IdentityAllocator.WatchRemoteKVStore(ctx, remoteName, remoteAlloc)
 }
 
 func (m *CachingIdentityAllocator) RemoveRemoteIdentities(name string) {

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -616,8 +616,9 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 	c.Assert(err, IsNil)
 	a2, err := allocator.NewAllocator(TestAllocatorKey(""), backend2, allocator.WithMax(idpool.ID(256)))
 	c.Assert(err, IsNil)
-	rc := a.WatchRemoteKVStore("", a2)
+	rc, err := a.WatchRemoteKVStore(context.Background(), "", a2)
 	c.Assert(rc, Not(IsNil))
+	c.Assert(err, IsNil)
 
 	// wait for remote cache to be populated
 	c.Assert(testutils.WaitUntil(func() bool {

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -758,9 +758,9 @@ func (c *consulClient) Decode(in string) (out []byte, err error) {
 
 // ListAndWatch implements the BackendOperations.ListAndWatch using consul
 func (c *consulClient) ListAndWatch(ctx context.Context, name, prefix string, chanSize int) *Watcher {
-	w := newWatcher(name, prefix, chanSize)
+	w := newWatcher(name, prefix, chanSize, log)
 
-	log.WithField(fieldWatcher, w).Debug("Starting watcher...")
+	w.log.Debug("Starting watcher...")
 
 	go c.Watch(ctx, w)
 

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -946,10 +946,7 @@ func (e *etcdClient) Watch(ctx context.Context, w *Watcher) {
 		w.Stop()
 	}()
 
-	scopedLog := e.getLogger().WithFields(logrus.Fields{
-		fieldWatcher: w,
-		fieldPrefix:  w.Prefix,
-	})
+	scopedLog := w.log
 
 	err := <-e.Connected(ctx)
 	if err != nil {
@@ -1726,9 +1723,9 @@ func (e *etcdClient) Decode(in string) (out []byte, err error) {
 
 // ListAndWatch implements the BackendOperations.ListAndWatch using etcd
 func (e *etcdClient) ListAndWatch(ctx context.Context, name, prefix string, chanSize int) *Watcher {
-	w := newWatcher(name, prefix, chanSize)
+	w := newWatcher(name, prefix, chanSize, e.getLogger())
 
-	e.getLogger().WithField(fieldWatcher, w).Debug("Starting watcher...")
+	w.log.Debug("Starting watcher...")
 
 	go e.Watch(ctx, w)
 

--- a/pkg/kvstore/events_test.go
+++ b/pkg/kvstore/events_test.go
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstore
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestartableWatcherSuite(t *testing.T) {
+	rw := NewRestartableWatcher(10)
+
+	newWatcher := func() *Watcher {
+		watcher := Watcher{Events: make(EventChan, 10), stopWatch: make(stopChan), log: log}
+		go func() {
+			// This is required since we are not actually starting the watcher,
+			// which would take care of closing the Events channel when stopped.
+			<-watcher.stopWatch
+			close(watcher.Events)
+		}()
+		return &watcher
+	}
+
+	// Stopping and draining an uninitialized restastable watcher should emit the DrainDone event only.
+	rw.StopAndDrain()
+	require.Equal(t, KeyValueEvent{Typ: EventTypeDrainDone}, <-rw.Events)
+
+	watcher1 := newWatcher()
+	rw.Wrap(watcher1)
+
+	watcher1.Events <- KeyValueEvent{Typ: EventTypeCreate, Key: "foo"}
+	watcher1.Events <- KeyValueEvent{Typ: EventTypeCreate, Key: "bar"}
+	watcher1.Events <- KeyValueEvent{Typ: EventTypeCreate, Key: "baz"}
+	watcher1.Events <- KeyValueEvent{Typ: EventTypeListDone}
+	watcher1.Events <- KeyValueEvent{Typ: EventTypeModify, Key: "bar"}
+	watcher1.Events <- KeyValueEvent{Typ: EventTypeDelete, Key: "foo"}
+
+	// Assert that all events are properly propagated
+	require.Equal(t, KeyValueEvent{Typ: EventTypeCreate, Key: "foo"}, <-rw.Events)
+	require.Equal(t, KeyValueEvent{Typ: EventTypeCreate, Key: "bar"}, <-rw.Events)
+	require.Equal(t, KeyValueEvent{Typ: EventTypeCreate, Key: "baz"}, <-rw.Events)
+	require.Equal(t, KeyValueEvent{Typ: EventTypeListDone}, <-rw.Events)
+	require.Equal(t, KeyValueEvent{Typ: EventTypeModify, Key: "bar"}, <-rw.Events)
+	require.Equal(t, KeyValueEvent{Typ: EventTypeDelete, Key: "foo"}, <-rw.Events)
+
+	watcher2 := newWatcher()
+	rw.Wrap(watcher2)
+
+	watcher2.Events <- KeyValueEvent{Typ: EventTypeCreate, Key: "bar"}
+	watcher2.Events <- KeyValueEvent{Typ: EventTypeCreate, Key: "qux"}
+	watcher2.Events <- KeyValueEvent{Typ: EventTypeListDone}
+	watcher2.Events <- KeyValueEvent{Typ: EventTypeCreate, Key: "baz"}
+
+	// The "bar" key was already known, hence the event is converted to Modify.
+	require.Equal(t, KeyValueEvent{Typ: EventTypeModify, Key: "bar"}, <-rw.Events)
+	require.Equal(t, KeyValueEvent{Typ: EventTypeCreate, Key: "qux"}, <-rw.Events)
+	require.Equal(t, KeyValueEvent{Typ: EventTypeDelete, Key: "baz"}, <-rw.Events)
+	require.Equal(t, KeyValueEvent{Typ: EventTypeListDone}, <-rw.Events)
+	require.Equal(t, KeyValueEvent{Typ: EventTypeCreate, Key: "baz"}, <-rw.Events)
+
+	// Drain all remaining events. Given that they are spilled out from a map
+	// there is no ordering guarantee; hence, let's sort them before checking.
+	rw.CloseAndDrain()
+
+	var events []KeyValueEvent
+	events = append(events, <-rw.Events)
+	events = append(events, <-rw.Events)
+	events = append(events, <-rw.Events)
+	sort.Slice(events, func(i, j int) bool { return events[i].Key < events[j].Key })
+
+	require.Equal(t, KeyValueEvent{Typ: EventTypeDelete, Key: "bar"}, events[0])
+	require.Equal(t, KeyValueEvent{Typ: EventTypeDelete, Key: "baz"}, events[1])
+	require.Equal(t, KeyValueEvent{Typ: EventTypeDelete, Key: "qux"}, events[2])
+
+	select {
+	case _, ok := <-rw.Events:
+		require.False(t, ok, "The Events channel should have been closed")
+	default:
+		require.Fail(t, "The Events channel should have been closed")
+	}
+}

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -292,7 +292,7 @@ func (s *SharedStore) Stop() {
 // kvstore intact
 func (s *SharedStore) Release() {
 	if s.kvstoreWatcher != nil {
-		s.kvstoreWatcher.Stop()
+		s.kvstoreWatcher.Close()
 	}
 
 	controllers.RemoveControllerAndWait(s.controllerName)

--- a/pkg/kvstore/watcher_cache.go
+++ b/pkg/kvstore/watcher_cache.go
@@ -9,8 +9,8 @@ type watchState struct {
 
 type watcherCache map[string]watchState
 
-func (wc watcherCache) Exists(key []byte) bool {
-	if _, ok := wc[string(key)]; ok {
+func (wc watcherCache) Exists(key string) bool {
+	if _, ok := wc[key]; ok {
 		return true
 	}
 
@@ -32,10 +32,10 @@ func (wc watcherCache) MarkAllForDeletion() {
 	}
 }
 
-func (wc watcherCache) MarkInUse(key []byte) {
+func (wc watcherCache) MarkInUse(key string) {
 	wc[string(key)] = watchState{deletionMark: false}
 }
 
-func (wc watcherCache) RemoveKey(key []byte) {
-	delete(wc, string(key))
+func (wc watcherCache) RemoveKey(key string) {
+	delete(wc, key)
 }


### PR DESCRIPTION
Currently, restarting the connection to remote clusters leaves a time window in which possible deletion events are missed, and never recovered once the new watchers are started. Similarly, the status is not properly cleaned-up when removing one remote cluster from the clustermesh configuration. This PR fixes these two issues. 

Please, refer to the individual commits for more details.  

I've currently marked this PR as backport for the current stable version (i.e., v1.13). I've also marked it as `backport/author` due to the conflicts concerning IPCache modifications with https://github.com/cilium/cilium/pull/22935, which was not present in v1.13 and earlier. 

<!-- Description of change -->

Fixes: #24740

```release-note
Fix missed deletion events when reconnecting to/disconnecting from remote clusters
```
