### PR TITLE
Avoid clearing objects in CiliumEndpoint conversion funcs

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -941,7 +941,6 @@ func ConvertToCiliumEndpoint(obj interface{}) interface{} {
 			Networking: concreteObj.Status.Networking,
 			NamedPorts: concreteObj.Status.NamedPorts,
 		}
-		*concreteObj = cilium_v2.CiliumEndpoint{}
 		return p
 	case cache.DeletedFinalStateUnknown:
 		ciliumEndpoint, ok := concreteObj.Obj.(*cilium_v2.CiliumEndpoint)
@@ -974,7 +973,6 @@ func ConvertToCiliumEndpoint(obj interface{}) interface{} {
 				NamedPorts: ciliumEndpoint.Status.NamedPorts,
 			},
 		}
-		*ciliumEndpoint = cilium_v2.CiliumEndpoint{}
 		return dfsu
 	default:
 		return obj


### PR DESCRIPTION
This removes the behavior of mutating the objects received from the client-go library. To begin with there isn't really any benefit from doing so, given we don't store the object afterwards, and it will be ready for gc when it leaves the scope inside client-go. client-go can possibly return the same pointer twice here, to trigger eg. both an object update delta and then a DeletedFinalStateUnknown delta with the same pointer.

For more info, see the issue 115658 in the kubernetes/kubernetes repo on github.

Follow-up of: 74307f175ceb ("Avoid clearing objects in conversion funcs")