### PR TITLE
jenkins: bump timeout to 210 minutes

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -199,7 +199,7 @@ pipeline {
         }
         stage ("BDD-Test-PR"){
             options {
-                timeout(time: 180, unit: 'MINUTES')
+                timeout(time: 210, unit: 'MINUTES')
             }
             environment {
                 KUBECONFIG="${TESTDIR}/vagrant-kubeconfig"


### PR DESCRIPTION
The net-next test has been timing out at the 2h50m mark. We need to increase its timeout in order to avoid such failures.