### PR TITLE
treewide: Fix code comment stutters

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -439,7 +439,7 @@ type AllocatorKey interface {
 	// GetKey returns the canonical string representation of the key
 	GetKey() string
 
-	// PutKey stores the information in v into the key. This is is the inverse
+	// PutKey stores the information in v into the key. This is the inverse
 	// operation to GetKey
 	PutKey(v string) AllocatorKey
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
@@ -240,7 +240,7 @@ spec:
                   addressing:
                     description: IP4/6 addresses assigned to this Endpoint
                     items:
-                      description: AddressPair is a par of IPv4 and/or IPv6 address.
+                      description: AddressPair is a pair of IPv4 and/or IPv6 address.
                       properties:
                         ipv4:
                           type: string

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
@@ -240,7 +240,7 @@ spec:
                   addressing:
                     description: IP4/6 addresses assigned to this Endpoint
                     items:
-                      description: AddressPair is is a par of IPv4 and/or IPv6 address.
+                      description: AddressPair is a par of IPv4 and/or IPv6 address.
                       properties:
                         ipv4:
                           type: string

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml
@@ -78,7 +78,7 @@ spec:
                     addressing:
                       description: IP4/6 addresses assigned to this Endpoint
                       items:
-                        description: AddressPair is is a par of IPv4 and/or IPv6 address.
+                        description: AddressPair is a par of IPv4 and/or IPv6 address.
                         properties:
                           ipv4:
                             type: string

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumendpointslices.yaml
@@ -78,7 +78,7 @@ spec:
                     addressing:
                       description: IP4/6 addresses assigned to this Endpoint
                       items:
-                        description: AddressPair is a par of IPv4 and/or IPv6 address.
+                        description: AddressPair is a pair of IPv4 and/or IPv6 address.
                         properties:
                           ipv4:
                             type: string

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -255,7 +255,7 @@ type CiliumIdentityList struct {
 
 // +k8s:deepcopy-gen=false
 
-// AddressPair is is a par of IPv4 and/or IPv6 address.
+// AddressPair is a par of IPv4 and/or IPv6 address.
 type AddressPair struct {
 	IPV4 string `json:"ipv4,omitempty"`
 	IPV6 string `json:"ipv6,omitempty"`

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -255,7 +255,7 @@ type CiliumIdentityList struct {
 
 // +k8s:deepcopy-gen=false
 
-// AddressPair is a par of IPv4 and/or IPv6 address.
+// AddressPair is a pair of IPv4 and/or IPv6 address.
 type AddressPair struct {
 	IPV4 string `json:"ipv4,omitempty"`
 	IPV6 string `json:"ipv6,omitempty"`


### PR DESCRIPTION
It is is common to accidentally introduce a small stutter into code
comments like this and not realize until much later. Fix it.
