### PR TITLE
ingress: Add ownerReferences for shared mode

### DIFF
--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -557,6 +557,7 @@ func (ic *Controller) createEnvoyConfig(cec *ciliumv2.CiliumEnvoyConfig) error {
 		// Update existing CEC
 		newEnvoyConfig := existingEnvoyConfig.DeepCopy()
 		newEnvoyConfig.Spec = cec.Spec
+		newEnvoyConfig.OwnerReferences = cec.OwnerReferences
 		_, err = ic.clientset.CiliumV2().CiliumEnvoyConfigs(cec.GetNamespace()).Update(context.Background(), newEnvoyConfig, metav1.UpdateOptions{})
 		if err != nil {
 			log.WithError(err).Error("Failed to update CiliumEnvoyConfig for ingress")

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -54,15 +54,6 @@ func (d *DedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 
 	// Set the name to avoid any breaking change during upgrade.
 	cec.Name = fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, namespace, m.HTTP[0].Sources[0].Name)
-	// Set the owner reference to the CEC object.
-	cec.OwnerReferences = []metav1.OwnerReference{
-		{
-			APIVersion: m.HTTP[0].Sources[0].Version,
-			Kind:       m.HTTP[0].Sources[0].Kind,
-			Name:       m.HTTP[0].Sources[0].Name,
-			UID:        types.UID(m.HTTP[0].Sources[0].UID),
-		},
-	}
 	return cec, getService(m.HTTP[0].Sources[0], m.HTTP[0].Service), getEndpoints(m.HTTP[0].Sources[0]), err
 }
 

--- a/operator/pkg/model/translation/translator.go
+++ b/operator/pkg/model/translation/translator.go
@@ -10,6 +10,7 @@ import (
 	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -65,6 +66,22 @@ func (i *defaultTranslator) Translate(model *model.Model) (*ciliumv2.CiliumEnvoy
 	cec.Spec.Services = i.getServices(model)
 	cec.Spec.Resources = i.getResources(model)
 
+	ownerReferences := make([]metav1.OwnerReference, 0, len(model.HTTP))
+	uniqueMap := map[string]struct{}{}
+	for _, h := range model.HTTP {
+		key := fmt.Sprintf("%s/%s/%s", h.Sources[0].Version, h.Sources[0].Kind, h.Sources[0].Name)
+		if _, exists := uniqueMap[key]; exists {
+			continue
+		}
+		uniqueMap[key] = struct{}{}
+		ownerReferences = append(ownerReferences, metav1.OwnerReference{
+			APIVersion: h.Sources[0].Version,
+			Kind:       h.Sources[0].Kind,
+			Name:       h.Sources[0].Name,
+			UID:        types.UID(h.Sources[0].UID),
+		})
+	}
+	cec.OwnerReferences = ownerReferences
 	return cec, nil, nil, nil
 }
 


### PR DESCRIPTION
This commit is to make sure that you have all required ownerReferences for shared CEC, which can be useful for debugging purposes (i.e. find out which cross namespace Ingress resources). Unit test fixtures are already having owner reference information.
