### PR TITLE
enabled logOptions in the helm chart

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1515,8 +1515,8 @@ localRedirectPolicy: false
 # labels: ""
 
 # logOptions allows you to define logging options. eg:
-# logOptions:
-#   format: json
+logOptions:
+  format: json
 
 # -- Enables periodic logging of system load
 logSystemLoad: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1512,8 +1512,8 @@ localRedirectPolicy: false
 # labels: ""
 
 # logOptions allows you to define logging options. eg:
-# logOptions:
-#   format: json
+logOptions:
+  format: json
 
 # -- Enables periodic logging of system load
 logSystemLoad: false


### PR DESCRIPTION
## Changes
Enable again logOptions on the helm chart. I'm not sure why in the past was comment out but on the code still available:

https://github.com/cilium/cilium/blob/master/pkg/logging/logging.go#L103