### PR TITLE
treewide: use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/.github/gcp-vm-startup.sh
+++ b/.github/gcp-vm-startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 apt-get update
 apt-get install -y --no-install-recommends \

--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 

--- a/.travis/prepare.sh
+++ b/.travis/prepare.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CLANG_VERSION=10.0.0
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -1,7 +1,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-SHELL := /bin/bash
+SHELL := /usr/bin/env bash
 .SHELLFLAGS := -eu -o pipefail -c
 
 # define a function replacing spaces with commas in a list

--- a/contrib/ansible/run.sh
+++ b/contrib/ansible/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ansible-playbook -u vagrant --skip-tags=common:delete site.yml
 ansible-playbook -u vagrant --tags=common:delete site.yml

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 # Copyright Authors of Cilium

--- a/contrib/backporting/cherry-pick
+++ b/contrib/backporting/cherry-pick
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 source $(dirname $(readlink -ne $BASH_SOURCE))/common.sh

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/backporting/start-backport
+++ b/contrib/backporting/start-backport
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/coccinelle/check-cocci.sh
+++ b/contrib/coccinelle/check-cocci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o pipefail

--- a/contrib/gofat/gofat
+++ b/contrib/gofat/gofat
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 eval `go build -work -a 2>&1`
 find $WORK -type f -name "*.a" | xargs -I{} du -hxs "{}" | sort -rh | sed s@_pkg_.a@importcfg@g | xargs -I{} echo {} | awk '{print $1; system("bash -c '\''grep importmap "$2" | head -1'\''")}'

--- a/contrib/k8s/k8s-cilium-exec.sh
+++ b/contrib/k8s/k8s-cilium-exec.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/k8s/k8s-extract-clustermesh-nodeport-secret.sh
+++ b/contrib/k8s/k8s-extract-clustermesh-nodeport-secret.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/k8s/k8s-get-cilium-pod.sh
+++ b/contrib/k8s/k8s-get-cilium-pod.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/k8s/k8s-heap-dump.sh
+++ b/contrib/k8s/k8s-heap-dump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/k8s/k8s-import-clustermesh-secrets.sh
+++ b/contrib/k8s/k8s-import-clustermesh-secrets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/k8s/k8s-unmanaged.sh
+++ b/contrib/k8s/k8s-unmanaged.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/policy-watcher/cilium-policy-watcher
+++ b/contrib/policy-watcher/cilium-policy-watcher
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/policy-watcher/post-merge
+++ b/contrib/policy-watcher/post-merge
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
 

--- a/contrib/release/bump-docker-stable.sh
+++ b/contrib/release/bump-docker-stable.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/release/lib/common.sh
+++ b/contrib/release/lib/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/contrib/release/lib/gitlib.sh
+++ b/contrib/release/lib/gitlib.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 #

--- a/contrib/release/post-release.sh
+++ b/contrib/release/post-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/release/pull-docker-manifests.sh
+++ b/contrib/release/pull-docker-manifests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/release/submit-release.sh
+++ b/contrib/release/submit-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/scripts/add_vagrant_box.sh
+++ b/contrib/scripts/add_vagrant_box.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/contrib/scripts/bugtool-multinode-gather.sh
+++ b/contrib/scripts/bugtool-multinode-gather.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage
 # ./bugtool-multinode-gather.sh <OUTPUT_DIR> <NAMESPACE> <LABEL> <OUTPUT_ARCHIVE>

--- a/contrib/scripts/check-assert-deep-equals.sh
+++ b/contrib/scripts/check-assert-deep-equals.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # check-assert-deep-equals.sh checks whether DeepEquals checker from
 # pkg/checker is used every time instead of the checker from gopkg.in/check.v1.

--- a/contrib/scripts/check-logging-subsys-field.sh
+++ b/contrib/scripts/check-logging-subsys-field.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # check-logging-subsys-field.sh checks whether all logging entry instancs
 # created from DefaultLogger contain the LogSubsys field. This is required for

--- a/contrib/scripts/check-preflight-clusterrole.sh
+++ b/contrib/scripts/check-preflight-clusterrole.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd install/kubernetes/cilium/templates
 echo "Checking for differences between preflight and agent clusterrole"

--- a/contrib/scripts/check-viper.sh
+++ b/contrib/scripts/check-viper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/scripts/custom-vet-check.sh
+++ b/contrib/scripts/custom-vet-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/scripts/extract_authors.sh
+++ b/contrib/scripts/extract_authors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Ensure sort order doesn't depend on locale
 export LANG=en_US.UTF-8

--- a/contrib/scripts/go-mod-update-cloud-providers.sh
+++ b/contrib/scripts/go-mod-update-cloud-providers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script updates all vendored cloud provider SDK Go modules to their latest
 # version.

--- a/contrib/scripts/jenkins-failures.sh
+++ b/contrib/scripts/jenkins-failures.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 

--- a/contrib/scripts/kind-shell-helpers.sh
+++ b/contrib/scripts/kind-shell-helpers.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Here are a set of functions designed to be sourced into your shell.
 # They implement commands which build, push, and install the Cilium agent and

--- a/contrib/scripts/lock-check.sh
+++ b/contrib/scripts/lock-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/scripts/print-chart-version.sh
+++ b/contrib/scripts/print-chart-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC2001
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )

--- a/contrib/scripts/push_manifest.sh
+++ b/contrib/scripts/push_manifest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 IMAGE_NAME=${1:-}

--- a/contrib/scripts/quarantine.sh
+++ b/contrib/scripts/quarantine.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail

--- a/contrib/scripts/rand-check.sh
+++ b/contrib/scripts/rand-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/shell/test.sh
+++ b/contrib/shell/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/contrib/shell/util.sh
+++ b/contrib/shell/util.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2016 The Kubernetes Authors All rights reserved.
 # Copyright Authors of Cilium
 #

--- a/contrib/testing/integrations.sh
+++ b/contrib/testing/integrations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 

--- a/contrib/vagrant/build.sh
+++ b/contrib/vagrant/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/examples/kubernetes-cassandra/cass-populate-tables.sh
+++ b/examples/kubernetes-cassandra/cass-populate-tables.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 CASS_SERVER_POD=$(kubectl get pods -l app=cass-server -o jsonpath='{.items[0].metadata.name}')
 

--- a/examples/kubernetes-kafka/kafka-sw-gen-traffic.sh
+++ b/examples/kubernetes-kafka/kafka-sw-gen-traffic.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 
 HQ_POD=$(kubectl get pods -l app=empire-hq -o jsonpath='{.items[0].metadata.name}')

--- a/examples/kubernetes-memcached/memcd-env.sh
+++ b/examples/kubernetes-memcached/memcd-env.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 #define ENV variables for memcached demo
 MEMCD_SERVER_POD=$(kubectl get pods -l app=memcd-server -o jsonpath='{.items[0].metadata.name}')
 AWING_POD=$(kubectl get pods -l app=a-wing -o jsonpath='{.items[0].metadata.name}')

--- a/test/archive_test_results.sh
+++ b/test/archive_test_results.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd ${WORKSPACE}/test
 

--- a/test/archive_test_results_eks.sh
+++ b/test/archive_test_results_eks.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 

--- a/test/bigtcp/test.sh
+++ b/test/bigtcp/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/test/bpf/probes-test.sh
+++ b/test/bpf/probes-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 

--- a/test/eks/release-cluster.sh
+++ b/test/eks/release-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/eks/select-cluster.sh
+++ b/test/eks/select-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/envoy/envoy-smoke-test.sh
+++ b/test/envoy/envoy-smoke-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 source "${dir}/helpers.bash"

--- a/test/fuzzing/oss-fuzz-build.sh
+++ b/test/fuzzing/oss-fuzz-build.sh
@@ -1,4 +1,6 @@
-#/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 # The oss-fuzz-build.sh is meant to only be run inside the OSS-Fuzz build environment.
 # In that environment, the fuzzers are built with go build which does not include _test.go files

--- a/test/get-vagrant-kubeconfig.sh
+++ b/test/get-vagrant-kubeconfig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/gke/create-cluster.sh
+++ b/test/gke/create-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ "$#" != 1 ]; then
     >&2 printf "Illegal number of parameters\n"

--- a/test/gke/release-cluster.sh
+++ b/test/gke/release-cluster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/test/k8s/manifests/frr.yaml.tmpl
+++ b/test/k8s/manifests/frr.yaml.tmpl
@@ -17,7 +17,7 @@ spec:
       - "/bin/sh"
       - "-c"
       - |
-        #!/bin/bash
+        #!/usr/bin/env bash
 
         set -o errexit
         set -o pipefail

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -73,7 +73,7 @@ func testCommand(cmd string, count, fails int) string {
 	// Note: All newlines and the following whitespace is removed from the script below.
 	//       This requires explicit semicolons also at the ends of lines!
 	return trimNewlines(fmt.Sprintf(
-		`/bin/bash -c
+		`/usr/bin/env bash -c
 			'fails="";
 			id=$RANDOM;
 			for i in $(seq 1 %d); do

--- a/test/kubernetes-netperftest.sh
+++ b/test/kubernetes-netperftest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export PROMETHEUS_URL="$1"
 export PROMETHEUS_USR="$2"

--- a/test/kubernetes-test.sh
+++ b/test/kubernetes-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Comment for the '--set identityChangeGracePeriod="0s"'
 # We need to change the identity as quickly as possible as there

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PS4='+[\t] '
 set -eux

--- a/test/nat46x64/test.sh
+++ b/test/nat46x64/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 PS4='+[\t] '
 set -eux

--- a/test/packet/scripts/install.sh
+++ b/test/packet/scripts/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/post_build_agent.sh
+++ b/test/post_build_agent.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "output of following commands are ran on the Jenkins agent itself"
 echo "output of: \"ps -ef | grep -i vbox\" "

--- a/test/print-node-ip.sh
+++ b/test/print-node-ip.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/provision/compile.sh
+++ b/test/provision/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export CILIUM_DS_TAG="k8s-app=cilium"

--- a/test/provision/container-images.sh
+++ b/test/provision/container-images.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function check_img_list {
   local imgs=$@

--- a/test/provision/dns.sh
+++ b/test/provision/dns.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script update the dns servers to use google ones.
 set -e

--- a/test/provision/docker-run-cilium.sh
+++ b/test/provision/docker-run-cilium.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # all args are passed as cilium-agent options (except for "uninstall" below)
 CILIUM_OPTS=$@

--- a/test/provision/externalworkload_install.sh
+++ b/test/provision/externalworkload_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd /home/vagrant/go/src/github.com/cilium/cilium

--- a/test/provision/k8s_install.sh
+++ b/test/provision/k8s_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/provision/runtime_install.sh
+++ b/test/provision/runtime_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if ! [[ -z $DOCKER_LOGIN && -z $DOCKER_PASSWORD ]]; then

--- a/test/provision/wait-cilium-in-docker.sh
+++ b/test/provision/wait-cilium-in-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Wait for cilium agent to become available
 for ((i = 0 ; i < 12; i++)); do

--- a/test/standalone/microk8s-static-pods.sh
+++ b/test/standalone/microk8s-static-pods.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SNAP_COMMON=${SNAP_COMMON:-"/var/snap/microk8s/common"}
 KUBELET_CONF="/var/snap/microk8s/current/args/kubelet"

--- a/test/test_suite_test.go
+++ b/test/test_suite_test.go
@@ -325,7 +325,7 @@ var _ = AfterEach(func() {
 		zipFilePath := filepath.Join(helpers.TestResultsPath, zipFileName)
 
 		_, err := exec.Command(
-			"/bin/bash", "-c",
+			"/usr/bin/env", "bash", "-c",
 			fmt.Sprintf("zip -qr \"%s\" \"%s\"", zipFilePath, path)).CombinedOutput()
 		if err != nil {
 			log.WithError(err).Errorf("cannot create zip file '%s'", zipFilePath)

--- a/test/vagrant-ci-start.sh
+++ b/test/vagrant-ci-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/vagrant-local-create-box.sh
+++ b/test/vagrant-local-create-box.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/vagrant-local-start-runtime.sh
+++ b/test/vagrant-local-start-runtime.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/vagrant-local-start.sh
+++ b/test/vagrant-local-start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/vagrant_cleanup.sh
+++ b/test/vagrant_cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 K8S_NODES="${K8S_NODES:-2}"
 

--- a/test/vtep/install.sh
+++ b/test/vtep/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # Copyright Authors of Cilium
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/master/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
This commit switch most usage of "/bin/bash" to "/usr/bin/env bash". This allows to conform to the PATH env variable when invoking bash which is especially important on distros/installs in which bash is *NOT* installed in /bin/bash (for instance in some more "exotic" distros like NixOS or even if bash is installed in /usr/local/bin/ for whatever reasons).

The goal here is not to be perfectly exhaustive but to address most low hanging fruits whenever this happens and most importantly should ease Cilium contributions for people which don't have bash installed in /bin/bash.

```release-note
use /usr/bin/env bash instead of /bin/bash in contrib, examples and test dirs
```
