### PR TITLE
vagrant: Default to 4.19

### DIFF
--- a/vagrant_box_defaults.rb
+++ b/vagrant_box_defaults.rb
@@ -2,8 +2,8 @@
 # vi: set ft=ruby
 Vagrant.require_version ">= 2.2.0"
 
-$SERVER_BOX = "cilium/ubuntu-dev"
-$SERVER_VERSION= "234"
+$SERVER_BOX = "cilium/ubuntu-4-19"
+$SERVER_VERSION= "70"
 $NETNEXT_SERVER_BOX= "cilium/ubuntu-next"
 $NETNEXT_SERVER_VERSION= "161"
 @v54_SERVER_BOX= "cilium/ubuntu-5-4"


### PR DESCRIPTION
Given we removed the 4.9 VM image in 02041e7714 ("vagrant: remove 4.9 vagrant box") and dropped support in Cilium v1.13, we should also make 4.19 the default for the development VM.