### PR TITLE
pkg/nodediscovery: add security tags as part of CiliumNode

### DIFF
--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -588,6 +588,10 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 				nodeResource.Spec.ENI.SecurityGroups = c.ENI.SecurityGroups
 			}
 
+			if len(c.ENI.SecurityGroupTags) > 0 {
+				nodeResource.Spec.ENI.SecurityGroupTags = c.ENI.SecurityGroupTags
+			}
+
 			if len(c.ENI.SubnetIDs) > 0 {
 				nodeResource.Spec.ENI.SubnetIDs = c.ENI.SubnetIDs
 			}


### PR DESCRIPTION
The security tags were missing in the CiliumNode because they were never copied from the CiliumCNI configuration. This commit adds that missing functionality.

```release-note
Fix security-group-tags not working in ENI
```

Fixes https://github.com/cilium/cilium/issues/23678