### PR TITLE
mlh: update Jenkins jobs names (`master` > `main`)

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -52,149 +52,149 @@ flake-tracker:
     jenkins-url: https://jenkins.cilium.io
     regex-trigger: (^/test)
     stable-jobs:
-    - cilium-master-k8s-1.16-kernel-4.19
-    - cilium-master-k8s-1.17-kernel-4.19
-    - cilium-master-k8s-1.18-kernel-4.19
-    - cilium-master-k8s-1.19-kernel-4.19
-    - cilium-master-k8s-1.20-kernel-4.19
-    - cilium-master-k8s-1.21-kernel-4.19
-    - cilium-master-k8s-1.22-kernel-4.19
-    - cilium-master-k8s-1.23-kernel-4.19
-    - cilium-master-k8s-1.24-kernel-4.19
-    - cilium-master-k8s-1.24-kernel-5.4
-    - cilium-master-k8s-1.25-kernel-4.19
-    - cilium-master-k8s-1.26-kernel-net-next
-    - cilium-master-k8s-upstream
+    - cilium-main-k8s-1.16-kernel-4.19
+    - cilium-main-k8s-1.17-kernel-4.19
+    - cilium-main-k8s-1.18-kernel-4.19
+    - cilium-main-k8s-1.19-kernel-4.19
+    - cilium-main-k8s-1.20-kernel-4.19
+    - cilium-main-k8s-1.21-kernel-4.19
+    - cilium-main-k8s-1.22-kernel-4.19
+    - cilium-main-k8s-1.23-kernel-4.19
+    - cilium-main-k8s-1.24-kernel-4.19
+    - cilium-main-k8s-1.24-kernel-5.4
+    - cilium-main-k8s-1.25-kernel-4.19
+    - cilium-main-k8s-1.26-kernel-net-next
+    - cilium-main-k8s-upstream
     pr-jobs:
       Cilium-PR-K8s-1.16-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.17-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.18-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.19-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.20-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.21-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.22-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.23-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.24-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.24-kernel-5.4:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.24-kernel-5.4
+        - cilium-main-k8s-1.24-kernel-5.4
       Cilium-PR-K8s-1.25-kernel-4.19:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.16-kernel-4.19
-        - cilium-master-k8s-1.17-kernel-4.19
-        - cilium-master-k8s-1.18-kernel-4.19
-        - cilium-master-k8s-1.19-kernel-4.19
-        - cilium-master-k8s-1.20-kernel-4.19
-        - cilium-master-k8s-1.21-kernel-4.19
-        - cilium-master-k8s-1.22-kernel-4.19
-        - cilium-master-k8s-1.23-kernel-4.19
-        - cilium-master-k8s-1.24-kernel-4.19
-        - cilium-master-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
       Cilium-PR-K8s-1.26-kernel-net-next:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-1.26-kernel-net-next
+        - cilium-main-k8s-1.26-kernel-net-next
       Cilium-PR-K8s-Upstream:
         correlate-with-stable-jobs:
-        - cilium-master-k8s-upstream
+        - cilium-main-k8s-upstream
   max-flakes-per-test: 5
   flake-similarity: 0.85
   ignore-failures:


### PR DESCRIPTION
Following merge of a04c49403c9ff0590a85db774f1df0b98e4685d7, all CI has been updated to track the `main` branch instead of `master`.

In doing so, all Jenkins jobs previously named after `master` were changed to use `main` instead, hence we update the MLH configuration accordingly.