### PR TITLE
v1.13: docs: Document upgrade impact for IPsec

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -304,6 +304,15 @@ Annotations:
 
 .. _1.13_upgrade_notes:
 
+1.13.2+ Upgrade Notes
+---------------------
+
+* When upgrading from Cilium <v1.13.1 or <1.12.8 to Cilium >v1.13.2 with IPsec
+  enabled, packet drops may occur during the upgrade. These drops are expected
+  to stop as soon as the Cilium agent is ready. IPsec error counters
+  ``XfrmInNoStates`` and ``XfrmOutPolBlock`` may increase as a result of these
+  drops.
+
 1.13.1 Upgrade Notes
 --------------------
 


### PR DESCRIPTION
The IPsec upgrade issue mentioned in ffa1140761 ("docs: Document IPsec upgrade issue on v1.13.1") is fixed in v1.13.2. Nonetheless, a small impact remains, with a few packet drops happening during the upgrade. This commit documents that impact.