### PR TITLE
bpf: init.sh: rename TUNNEL_MODE variable to TUNNEL_PROTOCOL

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -9,8 +9,8 @@ SYSCLASSNETDIR=${4}
 IP4_HOST=${5}
 IP6_HOST=${6}
 MODE=${7}
-TUNNEL_MODE=${8}
-# Only set if TUNNEL_MODE = "vxlan", "geneve"
+TUNNEL_PROTOCOL=${8}
+# Only set if TUNNEL_PROTOCOL = "vxlan", "geneve"
 TUNNEL_PORT=${9}
 # Only set if MODE = "direct"
 NATIVE_DEVS=${10}
@@ -197,7 +197,7 @@ function create_encap_dev()
 	if [ "${TUNNEL_PORT}" != "<nil>" ]; then
 		TUNNEL_OPTS="dstport $TUNNEL_PORT $TUNNEL_OPTS"
 	fi
-	ip link add name $ENCAP_DEV address $(rnd_mac_addr) type $TUNNEL_MODE $TUNNEL_OPTS || encap_fail
+	ip link add name $ENCAP_DEV address $(rnd_mac_addr) type $TUNNEL_PROTOCOL $TUNNEL_OPTS || encap_fail
 }
 
 function encap_fail()
@@ -311,7 +311,7 @@ if [ "$MODE" = "tunnel" ]; then
 fi
 
 # Remove eventual existing encapsulation device from previous run
-case "${TUNNEL_MODE}" in
+case "${TUNNEL_PROTOCOL}" in
   "<nil>")
 	ip link del cilium_vxlan 2> /dev/null || true
 	ip link del cilium_geneve 2> /dev/null || true
@@ -328,14 +328,14 @@ case "${TUNNEL_MODE}" in
     ;;
 esac
 
-if [ "${TUNNEL_MODE}" != "<nil>" ]; then
-	ENCAP_DEV="cilium_${TUNNEL_MODE}"
+if [ "${TUNNEL_PROTOCOL}" != "<nil>" ]; then
+	ENCAP_DEV="cilium_${TUNNEL_PROTOCOL}"
 
 	ip link show $ENCAP_DEV || create_encap_dev
 
 	if [ "${TUNNEL_PORT}" != "<nil>" ]; then
 		ip -details link show $ENCAP_DEV | grep "dstport $TUNNEL_PORT" || {
-			ip link delete name $ENCAP_DEV type $TUNNEL_MODE
+			ip link delete name $ENCAP_DEV type $TUNNEL_PROTOCOL
 			create_encap_dev
 		}
 	fi

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -44,7 +44,7 @@ const (
 	initArgIPv4NodeIP
 	initArgIPv6NodeIP
 	initArgMode
-	initArgTunnelMode
+	initArgTunnelProtocol
 	initArgTunnelPort
 	initArgDevices
 	initArgHostDev1
@@ -375,10 +375,10 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	// set init.sh args based on encapProto
-	args[initArgTunnelMode] = "<nil>"
+	args[initArgTunnelProtocol] = "<nil>"
 	args[initArgTunnelPort] = "<nil>"
 	if encapProto != option.TunnelDisabled {
-		args[initArgTunnelMode] = encapProto
+		args[initArgTunnelProtocol] = encapProto
 		args[initArgTunnelPort] = fmt.Sprintf("%d", option.Config.TunnelPort)
 	}
 


### PR DESCRIPTION
The datapath uses the TUNNEL_MODE macro to determine whether routing is direct or via a tunnel. TUNNEL_MODE is *not* set in a direct-routing config with ad-hoc tunnel for eg. EgressGW.

The TUNNEL_MODE shell variable in init.sh contains the actual protocol of the tunnel (vxlan or geneve), and is also set for an ad-hoc tunnel.

Avoid any confusion when reading the code, by renaming the shell variable to the more fitting TUNNEL_PROTOCOL. Do the same thing in the agent code that calls the script.