### PR TITLE
statedb: Support for initializers

### DIFF
--- a/pkg/statedb/types.go
+++ b/pkg/statedb/types.go
@@ -108,6 +108,20 @@ type Table[Obj ObjectConstraints[Obj]] interface {
 	// Writer when given a write transaction returns a table writer
 	// that can be used to modify the table.
 	Writer(tx WriteTransaction) TableReaderWriter[Obj]
+
+	// Initialized returns a channel that is closed when the table
+	// has been fully initialized. This method can only be used
+	// from start onwards.
+	Initialized() <-chan struct{}
+
+	// RegisterInitializer registers an initializer. Returns
+	// a channel that the initializer should close once it
+	// has completed.
+	//
+	// This method can only be called before starting in order
+	// to guarantee that all initializers are registered before
+	// Initialized() is called.
+	RegisterInitializer(name string) chan<- struct{}
 }
 
 // TableReader provides a set of read-only queries to a table.


### PR DESCRIPTION
In many cases we want to avoid accessing a table until it has been synchronized with an external data source. This adds support for registering any number of initializers (before starting) and then waiting for the table initializers to complete.  To keep things flexible we don't prevent reading the table while it's being initialized as in many cases we want to start processing data immediately as it flows in. Waiting on Initialized() is useful especially for garbage collection, e.g. to clean up BPF map values from a previous run and that's where we need a consistent snapshot.

Example use:

```
func registerExampleController(db statedb.DB, table statedb.Table[*Something], lc hive.Lifecycle) {
  // Register the initializer before we start
  initialized := t.RegisterInitializer("example")

  // Append lifecycle hooks to start populating the table.
  lc.Append(&exampleController{db, table, initialized})
}

func (e *exampleController) processLoop() {
  // ...
  // Initial listing done, we're done initializing the table.
  txn.Commit()
  close(e.initialized)
  // ...
}

// -----

func getSomethings(ctx context.Context, db statedb.DB, t statedb.Table[*Something]) {
  select {
  case <-ctx.Done():
     // timed out waiting for table to be ready
    return
  case  <-t.Initialized():
    // All table initializers have finished, table is now ready.
  }
  // use the table
  ...
}
```