### PR TITLE
v1.12: docs: Document upgrade impact for IPsec

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -304,6 +304,15 @@ Annotations:
 
 .. _1.12_upgrade_notes:
 
+1.12.9+ Upgrade Notes
+---------------------
+
+* When upgrading from Cilium <v1.12.8 or <v1.11.15 to Cilium >=v1.12.9 with
+  IPsec enabled, packet drops may occur during the upgrade. These drops are
+  expected to stop as soon as the Cilium agent is ready. IPsec error counters
+  ``XfrmInNoStates`` and ``XfrmOutPolBlock`` may increase as a result of these
+  drops.
+
 1.12 Regressions Fixed from 1.11
 --------------------------------
 


### PR DESCRIPTION
The IPsec upgrade issue mentioned in fbab91dc73 ("Add IPSec remark for upgrade to v1.12.8") is fixed in v1.12.9. Nonetheless, a small impact remains, with a few packet drops happening during the upgrade. This commit documents that impact.