### PR TITLE
v1.13: docs: Fix typo in IPsec upgrade note

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -307,9 +307,9 @@ Annotations:
 1.13.2+ Upgrade Notes
 ---------------------
 
-* When upgrading from Cilium <v1.13.1 or <1.12.8 to Cilium >v1.13.2 with IPsec
-  enabled, packet drops may occur during the upgrade. These drops are expected
-  to stop as soon as the Cilium agent is ready. IPsec error counters
+* When upgrading from Cilium <v1.13.1 or <v1.12.8 to Cilium >=v1.13.2 with
+  IPsec enabled, packet drops may occur during the upgrade. These drops are
+  expected to stop as soon as the Cilium agent is ready. IPsec error counters
   ``XfrmInNoStates`` and ``XfrmOutPolBlock`` may increase as a result of these
   drops.
 


### PR DESCRIPTION
This commit fixes the comparison sign for the v1.13.2 (the fix is in v1.13.2).

These signs are always hard :roll_eyes: Good thing I caught it before doing all backports I guess :smiling_face_with_tear: 

Fixes: https://github.com/cilium/cilium/pull/24963.