### PR TITLE
Fix operator shutdown hanging when kvstore is enabled

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -198,6 +198,7 @@ func (c *Controller) runController() {
 	errorRetries := 1
 
 	c.mutex.RLock()
+	ctx := c.ctxDoFunc
 	params := c.params
 	c.mutex.RUnlock()
 	runFunc := true
@@ -212,7 +213,7 @@ func (c *Controller) runController() {
 			interval = params.RunInterval
 
 			start := time.Now()
-			err = params.DoFunc(c.ctxDoFunc)
+			err = params.DoFunc(ctx)
 			duration := time.Since(start)
 
 			c.mutex.Lock()
@@ -293,6 +294,7 @@ func (c *Controller) runController() {
 			// Pick up any changes to the parameters in case the controller has
 			// been updated.
 			c.mutex.RLock()
+			ctx = c.ctxDoFunc
 			params = c.params
 			c.mutex.RUnlock()
 			runFunc = true

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -221,6 +221,12 @@ func (c *Controller) runController() {
 			c.getLogger().Debug("Controller func execution time: ", c.lastDuration)
 
 			if err != nil {
+				if ctx.Err() != nil {
+					// The controller's context was canceled. Let's wait for the
+					// next controller update (or stop).
+					err = NewExitReason("controller context canceled")
+				}
+
 				switch err := err.(type) {
 				case ExitReason:
 					// This is actually not an error case, but it causes an exit


### PR DESCRIPTION
Reporting here the message of the last commit, which addresses the core issue, for convenience:

> https://github.com/cilium/cilium/commit/f487647f4b5da61bd047a36d561cc61effe4943c ("operator: Wait for informers to shut down when stopping") introduced a WaitGroup to wait for the shutdown of all goroutines started by `legacy.onStart`. When running in kvstore mode, the operator spawns one goroutine to synchronize global services to the kvstore, continuously reading from a channel. Since that channel is never closed, the goroutine does not terminate, preventing the correct shutdown of the operator. This commit fixes it propagating the context, and stopping the goroutine when it is canceled.

The first two commits instead, perform the following modifications to the controller implementation:
1. Access the controller context while holding the mutex, to avoid reading it while being overwritten on restart.
2. Do not rerun the DoFunc once the context has been canceled. This caused spurious errors during operator shutdown, since the controllers handling the renew of etcd leases started failing repeatedly due to the context being closed.

<!-- Description of change -->

```release-note
Fix operator shutdown hanging when kvstore is enabled
```
