### PR TITLE
conformance-k8s-kind: disable kindnet, enable log dumping

### DIFF
--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -84,6 +84,7 @@ jobs:
           networking:
             ipFamily: ${IP_FAMILY}
             kubeProxyMode: "none"
+            disableDefaultCNI: true
           nodes:
           - role: control-plane
           - role: worker
@@ -215,7 +216,7 @@ jobs:
             --                                            \
             --kubeconfig=${PWD}/_artifacts/kubeconfig.conf     \
             --provider=local                              \
-            --dump-logs-on-failure=false                  \
+            --dump-logs-on-failure=true                   \
             --report-dir=${E2E_REPORT_DIR}                \
             --disable-log-dump=true
 


### PR DESCRIPTION
While debugging a test failure, I noticed that this workflow missed disabling the kindnet CNI (every other workflow already does this).

Separately, enable log dumping on failure, otherwise there isn't enough to go on when tests fail.