### PR TITLE
mlh: update Jenkins jobs following 1.27 support

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -61,9 +61,10 @@ flake-tracker:
     - cilium-main-k8s-1.22-kernel-4.19
     - cilium-main-k8s-1.23-kernel-4.19
     - cilium-main-k8s-1.24-kernel-4.19
-    - cilium-main-k8s-1.24-kernel-5.4
     - cilium-main-k8s-1.25-kernel-4.19
-    - cilium-main-k8s-1.26-kernel-net-next
+    - cilium-main-k8s-1.25-kernel-5.4
+    - cilium-main-k8s-1.26-kernel-4.19
+    - cilium-main-k8s-1.27-kernel-net-next
     - cilium-main-k8s-upstream
     pr-jobs:
       Cilium-PR-K8s-1.16-kernel-4.19:
@@ -78,6 +79,7 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.26-kernel-4.19
       Cilium-PR-K8s-1.17-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-main-k8s-1.16-kernel-4.19
@@ -90,6 +92,7 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.26-kernel-4.19
       Cilium-PR-K8s-1.18-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-main-k8s-1.16-kernel-4.19
@@ -102,6 +105,7 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.26-kernel-4.19
       Cilium-PR-K8s-1.19-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-main-k8s-1.16-kernel-4.19
@@ -114,6 +118,7 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.26-kernel-4.19
       Cilium-PR-K8s-1.20-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-main-k8s-1.16-kernel-4.19
@@ -126,6 +131,7 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.26-kernel-4.19
       Cilium-PR-K8s-1.21-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-main-k8s-1.16-kernel-4.19
@@ -138,6 +144,7 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.26-kernel-4.19
       Cilium-PR-K8s-1.22-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-main-k8s-1.16-kernel-4.19
@@ -150,6 +157,7 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.26-kernel-4.19
       Cilium-PR-K8s-1.23-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-main-k8s-1.16-kernel-4.19
@@ -162,6 +170,7 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.26-kernel-4.19
       Cilium-PR-K8s-1.24-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-main-k8s-1.16-kernel-4.19
@@ -174,9 +183,7 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
-      Cilium-PR-K8s-1.24-kernel-5.4:
-        correlate-with-stable-jobs:
-        - cilium-main-k8s-1.24-kernel-5.4
+        - cilium-main-k8s-1.26-kernel-4.19
       Cilium-PR-K8s-1.25-kernel-4.19:
         correlate-with-stable-jobs:
         - cilium-main-k8s-1.16-kernel-4.19
@@ -189,9 +196,25 @@ flake-tracker:
         - cilium-main-k8s-1.23-kernel-4.19
         - cilium-main-k8s-1.24-kernel-4.19
         - cilium-main-k8s-1.25-kernel-4.19
-      Cilium-PR-K8s-1.26-kernel-net-next:
+      Cilium-PR-K8s-1.25-kernel-5.4:
         correlate-with-stable-jobs:
-        - cilium-main-k8s-1.26-kernel-net-next
+        - cilium-main-k8s-1.25-kernel-5.4
+      Cilium-PR-K8s-1.26-kernel-4.19:
+        correlate-with-stable-jobs:
+        - cilium-main-k8s-1.16-kernel-4.19
+        - cilium-main-k8s-1.17-kernel-4.19
+        - cilium-main-k8s-1.18-kernel-4.19
+        - cilium-main-k8s-1.19-kernel-4.19
+        - cilium-main-k8s-1.20-kernel-4.19
+        - cilium-main-k8s-1.21-kernel-4.19
+        - cilium-main-k8s-1.22-kernel-4.19
+        - cilium-main-k8s-1.23-kernel-4.19
+        - cilium-main-k8s-1.24-kernel-4.19
+        - cilium-main-k8s-1.25-kernel-4.19
+        - cilium-main-k8s-1.26-kernel-4.19
+      Cilium-PR-K8s-1.27-kernel-net-next:
+        correlate-with-stable-jobs:
+        - cilium-main-k8s-1.27-kernel-net-next
       Cilium-PR-K8s-Upstream:
         correlate-with-stable-jobs:
         - cilium-main-k8s-upstream


### PR DESCRIPTION
K8s 1.27 support was added in a19558d5f9902d4ebeb69cafd4a257a492b99d80.

We have rotated / expanded the Jenkins test jobs as follow:

- Changed: Kernel net-next on K8s 1.27 (instead of 1.26, triggered on `/test`).
- Added: Kernel 4.19 on K8s 1.26 (instead of 1.25, triggered on `/test`).
- Changed: Kernel 5.4 on K8s 1.25 (instead of 1.24, triggered on `/test`).
- Changed: Kernel 4.19 on K8s 1.25 (now triggered on `/test-missed-k8s` instead of `/test`).

See the Table of Truth™️ for up to date status on all trigger phrases: https://docs.google.com/spreadsheets/d/1TThkqvVZxaqLR-Ela4ZrcJ0lrTJByCqrbdCjnI32_X0/edit#gid=0