### PR TITLE
bgpv1: initialize service announcement map on reinit

### DIFF
--- a/pkg/bgpv1/gobgp/reconcile.go
+++ b/pkg/bgpv1/gobgp/reconcile.go
@@ -171,7 +171,7 @@ func preflightReconciler(ctx context.Context, _ *BGPRouterManager, sc *ServerWit
 
 	// Clear the shadow state since any advertisements will be gone now that the server has been recreated.
 	sc.PodCIDRAnnouncements = nil
-	sc.ServiceAnnouncements = nil
+	sc.ServiceAnnouncements = make(map[resource.Key][]Advertisement)
 
 	return nil
 }


### PR DESCRIPTION
On modification to BGP global parameters like router-id, we reinitialize BGP server config. This change initializes ServiceAnnouncements map correctly to fix panic in subsequent writes to it.

Fixes: #24975

```release-note
Fix panic due to assignment to nil BGP service announcements map.
```
