### PR TITLE
bpf: Allow maps to be opened or created without warning for mismatches

### DIFF
--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -162,7 +162,7 @@ func OpenMapElems(path string, prefixlen int, prefixdyn bool, maxelem uint32) (*
 		uint32(unsafe.Sizeof(uint32(0))+uintptr(bytes)),
 		uint32(LPM_MAP_VALUE_SIZE),
 		maxelem,
-		bpf.BPF_F_NO_PREALLOC, 0, true,
+		bpf.BPF_F_NO_PREALLOC, 0, true, true,
 	)
 
 	if err != nil {

--- a/pkg/maps/policymap/policymap.go
+++ b/pkg/maps/policymap/policymap.go
@@ -408,7 +408,8 @@ func newMap(path string) *PolicyMap {
 // protected by this map.
 func OpenOrCreate(path string) (*PolicyMap, bool, error) {
 	m := newMap(path)
-	isNewMap, err := m.OpenOrCreate()
+	// Open the map without triggring a warning if the map type, key, or value have changed.
+	isNewMap, err := m.OpenOrCreateWithoutWarning()
 	return m, isNewMap, err
 }
 


### PR DESCRIPTION
Add a new function `OpenOrCreateWithoutWarning()` to allow map to be upgraded without logging a warning. This can safely be used in cases where the map is completely populated from the userspace.

Only the policymap uses this function for now, but other maps should start using this when they need to be upgraded and that can be done without upgrade or downgrade impact.

Note that for downgrade tests to succeed, the map needs to use `OpenOrCreateWithoutWarning()` also in the old version.
