### PR TITLE
workflows: Run stable branches' workflows on a schedule

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 13 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 12 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 11 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 16 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 15 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 14 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-datapath-v1.13.yaml
+++ b/.github/workflows/conformance-datapath-v1.13.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 10 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 19 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 18 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 17 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 9 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 8 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 7 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 3 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 2 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 1 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 6 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-multicluster-v1.12.yaml
+++ b/.github/workflows/conformance-multicluster-v1.12.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 5 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/conformance-multicluster-v1.13.yaml
+++ b/.github/workflows/conformance-multicluster-v1.13.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 4 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:


### PR DESCRIPTION
It's currently difficult to get an idea of the current state of issue_comment workflows in the stable branches because we don't have a baseline there. That is, we don't have a regular run of those workflows against the stable branches. They only run as a reaction to backport PRs.

Having a baseline is useful to get an idea of what is already flaky when hitting a test failure in a backport PR. It's also useful to keep an eye on the general stability of CI for stable branches.

This commits adds a scheduled run to all issue_comment workflows of stable branches, such that they run once a day. The hour were picked to try and distribute the runs over the day, to avoid hitting any quota on e.g. GKE clusters.