### PR TITLE
daemon: Use API server cell and adapt handlers

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -19,7 +19,7 @@ cilium-agent [flags]
       --allow-icmp-frag-needed                                  Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU. (default true)
       --allow-localhost string                                  Policy when to allow local stack to reach local endpoints { auto | always | policy } (default "auto")
       --annotate-k8s-node                                       Annotate Kubernetes node
-      --api-rate-limit map                                      API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)
+      --api-rate-limit stringToString                           API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
       --arping-refresh-period duration                          Period for remote node ARP entry refresh (set 0 to disable) (default 30s)
       --auto-create-cilium-node-resource                        Automatically create CiliumNode resource for own node on startup (default true)
       --auto-direct-node-routes                                 Enable automatic L2 routing between nodes

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -12,6 +12,7 @@ cilium-agent hive [flags]
 
 ```
       --agent-liveness-update-interval duration          Interval at which the agent updates liveness time for the datapath (default 1s)
+      --api-rate-limit stringToString                    API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
       --certificates-directory string                    Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --clustermesh-config string                        Path to the ClusterMesh configuration directory
       --cni-chaining-mode string                         Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -18,6 +18,7 @@ cilium-agent hive dot-graph [flags]
 
 ```
       --agent-liveness-update-interval duration          Interval at which the agent updates liveness time for the datapath (default 1s)
+      --api-rate-limit stringToString                    API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
       --certificates-directory string                    Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --clustermesh-config string                        Path to the ClusterMesh configuration directory
       --cni-chaining-mode string                         Enable CNI chaining with the specified plugin (default "none")

--- a/api/v1/health/server/server.go
+++ b/api/v1/health/server/server.go
@@ -256,6 +256,12 @@ func (s *Server) SetAPI(api *restapi.CiliumHealthAPIAPI) {
 	s.handler = configureAPI(api)
 }
 
+// GetAPI returns the configured API. Modifications on the API must be performed
+// before server is started.
+func (s *Server) GetAPI() *restapi.CiliumHealthAPIAPI {
+	return s.api
+}
+
 func (s *Server) hasScheme(scheme string) bool {
 	schemes := s.EnabledListeners
 	if len(schemes) == 0 {

--- a/api/v1/operator/server/server.go
+++ b/api/v1/operator/server/server.go
@@ -256,6 +256,12 @@ func (s *Server) SetAPI(api *restapi.CiliumOperatorAPI) {
 	s.handler = configureAPI(api)
 }
 
+// GetAPI returns the configured API. Modifications on the API must be performed
+// before server is started.
+func (s *Server) GetAPI() *restapi.CiliumOperatorAPI {
+	return s.api
+}
+
 func (s *Server) hasScheme(scheme string) bool {
 	schemes := s.EnabledListeners
 	if len(schemes) == 0 {

--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -266,6 +266,12 @@ func (s *Server) SetAPI(api *{{ .Package }}.{{ pascalize .Name }}API) {
 	s.handler = configureAPI(api)
 }
 
+// GetAPI returns the configured API. Modifications on the API must be performed
+// before server is started.
+func (s *Server) GetAPI() *{{ .Package }}.{{ pascalize .Name }}API {
+	return s.api
+}
+
 func (s *Server) hasScheme(scheme string) bool {
 	schemes := s.EnabledListeners
 	if len(schemes) == 0 {

--- a/api/v1/server/server.go
+++ b/api/v1/server/server.go
@@ -363,6 +363,12 @@ func (s *Server) SetAPI(api *restapi.CiliumAPIAPI) {
 	s.handler = configureAPI(api)
 }
 
+// GetAPI returns the configured API. Modifications on the API must be performed
+// before server is started.
+func (s *Server) GetAPI() *restapi.CiliumAPIAPI {
+	return s.api
+}
+
 func (s *Server) hasScheme(scheme string) bool {
 	schemes := s.EnabledListeners
 	if len(schemes) == 0 {

--- a/daemon/cmd/api_handlers.go
+++ b/daemon/cmd/api_handlers.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-openapi/runtime/middleware"
+
+	"github.com/cilium/cilium/api/v1/server/restapi/bgp"
+	"github.com/cilium/cilium/api/v1/server/restapi/daemon"
+	"github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/api/v1/server/restapi/ipam"
+	"github.com/cilium/cilium/api/v1/server/restapi/metrics"
+	"github.com/cilium/cilium/api/v1/server/restapi/policy"
+	"github.com/cilium/cilium/api/v1/server/restapi/prefilter"
+	"github.com/cilium/cilium/api/v1/server/restapi/recorder"
+	"github.com/cilium/cilium/api/v1/server/restapi/service"
+	"github.com/cilium/cilium/api/v1/server/restapi/statedb"
+	"github.com/cilium/cilium/pkg/api"
+	datapathOption "github.com/cilium/cilium/pkg/datapath/option"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+type handlersOut struct {
+	cell.Out
+
+	DaemonGetCgroupDumpMetadataHandler daemon.GetCgroupDumpMetadataHandler
+	DaemonGetClusterNodesHandler       daemon.GetClusterNodesHandler
+	DaemonGetConfigHandler             daemon.GetConfigHandler
+	DaemonGetDebuginfoHandler          daemon.GetDebuginfoHandler
+	DaemonGetHealthzHandler            daemon.GetHealthzHandler
+	DaemonGetMapHandler                daemon.GetMapHandler
+	DaemonGetMapNameEventsHandler      daemon.GetMapNameEventsHandler
+	DaemonGetMapNameHandler            daemon.GetMapNameHandler
+	DaemonGetNodeIdsHandler            daemon.GetNodeIdsHandler
+	DaemonPatchConfigHandler           daemon.PatchConfigHandler
+
+	EndpointDeleteEndpointIDHandler      endpoint.DeleteEndpointIDHandler
+	EndpointGetEndpointHandler           endpoint.GetEndpointHandler
+	EndpointGetEndpointIDConfigHandler   endpoint.GetEndpointIDConfigHandler
+	EndpointGetEndpointIDHandler         endpoint.GetEndpointIDHandler
+	EndpointGetEndpointIDHealthzHandler  endpoint.GetEndpointIDHealthzHandler
+	EndpointGetEndpointIDLabelsHandler   endpoint.GetEndpointIDLabelsHandler
+	EndpointGetEndpointIDLogHandler      endpoint.GetEndpointIDLogHandler
+	EndpointPatchEndpointIDConfigHandler endpoint.PatchEndpointIDConfigHandler
+	EndpointPatchEndpointIDHandler       endpoint.PatchEndpointIDHandler
+	EndpointPatchEndpointIDLabelsHandler endpoint.PatchEndpointIDLabelsHandler
+	EndpointPutEndpointIDHandler         endpoint.PutEndpointIDHandler
+
+	IpamDeleteIpamIPHandler ipam.DeleteIpamIPHandler
+	IpamPostIpamHandler     ipam.PostIpamHandler
+	IpamPostIpamIPHandler   ipam.PostIpamIPHandler
+
+	MetricsGetMetricsHandler metrics.GetMetricsHandler
+
+	PolicyDeleteFqdnCacheHandler      policy.DeleteFqdnCacheHandler
+	PolicyDeletePolicyHandler         policy.DeletePolicyHandler
+	PolicyGetFqdnCacheHandler         policy.GetFqdnCacheHandler
+	PolicyGetFqdnCacheIDHandler       policy.GetFqdnCacheIDHandler
+	PolicyGetFqdnNamesHandler         policy.GetFqdnNamesHandler
+	PolicyGetIdentityEndpointsHandler policy.GetIdentityEndpointsHandler
+	PolicyGetIdentityHandler          policy.GetIdentityHandler
+	PolicyGetIdentityIDHandler        policy.GetIdentityIDHandler
+	PolicyGetIPHandler                policy.GetIPHandler
+	PolicyGetPolicyHandler            policy.GetPolicyHandler
+	PolicyGetPolicySelectorsHandler   policy.GetPolicySelectorsHandler
+	PolicyPutPolicyHandler            policy.PutPolicyHandler
+
+	PrefilterDeletePrefilterHandler prefilter.DeletePrefilterHandler
+	PrefilterGetPrefilterHandler    prefilter.GetPrefilterHandler
+	PrefilterPatchPrefilterHandler  prefilter.PatchPrefilterHandler
+
+	RecorderDeleteRecorderIDHandler recorder.DeleteRecorderIDHandler
+	RecorderGetRecorderHandler      recorder.GetRecorderHandler
+	RecorderGetRecorderIDHandler    recorder.GetRecorderIDHandler
+	RecorderGetRecorderMasksHandler recorder.GetRecorderMasksHandler
+	RecorderPutRecorderIDHandler    recorder.PutRecorderIDHandler
+
+	ServiceDeleteServiceIDHandler service.DeleteServiceIDHandler
+	ServiceGetLrpHandler          service.GetLrpHandler
+	ServiceGetServiceHandler      service.GetServiceHandler
+	ServiceGetServiceIDHandler    service.GetServiceIDHandler
+	ServicePutServiceIDHandler    service.PutServiceIDHandler
+
+	StatedbGetStatedbDumpHandler statedb.GetStatedbDumpHandler
+
+	BgpGetBgpPeersHandler bgp.GetBgpPeersHandler
+}
+
+// apiHandler implements Handle() for the given parameter type.
+// It allows expressing the API handlers requiring *Daemon as simply
+// as a function of form `func(d *Daemon, p ParamType) middleware.Responder`.
+// This wrapper takes care of Await'ing for *Daemon.
+type apiHandler[Params any] struct {
+	dp      promise.Promise[*Daemon]
+	handler func(d *Daemon, p Params) middleware.Responder
+}
+
+func (a *apiHandler[Params]) Handle(p Params) middleware.Responder {
+	// Wait for *Daemon to be ready. While 'p' would have a context, it's hard to get it
+	// since it's a struct. Could use reflection, but since we'll stop the agent anyway
+	// if daemon initialization fails it doesn't really matter that much here what context
+	// to use.
+	d, err := a.dp.Await(context.Background())
+	if err != nil {
+		return api.Error(http.StatusServiceUnavailable, err)
+	}
+	return a.handler(d, p)
+}
+
+func wrapAPIHandler[Params any](dp promise.Promise[*Daemon], handler func(d *Daemon, p Params) middleware.Responder) *apiHandler[Params] {
+	return &apiHandler[Params]{dp: dp, handler: handler}
+}
+
+// apiHandlers bridges the API handlers still implemented inside Daemon into a set of
+// individual handlers. Since NewDaemon() is side-effectful, we can only get a promise for
+// *Daemon, and thus the handlers will need to Await() for it to be ready.
+// This is meant to be a temporary measure until handlers have been moved out from *Daemon.
+func ciliumAPIHandlers(dp promise.Promise[*Daemon], cfg *option.DaemonConfig) (out handlersOut) {
+	// /healthz/
+	out.DaemonGetHealthzHandler = wrapAPIHandler(dp, getHealthzHandler)
+
+	// /cluster/nodes
+	out.DaemonGetClusterNodesHandler = NewGetClusterNodesHandler(dp)
+
+	// /config/
+	out.DaemonGetConfigHandler = wrapAPIHandler(dp, getConfigHandler)
+	out.DaemonPatchConfigHandler = wrapAPIHandler(dp, patchConfigHandler)
+
+	if cfg.DatapathMode != datapathOption.DatapathModeLBOnly {
+		// /endpoint/
+		out.EndpointGetEndpointHandler = wrapAPIHandler(dp, getEndpointHandler)
+
+		// /endpoint/{id}
+		out.EndpointGetEndpointIDHandler = wrapAPIHandler(dp, getEndpointIDHandler)
+		out.EndpointPutEndpointIDHandler = wrapAPIHandler(dp, putEndpointIDHandler)
+		out.EndpointPatchEndpointIDHandler = wrapAPIHandler(dp, patchEndpointIDHandler)
+		out.EndpointDeleteEndpointIDHandler = wrapAPIHandler(dp, deleteEndpointIDHandler)
+
+		// /endpoint/{id}config/
+		out.EndpointGetEndpointIDConfigHandler = wrapAPIHandler(dp, getEndpointIDConfigHandler)
+		out.EndpointPatchEndpointIDConfigHandler = wrapAPIHandler(dp, patchEndpointIDConfigHandler)
+
+		// /endpoint/{id}/labels/
+		out.EndpointGetEndpointIDLabelsHandler = wrapAPIHandler(dp, getEndpointIDLabelsHandler)
+		out.EndpointPatchEndpointIDLabelsHandler = wrapAPIHandler(dp, putEndpointIDLabelsHandler)
+
+		// /endpoint/{id}/log/
+		out.EndpointGetEndpointIDLogHandler = wrapAPIHandler(dp, getEndpointIDLogHandler)
+
+		// /endpoint/{id}/healthz
+		out.EndpointGetEndpointIDHealthzHandler = wrapAPIHandler(dp, getEndpointIDHealthzHandler)
+
+		// /identity/
+		out.PolicyGetIdentityHandler = wrapAPIHandler(dp, getIdentityHandler)
+		out.PolicyGetIdentityIDHandler = wrapAPIHandler(dp, getIdentityIDHandler)
+
+		// /identity/endpoints
+		out.PolicyGetIdentityEndpointsHandler = wrapAPIHandler(dp, getIdentityEndpointsHandler)
+
+		// /policy/
+		out.PolicyGetPolicyHandler = wrapAPIHandler(dp, getPolicyHandler)
+		out.PolicyPutPolicyHandler = wrapAPIHandler(dp, putPolicyHandler)
+		out.PolicyDeletePolicyHandler = wrapAPIHandler(dp, deletePolicyHandler)
+		out.PolicyGetPolicySelectorsHandler = wrapAPIHandler(dp, getPolicySelectorsHandler)
+
+		// /lrp/
+		out.ServiceGetLrpHandler = wrapAPIHandler(dp, getLRPHandler)
+	}
+
+	// /service/{id}/
+	out.ServiceGetServiceIDHandler = wrapAPIHandler(dp, getServiceIDHandler)
+	out.ServiceDeleteServiceIDHandler = wrapAPIHandler(dp, deleteServiceIDHandler)
+	out.ServicePutServiceIDHandler = wrapAPIHandler(dp, putServiceIDHandler)
+
+	// /service/
+	out.ServiceGetServiceHandler = wrapAPIHandler(dp, getServiceHandler)
+
+	// /recorder/{id}/
+	out.RecorderGetRecorderIDHandler = wrapAPIHandler(dp, getRecorderIDHandler)
+	out.RecorderDeleteRecorderIDHandler = wrapAPIHandler(dp, deleteRecorderIDHandler)
+	out.RecorderPutRecorderIDHandler = wrapAPIHandler(dp, putRecorderIDHandler)
+
+	// /recorder/
+	out.RecorderGetRecorderHandler = wrapAPIHandler(dp, getRecorderHandler)
+
+	// /recorder/masks
+	out.RecorderGetRecorderMasksHandler = wrapAPIHandler(dp, getRecorderMasksHandler)
+
+	// /prefilter/
+	out.PrefilterGetPrefilterHandler = wrapAPIHandler(dp, getPrefilterHandler)
+	out.PrefilterDeletePrefilterHandler = wrapAPIHandler(dp, deletePrefilterHandler)
+	out.PrefilterPatchPrefilterHandler = wrapAPIHandler(dp, patchPrefilterHandler)
+
+	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
+		// /ipam/{ip}/
+		out.IpamPostIpamHandler = wrapAPIHandler(dp, postIPAMHandler)
+		out.IpamPostIpamIPHandler = wrapAPIHandler(dp, postIPAMIPHandler)
+		out.IpamDeleteIpamIPHandler = wrapAPIHandler(dp, deleteIPAMIPHandler)
+	}
+
+	// /debuginfo
+	out.DaemonGetDebuginfoHandler = wrapAPIHandler(dp, getDebugInfoHandler)
+
+	// /cgroup-dump-metadata
+	out.DaemonGetCgroupDumpMetadataHandler = wrapAPIHandler(dp, getCgroupDumpMetadataHandler)
+
+	// /map
+	out.DaemonGetMapHandler = wrapAPIHandler(dp, getMapHandler)
+	out.DaemonGetMapNameHandler = wrapAPIHandler(dp, getMapNameHandler)
+	out.DaemonGetMapNameEventsHandler = wrapAPIHandler(dp, getMapNameEventsHandler)
+
+	// metrics
+	out.MetricsGetMetricsHandler = wrapAPIHandler(dp, getMetricsHandler)
+
+	if cfg.DatapathMode != datapathOption.DatapathModeLBOnly {
+		// /fqdn/cache
+		out.PolicyGetFqdnCacheHandler = wrapAPIHandler(dp, getFqdnCacheHandler)
+		out.PolicyDeleteFqdnCacheHandler = wrapAPIHandler(dp, deleteFqdnCacheHandler)
+		out.PolicyGetFqdnCacheIDHandler = wrapAPIHandler(dp, getFqdnCacheIDHandler)
+		out.PolicyGetFqdnNamesHandler = wrapAPIHandler(dp, getFqdnNamesHandler)
+	}
+
+	// /ip/
+	out.PolicyGetIPHandler = wrapAPIHandler(dp, getIPHandler)
+
+	// /node/ids
+	out.DaemonGetNodeIdsHandler = wrapAPIHandler(dp, getNodeIDHandlerHandler)
+
+	// /bgp
+	out.BgpGetBgpPeersHandler = wrapAPIHandler(dp, getBGPPeersHandler)
+
+	// /statedb/dump
+	out.StatedbGetStatedbDumpHandler = wrapAPIHandler(dp, getStateDBDump)
+
+	return
+}

--- a/daemon/cmd/api_handlers.go
+++ b/daemon/cmd/api_handlers.go
@@ -120,8 +120,14 @@ func wrapAPIHandler[Params any](dp promise.Promise[*Daemon], handler func(d *Dae
 // apiHandlers bridges the API handlers still implemented inside Daemon into a set of
 // individual handlers. Since NewDaemon() is side-effectful, we can only get a promise for
 // *Daemon, and thus the handlers will need to Await() for it to be ready.
-// This is meant to be a temporary measure until handlers have been moved out from *Daemon.
-func ciliumAPIHandlers(dp promise.Promise[*Daemon], cfg *option.DaemonConfig) (out handlersOut) {
+//
+// This method depends on [deletionQueue] to make sure the deletion lock file is created and locked
+// before the API server starts.
+//
+// This is meant to be a temporary measure until handlers have been moved out from *Daemon
+// to daemon/restapi or feature-specific packages. At that point the dependency on *deletionQueue
+// should be moved to the cell in daemon/restapi.
+func ciliumAPIHandlers(dp promise.Promise[*Daemon], cfg *option.DaemonConfig, _ *deletionQueue) (out handlersOut) {
 	// /healthz/
 	out.DaemonGetHealthzHandler = wrapAPIHandler(dp, getHealthzHandler)
 

--- a/daemon/cmd/bgp.go
+++ b/daemon/cmd/bgp.go
@@ -11,25 +11,14 @@ import (
 
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
 	"github.com/cilium/cilium/pkg/api"
-	bgpv1 "github.com/cilium/cilium/pkg/bgpv1/agent"
 )
 
-type getBGP struct {
-	bgpController *bgpv1.Controller
-}
-
-// NewGetBGPHandler returns bgp peering status endpoint
-func NewGetBGPHandler(c *bgpv1.Controller) restapi.GetBgpPeersHandler {
-	return &getBGP{bgpController: c}
-}
-
-// Handle gets peering information from BGP controller
-func (b *getBGP) Handle(params restapi.GetBgpPeersParams) middleware.Responder {
-	peers, err := b.bgpController.BGPMgr.GetPeers(params.HTTPRequest.Context())
+// getBGPPeersHandler gets peering information from BGP controller
+func getBGPPeersHandler(d *Daemon, params restapi.GetBgpPeersParams) middleware.Responder {
+	peers, err := d.bgpControlPlaneController.BGPMgr.GetPeers(params.HTTPRequest.Context())
 	if err != nil {
 		msg := fmt.Errorf("failed to get peers, %w", err)
 		return api.Error(http.StatusInternalServerError, msg)
 	}
-
 	return restapi.NewGetBgpPeersOK().WithPayload(peers)
 }

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/daemon/restapi"
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/clustermesh"
@@ -121,6 +122,9 @@ var (
 		// makes different L7 proxies (Envoy, DNS proxy) usable to Cilium endpoints through
 		// a common Proxy 'redirect' abstraction.
 		proxy.Cell,
+
+		// Cilium REST API handlers
+		restapi.Cell,
 
 		// The BGP Control Plane which enables various BGP related interop.
 		bgpv1.Cell,

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -86,6 +86,14 @@ var (
 		// Cilium API served over UNIX sockets. Accessed by the 'cilium' utility (not cilium-cli).
 		server.Cell,
 		cell.Invoke(configureAPIServer),
+
+		// Cilium API handlers
+		cell.Provide(ciliumAPIHandlers),
+
+		// Processes endpoint deletions that occurred while the agent was down.
+		// This starts before the API server as ciliumAPIHandlers() depends on
+		// the 'deletionQueue' provided by this cell.
+		deletionQueueCell,
 	)
 
 	// ControlPlane implement the per-node control functions. These are pure

--- a/daemon/cmd/cgroup_dump_metadata.go
+++ b/daemon/cmd/cgroup_dump_metadata.go
@@ -10,18 +10,8 @@ import (
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 )
 
-type getCgroupDumpMetadata struct {
-	daemon *Daemon
-}
-
-// NewGetCgroupDumpMetadataHandler returns the cgroup dump metadata handler for the agent
-func NewGetCgroupDumpMetadataHandler(d *Daemon) restapi.GetCgroupDumpMetadataHandler {
-	return &getCgroupDumpMetadata{daemon: d}
-}
-
-func (h *getCgroupDumpMetadata) Handle(params restapi.GetCgroupDumpMetadataParams) middleware.Responder {
+func getCgroupDumpMetadataHandler(d *Daemon, params restapi.GetCgroupDumpMetadataParams) middleware.Responder {
 	resp := models.CgroupDumpMetadata{}
-	d := h.daemon
 	metadata := d.cgroupManager.DumpPodMetadata()
 
 	for _, pm := range metadata {

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -22,16 +22,16 @@ import (
 // ConfigModifyEvent is a wrapper around the parameters for configModify.
 type ConfigModifyEvent struct {
 	params PatchConfigParams
-	h      *patchConfig
+	daemon *Daemon
 }
 
 // Handle implements pkg/eventqueue/EventHandler interface.
 func (c *ConfigModifyEvent) Handle(res chan interface{}) {
-	c.h.configModify(c.params, res)
+	c.configModify(c.params, res)
 }
 
-func (h *patchConfig) configModify(params PatchConfigParams, resChan chan interface{}) {
-	d := h.daemon
+func (c *ConfigModifyEvent) configModify(params PatchConfigParams, resChan chan interface{}) {
+	d := c.daemon
 
 	cfgSpec := params.Configuration
 
@@ -112,23 +112,15 @@ func (h *patchConfig) configModify(params PatchConfigParams, resChan chan interf
 	return
 }
 
-type patchConfig struct {
-	daemon *Daemon
-}
-
-func NewPatchConfigHandler(d *Daemon) PatchConfigHandler {
-	return &patchConfig{daemon: d}
-}
-
-func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
+func patchConfigHandler(d *Daemon, params PatchConfigParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /config request")
 
 	c := &ConfigModifyEvent{
 		params: params,
-		h:      h,
+		daemon: d,
 	}
 	cfgModEvent := eventqueue.NewEvent(c)
-	resChan, err := h.daemon.configModifyQueue.Enqueue(cfgModEvent)
+	resChan, err := d.configModifyQueue.Enqueue(cfgModEvent)
 	if err != nil {
 		msg := fmt.Errorf("enqueue of ConfigModifyEvent failed: %w", err)
 		return api.Error(PatchConfigFailureCode, msg)
@@ -143,18 +135,9 @@ func (h *patchConfig) Handle(params PatchConfigParams) middleware.Responder {
 	return api.Error(PatchConfigFailureCode, msg)
 }
 
-type getConfig struct {
-	daemon *Daemon
-}
-
-func NewGetConfigHandler(d *Daemon) GetConfigHandler {
-	return &getConfig{daemon: d}
-}
-
-func (h *getConfig) Handle(params GetConfigParams) middleware.Responder {
+func getConfigHandler(d *Daemon, params GetConfigParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /config request")
 
-	d := h.daemon
 	m := make(map[string]interface{})
 	option.Config.ConfigPatchMutex.RLock()
 	e := reflect.ValueOf(option.Config).Elem()

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -84,7 +84,6 @@ import (
 	policyAPI "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
-	ratemetrics "github.com/cilium/cilium/pkg/rate/metrics"
 	"github.com/cilium/cilium/pkg/recorder"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
@@ -422,12 +421,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		log.WithField("mtu", configuredMTU).Info("Overwriting MTU based on CNI configuration")
 	}
 
-	apiLimiterSet, err := rate.NewAPILimiterSet(option.Config.APIRateLimit, apiRateLimitDefaults, ratemetrics.APILimiterObserver())
-	if err != nil {
-		log.WithError(err).Error("unable to configure API rate limiting")
-		return nil, nil, fmt.Errorf("unable to configure API rate limiting: %w", err)
-	}
-
 	// Check the kernel if we can make use of managed neighbor entries which
 	// simplifies and fully 'offloads' L2 resolution handling to the kernel.
 	if !option.Config.DryMode {
@@ -536,7 +529,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		nodeDiscovery:     nd,
 		nodeLocalStore:    params.LocalNodeStore,
 		endpointCreations: newEndpointCreationManager(params.Clientset),
-		apiLimiterSet:     apiLimiterSet,
+		apiLimiterSet:     params.APILimiterSet,
 		controllers:       controller.NewManager(),
 		// **NOTE** The global identity allocator is not yet initialized here; that
 		// happens below via InitIdentityAllocator(). Only the local identity

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1591,7 +1591,6 @@ var daemonCell = cell.Module(
 
 	cell.Provide(newDaemonPromise),
 	cell.Provide(func() k8s.CacheStatus { return make(k8s.CacheStatus) }),
-	cell.Provide(ciliumAPIHandlers),
 	cell.Invoke(func(promise.Promise[*Daemon]) {}), // Force instantiation.
 )
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -85,6 +85,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
+	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/version"
@@ -1027,9 +1028,6 @@ func initializeFlags() {
 	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
 	option.BindEnv(Vp, option.K8sServiceProxyName)
 
-	flags.Var(option.NewNamedMapOptions(option.APIRateLimitName, &option.Config.APIRateLimit, nil), option.APIRateLimitName, "API rate limiting configuration (example: --rate-limit endpoint-create=rate-limit:10/m,rate-burst:2)")
-	option.BindEnv(Vp, option.APIRateLimitName)
-
 	flags.Var(option.NewNamedMapOptions(option.BPFMapEventBuffers, &option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "Configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache=true,1024,1h)")
 	flags.MarkHidden(option.BPFMapEventBuffers)
 
@@ -1629,6 +1627,7 @@ type daemonParams struct {
 	L2Announcer          *l2announcer.L2Announcer
 	L7Proxy              *proxy.Proxy
 	DB                   statedb.DB
+	APILimiterSet        *rate.APILimiterSet
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/debuginfo.go
+++ b/daemon/cmd/debuginfo.go
@@ -17,18 +17,8 @@ import (
 	"github.com/cilium/cilium/pkg/version"
 )
 
-type getDebugInfo struct {
-	daemon *Daemon
-}
-
-// NewGetDebugInfoHandler returns the debug info endpoint handler for the agent
-func NewGetDebugInfoHandler(d *Daemon) restapi.GetDebuginfoHandler {
-	return &getDebugInfo{daemon: d}
-}
-
-func (h *getDebugInfo) Handle(params restapi.GetDebuginfoParams) middleware.Responder {
+func getDebugInfoHandler(d *Daemon, params restapi.GetDebuginfoParams) middleware.Responder {
 	dr := models.DebugInfo{}
-	d := h.daemon
 
 	dr.CiliumVersion = version.Version
 	if kver, err := version.GetKernelVersion(); err != nil {

--- a/daemon/cmd/deletion_queue.go
+++ b/daemon/cmd/deletion_queue.go
@@ -7,12 +7,73 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"time"
 
+	"github.com/cilium/cilium/api/v1/server"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/lock/lockfile"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/promise"
 )
+
+var deletionQueueCell = cell.Group(
+	cell.Provide(newDeletionQueue),
+	cell.Invoke(unlockAfterAPIServer),
+)
+
+type deletionQueue struct {
+	lf            *lockfile.Lockfile
+	daemonPromise promise.Promise[*Daemon]
+}
+
+func (dq *deletionQueue) Start(ctx hive.HookContext) error {
+	d, err := dq.daemonPromise.Await(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := dq.lock(ctx); err != nil {
+		return err
+	}
+
+	bootstrapStats.deleteQueue.Start()
+	err = dq.processQueuedDeletes(d, ctx)
+	bootstrapStats.deleteQueue.EndError(err)
+	return err
+
+}
+
+func (dq *deletionQueue) Stop(ctx hive.HookContext) error {
+	return nil
+}
+
+func newDeletionQueue(lc hive.Lifecycle, p promise.Promise[*Daemon]) *deletionQueue {
+	dq := &deletionQueue{daemonPromise: p}
+	lc.Append(dq)
+	return dq
+}
+
+func (dq *deletionQueue) lock(ctx context.Context) error {
+	if err := os.MkdirAll(defaults.DeleteQueueDir, 0755); err != nil {
+		log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueDir).Error("Failed to ensure CNI deletion queue directory exists")
+		return nil
+	}
+
+	var err error
+	dq.lf, err = lockfile.NewLockfile(defaults.DeleteQueueLockfile)
+	if err != nil {
+		log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueLockfile).Warn("Failed to lock queued deletion directory, proceeding anyways. This may cause CNI deletions to be missed.")
+	} else {
+		err = dq.lf.Lock(ctx, true)
+		if err != nil {
+			log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueLockfile).Warn("Failed to lock queued deletion directory, proceeding anyways. This may cause CNI deletions to be missed.")
+			dq.lf.Close()
+			dq.lf = nil
+		}
+	}
+	return nil
+}
 
 // processQueuedDeletes is the agent-side of the identity deletion queue.
 // The CNI plugin queues deletions when the agent is down, because
@@ -24,50 +85,14 @@ import (
 // all deletions. Then, we start up the agent server, then drop the lock.
 // Any CNI processes waiting in that period of time will, after getting
 // the lock.
-//
-// Returns a done function that drops the lock. It should be called
-// after the server is running.
-func (d *Daemon) processQueuedDeletes() func() {
-	if err := os.MkdirAll(defaults.DeleteQueueDir, 0755); err != nil {
-		log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueDir).Error("Failed to ensure CNI deletion queue directory exists")
-		return func() {}
-	}
-
-	log.Infof("Processing queued endpoint deletion requests from %s", defaults.DeleteQueueDir)
-
-	var lf *lockfile.Lockfile
-	locked := false
-
-	unlock := func() {
-		if lf != nil && locked {
-			lf.Unlock()
-		}
-		if lf != nil {
-			lf.Close()
-		}
-	}
-
-	lf, err := lockfile.NewLockfile(defaults.DeleteQueueLockfile)
-	if err != nil {
-		log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueLockfile).Warn("Failed to lock queued deletion directory, proceeding anyways. This may cause CNI deletions to be missed.")
-	} else {
-		ctx, cancel := context.WithTimeout(d.ctx, 10*time.Second)
-		defer cancel()
-		err = lf.Lock(ctx, true)
-		if err != nil {
-			log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueLockfile).Warn("Failed to lock queued deletion directory, proceeding anyways. This may cause CNI deletions to be missed.")
-		} else {
-			locked = true
-		}
-	}
-
-	// OK, we have the lock; process the deletes
+func (dq *deletionQueue) processQueuedDeletes(d *Daemon, ctx context.Context) error {
 	files, err := filepath.Glob(defaults.DeleteQueueDir + "/*.delete")
 	if err != nil {
 		log.WithError(err).WithField(logfields.Path, defaults.DeleteQueueDir).Error("Failed to list queued CNI deletion requests. CNI deletions may be missed.")
 	}
 
-	log.Infof("processing %d queued deletion requests", len(files))
+	log.Infof("Processing %d queued deletion requests", len(files))
+
 	for _, file := range files {
 		// get the container id
 		epID, err := os.ReadFile(file)
@@ -82,5 +107,20 @@ func (d *Daemon) processQueuedDeletes() func() {
 		}
 	}
 
-	return unlock
+	return nil
+}
+
+// unlockAfterAPIServer registers a start hook that runs after API server
+// has started and the deletion queue has been drained to unlock the
+// delete queue and thus allow CNI plugin to proceed.
+func unlockAfterAPIServer(lc hive.Lifecycle, _ *server.Server, dq *deletionQueue) {
+	lc.Append(hive.Hook{
+		OnStart: func(hive.HookContext) error {
+			if dq.lf != nil {
+				dq.lf.Unlock()
+				dq.lf.Close()
+			}
+			return nil
+		},
+	})
 }

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -45,24 +45,16 @@ import (
 
 var errEndpointNotFound = errors.New("endpoint not found")
 
-type getEndpoint struct {
-	d *Daemon
-}
-
-func NewGetEndpointHandler(d *Daemon) GetEndpointHandler {
-	return &getEndpoint{d: d}
-}
-
-func (h *getEndpoint) Handle(params GetEndpointParams) middleware.Responder {
+func getEndpointHandler(d *Daemon, params GetEndpointParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointList)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointList)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	resEPs := h.d.getEndpointList(params)
+	resEPs := d.getEndpointList(params)
 
 	if params.Labels != nil && len(resEPs) == 0 {
 		r.Error(errEndpointNotFound)
@@ -133,24 +125,16 @@ func (d *Daemon) getEndpointList(params GetEndpointParams) []*models.Endpoint {
 	return resEPs
 }
 
-type getEndpointID struct {
-	d *Daemon
-}
-
-func NewGetEndpointIDHandler(d *Daemon) GetEndpointIDHandler {
-	return &getEndpointID{d: d}
-}
-
-func (h *getEndpointID) Handle(params GetEndpointIDParams) middleware.Responder {
+func getEndpointIDHandler(d *Daemon, params GetEndpointIDParams) middleware.Responder {
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id} request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	ep, err := h.d.endpointManager.Lookup(params.ID)
+	ep, err := d.endpointManager.Lookup(params.ID)
 
 	if err != nil {
 		r.Error(err)
@@ -161,14 +145,6 @@ func (h *getEndpointID) Handle(params GetEndpointIDParams) middleware.Responder 
 	} else {
 		return NewGetEndpointIDOK().WithPayload(ep.GetModel())
 	}
-}
-
-type putEndpointID struct {
-	d *Daemon
-}
-
-func NewPutEndpointIDHandler(d *Daemon) PutEndpointIDHandler {
-	return &putEndpointID{d: d}
 }
 
 // fetchK8sMetadataForEndpoint wraps the k8s package to fetch and provide
@@ -559,7 +535,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	return ep, 0, nil
 }
 
-func (h *putEndpointID) Handle(params PutEndpointIDParams) (resp middleware.Responder) {
+func putEndpointIDHandler(d *Daemon, params PutEndpointIDParams) (resp middleware.Responder) {
 	if ep := params.Endpoint; ep != nil {
 		log.WithField("endpoint", logfields.Repr(*ep)).Debug("PUT /endpoint/{id} request")
 	} else {
@@ -567,13 +543,13 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) (resp middleware.Resp
 	}
 	epTemplate := params.Endpoint
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointCreate)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointCreate)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	ep, code, err := h.d.createEndpoint(params.HTTPRequest.Context(), h.d, epTemplate)
+	ep, code, err := d.createEndpoint(params.HTTPRequest.Context(), d, epTemplate)
 	if err != nil {
 		r.Error(err)
 		return api.Error(code, err)
@@ -582,14 +558,6 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) (resp middleware.Resp
 	ep.Logger(daemonSubsys).Info("Successful endpoint creation")
 
 	return NewPutEndpointIDCreated()
-}
-
-type patchEndpointID struct {
-	d *Daemon
-}
-
-func NewPatchEndpointIDHandler(d *Daemon) PatchEndpointIDHandler {
-	return &patchEndpointID{d: d}
 }
 
 // validPatchTransitionState checks whether the state to which the provided
@@ -605,14 +573,14 @@ func validPatchTransitionState(state *models.EndpointState) bool {
 	return false
 }
 
-func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Responder {
+func patchEndpointIDHandler(d *Daemon, params PatchEndpointIDParams) middleware.Responder {
 	scopedLog := log.WithField(logfields.Params, logfields.Repr(params))
 	if ep := params.Endpoint; ep != nil {
 		scopedLog = scopedLog.WithField("endpoint", logfields.Repr(*ep))
 	}
 	scopedLog.Debug("PATCH /endpoint/{id} request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointPatch)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointPatch)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -632,7 +600,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 
 	// Validate the template. Assignment afterwards is atomic.
 	// Note: newEp's labels are ignored.
-	newEp, err2 := endpoint.NewEndpointFromChangeModel(h.d.ctx, h.d, h.d, h.d.ipcache, h.d.l7Proxy, h.d.identityAllocator, epTemplate)
+	newEp, err2 := endpoint.NewEndpointFromChangeModel(d.ctx, d, d, d.ipcache, d.l7Proxy, d.identityAllocator, epTemplate)
 	if err2 != nil {
 		r.Error(err2)
 		return api.Error(PutEndpointIDInvalidCode, err2)
@@ -648,7 +616,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 		validStateTransition = true
 	}
 
-	ep, err := h.d.endpointManager.Lookup(params.ID)
+	ep, err := d.endpointManager.Lookup(params.ID)
 	if err != nil {
 		r.Error(err)
 		return api.Error(GetEndpointIDInvalidCode, err)
@@ -783,24 +751,15 @@ func (d *Daemon) EndpointCreated(ep *endpoint.Endpoint) {
 	d.SendNotification(monitorAPI.EndpointCreateMessage(ep))
 }
 
-type deleteEndpointID struct {
-	daemon *Daemon
-}
-
-func NewDeleteEndpointIDHandler(d *Daemon) DeleteEndpointIDHandler {
-	return &deleteEndpointID{daemon: d}
-}
-
-func (h *deleteEndpointID) Handle(params DeleteEndpointIDParams) middleware.Responder {
+func deleteEndpointIDHandler(d *Daemon, params DeleteEndpointIDParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("DELETE /endpoint/{id} request")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointDelete)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointDelete)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	d := h.daemon
 	if nerr, err := d.DeleteEndpoint(params.ID); err != nil {
 		r.Error(err)
 		if apierr, ok := err.(*api.APIError); ok {
@@ -840,24 +799,15 @@ func (d *Daemon) EndpointUpdate(id string, cfg *models.EndpointConfigurationSpec
 	return nil
 }
 
-type patchEndpointIDConfig struct {
-	daemon *Daemon
-}
-
-func NewPatchEndpointIDConfigHandler(d *Daemon) PatchEndpointIDConfigHandler {
-	return &patchEndpointIDConfig{daemon: d}
-}
-
-func (h *patchEndpointIDConfig) Handle(params PatchEndpointIDConfigParams) middleware.Responder {
+func patchEndpointIDConfigHandler(d *Daemon, params PatchEndpointIDConfigParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id}/config request")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointPatch)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointPatch)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	d := h.daemon
 	if err := d.EndpointUpdate(params.ID, params.EndpointConfiguration); err != nil {
 		r.Error(err)
 		if apierr, ok := err.(*api.APIError); ok {
@@ -869,24 +819,16 @@ func (h *patchEndpointIDConfig) Handle(params PatchEndpointIDConfigParams) middl
 	return NewPatchEndpointIDConfigOK()
 }
 
-type getEndpointIDConfig struct {
-	daemon *Daemon
-}
-
-func NewGetEndpointIDConfigHandler(d *Daemon) GetEndpointIDConfigHandler {
-	return &getEndpointIDConfig{daemon: d}
-}
-
-func (h *getEndpointIDConfig) Handle(params GetEndpointIDConfigParams) middleware.Responder {
+func getEndpointIDConfigHandler(d *Daemon, params GetEndpointIDConfigParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/config")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	ep, err := h.daemon.endpointManager.Lookup(params.ID)
+	ep, err := d.endpointManager.Lookup(params.ID)
 	if err != nil {
 		r.Error(err)
 		return api.Error(GetEndpointIDInvalidCode, err)
@@ -900,24 +842,16 @@ func (h *getEndpointIDConfig) Handle(params GetEndpointIDConfigParams) middlewar
 	}
 }
 
-type getEndpointIDLabels struct {
-	daemon *Daemon
-}
-
-func NewGetEndpointIDLabelsHandler(d *Daemon) GetEndpointIDLabelsHandler {
-	return &getEndpointIDLabels{daemon: d}
-}
-
-func (h *getEndpointIDLabels) Handle(params GetEndpointIDLabelsParams) middleware.Responder {
+func getEndpointIDLabelsHandler(d *Daemon, params GetEndpointIDLabelsParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/labels")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	ep, err := h.daemon.endpointManager.Lookup(params.ID)
+	ep, err := d.endpointManager.Lookup(params.ID)
 	if err != nil {
 		r.Error(err)
 		return api.Error(GetEndpointIDInvalidCode, err)
@@ -936,24 +870,16 @@ func (h *getEndpointIDLabels) Handle(params GetEndpointIDLabelsParams) middlewar
 	return NewGetEndpointIDLabelsOK().WithPayload(cfg)
 }
 
-type getEndpointIDLog struct {
-	d *Daemon
-}
-
-func NewGetEndpointIDLogHandler(d *Daemon) GetEndpointIDLogHandler {
-	return &getEndpointIDLog{d: d}
-}
-
-func (h *getEndpointIDLog) Handle(params GetEndpointIDLogParams) middleware.Responder {
+func getEndpointIDLogHandler(d *Daemon, params GetEndpointIDLogParams) middleware.Responder {
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id}/log request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	ep, err := h.d.endpointManager.Lookup(params.ID)
+	ep, err := d.endpointManager.Lookup(params.ID)
 
 	if err != nil {
 		r.Error(err)
@@ -966,24 +892,16 @@ func (h *getEndpointIDLog) Handle(params GetEndpointIDLogParams) middleware.Resp
 	}
 }
 
-type getEndpointIDHealthz struct {
-	d *Daemon
-}
-
-func NewGetEndpointIDHealthzHandler(d *Daemon) GetEndpointIDHealthzHandler {
-	return &getEndpointIDHealthz{d: d}
-}
-
-func (h *getEndpointIDHealthz) Handle(params GetEndpointIDHealthzParams) middleware.Responder {
+func getEndpointIDHealthzHandler(d *Daemon, params GetEndpointIDHealthzParams) middleware.Responder {
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id}/log request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	ep, err := h.d.endpointManager.Lookup(params.ID)
+	ep, err := d.endpointManager.Lookup(params.ID)
 
 	if err != nil {
 		r.Error(err)
@@ -1030,24 +948,15 @@ func (d *Daemon) modifyEndpointIdentityLabelsFromAPI(id string, add, del labels.
 	return PatchEndpointIDLabelsOKCode, nil
 }
 
-type putEndpointIDLabels struct {
-	daemon *Daemon
-}
-
-func NewPatchEndpointIDLabelsHandler(d *Daemon) PatchEndpointIDLabelsHandler {
-	return &putEndpointIDLabels{daemon: d}
-}
-
-func (h *putEndpointIDLabels) Handle(params PatchEndpointIDLabelsParams) middleware.Responder {
+func putEndpointIDLabelsHandler(d *Daemon, params PatchEndpointIDLabelsParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id}/labels request")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointPatch)
+	r, err := d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointPatch)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
 	defer r.Done()
 
-	d := h.daemon
 	mod := params.Configuration
 	lbls := labels.NewLabelsFromModel(mod.User)
 

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/daemon/restapi"
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/bandwidth"
@@ -55,7 +56,7 @@ func NewGetEndpointHandler(d *Daemon) GetEndpointHandler {
 func (h *getEndpoint) Handle(params GetEndpointParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointList)
+	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointList)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -143,7 +144,7 @@ func NewGetEndpointIDHandler(d *Daemon) GetEndpointIDHandler {
 func (h *getEndpointID) Handle(params GetEndpointIDParams) middleware.Responder {
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id} request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointGet)
+	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -566,7 +567,7 @@ func (h *putEndpointID) Handle(params PutEndpointIDParams) (resp middleware.Resp
 	}
 	epTemplate := params.Endpoint
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointCreate)
+	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointCreate)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -611,7 +612,7 @@ func (h *patchEndpointID) Handle(params PatchEndpointIDParams) middleware.Respon
 	}
 	scopedLog.Debug("PATCH /endpoint/{id} request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointPatch)
+	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointPatch)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -793,7 +794,7 @@ func NewDeleteEndpointIDHandler(d *Daemon) DeleteEndpointIDHandler {
 func (h *deleteEndpointID) Handle(params DeleteEndpointIDParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("DELETE /endpoint/{id} request")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointDelete)
+	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointDelete)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -850,7 +851,7 @@ func NewPatchEndpointIDConfigHandler(d *Daemon) PatchEndpointIDConfigHandler {
 func (h *patchEndpointIDConfig) Handle(params PatchEndpointIDConfigParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id}/config request")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointPatch)
+	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointPatch)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -879,7 +880,7 @@ func NewGetEndpointIDConfigHandler(d *Daemon) GetEndpointIDConfigHandler {
 func (h *getEndpointIDConfig) Handle(params GetEndpointIDConfigParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/config")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointGet)
+	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -910,7 +911,7 @@ func NewGetEndpointIDLabelsHandler(d *Daemon) GetEndpointIDLabelsHandler {
 func (h *getEndpointIDLabels) Handle(params GetEndpointIDLabelsParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/labels")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointGet)
+	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -946,7 +947,7 @@ func NewGetEndpointIDLogHandler(d *Daemon) GetEndpointIDLogHandler {
 func (h *getEndpointIDLog) Handle(params GetEndpointIDLogParams) middleware.Responder {
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id}/log request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointGet)
+	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -976,7 +977,7 @@ func NewGetEndpointIDHealthzHandler(d *Daemon) GetEndpointIDHealthzHandler {
 func (h *getEndpointIDHealthz) Handle(params GetEndpointIDHealthzParams) middleware.Responder {
 	log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id}/log request")
 
-	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointGet)
+	r, err := h.d.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointGet)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}
@@ -1040,7 +1041,7 @@ func NewPatchEndpointIDLabelsHandler(d *Daemon) PatchEndpointIDLabelsHandler {
 func (h *putEndpointIDLabels) Handle(params PatchEndpointIDLabelsParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id}/labels request")
 
-	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), apiRequestEndpointPatch)
+	r, err := h.daemon.apiLimiterSet.Wait(params.HTTPRequest.Context(), restapi.APIRequestEndpointPatch)
 	if err != nil {
 		return api.Error(http.StatusTooManyRequests, err)
 	}

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -712,17 +712,9 @@ func ipToInt(addr net.IP) *big.Int {
 	return i
 }
 
-type getFqdnCache struct {
-	daemon *Daemon
-}
-
-func NewGetFqdnCacheHandler(d *Daemon) GetFqdnCacheHandler {
-	return &getFqdnCache{daemon: d}
-}
-
-func (h *getFqdnCache) Handle(params GetFqdnCacheParams) middleware.Responder {
+func getFqdnCacheHandler(d *Daemon, params GetFqdnCacheParams) middleware.Responder {
 	// endpoints we want data from
-	endpoints := h.daemon.endpointManager.GetEndpoints()
+	endpoints := d.endpointManager.GetEndpoints()
 
 	CIDRStr := ""
 	if params.Cidr != nil {
@@ -750,17 +742,9 @@ func (h *getFqdnCache) Handle(params GetFqdnCacheParams) middleware.Responder {
 	return NewGetFqdnCacheOK().WithPayload(lookups)
 }
 
-type deleteFqdnCache struct {
-	daemon *Daemon
-}
-
-func NewDeleteFqdnCacheHandler(d *Daemon) DeleteFqdnCacheHandler {
-	return &deleteFqdnCache{daemon: d}
-}
-
-func (h *deleteFqdnCache) Handle(params DeleteFqdnCacheParams) middleware.Responder {
+func deleteFqdnCacheHandler(d *Daemon, params DeleteFqdnCacheParams) middleware.Responder {
 	// endpoints we want to modify
-	endpoints := h.daemon.endpointManager.GetEndpoints()
+	endpoints := d.endpointManager.GetEndpoints()
 
 	matchPatternStr := ""
 	if params.Matchpattern != nil {
@@ -768,29 +752,21 @@ func (h *deleteFqdnCache) Handle(params DeleteFqdnCacheParams) middleware.Respon
 	}
 
 	namesToRegen, err := deleteDNSLookups(
-		h.daemon.dnsNameManager.GetDNSCache(),
+		d.dnsNameManager.GetDNSCache(),
 		endpoints,
 		time.Now(),
 		matchPatternStr)
 	if err != nil {
 		return api.Error(DeleteFqdnCacheBadRequestCode, err)
 	}
-	h.daemon.dnsNameManager.ForceGenerateDNS(context.TODO(), namesToRegen)
+	d.dnsNameManager.ForceGenerateDNS(context.TODO(), namesToRegen)
 	return NewDeleteFqdnCacheOK()
 }
 
-type getFqdnCacheID struct {
-	daemon *Daemon
-}
-
-func NewGetFqdnCacheIDHandler(d *Daemon) GetFqdnCacheIDHandler {
-	return &getFqdnCacheID{daemon: d}
-}
-
-func (h *getFqdnCacheID) Handle(params GetFqdnCacheIDParams) middleware.Responder {
+func getFqdnCacheIDHandler(d *Daemon, params GetFqdnCacheIDParams) middleware.Responder {
 	var endpoints []*endpoint.Endpoint
 	if params.ID != "" {
-		ep, err := h.daemon.endpointManager.Lookup(params.ID)
+		ep, err := d.endpointManager.Lookup(params.ID)
 		switch {
 		case err != nil:
 			return api.Error(GetFqdnCacheIDBadRequestCode, err)
@@ -827,16 +803,8 @@ func (h *getFqdnCacheID) Handle(params GetFqdnCacheIDParams) middleware.Responde
 	return NewGetFqdnCacheIDOK().WithPayload(lookups)
 }
 
-type getFqdnNamesHandler struct {
-	daemon *Daemon
-}
-
-func NewGetFqdnNamesHandler(d *Daemon) GetFqdnNamesHandler {
-	return &getFqdnNamesHandler{daemon: d}
-}
-
-func (h *getFqdnNamesHandler) Handle(params GetFqdnNamesParams) middleware.Responder {
-	payload := h.daemon.dnsNameManager.GetModel()
+func getFqdnNamesHandler(d *Daemon, params GetFqdnNamesParams) middleware.Responder {
+	payload := d.dnsNameManager.GetModel()
 	return NewGetFqdnNamesOK().WithPayload(payload)
 }
 

--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -15,16 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 )
 
-type getIP struct {
-	d *Daemon
-}
-
-// NewGetIPHandler for the global IP cache
-func NewGetIPHandler(d *Daemon) GetIPHandler {
-	return &getIP{d: d}
-}
-
-func (h *getIP) Handle(params GetIPParams) middleware.Responder {
+func getIPHandler(d *Daemon, params GetIPParams) middleware.Responder {
 	listener := &ipCacheDumpListener{}
 	if params.Cidr != nil {
 		_, cidrFilter, err := net.ParseCIDR(*params.Cidr)
@@ -33,7 +24,7 @@ func (h *getIP) Handle(params GetIPParams) middleware.Responder {
 		}
 		listener.cidrFilter = cidrFilter
 	}
-	h.d.ipcache.DumpToListener(listener)
+	d.ipcache.DumpToListener(listener)
 	if len(listener.entries) == 0 {
 		return NewGetIPNotFound()
 	}

--- a/daemon/cmd/lrp.go
+++ b/daemon/cmd/lrp.go
@@ -12,17 +12,9 @@ import (
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 )
 
-type getLRP struct {
-	rpm *redirectpolicy.Manager
-}
-
-func NewGetLrpHandler(rpm *redirectpolicy.Manager) GetLrpHandler {
-	return &getLRP{rpm: rpm}
-}
-
-func (h *getLRP) Handle(params GetLrpParams) middleware.Responder {
+func getLRPHandler(d *Daemon, params GetLrpParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /lrp request")
-	return NewGetLrpOK().WithPayload(getLRPs(h.rpm))
+	return NewGetLrpOK().WithPayload(getLRPs(d.redirectPolicyManager))
 }
 
 func getLRPs(rpm *redirectpolicy.Manager) []*models.LRPSpec {

--- a/daemon/cmd/map.go
+++ b/daemon/cmd/map.go
@@ -76,6 +76,11 @@ func (fw *flushWriter) Write(p []byte) (n int, err error) {
 	return
 }
 
+func getMapNameEventsHandler(d *Daemon, params restapi.GetMapNameEventsParams) middleware.Responder {
+	g := &getMapNameEvents{daemon: d, mapGetter: mapGetterImpl{}}
+	return g.Handle(params)
+}
+
 func (h *getMapNameEvents) Handle(params restapi.GetMapNameEventsParams) middleware.Responder {
 	follow := false
 	if params.Follow != nil {
@@ -135,15 +140,7 @@ func (h *getMapNameEvents) Handle(params restapi.GetMapNameEventsParams) middlew
 	})
 }
 
-type getMapName struct {
-	daemon *Daemon
-}
-
-func NewGetMapNameHandler(d *Daemon) restapi.GetMapNameHandler {
-	return &getMapName{daemon: d}
-}
-
-func (h *getMapName) Handle(params restapi.GetMapNameParams) middleware.Responder {
+func getMapNameHandler(_ *Daemon, params restapi.GetMapNameParams) middleware.Responder {
 	m := bpf.GetMap(params.Name)
 	if m == nil {
 		return restapi.NewGetMapNameNotFound()
@@ -152,15 +149,7 @@ func (h *getMapName) Handle(params restapi.GetMapNameParams) middleware.Responde
 	return restapi.NewGetMapNameOK().WithPayload(m.GetModel())
 }
 
-type getMap struct {
-	daemon *Daemon
-}
-
-func NewGetMapHandler(d *Daemon) restapi.GetMapHandler {
-	return &getMap{daemon: d}
-}
-
-func (h *getMap) Handle(params restapi.GetMapParams) middleware.Responder {
+func getMapHandler(_ *Daemon, params restapi.GetMapParams) middleware.Responder {
 	mapList := &models.BPFMapList{
 		Maps: append(bpf.GetOpenMaps(), ebpf.GetOpenMaps()...),
 	}

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -15,16 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/spanstat"
 )
 
-type getMetrics struct {
-	daemon *Daemon
-}
-
-// NewGetMetricsHandler returns the metrics handler
-func NewGetMetricsHandler(d *Daemon) restapi.GetMetricsHandler {
-	return &getMetrics{daemon: d}
-}
-
-func (h *getMetrics) Handle(params restapi.GetMetricsParams) middleware.Responder {
+func getMetricsHandler(_ *Daemon, params restapi.GetMetricsParams) middleware.Responder {
 	metrics, err := metrics.DumpMetrics()
 	if err != nil {
 		return api.Error(

--- a/daemon/cmd/node_ids.go
+++ b/daemon/cmd/node_ids.go
@@ -7,18 +7,9 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
-	datapath "github.com/cilium/cilium/pkg/datapath/types"
 )
 
-type getNodeIDHandler struct {
-	nodeIDHandler datapath.NodeIDHandler
-}
-
-func NewGetNodeIDsHandler(h datapath.NodeIDHandler) GetNodeIdsHandler {
-	return &getNodeIDHandler{nodeIDHandler: h}
-}
-
-func (h *getNodeIDHandler) Handle(_ GetNodeIdsParams) middleware.Responder {
-	dump := h.nodeIDHandler.DumpNodeIDs()
+func getNodeIDHandlerHandler(d *Daemon, _ GetNodeIdsParams) middleware.Responder {
+	dump := d.datapath.NodeIDs().DumpNodeIDs()
 	return NewGetNodeIdsOK().WithPayload(dump)
 }

--- a/daemon/cmd/prefilter.go
+++ b/daemon/cmd/prefilter.go
@@ -14,23 +14,14 @@ import (
 	"github.com/cilium/cilium/pkg/api"
 )
 
-type getPrefilter struct {
-	d *Daemon
-}
-
-// NewGetPrefilterHandler returns new get handler for api
-func NewGetPrefilterHandler(d *Daemon) GetPrefilterHandler {
-	return &getPrefilter{d: d}
-}
-
-func (h *getPrefilter) Handle(params GetPrefilterParams) middleware.Responder {
+func getPrefilterHandler(d *Daemon, params GetPrefilterParams) middleware.Responder {
 	var list []string
 	var revision int64
-	if h.d.preFilter == nil {
+	if d.preFilter == nil {
 		msg := fmt.Errorf("Prefilter is not enabled in daemon")
 		return api.Error(GetPrefilterFailureCode, msg)
 	}
-	list, revision = h.d.preFilter.Dump(list)
+	list, revision = d.preFilter.Dump(list)
 	spec := &models.PrefilterSpec{
 		Revision: revision,
 		Deny:     list,
@@ -44,17 +35,8 @@ func (h *getPrefilter) Handle(params GetPrefilterParams) middleware.Responder {
 	return NewGetPrefilterOK().WithPayload(status)
 }
 
-type patchPrefilter struct {
-	d *Daemon
-}
-
-// NewPatchPrefilterHandler returns new patch handler for api
-func NewPatchPrefilterHandler(d *Daemon) PatchPrefilterHandler {
-	return &patchPrefilter{d: d}
-}
-
-func (h *patchPrefilter) Handle(params PatchPrefilterParams) middleware.Responder {
-	if h.d.preFilter == nil {
+func patchPrefilterHandler(d *Daemon, params PatchPrefilterParams) middleware.Responder {
+	if d.preFilter == nil {
 		msg := fmt.Errorf("Prefilter is not enabled in daemon")
 		return api.Error(PatchPrefilterFailureCode, msg)
 	}
@@ -69,24 +51,15 @@ func (h *patchPrefilter) Handle(params PatchPrefilterParams) middleware.Responde
 		}
 		list = append(list, *cidr)
 	}
-	err := h.d.preFilter.Insert(spec.Revision, list)
+	err := d.preFilter.Insert(spec.Revision, list)
 	if err != nil {
 		return api.Error(PatchPrefilterFailureCode, err)
 	}
 	return NewPatchPrefilterOK()
 }
 
-type deletePrefilter struct {
-	d *Daemon
-}
-
-// NewDeletePrefilterHandler returns new patch handler for api
-func NewDeletePrefilterHandler(d *Daemon) DeletePrefilterHandler {
-	return &deletePrefilter{d: d}
-}
-
-func (h *deletePrefilter) Handle(params DeletePrefilterParams) middleware.Responder {
-	if h.d.preFilter == nil {
+func deletePrefilterHandler(d *Daemon, params DeletePrefilterParams) middleware.Responder {
+	if d.preFilter == nil {
 		msg := fmt.Errorf("Prefilter is not enabled in daemon")
 		return api.Error(DeletePrefilterFailureCode, msg)
 	}
@@ -101,7 +74,7 @@ func (h *deletePrefilter) Handle(params DeletePrefilterParams) middleware.Respon
 		}
 		list = append(list, *cidr)
 	}
-	err := h.d.preFilter.Delete(spec.Revision, list)
+	err := d.preFilter.Delete(spec.Revision, list)
 	if err != nil {
 		return api.Error(DeletePrefilterFailureCode, err)
 	}

--- a/daemon/cmd/recorder.go
+++ b/daemon/cmd/recorder.go
@@ -15,15 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/recorder"
 )
 
-type putRecorderID struct {
-	rec *recorder.Recorder
-}
-
-func NewPutRecorderIDHandler(rec *recorder.Recorder) PutRecorderIDHandler {
-	return &putRecorderID{rec: rec}
-}
-
-func (h *putRecorderID) Handle(params PutRecorderIDParams) middleware.Responder {
+func putRecorderIDHandler(d *Daemon, params PutRecorderIDParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("PUT /recorder/{id} request")
 	if params.Config.ID == nil {
 		return api.Error(PutRecorderIDFailureCode, fmt.Errorf("invalid recorder ID 0"))
@@ -32,7 +24,7 @@ func (h *putRecorderID) Handle(params PutRecorderIDParams) middleware.Responder 
 	if err != nil {
 		return api.Error(PutRecorderIDFailureCode, err)
 	}
-	created, err := h.rec.UpsertRecorder(ri)
+	created, err := d.rec.UpsertRecorder(ri)
 	if err != nil {
 		return api.Error(PutRecorderIDFailureCode, err)
 	} else if created {
@@ -42,17 +34,9 @@ func (h *putRecorderID) Handle(params PutRecorderIDParams) middleware.Responder 
 	}
 }
 
-type deleteRecorderID struct {
-	rec *recorder.Recorder
-}
-
-func NewDeleteRecorderIDHandler(rec *recorder.Recorder) DeleteRecorderIDHandler {
-	return &deleteRecorderID{rec: rec}
-}
-
-func (h *deleteRecorderID) Handle(params DeleteRecorderIDParams) middleware.Responder {
+func deleteRecorderIDHandler(d *Daemon, params DeleteRecorderIDParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("DELETE /recorder/{id} request")
-	found, err := h.rec.DeleteRecorder(recorder.ID(params.ID))
+	found, err := d.rec.DeleteRecorder(recorder.ID(params.ID))
 	switch {
 	case err != nil:
 		return api.Error(DeleteRecorderIDFailureCode, err)
@@ -63,17 +47,9 @@ func (h *deleteRecorderID) Handle(params DeleteRecorderIDParams) middleware.Resp
 	}
 }
 
-type getRecorderID struct {
-	rec *recorder.Recorder
-}
-
-func NewGetRecorderIDHandler(rec *recorder.Recorder) GetRecorderIDHandler {
-	return &getRecorderID{rec: rec}
-}
-
-func (h *getRecorderID) Handle(params GetRecorderIDParams) middleware.Responder {
+func getRecorderIDHandler(d *Daemon, params GetRecorderIDParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /recorder/{id} request")
-	ri, err := h.rec.RetrieveRecorder(recorder.ID(params.ID))
+	ri, err := d.rec.RetrieveRecorder(recorder.ID(params.ID))
 	if err != nil {
 		return NewGetRecorderIDNotFound()
 	}
@@ -90,17 +66,9 @@ func (h *getRecorderID) Handle(params GetRecorderIDParams) middleware.Responder 
 	return NewGetRecorderIDOK().WithPayload(rec)
 }
 
-type getRecorder struct {
-	rec *recorder.Recorder
-}
-
-func NewGetRecorderHandler(rec *recorder.Recorder) GetRecorderHandler {
-	return &getRecorder{rec: rec}
-}
-
-func (h *getRecorder) Handle(params GetRecorderParams) middleware.Responder {
+func getRecorderHandler(d *Daemon, params GetRecorderParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /recorder request")
-	recList := getRecorderList(h.rec)
+	recList := getRecorderList(d.rec)
 	return NewGetRecorderOK().WithPayload(recList)
 }
 
@@ -120,17 +88,9 @@ func getRecorderList(rec *recorder.Recorder) []*models.Recorder {
 	return recList
 }
 
-type getRecorderMasks struct {
-	rec *recorder.Recorder
-}
-
-func NewGetRecorderMasksHandler(rec *recorder.Recorder) GetRecorderMasksHandler {
-	return &getRecorderMasks{rec: rec}
-}
-
-func (h *getRecorderMasks) Handle(params GetRecorderMasksParams) middleware.Responder {
+func getRecorderMasksHandler(d *Daemon, params GetRecorderMasksParams) middleware.Responder {
 	log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /recorder/masks request")
-	recMaskList := getRecorderMaskList(h.rec)
+	recMaskList := getRecorderMaskList(d.rec)
 	return NewGetRecorderMasksOK().WithPayload(recMaskList)
 }
 

--- a/daemon/cmd/statedb.go
+++ b/daemon/cmd/statedb.go
@@ -10,15 +10,10 @@ import (
 	"github.com/go-openapi/runtime/middleware"
 
 	. "github.com/cilium/cilium/api/v1/server/restapi/statedb"
-	"github.com/cilium/cilium/pkg/statedb"
 )
 
-type getStateDBDump struct {
-	db statedb.DB
-}
-
-func (h *getStateDBDump) Handle(params GetStatedbDumpParams) middleware.Responder {
+func getStateDBDump(d *Daemon, params GetStatedbDumpParams) middleware.Responder {
 	return middleware.ResponderFunc(func(w http.ResponseWriter, _ runtime.Producer) {
-		h.db.WriteJSON(w)
+		d.db.WriteJSON(w)
 	})
 }

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -355,11 +355,8 @@ func (g *GetNodesSuite) Test_getNodesHandle(c *C) {
 		randGen.Seed(0)
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		h := &getNodes{
-			clients: args.clients,
-			d:       args.daemon,
-		}
-		responder := h.Handle(args.params)
+		h := &getNodes{clients: args.clients}
+		responder := h.Handle(args.daemon, args.params)
 		c.Assert(len(h.clients), checker.DeepEquals, len(want.clients))
 		for k, v := range h.clients {
 			wantClient, ok := want.clients[k]
@@ -410,13 +407,11 @@ func (g *GetNodesSuite) Test_cleanupClients(c *C) {
 		c.Log(tt.name)
 		args := tt.setupArgs()
 		want := tt.setupWanted()
-		h := &getNodes{
-			clients: args.clients,
-			d: &Daemon{
+		h := &getNodes{clients: args.clients}
+		h.cleanupClients(
+			&Daemon{
 				nodeDiscovery: nodediscovery.NewNodeDiscovery(nm, nil, mtu.NewConfiguration(0, false, false, false, false, 0, nil), &cnitypes.NetConf{}),
-			},
-		}
-		h.cleanupClients()
+			})
 		c.Assert(h.clients, checker.DeepEquals, want.clients)
 	}
 }

--- a/daemon/restapi/api_limits_test.go
+++ b/daemon/restapi/api_limits_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package restapi
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	timeRate "golang.org/x/time/rate"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/rate"
+)
+
+// TestRateLimiterConfigFlag checks that rateLimiterConfig is properly parsed from
+// command-line flag.
+func testRateLimiterConfig(t *testing.T, setConfig func(h *hive.Hive, limiter string, limits string)) {
+	var limiterSet *rate.APILimiterSet
+	take := cell.Invoke(func(l *rate.APILimiterSet) { limiterSet = l })
+
+	h := hive.New(rateLimiterCell, take)
+
+	setConfig(h, APIRequestEndpointCreate, "rate-limit:42/m,rate-burst:1234")
+	assert.Nil(t, h.Start(context.TODO()))
+
+	l := limiterSet.Limiter(APIRequestEndpointCreate)
+	assert.NotNil(t, l)
+
+	p := l.Parameters()
+	assert.Equal(t, timeRate.Limit(42.0/60.0), p.RateLimit)
+	assert.Equal(t, 1234, p.RateBurst)
+	assert.Nil(t, h.Stop(context.TODO()))
+}
+
+// TestRateLimiterConfigFlag checks that rateLimiterConfig is properly parsed from
+// command-line flag.
+func TestRateLimiterConfigFlag(t *testing.T) {
+	testRateLimiterConfig(t,
+		func(h *hive.Hive, limiter string, limits string) {
+			flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+			h.RegisterFlags(flags)
+			err := flags.Parse([]string{"--api-rate-limit", limiter + "=" + limits})
+			assert.Nil(t, err, "failed to parse flags")
+		})
+}
+
+// TestRateLimiterConfigFile checks that rateLimiterConfig is properly parsed from
+// a config file.
+func TestRateLimiterConfigFile(t *testing.T) {
+	testRateLimiterConfig(t,
+		func(h *hive.Hive, limiter string, limits string) {
+			cfg := fmt.Sprintf("api-rate-limit:\n  %s:%s\n", limiter, limits)
+			buf := bytes.NewReader([]byte(cfg))
+			err := h.Viper().ReadConfig(buf)
+			assert.Nil(t, err, "failed to ReadConfig with Viper")
+		})
+}

--- a/daemon/restapi/cell.go
+++ b/daemon/restapi/cell.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package restapi
+
+import "github.com/cilium/cilium/pkg/hive/cell"
+
+var Cell = cell.Module(
+	"cilium-restapi",
+	"Cilium Agent API handlers",
+
+	rateLimiterCell, // Request rate-limiting
+)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1083,9 +1083,6 @@ const (
 	// service.kubernetes.io/service-proxy-name label equals the provided value.
 	K8sServiceProxyName = "k8s-service-proxy-name"
 
-	// APIRateLimitName enables configuration of the API rate limits
-	APIRateLimitName = "api-rate-limit"
-
 	// CRDWaitTimeout is the timeout in which Cilium will exit if CRDs are not
 	// available.
 	CRDWaitTimeout = "crd-wait-timeout"
@@ -2313,9 +2310,6 @@ type DaemonConfig struct {
 	// https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/2447-Make-kube-proxy-service-abstraction-optional
 	K8sServiceProxyName string
 
-	// APIRateLimitName enables configuration of the API rate limits
-	APIRateLimit map[string]string
-
 	// CRDWaitTimeout is the timeout in which Cilium will exit if CRDs are not
 	// available.
 	CRDWaitTimeout time.Duration
@@ -2462,7 +2456,6 @@ var (
 		UseCiliumInternalIPForIPsec:  defaults.UseCiliumInternalIPForIPsec,
 
 		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
-		APIRateLimit:                     make(map[string]string),
 
 		ExternalClusterIP:      defaults.ExternalClusterIP,
 		EnableVTEP:             defaults.EnableVTEP,
@@ -3383,12 +3376,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 		log.Fatalf("unable to parse %s: %s", LogOpt, err)
 	} else {
 		c.LogOpt = m
-	}
-
-	if m, err := command.GetStringMapStringE(vp, APIRateLimitName); err != nil {
-		log.Fatalf("unable to parse %s: %s", APIRateLimitName, err)
-	} else {
-		c.APIRateLimit = m
 	}
 
 	c.bpfMapEventConfigs = make(BPFEventBufferConfigs)

--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -389,6 +389,10 @@ func (p *APILimiterParameters) mergeUserConfig(config string) error {
 	return nil
 }
 
+func (l *APILimiter) Parameters() APILimiterParameters {
+	return l.params
+}
+
 func (l *APILimiter) delayedAdjustment(current, min, max float64) (n float64) {
 	n = current * l.adjustmentFactor
 	n = current + ((n - current) * l.params.DelayedAdjustmentFactor)


### PR DESCRIPTION
This is a follow-up to the [API server modularization](https://github.com/cilium/cilium/pull/24016) to adapt the daemon to actually use the API server cell. After this PR API handlers can be [implemented from any cell](https://github.com/cilium/cilium/blob/82bac1c27e9f1df80f980c3048164508f00db461/daemon/restapi/endpoint.go) by removing the handler type from `api_handlers.go` and providing it instead from another cell.

To facilitate the decoupling of API handlers from the `Daemon` struct, this refactors the handlers to depend on `Promise[*Daemon]` instead of `Daemon` in order to be able to `Provide()` them to the API server cell from the `ciliumAPIHandlers` constructor prior to `Daemon` initialization. 

To motivate this PR, check the follow-up PR (https://github.com/cilium/cilium/pull/25583), which decouples the endpoint API handlers from `Daemon`, allowing them to be tested without `Daemon` dependency. 



