### PR TITLE
k8s: remove unused singular CRD name consts

### DIFF
--- a/Documentation/contributing/development/introducing_new_crds.rst
+++ b/Documentation/contributing/development/introducing_new_crds.rst
@@ -181,9 +181,6 @@ scheme.
    +
    +       // Cilium BGP Peering Policy (BGPP)
    +
-   +       // BGPPSingularName is the singular name of Cilium BGP Peering Policy
-   +       BGPPSingularName = "ciliumbgppeeringpolicy"
-   +
    +       // BGPPPluralName is the plural name of Cilium BGP Peering Policy
    +       BGPPPluralName = "ciliumbgppeeringpolicies"
    +
@@ -194,9 +191,6 @@ scheme.
    +       BGPPName = BGPPPluralName + "." + CustomResourceDefinitionGroup
    +
    +       // Cilium BGP Load Balancer IP Pool (BGPPool)
-   +
-   +       // BGPPoolSingularName is the singular name of Cilium BGP Load Balancer IP Pool
-   +       BGPPoolSingularName = "ciliumbgploadbalancerippool"
    +
    +       // BGPPoolPluralName is the plural name of Cilium BGP Load Balancer IP Pool
    +       BGPPoolPluralName = "ciliumbgploadbalancerippools"

--- a/pkg/k8s/apis/cilium.io/v2/register.go
+++ b/pkg/k8s/apis/cilium.io/v2/register.go
@@ -20,9 +20,6 @@ const (
 
 	// Cilium Network Policy (CNP)
 
-	// CNPSingularName is the singular name of Cilium Network Policy
-	CNPSingularName = "ciliumnetworkpolicy"
-
 	// CNPPluralName is the plural name of Cilium Network Policy
 	CNPPluralName = "ciliumnetworkpolicies"
 
@@ -33,9 +30,6 @@ const (
 	CNPName = CNPPluralName + "." + CustomResourceDefinitionGroup
 
 	// Cilium Cluster wide Network Policy (CCNP)
-
-	// CCNPSingularName is the singular name of Cilium Cluster wide Network Policy
-	CCNPSingularName = "ciliumclusterwidenetworkpolicy"
 
 	// CCNPPluralName is the plural name of Cilium Cluster wide Network Policy
 	CCNPPluralName = "ciliumclusterwidenetworkpolicies"
@@ -48,9 +42,6 @@ const (
 
 	// Cilium Egress Gateway Policy (CEGP)
 
-	// CEGPSingularName is the singular name of Cilium Egress Gateway Policy
-	CEGPSingularName = "ciliumegressgatewaypolicy"
-
 	// CEGPPluralName is the plural name of Cilium Egress Gateway Policy
 	CEGPPluralName = "ciliumegressgatewaypolicies"
 
@@ -61,9 +52,6 @@ const (
 	CEGPName = CEGPPluralName + "." + CustomResourceDefinitionGroup
 
 	// Cilium Endpoint (CEP)
-
-	// CESingularName is the singular name of Cilium Endpoint
-	CEPSingularName = "ciliumendpoint"
 
 	// CEPluralName is the plural name of Cilium Endpoint
 	CEPPluralName = "ciliumendpoints"
@@ -76,9 +64,6 @@ const (
 
 	// Cilium Node (CN)
 
-	// CNSingularName is the singular name of Cilium Node
-	CNSingularName = "ciliumnode"
-
 	// CNPluralName is the plural name of Cilium Node
 	CNPluralName = "ciliumnodes"
 
@@ -89,9 +74,6 @@ const (
 	CNName = CNPluralName + "." + CustomResourceDefinitionGroup
 
 	// Cilium Identity
-
-	// CIDSingularName is the singular name of Cilium Identity
-	CIDSingularName = "ciliumidentity"
 
 	// CIDPluralName is the plural name of Cilium Identity
 	CIDPluralName = "ciliumidentities"
@@ -104,9 +86,6 @@ const (
 
 	// Cilium Local Redirect Policy (CLRP)
 
-	// CLRPSingularName is the singular name of Local Redirect Policy
-	CLRPSingularName = "ciliumlocalredirectpolicy"
-
 	// CLRPPluralName is the plural name of Local Redirect Policy
 	CLRPPluralName = "ciliumlocalredirectpolicies"
 
@@ -117,9 +96,6 @@ const (
 	CLRPName = CLRPPluralName + "." + CustomResourceDefinitionGroup
 
 	// Cilium External Workload (CEW)
-
-	// CEWSingularName is the singular name of Cilium External Workload
-	CEWSingularName = "ciliumexternalworkload"
 
 	// CEWPluralName is the plural name of Cilium External Workload
 	CEWPluralName = "ciliumexternalworkloads"
@@ -132,9 +108,6 @@ const (
 
 	// Cilium Cluster Envoy Config (CCEC)
 
-	// CCECSingularName is the singular name of Cilium Clusterwide Envoy Config
-	CCECSingularName = "ciliumclusterwideenvoyconfig"
-
 	// CCECPluralName is the plural name of Cilium Clusterwide Envoy Config
 	CCECPluralName = "ciliumclusterwideenvoyconfigs"
 
@@ -145,9 +118,6 @@ const (
 	CCECName = CCECPluralName + "." + CustomResourceDefinitionGroup
 
 	// Cilium Envoy Config (CEC)
-
-	// CECSingularName is the singular name of Cilium Envoy Config
-	CECSingularName = "ciliumenvoyconfig"
 
 	// CECPluralName is the plural name of Cilium Envoy Config
 	CECPluralName = "ciliumenvoyconfigs"

--- a/pkg/k8s/apis/cilium.io/v2alpha1/register.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/register.go
@@ -20,9 +20,6 @@ const (
 
 	// Cilium Endpoint Slice (CES)
 
-	// CESSingularName is the singular name of Cilium Endpoint Slice
-	CESSingularName = "ciliumendpointslice"
-
 	// CESPluralName is the plural name of Cilium Endpoint Slice
 	CESPluralName = "ciliumendpointslices"
 
@@ -34,9 +31,6 @@ const (
 
 	// Cilium BGP Peering Policy (BGPP)
 
-	// BGPPSingularName is the singular name of Cilium BGP Peering Policy
-	BGPPSingularName = "ciliumbgppeeringpolicy"
-
 	// BGPPPluralName is the plural name of Cilium BGP Peering Policy
 	BGPPPluralName = "ciliumbgppeeringpolicies"
 
@@ -47,9 +41,6 @@ const (
 	BGPPName = BGPPPluralName + "." + CustomResourceDefinitionGroup
 
 	// Cilium Load Balancer IP Pool (IPPool)
-
-	// PoolSingularName is the singular name of Cilium Load Balancer IP Pool
-	PoolSingularName = "ciliumloadbalancerippool"
 
 	// PoolPluralName is the plural name of Cilium Load Balancer IP Pool
 	PoolPluralName = "ciliumloadbalancerippools"


### PR DESCRIPTION
These consts are no longer used because they are auto-generated from // +kubebuilder:resource: comments since commit 87652268f8f4 ("k8s: Generate CiliumNode CRD") and thus also don't need to be defined for newly introduced CRDs.
