### PR TITLE
Address ipcache startup perfomance regression

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -246,14 +246,6 @@ func (ipc *IPCache) getK8sMetadata(ip string) *K8sMetadata {
 	return nil
 }
 
-// updateNamedPortsRLocked accumulates named ports from all K8sMetadata entries
-// to a single map. It is required to hold _at least_ the read lock when calling
-// this function, holding the write lock is also allowed.
-func (ipc *IPCache) updateNamedPortsRLocked(old, new types.NamedPortMap) (namedPortsChanged bool) {
-	namedPortsChanged = ipc.namedPorts.Update(old, new)
-	return namedPortsChanged && ipc.needNamedPorts.Load()
-}
-
 // Upsert adds / updates the provided IP (endpoint or CIDR prefix) and identity
 // into the IPCache.
 //
@@ -428,28 +420,10 @@ func (ipc *IPCache) upsertLocked(
 		} else {
 			ipc.ipToK8sMetadata[ip] = *k8sMeta
 		}
-
-		// Update named ports, first check for deleted values
-		for k := range oldK8sMeta.NamedPorts {
-			if _, ok := newNamedPorts[k]; !ok {
-				namedPortsChanged = true
-				break
-			}
-		}
-		if !namedPortsChanged {
-			// Check for added new or changed entries
-			for k, v := range newNamedPorts {
-				if v2, ok := oldK8sMeta.NamedPorts[k]; !ok || v2 != v {
-					namedPortsChanged = true
-					break
-				}
-			}
-		}
-		if namedPortsChanged {
-			// It is possible that some other POD defines same values, check if
-			// anything changes over all the PODs.
-			namedPortsChanged = ipc.updateNamedPortsRLocked(oldK8sMeta.NamedPorts, newNamedPorts)
-		}
+		// Update the named ports reference counting, but don't cause policy
+		// updates if no policy uses named ports.
+		namedPortsChanged = ipc.namedPorts.Update(oldK8sMeta.NamedPorts, newNamedPorts)
+		namedPortsChanged = namedPortsChanged && ipc.needNamedPorts.Load()
 	}
 
 	if hostIP != nil {
@@ -678,7 +652,9 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	// Update named ports
 	namedPortsChanged = false
 	if oldK8sMeta != nil && len(oldK8sMeta.NamedPorts) > 0 {
-		namedPortsChanged = ipc.updateNamedPortsRLocked(oldK8sMeta.NamedPorts, nil)
+		namedPortsChanged = ipc.namedPorts.Update(oldK8sMeta.NamedPorts, nil)
+		// Only trigger policy updates if named ports are used in policy.
+		namedPortsChanged = namedPortsChanged && ipc.needNamedPorts.Load()
 	}
 
 	if newHostIP != nil {

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -113,9 +113,10 @@ type IPCache struct {
 
 	// namedPorts is a collection of all named ports in the cluster. This is needed
 	// only if an egress policy refers to a port by name.
-	// This map is returned to users so all updates must be made into a fresh map that
-	// is then swapped in place atomically.
-	namedPorts atomic.Pointer[types.NamedPortMultiMap]
+	// This map is returned (read-only, as a NamedPortMultiMap) to users.
+	// Therefore, all updates must be made atomically, which is guaranteed by the
+	// interface.
+	namedPorts namedPortMultiMapUpdater
 
 	cacheStatus k8s.CacheStatus
 
@@ -142,7 +143,7 @@ func NewIPCache(c *Configuration) *IPCache {
 		ipToHostIPCache:   map[string]IPKeyPair{},
 		ipToK8sMetadata:   map[string]K8sMetadata{},
 		controllers:       controller.NewManager(),
-		namedPorts:        atomic.Pointer[types.NamedPortMultiMap]{},
+		namedPorts:        types.NewNamedPortMultiMap(),
 		metadata:          newMetadata(),
 		Configuration:     c,
 	}
@@ -248,38 +249,9 @@ func (ipc *IPCache) getK8sMetadata(ip string) *K8sMetadata {
 // updateNamedPortsRLocked accumulates named ports from all K8sMetadata entries
 // to a single map. It is required to hold _at least_ the read lock when calling
 // this function, holding the write lock is also allowed.
-func (ipc *IPCache) updateNamedPortsRLocked() (namedPortsChanged bool) {
-	// Collect new named Ports
-	var old types.NamedPortMultiMap
-	if m := ipc.namedPorts.Load(); m != nil {
-		old = *m
-	}
-
-	npm := types.NewNamedPortMultiMap()
-	for _, km := range ipc.ipToK8sMetadata {
-		for name, port := range km.NamedPorts {
-			if npm[name] == nil {
-				npm[name] = make(types.PortProtoSet)
-			}
-			npm[name][port] = struct{}{}
-		}
-	}
-	namedPortsChanged = !npm.Equal(old)
-	if namedPortsChanged {
-		// atomically swap the new map in
-		n := types.NamedPortMultiMap(npm)
-		ipc.namedPorts.Store(&n)
-	}
-
-	// Set namedPortsChanged to false if they have not (yet) been requested.
-	// This avoids triggering policy updates if named ports changed, but no
-	// policy actually needs them. We still pre-compute the namedPorts map,
-	// so we don't have to acquire the IPCache lock in GetNamedPorts
-	if !ipc.needNamedPorts.Load() {
-		namedPortsChanged = false
-	}
-
-	return namedPortsChanged
+func (ipc *IPCache) updateNamedPortsRLocked(old, new types.NamedPortMap) (namedPortsChanged bool) {
+	namedPortsChanged = ipc.namedPorts.Update(old, new)
+	return namedPortsChanged && ipc.needNamedPorts.Load()
 }
 
 // Upsert adds / updates the provided IP (endpoint or CIDR prefix) and identity
@@ -476,7 +448,7 @@ func (ipc *IPCache) upsertLocked(
 		if namedPortsChanged {
 			// It is possible that some other POD defines same values, check if
 			// anything changes over all the PODs.
-			namedPortsChanged = ipc.updateNamedPortsRLocked()
+			namedPortsChanged = ipc.updateNamedPortsRLocked(oldK8sMeta.NamedPorts, newNamedPorts)
 		}
 	}
 
@@ -706,7 +678,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	// Update named ports
 	namedPortsChanged = false
 	if oldK8sMeta != nil && len(oldK8sMeta.NamedPorts) > 0 {
-		namedPortsChanged = ipc.updateNamedPortsRLocked()
+		namedPortsChanged = ipc.updateNamedPortsRLocked(oldK8sMeta.NamedPorts, nil)
 	}
 
 	if newHostIP != nil {
@@ -740,12 +712,8 @@ func (ipc *IPCache) GetNamedPorts() (npm types.NamedPortMultiMap) {
 	// uses named ports anymore.
 	ipc.needNamedPorts.Store(true)
 
-	// Caller can keep using the map after the lock is released, as the map is never changed
-	// once published.
-	if ptr := ipc.namedPorts.Load(); ptr != nil {
-		npm = *ptr
-	}
-	return npm
+	// Caller can keep using the map, operations on it are protected by its mutex.
+	return ipc.namedPorts
 }
 
 // DeleteOnMetadataMatch removes the provided IP to security identity mapping from the IPCache

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -344,13 +344,18 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	c.Assert(cachedIdentity.ID, Equals, identity)
 	c.Assert(cachedIdentity.Source, Equals, source.Kubernetes)
 
-	// Named ports have been updated
-	c.Assert(namedPortsChanged, Equals, false) // not before GetNamedPorts() has been called once
+	// Named ports have been updated, but no policy uses them, hence don't
+	// trigger policy regen until GetNamedPorts has been called at least once.
+	c.Assert(namedPortsChanged, Equals, false)
 	npm := IPIdentityCache.GetNamedPorts()
 	c.Assert(npm, NotNil)
-	c.Assert(len(npm), Equals, 2)
-	c.Assert(npm["http"], checker.HasKey, types.PortProto{Port: uint16(80), Proto: uint8(6)})
-	c.Assert(npm["dns"], checker.HasKey, types.PortProto{Port: uint16(53), Proto: uint8(0)})
+	c.Assert(npm.Len(), Equals, 2)
+	port, err := npm.GetNamedPort("http", uint8(6))
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(80))
+	port, err = npm.GetNamedPort("dns", uint8(0))
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(53))
 
 	// No duplicates.
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
@@ -397,18 +402,29 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	c.Assert(namedPortsChanged, Equals, true)
 	npm = IPIdentityCache.GetNamedPorts()
 	c.Assert(npm, NotNil)
-	c.Assert(len(npm), Equals, 3)
-	c.Assert(npm["http"], checker.HasKey, types.PortProto{Port: uint16(80), Proto: uint8(6)})
-	c.Assert(npm["dns"], checker.HasKey, types.PortProto{Port: uint16(53), Proto: uint8(0)})
-	c.Assert(npm["https"], checker.HasKey, types.PortProto{Port: uint16(443), Proto: uint8(6)})
+	c.Assert(npm.Len(), Equals, 3)
+	port, err = npm.GetNamedPort("http", uint8(6))
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(80))
+	port, err = npm.GetNamedPort("dns", uint8(0))
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(53))
+	port, err = npm.GetNamedPort("https", uint8(6))
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(443))
 
 	namedPortsChanged = IPIdentityCache.Delete(endpointIP, source.Kubernetes)
 	c.Assert(namedPortsChanged, Equals, true)
 	npm = IPIdentityCache.GetNamedPorts()
 	c.Assert(npm, NotNil)
-	c.Assert(len(npm), Equals, 2)
-	c.Assert(npm["dns"], checker.HasKey, types.PortProto{Port: uint16(53), Proto: uint8(0)})
-	c.Assert(npm["https"], checker.HasKey, types.PortProto{Port: uint16(443), Proto: uint8(6)})
+	c.Assert(npm.Len(), Equals, 2)
+
+	port, err = npm.GetNamedPort("dns", uint8(0))
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(53))
+	port, err = npm.GetNamedPort("https", uint8(6))
+	c.Assert(err, IsNil)
+	c.Assert(port, Equals, uint16(443))
 
 	// Assure deletion occurs across all mappings.
 	c.Assert(len(IPIdentityCache.ipToIdentityCache), Equals, 1)
@@ -494,7 +510,9 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 		c.Assert(err, IsNil)
 		npm = IPIdentityCache.GetNamedPorts()
 		c.Assert(npm, NotNil)
-		c.Assert(npm["http2"], checker.HasKey, types.PortProto{Port: uint16(8080), Proto: uint8(6)})
+		port, err := npm.GetNamedPort("http2", uint8(6))
+		c.Assert(err, IsNil)
+		c.Assert(port, Equals, uint16(8080))
 		// only the first changes named ports, as they are all the same
 		c.Assert(namedPortsChanged, Equals, index == 0)
 		cachedIdentity, _ := IPIdentityCache.LookupByIP(endpointIPs[index])
@@ -553,7 +571,7 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	namedPortsChanged = IPIdentityCache.Delete(endpointIP2, source.Kubernetes)
 	c.Assert(namedPortsChanged, Equals, true)
 	npm = IPIdentityCache.GetNamedPorts()
-	c.Assert(npm, HasLen, 0)
+	c.Assert(npm.Len(), Equals, 0)
 }
 
 func BenchmarkIPCacheUpsert10(b *testing.B) {

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -5,10 +5,13 @@ package ipcache
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"sort"
+	"strconv"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -551,6 +554,75 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 	c.Assert(namedPortsChanged, Equals, true)
 	npm = IPIdentityCache.GetNamedPorts()
 	c.Assert(npm, HasLen, 0)
+}
+
+func BenchmarkIPCacheUpsert10(b *testing.B) {
+	benchmarkIPCacheUpsert(b, 10)
+}
+
+func BenchmarkIPCacheUpsert100(b *testing.B) {
+	benchmarkIPCacheUpsert(b, 100)
+}
+
+func BenchmarkIPCacheUpsert1000(b *testing.B) {
+	benchmarkIPCacheUpsert(b, 1000)
+}
+
+func BenchmarkIPCacheUpsert10000(b *testing.B) {
+	benchmarkIPCacheUpsert(b, 10000)
+}
+
+func benchmarkIPCacheUpsert(b *testing.B, num int) {
+	meta := K8sMetadata{
+		Namespace: "default",
+		PodName:   "app",
+		NamedPorts: types.NamedPortMap{
+			"http": types.PortProto{Port: 80, Proto: uint8(u8proto.TCP)},
+			"dns":  types.PortProto{Port: 53},
+		},
+	}
+
+	buf := make([]byte, 4)
+	ips := make([]string, num)
+	nms := make([]string, num)
+	for i := range nms {
+		binary.BigEndian.PutUint32(buf, uint32(i+2<<26))
+		ip, _ := netip.AddrFromSlice(buf)
+		ips[i] = ip.String()
+		nms[i] = strconv.Itoa(i)
+	}
+
+	b.StopTimer()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		allocator := testidentity.NewMockIdentityAllocator(nil)
+		ipcache := NewIPCache(&Configuration{
+			Context:           ctx,
+			IdentityAllocator: allocator,
+			PolicyHandler:     &mockUpdater{},
+			DatapathHandler:   &mockTriggerer{},
+			NodeHandler:       &mockNodeHandler{},
+		})
+
+		// We only want to measure the calls to upsert.
+		b.StartTimer()
+		for j := 0; j < num; j++ {
+			meta.PodName = nms[j]
+			_, err := ipcache.Upsert(ips[j], nil, 0, &meta, Identity{
+				ID:     identityPkg.NumericIdentity(j),
+				Source: source.Kubernetes,
+			})
+			if err != nil {
+				b.Fatalf("failed to upsert: %v", err)
+			}
+		}
+		b.StopTimer()
+
+		// Clean up after ourselves, so that the individual runs are comparable.
+		cancel()
+		ipcache.Shutdown()
+	}
 }
 
 type dummyListener struct {

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -9,17 +9,18 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/cilium/cilium/pkg/ipcache/types"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/types"
 )
 
 // prefixInfo holds all of the information (labels, etc.) about a given prefix
 // independently based on the ResourceID of the origin of that information, and
 // provides convenient accessors to consistently merge the stored information
 // to generate ipcache output based on a range of inputs.
-type prefixInfo map[types.ResourceID]*resourceInfo
+type prefixInfo map[ipcacheTypes.ResourceID]*resourceInfo
 
 // IdentityOverride can be used to override the identity of a given prefix.
 // Must be provided together with a set of labels. Any other labels associated
@@ -46,6 +47,13 @@ type resourceInfo struct {
 // cannot be used in conjunction with methods, which is how the information
 // gets injected into the IPCache.
 type IPMetadata any
+
+// namedPortMultiMapUpdater allows for mutation of the NamedPortMultiMap, which
+// is otherwise read-only.
+type namedPortMultiMapUpdater interface {
+	types.NamedPortMultiMap
+	Update(old, new types.NamedPortMap) (namedPortChanged bool)
+}
 
 // merge overwrites the field in 'resourceInfo' corresponding to 'info'. This
 // associates the new information with the prefix and ResourceID that this
@@ -149,7 +157,7 @@ func (s prefixInfo) identityOverride() (lbls labels.Labels, hasOverride bool) {
 func (s prefixInfo) logConflicts(scopedLog *logrus.Entry) {
 	var (
 		override           labels.Labels
-		overrideResourceID types.ResourceID
+		overrideResourceID ipcacheTypes.ResourceID
 	)
 
 	for resourceID, info := range s {

--- a/pkg/types/portmap_test.go
+++ b/pkg/types/portmap_test.go
@@ -103,7 +103,7 @@ func (ds *PortsTestSuite) TestPolicyPortProtoSet(c *C) {
 }
 
 func (ds *PortsTestSuite) TestPolicyNamedPortMultiMap(c *C) {
-	a := NamedPortMultiMap{
+	a := namedPortMultiMap{
 		"http": PortProtoSet{
 			PortProto{Port: 80, Proto: 6}:   struct{}{},
 			PortProto{Port: 8080, Proto: 6}: struct{}{},
@@ -120,7 +120,7 @@ func (ds *PortsTestSuite) TestPolicyNamedPortMultiMap(c *C) {
 			PortProto{Port: 53, Proto: 6}:  struct{}{},
 		},
 	}
-	b := NamedPortMultiMap{
+	b := namedPortMultiMap{
 		"http": PortProtoSet{
 			PortProto{Port: 80, Proto: 6}:   struct{}{},
 			PortProto{Port: 8080, Proto: 6}: struct{}{},
@@ -161,7 +161,8 @@ func (ds *PortsTestSuite) TestPolicyNamedPortMultiMap(c *C) {
 	c.Assert(err, Equals, ErrUnknownNamedPort)
 	c.Assert(port, Equals, uint16(0))
 
-	port, err = NamedPortMultiMap(nil).GetNamedPort("unknown", 6)
+	var nilvalued namedPortMultiMap
+	port, err = NamedPortMultiMap(nilvalued).GetNamedPort("unknown", 6)
 	c.Assert(err, Equals, ErrNilMap)
 	c.Assert(port, Equals, uint16(0))
 


### PR DESCRIPTION
The commit messages should be descriptive, here's the summary line for each.

1. ipcache: add benchmark for Upsert (`regression.txt` below)
2. ipcache: make NamedPortMultiMap an interface (`interface.txt` below)
3. ipcache: switch named ports to reference counting (`fix.txt` below)
4. ipcache: simplify the named ports update code (`cleanup.txt` below)

The following is a comparison of running the benchmark added in commit 1 over the course of the four commits.

```
goos: linux
goarch: arm64
pkg: github.com/cilium/cilium/pkg/ipcache
                      │ regression.txt │             interface.txt             │               fix.txt               │             cleanup.txt             │
                      │     sec/op     │     sec/op      vs base               │   sec/op     vs base                │   sec/op     vs base                │
IPCacheUpsert10-10        97.10µ ±  3%     94.58µ ±  3%       ~ (p=0.052 n=10)   48.84µ ± 5%  -49.70% (p=0.000 n=10)   47.59µ ± 5%  -50.98% (p=0.000 n=10)
IPCacheUpsert100-10      2672.3µ ±  5%    2718.4µ ±  8%       ~ (p=0.481 n=10)   508.3µ ± 5%  -80.98% (p=0.000 n=10)   485.0µ ± 2%  -81.85% (p=0.000 n=10)
IPCacheUpsert1000-10     69.543m ± 13%    66.515m ± 17%       ~ (p=0.481 n=10)   5.282m ± 5%  -92.40% (p=0.000 n=10)   5.056m ± 2%  -92.73% (p=0.000 n=10)
IPCacheUpsert10000-10   4166.59m ±  1%   4299.95m ±  2%  +3.20% (p=0.000 n=10)   48.63m ± 5%  -98.83% (p=0.000 n=10)   44.87m ± 5%  -98.92% (p=0.000 n=10)
geomean                   16.56m           16.47m        -0.55%                  1.589m       -90.40%                  1.513m       -90.86%
```

The last commit, `cleanup.txt` removes some now redundant work, and hence gets a mild speedup. If preferred, it can be squashed into the third commit, but like this the algorithmic changes are easier to understand.

```
goos: linux
goarch: arm64
pkg: github.com/cilium/cilium/pkg/ipcache
                      │   fix.txt   │            cleanup.txt             │
                      │   sec/op    │   sec/op     vs base               │
IPCacheUpsert10-10      48.84µ ± 5%   47.59µ ± 5%       ~ (p=0.165 n=10)
IPCacheUpsert100-10     508.3µ ± 5%   485.0µ ± 2%  -4.58% (p=0.005 n=10)
IPCacheUpsert1000-10    5.282m ± 5%   5.056m ± 2%  -4.28% (p=0.011 n=10)
IPCacheUpsert10000-10   48.63m ± 5%   44.87m ± 5%  -7.74% (p=0.009 n=10)
geomean                 1.589m        1.513m       -4.81%
```

Note that simply reverting 93cd67f2994a618865fbcdb0294bcd9b4d44036a is not actually a fix, as the quadratic behaviour still lurks. This can be observed by forcefully setting `ipcache.needNamedPorts = true` when benchmarking:

```
                      │ main-head.txt  │    revert-with-neednamedports.txt     │ 
                      │     sec/op     │     sec/op      vs base               │  
IPCacheUpsert10-10        95.00µ ±  5%     92.12µ ±  3%  -3.04% (p=0.000 n=10)   
IPCacheUpsert100-10      2729.7µ ±  4%    2617.5µ ± 12%       ~ (p=0.165 n=10)   
IPCacheUpsert1000-10     70.192m ± 11%    68.974m ± 10%       ~ (p=0.579 n=10)   
IPCacheUpsert10000-10   4247.52m ±  3%   4233.62m ±  1%       ~ (p=0.853 n=10)   
geomean                   16.68m           16.29m        -2.31%                 
```

Fixes: #24987 

```release-note
Address cilium-agent startup performance regression.
```
