### PR TITLE
operator/cmd: Move Cilium Operator version log earlier

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -225,6 +225,7 @@ func initEnv() {
 	}
 
 	option.LogRegisteredOptions(vp, log)
+	log.Infof("Cilium Operator %s", version.Version)
 }
 
 func doCleanup() {
@@ -239,8 +240,6 @@ func doCleanup() {
 // built-in leader election capbility in kubernetes.
 // See: https://github.com/kubernetes/client-go/blob/master/examples/leader-election/main.go
 func runOperator(lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) {
-	log.Infof("Cilium Operator %s", version.Version)
-
 	isLeader.Store(false)
 
 	leaderElectionCtx, leaderElectionCtxCancel = context.WithCancel(context.Background())


### PR DESCRIPTION
To be consistent with where the version log is printed in the Agent,
move the Operator's log statement accordingly to be after the options
are printed.

This is a very minor change, but I found it much easier to find the
version when it's in the usual spot that we are used to when looking
at the Agent. Without this change, the version is printed after the hive
framework initialization. If that fails, we wouldn't be able to see the
version log anyway.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
