### PR TITLE
bpf: Fix incorrect source identity for IPv6 host policies

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -94,28 +94,6 @@ static __always_inline bool identity_from_ipcache_ok(void)
 #endif
 
 #ifdef ENABLE_IPV6
-# ifdef ENABLE_HOST_FIREWALL
-static __always_inline __u32
-ipcache_lookup_srcid6(struct __ctx_buff *ctx)
-{
-	struct remote_endpoint_info *info = NULL;
-	void *data, *data_end;
-	struct ipv6hdr *ip6;
-	__u32 srcid = 0;
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
-
-	info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
-	if (info != NULL)
-		srcid = info->sec_label;
-	cilium_dbg(ctx, info ? DBG_IP_ID_MAP_SUCCEED6 : DBG_IP_ID_MAP_FAILED6,
-		   ip6->saddr.s6_addr32[3], srcid);
-
-	return srcid;
-}
-# endif /* ENABLE_HOST_FIREWALL */
-
 static __always_inline __u32
 resolve_srcid_ipv6(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 		   const bool from_host)
@@ -372,8 +350,8 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 {
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	int hdrlen, ret;
 	__u32 src_id = 0;
+	int hdrlen, ret;
 	__u8 nexthdr;
 
 	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
@@ -392,8 +370,11 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 			return ret;
 	}
 
+	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_HOST)
+		src_id = HOST_ID;
+	src_id = resolve_srcid_ipv6(ctx, src_id, true);
+
 	/* to-netdev is attached to the egress path of the native device. */
-	src_id = ipcache_lookup_srcid6(ctx);
 	return ipv6_host_policy_egress(ctx, src_id, trace, ext_err);
 }
 #endif /* ENABLE_HOST_FIREWALL */


### PR DESCRIPTION
When running the host firewall over IPv6 NodePort traffic, it would enforce policies on the SYN+ACK packet with the SNATed IP address. Obviously that didn't work great.

This happened because the IPv6 logic would simply lookup the source security identity in the ipcache using the source IP address, without considering that it might be SNATed. In case it is SNATed, the source IP is always a host IP and the identity always `HOST_ID`. Thus, the host firewall starts incorrectly enforcing policies on the packet.

The IPv4 path, on the other hand, does this source identity lookup right: it only assumes a packet is coming from the local host if it has the HOST magic mark (which we set via netfilter). SNATed packets don't have this mark and therefore end up with an `UNKNOWN_ID` identity.

This pull request fixes the IPv6 logic to match the IPv4 logic.

This bug has always existed in the IPv6 code path. For IPv4, it was fixed in commit cfd8fbffd1 ("bpf: Fix srcID resolution on to-netdev in case of SNAT"). I don't remember why I seemed to think the IPv6 code path didn't need the same fix :(

We already have an end-to-end test to cover this code path, but it is currently quarantined. Other changes are required before we can unquarantine it, so I'll send those in a separate patchset.

Fixes: https://github.com/cilium/cilium/pull/11507.
```release-note
Fix bug that causes enforcement of host policies on reply IPv6 pod traffic.
```