### PR TITLE
workflows: add the kind-based clustermesh conformance test for stable branches

### DIFF
--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.27.0
+    image: kindest/node:${K8S_VERSION}
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +12,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:v1.27.0
+    image: kindest/node:${K8S_VERSION}
 networking:
   disableDefaultCNI: true
   ipFamily: ${IPFAMILY}

--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -1,0 +1,561 @@
+name: ClusterMesh (ci-multicluster-1.11)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  issue_comment:
+    types:
+      - created
+  # Run once a day
+  schedule:
+    - cron:  '0 6 * * *'
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `main`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  #
+  # pull_request: {}
+  ###
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # So that Sibz/github-status-action can write into the status API
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - issue_comment: PR number
+  #   - pull_request: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing:
+  # - schedule: {name} schedule {SHA}
+  # - issue_comment: {name} issue_comment {PR number}
+  # - pull_request: {name} pull_request {PR number}
+  #
+  # Note: for `issue_comment` triggers, we additionally need to filter out based
+  # on comment content, otherwise any comment will interrupt workflow runs.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/ci-multicluster-1.11' ||
+        github.event.comment.body == '/test-backport-1.11'
+      ) && github.event.issue.number) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.number)
+    }}
+  cancel-in-progress: true
+
+env:
+  kind_version: v0.17.0
+  k8s_version: v1.23.17
+  # renovate: datasource=github-releases depName=cilium/cilium-cli
+  cilium_cli_version: v0.13.1
+  clusterName1: cluster1-${{ github.run_id }}
+  clusterName2: cluster2-${{ github.run_id }}
+  contextName1: kind-cluster1-${{ github.run_id }}
+  contextName2: kind-cluster2-${{ github.run_id }}
+  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    if: |
+      (github.event_name == 'issue_comment' &&
+        (github.event.comment.body == '/ci-multicluster-1.11' ||
+         github.event.comment.body == '/test-backport-1.11')) ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      # Because we run on issue comments, we need to checkout the code for
+      # paths-filter to work.
+      - name: Checkout code
+        if: ${{ github.event.issue.pull_request }}
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        with:
+          persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "base=$(jq -r '.base.sha' pr.json)" >> $GITHUB_OUTPUT
+          echo "head=$(jq -r '.head.sha' pr.json)" >> $GITHUB_OUTPUT
+      - name: Check code changes
+        if: ${{ github.event.issue.pull_request }}
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: tested-tree
+        with:
+          base: ${{ steps.pr.outputs.base }}
+          ref: ${{ steps.pr.outputs.head }}
+          filters: |
+            src:
+              - '!(test|Documentation)/**'
+
+  setup-report:
+    runs-on: ubuntu-latest
+    needs: check_changes
+    name: Set commit status to pending
+    outputs:
+      sha: ${{ steps.vars.outputs.sha }}
+    steps:
+    - name: Set up job variables
+      id: vars
+      run: |
+        if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
+          PR_API_JSON=$(curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
+          SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+        else
+          SHA=${{ github.sha }}
+        fi
+        echo "sha=${SHA}" >> $GITHUB_OUTPUT
+
+    - name: Set commit status to pending
+      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ steps.vars.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity test in progress...
+        state: pending
+        target_url: ${{ env.check_url }}
+
+  skip-test-run:
+    # If the modified files are not relevant for this test then we can skip
+    # this test and mark it as successful.
+    if: github.event.comment.body == '/test-backport-1.11' && needs.check_changes.outputs.tested == 'false'
+    runs-on: ubuntu-latest
+    needs: setup-report
+    name: Set commit status to success (skipped)
+    steps:
+    - name: Set commit status to success
+      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests skipped
+        state: success
+        target_url: ${{ env.check_url }}
+
+  # This job is skipped when the workflow was triggered with the generic `/test-backport-1.11`
+  # trigger if the only modified files were under `test/` or `Documentation/`.
+  installation-and-connectivity:
+    needs: setup-report
+    name: Setup & Test
+    if: |
+      ((github.event_name == 'issue_comment' &&
+        ((github.event.comment.body == '/ci-multicluster-1.11') ||
+         (github.event.comment.body == '/test-backport-1.11' && needs.check_changes.outputs.tested == 'true'))) ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: '1'
+            tunnel: 'disabled'
+            ipfamily: 'ipv4'
+            encryption: 'disabled'
+            kube-proxy: 'iptables'
+
+          - name: '2'
+            tunnel: 'disabled'
+            ipfamily: 'ipv4'
+            encryption: 'wireguard'
+            kube-proxy: 'none'
+
+          # IPsec encryption cannot be used with BPF NodePort.
+          - name: '3'
+            tunnel: 'disabled'
+            ipfamily: 'ipv4'
+            encryption: 'ipsec'
+            kube-proxy: 'iptables'
+
+          # v1.11 is currently affected by a bug in case of direct routing configurations
+          # which causes IPv6 traffic destined to a remote pod to be masqueraded. Given
+          # that this is a rather niche use-case, and it has been fixed in newer versions,
+          # let's skip this test.
+          # - name: '4'
+          #   tunnel: 'disabled'
+          #   ipfamily: 'ipv6'
+          #   encryption: 'disabled'
+          #   kube-proxy: 'none'
+
+          # v1.11 is currently affected by a bug in case of direct routing configurations
+          # which causes IPv6 traffic destined to a remote pod to be masqueraded. Given
+          # that this is a rather niche use-case, and it has been fixed in newer versions,
+          # let's skip this test.
+          # - name: '5'
+          #   tunnel: 'disabled'
+          #   ipfamily: 'dual'
+          #   encryption: 'ipsec'
+          #   kube-proxy: 'iptables'
+
+          - name: '6'
+            tunnel: 'vxlan'
+            ipfamily: 'ipv4'
+            encryption: 'disabled'
+            kube-proxy: 'none'
+
+          - name: '7'
+            tunnel: 'vxlan'
+            ipfamily: 'ipv4'
+            encryption: 'wireguard'
+            kube-proxy: 'iptables'
+
+          # IPsec encryption cannot be used with BPF NodePort.
+          - name: '8'
+            tunnel: 'vxlan'
+            ipfamily: 'ipv4'
+            encryption: 'ipsec'
+            kube-proxy: 'iptables'
+
+        # Tunneling is currently not supported in case of ipv6-only clusters (#17240)
+        #  - name: '9'
+        #    tunnel: 'vxlan'
+        #    ipfamily: 'ipv6'
+        #    encryption: 'disabled'
+        #    kube-proxy: 'none'
+
+          - name: '10'
+            tunnel: 'vxlan'
+            ipfamily: 'dual'
+            encryption: 'wireguard'
+            kube-proxy: 'iptables'
+
+    steps:
+    - name: Checkout GitHub main
+      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        persist-credentials: false
+
+    - name: Set Environment Variables
+      uses: ./.github/actions/set-env-variables
+
+    - name: Set up job variables for GHA environment
+      id: vars
+      run: |
+        SHA=${{ needs.setup-report.outputs.sha }}
+
+        # bpf.masquerade is disabled due to #23283
+        CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+          --helm-set=image.useDigest=false \
+          --helm-set=image.tag=${SHA} \
+          --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+          --helm-set=operator.image.suffix=-ci \
+          --helm-set=operator.image.tag=${SHA} \
+          --helm-set=operator.image.useDigest=false \
+          --helm-set=bpf.masquerade=false \
+          --config monitor-aggregation=none \
+          --rollback=false \
+          --version="
+
+        CILIUM_INSTALL_TUNNEL="--helm-set=tunnel=vxlan"
+        if [ "${{ matrix.tunnel }}" == "disabled" ]; then
+          CILIUM_INSTALL_TUNNEL="--helm-set-string=tunnel=disabled \
+            --helm-set=autoDirectNodeRoutes=true \
+            --helm-set=ipv4NativeRoutingCIDR=10.240.0.0/12 \
+            --helm-set=ipv6NativeRoutingCIDR=fd00:10:240::/44"
+        fi
+
+        case "${{ matrix.ipFamily }}" in
+          ipv4)
+            CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=true --helm-set=ipv6.enabled=false"
+            KIND_POD_CIDR_1="10.242.0.0/16"
+            KIND_SVC_CIDR_1="10.243.0.0/16"
+            KIND_POD_CIDR_2="10.244.0.0/16"
+            KIND_SVC_CIDR_2="10.245.0.0/16"
+            ;;
+          ipv6)
+            CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=false --helm-set=ipv6.enabled=true"
+            KIND_POD_CIDR_1="fd00:10:242::/48"
+            KIND_SVC_CIDR_1="fd00:10:243::/112"
+            KIND_POD_CIDR_2="fd00:10:244::/48"
+            KIND_SVC_CIDR_2="fd00:10:245::/112"
+            ;;
+          dual)
+            CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=true --helm-set=ipv6.enabled=true"
+            KIND_POD_CIDR_1="10.242.0.0/16,fd00:10:242::/48"
+            KIND_SVC_CIDR_1="10.243.0.0/16,fd00:10:243::/112"
+            KIND_POD_CIDR_2="10.244.0.0/16,fd00:10:244::/48"
+            KIND_SVC_CIDR_2="10.245.0.0/16,fd00:10:245::/112"
+            ;;
+          *)
+            echo "Unknown IP family '${{ matrix.ipFamily }}'" && false
+            ;;
+        esac
+
+        CILIUM_INSTALL_L7_PROXY="--helm-set=l7Proxy=true"
+        if [ "${{ matrix.encryption }}" == "wireguard" ]; then
+          # Wireguard (--enable-wireguard) is not compatible with L7 proxy (--enable-l7-proxy)
+          CILIUM_INSTALL_L7_PROXY="--helm-set=l7Proxy=false"
+        fi
+
+        HUBBLE_ENABLE_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=hubble.relay.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci:${SHA} \
+          --helm-set=hubble.relay.image.useDigest=false"
+        CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
+          --apiserver-version=${SHA} --service-type=NodePort"
+
+        CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
+          --flow-validation=disabled \
+          --multi-cluster=${{ env.contextName2 }} \
+          --external-target=google.com \
+          --collect-sysdump-on-failure"
+
+        # Skip external traffic (e.g. 1.1.1.1 and www.google.com) tests as IPv6 is not supported
+        # in GitHub runners: https://github.com/actions/runner-images/issues/668
+        if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
+          CONNECTIVITY_TEST_DEFAULTS="$CONNECTIVITY_TEST_DEFAULTS \
+            --test='!/pod-to-world' \
+            --test='!/pod-to-cidr'"
+        fi
+
+        echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_L7_PROXY}" >> $GITHUB_OUTPUT
+        echo hubble_enable_defaults=${HUBBLE_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
+        echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
+        echo clustermesh_enable_defaults=${CLUSTERMESH_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
+
+        echo kind_pod_cidr_1=${KIND_POD_CIDR_1} >> $GITHUB_OUTPUT
+        echo kind_svc_cidr_1=${KIND_SVC_CIDR_1} >> $GITHUB_OUTPUT
+        echo kind_pod_cidr_2=${KIND_POD_CIDR_2} >> $GITHUB_OUTPUT
+        echo kind_svc_cidr_2=${KIND_SVC_CIDR_2} >> $GITHUB_OUTPUT
+
+    - name: Checkout code
+      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      with:
+        ref: ${{ needs.setup-report.outputs.sha }}
+        persist-credentials: false
+
+    - name: Install Cilium CLI
+      run: |
+        curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
+        sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+        sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
+        rm cilium-linux-amd64.tar.gz{,.sha256sum}
+        cilium version
+
+    - name: Generate Kind configuration files
+      run: |
+        K8S_VERSION=${{ env.k8s_version }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_1 }} \
+          SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_1 }} \
+          IPFAMILY=${{ matrix.ipFamily }} \
+          KUBEPROXYMODE=${{ matrix.kube-proxy }} \
+          envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
+
+        K8S_VERSION=${{ env.k8s_version }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_2 }} \
+          SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_2 }} \
+          IPFAMILY=${{ matrix.ipFamily }} \
+          KUBEPROXYMODE=${{ matrix.kube-proxy }} \
+          envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
+
+    - name: Create Kind cluster 1
+      uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
+      with:
+        cluster_name: ${{ env.clusterName1 }}
+        version: ${{ env.kind_version }}
+        config: ./.github/kind-config-cluster1.yaml
+        wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+    - name: Create Kind cluster 2
+      uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
+      with:
+        cluster_name: ${{ env.clusterName2 }}
+        version: ${{ env.kind_version }}
+        config: ./.github/kind-config-cluster2.yaml
+        wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+    # Make sure that coredns uses IPv4-only upstream DNS servers also in case of clusters
+    # with IP family dual, since IPv6 ones are not reachable and cause spurious failures.
+    - name: Configure the coredns nameservers
+      if: matrix.ipfamily == 'dual'
+      run: |
+        COREDNS_PATCH="
+        spec:
+          template:
+            spec:
+              dnsPolicy: None
+              dnsConfig:
+                nameservers:
+                - 8.8.4.4
+                - 8.8.8.8
+        "
+
+        kubectl --context ${{ env.contextName1 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
+        kubectl --context ${{ env.contextName2 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
+
+    - name: Wait for images to be available
+      timeout-minutes: 10
+      shell: bash
+      run: |
+        for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
+          until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ needs.setup-report.outputs.sha }} &> /dev/null; do sleep 45s; done
+        done
+
+    - name: Install Cilium in cluster1
+      run: |
+        # Using the deprecated flag --cluster-name due to cilium/cilium-cli#1347
+        # --helm-set cluster.name ${{ env.clusterName1 }}
+        cilium --context ${{ env.contextName1 }} install \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --encryption ${{ matrix.encryption }} \
+          --cluster-name ${{ env.clusterName1 }} \
+          --helm-set cluster.id=1
+
+    - name: Copy the IPsec secret to cluster2, as they must match
+      if: matrix.encryption == 'ipsec'
+      run: |
+        kubectl --context ${{ env.contextName1 }} get secret -n kube-system cilium-ipsec-keys -o yaml |
+          kubectl --context ${{ env.contextName2 }} create -f -
+
+    - name: Install Cilium in cluster2
+      run: |
+        # Using the deprecated form --cluster-name due to cilium/cilium-cli#1347
+        # --helm-set cluster.name ${{ env.clusterName2 }}
+        cilium --context ${{ env.contextName2 }} install \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --encryption ${{ matrix.encryption }} \
+          --cluster-name ${{ env.clusterName2 }} \
+          --helm-set cluster.id=255 \
+          --inherit-ca ${{ env.contextName1 }}
+
+    - name: Enable Hubble
+      run: |
+        cilium --context ${{ env.contextName1 }} hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false
+        cilium --context ${{ env.contextName2 }} hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false --relay=false
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+
+    - name: Enable Cluster Mesh
+      run: |
+        cilium --context ${{ env.contextName1 }} clustermesh enable ${{ steps.vars.outputs.clustermesh_enable_defaults }}
+        cilium --context ${{ env.contextName2 }} clustermesh enable ${{ steps.vars.outputs.clustermesh_enable_defaults }}
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait
+
+    - name: Connect clusters
+      run: |
+        cilium --context ${{ env.contextName1 }} clustermesh connect --destination-context ${{ env.contextName2 }}
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait
+
+    - name: Port forward Relay
+      run: |
+        cilium --context ${{ env.contextName1 }} hubble port-forward &
+        sleep 10s
+        [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
+
+    - name: Run connectivity test
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+
+    - name: Post-test information gathering
+      if: ${{ !success() }}
+      run: |
+        cilium --context ${{ env.contextName1 }} status
+        cilium --context ${{ env.contextName1 }} clustermesh status
+        cilium --context ${{ env.contextName2 }} status
+        cilium --context ${{ env.contextName2 }} clustermesh status
+
+        kubectl config use-context ${{ env.contextName1 }}
+        kubectl get pods --all-namespaces -o wide
+        cilium sysdump --output-filename cilium-sysdump-context1-final
+
+        kubectl config use-context ${{ env.contextName2 }}
+        kubectl get pods --all-namespaces -o wide
+        cilium sysdump --output-filename cilium-sysdump-context2-final
+      shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+
+    - name: Upload artifacts
+      if: ${{ !success() }}
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: cilium-sysdumps-${{ matrix.name }}
+        path: cilium-sysdump-*.zip
+        retention-days: 5
+
+  report-success:
+    runs-on: ubuntu-latest
+    needs: [setup-report, installation-and-connectivity]
+    name: Set commit status to success
+    if: ${{ success() }}
+    steps:
+    - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests succeeded
+        state: success
+        target_url: ${{ env.check_url }}
+
+  report-failure:
+    runs-on: ubuntu-latest
+    needs: [setup-report, installation-and-connectivity]
+    name: Set commit status to failure
+    if: ${{ failure() }}
+    steps:
+    - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests failed
+        state: failure
+        target_url: ${{ env.check_url }}
+
+  report-cancelled:
+    runs-on: ubuntu-latest
+    needs: [setup-report, installation-and-connectivity]
+    name: Set commit status to cancelled
+    if: ${{ cancelled() }}
+    steps:
+    - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests cancelled
+        state: error
+        target_url: ${{ env.check_url }}

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -1,0 +1,556 @@
+name: ClusterMesh (ci-multicluster-1.12)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  issue_comment:
+    types:
+      - created
+  # Run once a day
+  schedule:
+    - cron:  '0 5 * * *'
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `main`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  #
+  # pull_request: {}
+  ###
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # So that Sibz/github-status-action can write into the status API
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - issue_comment: PR number
+  #   - pull_request: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing:
+  # - schedule: {name} schedule {SHA}
+  # - issue_comment: {name} issue_comment {PR number}
+  # - pull_request: {name} pull_request {PR number}
+  #
+  # Note: for `issue_comment` triggers, we additionally need to filter out based
+  # on comment content, otherwise any comment will interrupt workflow runs.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/ci-multicluster-1.12' ||
+        github.event.comment.body == '/test-backport-1.12'
+      ) && github.event.issue.number) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.number)
+    }}
+  cancel-in-progress: true
+
+env:
+  kind_version: v0.17.0
+  k8s_version: v1.24.12
+  # renovate: datasource=github-releases depName=cilium/cilium-cli
+  cilium_cli_version: v0.13.1
+  clusterName1: cluster1-${{ github.run_id }}
+  clusterName2: cluster2-${{ github.run_id }}
+  contextName1: kind-cluster1-${{ github.run_id }}
+  contextName2: kind-cluster2-${{ github.run_id }}
+  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    if: |
+      (github.event_name == 'issue_comment' &&
+        (github.event.comment.body == '/ci-multicluster-1.12' ||
+         github.event.comment.body == '/test-backport-1.12')) ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      # Because we run on issue comments, we need to checkout the code for
+      # paths-filter to work.
+      - name: Checkout code
+        if: ${{ github.event.issue.pull_request }}
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        with:
+          persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "base=$(jq -r '.base.sha' pr.json)" >> $GITHUB_OUTPUT
+          echo "head=$(jq -r '.head.sha' pr.json)" >> $GITHUB_OUTPUT
+      - name: Check code changes
+        if: ${{ github.event.issue.pull_request }}
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: tested-tree
+        with:
+          base: ${{ steps.pr.outputs.base }}
+          ref: ${{ steps.pr.outputs.head }}
+          filters: |
+            src:
+              - '!(test|Documentation)/**'
+
+  setup-report:
+    runs-on: ubuntu-latest
+    needs: check_changes
+    name: Set commit status to pending
+    outputs:
+      sha: ${{ steps.vars.outputs.sha }}
+    steps:
+    - name: Set up job variables
+      id: vars
+      run: |
+        if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
+          PR_API_JSON=$(curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
+          SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+        else
+          SHA=${{ github.sha }}
+        fi
+        echo "sha=${SHA}" >> $GITHUB_OUTPUT
+
+    - name: Set commit status to pending
+      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ steps.vars.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity test in progress...
+        state: pending
+        target_url: ${{ env.check_url }}
+
+  skip-test-run:
+    # If the modified files are not relevant for this test then we can skip
+    # this test and mark it as successful.
+    if: github.event.comment.body == '/test-backport-1.12' && needs.check_changes.outputs.tested == 'false'
+    runs-on: ubuntu-latest
+    needs: setup-report
+    name: Set commit status to success (skipped)
+    steps:
+    - name: Set commit status to success
+      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests skipped
+        state: success
+        target_url: ${{ env.check_url }}
+
+  # This job is skipped when the workflow was triggered with the generic `/test-backport-1.12`
+  # trigger if the only modified files were under `test/` or `Documentation/`.
+  installation-and-connectivity:
+    needs: setup-report
+    name: Setup & Test
+    if: |
+      ((github.event_name == 'issue_comment' &&
+        ((github.event.comment.body == '/ci-multicluster-1.12') ||
+         (github.event.comment.body == '/test-backport-1.12' && needs.check_changes.outputs.tested == 'true'))) ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: '1'
+            tunnel: 'disabled'
+            ipfamily: 'ipv4'
+            encryption: 'disabled'
+            kube-proxy: 'iptables'
+
+          - name: '2'
+            tunnel: 'disabled'
+            ipfamily: 'ipv4'
+            encryption: 'wireguard'
+            kube-proxy: 'none'
+
+          # IPsec encryption cannot be used with BPF NodePort.
+          - name: '3'
+            tunnel: 'disabled'
+            ipfamily: 'ipv4'
+            encryption: 'ipsec'
+            kube-proxy: 'iptables'
+
+          # IPsec encryption is currently not supported in case of ipv6-only clusters (#23553)
+          # Wireguard encryption is currently affected by a bug in case of ipv6-only clusters (#23917)
+          - name: '4'
+            tunnel: 'disabled'
+            ipfamily: 'ipv6'
+            encryption: 'disabled'
+            kube-proxy: 'none'
+
+          # IPsec encryption cannot be used with BPF NodePort.
+          - name: '5'
+            tunnel: 'disabled'
+            ipfamily: 'dual'
+            encryption: 'ipsec'
+            kube-proxy: 'iptables'
+
+          - name: '6'
+            tunnel: 'vxlan'
+            ipfamily: 'ipv4'
+            encryption: 'disabled'
+            kube-proxy: 'none'
+
+          - name: '7'
+            tunnel: 'vxlan'
+            ipfamily: 'ipv4'
+            encryption: 'wireguard'
+            kube-proxy: 'iptables'
+
+          # IPsec encryption cannot be used with BPF NodePort.
+          - name: '8'
+            tunnel: 'vxlan'
+            ipfamily: 'ipv4'
+            encryption: 'ipsec'
+            kube-proxy: 'iptables'
+
+        # Tunneling is currently not supported in case of ipv6-only clusters (#17240)
+        #  - name: '9'
+        #    tunnel: 'vxlan'
+        #    ipfamily: 'ipv6'
+        #    encryption: 'disabled'
+        #    kube-proxy: 'none'
+
+          - name: '10'
+            tunnel: 'vxlan'
+            ipfamily: 'dual'
+            encryption: 'wireguard'
+            kube-proxy: 'iptables'
+
+    steps:
+    - name: Checkout GitHub main
+      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        persist-credentials: false
+
+    - name: Set Environment Variables
+      uses: ./.github/actions/set-env-variables
+
+    - name: Set up job variables for GHA environment
+      id: vars
+      run: |
+        SHA=${{ needs.setup-report.outputs.sha }}
+
+        # bpf.masquerade is disabled due to #23283
+        CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+          --helm-set=image.useDigest=false \
+          --helm-set=image.tag=${SHA} \
+          --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+          --helm-set=operator.image.suffix=-ci \
+          --helm-set=operator.image.tag=${SHA} \
+          --helm-set=operator.image.useDigest=false \
+          --helm-set=bpf.masquerade=false \
+          --config monitor-aggregation=none \
+          --rollback=false \
+          --version="
+
+        CILIUM_INSTALL_TUNNEL="--helm-set=tunnel=vxlan"
+        if [ "${{ matrix.tunnel }}" == "disabled" ]; then
+          CILIUM_INSTALL_TUNNEL="--helm-set-string=tunnel=disabled \
+            --helm-set=autoDirectNodeRoutes=true \
+            --helm-set=ipv4NativeRoutingCIDR=10.240.0.0/12 \
+            --helm-set=ipv6NativeRoutingCIDR=fd00:10:240::/44"
+        fi
+
+        case "${{ matrix.ipFamily }}" in
+          ipv4)
+            CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=true --helm-set=ipv6.enabled=false"
+            KIND_POD_CIDR_1="10.242.0.0/16"
+            KIND_SVC_CIDR_1="10.243.0.0/16"
+            KIND_POD_CIDR_2="10.244.0.0/16"
+            KIND_SVC_CIDR_2="10.245.0.0/16"
+            ;;
+          ipv6)
+            CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=false --helm-set=ipv6.enabled=true"
+            KIND_POD_CIDR_1="fd00:10:242::/48"
+            KIND_SVC_CIDR_1="fd00:10:243::/112"
+            KIND_POD_CIDR_2="fd00:10:244::/48"
+            KIND_SVC_CIDR_2="fd00:10:245::/112"
+            ;;
+          dual)
+            CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=true --helm-set=ipv6.enabled=true"
+            KIND_POD_CIDR_1="10.242.0.0/16,fd00:10:242::/48"
+            KIND_SVC_CIDR_1="10.243.0.0/16,fd00:10:243::/112"
+            KIND_POD_CIDR_2="10.244.0.0/16,fd00:10:244::/48"
+            KIND_SVC_CIDR_2="10.245.0.0/16,fd00:10:245::/112"
+            ;;
+          *)
+            echo "Unknown IP family '${{ matrix.ipFamily }}'" && false
+            ;;
+        esac
+
+        CILIUM_INSTALL_L7_PROXY="--helm-set=l7Proxy=true"
+        if [ "${{ matrix.encryption }}" == "wireguard" ]; then
+          # Wireguard (--enable-wireguard) is not compatible with L7 proxy (--enable-l7-proxy)
+          CILIUM_INSTALL_L7_PROXY="--helm-set=l7Proxy=false"
+        fi
+
+        HUBBLE_ENABLE_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=hubble.relay.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci:${SHA} \
+          --helm-set=hubble.relay.image.useDigest=false"
+        CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
+          --apiserver-version=${SHA} --service-type=NodePort"
+
+        CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
+          --flow-validation=disabled \
+          --multi-cluster=${{ env.contextName2 }} \
+          --external-target=google.com \
+          --collect-sysdump-on-failure"
+
+        # Skip external traffic (e.g. 1.1.1.1 and www.google.com) tests as IPv6 is not supported
+        # in GitHub runners: https://github.com/actions/runner-images/issues/668
+        if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
+          CONNECTIVITY_TEST_DEFAULTS="$CONNECTIVITY_TEST_DEFAULTS \
+            --test='!/pod-to-world' \
+            --test='!/pod-to-cidr'"
+        fi
+
+        echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_L7_PROXY}" >> $GITHUB_OUTPUT
+        echo hubble_enable_defaults=${HUBBLE_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
+        echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
+        echo clustermesh_enable_defaults=${CLUSTERMESH_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
+
+        echo kind_pod_cidr_1=${KIND_POD_CIDR_1} >> $GITHUB_OUTPUT
+        echo kind_svc_cidr_1=${KIND_SVC_CIDR_1} >> $GITHUB_OUTPUT
+        echo kind_pod_cidr_2=${KIND_POD_CIDR_2} >> $GITHUB_OUTPUT
+        echo kind_svc_cidr_2=${KIND_SVC_CIDR_2} >> $GITHUB_OUTPUT
+
+    - name: Checkout code
+      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      with:
+        ref: ${{ needs.setup-report.outputs.sha }}
+        persist-credentials: false
+
+    - name: Install Cilium CLI
+      run: |
+        curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
+        sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+        sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
+        rm cilium-linux-amd64.tar.gz{,.sha256sum}
+        cilium version
+
+    - name: Generate Kind configuration files
+      run: |
+        K8S_VERSION=${{ env.k8s_version }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_1 }} \
+          SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_1 }} \
+          IPFAMILY=${{ matrix.ipFamily }} \
+          KUBEPROXYMODE=${{ matrix.kube-proxy }} \
+          envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
+
+        K8S_VERSION=${{ env.k8s_version }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_2 }} \
+          SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_2 }} \
+          IPFAMILY=${{ matrix.ipFamily }} \
+          KUBEPROXYMODE=${{ matrix.kube-proxy }} \
+          envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
+
+    - name: Create Kind cluster 1
+      uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
+      with:
+        cluster_name: ${{ env.clusterName1 }}
+        version: ${{ env.kind_version }}
+        config: ./.github/kind-config-cluster1.yaml
+        wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+    - name: Create Kind cluster 2
+      uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
+      with:
+        cluster_name: ${{ env.clusterName2 }}
+        version: ${{ env.kind_version }}
+        config: ./.github/kind-config-cluster2.yaml
+        wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+    # Make sure that coredns uses IPv4-only upstream DNS servers also in case of clusters
+    # with IP family dual, since IPv6 ones are not reachable and cause spurious failures.
+    - name: Configure the coredns nameservers
+      if: matrix.ipfamily == 'dual'
+      run: |
+        COREDNS_PATCH="
+        spec:
+          template:
+            spec:
+              dnsPolicy: None
+              dnsConfig:
+                nameservers:
+                - 8.8.4.4
+                - 8.8.8.8
+        "
+
+        kubectl --context ${{ env.contextName1 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
+        kubectl --context ${{ env.contextName2 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
+
+    - name: Wait for images to be available
+      timeout-minutes: 10
+      shell: bash
+      run: |
+        for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
+          until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ needs.setup-report.outputs.sha }} &> /dev/null; do sleep 45s; done
+        done
+
+    - name: Install Cilium in cluster1
+      run: |
+        # Using the deprecated flag --cluster-name due to cilium/cilium-cli#1347
+        # --helm-set cluster.name ${{ env.clusterName1 }}
+        cilium --context ${{ env.contextName1 }} install \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --encryption ${{ matrix.encryption }} \
+          --cluster-name ${{ env.clusterName1 }} \
+          --helm-set cluster.id=1
+
+    - name: Copy the IPsec secret to cluster2, as they must match
+      if: matrix.encryption == 'ipsec'
+      run: |
+        kubectl --context ${{ env.contextName1 }} get secret -n kube-system cilium-ipsec-keys -o yaml |
+          kubectl --context ${{ env.contextName2 }} create -f -
+
+    - name: Install Cilium in cluster2
+      run: |
+        # Using the deprecated form --cluster-name due to cilium/cilium-cli#1347
+        # --helm-set cluster.name ${{ env.clusterName2 }}
+        cilium --context ${{ env.contextName2 }} install \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --encryption ${{ matrix.encryption }} \
+          --cluster-name ${{ env.clusterName2 }} \
+          --helm-set cluster.id=255 \
+          --inherit-ca ${{ env.contextName1 }}
+
+    - name: Enable Hubble
+      run: |
+        cilium --context ${{ env.contextName1 }} hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false
+        cilium --context ${{ env.contextName2 }} hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false --relay=false
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+
+    - name: Enable Cluster Mesh
+      run: |
+        cilium --context ${{ env.contextName1 }} clustermesh enable ${{ steps.vars.outputs.clustermesh_enable_defaults }}
+        cilium --context ${{ env.contextName2 }} clustermesh enable ${{ steps.vars.outputs.clustermesh_enable_defaults }}
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait
+
+    - name: Connect clusters
+      run: |
+        cilium --context ${{ env.contextName1 }} clustermesh connect --destination-context ${{ env.contextName2 }}
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait
+
+    - name: Port forward Relay
+      run: |
+        cilium --context ${{ env.contextName1 }} hubble port-forward &
+        sleep 10s
+        [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
+
+    - name: Run connectivity test
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+
+    - name: Post-test information gathering
+      if: ${{ !success() }}
+      run: |
+        cilium --context ${{ env.contextName1 }} status
+        cilium --context ${{ env.contextName1 }} clustermesh status
+        cilium --context ${{ env.contextName2 }} status
+        cilium --context ${{ env.contextName2 }} clustermesh status
+
+        kubectl config use-context ${{ env.contextName1 }}
+        kubectl get pods --all-namespaces -o wide
+        cilium sysdump --output-filename cilium-sysdump-context1-final
+
+        kubectl config use-context ${{ env.contextName2 }}
+        kubectl get pods --all-namespaces -o wide
+        cilium sysdump --output-filename cilium-sysdump-context2-final
+      shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+
+    - name: Upload artifacts
+      if: ${{ !success() }}
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: cilium-sysdumps-${{ matrix.name }}
+        path: cilium-sysdump-*.zip
+        retention-days: 5
+
+  report-success:
+    runs-on: ubuntu-latest
+    needs: [setup-report, installation-and-connectivity]
+    name: Set commit status to success
+    if: ${{ success() }}
+    steps:
+    - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests succeeded
+        state: success
+        target_url: ${{ env.check_url }}
+
+  report-failure:
+    runs-on: ubuntu-latest
+    needs: [setup-report, installation-and-connectivity]
+    name: Set commit status to failure
+    if: ${{ failure() }}
+    steps:
+    - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests failed
+        state: failure
+        target_url: ${{ env.check_url }}
+
+  report-cancelled:
+    runs-on: ubuntu-latest
+    needs: [setup-report, installation-and-connectivity]
+    name: Set commit status to cancelled
+    if: ${{ cancelled() }}
+    steps:
+    - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests cancelled
+        state: error
+        target_url: ${{ env.check_url }}

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -1,0 +1,556 @@
+name: ClusterMesh (ci-multicluster-1.13)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  issue_comment:
+    types:
+      - created
+  # Run once a day
+  schedule:
+    - cron:  '0 4 * * *'
+  ### FOR TESTING PURPOSES
+  # This workflow runs in the context of `main`, and ignores changes to
+  # workflow files in PRs. For testing changes to this workflow from a PR:
+  # - Make sure the PR uses a branch from the base repository (requires write
+  #   privileges). It will not work with a branch from a fork (missing secrets).
+  # - Uncomment the `pull_request` event below, commit separately with a `DO
+  #   NOT MERGE` message, and push to the PR. As long as the commit is present,
+  #   any push to the PR will trigger this workflow.
+  # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
+  #   will disappear from the PR checks: please provide a direct link to the
+  #   successful workflow run (can be found from Actions tab) in a comment.
+  #
+  # pull_request: {}
+  ###
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # So that Sibz/github-status-action can write into the status API
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - issue_comment: PR number
+  #   - pull_request: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing:
+  # - schedule: {name} schedule {SHA}
+  # - issue_comment: {name} issue_comment {PR number}
+  # - pull_request: {name} pull_request {PR number}
+  #
+  # Note: for `issue_comment` triggers, we additionally need to filter out based
+  # on comment content, otherwise any comment will interrupt workflow runs.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'issue_comment' && (
+        github.event.comment.body == '/ci-multicluster-1.13' ||
+        github.event.comment.body == '/test-backport-1.13'
+      ) && github.event.issue.number) ||
+      (github.event_name == 'pull_request' && github.event.pull_request.number)
+    }}
+  cancel-in-progress: true
+
+env:
+  kind_version: v0.17.0
+  k8s_version: v1.24.12
+  # renovate: datasource=github-releases depName=cilium/cilium-cli
+  cilium_cli_version: v0.13.1
+  clusterName1: cluster1-${{ github.run_id }}
+  clusterName2: cluster2-${{ github.run_id }}
+  contextName1: kind-cluster1-${{ github.run_id }}
+  contextName2: kind-cluster2-${{ github.run_id }}
+  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+jobs:
+  check_changes:
+    name: Deduce required tests from code changes
+    if: |
+      (github.event_name == 'issue_comment' &&
+        (github.event.comment.body == '/ci-multicluster-1.13' ||
+         github.event.comment.body == '/test-backport-1.13')) ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      tested: ${{ steps.tested-tree.outputs.src }}
+    steps:
+      # Because we run on issue comments, we need to checkout the code for
+      # paths-filter to work.
+      - name: Checkout code
+        if: ${{ github.event.issue.pull_request }}
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+        with:
+          persist-credentials: false
+      - name: Retrieve pull request's base and head
+        if: ${{ github.event.issue.pull_request }}
+        id: pr
+        run: |
+          curl ${{ github.event.issue.pull_request.url }} > pr.json
+          echo "base=$(jq -r '.base.sha' pr.json)" >> $GITHUB_OUTPUT
+          echo "head=$(jq -r '.head.sha' pr.json)" >> $GITHUB_OUTPUT
+      - name: Check code changes
+        if: ${{ github.event.issue.pull_request }}
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: tested-tree
+        with:
+          base: ${{ steps.pr.outputs.base }}
+          ref: ${{ steps.pr.outputs.head }}
+          filters: |
+            src:
+              - '!(test|Documentation)/**'
+
+  setup-report:
+    runs-on: ubuntu-latest
+    needs: check_changes
+    name: Set commit status to pending
+    outputs:
+      sha: ${{ steps.vars.outputs.sha }}
+    steps:
+    - name: Set up job variables
+      id: vars
+      run: |
+        if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
+          PR_API_JSON=$(curl \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
+          SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+        else
+          SHA=${{ github.sha }}
+        fi
+        echo "sha=${SHA}" >> $GITHUB_OUTPUT
+
+    - name: Set commit status to pending
+      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ steps.vars.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity test in progress...
+        state: pending
+        target_url: ${{ env.check_url }}
+
+  skip-test-run:
+    # If the modified files are not relevant for this test then we can skip
+    # this test and mark it as successful.
+    if: github.event.comment.body == '/test-backport-1.13' && needs.check_changes.outputs.tested == 'false'
+    runs-on: ubuntu-latest
+    needs: setup-report
+    name: Set commit status to success (skipped)
+    steps:
+    - name: Set commit status to success
+      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests skipped
+        state: success
+        target_url: ${{ env.check_url }}
+
+  # This job is skipped when the workflow was triggered with the generic `/test-backport-1.13`
+  # trigger if the only modified files were under `test/` or `Documentation/`.
+  installation-and-connectivity:
+    needs: setup-report
+    name: Setup & Test
+    if: |
+      ((github.event_name == 'issue_comment' &&
+        ((github.event.comment.body == '/ci-multicluster-1.13') ||
+         (github.event.comment.body == '/test-backport-1.13' && needs.check_changes.outputs.tested == 'true'))) ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'pull_request')
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: '1'
+            tunnel: 'disabled'
+            ipfamily: 'ipv4'
+            encryption: 'disabled'
+            kube-proxy: 'iptables'
+
+          - name: '2'
+            tunnel: 'disabled'
+            ipfamily: 'ipv4'
+            encryption: 'wireguard'
+            kube-proxy: 'none'
+
+          # IPsec encryption cannot be used with BPF NodePort.
+          - name: '3'
+            tunnel: 'disabled'
+            ipfamily: 'ipv4'
+            encryption: 'ipsec'
+            kube-proxy: 'iptables'
+
+          # IPsec encryption is currently not supported in case of ipv6-only clusters (#23553)
+          # Wireguard encryption is currently affected by a bug in case of ipv6-only clusters (#23917)
+          - name: '4'
+            tunnel: 'disabled'
+            ipfamily: 'ipv6'
+            encryption: 'disabled'
+            kube-proxy: 'none'
+
+          # IPsec encryption cannot be used with BPF NodePort.
+          - name: '5'
+            tunnel: 'disabled'
+            ipfamily: 'dual'
+            encryption: 'ipsec'
+            kube-proxy: 'iptables'
+
+          - name: '6'
+            tunnel: 'vxlan'
+            ipfamily: 'ipv4'
+            encryption: 'disabled'
+            kube-proxy: 'none'
+
+          - name: '7'
+            tunnel: 'vxlan'
+            ipfamily: 'ipv4'
+            encryption: 'wireguard'
+            kube-proxy: 'iptables'
+
+          # IPsec encryption cannot be used with BPF NodePort.
+          - name: '8'
+            tunnel: 'vxlan'
+            ipfamily: 'ipv4'
+            encryption: 'ipsec'
+            kube-proxy: 'iptables'
+
+        # Tunneling is currently not supported in case of ipv6-only clusters (#17240)
+        #  - name: '9'
+        #    tunnel: 'vxlan'
+        #    ipfamily: 'ipv6'
+        #    encryption: 'disabled'
+        #    kube-proxy: 'none'
+
+          - name: '10'
+            tunnel: 'vxlan'
+            ipfamily: 'dual'
+            encryption: 'wireguard'
+            kube-proxy: 'iptables'
+
+    steps:
+    - name: Checkout GitHub main
+      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        persist-credentials: false
+
+    - name: Set Environment Variables
+      uses: ./.github/actions/set-env-variables
+
+    - name: Set up job variables for GHA environment
+      id: vars
+      run: |
+        SHA=${{ needs.setup-report.outputs.sha }}
+
+        # bpf.masquerade is disabled due to #23283
+        CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+          --helm-set=image.useDigest=false \
+          --helm-set=image.tag=${SHA} \
+          --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+          --helm-set=operator.image.suffix=-ci \
+          --helm-set=operator.image.tag=${SHA} \
+          --helm-set=operator.image.useDigest=false \
+          --helm-set=bpf.masquerade=false \
+          --config monitor-aggregation=none \
+          --rollback=false \
+          --version="
+
+        CILIUM_INSTALL_TUNNEL="--helm-set=tunnel=vxlan"
+        if [ "${{ matrix.tunnel }}" == "disabled" ]; then
+          CILIUM_INSTALL_TUNNEL="--helm-set-string=tunnel=disabled \
+            --helm-set=autoDirectNodeRoutes=true \
+            --helm-set=ipv4NativeRoutingCIDR=10.240.0.0/12 \
+            --helm-set=ipv6NativeRoutingCIDR=fd00:10:240::/44"
+        fi
+
+        case "${{ matrix.ipFamily }}" in
+          ipv4)
+            CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=true --helm-set=ipv6.enabled=false"
+            KIND_POD_CIDR_1="10.242.0.0/16"
+            KIND_SVC_CIDR_1="10.243.0.0/16"
+            KIND_POD_CIDR_2="10.244.0.0/16"
+            KIND_SVC_CIDR_2="10.245.0.0/16"
+            ;;
+          ipv6)
+            CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=false --helm-set=ipv6.enabled=true"
+            KIND_POD_CIDR_1="fd00:10:242::/48"
+            KIND_SVC_CIDR_1="fd00:10:243::/112"
+            KIND_POD_CIDR_2="fd00:10:244::/48"
+            KIND_SVC_CIDR_2="fd00:10:245::/112"
+            ;;
+          dual)
+            CILIUM_INSTALL_IPFAMILY="--helm-set=ipv4.enabled=true --helm-set=ipv6.enabled=true"
+            KIND_POD_CIDR_1="10.242.0.0/16,fd00:10:242::/48"
+            KIND_SVC_CIDR_1="10.243.0.0/16,fd00:10:243::/112"
+            KIND_POD_CIDR_2="10.244.0.0/16,fd00:10:244::/48"
+            KIND_SVC_CIDR_2="10.245.0.0/16,fd00:10:245::/112"
+            ;;
+          *)
+            echo "Unknown IP family '${{ matrix.ipFamily }}'" && false
+            ;;
+        esac
+
+        CILIUM_INSTALL_L7_PROXY="--helm-set=l7Proxy=true"
+        if [ "${{ matrix.encryption }}" == "wireguard" ]; then
+          # Wireguard (--enable-wireguard) is not compatible with L7 proxy (--enable-l7-proxy)
+          CILIUM_INSTALL_L7_PROXY="--helm-set=l7Proxy=false"
+        fi
+
+        HUBBLE_ENABLE_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=hubble.relay.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci:${SHA} \
+          --helm-set=hubble.relay.image.useDigest=false"
+        CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
+          --apiserver-version=${SHA} --service-type=NodePort"
+
+        CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
+          --flow-validation=disabled \
+          --multi-cluster=${{ env.contextName2 }} \
+          --external-target=google.com \
+          --collect-sysdump-on-failure"
+
+        # Skip external traffic (e.g. 1.1.1.1 and www.google.com) tests as IPv6 is not supported
+        # in GitHub runners: https://github.com/actions/runner-images/issues/668
+        if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
+          CONNECTIVITY_TEST_DEFAULTS="$CONNECTIVITY_TEST_DEFAULTS \
+            --test='!/pod-to-world' \
+            --test='!/pod-to-cidr'"
+        fi
+
+        echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_L7_PROXY}" >> $GITHUB_OUTPUT
+        echo hubble_enable_defaults=${HUBBLE_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
+        echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
+        echo clustermesh_enable_defaults=${CLUSTERMESH_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
+
+        echo kind_pod_cidr_1=${KIND_POD_CIDR_1} >> $GITHUB_OUTPUT
+        echo kind_svc_cidr_1=${KIND_SVC_CIDR_1} >> $GITHUB_OUTPUT
+        echo kind_pod_cidr_2=${KIND_POD_CIDR_2} >> $GITHUB_OUTPUT
+        echo kind_svc_cidr_2=${KIND_SVC_CIDR_2} >> $GITHUB_OUTPUT
+
+    - name: Checkout code
+      uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0
+      with:
+        ref: ${{ needs.setup-report.outputs.sha }}
+        persist-credentials: false
+
+    - name: Install Cilium CLI
+      run: |
+        curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
+        sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
+        sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
+        rm cilium-linux-amd64.tar.gz{,.sha256sum}
+        cilium version
+
+    - name: Generate Kind configuration files
+      run: |
+        K8S_VERSION=${{ env.k8s_version }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_1 }} \
+          SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_1 }} \
+          IPFAMILY=${{ matrix.ipFamily }} \
+          KUBEPROXYMODE=${{ matrix.kube-proxy }} \
+          envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
+
+        K8S_VERSION=${{ env.k8s_version }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_2 }} \
+          SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_2 }} \
+          IPFAMILY=${{ matrix.ipFamily }} \
+          KUBEPROXYMODE=${{ matrix.kube-proxy }} \
+          envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster2.yaml
+
+    - name: Create Kind cluster 1
+      uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
+      with:
+        cluster_name: ${{ env.clusterName1 }}
+        version: ${{ env.kind_version }}
+        config: ./.github/kind-config-cluster1.yaml
+        wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+    - name: Create Kind cluster 2
+      uses: helm/kind-action@d8ccf8fb623ce1bb360ae2f45f323d9d5c5e9f00 # v1.5.0
+      with:
+        cluster_name: ${{ env.clusterName2 }}
+        version: ${{ env.kind_version }}
+        config: ./.github/kind-config-cluster2.yaml
+        wait: 0 # The control-plane never becomes ready, since no CNI is present
+
+    # Make sure that coredns uses IPv4-only upstream DNS servers also in case of clusters
+    # with IP family dual, since IPv6 ones are not reachable and cause spurious failures.
+    - name: Configure the coredns nameservers
+      if: matrix.ipfamily == 'dual'
+      run: |
+        COREDNS_PATCH="
+        spec:
+          template:
+            spec:
+              dnsPolicy: None
+              dnsConfig:
+                nameservers:
+                - 8.8.4.4
+                - 8.8.8.8
+        "
+
+        kubectl --context ${{ env.contextName1 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
+        kubectl --context ${{ env.contextName2 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
+
+    - name: Wait for images to be available
+      timeout-minutes: 10
+      shell: bash
+      run: |
+        for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do
+          until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ needs.setup-report.outputs.sha }} &> /dev/null; do sleep 45s; done
+        done
+
+    - name: Install Cilium in cluster1
+      run: |
+        # Using the deprecated flag --cluster-name due to cilium/cilium-cli#1347
+        # --helm-set cluster.name ${{ env.clusterName1 }}
+        cilium --context ${{ env.contextName1 }} install \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --encryption ${{ matrix.encryption }} \
+          --cluster-name ${{ env.clusterName1 }} \
+          --helm-set cluster.id=1
+
+    - name: Copy the IPsec secret to cluster2, as they must match
+      if: matrix.encryption == 'ipsec'
+      run: |
+        kubectl --context ${{ env.contextName1 }} get secret -n kube-system cilium-ipsec-keys -o yaml |
+          kubectl --context ${{ env.contextName2 }} create -f -
+
+    - name: Install Cilium in cluster2
+      run: |
+        # Using the deprecated form --cluster-name due to cilium/cilium-cli#1347
+        # --helm-set cluster.name ${{ env.clusterName2 }}
+        cilium --context ${{ env.contextName2 }} install \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --encryption ${{ matrix.encryption }} \
+          --cluster-name ${{ env.clusterName2 }} \
+          --helm-set cluster.id=255 \
+          --inherit-ca ${{ env.contextName1 }}
+
+    - name: Enable Hubble
+      run: |
+        cilium --context ${{ env.contextName1 }} hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false
+        cilium --context ${{ env.contextName2 }} hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false --relay=false
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+
+    - name: Enable Cluster Mesh
+      run: |
+        cilium --context ${{ env.contextName1 }} clustermesh enable ${{ steps.vars.outputs.clustermesh_enable_defaults }}
+        cilium --context ${{ env.contextName2 }} clustermesh enable ${{ steps.vars.outputs.clustermesh_enable_defaults }}
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait
+
+    - name: Connect clusters
+      run: |
+        cilium --context ${{ env.contextName1 }} clustermesh connect --destination-context ${{ env.contextName2 }}
+
+    - name: Wait for cluster mesh status to be ready
+      run: |
+        cilium --context ${{ env.contextName1 }} status --wait
+        cilium --context ${{ env.contextName2 }} status --wait
+        cilium --context ${{ env.contextName1 }} clustermesh status --wait
+        cilium --context ${{ env.contextName2 }} clustermesh status --wait
+
+    - name: Port forward Relay
+      run: |
+        cilium --context ${{ env.contextName1 }} hubble port-forward &
+        sleep 10s
+        [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
+
+    - name: Run connectivity test
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+
+    - name: Post-test information gathering
+      if: ${{ !success() }}
+      run: |
+        cilium --context ${{ env.contextName1 }} status
+        cilium --context ${{ env.contextName1 }} clustermesh status
+        cilium --context ${{ env.contextName2 }} status
+        cilium --context ${{ env.contextName2 }} clustermesh status
+
+        kubectl config use-context ${{ env.contextName1 }}
+        kubectl get pods --all-namespaces -o wide
+        cilium sysdump --output-filename cilium-sysdump-context1-final
+
+        kubectl config use-context ${{ env.contextName2 }}
+        kubectl get pods --all-namespaces -o wide
+        cilium sysdump --output-filename cilium-sysdump-context2-final
+      shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
+
+    - name: Upload artifacts
+      if: ${{ !success() }}
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: cilium-sysdumps-${{ matrix.name }}
+        path: cilium-sysdump-*.zip
+        retention-days: 5
+
+  report-success:
+    runs-on: ubuntu-latest
+    needs: [setup-report, installation-and-connectivity]
+    name: Set commit status to success
+    if: ${{ success() }}
+    steps:
+    - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests succeeded
+        state: success
+        target_url: ${{ env.check_url }}
+
+  report-failure:
+    runs-on: ubuntu-latest
+    needs: [setup-report, installation-and-connectivity]
+    name: Set commit status to failure
+    if: ${{ failure() }}
+    steps:
+    - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests failed
+        state: failure
+        target_url: ${{ env.check_url }}
+
+  report-cancelled:
+    runs-on: ubuntu-latest
+    needs: [setup-report, installation-and-connectivity]
+    name: Set commit status to cancelled
+    if: ${{ cancelled() }}
+    steps:
+    - uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      with:
+        authToken: ${{ secrets.GITHUB_TOKEN }}
+        sha: ${{ needs.setup-report.outputs.sha }}
+        context: ${{ github.workflow }}
+        description: ClusterMesh connectivity tests cancelled
+        state: error
+        target_url: ${{ env.check_url }}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -65,6 +65,7 @@ concurrency:
 
 env:
   kind_version: v0.17.0
+  k8s_version: v1.27.1
   # renovate: datasource=github-releases depName=cilium/cilium-cli
   cilium_cli_version: v0.13.1
   clusterName1: cluster1-${{ github.run_id }}
@@ -354,13 +355,15 @@ jobs:
 
     - name: Generate Kind configuration files
       run: |
-        PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_1 }} \
+        K8S_VERSION=${{ env.k8s_version }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_1 }} \
           SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_1 }} \
           IPFAMILY=${{ matrix.ipFamily }} \
           KUBEPROXYMODE=${{ matrix.kube-proxy }} \
           envsubst < ./.github/kind-config.yaml.tmpl > ./.github/kind-config-cluster1.yaml
 
-        PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_2 }} \
+        K8S_VERSION=${{ env.k8s_version }} \
+          PODCIDR=${{ steps.vars.outputs.kind_pod_cidr_2 }} \
           SVCCIDR=${{ steps.vars.outputs.kind_svc_cidr_2 }} \
           IPFAMILY=${{ matrix.ipFamily }} \
           KUBEPROXYMODE=${{ matrix.kube-proxy }} \


### PR DESCRIPTION
This PR adds a copy of the new clustermesh conformance test initially introduced in https://github.com/cilium/cilium/pull/23496 for each of the currently active stable branches (i.e., v1.11, v1.12 and v1.13). Trigger phrases and Kubernetes
versions are updated accordingly.

<!-- Description of change -->

Fixes: #issue-number

```release-note
workflows: add the kind-based clustermesh conformance test for stable branches
```
