### PR TITLE
test: Fix consistent failure in IPv6 masquerading test

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -191,8 +191,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 	}, "IPv6 masquerading", func() {
 		var (
 			k8s1EndpointIPs map[string]string
+			testDSK8s1IPv6  string = "fd03::310"
 
-			testDSK8s1IPv6 string = "fd03::310"
+			demoYAML string
 		)
 
 		BeforeAll(func() {
@@ -201,6 +202,11 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"autoDirectNodeRoutes":  "true",
 				"ipv6NativeRoutingCIDR": helpers.IPv6NativeRoutingCIDR,
 			}, DeployCiliumOptionsAndDNS)
+
+			demoYAML = helpers.ManifestGet(kubectl.BasePath(), "demo_ds.yaml")
+			res := kubectl.ApplyDefault(demoYAML)
+			Expect(res).Should(helpers.CMDSuccess(), "Unable to apply %s", demoYAML)
+			waitPodsDs(kubectl, []string{testDS, testDSClient, testDSK8s2})
 
 			pod, err := kubectl.GetCiliumPodOnNode(helpers.K8s1)
 			Expect(err).Should(BeNil(), "Cannot get cilium pod on node %s", helpers.K8s1)
@@ -261,6 +267,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 
 		AfterAll(func() {
 			ciliumDelService(kubectl, 31080)
+			_ = kubectl.Delete(demoYAML)
 		})
 	})
 


### PR DESCRIPTION
This IPv6 masquerading test has been failing consistently for a while with:

    Cannot get client IPv6

The reason this happens is very simple: the pod whose IPv6 it tries to retrieve was never deployed.

This bug was introduced in 70d3f99fc ("test: Move IPv6 iptables masquerade test to DP suite"). It wasn't noticed because the test was already quarantined at the time.

This fix is never not expected to completely fix the test. I'm therefore not unquarantining it yet.

Fixes: https://github.com/cilium/cilium/pull/18655.
Updates: https://github.com/cilium/cilium/issues/23355.