### PR TITLE
daemon, ipam: omit IPAM mode check before calling ipam.Allocator.RestoreFinished

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1148,14 +1148,11 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	// Trigger refresh and update custom resource in the apiserver with all restored endpoints.
 	// Trigger after nodeDiscovery.StartDiscovery to avoid custom resource update conflict.
-	if option.Config.IPAM == ipamOption.IPAMCRD || option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure ||
-		option.Config.IPAM == ipamOption.IPAMAlibabaCloud || option.Config.IPAM == ipamOption.IPAMClusterPoolV2 {
-		if option.Config.EnableIPv6 {
-			d.ipam.IPv6Allocator.RestoreFinished()
-		}
-		if option.Config.EnableIPv4 {
-			d.ipam.IPv4Allocator.RestoreFinished()
-		}
+	if option.Config.EnableIPv6 {
+		d.ipam.IPv6Allocator.RestoreFinished()
+	}
+	if option.Config.EnableIPv4 {
+		d.ipam.IPv4Allocator.RestoreFinished()
 	}
 
 	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {


### PR DESCRIPTION
The IPAM modes which were left out of the condition (kubernetes, cluster-pool and delegated-plugin) all implement a noop RestoreFinished method in their allocator.

The kubernetes and cluster-pool modes uses hostscopeAllocator:
  https://github.com/cilium/cilium/blob/e84e99f16ed0862dc6fd79c09480eb7e08e50ad2/pkg/ipam/ipam.go#L116-L128

and thus its noop RestoreFinished method:

https://github.com/cilium/cilium/blob/e84e99f16ed0862dc6fd79c09480eb7e08e50ad2/pkg/ipam/hostscope.go#L98-L99

The delegated-plugin mode uses noopAllocator:
  https://github.com/cilium/cilium/blob/e84e99f16ed0862dc6fd79c09480eb7e08e50ad2/pkg/ipam/ipam.go#L147-L154

and thus its noop RestoreFinished method:
  https://github.com/cilium/cilium/blob/e84e99f16ed0862dc6fd79c09480eb7e08e50ad2/pkg/ipam/noop_allocator.go#L42-L43