### PR TITLE
clustermesh-apiserver: rework identities, endpoints and nodes synchronization to improve performance

### DIFF
--- a/clustermesh-apiserver/k8s/resources.go
+++ b/clustermesh-apiserver/k8s/resources.go
@@ -6,6 +6,9 @@ package k8s
 import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
 var (
@@ -21,6 +24,16 @@ var (
 		cell.Provide(
 			k8s.ServiceResource,
 			k8s.EndpointsResource,
+			k8s.CiliumNodeResource,
 		),
 	)
 )
+
+// Resources is a convenience struct to group all the agent k8s resources as cell constructor parameters.
+type Resources struct {
+	cell.In
+
+	Services    resource.Resource[*slim_corev1.Service]
+	Endpoints   resource.Resource[*k8s.Endpoints]
+	CiliumNodes resource.Resource[*cilium_api_v2.CiliumNode]
+}

--- a/clustermesh-apiserver/k8s/resources.go
+++ b/clustermesh-apiserver/k8s/resources.go
@@ -25,6 +25,7 @@ var (
 			k8s.ServiceResource,
 			k8s.EndpointsResource,
 			k8s.CiliumNodeResource,
+			k8s.CiliumIdentityResource,
 		),
 	)
 )
@@ -33,7 +34,8 @@ var (
 type Resources struct {
 	cell.In
 
-	Services    resource.Resource[*slim_corev1.Service]
-	Endpoints   resource.Resource[*k8s.Endpoints]
-	CiliumNodes resource.Resource[*cilium_api_v2.CiliumNode]
+	Services         resource.Resource[*slim_corev1.Service]
+	Endpoints        resource.Resource[*k8s.Endpoints]
+	CiliumNodes      resource.Resource[*cilium_api_v2.CiliumNode]
+	CiliumIdentities resource.Resource[*cilium_api_v2.CiliumIdentity]
 }

--- a/clustermesh-apiserver/k8s/resources.go
+++ b/clustermesh-apiserver/k8s/resources.go
@@ -9,6 +9,7 @@ import (
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
 )
 
 var (
@@ -26,6 +27,7 @@ var (
 			k8s.EndpointsResource,
 			k8s.CiliumNodeResource,
 			k8s.CiliumIdentityResource,
+			k8s.CiliumSlimEndpointResource,
 		),
 	)
 )
@@ -34,8 +36,9 @@ var (
 type Resources struct {
 	cell.In
 
-	Services         resource.Resource[*slim_corev1.Service]
-	Endpoints        resource.Resource[*k8s.Endpoints]
-	CiliumNodes      resource.Resource[*cilium_api_v2.CiliumNode]
-	CiliumIdentities resource.Resource[*cilium_api_v2.CiliumIdentity]
+	Services            resource.Resource[*slim_corev1.Service]
+	Endpoints           resource.Resource[*k8s.Endpoints]
+	CiliumNodes         resource.Resource[*cilium_api_v2.CiliumNode]
+	CiliumIdentities    resource.Resource[*cilium_api_v2.CiliumIdentity]
+	CiliumSlimEndpoints resource.Resource[*types.CiliumEndpoint]
 }

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -130,8 +130,8 @@ func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, cfg Ser
 			cfg.Backend = kvstore.Client()
 		}
 
-		store := store.NewWorkqueueSyncStore(cfg.Backend, serviceStore.ServiceStorePrefix,
-			store.WSSWithSourceClusterName(cfg.LocalClusterName()))
+		store := store.NewWorkqueueSyncStore(cfg.LocalClusterName(),
+			cfg.Backend, serviceStore.ServiceStorePrefix)
 		kvs = store
 		close(kvstoreReady)
 		store.Run(ctx)

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -164,9 +164,8 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	})
 	c.Assert(cm, Not(IsNil))
 
-	nodesWSS := store.NewWorkqueueSyncStore(kvstore.Client(), nodeStore.NodeStorePrefix,
-		store.WSSWithSourceClusterName("cluster2"), // The one which is tested with sync canaries
-	)
+	// cluster2 is the cluster which is tested with sync canaries
+	nodesWSS := store.NewWorkqueueSyncStore("cluster2", kvstore.Client(), nodeStore.NodeStorePrefix)
 	go nodesWSS.Run(ctx)
 	nodeNames := []string{"foo", "bar", "baz"}
 

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -4,6 +4,7 @@
 package identity
 
 import (
+	"encoding/json"
 	"net"
 	"strconv"
 
@@ -62,6 +63,23 @@ type IPIdentityPair struct {
 	K8sNamespace string          `json:"K8sNamespace,omitempty"`
 	K8sPodName   string          `json:"K8sPodName,omitempty"`
 	NamedPorts   []NamedPort     `json:"NamedPorts,omitempty"`
+}
+
+// GetKeyName returns the kvstore key to be used for the IPIdentityPair
+func (pair *IPIdentityPair) GetKeyName() string { return pair.PrefixString() }
+
+// Marshal returns the IPIdentityPair object as JSON byte slice
+func (pair *IPIdentityPair) Marshal() ([]byte, error) { return json.Marshal(pair) }
+
+// Unmarshal parses the JSON byte slice and updates the IPIdentityPair receiver
+func (pair *IPIdentityPair) Unmarshal(_ string, data []byte) error {
+	newPair := IPIdentityPair{}
+	if err := json.Unmarshal(data, &newPair); err != nil {
+		return err
+	}
+
+	*pair = newPair
+	return nil
 }
 
 // NamedPort is a mapping from a port name to a port number and protocol.

--- a/pkg/kvstore/store/syncstore.go
+++ b/pkg/kvstore/store/syncstore.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 // SyncStore abstracts the operations allowing to synchronize key/value pairs
@@ -78,14 +77,6 @@ type syncCanary struct{}
 
 type WSSOpt func(*wqSyncStore)
 
-// WSSWithSourceClusterName configures the name of the source cluster the information
-// is synchronized from, which is used to scope the "synced" prefix and enrich the metrics.
-func WSSWithSourceClusterName(cluster string) WSSOpt {
-	return func(wss *wqSyncStore) {
-		wss.source = cluster
-	}
-}
-
 // WSSWithRateLimiter sets the rate limiting algorithm to be used when requeueing failed events.
 func WSSWithRateLimiter(limiter workqueue.RateLimiter) WSSOpt {
 	return func(wss *wqSyncStore) {
@@ -117,11 +108,11 @@ func WSSWithSyncedKeyOverride(key string) WSSOpt {
 
 // NewWorkqueueSyncStore returns a SyncStore instance which leverages a workqueue
 // to coalescence update/delete requests and handle retries in case of errors.
-func NewWorkqueueSyncStore(backend SyncStoreBackend, prefix string, opts ...WSSOpt) SyncStore {
+func NewWorkqueueSyncStore(clusterName string, backend SyncStoreBackend, prefix string, opts ...WSSOpt) SyncStore {
 	wss := &wqSyncStore{
 		backend: backend,
 		prefix:  prefix,
-		source:  option.Config.ClusterName,
+		source:  clusterName,
 
 		workers:   1,
 		withLease: true,


### PR DESCRIPTION
This PR modifies the clustermesh-apiserver implementation to use the Resource[T] abstraction to retrieve CiliumIdentities, CiliumNodes and CiliumEndpoints from Kubernetes, rather than a vanilla informer, and synchronize them through the WorkqueueSyncStore. This ensures consistent behavior across all resource types (i.e., the retry logic is implemented by the SyncStore, rather than through the Resource[T] underlying workqueue).

This approach has several advantages, including:
* Enables retrying kvstore operations in case of temporary failures;
* Performs coalescencing in case of multiple updates for the same key;
* Simplifies the overall logic, since conversions and sanity checks are already performed by the Resource[T] abstraction.

Please, refer to the commit descriptions for more details about the individual changes.

<!-- Description of change -->

Related: #25562

```release-note
clustermesh-apiserver: rework identities, endpoints and nodes synchronization to improve performance
```
