### PR TITLE
ipam/allocator: remove unused Allocator methods

### DIFF
--- a/pkg/ipam/allocator/allocator.go
+++ b/pkg/ipam/allocator/allocator.go
@@ -16,8 +16,6 @@ import (
 //   - NoOpAllocator
 type Allocator interface {
 	GetPoolQuota() types.PoolQuotaMap
-	FirstPoolWithAvailableQuota(preferredPoolIDs []types.PoolID) (types.PoolID, int)
-	PoolExists(poolID types.PoolID) bool
 	Allocate(poolID types.PoolID, ip net.IP) error
 	AllocateMany(poolID types.PoolID, num int) ([]net.IP, error)
 	ReleaseMany(poolID types.PoolID, ips []net.IP) error

--- a/pkg/ipam/allocator/group.go
+++ b/pkg/ipam/allocator/group.go
@@ -143,35 +143,3 @@ func (g *PoolGroupAllocator) getAllocator(poolID types.PoolID) *PoolAllocator {
 
 	return g.allocators[poolID]
 }
-
-// FirstPoolWithAvailableQuota returns the first pool ID in the list of pools
-// with available addresses. If any of the preferred pool IDs have available
-// addresses, the first pool in that list is returned.
-func (g *PoolGroupAllocator) FirstPoolWithAvailableQuota(preferredPoolIDs []types.PoolID) (types.PoolID, int) {
-	g.mutex.RLock()
-	defer g.mutex.RUnlock()
-
-	for _, p := range preferredPoolIDs {
-		if allocator := g.allocators[p]; allocator != nil {
-			if available := allocator.Free(); available > 0 {
-				return p, available
-			}
-		}
-	}
-
-	for poolID, allocator := range g.allocators {
-		if available := allocator.Free(); available > 0 {
-			return poolID, available
-		}
-	}
-
-	return types.PoolNotExists, 0
-}
-
-// PoolExists returns true if an allocation pool exists.
-func (g *PoolGroupAllocator) PoolExists(poolID types.PoolID) bool {
-	g.mutex.RLock()
-	_, ok := g.allocators[poolID]
-	g.mutex.RUnlock()
-	return ok
-}

--- a/pkg/ipam/allocator/group_test.go
+++ b/pkg/ipam/allocator/group_test.go
@@ -19,9 +19,6 @@ func (e *AllocatorSuite) TestPoolGroupAllocator(c *check.C) {
 	})
 	c.Assert(err, check.IsNil)
 	c.Assert(g, check.Not(check.IsNil))
-	c.Assert(g.PoolExists("s1"), check.Equals, true)
-	c.Assert(g.PoolExists("s2"), check.Equals, true)
-	c.Assert(g.PoolExists("s3"), check.Equals, false)
 	quota := g.GetPoolQuota()
 	c.Assert(quota["s1"].AvailableIPs, check.Equals, 1<<16-2)
 	c.Assert(quota["s2"].AvailableIPs, check.Equals, 1<<16-2)
@@ -41,14 +38,12 @@ func (e *AllocatorSuite) TestPoolGroupAllocatorLimit(c *check.C) {
 	c.Assert(quota["s1"].AvailableIPs, check.Equals, maxAvailablePerPool)
 	c.Assert(quota["s2"].AvailableIPs, check.Equals, maxAvailablePerPool)
 
-	for i := 0; i < 2*maxAvailablePerPool; i++ {
-		poolID, available := g.FirstPoolWithAvailableQuota([]types.PoolID{})
-		c.Assert(poolID, check.Not(check.Equals), types.PoolNotExists)
-		c.Assert(available, check.Not(check.Equals), 0)
-
-		ips, err := g.AllocateMany(poolID, 1)
-		c.Assert(err, check.IsNil)
-		c.Assert(len(ips), check.Equals, 1)
+	for _, poolID := range []types.PoolID{"s1", "s2"} {
+		for i := 0; i < maxAvailablePerPool; i++ {
+			ips, err := g.AllocateMany(poolID, 1)
+			c.Assert(err, check.IsNil)
+			c.Assert(len(ips), check.Equals, 1)
+		}
 	}
 
 	quota = g.GetPoolQuota()

--- a/pkg/ipam/allocator/noop.go
+++ b/pkg/ipam/allocator/noop.go
@@ -20,12 +20,6 @@ func (n *NoOpAllocator) GetPoolQuota() types.PoolQuotaMap {
 	return types.PoolQuotaMap{}
 }
 
-// FirstPoolWithAvailableQuota returns the first pool ID in the list of pools
-// with available addresses. This function always returns types.PoolNotExists
-func (n *NoOpAllocator) FirstPoolWithAvailableQuota(preferredPoolIDs []types.PoolID) (types.PoolID, int) {
-	return types.PoolNotExists, 0
-}
-
 // Allocate allocates a paritcular IP in a particular pool. This function
 // always returns an error as this operation is not supported for the no-op
 // allocator.
@@ -42,10 +36,4 @@ func (n *NoOpAllocator) AllocateMany(poolID types.PoolID, num int) ([]net.IP, er
 // ReleaseMany releases a slice of IP addresses. This function has no effect
 func (n *NoOpAllocator) ReleaseMany(poolID types.PoolID, ips []net.IP) error {
 	return nil
-}
-
-// PoolExists returns true if an allocation pool exists. This function always
-// returns false.
-func (n *NoOpAllocator) PoolExists(poolID types.PoolID) bool {
-	return false
 }

--- a/pkg/ipam/allocator/noop_test.go
+++ b/pkg/ipam/allocator/noop_test.go
@@ -7,21 +7,13 @@ import (
 	"net"
 
 	"gopkg.in/check.v1"
-
-	"github.com/cilium/cilium/pkg/ipam/types"
 )
 
 func (e *AllocatorSuite) TestNoOpAllocator(c *check.C) {
 	g := &NoOpAllocator{}
 
-	c.Assert(g.PoolExists("s1"), check.Equals, false)
-
 	quota := g.GetPoolQuota()
 	c.Assert(quota["s1"].AvailableIPs, check.Equals, 0)
-
-	poolID, available := g.FirstPoolWithAvailableQuota([]types.PoolID{})
-	c.Assert(poolID, check.Equals, types.PoolNotExists)
-	c.Assert(available, check.Equals, 0)
 
 	err := g.Allocate("s1", net.ParseIP("1.1.1.1"))
 	c.Assert(err, check.Not(check.IsNil))


### PR DESCRIPTION
The FirstPoolWithAvailableQuota and PoolExists methods are only used in test code since commit 24cb0618756b ("azure: Calculate available addresses based on subnet resource"). Remove or replace their use in the test code and remove the implementations.