### PR TITLE
bpf/nat: implement support of ICMP4 fragmentation needed at egress

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -406,10 +406,11 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 		       NAT_PUNT_TO_STACK : DROP_NAT_NO_MAPPING;
 }
 
-static __always_inline int snat_v4_icmp_rewrite_embedded(struct __ctx_buff *ctx,
-							 struct ipv4_ct_tuple *tuple,
-							 struct ipv4_nat_entry *state,
-							 __u32 l4_off, __u32 inner_l4_off)
+static __always_inline int
+snat_v4_icmp_rewrite_ingress_embedded(struct __ctx_buff *ctx,
+				      struct ipv4_ct_tuple *tuple,
+				      struct ipv4_nat_entry *state,
+				      __u32 l4_off, __u32 inner_l4_off)
 {
 	struct csum_offset csum = {};
 	__be32 sum;
@@ -474,6 +475,71 @@ static __always_inline int snat_v4_icmp_rewrite_embedded(struct __ctx_buff *ctx,
 		return DROP_WRITE_ERROR;
 	if (ipv4_csum_update_by_diff(ctx, l4_off + sizeof(struct icmphdr), sum) < 0)
 		return DROP_CSUM_L3;
+	return 0;
+}
+
+/* NAT dest of the inner IP and L4 header of the ICMP packet.
+ * It's like SNAT (endpoint -> host) but on the dest because
+ * the inner packets are sent from remote to endpoint.
+ */
+static __always_inline int
+snat_v4_icmp_rewrite_egress_embedded(struct __ctx_buff *ctx,
+				     struct ipv4_ct_tuple *tuple,
+				     struct ipv4_nat_entry *state,
+				     __u32 l4_off, __u32 inner_l4_off)
+{
+	int ret;
+	int flags = BPF_F_PSEUDO_HDR;
+	struct csum_offset csum = {};
+	__be32 sum_l4 = 0;
+	__be32 sum;
+
+	if (state->to_saddr == tuple->saddr &&
+	    state->to_sport == tuple->sport)
+		return 0;
+	sum = csum_diff(&tuple->saddr, 4, &state->to_saddr, 4, 0);
+	csum_l4_offset_and_flags(tuple->nexthdr, &csum);
+
+	if (state->to_sport != tuple->sport) {
+		switch (tuple->nexthdr) {
+		case IPPROTO_TCP:
+		case IPPROTO_UDP:
+			ret = l4_modify_port(ctx, inner_l4_off,
+					     offsetof(struct tcphdr, dest),
+					     &csum, state->to_sport, tuple->sport);
+			if (ret < 0)
+				return ret;
+			break;
+#ifdef ENABLE_SCTP
+		case IPPROTO_SCTP:
+			return DROP_CSUM_L4;
+#endif  /* ENABLE_SCTP */
+		case IPPROTO_ICMP: {
+			__be32 from, to;
+
+			if (ctx_store_bytes(ctx, inner_l4_off +
+						offsetof(struct icmphdr, un.echo.id),
+						&state->to_sport,
+						sizeof(state->to_sport), 0) < 0)
+				return DROP_WRITE_ERROR;
+			from = tuple->sport;
+			to = state->to_sport;
+			flags = 0; /* ICMPv4 has no pseudo-header */
+			sum_l4 = csum_diff(&from, 4, &to, 4, 0);
+			csum.offset = offsetof(struct icmphdr, checksum);
+			break;
+		}}
+	}
+	if (ctx_store_bytes(ctx, l4_off + sizeof(struct icmphdr) + offsetof(struct iphdr, daddr),
+			    &state->to_saddr, 4, 0) < 0)
+		return DROP_WRITE_ERROR;
+	if (ipv4_csum_update_by_diff(ctx, l4_off + sizeof(struct icmphdr), sum) < 0)
+		return DROP_CSUM_L3;
+	if (tuple->nexthdr == IPPROTO_ICMP)
+		sum = sum_l4;
+	if (csum.offset &&
+	    csum_l4_replace(ctx, inner_l4_off, &csum, 0, sum, flags) < 0)
+		return DROP_CSUM_L4;
 	return 0;
 }
 
@@ -859,6 +925,7 @@ snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __s8 *
 	bool icmp_echoreply = false;
 	__u64 off;
 	int ret;
+	__u8 nexthdr;
 
 	build_bug_on(sizeof(struct ipv4_nat_entry) > 64);
 
@@ -866,6 +933,7 @@ snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __s8 *
 		return DROP_INVALID;
 
 	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &tuple);
+	nexthdr = tuple.nexthdr;
 
 	off = ((void *)ip4 - data) + ipv4_hdrlen(ip4);
 	switch (tuple.nexthdr) {
@@ -882,16 +950,107 @@ snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __s8 *
 	case IPPROTO_ICMP:
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
 			return DROP_INVALID;
-		if (icmphdr.type != ICMP_ECHO &&
-		    icmphdr.type != ICMP_ECHOREPLY)
-			return DROP_NAT_UNSUPP_PROTO;
-		if (icmphdr.type == ICMP_ECHO) {
+
+		switch (icmphdr.type) {
+		case ICMP_ECHO:
 			tuple.dport = 0;
 			tuple.sport = icmphdr.un.echo.id;
-		} else {
+			break;
+		case ICMP_ECHOREPLY:
 			tuple.dport = icmphdr.un.echo.id;
 			tuple.sport = 0;
 			icmp_echoreply = true;
+			break;
+		case ICMP_DEST_UNREACH:
+			switch (icmphdr.code) {
+			case ICMP_FRAG_NEEDED: {
+				struct iphdr iphdr;
+				__u32 icmpoff = off + sizeof(icmphdr);
+				__be16 identifier;
+				__u8 type;
+
+				/* According to the RFC 5508, any networking
+				 * equipment that is responding with an ICMP
+				 * Error packet should embed the original packet
+				 * in its response.
+				 */
+				if (ctx_load_bytes(ctx, icmpoff, &iphdr,
+						   sizeof(iphdr)) < 0)
+					return DROP_INVALID;
+				/* From the embedded IP headers we should be
+				 * able to determine corresponding protocol, IP
+				 * src/dst of the packet sent to resolve the NAT
+				 * session.
+				 */
+				tuple.nexthdr = iphdr.protocol;
+				tuple.saddr = iphdr.daddr;
+				tuple.daddr = iphdr.saddr;
+
+				icmpoff += ipv4_hdrlen(&iphdr);
+				switch (tuple.nexthdr) {
+				case IPPROTO_TCP:
+				case IPPROTO_UDP:
+#ifdef ENABLE_SCTP
+				case IPPROTO_SCTP:
+#endif /* ENABLE_SCTP */
+					/* No reasons to handle IP fragmentation
+					 * for this case as it is expected that
+					 * DF isn't set for this particular
+					 * context.
+					 */
+					if (l4_load_ports(ctx, icmpoff, &tuple.dport) < 0)
+						return DROP_INVALID;
+					break;
+				case IPPROTO_ICMP:
+					/* No reasons to see a packet different
+					 * than ICMP_ECHOREPLY.
+					 */
+					if (ctx_load_bytes(ctx, icmpoff, &type,
+							   sizeof(type)) < 0 ||
+					    type != ICMP_ECHOREPLY)
+						return DROP_INVALID;
+					if (ctx_load_bytes(ctx, icmpoff +
+						    offsetof(struct icmphdr, un.echo.id),
+						&identifier, sizeof(identifier)) < 0)
+						return DROP_INVALID;
+					tuple.sport = identifier;
+					tuple.dport = 0;
+					break;
+				default:
+					return DROP_UNKNOWN_L4;
+				}
+				state = snat_v4_lookup(&tuple);
+				if (!state)
+					return NAT_PUNT_TO_STACK;
+
+				/* We found SNAT entry to NAT embedded packet.
+				 * The destination addr should be NATTed
+				 * according to the entry.
+				 */
+				ret = snat_v4_icmp_rewrite_egress_embedded(ctx, &tuple, state,
+									   off, icmpoff);
+				if (IS_ERR(ret))
+					return ret;
+
+				if (!revalidate_data(ctx, &data, &data_end,
+						     &ip4))
+					return DROP_INVALID;
+				/* Switch back to the outer header. */
+				tuple.nexthdr = nexthdr;
+				/* Reset so no l4 NAT is done in
+				 * snat_v4_rewrite_egress.
+				 * We don't need it because we are handling
+				 * ICMP_DEST_UNREACH which doesn't have id.
+				 */
+				tuple.sport = state->to_sport;
+				goto rewrite_egress;
+			}
+			default:
+				return DROP_UNKNOWN_ICMP_CODE;
+			}
+			break;
+		default:
+			return DROP_NAT_UNSUPP_PROTO;
 		}
 		break;
 	default:
@@ -906,6 +1065,7 @@ snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __s8 *
 	if (ret < 0)
 		return ret;
 
+rewrite_egress:
 	return snat_v4_rewrite_egress(ctx, &tuple, state, off, ipv4_has_l4_header(ip4));
 }
 
@@ -1020,8 +1180,8 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __
 				 * should point to endpoint that initiated the packet, as-well if
 				 * dest port had been NATed.
 				 */
-				ret = snat_v4_icmp_rewrite_embedded(ctx, &tuple, state, off,
-								    icmpoff);
+				ret = snat_v4_icmp_rewrite_ingress_embedded(ctx, &tuple, state,
+									    off, icmpoff);
 				if (IS_ERR(ret))
 					return ret;
 

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -27,7 +27,7 @@
 
 static char pkt[100];
 
-__always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
+__always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr, bool egress)
 {
 	void *orig = dst;
 
@@ -43,12 +43,14 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 	 * a networking equipment IP_ROUTER in response to a packet
 	 * that is exceeding the MTU.
 	 */
+	unsigned int saddr = egress ? IP_ENDPOINT : IP_ROUTER;
+	unsigned int daddr = egress ? IP_WORLD : IP_HOST;
 	struct iphdr l3 = {
 		.version = 4,
 		.ihl = 5,
 		.protocol = IPPROTO_ICMP,
-		.saddr = bpf_htonl(IP_ROUTER),
-		.daddr = bpf_htonl(IP_HOST),
+		.saddr = bpf_htonl(saddr),
+		.daddr = bpf_htonl(daddr),
 	};
 	memcpy(dst, &l3, sizeof(struct iphdr));
 	dst += sizeof(struct iphdr);
@@ -65,8 +67,8 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 	memcpy(dst, &icmphdr, sizeof(struct icmphdr));
 	dst += sizeof(struct icmphdr);
 
-	/* Embedded packet is referring packet sent by Cilium to the
-	 * world using IP_HOST.
+	/* Embedded packet is referring the original packet that triggers the
+	 * ICMP.
 	 */
 	struct iphdr inner_l3 = {
 		.version = 4,
@@ -75,14 +77,26 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 		.saddr = bpf_htonl(IP_HOST),
 		.daddr = bpf_htonl(IP_WORLD),
 	};
+	if (egress) {
+		inner_l3.saddr = bpf_htonl(IP_WORLD);
+		inner_l3.daddr = bpf_htonl(IP_ENDPOINT);
+	}
+
 	memcpy(dst, &inner_l3, sizeof(struct iphdr));
 	dst += sizeof(struct iphdr);
+
+	__u16 sport = 32768, dport = 80;
+
+	if (egress) {
+		sport = 79;
+		dport = error_hdr == IPPROTO_SCTP ? 32767 : 3030;
+	}
 
 	switch (error_hdr) {
 	case IPPROTO_TCP: {
 		struct tcphdr inner_l4 = {
-			.source = bpf_htons(32768),
-			.dest = bpf_htons(80),
+			.source = bpf_htons(sport),
+			.dest = bpf_htons(dport),
 		};
 		memcpy(dst, &inner_l4, sizeof(struct tcphdr));
 		dst += sizeof(struct tcphdr);
@@ -90,8 +104,8 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 		break;
 	case IPPROTO_UDP: {
 		struct udphdr inner_l4 = {
-			.source = bpf_htons(32768),
-			.dest = bpf_htons(333),
+			.source = bpf_htons(sport),
+			.dest = bpf_htons(dport),
 		};
 		memcpy(dst, &inner_l4, sizeof(struct udphdr));
 		dst += sizeof(struct udphdr);
@@ -103,8 +117,8 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 			__be16 dport;
 		} inner_l4;
 
-		inner_l4.sport = bpf_htons(32768),
-		inner_l4.dport = bpf_htons(333),
+		inner_l4.sport = bpf_htons(sport),
+		inner_l4.dport = bpf_htons(dport),
 
 		memcpy(dst, &inner_l4, sizeof(inner_l4));
 		dst += sizeof(inner_l4);
@@ -112,10 +126,10 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 		break;
 	case IPPROTO_ICMP: {
 		struct icmphdr inner_l4 __align_stack_8 = {
-			.type = ICMP_ECHO,
+			.type = egress ? ICMP_ECHOREPLY : ICMP_ECHO,
 			.un = {
 				.echo = {
-					.id = bpf_htons(32768)
+					.id = bpf_htons(egress ? dport : sport)
 				},
 			},
 		};
@@ -130,7 +144,7 @@ __always_inline int mk_icmp4_error_pkt(void *dst, __u8 error_hdr)
 CHECK("tc", "nat4_icmp_error_tcp")
 int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, false);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -238,7 +252,7 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 CHECK("tc", "nat4_icmp_error_udp")
 int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP, false);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -272,7 +286,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 		.saddr = bpf_htonl(IP_ENDPOINT),
 		.daddr = bpf_htonl(IP_WORLD),
 		.sport = bpf_htons(9999),
-		.dport = bpf_htons(333),
+		.dport = bpf_htons(80),
 		.flags = 0,
 	};
 	struct ipv4_nat_target target = {
@@ -338,7 +352,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
 		test_fatal("can't load embedded l4 headers");
 	assert(in_l4hdr.sport == bpf_htons(9999));
-	assert(in_l4hdr.dport == bpf_htons(333));
+	assert(in_l4hdr.dport == bpf_htons(80));
 
 	test_finish();
 }
@@ -346,7 +360,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 CHECK("tc", "nat4_icmp_error_icmp")
 int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP, false);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -449,7 +463,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 CHECK("tc", "nat4_icmp_error_sctp")
 int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 {
-	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_SCTP);
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_SCTP, false);
 	{
 		void *data = (void *)(long)ctx->data;
 		void *data_end = (void *)(long)ctx->data_end;
@@ -475,7 +489,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 		.saddr = bpf_htonl(IP_ENDPOINT),
 		.daddr = bpf_htonl(IP_WORLD),
 		.sport = bpf_htons(9999),
-		.dport = bpf_htons(333),
+		.dport = bpf_htons(80),
 		.flags = 0,
 	};
 	struct ipv4_nat_target target = {
@@ -495,6 +509,425 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	assert(ret == 0);
 
 	/* nothing really change with udp/tcp */
+	test_finish();
+}
+
+CHECK("tc", "nat4_icmp_error_tcp_egress")
+int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
+{
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_TCP, true);
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+
+		if (data + pkt_size > data_end)
+			return TEST_ERROR;
+
+		memcpy(data, pkt, pkt_size);
+	}
+
+	test_init();
+	/* The test is validating that the function snat_v4_nat()
+	 * will nat the ICMP Unreach error need to fragment to the
+	 * correct source.  Also, to be valid, the embedded packet
+	 * should be NATed as-well, meaning that the dest addr of
+	 * the original packet will be switched from IP_ENDPOINT to
+	 * IP_HOST, Also for TCP/UDP the dest port and ICMP the
+	 * identifier.
+	 *
+	 * This test is validating the TCP case.
+	 */
+
+	int ret;
+
+	/* As a pre-requist we intruct the NAT table
+	 * to simulate an egress packet sent by
+	 * endpoint to the world.
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_TCP,
+		.saddr = bpf_htonl(IP_ENDPOINT),
+		.daddr = bpf_htonl(IP_WORLD),
+		.sport = bpf_htons(3030),
+		.dport = bpf_htons(79),
+		.flags = 0,
+	};
+	struct ipv4_nat_target target = {
+		.addr = bpf_htonl(IP_HOST),
+		.min_port = NODEPORT_PORT_MIN_NAT - 1,
+		.max_port = NODEPORT_PORT_MIN_NAT,
+	};
+	struct ipv4_nat_entry state;
+
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	assert(ret == 0);
+
+	/* This is the entry-point of the test, calling
+	 * snat_v4_nat().
+	 */
+	ret = snat_v4_nat(ctx, &target, NULL);
+	assert(ret == 0);
+
+	__u16 proto;
+	void *data;
+	void *data_end;
+
+	int l3_off;
+	int l4_off;
+	struct iphdr *ip4;
+	struct icmphdr icmphdr __align_stack_8;
+
+	assert(validate_ethertype(ctx, &proto));
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	if (data + pkt_size > data_end)
+		test_fatal("packet shrank");
+
+	/* Validating outer headers */
+	assert(ip4->protocol == IPPROTO_ICMP);
+	assert(ip4->saddr == bpf_htonl(IP_HOST));
+	assert(ip4->daddr == bpf_htonl(IP_WORLD));
+
+	l3_off = ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		test_fatal("can't load icmp headers");
+	assert(icmphdr.type == ICMP_DEST_UNREACH);
+	assert(icmphdr.code == ICMP_FRAG_NEEDED);
+
+	/* Validating inner headers */
+	int in_l3_off;
+	int in_l4_off;
+	struct iphdr in_ip4;
+	struct {
+		__be16 sport;
+		__be16 dport;
+	} in_l4hdr;
+
+	in_l3_off = l4_off + sizeof(icmphdr);
+	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,
+			   sizeof(in_ip4)) < 0)
+		test_fatal("can't load embedded ip headers");
+	assert(in_ip4.protocol == IPPROTO_TCP);
+	assert(in_ip4.saddr == bpf_htonl(IP_WORLD));
+	assert(in_ip4.daddr == bpf_htonl(IP_HOST));
+
+	in_l4_off = in_l3_off + ipv4_hdrlen(&in_ip4);
+	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
+		test_fatal("can't load embedded l4 headers");
+	assert(in_l4hdr.sport == bpf_htons(79));
+	assert(in_l4hdr.dport == bpf_htons(32767));
+
+	test_finish();
+}
+
+CHECK("tc", "nat4_icmp_error_udp_egress")
+int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
+{
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_UDP, true);
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+
+		if (data + pkt_size > data_end)
+			return TEST_ERROR;
+
+		memcpy(data, pkt, pkt_size);
+	}
+
+	test_init();
+	/* The test is validating that the function snat_v4_nat()
+	 * will nat the ICMP Unreach error need to fragment to the
+	 * correct source.  Also, to be valid, the embedded packet
+	 * should be NATed as-well, meaning that the dest addr of
+	 * the original packet will be switched from IP_ENDPOINT to
+	 * IP_HOST, Also for TCP/UDP the dest port and ICMP the
+	 * identifier.
+	 *
+	 * This test is validating the UDP case.
+	 */
+
+	int ret;
+
+	/* As a pre-requist we intruct the NAT table
+	 * to simulate an egress packet sent by
+	 * endpoint to the world.
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_UDP,
+		.saddr = bpf_htonl(IP_ENDPOINT),
+		.daddr = bpf_htonl(IP_WORLD),
+		.sport = bpf_htons(3030),
+		.dport = bpf_htons(79),
+		.flags = 0,
+	};
+	struct ipv4_nat_target target = {
+	    .addr = bpf_htonl(IP_HOST),
+	    .min_port = NODEPORT_PORT_MIN_NAT - 1,
+	    .max_port = NODEPORT_PORT_MIN_NAT,
+	};
+	struct ipv4_nat_entry state;
+
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	assert(ret == 0);
+
+	/* This is the entry-point of the test, calling
+	 * snat_v4_nat().
+	 */
+	ret = snat_v4_nat(ctx, &target, NULL);
+	assert(ret == 0);
+
+	__u16 proto;
+	void *data;
+	void *data_end;
+
+	int l3_off;
+	int l4_off;
+	struct iphdr *ip4;
+	struct icmphdr icmphdr __align_stack_8;
+
+	assert(validate_ethertype(ctx, &proto));
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	if (data + pkt_size > data_end)
+		test_fatal("packet shrank");
+
+	/* Validating outer headers */
+	assert(ip4->protocol == IPPROTO_ICMP);
+	assert(ip4->saddr == bpf_htonl(IP_HOST));
+	assert(ip4->daddr == bpf_htonl(IP_WORLD));
+
+	l3_off = ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		test_fatal("can't load icmp headers");
+	assert(icmphdr.type == ICMP_DEST_UNREACH);
+	assert(icmphdr.code == ICMP_FRAG_NEEDED);
+
+	/* Validating inner headers */
+	int in_l3_off;
+	int in_l4_off;
+	struct iphdr in_ip4;
+	struct {
+		__be16 sport;
+		__be16 dport;
+	} in_l4hdr;
+
+	in_l3_off = l4_off + sizeof(icmphdr);
+	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,
+			   sizeof(in_ip4)) < 0)
+		test_fatal("can't load embedded ip headers");
+	assert(in_ip4.protocol == IPPROTO_UDP);
+	assert(in_ip4.saddr == bpf_htonl(IP_WORLD));
+	assert(in_ip4.daddr == bpf_htonl(IP_HOST));
+
+	in_l4_off = in_l3_off + ipv4_hdrlen(&in_ip4);
+	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
+		test_fatal("can't load embedded l4 headers");
+	assert(in_l4hdr.sport == bpf_htons(79));
+	assert(in_l4hdr.dport == bpf_htons(32767));
+
+	test_finish();
+}
+
+CHECK("tc", "nat4_icmp_error_icmp_egress")
+int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
+{
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_ICMP, true);
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+
+		if (data + pkt_size > data_end)
+			return TEST_ERROR;
+
+		memcpy(data, pkt, pkt_size);
+	}
+
+	test_init();
+	/* The test is validating that the function snat_v4_nat()
+	 * will nat the ICMP Unreach error need to fragment to the
+	 * correct source.  Also, to be valid, the embedded packet
+	 * should be NATed as-well, meaning that the dest addr of
+	 * the original packet will be switched from IP_ENDPOINT to
+	 * IP_HOST, Also for TCP/UDP the dest port and ICMP the
+	 * identifier.
+	 *
+	 * This test is validating the ICMP case.
+	 */
+
+	int ret;
+
+	/* As a pre-requist we intruct the NAT table
+	 * to simulate an egress packet sent by
+	 * endpoint to the world.
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_ICMP,
+		.saddr = bpf_htonl(IP_ENDPOINT),
+		.daddr = bpf_htonl(IP_WORLD),
+		.sport = bpf_htons(3030),
+		.flags = 0,
+	};
+	struct ipv4_nat_target target = {
+	    .addr = bpf_htonl(IP_HOST),
+	    .min_port = NODEPORT_PORT_MIN_NAT - 1,
+	    .max_port = NODEPORT_PORT_MIN_NAT,
+	};
+	struct ipv4_nat_entry state;
+
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	assert(ret == 0);
+
+	/* This is the entry-point of the test, calling
+	 * snat_v4_nat().
+	 */
+	ret = snat_v4_nat(ctx, &target, NULL);
+	assert(ret == 0);
+
+	__u16 proto;
+	void *data;
+	void *data_end;
+
+	int l3_off;
+	int l4_off;
+	struct iphdr *ip4;
+	struct icmphdr icmphdr __align_stack_8;
+
+	assert(validate_ethertype(ctx, &proto));
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	if (data + pkt_size > data_end)
+		test_fatal("packet shrank");
+
+	/* Validating outer headers */
+	assert(ip4->protocol == IPPROTO_ICMP);
+	assert(ip4->saddr == bpf_htonl(IP_HOST));
+	assert(ip4->daddr == bpf_htonl(IP_WORLD));
+
+	l3_off = ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		test_fatal("can't load icmp headers");
+	assert(icmphdr.type == ICMP_DEST_UNREACH);
+	assert(icmphdr.code == ICMP_FRAG_NEEDED);
+
+	/* Validating inner headers */
+	int in_l3_off;
+	int in_l4_off;
+	struct iphdr in_ip4;
+	struct icmphdr in_l4hdr __align_stack_8;
+
+	in_l3_off = l4_off + sizeof(icmphdr);
+	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,
+			   sizeof(in_ip4)) < 0)
+		test_fatal("can't load embedded ip headers");
+	assert(in_ip4.protocol == IPPROTO_ICMP);
+	assert(in_ip4.saddr == bpf_htonl(IP_WORLD));
+	assert(in_ip4.daddr == bpf_htonl(IP_HOST));
+
+	in_l4_off = in_l3_off + ipv4_hdrlen(&in_ip4);
+	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
+		test_fatal("can't load embedded l4 headers");
+	assert(in_l4hdr.un.echo.id == bpf_htons(32767));
+
+	test_finish();
+}
+
+CHECK("tc", "nat4_icmp_error_sctp_egress")
+int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
+{
+	int pkt_size = mk_icmp4_error_pkt(pkt, IPPROTO_SCTP, true);
+	{
+		void *data = (void *)(long)ctx->data;
+		void *data_end = (void *)(long)ctx->data_end;
+
+		if (data + pkt_size > data_end)
+			return TEST_ERROR;
+
+		memcpy(data, pkt, pkt_size);
+	}
+
+	test_init();
+	/* This test is validating the SCTP case.
+	 */
+
+	int ret;
+
+	/* As a pre-requist we intruct the NAT table
+	 * to simulate an egress packet sent by
+	 * endpoint to the world.
+	 */
+	struct ipv4_ct_tuple tuple = {
+		.nexthdr = IPPROTO_SCTP,
+		.saddr = bpf_htonl(IP_ENDPOINT),
+		.daddr = bpf_htonl(IP_WORLD),
+		.sport = bpf_htons(32767),  /* STCP requires ports are the same after NAT */
+		.dport = bpf_htons(79),
+		.flags = 0,
+	};
+	struct ipv4_nat_target target = {
+	    .addr = bpf_htonl(IP_HOST),
+	    .min_port = NODEPORT_PORT_MIN_NAT - 1,
+	    .max_port = NODEPORT_PORT_MIN_NAT,
+	};
+	struct ipv4_nat_entry state;
+
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	assert(ret == 0);
+
+	/* This is the entry-point of the test, calling
+	 * snat_v4_nat().
+	 */
+	ret = snat_v4_nat(ctx, &target, NULL);
+	assert(ret == 0);
+
+	__u16 proto;
+	void *data;
+	void *data_end;
+
+	int l3_off;
+	int l4_off;
+	struct iphdr *ip4;
+	struct icmphdr icmphdr __align_stack_8;
+
+	assert(validate_ethertype(ctx, &proto));
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	if (data + pkt_size > data_end)
+		test_fatal("packet shrank");
+
+	/* Validating outer headers */
+	assert(ip4->protocol == IPPROTO_ICMP);
+	assert(ip4->saddr == bpf_htonl(IP_HOST));
+	assert(ip4->daddr == bpf_htonl(IP_WORLD));
+
+	l3_off = ETH_HLEN;
+	l4_off = l3_off + ipv4_hdrlen(ip4);
+	if (ctx_load_bytes(ctx, l4_off, &icmphdr, sizeof(icmphdr)) < 0)
+		test_fatal("can't load icmp headers");
+	assert(icmphdr.type == ICMP_DEST_UNREACH);
+	assert(icmphdr.code == ICMP_FRAG_NEEDED);
+
+	/* Validating inner headers */
+	int in_l3_off;
+	int in_l4_off;
+	struct iphdr in_ip4;
+	struct {
+		__be16 sport;
+		__be16 dport;
+	} in_l4hdr;
+
+	in_l3_off = l4_off + sizeof(icmphdr);
+	if (ctx_load_bytes(ctx, in_l3_off, &in_ip4,
+			   sizeof(in_ip4)) < 0)
+		test_fatal("can't load embedded ip headers");
+	assert(in_ip4.protocol == IPPROTO_SCTP);
+	assert(in_ip4.saddr == bpf_htonl(IP_WORLD));
+	assert(in_ip4.daddr == bpf_htonl(IP_HOST));
+
+	in_l4_off = in_l3_off + ipv4_hdrlen(&in_ip4);
+	if (ctx_load_bytes(ctx, in_l4_off, &in_l4hdr, sizeof(in_l4hdr)) < 0)
+		test_fatal("can't load embedded l4 headers");
+	assert(in_l4hdr.sport == bpf_htons(79));
+	assert(in_l4hdr.dport == bpf_htons(32767));
+
 	test_finish();
 }
 


### PR DESCRIPTION
PR #18414 added support for ingress ICMP "fragmentation needed" support to hande those sent by remote routers. This commit mirrors it to support such ICMP sent from endpoints.

The use case is that pod is redirecting traffic from the world into a tunnel, which has smaller MTU. It may return a ICMP "frag needed" to the remote server that requires SNAT to happen properly on both outer and inner headers.

Address IPv4 "fragmentation needed"  part of : #23955

```release-note
Supports IPv4 ICMP "fragmentation needed" in egress SNAT
```
