### PR TITLE
Ldelossa/phase out sec label pt1

### DIFF
--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -166,7 +166,7 @@ sock4_skip_xlate(struct lb4_service *svc, __be32 address)
 
 		info = ipcache_lookup4(&IPCACHE_MAP, address,
 				       V4_CACHE_KEY_LEN, 0);
-		if (info == NULL || info->sec_label != HOST_ID)
+		if (!info || info->sec_identity != HOST_ID)
 			return true;
 	}
 
@@ -196,8 +196,8 @@ sock4_wildcard_lookup(struct lb4_key *key __maybe_unused,
 		goto wildcard_lookup;
 
 	info = ipcache_lookup4(&IPCACHE_MAP, key->address, V4_CACHE_KEY_LEN, 0);
-	if (info != NULL && (info->sec_label == HOST_ID ||
-	    (include_remote_hosts && identity_is_remote_node(info->sec_label))))
+	if (info && (info->sec_identity == HOST_ID ||
+		     (include_remote_hosts && identity_is_remote_node(info->sec_identity))))
 		goto wildcard_lookup;
 
 	return NULL;
@@ -730,7 +730,7 @@ sock6_skip_xlate(struct lb6_service *svc, const union v6addr *address)
 
 		info = ipcache_lookup6(&IPCACHE_MAP, address,
 				       V6_CACHE_KEY_LEN, 0);
-		if (info == NULL || info->sec_label != HOST_ID)
+		if (!info || info->sec_identity != HOST_ID)
 			return true;
 	}
 
@@ -760,8 +760,8 @@ sock6_wildcard_lookup(struct lb6_key *key __maybe_unused,
 		goto wildcard_lookup;
 
 	info = ipcache_lookup6(&IPCACHE_MAP, &key->address, V6_CACHE_KEY_LEN, 0);
-	if (info != NULL && (info->sec_label == HOST_ID ||
-	    (include_remote_hosts && identity_is_remote_node(info->sec_label))))
+	if (info && (info->sec_identity == HOST_ID ||
+		     (include_remote_hosts && identity_is_remote_node(info->sec_identity))))
 		goto wildcard_lookup;
 
 	return NULL;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -310,7 +310,7 @@ struct edt_info {
 };
 
 struct remote_endpoint_info {
-	__u32		sec_label;
+	__u32		sec_identity;
 	__u32		tunnel_endpoint;
 	__u16		node_id;
 	__u8		key;

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -86,7 +86,7 @@ bool egress_gw_snat_needed(struct iphdr *ip4, __be32 *snat_addr)
 
 static __always_inline
 bool egress_gw_reply_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint,
-				    __u32 *dst_id)
+				    __u32 *dst_sec_identity)
 {
 	struct egress_gw_policy_entry *egress_policy;
 	struct remote_endpoint_info *info;
@@ -105,7 +105,7 @@ bool egress_gw_reply_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint,
 		return false;
 
 	*tunnel_endpoint = info->tunnel_endpoint;
-	*dst_id = info->sec_label;
+	*dst_sec_identity = info->sec_identity;
 	return true;
 }
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -771,7 +771,7 @@ static __always_inline bool snat_v4_prepare_state(struct __ctx_buff *ctx,
 	 * to be masqueraded with an egress IP.
 	 */
 	if (remote_ep &&
-	    identity_is_cluster(remote_ep->sec_label))
+	    identity_is_cluster(remote_ep->sec_identity))
 		goto skip_egress_gateway;
 
 	/* If the packet is a reply it means that outside has initiated the
@@ -826,7 +826,7 @@ skip_egress_gateway:
 		 * by the remote node if its native dev's
 		 * rp_filter=1.
 		 */
-		if (identity_is_remote_node(remote_ep->sec_label))
+		if (identity_is_remote_node(remote_ep->sec_identity))
 			return false;
 #endif
 

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -84,7 +84,7 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	 * as with --encrypt-node=false we encrypt only pod-to-pod packets.
 	 */
 #ifndef ENABLE_NODE_ENCRYPTION
-	if (!src || src->sec_label == HOST_ID)
+	if (!src || src->sec_identity == HOST_ID)
 		goto out;
 #endif /* ENABLE_NODE_ENCRYPTION */
 
@@ -94,7 +94,7 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	 * reply traffic arrives from the cluster-external server and goes to
 	 * the client pod.
 	 */
-	if (!src || !identity_is_cluster(src->sec_label))
+	if (!src || !identity_is_cluster(src->sec_identity))
 		goto out;
 
 	/* Redirect to the WireGuard tunnel device if the encryption is

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -145,7 +145,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	cache_key.family = ENDPOINT_KEY_IPV4;
 	cache_key.ip4 = v4_pod_one;
 	/* a random sec id for the pod */
-	cache_value.sec_label = 112233;
+	cache_value.sec_identity = 112233;
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 
 	ep_key.ip4 = v4_pod_one;

--- a/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_backend_lxc.c
@@ -294,7 +294,7 @@ int lxc_to_overlay_synack_setup(struct __ctx_buff *ctx)
 	};
 
 	struct remote_endpoint_info cache_value = {
-		.sec_label = REMOTE_NODE_ID,
+		.sec_identity = REMOTE_NODE_ID,
 	};
 
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);

--- a/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
+++ b/bpf/tests/inter_cluster_snat_clusterip_client_lxc.c
@@ -224,7 +224,7 @@ int lxc_to_overlay_syn_setup(struct __ctx_buff *ctx)
 		.cluster_id = BACKEND_CLUSTER_ID
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = BACKEND_IDENTITY,
+		.sec_identity = BACKEND_IDENTITY,
 
 		/* Assuming node IP is unique for now */
 		.tunnel_endpoint = BACKEND_NODE_IP,

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -171,7 +171,7 @@ int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 		.ip4 = BACKEND_IP,
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = 112233,
+		.sec_identity = 112233,
 	};
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 

--- a/bpf/tests/tc_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_lb.c
@@ -181,7 +181,7 @@ int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
 		.ip4 = BACKEND_IP,
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = 112233,
+		.sec_identity = 112233,
 	};
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 

--- a/bpf/tests/tc_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_backend.c
@@ -163,7 +163,7 @@ int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 		.ip4 = BACKEND_IP,
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = 112233,
+		.sec_identity = 112233,
 	};
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -199,7 +199,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 		.ip4 = BACKEND_IP_LOCAL,
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = 112233,
+		.sec_identity = 112233,
 	};
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 
@@ -475,7 +475,7 @@ int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 		.ip4 = BACKEND_IP_REMOTE,
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = 112233,
+		.sec_identity = 112233,
 	};
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -159,7 +159,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	cache_key.family = ENDPOINT_KEY_IPV4;
 	cache_key.ip4 = v4_pod_one;
 	/* a random sec id for the pod */
-	cache_value.sec_label = 112233;
+	cache_value.sec_identity = 112233;
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 
 	ep_key.ip4 = v4_pod_one;

--- a/bpf/tests/wildcard_lookup.c
+++ b/bpf/tests/wildcard_lookup.c
@@ -97,7 +97,7 @@ static inline void __setup_v4(void)
 	cache_key.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(32);
 	cache_key.family = ENDPOINT_KEY_IPV4;
 	cache_key.ip4 = bpf_htonl(HOST_IP);
-	cache_value.sec_label = HOST_ID;
+	cache_value.sec_identity = HOST_ID;
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 
 	for (i = 0; i < ARRAY_SIZE(services); i++)
@@ -282,7 +282,7 @@ static inline void __setup_v6_ipcache(const union v6addr *HOST_IP6)
 	cache_key.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(128);
 	cache_key.family = ENDPOINT_KEY_IPV6;
 	cache_key.ip6 = *HOST_IP6;
-	cache_value.sec_label = HOST_ID;
+	cache_value.sec_identity = HOST_ID;
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 }
 

--- a/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_dsr_lb.c
@@ -177,7 +177,7 @@ int nodeport_dsr_fwd_setup(struct __ctx_buff *ctx)
 		.ip4 = BACKEND_IP,
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = 112233,
+		.sec_identity = 112233,
 	};
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 

--- a/bpf/tests/xdp_nodeport_lb4_nat_backend.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_backend.c
@@ -153,7 +153,7 @@ int nodeport_nat_backend_setup(struct __ctx_buff *ctx)
 		.ip4 = BACKEND_IP,
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = 112233,
+		.sec_identity = 112233,
 	};
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 

--- a/bpf/tests/xdp_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/xdp_nodeport_lb4_nat_lb.c
@@ -197,7 +197,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 		.ip4 = BACKEND_IP_LOCAL,
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = 112233,
+		.sec_identity = 112233,
 	};
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 
@@ -371,7 +371,7 @@ int nodeport_nat_fwd_setup(struct __ctx_buff *ctx)
 		.ip4 = BACKEND_IP_REMOTE,
 	};
 	struct remote_endpoint_info cache_value = {
-		.sec_label = 112233,
+		.sec_identity = 112233,
 	};
 	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -143,7 +143,7 @@ func NewKey(ip net.IP, mask net.IPMask, clusterID uint8) Key {
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
 type RemoteEndpointInfo struct {
-	SecurityIdentity uint32     `align:"sec_label"`
+	SecurityIdentity uint32     `align:"sec_identity"`
 	TunnelEndpoint   types.IPv4 `align:"tunnel_endpoint"`
 	NodeID           uint16     `align:"node_id"`
 	Key              uint8      `align:"key"`


### PR DESCRIPTION
Currently in the datapath we swap around the terminology `sec_label` and `identity`. 

As an effort to consolidate our terminology, this PR begins the phasing out of the keywords `sec_label` in favor of `sec_identity`.

An arbitrary starting point was picked, the `remote_endpoint_info` struct, and further renames will take place over time, as to not create too many conflicts with other PRs. 

```release-note
Rename the `sec_label` field in remote_endpoint_info structure to `sec_identity`
```
