### PR TITLE
bpf: nodeport: handle result from encap ctx_redirect() in revDNAT path

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1226,7 +1226,7 @@ encap_redirect:
 	ret = __encap_with_nodeid(ctx, tunnel_endpoint, SECLABEL, dst_id,
 				  NOT_VTEP_DST, reason, monitor, &ifindex);
 	if (ret == CTX_ACT_REDIRECT)
-		ctx_redirect(ctx, ifindex, 0);
+		ret = ctx_redirect(ctx, ifindex, 0);
 	return ret;
 #endif
 }
@@ -2458,7 +2458,7 @@ encap_redirect:
 	ret = __encap_with_nodeid(ctx, tunnel_endpoint, SECLABEL, dst_id,
 				  NOT_VTEP_DST, reason, monitor, &ifindex);
 	if (ret == CTX_ACT_REDIRECT)
-		ctx_redirect(ctx, ifindex, 0);
+		ret = ctx_redirect(ctx, ifindex, 0);
 	return ret;
 #endif
 }


### PR DESCRIPTION
When redirecting a packet into the tunnel, return the result of that operation. Right now we're not reporting potential errors from the helper call.

This will become more relevant with native XDP encapsulation, where ctx_redirect() can also turn the CTX_REDIRECT into a XDP_TX.

Fixes: ff441649adb1 ("bpf: Align rev_nodeport_lb{4,6} wrt egress GW tunnel mode")