### PR TITLE
bpf: nodeport: remove lb4_populate_ports()

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1211,27 +1211,6 @@ bool lb4_src_range_ok(const struct lb4_service *svc __maybe_unused,
 #endif /* ENABLE_SRC_RANGE_CHECK */
 }
 
-static __always_inline int
-lb4_populate_ports(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off)
-{
-	if (tuple->nexthdr == IPPROTO_TCP ||
-#ifdef ENABLE_SCTP
-	    tuple->nexthdr == IPPROTO_SCTP ||
-#endif  /* ENABLE_SCTP */
-	    tuple->nexthdr == IPPROTO_UDP) {
-		struct {
-			__be16 sport;
-			__be16 dport;
-		} l4hdr;
-		if (ctx_load_bytes(ctx, off, &l4hdr, sizeof(l4hdr)) < 0)
-			return -EFAULT;
-		tuple->sport = l4hdr.sport;
-		tuple->dport = l4hdr.dport;
-		return 0;
-	}
-	return -ENOTSUP;
-}
-
 static __always_inline bool
 lb4_to_lb6_service(const struct lb4_service *svc __maybe_unused)
 {

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1856,8 +1856,9 @@ __snat_v6_has_v4_complete(struct ipv6_ct_tuple *tuple6,
 {
 	build_v4_in_v6(&tuple6->daddr, tuple4->daddr);
 	tuple6->nexthdr = tuple4->nexthdr;
-	tuple6->sport = tuple4->sport;
-	tuple6->dport = tuple4->dport;
+	/* tuple4 has ports in swapped order: */
+	tuple6->sport = tuple4->dport;
+	tuple6->dport = tuple4->sport;
 	tuple6->flags = NAT_DIR_INGRESS;
 	return snat_v6_lookup(tuple6);
 }


### PR DESCRIPTION
lb4_extract_tuple() already extracts the full tuple, there's no need to extract the ports again. On top it also deals with L4 ports for fragmented packets. We just need to adjust __snat_v6_has_v4_complete() so that it load the ports from the right locations.

We can also trust that the L4 proto type has been checked by lb4_extract_tuple(), and thus only need to special-case ICMP.