### PR TITLE
node/manager: Only remove old IPs if they weren't already added

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/exp/slices"
 
 	"github.com/cilium/workerpool"
 
@@ -484,7 +485,8 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		// Delete the old node IP addresses if they have changed in this node.
 		var oldNodeIPAddrs []string
 		for _, address := range oldNode.IPAddresses {
-			if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP {
+			if option.Config.NodeIpsetNeeded() && address.Type == addressing.NodeInternalIP &&
+				!slices.Contains(ipsAdded, address.IP.String()) {
 				iptables.RemoveFromNodeIpset(address.IP)
 			}
 			if skipIPCache(address) {


### PR DESCRIPTION
Previously, IPs that were added to the ipset would be removed upon a
node update event.

For example, take the following scenario:

1. Node add event received, N:{IPs:[X]}
2. Add IP X to ipset
3. Node update event received, N:{IPs:[X, Y, Z]}
4. Add IPs Y and Z to ipset
5. Remove IP X from ipset

Step (5) would occur because upon a node update event, we iterate
through the old IPs from the previous event (i.e. IPs:[X]) and delete
the IPs from the previous event.

Therefore, we need to add a check before processing an ipset delete to
ensure that the IPs being deleted are not currently present inside the
node event.

Fixes: d5e5bf3485d ("node/manager: Remove ipset config from previous node state")

Signed-off-by: Chris Tarazi <chris@isovalent.com>
