### PR TITLE
gha: Enable debug and debug verbose for Ingress/Gateway

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -73,6 +73,8 @@ jobs:
             --helm-set kubeProxyReplacement=strict \
             --helm-set=securityContext.privileged=true \
             --helm-set=gatewayAPI.enabled=true \
+            --helm-set=debug.enabled=true \
+            --helm-set=debug.verbose=flow \
             --rollback=false \
             --version="
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -96,6 +96,8 @@ jobs:
             --helm-set=ingressController.loadbalancerMode=${{ matrix.loadbalancer-mode }} \
             --helm-set=ingressController.default=${{ matrix.default-ingress-controller }} \
             --helm-set=extraConfig.bpf-lb-acceleration=${{ matrix.bpf-lb-acceleration }} \
+            --helm-set=debug.enabled=true \
+            --helm-set=debug.verbose=flow \
             --rollback=false \
             --version="
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT


### PR DESCRIPTION
This is to capture more info to debug and troubleshot a couple of flakes in Ingress and Gateway API conformance tests.

Suggested-by: Jarno Rajahalme <jarno@isovalent.com>