### PR TITLE
k8s/watchers: Fix erroneous warning logs due to empty CIDRGroupRef

### DIFF
--- a/pkg/k8s/watchers/cilium_cidr_group_test.go
+++ b/pkg/k8s/watchers/cilium_cidr_group_test.go
@@ -177,6 +177,51 @@ func TestHasCIDRGroupRef(t *testing.T) {
 			expected:  true,
 		},
 		{
+			name: "CIDR in Spec",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						Ingress: []api.IngressRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							Ingress: []api.IngressRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr: "1.1.1.1/32",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			cidrGroup: "cidr-group-1",
+			expected:  true,
+		},
+		{
 			name: "CIDRGroupRef in Specs",
 			cnp: &types.SlimCNP{
 				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
@@ -373,6 +418,50 @@ func TestCIDRGroupRefsGet(t *testing.T) {
 				},
 			},
 			expected: []string{"cidr-group-1", "cidr-group-2"},
+		},
+		{
+			name: "single FromCidrSet rule with only CIDR",
+			cnp: &types.SlimCNP{
+				CiliumNetworkPolicy: &cilium_v2.CiliumNetworkPolicy{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "cilium.io/v2",
+						Kind:       "CiliumNetworkPolicy",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-policy",
+						Namespace: "test-namespace",
+					},
+					Spec: &api.Rule{
+						Ingress: []api.IngressRule{
+							{
+								IngressCommonRule: api.IngressCommonRule{
+									FromCIDRSet: api.CIDRRuleSlice{
+										{
+											CIDRGroupRef: "cidr-group-1",
+										},
+									},
+								},
+							},
+						},
+					},
+					Specs: api.Rules{
+						{
+							Ingress: []api.IngressRule{
+								{
+									IngressCommonRule: api.IngressCommonRule{
+										FromCIDRSet: api.CIDRRuleSlice{
+											{
+												Cidr: "1.1.1.1/32",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []string{"cidr-group-1"},
 		},
 		{
 			name: "multiple FromCidrSet rules",


### PR DESCRIPTION
Previously, the logic to detect whether a CIDRGroupRef has been set did
not consider CNP policies which only reference a CIDR. This is relevant
because CIDRs and CIDRGroupRefs are mutually exclusive, i.e.  oneOf
validation is applied on them.

This triggered the following warning log to be triggered quite often as
each update to the CNP would run through the translation logic:

```
level=warning msg="Unable to translate all cidr groups to cidrs" cidrGroupRef="[group-1 ]" ciliumNetworkPolicyName=tofqdn-dns-visibility error="cidr group \"group-1\" not found, skipping translation; cidr group \"\" not found, skipping translation" k8sApiVersion= k8sNamespace=default subsys=k8s-watcher
```

For example, the following will trigger the buggy behavior:

```
ingress:
  - fromCIDRSet:
    - cidr: "3.3.3.3/32"
```

With the fix, we detect that a CIDR has been set and therefore, we avoid
returning an empty CIDRGroupRef name.

Fixes: dd4aba42311 ("k8s: Add support for cidrGroupRef field in
    CNP/CCNP")
Fixes: https://github.com/cilium/cilium/issues/25020

Signed-off-by: Chris Tarazi <chris@isovalent.com>
