### PR TITLE
[backport-v1.13] ipcache: don't short-circuit InjectLabels if source differs

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -176,6 +176,9 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 		entriesToReplace   = make(map[netip.Prefix]Identity)
 		entriesToDelete    = make(map[netip.Prefix]Identity)
 		forceIPCacheUpdate = make(map[netip.Prefix]bool) // prefix => force
+
+		// Just used to silence a warning where it is safe
+		oldIDs = make(map[netip.Prefix]Identity)
 	)
 
 	ipc.metadata.RLock()
@@ -189,6 +192,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				continue
 			} // else continue below to remove the old entry
 		} else {
+			oldIDs[prefix] = id
 			var newID *identity.Identity
 
 			lbls := prefixInfo.ToLabels()
@@ -218,13 +222,10 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				break
 			}
 
-			// It's plausible to pull the same information twice
-			// from different sources, for instance in etcd mode
-			// where node information is propagated both via the
-			// kvstore and via the k8s control plane. If the new
-			// security identity is the same as the one currently
-			// being used, then no need to update it.
-			if id.ID == newID.ID {
+			// We can safely skip the ipcache upsert if the ID and source
+			// in the metadata cache match the ipcache exactly.
+			// Note that checking ID alone is insufficient, see GH-24502
+			if id.ID == newID.ID && prefixInfo.Source() == id.Source {
 				goto releaseIdentity
 			}
 
@@ -239,7 +240,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			// have now been removed, then we need to explicitly
 			// work around that to remove the old higher-priority
 			// identity and replace it with this new identity.
-			if entryExists && prefixInfo.Source() != id.Source {
+			if entryExists && prefixInfo.Source() != id.Source && id.ID != newID.ID {
 				forceIPCacheUpdate[prefix] = true
 			}
 		}
@@ -279,10 +280,23 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			id,
 			forceIPCacheUpdate[p],
 		); err2 != nil {
-			log.WithError(err2).WithFields(logrus.Fields{
-				logfields.IPAddr:   prefix,
-				logfields.Identity: id,
-			}).Error("Failed to replace ipcache entry with new identity after label removal. Traffic may be disrupted.")
+			// It's plausible to pull the same information twice
+			// from different sources, for instance in etcd mode
+			// where node information is propagated both via the
+			// kvstore and via the k8s control plane. If the
+			// upsert was rejected due to source precedence, but the
+			// identity is unchanged, then we can safely ignore the
+			// error message.
+			oldID, ok := oldIDs[p]
+			if !(ok && oldID.ID == id.ID && errors.Is(err2, &ErrOverwrite{
+				ExistingSrc: oldID.Source,
+				NewSrc:      id.Source,
+			})) {
+				log.WithError(err2).WithFields(logrus.Fields{
+					logfields.IPAddr:   prefix,
+					logfields.Identity: id,
+				}).Error("Failed to replace ipcache entry with new identity after label removal. Traffic may be disrupted.")
+			}
 		}
 	}
 

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -74,6 +75,54 @@ func TestInjectLabels(t *testing.T) {
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 3)
 	assert.False(t, IPIdentityCache.ipToIdentityCache["100.4.16.32/32"].ID.HasLocalScope())
+}
+
+// TestInjectExisting tests "upgrading" an existing identity to the apiserver.
+// This is a common occurrence on startup - and this tests ensures we don't
+// regress the known issue in GH-24502
+func TestInjectExisting(t *testing.T) {
+	cancel := setupTest(t)
+	defer cancel()
+
+	// mimic the "restore cidr" logic from daemon.go
+	// for every ip -> identity mapping in the bpf ipcache
+	// - allocate that identity
+	// - insert the cidr=>identity mapping back in to the go ipcache
+	identities := make(map[netip.Prefix]*identity.Identity)
+	prefix := netip.MustParsePrefix("172.19.0.5/32")
+	oldID := identity.NumericIdentity(16777219)
+	_, err := IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, []identity.NumericIdentity{oldID}, identities)
+	assert.NoError(t, err)
+
+	IPIdentityCache.UpsertGeneratedIdentities(identities, nil)
+
+	// sanity check: ensure the cidr is correctly in the ipcache
+	id, ok := IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, int32(16777219), int32(id.ID))
+
+	// Simulate the first half of UpsertLabels -- insert the labels only in to the metadata cache
+	// This is to "force" a race condition
+	resource := ipcacheTypes.NewResourceID(
+		ipcacheTypes.ResourceKindEndpoint, "default", "kubernetes")
+	IPIdentityCache.metadata.upsertLocked(prefix, source.KubeAPIServer, resource, labels.LabelKubeAPIServer)
+
+	// Now, emulate policyAdd(), which calls AllocateCIDRs()
+	_, err = IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, []identity.NumericIdentity{oldID}, nil)
+	assert.NoError(t, err)
+
+	// Now, trigger label injection
+	// This will allocate a new ID for the same /32 since the labels have changed
+	IPIdentityCache.UpsertLabels(prefix, labels.LabelKubeAPIServer, source.KubeAPIServer, resource)
+
+	// Need to wait for the label injector to finish; easiest just to remove it
+	IPIdentityCache.controllers.RemoveControllerAndWait(LabelInjectorName)
+
+	// Ensure the source is now correctly understood in the ipcache
+	id, ok = IPIdentityCache.LookupByIP(prefix.String())
+	assert.True(t, ok)
+	assert.Equal(t, source.KubeAPIServer, id.Source)
+
 }
 
 func TestFilterMetadataByLabels(t *testing.T) {


### PR DESCRIPTION
Backporting
- [x]  https://github.com/cilium/cilium/pull/24875

InjectLabels is one of the functions responsible for synchronizing the ipcache metadata store and ip store. As such, it shouldn't shortcut when the numeric identity is the same, but the source is different; this means that an update to the ipcache isn't complete.

This can happen, for example, when there are two identities for the same IP, which can happen on daemon restart whenever a CIDR is referenced.

Signed-off-by: Casey Callendrello <cdc@isovalent.com>


Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 24875; do contrib/backporting/set-labels.py $pr done 1.13; done
```