### PR TITLE
fix(docs): Update AWS IAM Policy docs

### DIFF
--- a/Documentation/network/concepts/ipam/eni.rst
+++ b/Documentation/network/concepts/ipam/eni.rst
@@ -480,6 +480,10 @@ perform ENI creation and IP allocation:
  * ``AssignPrivateIpAddresses``
  * ``CreateTags``
 
+If ENI GC is enabled (which is the default), and ``--cluster-name`` and ``--eni-gc-tags`` are not set to custom values:
+
+ * ``DescribeTags``
+
 If release excess IP enabled:
 
  * ``UnassignPrivateIpAddresses``


### PR DESCRIPTION
Missing ec2:DescribeTags after https://github.com/cilium/cilium/commit/e66ed7fee9513b7ac23b3eb8327679a8121dd6c2 got merged. This commit introduced a helper function which would require the AWS IAM Policy `ec2:DescribeTags` to be added to the cilium operator.

I'm not sure the full implications of not having this policy present, as it seems to be only used in certain cases. Either way, including this policy seems fair and I don't see any security implications of it. 

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Commit https://github.com/cilium/cilium/commit/e66ed7fee9513b7ac23b3eb8327679a8121dd6c2 introduced a helper function for looking up EKS cluster name in AWS. This requires the IAM Policy `ec2:DescribeTags`, which is not documented.

This PR updates the documentation for required IAM Policy rights needed for Cilium to work in EKS.

```release-note
Update the documentation for required IAM policy rights needed for Cilium to work in EKS.
```
