### PR TITLE
workflows: Run stable branches' L4LB workflows on a schedule

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -145,6 +145,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -145,6 +145,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -145,6 +145,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -144,6 +144,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -144,6 +144,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -144,6 +144,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -128,6 +128,9 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
           SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+        elif [ "${{ github.event_name }}" = "schedule" ]; then
+          curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
+          SHA=$(jq -r '.commit.sha' branch.json)
         else
           SHA=${{ github.sha }}
         fi

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -128,6 +128,9 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
           SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+        elif [ "${{ github.event_name }}" = "schedule" ]; then
+          curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
+          SHA=$(jq -r '.commit.sha' branch.json)
         else
           SHA=${{ github.sha }}
         fi

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -128,6 +128,9 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
           SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+        elif [ "${{ github.event_name }}" = "schedule" ]; then
+          curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
+          SHA=$(jq -r '.commit.sha' branch.json)
         else
           SHA=${{ github.sha }}
         fi

--- a/.github/workflows/conformance-datapath-v1.13.yaml
+++ b/.github/workflows/conformance-datapath-v1.13.yaml
@@ -123,6 +123,9 @@ jobs:
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
           else
             SHA=${{ github.sha }}
           fi

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -144,6 +144,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -144,6 +144,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -144,6 +144,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -145,6 +145,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -145,6 +145,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -145,6 +145,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -143,6 +143,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -143,6 +143,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -143,6 +143,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -146,6 +146,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-multicluster-v1.12.yaml
+++ b/.github/workflows/conformance-multicluster-v1.12.yaml
@@ -146,6 +146,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-multicluster-v1.13.yaml
+++ b/.github/workflows/conformance-multicluster-v1.13.yaml
@@ -146,6 +146,10 @@ jobs:
               ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
             SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
             OWNER=$(echo "$PR_API_JSON" | jq -r ".number")
+          elif [ "${{ github.event_name }}" = "schedule" ]; then
+            curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
+            SHA=$(jq -r '.commit.sha' branch.json)
+            OWNER=v1.13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 20 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -128,6 +128,9 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
           SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+        elif [ "${{ github.event_name }}" = "schedule" ]; then
+          curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
+          SHA=$(jq -r '.commit.sha' branch.json)
         else
           SHA=${{ github.sha }}
         fi

--- a/.github/workflows/tests-l4lb-v1.12.yaml
+++ b/.github/workflows/tests-l4lb-v1.12.yaml
@@ -128,6 +128,9 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
           SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+        elif [ "${{ github.event_name }}" = "schedule" ]; then
+          curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
+          SHA=$(jq -r '.commit.sha' branch.json)
         else
           SHA=${{ github.sha }}
         fi

--- a/.github/workflows/tests-l4lb-v1.12.yaml
+++ b/.github/workflows/tests-l4lb-v1.12.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 21 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/tests-l4lb-v1.13.yaml
+++ b/.github/workflows/tests-l4lb-v1.13.yaml
@@ -5,6 +5,9 @@ on:
   issue_comment:
     types:
       - created
+  # Run once a day
+  schedule:
+    - cron:  '0 22 * * *'
   ### FOR TESTING PURPOSES
   # This workflow runs in the context of `main`, and ignores changes to
   # workflow files in PRs. For testing changes to this workflow from a PR:

--- a/.github/workflows/tests-l4lb-v1.13.yaml
+++ b/.github/workflows/tests-l4lb-v1.13.yaml
@@ -128,6 +128,9 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             ${{ github.event.issue.pull_request.url || github.event.pull_request.url }})
           SHA=$(echo "$PR_API_JSON" | jq -r ".head.sha")
+        elif [ "${{ github.event_name }}" = "schedule" ]; then
+          curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
+          SHA=$(jq -r '.commit.sha' branch.json)
         else
           SHA=${{ github.sha }}
         fi


### PR DESCRIPTION
First commit adds the scheduled runs for a few L4LB, which was missed in https://github.com/cilium/cilium/pull/24991. Second commit fixes the workflows in case of scheduled runs on stable branches to select the proper SHA. See commits for details.

I've tested the new code in https://github.com/cilium/cilium/pull/25082. We can't actually test the `schedule` trigger until we merge unfortunately.

Fixes: https://github.com/cilium/cilium/pull/24991.