### PR TITLE
[v1.13] datapath: Remove 2005 route table for IPv4

### DIFF
--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -492,17 +492,6 @@ func testNodePort(kubectl *helpers.Kubectl, ni *helpers.NodesInfo, bpfNodePort, 
 			getHTTPLink(ni.K8s2IP, data.Spec.Ports[0].NodePort),
 			getTFTPLink(ni.K8s2IP, data.Spec.Ports[1].NodePort),
 		}
-
-		if helpers.DualStackSupported() {
-			testURLsFromOutside = append(testURLsFromOutside,
-				getHTTPLink(ni.PrimaryK8s1IPv6, v6Data.Spec.Ports[0].NodePort),
-				getTFTPLink(ni.PrimaryK8s1IPv6, v6Data.Spec.Ports[1].NodePort),
-
-				getHTTPLink(ni.PrimaryK8s2IPv6, v6Data.Spec.Ports[0].NodePort),
-				getTFTPLink(ni.PrimaryK8s2IPv6, v6Data.Spec.Ports[1].NodePort),
-			)
-		}
-
 	}
 
 	count := 10


### PR DESCRIPTION
Backporting
* [x] https://github.com/cilium/cilium/pull/24807

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 24807; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=24807
```
