### PR TITLE
k8s: Fix data race between ServiceCache and K8sWatcher

### DIFF
--- a/pkg/envoy/ciliumenvoyconfig_test.go
+++ b/pkg/envoy/ciliumenvoyconfig_test.go
@@ -4,7 +4,6 @@
 package envoy
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -157,9 +156,6 @@ func (s *JSONSuite) TestCiliumEnvoyConfig(c *C) {
 	portAllocator := NewMockPortAllocator()
 	jsonBytes, err := yaml.YAMLToJSON([]byte(ciliumEnvoyConfig))
 	c.Assert(err, IsNil)
-	// var buf bytes.Buffer
-	// json.Indent(&buf, jsonBytes, "", "\t")
-	// fmt.Printf("JSON spec:\n%s\n", buf.String())
 	cec := &cilium_v2.CiliumEnvoyConfig{}
 	err = json.Unmarshal(jsonBytes, cec)
 	c.Assert(err, IsNil)
@@ -248,9 +244,6 @@ func (s *JSONSuite) TestCiliumEnvoyConfigValidation(c *C) {
 	portAllocator := NewMockPortAllocator()
 	jsonBytes, err := yaml.YAMLToJSON([]byte(ciliumEnvoyConfigInvalid))
 	c.Assert(err, IsNil)
-	// var buf bytes.Buffer
-	// json.Indent(&buf, jsonBytes, "", "\t")
-	// fmt.Printf("JSON spec:\n%s\n", buf.String())
 	cec := &cilium_v2.CiliumEnvoyConfig{}
 	err = json.Unmarshal(jsonBytes, cec)
 	c.Assert(err, IsNil)
@@ -321,9 +314,6 @@ func (s *JSONSuite) TestCiliumEnvoyConfigNoAddress(c *C) {
 	portAllocator := NewMockPortAllocator()
 	jsonBytes, err := yaml.YAMLToJSON([]byte(ciliumEnvoyConfigNoAddress))
 	c.Assert(err, IsNil)
-	// var buf bytes.Buffer
-	// json.Indent(&buf, jsonBytes, "", "\t")
-	// fmt.Printf("JSON spec:\n%s\n", buf.String())
 	cec := &cilium_v2.CiliumEnvoyConfig{}
 	err = json.Unmarshal(jsonBytes, cec)
 	c.Assert(err, IsNil)
@@ -436,9 +426,6 @@ func (s *JSONSuite) TestCiliumEnvoyConfigMulti(c *C) {
 	portAllocator := NewMockPortAllocator()
 	jsonBytes, err := yaml.YAMLToJSON([]byte(ciliumEnvoyConfigMulti))
 	c.Assert(err, IsNil)
-	// var buf bytes.Buffer
-	// json.Indent(&buf, jsonBytes, "", "\t")
-	// fmt.Printf("JSON spec:\n%s\n", buf.String())
 	cec := &cilium_v2.CiliumEnvoyConfig{}
 	err = json.Unmarshal(jsonBytes, cec)
 	c.Assert(err, IsNil)
@@ -599,10 +586,6 @@ func (s *JSONSuite) TestCiliumEnvoyConfigTCPProxy(c *C) {
 	jsonBytes, err := yaml.YAMLToJSON([]byte(ciliumEnvoyConfigTCPProxy))
 	c.Assert(err, IsNil)
 
-	var buf bytes.Buffer
-	json.Indent(&buf, jsonBytes, "", "\t")
-	fmt.Printf("JSON spec:\n%s\n", buf.String())
-
 	cec := &cilium_v2.CiliumEnvoyConfig{}
 	err = json.Unmarshal(jsonBytes, cec)
 	c.Assert(err, IsNil)
@@ -730,10 +713,6 @@ func (s *JSONSuite) TestCiliumEnvoyConfigTCPProxyTermination(c *C) {
 	portAllocator := NewMockPortAllocator()
 	jsonBytes, err := yaml.YAMLToJSON([]byte(ciliumEnvoyConfigTCPProxyTermination))
 	c.Assert(err, IsNil)
-
-	var buf bytes.Buffer
-	json.Indent(&buf, jsonBytes, "", "\t")
-	fmt.Printf("JSON spec:\n%s\n", buf.String())
 
 	cec := &cilium_v2.CiliumEnvoyConfig{}
 	err = json.Unmarshal(jsonBytes, cec)

--- a/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
@@ -5,7 +5,6 @@ package v2
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"sigs.k8s.io/yaml"
 
@@ -50,7 +49,6 @@ func (s *CiliumV2Suite) TestParseEnvoySpec(c *C) {
 
 	jsonBytes, err := yaml.YAMLToJSON([]byte(envoySpec))
 	c.Assert(err, IsNil)
-	fmt.Printf("\nJSON spec:\n%s\n", string(jsonBytes))
 	cec := &CiliumEnvoyConfig{}
 	err = json.Unmarshal(jsonBytes, &cec.Spec)
 	c.Assert(err, IsNil)

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -436,7 +436,7 @@ func (es *EndpointSlices) GetEndpoints() *Endpoints {
 			// example-custom-endpoints-g6r6v   IPv4          8090    10.244.1.49   28s
 			b, ok := allEps.Backends[backend]
 			if !ok {
-				allEps.Backends[backend] = ep
+				allEps.Backends[backend] = ep.DeepCopy()
 			} else {
 				clone := b.DeepCopy()
 				for k, v := range ep.Ports {

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -499,7 +499,7 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 
 		for ip, e := range localEndpoints.Backends {
 			e.Preferred = svcFound && svc.IncludeExternal && svc.ServiceAffinity == serviceAffinityLocal
-			endpoints.Backends[ip] = e
+			endpoints.Backends[ip] = e.DeepCopy()
 		}
 	}
 
@@ -522,7 +522,7 @@ func (s *ServiceCache) correlateEndpoints(id ServiceID) (*Endpoints, bool) {
 						}).Warning("Conflicting service backend IP")
 					} else {
 						e.Preferred = svc.ServiceAffinity == serviceAffinityRemote
-						endpoints.Backends[ip] = e
+						endpoints.Backends[ip] = e.DeepCopy()
 					}
 				}
 			}

--- a/pkg/k8s/watchers/cilium_envoy_config_test.go
+++ b/pkg/k8s/watchers/cilium_envoy_config_test.go
@@ -4,9 +4,7 @@
 package watchers
 
 import (
-	"bytes"
 	"encoding/json"
-	"fmt"
 
 	_ "github.com/cilium/proxy/go/envoy/config/listener/v3"
 	envoy_config_http "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -56,9 +54,6 @@ spec:
 func (s *K8sWatcherSuite) TestParseEnvoySpec(c *C) {
 	jsonBytes, err := yaml.YAMLToJSON([]byte(envoySpec))
 	c.Assert(err, IsNil)
-	var buf bytes.Buffer
-	json.Indent(&buf, jsonBytes, "", "\t")
-	fmt.Printf("JSON spec:\n%s\n", buf.String())
 	cec := &cilium_v2.CiliumEnvoyConfig{}
 	err = json.Unmarshal(jsonBytes, cec)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
correlateEndpoints was modifying a Backend object that was read by
K8sWatcher:

```
WARNING: DATA RACE
Read at 0x00c000942278 by goroutine 71:
github.com/cilium/cilium/pkg/k8s/watchers.genCartesianProduct()
    /home/chris/code/cilium/cilium/pkg/k8s/watchers/watcher.go:787 +0xb56
github.com/cilium/cilium/pkg/k8s/watchers.datapathSVCs()
    /home/chris/code/cilium/cilium/pkg/k8s/watchers/watcher.go:852 +0x77e
github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcher).addK8sSVCs()
...
Previous write at 0x00c000942278 by goroutine 70:
github.com/cilium/cilium/pkg/k8s.(*ServiceCache).correlateEndpoints()
    /home/chris/code/cilium/cilium/pkg/k8s/service_cache.go:501 +0x409
github.com/cilium/cilium/pkg/k8s.(*ServiceCache).UpdateService()
    /home/chris/code/cilium/cilium/pkg/k8s/service_cache.go:214 +0x3e4
github.com/cilium/cilium/pkg/k8s/watchers.(*K8sWatcherSuite).TestChangeSVCPort()
    /home/chris/code/cilium/cilium/pkg/k8s/watchers/watcher_test.go:685 +0x1d09
...
```

Since the backends are owned by the ServiceCache and allowing to mutate them when holding a lock is something one might expect, fix the issues by making all public ServiceCache methods return a DeepCopy'd *Endpoint and *Backends.

```release-note
Fix data race affecting the preferred mark in backends, e.g. backends selected by service with affinity set to local. In very rare cases a backend might be missing its preferred status and a non-local backend might be selected.
```