### PR TITLE
test: Block HubbleObserveFollow until ready

### DIFF
--- a/test/helpers/cmd.go
+++ b/test/helpers/cmd.go
@@ -441,6 +441,12 @@ func (res *CmdRes) GetDebugMessage() string {
 // WaitUntilMatch waits until the given substring is present in the `CmdRes.stdout`
 // If the timeout is reached it will return an error.
 func (res *CmdRes) WaitUntilMatch(substr string) error {
+	return res.WaitUntilMatchTimeout(substr, HelperTimeout)
+}
+
+// WaitUntilMatchTimeout is the same as WaitUntilMatch but with a user-provided
+// timeout value.
+func (res *CmdRes) WaitUntilMatchTimeout(substr string, timeout time.Duration) error {
 	body := func() bool {
 		return strings.Contains(res.OutputPrettyPrint(), substr)
 	}
@@ -448,7 +454,7 @@ func (res *CmdRes) WaitUntilMatch(substr string) error {
 	return WithTimeout(
 		body,
 		fmt.Sprintf("%s is not in the output after timeout", substr),
-		&TimeoutConfig{Timeout: HelperTimeout})
+		&TimeoutConfig{Timeout: timeout})
 }
 
 // WaitUntilMatchRegexp waits until the `CmdRes.stdout` matches the given regexp.

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -179,15 +179,16 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 		It("Test L3/L4 Flow", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), helpers.MidCommandTimeout)
 			defer cancel()
-			follow := kubectl.HubbleObserveFollow(ctx, ciliumPodK8s1, fmt.Sprintf(
+			follow, err := kubectl.HubbleObserveFollow(ctx, ciliumPodK8s1, fmt.Sprintf(
 				"--last 1 --type trace --from-pod %s/%s --to-namespace %s --to-label %s --to-port %d",
 				namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels, app1Port))
+			Expect(err).To(BeNil(), "Failed to start hubble observe")
 
 			res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
 			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
 
-			err := follow.WaitUntilMatchFilterLineTimeout(`{$.flow.Type}`, "L3_L4", helpers.ShortCommandTimeout)
+			err = follow.WaitUntilMatchFilterLineTimeout(`{$.flow.Type}`, "L3_L4", helpers.ShortCommandTimeout)
 			Expect(err).To(BeNil(), fmt.Sprintf("hubble observe query timed out on %q", follow.OutputPrettyPrint()))
 
 			// Basic check for L4 Prometheus metrics.
@@ -230,15 +231,16 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 
 			ctx, cancel := context.WithTimeout(context.Background(), helpers.MidCommandTimeout)
 			defer cancel()
-			follow := kubectl.HubbleObserveFollow(ctx, ciliumPodK8s1, fmt.Sprintf(
+			follow, err := kubectl.HubbleObserveFollow(ctx, ciliumPodK8s1, fmt.Sprintf(
 				"--last 1 --type l7 --from-pod %s/%s --to-namespace %s --to-label %s --protocol http",
 				namespaceForTest, appPods[helpers.App2], namespaceForTest, app1Labels))
+			Expect(err).To(BeNil(), "Failed to start hubble observe")
 
 			res := kubectl.ExecPodCmd(namespaceForTest, appPods[helpers.App2],
 				helpers.CurlFail(fmt.Sprintf("http://%s/public", app1ClusterIP)))
 			res.ExpectSuccess("%q cannot curl clusterIP %q", appPods[helpers.App2], app1ClusterIP)
 
-			err := follow.WaitUntilMatchFilterLineTimeout(`{$.flow.Type}`, "L7", helpers.ShortCommandTimeout)
+			err = follow.WaitUntilMatchFilterLineTimeout(`{$.flow.Type}`, "L7", helpers.ShortCommandTimeout)
 			Expect(err).To(BeNil(), fmt.Sprintf("hubble observe query timed out on %q", follow.OutputPrettyPrint()))
 
 			// Basic check for L7 Prometheus metrics.

--- a/test/k8s/net_policies.go
+++ b/test/k8s/net_policies.go
@@ -266,12 +266,13 @@ var _ = SkipDescribeIf(func() bool {
 				// the app instances are running
 				By("Starting hubble observe and generating traffic which should%s redirect to proxy", not)
 				ctx, cancel := context.WithCancel(context.Background())
-				hubbleRes := kubectl.HubbleObserveFollow(
+				hubbleRes, err := kubectl.HubbleObserveFollow(
 					ctx, ciliumPod,
 					// since 0s is important here so no historic events from the
 					// buffer are shown, only follow from the current time
 					"--type l7 --since 0s",
 				)
+				Expect(err).To(BeNil(), "Failed to start hubble observe")
 
 				// clean up at the end of the test
 				defer func() {
@@ -281,7 +282,6 @@ var _ = SkipDescribeIf(func() bool {
 				}()
 
 				// Let the monitor get started since it is started in the background.
-				time.Sleep(2 * time.Second)
 				res := kubectl.ExecPodCmd(
 					namespaceForTest, appPods[helpers.App2],
 					curlCmd)
@@ -290,7 +290,7 @@ var _ = SkipDescribeIf(func() bool {
 				res.ExpectSuccess("%q cannot curl %q", appPods[helpers.App2], resource)
 
 				By("Checking that aforementioned traffic was%sredirected to the proxy", not)
-				err := hubbleRes.WaitUntilMatchFilterLineTimeout(filter, expect, hubbleTimeout)
+				err = hubbleRes.WaitUntilMatchFilterLineTimeout(filter, expect, hubbleTimeout)
 				if redirected {
 					ExpectWithOffset(1, err).To(BeNil(), "traffic was not redirected to the proxy when it should have been")
 				} else {


### PR DESCRIPTION
One of our flaky tests has been failing because we can't find the expected flow event in the `hubble observe` output. Looking at the logs revealed that the expected flow event was emitted before our `hubble observe` command running in the background was ready.

This happened because we start `hubble observe` in the background and directly make the test request without waiting [1]. This pull request changes that to ensure `HubbleObserveFollow` (which starts `hubble observe` in the background) waits for Hubble to be ready before returning.

To that end, debug mode is enabled. In that mode, `hubble observe` will the following debug message once connected to the server:

    time="2023-04-21T16:29:45Z" level=debug msg="Sending GetFlows request" request="follow:true whitelist:{event_type:{type:129}}"

We can wait until we see that message to exit from `HubbleObserveFollow`. After that we'll simply call `WaitUntilMatchFilterLineTimeout` as usual, but we'll be sure Hubble was ready when we made the test query.

This works because the debug message is sent over stderr, whereas `WaitUntilMatchFilterLineTimeout` reads from stdout. `WaitUntilMatchTimeout`, the helper function we use to block in `HubbleObserveFollow`, searches for a match in both stdout and stderr.

1 - In that particular flaky test, we were actually waiting 2s, but that wasn't always enough.
Fixes: https://github.com/cilium/cilium/pull/11232.
Fixes: https://github.com/cilium/cilium/issues/22056.