### PR TITLE
[v1.11] contrib/backporting: Fix main branch reference

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -147,8 +147,8 @@ generate_commit_list_for_pr () {
   done
   git branch -q -D $branch
   echo "   Merge with $n_commits commit(s) merged at: `date -R -d "$(echo $merged_at | sed 's/T/ /')"`!"
-  echo "     Branch:     master (!)                          refs/pull/$pr/head"
-  echo "                 ----------                          -------------------"
+  echo "     Branch:     main (!)                          refs/pull/$pr/head"
+  echo "                 --------                          -------------------"
   echo "     v (start)"
   while read entry; do
     entry_array=($entry)
@@ -156,7 +156,7 @@ generate_commit_list_for_pr () {
     entry_sha=${entry_array[1]}
     entry_sub=${entry_array[@]:2}
     entry_sub_re="^$(sed 's/[.^$*+?()[{\|]/\\&/g' <<< "$entry_sub")$" # adds backslashes for extended regex
-    related_commits="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/master)"
+    related_commits="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/main)"
     found_commit=0
     for upstream_commit in ${related_commits}; do
       upstream_id="$(git log -n1 --pretty=format:"%ae%at" $upstream_commit)"

--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -89,7 +89,7 @@ get_branch_from_version() {
     local remote="$1"
     local branch="$(echo $2 | sed 's/.*\(v[0-9]\+\.[0-9]\+\).*/\1/')"
     if [ -z "$(git ls-remote --heads $remote $branch)" ]; then
-        branch="master"
+        branch="main"
     fi
     echo "$branch"
 }


### PR DESCRIPTION
The "master" branch was renamed to "main" recently. Fix this for the
older branch here.
