### PR TITLE
ingress: Allow headless service in Ingress

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -257,6 +257,65 @@ jobs:
           fi
           docker exec -i chart-testing-control-plane curl -s -v --connect-timeout 5 --max-time 20 --retry 3 --fail http://localhost:$node_port/details/1 
 
+      - name: Run Sanity check (headless service)
+        if: ${{ matrix.loadbalancer-mode == 'dedicated' }}
+        timeout-minutes: 5
+        run: |
+          BACKEND_IP=$(kubectl get pod -l app=details -o jsonpath="{.items[*].status.podIP}")
+          cat << EOF > ingress-with-headless-service.yaml
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: details-headless
+          spec:
+            ports:
+            - name: http
+              port: 9080
+              protocol: TCP
+              targetPort: 9080
+            clusterIP: None
+            ipFamilies:
+            - IPv4
+            ipFamilyPolicy: SingleStack
+          ---
+          apiVersion: v1
+          kind: Endpoints
+          metadata:
+            name: details-headless
+          subsets:
+          - addresses:
+            - ip: ${BACKEND_IP}
+            ports:
+            - name: http
+              port: 9080
+              protocol: TCP
+          ---
+          apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: basic-ingress-headless
+          spec:
+            ingressClassName: cilium
+            rules:
+            - http:
+                paths:
+                - backend:
+                    service:
+                      name: details-headless
+                      port:
+                        number: 9080
+                  path: /details
+                  pathType: Prefix
+          EOF
+
+          kubectl apply -n default -f ingress-with-headless-service.yaml
+          until [ -n "$(kubectl get ingress basic-ingress-headless -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do
+            sleep 3
+          done
+
+          lb=$(kubectl get ingress basic-ingress-headless -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+          curl -s -v --connect-timeout 2 --max-time 20 --retry 3 --retry-all-errors --retry-delay 3 --fail -- http://"$lb"/details/1      
+
       - name: Cleanup Sanity check
         timeout-minutes: 5
         run: |

--- a/api/v1/models/service_spec.go
+++ b/api/v1/models/service_spec.go
@@ -256,7 +256,7 @@ type ServiceSpecFlags struct {
 	TrafficPolicy string `json:"trafficPolicy,omitempty"`
 
 	// Service type
-	// Enum: [ClusterIP NodePort ExternalIPs HostPort LoadBalancer LocalRedirect]
+	// Enum: [ClusterIP NodePort ExternalIPs HostPort LoadBalancer LocalRedirect Headless]
 	Type string `json:"type,omitempty"`
 }
 
@@ -465,7 +465,7 @@ var serviceSpecFlagsTypeTypePropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["ClusterIP","NodePort","ExternalIPs","HostPort","LoadBalancer","LocalRedirect"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["ClusterIP","NodePort","ExternalIPs","HostPort","LoadBalancer","LocalRedirect","Headless"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -492,6 +492,9 @@ const (
 
 	// ServiceSpecFlagsTypeLocalRedirect captures enum value "LocalRedirect"
 	ServiceSpecFlagsTypeLocalRedirect string = "LocalRedirect"
+
+	// ServiceSpecFlagsTypeHeadless captures enum value "Headless"
+	ServiceSpecFlagsTypeHeadless string = "Headless"
 )
 
 // prop value enum

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3124,6 +3124,7 @@ definitions:
             - HostPort
             - LoadBalancer
             - LocalRedirect
+            - Headless
           trafficPolicy:
             description: Service external traffic policy (deprecated in favor of extTrafficPolicy)
             type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -4808,7 +4808,8 @@ func init() {
                 "ExternalIPs",
                 "HostPort",
                 "LoadBalancer",
-                "LocalRedirect"
+                "LocalRedirect",
+                "Headless"
               ]
             }
           }
@@ -10871,7 +10872,8 @@ func init() {
                 "ExternalIPs",
                 "HostPort",
                 "LoadBalancer",
-                "LocalRedirect"
+                "LocalRedirect",
+                "Headless"
               ]
             }
           }
@@ -10953,7 +10955,8 @@ func init() {
             "ExternalIPs",
             "HostPort",
             "LoadBalancer",
-            "LocalRedirect"
+            "LocalRedirect",
+            "Headless"
           ]
         }
       }

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -27,6 +27,7 @@ const (
 	SVCTypeExternalIPs   = SVCType("ExternalIPs")
 	SVCTypeLoadBalancer  = SVCType("LoadBalancer")
 	SVCTypeLocalRedirect = SVCType("LocalRedirect")
+	SVCTypeHeadless      = SVCType("Headless")
 )
 
 // SVCTrafficPolicy defines which backends are chosen


### PR DESCRIPTION
Currently, we don't inject headless endpoints into envoy XDS, hence the response is coming with error `no healthy upstream`. This commit is to partially allow headless service endpoints going through the current code path and short circuit before we actually update BPF LB maps.

- Remove guard check if the service is headless in service update/delete
- Generate Cartesian product for headless service with serviceType as None
- Short circuit before BPF LB map update step.

Fixes: #23182

