### PR TITLE
Add detailed panic messages for slim ObjectMeta and ListMeta

### DIFF
--- a/pkg/k8s/slim/k8s/apis/meta/v1/meta.go
+++ b/pkg/k8s/slim/k8s/apis/meta/v1/meta.go
@@ -13,8 +13,8 @@ import (
 
 func (meta *ListMeta) GetResourceVersion() string        { return meta.ResourceVersion }
 func (meta *ListMeta) SetResourceVersion(version string) { meta.ResourceVersion = version }
-func (meta *ListMeta) GetSelfLink() string               { panic("not implemented") }
-func (meta *ListMeta) SetSelfLink(_ string)              { panic("not implemented") }
+func (meta *ListMeta) GetSelfLink() string               { panic("ListMeta - GetSelfLink() not implemented") }
+func (meta *ListMeta) SetSelfLink(_ string)              { panic("ListMeta - SetSelfLink() not implemented") }
 func (meta *ListMeta) GetContinue() string               { return meta.Continue }
 func (meta *ListMeta) SetContinue(c string)              { meta.Continue = c }
 func (meta *ListMeta) GetRemainingItemCount() *int64     { return meta.RemainingItemCount }
@@ -38,23 +38,29 @@ func (obj *ObjectMeta) GetObjectMeta() metav1.Object { return obj }
 
 // Namespace implements metav1.Object for any object with an ObjectMeta typed field. Allows
 // fast, direct access to metadata fields for API objects.
-func (meta *ObjectMeta) GetNamespace() string              { return meta.Namespace }
-func (meta *ObjectMeta) SetNamespace(namespace string)     { meta.Namespace = namespace }
-func (meta *ObjectMeta) GetName() string                   { return meta.Name }
-func (meta *ObjectMeta) SetName(name string)               { meta.Name = name }
-func (meta *ObjectMeta) GetGenerateName() string           { panic("not implemented") }
-func (meta *ObjectMeta) SetGenerateName(string)            { panic("not implemented") }
-func (meta *ObjectMeta) GetUID() types.UID                 { return meta.UID }
-func (meta *ObjectMeta) SetUID(uid types.UID)              { meta.UID = uid }
-func (meta *ObjectMeta) GetResourceVersion() string        { return meta.ResourceVersion }
-func (meta *ObjectMeta) SetResourceVersion(ver string)     { meta.ResourceVersion = ver }
-func (meta *ObjectMeta) GetGeneration() int64              { panic("not implemented") }
-func (meta *ObjectMeta) SetGeneration(_ int64)             { panic("not implemented") }
-func (meta *ObjectMeta) GetSelfLink() string               { panic("not implemented") }
-func (meta *ObjectMeta) SetSelfLink(_ string)              { panic("not implemented") }
-func (meta *ObjectMeta) GetCreationTimestamp() metav1.Time { panic("not implemented") }
+func (meta *ObjectMeta) GetNamespace() string          { return meta.Namespace }
+func (meta *ObjectMeta) SetNamespace(namespace string) { meta.Namespace = namespace }
+func (meta *ObjectMeta) GetName() string               { return meta.Name }
+func (meta *ObjectMeta) SetName(name string)           { meta.Name = name }
+func (meta *ObjectMeta) GetGenerateName() string {
+	panic("ObjectMeta - GetGenerateName() not implemented")
+}
+func (meta *ObjectMeta) SetGenerateName(string) {
+	panic("ObjectMeta - SetGenerateName() not implemented")
+}
+func (meta *ObjectMeta) GetUID() types.UID             { return meta.UID }
+func (meta *ObjectMeta) SetUID(uid types.UID)          { meta.UID = uid }
+func (meta *ObjectMeta) GetResourceVersion() string    { return meta.ResourceVersion }
+func (meta *ObjectMeta) SetResourceVersion(ver string) { meta.ResourceVersion = ver }
+func (meta *ObjectMeta) GetGeneration() int64          { panic("ObjectMeta - GetGeneration() not implemented") }
+func (meta *ObjectMeta) SetGeneration(_ int64)         { panic("ObjectMeta - SetGeneration() not implemented") }
+func (meta *ObjectMeta) GetSelfLink() string           { panic("ObjectMeta - GetSelfLink() not implemented") }
+func (meta *ObjectMeta) SetSelfLink(_ string)          { panic("ObjectMeta - SetSelfLink() not implemented") }
+func (meta *ObjectMeta) GetCreationTimestamp() metav1.Time {
+	panic("ObjectMeta - GetCreationTimestamp() not implemented")
+}
 func (meta *ObjectMeta) SetCreationTimestamp(_ metav1.Time) {
-	panic("not implemented")
+	panic("ObjectMeta - SetCreationTimestamp() not implemented")
 }
 func (meta *ObjectMeta) GetDeletionTimestamp() *metav1.Time {
 	if meta.DeletionTimestamp == nil {
@@ -65,27 +71,36 @@ func (meta *ObjectMeta) GetDeletionTimestamp() *metav1.Time {
 	}
 }
 func (meta *ObjectMeta) SetDeletionTimestamp(_ *metav1.Time) {
-	panic("not implemented")
+	panic("ObjectMeta - SetDeletionTimestamp() not implemented")
 }
 func (meta *ObjectMeta) GetDeletionGracePeriodSeconds() *int64 {
-	panic("not implemented")
+	panic("ObjectMeta - GetDeletionGracePeriodSeconds() not implemented")
 }
 func (meta *ObjectMeta) SetDeletionGracePeriodSeconds(_ *int64) {
-	panic("not implemented")
+	panic("ObjectMeta - SetDeletionGracePeriodSeconds() not implemented")
 }
 func (meta *ObjectMeta) GetLabels() map[string]string                 { return meta.Labels }
 func (meta *ObjectMeta) SetLabels(labels map[string]string)           { meta.Labels = labels }
 func (meta *ObjectMeta) GetAnnotations() map[string]string            { return meta.Annotations }
 func (meta *ObjectMeta) SetAnnotations(annotations map[string]string) { meta.Annotations = annotations }
-func (meta *ObjectMeta) GetFinalizers() []string                      { panic("not implemented") }
-func (meta *ObjectMeta) SetFinalizers(_ []string)                     { panic("not implemented") }
+func (meta *ObjectMeta) GetFinalizers() []string {
+	panic("ObjectMeta - GetFinalizers() not implemented")
+}
+func (meta *ObjectMeta) SetFinalizers(_ []string) {
+	panic("ObjectMeta - SetFinalizers() not implemented")
+}
 func (meta *ObjectMeta) GetOwnerReferences() []metav1.OwnerReference {
 	return FullOwnerReferences(meta.OwnerReferences)
 }
 func (meta *ObjectMeta) SetOwnerReferences(references []metav1.OwnerReference) {
 	meta.OwnerReferences = SlimOwnerReferences(references)
 }
-func (meta *ObjectMeta) GetZZZ_DeprecatedClusterName() string           { panic("not implemented") }
-func (meta *ObjectMeta) SetZZZ_DeprecatedClusterName(_ string)          { panic("not implemented") }
-func (meta *ObjectMeta) GetManagedFields() []metav1.ManagedFieldsEntry  { panic("not implemented") }
-func (meta *ObjectMeta) SetManagedFields(_ []metav1.ManagedFieldsEntry) { panic("not implemented") }
+func (meta *ObjectMeta) GetZZZ_DeprecatedClusterName() string  { panic("not implemented") }
+func (meta *ObjectMeta) SetZZZ_DeprecatedClusterName(_ string) { panic("not implemented") }
+
+func (meta *ObjectMeta) GetManagedFields() []metav1.ManagedFieldsEntry {
+	panic("ObjectMeta - GetManagedFields() not implemented")
+}
+func (meta *ObjectMeta) SetManagedFields(_ []metav1.ManagedFieldsEntry) {
+	panic("ObjectMeta - SetManagedFields() not implemented")
+}


### PR DESCRIPTION
Currently its hard to track down which method panics are coming from when we do hit them during upgrades. Stack-traces don't seem to have enough information to pinpoint the origin either.

<img width="1021" alt="image" src="https://user-images.githubusercontent.com/3775612/234273162-505ddcec-453a-4db5-a8a8-21bb8e32ed42.png">
