### PR TITLE
ci-datapath: Enable IPV6 masquerading when KPR=off

### DIFF
--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -245,7 +245,6 @@ jobs:
             tunnel: 'vxlan'
             encryption: 'ipsec'
             encryption-node: 'false'
-            ipv6: 'false' # until https://github.com/cilium/cilium/issues/23461 has been fixed
 
           - name: '10'
             kernel: '5.4-main'

--- a/.github/workflows/conformance-datapath.yaml
+++ b/.github/workflows/conformance-datapath.yaml
@@ -342,9 +342,7 @@ jobs:
             --rollback=false \
             --config monitor-aggregation=none \
             --nodes-without-cilium=kind-worker3 \
-            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }} \
-            --helm-set=bpf.masquerade=true \
-            --helm-set=enableIPv6Masquerade=false"
+            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
           TUNNEL="--helm-set-string=tunnelProtocol=${{ matrix.tunnel }}"
           if [ "${{ matrix.tunnel }}" == "disabled" ]; then
             TUNNEL="--helm-set-string=routingMode=native --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16"
@@ -361,6 +359,12 @@ jobs:
           IPV6=""
           if [ "${{ matrix.ipv6 }}" != "false" ]; then
             IPV6="--helm-set=ipv6.enabled=true"
+          fi
+          MASQ=""
+          if [ "${{ matrix.kpr }}" == "strict" ]; then
+            # BPF-masq requires KPR=strict.
+            # Disable IPv6 until https://github.com/cilium/cilium/issues/14350 has been resolved
+            MASQ="--helm-set=bpf.masquerade=true --helm-set=enableIPv6Masquerade=false"
           fi
           EGRESS_GATEWAY=""
           if [ "${{ matrix.egress-gateway }}" == "true" ]; then
@@ -384,7 +388,7 @@ jobs:
             HOST_FW="--helm-set=hostFirewall.enabled=true"
           fi
 
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
       - name: Checkout pull request for Helm chart

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -168,23 +168,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, true)).
 				Should(BeTrue(), "IPv6 connectivity test to http://google.com failed")
 		})
-
-		// TODO(brb) Enable IPv6 masq in ci-datapath, and then drop this test case
-		It("Check iptables masquerading without random-fully", func() {
-			options := map[string]string{
-				"bpf.masquerade":       "false",
-				"enableIPv6Masquerade": "true",
-			}
-			enableVXLANTunneling(options)
-			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
-			Expect(testPodConnectivityAcrossNodes(kubectl)).Should(BeTrue(), "Connectivity test between nodes failed")
-
-			By("Test iptables masquerading")
-			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, false)).
-				Should(BeTrue(), "IPv4 connectivity test to http://google.com failed")
-			Expect(testPodHTTPToOutside(kubectl, "http://google.com", false, false, true)).
-				Should(BeTrue(), "IPv6 connectivity test to http://google.com failed")
-		})
 	})
 
 	SkipContextIf(func() bool {


### PR DESCRIPTION
ci-dp successful run https://github.com/cilium/cilium/actions/runs/4798712433/jobs/8537364470?pr=25111.

Before removing the WIP commit, all ginkgo tests have passed. 