### PR TITLE
bpf: Track reply packets of egress gateway and SNATed host-local connections

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -346,6 +346,21 @@ ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
 	ct_flip_tuple_dir6(tuple);
 }
 
+static __always_inline void
+ipv6_ct_tuple_swap_ports(struct ipv6_ct_tuple *tuple)
+{
+	__be16 tmp;
+
+	/* Conntrack code uses tuples that have source and destination ports in
+	 * the reversed order. Other code, such as BPF helpers and NAT, requires
+	 * normal tuples that match the actual packet contents. This function
+	 * converts between these two formats.
+	 */
+	tmp = tuple->sport;
+	tuple->sport = tuple->dport;
+	tuple->dport = tmp;
+}
+
 static __always_inline int
 __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ctx,
 	     int l4_off, int action, enum ct_dir dir, struct ct_state *ct_state,

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -394,13 +394,11 @@ out:
 	return ret;
 }
 
-/* Like an IPv6 version of ct_lazy_lookup4, but also assumes that the L4
- * protocol is a service protocol (SCTP, UDP or TCP).
- */
+/* An IPv6 version of ct_lazy_lookup4. */
 static __always_inline int
-ct_lb_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
-	      struct __ctx_buff *ctx, int l4_off, enum ct_dir dir,
-	      struct ct_state *ct_state, __u32 *monitor)
+ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
+		struct __ctx_buff *ctx, int l4_off, int action, enum ct_dir dir,
+		struct ct_state *ct_state, __u32 *monitor)
 {
 	/* The tuple is created in reverse order initially to find a
 	 * potential reverse flow. This is required because the RELATED
@@ -418,7 +416,7 @@ ct_lb_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
 	else
 		return DROP_CT_INVALID_HDR;
 
-	return __ct_lookup6(map, tuple, ctx, l4_off, ACTION_CREATE, dir,
+	return __ct_lookup6(map, tuple, ctx, l4_off, action, dir,
 			    ct_state, monitor);
 }
 

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -562,6 +562,21 @@ ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 	ct_flip_tuple_dir4(tuple);
 }
 
+static __always_inline void
+ipv4_ct_tuple_swap_ports(struct ipv4_ct_tuple *tuple)
+{
+	__be16 tmp;
+
+	/* Conntrack code uses tuples that have source and destination ports in
+	 * the reversed order. Other code, such as BPF helpers and NAT, requires
+	 * normal tuples that match the actual packet contents. This function
+	 * converts between these two formats.
+	 */
+	tmp = tuple->sport;
+	tuple->sport = tuple->dport;
+	tuple->dport = tmp;
+}
+
 static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 						    int off,
 						    enum ct_dir dir __maybe_unused,

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -854,7 +854,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		return DROP_NO_SERVICE;
 
 	/* See lb4_local comments re svc endpoint lookup process */
-	ret = ct_lb_lookup6(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
+	ret = ct_lazy_lookup6(map, tuple, ctx, l4_off, ACTION_CREATE, CT_SERVICE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1526,8 +1526,8 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 	if (unlikely(svc->count == 0))
 		return DROP_NO_SERVICE;
 
-	ret = ct_lb_lookup4(map, tuple, ctx, l4_off, has_l4_header, CT_SERVICE,
-			    state, &monitor);
+	ret = ct_lazy_lookup4(map, tuple, ctx, l4_off, has_l4_header, ACTION_CREATE,
+			      CT_SERVICE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -306,6 +306,7 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 static __always_inline int snat_v4_track_connection(struct __ctx_buff *ctx,
 						    const struct ipv4_ct_tuple *tuple,
 						    const struct ipv4_nat_entry *state,
+						    bool has_l4_header, int ct_action,
 						    enum nat_dir dir, __u32 off,
 						    const struct ipv4_nat_target *target,
 						    __s8 *ext_err)
@@ -339,8 +340,13 @@ static __always_inline int snat_v4_track_connection(struct __ctx_buff *ctx,
 
 	where = dir == NAT_DIR_INGRESS ? CT_INGRESS : CT_EGRESS;
 
-	ret = ct_lookup4(get_ct_map4(&tmp), &tmp, ctx, off, where,
-			 &ct_state, &monitor);
+	/* CT expects a tuple with the source and destination ports reversed,
+	 * while NAT uses normal tuples that match packet headers.
+	 */
+	ipv4_ct_tuple_swap_ports(&tmp);
+
+	ret = ct_lazy_lookup4(get_ct_map4(&tmp), &tmp, ctx, off, has_l4_header,
+			      ct_action, where, &ct_state, &monitor);
 	if (ret < 0) {
 		return ret;
 	} else if (ret == CT_NEW) {
@@ -356,6 +362,8 @@ static __always_inline int snat_v4_track_connection(struct __ctx_buff *ctx,
 static __always_inline int
 snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 			   struct ipv4_ct_tuple *tuple,
+			   bool has_l4_header,
+			   int ct_action,
 			   struct ipv4_nat_entry **state,
 			   struct ipv4_nat_entry *tmp,
 			   __u32 off,
@@ -370,7 +378,8 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 		return DROP_SNAT_NO_MAP_FOUND;
 
 	*state = __snat_lookup(map, tuple);
-	ret = snat_v4_track_connection(ctx, tuple, *state, NAT_DIR_EGRESS, off, target, ext_err);
+	ret = snat_v4_track_connection(ctx, tuple, *state, has_l4_header, ct_action,
+				       NAT_DIR_EGRESS, off, target, ext_err);
 	if (ret < 0)
 		return ret;
 	else if (*state)
@@ -382,6 +391,8 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 static __always_inline int
 snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       struct ipv4_ct_tuple *tuple,
+			       bool has_l4_header,
+			       int ct_action,
 			       struct ipv4_nat_entry **state,
 			       __u32 off,
 			       const struct ipv4_nat_target *target,
@@ -395,7 +406,8 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 		return DROP_SNAT_NO_MAP_FOUND;
 
 	*state = __snat_lookup(map, tuple);
-	ret = snat_v4_track_connection(ctx, tuple, *state, NAT_DIR_INGRESS, off, target, ext_err);
+	ret = snat_v4_track_connection(ctx, tuple, *state, has_l4_header, ct_action,
+				       NAT_DIR_INGRESS, off, target, ext_err);
 	if (ret < 0)
 		return ret;
 	else if (*state)
@@ -922,6 +934,8 @@ snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __s8 *
 		__be16 dport;
 	} l4hdr;
 	bool icmp_echoreply = false;
+	bool has_l4_header = true;
+	int ct_action = ACTION_UNSPEC;
 	__u64 off;
 	int ret;
 	__u8 nexthdr;
@@ -945,6 +959,7 @@ snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __s8 *
 			return DROP_INVALID;
 		tuple.dport = l4hdr.dport;
 		tuple.sport = l4hdr.sport;
+		ct_action = ACTION_CREATE;
 		break;
 	case IPPROTO_ICMP:
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
@@ -954,6 +969,7 @@ snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __s8 *
 		case ICMP_ECHO:
 			tuple.dport = 0;
 			tuple.sport = icmphdr.un.echo.id;
+			ct_action = ACTION_CREATE;
 			break;
 		case ICMP_ECHOREPLY:
 			tuple.dport = icmphdr.un.echo.id;
@@ -1058,7 +1074,8 @@ snat_v4_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __s8 *
 
 	if (snat_v4_nat_can_skip(target, &tuple, icmp_echoreply))
 		return NAT_PUNT_TO_STACK;
-	ret = snat_v4_nat_handle_mapping(ctx, &tuple, &state, &tmp, off, target, ext_err);
+	ret = snat_v4_nat_handle_mapping(ctx, &tuple, has_l4_header, ct_action, &state, &tmp,
+					 off, target, ext_err);
 	if (ret > 0)
 		return CTX_ACT_OK;
 	if (ret < 0)
@@ -1080,6 +1097,8 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __
 		__be16 sport;
 		__be16 dport;
 	} l4hdr;
+	bool has_l4_header = true;
+	int ct_action = ACTION_UNSPEC;
 	__u64 off;
 	int ret;
 
@@ -1101,6 +1120,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __
 			return DROP_INVALID;
 		tuple.dport = l4hdr.dport;
 		tuple.sport = l4hdr.sport;
+		ct_action = ACTION_CREATE;
 		break;
 	case IPPROTO_ICMP:
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
@@ -1109,6 +1129,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __
 		case ICMP_ECHO:
 			tuple.dport = 0;
 			tuple.sport = icmphdr.un.echo.id;
+			ct_action = ACTION_CREATE;
 			break;
 		case ICMP_ECHOREPLY:
 			tuple.dport = icmphdr.un.echo.id;
@@ -1202,7 +1223,8 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __
 
 	if (snat_v4_rev_nat_can_skip(target, &tuple))
 		return NAT_PUNT_TO_STACK;
-	ret = snat_v4_rev_nat_handle_mapping(ctx, &tuple, &state, off, target, ext_err);
+	ret = snat_v4_rev_nat_handle_mapping(ctx, &tuple, has_l4_header, ct_action, &state,
+					     off, target, ext_err);
 	if (ret > 0)
 		return CTX_ACT_OK;
 	if (ret < 0)

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -247,7 +247,8 @@ static __always_inline void snat_v4_delete_tuples(struct ipv4_ct_tuple *otuple)
 static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 					       struct ipv4_ct_tuple *otuple,
 					       struct ipv4_nat_entry *ostate,
-					       const struct ipv4_nat_target *target)
+					       const struct ipv4_nat_target *target,
+					       bool needs_ct)
 {
 	int ret = DROP_NAT_NO_MAPPING, retries;
 	struct ipv4_nat_entry rstate;
@@ -271,21 +272,8 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 	rtuple.dport = ostate->to_sport = bpf_htons(port);
 	rtuple.daddr = target->addr;
 
-	if (otuple->saddr == target->addr) {
-		/* Host-local connection. */
-		ostate->common.needs_ct = 1;
-		rstate.common.needs_ct = ostate->common.needs_ct;
-	}
-
-#if defined(ENABLE_EGRESS_GATEWAY)
-	if (target->egress_gateway && !target->from_local_endpoint) {
-		/* Track established egress gateway connections to extend the
-		 * CT entry expiration timeout.
-		 */
-		ostate->common.needs_ct = 1;
-		rstate.common.needs_ct = ostate->common.needs_ct;
-	}
-#endif
+	ostate->common.needs_ct = needs_ct;
+	rstate.common.needs_ct = needs_ct;
 
 	map = get_cluster_snat_map_v4(target->cluster_id);
 	if (!map)
@@ -314,40 +302,42 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 	return !ret ? 0 : DROP_NAT_NO_MAPPING;
 }
 
+static __always_inline bool
+snat_v4_needs_ct(const struct ipv4_ct_tuple *tuple,
+		 const struct ipv4_nat_target *target)
+{
+	if (tuple->saddr == target->addr) {
+		/* Host-local connection. */
+		return true;
+	}
+
+#if defined(ENABLE_EGRESS_GATEWAY)
+	/* Track egress gateway connections, but only if they are related to a
+	 * remote endpoint (if the endpoint is local then the connection is
+	 * already tracked).
+	 */
+	if (target->egress_gateway && !target->from_local_endpoint) {
+		/* Track established egress gateway connections to extend the
+		 * CT entry expiration timeout.
+		 */
+		return true;
+	}
+#endif
+
+	return false;
+}
+
 static __always_inline int snat_v4_track_connection(struct __ctx_buff *ctx,
 						    const struct ipv4_ct_tuple *tuple,
-						    const struct ipv4_nat_entry *state,
 						    bool has_l4_header, int ct_action,
 						    enum nat_dir dir, __u32 off,
-						    const struct ipv4_nat_target *target,
 						    __s8 *ext_err)
 {
 	struct ct_state ct_state;
 	struct ipv4_ct_tuple tmp;
-	bool needs_ct = false;
 	__u32 monitor = 0;
 	enum ct_dir where;
 	int ret;
-
-	if (state && state->common.needs_ct) {
-		needs_ct = true;
-#if defined(ENABLE_EGRESS_GATEWAY)
-	/* Track egress gateway connections, but only if they are related to a
-	 * remote endpoint (if the endpoint is local then the connection is
-	 * already tracked). NAT_DIR_EGRESS is implied.
-	 * This check is only relevant for the first packet; the subsequent ones
-	 * will have state->common.needs_ct set, therefore, both egress and
-	 * ingress packets will trigger ct_lookup4 and extend the expiration
-	 * timeout.
-	 */
-	} else if (target->egress_gateway && !target->from_local_endpoint) {
-		needs_ct = true;
-#endif
-	} else if (!state && dir == NAT_DIR_EGRESS && tuple->saddr == target->addr) {
-		needs_ct = true;
-	}
-	if (!needs_ct)
-		return 0;
 
 	memset(&ct_state, 0, sizeof(ct_state));
 	memcpy(&tmp, tuple, sizeof(tmp));
@@ -384,6 +374,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 			   const struct ipv4_nat_target *target,
 			   __s8 *ext_err)
 {
+	bool needs_ct;
 	int ret;
 	void *map;
 
@@ -392,14 +383,17 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 		return DROP_SNAT_NO_MAP_FOUND;
 
 	*state = __snat_lookup(map, tuple);
-	ret = snat_v4_track_connection(ctx, tuple, *state, has_l4_header, ct_action,
-				       NAT_DIR_EGRESS, off, target, ext_err);
-	if (ret < 0)
-		return ret;
-	else if (*state)
+	needs_ct = *state ? (*state)->common.needs_ct : snat_v4_needs_ct(tuple, target);
+	if (needs_ct) {
+		ret = snat_v4_track_connection(ctx, tuple, has_l4_header, ct_action,
+					       NAT_DIR_EGRESS, off, ext_err);
+		if (ret < 0)
+			return ret;
+	}
+	if (*state)
 		return NAT_CONTINUE_XLATE;
 	else
-		return snat_v4_new_mapping(ctx, tuple, (*state = tmp), target);
+		return snat_v4_new_mapping(ctx, tuple, (*state = tmp), target, needs_ct);
 }
 
 static __always_inline int
@@ -412,7 +406,6 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       const struct ipv4_nat_target *target,
 			       __s8 *ext_err)
 {
-	struct ipv4_ct_tuple tuple_revsnat;
 	int ret;
 	void *map;
 
@@ -421,18 +414,19 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 		return DROP_SNAT_NO_MAP_FOUND;
 
 	*state = __snat_lookup(map, tuple);
+	if (*state && (*state)->common.needs_ct) {
+		struct ipv4_ct_tuple tuple_revsnat;
 
-	memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
-	if (*state) {
+		memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
 		tuple_revsnat.daddr = (*state)->to_daddr;
 		tuple_revsnat.dport = (*state)->to_dport;
-	}
 
-	ret = snat_v4_track_connection(ctx, &tuple_revsnat, *state, has_l4_header, ct_action,
-				       NAT_DIR_INGRESS, off, target, ext_err);
-	if (ret < 0)
-		return ret;
-	else if (*state)
+		ret = snat_v4_track_connection(ctx, &tuple_revsnat, has_l4_header, ct_action,
+					       NAT_DIR_INGRESS, off, ext_err);
+		if (ret < 0)
+			return ret;
+	}
+	if (*state)
 		return NAT_CONTINUE_XLATE;
 	else
 		return tuple->nexthdr != IPPROTO_ICMP &&
@@ -1406,7 +1400,8 @@ static __always_inline void snat_v6_delete_tuples(struct ipv6_ct_tuple *otuple)
 static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 					       struct ipv6_ct_tuple *otuple,
 					       struct ipv6_nat_entry *ostate,
-					       const struct ipv6_nat_target *target)
+					       const struct ipv6_nat_target *target,
+					       bool needs_ct)
 {
 	int ret = DROP_NAT_NO_MAPPING, retries;
 	struct ipv6_nat_entry rstate;
@@ -1429,11 +1424,8 @@ static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 	rtuple.dport = ostate->to_sport = bpf_htons(port);
 	rtuple.daddr = target->addr;
 
-	if (!ipv6_addrcmp(&otuple->saddr, &rtuple.daddr)) {
-		/* Host-local connection. */
-		ostate->common.needs_ct = 1;
-		rstate.common.needs_ct = ostate->common.needs_ct;
-	}
+	ostate->common.needs_ct = needs_ct;
+	rstate.common.needs_ct = needs_ct;
 
 #pragma unroll
 	for (retries = 0; retries < SNAT_COLLISION_RETRIES; retries++) {
@@ -1458,29 +1450,29 @@ static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 	return !ret ? 0 : DROP_NAT_NO_MAPPING;
 }
 
+static __always_inline bool
+snat_v6_needs_ct(struct ipv6_ct_tuple *tuple,
+		 const struct ipv6_nat_target *target)
+{
+	if (!ipv6_addrcmp(&tuple->saddr, &target->addr)) {
+		/* Host-local connection. */
+		return true;
+	}
+
+	return false;
+}
+
 static __always_inline int snat_v6_track_connection(struct __ctx_buff *ctx,
 						    struct ipv6_ct_tuple *tuple,
-						    const struct ipv6_nat_entry *state,
 						    int ct_action,
 						    enum nat_dir dir, __u32 off,
-						    const struct ipv6_nat_target *target,
 						    __s8 *ext_err)
 {
 	struct ct_state ct_state;
 	struct ipv6_ct_tuple tmp;
-	bool needs_ct = false;
 	__u32 monitor = 0;
 	enum ct_dir where;
 	int ret;
-
-	if (state && state->common.needs_ct) {
-		needs_ct = true;
-	} else if (!state && dir == NAT_DIR_EGRESS) {
-		if (!ipv6_addrcmp(&tuple->saddr, (void *)&target->addr))
-			needs_ct = true;
-	}
-	if (!needs_ct)
-		return 0;
 
 	memset(&ct_state, 0, sizeof(ct_state));
 	memcpy(&tmp, tuple, sizeof(tmp));
@@ -1516,17 +1508,21 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			   const struct ipv6_nat_target *target,
 			   __s8 *ext_err)
 {
+	bool needs_ct;
 	int ret;
 
 	*state = snat_v6_lookup(tuple);
-	ret = snat_v6_track_connection(ctx, tuple, *state, ct_action,
-				       NAT_DIR_EGRESS, off, target, ext_err);
-	if (ret < 0)
-		return ret;
-	else if (*state)
+	needs_ct = *state ? (*state)->common.needs_ct : snat_v6_needs_ct(tuple, target);
+	if (needs_ct) {
+		ret = snat_v6_track_connection(ctx, tuple, ct_action,
+					       NAT_DIR_EGRESS, off, ext_err);
+		if (ret < 0)
+			return ret;
+	}
+	if (*state)
 		return NAT_CONTINUE_XLATE;
 	else
-		return snat_v6_new_mapping(ctx, tuple, (*state = tmp), target);
+		return snat_v6_new_mapping(ctx, tuple, (*state = tmp), target, needs_ct);
 }
 
 static __always_inline int
@@ -1538,22 +1534,22 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       const struct ipv6_nat_target *target,
 			       __s8 *ext_err)
 {
-	struct ipv6_ct_tuple tuple_revsnat;
 	int ret;
 
 	*state = snat_v6_lookup(tuple);
+	if (*state && (*state)->common.needs_ct) {
+		struct ipv6_ct_tuple tuple_revsnat;
 
-	memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
-	if (*state) {
+		memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
 		ipv6_addr_copy(&tuple_revsnat.daddr, &(*state)->to_daddr);
 		tuple_revsnat.dport = (*state)->to_dport;
-	}
 
-	ret = snat_v6_track_connection(ctx, &tuple_revsnat, *state, ct_action,
-				       NAT_DIR_INGRESS, off, target, ext_err);
-	if (ret < 0)
-		return ret;
-	else if (*state)
+		ret = snat_v6_track_connection(ctx, &tuple_revsnat, ct_action,
+					       NAT_DIR_INGRESS, off, ext_err);
+		if (ret < 0)
+			return ret;
+	}
+	if (*state)
 		return NAT_CONTINUE_XLATE;
 	else
 		return tuple->nexthdr != IPPROTO_ICMPV6 &&

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1908,8 +1908,8 @@ int tail_nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-			    has_l4_header, CT_EGRESS, &ct_state, &monitor);
+	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
+			      has_l4_header, ACTION_CREATE, CT_EGRESS, &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	/* Maybe we can be a bit more selective about CT_REOPENED?
@@ -2275,8 +2275,8 @@ skip_service_lookup:
 	if (backend_local || !nodeport_uses_dsr4(&tuple)) {
 		struct ct_state ct_state = {};
 
-		ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-				    has_l4_header, CT_EGRESS, &ct_state, &monitor);
+		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
+				      ACTION_CREATE, CT_EGRESS, &ct_state, &monitor);
 		switch (ret) {
 		case CT_REPLY:
 			/* SVC request should never be considered a reply, so this
@@ -2363,8 +2363,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 					   is_defined(ENABLE_DSR)))
 		return CTX_ACT_OK;
 
-	ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-			    has_l4_header, CT_INGRESS, &ct_state, &trace->monitor);
+	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
+			      ACTION_CREATE, CT_INGRESS, &ct_state, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -2437,8 +2437,8 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 	if (!ct_has_nodeport_egress_entry4(get_ct_map4(&tuple), &tuple, false))
 		goto out;
 
-	ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-			    has_l4_header, CT_INGRESS, &ct_state, &monitor);
+	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
+			      ACTION_CREATE, CT_INGRESS, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		reason = TRACE_REASON_CT_REPLY;
 		ret = lb4_rev_nat(ctx, l3_off, l4_off, &ct_state, &tuple,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -650,8 +650,8 @@ int tail_nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
-			    CT_EGRESS, &ct_state, &monitor);
+	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+			      CT_EGRESS, &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	case CT_REOPENED:
@@ -1021,8 +1021,8 @@ skip_service_lookup:
 	if (backend_local || !nodeport_uses_dsr6(&tuple)) {
 		struct ct_state ct_state = {};
 
-		ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
-				    CT_EGRESS, &ct_state, &monitor);
+		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+				      CT_EGRESS, &ct_state, &monitor);
 		switch (ret) {
 		case CT_REPLY:
 			ipv6_ct_tuple_reverse(&tuple);
@@ -1113,8 +1113,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 					   is_defined(ENABLE_DSR)))
 		return CTX_ACT_OK;
 
-	ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
-			    &ct_state, &trace->monitor);
+	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+			      CT_INGRESS, &ct_state, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -1175,8 +1175,8 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __s8 *ext_er
 	if (!ct_has_nodeport_egress_entry6(get_ct_map6(&tuple), &tuple, false))
 		goto out;
 
-	ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
-			    &ct_state, &monitor);
+	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+			      CT_INGRESS, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index,
 				  &tuple, REV_NAT_F_TUPLE_SADDR);

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -188,7 +188,8 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 
-	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
+				  snat_v4_needs_ct(&tuple, &target));
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -296,7 +297,8 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 
-	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
+				  snat_v4_needs_ct(&tuple, &target));
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -403,7 +405,8 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 
-	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
+				  snat_v4_needs_ct(&tuple, &target));
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -499,7 +502,8 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 
-	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
+				  snat_v4_needs_ct(&tuple, &target));
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -559,7 +563,8 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 
-	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
+				  snat_v4_needs_ct(&tuple, &target));
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -667,7 +672,8 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 
-	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
+				  snat_v4_needs_ct(&tuple, &target));
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -774,7 +780,8 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 
-	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
+				  snat_v4_needs_ct(&tuple, &target));
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -870,7 +877,8 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	};
 	struct ipv4_nat_entry state;
 
-	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target);
+	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
+				  snat_v4_needs_ct(&tuple, &target));
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling

--- a/bpf/tests/nat_test.c
+++ b/bpf/tests/nat_test.c
@@ -106,8 +106,6 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 
 	struct __ctx_buff ctx_buff;
 	struct ipv4_ct_tuple tuple;
-	struct ipv4_nat_entry state;
-	struct ipv4_nat_target target;
 
 	/* If there is an error in ct_lazy_lookup4, it will return a negative value. We */
 	/* can simply assume it to be -1 because the actually value does not matter. */
@@ -116,8 +114,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return exactly the same value which means */
 	/* an error occurs when snat_v4_track_connection is looking for the ipv4_ct_tuple. */
 	TEST("return -1 on error", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
-					     NAT_DIR_EGRESS, 0, &target, NULL) != -1) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0, NULL) != -1) {
 			test_fail();
 		}
 	});
@@ -129,8 +127,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return 0 which means snat_v4_track_connection */
 	/* successfully tracks ipv4_ct_tuple. */
 	TEST("return 0 on track", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
-					     NAT_DIR_EGRESS, 0, &target, NULL) != 0) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0, NULL) != 0) {
 			test_fail();
 		}
 	});
@@ -145,8 +143,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return that value which means an error occurs */
 	/* when snat_v4_track_connection is trying to create the ipv4_ct_tuple. */
 	TEST("return -1 on create error", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
-					     NAT_DIR_EGRESS, 0, &target, NULL) != -1) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0, NULL) != -1) {
 			test_fail();
 		}
 	});
@@ -160,8 +158,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return 0 which means snat_v4_track_connection */
 	/* successfully creates the ipv4_ct_tuple. */
 	TEST("return 0 on create success", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
-					     NAT_DIR_EGRESS, 0, &target, NULL) != 0) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0, NULL) != 0) {
 			test_fail();
 		}
 	});

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -194,15 +194,8 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, boo
 		test_fatal("bad TX packet count (expected %u, actual %u)",
 			   tx_packets, ct_entry->tx_packets)
 	if (ct_entry->rx_packets != rx_packets)
-#ifdef ISSUE_25110_FIXED
-		/* This test fails until this issue is fixed:
-		 * https://github.com/cilium/cilium/issues/25110
-		 */
 		test_fatal("bad RX packet count (expected %u, actual %u)",
 			   rx_packets, ct_entry->rx_packets)
-#else
-		;
-#endif
 
 	tuple.saddr = CLIENT_IP;
 	tuple.daddr = EXTERNAL_SVC_IP;

--- a/cilium/cmd/bpf_nat_list_test.go
+++ b/cilium/cmd/bpf_nat_list_test.go
@@ -46,16 +46,16 @@ var (
 		},
 	}
 	natValue4 = nat.NatEntry4{
-		Created:   12345,
-		HostLocal: 6789,
-		Addr:      types.IPv4{10, 10, 10, 3},
-		Port:      byteorder.HostToNetwork16(53),
+		Created: 12345,
+		NeedsCT: 6789,
+		Addr:    types.IPv4{10, 10, 10, 3},
+		Port:    byteorder.HostToNetwork16(53),
 	}
 	natValue6 = nat.NatEntry6{
-		Created:   12345,
-		HostLocal: 6789,
-		Addr:      types.IPv6{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53},
-		Port:      byteorder.HostToNetwork16(53),
+		Created: 12345,
+		NeedsCT: 6789,
+		Addr:    types.IPv6{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53},
+		Port:    byteorder.HostToNetwork16(53),
 	}
 )
 

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -151,10 +151,10 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 		},
 	}
 	natVal := &nat.NatEntry4{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv4{192, 168, 61, 11},
-		Port:      0x3195,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{192, 168, 61, 11},
+		Port:    0x3195,
 	}
 	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
 		unsafe.Pointer(natVal), 0)
@@ -172,10 +172,10 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 		},
 	}
 	natVal = &nat.NatEntry4{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv4{192, 168, 61, 11},
-		Port:      0x3195,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{192, 168, 61, 11},
+		Port:    0x3195,
 	}
 	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
 		unsafe.Pointer(natVal), 0)
@@ -287,10 +287,10 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		},
 	}
 	natVal := &nat.NatEntry4{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv4{10, 23, 32, 45},
-		Port:      0x51d6,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{10, 23, 32, 45},
+		Port:    0x51d6,
 	}
 	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
 		unsafe.Pointer(natVal), 0)
@@ -308,10 +308,10 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		},
 	}
 	natVal = &nat.NatEntry4{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv4{10, 23, 32, 45},
-		Port:      0x50d6,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{10, 23, 32, 45},
+		Port:    0x50d6,
 	}
 	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
 		unsafe.Pointer(natVal), 0)
@@ -543,10 +543,10 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		},
 	}
 	natValV6 := &nat.NatEntry6{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv6{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
-		Port:      0x51d6,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv6{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+		Port:    0x51d6,
 	}
 	err = bpf.UpdateElement(natMapV6.Map.GetFd(), natMapV6.Map.Name(), unsafe.Pointer(natKeyV6),
 		unsafe.Pointer(natValV6), 0)

--- a/pkg/maps/nat/ipv4.go
+++ b/pkg/maps/nat/ipv4.go
@@ -16,12 +16,12 @@ import (
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
 type NatEntry4 struct {
-	Created   uint64     `align:"created"`
-	HostLocal uint64     `align:"host_local"`
-	Pad1      uint64     `align:"pad1"`
-	Pad2      uint64     `align:"pad2"`
-	Addr      types.IPv4 `align:"to_saddr"`
-	Port      uint16     `align:"to_sport"`
+	Created uint64     `align:"created"`
+	NeedsCT uint64     `align:"needs_ct"`
+	Pad1    uint64     `align:"pad1"`
+	Pad2    uint64     `align:"pad2"`
+	Addr    types.IPv4 `align:"to_saddr"`
+	Port    uint16     `align:"to_sport"`
 }
 
 // SizeofNatEntry4 is the size of the NatEntry4 type in bytes.
@@ -32,11 +32,11 @@ func (n *NatEntry4) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(n) }
 
 // String returns the readable format.
 func (n *NatEntry4) String() string {
-	return fmt.Sprintf("Addr=%s Port=%d Created=%d HostLocal=%d\n",
+	return fmt.Sprintf("Addr=%s Port=%d Created=%d NeedsCT=%d\n",
 		n.Addr,
 		n.Port,
 		n.Created,
-		n.HostLocal)
+		n.NeedsCT)
 }
 
 // Dump dumps NAT entry to string.
@@ -48,12 +48,12 @@ func (n *NatEntry4) Dump(key NatKey, start uint64) string {
 	} else {
 		which = "SRC"
 	}
-	return fmt.Sprintf("XLATE_%s %s:%d Created=%s HostLocal=%d\n",
+	return fmt.Sprintf("XLATE_%s %s:%d Created=%s NeedsCT=%d\n",
 		which,
 		n.Addr,
 		n.Port,
 		NatDumpCreated(start, n.Created),
-		n.HostLocal)
+		n.NeedsCT)
 }
 
 // ToHost converts NatEntry4 ports to host byte order.

--- a/pkg/maps/nat/ipv6.go
+++ b/pkg/maps/nat/ipv6.go
@@ -16,12 +16,12 @@ import (
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
 type NatEntry6 struct {
-	Created   uint64     `align:"created"`
-	HostLocal uint64     `align:"host_local"`
-	Pad1      uint64     `align:"pad1"`
-	Pad2      uint64     `align:"pad2"`
-	Addr      types.IPv6 `align:"to_saddr"`
-	Port      uint16     `align:"to_sport"`
+	Created uint64     `align:"created"`
+	NeedsCT uint64     `align:"needs_ct"`
+	Pad1    uint64     `align:"pad1"`
+	Pad2    uint64     `align:"pad2"`
+	Addr    types.IPv6 `align:"to_saddr"`
+	Port    uint16     `align:"to_sport"`
 }
 
 // SizeofNatEntry6 is the size of the NatEntry6 type in bytes.
@@ -32,11 +32,11 @@ func (n *NatEntry6) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(n) }
 
 // String returns the readable format.
 func (n *NatEntry6) String() string {
-	return fmt.Sprintf("Addr=%s Port=%d Created=%d HostLocal=%d\n",
+	return fmt.Sprintf("Addr=%s Port=%d Created=%d NeedsCT=%d\n",
 		n.Addr,
 		n.Port,
 		n.Created,
-		n.HostLocal)
+		n.NeedsCT)
 }
 
 // Dump dumps NAT entry to string.
@@ -48,12 +48,12 @@ func (n *NatEntry6) Dump(key NatKey, start uint64) string {
 	} else {
 		which = "SRC"
 	}
-	return fmt.Sprintf("XLATE_%s [%s]:%d Created=%s HostLocal=%d\n",
+	return fmt.Sprintf("XLATE_%s [%s]:%d Created=%s NeedsCT=%d\n",
 		which,
 		n.Addr,
 		n.Port,
 		NatDumpCreated(start, n.Created),
-		n.HostLocal)
+		n.NeedsCT)
 }
 
 // ToHost converts NatEntry4 ports to host byte order.


### PR DESCRIPTION
Flag the egress gateway NAT entries as needs_ct, so that reply packets could extend the expiration timeout as well.

Fix the conntrack tuple matching for packets in the reply direction, so that the needs_ct flag could actually be useful. Currently, the tuple before revSNAT is used for conntrack and doesn't match the original CT entry. After the fix, the tuple is adjusted to contain data like after revSNAT, so that it could match the original CT entry and get the needs_ct flag from it.

Fixes: #25110

```release-note
Track reply packets in long-living egress gateway connections and SNATed host-local connections.
```
