### PR TITLE
bpf: test: Fix the byte order in the IPV4 macro

### DIFF
--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -37,7 +37,7 @@ static volatile const __u8 mac_six[] =   {0x08, 0x14, 0x1C, 0x32, 0x52, 0x7E};
  *  having to come up with custom ips.
  */
 
-#define IPV4(a, b, c, d) __bpf_htonl(((d) << 24) + ((c) << 16) + ((b) << 8) + (a))
+#define IPV4(a, b, c, d) __bpf_htonl(((a) << 24) + ((b) << 16) + ((c) << 8) + (d))
 
 /* IPv4 addresses for hosts, external to the cluster */
 #define v4_ext_one	IPV4(110, 0, 11, 1)


### PR DESCRIPTION
All the usages suggest that the order of parameters of the IPV4 macro in bpf/tests/pktgen.h is natural: IPV4(192, 168, 0, 1) means 192.168.0.1, not 1.0.168.192. However, the IPV4 macro assembles the bytes in the opposite order, i.e. like 1.0.168.192.

Fix the macro by putting the bytes in the intended order. This change should only have a cosmetic effect when IP addresses are printed in the failed tests, but it might expose some real issues if some tests rely on the IP prefixes.