### PR TITLE
cmd/cleanup: Fix cleanup of generic XDP programs

### DIFF
--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/ebpf"
@@ -543,7 +544,11 @@ func removeTCFilters(linkAndFilters map[string][]*netlink.BpfFilter) error {
 
 func removeXDPs(links []netlink.Link) error {
 	for _, link := range links {
-		err := netlink.LinkSetXdpFd(link, -1)
+		err := netlink.LinkSetXdpFdWithFlags(link, -1, int(nl.XDP_FLAGS_DRV_MODE))
+		if err != nil {
+			return err
+		}
+		err = netlink.LinkSetXdpFdWithFlags(link, -1, int(nl.XDP_FLAGS_SKB_MODE))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The `cilium cleanup` command wasn't actually removing XDP programs attached to the generic hook point. This was causing issues when an XDP test in ginkgo was immediately followed by the upgrade test. The upgrade test would run `cilium cleanup` and remove everything except for the XDP programs. That would isolate the Cilium-managed nodes from the outside network (both SSH and intra-cluster connectivity).

Obviously, this works when we change the Cilium configuration to disable XDP. There we have some logic to remove any leftover XDP programs on agent startup. Comparing that logic with the `cilium cleanup` logic, we can see that the difference is that the agent removes XDP programs explicitly for each hook point (generic and driver). Let's do the same.

This fix was tested manually on a setup with Cilium's generic XDP programs installed.

Fixes: https://github.com/cilium/cilium/pull/19735.
Fixes: https://github.com/cilium/cilium/issues/24687.
