### PR TITLE
daemon: use netlink for managed neighbor support probe

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -419,7 +419,12 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	// Check the kernel if we can make use of managed neighbor entries which
 	// simplifies and fully 'offloads' L2 resolution handling to the kernel.
-	probeManagedNeighborSupport()
+	if !option.Config.DryMode {
+		if err := probes.HaveManagedNeighbors(); err == nil {
+			log.Info("Using Managed Neighbor Kernel support")
+			option.Config.ARPPingKernelManaged = true
+		}
+	}
 
 	// Do the partial kube-proxy replacement initialization before creating BPF
 	// maps. Otherwise, some maps might not be created (e.g. session affinity).

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -361,22 +361,6 @@ func probeKubeProxyReplacementOptions() error {
 	return nil
 }
 
-func probeManagedNeighborSupport() {
-	if option.Config.DryMode {
-		return
-	}
-
-	// Probes for kernel commit:
-	//   856c02dbce4f ("bpf: Introduce helper bpf_get_branch_snapshot")
-	// This is a bit of a workaround given feature probing for netlink
-	// neighboring subsystem is cumbersome. The commit was added in the
-	// same release as managed neighbors, that is, 5.16+.
-	if probes.HaveProgramHelper(ebpf.Kprobe, asm.FnGetBranchSnapshot) == nil {
-		log.Info("Using Managed Neighbor Kernel support")
-		option.Config.ARPPingKernelManaged = true
-	}
-}
-
 func probeCgroupSupportTCP(ipv4 bool) error {
 	var err error
 

--- a/pkg/datapath/linux/probes/managed_neighbors.go
+++ b/pkg/datapath/linux/probes/managed_neighbors.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package probes
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"runtime"
+	"sync"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+var (
+	managedNeighborOnce   sync.Once
+	managedNeighborResult error
+)
+
+// HaveManagedNeighbors returns nil if the host supports managed neighbor entries (NTF_EXT_MANAGED).
+// On unexpected probe results this function will terminate with log.Fatal().
+func HaveManagedNeighbors() error {
+	managedNeighborOnce.Do(func() {
+		ch := make(chan struct{})
+
+		// In order to call haveManagedNeighbors safely, it has to be started
+		// in a goroutine, so we can make sure the goroutine ends when the function exits.
+		// This makes sure the underlying OS thread exits if we fail to restore it to the original netns.
+		go func() {
+			managedNeighborResult = haveManagedNeighbors()
+			close(ch)
+		}()
+		<-ch // wait for probe to finish
+
+		// if we encounter a different error than ErrNotSupported, terminate the agent.
+		if managedNeighborResult != nil && !errors.Is(managedNeighborResult, ErrNotSupported) {
+			log.WithError(managedNeighborResult).Fatal("failed to probe managed neighbor support")
+		}
+	})
+
+	return managedNeighborResult
+}
+
+func haveManagedNeighbors() (outer error) {
+	runtime.LockOSThread()
+	oldns, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("failed to get current netns: %w", err)
+	}
+	defer oldns.Close()
+
+	newns, err := netns.New()
+	if err != nil {
+		return fmt.Errorf("failed to create new netns: %w", err)
+	}
+	defer newns.Close()
+	defer func() {
+		// defer closes over named return variable err
+		if nerr := netns.Set(oldns); nerr != nil {
+			// The current goroutine is locked to an OS thread and we've failed
+			// to undo state modifications to the thread. Returning without unlocking
+			// the goroutine will make sure the underlying OS thread dies.
+			outer = fmt.Errorf("error setting thread back to its original netns: %w (original error: %s)", nerr, outer)
+			return
+		}
+		// only now that we have successfully changed the thread back to its
+		// original state (netns) we can safely unlock the goroutine from its OS thread.
+		runtime.UnlockOSThread()
+	}()
+
+	la := netlink.NewLinkAttrs()
+	la.Name = "cilium-dummy"
+
+	dummy := &netlink.Dummy{LinkAttrs: la}
+	if err := netlink.LinkAdd(dummy); err != nil {
+		return fmt.Errorf("failed to add dummy link: %w", err)
+	}
+
+	neigh := netlink.Neigh{
+		LinkIndex: dummy.Index,
+		IP:        net.IPv4(10, 1, 1, 1),
+		Flags:     netlink.NTF_EXT_LEARNED,
+		FlagsExt:  netlink.NTF_EXT_MANAGED,
+	}
+
+	if err := netlink.NeighAdd(&neigh); err != nil {
+		return fmt.Errorf("failed to add neighbor: %w", err)
+	}
+
+	nl, err := netlink.NeighList(dummy.Index, 0)
+	if err != nil {
+		return fmt.Errorf("failed to list neighbors: %w", err)
+	}
+
+	for _, n := range nl {
+		if n.IP.Equal(neigh.IP) && n.Flags == netlink.NTF_EXT_LEARNED && n.FlagsExt == netlink.NTF_EXT_MANAGED {
+			return nil
+		}
+	}
+
+	return ErrNotSupported
+}

--- a/pkg/datapath/linux/probes/managed_neighbors_test.go
+++ b/pkg/datapath/linux/probes/managed_neighbors_test.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package probes
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestManagedNeighbors(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	testutils.SkipOnOldKernel(t, "5.16", "NTF_EXT_MANAGED")
+
+	if err := HaveManagedNeighbors(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -59,6 +59,9 @@ func init() {
 	}
 }
 
+// ErrNotSupported indicates that a feature is not supported by the current kernel.
+var ErrNotSupported = errors.New("not supported")
+
 // KernelParam is a type based on string which represents CONFIG_* kernel
 // parameters which usually have values "y", "n" or "m".
 type KernelParam string

--- a/pkg/testutils/version.go
+++ b/pkg/testutils/version.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testutils
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/version"
+	"github.com/cilium/cilium/pkg/versioncheck"
+)
+
+// SkipOnOldKernel skips the test if minVersion is lower than the detected kernel
+// version. Parameter feature is mentioned as the reason in the Skip message.
+func SkipOnOldKernel(tb testing.TB, minVersion, feature string) {
+	tb.Helper()
+
+	v, err := versioncheck.Version(minVersion)
+	if err != nil {
+		tb.Fatalf("Can't parse version %s: %s", minVersion, err)
+	}
+
+	kv, err := version.GetKernelVersion()
+	if err != nil {
+		tb.Fatalf("Can't get kernel version: %s", err)
+	}
+
+	if kv.LT(v) {
+		tb.Skipf("Test requires at least kernel %s (missing feature %s)", minVersion, feature)
+	}
+}


### PR DESCRIPTION
With this commit we refactor the probe logic that checks for the existence of a certain helper as this could break on older distro kernels that have backported the commit we probed for.

Using actual netlink calls to probe for managed neighbor support will only succeed if the underlying kernel actually supports it.

Fixes #20694.