### PR TITLE
v1.12 backports 2023-04-26

### DIFF
--- a/jenkinsfiles/kubernetes-upstream.Jenkinsfile
+++ b/jenkinsfiles/kubernetes-upstream.Jenkinsfile
@@ -39,7 +39,6 @@ pipeline {
         stage('Checkout') {
             steps {
                 sh 'env'
-                Status("PENDING", "${env.JOB_NAME}")
                 checkout scm
                 sh 'mkdir -p ${PROJ_PATH}'
                 sh 'ls -A | grep -v src | xargs mv -t ${PROJ_PATH}'
@@ -128,12 +127,6 @@ pipeline {
             sh 'cd ${TESTDIR}; K8S_VERSION=${K8S_VERSION} vagrant destroy -f || true'
             cleanWs()
             sh '/usr/local/bin/cleanup || true'
-        }
-        success {
-            Status("SUCCESS", "$JOB_BASE_NAME")
-        }
-        failure {
-            Status("FAILURE", "$JOB_BASE_NAME")
         }
     }
 }


### PR DESCRIPTION
- [x] #25043 -- bgp: do not advertise ipv6 prefixes via metallb (@harsimran-pabla)
- [x] #25046 -- ci: remove STATUS commands from upstream tests' Jenkinsfile

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25043 25046; do contrib/backporting/set-labels.py $pr done 1.12; done
```