### PR TITLE
fqdn: use map to dedup to reduce memory usage of dns gc job

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -42,7 +42,6 @@ import (
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
-	"github.com/cilium/cilium/pkg/slices"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -197,8 +196,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		RunInterval: dnsGCJobInterval,
 		DoFunc: func(ctx context.Context) error {
 			var (
-				GCStart      = time.Now()
-				namesToClean []string
+				GCStart = time.Now()
 
 				// activeConnections holds DNSName -> single IP entries that have been
 				// marked active by the CT GC. Since we expire in this controller, we
@@ -207,6 +205,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 				activeConnectionsTTL = int(2 * dnsGCJobInterval.Seconds())
 				activeConnections    = fqdn.NewDNSCache(activeConnectionsTTL)
 			)
+			namesToClean := make(map[string]struct{})
 
 			// Cleanup each endpoint cache, deferring deletions via DNSZombies.
 			endpoints := d.endpointManager.GetEndpoints()
@@ -221,7 +220,12 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 						metrics.FQDNActiveIPs.WithLabelValues(epID).Set(float64(countIPs))
 					}
 				}
-				namesToClean = append(namesToClean, ep.DNSHistory.GC(GCStart, ep.DNSZombies)...)
+				affectedNames := ep.DNSHistory.GC(GCStart, ep.DNSZombies)
+				for _, name := range affectedNames {
+					if _, found := namesToClean[name]; !found {
+						namesToClean[name] = struct{}{}
+					}
+				}
 				alive, dead := ep.DNSZombies.GC()
 				if option.Config.MetricsConfig.FQDNActiveZombiesConnections {
 					metrics.FQDNAliveZombieConnections.WithLabelValues(epID).Set(float64(len(alive)))
@@ -241,8 +245,10 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 				//
 				lookupTime := time.Now()
 				for _, zombie := range alive {
-					namesToClean = slices.Unique(append(namesToClean, zombie.Names...))
 					for _, name := range zombie.Names {
+						if _, found := namesToClean[name]; !found {
+							namesToClean[name] = struct{}{}
+						}
 						activeConnections.Update(lookupTime, name, []netip.Addr{zombie.IP}, activeConnectionsTTL)
 					}
 				}
@@ -251,11 +257,14 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 				// Entries here have been evicted from the DNS cache (via .GC due to
 				// TTL expiration or overlimit) and are no longer active connections.
 				for _, zombie := range dead {
-					namesToClean = slices.Unique(append(namesToClean, zombie.Names...))
+					for _, name := range zombie.Names {
+						if _, found := namesToClean[name]; !found {
+							namesToClean[name] = struct{}{}
+						}
+					}
 				}
 			}
 
-			namesToClean = slices.Unique(namesToClean)
 			if len(namesToClean) == 0 {
 				return nil
 			}
@@ -272,18 +281,24 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 			for _, ep := range endpoints {
 				caches = append(caches, ep.DNSHistory)
 			}
-			cfg.Cache.ReplaceFromCacheByNames(namesToClean, caches...)
 
-			metrics.FQDNGarbageCollectorCleanedTotal.Add(float64(len(namesToClean)))
-			_, err := d.dnsNameManager.ForceGenerateDNS(context.TODO(), namesToClean)
-			namesCount := len(namesToClean)
+			namesToCleanSlice := make([]string, 0, len(namesToClean))
+			for name := range namesToClean {
+				namesToCleanSlice = append(namesToCleanSlice, name)
+			}
+
+			cfg.Cache.ReplaceFromCacheByNames(namesToCleanSlice, caches...)
+
+			metrics.FQDNGarbageCollectorCleanedTotal.Add(float64(len(namesToCleanSlice)))
+			_, err := d.dnsNameManager.ForceGenerateDNS(context.TODO(), namesToCleanSlice)
+			namesCount := len(namesToCleanSlice)
 			// Limit the amount of info level logging to some sane amount
 			if namesCount > 20 {
 				// namedsToClean is only used for logging after this so we can reslice it in place
-				namesToClean = namesToClean[:20]
+				namesToCleanSlice = namesToCleanSlice[:20]
 			}
 			log.WithField(logfields.Controller, dnsGCJobName).Infof(
-				"FQDN garbage collector work deleted %d name entries: %s", namesCount, strings.Join(namesToClean, ","))
+				"FQDN garbage collector work deleted %d name entries: %s", namesCount, strings.Join(namesToCleanSlice, ","))
 			return err
 		},
 		Context: d.ctx,


### PR DESCRIPTION
On some host we have a lot of DNS lookups, and this job allocates a lot of memory and burn a lot of cpu. We often see loglines like these; "FQDN garbage collector work deleted 16211 name entries"

This will now dedup using a map directly instead of deduping via merging slices. It doesn't seem like the code care about the order, so I think this should be fine. It would be nice to benchmark this, but its a bit difficult in the way the job is set up. Happy to iterate on that after we can test this.

Peek from a pprof, where this comes on top (running cilium v1.11.13);

```
Type: alloc_space
Showing nodes accounting for 24333619.24MB, 100% of 24333619.24MB total ----------------------------------------------------------+-------------
      flat  flat%   sum%        cum   cum%   calls calls% + context
----------------------------------------------------------+-------------
                                      4686095.18MB 95.24% |   github.com/cilium/cilium/daemon/cmd.(*Daemon).bootstrapFQDN.func1 /go/src/github.com/cilium/cilium/daemon/cmd/fqdn.go:236
                                       230562.07MB  4.69% |   github.com/cilium/cilium/daemon/cmd.(*Daemon).bootstrapFQDN.func1 /go/src/github.com/cilium/cilium/daemon/cmd/fqdn.go:246
                                         2609.33MB 0.053% |   github.com/cilium/cilium/pkg/fqdn.(*DNSCache).cleanupExpiredEntries /go/src/github.com/cilium/cilium/pkg/fqdn/cache.go:256
                                          997.05MB  0.02% |   github.com/cilium/cilium/daemon/cmd.(*Daemon).bootstrapFQDN.func1 /go/src/github.com/cilium/cilium/daemon/cmd/fqdn.go:250
                                          175.82MB 0.0036% |   github.com/cilium/cilium/pkg/fqdn.(*DNSCache).GC /go/src/github.com/cilium/cilium/pkg/fqdn/cache.go:339
4920439.45MB 20.22% 20.22% 4920439.45MB 20.22%                | github.com/cilium/cilium/pkg/fqdn.KeepUniqueNames /go/src/github.com/cilium/cilium/pkg/fqdn/helpers.go:127
```

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
fqdn: use map to dedup to reduce memory usage of dns gc job
```
