### PR TITLE
endpoint: Always compute proxy policies after DNS proxy updates

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -145,22 +145,6 @@ func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (re
 	return e.proxy.UpdateNetworkPolicy(e, e.visibilityPolicy, e.desiredPolicy.L4Policy, e.desiredPolicy.IngressPolicyEnabled, e.desiredPolicy.EgressPolicyEnabled, proxyWaitGroup)
 }
 
-func (e *Endpoint) useCurrentNetworkPolicy(proxyWaitGroup *completion.WaitGroup) {
-	if e.SecurityIdentity == nil {
-		return
-	}
-
-	// If desired L4Policy is nil then no policy change is needed.
-	if e.desiredPolicy == nil || e.desiredPolicy.L4Policy == nil {
-		return
-	}
-
-	if !e.isProxyDisabled() {
-		// Wait for the current network policy to be acked
-		e.proxy.UseCurrentNetworkPolicy(e, e.desiredPolicy.L4Policy, proxyWaitGroup)
-	}
-}
-
 // setNextPolicyRevision updates the desired policy revision field
 // Must be called with the endpoint lock held for at least reading
 func (e *Endpoint) setNextPolicyRevision(revision uint64) {

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -18,7 +18,6 @@ type EndpointProxy interface {
 	CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint logger.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc)
 	RemoveRedirect(id string, wg *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc)
 	UpdateNetworkPolicy(ep logger.EndpointUpdater, vis *policy.VisibilityPolicy, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error)
-	UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup)
 	RemoveNetworkPolicy(ep logger.EndpointInfoSource)
 }
 
@@ -56,10 +55,6 @@ func (f *FakeEndpointProxy) RemoveRedirect(id string, wg *completion.WaitGroup) 
 // UpdateNetworkPolicy does nothing.
 func (f *FakeEndpointProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, vis *policy.VisibilityPolicy, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	return nil, nil
-}
-
-// UseCurrentNetworkPolicy does nothing.
-func (f *FakeEndpointProxy) UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
 }
 
 // RemoveNetworkPolicy does nothing.

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -62,10 +62,6 @@ func (r *RedirectSuiteProxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, vis 
 	return nil, nil
 }
 
-// UseCurrentNetworkPolicy does nothing.
-func (r *RedirectSuiteProxy) UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
-}
-
 // RemoveNetworkPolicy does nothing.
 func (r *RedirectSuiteProxy) RemoveNetworkPolicy(ep logger.EndpointInfoSource) {}
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1843,23 +1843,6 @@ func (s *XDSServer) UpdateNetworkPolicy(ep logger.EndpointUpdater, vis *policy.V
 	}
 }
 
-// UseCurrentNetworkPolicy inserts a Completion to the WaitGroup if the current network policy has not yet been acked.
-// 'wg' may not be nil.
-func (s *XDSServer) UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	// If there are no listeners configured, the local node's Envoy proxy won't
-	// query for network policies and therefore will never ACK them, and we'd
-	// wait forever.
-	if !ep.HasSidecarProxy() && s.proxyListeners == 0 {
-		return
-	}
-
-	nodeIDs := getNodeIDs(ep, policy)
-	s.NetworkPolicyMutator.UseCurrent(NetworkPolicyTypeURL, nodeIDs, wg)
-}
-
 // RemoveNetworkPolicy removes network policies relevant to the specified
 // endpoint from the set published to L7 proxies, and stops listening for
 // acks for policies on this endpoint.

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -763,8 +763,3 @@ func (p *Proxy) updateRedirectMetrics() {
 func (p *Proxy) UpdateNetworkPolicy(ep logger.EndpointUpdater, vis *policy.VisibilityPolicy, policy *policy.L4Policy, ingressPolicyEnforced, egressPolicyEnforced bool, wg *completion.WaitGroup) (error, func() error) {
 	return p.XDSServer.UpdateNetworkPolicy(ep, vis, policy, ingressPolicyEnforced, egressPolicyEnforced, wg)
 }
-
-// UseCurrentNetworkPolicy inserts a Completion to the WaitGroup if the current network policy has not yet been acked
-func (p *Proxy) UseCurrentNetworkPolicy(ep logger.EndpointUpdater, policy *policy.L4Policy, wg *completion.WaitGroup) {
-	p.XDSServer.UseCurrentNetworkPolicy(ep, policy, wg)
-}


### PR DESCRIPTION
The planned logic was to only update proxy network policy if the added policy map entries included proxy redirections. This design did not consider the possibility a concurrent endpoint policy computation consuming the part of the policy map entries with redirection, which lead to the policy update to be missed after the remaining FQDN selectors were applied.

For example:

 1. DNS proxy answer to query 'www.example.com' applies to two FQDN selectors: 'www.example.com' with an L3-only rule, and '*.example.com' with a rule on port 80 for which HTTP policy only allowing GET requests is applied.
 2. New local security ID is allocated for the IP in the DNS answer
    3. Endpoint regenerations are spawned due to the new ID (which could also match an CIDR-based identity selector in addition to the FQDN selectors).
 4. DNS proxy adds the new security ID to the '*.example.com' selector associated with the HTTP rule. 5. Endpoint regeneration consumes the above ID update (from another goroutine). As this update is associated with an HTTP rule, proxy network plicy is recomputed. During this computation the new security ID is only associated with selector '*.example.com'.
 6. DNS proxy adds the same new security ID to the selector 'www.example.com', which has no HTTP rules.
 7. DNS proxy waits for the FQDN selector updates to finish.
 8. DNS proxy consumes the computed policy map keys, but only sees the ones for the selector 'www.example.com' as the ones for the selector `*.example.com' were already consumed. Since 'www.selector.com' has no HTTP rules, the proxy network policy update is skipped.
 9. DNS proxy responds to the pod with the DNS answer.
10. pod sends a HTTP POST request to the resolved IP on port 80.
11. Traffic to port 80 is redirected to the proxy.
12. Proxy only has the ID associated with the destination IP in the rule that only allows PUT requests and drops the request.
13. Proxy policy is synced by a controller and the proxy policy is healed, so that it is eventyally consistent. This was too late for the traffic the pod was sending.

Fix this by unconditionally computing proxy policy at (8) above.

A more efficient implementation would make sure that all the map updates due to a specific DNS response get to each endpoint's policy map changes as one transaction, so that it is only possible to consume them as one unit. This would make sure that proxy network policy updates are done for all of the updated selectors if any of the them have proxy redirections.

```release-note
DNS proxy now always updates the proxy policy to avoid intermittent policy drops.
```
