### PR TITLE
High-Scale IPcache: Chapter 1

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -102,6 +102,7 @@ cilium-agent [flags]
       --enable-external-ips                                     Enable k8s service externalIPs feature (requires enabling enable-node-port) (default true)
       --enable-health-check-nodeport                            Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set (default true)
       --enable-health-checking                                  Enable connectivity health checking (default true)
+      --enable-high-scale-ipcache                               Enable the high scale mode for ipcache
       --enable-host-firewall                                    Enable host network policies
       --enable-host-legacy-routing                              Enable the legacy host forwarding model which does not bypass upper stack in host namespace
       --enable-host-port                                        Enable k8s hostPort mapping feature (requires enabling enable-node-port) (default true)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -976,6 +976,14 @@
      - TCP port for the agent health API. This is not the port for cilium-health.
      - int
      - ``9879``
+   * - highScaleIPcache
+     - EnableHighScaleIPcache enables the special ipcache mode for high scale clusters. The ipcache content will be reduced to the strict minimum and traffic will be encapsulated to carry security identities.
+     - object
+     - ``{"enabled":false}``
+   * - highScaleIPcache.enabled
+     - Enable the high scale mode for the ipcache.
+     - bool
+     - ``false``
    * - hostFirewall
      - Configure the host firewall.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -518,6 +518,7 @@ healthcheck
 healthz
 herokuapp
 hexData
+highScaleIPcache
 hoc
 hostAliases
 hostConfDirMountPath

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -58,6 +58,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
@@ -167,6 +168,9 @@ type Daemon struct {
 	ipcache *ipcache.IPCache
 
 	k8sWatcher *watchers.K8sWatcher
+
+	// endpointMetadataFetcher knows how to fetch Kubernetes metadata for endpoints.
+	endpointMetadataFetcher endpointMetadataFetcher
 
 	// healthEndpointRouting is the information required to set up the health
 	// endpoint's routing in ENI or Azure IPAM mode
@@ -1411,4 +1415,8 @@ func (d *Daemon) SendNotification(notification monitorAPI.AgentNotifyMessage) er
 		return nil
 	}
 	return d.monitorAgent.SendEvent(monitorAPI.MessageTypeAgent, notification)
+}
+
+type endpointMetadataFetcher interface {
+	Fetch(nsName, podName string) (*slim_corev1.Namespace, *slim_corev1.Pod, error)
 }

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -606,6 +606,9 @@ func initializeFlags() {
 	flags.Bool(option.EnableIdentityMark, true, "Enable setting identity mark for local traffic")
 	option.BindEnv(Vp, option.EnableIdentityMark)
 
+	flags.Bool(option.EnableHighScaleIPcache, defaults.EnableHighScaleIPcache, "Enable the high scale mode for ipcache")
+	option.BindEnv(Vp, option.EnableHighScaleIPcache)
+
 	flags.Bool(option.EnableHostFirewall, false, "Enable host network policies")
 	option.BindEnv(Vp, option.EnableHostFirewall)
 
@@ -1391,6 +1394,24 @@ func initEnv() {
 
 	if option.Config.EnableIPv6Masquerade && option.Config.EnableBPFMasquerade {
 		log.Fatal("BPF masquerade is not supported for IPv6.")
+	}
+
+	if option.Config.EnableHighScaleIPcache {
+		if option.Config.TunnelingEnabled() {
+			log.Fatal("The high-scale IPcache mode requires native routing.")
+		}
+		if option.Config.EnableIPv4EgressGateway {
+			log.Fatal("The egress gateway is not supported in high scale IPcache mode.")
+		}
+		if option.Config.EnableIPSec {
+			log.Fatal("IPsec is not supported in high scale IPcache mode.")
+		}
+		if option.Config.EnableIPv6 {
+			log.Fatal("The high-scale IPcache mode is not supported with IPv6.")
+		}
+		if !option.Config.EnableWellKnownIdentities {
+			log.Fatal("The high-scale IPcache mode requires well-known identities to be enabled.")
+		}
 	}
 
 	// If there is one device specified, use it to derive better default

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
@@ -30,6 +31,8 @@ import (
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slimclientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
+	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
@@ -172,11 +175,7 @@ func NewPutEndpointIDHandler(d *Daemon) PutEndpointIDHandler {
 // The returned pod is deepcopied which means the its fields can be written
 // into.
 func (d *Daemon) fetchK8sMetadataForEndpoint(nsName, podName string) (*slim_corev1.Pod, []slim_corev1.ContainerPort, labels.Labels, labels.Labels, map[string]string, error) {
-	p, err := d.k8sWatcher.GetCachedPod(nsName, podName)
-	if err != nil {
-		return nil, nil, nil, nil, nil, err
-	}
-	ns, err := d.k8sWatcher.GetCachedNamespace(nsName)
+	ns, p, err := d.endpointMetadataFetcher.Fetch(nsName, podName)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -189,6 +188,38 @@ func (d *Daemon) fetchK8sMetadataForEndpoint(nsName, podName string) (*slim_core
 	k8sLbls := labels.Map2Labels(lbls, labels.LabelSourceK8s)
 	identityLabels, infoLabels := labelsfilter.Filter(k8sLbls)
 	return p, containerPorts, identityLabels, infoLabels, annotations, nil
+}
+
+type cachedEndpointMetadataFetcher struct {
+	k8sWatcher *watchers.K8sWatcher
+}
+
+func (cemf *cachedEndpointMetadataFetcher) Fetch(nsName, podName string) (*slim_corev1.Namespace, *slim_corev1.Pod, error) {
+	p, err := cemf.k8sWatcher.GetCachedPod(nsName, podName)
+	if err != nil {
+		return nil, nil, err
+	}
+	ns, err := cemf.k8sWatcher.GetCachedNamespace(nsName)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ns, p, err
+}
+
+type uncachedEndpointMetadataFetcher struct {
+	slimcli slimclientset.Interface
+}
+
+func (uemf *uncachedEndpointMetadataFetcher) Fetch(nsName, podName string) (*slim_corev1.Namespace, *slim_corev1.Pod, error) {
+	p, err := uemf.slimcli.CoreV1().Pods(nsName).Get(context.TODO(), podName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	ns, err := uemf.slimcli.CoreV1().Namespaces().Get(context.TODO(), nsName, metav1.GetOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	return ns, p, err
 }
 
 func invalidDataError(ep *endpoint.Endpoint, err error) (*endpoint.Endpoint, int, error) {
@@ -452,7 +483,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	// manager creates the endpoint queue the operation will fail.
 	if ep.K8sNamespaceAndPodNameIsSet() && d.clientset.IsEnabled() && k8sLabelsConfigured {
 		ep.UpdateVisibilityPolicy(func(ns, podName string) (proxyVisibility string, err error) {
-			p, err := d.k8sWatcher.GetCachedPod(ns, podName)
+			_, p, err := d.endpointMetadataFetcher.Fetch(ns, podName)
 			if err != nil {
 				return "", err
 			}
@@ -460,14 +491,14 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 			return value, nil
 		})
 		ep.UpdateBandwidthPolicy(func(ns, podName string) (bandwidthEgress string, err error) {
-			p, err := d.k8sWatcher.GetCachedPod(ns, podName)
+			_, p, err := d.endpointMetadataFetcher.Fetch(ns, podName)
 			if err != nil {
 				return "", err
 			}
 			return p.Annotations[bandwidth.EgressBandwidth], nil
 		})
 		ep.UpdateNoTrackRules(func(ns, podName string) (noTrackPort string, err error) {
-			p, err := d.k8sWatcher.GetCachedPod(ns, podName)
+			_, p, err := d.endpointMetadataFetcher.Fetch(ns, podName)
 			if err != nil {
 				return "", err
 			}

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -81,7 +81,7 @@ func (d *Daemon) validateEndpoint(ep *endpoint.Endpoint) (valid bool, err error)
 		// which the endpoint manager will begin processing the events off the
 		// queue.
 		ep.InitEventQueue()
-		ep.RunMetadataResolver(d.fetchK8sLabelsAndAnnotations)
+		ep.RunMetadataResolver(d.fetchK8sMetadataForEndpoint)
 	}
 
 	if err := ep.ValidateConnectorPlumbing(checkLink); err != nil {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -158,6 +158,14 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) er
 		return nil
 	}
 
+	var emf endpointMetadataFetcher
+	if option.Config.EnableHighScaleIPcache {
+		emf = &uncachedEndpointMetadataFetcher{slimcli: d.clientset.Slim()}
+	} else {
+		emf = &cachedEndpointMetadataFetcher{k8sWatcher: d.k8sWatcher}
+	}
+	d.endpointMetadataFetcher = emf
+
 	log.Info("Restoring endpoints...")
 
 	var (

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -294,6 +294,8 @@ contributors across the globe, there is almost always someone available to help.
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
 | healthPort | int | `9879` | TCP port for the agent health API. This is not the port for cilium-health. |
+| highScaleIPcache | object | `{"enabled":false}` | EnableHighScaleIPcache enables the special ipcache mode for high scale clusters. The ipcache content will be reduced to the strict minimum and traffic will be encapsulated to carry security identities. |
+| highScaleIPcache.enabled | bool | `false` | Enable the high scale mode for the ipcache. |
 | hostFirewall | object | `{"enabled":false}` | Configure the host firewall. |
 | hostFirewall.enabled | bool | `false` | Enables the enforcement of host policies in the eBPF datapath. |
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -577,6 +577,10 @@ data:
 {{- end }}
 {{- end }}
 
+{{- if .Values.highScaleIPcache.enabled }}
+  enable-high-scale-ipcache: {{ .Values.highScaleIPcache.enabled | quote }}
+{{- end }}
+
 {{- if hasKey .Values "localRedirectPolicy" }}
   enable-local-redirect-policy: {{ .Values.localRedirectPolicy | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -346,6 +346,13 @@ nat46x64Gateway:
   # -- Enable RFC8215-prefixed translation
   enabled: false
 
+# -- EnableHighScaleIPcache enables the special ipcache mode for high scale
+# clusters. The ipcache content will be reduced to the strict minimum and
+# traffic will be encapsulated to carry security identities.
+highScaleIPcache:
+  # -- Enable the high scale mode for the ipcache.
+  enabled: false
+
 # -- Configure BGP
 bgp:
   # -- Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -343,6 +343,13 @@ nat46x64Gateway:
   # -- Enable RFC8215-prefixed translation
   enabled: false
 
+# -- EnableHighScaleIPcache enables the special ipcache mode for high scale
+# clusters. The ipcache content will be reduced to the strict minimum and
+# traffic will be encapsulated to carry security identities.
+highScaleIPcache:
+  # -- Enable the high scale mode for the ipcache.
+  enabled: false
+
 # -- Configure BGP
 bgp:
   # -- Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -591,6 +591,10 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["ENABLE_IDENTITY_MARK"] = "1"
 	}
 
+	if option.Config.EnableHighScaleIPcache {
+		cDefinesMap["ENABLE_HIGH_SCALE_IPCACHE"] = "1"
+	}
+
 	if option.Config.EnableCustomCalls {
 		cDefinesMap["ENABLE_CUSTOM_CALLS"] = "1"
 	}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -478,6 +478,11 @@ const (
 	// for local traffic
 	EnableIdentityMark = true
 
+	// EnableHighScaleIPcache enables the special ipcache mode for high scale
+	// clusters. The ipcache content will be reduced to the strict minimum and
+	// traffic will be encapsulated to carry security identities.
+	EnableHighScaleIPcache = false
+
 	// K8sEnableLeasesFallbackDiscovery enables k8s to fallback to API probing to check
 	// for the support of Leases in Kubernetes when there is an error in discovering
 	// API groups using Discovery API.

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -113,6 +113,12 @@ func (id *Identity) IsWellKnown() bool {
 	return WellKnown.lookupByNumericIdentity(id.ID) != nil
 }
 
+// IsWellKnownIdentity returns true if the identity represents a well-known
+// identity, false otherwise.
+func IsWellKnownIdentity(id NumericIdentity) bool {
+	return WellKnown.lookupByNumericIdentity(id) != nil
+}
+
 // NewIdentityFromLabelArray creates a new identity
 func NewIdentityFromLabelArray(id NumericIdentity, lblArray labels.LabelArray) *Identity {
 	var lbls labels.Labels

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -311,6 +311,11 @@ const (
 	// conflicting marks.
 	EnableIdentityMark = "enable-identity-mark"
 
+	// EnableHighScaleIPcache enables the special ipcache mode for high scale
+	// clusters. The ipcache content will be reduced to the strict minimum and
+	// traffic will be encapsulated to carry security identities.
+	EnableHighScaleIPcache = "enable-high-scale-ipcache"
+
 	// AddressScopeMax controls the maximum address scope for addresses to be
 	// considered local ones with HOST_ID in the ipcache
 	AddressScopeMax = "local-max-addr-scope"
@@ -2027,6 +2032,11 @@ type DaemonConfig struct {
 	// conflicting marks.
 	EnableIdentityMark bool
 
+	// EnableHighScaleIPcache enables the special ipcache mode for high scale
+	// clusters. The ipcache content will be reduced to the strict minimum and
+	// traffic will be encapsulated to carry security identities.
+	EnableHighScaleIPcache bool
+
 	// KernelHz is the HZ rate the kernel is operating in
 	KernelHz int
 
@@ -3059,6 +3069,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.BGPConfigPath = vp.GetString(BGPConfigPath)
 	c.ExternalClusterIP = vp.GetBool(ExternalClusterIPName)
 	c.EnableNat46X64Gateway = vp.GetBool(EnableNat46X64Gateway)
+	c.EnableHighScaleIPcache = vp.GetBool(EnableHighScaleIPcache)
 	c.EnableIPv4Masquerade = vp.GetBool(EnableIPv4Masquerade) && c.EnableIPv4
 	c.EnableIPv6Masquerade = vp.GetBool(EnableIPv6Masquerade) && c.EnableIPv6
 	c.EnableBPFMasquerade = vp.GetBool(EnableBPFMasquerade)

--- a/test/k8s/manifests/high-scale-ipcache.yaml
+++ b/test/k8s/manifests/high-scale-ipcache.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: server
+spec:
+  replicas: 50
+  selector:
+    matchLabels:
+      type: server
+  template:
+    metadata:
+      labels:
+        type: server
+    spec:
+      containers:
+      - name: web
+        image: quay.io/cilium/echoserver:1.10.1
+        imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 80
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: client
+spec:
+  replicas: 50
+  selector:
+    matchLabels:
+      type: client
+  template:
+    metadata:
+      labels:
+        type: client
+    spec:
+      containers:
+      - name: web
+        image: quay.io/cilium/demo-client:1.0
+        imagePullPolicy: IfNotPresent
+        command: [ "sleep" ]
+        args:
+          - "1000h"
+        readinessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - http:80/public
+        livenessProbe:
+          timeoutSeconds: 7
+          exec:
+            command:
+            - curl
+            - -sS
+            - --fail
+            - --connect-timeout
+            - "5"
+            - -o
+            - /dev/null
+            - http:80/public
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+    protocol: TCP
+  selector:
+    type: server


### PR DESCRIPTION
This new feature has a CFP at https://github.com/cilium/design-cfps/pull/7. The goal of this first PR is to define the new flag and remove all pod entries (see exceptions in CFP) from the ipcache when that flag is set.

Updates: https://github.com/cilium/cilium/issues/25243.
```release-note
New high-scale ipcache mode to support clustermeshes with millions of pods.
```