### PR TITLE
test: Unquarantine IPv6 masquerading test

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -188,7 +188,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 	})
 
 	SkipContextIf(func() bool {
-		return helpers.RunsWithKubeProxyReplacement() || helpers.GetCurrentIntegration() != "" || helpers.SkipQuarantined()
+		return helpers.RunsWithKubeProxyReplacement() || helpers.GetCurrentIntegration() != ""
 	}, "IPv6 masquerading", func() {
 		var (
 			k8s1EndpointIPs map[string]string


### PR DESCRIPTION
Commit 166a1097c4 ("test: Fix consistent failure in IPv6 masquerading test") seems to have fixed the IPv6 masquerading test so let's unquarantine it.

Fixes: https://github.com/cilium/cilium/issues/23355.