### PR TITLE
Clean up prefix length tracking implementations

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -305,8 +305,7 @@ func (d *Daemon) init() error {
 // createPrefixLengthCounter wraps around the counter library, providing
 // references to prefix lengths that will always be present.
 func createPrefixLengthCounter() *counter.PrefixLengthCounter {
-	max6, max4 := ipcachemap.IPCacheMap().GetMaxPrefixLengths()
-	return counter.DefaultPrefixLengthCounter(max6, max4)
+	return counter.DefaultPrefixLengthCounter()
 }
 
 // restoreCiliumHostIPs completes the `cilium_host` IP restoration process

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
@@ -141,10 +140,6 @@ type Daemon struct {
 	// Used to synchronize generation of daemon's BPF programs and endpoint BPF
 	// programs.
 	compilationMutex *lock.RWMutex
-
-	// prefixLengths tracks a mapping from CIDR prefix length to the count
-	// of rules that refer to that prefix length.
-	prefixLengths *counter.PrefixLengthCounter
 
 	clustermesh *clustermesh.ClusterMesh
 
@@ -258,12 +253,6 @@ func (d *Daemon) DebugEnabled() bool {
 	return option.Config.Opts.IsEnabled(option.Debug)
 }
 
-// GetCIDRPrefixLengths returns the sorted list of unique prefix lengths used
-// by CIDR policies.
-func (d *Daemon) GetCIDRPrefixLengths() (s6, s4 []int) {
-	return d.prefixLengths.ToBPFData()
-}
-
 // GetOptions returns the datapath configuration options of the daemon.
 func (d *Daemon) GetOptions() *option.IntOptions {
 	return option.Config.Opts
@@ -300,12 +289,6 @@ func (d *Daemon) init() error {
 	}
 
 	return nil
-}
-
-// createPrefixLengthCounter wraps around the counter library, providing
-// references to prefix lengths that will always be present.
-func createPrefixLengthCounter() *counter.PrefixLengthCounter {
-	return counter.DefaultPrefixLengthCounter()
 }
 
 // restoreCiliumHostIPs completes the `cilium_host` IP restoration process
@@ -500,7 +483,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	d := Daemon{
 		ctx:               ctx,
 		clientset:         params.Clientset,
-		prefixLengths:     createPrefixLengthCounter(),
 		buildEndpointSem:  semaphore.NewWeighted(int64(numWorkerThreads())),
 		compilationMutex:  new(lock.RWMutex),
 		mtuConfig:         mtuConfig,

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -378,7 +378,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 		return fmt.Errorf("could not initialize regex LRU cache: %w", err)
 	}
 	proxy.DefaultDNSProxy, err = dnsproxy.StartDNSProxy("", port, option.Config.ToFQDNsEnableDNSCompression,
-		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.LookupSecIDByIP, d.lookupIPsBySecID,
+		option.Config.DNSMaxIPsPerRestoredRule, d.lookupEPByIP, d.ipcache.LookupSecIDByIP, d.lookupIPsBySecID,
 		d.notifyOnDNSMsg, option.Config.DNSProxyConcurrencyLimit, option.Config.DNSProxyConcurrencyProcessingGracePeriod)
 	if err == nil {
 		// Increase the ProxyPort reference count so that it will never get released.

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -735,25 +735,6 @@ func (ds *DaemonSuite) TestReplacePolicy(c *C) {
 	ds.d.policy.Mutex.RLock()
 	c.Assert(len(ds.d.policy.SearchRLocked(lbls)), Equals, 2)
 	ds.d.policy.Mutex.RUnlock()
-
-	// Updating of prefix lengths may complete *after* PolicyAdd returns. Add a
-	// wait for prefix lengths to be correct after timeout to ensure that we
-	// do not assert before the releasing of CIDRs has been performed.
-	testutils.WaitUntil(func() bool {
-		_, s4 := ds.d.prefixLengths.ToBPFData()
-		sort.Ints(s4)
-		if len(s4) != 2 {
-			c.Logf("IPv4 Prefix lengths incorrect (expected [0, 32]). This may be because CIDRs were not released on replace. %+v", s4)
-			return false
-		}
-		for i, v := range []int{0, 32} {
-			if s4[i] != v {
-				c.Logf("Unexpected IPv4 Prefix length. This may be because CIDRs were not released on replace. %+v", s4)
-				return false
-			}
-		}
-		return true
-	}, time.Second*5)
 }
 
 func (ds *DaemonSuite) TestRemovePolicy(c *C) {

--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"go4.org/netipx"
+
 	"github.com/cilium/cilium/pkg/cidr"
 	ippkg "github.com/cilium/cilium/pkg/ip"
 )
@@ -343,17 +345,22 @@ func (pc PrefixCluster) String() string {
 	return pc.prefix.String() + "@" + strconv.FormatUint(uint64(pc.clusterID), 10)
 }
 
+// AsPrefix returns the IP prefix part of PrefixCluster as a netip.Prefix type.
+// This function exists for keeping backward compatibility between the existing
+// components which are not aware of the cluster-aware addressing. Calling
+// this function against the PrefixCluster which has non-zero clusterID will
+// lose the ClusterID information. It should be used with an extra care.
+func (pc PrefixCluster) AsPrefix() netip.Prefix {
+	return netip.PrefixFrom(pc.prefix.Addr(), pc.prefix.Bits())
+}
+
 // AsIPNet returns the IP prefix part of PrefixCluster as a net.IPNet type. This
 // function exists for keeping backward compatibility between the existing
 // components which are not aware of the cluster-aware addressing. Calling
 // this function against the PrefixCluster which has non-zero clusterID will
 // lose the ClusterID information. It should be used with an extra care.
 func (pc PrefixCluster) AsIPNet() net.IPNet {
-	addr := pc.prefix.Addr()
-	return net.IPNet{
-		IP:   addr.AsSlice(),
-		Mask: net.CIDRMask(pc.prefix.Bits(), addr.BitLen()),
-	}
+	return *netipx.PrefixIPNet(pc.AsPrefix())
 }
 
 // This function is solely exists for annotating IPCache's key string with ClusterID.

--- a/pkg/counter/prefixes.go
+++ b/pkg/counter/prefixes.go
@@ -50,10 +50,12 @@ func createIPNet(ones, bits int) netip.Prefix {
 
 // DefaultPrefixLengthCounter creates a default prefix length counter that
 // already counts the minimum and maximum prefix lengths for IP hosts and
-// default routes (ie, /32 and /0). As with NewPrefixLengthCounter, inesrtions
+// default routes (ie, /32 and /0). As with NewPrefixLengthCounter, insertions
 // are limited to the specified maximum number of unique prefix lengths.
-func DefaultPrefixLengthCounter(maxUniquePrefixes6, maxUniquePrefixes4 int) *PrefixLengthCounter {
-	counter := NewPrefixLengthCounter(maxUniquePrefixes6, maxUniquePrefixes4)
+func DefaultPrefixLengthCounter() *PrefixLengthCounter {
+	maxIPv4 := net.IPv4len*8 + 1
+	maxIPv6 := net.IPv6len*8 + 1
+	counter := NewPrefixLengthCounter(maxIPv6, maxIPv4)
 
 	defaultPrefixes := []netip.Prefix{
 		// IPv4

--- a/pkg/counter/prefixes_test.go
+++ b/pkg/counter/prefixes_test.go
@@ -183,7 +183,7 @@ func (cs *CounterTestSuite) TestToBPFData(c *C) {
 }
 
 func (cs *CounterTestSuite) TestDefaultPrefixLengthCounter(c *C) {
-	result := DefaultPrefixLengthCounter(net.IPv6len*8, net.IPv4len*8)
+	result := DefaultPrefixLengthCounter()
 	c.Assert(result.v4[0], Equals, 1)
 	c.Assert(result.v6[0], Equals, 1)
 	c.Assert(result.v4[net.IPv4len*8], Equals, 1)

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -18,12 +18,6 @@ import (
 // options that affect lookups and logic applied at a per-device level, whether
 // those are devices associated with the endpoint or associated with the host.
 type DeviceConfiguration interface {
-	// GetCIDRPrefixLengths fetches the lists of unique IPv6 and IPv4
-	// prefix lengths used for datapath lookups, each of which is sorted
-	// from longest prefix to shortest prefix. It must return more than
-	// one element in each returned array.
-	GetCIDRPrefixLengths() (s6, s4 []int)
-
 	// GetOptions fetches the configurable datapath options from the owner.
 	GetOptions() *option.IntOptions
 }

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -29,20 +29,19 @@ type epInfoCache struct {
 	ifName string
 
 	// For datapath.EndpointConfiguration
-	identity                               identity.NumericIdentity
-	mac                                    mac.MAC
-	ipv4                                   netip.Addr
-	ipv6                                   netip.Addr
-	conntrackLocal                         bool
-	requireARPPassthrough                  bool
-	requireEgressProg                      bool
-	requireRouting                         bool
-	requireEndpointRoute                   bool
-	policyVerdictLogFilter                 uint32
-	cidr4PrefixLengths, cidr6PrefixLengths []int
-	options                                *option.IntOptions
-	lxcMAC                                 mac.MAC
-	ifIndex                                int
+	identity               identity.NumericIdentity
+	mac                    mac.MAC
+	ipv4                   netip.Addr
+	ipv6                   netip.Addr
+	conntrackLocal         bool
+	requireARPPassthrough  bool
+	requireEgressProg      bool
+	requireRouting         bool
+	requireEndpointRoute   bool
+	policyVerdictLogFilter uint32
+	options                *option.IntOptions
+	lxcMAC                 mac.MAC
+	ifIndex                int
 
 	// endpoint is used to get the endpoint's logger.
 	//
@@ -55,8 +54,6 @@ type epInfoCache struct {
 
 // Must be called when endpoint is still locked.
 func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
-	cidr6, cidr4 := e.GetCIDRPrefixLengths()
-
 	ep := &epInfoCache{
 		revision: e.nextPolicyRevision,
 
@@ -73,8 +70,6 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		requireRouting:         e.RequireRouting(),
 		requireEndpointRoute:   e.RequireEndpointRoute(),
 		policyVerdictLogFilter: e.GetPolicyVerdictLogFilter(),
-		cidr4PrefixLengths:     cidr4,
-		cidr6PrefixLengths:     cidr6,
 		options:                e.Options.DeepCopy(),
 		lxcMAC:                 e.mac,
 		ifIndex:                e.ifIndex,
@@ -139,10 +134,6 @@ func (ep *epInfoCache) GetNodeMAC() mac.MAC { return ep.mac }
 
 func (ep *epInfoCache) ConntrackLocalLocked() bool {
 	return ep.conntrackLocal
-}
-
-func (ep *epInfoCache) GetCIDRPrefixLengths() ([]int, []int) {
-	return ep.cidr6PrefixLengths, ep.cidr4PrefixLengths
 }
 
 func (ep *epInfoCache) GetOptions() *option.IntOptions {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -910,12 +910,6 @@ func (e *Endpoint) SetIdentity(identity *identityPkg.Identity, newEndpoint bool)
 	})
 }
 
-// GetCIDRPrefixLengths returns the sorted list of unique prefix lengths used
-// for CIDR policy or IPcache lookup from this endpoint.
-func (e *Endpoint) GetCIDRPrefixLengths() (s6, s4 []int) {
-	return e.owner.GetCIDRPrefixLengths()
-}
-
 // AnnotationsResolverCB provides an implementation for resolving the pod
 // annotations.
 type AnnotationsResolverCB func(ns, podName string) (proxyVisibility string, err error)

--- a/pkg/endpoint/regeneration/owner.go
+++ b/pkg/endpoint/regeneration/owner.go
@@ -23,10 +23,6 @@ type Owner interface {
 	// of BPF programs.
 	GetCompilationLock() *lock.RWMutex
 
-	// GetCIDRPrefixLengths returns the sorted list of unique prefix lengths used
-	// by CIDR policies.
-	GetCIDRPrefixLengths() (s6, s4 []int)
-
 	// SendNotification is called to emit an agent notification
 	SendNotification(msg monitorAPI.AgentNotifyMessage) error
 

--- a/pkg/hubble/parser/getters/getters.go
+++ b/pkg/hubble/parser/getters/getters.go
@@ -42,7 +42,7 @@ type IPGetter interface {
 	// GetK8sMetadata returns Kubernetes metadata for the given IP address.
 	GetK8sMetadata(ip netip.Addr) *ipcache.K8sMetadata
 	// LookupSecIDByIP returns the corresponding security identity that
-	// endpoint IP maps to as well as if the corresponding entry exists.
+	// the specified IP maps to as well as if the corresponding entry exists.
 	LookupSecIDByIP(ip netip.Addr) (ipcache.Identity, bool)
 }
 

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -14,6 +14,7 @@ import (
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/counter"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -127,6 +128,10 @@ type IPCache struct {
 	// references to identities and removing the corresponding IPCache
 	// entries if unused.
 	deferredPrefixRelease *asyncPrefixReleaser
+
+	// prefixLengths tracks the unique set of prefix lengths for IPv4 and
+	// IPv6 addresses in order to optimize longest prefix match lookups.
+	prefixLengths *counter.PrefixLengthCounter
 }
 
 // NewIPCache returns a new IPCache with the mappings of endpoint IP to security
@@ -141,6 +146,7 @@ func NewIPCache(c *Configuration) *IPCache {
 		controllers:       controller.NewManager(),
 		namedPorts:        types.NewNamedPortMultiMap(),
 		metadata:          newMetadata(),
+		prefixLengths:     counter.DefaultPrefixLengthCounter(),
 		Configuration:     c,
 	}
 	ipc.deferredPrefixRelease = newAsyncPrefixReleaser(c.Context, ipc, 1*time.Millisecond)
@@ -408,6 +414,7 @@ func (ipc *IPCache) upsertLocked(
 		ipc.identityToIPCache[newIdentity.ID] = map[string]struct{}{}
 	}
 	ipc.identityToIPCache[newIdentity.ID][ip] = struct{}{}
+	ipc.prefixLengths.Add([]netip.Prefix{cidrCluster.AsPrefix()})
 
 	if hostIP == nil {
 		delete(ipc.ipToHostIPCache, ip)
@@ -651,6 +658,7 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	}
 	delete(ipc.ipToHostIPCache, ip)
 	delete(ipc.ipToK8sMetadata, ip)
+	ipc.prefixLengths.Delete([]netip.Prefix{cidrCluster.AsPrefix()})
 
 	// Update named ports
 	namedPortsChanged = false

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -130,7 +130,7 @@ func (s *IPCacheTestSuite) TestIPCache(c *C) {
 
 	cachedHostIP, _ := IPIdentityCache.getHostIPCache(endpointIP)
 	c.Assert(cachedHostIP, checker.DeepEquals, hostIP)
-	c.Assert(IPIdentityCache.GetK8sMetadata(endpointIP), checker.DeepEquals, k8sMeta)
+	c.Assert(IPIdentityCache.GetK8sMetadata(netip.MustParseAddr(endpointIP)), checker.DeepEquals, k8sMeta)
 
 	newIdentity := identityPkg.NumericIdentity(69)
 	IPIdentityCache.Upsert(endpointIP, hostIP, 0, k8sMeta, Identity{
@@ -394,7 +394,7 @@ func (s *IPCacheTestSuite) TestIPCacheNamedPorts(c *C) {
 
 	cachedHostIP, _ := IPIdentityCache.getHostIPCache(endpointIP)
 	c.Assert(cachedHostIP, checker.DeepEquals, hostIP)
-	c.Assert(IPIdentityCache.GetK8sMetadata(endpointIP), checker.DeepEquals, k8sMeta)
+	c.Assert(IPIdentityCache.GetK8sMetadata(netip.MustParseAddr(endpointIP)), checker.DeepEquals, k8sMeta)
 
 	newIdentity := identityPkg.NumericIdentity(69)
 	namedPortsChanged, err = IPIdentityCache.Upsert(endpointIP, hostIP, 0, k8sMeta, Identity{

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -158,12 +158,6 @@ func NewMap(name string) *Map {
 	}
 }
 
-// GetMaxPrefixLengths determines how many unique prefix lengths are supported
-// simultaneously based on the underlying BPF map type in use.
-func (m *Map) GetMaxPrefixLengths() (ipv6, ipv4 int) {
-	return net.IPv6len*8 + 1, net.IPv4len*8 + 1
-}
-
 var (
 	// IPCache is a mapping of all endpoint IPs in the cluster which this
 	// Cilium agent is a part of to their corresponding security identities.

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -561,39 +561,33 @@ func (s *PolicyAPITestSuite) TestHTTPRuleRegexes(c *C) {
 func (s *PolicyAPITestSuite) TestCIDRsanitize(c *C) {
 	// IPv4
 	cidr := CIDRRule{Cidr: "0.0.0.0/0"}
-	length, err := cidr.sanitize()
+	err := cidr.sanitize()
 	c.Assert(err, IsNil)
-	c.Assert(length, Equals, 0)
 
 	cidr = CIDRRule{Cidr: "10.0.0.0/24"}
-	length, err = cidr.sanitize()
+	err = cidr.sanitize()
 	c.Assert(err, IsNil)
-	c.Assert(length, Equals, 24)
 
 	cidr = CIDRRule{Cidr: "192.0.2.3/32"}
-	length, err = cidr.sanitize()
+	err = cidr.sanitize()
 	c.Assert(err, IsNil)
-	c.Assert(length, Equals, 32)
 
 	// IPv6
 	cidr = CIDRRule{Cidr: "::/0"}
-	length, err = cidr.sanitize()
+	err = cidr.sanitize()
 	c.Assert(err, IsNil)
-	c.Assert(length, Equals, 0)
 
 	cidr = CIDRRule{Cidr: "ff02::/64"}
-	length, err = cidr.sanitize()
+	err = cidr.sanitize()
 	c.Assert(err, IsNil)
-	c.Assert(length, Equals, 64)
 
 	cidr = CIDRRule{Cidr: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128"}
-	length, err = cidr.sanitize()
+	err = cidr.sanitize()
 	c.Assert(err, IsNil)
-	c.Assert(length, Equals, 128)
 
 	// Non-contiguous mask.
 	cidr = CIDRRule{Cidr: "10.0.0.0/254.0.0.255"}
-	_, err = cidr.sanitize()
+	err = cidr.sanitize()
 	c.Assert(err, NotNil)
 }
 
@@ -1083,11 +1077,11 @@ func BenchmarkCIDRSanitize(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := cidr4.sanitize()
+		err := cidr4.sanitize()
 		if err != nil {
 			b.Fatal(err)
 		}
-		_, err = cidr6.sanitize()
+		err = cidr6.sanitize()
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
Until Cilium v1.13, we supported a special mode for the ipcache BPF map where
Cilium synthesized an LPM map using a set of hash maps. In order to implement
this, Cilium in userspace implemented unique prefix length tracking in the
policy logic in the daemon in order to ensure that the lookups for each
"currently in use" prefix would be encoded into the datapath in order to
perform lookups for that prefix length in the hashmap.

Since we've gotten rid of Linux v4.9 support and that older implementation, we
can now clean up this prefix length tracking code in the daemon.

One user remains for the prefix length tracking, specifically for Hubble to
determine the identity (+ labels) of flows as they are observed. Really all
this needs is a userspace LPM lookup, which we can now expose directly in the
pkg/ipcache API instead of tracking in the daemon. This allows us to improve
the abstractions, simplify various interfaces, and better separate concerns
between packages (which should help improving this code further in future).

Review commit-by-commit:
- counter: Simplify DefaultPrefixLengthCounter()
- clustermesh: Add prefix helper
- ipcache: Add prefix length tracking
- daemon: Move ip metadata lookups to ipcache
- endpoint: Remove CIDR prefix length tracking code
- daemon: Remove IP prefix length tracking
- api: Remove prefix length tracking

Related: https://github.com/cilium/cilium/issues/22116
Related: https://github.com/cilium/cilium/pull/24363
