### PR TITLE
Improve golangci-lint usage

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -52,6 +52,7 @@ jobs:
           # renovate: datasource=docker depName=golangci/golangci-lint
           version: v1.52.2
           skip-cache: true
+          args: "--out-${NO_FUTURE}format colored-line-number"
 
   precheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -52,7 +52,7 @@ jobs:
           # renovate: datasource=docker depName=golangci/golangci-lint
           version: v1.52.2
           skip-cache: true
-          args: "--out-${NO_FUTURE}format colored-line-number --verbose"
+          args: "--out-${NO_FUTURE}format colored-line-number --verbose --modules-download-mode=vendor"
 
   precheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -52,7 +52,7 @@ jobs:
           # renovate: datasource=docker depName=golangci/golangci-lint
           version: v1.52.2
           skip-cache: true
-          args: "--out-${NO_FUTURE}format colored-line-number"
+          args: "--out-${NO_FUTURE}format colored-line-number --verbose"
 
   precheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- .github: Add line output to golangci-lint
- .github: Verbosely print golangci-lint output
- .github: Use tree /vendor for golangci-lint 

Related: #25155