### PR TITLE
workflows: Fix owner tag for stable branch workflows

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -148,7 +148,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.11
+            OWNER=v1-11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -148,7 +148,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.12
+            OWNER=v1-12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -148,7 +148,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.13
+            OWNER=v1-13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -147,7 +147,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.11
+            OWNER=v1-11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -147,7 +147,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.12
+            OWNER=v1-12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -147,7 +147,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.13
+            OWNER=v1-13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -147,7 +147,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.11
+            OWNER=v1-11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -147,7 +147,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.12
+            OWNER=v1-12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -147,7 +147,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.13
+            OWNER=v1-13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -148,7 +148,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.11
+            OWNER=v1-11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -148,7 +148,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.12
+            OWNER=v1-12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -148,7 +148,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.13
+            OWNER=v1-13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -146,7 +146,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.11
+            OWNER=v1-11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -146,7 +146,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.12
+            OWNER=v1-12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -146,7 +146,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.13
+            OWNER=v1-13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -149,7 +149,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.11 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.11
+            OWNER=v1-11
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-multicluster-v1.12.yaml
+++ b/.github/workflows/conformance-multicluster-v1.12.yaml
@@ -149,7 +149,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.12 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.12
+            OWNER=v1-12
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}

--- a/.github/workflows/conformance-multicluster-v1.13.yaml
+++ b/.github/workflows/conformance-multicluster-v1.13.yaml
@@ -149,7 +149,7 @@ jobs:
           elif [ "${{ github.event_name }}" = "schedule" ]; then
             curl https://api.github.com/repos/cilium/cilium/branches/v1.13 > branch.json
             SHA=$(jq -r '.commit.sha' branch.json)
-            OWNER=v1.13
+            OWNER=v1-13
           else
             SHA=${{ github.sha }}
             OWNER=${{ github.sha }}


### PR DESCRIPTION
GKE-based workflows on stable branches are currently failing with:

    ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Invalid field 'resource_labels.value': "v1.11". It must only contain lowercase letters ([a-z]), numeric characters ([0-9]), underscores (_) and dashes (-). International characters are allowed.

This commit therefore changes the owner tag for all workflows, to remove the dot character.

Fixes: https://github.com/cilium/cilium/pull/25080.