### PR TITLE
bpf: improve handling for short packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -510,7 +510,7 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	struct iphdr *ip4;
 
 	/* This is the first time revalidate_data() is going to be called in
-	 * the "to-netdev" path. Make sure that we don't legitimately drop
+	 * the "from-netdev" path. Make sure that we don't legitimately drop
 	 * the packet if the skb arrived with the header not being not in the
 	 * linear data.
 	 */
@@ -916,10 +916,10 @@ handle_to_netdev_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_HOST)
 		src_id = HOST_ID;
 
-	src_id = resolve_srcid_ipv4(ctx, src_id, &ipcache_srcid, true);
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
+
+	src_id = resolve_srcid_ipv4(ctx, src_id, &ipcache_srcid, true);
 
 	/* We need to pass the srcid from ipcache to host firewall. See
 	 * comment in ipv4_host_policy_egress() for details.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -103,7 +103,7 @@ resolve_srcid_ipv6(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	struct ipv6hdr *ip6;
 	union v6addr *src;
 
-	if (!revalidate_data_maybe_pull(ctx, &data, &data_end, &ip6, !from_host))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	/* Packets from the proxy will already have a real identity. */
@@ -510,11 +510,11 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	struct iphdr *ip4;
 
 	/* This is the first time revalidate_data() is going to be called in
-	 * the "from-netdev" path. Make sure that we don't legitimately drop
-	 * the packet if the skb arrived with the header not being not in the
-	 * linear data.
+	 * the "from-netdev" and "from-host" paths. Make sure that we don't
+	 * legitimately drop the packet if the skb arrived with the header
+	 * not being not in the linear data.
 	 */
-	if (!revalidate_data_maybe_pull(ctx, &data, &data_end, &ip4, !from_host))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	/* Packets from the proxy will already have a real identity. */

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -216,13 +216,6 @@ __revalidate_data_pull(struct __ctx_buff *ctx, void **data, void **data_end,
 #define revalidate_data_pull(ctx, data, data_end, ip)			\
 	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), true)
 
-/* revalidate_data_maybe_pull() does the same as revalidate_data_pull()
- * except that the skb data pull is controlled by the "pull" argument.
- */
-#define revalidate_data_maybe_pull(ctx, data, data_end, ip, pull)	\
-	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), pull)
-
-
 /* revalidate_data() initializes the provided pointers from the ctx.
  * Returns true if 'ctx' is long enough for an IP header of the provided type,
  * false otherwise.


### PR DESCRIPTION
Align the different packet paths in how they handle traffic where the IP header is not in the skb's linear data.

```release-note
Avoid dropping short packets (that don't have their L3 header in linear data) in the to-netdev and from-host paths.
```