### PR TITLE
Invert `--hubble-monitor-events` logic to be an allowlist

### DIFF
--- a/pkg/hubble/monitor/filter.go
+++ b/pkg/hubble/monitor/filter.go
@@ -63,38 +63,40 @@ func NewMonitorFilter(logger logrus.FieldLogger, monitorEventFilters []string) (
 	return &monitorFilter, nil
 }
 
+// OnMonitorEvent implements observeroption.OnMonitorEvent interface
+// It returns true if an event is to be dropped, false otherwise.
 func (m *monitorFilter) OnMonitorEvent(ctx context.Context, event *observerTypes.MonitorEvent) (bool, error) {
 	switch payload := event.Payload.(type) {
 	case *observerTypes.PerfEvent:
 		if len(payload.Data) == 0 {
-			return false, errors.ErrEmptyData
+			return true, errors.ErrEmptyData
 		}
 
 		switch payload.Data[0] {
 		case monitorAPI.MessageTypeDrop:
-			return m.drop, nil
+			return !m.drop, nil
 		case monitorAPI.MessageTypeDebug:
-			return m.debug, nil
+			return !m.debug, nil
 		case monitorAPI.MessageTypeCapture:
-			return m.capture, nil
+			return !m.capture, nil
 		case monitorAPI.MessageTypeTrace:
-			return m.trace, nil
+			return !m.trace, nil
 		case monitorAPI.MessageTypeAccessLog: // MessageTypeAccessLog maps to MessageTypeNameL7
-			return m.l7, nil
+			return !m.l7, nil
 		case monitorAPI.MessageTypePolicyVerdict:
-			return m.policyVerdict, nil
+			return !m.policyVerdict, nil
 		case monitorAPI.MessageTypeRecCapture:
-			return m.recCapture, nil
+			return !m.recCapture, nil
 		case monitorAPI.MessageTypeTraceSock:
-			return m.traceSock, nil
+			return !m.traceSock, nil
 		default:
-			return false, errors.ErrUnknownEventType
+			return true, errors.ErrUnknownEventType
 		}
 	case *observerTypes.AgentEvent:
-		return m.agent, nil
+		return !m.agent, nil
 	case nil:
-		return false, errors.ErrEmptyData
+		return true, errors.ErrEmptyData
 	default:
-		return false, errors.ErrUnknownEventType
+		return true, errors.ErrUnknownEventType
 	}
 }

--- a/pkg/hubble/monitor/filter_test.go
+++ b/pkg/hubble/monitor/filter_test.go
@@ -82,7 +82,7 @@ func TestNewMonitorFilter(t *testing.T) {
 
 type testEvent struct {
 	event       *observerTypes.MonitorEvent
-	allowed     bool
+	stop        bool
 	expectedErr error
 }
 
@@ -102,7 +102,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 					event: &observerTypes.MonitorEvent{
 						Payload: nil,
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: errors.ErrEmptyData,
 				},
 			},
@@ -115,7 +115,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 					event: &observerTypes.MonitorEvent{
 						Payload: &struct{}{},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: errors.ErrUnknownEventType,
 				},
 			},
@@ -130,7 +130,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{0xff},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: errors.ErrUnknownEventType,
 				},
 			},
@@ -145,7 +145,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Type: monitorAPI.MessageTypeAgent,
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 			},
@@ -160,7 +160,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeAccessLog},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 			},
@@ -175,7 +175,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: errors.ErrEmptyData,
 				},
 			},
@@ -190,7 +190,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeDrop},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 			},
@@ -205,7 +205,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeDebug},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 			},
@@ -220,7 +220,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeCapture},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 			},
@@ -235,7 +235,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeTrace},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 			},
@@ -250,7 +250,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypePolicyVerdict},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 			},
@@ -265,7 +265,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeRecCapture},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 			},
@@ -280,7 +280,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeTraceSock},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 			},
@@ -295,7 +295,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeTrace},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 				{
@@ -304,7 +304,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeDebug},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 				{
@@ -313,7 +313,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeCapture},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 			},
@@ -328,7 +328,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeDebug},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 				{
@@ -337,7 +337,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypePolicyVerdict},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 				{
@@ -346,7 +346,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeTrace},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 				{
@@ -355,7 +355,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeDrop},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 			},
@@ -370,7 +370,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeCapture},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 				{
@@ -379,7 +379,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeTrace},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 				{
@@ -388,7 +388,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeDrop},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 				{
@@ -397,7 +397,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeDebug},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 			},
@@ -412,7 +412,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeDrop},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 				{
@@ -421,7 +421,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeDebug},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 				{
@@ -430,7 +430,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeCapture},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 				{
@@ -439,7 +439,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeTrace},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 				{
@@ -448,7 +448,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypePolicyVerdict},
 						},
 					},
-					allowed:     true,
+					stop:        false,
 					expectedErr: nil,
 				},
 				{
@@ -457,7 +457,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Data: []byte{monitorAPI.MessageTypeTraceSock},
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 				{
@@ -466,7 +466,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Type: monitorAPI.MessageTypeAccessLog,
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 				{
@@ -475,7 +475,7 @@ func Test_OnMonitorEvent(t *testing.T) {
 							Type: monitorAPI.MessageTypeAgent,
 						},
 					},
-					allowed:     false,
+					stop:        true,
 					expectedErr: nil,
 				},
 			},
@@ -488,9 +488,9 @@ func Test_OnMonitorEvent(t *testing.T) {
 			assert.NoError(t, err)
 
 			for _, event := range tc.events {
-				allowed, err := mf.OnMonitorEvent(context.Background(), event.event)
+				stop, err := mf.OnMonitorEvent(context.Background(), event.event)
 				assert.Equal(t, event.expectedErr, err)
-				assert.Equal(t, event.allowed, allowed)
+				assert.Equal(t, event.stop, stop)
 			}
 		})
 	}


### PR DESCRIPTION
Follow up to https://github.com/cilium/cilium/pull/24828

Addresses @marqc's comments.

#24828 was excluding events set by `--hubble-monitor-events` instead of monitoring them


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->


```release-note
Bugfix: Invert `--hubble-monitor-events` logic to be an allowlist
```
