### PR TITLE
Socket-lb: Handle connections to deleted backends

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1617,6 +1617,16 @@ Limitations
     * The neighbor discovery in a multi-device environment doesn't work with the runtime device
       detection which means that the target devices for the neighbor discovery doesn't follow the
       device changes.
+    * When socket-LB feature is enabled, pods sending (connected) UDP traffic to services
+      can continue to send traffic to a service backend even after it's deleted. Cilium agent
+      handles such scenarios by forcefully terminating pod sockets in the host network
+      namespace that are connected to deleted backends, so that the pods can be
+      load-balanced to active backends. This functionality requires these
+      kernel configs to be enabled: ``CONFIG_INET_DIAG``, ``CONFIG_INET_UDP_DIAG``
+      and ``CONFIG_INET_DIAG_DESTROY``. If you have application pods (not deployed in the
+      host network namespace) making long-lived connections using (connected) UDP,
+      you can enable ``bpf-lb-sock-hostns-only`` in order to enable the socket-LB
+      feature only in the host network namespace.
 
 Further Readings
 ################

--- a/pkg/datapath/sockets/sockets.go
+++ b/pkg/datapath/sockets/sockets.go
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package sockets
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"syscall"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+const (
+	sizeofSocketID      = 0x30
+	sizeofSocketRequest = sizeofSocketID + 0x8
+	sizeofSocket        = sizeofSocketID + 0x18
+	SOCK_DESTROY        = 21
+)
+
+var (
+	log          = logging.DefaultLogger.WithField(logfields.LogSubsys, "datapath-sockets")
+	native       = nl.NativeEndian()
+	networkOrder = binary.BigEndian
+)
+
+type SocketDestroyer interface {
+	Destroy(filter SocketFilter) error
+}
+
+type SocketFilter struct {
+	DestIp   net.IP
+	DestPort uint16
+	Family   uint8
+	Protocol uint8
+	// Optional callback function to determine whether a filtered socket needs to be destroyed
+	DestroyCB DestroySocketCB
+}
+
+type DestroySocketCB func(id netlink.SocketID) bool
+
+// Destroy destroys sockets matching the passed filter parameters using the
+// sock_diag netlink framework.
+//
+// Supported families in the filter: syscall.AF_INET, syscall.AF_INET6
+// Supported protocols in the filter: unix.IPPROTO_UDP
+func Destroy(filter SocketFilter) error {
+	family := filter.Family
+	protocol := filter.Protocol
+
+	if family != syscall.AF_INET && family != syscall.AF_INET6 {
+		return fmt.Errorf("unsupported family for socket destroy: %d", family)
+	}
+	var errs error
+	success, failed := 0, 0
+
+	// Query sockets matching the passed filter, and then destroy the filtered
+	// sockets.
+	switch protocol {
+	case unix.IPPROTO_UDP:
+		err := filterAndDestroyUDPSockets(family, func(sock netlink.SocketID, err error) {
+			if err != nil {
+				errs = errors.Join(errs, fmt.Errorf("UDP socket with filter [%v]: %w", filter, err))
+				failed++
+				return
+			}
+			if filter.MatchSocket(sock) {
+				log.Infof("socket %v", sock)
+				if err := destroySocket(sock, family, unix.IPPROTO_UDP); err != nil {
+					errs = errors.Join(errs, fmt.Errorf("destroying UDP socket with filter [%v]: %w", filter, err))
+					failed++
+					return
+				}
+				log.Debugf("Destroyed socket: %v", sock)
+				success++
+			}
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get sockets with filter %v: %w", filter, err)
+		}
+
+	default:
+		return fmt.Errorf("unsupported protocol for socket destroy: %d", protocol)
+	}
+	if success > 0 || failed > 0 || errs != nil {
+		log.WithFields(logrus.Fields{
+			"filter":  filter,
+			"success": success,
+			"failed":  failed,
+			"errors":  errs,
+		}).Info("Forcefully terminated sockets")
+	}
+
+	return nil
+}
+
+func (f *SocketFilter) MatchSocket(socket netlink.SocketID) bool {
+	if socket.Destination.Equal(f.DestIp) && socket.DestinationPort == f.DestPort {
+		if f.DestroyCB == nil || f.DestroyCB(socket) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func filterAndDestroyUDPSockets(family uint8, socketCB func(socket netlink.SocketID, err error)) error {
+	err := socketDiagUDPExecutor(family, func(m syscall.NetlinkMessage) error {
+		sockInfo := &socket{}
+		err := sockInfo.deserialize(m.Data)
+		socketCB(sockInfo.ID, err)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Below handlers are adapted from netlink/socket_linux.go to avoid memory allocations.
+
+type socketRequest struct {
+	Family   uint8
+	Protocol uint8
+	Ext      uint8
+	pad      uint8
+	States   uint32
+	ID       netlink.SocketID
+}
+
+type writeBuffer struct {
+	Bytes []byte
+	pos   int
+}
+
+func (b *writeBuffer) write(c byte) {
+	b.Bytes[b.pos] = c
+	b.pos++
+}
+
+func (b *writeBuffer) next(n int) []byte {
+	s := b.Bytes[b.pos : b.pos+n]
+	b.pos += n
+	return s
+}
+
+func (r *socketRequest) Serialize() []byte {
+	b := writeBuffer{Bytes: make([]byte, sizeofSocketRequest)}
+	b.write(r.Family)
+	b.write(r.Protocol)
+	b.write(r.Ext)
+	b.write(r.pad)
+	native.PutUint32(b.next(4), r.States)
+	networkOrder.PutUint16(b.next(2), r.ID.SourcePort)
+	networkOrder.PutUint16(b.next(2), r.ID.DestinationPort)
+	if r.Family == unix.AF_INET6 {
+		copy(b.next(16), r.ID.Source)
+		copy(b.next(16), r.ID.Destination)
+	} else {
+		copy(b.next(4), r.ID.Source.To4())
+		b.next(12)
+		copy(b.next(4), r.ID.Destination.To4())
+		b.next(12)
+	}
+	native.PutUint32(b.next(4), r.ID.Interface)
+	native.PutUint32(b.next(4), r.ID.Cookie[0])
+	native.PutUint32(b.next(4), r.ID.Cookie[1])
+	return b.Bytes
+}
+
+func (r *socketRequest) Len() int { return sizeofSocketRequest }
+
+type readBuffer struct {
+	Bytes []byte
+	pos   int
+}
+
+func (b *readBuffer) Read() byte {
+	c := b.Bytes[b.pos]
+	b.pos++
+	return c
+}
+
+func (b *readBuffer) Next(n int) []byte {
+	s := b.Bytes[b.pos : b.pos+n]
+	b.pos += n
+	return s
+}
+
+type socket netlink.Socket
+
+func (s *socket) deserialize(b []byte) error {
+	if len(b) < sizeofSocket {
+		return fmt.Errorf("socket data short read (%d); want %d", len(b), sizeofSocket)
+	}
+	rb := readBuffer{Bytes: b}
+	s.Family = rb.Read()
+	s.State = rb.Read()
+	s.Timer = rb.Read()
+	s.Retrans = rb.Read()
+	s.ID.SourcePort = networkOrder.Uint16(rb.Next(2))
+	s.ID.DestinationPort = networkOrder.Uint16(rb.Next(2))
+	if s.Family == unix.AF_INET6 {
+		s.ID.Source = net.IP(rb.Next(16))
+		s.ID.Destination = net.IP(rb.Next(16))
+	} else {
+		s.ID.Source = net.IPv4(rb.Read(), rb.Read(), rb.Read(), rb.Read())
+		rb.Next(12)
+		s.ID.Destination = net.IPv4(rb.Read(), rb.Read(), rb.Read(), rb.Read())
+		rb.Next(12)
+	}
+	s.ID.Interface = native.Uint32(rb.Next(4))
+	s.ID.Cookie[0] = native.Uint32(rb.Next(4))
+	s.ID.Cookie[1] = native.Uint32(rb.Next(4))
+	s.Expires = native.Uint32(rb.Next(4))
+	s.RQueue = native.Uint32(rb.Next(4))
+	s.WQueue = native.Uint32(rb.Next(4))
+	s.UID = native.Uint32(rb.Next(4))
+	s.INode = native.Uint32(rb.Next(4))
+	return nil
+}
+
+func destroySocket(sockId netlink.SocketID, family uint8, protocol uint8) error {
+	s, err := nl.Subscribe(unix.NETLINK_INET_DIAG)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	req := nl.NewNetlinkRequest(SOCK_DESTROY, unix.NLM_F_REQUEST)
+	req.AddData(&socketRequest{
+		Family:   family,
+		Protocol: protocol,
+		States:   uint32(0xfff),
+		ID:       sockId,
+	})
+	err = s.Send(req)
+	if err != nil {
+		fmt.Printf("error in destroying socket: %v", sockId)
+	}
+	return err
+}
+
+func socketDiagUDPExecutor(family uint8, receiver func(message syscall.NetlinkMessage) error) error {
+	s, err := nl.Subscribe(unix.NETLINK_INET_DIAG)
+	if err != nil {
+		return err
+	}
+	defer s.Close()
+
+	req := nl.NewNetlinkRequest(nl.SOCK_DIAG_BY_FAMILY, unix.NLM_F_DUMP)
+	req.AddData(&socketRequest{
+		Family:   family,
+		Protocol: unix.IPPROTO_UDP,
+		States:   uint32(0xfff),
+	})
+	s.Send(req)
+
+loop:
+	for {
+		msgs, from, err := s.Receive()
+		if err != nil {
+			return err
+		}
+		if from.Pid != nl.PidKernel {
+			return fmt.Errorf("Wrong sender portid %d, expected %d", from.Pid, nl.PidKernel)
+		}
+		if len(msgs) == 0 {
+			return errors.New("no message nor error from netlink")
+		}
+
+		for _, m := range msgs {
+			switch m.Header.Type {
+			case unix.NLMSG_DONE:
+				break loop
+			case unix.NLMSG_ERROR:
+				error := int32(native.Uint32(m.Data[0:4]))
+				return syscall.Errno(-error)
+			}
+			if err := receiver(m); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/datapath/types/lbmap.go
+++ b/pkg/datapath/types/lbmap.go
@@ -27,6 +27,7 @@ type LBMap interface {
 	DumpBackendMaps() ([]*loadbalancer.Backend, error)
 	DumpAffinityMatches() (BackendIDByServiceIDSet, error)
 	DumpSourceRanges(bool) (SourceRangeSetByServiceID, error)
+	ExistsSockRevNat(cookie uint64, addr net.IP, port uint16) bool
 }
 
 type UpsertServiceParams struct {

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -57,6 +57,8 @@ var (
 	Backend4MapV3 *bpf.Map
 	// RevNat4Map is the IPv4 LB reverse NAT BPF map.
 	RevNat4Map *bpf.Map
+	// SockRevNat4Map is the IPv4 LB sock reverse NAT BPF map.
+	SockRevNat4Map *bpf.Map
 )
 
 // initSVC constructs the IPv4 & IPv6 LB BPF maps used for Services. The maps
@@ -575,12 +577,12 @@ func (v *SockRevNat4Value) New() bpf.MapValue { return &SockRevNat4Value{} }
 
 // CreateSockRevNat4Map creates the reverse NAT sock map.
 func CreateSockRevNat4Map() error {
-	sockRevNat4Map := bpf.NewMap(SockRevNat4MapName,
+	SockRevNat4Map = bpf.NewMap(SockRevNat4MapName,
 		ebpf.LRUHash,
 		&SockRevNat4Key{},
 		&SockRevNat4Value{},
 		MaxSockRevNat4MapEntries,
 		0,
 	).WithPressureMetric()
-	return sockRevNat4Map.Create()
+	return SockRevNat4Map.OpenOrCreate()
 }

--- a/pkg/maps/lbmap/ipv4.go
+++ b/pkg/maps/lbmap/ipv4.go
@@ -548,29 +548,40 @@ func (b *Backend4) GetValue() BackendValue { return b.Value }
 // SockRevNat4Key is the tuple with address, port and cookie used as key in
 // the reverse NAT sock map.
 type SockRevNat4Key struct {
-	cookie  uint64     `align:"cookie"`
-	address types.IPv4 `align:"address"`
-	port    int16      `align:"port"`
+	Cookie  uint64     `align:"cookie"`
+	Address types.IPv4 `align:"address"`
+	Port    int16      `align:"port"`
 	_       int16
 }
 
 // SockRevNat4Value is an entry in the reverse NAT sock map.
 type SockRevNat4Value struct {
-	address     types.IPv4 `align:"address"`
-	port        int16      `align:"port"`
-	revNatIndex uint16     `align:"rev_nat_index"`
+	Address     types.IPv4 `align:"address"`
+	Port        int16      `align:"port"`
+	RevNatIndex uint16     `align:"rev_nat_index"`
+}
+
+func (k *SockRevNat4Key) Map() *bpf.Map { return SockRevNat4Map }
+
+func NewSockRevNat4Key(cookie uint64, addr net.IP, port uint16) *SockRevNat4Key {
+	var key SockRevNat4Key
+	key.Cookie = cookie
+	key.Port = int16(byteorder.NetworkToHost16(port))
+	copy(key.Address[:], addr.To4())
+
+	return &key
 }
 
 // String converts the key into a human readable string format.
 func (k *SockRevNat4Key) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", k.address, k.port, k.cookie)
+	return fmt.Sprintf("[%s]:%d, %d", k.Address, k.Port, k.Cookie)
 }
 
 func (k *SockRevNat4Key) New() bpf.MapKey { return &SockRevNat4Key{} }
 
 // String converts the value into a human readable string format.
 func (v *SockRevNat4Value) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", v.address, v.port, v.revNatIndex)
+	return fmt.Sprintf("[%s]:%d, %d", v.Address, v.Port, v.RevNatIndex)
 }
 
 func (v *SockRevNat4Value) New() bpf.MapValue { return &SockRevNat4Value{} }

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -57,6 +57,8 @@ var (
 	Backend6MapV3 *bpf.Map
 	// RevNat6Map is the IPv6 LB reverse NAT BPF map.
 	RevNat6Map *bpf.Map
+	// SockRevNat6Map is the IPv6 LB sock reverse NAT BPF map.
+	SockRevNat6Map *bpf.Map
 )
 
 // The compile-time check for whether the structs implement the interfaces
@@ -476,12 +478,12 @@ func (v *SockRevNat6Value) New() bpf.MapValue { return &SockRevNat6Value{} }
 
 // CreateSockRevNat6Map creates the reverse NAT sock map.
 func CreateSockRevNat6Map() error {
-	sockRevNat6Map := bpf.NewMap(SockRevNat6MapName,
+	SockRevNat6Map = bpf.NewMap(SockRevNat6MapName,
 		ebpf.LRUHash,
 		&SockRevNat6Key{},
 		&SockRevNat6Value{},
 		MaxSockRevNat6MapEntries,
 		0,
 	).WithPressureMetric()
-	return sockRevNat6Map.Create()
+	return SockRevNat6Map.OpenOrCreate()
 }

--- a/pkg/maps/lbmap/ipv6.go
+++ b/pkg/maps/lbmap/ipv6.go
@@ -443,9 +443,9 @@ func (b *Backend6) GetValue() BackendValue { return b.Value }
 // SockRevNat6Key is the tuple with address, port and cookie used as key in
 // the reverse NAT sock map.
 type SockRevNat6Key struct {
-	cookie  uint64     `align:"cookie"`
-	address types.IPv6 `align:"address"`
-	port    int16      `align:"port"`
+	Cookie  uint64     `align:"cookie"`
+	Address types.IPv6 `align:"address"`
+	Port    int16      `align:"port"`
 	_       [6]byte
 }
 
@@ -462,9 +462,22 @@ type SockRevNat6Value struct {
 // SizeofSockRevNat6Value is the size of type SockRevNat6Value.
 const SizeofSockRevNat6Value = int(unsafe.Sizeof(SockRevNat6Value{}))
 
+func (k *SockRevNat6Key) Map() *bpf.Map { return SockRevNat6Map }
+
+func NewSockRevNat6Key(cookie uint64, addr net.IP, port uint16) *SockRevNat6Key {
+	var key SockRevNat6Key
+
+	key.Cookie = cookie
+	key.Port = int16(byteorder.NetworkToHost16(port))
+	ipv6Array := addr.To16()
+	copy(key.Address[:], ipv6Array[:])
+
+	return &key
+}
+
 // String converts the key into a human readable string format.
 func (k *SockRevNat6Key) String() string {
-	return fmt.Sprintf("[%s]:%d, %d", k.address, k.port, k.cookie)
+	return fmt.Sprintf("[%s]:%d, %d", k.Address, k.Port, k.Cookie)
 }
 
 func (k *SockRevNat6Key) New() bpf.MapKey { return &SockRevNat6Key{} }

--- a/pkg/maps/lbmap/lbmap.go
+++ b/pkg/maps/lbmap/lbmap.go
@@ -730,6 +730,23 @@ func Init(params InitParams) {
 	initSourceRange(params)
 }
 
+// ExistsSockRevNat checks if the passed entry exists in the sock rev nat map.
+func (*LBBPFMap) ExistsSockRevNat(cookie uint64, addr net.IP, port uint16) bool {
+	if addr.To4() != nil {
+		key := NewSockRevNat4Key(cookie, addr, port)
+		if _, err := key.Map().Lookup(key); err == nil {
+			return true
+		}
+	} else {
+		key := NewSockRevNat6Key(cookie, addr, port)
+		if _, err := key.Map().Lookup(key); err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 // InitParams represents the parameters to be passed to Init().
 type InitParams struct {
 	IPv4, IPv6 bool

--- a/pkg/service/connections.go
+++ b/pkg/service/connections.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"errors"
+	"net"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/datapath/sockets"
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+)
+
+var opSupported = true
+
+func (s *Service) destroyConnectionsToBackend(be *lb.Backend) {
+	if !opSupported {
+		return
+	}
+	var (
+		family   uint8
+		protocol uint8
+	)
+	ip := net.IP(be.L3n4Addr.AddrCluster.Addr().AsSlice())
+	l4Addr := be.L3n4Addr.L4Addr
+
+	switch be.L3n4Addr.Protocol {
+	case lb.UDP:
+		protocol = unix.IPPROTO_UDP
+	default:
+		return
+	}
+	log.Debugf("handling connections to deleted backend %v", be.L3n4Addr)
+	if be.L3n4Addr.IsIPv6() {
+		family = syscall.AF_INET6
+	} else {
+		family = syscall.AF_INET
+	}
+	// Filter pod connections load-balanced to the passed service backend.
+	//
+	// When pod traffic is load-balanced to service backends, the cilium datapath
+	// records entries in the sock rev nat map that store the pod socket cookie
+	// (unique identifier in the kernel) along with the destination backend ip/port.
+	checkSockInRevNat := func(id netlink.SocketID) bool {
+		cookie := uint64(id.Cookie[1])
+		cookie = cookie<<32 + uint64(id.Cookie[0])
+
+		return s.lbmap.ExistsSockRevNat(cookie, id.Destination, id.DestinationPort)
+	}
+
+	err := s.backendConnectionHandler.Destroy(sockets.SocketFilter{
+		Family:    family,
+		Protocol:  protocol,
+		DestIp:    ip,
+		DestPort:  l4Addr.Port,
+		DestroyCB: checkSockInRevNat,
+	})
+	if err != nil {
+		if errors.Is(err, unix.EOPNOTSUPP) {
+			opSupported = false
+			log.Errorf("Forcefully terminating sockets connected to deleted service backends " +
+				"not supported by underlying kernel: see kube-proxy free guide for " +
+				"the required kernel configurations")
+		} else {
+			log.Errorf("Error while forcefully terminating sockets connected to"+
+				"deleted service backend: %v. If you see any traffic going to such"+
+				"deleted backends, consider restarting application pods sending the traffic.", err)
+		}
+	}
+}
+
+// backendConnectionHandler is added for dependency injection in tests.
+type backendConnectionHandler struct{}
+
+func (h backendConnectionHandler) Destroy(filter sockets.SocketFilter) error {
+	return sockets.Destroy(filter)
+}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -155,7 +155,7 @@ func (m *ManagerTestSuite) SetUpTest(c *C) {
 	backendIDAlloc.resetLocalID()
 
 	m.lbmap = mockmaps.NewLBMockMap()
-	m.svc = NewService(nil, nil, m.lbmap)
+	m.newServiceMock(m.lbmap)
 
 	m.svcHealth = healthserver.NewMockHealthHTTPServerFactory()
 	m.svc.healthServer = healthserver.WithHealthHTTPServerFactory(m.svcHealth)
@@ -204,6 +204,10 @@ func (m *ManagerTestSuite) TearDownTest(c *C) {
 	option.Config.DatapathMode = m.prevOptionDPMode
 	option.Config.ExternalClusterIP = m.prevOptionExternalClusterIP
 	option.Config.EnableIPv6 = m.ipv6
+}
+
+func (m *ManagerTestSuite) newServiceMock(lbmap datapathTypes.LBMap) {
+	m.svc = NewService(nil, nil, lbmap)
 }
 
 func (m *ManagerTestSuite) TestUpsertAndDeleteService(c *C) {
@@ -523,7 +527,7 @@ func (m *ManagerTestSuite) TestRestoreServices(c *C) {
 	option.Config.NodePortAlg = option.NodePortAlgMaglev
 	option.Config.DatapathMode = datapathOpt.DatapathModeLBOnly
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
-	m.svc = NewService(nil, nil, lbmap)
+	m.newServiceMock(lbmap)
 
 	// Restore services from lbmap
 	err = m.svc.RestoreServices()
@@ -594,7 +598,7 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 
 	// Restart service, but keep the lbmap to restore services from
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
-	m.svc = NewService(nil, nil, lbmap)
+	m.newServiceMock(lbmap)
 	err = m.svc.RestoreServices()
 	c.Assert(err, IsNil)
 	c.Assert(len(m.svc.svcByID), Equals, 2)
@@ -1352,7 +1356,7 @@ func (m *ManagerTestSuite) TestRestoreServiceWithTerminatingBackends(c *C) {
 
 	// Simulate agent restart.
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
-	m.svc = NewService(nil, nil, lbmap)
+	m.newServiceMock(lbmap)
 
 	// Restore services from lbmap
 	err = m.svc.RestoreServices()
@@ -1586,7 +1590,7 @@ func (m *ManagerTestSuite) TestRestoreServiceWithBackendStates(c *C) {
 
 	// Simulate agent restart.
 	lbmap := m.svc.lbmap.(*mockmaps.LBMockMap)
-	m.svc = NewService(nil, nil, lbmap)
+	m.newServiceMock(lbmap)
 
 	// Restore services from lbmap
 	err = m.svc.RestoreServices()

--- a/pkg/testutils/sockets/sockets.go
+++ b/pkg/testutils/sockets/sockets.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testsockets
+
+import (
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/sockets"
+)
+
+type MockSockets struct {
+	sockets []*MockSocket
+}
+
+type MockSocket struct {
+	SockID    netlink.SocketID
+	Family    uint8
+	Protocol  uint8
+	Destroyed bool
+}
+
+func NewMockSockets(sockets []*MockSocket) *MockSockets {
+	mocks := &MockSockets{sockets: make([]*MockSocket, len(sockets))}
+	for i := range mocks.sockets {
+		mocks.sockets[i] = sockets[i]
+	}
+	return mocks
+}
+
+func (s *MockSockets) Destroy(filter sockets.SocketFilter) error {
+	for _, socket := range s.sockets {
+		if filter.MatchSocket(socket.SockID) && filter.Family == socket.Family &&
+			filter.Protocol == socket.Protocol {
+			socket.Destroyed = true
+		}
+	}
+
+	return nil
+}
+
+func (s *MockSocket) Equal(s2 *MockSocket) bool {
+	return s.SockID.Destination.Equal(s2.SockID.Destination) &&
+		s.SockID.DestinationPort == s2.SockID.DestinationPort &&
+		s.Family == s2.Family && s.Protocol == s2.Protocol
+}


### PR DESCRIPTION
This PR addresses a limitation with socket-lb by handling stale connections to deleted service backends.

### Background

When socket-lb is enabled, traffic destined to service cluster IPs is load-balanced to service backends in the BPF cgroup hooks at the socket layer (socket `connect()` aka fast path).  When service backends are deleted, source application sockets continue to send traffic to deleted backends (particularly, for connected UDP) as there are no hooks in the slow path (e.g., socket `send()`/`receive()` calls). 

### Fix

When backends are deleted, filter host-wide sockets based on socket cookie and destination ip/port, and destroy the sockets connected to deleted backends. We use the `SOCK_DESTROY` capability in the kernel based on `NETLINK_SOCK_DIAG` infrastructure. This requires kernel to be compiled with `CONFIG_INET_DIAG_DESTROY` config.

 ### Caveats

The `SOCK_DESTROY` framework is network namespace aware, which means cilium would have to enter all network namespaces on a host, and iterate and destroy stale sockets. Cilium agent is deployed as a pod in the host netns, and we currently don't bind mount `/var/run/netns` directory on host inside the agent pod, so it doesn't see pod netns's. Options  to enable netns access: (1) run cilium agent with hostPID (security implications) so that it can scan netns (2) run this stale connections handling logic on a k8s node (similar to cilium-cni process), but this would require some kind of RPC communication channel with the agent. There are pros and cons with these options. 
For these reasons, the PR only handles stale sockets (either connected to regular backend pods or host networked backend pods) in the host netns. 

### Notes

- The long term option is to use the bpf_sock_destroy capability on kernel bpf-next/6.5+, and destroy sockets entirely in BPF using BPF iterators [1]. These changes will be done in a separate PR, and are outside of the scope of this PR.
For more details, reference the [LPC talk](https://lpc.events/event/16/contributions/1358/).

- One of the options we considered was to drop packets in the TC hooks by matching destination address. While this would have performance implications in the per packet processing, this doesn't address the issue in the host netns, as TC programs are not executed for traffic in the host netns.

TODOs

- [x] Feature detection as configs may not be enabled on all kernels
- [ ] CI test: Tested manually. New CI test will be added to the cilium-cli connectivity test suite as a follow-up. 
- [x] Document the requirements

Fixes: #12859 

```release-note
Forcefully terminate stale sockets connected to deleted service backends when socket-lb is enabled, and allow applications to re-connect to active backends.
```

[1] https://www.spinics.net/lists/bpf/msg87652.html