### PR TITLE
Fixed documentation regarding cilium versioning scheme and support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,15 +31,15 @@ and flexible. To learn more about eBPF, visit `eBPF.io`_.
 Stable Releases
 ===============
 
-The Cilium community maintains minor stable releases for the last three major
-Cilium versions. Older Cilium stable versions from major releases prior to that
+The Cilium community maintains minor stable releases for the last three minor
+Cilium versions. Older Cilium stable versions from minor releases prior to that
 are considered EOL.
 
-For upgrades to new major releases please consult the `Cilium Upgrade Guide
+For upgrades to new minor releases please consult the `Cilium Upgrade Guide
 <https://docs.cilium.io/en/stable/operations/upgrade/>`_.
 
 Listed below are the actively maintained release branches along with their latest
-minor release, corresponding image pull tags and their release notes:
+patch release, corresponding image pull tags and their release notes:
 
 +---------------------------------------------------------+------------+------------------------------------+----------------------------------------------------------------------------+
 | `v1.13 <https://github.com/cilium/cilium/tree/v1.13>`__ | 2023-04-17 | ``quay.io/cilium/cilium:v1.13.2``  | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.13.2>`__  |


### PR DESCRIPTION
Cilium follows major.minor.patch version scheme. The section on ReadMe telling about the end of support is incorrect. This PR is fixing it.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->


