### PR TITLE
bpf,make: add ability to run bpf unit tests in the Cilium builder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -674,3 +674,9 @@ help: ## Display help for the Makefile, from https://www.thapaliya.com/en/writin
 
 .PHONY: help clean clean-container dev-doctor force generate-api generate-health-api generate-operator-api generate-hubble-api install licenses-all veryclean check-sources
 force :;
+
+# this top level run_bpf_tests target will run the bpf unit tests inside the Cilium Builder container.
+# it exists here so the entire source code repo can be mounted into the container.
+CILIUM_BUILDER_IMAGE=$(shell cat images/cilium/Dockerfile | grep "ARG CILIUM_BUILDER_IMAGE=" | cut -d"=" -f2)
+run_bpf_tests:
+	docker run -v $$(pwd):/src --privileged -w /src -e RUN_WITH_SUDO=false $(CILIUM_BUILDER_IMAGE) "make" "-C" "test/" "run_bpf_tests"

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,6 +3,14 @@
 
 include ../Makefile.defs
 
+# Determines if the eBPF unit tests are ran with `sudo`
+RUN_WITH_SUDO ?= true
+ifeq ($(RUN_WITH_SUDO), true)
+	RUN_WITH_SUDO=-exec sudo
+else
+	RUN_WITH_SUDO=
+endif
+
 PROVISION ?= true
 # If you set provision to false the test will run without bootstrapping the
 # cluster again.
@@ -92,4 +100,4 @@ endif
 
 run_bpf_tests:
 	$(QUIET)$(MAKE) -C ../bpf/tests all
-	$(QUIET)$(GO) test ./bpf_tests -exec sudo -bpf-test-path $(ROOT_DIR)/bpf/tests $(BPF_TEST_FLAGS)
+	$(QUIET)$(GO) test ./bpf_tests $(RUN_WITH_SUDO) -bpf-test-path $(ROOT_DIR)/bpf/tests $(BPF_TEST_FLAGS)


### PR DESCRIPTION
This commit adds a top level Makefile target for running eBPF unit tests within the Cilium builder container.

The Cilium builder container ensures all the dependencies necessary to build and run the tests are present.

After this commit, running `make run_bpf_tests` from the root of the repo will run the tests in a container, while running the same target in the `./test` directory will run the tests locally, outside of the container

```release-note
Add top level `make run_bpf_tests` target to run eBPF unit tests in the Cilium builder container
```
