### PR TITLE
docs: Add platform support to docs

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -19,6 +19,7 @@ Summary
 When running Cilium using the container image ``cilium/cilium``, the host
 system must meet these requirements:
 
+- Hosts with either AMD64 or AArch64 architecture
 - `Linux kernel`_ >= 4.19.57 or equivalent (e.g., 4.18 on RHEL8)
 
 When running Cilium as a native process on your host (i.e. **not** running the
@@ -46,6 +47,14 @@ iproute2                 >= 5.9.0 [#iproute2_foot]_     yes
 
 .. [#iproute2_foot] Requires support for eBPF templating as documented
    :ref:`below <iproute2_requirements>`.
+
+Architecture Support
+====================
+
+Cilium images are built for the following platforms:
+
+- AMD64
+- AArch64
 
 Linux Distribution Compatibility & Considerations
 =================================================

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -1,3 +1,4 @@
+AArch
 ACK
 AKS
 APIEndpoint

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,11 @@ minor release, corresponding image pull tags and their release notes:
 | `v1.11 <https://github.com/cilium/cilium/tree/v1.11>`__ | 2023-04-18 | ``quay.io/cilium/cilium:v1.11.16`` | `Release Notes <https://github.com/cilium/cilium/releases/tag/v1.11.16>`__ |
 +---------------------------------------------------------+------------+------------------------------------+----------------------------------------------------------------------------+
 
+Architectures
+-------------
+
+Cilium images are distributed for AMD64 and AArch64 architectures.
+
 Software Bill of Materials
 --------------------------
 


### PR DESCRIPTION
We've been distributing ARM architecture images for Cilium for almost
two years, but neglected to mention this up front in the system
requirements or the main docs page. Add this to the docs.
