### PR TITLE
source: Reorder sources based on strength

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -26,12 +26,12 @@ const (
 	// system state such as Kubernetes.
 	KVStore Source = "kvstore"
 
-	// Kubernetes is the source used for state derived from Kubernetes
-	Kubernetes Source = "k8s"
-
 	// CustomResource is the source used for state derived from Kubernetes
 	// custom resources
 	CustomResource Source = "custom-resource"
+
+	// Kubernetes is the source used for state derived from Kubernetes
+	Kubernetes Source = "k8s"
 
 	// LocalAPI is the source used for state derived from the API served
 	// locally on the node.


### PR DESCRIPTION
This commit is purely cosmetic and only reorders the definition based
on the strength of the source, from top to bottom.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
