### PR TITLE
mirror: Only run on cilium/cilium

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   mirror_job:
+    if: github.repository == 'cilium/cilium'
     runs-on: ubuntu-latest
     environment: mirror
     name: Mirror main branch to master branch


### PR DESCRIPTION
We only need to run this workflow in cilium/cilium. Other forks can pull from cilium/cilium master branch if they need master branch to be in sync with main branch.