### PR TITLE
node/manager: Utilize set.SliceSubsetOf in ipcache deletion

### DIFF
--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -7,6 +7,13 @@ package set
 // not, it also returns slice of elements which are the difference of both
 // input slices.
 func SliceSubsetOf(sub, main []string) (bool, []string) {
+	if len(sub) == 0 {
+		return true, nil
+	}
+	if len(main) == 0 {
+		return len(sub) == 0, sub
+	}
+
 	var diff []string
 	occurrences := make(map[string]int, len(main))
 	result := true

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -93,6 +93,24 @@ func (s *SetTestSuite) TestSliceSubsetOf(c *C) {
 			isSubset:     true,
 			expectedDiff: nil,
 		},
+		{
+			sub:          []string{"foo"},
+			main:         nil,
+			isSubset:     false,
+			expectedDiff: []string{"foo"},
+		},
+		{
+			sub:          nil,
+			main:         []string{"foo"},
+			isSubset:     true,
+			expectedDiff: nil,
+		},
+		{
+			sub:          []string{},
+			main:         nil,
+			isSubset:     true,
+			expectedDiff: nil,
+		},
 	}
 	for _, tc := range testCases {
 		isSubset, diff := SliceSubsetOf(tc.sub, tc.main)


### PR DESCRIPTION
- pkg/set: Support cases where input can be nil
- node/manager: Utilize set.SliceSubsetOf in ipcache deletion

Copying the more relevant commit for ease of review:

    node/manager: Utilize set.SliceSubsetOf in ipcache deletion

    This cleans up the code to have proper diffing logic when delete node
    IPs from the ipcache. Previously, the logic had a potential for a bug
    because it assumed that oldIPs and newIPs were sorted.

    FWIW, no bug has been reported in regards to the previous code fixed by
    this commit, so it's theoretical for now. In the end, this is a
    defensive change to prevent it from happening.

    Additionally, this commit will ease the changes that will be introduced
    in https://github.com/cilium/cilium/pull/23208.
