### PR TITLE
bpf: add missing drop notifications

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1000,7 +1000,8 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 
 			ctx->mark = 0;
 			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
-			return DROP_MISSED_TAIL_CALL;
+			return send_drop_notify_error(ctx, identity, DROP_MISSED_TAIL_CALL,
+						      CTX_ACT_DROP, METRIC_EGRESS);
 		}
 	}
 #endif

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1236,6 +1236,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 	};
 #endif
 #endif
+	int ret;
 
 	/* Filter allowed vlan id's and pass them back to kernel.
 	 * We will see the packet again in from-netdev@eth0.vlanXXX.
@@ -1246,9 +1247,9 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 		if (vlan_id) {
 			if (allow_vlan(ctx->ifindex, vlan_id))
 				return CTX_ACT_OK;
-			else
-				return send_drop_notify_error(ctx, 0, DROP_VLAN_FILTERED,
-							      CTX_ACT_DROP, METRIC_INGRESS);
+
+			ret = DROP_VLAN_FILTERED;
+			goto drop_err;
 		}
 	}
 
@@ -1288,15 +1289,22 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 			}
 		}
 #endif
-		return __encap_and_redirect_with_nodeid(ctx, ctx_get_xfer(ctx, XFER_ENCAP_NODEID),
-							ctx_get_xfer(ctx, XFER_ENCAP_SECLABEL),
-							ctx_get_xfer(ctx, XFER_ENCAP_DSTID),
-							NOT_VTEP_DST, &trace);
+		ret = __encap_and_redirect_with_nodeid(ctx, ctx_get_xfer(ctx, XFER_ENCAP_NODEID),
+						       ctx_get_xfer(ctx, XFER_ENCAP_SECLABEL),
+						       ctx_get_xfer(ctx, XFER_ENCAP_DSTID),
+						       NOT_VTEP_DST, &trace);
+		if (IS_ERR(ret))
+			goto drop_err;
+
+		return ret;
 	}
 #endif
 #endif
 
 	return handle_netdev(ctx, false);
+
+drop_err:
+	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
 }
 
 /*

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -965,7 +965,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 		break;
 # endif /* ENABLE_IPV4 */
 	}
-	if (!ep)
+	if (!ep || !ep->tunnel_endpoint)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
 	ctx->mark = 0;

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -966,9 +966,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 # endif /* ENABLE_IPV4 */
 	}
 	if (!ep)
-		return send_drop_notify_error(ctx, src_id,
-					      DROP_NO_TUNNEL_ENDPOINT,
-					      CTX_ACT_DROP, METRIC_EGRESS);
+		return DROP_NO_TUNNEL_ENDPOINT;
 
 	ctx->mark = 0;
 	bpf_clear_meta(ctx);
@@ -1024,7 +1022,11 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 			send_trace_notify(ctx, TRACE_FROM_STACK, identity, 0, 0,
 					  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
 					  TRACE_PAYLOAD_LEN);
-			return do_netdev_encrypt(ctx, identity);
+			ret = do_netdev_encrypt(ctx, identity);
+			if (IS_ERR(ret))
+				return send_drop_notify_error(ctx, identity, ret,
+							      CTX_ACT_DROP, METRIC_EGRESS);
+			return ret;
 		}
 #endif
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1274,7 +1274,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 			if (port && addr) {
 				set_geneve_dsr_opt4(port, addr, &gopt);
 
-				return encap_and_redirect_with_nodeid_opt(ctx,
+				ret = encap_and_redirect_with_nodeid_opt(ctx,
 								  ctx_get_xfer(ctx,
 									       XFER_ENCAP_NODEID),
 								  ctx_get_xfer(ctx,
@@ -1286,6 +1286,10 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 								  sizeof(gopt),
 								  false,
 								  &trace);
+				if (IS_ERR(ret))
+					goto drop_err;
+
+				return ret;
 			}
 		}
 #endif

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -98,11 +98,8 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
 	 * VXLAN/Geneve encapsulation when the WG feature was on.
 	 */
 	ret = wg_maybe_redirect_to_encrypt(ctx);
-	if (ret == CTX_ACT_REDIRECT)
+	if (IS_ERR(ret) || ret == CTX_ACT_REDIRECT)
 		return ret;
-	else if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, seclabel, ret, CTX_ACT_DROP,
-					      METRIC_EGRESS);
 #endif /* ENABLE_WIREGUARD */
 
 	ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, dstid,

--- a/bpf/source_names_to_ids.h
+++ b/bpf/source_names_to_ids.h
@@ -31,7 +31,6 @@ __source_file_name_to_id(const char *const header_name)
 	_strcase_(103, "egress_policies.h");
 	_strcase_(104, "icmp6.h");
 	_strcase_(105, "nodeport.h");
-	_strcase_(106, "encap.h");
 
 	return 0;
 }

--- a/pkg/monitor/datapath_drop.go
+++ b/pkg/monitor/datapath_drop.go
@@ -59,7 +59,6 @@ var sourceFileNames = map[int]string{
 	103: "egress_policies.h",
 	104: "icmp6.h",
 	105: "nodeport.h",
-	106: "encap.h",
 	//end
 }
 


### PR DESCRIPTION
End goal was to get rid of the stray drop notification that's currently buried in `__encap_and_redirect_with_nodeid()`. Getting there took quite a few additional drive-by fixes :).

The last two patches can be dropped from the backport (`encap_and_redirect_with_nodeid_opt()` didn't exist in v1.13).

```release-note
Add drop notifications for various error paths in the datapath.
```
