### PR TITLE
v1.12 backports 2023-04-28

### DIFF
--- a/pkg/k8s/watchers/cilium_endpoint_slice.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice.go
@@ -22,8 +22,6 @@ import (
 
 var (
 	cesNotify = subscriber.NewCES()
-	// cepMap maps CEPName to CEBName.
-	cepMap = newCEPToCESMap()
 )
 
 // CreateCiliumEndpointSliceLocalPodIndexFunc returns an IndexFunc that indexes CiliumEndpointSlices

--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
@@ -8,20 +8,36 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/pkg/endpoint"
+
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/types"
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
 )
 
+type endpointWatcher interface {
+	endpointUpdated(oldC, newC *types.CiliumEndpoint)
+	endpointDeleted(c *types.CiliumEndpoint)
+}
+
+type localEndpointCache interface {
+	LookupPodName(namespacedName string) *endpoint.Endpoint
+}
+
 type cesSubscriber struct {
-	kWatcher *K8sWatcher
+	epWatcher endpointWatcher
+	epCache   localEndpointCache
+	cepMap    *cepToCESmap
 }
 
 func newCESSubscriber(k *K8sWatcher) *cesSubscriber {
 	return &cesSubscriber{
-		kWatcher: k,
+		epWatcher: k,
+		epCache:   k.endpointManager,
+		cepMap:    newCEPToCESMap(),
 	}
 }
 
@@ -29,18 +45,18 @@ func newCESSubscriber(k *K8sWatcher) *cesSubscriber {
 // packed in the CES, converts coreCEP into types.CEP and calls endpointUpdated only for remoteNode CEPs.
 func (cs *cesSubscriber) OnAdd(ces *cilium_v2a1.CiliumEndpointSlice) {
 	for i, ep := range ces.Endpoints {
+		CEPName := ces.Namespace + "/" + ep.Name
 		log.WithFields(logrus.Fields{
 			"CESName": ces.GetName(),
-			"CEPName": ep.Name,
+			"CEPName": CEPName,
 		}).Debug("CES added, calling CoreEndpointUpdate")
-		c := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(&ces.Endpoints[i], ces.Namespace)
-		// Map cep name to CES name
-		cepMap.insertCEP(ces.Namespace+"/"+ep.Name, ces.GetName())
-		if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(c)); p != nil {
+		cep := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(&ces.Endpoints[i], ces.Namespace)
+		if p := cs.epCache.LookupPodName(k8sUtils.GetObjNamespaceName(cep)); p != nil {
 			timeSinceCepCreated := time.Since(p.GetCreatedAt())
 			metrics.EndpointPropagationDelay.WithLabelValues().Observe(timeSinceCepCreated.Seconds())
 		}
-		cs.kWatcher.endpointUpdated(nil, c)
+		// Map cep name to CES name
+		cs.addCEPwithCES(CEPName, ces.GetName(), cep)
 	}
 }
 
@@ -66,21 +82,16 @@ func (cs *cesSubscriber) OnUpdate(oldCES, newCES *cilium_v2a1.CiliumEndpointSlic
 	for CEPName, oldCEP := range oldCEPs {
 		if _, exists := newCEPs[CEPName]; !exists {
 			log.WithFields(logrus.Fields{
-				"CESName": oldCES.GetName(),
+				"CESName": newCES.GetName(),
 				"CEPName": CEPName,
 			}).Debug("CEP deleted, calling endpointDeleted")
-			c := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(oldCEP, oldCES.Namespace)
+			cep := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(oldCEP, oldCES.Namespace)
 			// LocalNode already has the latest CEP.
 			// Hence, skip processing endpointupdate for localNode CEPs.
-			if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(c)); p != nil {
+			if p := cs.epCache.LookupPodName(k8sUtils.GetObjNamespaceName(cep)); p != nil {
 				continue
 			}
-			// Delete CEP if and only if that CEP is owned by a CES, that was used during CES updated.
-			// Delete CEP only if there is match in CEPToCES map and also delete CEPName in CEPToCES map.
-			if cesName := cepMap.getCESName(CEPName); cesName == oldCES.GetName() {
-				cs.kWatcher.endpointDeleted(c)
-				cepMap.deleteCEP(CEPName)
-			}
+			cs.deleteCEPfromCES(CEPName, newCES.GetName(), cep)
 		}
 	}
 
@@ -88,16 +99,15 @@ func (cs *cesSubscriber) OnUpdate(oldCES, newCES *cilium_v2a1.CiliumEndpointSlic
 	for CEPName, newCEP := range newCEPs {
 		if _, exists := oldCEPs[CEPName]; !exists {
 			log.WithFields(logrus.Fields{
-				"CESName": oldCES.GetName(),
+				"CESName": newCES.GetName(),
 				"CEPName": CEPName,
 			}).Debug("CEP inserted, calling endpointUpdated")
-			c := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(newCEP, newCES.Namespace)
-			if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(c)); p != nil {
+			cep := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(newCEP, newCES.Namespace)
+			if p := cs.epCache.LookupPodName(k8sUtils.GetObjNamespaceName(cep)); p != nil {
 				timeSinceCepCreated := time.Since(p.GetCreatedAt())
 				metrics.EndpointPropagationDelay.WithLabelValues().Observe(timeSinceCepCreated.Seconds())
 			}
-			cs.kWatcher.endpointUpdated(nil, c)
-			cepMap.insertCEP(CEPName, oldCES.GetName())
+			cs.addCEPwithCES(CEPName, newCES.GetName(), cep)
 		}
 	}
 
@@ -108,13 +118,11 @@ func (cs *cesSubscriber) OnUpdate(oldCES, newCES *cilium_v2a1.CiliumEndpointSlic
 				continue
 			}
 			log.WithFields(logrus.Fields{
-				"CESName": oldCES.GetName(),
+				"CESName": newCES.GetName(),
 				"CEPName": CEPName,
 			}).Debug("CES updated, calling endpointUpdated")
 			newC := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(newCEP, newCES.Namespace)
-			oldC := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(oldCEP, oldCES.Namespace)
-			cs.kWatcher.endpointUpdated(oldC, newC)
-			cepMap.insertCEP(CEPName, oldCES.GetName())
+			cs.addCEPwithCES(CEPName, newCES.GetName(), newC)
 		}
 	}
 }
@@ -123,51 +131,122 @@ func (cs *cesSubscriber) OnUpdate(oldCES, newCES *cilium_v2a1.CiliumEndpointSlic
 // and calls endpointDeleted only for remoteNode CEPs.
 func (cs *cesSubscriber) OnDelete(ces *cilium_v2a1.CiliumEndpointSlice) {
 	for i, ep := range ces.Endpoints {
+		CEPName := ces.Namespace + "/" + ep.Name
 		log.WithFields(logrus.Fields{
 			"CESName": ces.GetName(),
-			"CEPName": ep.Name,
+			"CEPName": CEPName,
 		}).Debug("CES deleted, calling endpointDeleted")
-		c := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(&ces.Endpoints[i], ces.Namespace)
+		cep := k8s.ConvertCoreCiliumEndpointToTypesCiliumEndpoint(&ces.Endpoints[i], ces.Namespace)
 		// LocalNode already deleted the CEP.
 		// Hence, skip processing endpointDeleted for localNode CEPs.
-		if p := cs.kWatcher.endpointManager.LookupPodName(k8sUtils.GetObjNamespaceName(c)); p != nil {
+		if p := cs.epCache.LookupPodName(k8sUtils.GetObjNamespaceName(cep)); p != nil {
 			continue
 		}
 		// Delete CEP if and only if that CEP is owned by a CES, that was used during CES updated.
 		// Delete CEP only if there is match in CEPToCES map and also delete CEPName in CEPToCES map.
-		if cesName := cepMap.getCESName(ces.Namespace + "/" + ep.Name); cesName == ces.GetName() {
-			cs.kWatcher.endpointDeleted(c)
-			cepMap.deleteCEP(ep.Name)
-		}
+		cs.deleteCEPfromCES(CEPName, ces.GetName(), cep)
 	}
 }
 
-// cepToCESmap is used to map CiliumEndpoint name to CiliumEndpointBatch name.
+// deleteCEP deletes the CEP and CES from the map.
+// If this was last CES for the CEP it triggers endpointDeleted.
+// If this was used CES for the CEP it picks other CES and triggers endpointUpdated.
+func (cs *cesSubscriber) deleteCEPfromCES(CEPName, CESName string, c *types.CiliumEndpoint) {
+	cs.cepMap.cesMutex.Lock()
+	defer cs.cepMap.cesMutex.Unlock()
+	needUpdate := cs.cepMap.currentCES[CEPName] == CESName
+	cs.cepMap.deleteCEPLocked(CEPName, CESName)
+	if !needUpdate {
+		return
+	}
+	cep, exists := cs.cepMap.getCEPLocked(CEPName)
+	if !exists {
+		log.WithFields(logrus.Fields{
+			"CESName": CESName,
+			"CEPName": CEPName,
+		}).Info("CEP deleted, calling endpointDeleted")
+		cs.epWatcher.endpointDeleted(c)
+	} else {
+		log.WithFields(logrus.Fields{
+			"CESName": CESName,
+			"CEPName": CEPName,
+		}).Info("CEP deleted, other CEP exists, calling endpointUpdated")
+		cs.epWatcher.endpointUpdated(c, cep)
+	}
+}
+
+// addCEPwithCES insert CEP with CES to the map and triggers endpointUpdated.
+func (cs *cesSubscriber) addCEPwithCES(CEPName, CESName string, newCep *types.CiliumEndpoint) {
+	cs.cepMap.cesMutex.Lock()
+	defer cs.cepMap.cesMutex.Unlock()
+	// Not checking if exists because it's fine and WAI if oldCep is nil.
+	// When there is no previous endpoint the endpointUpdated should be called with nil.
+	oldCep, _ := cs.cepMap.getCEPLocked(CEPName)
+	cs.cepMap.insertCEPLocked(CEPName, CESName, newCep)
+	cs.epWatcher.endpointUpdated(oldCep, newCep)
+}
+
+type cesToCEPRef map[string]*types.CiliumEndpoint
+
+// cepToCESmap is used to map CiliumEndpoint name to CiliumEndpointSlice names.
+// In steady state, there should be exactly one CiliumEndpointSlice associated
+// with a CiliumEndpoint. But when a CEP is being transferred between two CESes,
+// there will be a brief period of time in which the CEP exists in both the CESes.
 type cepToCESmap struct {
-	cesMutex lock.RWMutex
-	cepMap   map[string]string
+	// cesMutex is used to lock all the operations changing cepMap and ipcache.
+	cesMutex lock.Mutex
+	// Maps CEP by name to a map of CES and pointer to CiliumEndpoint.
+	// In rare case when CEP exists in multiple CESs it would contain all the
+	// occurrences. This is needed to retrieve currently used Cilium Endpoint
+	// (cepMap[cepName][currentCES[cepName]]) when update comes and to pick other
+	// representation when the current one is deleted and other exist.
+	// The Cilium Endpoint pointers will point to different objects from different
+	// CES. They may or may not be equal to each other.
+	cepMap map[string]cesToCEPRef
+	// map of CEP name and currently used CES name.
+	// Current CEP is cepMap[CEP][currentCES[CEP]]
+	currentCES map[string]string
 }
 
 func newCEPToCESMap() *cepToCESmap {
 	return &cepToCESmap{
-		cepMap: make(map[string]string),
+		cepMap:     make(map[string]cesToCEPRef),
+		currentCES: make(map[string]string),
 	}
 }
 
-func (c *cepToCESmap) insertCEP(cepName, cesName string) {
-	c.cesMutex.Lock()
-	defer c.cesMutex.Unlock()
-	c.cepMap[cepName] = cesName
+func (c *cepToCESmap) insertCEPLocked(cepName, cesName string, cep *types.CiliumEndpoint) {
+	if _, exists := c.cepMap[cepName]; !exists {
+		c.cepMap[cepName] = make(map[string]*types.CiliumEndpoint)
+	}
+	c.cepMap[cepName][cesName] = cep
+	c.currentCES[cepName] = cesName
 }
 
-func (c *cepToCESmap) deleteCEP(cepName string) {
-	c.cesMutex.Lock()
-	defer c.cesMutex.Unlock()
-	delete(c.cepMap, cepName)
+func (c *cepToCESmap) deleteCEPLocked(cepName, cesName string) {
+	cesToCEPMap, exists := c.cepMap[cepName]
+	if !exists {
+		return
+	}
+	if _, exists = cesToCEPMap[cesName]; !exists {
+		return
+	}
+	if len(cesToCEPMap) == 1 {
+		delete(c.cepMap, cepName)
+		delete(c.currentCES, cepName)
+	} else {
+		delete(cesToCEPMap, cesName)
+		if c.currentCES[cepName] == cesName {
+			for k := range cesToCEPMap {
+				c.currentCES[cepName] = k
+				break
+			}
+		}
+	}
 }
 
-func (c *cepToCESmap) getCESName(cepName string) string {
-	c.cesMutex.RLock()
-	defer c.cesMutex.RUnlock()
-	return c.cepMap[cepName]
+// getCEPLocked returns a currently used CEP associated with one of the CESes for the given CEP name.
+func (c *cepToCESmap) getCEPLocked(cepName string) (*types.CiliumEndpoint, bool) {
+	cep, exists := c.cepMap[cepName][c.currentCES[cepName]]
+	return cep, exists
 }

--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber_test.go
@@ -1,0 +1,499 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package watchers
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/endpoint"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/k8s/types"
+)
+
+type endpointUpdate struct {
+	oldEp, newEp *types.CiliumEndpoint
+}
+
+func epToString(e *types.CiliumEndpoint) string {
+	if e == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("ep(id: %d)", e.Identity.ID)
+}
+
+func (u endpointUpdate) toString() string {
+	return fmt.Sprintf("(%s, %s)", epToString(u.oldEp), epToString(u.newEp))
+}
+
+func epEqual(e1, e2 *types.CiliumEndpoint) bool {
+	return ((e1 == nil) == (e2 == nil)) && (e1 == nil || e1.Identity.ID == e2.Identity.ID)
+}
+
+func updateEqual(u1, u2 endpointUpdate) bool {
+	return epEqual(u1.oldEp, u2.oldEp) && epEqual(u1.newEp, u2.newEp)
+}
+
+type fakeEPWatcher struct {
+	lastUpdate endpointUpdate
+	lastDelete *types.CiliumEndpoint
+}
+
+func createFakeEPWatcher() *fakeEPWatcher {
+	return &fakeEPWatcher{}
+}
+
+func (fw *fakeEPWatcher) endpointUpdated(oldC, newC *types.CiliumEndpoint) {
+	fw.lastUpdate = endpointUpdate{oldC, newC}
+}
+
+func (fw *fakeEPWatcher) endpointDeleted(c *types.CiliumEndpoint) {
+	fw.lastDelete = c
+}
+
+func (fw *fakeEPWatcher) assertUpdate(u endpointUpdate) (string, bool) {
+	if !updateEqual(fw.lastUpdate, u) {
+		return fmt.Sprintf("Expected %s, got %s", u.toString(), fw.lastUpdate.toString()), false
+	}
+	return "", true
+}
+
+func (fw *fakeEPWatcher) assertNoDelete() (string, bool) {
+	if fw.lastDelete != nil {
+		return fmt.Sprintf("Expected no delete, got %s", epToString(fw.lastDelete)), false
+	}
+	return "", true
+}
+
+func (fw *fakeEPWatcher) assertDelete(e *types.CiliumEndpoint) (string, bool) {
+	if !epEqual(fw.lastDelete, e) {
+		return fmt.Sprintf("Expected no delete, got %s", epToString(fw.lastDelete)), false
+	}
+	return "", true
+}
+
+type fakeEndpointCache struct{}
+
+func (fe *fakeEndpointCache) LookupPodName(namespacedName string) *endpoint.Endpoint {
+	return nil
+}
+
+func createCES(name, namespace string, endpoints []v2alpha1.CoreCiliumEndpoint) *v2alpha1.CiliumEndpointSlice {
+	return &v2alpha1.CiliumEndpointSlice{
+		Namespace: namespace,
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+		Endpoints: endpoints,
+	}
+}
+
+func createEndpoint(name, namespace string, id int64) *types.CiliumEndpoint {
+	return &types.CiliumEndpoint{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Identity:   &v2.EndpointIdentity{ID: id},
+		Encryption: &v2.EncryptionSpec{},
+	}
+}
+
+// TestCESSubscriber_CEPTransfer tests a CEP being transferred between two
+// CESes. The order of events:
+// 1. CES add event for the new CES with latest CEP state
+// 2. CES add event for the old CES with old CEP state
+// 3. CES delete event for the old CES.
+func TestCESSubscriber_CEPTransferOnStartup(t *testing.T) {
+	cepNamespace := "ns1"
+	cepName := "cep1"
+	newCEPID := int64(3)
+	oldCEPID := int64(2)
+	fakeEPWatcher := createFakeEPWatcher()
+	fakeEndpointCache := &fakeEndpointCache{}
+	cesSub := &cesSubscriber{
+		epWatcher: fakeEPWatcher,
+		epCache:   fakeEndpointCache,
+		cepMap:    newCEPToCESMap(),
+	}
+	// Add for new CES
+	cesSub.OnAdd(
+		createCES("new-ces", cepNamespace, []v2alpha1.CoreCiliumEndpoint{
+			{
+				Name:       cepName,
+				IdentityID: newCEPID,
+			},
+		}))
+	diff, ok := fakeEPWatcher.assertUpdate(endpointUpdate{
+		newEp: createEndpoint("cep1", "ns1", newCEPID),
+	})
+	if !ok {
+		t.Fatal(diff)
+	}
+	// Add for old CES
+	cesSub.OnAdd(
+		createCES("old-ces", cepNamespace, []v2alpha1.CoreCiliumEndpoint{
+			{
+				Name:       cepName,
+				IdentityID: oldCEPID,
+			},
+		}))
+	diff, ok = fakeEPWatcher.assertUpdate(endpointUpdate{
+		oldEp: createEndpoint("cep1", "ns1", newCEPID),
+		newEp: createEndpoint("cep1", "ns1", oldCEPID),
+	})
+	if !ok {
+		t.Fatal(diff)
+	}
+	// Delete the old CES
+	cesSub.OnDelete(
+		createCES("old-ces", cepNamespace, []v2alpha1.CoreCiliumEndpoint{
+			{
+				Name:       cepName,
+				IdentityID: oldCEPID,
+			},
+		}))
+	diff, ok = fakeEPWatcher.assertUpdate(endpointUpdate{
+		oldEp: createEndpoint("cep1", "ns1", oldCEPID),
+		newEp: createEndpoint("cep1", "ns1", newCEPID),
+	})
+	if !ok {
+		t.Fatal(diff)
+	}
+	diff, ok = fakeEPWatcher.assertNoDelete()
+	if !ok {
+		t.Fatal(diff)
+	}
+	wantCEPMap := map[string]cesToCEPRef{
+		"ns1/cep1": {
+			"new-ces": createEndpoint("cep1", "ns1", 3),
+		},
+	}
+	if diff := cmp.Diff(wantCEPMap, cesSub.cepMap.cepMap); diff != "" {
+		t.Fatalf("Unexpected CEP map (-want +got):\n%s", diff)
+	}
+}
+
+// TestCESSubscriber_CEPTransferViaUpdate tests a CEP being transferred between
+// two CESes. The order of events:
+// 1. CES add event for the old CES with old CEP state
+// 2. CES update event for the old CES with deleting old CEP state
+// 3. CES update event for the new CES with latest CEP state
+func TestCESSubscriber_CEPTransferViaUpdate(t *testing.T) {
+	cepNamespace := "ns1"
+	cepName := "cep1"
+	newCEPID := int64(3)
+	oldCEPID := int64(2)
+	fakeEPWatcher := createFakeEPWatcher()
+	fakeEndpointCache := &fakeEndpointCache{}
+	cesSub := &cesSubscriber{
+		epWatcher: fakeEPWatcher,
+		epCache:   fakeEndpointCache,
+		cepMap:    newCEPToCESMap(),
+	}
+	// Add for old CES
+	cesSub.OnAdd(
+		createCES("old-ces", cepNamespace, []v2alpha1.CoreCiliumEndpoint{
+			{
+				Name:       cepName,
+				IdentityID: oldCEPID,
+			},
+		}))
+	diff, ok := fakeEPWatcher.assertUpdate(endpointUpdate{
+		newEp: createEndpoint("cep1", "ns1", oldCEPID),
+	})
+	if !ok {
+		t.Fatal(diff)
+	}
+	// Update for old CES removing CEP
+	cesSub.OnUpdate(
+		createCES("old-ces", cepNamespace, []v2alpha1.CoreCiliumEndpoint{
+			{
+				Name:       cepName,
+				IdentityID: oldCEPID,
+			},
+		}),
+		createCES("old-ces", cepNamespace, []v2alpha1.CoreCiliumEndpoint{}))
+
+	diff, ok = fakeEPWatcher.assertDelete(createEndpoint("cep1", "ns1", oldCEPID))
+	if !ok {
+		t.Fatal(diff)
+	}
+	// Update for new CES
+	cesSub.OnUpdate(
+		createCES("new-ces", cepNamespace, []v2alpha1.CoreCiliumEndpoint{}),
+		createCES("new-ces", cepNamespace, []v2alpha1.CoreCiliumEndpoint{
+			{
+				Name:       cepName,
+				IdentityID: newCEPID,
+			},
+		}))
+	diff, ok = fakeEPWatcher.assertUpdate(endpointUpdate{
+		newEp: createEndpoint("cep1", "ns1", newCEPID),
+	})
+	if !ok {
+		t.Fatal(diff)
+	}
+	wantCEPMap := map[string]cesToCEPRef{
+		"ns1/cep1": {
+			"new-ces": createEndpoint("cep1", "ns1", 3),
+		},
+	}
+	if diff := cmp.Diff(wantCEPMap, cesSub.cepMap.cepMap); diff != "" {
+		t.Fatalf("Unexpected CEP map (-want +got):\n%s", diff)
+	}
+}
+
+func TestCESSubscriber_deleteCEPfromCES(t *testing.T) {
+	for _, tc := range []struct {
+		desc           string
+		initCEPMap     map[string]cesToCEPRef
+		initCurrentCES map[string]string
+		deletedCesName string
+		deletedCep     *types.CiliumEndpoint
+		expectedUpdate endpointUpdate
+		expectedDelete *types.CiliumEndpoint
+	}{
+		{
+			desc: "delete CEP triggers deletion",
+			initCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"ces1": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			initCurrentCES: map[string]string{"ns1/cep1": "ces1"},
+			deletedCesName: "ces1",
+			deletedCep:     createEndpoint("cep1", "ns1", 3),
+			expectedDelete: createEndpoint("cep1", "ns1", 3),
+		},
+		{
+			desc: "delete CEP triggers update",
+			initCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"ces1": createEndpoint("cep1", "ns1", 2),
+					"ces2": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			initCurrentCES: map[string]string{"ns1/cep1": "ces1"},
+			deletedCesName: "ces1",
+			deletedCep:     createEndpoint("cep1", "ns1", 2),
+			expectedUpdate: endpointUpdate{
+				oldEp: createEndpoint("cep1", "ns1", 2),
+				newEp: createEndpoint("cep1", "ns1", 3),
+			},
+		},
+		{
+			desc: "delete CEP triggers no update or deletion",
+			initCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"ces1": createEndpoint("cep1", "ns1", 1),
+					"ces2": createEndpoint("cep1", "ns1", 2),
+				},
+			},
+			initCurrentCES: map[string]string{"ns1/cep1": "ces1"},
+			deletedCesName: "ces2",
+			deletedCep:     createEndpoint("cep1", "ns1", 2),
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			fakeEPWatcher := createFakeEPWatcher()
+			cesSub := &cesSubscriber{
+				epWatcher: fakeEPWatcher,
+				cepMap:    newCEPToCESMap(),
+			}
+			if tc.initCEPMap != nil {
+				cesSub.cepMap.cepMap = tc.initCEPMap
+			}
+			if tc.initCurrentCES != nil {
+				cesSub.cepMap.currentCES = tc.initCurrentCES
+			}
+			cepName := tc.deletedCep.Namespace + "/" + tc.deletedCep.Name
+			cesSub.deleteCEPfromCES(cepName, tc.deletedCesName, tc.deletedCep)
+			diff, ok := fakeEPWatcher.assertUpdate(tc.expectedUpdate)
+			if !ok {
+				t.Error(diff)
+			}
+			diff, ok = fakeEPWatcher.assertDelete(tc.expectedDelete)
+			if !ok {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func TestCEPToCESmap_insertCEP(t *testing.T) {
+	for _, tc := range []struct {
+		desc           string
+		initCEPMap     map[string]cesToCEPRef
+		initCurrentCES map[string]string
+		cesName        string
+		cep            *types.CiliumEndpoint
+		wantCEPMap     map[string]cesToCEPRef
+		wantCurrentCES map[string]string
+	}{
+		{
+			desc:    "add new cep",
+			cep:     createEndpoint("cep1", "ns1", 3),
+			cesName: "cesx",
+			wantCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			wantCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+		},
+		{
+			desc: "update cep object",
+			initCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			initCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+			cep:            createEndpoint("cep1", "ns1", 1),
+			cesName:        "cesx",
+			wantCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 1),
+				},
+			},
+			wantCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+		},
+		{
+			desc: "add new ces for existing cep",
+			initCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			initCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+			cep:            createEndpoint("cep1", "ns1", 1),
+			cesName:        "cesy",
+			wantCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+					"cesy": createEndpoint("cep1", "ns1", 1),
+				},
+			},
+			wantCurrentCES: map[string]string{"ns1/cep1": "cesy"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			cepToCESmap := newCEPToCESMap()
+			if tc.initCEPMap != nil {
+				cepToCESmap.cepMap = tc.initCEPMap
+			}
+			if tc.initCurrentCES != nil {
+				cepToCESmap.currentCES = tc.initCurrentCES
+			}
+			cepName := tc.cep.Namespace + "/" + tc.cep.Name
+			cepToCESmap.insertCEPLocked(cepName, tc.cesName, tc.cep)
+			if diff := cmp.Diff(tc.wantCEPMap, cepToCESmap.cepMap); diff != "" {
+				t.Fatalf("Unexpected CEP map entries (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantCurrentCES, cepToCESmap.currentCES); diff != "" {
+				t.Fatalf("Unexpected currentCES map entries (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCEPToCESmap_deleteCEP(t *testing.T) {
+	for _, tc := range []struct {
+		desc           string
+		initCEPMap     map[string]cesToCEPRef
+		initCurrentCES map[string]string
+		cesName        string
+		cepName        string
+		wantCEPMap     map[string]cesToCEPRef
+		wantCurrentCES map[string]string
+	}{
+		{
+			desc: "missing ces does not delete any entries",
+			initCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			initCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+			cepName:        "ns1/cep1",
+			cesName:        "cesy",
+			wantCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			wantCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+		},
+		{
+			desc: "missing cep does not delete any entries",
+			initCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			initCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+			cepName:        "ns1/cep2",
+			cesName:        "cesx",
+			wantCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			wantCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+		},
+		{
+			desc: "last ces entry",
+			initCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+				},
+			},
+			initCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+			cepName:        "ns1/cep1",
+			cesName:        "cesx",
+			wantCEPMap:     map[string]cesToCEPRef{},
+			wantCurrentCES: map[string]string{},
+		},
+		{
+			desc: "multiple ces entries",
+			initCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesx": createEndpoint("cep1", "ns1", 3),
+					"cesy": createEndpoint("cep1", "ns1", 2),
+				},
+			},
+			initCurrentCES: map[string]string{"ns1/cep1": "cesx"},
+			cepName:        "ns1/cep1",
+			cesName:        "cesx",
+			wantCEPMap: map[string]cesToCEPRef{
+				"ns1/cep1": {
+					"cesy": createEndpoint("cep1", "ns1", 2),
+				},
+			},
+			wantCurrentCES: map[string]string{"ns1/cep1": "cesy"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			cepToCESmap := newCEPToCESMap()
+			if tc.initCEPMap != nil {
+				cepToCESmap.cepMap = tc.initCEPMap
+			}
+			if tc.initCurrentCES != nil {
+				cepToCESmap.currentCES = tc.initCurrentCES
+			}
+			cepToCESmap.deleteCEPLocked(tc.cepName, tc.cesName)
+			if diff := cmp.Diff(tc.wantCEPMap, cepToCESmap.cepMap); diff != "" {
+				t.Fatalf("Unexpected CEP map entries (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantCurrentCES, cepToCESmap.currentCES); diff != "" {
+				t.Fatalf("Unexpected currentCES map entries (-want +got):\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- [x] #24838 -- agent: Handle correctly state when CEP is present in multiple CESs (@alan-kut)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 24838; do contrib/backporting/set-labels.py $pr done 1.12; done
```