### PR TITLE
datapath: Fix double SNAT

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -114,6 +114,10 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 	      snat_v6_nat(ctx, &target, ext_err) : CTX_ACT_OK;
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
+
+	/* See the equivalent v4 path for comment */
+	ctx_snat_done_set(ctx);
+
 	return ret;
 }
 
@@ -1375,6 +1379,12 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 		ret = snat_v4_nat(ctx, &target, ext_err);
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
+
+	/* If multiple netdevs process an outgoing packet, then this packets will
+	 * be handled multiple times by the "to-netdev" section. This can lead
+	 * to multiple SNATs. To prevent from that, set the SNAT done flag.
+	 */
+	ctx_snat_done_set(ctx);
 
 	return ret;
 }


### PR DESCRIPTION
We have observed, that the same packet can be handled multiple times by
the bpf_host's to-netdev. This can happen when the to-netdev is attached
to a bridge and to an outgoing netdev which is attached to the bridge.
This can result e.g., into multiple unnecessary SNATs for the same
packet which can break the host-firewall (the host-firewall for a reply
to such a packet is invoked after only the first rev-SNAT).

To fix that particular case set the SNAT done flag (an SKB mark).

Tested manually. On kind-worker node (172.18.0.3):

    ip link add br0 type bridge
    ip addr add 172.18.0.3/16 dev br0
    ip addr del 172.18.0.3/16 dev eth0
    ip link set dev br0 up
    ip link set dev eth0 master br0
    ip route replace 0.0.0.0/0 via 172.18.0.1

Make sure that Cilium attached to both:

    cilium status | grep KubeProxy
    KubeProxyReplacement:    Strict [br0 172.18.0.3, eth0 172.18.0.3]

Then start any pod on kind-worker, and run tcpdump on kind-work. curl
1.1.1.1 from that pod.

    tcpdump -i any -n 'dst port 80'
    lxc2663158aafe1 In  IP 10.244.1.161.43710 > 1.1.1.1.80: Flags [S]
    br0   Out IP 172.18.0.3.43710 > 1.1.1.1.80: Flags [S]
    eth0  Out IP 172.18.0.3.43710 > 1.1.1.1.80: Flags [S]

Redo the same test w/o the fix. The relevant tcpdump output:

    tcpdump -i any -n 'dst host 1.1.1.1'
    lxcbce3c2f349e1 In  IP 10.244.1.120.57408 > 1.1.1.1.80: Flags [S]
    br0   Out IP 172.18.0.3.57408 > 1.1.1.1.80: Flags [S]
    eth0  Out IP 172.18.0.3.56763 > 1.1.1.1.80: Flags [S] <-- 2nd SNAT!

Suggested-by: Julian Wiedmann <jwi@isovalent.com>


Fix #24916