### PR TITLE
workflows: e2e: bump Cilium CLI to v0.14.2

### DIFF
--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -65,7 +65,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.13.2
+  cilium_cli_version: v0.14.2
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -335,10 +335,64 @@ jobs:
             ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
             ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
 
+            # install static routes
+            EXTERNAL_FROM_CIDRS=(\$(kubectl get nodes -o jsonpath='{range .items[*]}{.spec.podCIDR}{"\n"}{end}'))
+            EXTERNAL_NODE_IPS=() # Nodes IPs are collected to be passed to the Cilium CLI later on.
+            NODES_WITHOUT_CILIUM=kind-worker3 # To add more elements, keep it comma-separated.
+
+            # Loop over each pod CIDR from all nodes.
+            for i in "\${!EXTERNAL_FROM_CIDRS[@]}"; do
+              EXTERNAL_FROM_CIDR=\${EXTERNAL_FROM_CIDRS[i]}
+
+              if [[ \$EXTERNAL_FROM_CIDR =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]; then
+                IP_FAMILY="v4"
+              elif [[ \$EXTERNAL_FROM_CIDR =~ ^[0-9a-fA-F:]+/[0-9]+$ ]]; then
+                IP_FAMILY="v6"
+              else
+                echo "ERROR: Malformed pod CIDR '\${EXTERNAL_FROM_CIDR}'" >&2
+                exit 1
+              fi
+
+              IFS=',' read -ra NODES_WITHOUT <<< "\$NODES_WITHOUT_CILIUM" # Split by comma into an array
+              for WITHOUT in "\${NODES_WITHOUT[@]}"; do
+                # Fetch node with a specific pod CIDR.
+                node=\$(kubectl get nodes -o jsonpath="{range .items[?(@.spec.podCIDR == '\$EXTERNAL_FROM_CIDR')]}{@.metadata.name}{end}")
+                if [[ -z "\$node" ]]; then
+                  echo "ERROR: Could not find node with .spec.podCIDR matching \${EXTERNAL_FROM_CIDR}" >&2
+                  exit 1
+                fi
+                for NODE_IP in \$(kubectl get node "\$node" -o jsonpath="{.status.addresses[?(@.type == 'InternalIP')].address}"); do
+                  # Skip if the node IP's family mismatches with pod CIDR's
+                  # family. Cannot create a route with the gateway IP family
+                  # mismatching the subnet.
+                  if [[ "\$IP_FAMILY" == "v4" && ! "\$NODE_IP" =~ \. ]]; then
+                    continue
+                  elif [[ "\$IP_FAMILY" == "v6" && ! "\$NODE_IP" =~ \: ]]; then
+                    continue
+                  fi
+                  # Install static route on the host, towards the pod CIDR via the node IP.
+                  docker exec "\$WITHOUT" ip route replace "\${EXTERNAL_FROM_CIDR}" via "\${NODE_IP}"
+                  EXTERNAL_NODE_IPS+=("\${NODE_IP}")
+                done
+              done
+            done
+
+            # Join the elements with a comma delimiter, or leave them unmodified
+            # if there's only one element so that it can be passed properly to
+            # the CLI.
+            if [[ \${#EXTERNAL_NODE_IPS[@]} -eq 1 ]]; then
+              EXTERNAL_NODE_IPS_PARAM="\${EXTERNAL_NODE_IPS[0]}"
+            else
+              EXTERNAL_NODE_IPS_PARAM=\$(IFS=','; echo "\${EXTERNAL_NODE_IPS[*]}")
+            fi
+            EXTERNAL_NODE_IPS_PARAM=\${EXTERNAL_NODE_IPS_PARAM}
+
             ./cilium-cli status --wait
             ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
+              --external-from-cidrs="\${EXTERNAL_NODE_IPS_PARAM}" \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./cilium-cli connectivity test --collect-sysdump-on-failure \
+              --external-from-cidrs="\${EXTERNAL_NODE_IPS_PARAM}" \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             kind delete cluster
 

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -65,7 +65,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.13.2
+  cilium_cli_version: v0.14.2
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -438,9 +438,63 @@ jobs:
             ./cilium-cli status --wait
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
+            # install static routes
+            EXTERNAL_FROM_CIDRS=(\$(kubectl get nodes -o jsonpath='{range .items[*]}{.spec.podCIDR}{"\n"}{end}'))
+            EXTERNAL_NODE_IPS=() # Nodes IPs are collected to be passed to the Cilium CLI later on.
+            NODES_WITHOUT_CILIUM=kind-worker3 # To add more elements, keep it comma-separated.
+
+            # Loop over each pod CIDR from all nodes.
+            for i in "\${!EXTERNAL_FROM_CIDRS[@]}"; do
+              EXTERNAL_FROM_CIDR=\${EXTERNAL_FROM_CIDRS[i]}
+
+              if [[ \$EXTERNAL_FROM_CIDR =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]; then
+                IP_FAMILY="v4"
+              elif [[ \$EXTERNAL_FROM_CIDR =~ ^[0-9a-fA-F:]+/[0-9]+$ ]]; then
+                IP_FAMILY="v6"
+              else
+                echo "ERROR: Malformed pod CIDR '\${EXTERNAL_FROM_CIDR}'" >&2
+                exit 1
+              fi
+
+              IFS=',' read -ra NODES_WITHOUT <<< "\$NODES_WITHOUT_CILIUM" # Split by comma into an array
+              for WITHOUT in "\${NODES_WITHOUT[@]}"; do
+                # Fetch node with a specific pod CIDR.
+                node=\$(kubectl get nodes -o jsonpath="{range .items[?(@.spec.podCIDR == '\$EXTERNAL_FROM_CIDR')]}{@.metadata.name}{end}")
+                if [[ -z "\$node" ]]; then
+                  echo "ERROR: Could not find node with .spec.podCIDR matching \${EXTERNAL_FROM_CIDR}" >&2
+                  exit 1
+                fi
+                for NODE_IP in \$(kubectl get node "\$node" -o jsonpath="{.status.addresses[?(@.type == 'InternalIP')].address}"); do
+                  # Skip if the node IP's family mismatches with pod CIDR's
+                  # family. Cannot create a route with the gateway IP family
+                  # mismatching the subnet.
+                  if [[ "\$IP_FAMILY" == "v4" && ! "\$NODE_IP" =~ \. ]]; then
+                    continue
+                  elif [[ "\$IP_FAMILY" == "v6" && ! "\$NODE_IP" =~ \: ]]; then
+                    continue
+                  fi
+                  # Install static route on the host, towards the pod CIDR via the node IP.
+                  docker exec "\$WITHOUT" ip route replace "\${EXTERNAL_FROM_CIDR}" via "\${NODE_IP}"
+                  EXTERNAL_NODE_IPS+=("\${NODE_IP}")
+                done
+              done
+            done
+
+            # Join the elements with a comma delimiter, or leave them unmodified
+            # if there's only one element so that it can be passed properly to
+            # the CLI.
+            if [[ \${#EXTERNAL_NODE_IPS[@]} -eq 1 ]]; then
+              EXTERNAL_NODE_IPS_PARAM="\${EXTERNAL_NODE_IPS[0]}"
+            else
+              EXTERNAL_NODE_IPS_PARAM=\$(IFS=','; echo "\${EXTERNAL_NODE_IPS[*]}")
+            fi
+            EXTERNAL_NODE_IPS_PARAM=\${EXTERNAL_NODE_IPS_PARAM}
+
             ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
+              --external-from-cidrs="\${EXTERNAL_NODE_IPS_PARAM}" \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./cilium-cli connectivity test --collect-sysdump-on-failure \
+              --external-from-cidrs="\${EXTERNAL_NODE_IPS_PARAM}" \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./contrib/scripts/kind-down.sh
 


### PR DESCRIPTION
which includes a new basic egress gateway test.

Bumping required also some extra logic to install static routes for
external CIDRs and figure out the correct external node IPs value to
pass to the --external-from-cidrs connectivity test parameters