### PR TITLE
bpf: dynamic-width static data inlining

### DIFF
--- a/bpf/include/bpf/compiler.h
+++ b/bpf/include/bpf/compiler.h
@@ -54,7 +54,7 @@
 #endif
 
 #ifndef __fetch
-# define __fetch(X)		(__u32)(__u64)(&(X))
+# define __fetch(X)		(__u64)(&(X))
 #endif
 
 #ifndef __aligned

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -232,13 +232,11 @@ __revalidate_data_pull(struct __ctx_buff *ctx, void **data, void **data_end,
 
 /* Macros for working with L3 cilium defined IPV6 addresses */
 #define BPF_V6(dst, ...)	BPF_V6_1(dst, fetch_ipv6(__VA_ARGS__))
-#define BPF_V6_1(dst, ...)	BPF_V6_4(dst, __VA_ARGS__)
-#define BPF_V6_4(dst, a1, a2, a3, a4)		\
+#define BPF_V6_1(dst, ...)	BPF_V6_2(dst, __VA_ARGS__)
+#define BPF_V6_2(dst, a1, a2)		\
 	({					\
-		dst.p1 = a1;			\
-		dst.p2 = a2;			\
-		dst.p3 = a3;			\
-		dst.p4 = a4;			\
+		dst.d1 = a1;			\
+		dst.d2 = a2;			\
 	})
 
 #define ENDPOINT_KEY_IPV4 1

--- a/bpf/lib/endian.h
+++ b/bpf/lib/endian.h
@@ -7,34 +7,75 @@
 #include <bpf/ctx/ctx.h>
 #include <bpf/api.h>
 
-#if defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
-	__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-# define __bpf_ntohs(x)		__builtin_bswap16(x)
-# define __bpf_htons(x)		__builtin_bswap16(x)
-# define __bpf_ntohl(x)		__builtin_bswap32(x)
-# define __bpf_htonl(x)		__builtin_bswap32(x)
-#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
-	__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-# define __bpf_ntohs(x)		(x)
-# define __bpf_htons(x)		(x)
-# define __bpf_ntohl(x)		(x)
-# define __bpf_htonl(x)		(x)
+#define ___bpf_mvb(x, b, n, m) ((__u##b)(x) << (b-(n+1)*8) >> (b-8) << (m*8))
+
+#define ___bpf_swab16(x) ((__u16)(			\
+			  ___bpf_mvb(x, 16, 0, 1) |	\
+			  ___bpf_mvb(x, 16, 1, 0)))
+
+#define ___bpf_swab32(x) ((__u32)(			\
+			  ___bpf_mvb(x, 32, 0, 3) |	\
+			  ___bpf_mvb(x, 32, 1, 2) |	\
+			  ___bpf_mvb(x, 32, 2, 1) |	\
+			  ___bpf_mvb(x, 32, 3, 0)))
+
+#define ___bpf_swab64(x) ((__u64)(			\
+			  ___bpf_mvb(x, 64, 0, 7) |	\
+			  ___bpf_mvb(x, 64, 1, 6) |	\
+			  ___bpf_mvb(x, 64, 2, 5) |	\
+			  ___bpf_mvb(x, 64, 3, 4) |	\
+			  ___bpf_mvb(x, 64, 4, 3) |	\
+			  ___bpf_mvb(x, 64, 5, 2) |	\
+			  ___bpf_mvb(x, 64, 6, 1) |	\
+			  ___bpf_mvb(x, 64, 7, 0)))
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+# define __bpf_ntohs(x)			__builtin_bswap16(x)
+# define __bpf_htons(x)			__builtin_bswap16(x)
+# define __bpf_constant_ntohs(x)	___bpf_swab16(x)
+# define __bpf_constant_htons(x)	___bpf_swab16(x)
+# define __bpf_ntohl(x)			__builtin_bswap32(x)
+# define __bpf_htonl(x)			__builtin_bswap32(x)
+# define __bpf_constant_ntohl(x)	___bpf_swab32(x)
+# define __bpf_constant_htonl(x)	___bpf_swab32(x)
+# define __bpf_be64_to_cpu(x)		__builtin_bswap64(x)
+# define __bpf_cpu_to_be64(x)		__builtin_bswap64(x)
+# define __bpf_constant_be64_to_cpu(x)	___bpf_swab64(x)
+# define __bpf_constant_cpu_to_be64(x)	___bpf_swab64(x)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+# define __bpf_ntohs(x)			(x)
+# define __bpf_htons(x)			(x)
+# define __bpf_constant_ntohs(x)	(x)
+# define __bpf_constant_htons(x)	(x)
+# define __bpf_ntohl(x)			(x)
+# define __bpf_htonl(x)			(x)
+# define __bpf_constant_ntohl(x)	(x)
+# define __bpf_constant_htonl(x)	(x)
+# define __bpf_be64_to_cpu(x)		(x)
+# define __bpf_cpu_to_be64(x)		(x)
+# define __bpf_constant_be64_to_cpu(x)  (x)
+# define __bpf_constant_cpu_to_be64(x)  (x)
 #else
-# error "Endianness detection needs to be set up for your compiler?!"
+# error "Fix your compiler's __BYTE_ORDER__?!"
 #endif
 
 #define bpf_htons(x)				\
 	(__builtin_constant_p(x) ?		\
-	 __constant_htons(x) : __bpf_htons(x))
+	 __bpf_constant_htons(x) : __bpf_htons(x))
 #define bpf_ntohs(x)				\
 	(__builtin_constant_p(x) ?		\
-	 __constant_ntohs(x) : __bpf_ntohs(x))
-
+	 __bpf_constant_ntohs(x) : __bpf_ntohs(x))
 #define bpf_htonl(x)				\
 	(__builtin_constant_p(x) ?		\
-	 __constant_htonl(x) : __bpf_htonl(x))
+	 __bpf_constant_htonl(x) : __bpf_htonl(x))
 #define bpf_ntohl(x)				\
 	(__builtin_constant_p(x) ?		\
-	 __constant_ntohl(x) : __bpf_ntohl(x))
+	 __bpf_constant_ntohl(x) : __bpf_ntohl(x))
+#define bpf_cpu_to_be64(x)			\
+	(__builtin_constant_p(x) ?		\
+	 __bpf_constant_cpu_to_be64(x) : __bpf_cpu_to_be64(x))
+#define bpf_be64_to_cpu(x)			\
+	(__builtin_constant_p(x) ?		\
+	 __bpf_constant_be64_to_cpu(x) : __bpf_be64_to_cpu(x))
 
 #endif /* __LIB_ENDIAN_H_ */

--- a/bpf/lib/static_data.h
+++ b/bpf/lib/static_data.h
@@ -11,21 +11,27 @@
 
 /* fetch_* macros assist in fetching variously sized static data */
 #define fetch_u16(x) (__u16)__fetch(x)
-#define fetch_u32(x) __fetch(x)
-#define fetch_u32_i(x, i) __fetch(x ## _ ## i)
-#define fetch_ipv6(x) fetch_u32_i(x, 1), fetch_u32_i(x, 2), fetch_u32_i(x, 3), fetch_u32_i(x, 4)
+#define fetch_u32(x) (__u32)__fetch(x)
+#define fetch_u32_i(x, i) fetch_u32(x ## _ ## i)
+#define fetch_u64(x) __fetch(x)
+#define fetch_u64_i(x, i) fetch_u64(x ## _ ## i)
+#define fetch_ipv6(x) fetch_u64_i(x, 1), fetch_u64_i(x, 2)
 #define fetch_mac(x) { { fetch_u32_i(x, 1), (__u16)fetch_u32_i(x, 2) } }
 
 /* DEFINE_* macros help to declare static data. */
 #define DEFINE_U16(NAME, value) volatile __u16 NAME = value
 #define DEFINE_U32(NAME, value) volatile __u32 NAME = value
 #define DEFINE_U32_I(NAME, i) volatile __u32 NAME ## _ ## i
-#define DEFINE_IPV6(NAME,									\
-		    a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16)	\
-DEFINE_U32_I(NAME, 1) = bpf_htonl( (a1) << 24 |  (a2) << 16 |  (a3) << 8 |  (a4));		\
-DEFINE_U32_I(NAME, 2) = bpf_htonl( (a5) << 24 |  (a6) << 16 |  (a7) << 8 |  (a8));		\
-DEFINE_U32_I(NAME, 3) = bpf_htonl( (a9) << 24 | (a10) << 16 | (a11) << 8 | (a12));		\
-DEFINE_U32_I(NAME, 4) = bpf_htonl((a13) << 24 | (a14) << 16 | (a15) << 8 | (a16))
+#define DEFINE_U64(NAME, value) volatile __u64 NAME = value
+#define DEFINE_U64_I(NAME, i) volatile __u64 NAME ## _ ## i
+
+#define DEFINE_IPV6(NAME, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) \
+DEFINE_U64_I(NAME, 1) = bpf_cpu_to_be64( \
+			(__u64)(a1) << 56 | (__u64)(a2) << 48 | (__u64)(a3) << 40 | \
+			(__u64)(a4) << 32 | (a5) << 24 | (a6) << 16 | (a7) << 8 | (a8)); \
+DEFINE_U64_I(NAME, 2) = bpf_cpu_to_be64( \
+			(__u64)(a9) << 56 | (__u64)(a10) << 48 | (__u64)(a11) << 40 | \
+			(__u64)(a12) << 32 | (a13) << 24 | (a14) << 16 | (a15) << 8 | (a16));
 
 #define DEFINE_MAC(NAME, a1, a2, a3, a4, a5, a6)			\
 DEFINE_U32_I(NAME, 1) = (a1) << 24 | (a2) << 16 |  (a3) << 8 | (a4);	\

--- a/bpf/tests/config_replacement.h
+++ b/bpf/tests/config_replacement.h
@@ -10,11 +10,13 @@
 #define ___EP_CONFIG____
 
 #ifndef LXC_IP
-#define LXC_IP_1 bpf_htonl((0xbe) << 24 | (0xef) << 16 | (0) << 8 | (0))
-#define LXC_IP_2 bpf_htonl((0) << 24 | (0) << 16 | (0) << 8 | (0x01))
-#define LXC_IP_3 bpf_htonl((0) << 24 | (0) << 16 | (0) << 8 | (0x01))
-#define LXC_IP_4 bpf_htonl((0x01) << 24 | (0x65) << 16 | (0x82) << 8 | (0xbc))
-#define LXC_IP { { LXC_IP_1, LXC_IP_2, LXC_IP_3, LXC_IP_4 } }
+#define LXC_IP_1 bpf_cpu_to_be64( \
+		(__u64)(0xbe) << 56 | (__u64)(0xef) << 48 | (__u64)(0) << 40 | (__u64)(0) << 32 | \
+		(0) << 24 | (0) << 16 | (0) << 8 | (0x01))
+#define LXC_IP_2 bpf_cpu_to_be64( \
+		(__u64)(0) << 56 | (__u64)(0) << 48 | (__u64)(0) << 40 | (__u64)(0x01) << 32 | \
+		(0x01) << 24 | (0x65) << 16 | (0x82) << 8 | (0xbc))
+#define LXC_IP { { LXC_IP_1, LXC_IP_2 } }
 #endif /* LXC_IP */
 
 #ifndef LXC_IPV4

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/btf"
 )
 
 const globalDataMap = ".data"
@@ -229,19 +230,15 @@ func classifyProgramTypes(spec *ebpf.CollectionSpec) error {
 // loader. This is done for compatibility with kernels that don't support
 // global data maps yet.
 //
-// Currently, all map reads are expected to be 32 bits wide until BTF MapKV
-// can be fully accessed by the caller, which would allow for querying value
-// widths.
-//
 // This works in conjunction with the __fetch macros in the datapath, which
 // emit direct array accesses instead of memory loads with an offset from the
 // map's pointer.
 func inlineGlobalData(spec *ebpf.CollectionSpec) error {
-	data, err := globalData(spec)
+	vars, err := globalData(spec)
 	if err != nil {
 		return err
 	}
-	if data == nil {
+	if vars == nil {
 		// No static data, nothing to replace.
 		return nil
 	}
@@ -270,11 +267,14 @@ func inlineGlobalData(spec *ebpf.CollectionSpec) error {
 			// Equivalent to Instruction.mapOffset().
 			off := uint32(uint64(ins.Constant) >> 32)
 
-			if off%4 != 0 {
-				return fmt.Errorf("global const access at offset %d not 32-bit aligned", off)
+			// Look up the value of the variable stored at the Datasec offset pointed
+			// at by the instruction.
+			value, ok := vars[off]
+			if !ok {
+				return fmt.Errorf("no global constant found in %s at offset %d", globalDataMap, off)
 			}
 
-			imm := spec.ByteOrder.Uint32(data[off : off+4])
+			imm := spec.ByteOrder.Uint64(value)
 
 			// Replace the map load with an immediate load. Must be a dword load
 			// to match the instruction width of a map load.
@@ -292,22 +292,50 @@ func inlineGlobalData(spec *ebpf.CollectionSpec) error {
 	return nil
 }
 
+type varOffsets map[uint32][]byte
+
 // globalData gets the contents of the first entry in the global data map
 // and removes it from the spec to prevent it from being created in the kernel.
-func globalData(spec *ebpf.CollectionSpec) ([]byte, error) {
-	data := spec.Maps[globalDataMap]
-	if data == nil {
+func globalData(spec *ebpf.CollectionSpec) (varOffsets, error) {
+	dm := spec.Maps[globalDataMap]
+	if dm == nil {
 		return nil, nil
 	}
 
-	if dl := len(data.Contents); dl != 1 {
+	if dl := len(dm.Contents); dl != 1 {
 		return nil, fmt.Errorf("expected one key in %s, found %d", globalDataMap, dl)
 	}
 
-	out, ok := (data.Contents[0].Value).([]byte)
+	ds, ok := dm.Value.(*btf.Datasec)
+	if !ok {
+		return nil, fmt.Errorf("no BTF datasec found for %s", globalDataMap)
+	}
+
+	data, ok := (dm.Contents[0].Value).([]byte)
 	if !ok {
 		return nil, fmt.Errorf("expected %s value to be a byte slice, got: %T",
-			globalDataMap, data.Contents[0].Value)
+			globalDataMap, dm.Contents[0].Value)
+	}
+
+	// Slice up the binary contents of the global data map according to the
+	// variables described in its Datasec.
+	out := make(varOffsets)
+	for _, vsi := range ds.Vars {
+		if vsi.Size > 8 {
+			return nil, fmt.Errorf("variables larger than 8 bytes are not supported (got %d)", vsi.Size)
+		}
+
+		if _, ok := out[vsi.Offset]; ok {
+			return nil, fmt.Errorf("duplicate VarSecInfo for offset %d", vsi.Offset)
+		}
+
+		// Allocate a fixed slice of 8 bytes so it can be used to store in an imm64
+		// instruction later using ByteOrder.Uint64().
+		v := make([]byte, 8)
+		copy(v, data[vsi.Offset:vsi.Offset+vsi.Size])
+
+		// Emit the variable's value by its offset in the datasec.
+		out[vsi.Offset] = v
 	}
 
 	// Remove the map definition to skip loading it into the kernel.

--- a/pkg/byteorder/byteorder_bigendian.go
+++ b/pkg/byteorder/byteorder_bigendian.go
@@ -11,5 +11,7 @@ var Native binary.ByteOrder = binary.BigEndian
 
 func HostToNetwork16(u uint16) uint16 { return u }
 func HostToNetwork32(u uint32) uint32 { return u }
+func HostToNetwork64(u uint64) uint64 { return u }
 func NetworkToHost16(u uint16) uint16 { return u }
 func NetworkToHost32(u uint32) uint32 { return u }
+func NetworkToHost64(u uint64) uint64 { return u }

--- a/pkg/byteorder/byteorder_littleendian.go
+++ b/pkg/byteorder/byteorder_littleendian.go
@@ -14,5 +14,7 @@ var Native binary.ByteOrder = binary.LittleEndian
 
 func HostToNetwork16(u uint16) uint16 { return bits.ReverseBytes16(u) }
 func HostToNetwork32(u uint32) uint32 { return bits.ReverseBytes32(u) }
+func HostToNetwork64(u uint64) uint64 { return bits.ReverseBytes64(u) }
 func NetworkToHost16(u uint16) uint16 { return bits.ReverseBytes16(u) }
 func NetworkToHost32(u uint32) uint32 { return bits.ReverseBytes32(u) }
+func NetworkToHost64(u uint64) uint64 { return bits.ReverseBytes64(u) }

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -128,7 +128,7 @@ func (s *ConfigSuite) TestWriteEndpointConfig(c *C) {
 		return buf.Bytes(), varSub, stringSub
 	}
 
-	lxcIPs := []string{"LXC_IP_1", "LXC_IP_2", "LXC_IP_3", "LXC_IP_4"}
+	lxcIPs := []string{"LXC_IP_1", "LXC_IP_2"}
 
 	tests := []struct {
 		description string
@@ -211,9 +211,9 @@ func (s *ConfigSuite) TestWriteStaticData(c *C) {
 	cfg.writeStaticData(&buf, ep)
 	b := buf.Bytes()
 	for k := range varSub {
-		for _, suffix := range []string{"_1", "_2", "_3", "_4"} {
+		for _, suffix := range []string{"_1", "_2"} {
 			// Variables with these suffixes are implemented via
-			// multiple 32-bit values. The header define doesn't
+			// multiple 64-bit values. The header define doesn't
 			// include these numbers though, so strip them.
 			if strings.HasSuffix(k, suffix) {
 				k = strings.TrimSuffix(k, suffix)

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -118,7 +118,7 @@ func (s *ConfigSuite) TestWriteEndpointConfig(c *C) {
 		option.Config.EnableIPv6 = oldEnableIPv6
 	}()
 
-	testRun := func(t *testutils.TestEndpoint) ([]byte, map[string]uint32, map[string]string) {
+	testRun := func(t *testutils.TestEndpoint) ([]byte, map[string]uint64, map[string]string) {
 		cfg := &HeaderfileWriter{}
 		varSub, stringSub := loader.ELFSubstitutions(t)
 
@@ -232,7 +232,7 @@ func (s *ConfigSuite) TestWriteStaticData(c *C) {
 	}
 }
 
-func assertKeysInsideMap(c *C, m map[string]uint32, keys []string, want bool) {
+func assertKeysInsideMap(c *C, m map[string]uint64, keys []string, want bool) {
 	for _, v := range keys {
 		_, ok := m[v]
 		c.Assert(ok, Equals, want)

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -151,10 +151,10 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 	if mac == nil {
 		// L2-less device
 		mac = make([]byte, 6)
-		opts["ETH_HLEN"] = uint32(0)
+		opts["ETH_HLEN"] = uint64(0)
 	}
-	opts["NODE_MAC_1"] = sliceToBe32(mac[0:4])
-	opts["NODE_MAC_2"] = uint32(sliceToBe16(mac[4:6]))
+	opts["NODE_MAC_1"] = uint64(sliceToBe32(mac[0:4]))
+	opts["NODE_MAC_2"] = uint64(sliceToBe16(mac[4:6]))
 
 	ifIndex, err := link.GetIfIndex(ifName)
 	if err != nil {
@@ -162,18 +162,18 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 	}
 
 	if !option.Config.EnableHostLegacyRouting {
-		opts["SECCTX_FROM_IPCACHE"] = uint32(SecctxFromIpcacheEnabled)
+		opts["SECCTX_FROM_IPCACHE"] = uint64(SecctxFromIpcacheEnabled)
 	} else {
-		opts["SECCTX_FROM_IPCACHE"] = uint32(SecctxFromIpcacheDisabled)
+		opts["SECCTX_FROM_IPCACHE"] = uint64(SecctxFromIpcacheDisabled)
 	}
 
 	if option.Config.EnableNodePort {
-		opts["NATIVE_DEV_IFINDEX"] = ifIndex
+		opts["NATIVE_DEV_IFINDEX"] = uint64(ifIndex)
 	}
 	if option.Config.EnableIPv4Masquerade && option.Config.EnableBPFMasquerade && bpfMasqIPv4Addrs != nil {
 		if option.Config.EnableIPv4 {
 			ipv4 := bpfMasqIPv4Addrs[ifName]
-			opts["IPV4_MASQUERADE"] = byteorder.NetIPv4ToHost32(ipv4)
+			opts["IPV4_MASQUERADE"] = uint64(byteorder.NetIPv4ToHost32(ipv4))
 		}
 	}
 

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -208,6 +208,24 @@ func sliceToBe32(input []byte) uint32 {
 	return byteorder.HostToNetwork32(sliceToU32(input))
 }
 
+// sliceToU64 converts the input slice of eight bytes to a uint64.
+func sliceToU64(input []byte) uint64 {
+	result := uint64(input[0]) << 56
+	result |= uint64(input[1]) << 48
+	result |= uint64(input[2]) << 40
+	result |= uint64(input[3]) << 32
+	result |= uint64(input[4]) << 24
+	result |= uint64(input[5]) << 16
+	result |= uint64(input[6]) << 8
+	result |= uint64(input[7])
+	return result
+}
+
+// sliceToBe64 converts the input slice of eight bytes to a big-endian uint64.
+func sliceToBe64(input []byte) uint64 {
+	return byteorder.HostToNetwork64(sliceToU64(input))
+}
+
 // elfVariableSubstitutions returns the set of data substitutions that must
 // occur in an ELF template object file to update static data for the specified
 // endpoint.
@@ -216,10 +234,8 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint64 {
 
 	if ipv6 := ep.IPv6Address().AsSlice(); ipv6 != nil {
 		// Corresponds to DEFINE_IPV6() in bpf/lib/utils.h
-		result["LXC_IP_1"] = uint64(sliceToBe32(ipv6[0:4]))
-		result["LXC_IP_2"] = uint64(sliceToBe32(ipv6[4:8]))
-		result["LXC_IP_3"] = uint64(sliceToBe32(ipv6[8:12]))
-		result["LXC_IP_4"] = uint64(sliceToBe32(ipv6[12:16]))
+		result["LXC_IP_1"] = sliceToBe64(ipv6[0:8])
+		result["LXC_IP_2"] = sliceToBe64(ipv6[8:16])
 	}
 	if ipv4 := ep.IPv4Address().AsSlice(); ipv4 != nil {
 		result["LXC_IPV4"] = uint64(byteorder.NetIPv4ToHost32(net.IP(ipv4)))

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -211,23 +211,23 @@ func sliceToBe32(input []byte) uint32 {
 // elfVariableSubstitutions returns the set of data substitutions that must
 // occur in an ELF template object file to update static data for the specified
 // endpoint.
-func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
-	result := make(map[string]uint32)
+func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint64 {
+	result := make(map[string]uint64)
 
 	if ipv6 := ep.IPv6Address().AsSlice(); ipv6 != nil {
 		// Corresponds to DEFINE_IPV6() in bpf/lib/utils.h
-		result["LXC_IP_1"] = sliceToBe32(ipv6[0:4])
-		result["LXC_IP_2"] = sliceToBe32(ipv6[4:8])
-		result["LXC_IP_3"] = sliceToBe32(ipv6[8:12])
-		result["LXC_IP_4"] = sliceToBe32(ipv6[12:16])
+		result["LXC_IP_1"] = uint64(sliceToBe32(ipv6[0:4]))
+		result["LXC_IP_2"] = uint64(sliceToBe32(ipv6[4:8]))
+		result["LXC_IP_3"] = uint64(sliceToBe32(ipv6[8:12]))
+		result["LXC_IP_4"] = uint64(sliceToBe32(ipv6[12:16]))
 	}
 	if ipv4 := ep.IPv4Address().AsSlice(); ipv4 != nil {
-		result["LXC_IPV4"] = byteorder.NetIPv4ToHost32(net.IP(ipv4))
+		result["LXC_IPV4"] = uint64(byteorder.NetIPv4ToHost32(net.IP(ipv4)))
 	}
 
 	mac := ep.GetNodeMAC()
-	result["NODE_MAC_1"] = sliceToBe32(mac[0:4])
-	result["NODE_MAC_2"] = uint32(sliceToBe16(mac[4:6]))
+	result["NODE_MAC_1"] = uint64(sliceToBe32(mac[0:4]))
+	result["NODE_MAC_2"] = uint64(sliceToBe16(mac[4:6]))
 
 	if ep.IsHost() {
 		if option.Config.EnableNodePort {
@@ -238,15 +238,15 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 				result["IPV4_MASQUERADE"] = 0
 			}
 		}
-		result["SECCTX_FROM_IPCACHE"] = uint32(SecctxFromIpcacheDisabled)
+		result["SECCTX_FROM_IPCACHE"] = uint64(SecctxFromIpcacheDisabled)
 	} else {
-		result["LXC_ID"] = uint32(ep.GetID())
+		result["LXC_ID"] = uint64(ep.GetID())
 	}
 
 	identity := ep.GetIdentity().Uint32()
-	result["SECLABEL"] = identity
-	result["SECLABEL_NB"] = byteorder.HostToNetwork32(identity)
-	result["POLICY_VERDICT_LOG_FILTER"] = ep.GetPolicyVerdictLogFilter()
+	result["SECLABEL"] = uint64(identity)
+	result["SECLABEL_NB"] = uint64(byteorder.HostToNetwork32(identity))
+	result["POLICY_VERDICT_LOG_FILTER"] = uint64(ep.GetPolicyVerdictLogFilter())
 	return result
 
 }
@@ -254,6 +254,6 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint32 {
 // ELFSubstitutions fetches the set of variable and map substitutions that
 // must be implemented against an ELF template to configure the datapath for
 // the specified endpoint.
-func ELFSubstitutions(ep datapath.Endpoint) (map[string]uint32, map[string]string) {
+func ELFSubstitutions(ep datapath.Endpoint) (map[string]uint64, map[string]string) {
 	return elfVariableSubstitutions(ep), elfMapSubstitutions(ep)
 }

--- a/pkg/elf/elf_test.go
+++ b/pkg/elf/elf_test.go
@@ -85,7 +85,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 		description  string
 		key          string
 		kind         symbolKind
-		intValue     uint32
+		intValue     uint64
 		strValue     string
 		elfValid     Checker
 		elfChangeErr error
@@ -154,7 +154,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 		c.Logf("%s", test.description)
 
 		// Create the copy of the ELF with an optional substitution
-		intOptions := make(map[string]uint32)
+		intOptions := make(map[string]uint64)
 		strOptions := make(map[string]string)
 		switch test.kind {
 		case symbolData:
@@ -213,7 +213,7 @@ func BenchmarkWriteELF(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		intOptions := make(map[string]uint32)
+		intOptions := make(map[string]uint64)
 		strOptions := make(map[string]string)
 
 		objectCopy := filepath.Join(tmpDir, fmt.Sprintf("%d_%s", i, elfObjCopy))
@@ -234,7 +234,7 @@ func (elf *ELF) findString(key string) error {
 	return nil
 }
 
-func (elf *ELF) readOption(key string) (result uint32, err error) {
+func (elf *ELF) readOption(key string) (result uint64, err error) {
 	opt, exists := elf.symbols.data[key]
 	if !exists {
 		return 0, fmt.Errorf("no such option %q in ELF", key)
@@ -243,7 +243,10 @@ func (elf *ELF) readOption(key string) (result uint32, err error) {
 	if err != nil {
 		return 0, err
 	}
-	return elf.metadata.ByteOrder.Uint32(value), err
+
+	out := make([]byte, 8)
+	copy(out, value)
+	return elf.metadata.ByteOrder.Uint64(out), err
 }
 
 func (elf *ELF) readValue(offset int64, size int64) ([]byte, error) {

--- a/pkg/elf/elf_test.go
+++ b/pkg/elf/elf_test.go
@@ -128,7 +128,7 @@ func (s *ELFTestSuite) TestWrite(c *C) {
 		},
 	}
 
-	for i := 1; i <= 4; i++ {
+	for i := 1; i <= 2; i++ {
 		testOptions = append(testOptions, testOption{
 			description:  fmt.Sprintf("test ipv6 substitution %d", i),
 			key:          fmt.Sprintf("GLOBAL_IPV6_%d", i),


### PR DESCRIPTION
```
Historically, the largest data type used for declaring global data was uint32.
Cilium's iproute2 fork had patches that made the assumption all values are
32 bits, so this behaviour was replicated when it was ported to Go. This only
works well if the largest variable emitted to .data is 32 bits wide. Any
smaller and the section's alignment would drop, causing the inliner to read
part of the next variable. Any larger and only part of a u64 would be read.

Since we now no longer rely on iproute2 for loading any ELFs, we can start
changing the way this works. In Go, we have access to .data's BTF Datasec,
so we can be a bit smarter about it and detect how wide each variable is,
so we can accurately copy out the bits needed.

This patch introduces a uint64 global data macro, DEFINE_U64, and updates
DEFINE_IPV6 to use it. This cuts down on the amount of instructions needed
to carry ipv6 values in the instruction stream from 8 to 4.
```

Closes: #7123

```release-note
Reduce amount of bpf instructions needed for handling ipv6 addresses
```
