### PR TITLE
Modularize eventsmap and monitor.Agent

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -22,6 +22,7 @@ cilium-agent hive [flags]
       --enable-cilium-health-api-server-access strings   List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                       Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                         Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-monitor                                   Enable the monitor unix domain socket server (default true)
       --gops-port uint16                                 Port for gops server to listen on (default 9890)
   -h, --help                                             help for hive
       --install-egress-gateway-routes                    Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
@@ -35,6 +36,7 @@ cilium-agent hive [flags]
       --mesh-auth-rotated-identities-queue-size int      The size of the queue for signaling rotated identities. (default 1024)
       --mesh-auth-spiffe-trust-domain string             The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-admin-socket string              The path for the SPIRE admin agent Unix socket.
+      --monitor-queue-size int                           Size of the event queue when reading monitor events
       --pprof                                            Enable serving pprof debugging API
       --pprof-address string                             Address that pprof listens on (default "localhost")
       --pprof-port uint16                                Port that pprof listens on (default 6060)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -28,6 +28,7 @@ cilium-agent hive dot-graph [flags]
       --enable-cilium-health-api-server-access strings   List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                       Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                         Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-monitor                                   Enable the monitor unix domain socket server (default true)
       --gops-port uint16                                 Port for gops server to listen on (default 9890)
       --install-egress-gateway-routes                    Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
       --k8s-api-server string                            Kubernetes API server URL
@@ -40,6 +41,7 @@ cilium-agent hive dot-graph [flags]
       --mesh-auth-rotated-identities-queue-size int      The size of the queue for signaling rotated identities. (default 1024)
       --mesh-auth-spiffe-trust-domain string             The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-admin-socket string              The path for the SPIRE admin agent Unix socket.
+      --monitor-queue-size int                           Size of the event queue when reading monitor events
       --pprof                                            Enable serving pprof debugging API
       --pprof-address string                             Address that pprof listens on (default "localhost")
       --pprof-port uint16                                Port that pprof listens on (default 6060)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -75,6 +75,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
+	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
@@ -694,15 +695,9 @@ func initializeFlags() {
 	flags.StringSlice(option.Metrics, []string{}, "Metrics that should be enabled or disabled from the default metric list. The list is expected to be separated by a space. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar)")
 	option.BindEnv(Vp, option.Metrics)
 
-	flags.Bool(option.EnableMonitorName, true, "Enable the monitor unix domain socket server")
-	option.BindEnv(Vp, option.EnableMonitorName)
-
 	flags.String(option.MonitorAggregationName, "None",
 		"Level of monitor aggregation for traces from the datapath")
 	option.BindEnvWithLegacyEnvFallback(Vp, option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
-
-	flags.Int(option.MonitorQueueSizeName, 0, "Size of the event queue when reading monitor events")
-	option.BindEnv(Vp, option.MonitorQueueSizeName)
 
 	flags.Int(option.MTUName, 0, "Overwrite auto-detected MTU of underlying network")
 	option.BindEnv(Vp, option.MTUName)
@@ -1153,9 +1148,6 @@ func initEnv() {
 	defer bootstrapStats.earlyInit.End(true)
 
 	var debugDatapath bool
-
-	// Not running tests -> enable the monitor agent.
-	option.Config.RunMonitorAgent = true
 
 	option.LogRegisteredOptions(Vp, log)
 
@@ -1623,6 +1615,7 @@ type daemonParams struct {
 	HealthAPISpec        *healthApi.Spec
 	ServiceCache         *k8s.ServiceCache
 	ClusterMesh          *clustermesh.ClusterMesh
+	MonitorAgent         monitorAgent.Agent
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/signalmap"
 	fakesignalmap "github.com/cilium/cilium/pkg/maps/signalmap/fake"
 	"github.com/cilium/cilium/pkg/metrics"
+	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
@@ -173,6 +174,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 			func() authmap.Map { return fakeauthmap.NewFakeAuthMap() },
 			func() egressmap.PolicyMap { return nil },
 		),
+		monitorAgent.Cell,
 		ControlPlane,
 		cell.Invoke(func(p promise.Promise[*Daemon]) {
 			daemonPromise = p

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -14,7 +14,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/controller"
 	datapathIpcache "github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
@@ -29,7 +28,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
-	"github.com/cilium/cilium/pkg/maps/eventsmap"
 	"github.com/cilium/cilium/pkg/maps/fragmap"
 	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
 	"github.com/cilium/cilium/pkg/maps/ipmasq"
@@ -360,12 +358,6 @@ func (d *Daemon) initMaps() error {
 	if err := d.svc.InitMaps(option.Config.EnableIPv6, option.Config.EnableIPv4,
 		option.Config.EnableSocketLB, option.Config.RestoreState); err != nil {
 		log.WithError(err).Fatal("Unable to initialize service maps")
-	}
-
-	possibleCPUs := common.GetNumPossibleCPUs(log)
-
-	if err := eventsmap.InitMap(possibleCPUs); err != nil {
-		return fmt.Errorf("initializing events map: %w", err)
 	}
 
 	if err := policymap.InitCallMaps(option.Config.EnableEnvoyConfig); err != nil {

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipcache "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/maps"
+	"github.com/cilium/cilium/pkg/maps/eventsmap"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -34,6 +35,9 @@ var Cell = cell.Module(
 
 	// Utime synchronizes utime from userspace to datapath via configmap.Map.
 	utime.Cell,
+
+	// The cilium events map, used by the monitor agent.
+	eventsmap.Cell,
 
 	cell.Provide(
 		newWireguardAgent,

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -19,6 +19,7 @@ import (
 	ipcache "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/maps"
 	"github.com/cilium/cilium/pkg/maps/eventsmap"
+	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
@@ -38,6 +39,9 @@ var Cell = cell.Module(
 
 	// The cilium events map, used by the monitor agent.
 	eventsmap.Cell,
+
+	// The monitor agent, which multicasts cilium and agent events to its subscribers.
+	monitorAgent.Cell,
 
 	cell.Provide(
 		newWireguardAgent,

--- a/pkg/maps/eventsmap/cell.go
+++ b/pkg/maps/eventsmap/cell.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package eventsmap
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/common"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+// Cell provides eventsmap.Map, which is the hive representation of the cilium
+// events perf event ring buffer.
+var Cell = cell.Module(
+	"events-map",
+	"eBPF ring buffer of cilium events",
+
+	cell.Provide(newEventsMap),
+)
+
+var (
+	MaxEntries int
+)
+
+type Map interface{}
+
+func newEventsMap(log logrus.FieldLogger, lifecycle hive.Lifecycle) bpf.MapOut[Map] {
+	eventsMap := &eventsMap{}
+
+	lifecycle.Append(hive.Hook{
+		OnStart: func(context hive.HookContext) error {
+			cpus := common.GetNumPossibleCPUs(log)
+			err := eventsMap.init(cpus)
+			if err != nil {
+				return fmt.Errorf("initializing events map: %w", err)
+			}
+			return nil
+		},
+		OnStop: func(context hive.HookContext) error {
+			// We don't currently care for cleaning up.
+			return nil
+		},
+	})
+
+	return bpf.NewMapOut(Map(eventsMap))
+}

--- a/pkg/monitor/agent/agent.go
+++ b/pkg/monitor/agent/agent.go
@@ -21,13 +21,12 @@ import (
 	oldBPF "github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/eventsmap"
 	"github.com/cilium/cilium/pkg/monitor/agent/consumer"
 	"github.com/cilium/cilium/pkg/monitor/agent/listener"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/monitor/payload"
 )
-
-const eventsMapName = "cilium_events"
 
 // isCtxDone is a utility function that returns true when the context's Done()
 // channel is closed. It is intended to simplify goroutines that need to check
@@ -99,7 +98,7 @@ func (a *Agent) AttachToEventsMap(nPages int) error {
 	}
 
 	// assert that we can actually connect the monitor
-	path := oldBPF.MapPath(eventsMapName)
+	path := oldBPF.MapPath(eventsmap.MapName)
 	eventsMap, err := ebpf.LoadPinnedMap(path, nil)
 	if err != nil {
 		return err

--- a/pkg/monitor/agent/cell.go
+++ b/pkg/monitor/agent/cell.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/common"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/maps/eventsmap"
+)
+
+// Cell provides the monitor agent, which monitors the cilium events perf event
+// buffer and forwards events to consumers/listeners. It also handles
+// multicasting of other agent events.
+var Cell = cell.Module(
+	"monitor-agent",
+	"Consumes the cilium events map and distributes those and other agent events",
+
+	cell.Provide(newMonitorAgent),
+	cell.Config(defaultConfig),
+)
+
+type AgentConfig struct {
+	// EnableMonitor enables the monitor unix domain socket server
+	EnableMonitor bool
+
+	// MonitorQueueSize is the size of the monitor event queue
+	MonitorQueueSize int
+}
+
+var defaultConfig = AgentConfig{
+	EnableMonitor: true,
+}
+
+func (def AgentConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("enable-monitor", def.EnableMonitor, "Enable the monitor unix domain socket server")
+	flags.Int("monitor-queue-size", 0, "Size of the event queue when reading monitor events")
+}
+
+type agentParams struct {
+	cell.In
+
+	Lifecycle hive.Lifecycle
+	Log       logrus.FieldLogger
+	Config    AgentConfig
+	EventsMap eventsmap.Map `optional:"true"`
+}
+
+func newMonitorAgent(params agentParams) Agent {
+	ctx, cancel := context.WithCancel(context.Background())
+	agent := newAgent(ctx)
+
+	params.Lifecycle.Append(hive.Hook{
+		OnStart: func(hive.HookContext) error {
+			if params.EventsMap == nil {
+				// If there's no event map, function only for agent events.
+				log.Info("No eventsmap: monitor works only for agent events.")
+				return nil
+			}
+
+			err := agent.AttachToEventsMap(defaults.MonitorBufferPages)
+			if err != nil {
+				log.WithError(err).Error("encountered error when attaching the monitor agent to eventsmap")
+				return fmt.Errorf("encountered error when attaching the monitor agent: %w", err)
+			}
+
+			if params.Config.EnableMonitor {
+				queueSize := params.Config.MonitorQueueSize
+				if queueSize == 0 {
+					queueSize = common.GetNumPossibleCPUs(log) * defaults.MonitorQueueSizePerCPU
+					if queueSize > defaults.MonitorQueueSizePerCPUMaximum {
+						queueSize = defaults.MonitorQueueSizePerCPUMaximum
+					}
+				}
+
+				err = ServeMonitorAPI(ctx, agent, queueSize)
+				if err != nil {
+					log.WithError(err).Error("encountered error serving monitor agent API")
+					return fmt.Errorf("encountered error serving monitor agent API: %w", err)
+				}
+			}
+			return err
+		},
+		OnStop: func(hive.HookContext) error {
+			cancel()
+			return nil
+		},
+	})
+
+	return agent
+}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -710,12 +710,6 @@ const (
 	// IPv6MCastDevice is the name of the option to select IPv6 multicast device
 	IPv6MCastDevice = "ipv6-mcast-device"
 
-	// EnableMonitor is the name of the option to enable the monitor socket
-	EnableMonitorName = "enable-monitor"
-
-	// MonitorQueueSizeName is the name of the option MonitorQueueSize
-	MonitorQueueSizeName = "monitor-queue-size"
-
 	// FQDNRejectResponseCode is the name for the option for dns-proxy reject response code
 	FQDNRejectResponseCode = "tofqdns-dns-reject-response-code"
 
@@ -1494,9 +1488,6 @@ type DaemonConfig struct {
 	CTMapEntriesTimeoutSYN         time.Duration
 	CTMapEntriesTimeoutFIN         time.Duration
 
-	// EnableMonitor enables the monitor unix domain socket server
-	EnableMonitor bool
-
 	// MonitorAggregationInterval configures the interval between monitor
 	// messages when monitor aggregation is enabled.
 	MonitorAggregationInterval time.Duration
@@ -1680,9 +1671,6 @@ type DaemonConfig struct {
 	// NodeEncryptionOptOutLabelsString is the string is used to construct
 	// the label selector in the above field.
 	NodeEncryptionOptOutLabelsString string
-
-	// MonitorQueueSize is the size of the monitor event queue
-	MonitorQueueSize int
 
 	// CLI options
 
@@ -1911,9 +1899,6 @@ type DaemonConfig struct {
 
 	// Specifies wheather to annotate the kubernetes nodes or not
 	AnnotateK8sNode bool
-
-	// RunMonitorAgent indicates whether to run the monitor agent
-	RunMonitorAgent bool
 
 	// EnableNodePort enables k8s NodePort service implementation in BPF
 	EnableNodePort bool
@@ -3035,10 +3020,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.IPTablesRandomFully = vp.GetBool(IPTablesRandomFully)
 	c.IPSecKeyFile = vp.GetString(IPSecKeyFileName)
 	c.IPsecKeyRotationDuration = vp.GetDuration(IPsecKeyRotationDuration)
-	c.EnableMonitor = vp.GetBool(EnableMonitorName)
 	c.MonitorAggregation = vp.GetString(MonitorAggregationName)
 	c.MonitorAggregationInterval = vp.GetDuration(MonitorAggregationInterval)
-	c.MonitorQueueSize = vp.GetInt(MonitorQueueSizeName)
 	c.MTU = vp.GetInt(MTUName)
 	c.PreAllocateMaps = vp.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = vp.GetBool(PrependIptablesChainsName)
@@ -3315,10 +3298,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 
 	for _, option := range vp.GetStringSlice(EndpointStatus) {
 		c.EndpointStatus[option] = struct{}{}
-	}
-
-	if c.MonitorQueueSize == 0 {
-		c.MonitorQueueSize = getDefaultMonitorQueueSize(runtime.NumCPU())
 	}
 
 	// Metrics Setup

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
 	fakesignalmap "github.com/cilium/cilium/pkg/maps/signalmap/fake"
+	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	agentOption "github.com/cilium/cilium/pkg/option"
@@ -79,6 +80,7 @@ func startCiliumAgent(t *testing.T, clientset k8sClient.Clientset) (*fakeDatapat
 			func() authmap.Map { return fakeauthmap.NewFakeAuthMap() },
 			func() egressmap.PolicyMap { return nil },
 		),
+		monitorAgent.Cell,
 		cmd.ControlPlane,
 		cell.Invoke(func(p promise.Promise[*cmd.Daemon]) {
 			daemonPromise = p


### PR DESCRIPTION
Modularizes both the eventsmap and the monitor agent in the simplest way possible.

Would be happy to get some input on:
- There's still [pkg/option/monitor{_test}.go](https://github.com/cilium/cilium/blob/main/pkg/option/monitor.go) which are at least somewhat related. It's unclear to me whether there's a benefit in pulling all of that into `pkg/monitor`, though.
- I've done a little copying instead of adding a little dependency (see https://github.com/cilium/cilium/pull/25197/files#r1192527976) , is that acceptable?

Ref: #24192
