### PR TITLE
Fixed incorrectly rendered chart when specified both configMap and customConf

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -724,7 +724,7 @@ data:
 {{- if .Values.cni.configMap }}
   read-cni-conf: {{ .Values.cni.confFileMountPath }}/{{ .Values.cni.configMapKey }}
 {{- if .Values.cni.customConf  }}
-  {{- /* legacy: v1.13 and before needed cni.customConf: true with cni.configMap */ -}}
+  # legacy: v1.13 and before needed cni.customConf: true with cni.configMap
   write-cni-conf-when-ready: {{ .Values.cni.hostConfDirMountPath }}/05-cilium.conflist
 {{- end }}
 {{- else if .Values.cni.readCniConf }}


### PR DESCRIPTION
Trying to render helm chart with following values:
```
cni:
    configMap: cni-configuration
    customConf: true
```
using command
```
helm lint cilium -f values.yaml
```
resulted in following error:
```
==> Linting cilium
[ERROR] templates/cilium-configmap.yaml: unable to parse YAML: error converting YAML to JSON: yaml: line 129: mapping values are not allowed in this context
```
due to the fact that ```{{- -}}``` removes whitespaces, which was generating following line in yaml:
```
read-cni-conf: /tmp/cni-configuration/cni-configwrite-cni-conf-when-ready: /host/etc/cni/net.d/05-cilium.conflist
```
Issue introduced by https://github.com/cilium/cilium/pull/24389
