### PR TITLE
jobs,test: Fix TestTimer_ExitOnCloseFnCtx channel close panic

### DIFF
--- a/pkg/hive/job/job.go
+++ b/pkg/hive/job/job.go
@@ -400,6 +400,12 @@ func (jt *jobTimer) start(ctx context.Context, wg *sync.WaitGroup, options optio
 				jt.shutdown.Shutdown(hive.ShutdownWithError(err))
 			}
 		}
+
+		// If we exited due to the ctx closing we do not guaranteed return.
+		// The select can pick the timer or trigger signals over ctx.Done due to fair scheduling, so this guarantees it.
+		if ctx.Err() != nil {
+			return
+		}
 	}
 }
 

--- a/pkg/hive/job/job_test.go
+++ b/pkg/hive/job/job_test.go
@@ -574,7 +574,10 @@ func TestTimer_ExitOnCloseFnCtx(t *testing.T) {
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {
 				i++
-				close(started)
+				if started != nil {
+					close(started)
+					started = nil
+				}
 				<-ctx.Done()
 				return nil
 			}, 1*time.Millisecond),


### PR DESCRIPTION
This test enforces that a timer callback will not be called after the context has been canceled. However, it was written such that if the test fails a panic is thrown. This fixes both the panic-on-fail and resolves the edge case causing the flake.

Fixes: #25177

```release-note
Fixed TestTimer_ExitOnCloseFnCtx channel close panic
```
