### PR TITLE
Delete "Cilium monitor verbose mode" test

### DIFF
--- a/test/runtime/monitor.go
+++ b/test/runtime/monitor.go
@@ -101,27 +101,6 @@ var _ = Describe("RuntimeDatapathMonitorTest", func() {
 			ExpectWithOffset(1, res.WasSuccessful()).To(BeTrue(), "cannot update monitor config")
 		}
 
-		It("Cilium monitor verbose mode", func() {
-			monitorConfig()
-
-			ctx, cancel := context.WithCancel(context.Background())
-			res := vm.ExecInBackground(ctx, "cilium monitor -vv")
-			defer cancel()
-
-			Expect(vm.WaitEndpointsReady()).Should(BeTrue(), "Endpoints are not ready after timeout")
-
-			endpoints, err := vm.GetEndpointsIds()
-			Expect(err).Should(BeNil())
-
-			for k, v := range endpoints {
-				filter := fmt.Sprintf("FROM %s DEBUG:", v)
-				vm.ContainerExec(k, helpers.Ping(helpers.Httpd1))
-				Expect(res.WaitUntilMatch(filter)).To(BeNil(),
-					"%q is not in the output after timeout", filter)
-				Expect(res.Stdout()).Should(ContainSubstring(filter))
-			}
-		})
-
 		It("Cilium monitor event types", func() {
 			monitorConfig()
 


### PR DESCRIPTION
Another option would be to quarantine the test and find an assignee to make the test more robust, but I assert that we don't need test coverage for monitor verbose output.

Fixes: #25178