### PR TITLE
Add validation to ensure l7proxy cannot be disabled when Ingress is enabled

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -47,6 +47,14 @@
 {{- end }}
 
 {{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled }}
+  {{- if hasKey .Values "l7proxy" }}
+    {{- if not .Values.l7proxy }}
+      {{ fail "Ingress or Gateway API controller requires .Values.l7proxy to be set to 'true'" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled }}
   {{- if hasKey .Values "kubeProxyReplacement" }}
     {{- if and (ne .Values.kubeProxyReplacement "partial") (ne .Values.kubeProxyReplacement "strict") }}
       {{ fail "Ingress/Gateway API controller requires .Values.kubeProxyReplacement to be set to either 'partial' or 'strict'" }}


### PR DESCRIPTION
Adds validation to ensure that trying to enable Ingress or Gateway API support while having l7proxy disabled will cause installs to fail.

Fixes: #21354
Fixes: #22789
Updates: #22698

```release-note
Added validation to ensure that enabling Ingress or Gateway API support while l7proxy is disabled will fail, as this is an incompatible configuration.
```
