### PR TITLE
workflows/clustermesh: set kubectl version to match the one of the kubernetes cluster

### DIFF
--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -382,6 +382,7 @@ jobs:
       with:
         cluster_name: ${{ env.clusterName1 }}
         version: ${{ env.kind_version }}
+        kubectl_version: ${{ env.k8s_version }}
         config: ./.github/kind-config-cluster1.yaml
         wait: 0 # The control-plane never becomes ready, since no CNI is present
 
@@ -390,6 +391,7 @@ jobs:
       with:
         cluster_name: ${{ env.clusterName2 }}
         version: ${{ env.kind_version }}
+        kubectl_version: ${{ env.k8s_version }}
         config: ./.github/kind-config-cluster2.yaml
         wait: 0 # The control-plane never becomes ready, since no CNI is present
 

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -377,6 +377,7 @@ jobs:
       with:
         cluster_name: ${{ env.clusterName1 }}
         version: ${{ env.kind_version }}
+        kubectl_version: ${{ env.k8s_version }}
         config: ./.github/kind-config-cluster1.yaml
         wait: 0 # The control-plane never becomes ready, since no CNI is present
 
@@ -385,6 +386,7 @@ jobs:
       with:
         cluster_name: ${{ env.clusterName2 }}
         version: ${{ env.kind_version }}
+        kubectl_version: ${{ env.k8s_version }}
         config: ./.github/kind-config-cluster2.yaml
         wait: 0 # The control-plane never becomes ready, since no CNI is present
 

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -377,6 +377,7 @@ jobs:
       with:
         cluster_name: ${{ env.clusterName1 }}
         version: ${{ env.kind_version }}
+        kubectl_version: ${{ env.k8s_version }}
         config: ./.github/kind-config-cluster1.yaml
         wait: 0 # The control-plane never becomes ready, since no CNI is present
 
@@ -385,6 +386,7 @@ jobs:
       with:
         cluster_name: ${{ env.clusterName2 }}
         version: ${{ env.kind_version }}
+        kubectl_version: ${{ env.k8s_version }}
         config: ./.github/kind-config-cluster2.yaml
         wait: 0 # The control-plane never becomes ready, since no CNI is present
 

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -368,6 +368,7 @@ jobs:
       with:
         cluster_name: ${{ env.clusterName1 }}
         version: ${{ env.kind_version }}
+        kubectl_version: ${{ env.k8s_version }}
         config: ./.github/kind-config-cluster1.yaml
         wait: 0 # The control-plane never becomes ready, since no CNI is present
 
@@ -376,6 +377,7 @@ jobs:
       with:
         cluster_name: ${{ env.clusterName2 }}
         version: ${{ env.kind_version }}
+        kubectl_version: ${{ env.k8s_version }}
         config: ./.github/kind-config-cluster2.yaml
         wait: 0 # The control-plane never becomes ready, since no CNI is present
 


### PR DESCRIPTION
By default, the helm/kind-action action downloads a fixed version of kubectl (v1.23.12 in v1.5.0). Let's configure it so that the kubectl version matches that of the kubernetes cluster we are creating, to ensure better compatibility.

<!-- Description of change -->

```release-note
workflows/clustermesh: set kubectl version to match the one of the kubernetes cluster
```
