### PR TITLE
linux/node_id: do not attempt to map NoID

### DIFF
--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -49,6 +49,7 @@ func (n *linuxNodeHandler) AllocateNodeID(nodeIP net.IP) uint16 {
 	nodeID := uint16(n.nodeIDs.AllocateID())
 	if nodeID == uint16(idpool.NoID) {
 		log.Error("No more IDs available for nodes")
+		return nodeID
 	} else {
 		log.WithFields(logrus.Fields{
 			logfields.NodeID: nodeID,


### PR DESCRIPTION
Noticed during code review for a different issue.

We correctly detect that we failed to allocate a new node ID (due to exhaustion of the idpool), but then still go ahead and map it. This leads to spurious errors which include "Failed to map node IP address to allocated ID".

Instead, don't try to map NoID and return it directly.


```release-note
Fix spurious errors containing "Failed to map node IP address to allocated ID".
```
