### PR TITLE
Fix possible panic in the ipcache when removing the prefix labels for an unknown resource ID

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -483,7 +483,7 @@ func (m *metadata) filterByLabels(filter labels.Labels) []netip.Prefix {
 // This function assumes that the ipcache metadata lock is held for writing.
 func (m *metadata) remove(prefix netip.Prefix, resource types.ResourceID, aux ...IPMetadata) {
 	info, ok := m.m[prefix]
-	if !ok {
+	if !ok || info[resource] == nil {
 		return
 	}
 	for _, a := range aux {

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -166,6 +166,14 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.Len(t, remaining, 0)
 	assert.Len(t, IPIdentityCache.ipToIdentityCache, 1)
 
+	// Attempting to remove a label for a ResourceID which does not exist
+	// should not remove anything.
+	IPIdentityCache.RemoveLabelsExcluded(
+		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
+		"foo")
+	assert.Len(t, IPIdentityCache.metadata.m, 1)
+	assert.Contains(t, IPIdentityCache.metadata.m[worldPrefix].ToLabels(), labels.IDNameKubeAPIServer)
+
 	IPIdentityCache.RemoveLabelsExcluded(
 		labels.LabelKubeAPIServer, map[netip.Prefix]struct{}{},
 		"kube-uid")


### PR DESCRIPTION
This PR introduces a sanity check to avoid accessing the ipcache metadata map entry for a given prefix during removal if the corresponding resource ID was not present, since that would cause a panic.

Marking with `release-note/misc` since I'm not sure whether this bug could happen with "legitimate" usage. I experienced it after creating a custom endpointslice for the kubernetes service for testing purposes.

<!-- Description of change -->

```release-note
Fix possible panic in the ipcache when removing the prefix labels for an unknown resource ID
```
