### PR TITLE
tests: quarantine services nodeport w/ L7 policy test.

### DIFF
--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -645,7 +645,8 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 		})
 
 		SkipContextIf(func() bool {
-			return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.RunsOnAKS() || helpers.DoesNotExistNodeWithoutCilium()
+			return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.RunsOnAKS() || helpers.DoesNotExistNodeWithoutCilium() ||
+				helpers.SkipQuarantined()
 		}, "with L7 policy", func() {
 			var demoPolicyL7 string
 


### PR DESCRIPTION
Changes in c1a0dba may have introduced flakes for this set of tests when attempting to reach NodePort from outside the cluster.

A replacement test is being added to cilium cli connectivity tests:

https://github.com/cilium/cilium-cli/pull/1547

Quarantine this test for now until we can remove it.

Addresses: #25119