### PR TITLE
identities: fix incorrectly overwriting the labels of kube-apiserver IPs

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -195,10 +195,8 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			oldIDs[prefix] = id
 			var newID *identity.Identity
 
-			lbls := prefixInfo.ToLabels()
-
 			// Insert to propagate the updated set of labels after removal.
-			newID, _, err = ipc.injectLabels(ctx, prefix, lbls)
+			newID, _, err = ipc.injectLabels(ctx, prefix, prefixInfo.ToLabels())
 			if err != nil {
 				// NOTE: This may fail during a 2nd or later
 				// iteration of the loop. To handle this, break
@@ -213,7 +211,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				log.WithError(err).WithFields(logrus.Fields{
 					logfields.IPAddr:   prefix,
 					logfields.Identity: id,
-					logfields.Labels:   lbls, // new labels
+					logfields.Labels:   newID.Labels, // new labels
 				}).Warning(
 					"Failed to allocate new identity while handling change in labels associated with a prefix.",
 				)
@@ -229,7 +227,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				goto releaseIdentity
 			}
 
-			idsToAdd[newID.ID] = lbls.LabelArray()
+			idsToAdd[newID.ID] = newID.Labels.LabelArray()
 			entriesToReplace[prefix] = Identity{
 				ID:     newID.ID,
 				Source: prefixInfo.Source(),


### PR DESCRIPTION
This PR fixes the propagation of the identity labels associated with the kube-apiserver IPs (if they are external to the cluster, as in cloud environments) to the selector cache, to ensure that the ones representing the CIDR itself and the enclosing ones are not overwritten. That could cause traffic towards the API server to be incorrectly dropped when it should be allowed by `ToCIDR` network policy entries. This bug affects only v1.13, since the logic in the main branch has been refactored, and (among others) it already includes the changes proposed here.

It additionally fixes the occurrence of the warning log reported in #24401, since the kube-apiserver identity labels are now consistent across different invocations of `selectorcache.UpdateIdentities`.

<!-- Description of change -->

Fixes: #24401

```release-note
Fix bug that caused ToCIDR netpols matching kube-apiserver IPs (when external to the cluster) to not reliably allow connectivity.
```
