### PR TITLE
daemon: Remove encrypt key from syncHostIPs()

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -252,7 +252,6 @@ func (d *Daemon) syncHostIPs() error {
 	}
 
 	for _, ipIDPair := range specialIdentities {
-		hostKey := node.GetIPsecKeyIdentity()
 		isHost := ipIDPair.ID == identity.ReservedIdentityHost
 		if isHost {
 			added, err := lxcmap.SyncHostEntry(ipIDPair.IP)
@@ -272,7 +271,7 @@ func (d *Daemon) syncHostIPs() error {
 		// This upsert will fail with ErrOverwrite continuously as long as the
 		// EP / CN watcher have found an apiserver IP and upserted it into the
 		// ipcache. Until then, it is expected to succeed.
-		d.ipcache.Upsert(ipIDPair.PrefixString(), nil, hostKey, nil, ipcache.Identity{
+		d.ipcache.Upsert(ipIDPair.PrefixString(), nil, 0, nil, ipcache.Identity{
 			ID:     ipIDPair.ID,
 			Source: d.sourceByIP(ipIDPair.IP, source.Local),
 		})


### PR DESCRIPTION
There's no need for the encrypt key to be set on host IPs. Additionally,
this code was also setting the encrypt key for the `0.0.0.0/0` `world`
entry as well, which isn't necessary.

Encryption is done for node-to-node traffic therefore it's not necessary
for encrypt key to be set on local host IPs.

Fixes: b6989723a7 (cilium: ipsec, support rolling updates)

Signed-off-by: Chris Tarazi <chris@isovalent.com>
