### PR TITLE
observe: add support for first and follow at the same time

### DIFF
--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -547,12 +547,12 @@ func (r *eventsReader) Next(ctx context.Context) (*v1.Event, error) {
 		}
 		var e *v1.Event
 		var err error
+		if r.maxEvents > 0 && (r.eventCount >= r.maxEvents) {
+			return nil, io.EOF
+		}
 		if r.follow {
 			e = r.ringReader.NextFollow(ctx)
 		} else {
-			if r.maxEvents > 0 && (r.eventCount >= r.maxEvents) {
-				return nil, io.EOF
-			}
 			e, err = r.ringReader.Next()
 			if err != nil {
 				return nil, err
@@ -595,9 +595,6 @@ func (r *eventsReader) Next(ctx context.Context) (*v1.Event, error) {
 }
 
 func validateRequest(req genericRequest) error {
-	if req.GetFirst() && req.GetFollow() {
-		return status.Errorf(codes.InvalidArgument, "first cannot be specified with follow")
-	}
 	return nil
 }
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Support -f and --first at the same time

Fixes: #959

```release-note
Support -f and --first at the same time
<!-- Enter the release note text here if needed or remove this section! -->
```
