### PR TITLE
Using new Prometheus native histograms for Cilium metrics

### DIFF
--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"context"
+	"github.com/cilium/cilium/pkg/metrics"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -185,17 +186,22 @@ func registerMetrics() []prometheus.Collector {
 	collectors = append(collectors, EndpointGCObjects)
 
 	CiliumEndpointSliceDensity = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: Namespace,
-		Name:      "number_of_ceps_per_ces",
-		Help:      "The number of CEPs batched in a CES",
-		Buckets:   []float64{1, 10, 25, 50, 100, 200, 500, 1000},
+		Namespace:                      Namespace,
+		Name:                           "number_of_ceps_per_ces",
+		Help:                           "The number of CEPs batched in a CES",
+		Buckets:                        []float64{1, 10, 25, 50, 100, 200, 500, 1000},
+		NativeHistogramBucketFactor:    metrics.HistogramFactor,
+		NativeHistogramMaxBucketNumber: metrics.HistogramMaxBuckets,
 	})
 	collectors = append(collectors, CiliumEndpointSliceDensity)
 
 	CiliumEndpointsChangeCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: Namespace,
-		Name:      "number_of_cep_changes_per_ces",
-		Help:      "The number of changed CEPs in each CES update",
+		Namespace:                      Namespace,
+		Name:                           "number_of_cep_changes_per_ces",
+		Help:                           "The number of changed CEPs in each CES update",
+		Buckets:                        prometheus.DefBuckets,
+		NativeHistogramBucketFactor:    metrics.HistogramFactor,
+		NativeHistogramMaxBucketNumber: metrics.HistogramMaxBuckets,
 	}, []string{LabelOpcode})
 	collectors = append(collectors, CiliumEndpointsChangeCount)
 
@@ -214,10 +220,12 @@ func registerMetrics() []prometheus.Collector {
 	collectors = append(collectors, CiliumEndpointSliceSyncTotal)
 
 	CiliumEndpointSliceQueueDelay = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: Namespace,
-		Name:      "ces_queueing_delay_seconds",
-		Help:      "CiliumEndpointSlice queueing delay in seconds",
-		Buckets:   append(prometheus.DefBuckets, 60, 300, 900, 1800, 3600),
+		Namespace:                      Namespace,
+		Name:                           "ces_queueing_delay_seconds",
+		Help:                           "CiliumEndpointSlice queueing delay in seconds",
+		Buckets:                        append(prometheus.DefBuckets, 60, 300, 900, 1800, 3600),
+		NativeHistogramBucketFactor:    metrics.HistogramFactor,
+		NativeHistogramMaxBucketNumber: metrics.HistogramMaxBuckets,
 	})
 	collectors = append(collectors, CiliumEndpointSliceQueueDelay)
 

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/cilium/operator/metrics"
+	metrics2 "github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 
@@ -149,6 +150,8 @@ func NewPrometheusMetrics(namespace string, registry metrics.RegisterGatherer) *
 			prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
 			prometheus.LinearBuckets(1, 1, 60),      // 1s, 2s, 3s, ... 60s,
 		),
+		NativeHistogramBucketFactor:    metrics2.HistogramFactor,
+		NativeHistogramMaxBucketNumber: metrics2.HistogramMaxBuckets,
 	}, []string{"type", "status", "subnet_id"})
 
 	m.Release = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -160,6 +163,8 @@ func NewPrometheusMetrics(namespace string, registry metrics.RegisterGatherer) *
 			prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
 			prometheus.LinearBuckets(1, 1, 60),      // 1s, 2s, 3s, ... 60s,
 		),
+		NativeHistogramBucketFactor:    metrics2.HistogramFactor,
+		NativeHistogramMaxBucketNumber: metrics2.HistogramMaxBuckets,
 	}, []string{"type", "status", "subnet_id"})
 
 	// pool_maintainer is a more generic name, but for backward compatibility

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -720,6 +720,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Subsystem:                      SubsystemAgent,
 				Name:                           "bootstrap_seconds",
 				Help:                           "Duration of bootstrap sequence",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelScope, LabelOutcome})
@@ -733,6 +734,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Subsystem:                      SubsystemAgent,
 				Name:                           "api_process_time_seconds",
 				Help:                           "Duration of processed API calls labeled by path, method and return code.",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelPath, LabelMethod, LabelAPIReturnCode})
@@ -768,6 +770,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Namespace:                      Namespace,
 				Name:                           "endpoint_regeneration_time_stats_seconds",
 				Help:                           "Endpoint regeneration time stats labeled by the scope",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelScope, LabelStatus})
@@ -800,6 +803,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Namespace:                      Namespace,
 				Name:                           "policy_regeneration_time_stats_seconds",
 				Help:                           "Policy regeneration time stats labeled by the scope",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelScope, LabelStatus})
@@ -852,6 +856,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Namespace:                      Namespace,
 				Name:                           "policy_implementation_delay",
 				Help:                           "Time between a policy change and it being fully deployed into the datapath",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelPolicySource})
@@ -864,6 +869,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Namespace:                      Namespace,
 				Name:                           "cidrgroup_translation_time_stats_seconds",
 				Help:                           "CIDRGroup translation time stats",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			})
@@ -976,6 +982,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Namespace:                      Namespace,
 				Name:                           "proxy_upstream_reply_seconds",
 				Help:                           "Seconds waited to get a reply from a upstream server",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{"error", LabelProtocolL7, LabelScope})
@@ -1089,6 +1096,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "conntrack_gc_duration_seconds",
 				Help: "Duration in seconds of the garbage collector process " +
 					"labeled by datapath family and completion status",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelDatapathFamily, LabelProtocol, LabelStatus})
@@ -1154,6 +1162,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Namespace:                      Namespace,
 				Name:                           "controllers_runs_duration_seconds",
 				Help:                           "Duration in seconds of the controller process labeled by completion status",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelStatus})
@@ -1197,6 +1206,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Subsystem:                      SubsystemK8sClient,
 				Name:                           "api_latency_time_seconds",
 				Help:                           "Duration of processed API calls labeled by path and method.",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelPath, LabelMethod})
@@ -1221,6 +1231,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Subsystem:                      SubsystemK8s,
 				Name:                           "cnp_status_completion_seconds",
 				Help:                           "Duration in seconds in how long it took to complete a CNP status update",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelAttempts, LabelOutcome})
@@ -1255,6 +1266,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Subsystem:                      SubsystemKVStore,
 				Name:                           "operations_duration_seconds",
 				Help:                           "Duration in seconds of kvstore operations",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelScope, LabelKind, LabelAction, LabelOutcome})
@@ -1370,6 +1382,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Subsystem:                      SubsystemBPF,
 				Name:                           "syscall_duration_seconds",
 				Help:                           "Duration of BPF system calls",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelOperation, LabelOutcome})
@@ -1419,6 +1432,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Subsystem:                      SubsystemTriggers,
 				Name:                           "policy_update_call_duration_seconds",
 				Help:                           "Duration of policy update trigger",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelType})
@@ -1445,6 +1459,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Subsystem:                      SubsystemAPILimiter,
 				Name:                           "wait_history_duration_seconds",
 				Help:                           "Histogram over duration of waiting period for API calls subjects to rate limiting",
+				Buckets:                        prometheus.DefBuckets,
 				NativeHistogramBucketFactor:    HistogramFactor,
 				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{"api_call"})

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -31,6 +31,11 @@ const (
 	// ErrorProxy is the value used to notify errors on Proxy.
 	ErrorProxy = "proxy"
 
+	// HistogramFactor configures the factor used for exponential/native histogram in Prometheus client
+	HistogramFactor = 1.1
+	// HistogramMaxBuckets configures the maximum number of buckets that will be exported in Prometheus client
+	HistogramMaxBuckets = 128
+
 	// L7DNS is the value used to report DNS label on metrics
 	L7DNS = "dns"
 
@@ -711,10 +716,12 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_" + SubsystemAgent + "_bootstrap_seconds":
 			BootstrapTimes = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemAgent,
-				Name:      "bootstrap_seconds",
-				Help:      "Duration of bootstrap sequence",
+				Namespace:                      Namespace,
+				Subsystem:                      SubsystemAgent,
+				Name:                           "bootstrap_seconds",
+				Help:                           "Duration of bootstrap sequence",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelScope, LabelOutcome})
 
 			collectors = append(collectors, BootstrapTimes)
@@ -722,10 +729,12 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_" + SubsystemAgent + "_api_process_time_seconds":
 			APIInteractions = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemAgent,
-				Name:      "api_process_time_seconds",
-				Help:      "Duration of processed API calls labeled by path, method and return code.",
+				Namespace:                      Namespace,
+				Subsystem:                      SubsystemAgent,
+				Name:                           "api_process_time_seconds",
+				Help:                           "Duration of processed API calls labeled by path, method and return code.",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelPath, LabelMethod, LabelAPIReturnCode})
 
 			collectors = append(collectors, APIInteractions)
@@ -756,9 +765,11 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_endpoint_regeneration_time_stats_seconds":
 			EndpointRegenerationTimeStats = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Name:      "endpoint_regeneration_time_stats_seconds",
-				Help:      "Endpoint regeneration time stats labeled by the scope",
+				Namespace:                      Namespace,
+				Name:                           "endpoint_regeneration_time_stats_seconds",
+				Help:                           "Endpoint regeneration time stats labeled by the scope",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelScope, LabelStatus})
 
 			collectors = append(collectors, EndpointRegenerationTimeStats)
@@ -786,9 +797,11 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_policy_regeneration_time_stats_seconds":
 			PolicyRegenerationTimeStats = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Name:      "policy_regeneration_time_stats_seconds",
-				Help:      "Policy regeneration time stats labeled by the scope",
+				Namespace:                      Namespace,
+				Name:                           "policy_regeneration_time_stats_seconds",
+				Help:                           "Policy regeneration time stats labeled by the scope",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelScope, LabelStatus})
 
 			collectors = append(collectors, PolicyRegenerationTimeStats)
@@ -836,9 +849,11 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_policy_implementation_delay":
 			PolicyImplementationDelay = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Name:      "policy_implementation_delay",
-				Help:      "Time between a policy change and it being fully deployed into the datapath",
+				Namespace:                      Namespace,
+				Name:                           "policy_implementation_delay",
+				Help:                           "Time between a policy change and it being fully deployed into the datapath",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelPolicySource})
 
 			collectors = append(collectors, PolicyImplementationDelay)
@@ -846,9 +861,11 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_cidrgroup_translation_time_stats_seconds":
 			CIDRGroupTranslationTimeStats = prometheus.NewHistogram(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Name:      "cidrgroup_translation_time_stats_seconds",
-				Help:      "CIDRGroup translation time stats",
+				Namespace:                      Namespace,
+				Name:                           "cidrgroup_translation_time_stats_seconds",
+				Help:                           "CIDRGroup translation time stats",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			})
 
 			collectors = append(collectors, CIDRGroupTranslationTimeStats)
@@ -956,9 +973,11 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_proxy_upstream_reply_seconds":
 			ProxyUpstreamTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Name:      "proxy_upstream_reply_seconds",
-				Help:      "Seconds waited to get a reply from a upstream server",
+				Namespace:                      Namespace,
+				Name:                           "proxy_upstream_reply_seconds",
+				Help:                           "Seconds waited to get a reply from a upstream server",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{"error", LabelProtocolL7, LabelScope})
 
 			collectors = append(collectors, ProxyUpstreamTime)
@@ -1070,6 +1089,8 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Name:      "conntrack_gc_duration_seconds",
 				Help: "Duration in seconds of the garbage collector process " +
 					"labeled by datapath family and completion status",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelDatapathFamily, LabelProtocol, LabelStatus})
 
 			collectors = append(collectors, ConntrackGCDuration)
@@ -1130,9 +1151,11 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_controllers_runs_duration_seconds":
 			ControllerRunsDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Name:      "controllers_runs_duration_seconds",
-				Help:      "Duration in seconds of the controller process labeled by completion status",
+				Namespace:                      Namespace,
+				Name:                           "controllers_runs_duration_seconds",
+				Help:                           "Duration in seconds of the controller process labeled by completion status",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelStatus})
 
 			collectors = append(collectors, ControllerRunsDuration)
@@ -1170,10 +1193,12 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_" + SubsystemK8sClient + "_api_latency_time_seconds":
 			KubernetesAPIInteractions = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemK8sClient,
-				Name:      "api_latency_time_seconds",
-				Help:      "Duration of processed API calls labeled by path and method.",
+				Namespace:                      Namespace,
+				Subsystem:                      SubsystemK8sClient,
+				Name:                           "api_latency_time_seconds",
+				Help:                           "Duration of processed API calls labeled by path and method.",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelPath, LabelMethod})
 
 			collectors = append(collectors, KubernetesAPIInteractions)
@@ -1192,10 +1217,12 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_" + SubsystemK8s + "_cnp_status_completion_seconds":
 			KubernetesCNPStatusCompletion = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemK8s,
-				Name:      "cnp_status_completion_seconds",
-				Help:      "Duration in seconds in how long it took to complete a CNP status update",
+				Namespace:                      Namespace,
+				Subsystem:                      SubsystemK8s,
+				Name:                           "cnp_status_completion_seconds",
+				Help:                           "Duration in seconds in how long it took to complete a CNP status update",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelAttempts, LabelOutcome})
 
 			collectors = append(collectors, KubernetesCNPStatusCompletion)
@@ -1224,10 +1251,12 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_" + SubsystemKVStore + "_operations_duration_seconds":
 			KVStoreOperationsDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemKVStore,
-				Name:      "operations_duration_seconds",
-				Help:      "Duration in seconds of kvstore operations",
+				Namespace:                      Namespace,
+				Subsystem:                      SubsystemKVStore,
+				Name:                           "operations_duration_seconds",
+				Help:                           "Duration in seconds of kvstore operations",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelScope, LabelKind, LabelAction, LabelOutcome})
 
 			collectors = append(collectors, KVStoreOperationsDuration)
@@ -1235,11 +1264,13 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_" + SubsystemKVStore + "_events_queue_seconds":
 			KVStoreEventsQueueDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemKVStore,
-				Name:      "events_queue_seconds",
-				Help:      "Duration in seconds of time received event was blocked before it could be queued",
-				Buckets:   []float64{.002, .005, .01, .015, .025, .05, .1, .25, .5, .75, 1},
+				Namespace:                      Namespace,
+				Subsystem:                      SubsystemKVStore,
+				Name:                           "events_queue_seconds",
+				Help:                           "Duration in seconds of time received event was blocked before it could be queued",
+				Buckets:                        []float64{.002, .005, .01, .015, .025, .05, .1, .25, .5, .75, 1},
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelScope, LabelAction})
 
 			collectors = append(collectors, KVStoreEventsQueueDuration)
@@ -1335,10 +1366,12 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_" + SubsystemBPF + "_syscall_duration_seconds":
 			BPFSyscallDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemBPF,
-				Name:      "syscall_duration_seconds",
-				Help:      "Duration of BPF system calls",
+				Namespace:                      Namespace,
+				Subsystem:                      SubsystemBPF,
+				Name:                           "syscall_duration_seconds",
+				Help:                           "Duration of BPF system calls",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelOperation, LabelOutcome})
 
 			collectors = append(collectors, BPFSyscallDuration)
@@ -1382,10 +1415,12 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_" + SubsystemTriggers + "_policy_update_call_duration_seconds":
 			TriggerPolicyUpdateCallDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemTriggers,
-				Name:      "policy_update_call_duration_seconds",
-				Help:      "Duration of policy update trigger",
+				Namespace:                      Namespace,
+				Subsystem:                      SubsystemTriggers,
+				Name:                           "policy_update_call_duration_seconds",
+				Help:                           "Duration of policy update trigger",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{LabelType})
 
 			collectors = append(collectors, TriggerPolicyUpdateCallDuration)
@@ -1406,10 +1441,12 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_" + SubsystemAPILimiter + "_wait_history_duration_seconds":
 			APILimiterWaitHistoryDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Subsystem: SubsystemAPILimiter,
-				Name:      "wait_history_duration_seconds",
-				Help:      "Histogram over duration of waiting period for API calls subjects to rate limiting",
+				Namespace:                      Namespace,
+				Subsystem:                      SubsystemAPILimiter,
+				Name:                           "wait_history_duration_seconds",
+				Help:                           "Histogram over duration of waiting period for API calls subjects to rate limiting",
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{"api_call"})
 
 			collectors = append(collectors, APILimiterWaitHistoryDuration)
@@ -1483,10 +1520,12 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 		case Namespace + "_endpoint_propagation_delay_seconds":
 			EndpointPropagationDelay = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-				Namespace: Namespace,
-				Name:      "endpoint_propagation_delay_seconds",
-				Help:      "CiliumEndpoint roundtrip propagation delay in seconds",
-				Buckets:   []float64{.05, .1, 1, 5, 30, 60, 120, 240, 300, 600},
+				Namespace:                      Namespace,
+				Name:                           "endpoint_propagation_delay_seconds",
+				Help:                           "CiliumEndpoint roundtrip propagation delay in seconds",
+				Buckets:                        []float64{.05, .1, 1, 5, 30, 60, 120, 240, 300, 600},
+				NativeHistogramBucketFactor:    HistogramFactor,
+				NativeHistogramMaxBucketNumber: HistogramMaxBuckets,
 			}, []string{})
 
 			collectors = append(collectors, EndpointPropagationDelay)


### PR DESCRIPTION
## Summary of changes

I have observed that Cilium is still using traditional native histograms to instrument most of its metrics, in this PR I am enabling native histogram for Cilium instrumentation. More info on native histograms in the [official Prometheus talk](https://promcon.io/2022-munich/talks/native-histograms-in-prometheus/). 

For ops teams, this change should bring no difference since native histograms are only scraped if a feature flag is enabled on Prometheus side, that is, if they are not using the feature their metrics will still be exporter with the same name and using the same bucket configuration of the existing metrics.
If the feature is enabled in the Prometheus scraping Cilium, the metric names will change, users won't see the metrics with suffixes like `_count`, `_sum`, `_bucket` anymore.

The main benefits of using native histogram are that the metrics become "lighter" in cardinality (since it removes the "fake label" `le`) and also becomes much more precise.


- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Enabling native histograms for Cilium related metrics to reduce cardinality and improve precision
```
