### PR TITLE
ipsec: Install default-drop XFRM policy sooner

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -949,11 +949,11 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 		wildcardIP := net.ParseIP(wildcardIPv4)
 		wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 
+		err = ipsec.IPsecDefaultDropPolicy(false)
+		upsertIPsecLog(err, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi)
+
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new4Net)
-
-			err = ipsec.IPsecDefaultDropPolicy(false)
-			upsertIPsecLog(err, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi)
 
 			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
 				if n.subnetEncryption() {
@@ -1003,11 +1003,11 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 		wildcardIP := net.ParseIP(wildcardIPv6)
 		wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 128)}
 
+		err = ipsec.IPsecDefaultDropPolicy(true)
+		upsertIPsecLog(err, "default-drop IPv6", wildcardCIDR, wildcardCIDR, spi)
+
 		if newNode.IsLocal() {
 			n.replaceNodeIPSecInRoute(new6Net)
-
-			err = ipsec.IPsecDefaultDropPolicy(true)
-			upsertIPsecLog(err, "default-drop IPv6", wildcardCIDR, wildcardCIDR, spi)
 
 			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
 				if n.subnetEncryption() {


### PR DESCRIPTION
We currently install the default-drop XFRM policy when we install the XFRM policies and states for the local node. It is however possible for us to start installing XFRM policies and states for remote nodes before we handle the local one.

The default-drop XFRM policy is a safety measure for when we move XFRM policies around. Because we don't always have a way to atomically update XFRM policies, it's possible that we end up with a very short time where no encryption XFRM OUT policy is matching a subset of traffic. The default-drop policy ensures that we drop such traffic instead of letting it leave the node as plain-text.

We therefore want this default-drop XFRM policy to be installed before we update any other other XFRM policy. This pull request therefore moves its installation before any other XFRM update instead of before just local-node XFRM updates.

Fixes: https://github.com/cilium/cilium/pull/24773.
