### PR TITLE
clustermesh-apiserver: add flag to disable external workloads support

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -57,9 +57,10 @@ import (
 )
 
 type configuration struct {
-	clusterName      string
-	clusterID        uint32
-	serviceProxyName string
+	clusterName             string
+	clusterID               uint32
+	serviceProxyName        string
+	enableExternalWorkloads bool
 }
 
 func (c configuration) LocalClusterName() string {
@@ -247,6 +248,11 @@ func runApiserver() error {
 
 	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enable support of Kubernetes EndpointSlice")
 	option.BindEnv(vp, option.K8sEnableEndpointSlice)
+
+	// The default values is set to true to match the existing behavior in case
+	// the flag is not configured (for instance by the legacy cilium CLI).
+	flags.BoolVar(&cfg.enableExternalWorkloads, option.EnableExternalWorkloads, true, "Enable support for external workloads")
+	option.BindEnv(vp, option.EnableExternalWorkloads)
 
 	vp.BindPFlags(flags)
 
@@ -564,8 +570,6 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, servi
 		synced.SyncCRDs(startCtx, clientset, synced.AllCiliumCRDResourceNames(), &synced.Resources{}, &synced.APIGroups{})
 	}
 
-	mgr := NewVMManager(clientset)
-
 	var err error
 	if err = kvstore.Setup(context.Background(), "etcd", option.Config.KVStoreOpt, nil); err != nil {
 		log.WithError(err).Fatal("Unable to connect to etcd")
@@ -579,14 +583,17 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, servi
 		log.WithError(err).Fatal("Unable to set local cluster config on kvstore")
 	}
 
-	_, err = store.JoinSharedStore(store.Configuration{
-		Prefix:               nodeStore.NodeRegisterStorePrefix,
-		KeyCreator:           nodeStore.RegisterKeyCreator,
-		SharedKeyDeleteDelay: defaults.NodeDeleteDelay,
-		Observer:             mgr,
-	})
-	if err != nil {
-		log.WithError(err).Fatal("Unable to set up node register store in etcd")
+	if cfg.enableExternalWorkloads {
+		mgr := NewVMManager(clientset)
+		_, err = store.JoinSharedStore(store.Configuration{
+			Prefix:               nodeStore.NodeRegisterStorePrefix,
+			KeyCreator:           nodeStore.RegisterKeyCreator,
+			SharedKeyDeleteDelay: defaults.NodeDeleteDelay,
+			Observer:             mgr,
+		})
+		if err != nil {
+			log.WithError(err).Fatal("Unable to set up node register store in etcd")
+		}
 	}
 
 	ciliumNodeStore, err = store.JoinSharedStore(store.Configuration{
@@ -605,7 +612,7 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, servi
 		synchronizeIdentities(clientset)
 		synchronizeNodes(clientset)
 		synchronizeCiliumEndpoints(clientset)
-		operatorWatchers.StartSynchronizingServices(context.Background(), &sync.WaitGroup{}, clientset, services, false, cfg)
+		operatorWatchers.StartSynchronizingServices(context.Background(), &sync.WaitGroup{}, clientset, services, !cfg.enableExternalWorkloads, cfg)
 	}
 
 	go func() {

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -140,6 +140,7 @@ spec:
         - --cluster-users-enabled
         - --cluster-users-config-path=/var/lib/cilium/etcd-config/users.yaml
         {{- end }}
+        - --enable-external-workloads={{ .Values.externalWorkloads.enabled }}
         env:
         - name: CLUSTER_NAME
           valueFrom:

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1230,6 +1230,9 @@ const (
 
 	// EnableCiliumEndpointSlice enables the cilium endpoint slicing feature.
 	EnableCiliumEndpointSlice = "enable-cilium-endpoint-slice"
+
+	// EnableExternalWorkloads enables the support for external workloads.
+	EnableExternalWorkloads = "enable-external-workloads"
 )
 
 const (


### PR DESCRIPTION
Currently, the support for external workloads is always enabled in the clustermesh-apiserver. Yet, this feature requires the synchronization of all the services present in the cluster to the kvstore, including the corresponding backends (plain clustermesh instead only requires the synchronization of shared services and associated backends).

Given that full synchronization is quite onerous in large clusters, let's make it configurable through a dedicated flag. By default, it is enabled, in order not to modify the current behavior when unspecified (e.g., by the legacy Cilium CLI). When installing cilium through Helm, instead, it is configured according to the pre-existing `externalWorkloads.enabled` configuration entry.

<!-- Description of change -->

```release-note
Allow to disable external workloads support in clustermesh-apiserver to improve performance when not needed.
```
