### PR TITLE
clustermesh-apiserver: rework services synchronization to improve performance 

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -428,6 +428,7 @@ Name                                     Labels                                 
 ``kvstore_operations_duration_seconds``  ``action``, ``kind``, ``outcome``, ``scope`` Enabled    Duration of kvstore operation
 ``kvstore_events_queue_seconds``         ``action``, ``scope``                        Enabled    Duration of seconds of time received event was blocked before it could be queued
 ``kvstore_quorum_errors_total``          ``error``                                    Enabled    Number of quorum errors
+``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Enabled    Number of elements queued for synchronization in the kvstore
 ======================================== ============================================ ========== ========================================================
 
 Agent

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -6,7 +6,6 @@ package watchers
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +23,7 @@ import (
 	slimclientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
+	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
@@ -38,7 +38,7 @@ var (
 	// k8sSvcCacheSynced is used do signalize when all services are synced with
 	// k8s.
 	k8sSvcCacheSynced = make(chan struct{})
-	kvs               *store.SharedStore
+	kvs               store.SyncStore
 )
 
 func k8sEventMetric(scope, action string) {
@@ -53,27 +53,32 @@ func k8sServiceHandler(ctx context.Context, clusterName string, shared bool, clu
 		svc.Cluster = clusterName
 		svc.ClusterID = clusterID
 
-		log.WithFields(logrus.Fields{
+		scopedLog := log.WithFields(logrus.Fields{
 			logfields.K8sSvcName:   event.ID.Name,
 			logfields.K8sNamespace: event.ID.Namespace,
 			"action":               event.Action.String(),
 			"service":              event.Service.String(),
 			"endpoints":            event.Endpoints.String(),
 			"shared":               event.Service.Shared,
-		}).Debug("Kubernetes service definition changed")
+		})
+		scopedLog.Debug("Kubernetes service definition changed")
 
 		if shared && !event.Service.Shared {
 			// The annotation may have been added, delete an eventual existing service
-			kvs.DeleteLocalKey(ctx, &svc)
+			kvs.DeleteKey(ctx, &svc)
 			return
 		}
 
 		switch event.Action {
 		case k8s.UpdateService:
-			kvs.UpdateLocalKeySync(ctx, &svc)
+			if err := kvs.UpsertKey(ctx, &svc); err != nil {
+				// An error is triggered only in case it concerns service marshaling,
+				// as kvstore operations are automatically re-tried in case of error.
+				scopedLog.WithError(err).Warning("Failed synchronizing service")
+			}
 
 		case k8s.DeleteService:
-			kvs.DeleteLocalKey(ctx, &svc)
+			kvs.DeleteKey(ctx, &svc)
 		}
 	}
 	for {
@@ -117,23 +122,11 @@ func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, clients
 	readyChan := make(chan struct{}, 0)
 
 	go func() {
-		store, err := store.JoinSharedStore(store.Configuration{
-			Prefix:                  serviceStore.ServiceStorePrefix,
-			SynchronizationInterval: 5 * time.Minute,
-			KeyCreator: func() store.Key {
-				return &serviceStore.ClusterService{}
-			},
-			Backend:  nil,
-			Observer: nil,
-			Context:  ctx,
-		})
-
-		if err != nil {
-			log.WithError(err).Fatal("Unable to join kvstore store to announce services")
-		}
-
+		store := store.NewWorkqueueSyncStore(kvstore.Client(), serviceStore.ServiceStorePrefix,
+			store.WSSWithSourceClusterName(cfg.LocalClusterName()))
 		kvs = store
 		close(readyChan)
+		store.Run(ctx)
 	}()
 
 	swgSvcs := lock.NewStoppableWaitGroup()

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -155,18 +155,18 @@ type BackendOperations interface {
 	// Set sets value of key
 	Set(ctx context.Context, key string, value []byte) error
 
-	// Delete deletes a key
+	// Delete deletes a key. It does not return an error if the key does not exist.
 	Delete(ctx context.Context, key string) error
 
-	// DeleteIfLocked deletes a key if the client is still holding the given lock.
+	// DeleteIfLocked deletes a key if the client is still holding the given lock. It does not return an error if the key does not exist.
 	DeleteIfLocked(ctx context.Context, key string, lock KVLocker) error
 
 	DeletePrefix(ctx context.Context, path string) error
 
-	// Update atomically creates a key or fails if it already exists
+	// Update creates or updates a key.
 	Update(ctx context.Context, key string, value []byte, lease bool) error
 
-	// UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
+	// UpdateIfLocked updates a key if the client is still holding the given lock.
 	UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error
 
 	// UpdateIfDifferent updates a key if the value is different

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -549,7 +549,7 @@ func (c *consulClient) getPrefix(ctx context.Context, prefix string) (k string, 
 	return pairs[0].Key, pairs[0].Value, nil
 }
 
-// UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
+// UpdateIfLocked updates a key if the client is still holding the given lock.
 func (c *consulClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error {
 	return c.Update(ctx, key, value, lease)
 }

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -1357,7 +1357,7 @@ func (e *etcdClient) createOpPut(key string, value []byte, leaseID client.LeaseI
 	return &op
 }
 
-// UpdateIfLocked atomically creates a key or fails if it already exists if the client is still holding the given lock.
+// UpdateIfLocked updates a key if the client is still holding the given lock.
 func (e *etcdClient) UpdateIfLocked(ctx context.Context, key string, value []byte, lease bool, lock KVLocker) error {
 	if err := e.waitForInitialSession(ctx); err != nil {
 		return err

--- a/pkg/kvstore/kvstore_test.go
+++ b/pkg/kvstore/kvstore_test.go
@@ -36,9 +36,10 @@ func (s *independentSuite) TestValidateScopesFromKey(c *C) {
 		"cilium/state/ip/v1/default/10.15.189.183":                                                  "ip/v1",
 		"cilium/state/ip/v1/default/f00d::a0f:0:0:6f2e":                                             "ip/v1",
 		"cilium/state/nodes/v1/default/runtime":                                                     "nodes/v1",
+		"cilium/state/nodes/v1":                                                                     "nodes/v1",
 	}
 
 	for key, val := range mockData {
-		c.Assert(getScopeFromKey(key), Equals, val)
+		c.Assert(GetScopeFromKey(key), Equals, val)
 	}
 }

--- a/pkg/kvstore/metrics.go
+++ b/pkg/kvstore/metrics.go
@@ -18,9 +18,9 @@ const (
 	metricSet    = "set"
 )
 
-func getScopeFromKey(key string) string {
+func GetScopeFromKey(key string) string {
 	s := strings.SplitN(key, "/", 5)
-	if len(s) != 5 {
+	if len(s) < 4 {
 		if len(key) >= 12 {
 			return key[:12]
 		}
@@ -33,7 +33,7 @@ func increaseMetric(key, kind, action string, duration time.Duration, err error)
 	if !option.Config.MetricsConfig.KVStoreOperationsDurationEnabled {
 		return
 	}
-	namespace := getScopeFromKey(key)
+	namespace := GetScopeFromKey(key)
 	outcome := metrics.Error2Outcome(err)
 	metrics.KVStoreOperationsDuration.
 		WithLabelValues(namespace, kind, action, outcome).Observe(duration.Seconds())
@@ -43,7 +43,7 @@ func trackEventQueued(key string, typ EventType, duration time.Duration) {
 	if !option.Config.MetricsConfig.KVStoreEventsQueueDurationEnabled {
 		return
 	}
-	metrics.KVStoreEventsQueueDuration.WithLabelValues(getScopeFromKey(key), typ.String()).Observe(duration.Seconds())
+	metrics.KVStoreEventsQueueDuration.WithLabelValues(GetScopeFromKey(key), typ.String()).Observe(duration.Seconds())
 }
 
 func recordQuorumError(err string) {

--- a/pkg/kvstore/store/syncstore.go
+++ b/pkg/kvstore/store/syncstore.go
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package store
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// SyncStore abstracts the operations allowing to synchronize key/value pairs
+// into a kvstore.
+type SyncStore interface {
+	// Run starts the SyncStore logic, blocking until the context is closed.
+	Run(ctx context.Context)
+
+	// UpsertKey upserts a key/value pair into the kvstore.
+	UpsertKey(ctx context.Context, key Key) error
+
+	// DeleteKey removes a key from the kvstore.
+	DeleteKey(ctx context.Context, key NamedKey) error
+}
+
+// SyncStoreBackend represents the subset kvstore.BackendOperations leveraged
+// by SyncStore implementations.
+type SyncStoreBackend interface {
+	// Update creates or updates a key.
+	Update(ctx context.Context, key string, value []byte, lease bool) error
+	// Delete deletes a key.
+	Delete(ctx context.Context, key string) error
+}
+
+// wqSyncStore implements the SyncStore interface leveraging a workqueue to
+// coalescence update/delete requests and handle retries in case of errors.
+type wqSyncStore struct {
+	backend SyncStoreBackend
+	prefix  string
+
+	workers   uint
+	withLease bool
+
+	limiter   workqueue.RateLimiter
+	workqueue workqueue.RateLimitingInterface
+	state     sync.Map /* map[string][]byte --- map[NamedKey.GetKeyName()]Key.Marshal() */
+
+	log *logrus.Entry
+}
+
+type WSSOpt func(*wqSyncStore)
+
+// WSSWithRateLimiter sets the rate limiting algorithm to be used when requeueing failed events.
+func WSSWithRateLimiter(limiter workqueue.RateLimiter) WSSOpt {
+	return func(wss *wqSyncStore) {
+		wss.limiter = limiter
+	}
+}
+
+// WSSWithWorkers configures the number of workers spawned by Run() to handle update/delete operations.
+func WSSWithWorkers(workers uint) WSSOpt {
+	return func(wss *wqSyncStore) {
+		wss.workers = workers
+	}
+}
+
+// WSSWithoutLease disables attaching the lease to upserted keys.
+func WSSWithoutLease() WSSOpt {
+	return func(wss *wqSyncStore) {
+		wss.withLease = false
+	}
+}
+
+// NewWorkqueueSyncStore returns a SyncStore instance which leverages a workqueue
+// to coalescence update/delete requests and handle retries in case of errors.
+func NewWorkqueueSyncStore(backend SyncStoreBackend, prefix string, opts ...WSSOpt) SyncStore {
+	wss := &wqSyncStore{
+		backend: backend,
+		prefix:  prefix,
+
+		workers:   1,
+		withLease: true,
+		limiter:   workqueue.DefaultControllerRateLimiter(),
+
+		log: log.WithField("prefix", prefix),
+	}
+
+	for _, opt := range opts {
+		opt(wss)
+	}
+
+	wss.workqueue = workqueue.NewRateLimitingQueue(wss.limiter)
+	return wss
+}
+
+// Run starts the SyncStore logic, blocking until the context is closed.
+func (wss *wqSyncStore) Run(ctx context.Context) {
+	var wg sync.WaitGroup
+
+	wss.log.WithField(logfields.Workers, wss.workers).Info("Starting workqueue-based sync store")
+	wg.Add(int(wss.workers))
+	for i := uint(0); i < wss.workers; i++ {
+		go func() {
+			defer wg.Done()
+			for wss.processNextItem(ctx) {
+			}
+		}()
+	}
+
+	<-ctx.Done()
+
+	wss.log.Info("Shutting down workqueue-based sync store")
+	wss.workqueue.ShutDown()
+	wg.Wait()
+}
+
+// UpsertKey registers the key for asynchronous upsertion in the kvstore, if the
+// corresponding value has changed. It returns an error in case it is impossible
+// to marshal the value, while kvstore failures are automatically handled through
+// a retry mechanism.
+func (wss *wqSyncStore) UpsertKey(_ context.Context, k Key) error {
+	key := k.GetKeyName()
+	value, err := k.Marshal()
+	if err != nil {
+		return fmt.Errorf("failed marshaling key %q: %w", k, err)
+	}
+
+	prevValue, loaded := wss.state.Swap(key, value)
+	if loaded && bytes.Equal(prevValue.([]byte), value) {
+		wss.log.WithField(logfields.Key, k).Debug("ignoring upsert request for already up-to-date key")
+	} else {
+		wss.workqueue.Add(key)
+	}
+
+	return nil
+}
+
+// DeleteKey registers the key for asynchronous deletion from the kvstore, if it
+// was known to be present. It never returns an error, because kvstore failures
+// are automatically handled through a retry mechanism.
+func (wss *wqSyncStore) DeleteKey(_ context.Context, k NamedKey) error {
+	key := k.GetKeyName()
+	if _, loaded := wss.state.LoadAndDelete(key); loaded {
+		wss.workqueue.Add(key)
+	} else {
+		wss.log.WithField(logfields.Key, key).Debug("ignoring delete request for non-existing key")
+	}
+
+	return nil
+}
+
+func (wss *wqSyncStore) processNextItem(ctx context.Context) bool {
+	// Retrieve the next key to process from the workqueue.
+	key, shutdown := wss.workqueue.Get()
+	if shutdown {
+		return false
+	}
+
+	// We call Done here so the workqueue knows we have finished
+	// processing this item.
+	defer wss.workqueue.Done(key)
+
+	// Run the handler, passing it the key to be processed as parameter.
+	if err := wss.handle(ctx, key.(string)); err != nil {
+		// Put the item back on the workqueue to handle any transient errors.
+		wss.workqueue.AddRateLimited(key)
+		return true
+	}
+
+	// Since no error occurred, forget this item so it does not get queued again
+	// until another change happens.
+	wss.workqueue.Forget(key)
+	return true
+}
+
+func (wss *wqSyncStore) handle(ctx context.Context, key string) error {
+	if value, ok := wss.state.Load(key); ok {
+		return wss.handleUpsert(ctx, key, value.([]byte))
+	}
+
+	return wss.handleDelete(ctx, key)
+}
+
+func (wss *wqSyncStore) handleUpsert(ctx context.Context, key string, value []byte) error {
+	scopedLog := wss.log.WithField(logfields.Key, key)
+
+	err := wss.backend.Update(ctx, wss.keyPath(key), value, wss.withLease)
+	if err != nil {
+		scopedLog.WithError(err).Warning("Failed upserting key in kvstore. Retrying...")
+		return err
+	}
+
+	scopedLog.Debug("Upserted key in kvstore")
+	return nil
+}
+
+func (wss *wqSyncStore) handleDelete(ctx context.Context, key string) error {
+	scopedLog := wss.log.WithField(logfields.Key, key)
+
+	if err := wss.backend.Delete(ctx, wss.keyPath(key)); err != nil {
+		scopedLog.WithError(err).Warning("Failed deleting key from kvstore. Retrying...")
+		return err
+	}
+
+	scopedLog.Debug("Deleted key from kvstore")
+	return nil
+}
+
+// keyPath returns the absolute kvstore path of a key
+func (wss *wqSyncStore) keyPath(key string) string {
+	// WARNING - STABLE API: The composition of the absolute key path
+	// cannot be changed without breaking up and downgrades.
+	return path.Join(wss.prefix, key)
+}

--- a/pkg/kvstore/store/syncstore_test.go
+++ b/pkg/kvstore/store/syncstore_test.go
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type KVPair struct{ Key, Value string }
+
+func NewKVPair(key, value string) *KVPair      { return &KVPair{Key: key, Value: value} }
+func (kv *KVPair) GetKeyName() string          { return kv.Key }
+func (kv *KVPair) Marshal() ([]byte, error)    { return []byte(kv.Value), nil }
+func (kv *KVPair) Unmarshal(data []byte) error { return nil /* not used */ }
+
+type fakeBackend struct {
+	t           *testing.T
+	expectLease bool
+
+	updated chan *KVPair
+	deleted chan *KVPair
+
+	errorsOnUpdate map[string]uint
+	errorsOnDelete map[string]uint
+}
+
+func NewFakeBackend(t *testing.T, expectLease bool) *fakeBackend {
+	return &fakeBackend{
+		t:           t,
+		expectLease: expectLease,
+
+		updated: make(chan *KVPair),
+		deleted: make(chan *KVPair),
+
+		errorsOnUpdate: make(map[string]uint),
+		errorsOnDelete: make(map[string]uint),
+	}
+}
+
+func (fb *fakeBackend) Update(ctx context.Context, key string, value []byte, lease bool) error {
+	if lease != fb.expectLease {
+		key = "error"
+		value = []byte(fmt.Sprintf("incorrect lease setting, expected(%v) - found(%v)", fb.expectLease, lease))
+	}
+
+	select {
+	case fb.updated <- NewKVPair(key, string(value)):
+	case <-ctx.Done():
+		require.Failf(fb.t, "Context closed before writing to updated channel", "key: %s, value: %s", key, value)
+	}
+
+	if cnt := fb.errorsOnUpdate[key]; cnt > 0 {
+		fb.errorsOnUpdate[key]--
+		return errors.New("failing on purpose")
+	}
+
+	return nil
+}
+
+func (fb *fakeBackend) Delete(ctx context.Context, key string) error {
+	select {
+	case fb.deleted <- NewKVPair(key, ""):
+	case <-ctx.Done():
+		require.Failf(fb.t, "Context closed before writing to deleted channel", "key: %s", key)
+	}
+
+	if cnt := fb.errorsOnDelete[key]; cnt > 0 {
+		fb.errorsOnDelete[key]--
+		return errors.New("failing on purpose")
+	}
+
+	return nil
+}
+
+type fakeRateLimiter struct{ whenCalled, forgetCalled chan *KVPair }
+
+func NewFakeRateLimiter() *fakeRateLimiter {
+	return &fakeRateLimiter{whenCalled: make(chan *KVPair), forgetCalled: make(chan *KVPair)}
+}
+
+func (frl *fakeRateLimiter) When(item interface{}) time.Duration {
+	frl.whenCalled <- NewKVPair(item.(string), "")
+	return time.Duration(0)
+}
+func (frl *fakeRateLimiter) Forget(item interface{}) {
+	frl.forgetCalled <- NewKVPair(item.(string), "")
+}
+func (frl *fakeRateLimiter) NumRequeues(item interface{}) int { return 0 }
+
+func eventually(in <-chan *KVPair, timeout time.Duration) *KVPair {
+	select {
+	case kv := <-in:
+		return kv
+	case <-time.After(timeout):
+		return NewKVPair("error", "timed out waiting for KV")
+	}
+}
+
+func TestWorkqueueSyncStore(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	backend := NewFakeBackend(t, true)
+	store := NewWorkqueueSyncStore(backend, "/foo/bar")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		store.Run(ctx)
+	}()
+
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	// Upserts should trigger the corresponding backend operation.
+	store.UpsertKey(ctx, NewKVPair("key1", "value1"))
+	store.UpsertKey(ctx, NewKVPair("key2", "value2"))
+	require.Equal(t, NewKVPair("/foo/bar/key1", "value1"), eventually(backend.updated, 100*time.Millisecond))
+	require.Equal(t, NewKVPair("/foo/bar/key2", "value2"), eventually(backend.updated, 100*time.Millisecond))
+
+	// Unless the pair is already part of the known state.
+	store.UpsertKey(ctx, NewKVPair("key1", "value1"))
+	store.UpsertKey(ctx, NewKVPair("key3", "value3"))
+	require.Equal(t, NewKVPair("/foo/bar/key3", "value3"), eventually(backend.updated, 100*time.Millisecond))
+
+	// Upserts for the same key should be coalescenced. In this case, it is guaranteed
+	// to happen since the first upsert blocks until we read from the channel.
+	store.UpsertKey(ctx, NewKVPair("key4", "value4"))
+	store.UpsertKey(ctx, NewKVPair("key1", "valueA"))
+	store.UpsertKey(ctx, NewKVPair("key1", "valueB"))
+	require.Equal(t, NewKVPair("/foo/bar/key4", "value4"), eventually(backend.updated, 100*time.Millisecond))
+	require.Equal(t, NewKVPair("/foo/bar/key1", "valueB"), eventually(backend.updated, 100*time.Millisecond))
+
+	// Deletions should trigger the corresponding backend operation, only if known to exist.
+	store.DeleteKey(ctx, NewKVPair("key5", ""))
+	store.DeleteKey(ctx, NewKVPair("key4", ""))
+	require.Equal(t, NewKVPair("/foo/bar/key4", ""), eventually(backend.deleted, 100*time.Millisecond))
+
+	// Both upserts and deletes should be retried in case an error is returned by the client
+	backend.errorsOnUpdate["/foo/bar/key1"] = 1
+	store.UpsertKey(ctx, NewKVPair("key1", "valueC"))
+	require.Equal(t, NewKVPair("/foo/bar/key1", "valueC"), eventually(backend.updated, 100*time.Millisecond))
+	require.Equal(t, NewKVPair("/foo/bar/key1", "valueC"), eventually(backend.updated, 250*time.Millisecond))
+
+	backend.errorsOnDelete["/foo/bar/key2"] = 1
+	store.DeleteKey(ctx, NewKVPair("key2", ""))
+	require.Equal(t, NewKVPair("/foo/bar/key2", ""), eventually(backend.deleted, 100*time.Millisecond))
+	require.Equal(t, NewKVPair("/foo/bar/key2", ""), eventually(backend.deleted, 250*time.Millisecond))
+}
+
+func TestWorkqueueSyncStoreWithoutLease(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	backend := NewFakeBackend(t, false)
+	store := NewWorkqueueSyncStore(backend, "/foo/bar", WSSWithoutLease())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		store.Run(ctx)
+	}()
+
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	// The fake backend checks whether the lease setting corresponds to the expected
+	// value, and emits a KVPair with the error message in case it does not match
+	store.UpsertKey(ctx, NewKVPair("key1", "value1"))
+	require.Equal(t, NewKVPair("/foo/bar/key1", "value1"), eventually(backend.updated, 100*time.Millisecond))
+}
+
+func TestWorkqueueSyncStoreWithRateLimiter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	backend := NewFakeBackend(t, true)
+	limiter := NewFakeRateLimiter()
+	store := NewWorkqueueSyncStore(backend, "/foo/bar", WSSWithRateLimiter(limiter))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		store.Run(ctx)
+	}()
+
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	backend.errorsOnUpdate["/foo/bar/key1"] = 1
+
+	// Assert that the custom rate limiter has been correctly called
+	store.UpsertKey(ctx, NewKVPair("key1", "value1"))
+	require.Equal(t, NewKVPair("/foo/bar/key1", "value1"), eventually(backend.updated, 100*time.Millisecond))
+	require.Equal(t, NewKVPair("key1", ""), eventually(limiter.whenCalled, 100*time.Millisecond))
+	require.Equal(t, NewKVPair("/foo/bar/key1", "value1"), eventually(backend.updated, 100*time.Millisecond))
+	require.Equal(t, NewKVPair("key1", ""), eventually(limiter.forgetCalled, 100*time.Millisecond))
+}
+
+func TestWorkqueueSyncStoreWithWorkers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	backend := NewFakeBackend(t, true)
+	store := NewWorkqueueSyncStore(backend, "/foo/bar", WSSWithWorkers(2))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		store.Run(ctx)
+	}()
+
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	store.UpsertKey(ctx, NewKVPair("key1", "value1"))
+	require.Equal(t, NewKVPair("/foo/bar/key1", "value1"), eventually(backend.updated, 100*time.Millisecond))
+
+	// Since the Update() and Delete() functions implemented by the fake backend
+	// block until we read from the correposponding channel, reading in reversed
+	// order the elements from the two channels requires at least two workers
+	store.DeleteKey(ctx, NewKVPair("key1", "value1"))
+	store.UpsertKey(ctx, NewKVPair("key2", "value2"))
+	require.Equal(t, NewKVPair("/foo/bar/key2", "value2"), eventually(backend.updated, 100*time.Millisecond))
+	require.Equal(t, NewKVPair("/foo/bar/key1", ""), eventually(backend.deleted, 100*time.Millisecond))
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -694,4 +694,7 @@ const (
 
 	// CIDRGroupRef is a references to a CiliumCIDRGroup object.
 	CIDRGroupRef = "cidrGroupRef"
+
+	// Workers represents the number of workers.
+	Workers = "workers"
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -463,6 +463,10 @@ var (
 	// KVStoreQuorumErrors records the number of kvstore quorum errors
 	KVStoreQuorumErrors = NoOpCounterVec
 
+	// KVStoreSyncQueueSize records the number of elements queued for
+	// synchronization in the kvstore.
+	KVStoreSyncQueueSize = NoOpGaugeVec
+
 	// FQDNGarbageCollectorCleanedTotal is the number of domains cleaned by the
 	// GC job.
 	FQDNGarbageCollectorCleanedTotal = NoOpCounter
@@ -605,6 +609,7 @@ type Configuration struct {
 	KVStoreOperationsDurationEnabled        bool
 	KVStoreEventsQueueDurationEnabled       bool
 	KVStoreQuorumErrorsEnabled              bool
+	KVStoreSyncQueueSizeEnabled             bool
 	FQDNGarbageCollectorCleanedTotalEnabled bool
 	FQDNActiveNames                         bool
 	FQDNActiveIPs                           bool
@@ -679,6 +684,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemKVStore + "_operations_duration_seconds":          {},
 		Namespace + "_" + SubsystemKVStore + "_events_queue_seconds":                 {},
 		Namespace + "_" + SubsystemKVStore + "_quorum_errors_total":                  {},
+		Namespace + "_" + SubsystemKVStore + "_sync_queue_size":                      {},
 		Namespace + "_" + SubsystemIPCache + "_errors_total":                         {},
 		Namespace + "_" + SubsystemFQDN + "_gc_deletions_total":                      {},
 		Namespace + "_" + SubsystemBPF + "_map_ops_total":                            {},
@@ -1255,6 +1261,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, KVStoreQuorumErrors)
 			c.KVStoreQuorumErrorsEnabled = true
+
+		case Namespace + "_" + SubsystemKVStore + "_sync_queue_size":
+			KVStoreSyncQueueSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemKVStore,
+				Name:      "sync_queue_size",
+				Help:      "Number of elements queued for synchronization in the kvstore",
+			}, []string{LabelScope, LabelSourceCluster})
+
+			collectors = append(collectors, KVStoreSyncQueueSize)
+			c.KVStoreSyncQueueSizeEnabled = true
 
 		case Namespace + "_" + SubsystemIPCache + "_errors_total":
 			IPCacheErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
This PR reworks the logic used by the clustermesh-apiserver to synchronize the services and the associated backends to the kvstore. Specifically, it introduces the SyncStore abstraction, which models the operations required to synchronize key/value pairs into a kvstore, and represents a simplified "write-only" version of the SharedStore abstraction currently available. The implementation relies on a workqueue to allow coalescence multiple updates of the same key into one operation only, as well as transparently handling temporary failures through retries. Notably, periodic update of all known keys is not performed, to reduce the load on the kvstore (it was already not performed for CiliumEndpoints and CiliumIdentities, which are also synchronized by the clustermesh-apiserver).

Please, refer to the commit descriptions for additional details about the different changes.

<!-- Description of change -->

```release-note
clustermesh-apiserver: rework services synchronization to improve performance
```
