### PR TITLE
identity/cache: fix panic when re-init of cache after close.

### DIFF
--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -140,7 +140,6 @@ func (w *identityWatcher) watch(events allocator.AllocatorEventChan) {
 		for {
 			added := IdentityCache{}
 			deleted := IdentityCache{}
-
 		First:
 			for {
 				// Wait for one identity add or delete or stop


### PR DESCRIPTION
The cache appears to be intended to tolerate being initialized, closed then reinitialized. However the events channel is not reset correctly leading to a double close panic in tests.

This ensures that the events channel is set to nil after being closed, and checked upon further closes.
As well, if init is called on Close()'d cache, the events channel/watcher will be recreated.

Also, added tests to check functionality/correctness in this case.

Fixes: #25235