### PR TITLE
Doc: Update k3s cilium installation to match k3s default podCIDR

### DIFF
--- a/Documentation/installation/k3s.rst
+++ b/Documentation/installation/k3s.rst
@@ -68,11 +68,15 @@ Install Cilium
 
 .. include:: cli-download.rst
 
+.. note::
+
+   Install Cilium with ``--helm-set=ipam.operator.clusterPoolIPv4PodCIDR="10.42.0.0/16"`` to match k3s default podCIDR 10.42.0.0/16.
+
 Install Cilium by running:
 
 .. code-block:: shell-session
 
-    cilium install
+    cilium install --helm-set=ipam.operator.clusterPoolIPv4PodCIDR="10.42.0.0/16"
 
 Validate the Installation
 =========================


### PR DESCRIPTION
Current k3s installation instruction allow k3s to
use the default podCIDR 10.42.0.0/16 for pod, which can be seen from node.Spec:

spec:
  podCIDR: 10.42.0.0/24
  podCIDRs:
  - 10.42.0.0/24

but "cilium install" result in pod IP to be allocated from 10.0.0.0/8 range, this cause confusion to users, the cilium installation should allow allocated pod IP match default k3s podCIDR.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Update k3s cilium installation to match k3s default podCIDR
```
