### PR TITLE
bpf/makefile: fix spelling issue and make it clear which bear cli.

### DIFF
--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -292,7 +292,8 @@ clean:
 BEAR_CLI   = $(shell which bear 2> /dev/null)
 gen_compile_commands:
 ifeq (, $(BEAR_CLI))
-	@echo "bear cli must be in $PATH to generate json compilation database"
+	@echo 'Bear cli must be in $$PATH to generate json compilation database'
+	@echo 'See: https://github.com/rizsotto/Bear'
 else
 	bear -- make
 endif


### PR DESCRIPTION
Bear CLI is a bit ambiguous, specify exactly what CLI to install. Also fixes escaping so it doesn't print out ATH instead of $PATH.

