### PR TITLE
alibabacloud: Reverse vswitch selection order

### DIFF
--- a/pkg/alibabacloud/eni/instances.go
+++ b/pkg/alibabacloud/eni/instances.go
@@ -161,7 +161,7 @@ func (m *InstancesManager) UpdateENI(instanceID string, eni *eniTypes.ENI) {
 	m.instances.Update(instanceID, eniRevision)
 }
 
-// FindOneVSwitch returns the vSwitch with the fewest available addresses, matching vpc and az.
+// FindOneVSwitch returns the vSwitch with the most available addresses, matching vpc and az.
 // If we have explicit ID or tag constraints, chose a matching vSwitch. ID constraints take
 // precedence.
 func (m *InstancesManager) FindOneVSwitch(spec eniTypes.Spec, toAllocate int) *ipamTypes.Subnet {
@@ -182,14 +182,14 @@ func (m *InstancesManager) FindOneVSwitch(spec eniTypes.Spec, toAllocate int) *i
 		if !vSwitch.Tags.Match(spec.VSwitchTags) {
 			continue
 		}
-		if bestSubnet == nil || bestSubnet.AvailableAddresses > vSwitch.AvailableAddresses {
+		if bestSubnet == nil || bestSubnet.AvailableAddresses < vSwitch.AvailableAddresses {
 			bestSubnet = vSwitch
 		}
 	}
 	return bestSubnet
 }
 
-// FindVSwitchByIDs returns the vSwitch within a provided list of vSwitch IDs with the fewest available addresses,
+// FindVSwitchByIDs returns the vSwitch within a provided list of vSwitch IDs with the most available addresses,
 // matching vpc and az.
 func (m *InstancesManager) FindVSwitchByIDs(spec eniTypes.Spec, toAllocate int) *ipamTypes.Subnet {
 	m.mutex.RLock()
@@ -207,7 +207,7 @@ func (m *InstancesManager) FindVSwitchByIDs(spec eniTypes.Spec, toAllocate int) 
 			if vSwitch.ID != vSwitchID {
 				continue
 			}
-			if bestSubnet == nil || bestSubnet.AvailableAddresses > vSwitch.AvailableAddresses {
+			if bestSubnet == nil || bestSubnet.AvailableAddresses < vSwitch.AvailableAddresses {
 				bestSubnet = vSwitch
 			}
 		}


### PR DESCRIPTION
Currently, in alibabacloud ipam mode, IP addresses are allocated from a matching vswitch with the fewest IP addresses. When many vswitches nearly reach the IP limit, a node might be attached with ENIs from different vswitches that only provide one or very few IP addresses.

This patch fixes this by selecting a matching vswitch with the most IP addresses, which also aligns with AWS eni mode.

```release-note
alibabacloud: Allocate from vswitches with the most IP addresses
```
