### PR TITLE
daemon: Log warning if BPF Clock probe fail

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -2024,7 +2024,13 @@ func initClockSourceOption() {
 			t, err := bpf.GetJtime()
 			if err == nil && t > 0 {
 				option.Config.ClockSource = option.ClockSourceJiffies
+			} else {
+				log.WithError(err).Warningf("Auto-disabling %q feature since kernel doesn't expose %q.", option.EnableBPFClockProbe, bpf.TimerInfoFilepath)
+				option.Config.EnableBPFClockProbe = false
 			}
+		} else {
+			log.WithError(err).Warningf("Auto-disabling %q feature since kernel support is missing (Linux 5.5 or later required).", option.EnableBPFClockProbe)
+			option.Config.EnableBPFClockProbe = false
 		}
 	}
 }

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -592,7 +592,7 @@ func GetMtime() (uint64, error) {
 }
 
 const (
-	timerInfoFilepath = "/proc/timer_list"
+	TimerInfoFilepath = "/proc/timer_list"
 )
 
 // GetJtime returns a close-enough approximation of kernel jiffies
@@ -602,7 +602,7 @@ const (
 func GetJtime() (uint64, error) {
 	jiffies := uint64(0)
 	scaler := uint64(8)
-	timers, err := os.Open(timerInfoFilepath)
+	timers, err := os.Open(TimerInfoFilepath)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
If a user enable BPF Clock and probe of the kernel support fails, we currently don't log anything and silently disable that feature. Let's instead log a warning so it's clear that the feature isn't used and why.