### PR TITLE
labelsfilter: Assign review to sig-policy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -435,6 +435,7 @@ jenkinsfiles @cilium/ci-structure
 /pkg/kafka/ @cilium/proxy
 /pkg/kvstore/ @cilium/kvstore
 /pkg/labels @cilium/sig-policy @cilium/api
+/pkg/labelsfilter @cilium/sig-policy
 /pkg/launcher @cilium/sig-agent
 /pkg/loadbalancer @cilium/sig-lb
 /pkg/lock @cilium/sig-agent


### PR DESCRIPTION
Context: https://github.com/cilium/cilium/pull/23762

There are policy and upgrade implications for any changes to this file, and
it requires specialist knowledge that the tophat does not have. Assign to
sig-policy for review.
