### PR TITLE
test,job: Fix deadlock in `TestOneShot_RetryRecoverNoShutdown`

### DIFF
--- a/pkg/hive/job/job_test.go
+++ b/pkg/hive/job/job_test.go
@@ -312,12 +312,9 @@ func TestOneShot_RetryRecoverNoShutdown(t *testing.T) {
 		g.Add(
 			OneShot("retry-recover-no-shutdown", func(ctx context.Context) error {
 				defer func() { i++ }()
-				if started != nil {
-					close(started)
-					started = nil
-				}
 
 				if i == 0 {
+					close(started)
 					return errors.New("First try error")
 				}
 
@@ -676,6 +673,7 @@ func TestObserver_LongStream(t *testing.T) {
 // stops even if there are still pending items in the stream.
 func TestObserver_CtxClose(t *testing.T) {
 	started := make(chan struct{})
+	i := 0
 	streamSlice := []string{"a", "b", "c"}
 
 	h := fixture(func(r Registry, l hive.Lifecycle) {
@@ -683,9 +681,9 @@ func TestObserver_CtxClose(t *testing.T) {
 
 		g.Add(
 			Observer("retry-fail", func(ctx context.Context, event string) error {
-				if started != nil {
+				if i == 0 {
 					close(started)
-					started = nil
+					i++
 				}
 				<-ctx.Done()
 				return nil


### PR DESCRIPTION
This test asserts that the function under test is called again if the first call to the callback returned an error. A channel is used to signal to the test function that the callback has started, this signal being the closure of a channel. But channels are only allowed to be closed once, so the code would set the channel to `nil` after closing it and wrap the closing code in a nil-check. This works 99.999% of the time since the consumer of the channel will continue. However, it sometimes happens that the channel is set to `nil` before the consumers flow has been started, resulting in a deadlock since reading from a nil channel always blocks. So, to fix it, we now simply look at the `i` variable and don't set the channel to `nil` anymore.

Fixes: #25276

```release-note
Fixed flake in pkg/hive/job tests.
```
