### PR TITLE
workflows/push charts: Checkout main branch before set-env-variables

### DIFF
--- a/.github/workflows/push-chart-ci.yaml
+++ b/.github/workflows/push-chart-ci.yaml
@@ -41,6 +41,15 @@ jobs:
     # we also check for push events in case someone is testing the workflow by uncommenting the push trigger above.
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' }}
     steps:
+    - name: Checkout GitHub main
+      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      with:
+        ref: ${{ github.event.repository.default_branch }}
+        persist-credentials: false
+
+    - name: Set Environment Variables
+      uses: ./.github/actions/set-env-variables
+
     - name: Get triggering event ref
       id: get-ref
       run: |
@@ -84,8 +93,7 @@ jobs:
     - id: get-version
       run: |
         echo "chart_version=$(./contrib/scripts/print-chart-version.sh)" | tee -a $GITHUB_OUTPUT
-    - name: Set Environment Variables
-      uses: ./.github/actions/set-env-variables
+
     - name: Push charts
       uses: cilium/reusable-workflows/.github/actions/push-helm-chart@v0.1.0
       with:


### PR DESCRIPTION
set-env-variables may not exist on older branches, so like other github actions, checkout the default branch before calling set-env-variables.

CI run on a branch testing this change: https://github.com/cilium/cilium/actions/runs/4898128686/jobs/8746928466