### PR TITLE
Fixed mtu unit test

### DIFF
--- a/pkg/mtu/detect_linux.go
+++ b/pkg/mtu/detect_linux.go
@@ -51,13 +51,13 @@ func autoDetect() (int, error) {
 		}
 	}
 
-	if routes[0].Gw == nil {
-		return 0, fmt.Errorf("unable to find default gateway from the routes: %s", routes)
-	}
-
 	link, err := netlink.LinkByIndex(routes[0].LinkIndex)
 	if err != nil {
 		return 0, fmt.Errorf("unable to find interface of default route: %w", err)
+	}
+
+	if attr := link.Attrs(); attr != nil && attr.Flags|net.FlagLoopback != 0 {
+		return 0, fmt.Errorf("interface for default route is a loopback device")
 	}
 
 	if mtu := link.Attrs().MTU; mtu != 0 {


### PR DESCRIPTION
While running inside a kubernetes pod where the default route is:

  default via 10.92.0.1 dev eth0

the unit test will raise error "unable to find default gateway from the routes". Remove the gateway check for MTU detection.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!



