### PR TITLE
datapath: link-local unicast addresses can be "host"

### DIFF
--- a/pkg/datapath/linux/node_addressing_test.go
+++ b/pkg/datapath/linux/node_addressing_test.go
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package linux
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestFilterLocalAddresses(t *testing.T) {
+	tests := []struct {
+		name         string
+		addrs        []netlink.Addr
+		ipsToExclude []net.IP
+		addrScopeMax int
+		want         []net.IP
+	}{
+		{
+			name: "simple",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+			},
+		},
+		{
+			name: "multiple",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.2")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+				net.ParseIP("10.0.0.2"),
+			},
+		},
+		{
+			name: "scopeMaxLink",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_LINK),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.2")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.3")},
+					Scope: int(netlink.SCOPE_NOWHERE),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_LINK),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+			},
+		},
+		{
+			name: "scopeMaxHost",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_LINK),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.2")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.3")},
+					Scope: int(netlink.SCOPE_NOWHERE),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+				net.ParseIP("10.0.0.2"),
+			},
+		},
+		{
+			name: "scopeMaxNowhere",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_LINK),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.2")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.3")},
+					Scope: int(netlink.SCOPE_NOWHERE),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_NOWHERE),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+				net.ParseIP("10.0.0.2"),
+				net.ParseIP("10.0.0.3"),
+			},
+		},
+		{
+			name: "exclude",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.2")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{
+				net.ParseIP("10.0.0.2"),
+			},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+			},
+		},
+		{
+			name: "excludeMultiple",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.2")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.3")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{
+				net.ParseIP("10.0.0.2"),
+				net.ParseIP("10.0.0.3"),
+			},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+			},
+		},
+		{
+			name: "ipv6 simple",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("2001:db8::")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("2001:db8::"),
+			},
+		},
+		{
+			name: "ipv6 multiple",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("2001:db8::")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("2600:beef::")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("2001:db8::"),
+				net.ParseIP("2600:beef::"),
+			},
+		},
+		{
+			name: "v4/v6 mix",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("2001:db8::")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+				net.ParseIP("2001:db8::"),
+			},
+		},
+		{
+			name: "v6 exclude",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("2001:db8::")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{
+				net.ParseIP("2001:db8::"),
+			},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+			},
+		},
+		{
+			name: "include link-local v4",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("169.254.20.10")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("169.254.169.254")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+				net.ParseIP("169.254.20.10"),
+				net.ParseIP("169.254.169.254"),
+			},
+		},
+		{
+			name: "include link-local v6",
+			addrs: []netlink.Addr{
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("10.0.0.1")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("fe80::")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+				{
+					IPNet: &net.IPNet{IP: net.ParseIP("fe80::1234")},
+					Scope: int(netlink.SCOPE_HOST),
+				},
+			},
+			ipsToExclude: []net.IP{},
+			addrScopeMax: int(netlink.SCOPE_HOST),
+			want: []net.IP{
+				net.ParseIP("10.0.0.1"),
+				net.ParseIP("fe80::"),
+				net.ParseIP("fe80::1234"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterLocalAddresses(tt.addrs, tt.ipsToExclude, tt.addrScopeMax)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("filterLocalAddresses(): got = %v, want = %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Background

This is a fix for a regression in the local addresses logic, introduced in 080857bdedca as part of the implementation for AddressScopeMax. Addresses with the form of a link-local unicast address began to be filtered out of the local address aggregation, causing them to labeled with the "world" identity for the sake of policy enforcement. Examples of such addresses include:

169.254.10.10
fe80::1234

This caused issues for a variety of users, whose policies allowing "host" traffic would no longer allow traffic to these addresses, forcing the use of workarounds involving CIDR policies, which is not the intended behavior for this type of address. This was a regression as of Cilium 1.12.0-rc2. One reason for this regression was that logic prior to the change looked at the address scope, whereas logic after the change looked at the address bytes, and it was found that many users had assigned addresses of the forms above but with scope global, causing them to again be filtered out unconditionally.

### Implementation

This patch factors out the local address filtering logic into a function, removes the skip over IsLinkLocalUnicast(), and adds a variety of unit tests for that function.

### Important Note

This change has no effect on link-local services such as the AWS Metadata service which operates on `169.254.169.254/32` because that address is not assigned to any interface of the local host and thus is not enumerated by rnetlink. The address is still labeled with the "world" identity as usual. This has been tested on EKS and kind.

### Fixes

<!-- Description of change -->

fixes: https://github.com/cilium/cilium/issues/25242
fixes: https://github.com/cilium/cilium/issues/23910
fixes: https://github.com/cilium/cilium/issues/16308
fixes: https://github.com/cilium/cilium/issues/20055

```release-note
Fix a regression in which link-local addresses were not treated with the "host" identity in some circumstances.
```