### PR TITLE
Updates k8s ParseNode() to Handle Multiple IPs

### DIFF
--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -372,6 +372,9 @@ const (
 	// with TunnelPeer
 	ConflictingTunnelPeer = "conflictingTunnelPeer"
 
+	// Type is the address type
+	Type = "type"
+
 	// Selector is a selector of any sort: endpoint, CIDR, toFQDNs
 	Selector = "Selector"
 


### PR DESCRIPTION
This PR updates `ParseNode()` in the k8s pkg to emit a warning-level log message when a k8s node contains multiple IPs of the same address type and family.

Fixes: https://github.com/cilium/cilium/issues/20787
Supercedes: https://github.com/cilium/cilium/pull/20811

```release-note
When a k8s node contains multiple addresses of the same type and family, Cilium will now emit a warning-level log message stating: "Detected multiple IPs of the same address type, Cilium will only consider the first IP in the Node resource"
```
