### PR TITLE
bpf: nat: fix ICMPv6 ECHO types in snat_v6_rewrite_ingress()

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1648,7 +1648,7 @@ static __always_inline int snat_v6_rewrite_ingress(struct __ctx_buff *ctx,
 
 			if (ctx_load_bytes(ctx, off, &type, 1) < 0)
 				return DROP_INVALID;
-			if (type == ICMP_ECHO || type == ICMP_ECHOREPLY) {
+			if (type == ICMPV6_ECHO_REQUEST || type == ICMPV6_ECHO_REPLY) {
 				if (ctx_store_bytes(ctx, off +
 						    offsetof(struct icmp6hdr,
 							     icmp6_dataun.u_echo.identifier),


### PR DESCRIPTION
When revSNATing ICMPv6 packets, check for the ICMPv6 type identifiers.

Fixes: 07592906e958 ("bpf/nat: review snat_v{4|6}_rewrite_ingress to support more ICMP types")

```release-note
Fix RevSNAT for ICMPv6 packets.
```
