### PR TITLE
dnsproxy: bind dns proxy to localhost only

### DIFF
--- a/pkg/fqdn/dnsproxy/ipfamily.go
+++ b/pkg/fqdn/dnsproxy/ipfamily.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dnsproxy
+
+type ipFamily struct {
+	Name        string
+	IPv4Enabled bool
+	IPv6Enabled bool
+	UDPAddress  string
+	TCPAddress  string
+	Localhost   string
+}
+
+func ipv4Family() ipFamily {
+	return ipFamily{
+		Name:        "ipv4",
+		IPv4Enabled: true,
+		IPv6Enabled: false,
+		UDPAddress:  "udp4",
+		TCPAddress:  "tcp4",
+		Localhost:   "127.0.0.1",
+	}
+}
+
+func ipv6Family() ipFamily {
+	return ipFamily{
+		Name:        "ipv6",
+		IPv4Enabled: false,
+		IPv6Enabled: true,
+		UDPAddress:  "udp6",
+		TCPAddress:  "tcp6",
+		Localhost:   "::1",
+	}
+}

--- a/pkg/fqdn/dnsproxy/udp.go
+++ b/pkg/fqdn/dnsproxy/udp.go
@@ -114,14 +114,13 @@ func listenConfig(mark int, ipv4, ipv6 bool) *net.ListenConfig {
 		}}
 }
 
-func bindUDP(addr string, ipv4, ipv6 bool) *net.IPConn {
+func bindUDP(addr string, ipv4, ipv6 bool) (*net.IPConn, error) {
 	// Mark outgoing packets as proxy egress return traffic (0x0b00)
 	conn, err := listenConfig(0xb00, ipv4, ipv6).ListenPacket(context.Background(), "ip:udp", addr)
 	if err != nil {
-		log.WithError(err).Errorf("bindUDP failed for address %s", addr)
-		return nil
+		return nil, fmt.Errorf("failed to bind UDP for address %s: %w", addr, err)
 	}
-	return conn.(*net.IPConn)
+	return conn.(*net.IPConn), nil
 }
 
 // NOTE: udpOnce is used in SetSocketOptions below, but assumes we have a
@@ -141,16 +140,23 @@ func (f *sessionUDPFactory) SetSocketOptions(conn *net.UDPConn) error {
 	//   v4 address from a socket bound to "::1" does not work due to kernel
 	//   checking that a route exists from the source address before
 	//   the source address is replaced with the (transparently) changed one
+	var err error
 	udpOnce.Do(func() {
 		if f.ipv4Enabled {
-			rawconn4 = bindUDP("127.0.0.1", f.ipv4Enabled, false) // raw socket for sending IPv4
+			rawconn4, err = bindUDP("127.0.0.1", true, false) // raw socket for sending IPv4
+			if err != nil {
+				return
+			}
 		}
 		if f.ipv6Enabled {
-			rawconn6 = bindUDP("::1", false, f.ipv6Enabled) // raw socket for sending IPv6
+			rawconn6, err = bindUDP("::1", false, true) // raw socket for sending IPv6
+			if err != nil {
+				return
+			}
 		}
 	})
-	if (f.ipv4Enabled && rawconn4 == nil) || (f.ipv6Enabled && rawconn6 == nil) {
-		return fmt.Errorf("Unable to open raw UDP sockets for DNS Proxy")
+	if err != nil {
+		return fmt.Errorf("failed to open raw UDP sockets for DNS Proxy: %w", err)
 	}
 	return nil
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -206,6 +206,7 @@ var (
 		DNSProxyName: {
 			proxyType: ProxyTypeDNS,
 			ingress:   false,
+			localOnly: true,
 		},
 		"cilium-proxylib-egress": {
 			proxyType: ProxyTypeAny,


### PR DESCRIPTION
Currently the dns proxy binds to all interfaces.

With this commit, the dns proxy only gets bound to the localhost interfaces. Therefore, up to 4 DNS servers are created (udpv4, tcpv4, udpv6, tcpv6 - depending on the configuration) which all are using the same DNS handler.

Fixes parts of https://github.com/cilium/cilium/issues/23353

```release-note
DNS Proxy binds to loopback interfaces only
```