### PR TITLE
Uniform HTTP servers shutdown handling behavior

### DIFF
--- a/cilium-health/launch/launcher.go
+++ b/cilium-health/launch/launcher.go
@@ -4,7 +4,9 @@
 package launch
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -86,7 +88,7 @@ func (ch *CiliumHealth) runServer() {
 	os.Remove(defaults.SockPath)
 	go func() {
 		defer ch.server.Shutdown()
-		if err := ch.server.Serve(); err != nil {
+		if err := ch.server.Serve(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.WithError(err).Error("Failed to serve cilium-health API")
 		}
 	}()

--- a/cilium-health/responder/main.go
+++ b/cilium-health/responder/main.go
@@ -5,7 +5,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 
@@ -32,7 +34,7 @@ func main() {
 	srv := responder.NewServer(listen)
 	defer srv.Shutdown()
 	go func() {
-		if err := srv.Serve(); err != nil {
+		if err := srv.Serve(); !errors.Is(err, http.ErrServerClosed) {
 			fmt.Fprintf(os.Stderr, "error while listening: %s\n", err.Error())
 			cancel()
 		}

--- a/clustermesh-apiserver/health.go
+++ b/clustermesh-apiserver/health.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -58,8 +59,8 @@ func registerHealthAPIServer(lc hive.Lifecycle, clientset k8sClient.Clientset, c
 		OnStart: func(hive.HookContext) error {
 			go func() {
 				log.Info("Started health API")
-				if err := srv.ListenAndServe(); err != nil {
-					log.WithError(err).Fatalf("Unable to start health API")
+				if err := srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+					log.WithError(err).Fatal("Unable to start health API")
 				}
 			}()
 			return nil

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -5,8 +5,10 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -1788,7 +1790,7 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 
 	go func(errs <-chan error) {
 		err := <-errs
-		if err != nil {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.WithError(err).Error("Cannot start metrics server")
 			params.Shutdowner.Shutdown(hive.ShutdownWithError(err))
 		}

--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -4,7 +4,9 @@
 package serve
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 
@@ -239,5 +241,9 @@ func runServe(vp *viper.Viper) error {
 			agent.Close()
 		}
 	}()
-	return srv.Serve()
+
+	if err := srv.Serve(); !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }

--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -131,7 +132,7 @@ func EnableMetrics(log logrus.FieldLogger, metricsServer string, m []string, grp
 	}
 	go func() {
 		err := <-errChan
-		if err != nil {
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.WithError(err).Error("Unable to initialize metrics server")
 		}
 	}()

--- a/pkg/pprof/pprof.go
+++ b/pkg/pprof/pprof.go
@@ -5,6 +5,7 @@
 package pprof
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -22,7 +23,7 @@ var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "pprof")
 func Enable(host string, port int) {
 	var apiAddress = net.JoinHostPort(host, strconv.Itoa(port))
 	go func() {
-		if err := http.ListenAndServe(apiAddress, nil); err != nil {
+		if err := http.ListenAndServe(apiAddress, nil); !errors.Is(err, http.ErrServerClosed) {
 			log.WithError(err).Warn("Unable to serve pprof API")
 		}
 	}()


### PR DESCRIPTION
The HTTP server `ListenAndServer()` returns the `ErrServerClosed` error when stopped. This PR uniforms the handling behavior in that case, avoiding to log such error or performing other actions. This is relevant in particular for the `OnStart` hook of the clustermesh-apiserver's health API cell, since the hive shutdown process was incorrectly aborted.

Edit: I've updated the PR title/description to reflect the different scope.

Fixes: 4b4ad4ea3289 ("clustermesh-apiserver: Use hive and k8s-client")

<!-- Description of change -->

```release-note
Fix fatal error when shutting down the clustermesh-apiserver
```
