### PR TITLE
bgpv1: Don't use net package for addressing

### DIFF
--- a/pkg/bgpv1/agent/annotations.go
+++ b/pkg/bgpv1/agent/annotations.go
@@ -6,7 +6,7 @@ package agent
 import (
 	"errors"
 	"math"
-	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 
@@ -165,8 +165,8 @@ func parseAnnotation(key string, value string) (int, Attributes, error) {
 		}
 		switch kv[0] {
 		case "router-id":
-			ip := net.ParseIP(kv[1])
-			if ip.IsUnspecified() {
+			addr, _ := netip.ParseAddr(kv[1])
+			if addr.IsUnspecified() {
 				return 0, out, ErrAttrib{key, kv[0], "could not parse in an IPv4 address"}
 			}
 			out.RouterID = kv[1]

--- a/pkg/bgpv1/agent/controller_test.go
+++ b/pkg/bgpv1/agent/controller_test.go
@@ -6,7 +6,7 @@ package agent_test
 import (
 	"context"
 	"errors"
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
@@ -20,7 +20,7 @@ import (
 var (
 	// the standard node name we'll use throughout our tests.
 	nodeName = "node-under-test-01"
-	nodeIPv4 = net.ParseIP("192.168.0.1")
+	nodeIPv4 = netip.MustParseAddr("192.168.0.1")
 )
 
 // a mock agent.nodeSpecer implementation.
@@ -92,7 +92,7 @@ func TestControllerSanity(t *testing.T) {
 				if p != wantPolicy {
 					t.Fatalf("got: %+v, want: %+v", p, wantPolicy)
 				}
-				if !c.IPv4.Equal(nodeIPv4) {
+				if c.IPv4 != nodeIPv4 {
 					t.Fatalf("got: %v, want: %v", c.IPv4, nodeIPv4)
 				}
 				return nil
@@ -182,7 +182,7 @@ func TestControllerSanity(t *testing.T) {
 	}
 	for _, tt := range table {
 		t.Run(tt.name, func(t *testing.T) {
-			nodeaddr.SetIPv4(nodeIPv4)
+			nodeaddr.SetIPv4(nodeIPv4.AsSlice())
 			nodetypes.SetName(nodeName)
 			nodeSpecer := &fakeNodeSpecer{
 				Annotations_: tt.annotations,
@@ -202,7 +202,7 @@ func TestControllerSanity(t *testing.T) {
 			}
 			err := c.Reconcile(context.Background())
 			if (tt.err == nil) != (err == nil) {
-				t.Fatalf("wanted error: %v", tt.err == nil)
+				t.Fatalf("want: %v, got: %v", tt.err, err)
 			}
 		})
 	}

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -5,7 +5,7 @@ package types
 
 import (
 	"context"
-	"net"
+	"net/netip"
 
 	"github.com/cilium/cilium/api/v1/models"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -25,15 +25,15 @@ type RouteSelectionOptions struct {
 	AdvertiseInactiveRoutes bool
 }
 
-// Advertisement is a container object which associates a net.IPNet
+// Advertisement is a container object which associates a netip.Prefix
 //
-// The `Net` field makes comparing this Advertisement with another IPNet encoded
+// The `Prefix` field makes comparing this Advertisement with another Prefix encoded
 // prefixes simple.
 //
 // The `GoBGPPathUUID` field is a gobgp.AddPathResponse.Uuid object which can be forwarded to gobgp's
 // WithdrawPath method, making withdrawing an advertised route simple.
 type Advertisement struct {
-	Net           *net.IPNet
+	Prefix        netip.Prefix
 	GoBGPPathUUID []byte // path identifier in underlying implementation
 }
 


### PR DESCRIPTION
We're now discouraging using net package for addressing. Convert all
net.IP and net.IPNet to netip.Addr and netip.Prefix. During the
conversion, routerID resolution code is duplicated to two places. As a
part of the cleanup, I consolidated them into the single function.

Related: https://github.com/cilium/cilium/issues/24246

```release-note
bgpv1: Don't use net package for addressing
```
