### PR TITLE
test: remove govalidator dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
 	github.com/Azure/go-autorest/autorest/to v0.4.0
 	github.com/aliyun/alibaba-cloud-sdk-go v1.62.301
-	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/aws/aws-sdk-go-v2 v1.17.8
 	github.com/aws/aws-sdk-go-v2/config v1.18.3
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.12.19
@@ -134,6 +133,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/alecthomas/participle/v2 v2.0.0-beta.4 // indirect
 	github.com/armon/go-metrics v0.4.0 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.13.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.25 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.19 // indirect

--- a/test/k8s/hubble.go
+++ b/test/k8s/hubble.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/asaskevich/govalidator"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -139,7 +138,7 @@ var _ = Describe("K8sAgentHubbleTest", func() {
 			ExpectHubbleRelayReady(kubectl, hubbleRelayNamespace)
 			hubbleRelayIP, hubbleRelayPort, err := kubectl.GetServiceHostPort(hubbleRelayNamespace, hubbleRelayService)
 			Expect(err).Should(BeNil(), "Cannot get service %s", hubbleRelayService)
-			Expect(govalidator.IsIP(hubbleRelayIP)).Should(BeTrue(), "hubbleRelayIP is not an IP")
+			Expect(net.ParseIP(hubbleRelayIP) != nil).Should(BeTrue(), "hubbleRelayIP is not an IP")
 			hubbleRelayAddress = net.JoinHostPort(hubbleRelayIP, strconv.Itoa(hubbleRelayPort))
 
 			namespaceForTest = helpers.GenerateNamespaceForTest("")

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/asaskevich/govalidator"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 
@@ -146,7 +145,7 @@ func testCurlFromPodsFail(kubectl *helpers.Kubectl, clientPodLabel, url string) 
 func curlClusterIPFromExternalHost(kubectl *helpers.Kubectl, ni *helpers.NodesInfo) *helpers.CmdRes {
 	clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, appServiceName)
 	ExpectWithOffset(1, err).Should(BeNil(), "Cannot get service %s", appServiceName)
-	ExpectWithOffset(1, govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
+	ExpectWithOffset(1, net.ParseIP(clusterIP) != nil).Should(BeTrue(), "ClusterIP is not an IP")
 	httpSVCURL := fmt.Sprintf("http://%s/", net.JoinHostPort(clusterIP, "80"))
 
 	By("testing external connectivity via cluster IP %s", clusterIP)

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/asaskevich/govalidator"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 
@@ -134,7 +133,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 			for _, svcName := range serviceNames {
 				clusterIP, _, err := kubectl.GetServiceHostPort(helpers.DefaultNamespace, svcName)
 				Expect(err).Should(BeNil(), "Cannot get service %q ClusterIP", svcName)
-				Expect(govalidator.IsIP(clusterIP)).Should(BeTrue(), "ClusterIP is not an IP")
+				Expect(net.ParseIP(clusterIP) != nil).Should(BeTrue(), "ClusterIP is not an IP")
 
 				url := fmt.Sprintf("http://%s/", net.JoinHostPort(clusterIP, "80"))
 				testCurlFromPods(kubectl, echoPodLabel, url, 10, 0)


### PR DESCRIPTION
The library `github.com/asaskevich/govalidator` barely sees any usage and doesn't seem to be maintained. Let's get rid of it as a direct dependency.
