### PR TITLE
bpf: nat: fix L4 csum case in ingress path for ICMP-embedded SCTP

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -427,10 +427,6 @@ snat_v4_icmp_rewrite_ingress_embedded(struct __ctx_buff *ctx,
 		switch (tuple->nexthdr) {
 		case IPPROTO_TCP:
 		case IPPROTO_UDP:
-#ifdef ENABLE_SCTP
-		case IPPROTO_SCTP:
-#endif  /* ENABLE_SCTP */
-		{
 			/* In case that the destination port has been NATed from
 			 * target to dest. We want the embedded packet which
 			 * should refer to endpoint dest going back to original.
@@ -441,7 +437,10 @@ snat_v4_icmp_rewrite_ingress_embedded(struct __ctx_buff *ctx,
 					    sizeof(state->to_dport), 0) < 0)
 				return DROP_WRITE_ERROR;
 			break;
-		}
+#ifdef ENABLE_SCTP
+		case IPPROTO_SCTP:
+			return DROP_CSUM_L4;
+#endif  /* ENABLE_SCTP */
 		case IPPROTO_ICMP: {
 			/* In case that the ID has been used as source port during
 			 * NAT from target to dest. We want the embedded packet
@@ -1517,10 +1516,6 @@ static __always_inline int snat_v6_icmp_rewrite_embedded(struct __ctx_buff *ctx,
 		switch (tuple->nexthdr) {
 		case IPPROTO_TCP:
 		case IPPROTO_UDP:
-#ifdef ENABLE_SCTP
-		case IPPROTO_SCTP:
-
-#endif  /* ENABLE_SCTP */
 			/* In case that the destination port has been NATed from
 			 * target to dest. We want the embedded packet which
 			 * should refer to endpoint dest going back to original.
@@ -1529,6 +1524,10 @@ static __always_inline int snat_v6_icmp_rewrite_embedded(struct __ctx_buff *ctx,
 					    &state->to_dport, sizeof(state->to_dport), 0) < 0)
 				return DROP_WRITE_ERROR;
 			break;
+#ifdef ENABLE_SCTP
+		case IPPROTO_SCTP:
+			return DROP_CSUM_L4;
+#endif  /* ENABLE_SCTP */
 		case IPPROTO_ICMPV6: {
 			/* In case that the ID has been used as source port during
 			 * NAT from target to dest. We want the embedded packet

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -506,7 +506,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	 * snat_v4_rev_nat().
 	 */
 	ret = snat_v4_rev_nat(ctx, &target, NULL);
-	assert(ret == 0);
+	assert(ret == DROP_CSUM_L4);
 
 	/* nothing really change with udp/tcp */
 	test_finish();


### PR DESCRIPTION
We can't adjust the L4 csum for a SCTP packet yet.