### PR TITLE
Add Prometheus metrics support to clustermesh-apiserver

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -364,6 +364,62 @@
      - Clustermesh API server image.
      - object
      - ``{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver-ci","tag":"latest","useDigest":false}``
+   * - clustermesh.apiserver.metrics.enabled
+     - Enables exporting apiserver metrics in OpenMetrics format.
+     - bool
+     - ``false``
+   * - clustermesh.apiserver.metrics.etcd.enabled
+     - Enables exporting etcd metrics in OpenMetrics format.
+     - bool
+     - ``false``
+   * - clustermesh.apiserver.metrics.etcd.mode
+     - Set level of detail for etcd metrics; specify 'extensive' to include server side gRPC histogram metrics.
+     - string
+     - ``"basic"``
+   * - clustermesh.apiserver.metrics.etcd.port
+     - Configure the port the etcd metric server listens on.
+     - int
+     - ``9963``
+   * - clustermesh.apiserver.metrics.port
+     - Configure the port the apiserver metric server listens on.
+     - int
+     - ``9962``
+   * - clustermesh.apiserver.metrics.serviceMonitor.annotations
+     - Annotations to add to ServiceMonitor clustermesh-apiserver
+     - object
+     - ``{}``
+   * - clustermesh.apiserver.metrics.serviceMonitor.enabled
+     - Enable service monitor. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+     - bool
+     - ``false``
+   * - clustermesh.apiserver.metrics.serviceMonitor.etcd.interval
+     - Interval for scrape metrics (etcd metrics)
+     - string
+     - ``"10s"``
+   * - clustermesh.apiserver.metrics.serviceMonitor.etcd.metricRelabelings
+     - Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
+     - string
+     - ``nil``
+   * - clustermesh.apiserver.metrics.serviceMonitor.etcd.relabelings
+     - Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
+     - string
+     - ``nil``
+   * - clustermesh.apiserver.metrics.serviceMonitor.interval
+     - Interval for scrape metrics (apiserver metrics)
+     - string
+     - ``"10s"``
+   * - clustermesh.apiserver.metrics.serviceMonitor.labels
+     - Labels to add to ServiceMonitor clustermesh-apiserver
+     - object
+     - ``{}``
+   * - clustermesh.apiserver.metrics.serviceMonitor.metricRelabelings
+     - Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
+     - string
+     - ``nil``
+   * - clustermesh.apiserver.metrics.serviceMonitor.relabelings
+     - Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
+     - string
+     - ``nil``
    * - clustermesh.apiserver.nodeSelector
      - Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object
@@ -2361,7 +2417,7 @@
      - object
      - ``{"annotations":{},"automount":true,"create":true,"name":"hubble-generate-certs"}``
    * - serviceAccounts.nodeinit.enabled
-     - Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented. Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by this issue. Name and automount can be configured, if enabled is set to true.  Otherwise, they are ignored. Enabled can be removed once the issue is fixed. Cilium-nodeinit DS must also be fixed.
+     - Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented. Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by this issue. Name and automount can be configured, if enabled is set to true. Otherwise, they are ignored. Enabled can be removed once the issue is fixed. Cilium-nodeinit DS must also be fixed.
      - bool
      - ``false``
    * - sleepAfterInit

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -426,7 +426,7 @@ KVstore
 Name                                     Labels                                       Default    Description
 ======================================== ============================================ ========== ========================================================
 ``kvstore_operations_duration_seconds``  ``action``, ``kind``, ``outcome``, ``scope`` Enabled    Duration of kvstore operation
-``kvstore_events_queue_seconds``         ``action``, ``scope``                        Enabled    Duration of seconds of time received event was blocked before it could be queued
+``kvstore_events_queue_seconds``         ``action``, ``scope``                        Enabled    Seconds waited before a received event was queued
 ``kvstore_quorum_errors_total``          ``error``                                    Enabled    Number of quorum errors
 ``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Enabled    Number of elements queued for synchronization in the kvstore
 ======================================== ============================================ ========== ========================================================

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -175,6 +175,39 @@ OpenMetrics imposes a few additional requirements on metrics names and labels,
 so this functionality is currently opt-in, though we believe all of the Hubble
 metrics conform to the OpenMetrics requirements.
 
+
+Cluster Mesh API Server Metrics
+===============================
+
+Cluster Mesh API Server metrics provide insights into both the state of the
+``clustermesh-apiserver`` process and the sidecar etcd instance.
+Cluster Mesh API Server metrics are exported under the ``cilium_clustermesh_apiserver_``
+Prometheus namespace. Etcd metrics are exported under the ``etcd_`` Prometheus namespace.
+
+
+Installation
+------------
+
+You can enable metrics for ``clustermesh-apiserver`` with the Helm value
+``clustermesh.apiserver.metrics.enabled=true``.
+To enable metrics for the sidecar etcd instance, use
+``clustermesh.apiserver.metrics.etcd.enabled=true``.
+
+.. parsed-literal::
+
+   helm install cilium |CHART_RELEASE| \\
+     --namespace kube-system \\
+     --set clustermesh.useAPIServer=true \\
+     --set clustermesh.apiserver.metrics.enabled=true \\
+     --set clustermesh.apiserver.metrics.etcd.enabled=true
+
+The ports can be configured via ``clustermesh.apiserver.metrics.port`` and
+``clustermesh.apiserver.metrics.etcd.port`` respectively.
+
+You can automatically create a
+`Prometheus Operator <https://github.com/prometheus-operator/prometheus-operator>`_
+``ServiceMonitor`` by setting ``clustermesh.apiserver.metrics.serviceMonitor.enabled=true``.
+
 Example Prometheus & Grafana Deployment
 =======================================
 
@@ -856,3 +889,32 @@ Options
 """""""
 
 This metric supports :ref:`Context Options<hubble_context_options>`.
+
+clustermesh-apiserver
+---------------------
+
+Configuration
+^^^^^^^^^^^^^
+
+To expose any metrics, invoke ``clustermesh-apiserver`` with the
+``--prometheus-serve-addr`` option. This option takes a ``IP:Port`` pair but
+passing an empty IP (e.g. ``:9962``) will bind the server to all available
+interfaces (there is usually only one in a container).
+
+Exported Metrics
+^^^^^^^^^^^^^^^^
+
+All metrics are exported under the ``cilium_clustermesh_apiserver_``
+Prometheus namespace.
+
+KVstore
+~~~~~~~
+
+======================================== ============================================ ========================================================
+Name                                     Labels                                       Description
+======================================== ============================================ ========================================================
+``kvstore_operations_duration_seconds``  ``action``, ``kind``, ``outcome``, ``scope`` Duration of kvstore operation
+``kvstore_events_queue_seconds``         ``action``, ``scope``                        Seconds waited before a received event was queued
+``kvstore_quorum_errors_total``          ``error``                                    Number of quorum errors
+``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Number of elements queued for synchronization in the kvstore
+======================================== ============================================ ========================================================

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
+	cmmetrics "github.com/cilium/cilium/clustermesh-apiserver/metrics"
 	apiserverOption "github.com/cilium/cilium/clustermesh-apiserver/option"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/clustermesh"
@@ -50,6 +51,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
@@ -90,6 +92,8 @@ var (
 			}
 		},
 		PreRun: func(cmd *cobra.Command, args []string) {
+			// Overwrite the metrics namespace with the one specific for the ClusterMesh API Server
+			metrics.Namespace = metrics.CiliumClusterMeshAPIServerNamespace
 			option.Config.Populate(vp)
 			if option.Config.Debug {
 				log.Logger.SetLevel(logrus.DebugLevel)
@@ -118,6 +122,7 @@ func init() {
 		k8sClient.Cell,
 		k8s.SharedResourcesCell,
 		healthAPIServerCell,
+		cmmetrics.Cell,
 		usersManagementCell,
 
 		cell.Invoke(registerHooks),

--- a/clustermesh-apiserver/metrics/metrics.go
+++ b/clustermesh-apiserver/metrics/metrics.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var Cell = cell.Module(
+	"clustermesh-apiserver-metrics",
+	"ClusterMesh apiserver metrics",
+
+	cell.Config(MetricsConfig{}),
+	cell.Invoke(registerMetricsManager),
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "metrics")
+
+type MetricsConfig struct {
+	// PrometheusServeAddr IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+	PrometheusServeAddr string
+}
+
+func (def MetricsConfig) Flags(flags *pflag.FlagSet) {
+	flags.String(option.PrometheusServeAddr, def.PrometheusServeAddr, "Address to serve Prometheus metrics")
+}
+
+type metricsManager struct {
+	registry *prometheus.Registry
+	server   http.Server
+}
+
+func registerMetricsManager(lc hive.Lifecycle, cfg MetricsConfig) error {
+	manager := metricsManager{
+		registry: prometheus.NewPedanticRegistry(),
+		server:   http.Server{Addr: cfg.PrometheusServeAddr},
+	}
+
+	if cfg.PrometheusServeAddr != "" {
+		lc.Append(&manager)
+	} else {
+		log.Info("Prometheus metrics are disabled")
+	}
+
+	return nil
+}
+
+func (mm *metricsManager) Start(hive.HookContext) error {
+	log.Info("Registering metrics")
+
+	mm.registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	mm.registry.MustRegister(collectors.NewGoCollector())
+	mm.registry.MustRegister(
+		metrics.KVStoreOperationsDuration,
+		metrics.KVStoreEventsQueueDuration,
+		metrics.KVStoreQuorumErrors,
+		metrics.KVStoreSyncQueueSize,
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(mm.registry, promhttp.HandlerOpts{}))
+	mm.server.Handler = mux
+
+	go func() {
+		log.WithField("address", mm.server.Addr).Info("Starting metrics server")
+		if err := mm.server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			log.WithError(err).Fatal("Unable to start metrics server")
+		}
+	}()
+
+	return nil
+}
+
+func (mm *metricsManager) Stop(ctx hive.HookContext) error {
+	log.Info("Stopping metrics server")
+
+	if err := mm.server.Shutdown(ctx); err != nil {
+		log.WithError(err).Error("Shutdown metrics server failed")
+		return err
+	}
+
+	return nil
+}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -141,6 +141,20 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
 | clustermesh.apiserver.image | object | `{"digest":"","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/clustermesh-apiserver-ci","tag":"latest","useDigest":false}` | Clustermesh API server image. |
+| clustermesh.apiserver.metrics.enabled | bool | `false` | Enables exporting apiserver metrics in OpenMetrics format. |
+| clustermesh.apiserver.metrics.etcd.enabled | bool | `false` | Enables exporting etcd metrics in OpenMetrics format. |
+| clustermesh.apiserver.metrics.etcd.mode | string | `"basic"` | Set level of detail for etcd metrics; specify 'extensive' to include server side gRPC histogram metrics. |
+| clustermesh.apiserver.metrics.etcd.port | int | `9963` | Configure the port the etcd metric server listens on. |
+| clustermesh.apiserver.metrics.port | int | `9962` | Configure the port the apiserver metric server listens on. |
+| clustermesh.apiserver.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor clustermesh-apiserver |
+| clustermesh.apiserver.metrics.serviceMonitor.enabled | bool | `false` | Enable service monitor. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
+| clustermesh.apiserver.metrics.serviceMonitor.etcd.interval | string | `"10s"` | Interval for scrape metrics (etcd metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.etcd.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.etcd.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics (apiserver metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor clustermesh-apiserver |
+| clustermesh.apiserver.metrics.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics) |
 | clustermesh.apiserver.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
@@ -640,7 +654,7 @@ contributors across the globe, there is almost always someone available to help.
 | serviceAccounts | object | Component's fully qualified name. | Define serviceAccount names for components. |
 | serviceAccounts.clustermeshcertgen | object | `{"annotations":{},"automount":true,"create":true,"name":"clustermesh-apiserver-generate-certs"}` | Clustermeshcertgen is used if clustermesh.apiserver.tls.auto.method=cronJob |
 | serviceAccounts.hubblecertgen | object | `{"annotations":{},"automount":true,"create":true,"name":"hubble-generate-certs"}` | Hubblecertgen is used if hubble.tls.auto.method=cronJob |
-| serviceAccounts.nodeinit.enabled | bool | `false` | Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented. Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by this issue. Name and automount can be configured, if enabled is set to true.  Otherwise, they are ignored. Enabled can be removed once the issue is fixed. Cilium-nodeinit DS must also be fixed.  |
+| serviceAccounts.nodeinit.enabled | bool | `false` | Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented. Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by this issue. Name and automount can be configured, if enabled is set to true. Otherwise, they are ignored. Enabled can be removed once the issue is fixed. Cilium-nodeinit DS must also be fixed. |
 | sleepAfterInit | bool | `false` | Do not run Cilium agent when running with clean mode. Useful to completely uninstall Cilium as it will stop Cilium from starting and create artifacts in the node. |
 | socketLB | object | `{"enabled":false}` | Configure socket LB |
 | socketLB.enabled | bool | `false` | Enable socket LB |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -101,6 +101,10 @@ spec:
         - --advertise-client-urls=https://[$(HOSTNAME_IP)]:2379
         - --initial-cluster-token=clustermesh-apiserver
         - --auto-compaction-retention=1
+        {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
+        - --listen-metrics-urls=http://[$(HOSTNAME_IP)]:{{ .Values.clustermesh.apiserver.metrics.etcd.port }}
+        - --metrics={{ .Values.clustermesh.apiserver.metrics.etcd.mode }}
+        {{- end }}
         env:
         - name: ETCDCTL_API
           value: "3"
@@ -108,6 +112,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        ports:
+        - name: etcd
+          containerPort: 2379
+          protocol: TCP
+        {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
+        - name: etcd-metrics
+          containerPort: {{ .Values.clustermesh.apiserver.metrics.etcd.port }}
+          protocol: TCP
+        {{- end }}
         volumeMounts:
         - name: etcd-server-secrets
           mountPath: /var/lib/etcd-secrets
@@ -141,6 +154,9 @@ spec:
         - --cluster-users-config-path=/var/lib/cilium/etcd-config/users.yaml
         {{- end }}
         - --enable-external-workloads={{ .Values.externalWorkloads.enabled }}
+        {{- if .Values.clustermesh.apiserver.metrics.enabled }}
+        - --prometheus-serve-addr=:{{ .Values.clustermesh.apiserver.metrics.port }}
+        {{- end }}
         env:
         - name: CLUSTER_NAME
           valueFrom:
@@ -166,6 +182,12 @@ spec:
               optional: true
         {{- with .Values.clustermesh.apiserver.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+        {{- if .Values.clustermesh.apiserver.metrics.enabled }}
+        ports:
+        - name: apiserv-metrics
+          containerPort: {{ .Values.clustermesh.apiserver.metrics.port }}
+          protocol: TCP
         {{- end }}
         {{- with .Values.clustermesh.apiserver.resources }}
         resources:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
@@ -1,0 +1,32 @@
+{{- if and
+  (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer)
+  (or .Values.clustermesh.apiserver.metrics.enabled .Values.clustermesh.apiserver.metrics.etcd.enabled) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: clustermesh-apiserver-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: clustermesh-apiserver
+    app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/name: clustermesh-apiserver
+    app.kubernetes.io/component: metrics
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  {{- if .Values.clustermesh.apiserver.metrics.enabled }}
+  - name: apiserv-metrics
+    port: {{ .Values.clustermesh.apiserver.metrics.port }}
+    protocol: TCP
+    targetPort: apiserv-metrics
+  {{- end }}
+  {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
+  - name: etcd-metrics
+    port: {{ .Values.clustermesh.apiserver.metrics.etcd.port }}
+    protocol: TCP
+    targetPort: etcd-metrics
+  {{- end }}
+  selector:
+    k8s-app: clustermesh-apiserver
+{{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -1,0 +1,57 @@
+{{- if and
+  (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer)
+  (or .Values.clustermesh.apiserver.metrics.enabled .Values.clustermesh.apiserver.metrics.etcd.enabled)
+  .Values.clustermesh.apiserver.metrics.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clustermesh-apiserver
+  namespace: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    app.kubernetes.io/part-of: cilium
+    {{- with .Values.clustermesh.apiserver.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- with .Values.clustermesh.apiserver.metrics.serviceMonitor.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: clustermesh-apiserver
+      app.kubernetes.io/component: metrics
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  endpoints:
+  {{- if .Values.clustermesh.apiserver.metrics.enabled }}
+  - port: apiserv-metrics
+    interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.interval | quote }}
+    honorLabels: true
+    path: /metrics
+    {{- with .Values.clustermesh.apiserver.metrics.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.clustermesh.apiserver.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.clustermesh.apiserver.metrics.etcd.enabled }}
+  - port: etcd-metrics
+    interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.etcd.interval | quote }}
+    honorLabels: true
+    path: /metrics
+    {{- with .Values.clustermesh.apiserver.metrics.serviceMonitor.etcd.relabelings }}
+    relabelings:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.clustermesh.apiserver.metrics.serviceMonitor.etcd.metricRelabelings }}
+    metricRelabelings:
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -59,9 +59,9 @@ serviceAccounts:
     create: true
     # -- Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented.
     # Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by
-    # this issue. Name and automount can be configured, if enabled is set to true. 
+    # this issue. Name and automount can be configured, if enabled is set to true.
     # Otherwise, they are ignored. Enabled can be removed once the issue is fixed.
-    # Cilium-nodeinit DS must also be fixed. 
+    # Cilium-nodeinit DS must also be fixed.
     enabled: false
     name: cilium-nodeinit
     automount: true
@@ -2814,6 +2814,48 @@ clustermesh:
       remote:
         cert: ""
         key: ""
+
+    # clustermesh-apiserver Prometheus metrics configuration
+    metrics:
+      # -- Enables exporting apiserver metrics in OpenMetrics format.
+      enabled: false
+      # -- Configure the port the apiserver metric server listens on.
+      port: 9962
+
+      etcd:
+        # -- Enables exporting etcd metrics in OpenMetrics format.
+        enabled: false
+        # -- Set level of detail for etcd metrics; specify 'extensive' to include server side gRPC histogram metrics.
+        mode: basic
+        # -- Configure the port the etcd metric server listens on.
+        port: 9963
+
+      serviceMonitor:
+        # -- Enable service monitor.
+        # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+        enabled: false
+        # -- Labels to add to ServiceMonitor clustermesh-apiserver
+        labels: {}
+        # -- Annotations to add to ServiceMonitor clustermesh-apiserver
+        annotations: {}
+        # -- Specify the Kubernetes namespace where Prometheus expects to find
+        # service monitors configured.
+        # namespace: ""
+
+        # -- Interval for scrape metrics (apiserver metrics)
+        interval: "10s"
+        # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
+        relabelings: ~
+        # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
+        metricRelabelings: ~
+
+        etcd:
+          # -- Interval for scrape metrics (etcd metrics)
+          interval: "10s"
+          # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
+          relabelings: ~
+          # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
+          metricRelabelings: ~
 
 # -- Configure external workloads support
 externalWorkloads:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -56,9 +56,9 @@ serviceAccounts:
     create: true
     # -- Enabled is temporary until https://github.com/cilium/cilium-cli/issues/1396 is implemented.
     # Cilium CLI doesn't create the SAs for node-init, thus the workaround. Helm is not affected by
-    # this issue. Name and automount can be configured, if enabled is set to true. 
+    # this issue. Name and automount can be configured, if enabled is set to true.
     # Otherwise, they are ignored. Enabled can be removed once the issue is fixed.
-    # Cilium-nodeinit DS must also be fixed. 
+    # Cilium-nodeinit DS must also be fixed.
     enabled: false
     name: cilium-nodeinit
     automount: true
@@ -2811,6 +2811,48 @@ clustermesh:
       remote:
         cert: ""
         key: ""
+
+    # clustermesh-apiserver Prometheus metrics configuration
+    metrics:
+      # -- Enables exporting apiserver metrics in OpenMetrics format.
+      enabled: false
+      # -- Configure the port the apiserver metric server listens on.
+      port: 9962
+
+      etcd:
+        # -- Enables exporting etcd metrics in OpenMetrics format.
+        enabled: false
+        # -- Set level of detail for etcd metrics; specify 'extensive' to include server side gRPC histogram metrics.
+        mode: basic
+        # -- Configure the port the etcd metric server listens on.
+        port: 9963
+
+      serviceMonitor:
+        # -- Enable service monitor.
+        # This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml)
+        enabled: false
+        # -- Labels to add to ServiceMonitor clustermesh-apiserver
+        labels: {}
+        # -- Annotations to add to ServiceMonitor clustermesh-apiserver
+        annotations: {}
+        # -- Specify the Kubernetes namespace where Prometheus expects to find
+        # service monitors configured.
+        # namespace: ""
+
+        # -- Interval for scrape metrics (apiserver metrics)
+        interval: "10s"
+        # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
+        relabelings: ~
+        # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
+        metricRelabelings: ~
+
+        etcd:
+          # -- Interval for scrape metrics (etcd metrics)
+          interval: "10s"
+          # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
+          relabelings: ~
+          # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
+          metricRelabelings: ~
 
 # -- Configure external workloads support
 externalWorkloads:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1251,7 +1251,7 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 				Namespace: Namespace,
 				Subsystem: SubsystemKVStore,
 				Name:      "events_queue_seconds",
-				Help:      "Duration in seconds of time received event was blocked before it could be queued",
+				Help:      "Seconds waited before a received event was queued",
 				Buckets:   []float64{.002, .005, .01, .015, .025, .05, .1, .25, .5, .75, 1},
 			}, []string{LabelScope, LabelAction})
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -68,9 +68,8 @@ const (
 	// SubsystemAPILimiter is the subsystem to scope metrics related to the API limiter package.
 	SubsystemAPILimiter = "api_limiter"
 
-	// Namespace is used to scope metrics from cilium. It is prepended to metric
-	// names and separated with a '_'
-	Namespace = "cilium"
+	// CiliumAgentNamespace is used to scope metrics from the Cilium Agent
+	CiliumAgentNamespace = "cilium"
 
 	// LabelError indicates the type of error (string)
 	LabelError = "error"
@@ -220,6 +219,10 @@ const (
 )
 
 var (
+	// Namespace is used to scope metrics from cilium. It is prepended to metric
+	// names and separated with a '_'
+	Namespace = CiliumAgentNamespace
+
 	// goCustomCollectorsRX tracks enabled go runtime metrics.
 	goCustomCollectorsRX = regexp.MustCompile(`^/sched/latencies:seconds`)
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,6 +71,10 @@ const (
 	// CiliumAgentNamespace is used to scope metrics from the Cilium Agent
 	CiliumAgentNamespace = "cilium"
 
+	// CiliumClusterMeshAPIServerNamespace is used to scope metrics from the
+	// Cilium Cluster Mesh API Server
+	CiliumClusterMeshAPIServerNamespace = "cilium_clustermesh_apiserver"
+
 	// LabelError indicates the type of error (string)
 	LabelError = "error"
 


### PR DESCRIPTION
This PR extends the clustermesh-apiserver implementation and the corresponding Helm chart configuration to enable exposing and scraping Prometheus metrics. In addition to the metrics automatically exposed by etcd, the apiserver currently exposes kvstore-related metrics and basic go-related ones.

The correct functioning has been tested with a local kube-prometheus installation.

<!-- Description of change -->

```release-note
Add Prometheus metrics support to clustermesh-apiserver
```
