### PR TITLE
Fix kind.sh development scripts on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ microk8s: check-microk8s ## Build cilium-dev docker image and import to microk8s
 	$(QUIET)./contrib/scripts/microk8s-import.sh $(LOCAL_OPERATOR_IMAGE)
 
 kind: ## Create a kind cluster for Cilium development.
-	$(QUIET)./contrib/scripts/kind.sh
+	SED=$(SED) $(QUIET)./contrib/scripts/kind.sh
 
 kind-down: ## Destroy a kind cluster for Cilium development.
 	$(QUIET)./contrib/scripts/kind-down.sh

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -39,7 +39,7 @@ DOCKER_BUILD_FLAGS?=
 
 # use gsed if avaiable, otherwise use sed.
 # gsed is needed for MacOS to make in-place replacement work correctly.
-SED ?= $(if $(shell command -v gsed), gsed, sed)
+SED ?= $(if $(shell command -v gsed),gsed,sed)
 
 # Set DOCKER_DEV_ACCOUNT with "cilium" by default
 ifeq ($(DOCKER_DEV_ACCOUNT),)

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -18,6 +18,8 @@ default_network="kind-cilium"
 
 PROG=${0}
 
+SED="${SED:-sed}"
+
 xdp=false
 if [ "${1:-}" = "--xdp" ]; then
   xdp=true
@@ -169,7 +171,7 @@ fi
 # Replace "forward . /etc/resolv.conf" in the coredns cm with "forward . 8.8.8.8".
 # This is required because in case of BPF Host Routing we bypass iptables thus
 # breaking DNS. See https://github.com/cilium/cilium/issues/23330
-NewCoreFile=$(kubectl get cm -n kube-system coredns -o jsonpath='{.data.Corefile}' | sed 's,forward . /etc/resolv.conf,forward . 8.8.8.8,' | sed -z 's/\n/\\n/g')
+NewCoreFile=$(kubectl get cm -n kube-system coredns -o jsonpath='{.data.Corefile}' | "${SED}" 's,forward . /etc/resolv.conf,forward . 8.8.8.8,' | "${SED}" -z 's/\n/\\n/g')
 kubectl patch configmap/coredns -n kube-system --type merge -p '{"data":{"Corefile": "'"$NewCoreFile"'"}}'
 
 set +e


### PR DESCRIPTION
Our Makefiles and scripts largely assume GNU sed, and kind.sh uses `sed -z` which requires GNU sed. MacOS ships with BSD sed, so to make the existing `kind.sh` script work, make the sed binary configurable, and pass through the Makefile SED to the script.

```release-note
Fix kind.sh development scripts on MacOS
```
