### PR TITLE
bgpv1: fix issue with pod cidr advertisement removal

### DIFF
--- a/pkg/bgpv1/manager/advertisements_reconciler.go
+++ b/pkg/bgpv1/manager/advertisements_reconciler.go
@@ -102,8 +102,11 @@ func exportAdvertisementsReconciler(params *advertisementsReconcilerParams) ([]t
 		key := advrt.Net.String()
 		if m, ok = aset[key]; !ok {
 			aset[key] = &member{
-				b:     true,
-				advrt: &advrt,
+				b: true,
+				advrt: &types.Advertisement{
+					Net:           advrt.Net,
+					GoBGPPathUUID: advrt.GoBGPPathUUID,
+				},
 			}
 			continue
 		}

--- a/pkg/bgpv1/manager/reconcile_test.go
+++ b/pkg/bgpv1/manager/reconcile_test.go
@@ -367,7 +367,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 			updated: []string{"192.168.0.0/24", "192.168.1.0/24"},
 		},
 		{
-			name:         "removal of network",
+			name:         "removal of both networks",
 			enabled:      true,
 			shouldEnable: true,
 			advertised: []*net.IPNet{
@@ -380,7 +380,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 					Mask: net.IPv4Mask(255, 255, 255, 0),
 				},
 			},
-			updated: []string{"192.168.0.0/24"},
+			updated: []string{},
 		},
 	}
 


### PR DESCRIPTION
This change fixes diff code when there is multiple pod cidr withdrawals done at once.

```release-note
Fixes issue in BGP reconciler when multiple pod cidr withdrawals are done.
```
