### PR TITLE
hubble: Remove spammy debug log message on lost events

### DIFF
--- a/pkg/hubble/monitor/consumer.go
+++ b/pkg/hubble/monitor/consumer.go
@@ -69,7 +69,6 @@ func (c *consumer) sendNumLostEvents() {
 		// We now now safely reset the counter, as at this point have
 		// successfully notified the observer about the amount of events
 		// that were lost since the previous LostEvent message
-		c.observer.GetLogger().Debugf("hubble events queue received a LostEvent message: %d messages were lost", c.numEventsLost)
 		c.numEventsLost = 0
 	default:
 		// We do not need to bump the numEventsLost counter here, as we will


### PR DESCRIPTION
When debug log is enabled, and in particular when monitor aggregation is disabled [1], this debug message tends to spam the agent logs. Instead of rate-limiting it, given we already have a metric for the same (`hubble_lost_events_total`), let's just remove it.

1 - This combination of debug enabled and monitor aggregation disabled is very frequent on datapath debugging sessions.