### PR TITLE
docs: `socketLB.hostNamespaceOnly` also needed for gVisor

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -600,7 +600,8 @@ therefore no additional lower layer NAT is required.
 Cilium has built-in support for bypassing the socket-level loadbalancer and falling back
 to the tc loadbalancer at the veth interface when a custom redirection/operation relies
 on the original ClusterIP within pod namespace (e.g., Istio side-car) or due to the Pod's
-nature the socket-level loadbalancer is ineffective (e.g., KubeVirt, Kata Containers).
+nature the socket-level loadbalancer is ineffective (e.g., KubeVirt, Kata Containers,
+gVisor).
 
 Setting ``socketLB.hostNamespaceOnly=true`` enables this bypassing mode. When enabled,
 this circumvents socket rewrite in the ``connect()`` and ``sendmsg()`` syscall bpf hook and

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -480,6 +480,7 @@ functionalities
 fwmark
 gRPC
 gVNIC
+gVisor
 gatewayAPI
 gcInterval
 gcTags


### PR DESCRIPTION
We confirmed with a user that `socketLB.hostNamespaceOnly=true` is also needed for gVisor when using KPR=strict. gVisor otherwise faces the same issue as KubeVirt or Kata containers.