### PR TITLE
`dev-doctor` - if path to `go.mod` invalid, look in current directory

### DIFF
--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -57,6 +57,13 @@ func readGoModGoVersion(rootDir string) (*semver.Version, error) {
 func rootCmdRun(cmd *cobra.Command, args []string) {
 	rootDir := goPath() + "/src/github.com/cilium/cilium"
 
+	// $GOPATH is optional to set with a module-based Go setup
+	// If we cannot find src path via `$GOPATH`, just look in
+	// the `make` dir for `go.mod`
+	if _, err := os.Stat(rootDir); os.IsNotExist(err) {
+		rootDir, _ = os.Getwd()
+	}
+
 	minGoVersion, err := readGoModGoVersion(rootDir)
 	if err != nil {
 		panic(fmt.Sprintf("cannot read go version from go.mod: %v", err))


### PR DESCRIPTION
### Minor annoyance/issue

If `$GOPATH` is not set, `make dev-doctor` tries to construct a path to `go.mod` that may not exist depending on Go configuration, does not check that the path exists, and as a consequence, fails later on.

This extremely mini PR changes `dev-doctor` to actually validate that the expected path for `go.mod` exists, and _IF_ it does not, as a last resort, look for `go.mod` in the current directory (where `make` is executed from), to support building with Go module-style non-opinionated source root locations.

This won't change behavior for anyone using the existing style, but now it won't break for everyone using contextless/non-global Go source root (e.g. pure Go modules style)

To repro:

1. Clone `cilium` repo to an arbitrary location outside of $GOPATH/GOROOT as supported by current Go.
1. e.g. `cd /Host/Source && git clone git@github.com:cilium/cilium.git`
1. Observe failure:
```
[bleggett@lima-fedora cilium]$ make dev-doctor
go version 2>/dev/null || ( echo "go not found, see https://golang.org/doc/install" ; false )
go version go1.20.2 linux/arm64
go run ./tools/dev-doctor
panic: cannot read go version from go.mod: open /home/bleggett.linux/go/src/github.com/cilium/cilium/go.mod: no such file or directory

goroutine 1 [running]:
main.rootCmdRun(0x39a340?, {0x3d2630?, 0x0?, 0x0?})
        /Host/Source/cilium/tools/dev-doctor/rootcmd.go:62 +0x20d4
github.com/spf13/cobra.(*Command).execute(0x39a340, {0x4000098200, 0x0, 0x0})
        /Host/Source/cilium/vendor/github.com/spf13/cobra/command.go:944 +0x5ac
github.com/spf13/cobra.(*Command).ExecuteC(0x39a340)
        /Host/Source/cilium/vendor/github.com/spf13/cobra/command.go:1068 +0x340
github.com/spf13/cobra.(*Command).Execute(...)
        /Host/Source/cilium/vendor/github.com/spf13/cobra/command.go:992
main.main()
        /Host/Source/cilium/tools/dev-doctor/main.go:13 +0x24
exit status 2
make: *** [Makefile:665: dev-doctor] Error 
```

With current Go+module, it is _not_ required to set `$GOPATH`, and cloning repos to `$GOPATH/src` (or `$[default_GOPATH]/src` if unset) is also not required.

Cilium image builds and other `make` targets also seem fine with this.

### Result with fix

1. `cd ~/Source && git clone git@github.com:cilium/cilium.git`
1. `make dev-doctor`
```
[bleggett@lima-fedora cilium]$ make dev-doctor
go version 2>/dev/null || ( echo "go not found, see https://golang.org/doc/install" ; false )
go version go1.20.2 linux/arm64
go run ./tools/dev-doctor
RESULT    CHECK           MESSAGE
warning   os/arch         linux/arm64
ok        uname           Linux lima-fedora 6.2.7-200.fc37.aarch64 #1 SMP PREEMPT_DYNAMIC Fri Mar 17 16:24:22 UTC 2023 aarch64 aarch64 aarch64 GNU/Linux
ok        root-dir        found /Host/Source/cilium
ok        make            found /usr/bin/make, version 4.3
ok        go              found /usr/local/go/bin/go, version 1.20.2
ok        tparse          found /home/bleggett.linux/go/bin/tparse, version 0.12.1
ok        clang           found /usr/bin/clang, version 15.0.7
ok        docker-server   found /usr/bin/docker, version 23.0.1
ok        docker-client   found /usr/bin/docker, version 23.0.1
ok        docker-buildx   found /usr/bin/docker, version 0.10.2
ok        ginkgo          found /home/bleggett.linux/go/bin/ginkgo, version 1.16.5
ok        golangci-lint   found /home/bleggett.linux/go/bin/golangci-lint, version 1.52.2
ok        docker          found /usr/bin/docker, version 23.0.1
ok        helm            found /usr/local/bin/helm, version 3.11.3
ok        llc             found /usr/bin/llc, version 15.0.7
failed    vagrant         exit status 1
info      virtualbox      virtualbox not found in $PATH
info      vboxheadless    vboxheadless not found in $PATH
ok        pip3            found /usr/bin/pip3, version 22.2.2
ok        cfssl           found /home/bleggett.linux/go/bin/cfssl, version dev
ok        cfssljson       found /home/bleggett.linux/go/bin/cfssljson, version dev
ok        docker-group    user bleggett in docker group

CHECK          HINT
vboxheadless   run "VBoxHeadless --help" to diagnose why vboxheadless failed to execute

See https://docs.cilium.io/en/latest/contributing/development/dev_setup/.
exit status 1
make: *** [Makefile:665: dev-doctor] Error 1
```


