### PR TITLE
bpf: Inline assembly for packet context access

### DIFF
--- a/bpf/include/bpf/ctx/common.h
+++ b/bpf/include/bpf/ctx/common.h
@@ -13,21 +13,6 @@
 #define __ctx_skb		1
 #define __ctx_xdp		2
 
-static __always_inline void *ctx_data(const struct __ctx_buff *ctx)
-{
-	return (void *)(unsigned long)ctx->data;
-}
-
-static __always_inline void *ctx_data_meta(const struct __ctx_buff *ctx)
-{
-	return (void *)(unsigned long)ctx->data_meta;
-}
-
-static __always_inline void *ctx_data_end(const struct __ctx_buff *ctx)
-{
-	return (void *)(unsigned long)ctx->data_end;
-}
-
 static __always_inline bool ctx_no_room(const void *needed, const void *limit)
 {
 	return unlikely(needed > limit);

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -110,6 +110,29 @@ xdp_store_bytes(const struct xdp_md *ctx, __u64 off, const void *from,
 #define get_hash(ctx)			({ 0; })
 #define get_hash_recalc(ctx)		get_hash(ctx)
 
+#define DEFINE_FUNC_CTX_POINTER(FIELD)						\
+static __always_inline void *							\
+ctx_ ## FIELD(const struct xdp_md *ctx)						\
+{										\
+	void *ptr;								\
+										\
+	/* LLVM may generate u32 assignments of ctx->{data,data_end,data_meta}.	\
+	 * With this inline asm, LLVM loses track of the fact this field is on	\
+	 * 32 bits.								\
+	 */									\
+	asm volatile("%0 = *(u32 *)(%1 + %2)"					\
+		     : "=r"(ptr)						\
+		     : "r"(ctx), "i"(offsetof(struct xdp_md, FIELD)));		\
+	return ptr;								\
+}
+/* This defines ctx_data(). */
+DEFINE_FUNC_CTX_POINTER(data)
+/* This defines ctx_data_end(). */
+DEFINE_FUNC_CTX_POINTER(data_end)
+/* This defines ctx_data_meta(). */
+DEFINE_FUNC_CTX_POINTER(data_meta)
+#undef DEFINE_FUNC_CTX_POINTER
+
 static __always_inline __maybe_unused void
 __csum_replace_by_diff(__sum16 *sum, __wsum diff)
 {

--- a/bpf/tests/ipv6_test.c
+++ b/bpf/tests/ipv6_test.c
@@ -75,6 +75,7 @@ int ipv6_without_extension_header_setup(__maybe_unused struct __ctx_buff *ctx)
 CHECK("xdp", "ipv6_without_extension_header")
 int ipv6_without_extension_header_check(struct __ctx_buff *ctx)
 {
+	void *data, *data_end;
 	struct ethhdr *l2;
 	struct ipv6hdr *l3;
 	__u32 *status_code;
@@ -82,21 +83,28 @@ int ipv6_without_extension_header_check(struct __ctx_buff *ctx)
 
 	test_init();
 
-	if (ctx_data(ctx) + sizeof(__u32) > ctx_data_end(ctx))
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+
+	if (data + sizeof(__u32) > data_end)
 		test_fatal("status code out of bounds");
 
-	status_code = ctx_data(ctx);
+	status_code = data;
 	assert(*status_code == 123);
 
 	xdp_adjust_head(ctx, 4);
-	l2 = ctx_data(ctx);
-	if ((void *)(l2 + 1) > ctx_data_end(ctx))
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+
+	l2 = data;
+	if ((void *)(l2 + 1) > data_end)
 		test_fatal("l2 out of bounds");
 
 	assert(l2->h_proto == __bpf_htons(ETH_P_IPV6));
 
 	l3 = (void *)l2 + ETH_HLEN;
-	if ((void *)(l3 + 1) > ctx_data_end(ctx))
+	if ((void *)(l3 + 1) > data_end)
 		test_fatal("l3 out of bounds");
 
 	nexthdr = l3->nexthdr;
@@ -175,6 +183,7 @@ int ipv6_with_hop_auth_tcp_setup(__maybe_unused struct __ctx_buff *ctx)
 CHECK("xdp", "ipv6_with_auth_hop_tcp")
 int ipv6_with_hop_auth_tcp_check(struct __ctx_buff *ctx)
 {
+	void *data, *data_end;
 	struct ethhdr *l2;
 	struct ipv6hdr *l3;
 	__u32 *status_code;
@@ -182,21 +191,28 @@ int ipv6_with_hop_auth_tcp_check(struct __ctx_buff *ctx)
 
 	test_init();
 
-	if (ctx_data(ctx) + sizeof(__u32) > ctx_data_end(ctx))
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+
+	if (data + sizeof(__u32) > data_end)
 		test_fatal("status code out of bounds");
 
-	status_code = ctx_data(ctx);
+	status_code = data;
 	assert(*status_code == 1234);
 
 	xdp_adjust_head(ctx, 4);
-	l2 = ctx_data(ctx);
-	if ((void *)(l2 + 1) > ctx_data_end(ctx))
+
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+
+	l2 = data;
+	if ((void *)(l2 + 1) > data_end)
 		test_fatal("l2 out of bounds");
 
 	assert(l2->h_proto == __bpf_htons(ETH_P_IPV6));
 
 	l3 = (void *)l2 + ETH_HLEN;
-	if ((void *)(l3 + 1) > ctx_data_end(ctx))
+	if ((void *)(l3 + 1) > data_end)
 		test_fatal("l3 out of bounds");
 
 	nexthdr = l3->nexthdr;

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -184,10 +184,12 @@ struct ethhdr *pktgen__push_ethhdr(struct pktgen *builder)
 	struct __ctx_buff *ctx = builder->ctx;
 	struct ethhdr *layer;
 	int layer_idx;
+	void *data;
 
 	/* Request additional tailroom, and check that we got it. */
 	ctx_adjust_troom(ctx, builder->cur_off + sizeof(struct ethhdr) - ctx_full_len(ctx));
-	if (ctx_data(ctx) + builder->cur_off + sizeof(struct ethhdr) > ctx_data_end(ctx))
+	data = ctx_data(ctx);
+	if (data + builder->cur_off + sizeof(struct ethhdr) > ctx_data_end(ctx))
 		return 0;
 
 	/* Check that any value within the struct will not exceed a u16 which
@@ -196,7 +198,7 @@ struct ethhdr *pktgen__push_ethhdr(struct pktgen *builder)
 	if (builder->cur_off >= MAX_PACKET_OFF - sizeof(struct ethhdr))
 		return 0;
 
-	layer = ctx_data(ctx) + builder->cur_off;
+	layer = data + builder->cur_off;
 	layer_idx = pktgen__free_layer(builder);
 
 	if (layer_idx < 0)
@@ -224,6 +226,7 @@ struct iphdr *pktgen__push_iphdr(struct pktgen *builder, __u32 option_bytes)
 {
 	__u32 length = sizeof(struct iphdr) + option_bytes;
 	struct __ctx_buff *ctx = builder->ctx;
+	void *data, *data_end;
 	struct iphdr *layer;
 	int layer_idx;
 
@@ -232,7 +235,9 @@ struct iphdr *pktgen__push_iphdr(struct pktgen *builder, __u32 option_bytes)
 
 	/* Request additional tailroom, and check that we got it. */
 	ctx_adjust_troom(ctx, builder->cur_off + length - ctx_full_len(ctx));
-	if (ctx_data(ctx) + builder->cur_off + length > ctx_data_end(ctx))
+	data = ctx_data(ctx);
+	data_end = ctx_data_end(ctx);
+	if (data + builder->cur_off + length > data_end)
 		return 0;
 
 	/* Check that any value within the struct will not exceed a u16 which
@@ -241,7 +246,7 @@ struct iphdr *pktgen__push_iphdr(struct pktgen *builder, __u32 option_bytes)
 	if (builder->cur_off >= MAX_PACKET_OFF - length)
 		return 0;
 
-	layer = ctx_data(ctx) + builder->cur_off;
+	layer = data + builder->cur_off;
 	layer_idx = pktgen__free_layer(builder);
 
 	if (layer_idx < 0)


### PR DESCRIPTION
- bpf: tests: Minimise calls to ctx_data{,_end}() in prep for inline asm
- bpf: Avoid 32bit assignment of packet pointer

Given that `ctx->`{`data`,`data_end`,`data_meta`} are 32-bits fields, LLVM sometimes generates 32-bit assignments for those pointers. This leads to verifier errors as the verifier is unable to track the packet pointers through the 32-bit assignments, as show below.

    ; return (void *)(unsigned long)ctx->data;
    2: (61) r9 = *(u32 *)(r7 +76)
    ; R7_w=ctx(id=0,off=0,imm=0) R9_w=pkt(id=0,off=0,r=0,imm=0)
    ; return (void *)(unsigned long)ctx->data;
    3: (bc) w6 = w9
    ; R6_w=inv(id=0,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R9_w=pkt(id=0,off=0,r=0,imm=0)
    ; if (data + tot_len > data_end)
    4: (bf) r2 = r6
    ; R2_w=inv(id=1,umax_value=4294967295,var_off=(0x0; 0xffffffff)) R6_w=inv(id=1,umax_value=4294967295,var_off=(0x0; 0xffffffff))
    5: (07) r2 += 54
    ; R2_w=inv(id=0,umin_value=54,umax_value=4294967349,var_off=(0x0; 0x1ffffffff))
    ; if (data + tot_len > data_end)
    6: (2d) if r2 > r1 goto pc+466
    ; R1_w=pkt_end(id=0,off=0,imm=0) R2_w=inv(id=0,umin_value=54,umax_value=4294967349,var_off=(0x0; 0x1ffffffff))
    ; tmp = a->d1 - b->d1;
    7: (71) r2 = *(u8 *)(r6 +22)
    R6 invalid mem access 'inv'

As a workaround, Yonghong Song [suggested](https://lore.kernel.org/bpf/c5a76b4d-abed-51f6-bf16-040eb0baf290@fb.com/T/#m933626f7404562a6e98af78a8f44c30977681ffa) to read those fields using asm bytecode. With that trick, LLVM is unaware that the original field is actually on 32 bits and can't perform the above "optimisation".

This workaround is needed only now because code for IPv6 masquerading, coming in a future PR, will cause this bytecode to be generated (snat_v6_needed).

Preliminary to this change, we also need some adjustments in the BPF unit tests, to avoid resetting range tracking for packet pointers by fetching them multiple times (these multiple fetches were previously optimised out by the compiler, but also drop _this_ optimisation by switching to inline assembly).

```release-note
bpf: Use inline assembly for packet context access, to prevent some undesirable optimizations from LLVM
```
