### PR TITLE
bpf: clean up some revalidate_data() users

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -170,7 +170,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #ifdef ENABLE_NODEPORT
 	if (!from_host) {
 		if (!ctx_skip_nodeport(ctx)) {
-			ret = nodeport_lb6(ctx, secctx, ext_err);
+			ret = nodeport_lb6(ctx, ip6, secctx, ext_err);
 			/* nodeport_lb6() returns with TC_ACT_REDIRECT for
 			 * traffic to L7 LB. Policy enforcement needs to take
 			 * place after L7 LB has processed the packet, so we

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1544,12 +1544,7 @@ skip_policy_enforcement:
 				 &ct_state_new, *proxy_port > 0, false, ext_err);
 		if (IS_ERR(ret))
 			return ret;
-
-		/* NOTE: tuple has been invalidated after this */
 	}
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
 
 	reason = (enum trace_reason)*ct_status;
 	if (*proxy_port > 0) {
@@ -1872,12 +1867,7 @@ skip_policy_enforcement:
 				 &ct_state_new, *proxy_port > 0, false, ext_err);
 		if (IS_ERR(ret))
 			return ret;
-
-		/* NOTE: tuple has been invalidated after this */
 	}
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
 
 	reason = (enum trace_reason)*ct_status;
 	if (*proxy_port > 0) {

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -57,7 +57,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		return DROP_INVALID;
 #ifdef ENABLE_NODEPORT
 	if (!ctx_skip_nodeport(ctx)) {
-		ret = nodeport_lb6(ctx, *identity, ext_err);
+		ret = nodeport_lb6(ctx, ip6, *identity, ext_err);
 		if (ret < 0)
 			return ret;
 	}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -947,13 +947,12 @@ drop_err:
 
 /* See nodeport_lb4(). */
 static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
+					struct ipv6hdr *ip6,
 					__u32 src_sec_identity,
 					__s8 *ext_err)
 {
 	int ret, l3_off = ETH_HLEN, l4_off;
 	struct ipv6_ct_tuple tuple = {};
-	void *data, *data_end;
-	struct ipv6hdr *ip6;
 	struct lb6_service *svc;
 	struct lb6_key key = {};
 	struct ct_state ct_state_new = {};
@@ -961,9 +960,6 @@ static __always_inline int nodeport_lb6(struct __ctx_buff *ctx,
 	__u32 monitor = 0;
 
 	cilium_capture_in(ctx);
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
 
 	ret = lb6_extract_tuple(ctx, ip6, ETH_HLEN, &l4_off, &tuple);
 	if (IS_ERR(ret)) {


### PR DESCRIPTION
Some completely innocent cleanups to our `revalidate_data()` usage.