### PR TITLE
bpf: Handle fragments in SNAT flows

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -105,8 +105,8 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 			goto skip_service_lookup;
 		}
 #endif /* ENABLE_L7_LB */
-		ret = lb4_local(get_ct_map4(&tuple), ctx, ETH_HLEN, l4_off,
-				&key, &tuple, svc, &ct_state_new,
+		ret = lb4_local(get_ct_map4(&tuple), ctx, ipv4_is_fragment(ip4),
+				ETH_HLEN, l4_off, &key, &tuple, svc, &ct_state_new,
 				has_l4_header, false, &cluster_id, ext_err);
 		if (IS_ERR(ret))
 			return ret;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -831,6 +831,7 @@ out:
  * @arg map		CT map
  * @arg tuple		CT tuple (with populated L4 ports)
  * @arg ctx		packet
+ * @arg is_fragment	the result of ipv4_is_fragment(ip4)
  * @arg l4_off		offset to L4 header
  * @arg has_l4_header	packet has L4 header
  * @arg dir		lookup direction
@@ -850,8 +851,8 @@ out:
  * ICMP types to ct_lazy_lookup4.
  */
 static __always_inline int
-ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple,
-		struct __ctx_buff *ctx, int l4_off, bool has_l4_header,
+ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx,
+		bool is_fragment __maybe_unused, int l4_off, bool has_l4_header,
 		enum ct_dir dir, enum ct_scope scope, __u32 ct_entry_types,
 		struct ct_state *ct_state, __u32 *monitor)
 {

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1521,7 +1521,7 @@ lb4_to_lb6(struct __ctx_buff *ctx __maybe_unused,
 }
 
 static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
-				     int l3_off, int l4_off,
+				     bool is_fragment, int l3_off, int l4_off,
 				     struct lb4_key *key,
 				     struct ipv4_ct_tuple *tuple,
 				     const struct lb4_service *svc,
@@ -1546,7 +1546,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 	if (unlikely(svc->count == 0))
 		return DROP_NO_SERVICE;
 
-	ret = ct_lazy_lookup4(map, tuple, ctx, l4_off, has_l4_header,
+	ret = ct_lazy_lookup4(map, tuple, ctx, is_fragment, l4_off, has_l4_header,
 			      CT_SERVICE, SCOPE_REVERSE, CT_ENTRY_ANY, state, &monitor);
 	switch (ret) {
 	case CT_NEW:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -484,72 +484,6 @@ snat_v4_icmp_rewrite_egress_embedded(struct __ctx_buff *ctx,
 	return 0;
 }
 
-static __always_inline int snat_v4_rewrite_ingress(struct __ctx_buff *ctx,
-						   struct ipv4_ct_tuple *tuple,
-						   struct ipv4_nat_entry *state,
-						   __u32 off, bool has_l4_header)
-{
-	int ret, flags = BPF_F_PSEUDO_HDR;
-	struct csum_offset csum = {};
-	__be32 sum;
-
-	if (state->to_daddr == tuple->daddr &&
-	    state->to_dport == tuple->dport)
-		return 0;
-	sum = csum_diff(&tuple->daddr, 4, &state->to_daddr, 4, 0);
-	if (has_l4_header) {
-		csum_l4_offset_and_flags(tuple->nexthdr, &csum);
-
-		if (state->to_dport != tuple->dport) {
-			switch (tuple->nexthdr) {
-			case IPPROTO_TCP:
-			case IPPROTO_UDP:
-				ret = l4_modify_port(ctx, off,
-						     offsetof(struct tcphdr, dest),
-						     &csum, state->to_dport,
-						     tuple->dport);
-				if (ret < 0)
-					return ret;
-				break;
-#ifdef ENABLE_SCTP
-			case IPPROTO_SCTP:
-				return DROP_CSUM_L4;
-#endif  /* ENABLE_SCTP */
-			case IPPROTO_ICMP: {
-				__u8 type = 0;
-
-				if (ctx_load_bytes(ctx, off +
-						   offsetof(struct icmphdr, type),
-						   &type, 1) < 0)
-					return DROP_INVALID;
-				if (type == ICMP_ECHOREPLY) {
-					if (ctx_store_bytes(ctx, off +
-							    offsetof(struct icmphdr, un.echo.id),
-							    &state->to_dport,
-							    sizeof(state->to_dport), 0) < 0)
-						return DROP_WRITE_ERROR;
-					if (l4_csum_replace(ctx, off +
-							    offsetof(struct icmphdr, checksum),
-							    tuple->dport,
-							    state->to_dport,
-							    sizeof(tuple->dport)) < 0)
-						return DROP_CSUM_L4;
-				}
-				break;
-			}}
-		}
-	}
-	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, daddr),
-			    &state->to_daddr, 4, 0) < 0)
-		return DROP_WRITE_ERROR;
-	if (ipv4_csum_update_by_diff(ctx, ETH_HLEN, sum) < 0)
-		return DROP_CSUM_L3;
-	if (csum.offset &&
-	    csum_l4_replace(ctx, off, &csum, 0, sum, flags) < 0)
-		return DROP_CSUM_L4;
-	return 0;
-}
-
 static __always_inline bool
 snat_v4_nat_can_skip(const struct ipv4_nat_target *target,
 		     const struct ipv4_ct_tuple *tuple)
@@ -1008,6 +942,8 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 	struct iphdr *ip4;
 	bool has_l4_header = true;
 	__u64 off, inner_l3_off;
+	__be16 to_dport = 0;
+	__u16 port_off = 0;
 	int ret;
 
 	build_bug_on(sizeof(struct ipv4_nat_entry) > 64);
@@ -1028,6 +964,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 				       &tuple.dport, &has_l4_header) < 0)
 			return DROP_INVALID;
 		ipv4_ct_tuple_swap_ports(&tuple);
+		port_off = TCP_DPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
@@ -1036,6 +973,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		case ICMP_ECHOREPLY:
 			tuple.dport = icmphdr.un.echo.id;
 			tuple.sport = 0;
+			port_off = offsetof(struct icmphdr, un.echo.id);
 			break;
 		case ICMP_DEST_UNREACH:
 			if (icmphdr.code != ICMP_FRAG_NEEDED)
@@ -1066,8 +1004,13 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 	if (ret < 0)
 		return ret;
 
+	/* Skip port rewrite for ICMP_DEST_UNREACH by passing old_port == new_port == 0. */
+	to_dport = state->to_dport;
+
 rewrite:
-	return snat_v4_rewrite_ingress(ctx, &tuple, state, off, has_l4_header);
+	return snat_v4_rewrite_headers(ctx, tuple.nexthdr, ETH_HLEN, has_l4_header, off,
+				       tuple.daddr, state->to_daddr, IPV4_DADDR_OFF,
+				       tuple.dport, to_dport, port_off);
 }
 #else
 static __always_inline __maybe_unused

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -263,7 +263,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 			   bool has_l4_header,
 			   struct ipv4_nat_entry **state,
 			   struct ipv4_nat_entry *tmp,
-			   __u32 off,
+			   struct iphdr *ip4, __u32 off,
 			   const struct ipv4_nat_target *target,
 			   struct trace_ctx *trace,
 			   __s8 *ext_err)
@@ -287,8 +287,8 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 		ipv4_ct_tuple_swap_addrs(&tuple_snat);
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_snat), &tuple_snat,
-				      ctx, off, has_l4_header, CT_EGRESS,
-				      SCOPE_FORWARD, CT_ENTRY_ANY,
+				      ctx, ipv4_is_fragment(ip4), off, has_l4_header,
+				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_ANY,
 				      &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
@@ -315,7 +315,7 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       struct ipv4_ct_tuple *tuple,
 			       bool has_l4_header,
 			       struct ipv4_nat_entry **state,
-			       __u32 off,
+			       struct iphdr *ip4, __u32 off,
 			       const struct ipv4_nat_target *target,
 			       struct trace_ctx *trace)
 {
@@ -342,8 +342,8 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 		ipv4_ct_tuple_swap_ports(&tuple_revsnat);
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_revsnat), &tuple_revsnat,
-				      ctx, off, has_l4_header, CT_INGRESS,
-				      SCOPE_REVERSE, CT_ENTRY_ANY,
+				      ctx, ipv4_is_fragment(ip4), off, has_l4_header,
+				      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_ANY,
 				      &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
@@ -846,15 +846,15 @@ snat_v4_nat_handle_icmp_frag_needed(struct __ctx_buff *ctx, __u64 off,
 
 static __always_inline int
 __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
-	      bool has_l4_header, int l4_off, bool update_tuple,
-	      const struct ipv4_nat_target *target, __u16 port_off,
-	      struct trace_ctx *trace, __s8 *ext_err)
+	      struct iphdr *ip4, bool has_l4_header, int l4_off,
+	      bool update_tuple, const struct ipv4_nat_target *target,
+	      __u16 port_off, struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ipv4_nat_entry *state, tmp;
 	int ret;
 
 	ret = snat_v4_nat_handle_mapping(ctx, tuple, has_l4_header, &state,
-					 &tmp, l4_off, target, trace, ext_err);
+					 &tmp, ip4, l4_off, target, trace, ext_err);
 	if (ret < 0)
 		return ret;
 
@@ -871,8 +871,9 @@ __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 }
 
 static __always_inline __maybe_unused int
-snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
-	    bool has_l4_header, const struct ipv4_nat_target *target,
+snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
+	    struct iphdr *ip4, int off, bool has_l4_header,
+	    const struct ipv4_nat_target *target,
 	    struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct icmphdr icmphdr __align_stack_8;
@@ -920,7 +921,7 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
 	if (snat_v4_nat_can_skip(target, tuple))
 		return NAT_PUNT_TO_STACK;
 
-	return __snat_v4_nat(ctx, tuple, has_l4_header, off, false, target,
+	return __snat_v4_nat(ctx, tuple, ip4, has_l4_header, off, false, target,
 			     port_off, trace, ext_err);
 }
 
@@ -1061,7 +1062,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 	if (snat_v4_rev_nat_can_skip(target, &tuple))
 		return NAT_PUNT_TO_STACK;
 	ret = snat_v4_rev_nat_handle_mapping(ctx, &tuple, has_l4_header, &state,
-					     off, target, trace);
+					     ip4, off, target, trace);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -487,7 +487,7 @@ snat_v4_icmp_rewrite_egress_embedded(struct __ctx_buff *ctx,
 static __always_inline int snat_v4_rewrite_ingress(struct __ctx_buff *ctx,
 						   struct ipv4_ct_tuple *tuple,
 						   struct ipv4_nat_entry *state,
-						   __u32 off)
+						   __u32 off, bool has_l4_header)
 {
 	int ret, flags = BPF_F_PSEUDO_HDR;
 	struct csum_offset csum = {};
@@ -497,43 +497,47 @@ static __always_inline int snat_v4_rewrite_ingress(struct __ctx_buff *ctx,
 	    state->to_dport == tuple->dport)
 		return 0;
 	sum = csum_diff(&tuple->daddr, 4, &state->to_daddr, 4, 0);
-	csum_l4_offset_and_flags(tuple->nexthdr, &csum);
-	if (state->to_dport != tuple->dport) {
-		switch (tuple->nexthdr) {
-		case IPPROTO_TCP:
-		case IPPROTO_UDP:
-			ret = l4_modify_port(ctx, off,
-					     offsetof(struct tcphdr, dest),
-					     &csum, state->to_dport,
-					     tuple->dport);
-			if (ret < 0)
-				return ret;
-			break;
-#ifdef ENABLE_SCTP
-		case IPPROTO_SCTP:
-			return DROP_CSUM_L4;
-#endif  /* ENABLE_SCTP */
-		case IPPROTO_ICMP: {
-			__u8 type = 0;
+	if (has_l4_header) {
+		csum_l4_offset_and_flags(tuple->nexthdr, &csum);
 
-			if (ctx_load_bytes(ctx, off +
-					   offsetof(struct icmphdr, type),
-					   &type, 1) < 0)
-				return DROP_INVALID;
-			if (type == ICMP_ECHOREPLY) {
-				if (ctx_store_bytes(ctx, off +
-						    offsetof(struct icmphdr, un.echo.id),
-						    &state->to_dport,
-						    sizeof(state->to_dport), 0) < 0)
-					return DROP_WRITE_ERROR;
-				if (l4_csum_replace(ctx, off + offsetof(struct icmphdr, checksum),
-						    tuple->dport,
-						    state->to_dport,
-						    sizeof(tuple->dport)) < 0)
-					return DROP_CSUM_L4;
-			}
-			break;
-		}}
+		if (state->to_dport != tuple->dport) {
+			switch (tuple->nexthdr) {
+			case IPPROTO_TCP:
+			case IPPROTO_UDP:
+				ret = l4_modify_port(ctx, off,
+						     offsetof(struct tcphdr, dest),
+						     &csum, state->to_dport,
+						     tuple->dport);
+				if (ret < 0)
+					return ret;
+				break;
+#ifdef ENABLE_SCTP
+			case IPPROTO_SCTP:
+				return DROP_CSUM_L4;
+#endif  /* ENABLE_SCTP */
+			case IPPROTO_ICMP: {
+				__u8 type = 0;
+
+				if (ctx_load_bytes(ctx, off +
+						   offsetof(struct icmphdr, type),
+						   &type, 1) < 0)
+					return DROP_INVALID;
+				if (type == ICMP_ECHOREPLY) {
+					if (ctx_store_bytes(ctx, off +
+							    offsetof(struct icmphdr, un.echo.id),
+							    &state->to_dport,
+							    sizeof(state->to_dport), 0) < 0)
+						return DROP_WRITE_ERROR;
+					if (l4_csum_replace(ctx, off +
+							    offsetof(struct icmphdr, checksum),
+							    tuple->dport,
+							    state->to_dport,
+							    sizeof(tuple->dport)) < 0)
+						return DROP_CSUM_L4;
+				}
+				break;
+			}}
+		}
 	}
 	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, daddr),
 			    &state->to_daddr, 4, 0) < 0)
@@ -872,10 +876,6 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
 	    struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct icmphdr icmphdr __align_stack_8;
-	struct {
-		__be16 sport;
-		__be16 dport;
-	} l4hdr;
 	__u16 port_off;
 
 	build_bug_on(sizeof(struct ipv4_nat_entry) > 64);
@@ -886,11 +886,11 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		if (ctx_load_bytes(ctx, off, &l4hdr, sizeof(l4hdr)) < 0)
+		if (ipv4_load_l4_ports(ctx, NULL, off, CT_EGRESS,
+				       &tuple->dport, &has_l4_header) < 0)
 			return DROP_INVALID;
 
-		tuple->dport = l4hdr.dport;
-		tuple->sport = l4hdr.sport;
+		ipv4_ct_tuple_swap_ports(tuple);
 		port_off = TCP_SPORT_OFF;
 		break;
 	case IPPROTO_ICMP:
@@ -1005,10 +1005,6 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 	struct ipv4_ct_tuple tuple = {};
 	void *data, *data_end;
 	struct iphdr *ip4;
-	struct {
-		__be16 sport;
-		__be16 dport;
-	} l4hdr;
 	bool has_l4_header = true;
 	__u64 off, inner_l3_off;
 	int ret;
@@ -1027,10 +1023,10 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-		if (ctx_load_bytes(ctx, off, &l4hdr, sizeof(l4hdr)) < 0)
+		if (ipv4_load_l4_ports(ctx, ip4, off, CT_INGRESS,
+				       &tuple.dport, &has_l4_header) < 0)
 			return DROP_INVALID;
-		tuple.dport = l4hdr.dport;
-		tuple.sport = l4hdr.sport;
+		ipv4_ct_tuple_swap_ports(&tuple);
 		break;
 	case IPPROTO_ICMP:
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
@@ -1052,6 +1048,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 			if (IS_ERR(ret))
 				return ret;
 
+			has_l4_header = true;
 			goto rewrite;
 		default:
 			return NAT_PUNT_TO_STACK;
@@ -1069,7 +1066,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		return ret;
 
 rewrite:
-	return snat_v4_rewrite_ingress(ctx, &tuple, state, off);
+	return snat_v4_rewrite_ingress(ctx, &tuple, state, off, has_l4_header);
 }
 #else
 static __always_inline __maybe_unused

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -584,7 +584,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
 			  &target, &trace, NULL);
 	assert(ret == 0);
 
@@ -699,7 +699,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
 			  &target, &trace, NULL);
 	assert(ret == 0);
 
@@ -813,7 +813,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
 			  &target, &trace, NULL);
 	assert(ret == 0);
 
@@ -916,7 +916,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
+	ret = snat_v4_nat(ctx, &icmp_tuple, ip4, l4_off, ipv4_has_l4_header(ip4),
 			  &target, &trace, NULL);
 	assert(ret == 0);
 


### PR DESCRIPTION
The code that extracts ports in snat_v4_nat and snat_v4_rev_nat doesn't take into account that the packet may be a second or further fragment. In this case, garbage will be read instead of the real port numbers. Fix this by using the existing ipv4_ct_extract_l4_ports that takes into account fragmentation.

This change makes the behavior of the switch inside the aforementioned functions closer to ct_extract_ports4.

Consider fragments in snat_v4_rewrite_ingress, avoid rewriting ports if it's not the first fragment.

Fixes: 14a653ad4aac ("bpf/nat: introduce snat_v4_nat() and snat_v4_rev_nat functions")

This should be applied on top of #25112.

```release-note
Handle IPv4 fragments in SNAT flows correctly.
```
