### PR TITLE
identity: cache: close channel in writing party

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -88,7 +88,7 @@ const (
 type Allocator struct {
 	// events is a channel which will receive AllocatorEvent as IDs are
 	// added, modified or removed from the allocator
-	events AllocatorEventChan
+	events AllocatorEventSendChan
 
 	// keyType is an instance of the type to be used as allocator key.
 	keyType AllocatorKey
@@ -345,7 +345,7 @@ func WithBackend(backend Backend) AllocatorOption {
 // read while NewAllocator() is being called to ensure that the channel does
 // not block indefinitely while NewAllocator() emits events on it while
 // populating the initial cache.
-func WithEvents(events AllocatorEventChan) AllocatorOption {
+func WithEvents(events AllocatorEventSendChan) AllocatorOption {
 	return func(a *Allocator) { a.events = events }
 }
 
@@ -381,7 +381,7 @@ func WithoutGC() AllocatorOption {
 // GetEvents returns the events channel given to the allocator when
 // constructed.
 // Note: This channel is not owned by the allocator!
-func (a *Allocator) GetEvents() AllocatorEventChan {
+func (a *Allocator) GetEvents() AllocatorEventSendChan {
 	return a.events
 }
 
@@ -866,6 +866,10 @@ func (a *Allocator) startLocalKeySync() {
 
 // AllocatorEventChan is a channel to receive allocator events on
 type AllocatorEventChan chan AllocatorEvent
+
+// Send- and receive-only versions of the above.
+type AllocatorEventRecvChan = <-chan AllocatorEvent
+type AllocatorEventSendChan = chan<- AllocatorEvent
 
 // AllocatorEvent is an event sent over AllocatorEventChan
 type AllocatorEvent struct {

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -134,7 +134,7 @@ func collectEvent(event allocator.AllocatorEvent, added, deleted IdentityCache) 
 }
 
 // watch starts the identity watcher
-func (w *identityWatcher) watch(events allocator.AllocatorEventChan) {
+func (w *identityWatcher) watch(events allocator.AllocatorEventRecvChan) {
 
 	go func() {
 		for {

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -22,10 +22,10 @@ type localIdentityCache struct {
 	nextNumericIdentity identity.NumericIdentity
 	minID               identity.NumericIdentity
 	maxID               identity.NumericIdentity
-	events              allocator.AllocatorEventChan
+	events              allocator.AllocatorEventSendChan
 }
 
-func newLocalIdentityCache(minID, maxID identity.NumericIdentity, events allocator.AllocatorEventChan) *localIdentityCache {
+func newLocalIdentityCache(minID, maxID identity.NumericIdentity, events allocator.AllocatorEventSendChan) *localIdentityCache {
 	return &localIdentityCache{
 		identitiesByID:      map[identity.NumericIdentity]*identity.Identity{},
 		identitiesByLabels:  map[string]*identity.Identity{},
@@ -190,4 +190,16 @@ func (l *localIdentityCache) GetIdentities() map[identity.NumericIdentity]*ident
 	}
 
 	return cache
+}
+
+// close closes the events channel. The local identity cache is the writing
+// party, hence also needs to close the channel.
+func (l *localIdentityCache) close() {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if l.events != nil {
+		close(l.events)
+		l.events = nil
+	}
 }


### PR DESCRIPTION
As part of the shutdown procedure involving IPCache and the identity allocation components, it was possible to hit a 'write on closed channel' panic, caused by writes of the localIdentityCache to the events channel, which is closed as part of the shutdown of the identity allocator.

Instead of directly closing the channel, call into the localIdentityCache (the only writer) to do so, with proper mutual exclusion guaranteed by the mutex.

The offending writes happened in `lookupOrCreate` as well as `release`, both of which take the mutex, and hence are correctly synchronised with the new `close()` method.

Fixes: #25235

Since this affects the shutdown procedure, I believe this not to impact actual cilium deployments, merely our integration tests; hence `release-note/misc`.
