### PR TITLE
bpf: migrate hand-written bpf syscalls to ebpf-go APIs

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -17,42 +17,6 @@ var (
 )
 
 const (
-	// BPF syscall command constants. Must match enum bpf_cmd from linux/bpf.h
-	// Deprecated: don't implement syscalls directly, use cilium/ebpf.
-
-	BPF_PROG_LOAD   = 5
-	BPF_PROG_ATTACH = 8
-
-	// BPF syscall attach types
-	BPF_CGROUP_INET_INGRESS      = 0
-	BPF_CGROUP_INET_EGRESS       = 1
-	BPF_CGROUP_INET_SOCK_CREATE  = 2
-	BPF_CGROUP_SOCK_OPS          = 3
-	BPF_SK_SKB_STREAM_PARSER     = 4
-	BPF_SK_SKB_STREAM_VERDICT    = 5
-	BPF_CGROUP_DEVICE            = 6
-	BPF_SK_MSG_VERDICT           = 7
-	BPF_CGROUP_INET4_BIND        = 8
-	BPF_CGROUP_INET6_BIND        = 9
-	BPF_CGROUP_INET4_CONNECT     = 10
-	BPF_CGROUP_INET6_CONNECT     = 11
-	BPF_CGROUP_INET4_POST_BIND   = 12
-	BPF_CGROUP_INET6_POST_BIND   = 13
-	BPF_CGROUP_UDP4_SENDMSG      = 14
-	BPF_CGROUP_UDP6_SENDMSG      = 15
-	BPF_LIRC_MODE2               = 16
-	BPF_FLOW_DISSECTOR           = 17
-	BPF_CGROUP_SYSCTL            = 18
-	BPF_CGROUP_UDP4_RECVMSG      = 19
-	BPF_CGROUP_UDP6_RECVMSG      = 20
-	BPF_CGROUP_INET4_GETPEERNAME = 29
-	BPF_CGROUP_INET6_GETPEERNAME = 30
-	BPF_CGROUP_INET4_GETSOCKNAME = 31
-	BPF_CGROUP_INET6_GETSOCKNAME = 32
-
-	// Flags for BPF_MAP_UPDATE_ELEM. Must match values from linux/bpf.h
-	BPF_ANY = 0
-
 	// Flags for BPF_MAP_CREATE. Must match values from linux/bpf.h
 	BPF_F_NO_PREALLOC = 1 << 0
 )

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -20,7 +20,6 @@ const (
 	// BPF syscall command constants. Must match enum bpf_cmd from linux/bpf.h
 	// Deprecated: don't implement syscalls directly, use cilium/ebpf.
 
-	BPF_MAP_LOOKUP_ELEM = 1
 	BPF_MAP_UPDATE_ELEM = 2
 	BPF_PROG_LOAD       = 5
 	BPF_PROG_ATTACH     = 8

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -20,9 +20,8 @@ const (
 	// BPF syscall command constants. Must match enum bpf_cmd from linux/bpf.h
 	// Deprecated: don't implement syscalls directly, use cilium/ebpf.
 
-	BPF_MAP_UPDATE_ELEM = 2
-	BPF_PROG_LOAD       = 5
-	BPF_PROG_ATTACH     = 8
+	BPF_PROG_LOAD   = 5
+	BPF_PROG_ATTACH = 8
 
 	// BPF syscall attach types
 	BPF_CGROUP_INET_INGRESS      = 0

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -21,7 +21,6 @@ const (
 	// Deprecated: don't implement syscalls directly, use cilium/ebpf.
 	BPF_MAP_LOOKUP_ELEM  = 1
 	BPF_MAP_UPDATE_ELEM  = 2
-	BPF_MAP_DELETE_ELEM  = 3
 	BPF_MAP_GET_NEXT_KEY = 4
 	BPF_PROG_LOAD        = 5
 	BPF_PROG_ATTACH      = 8

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -19,11 +19,11 @@ var (
 const (
 	// BPF syscall command constants. Must match enum bpf_cmd from linux/bpf.h
 	// Deprecated: don't implement syscalls directly, use cilium/ebpf.
-	BPF_MAP_LOOKUP_ELEM  = 1
-	BPF_MAP_UPDATE_ELEM  = 2
-	BPF_MAP_GET_NEXT_KEY = 4
-	BPF_PROG_LOAD        = 5
-	BPF_PROG_ATTACH      = 8
+
+	BPF_MAP_LOOKUP_ELEM = 1
+	BPF_MAP_UPDATE_ELEM = 2
+	BPF_PROG_LOAD       = 5
+	BPF_PROG_ATTACH     = 8
 
 	// BPF syscall attach types
 	BPF_CGROUP_INET_INGRESS      = 0

--- a/pkg/bpf/map_linux_test.go
+++ b/pkg/bpf/map_linux_test.go
@@ -765,13 +765,12 @@ func (s *BPFPrivilegedTestSuite) TestCreateUnpinned(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(exist, Equals, false)
 
-	key1 := &TestKey{Key: 105}
-	value1 := &TestValue{Value: 205}
-	err = m.Update(key1, value1)
+	k := &TestKey{Key: 105}
+	v := &TestValue{Value: 205}
+	err = m.Update(k, v)
 	c.Assert(err, IsNil)
 
-	var value2 TestValue
-	err = LookupElement(m.FD(), unsafe.Pointer(key1), unsafe.Pointer(&value2))
+	got, err := m.Lookup(k)
 	c.Assert(err, IsNil)
-	c.Assert(*value1, Equals, value2)
+	c.Assert(got, checker.DeepEquals, v)
 }

--- a/pkg/datapath/linux/probes/attach_cgroup.go
+++ b/pkg/datapath/linux/probes/attach_cgroup.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package probes
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/link"
+	"golang.org/x/sys/unix"
+)
+
+// HaveAttachCgroup returns nil if the kernel is compiled with
+// CONFIG_CGROUP_BPF.
+//
+// It's only an approximation and doesn't execute a successful cgroup attachment
+// under the hood. If any unexpected errors are encountered, the original error
+// is returned.
+func HaveAttachCgroup() error {
+	attachCgroupOnce.Do(func() {
+		attachCgroupResult = haveAttachCgroup()
+	})
+
+	return attachCgroupResult
+}
+
+func haveAttachCgroup() error {
+	// Load known-good program supported by the earliest kernels with cgroup
+	// support.
+	spec := &ebpf.ProgramSpec{
+		Type:       ebpf.CGroupSKB,
+		AttachType: ebpf.AttachCGroupInetIngress,
+		Instructions: asm.Instructions{
+			asm.LoadImm(asm.R0, 0, asm.DWord),
+			asm.Return(),
+		},
+	}
+
+	p, err := ebpf.NewProgramWithOptions(spec, ebpf.ProgramOptions{
+		LogDisabled: true,
+	})
+	if err != nil {
+		return fmt.Errorf("create cgroup program: %w: %w", err, ebpf.ErrNotSupported)
+	}
+	defer p.Close()
+
+	// Attaching to a non-cgroup node should result in EBADF when creating the
+	// link, compared to EINVAL if the kernel does not support or was compiled
+	// without CONFIG_CGROUP_BPF.
+	_, err = link.AttachCgroup(link.CgroupOptions{Path: "/dev/null", Program: p, Attach: spec.AttachType})
+	if errors.Is(err, unix.EBADF) {
+		// The kernel checked the given file descriptor from within the cgroup prog
+		// attach handler. Assume it supports attaching cgroup progs.
+		return nil
+	}
+	if err != nil {
+		// Preserve the original error in the error string. Needs Go 1.20.
+		return fmt.Errorf("link cgroup program to /dev/null: %w: %w", err, ebpf.ErrNotSupported)
+	}
+
+	return errors.New("attaching prog to /dev/null did not result in error")
+}
+
+var attachCgroupOnce sync.Once
+var attachCgroupResult error

--- a/pkg/datapath/linux/probes/attach_cgroup_test.go
+++ b/pkg/datapath/linux/probes/attach_cgroup_test.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package probes
+
+import (
+	"testing"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestAttachCgroup(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	// Cgroup attachment expected to succeed in all testing environments.
+	if err := HaveAttachCgroup(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/datapath/linux/probes/attach_type.go
+++ b/pkg/datapath/linux/probes/attach_type.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package probes
+
+import (
+	"errors"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/features"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// HaveAttachType returns nil if the given program/attach type combination is
+// supported by the underlying kernel. Returns ebpf.ErrNotSupported if loading a
+// program with the given Program/AttachType fails. If the probe is inconclusive
+// due to an unrecognized return code, the original error is returned.
+//
+// Note that program types that don't use attach types will silently succeed if
+// an attach type is specified.
+//
+// Probe results are cached by the package and shouldn't be memoized by the
+// caller.
+func HaveAttachType(pt ebpf.ProgramType, at ebpf.AttachType) (err error) {
+	if err := features.HaveProgramType(pt); err != nil {
+		return err
+	}
+
+	attachProbesMu.Lock()
+	defer attachProbesMu.Unlock()
+	if err, ok := attachProbes[attachProbe{pt, at}]; ok {
+		return err
+	}
+
+	defer func() {
+		// Closes over named return variable err to cache any returned errors.
+		attachProbes[attachProbe{pt, at}] = err
+	}()
+
+	spec := &ebpf.ProgramSpec{
+		Type:       pt,
+		AttachType: at,
+		Instructions: asm.Instructions{
+			// recvmsg and peername require a return value of 1, use it for all probes.
+			asm.LoadImm(asm.R0, 1, asm.DWord),
+			asm.Return(),
+		},
+	}
+
+	prog, err := ebpf.NewProgramWithOptions(spec, ebpf.ProgramOptions{
+		LogDisabled: true,
+	})
+	if err == nil {
+		prog.Close()
+	}
+
+	// EINVAL occurs when attempting to create a program with an unknown type.
+	// E2BIG occurs when ProgLoadAttr contains non-zero bytes past the end
+	// of the struct known by the running kernel, meaning the kernel is too old
+	// to support the given prog type.
+	if errors.Is(err, unix.EINVAL) || errors.Is(err, unix.E2BIG) {
+		err = ebpf.ErrNotSupported
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type attachProbe struct {
+	pt ebpf.ProgramType
+	at ebpf.AttachType
+}
+
+var attachProbesMu lock.Mutex
+var attachProbes map[attachProbe]error = make(map[attachProbe]error)

--- a/pkg/datapath/linux/probes/attach_type_test.go
+++ b/pkg/datapath/linux/probes/attach_type_test.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package probes
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestHaveAttachType(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	testCases := []struct {
+		pt      ebpf.ProgramType
+		at      ebpf.AttachType
+		version string
+	}{
+		// Table based on probes executed by the agent on startup.
+		{ebpf.CGroupSockAddr, ebpf.AttachCGroupInet4Connect, "4.17"},
+		{ebpf.CGroupSockAddr, ebpf.AttachCGroupInet6Connect, "4.17"},
+		{ebpf.CGroupSockAddr, ebpf.AttachCGroupUDP4Recvmsg, "4.19.57"},
+		{ebpf.CGroupSockAddr, ebpf.AttachCGroupUDP6Recvmsg, "4.19.57"},
+		{ebpf.CGroupSockAddr, ebpf.AttachCgroupInet4GetPeername, "5.8"},
+		{ebpf.CGroupSockAddr, ebpf.AttachCgroupInet6GetPeername, "5.8"},
+	}
+	for _, tt := range testCases {
+		t.Run(fmt.Sprintf("%s_%s_%s", tt.version, tt.pt, tt.at), func(t *testing.T) {
+			testutils.SkipOnOldKernel(t, tt.version, fmt.Sprintf("%s/%s", tt.pt, tt.at))
+
+			if err := HaveAttachType(tt.pt, tt.at); err != nil {
+				t.Fatalf("kernel doesn't support %s/%s: %s", tt.pt, tt.at, err)
+			}
+		})
+	}
+}
+
+func TestHaveAttachTypeUnsupported(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	if err := HaveAttachType(ebpf.CGroupSockAddr, ^ebpf.AttachType(0)); !errors.Is(err, ebpf.ErrNotSupported) {
+		t.Fatal("unexpected successful probe for nonexistent attach type")
+	}
+}

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -104,7 +104,7 @@ func (cm *CIDRMap) DeleteCIDR(cidr net.IPNet) error {
 func (cm *CIDRMap) CIDRExists(cidr net.IPNet) bool {
 	key := cm.cidrKeyInit(cidr)
 	var entry [LPM_MAP_VALUE_SIZE]byte
-	return bpf.LookupElement(cm.m.FD(), unsafe.Pointer(&key), unsafe.Pointer(&entry)) == nil
+	return cm.m.Lookup(unsafe.Pointer(&key), unsafe.Pointer(&entry)) == nil
 }
 
 // CIDRNext returns next CIDR entry in map 'cm'

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -113,8 +113,7 @@ func (cm *CIDRMap) CIDRNext(cidr *net.IPNet) *net.IPNet {
 	if cidr != nil {
 		key = cm.cidrKeyInit(*cidr)
 	}
-	err := bpf.GetNextKey(cm.m.FD(), unsafe.Pointer(&key), unsafe.Pointer(&keyNext))
-	if err != nil {
+	if err := cm.m.NextKey(unsafe.Pointer(&key), unsafe.Pointer(&keyNext)); err != nil {
 		return nil
 	}
 	out := cm.keyCidrInit(keyNext)

--- a/pkg/maps/cidrmap/cidrmap.go
+++ b/pkg/maps/cidrmap/cidrmap.go
@@ -87,7 +87,7 @@ func (cm *CIDRMap) InsertCIDR(cidr net.IPNet) error {
 		return err
 	}
 	log.WithField(logfields.Path, cm.path).Debugf("Inserting CIDR entry %s", cidr.String())
-	return bpf.UpdateElement(cm.m.FD(), cm.path, unsafe.Pointer(&key), unsafe.Pointer(&entry), 0)
+	return cm.m.Update(unsafe.Pointer(&key), unsafe.Pointer(&entry), ebpf.UpdateAny)
 }
 
 // DeleteCIDR deletes an entry from 'cm' with key 'cidr'.

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -71,7 +71,7 @@ func (k *CTMapPrivilegedTestSuite) Benchmark_MapUpdate(c *C) {
 	for i := 0; i < c.N; i++ {
 		key.DestPort = uint16(i % 0xFFFF)
 		key.SourcePort = uint16(i / 0xFFFF)
-		err := bpf.UpdateElement(m.Map.FD(), m.Map.Name(), unsafe.Pointer(key), unsafe.Pointer(value), 0)
+		err := m.Map.Update(key, value)
 		c.Assert(err, IsNil)
 	}
 
@@ -134,8 +134,7 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 		TxBytes:   216,
 		Lifetime:  37459,
 	}
-	err = bpf.UpdateElement(ctMap.Map.FD(), ctMap.Map.Name(), unsafe.Pointer(ctKey),
-		unsafe.Pointer(ctVal), 0)
+	err = ctMap.Map.Update(ctKey, ctVal)
 	c.Assert(err, IsNil)
 
 	natKey := &nat.NatKey4{
@@ -156,8 +155,7 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 		Addr:    types.IPv4{192, 168, 61, 11},
 		Port:    0x3195,
 	}
-	err = bpf.UpdateElement(natMap.Map.FD(), natMap.Map.Name(), unsafe.Pointer(natKey),
-		unsafe.Pointer(natVal), 0)
+	err = natMap.Map.Update(natKey, natVal)
 	c.Assert(err, IsNil)
 	natKey = &nat.NatKey4{
 		TupleKey4Global: tuple.TupleKey4Global{
@@ -177,8 +175,7 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 		Addr:    types.IPv4{192, 168, 61, 11},
 		Port:    0x3195,
 	}
-	err = bpf.UpdateElement(natMap.Map.FD(), natMap.Map.Name(), unsafe.Pointer(natKey),
-		unsafe.Pointer(natVal), 0)
+	err = natMap.Map.Update(natKey, natVal)
 	c.Assert(err, IsNil)
 
 	buf := make(map[string][]string)
@@ -270,8 +267,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		TxBytes:   216,
 		Lifetime:  37459,
 	}
-	err = bpf.UpdateElement(ctMapAny.Map.FD(), ctMapAny.Map.Name(), unsafe.Pointer(ctKey),
-		unsafe.Pointer(ctVal), 0)
+	err = ctMapAny.Map.Update(ctKey, ctVal)
 	c.Assert(err, IsNil)
 
 	natKey := &nat.NatKey4{
@@ -292,8 +288,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		Addr:    types.IPv4{10, 23, 32, 45},
 		Port:    0x51d6,
 	}
-	err = bpf.UpdateElement(natMap.Map.FD(), natMap.Map.Name(), unsafe.Pointer(natKey),
-		unsafe.Pointer(natVal), 0)
+	err = natMap.Map.Update(natKey, natVal)
 	c.Assert(err, IsNil)
 	natKey = &nat.NatKey4{
 		TupleKey4Global: tuple.TupleKey4Global{
@@ -313,8 +308,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		Addr:    types.IPv4{10, 23, 32, 45},
 		Port:    0x50d6,
 	}
-	err = bpf.UpdateElement(natMap.Map.FD(), natMap.Map.Name(), unsafe.Pointer(natKey),
-		unsafe.Pointer(natVal), 0)
+	err = natMap.Map.Update(natKey, natVal)
 	c.Assert(err, IsNil)
 
 	stats := PurgeOrphanNATEntries(ctMapTCP, ctMapAny)
@@ -343,8 +337,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	c.Assert(len(buf), Equals, 0)
 
 	// Create only CT_INGRESS NAT entry which should be removed
-	err = bpf.UpdateElement(natMap.Map.FD(), natMap.Map.Name(), unsafe.Pointer(natKey),
-		unsafe.Pointer(natVal), 0)
+	err = natMap.Map.Update(natKey, natVal)
 	c.Assert(err, IsNil)
 
 	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapAny)
@@ -380,8 +373,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		TxBytes:   216,
 		Lifetime:  37459,
 	}
-	err = bpf.UpdateElement(ctMapTCP.Map.FD(), ctMapTCP.Map.Name(), unsafe.Pointer(ctKey),
-		unsafe.Pointer(ctVal), 0)
+	err = ctMapTCP.Map.Update(ctKey, ctVal)
 	c.Assert(err, IsNil)
 
 	natKey = &nat.NatKey4{
@@ -401,8 +393,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		Addr:    types.IPv4{10, 0, 2, 20},
 		Port:    0x409c,
 	}
-	err = bpf.UpdateElement(natMap.Map.FD(), natMap.Map.Name(), unsafe.Pointer(natKey),
-		unsafe.Pointer(natVal), 0)
+	err = natMap.Map.Update(natKey, natVal)
 	c.Assert(err, IsNil)
 
 	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
@@ -455,8 +446,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		TxBytes:   216,
 		Lifetime:  37459,
 	}
-	err = bpf.UpdateElement(ctMapTCP.Map.FD(), ctMapTCP.Map.Name(), unsafe.Pointer(ctKey),
-		unsafe.Pointer(ctVal), 0)
+	err = ctMapTCP.Map.Update(ctKey, ctVal)
 	c.Assert(err, IsNil)
 
 	natKey = &nat.NatKey4{
@@ -476,8 +466,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		Addr:    types.IPv4{10, 0, 2, 20},
 		Port:    0x409c,
 	}
-	err = bpf.UpdateElement(natMap.Map.FD(), natMap.Map.Name(), unsafe.Pointer(natKey),
-		unsafe.Pointer(natVal), 0)
+	err = natMap.Map.Update(natKey, natVal)
 	c.Assert(err, IsNil)
 
 	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
@@ -548,8 +537,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		Addr:    types.IPv6{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
 		Port:    0x51d6,
 	}
-	err = bpf.UpdateElement(natMapV6.Map.FD(), natMapV6.Map.Name(), unsafe.Pointer(natKeyV6),
-		unsafe.Pointer(natValV6), 0)
+	err = natMapV6.Map.Update(natKeyV6, natValV6)
 	c.Assert(err, IsNil)
 
 	stats = PurgeOrphanNATEntries(ctMapTCPV6, ctMapAnyV6)

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -329,7 +329,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	c.Assert(len(buf), Equals, 2)
 
 	// Now remove the CT entry which should remove both NAT entries
-	err = bpf.DeleteElement(ctMapAny.Map.FD(), unsafe.Pointer(ctKey))
+	err = ctMapAny.Map.Delete(ctKey)
 	c.Assert(err, IsNil)
 	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapAny)
 	c.Assert(stats.IngressDeleted, Equals, uint32(1))
@@ -417,7 +417,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	c.Assert(len(buf), Equals, 1)
 
 	// Now remove the CT entry which should remove the NAT entry
-	err = bpf.DeleteElement(ctMapTCP.Map.FD(), unsafe.Pointer(ctKey))
+	err = ctMapTCP.Map.Delete(ctKey)
 	c.Assert(err, IsNil)
 	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
 	c.Assert(stats.IngressAlive, Equals, uint32(0))
@@ -492,7 +492,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	c.Assert(len(buf), Equals, 1)
 
 	// Now remove the CT entry which should remove the NAT entry
-	err = bpf.DeleteElement(ctMapTCP.Map.FD(), unsafe.Pointer(ctKey))
+	err = ctMapTCP.Map.Delete(ctKey)
 	c.Assert(err, IsNil)
 	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
 	c.Assert(stats.IngressAlive, Equals, uint32(0))


### PR DESCRIPTION
This is based on https://github.com/cilium/cilium/pull/22693 and contains all of its commits. That one is close to being merged, so this can be rebased later.

See individual commits. Again a bit of churn, but relatively straightforward.

Fixes: https://github.com/cilium/cilium/issues/22513
Fixes: https://github.com/cilium/cilium/issues/23558

```release-note
Replace legacy bpf syscalls with ebpf-go library APIs
```
