### PR TITLE
bpf: Remove unconditional context pull on revalidate_data()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -446,7 +446,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 	int hdrlen, ret;
 	__u8 nexthdr;
 
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	nexthdr = ip6->nexthdr;
@@ -701,9 +701,9 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		if (l2_hdr_required && ETH_HLEN == 0) {
 			/* l2 header is added */
 			l3_off += __ETH_HLEN;
-			if (!____revalidate_data_pull(ctx, &data, &data_end,
-						      (void **)&ip4, sizeof(*ip4),
-						      false, l3_off))
+			if (!__revalidate_data(ctx, &data, &data_end,
+					       (void **)&ip4, sizeof(*ip4),
+					       l3_off))
 				return DROP_INVALID;
 		}
 #endif
@@ -869,7 +869,7 @@ handle_to_netdev_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_HOST)
 		src_id = HOST_ID;
 
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	src_id = resolve_srcid_ipv4(ctx, ip4, src_id, &ipcache_srcid, true);
@@ -1120,7 +1120,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 # endif
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
+		if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
 			return send_drop_notify_error(ctx, identity, DROP_INVALID,
 						      CTX_ACT_DROP, METRIC_INGRESS);
 
@@ -1140,7 +1140,7 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 		 * Make sure that we don't legitimately drop the packet if the skb
 		 * arrived with the header not being not in the linear data.
 		 */
-		if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
+		if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
 			return send_drop_notify_error(ctx, identity, DROP_INVALID,
 						      CTX_ACT_DROP, METRIC_INGRESS);
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -744,7 +744,7 @@ static __always_inline int __tail_handle_ipv6(struct __ctx_buff *ctx,
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	/* Handle special ICMPv6 NDP messages, and all remaining packets
@@ -1278,7 +1278,7 @@ static __always_inline int __tail_handle_ipv4(struct __ctx_buff *ctx,
 	void *data, *data_end;
 	struct iphdr *ip4;
 
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 /* If IPv4 fragmentation is disabled

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -53,7 +53,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	__u32 key_size;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
+	if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 #ifdef ENABLE_NODEPORT
 	if (!ctx_skip_nodeport(ctx)) {
@@ -296,7 +296,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	bool decrypted;
 
 	/* verifier workaround (dereference of modified ctx ptr) */
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 /* If IPv4 fragmentation is disabled
@@ -527,14 +527,14 @@ static __always_inline bool is_esp(struct __ctx_buff *ctx, __u16 proto)
 	switch (proto) {
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
+		if (!revalidate_data_first(ctx, &data, &data_end, &ip6))
 			return false;
 		protocol = ip6->nexthdr;
 		break;
 #endif
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
+		if (!revalidate_data_first(ctx, &data, &data_end, &ip4))
 			return false;
 		protocol = ip4->protocol;
 		break;

--- a/bpf/bpf_xdp.c
+++ b/bpf/bpf_xdp.c
@@ -176,7 +176,7 @@ int tail_lb_ipv4(struct __ctx_buff *ctx)
 
 			l3_off = inner_l2_off + ETH_HLEN;
 
-			if (!revalidate_data_l3_off(ctx, &data, &data_end, &ip4, l3_off)) {
+			if (!revalidate_data_first_l3_off(ctx, &data, &data_end, &ip4, l3_off)) {
 				ret = DROP_INVALID;
 				goto out;
 			}

--- a/bpf/include/bpf/ctx/xdp.h
+++ b/bpf/include/bpf/ctx/xdp.h
@@ -97,7 +97,7 @@ xdp_store_bytes(const struct xdp_md *ctx, __u64 off, const void *from,
 #define ctx_change_type			xdp_change_type__stub
 #define ctx_change_tail			xdp_change_tail__stub
 
-#define ctx_pull_data(ctx, ...)		do { /* Already linear. */ } while (0)
+#define ctx_pull_data(ctx, ...)		({ 0; })
 
 #define ctx_get_tunnel_key		xdp_get_tunnel_key__stub
 #define ctx_set_tunnel_key		xdp_set_tunnel_key__stub

--- a/bpf/lib/encrypt.h
+++ b/bpf/lib/encrypt.h
@@ -30,7 +30,7 @@ do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 	switch (proto) {
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		if (!revalidate_data_pull(ctx, &data, &data_end, &ip6)) {
+		if (!revalidate_data_first(ctx, &data, &data_end, &ip6)) {
 			ctx->mark = 0;
 			return CTX_ACT_OK;
 		}
@@ -39,7 +39,7 @@ do_decrypt(struct __ctx_buff *ctx, __u16 proto)
 #endif
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		if (!revalidate_data_pull(ctx, &data, &data_end, &ip4)) {
+		if (!revalidate_data_first(ctx, &data, &data_end, &ip4)) {
 			ctx->mark = 0;
 			return CTX_ACT_OK;
 		}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1605,7 +1605,8 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, int l3_
 
 	if (has_encap) {
 		/* point at the inner IPv4 header */
-		if (!revalidate_data_l3_off(ctx, &data, &data_end, &ip4, encap_len + ETH_HLEN))
+		if (!revalidate_data_first_l3_off(ctx, &data, &data_end, &ip4,
+						  encap_len + ETH_HLEN))
 			return DROP_INVALID;
 
 		encap_len = 0;

--- a/contrib/coccinelle/const.cocci
+++ b/contrib/coccinelle/const.cocci
@@ -17,7 +17,7 @@ cnt = 0
 identifier f, fn, x, z;
 assignment operator op;
 expression e;
-type T0, T;
+type T0, T1, T;
 position p;
 @@
 
@@ -45,6 +45,7 @@ position p;
       when != WRITE_ONCE(x->z, ...)
       when != WRITE_ONCE(x->z[...], ...)
       when != f(..., x, ...)
+      when != f(..., (T1)x, ...)
       when != f(..., x->z, ...)
   }
 )


### PR DESCRIPTION
We used to require pulling the context (skb) unconditionally when revalidating data, as a workaround for some of the verifier's limitations. With commit 847014aa62f9 ("bpf: Avoid 32bit assignment of packet pointer"), we changed the way we access to the context, and we should now be able to discard this workaround.

To some extent, this reverts commit fdca23e2b23f ("bpf: fix verifier error due to repulling of skb->data/end"), although the code has changed quite a lot since then so the revert is not straightforwards.
