### PR TITLE
bgpv1: component test framework 

### DIFF
--- a/pkg/bgpv1/gobgp/logger.go
+++ b/pkg/bgpv1/gobgp/logger.go
@@ -11,56 +11,66 @@ import (
 
 // implement github.com/osrg/gobgp/v3/pkg/log/Logger interface
 type ServerLogger struct {
-	l   *logrus.Logger
-	asn uint32
+	l         *logrus.Logger
+	asn       uint32
+	component string
+	subsys    string
 }
 
-func NewServerLogger(l *logrus.Logger, asn uint32) *ServerLogger {
+type LogParams struct {
+	AS        uint32
+	Component string
+	SubSys    string
+}
+
+func NewServerLogger(l *logrus.Logger, params LogParams) *ServerLogger {
 	return &ServerLogger{
-		l:   l,
-		asn: asn,
+		l:         l,
+		asn:       params.AS,
+		component: params.Component,
+		subsys:    params.SubSys,
 	}
 }
 
 func (l *ServerLogger) Panic(msg string, fields gobgpLog.Fields) {
 	fields["asn"] = l.asn
-	fields["component"] = "gobgp.BgpServerInstance"
-	fields["subsys"] = "bgp-control-plane"
+	fields["component"] = l.component
+	fields["subsys"] = l.subsys
 	l.l.WithFields(logrus.Fields(fields)).Panic(msg)
 }
 
 func (l *ServerLogger) Fatal(msg string, fields gobgpLog.Fields) {
 	fields["asn"] = l.asn
-	fields["component"] = "gobgp.BgpServerInstance"
-	fields["subsys"] = "bgp-control-plane"
+	fields["component"] = l.component
+	fields["subsys"] = l.subsys
 	l.l.WithFields(logrus.Fields(fields)).Fatal(msg)
 }
 
 func (l *ServerLogger) Error(msg string, fields gobgpLog.Fields) {
 	fields["asn"] = l.asn
-	fields["component"] = "gobgp.BgpServerInstance"
-	fields["subsys"] = "bgp-control-plane"
+	fields["component"] = l.component
+	fields["subsys"] = l.subsys
 	l.l.WithFields(logrus.Fields(fields)).Error(msg)
 }
 
 func (l *ServerLogger) Warn(msg string, fields gobgpLog.Fields) {
 	fields["asn"] = l.asn
-	fields["component"] = "gobgp.BgpServerInstance"
-	fields["subsys"] = "bgp-control-plane"
+	fields["component"] = l.component
+	fields["subsys"] = l.subsys
 	l.l.WithFields(logrus.Fields(fields)).Warn(msg)
 }
 
 func (l *ServerLogger) Info(msg string, fields gobgpLog.Fields) {
 	fields["asn"] = l.asn
-	fields["component"] = "gobgp.BgpServerInstance"
-	fields["subsys"] = "bgp-control-plane"
+	fields["component"] = l.component
+	fields["subsys"] = l.subsys
 	l.l.WithFields(logrus.Fields(fields)).Info(msg)
 }
 
 func (l *ServerLogger) Debug(msg string, fields gobgpLog.Fields) {
 	fields["asn"] = l.asn
-	fields["component"] = "gobgp.BgpServerInstance"
-	fields["subsys"] = "bgp-control-plane"
+	fields["component"] = l.component
+	fields["subsys"] = l.subsys
 	l.l.WithFields(logrus.Fields(fields)).Debug(msg)
 }
 

--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -45,7 +45,11 @@ type GoBGPServer struct {
 
 // NewGoBGPServerWithConfig returns instance of go bgp router wrapper.
 func NewGoBGPServerWithConfig(ctx context.Context, log *logrus.Entry, params types.ServerParameters) (types.Router, error) {
-	logger := NewServerLogger(log.Logger, params.Global.ASN)
+	logger := NewServerLogger(log.Logger, LogParams{
+		AS:        params.Global.ASN,
+		Component: "gobgp.BgpServerInstance",
+		SubSys:    "bgp-control-plane",
+	})
 
 	s := server.NewBgpServer(server.LoggerOption(logger))
 	go s.Serve()

--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -1,0 +1,360 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/testutils"
+
+	"github.com/stretchr/testify/require"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// maxTestDuration is allowed time for test execution
+	maxTestDuration = 15 * time.Second
+)
+
+// Test_PodCIDRAdvert validates pod IPv4/v6 subnet is advertised, withdrawn and modified on node addresses change.
+func Test_PodCIDRAdvert(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	// steps define order in which test is run. Note, this is different from table tests, in which each unit is
+	// independent. In this case, tests are run sequentially and there is dependency on previous test step.
+	var steps = []struct {
+		description         string
+		podCIDRs            []string
+		expectedRouteEvents []routeEvent
+	}{
+		{
+			description: "advertise pod CIDRs",
+			podCIDRs: []string{
+				"10.1.0.0/16",
+				"aaaa::/64",
+			},
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.1.0.0",
+					prefixLen:   16,
+					isWithdrawn: false,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "aaaa::",
+					prefixLen:   64,
+					isWithdrawn: false,
+				},
+			},
+		},
+		{
+			description: "delete pod CIDRs",
+			podCIDRs:    []string{},
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.1.0.0",
+					prefixLen:   16,
+					isWithdrawn: true,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "aaaa::",
+					prefixLen:   64,
+					isWithdrawn: true,
+				},
+			},
+		},
+		{
+			description: "re-add pod CIDRs",
+			podCIDRs: []string{
+				"10.1.0.0/16",
+				"aaaa::/64",
+			},
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.1.0.0",
+					prefixLen:   16,
+					isWithdrawn: false,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "aaaa::",
+					prefixLen:   64,
+					isWithdrawn: false,
+				},
+			},
+		},
+		{
+			description: "update pod CIDRs",
+			podCIDRs: []string{
+				"10.2.0.0/16",
+				"bbbb::/64",
+			},
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.1.0.0",
+					prefixLen:   16,
+					isWithdrawn: true,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.2.0.0",
+					prefixLen:   16,
+					isWithdrawn: false,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "aaaa::",
+					prefixLen:   64,
+					isWithdrawn: true,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "bbbb::",
+					prefixLen:   64,
+					isWithdrawn: false,
+				},
+			},
+		},
+	}
+
+	testCtx, testDone := context.WithTimeout(context.Background(), maxTestDuration)
+	defer testDone()
+
+	// setup topology
+	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, fixtureConf)
+	require.NoError(t, err)
+	require.Len(t, gobgpPeers, 1)
+	defer cleanup()
+
+	// setup neighbor
+	err = setupSingleNeighbor(testCtx, fixture)
+	require.NoError(t, err)
+
+	// wait for peering to come up
+	err = gobgpPeers[0].waitForSessionState(testCtx, []string{"ESTABLISHED"})
+	require.NoError(t, err)
+
+	tracker := fixture.fakeClientSet.KubernetesFakeClientset.Tracker()
+
+	for _, step := range steps {
+		t.Run(step.description, func(t *testing.T) {
+			// update node spec
+			fixture.config.node.Spec.PodCIDRs = step.podCIDRs
+
+			err := tracker.Update(corev1.SchemeGroupVersion.WithResource("nodes"), fixture.config.node.DeepCopy(), "")
+			require.NoError(t, err, step.description)
+
+			// validate expected result
+			receivedEvents, err := gobgpPeers[0].getRouteEvents(testCtx, len(step.expectedRouteEvents))
+			require.NoError(t, err, step.description)
+
+			// match events in any order
+			require.ElementsMatch(t, step.expectedRouteEvents, receivedEvents, step.description)
+		})
+	}
+}
+
+// Test_LBEgressAdvertisement validates Service v4 and v6 IPs is advertised, withdrawn and modified on changing policy.
+func Test_LBEgressAdvertisement(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	var steps = []struct {
+		description         string
+		srvName             string
+		ingressIP           string
+		op                  string // add or update
+		expectedRouteEvents []routeEvent
+	}{
+		{
+			description: "advertise service IP",
+			srvName:     "service-a",
+			ingressIP:   "10.100.1.1",
+			op:          "add",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.100.1.1",
+					prefixLen:   32,
+					isWithdrawn: false,
+				},
+			},
+		},
+		{
+			description: "withdraw service IP",
+			srvName:     "service-a",
+			ingressIP:   "",
+			op:          "update",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.100.1.1",
+					prefixLen:   32,
+					isWithdrawn: true,
+				},
+			},
+		},
+		{
+			description: "re-advertise service IP",
+			srvName:     "service-a",
+			ingressIP:   "10.100.1.1",
+			op:          "update",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.100.1.1",
+					prefixLen:   32,
+					isWithdrawn: false,
+				},
+			},
+		},
+		{
+			description: "update service IP",
+			srvName:     "service-a",
+			ingressIP:   "10.200.1.1",
+			op:          "update",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.100.1.1",
+					prefixLen:   32,
+					isWithdrawn: true,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "10.200.1.1",
+					prefixLen:   32,
+					isWithdrawn: false,
+				},
+			},
+		},
+		{
+			description: "advertise v6 service IP",
+			srvName:     "service-b",
+			ingressIP:   "cccc::1",
+			op:          "add",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "cccc::1",
+					prefixLen:   128,
+					isWithdrawn: false,
+				},
+			},
+		},
+		{
+			description: "withdraw v6 service IP",
+			srvName:     "service-b",
+			ingressIP:   "",
+			op:          "update",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "cccc::1",
+					prefixLen:   128,
+					isWithdrawn: true,
+				},
+			},
+		},
+		{
+			description: "re-advertise v6 service IP",
+			srvName:     "service-b",
+			ingressIP:   "cccc::1",
+			op:          "update",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "cccc::1",
+					prefixLen:   128,
+					isWithdrawn: false,
+				},
+			},
+		},
+		{
+			description: "update v6 service IP",
+			srvName:     "service-b",
+			ingressIP:   "dddd::1",
+			op:          "update",
+			expectedRouteEvents: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "cccc::1",
+					prefixLen:   128,
+					isWithdrawn: true,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "dddd::1",
+					prefixLen:   128,
+					isWithdrawn: false,
+				},
+			},
+		},
+	}
+
+	testCtx, testDone := context.WithTimeout(context.Background(), maxTestDuration)
+	defer testDone()
+
+	// setup topology
+	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, fixtureConf)
+	require.NoError(t, err)
+	require.Len(t, gobgpPeers, 1)
+	defer cleanup()
+
+	// setup neighbor
+	err = setupSingleNeighbor(testCtx, fixture)
+	require.NoError(t, err)
+
+	// wait for peering to come up
+	err = gobgpPeers[0].waitForSessionState(testCtx, []string{"ESTABLISHED"})
+	require.NoError(t, err)
+
+	// setup bgp policy with service selection
+	fixture.config.policy.Spec.VirtualRouters[0].ServiceSelector = &slim_metav1.LabelSelector{
+		MatchExpressions: []slim_metav1.LabelSelectorRequirement{
+			// always true match
+			{
+				Key:      "somekey",
+				Operator: "NotIn",
+				Values:   []string{"not-somekey"},
+			},
+		},
+	}
+	_, err = fixture.policyClient.Update(testCtx, &fixture.config.policy, meta_v1.UpdateOptions{})
+	require.NoError(t, err)
+
+	tracker := fixture.fakeClientSet.SlimFakeClientset.Tracker()
+
+	for _, step := range steps {
+		t.Run(step.description, func(t *testing.T) {
+			srvObj := newLBServiceObj(lbSrvConfig{
+				name:      step.srvName,
+				ingressIP: step.ingressIP,
+			})
+
+			if step.op == "add" {
+				err = tracker.Add(&srvObj)
+			} else {
+				err = tracker.Update(slimv1.Unversioned.WithResource("services"), &srvObj, "")
+			}
+			require.NoError(t, err, step.description)
+
+			// validate expected result
+			receivedEvents, err := gobgpPeers[0].getRouteEvents(testCtx, len(step.expectedRouteEvents))
+			require.NoError(t, err, step.description)
+
+			// match events in any order
+			require.ElementsMatch(t, step.expectedRouteEvents, receivedEvents, step.description)
+		})
+	}
+}

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/bgpv1"
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/k8s"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	"github.com/cilium/cilium/pkg/option"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// log is used in the test as well as passed to gobgp instances.
+	log = &logrus.Logger{
+		Out:   os.Stdout,
+		Hooks: make(logrus.LevelHooks),
+		Formatter: &logrus.TextFormatter{
+			DisableTimestamp: false,
+			DisableColors:    false,
+		},
+		Level: logrus.DebugLevel,
+	}
+)
+
+// cilium BGP config
+var (
+	ciliumASN        = uint32(65001)
+	ciliumListenPort = uint32(1790)
+)
+
+// kubernetes policies
+var (
+	// base node spec
+	nodeAnnotationKey    = fmt.Sprintf("%s%d", annotation.BGPVRouterAnnoPrefix, ciliumASN)
+	nodeAnnotationValues = fmt.Sprintf("router-id=%s,local-port=%d",
+		dummies[ciliumLink].ipv4.Addr().String(), ciliumListenPort)
+
+	labels = map[string]string{
+		"rack": "rack0",
+	}
+
+	baseNodeConf = nodeConfig{
+		labels: labels,
+		annotations: map[string]string{
+			nodeAnnotationKey: nodeAnnotationValues,
+		},
+	}
+
+	baseBGPPolicy = policyConfig{
+		nodeSelector: labels,
+		virtualRouters: []cilium_api_v2alpha1.CiliumBGPVirtualRouter{
+			{
+				LocalASN: int(ciliumASN),
+			},
+		},
+	}
+
+	// Daemon start config
+	fixtureConf = fixtureConfig{
+		node:      newNodeObj(baseNodeConf),
+		policy:    newPolicyObj(baseBGPPolicy),
+		ipam:      ipamOption.IPAMKubernetes,
+		bgpEnable: true,
+	}
+)
+
+// fixture is test harness
+type fixture struct {
+	config        fixtureConfig
+	fakeClientSet *k8sClient.FakeClientset
+	policyClient  v2alpha1.CiliumBGPPeeringPolicyInterface
+	hive          *hive.Hive
+	bgp           *agent.Controller
+}
+
+type fixtureConfig struct {
+	node      corev1.Node
+	policy    cilium_api_v2alpha1.CiliumBGPPeeringPolicy
+	ipam      string
+	bgpEnable bool
+}
+
+func newFixture(conf fixtureConfig) *fixture {
+	f := &fixture{
+		config: conf,
+	}
+
+	f.fakeClientSet, _ = k8sClient.NewFakeClientset()
+	f.policyClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2alpha1().CiliumBGPPeeringPolicies()
+
+	// create default base node
+	f.fakeClientSet.KubernetesFakeClientset.Tracker().Create(
+		corev1.SchemeGroupVersion.WithResource("nodes"), conf.node.DeepCopy(), "")
+
+	// create initial bgp policy
+	f.fakeClientSet.CiliumFakeClientset.Tracker().Add(&conf.policy)
+
+	// Construct a new Hive with mocked out dependency cells.
+	f.hive = hive.New(
+		// node resource
+		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) *k8s.LocalNodeResource {
+			lw := utils.ListerWatcherFromTyped[*corev1.NodeList](c.CoreV1().Nodes())
+			return &k8s.LocalNodeResource{Resource: resource.New[*corev1.Node](lc, lw)}
+		}),
+
+		// cilium node resource
+		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) *k8s.LocalCiliumNodeResource {
+			lw := utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](c.CiliumV2().CiliumNodes())
+			return &k8s.LocalCiliumNodeResource{Resource: resource.New[*cilium_api_v2.CiliumNode](lc, lw)}
+		}),
+
+		// service
+		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) resource.Resource[*slim_core_v1.Service] {
+			return resource.New[*slim_core_v1.Service](
+				lc, utils.ListerWatcherFromTyped[*slim_core_v1.ServiceList](
+					c.Slim().CoreV1().Services(""),
+				),
+			)
+		}),
+
+		// Provide the mocked client cells directly
+		cell.Provide(func() k8sClient.Clientset {
+			return f.fakeClientSet
+		}),
+
+		// daemon config
+		cell.Provide(func() *option.DaemonConfig {
+			return &option.DaemonConfig{
+				EnableBGPControlPlane: conf.bgpEnable,
+				IPAM:                  conf.ipam,
+			}
+		}),
+
+		// local bgp state for inspection
+		cell.Invoke(func(bgp *agent.Controller) {
+			f.bgp = bgp
+		}),
+
+		job.Cell,
+		bgpv1.Cell,
+	)
+
+	return f
+}
+
+func setupSingleNeighbor(ctx context.Context, f *fixture) error {
+	bgpPolicy := baseBGPPolicy
+	bgpPolicy.virtualRouters[0] = cilium_api_v2alpha1.CiliumBGPVirtualRouter{
+		LocalASN:      int(ciliumASN),
+		ExportPodCIDR: true,
+		Neighbors: []cilium_api_v2alpha1.CiliumBGPNeighbor{
+			{
+				PeerAddress: dummies[instance1Link].ipv4.String(),
+				PeerASN:     int(gobgpASN),
+			},
+		},
+	}
+	policyObj := newPolicyObj(bgpPolicy)
+
+	_, err := f.policyClient.Update(ctx, &policyObj, meta_v1.UpdateOptions{})
+	return err
+}
+
+// setup configures dummy links, gobgp and cilium bgp cell.
+func setup(ctx context.Context, peerConfigs []gobgpConfig, fixConfig fixtureConfig) (peers []*goBGP, f *fixture, cleanup func(), err error) {
+	// cleanup old dummy links if they are hanging around
+	_ = teardownLinks()
+
+	err = setupLinks()
+	if err != nil {
+		return
+	}
+
+	err = setupLinkIPs()
+	if err != nil {
+		return
+	}
+
+	// setup goBGP
+	for _, pConf := range peerConfigs {
+		var peer *goBGP
+		peer, err = startGoBGP(ctx, pConf)
+		if err != nil {
+			return
+		}
+		peers = append(peers, peer)
+	}
+
+	// setup cilium
+	f = newFixture(fixConfig)
+	err = f.hive.Start(ctx)
+	if err != nil {
+		return
+	}
+
+	cleanup = func() {
+		for _, peer := range peers {
+			peer.stopGoBGP()
+		}
+
+		f.hive.Stop(ctx)
+		teardownLinks()
+	}
+
+	return
+}

--- a/pkg/bgpv1/test/gobgp.go
+++ b/pkg/bgpv1/test/gobgp.go
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
+
+	gobgpapi "github.com/osrg/gobgp/v3/api"
+	"github.com/osrg/gobgp/v3/pkg/apiutil"
+	gobgpb "github.com/osrg/gobgp/v3/pkg/packet/bgp"
+	"github.com/osrg/gobgp/v3/pkg/server"
+)
+
+// goBGP configuration used in tests
+var (
+	gobgpASN         = uint32(65011)
+	gobgpASN2        = uint32(65012)
+	gobgpListenPort  = int32(1791)
+	gobgpListenPort2 = int32(1792)
+
+	gobgpGlobal = &gobgpapi.Global{
+		Asn:        gobgpASN,
+		RouterId:   dummies[instance1Link].ipv4.Addr().String(),
+		ListenPort: gobgpListenPort,
+	}
+	gobgpGlobal2 = &gobgpapi.Global{
+		Asn:        gobgpASN2,
+		RouterId:   dummies[instance1Link].ipv4.Addr().String(),
+		ListenPort: gobgpListenPort2,
+	}
+
+	gbgpNeighConf = &gobgpapi.Peer{
+		Conf: &gobgpapi.PeerConf{
+			NeighborAddress: dummies[ciliumLink].ipv4.Addr().String(),
+			PeerAsn:         ciliumASN,
+		},
+		Transport: &gobgpapi.Transport{
+			RemoteAddress: dummies[ciliumLink].ipv4.Addr().String(),
+			RemotePort:    ciliumListenPort,
+			LocalAddress:  dummies[instance1Link].ipv4.Addr().String(),
+			PassiveMode:   false,
+		},
+		AfiSafis: []*gobgpapi.AfiSafi{
+			{
+				Config: &gobgpapi.AfiSafiConfig{
+					Family: gobgp.GoBGPIPv4Family,
+				},
+			},
+			{
+				Config: &gobgpapi.AfiSafiConfig{
+					Family: gobgp.GoBGPIPv6Family,
+				},
+			},
+		},
+	}
+	gbgpNeighConf2 = &gobgpapi.Peer{
+		Conf: &gobgpapi.PeerConf{
+			NeighborAddress: dummies[ciliumLink].ipv4.Addr().String(),
+			PeerAsn:         ciliumASN,
+		},
+		Transport: &gobgpapi.Transport{
+			RemoteAddress: dummies[ciliumLink].ipv4.Addr().String(),
+			RemotePort:    ciliumListenPort,
+			LocalAddress:  dummies[instance2Link].ipv4.Addr().String(),
+			PassiveMode:   false,
+		},
+		AfiSafis: []*gobgpapi.AfiSafi{
+			{
+				Config: &gobgpapi.AfiSafiConfig{
+					Family: gobgp.GoBGPIPv4Family,
+				},
+			},
+			{
+				Config: &gobgpapi.AfiSafiConfig{
+					Family: gobgp.GoBGPIPv6Family,
+				},
+			},
+		},
+	}
+
+	gobgpConf = gobgpConfig{
+		global: gobgpGlobal,
+		neighbors: []*gobgpapi.Peer{
+			gbgpNeighConf,
+		},
+	}
+	gobgpConf2 = gobgpConfig{
+		global: gobgpGlobal2,
+		neighbors: []*gobgpapi.Peer{
+			gbgpNeighConf2,
+		},
+	}
+)
+
+// gobgpConfig used for starting gobgp instance
+type gobgpConfig struct {
+	global    *gobgpapi.Global
+	neighbors []*gobgpapi.Peer
+}
+
+// routeEvent contains information about new event in routing table of gobgp
+type routeEvent struct {
+	sourceASN   uint32
+	prefix      string
+	prefixLen   uint8
+	isWithdrawn bool
+}
+
+// peerEvent contains information about peer state change of gobgp
+type peerEvent struct {
+	peerASN uint32
+	state   string
+}
+
+// goBGP wrapper on gobgp server and provides route and peer event handling
+type goBGP struct {
+	context context.Context
+
+	server      *server.BgpServer
+	peerEvents  chan *gobgpapi.WatchEventResponse_PeerEvent
+	tableEvents chan *gobgpapi.WatchEventResponse_TableEvent
+
+	peerNotif  chan peerEvent
+	routeNotif chan routeEvent
+}
+
+// startGoBGP initialized new gobgp server, configures neighbors and starts listening on route and peer events
+func startGoBGP(ctx context.Context, conf gobgpConfig) (g *goBGP, err error) {
+	g = &goBGP{
+		context: ctx,
+		server: server.NewBgpServer(server.LoggerOption(gobgp.NewServerLogger(log, gobgp.LogParams{
+			AS:        gobgpASN,
+			Component: "tests.BGP",
+			SubSys:    "basic",
+		}))),
+		peerEvents:  make(chan *gobgpapi.WatchEventResponse_PeerEvent),
+		tableEvents: make(chan *gobgpapi.WatchEventResponse_TableEvent),
+		peerNotif:   make(chan peerEvent),
+		routeNotif:  make(chan routeEvent),
+	}
+
+	go g.server.Serve()
+	go g.readEvents()
+
+	// in case of err, clean up
+	defer func() {
+		if err != nil {
+			g.server.Stop()
+		}
+	}()
+
+	log.Info("GoBGP test instance: starting")
+	err = g.server.StartBgp(ctx, &gobgpapi.StartBgpRequest{Global: conf.global})
+	if err != nil {
+		return
+	}
+
+	// register watchers for peer and route events
+	watchRequest := &gobgpapi.WatchEventRequest{
+		Peer: &gobgpapi.WatchEventRequest_Peer{},
+		Table: &gobgpapi.WatchEventRequest_Table{
+			Filters: []*gobgpapi.WatchEventRequest_Table_Filter{
+				{
+					Type: gobgpapi.WatchEventRequest_Table_Filter_BEST,
+					Init: true,
+				},
+			},
+		},
+	}
+
+	err = g.server.WatchEvent(ctx, watchRequest, func(r *gobgpapi.WatchEventResponse) {
+		switch r.Event.(type) {
+		case *gobgpapi.WatchEventResponse_Peer:
+			g.peerEvents <- r.GetPeer()
+		case *gobgpapi.WatchEventResponse_Table:
+			g.tableEvents <- r.GetTable()
+		}
+	})
+	if err != nil {
+		return
+	}
+
+	// configure neighbors
+	for _, peer := range conf.neighbors {
+		err = g.server.AddPeer(ctx, &gobgpapi.AddPeerRequest{Peer: peer})
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+// stopGoBGP stops server
+func (g *goBGP) stopGoBGP() {
+	log.Infof("GoBGP test instance: stopping")
+	g.server.Stop()
+}
+
+// readEvents receives peer and route events from gobgp callbacks, unmarshal response to well-defined structs and
+// pass this to consumers of peer and route events.
+// Note this will block if there is no consumer reading, in which case test context would timeout resulting in termination
+// of this goroutine.
+func (g *goBGP) readEvents() {
+	for {
+		select {
+		case e := <-g.tableEvents:
+			for _, p := range e.Paths {
+				var prefix string
+				var length uint8
+
+				nlri, err := apiutil.UnmarshalNLRI(gobgpb.AfiSafiToRouteFamily(uint16(p.Family.Afi), uint8(p.Family.Safi)), p.Nlri)
+				if err != nil {
+					log.Errorf("failed to unmarshal path nlri %v: %v", p, err)
+					continue
+				}
+
+				switch a := nlri.(type) {
+				case *gobgpb.IPAddrPrefix:
+					prefix = a.Prefix.String()
+					length = a.Length
+				case *gobgpb.IPv6AddrPrefix:
+					prefix = a.Prefix.String()
+					length = a.Length
+				default:
+					log.Errorf("failed to identify nlri %v", nlri)
+					continue
+				}
+
+				select {
+				case g.routeNotif <- routeEvent{
+					sourceASN:   p.SourceAsn,
+					prefix:      prefix,
+					prefixLen:   length,
+					isWithdrawn: p.IsWithdraw,
+				}:
+				case <-g.context.Done():
+					return
+				}
+			}
+
+		case e := <-g.peerEvents:
+			if e.Peer != nil {
+				select {
+				case g.peerNotif <- peerEvent{
+					peerASN: e.Peer.Conf.PeerAsn,
+					state:   e.Peer.State.SessionState.String(),
+				}:
+				case <-g.context.Done():
+					return
+				}
+			}
+
+		case <-g.context.Done():
+			return
+		}
+	}
+}
+
+// waitForSessionState consumes state changes from gobgp and compares it with expected states
+func (g *goBGP) waitForSessionState(ctx context.Context, expectedStates []string) error {
+	for {
+		select {
+		case e := <-g.peerNotif:
+			log.Infof("GoBGP test instance: Peer Event: %v", e)
+
+			for _, state := range expectedStates {
+				if e.state == state {
+					return nil
+				}
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("did not receive expected peering state %q, %v", expectedStates, ctx.Err())
+		}
+	}
+}
+
+// getRouteEvents drains number of events from routeNotif chan and return those events to caller.
+func (g *goBGP) getRouteEvents(ctx context.Context, numExpectedEvents int) ([]routeEvent, error) {
+	var receivedEvents []routeEvent
+
+	for i := 0; i < numExpectedEvents; i++ {
+		select {
+		case r := <-g.routeNotif:
+			log.Infof("GoBGP test instance: Route Event: %v", r)
+			receivedEvents = append(receivedEvents, r)
+		case <-ctx.Done():
+			return receivedEvents, fmt.Errorf("time elapsed waiting for all route events - received %d, expected %d : %v",
+				len(receivedEvents), numExpectedEvents, ctx.Err())
+		}
+	}
+
+	return receivedEvents, nil
+}

--- a/pkg/bgpv1/test/links.go
+++ b/pkg/bgpv1/test/links.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"net"
+	"net/netip"
+	"os"
+
+	"github.com/vishvananda/netlink"
+)
+
+// Note : this will work only in linux environment and requires CAP_NET_ADMIN privilege
+
+// dummyInterfaces contains IP addresses for the link
+type dummyInterfaces struct {
+	ipv4 netip.Prefix
+	ipv6 netip.Prefix
+}
+
+// default dummy links on which bgp sessions are communicating
+var (
+	ciliumLink      = "cilium-bgp"
+	instance1Link   = "instance1"
+	instance2Link   = "instance2"
+	ciliumIPEnv     = "CiliumPrefix"
+	ciliumIP6Env    = "CiliumPrefix6"
+	instance1IPEnv  = "Instance1Prefix"
+	instance1IP6Env = "Instance1Prefix6"
+	instance2IPEnv  = "Instance2Prefix"
+	instance2IP6Env = "Instance2Prefix6"
+	dummies         = map[string]dummyInterfaces{
+		// link used by BGP Control Plane
+		ciliumLink: {
+			ipv4: getIP(ciliumIPEnv, "172.16.100.1/32"),
+			ipv6: getIP(ciliumIP6Env, "a::1/128"),
+		},
+		// link used by gobgp instance 1
+		instance1Link: {
+			ipv4: getIP(instance1IPEnv, "172.16.100.2/32"),
+			ipv6: getIP(instance1IP6Env, "a::2/128"),
+		},
+		// link used by gobgp instance 2
+		instance2Link: {
+			ipv4: getIP(instance2IPEnv, "172.16.100.3/32"),
+			ipv6: getIP(instance2IP6Env, "a::3/128"),
+		},
+	}
+)
+
+// getIP gets Prefix from env if set, otherwise returns default values.
+var getIP = func(envPrefix, defPrefix string) netip.Prefix {
+	ip := os.Getenv(envPrefix)
+	if ip != "" {
+		return netip.MustParsePrefix(ip)
+	} else {
+		return netip.MustParsePrefix(defPrefix)
+	}
+}
+
+// setupLinks creates links defined in dummies
+func setupLinks() error {
+	log.Info("adding dummy links")
+
+	for name := range dummies {
+		err := netlink.LinkAdd(&netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: name,
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// teardownLinks deletes links defined in dummies
+func teardownLinks() error {
+	log.Info("deleting dummy links")
+
+	for name := range dummies {
+		err := netlink.LinkDel(&netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: name,
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// setupLinkIPs configures IPs and set links up which are defined in setupLinkIPs
+func setupLinkIPs() error {
+	for name, dummy := range dummies {
+		l, err := netlink.LinkByName(name)
+		if err != nil {
+			return err
+		}
+
+		err = netlink.AddrAdd(l, toNetlinkAddr(dummy.ipv4))
+		if err != nil {
+			return err
+		}
+
+		err = netlink.AddrAdd(l, toNetlinkAddr(dummy.ipv6))
+		if err != nil {
+			return err
+		}
+
+		err = netlink.LinkSetUp(l)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// toNetlinkAddr converts netip.Prefix to *netlink.Addr
+func toNetlinkAddr(prefix netip.Prefix) *netlink.Addr {
+	pLen := 128
+	if prefix.Addr().Is4() {
+		pLen = 32
+	}
+	return &netlink.Addr{
+		IPNet: &net.IPNet{
+			IP:   prefix.Addr().AsSlice(),
+			Mask: net.CIDRMask(prefix.Bits(), pLen),
+		},
+	}
+}

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/testutils"
+
+	"github.com/stretchr/testify/require"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// peeringState helper struct containing peering information of BGP neighbor
+type peeringState struct {
+	peerASN     uint32
+	peerAddr    string
+	peerSession string
+}
+
+// Test_NeighborAddDel validates neighbor add and delete are working as expected. Test validates this using
+// peering status which is reported from BGP control plane.
+// Topology - (BGP CP) === (2 x gobgp instances)
+func Test_NeighborAddDel(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	var steps = []struct {
+		description        string
+		neighbors          []cilium_api_v2alpha1.CiliumBGPNeighbor
+		waitState          []string
+		expectedPeerStates []peeringState
+	}{
+		{
+			description: "add two neighbors",
+			neighbors: []cilium_api_v2alpha1.CiliumBGPNeighbor{
+				{
+					PeerAddress: dummies[instance1Link].ipv4.String(),
+					PeerASN:     int(gobgpASN),
+				},
+				{
+					PeerAddress: dummies[instance2Link].ipv4.String(),
+					PeerASN:     int(gobgpASN2),
+				},
+			},
+			waitState: []string{"ESTABLISHED"},
+			expectedPeerStates: []peeringState{
+				{
+					peerASN:     gobgpASN,
+					peerAddr:    dummies[instance1Link].ipv4.Addr().String(),
+					peerSession: types.SessionEstablished.String(),
+				},
+				{
+					peerASN:     gobgpASN2,
+					peerAddr:    dummies[instance2Link].ipv4.Addr().String(),
+					peerSession: types.SessionEstablished.String(),
+				},
+			},
+		},
+		{
+			description:        "delete both neighbors",
+			neighbors:          []cilium_api_v2alpha1.CiliumBGPNeighbor{},
+			waitState:          []string{"IDLE", "ACTIVE"},
+			expectedPeerStates: []peeringState{},
+		},
+	}
+
+	testCtx, testDone := context.WithTimeout(context.Background(), maxTestDuration)
+	defer testDone()
+
+	// test setup, we configure two gobgp instances here.
+	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf, gobgpConf2}, fixtureConf)
+	require.NoError(t, err)
+	require.Len(t, gobgpInstances, 2)
+	defer cleanup()
+
+	for _, step := range steps {
+		t.Run(step.description, func(t *testing.T) {
+			// update bgp policy with neighbors defined in test step
+			policyObj := newPolicyObj(policyConfig{
+				nodeSelector: labels,
+				virtualRouters: []cilium_api_v2alpha1.CiliumBGPVirtualRouter{
+					{
+						LocalASN:      int(ciliumASN),
+						ExportPodCIDR: true,
+						Neighbors:     step.neighbors,
+					},
+				},
+			})
+			_, err = fixture.policyClient.Update(testCtx, &policyObj, meta_v1.UpdateOptions{})
+			require.NoError(t, err, step.description)
+
+			// wait for peers to reach expected state
+			for _, gobgpInstance := range gobgpInstances {
+				err = gobgpInstance.waitForSessionState(testCtx, step.waitState)
+				require.NoError(t, err, step.description)
+			}
+
+			// validate expected state vs state reported by BGP CP
+			var peers []*models.BgpPeer
+			peers, err = fixture.bgp.BGPMgr.GetPeers(testCtx)
+			require.NoError(t, err, step.description)
+
+			var runningState []peeringState
+			for _, peer := range peers {
+				runningState = append(runningState, peeringState{
+					peerASN:     uint32(peer.PeerAsn),
+					peerAddr:    peer.PeerAddress,
+					peerSession: peer.SessionState,
+				})
+			}
+
+			require.ElementsMatch(t, step.expectedPeerStates, runningState, step.description)
+		})
+	}
+}

--- a/pkg/bgpv1/test/objects.go
+++ b/pkg/bgpv1/test/objects.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package test
+
+import (
+	v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var (
+	// uid is static ID used in tests
+	uid = types.UID("610a54cf-e0e5-4dc6-ace9-0e6ca9a4aaae")
+)
+
+// policyConfig data used to create CiliumBGPPeeringPolicy
+type policyConfig struct {
+	nodeSelector   map[string]slim_meta_v1.MatchLabelsValue
+	virtualRouters []v2alpha1.CiliumBGPVirtualRouter
+}
+
+// newPolicyObj created CiliumBGPPeeringPolicy based on passed policy config
+func newPolicyObj(conf policyConfig) v2alpha1.CiliumBGPPeeringPolicy {
+	policyObj := v2alpha1.CiliumBGPPeeringPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "policy-1",
+			UID:               uid,
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+
+	if conf.nodeSelector != nil {
+		policyObj.Spec.NodeSelector = &slim_meta_v1.LabelSelector{
+			MatchLabels: conf.nodeSelector,
+		}
+	}
+
+	if conf.virtualRouters != nil {
+		policyObj.Spec.VirtualRouters = conf.virtualRouters
+	}
+
+	return policyObj
+}
+
+// nodeConfig data used to create/update node object
+type nodeConfig struct {
+	labels      map[string]string
+	annotations map[string]string
+	podCIDRs    []string
+}
+
+// newNodeObj creates new corev1.Node object based on passed config
+func newNodeObj(conf nodeConfig) corev1.Node {
+	nodeObj := corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "base-node",
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		},
+	}
+
+	if conf.labels != nil {
+		nodeObj.ObjectMeta.Labels = conf.labels
+	}
+
+	if conf.annotations != nil {
+		nodeObj.ObjectMeta.Annotations = conf.annotations
+	}
+
+	if conf.podCIDRs != nil {
+		nodeObj.Spec.PodCIDRs = conf.podCIDRs
+	}
+
+	return nodeObj
+}
+
+// lbSrvConfig contains lb service configuration data
+type lbSrvConfig struct {
+	name      string
+	ingressIP string
+}
+
+// newLBServiceObj creates slim_core_v1.Service object based on lbSrvConfig
+func newLBServiceObj(conf lbSrvConfig) slim_core_v1.Service {
+	srvObj := slim_core_v1.Service{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
+			Name: conf.name,
+		},
+		Spec: slim_core_v1.ServiceSpec{
+			Type: slim_core_v1.ServiceTypeLoadBalancer,
+		},
+	}
+
+	srvObj.Status = slim_core_v1.ServiceStatus{
+		LoadBalancer: slim_core_v1.LoadBalancerStatus{
+			Ingress: []slim_core_v1.LoadBalancerIngress{{IP: conf.ingressIP}},
+		},
+	}
+
+	return srvObj
+}


### PR DESCRIPTION
Introducing bgp control plane component tests. This change introduces test harness and basic BGP tests related to podCIDR advertisements, lb service advertisements and neighbor events.

## Motivation of this change

### Increase test coverage around boundaries of subcomponents

- For eg, we do not test complete flow of change from getting Kubernetes event and then validating that it is reflected in the peering router.
- Unit tests today exists for
-- Controller : This is limited to that policy change calls correct reconciler methods.
-- Reconcilers : Tests validate the diffs are generated correctly and we are inspecting gobgp directly for validation. Direct inspection of gobgp might not be suitable here in long term, if another underlying routing agent is used.

### Validate and make BGP Peering part of CI testing.

- This is mainly for neighbour configuration : like timers, graceful restart, authentication etc. And later on for more advanced BGP as well ( Routing policies and filters )
- During new feature development, we have to validate the expected behaviour and add tests for it. It is currently not possible with unit tests, as we only configure local gobgp and we have to validate the behaviour separately via container labs to test actual peering behaviour. Which is again not coded anywhere and we do not repeat those manual tests as we continue to modify the code ( I would say this is the biggest reason ).
- Also having this tests as part of CI, will ensure that there are no regressions introduced to feature behavior as we make changes.

## Types of test cases to add

This component level test is mainly cover high level BGP features

So, what I see following tests need to be added

* Pod CIDR advertisements
* LB Service advertisements
* Neighbor behavior
-- Authentication
-- Timers
-- Graceful restart
* Some special test cases
-- Restarts
-- Any customer reported bugs and issues with order of operations.