### PR TITLE
github: limit test runs if only Go test files have changed

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -112,10 +112,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -112,10 +112,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -112,10 +112,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -111,10 +111,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -111,10 +111,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -111,10 +111,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -111,10 +111,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -110,10 +110,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -111,7 +111,7 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   setup-report:
     runs-on: ubuntu-latest
@@ -166,7 +166,8 @@ jobs:
         target_url: ${{ env.check_url }}
 
   # This job is skipped when the workflow was triggered with the generic `/test-backport-1.11`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: setup-report
     name: Setup & Test

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -111,7 +111,7 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   setup-report:
     runs-on: ubuntu-latest
@@ -166,7 +166,8 @@ jobs:
         target_url: ${{ env.check_url }}
 
   # This job is skipped when the workflow was triggered with the generic `/test-backport-1.12`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: setup-report
     name: Setup & Test

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -111,7 +111,7 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   setup-report:
     runs-on: ubuntu-latest
@@ -166,7 +166,8 @@ jobs:
         target_url: ${{ env.check_url }}
 
   # This job is skipped when the workflow was triggered with the generic `/test-backport-1.13`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: setup-report
     name: Setup & Test

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -111,7 +111,7 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   setup-report:
     runs-on: ubuntu-latest
@@ -163,7 +163,8 @@ jobs:
         target_url: ${{ env.check_url }}
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: setup-report
     name: Setup & Test

--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -106,7 +106,7 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   setup-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -106,7 +106,7 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   setup-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -111,10 +111,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -111,10 +111,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -111,10 +111,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -110,10 +110,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -112,10 +112,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -112,10 +112,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -112,10 +112,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -111,10 +111,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -110,10 +110,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -110,10 +110,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -110,10 +110,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -110,10 +110,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -110,7 +110,7 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**/!(*_test.go)'
+              - '!(.github|test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`,
@@ -123,7 +123,8 @@ jobs:
         (github.event.comment.body == '/test' && needs.check_changes.outputs.tested == 'true')
       )) ||
       github.event_name == 'schedule' ||
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request' && needs.check_changes.outputs.tested == 'true')
+
     runs-on: ubuntu-latest
     timeout-minutes: 75
     steps:

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -113,10 +113,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-multicluster-v1.12.yaml
+++ b/.github/workflows/conformance-multicluster-v1.12.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-multicluster-v1.12.yaml
+++ b/.github/workflows/conformance-multicluster-v1.12.yaml
@@ -113,10 +113,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/conformance-multicluster-v1.13.yaml
+++ b/.github/workflows/conformance-multicluster-v1.13.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   # 
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/conformance-multicluster-v1.13.yaml
+++ b/.github/workflows/conformance-multicluster-v1.13.yaml
@@ -113,10 +113,11 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the only modified files were under `test/` or `Documentation/`,
+  # or of the only modified files are all Go test files.
   installation-and-connectivity:
     needs: check_changes
     if: |

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -107,8 +107,8 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - 'pkg/**'
-              - 'daemon/**'
+              - 'pkg/**/!(*_test.go)'
+              - 'daemon/**/!(*_test.go)'
               - 'bpf/**'
               - 'test/l4lb/**'
               - 'images/**'
@@ -147,7 +147,8 @@ jobs:
         target_url: ${{ env.check_url }}
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the there are no modified files in 'pkg/', 'daemon/', 'bpf/', 'test/l4lb/',
+  # 'test/nat46x64/', or 'images/', or if the modified files therein are Go test files.
   setup-and-test:
     needs: check_changes
     name: Setup & Test

--- a/.github/workflows/tests-l4lb-v1.12.yaml
+++ b/.github/workflows/tests-l4lb-v1.12.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/tests-l4lb-v1.12.yaml
+++ b/.github/workflows/tests-l4lb-v1.12.yaml
@@ -107,8 +107,8 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - 'pkg/**'
-              - 'daemon/**'
+              - 'pkg/**/!(*_test.go)'
+              - 'daemon/**/!(*_test.go)'
               - 'bpf/**'
               - 'test/l4lb/**'
               - 'images/**'
@@ -147,7 +147,8 @@ jobs:
         target_url: ${{ env.check_url }}
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the there are no modified files in 'pkg/', 'daemon/', 'bpf/', 'test/l4lb/',
+  # 'test/nat46x64/', or 'images/', or if the modified files therein are Go test files.
   setup-and-test:
     needs: check_changes
     name: Setup & Test

--- a/.github/workflows/tests-l4lb-v1.13.yaml
+++ b/.github/workflows/tests-l4lb-v1.13.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/tests-l4lb-v1.13.yaml
+++ b/.github/workflows/tests-l4lb-v1.13.yaml
@@ -106,8 +106,8 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - 'pkg/**'
-              - 'daemon/**'
+              - 'pkg/**/!(*_test.go)'
+              - 'daemon/**/!(*_test.go)'
               - 'bpf/**'
               - 'test/l4lb/**'
               - 'test/nat46x64/**'
@@ -147,7 +147,8 @@ jobs:
         target_url: ${{ env.check_url }}
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the there are no modified files in 'pkg/', 'daemon/', 'bpf/', 'test/l4lb/',
+  # 'test/nat46x64/', or 'images/', or if the modified files therein are Go test files.
   setup-and-test:
     needs: check_changes
     name: Setup & Test

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -20,7 +20,7 @@ on:
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
   #
-  # pull_request: {}
+  pull_request: {}
   ###
 
 # By specifying the access of one of the scopes, all of those that are not

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -106,8 +106,8 @@ jobs:
           ref: ${{ steps.pr.outputs.head }}
           filters: |
             src:
-              - 'pkg/**'
-              - 'daemon/**'
+              - 'pkg/**/!(*_test.go)'
+              - 'daemon/**/!(*_test.go)'
               - 'bpf/**'
               - 'test/l4lb/**'
               - 'test/nat46x64/**'
@@ -144,7 +144,8 @@ jobs:
         target_url: ${{ env.check_url }}
 
   # This job is skipped when the workflow was triggered with the generic `/test`
-  # trigger if the only modified files were under `test/` or `Documentation/`.
+  # trigger if the there are no modified files in 'pkg/', 'daemon/', 'bpf/', 'test/l4lb/',
+  # 'test/nat46x64/', or 'images/', or if the modified files therein are Go test files.
   setup-and-test:
     needs: check_changes
     name: Setup & Test

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -46,7 +46,7 @@ jobs:
           base: ${{ github.ref }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   conformance-test-ipv6:
     needs: check_changes

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -46,7 +46,7 @@ jobs:
           base: ${{ github.ref }}
           filters: |
             src:
-              - '!(test|Documentation)/**'
+              - '!(test|Documentation)/**/!(*_test.go)'
 
   preflight-clusterrole:
     runs-on: ubuntu-latest

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -398,7 +398,7 @@ func (ds *SelectorCacheTestSuite) TestIdentityUpdates(c *C) {
 	c.Assert(len(sc.selectors), Equals, 0)
 }
 
-func (ds *SelectorCacheTestSuite) TestFQDNSelectorUpdates(c *C) {
+func (ds *SelectorCacheTestSuite) TestFQDNSelectorUpdatesChangedName(c *C) {
 	sc := testNewSelectorCache(cache.IdentityCache{})
 
 	// Add some identities to the identity cache


### PR DESCRIPTION
Skip workflows that do not run Go tests if only Go test files have changed.

Glob syntax reference: https://github.com/dorny/paths-filter/issues/97
