### PR TITLE
docs: Clarify the steps to update images

### DIFF
--- a/Documentation/contributing/development/images.rst
+++ b/Documentation/contributing/development/images.rst
@@ -238,11 +238,20 @@ different value and then proceed with the steps below.
    generate one commit and push it to your branch with all the necessary changes
    across files in the repository. Once this is done the CI can be executed.
 
-#. Update the versions of the images that are pulled into the CI VMs.
+#. After merging the PR, do the following steps to update the versions of the
+   images that are pulled into the CI VMs.
 
-* Open a PR against the :ref:`packer_ci` with an update to said image versions. Once your PR is merged, a new version of the VM will be ready for consumption in the CI.
-* Update the ``SERVER_VERSION``  field in ``test/Vagrantfile`` to contain the new version, which is the build number from the `Jenkins Job for the VMs <https://jenkins.cilium.io/job/Vagrant-Master-Boxes-Packer-Build/>`_. For example, build 119 from the pipeline would be the value to set for ``SERVER_VERSION``.
-* Open a pull request with this version change in the cilium repository.
+* Open a PR against the :ref:`packer_ci` with an update to said image versions.
+  Once your PR is merged and the new boxes are built, a new version of the VM
+  will be ready for consumption in the CI.
+* Update all ``*SERVER_VERSION`` fields in ``vagrant_box_defaults.rb`` to
+  contain the new versions, which is the build number from the `Jenkins Jobs for
+  the VMs <https://jenkins.cilium.io/view/Packer%20builds/>`_. For example,
+  build 72 from the pipeline would be the value to set for ``SERVER_VERSION``.
+* After merging the `packer-ci-build`_ PR, open a pull request with this version
+  change in the cilium repository.
+
+.. _packer-ci-build: https://github.com/cilium/packer-ci-build/
 
 Nightly Docker image
 ~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -242,9 +242,12 @@ This box will need to be updated when a new developer needs a new dependency
 that is not installed in the current version of the box, or if a dependency that
 is cached within the box becomes stale.
 
+After the pull request to packer-ci-build is merged, builds for master boxes
+have to be triggered `here <https://jenkins.cilium.io/view/Packer%20builds/>`_.
+
 Make sure that you update vagrant box versions in `vagrant_box_defaults.rb
 <https://github.com/cilium/cilium/blob/main/vagrant_box_defaults.rb>`__ after
-new box is built and tested.
+new boxes are built and tested.
 
 Once you change the image versions locally, create a branch named
 ``pr/update-packer-ci-build`` and open a PR ``github.com/cilium/cilium``.


### PR DESCRIPTION
Clarify the order in which the pull requests have to be merged for a successful update of cilium-builder and cilium-runtime images.

Replace test/Vagrantfile with vagrant_box_defaults.rb to reflect the new location of SERVER_VERSION, that changed at least a few years ago.