### PR TITLE
test/k8s: update host policies for firewall tests.

### DIFF
--- a/test/k8s/manifests/host-policies.yaml
+++ b/test/k8s/manifests/host-policies.yaml
@@ -93,3 +93,71 @@ specs:
     - toEntities:
       - health
       - world
+  - description: "Allow kube-dns <> apiserver"
+    endpointSelector: {}
+    ingress:
+    - fromEndpoints:
+      - matchLabels:
+          k8s-app: kube-dns
+      toPorts:
+      - ports:
+        - port: "6443"
+          protocol: TCP
+    egress:
+    - toEntities:
+      - kube-apiserver
+      - world
+      toPorts:
+      - ports:
+        - port: "6443"
+          protocol: TCP
+        - port: "53"
+          protocol: TCP
+  - description: "Allow ICMP/ICMPv6 traffic on all nodes"
+    nodeSelector: {}
+    ingress:
+    - icmps:
+      - fields:
+        - type: 8
+          family: IPv4
+        - type: 128
+          family: IPv6
+    egress:
+    - icmps:
+      - fields:
+        - type: 8
+          family: IPv4
+        - type: 128
+          family: IPv6
+  - description: "Allow ICMP/ICMPv6 traffic on all nodes"
+    endpointSelector: {}
+    ingress:
+    - icmps:
+      - fields:
+        - type: 8
+          family: IPv4
+        - type: 128
+          family: IPv6
+    egress:
+    - icmps:
+      - fields:
+        - type: 8
+          family: IPv4
+        - type: 128
+          family: IPv6
+  - description: "Allow ingress to health endpoint port from endpoints"
+    endpointSelector: {}
+    ingress:
+    - fromEntities:
+      - "remote-node"
+      toPorts:
+      - ports:
+        - port: "4240"
+          protocol: TCP
+    egress:
+    - toEntities:
+      - "health"
+      toPorts:
+      - ports:
+        - port: "4240"
+          protocol: TCP


### PR DESCRIPTION
* Allow ICMP/ICMPv6 traffic on all endpoints/nodes.
* Allow connections required by kube-dns and kind deployments, in order to reduce clutter in drops file when debugging.

In local tests, this cleans up the `cilium-health status` output:

```
Probe time:   2023-05-11T01:42:25Z
Nodes:
  kind-kind/kind-worker (localhost):
    Host connectivity to 172.18.0.3:
      ICMP to stack:   OK, RTT=533.239µs
      HTTP to agent:   OK, RTT=150.976µs
    Endpoint connectivity to 10.244.1.216:
      ICMP to stack:   OK, RTT=608.257µs
      HTTP to agent:   OK, RTT=242.148µs
  kind-kind/kind-control-plane:
    Host connectivity to 172.18.0.2:
      ICMP to stack:   OK, RTT=582.786µs
      HTTP to agent:   OK, RTT=203.352µs
    Endpoint connectivity to 10.244.0.88:
      ICMP to stack:   OK, RTT=557.07µs
      HTTP to agent:   OK, RTT=460.655µs
```

Fixes: #25344 #25343 #25342
