### PR TITLE
test/k8s: update host policies for firewall tests.

### DIFF
--- a/test/k8s/manifests/host-policies.yaml
+++ b/test/k8s/manifests/host-policies.yaml
@@ -93,3 +93,19 @@ specs:
     - toEntities:
       - health
       - world
+  - description: "Allow ICMP/ICMPv6 traffic on all nodes"
+    nodeSelector: {}
+    ingress:
+    - icmps:
+      - fields:
+        - type: 8
+          family: IPv4
+        - type: 128
+          family: IPv6
+    egress:
+    - icmps:
+      - fields:
+        - type: 8
+          family: IPv4
+        - type: 128
+          family: IPv6


### PR DESCRIPTION
Allow ICMP/ICMPv6 traffic on all nodes.

Fixes: #25344 #25343 #25342

