### PR TITLE
bpf/init.sh: move node config generation to Go

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -275,10 +275,6 @@ func (d *Daemon) init() error {
 	if !option.Config.DryMode {
 		bandwidth.InitBandwidthManager()
 
-		if err := d.createNodeConfigHeaderfile(); err != nil {
-			return fmt.Errorf("failed while creating node config header file: %w", err)
-		}
-
 		if err := d.Datapath().Loader().Reinitialize(d.ctx, d, d.mtuConfig.GetDeviceMTU(), d.Datapath(), d.l7Proxy); err != nil {
 			return fmt.Errorf("failed while reinitializing datapath: %w", err)
 		}
@@ -1319,15 +1315,6 @@ func (d *Daemon) ReloadOnDeviceChange(devices []string) {
 			d.svc.SyncServicesOnDeviceChange(d.Datapath().LocalNodeAddressing())
 			d.controllers.TriggerController(syncHostIPsController)
 		}
-	}
-
-	// Recreate node_config.h to reflect the mac addresses of the new devices.
-	d.compilationMutex.Lock()
-	err := d.createNodeConfigHeaderfile()
-	d.compilationMutex.Unlock()
-	if err != nil {
-		log.WithError(err).Warn("Failed to re-create node config header")
-		return
 	}
 
 	// Reload the datapath.

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -56,22 +56,6 @@ func (d *Daemon) LocalConfig() *datapath.LocalNodeConfiguration {
 	return &d.nodeDiscovery.LocalConfig
 }
 
-func (d *Daemon) createNodeConfigHeaderfile() error {
-	nodeConfigPath := option.Config.GetNodeConfigPath()
-	f, err := os.Create(nodeConfigPath)
-	if err != nil {
-		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to create node configuration file")
-		return err
-	}
-	defer f.Close()
-
-	if err = d.datapath.WriteNodeConfig(f, &d.nodeDiscovery.LocalConfig); err != nil {
-		log.WithError(err).WithField(logfields.Path, nodeConfigPath).Fatal("Failed to write node configuration file")
-		return err
-	}
-	return nil
-}
-
 func deleteHostDevice() {
 	link, err := netlink.LinkByName(defaults.HostDevice)
 	if err != nil {


### PR DESCRIPTION
This PR refactors node_config.h generation code in init.sh to Go. In order for this to work properly the function that initially creates node_config.h had to move to Reinitialize().

Fixes: #25378
