### PR TITLE
config: fix tunnel port for DSR-GENEVE with direct-routing

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3105,20 +3105,19 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.Tunnel = ""
 
 	if c.TunnelPort == 0 {
-		switch c.TunnelProtocol {
-		case TunnelDisabled:
-			// tunnel might still be used by eg. DSR with Geneve dispatch or EgressGW
-			if (c.EnableNodePort || c.KubeProxyReplacement == KubeProxyReplacementStrict) &&
-				c.NodePortMode == NodePortModeDSR &&
-				c.LoadBalancerDSRDispatch == DSRDispatchGeneve {
-				c.TunnelPort = defaults.TunnelPortGeneve
-			} else {
-				c.TunnelPort = defaults.TunnelPortVXLAN
-			}
-		case TunnelVXLAN:
-			c.TunnelPort = defaults.TunnelPortVXLAN
-		case TunnelGeneve:
+		// manually pick port for native-routing and DSR with Geneve dispatch:
+		if !c.TunnelingEnabled() &&
+			(c.EnableNodePort || c.KubeProxyReplacement == KubeProxyReplacementStrict) &&
+			c.NodePortMode == NodePortModeDSR &&
+			c.LoadBalancerDSRDispatch == DSRDispatchGeneve {
 			c.TunnelPort = defaults.TunnelPortGeneve
+		} else {
+			switch c.TunnelProtocol {
+			case TunnelVXLAN:
+				c.TunnelPort = defaults.TunnelPortVXLAN
+			case TunnelGeneve:
+				c.TunnelPort = defaults.TunnelPortGeneve
+			}
 		}
 	}
 


### PR DESCRIPTION
The TunnelProtocol option currently defaults to VXLAN. For direct-routing and DSR-GENEVE we override this in Reinitialize() so that init.sh still creates a geneve tunnel interface.

But the config code that picks the default TunnelPort doesn't consider this situation - it will only apply the DSR-GENEVE override if the TunnelProtocol is set to "disabled", but not if it's VXLAN.

So in a config with
```
loadBalancer:
  mode: dsr
  dsrDispatch: geneve
routingMode: native
# no tunnelProtocol set
```

cilium ends up configuring the cilium_geneve interface with dstport 8472 (the VXLAN port), instead of dstport 6081 (the Geneve port).

Fix this by an explicit override for direct-routing with DSR-GENEVE. We can't add a low-level override for init.sh in Reinitialize(), as the TunnelPort also gets propagated to the datapath as TUNNEL_PORT by the agent. So we need a consistent config.

Note that we don't have to worry about the TunnelProtocol being set to "disabled" at all, as Validate() will reject such an invalid config later.