### PR TITLE
WiP: Add monitor agent perf-event rate limiter.

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -246,6 +246,7 @@ cilium-agent [flags]
       --monitor-aggregation string                              Level of monitor aggregation for traces from the datapath (default "None")
       --monitor-aggregation-flags strings                       TCP flags that trigger monitor reports when monitor aggregation is enabled (default [syn,fin,rst])
       --monitor-aggregation-interval duration                   Monitor report interval when monitor aggregation is enabled (default 5s)
+      --monitor-event-rate-limit int                            Limit of monitoring events to process per second. Zero is no limit. (default 0)
       --monitor-queue-size int                                  Size of the event queue when reading monitor events
       --mtu int                                                 Overwrite auto-detected MTU of underlying network
       --node-encryption-opt-out-labels string                   Label selector for nodes which will opt-out of node-to-node encryption (default "node-role.kubernetes.io/control-plane")

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -533,7 +533,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	if option.Config.RunMonitorAgent {
-		d.monitorAgent = monitoragent.NewAgent(ctx)
+		d.monitorAgent = monitoragent.NewAgent(ctx, option.Config.MonitorEventRateLimit)
 	}
 
 	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -699,6 +699,9 @@ func initializeFlags() {
 	flags.Int(option.MonitorQueueSizeName, 0, "Size of the event queue when reading monitor events")
 	option.BindEnv(Vp, option.MonitorQueueSizeName)
 
+	flags.Int(option.MonitorEventRateLimit, 0, "Limit of monitoring events to process per second. Zero is no limit. (default 0)")
+	option.BindEnv(Vp, option.MonitorEventRateLimit)
+
 	flags.Int(option.MTUName, 0, "Overwrite auto-detected MTU of underlying network")
 	option.BindEnv(Vp, option.MTUName)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -715,6 +715,9 @@ const (
 	// MonitorQueueSizeName is the name of the option MonitorQueueSize
 	MonitorQueueSizeName = "monitor-queue-size"
 
+	// MonitorEventRateLimit specifies the limit of monitor events to process per second.
+	MonitorEventRateLimit = "monitor-event-rate-limit"
+
 	// FQDNRejectResponseCode is the name for the option for dns-proxy reject response code
 	FQDNRejectResponseCode = "tofqdns-dns-reject-response-code"
 
@@ -1504,6 +1507,9 @@ type DaemonConfig struct {
 	// aggregation ensures reports are generated for when monitor-aggragation
 	// is enabled. Network byte-order.
 	MonitorAggregationFlags uint16
+
+	// MonitorEventRateLimit specifies the limit of monitor events to process per second.
+	MonitorEventRateLimit int
 
 	// BPFMapsDynamicSizeRatio is ratio of total system memory to use for
 	// dynamic sizing of the CT, NAT, Neighbor and SockRevNAT BPF maps.
@@ -3031,6 +3037,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.MonitorAggregation = vp.GetString(MonitorAggregationName)
 	c.MonitorAggregationInterval = vp.GetDuration(MonitorAggregationInterval)
 	c.MonitorQueueSize = vp.GetInt(MonitorQueueSizeName)
+	c.MonitorEventRateLimit = vp.GetInt(MonitorEventRateLimit)
 	c.MTU = vp.GetInt(MTUName)
 	c.PreAllocateMaps = vp.GetBool(PreAllocateMapsName)
 	c.PrependIptablesChains = vp.GetBool(PrependIptablesChainsName)

--- a/pkg/proxy/logger/logger_test.go
+++ b/pkg/proxy/logger/logger_test.go
@@ -121,7 +121,7 @@ type MockLogNotifier struct {
 
 // NewMockLogNotifier returns a MockLogNotifier ready to be used in the benchmarks below.
 func NewMockLogNotifier() *MockLogNotifier {
-	return &MockLogNotifier{agent.NewAgent(context.Background())}
+	return &MockLogNotifier{agent.NewAgent(context.Background(), 0)}
 }
 
 // NewProxyLogRecord sends the event to the monitor agent to notify the listeners.


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

This change introduce rate limiter that prevents from high CPU utilization by cilium-agent. This is particuraly important on smaller VMs where consuming ~3vCPU can starve other proceses on the node. In the same time CPU limit on the whole pod is not a good solution, as it may affect network programing latency.
The monitor agent perf enet rate limiter allows fine tuning on how many events get processed from the perf event ring buffer into observer event queue. When limit is reached, thread will wait without consuming CPU time. Events that cannot be processed because of rate limiter will naturally be processed as the lost events.
Option should be used when you either need to limit cilium-agent CPU usage (without disabling hubble subsystem at all) or you can observe a lot of event lost in the observer queue (as this is wasting CPU time on processing events that won't be consumed anyway.

This is an alternate solution of high cpu usage problem to the one proposed in
https://github.com/cilium/cilium/pull/24828

The main differences are:
- this change drops events between perf-event ring buffer and observer queue, while event filtering works after observer queue - it is more efficient to drop events sooner than later (ie. less stress on garbage collector for memory allocations)
- this gives more flexibility into fine-tuning as you can choose an acceptable perf events rate instead of dropping all events of a certain type.
- when problem is observed only on some nodes in a cluster (for example load balancer nodes) you can choose rate limit that will cut CPU usage on LB nodes and still get full flows view on the other nodes.

Below are some charts, that show CPU usage and events/flows rates without any optimization, with event filtering as proposed in PR24828 and with rate limit (of 32 000 events per second).

![image](https://github.com/cilium/cilium/assets/10026873/932830f0-5648-4222-b99d-a4db3702258e)


```release-note
Add monitor agent perf-event rate limiter.
```
