### PR TITLE
ci-e2e: backport changes in conformance-e2e into v1.13 tests 

### DIFF
--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -173,6 +173,7 @@ jobs:
       github.event_name == 'pull_request'
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         include:
           # See https://github.com/cilium/cilium/issues/20606 for configuration table
@@ -181,22 +182,18 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'
-            encryption: 'ipsec'
-            ipv6: 'false' # until https://github.com/cilium/cilium/issues/23461 has been fixed
 
           - name: '2'
             kernel: '5.4-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
-            encryption: 'ipsec'
 
           - name: '3'
             kernel: '5.10-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
-            encryption: 'ipsec'
             endpoint-routes: 'true'
 
           - name: '4'
@@ -204,41 +201,120 @@ jobs:
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
-            encryption: 'disabled'
             lb-mode: 'snat'
             endpoint-routes: 'true'
+            egress-gateway: 'true'
 
           - name: '5'
             kernel: '5.15-main'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
-            encryption: 'disabled'
-            lb-mode: 'snat'
+            lb-mode: 'dsr'
             endpoint-routes: 'true'
+            egress-gateway: 'true'
+            host-fw: 'true'
 
           - name: '6'
             kernel: '6.0-main'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'vxlan'
-            encryption: 'disabled'
             lb-mode: 'snat'
+            egress-gateway: 'true'
+            host-fw: 'true'
+            lb-acceleration: 'testing-only'
 
           - name: '7'
             kernel: 'bpf-next-main'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'disabled'
-            encryption: 'disabled'
             lb-mode: 'snat'
+            egress-gateway: 'true'
+            lb-acceleration: 'testing-only'
 
           - name: '8'
             kernel: 'bpf-next-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
+            tunnel: 'geneve'
+            endpoint-routes: 'true'
+
+          - name: '9'
+            kernel: '4.19-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
             tunnel: 'vxlan'
             encryption: 'ipsec'
+            encryption-node: 'false'
+
+          - name: '10'
+            kernel: '5.4-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+
+          - name: '11'
+            kernel: '5.10-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            endpoint-routes: 'true'
+
+          - name: '12'
+            kernel: '5.10-main'
+            kube-proxy: 'iptables'
+            kpr: 'strict'
+            tunnel: 'vxlan'
+            encryption: 'wireguard'
+            encryption-node: 'false'
+            lb-mode: 'snat'
+            endpoint-routes: 'true'
+            egress-gateway: 'true'
+
+          - name: '13'
+            kernel: '5.15-main'
+            kube-proxy: 'iptables'
+            kpr: 'strict'
+            tunnel: 'disabled'
+            encryption: 'wireguard'
+            encryption-node: 'false'
+            lb-mode: 'dsr'
+            endpoint-routes: 'true'
+            egress-gateway: 'true'
+
+          - name: '14'
+            kernel: '6.0-main'
+            kube-proxy: 'none'
+            kpr: 'strict'
+            tunnel: 'vxlan'
+            encryption: 'wireguard'
+            encryption-node: 'true'
+            lb-mode: 'snat'
+            egress-gateway: 'true'
+
+          - name: '15'
+            kernel: 'bpf-next-main'
+            kube-proxy: 'none'
+            kpr: 'strict'
+            tunnel: 'disabled'
+            encryption: 'wireguard'
+            encryption-node: 'true'
+            lb-mode: 'snat'
+            egress-gateway: 'true'
+
+          - name: '16'
+            kernel: 'bpf-next-main'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'geneve'
+            encryption: 'ipsec'
+            encryption-node: 'false'
             endpoint-routes: 'true'
 
     timeout-minutes: 60
@@ -269,11 +345,10 @@ jobs:
             --rollback=false \
             --config monitor-aggregation=none \
             --nodes-without-cilium=kind-worker3 \
-            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }} \
-            --helm-set=bpf.masquerade=false"
-          TUNNEL="--helm-set-string=tunnel=vxlan"
+            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
+          TUNNEL="--helm-set-string=tunnelProtocol=${{ matrix.tunnel }}"
           if [ "${{ matrix.tunnel }}" == "disabled" ]; then
-            TUNNEL="--helm-set-string=tunnel=disabled --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16"
+            TUNNEL="--helm-set-string=routingMode=native --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16"
             TUNNEL="${TUNNEL} --helm-set-string=ipv6NativeRoutingCIDR=fd00:10:244::/56"
           fi
           LB_MODE=""
@@ -288,8 +363,35 @@ jobs:
           if [ "${{ matrix.ipv6 }}" != "false" ]; then
             IPV6="--helm-set=ipv6.enabled=true"
           fi
+          MASQ=""
+          if [ "${{ matrix.kpr }}" == "strict" ]; then
+            # BPF-masq requires KPR=strict.
+            # Disable IPv6 until https://github.com/cilium/cilium/issues/14350 has been resolved
+            MASQ="--helm-set=bpf.masquerade=true --helm-set=enableIPv6Masquerade=false"
+          fi
+          EGRESS_GATEWAY=""
+          if [ "${{ matrix.egress-gateway }}" == "true" ]; then
+            EGRESS_GATEWAY="--helm-set=egressGateway.enabled=true"
+          fi
+          LB_ACCELERATION=""
+          if [ "${{ matrix.lb-acceleration }}" != "" ]; then
+            LB_ACCELERATION="--helm-set=loadBalancer.acceleration=${{ matrix.lb-acceleration }}"
+          fi
 
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6}"
+          ENCRYPT=""
+          if [ "${{ matrix.encryption }}" != "" ]; then
+            ENCRYPT="--encryption=${{ matrix.encryption }}"
+            if [ "${{ matrix.encryption-node }}" != "" ]; then
+              ENCRYPT+=" --node-encryption=${{ matrix.encryption-node }}"
+            fi
+          fi
+
+          HOST_FW=""
+          if [ "${{ matrix.host-fw }}" == "true" ]; then
+            HOST_FW="--helm-set=hostFirewall.enabled=true"
+          fi
+
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
       - name: Checkout pull request for Helm chart
@@ -326,14 +428,17 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ needs.setup-report.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
-      - name: Run kube-proxy tests
+      - name: Run tests
         uses: cilium/little-vm-helper@0b7d7157dae56a44dc531c852e7756dc671071af # v0.0.3
         with:
           provision: 'false'
           cmd: |
             cd /host/
-            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
+            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
             ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
+
+            ./cilium-cli status --wait
+            kubectl -n kube-system exec daemonset/cilium -- cilium status
 
             # install static routes
             EXTERNAL_FROM_CIDRS=(\$(kubectl get nodes -o jsonpath='{range .items[*]}{.spec.podCIDR}{"\n"}{end}'))
@@ -387,31 +492,13 @@ jobs:
             fi
             EXTERNAL_NODE_IPS_PARAM=\${EXTERNAL_NODE_IPS_PARAM}
 
-            ./cilium-cli status --wait
             ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
               --external-from-cidrs="\${EXTERNAL_NODE_IPS_PARAM}" \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./cilium-cli connectivity test --collect-sysdump-on-failure \
               --external-from-cidrs="\${EXTERNAL_NODE_IPS_PARAM}" \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
-            kind delete cluster
-
-      - name: Run encryption tests
-        if: ${{ matrix.encryption != 'disabled' }}
-        uses: cilium/little-vm-helper@0b7d7157dae56a44dc531c852e7756dc671071af # v0.0.3
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
-            ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }} \
-              --encryption=${{ matrix.encryption }}
-
-            ./cilium-cli status --wait
-            ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
-            ./cilium-cli connectivity test --collect-sysdump-on-failure \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
+            ./contrib/scripts/kind-down.sh
 
       - name: Fetch artifacts
         if: ${{ !success() }}
@@ -459,7 +546,7 @@ jobs:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.setup-report.outputs.sha }}
           context: ${{ github.workflow }}
-          description: Datapath tests failed
+          description: E2E conformance tests failed
           state: failure
           target_url: ${{ env.check_url }}
 
@@ -474,6 +561,6 @@ jobs:
           authToken: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ needs.setup-report.outputs.sha }}
           context: ${{ github.workflow }}
-          description: Datapath tests cancelled
+          description: E2E conformance tests cancelled
           state: error
           target_url: ${{ env.check_url }}


### PR DESCRIPTION
To unblock https://github.com/cilium/cilium/pull/25346 let's backport the whole conformance-e2e.yaml to conformance-e2e-v1.13.yaml.