### PR TITLE
clustermesh-apiserver: expose information about completion of initial synchronization through etcd

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -462,6 +462,7 @@ Name                                     Labels                                 
 ``kvstore_events_queue_seconds``         ``action``, ``scope``                        Enabled    Seconds waited before a received event was queued
 ``kvstore_quorum_errors_total``          ``error``                                    Enabled    Number of quorum errors
 ``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Enabled    Number of elements queued for synchronization in the kvstore
+``kvstore_initial_sync_completed``       ``scope``, ``source_cluster``, ``action``    Enabled    Whether the initial synchronization from/to the kvstore has completed
 ======================================== ============================================ ========== ========================================================
 
 Agent
@@ -917,4 +918,5 @@ Name                                     Labels                                 
 ``kvstore_events_queue_seconds``         ``action``, ``scope``                        Seconds waited before a received event was queued
 ``kvstore_quorum_errors_total``          ``error``                                    Number of quorum errors
 ``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Number of elements queued for synchronization in the kvstore
+``kvstore_initial_sync_completed``       ``scope``, ``source_cluster``, ``action``    Whether the initial synchronization from/to the kvstore has completed
 ======================================== ============================================ ========================================================

--- a/clustermesh-apiserver/metrics/metrics.go
+++ b/clustermesh-apiserver/metrics/metrics.go
@@ -69,6 +69,7 @@ func (mm *metricsManager) Start(hive.HookContext) error {
 		metrics.KVStoreEventsQueueDuration,
 		metrics.KVStoreQuorumErrors,
 		metrics.KVStoreSyncQueueSize,
+		metrics.KVStoreInitialSyncCompleted,
 	)
 
 	mux := http.NewServeMux()

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -183,6 +183,14 @@ func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, clients
 		}()
 	}
 
+	go func() {
+		<-k8sSvcCacheSynced
+		cache.WaitForCacheSync(ctx.Done(), endpointController.HasSynced)
+
+		log.Info("Initial list of services successfully received from Kubernetes")
+		kvs.Synced(ctx)
+	}()
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -29,6 +29,13 @@ func ValidateClusterID(clusterID uint32) error {
 
 type CiliumClusterConfig struct {
 	ID uint32 `json:"id,omitempty"`
+
+	Capabilities CiliumClusterConfigCapabilities `json:"capabilities,omitempty"`
+}
+
+type CiliumClusterConfigCapabilities struct {
+	// Supports per-prefix "synced" canaries
+	SyncedCanaries bool `json:"syncedFlags,omitempty"`
 }
 
 func (c0 *CiliumClusterConfig) IsCompatible(c1 *CiliumClusterConfig) error {

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -42,6 +42,10 @@ const (
 	// ClusterConfigPrefix is the kvstore prefix to cluster configuration
 	ClusterConfigPrefix = BaseKeyPrefix + "/cluster-config"
 
+	// SyncedPrefix is the kvstore prefix used to convey whether
+	// synchronization from an external source has completed for a given prefix
+	SyncedPrefix = BaseKeyPrefix + "/synced"
+
 	// HeartbeatWriteInterval is the interval in which the heartbeat key at
 	// HeartbeatPath is updated
 	HeartbeatWriteInterval = time.Minute

--- a/pkg/kvstore/store/syncstore.go
+++ b/pkg/kvstore/store/syncstore.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"path"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -31,6 +33,12 @@ type SyncStore interface {
 
 	// DeleteKey removes a key from the kvstore.
 	DeleteKey(ctx context.Context, key NamedKey) error
+
+	// Synced triggers the insertion of the "synced" key associated with this
+	// store into the kvstore once all upsertions already issued have completed
+	// successfully, eventually executing all specified callbacks (if any).
+	// Only the first invocation takes effect.
+	Synced(ctx context.Context, callbacks ...func(ctx context.Context)) error
 }
 
 // SyncStoreBackend represents the subset kvstore.BackendOperations leveraged
@@ -56,14 +64,22 @@ type wqSyncStore struct {
 	workqueue workqueue.RateLimitingInterface
 	state     sync.Map /* map[string][]byte --- map[NamedKey.GetKeyName()]Key.Marshal() */
 
+	synced          atomic.Bool // Synced() has been triggered
+	pendingSync     sync.Map    // map[string]struct{}: the set of keys still to sync
+	syncedKey       string
+	syncedCallbacks []func(context.Context)
+
 	log          *logrus.Entry
 	queuedMetric prometheus.Gauge
+	syncedMetric prometheus.Gauge
 }
+
+type syncCanary struct{}
 
 type WSSOpt func(*wqSyncStore)
 
 // WSSWithSourceClusterName configures the name of the source cluster the information
-// is synchronized from, which is used to enrich the metrics.
+// is synchronized from, which is used to scope the "synced" prefix and enrich the metrics.
 func WSSWithSourceClusterName(cluster string) WSSOpt {
 	return func(wss *wqSyncStore) {
 		wss.source = cluster
@@ -91,6 +107,14 @@ func WSSWithoutLease() WSSOpt {
 	}
 }
 
+// WSSWithSyncedKeyOverride overrides the "synced" key inserted into the kvstore
+// when initial synchronization completed (by default it corresponds to the prefix).
+func WSSWithSyncedKeyOverride(key string) WSSOpt {
+	return func(wss *wqSyncStore) {
+		wss.syncedKey = key
+	}
+}
+
 // NewWorkqueueSyncStore returns a SyncStore instance which leverages a workqueue
 // to coalescence update/delete requests and handle retries in case of errors.
 func NewWorkqueueSyncStore(backend SyncStoreBackend, prefix string, opts ...WSSOpt) SyncStore {
@@ -102,6 +126,7 @@ func NewWorkqueueSyncStore(backend SyncStoreBackend, prefix string, opts ...WSSO
 		workers:   1,
 		withLease: true,
 		limiter:   workqueue.DefaultControllerRateLimiter(),
+		syncedKey: prefix,
 
 		log: log.WithField("prefix", prefix),
 	}
@@ -110,14 +135,19 @@ func NewWorkqueueSyncStore(backend SyncStoreBackend, prefix string, opts ...WSSO
 		opt(wss)
 	}
 
+	wss.log = wss.log.WithField(logfields.ClusterName, wss.source)
 	wss.workqueue = workqueue.NewRateLimitingQueue(wss.limiter)
 	wss.queuedMetric = metrics.KVStoreSyncQueueSize.WithLabelValues(kvstore.GetScopeFromKey(prefix), wss.source)
+	wss.syncedMetric = metrics.KVStoreInitialSyncCompleted.WithLabelValues(kvstore.GetScopeFromKey(prefix), wss.source, "write")
 	return wss
 }
 
 // Run starts the SyncStore logic, blocking until the context is closed.
 func (wss *wqSyncStore) Run(ctx context.Context) {
 	var wg sync.WaitGroup
+
+	wss.syncedMetric.Set(metrics.BoolToFloat64(false))
+	defer wss.syncedMetric.Set(metrics.BoolToFloat64(false))
 
 	wss.log.WithField(logfields.Workers, wss.workers).Info("Starting workqueue-based sync store")
 	wg.Add(int(wss.workers))
@@ -151,6 +181,10 @@ func (wss *wqSyncStore) UpsertKey(_ context.Context, k Key) error {
 	if loaded && bytes.Equal(prevValue.([]byte), value) {
 		wss.log.WithField(logfields.Key, k).Debug("ignoring upsert request for already up-to-date key")
 	} else {
+		if !wss.synced.Load() {
+			wss.pendingSync.Store(key, struct{}{})
+		}
+
 		wss.workqueue.Add(key)
 		wss.queuedMetric.Set(float64(wss.workqueue.Len()))
 	}
@@ -173,6 +207,14 @@ func (wss *wqSyncStore) DeleteKey(_ context.Context, k NamedKey) error {
 	return nil
 }
 
+func (wss *wqSyncStore) Synced(_ context.Context, callbacks ...func(ctx context.Context)) error {
+	if synced := wss.synced.Swap(true); !synced {
+		wss.syncedCallbacks = callbacks
+		wss.workqueue.Add(syncCanary{})
+	}
+	return nil
+}
+
 func (wss *wqSyncStore) processNextItem(ctx context.Context) bool {
 	// Retrieve the next key to process from the workqueue.
 	key, shutdown := wss.workqueue.Get()
@@ -190,7 +232,7 @@ func (wss *wqSyncStore) processNextItem(ctx context.Context) bool {
 	}()
 
 	// Run the handler, passing it the key to be processed as parameter.
-	if err := wss.handle(ctx, key.(string)); err != nil {
+	if err := wss.handle(ctx, key); err != nil {
 		// Put the item back on the workqueue to handle any transient errors.
 		wss.workqueue.AddRateLimited(key)
 		return true
@@ -199,15 +241,20 @@ func (wss *wqSyncStore) processNextItem(ctx context.Context) bool {
 	// Since no error occurred, forget this item so it does not get queued again
 	// until another change happens.
 	wss.workqueue.Forget(key)
+	wss.pendingSync.Delete(key)
 	return true
 }
 
-func (wss *wqSyncStore) handle(ctx context.Context, key string) error {
-	if value, ok := wss.state.Load(key); ok {
-		return wss.handleUpsert(ctx, key, value.([]byte))
+func (wss *wqSyncStore) handle(ctx context.Context, key interface{}) error {
+	if _, ok := key.(syncCanary); ok {
+		return wss.handleSync(ctx)
 	}
 
-	return wss.handleDelete(ctx, key)
+	if value, ok := wss.state.Load(key); ok {
+		return wss.handleUpsert(ctx, key.(string), value.([]byte))
+	}
+
+	return wss.handleDelete(ctx, key.(string))
 }
 
 func (wss *wqSyncStore) handleUpsert(ctx context.Context, key string, value []byte) error {
@@ -232,6 +279,38 @@ func (wss *wqSyncStore) handleDelete(ctx context.Context, key string) error {
 	}
 
 	scopedLog.Debug("Deleted key from kvstore")
+	return nil
+}
+
+func (wss *wqSyncStore) handleSync(ctx context.Context) error {
+	// This could be replaced by wss.toSync.Len() == 0 if it only existed...
+	syncCompleted := true
+	wss.pendingSync.Range(func(any, any) bool {
+		syncCompleted = false
+		return false
+	})
+
+	if !syncCompleted {
+		return fmt.Errorf("there are still keys to be synchronized")
+	}
+
+	key := path.Join(kvstore.SyncedPrefix, wss.source, wss.syncedKey)
+	scopedLog := wss.log.WithField(logfields.Key, key)
+
+	err := wss.backend.Update(ctx, key, []byte(time.Now().Format(time.RFC3339)), wss.withLease)
+	if err != nil {
+		scopedLog.WithError(err).Warning("Failed upserting synced key in kvstore. Retrying...")
+		return err
+	}
+
+	wss.log.Info("Initial synchronization from the external source completed")
+	wss.syncedMetric.Set(metrics.BoolToFloat64(true))
+
+	// Execute any callback that might have been registered.
+	for _, callback := range wss.syncedCallbacks {
+		callback(ctx)
+	}
+
 	return nil
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -474,6 +474,10 @@ var (
 	// synchronization in the kvstore.
 	KVStoreSyncQueueSize = NoOpGaugeVec
 
+	// KVStoreInitialSyncCompleted records whether the initial synchronization
+	// from/to the kvstore has completed.
+	KVStoreInitialSyncCompleted = NoOpGaugeVec
+
 	// FQDNGarbageCollectorCleanedTotal is the number of domains cleaned by the
 	// GC job.
 	FQDNGarbageCollectorCleanedTotal = NoOpCounter
@@ -617,6 +621,7 @@ type Configuration struct {
 	KVStoreEventsQueueDurationEnabled       bool
 	KVStoreQuorumErrorsEnabled              bool
 	KVStoreSyncQueueSizeEnabled             bool
+	KVStoreInitialSyncCompletedEnabled      bool
 	FQDNGarbageCollectorCleanedTotalEnabled bool
 	FQDNActiveNames                         bool
 	FQDNActiveIPs                           bool
@@ -692,6 +697,7 @@ func DefaultMetrics() map[string]struct{} {
 		Namespace + "_" + SubsystemKVStore + "_events_queue_seconds":                 {},
 		Namespace + "_" + SubsystemKVStore + "_quorum_errors_total":                  {},
 		Namespace + "_" + SubsystemKVStore + "_sync_queue_size":                      {},
+		Namespace + "_" + SubsystemKVStore + "_initial_sync_completed":               {},
 		Namespace + "_" + SubsystemIPCache + "_errors_total":                         {},
 		Namespace + "_" + SubsystemFQDN + "_gc_deletions_total":                      {},
 		Namespace + "_" + SubsystemBPF + "_map_ops_total":                            {},
@@ -1279,6 +1285,17 @@ func CreateConfiguration(metricsEnabled []string) (Configuration, []prometheus.C
 
 			collectors = append(collectors, KVStoreSyncQueueSize)
 			c.KVStoreSyncQueueSizeEnabled = true
+
+		case Namespace + "_" + SubsystemKVStore + "_initial_sync_completed":
+			KVStoreInitialSyncCompleted = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+				Namespace: Namespace,
+				Subsystem: SubsystemKVStore,
+				Name:      "initial_sync_completed",
+				Help:      "Whether the initial synchronization from/to the kvstore has completed",
+			}, []string{LabelScope, LabelSourceCluster, LabelAction})
+
+			collectors = append(collectors, KVStoreInitialSyncCompleted)
+			c.KVStoreInitialSyncCompletedEnabled = true
 
 		case Namespace + "_" + SubsystemIPCache + "_errors_total":
 			IPCacheErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
This PR extends the *SyncStore* abstraction to add the support for *synced canaries*, which are used to convey the information that the initial synchronization from an external source (e.g., k8s or another kvstore) of the keys hosted at a different prefix has completed. This information is required when using an ephemeral etcd instance (e.g., the clustermesh-apiserver sidecar container), because from a client perspective the completion of the initial range operation is not sufficient in this case to guarantee that an up-to-date snapshot of the state has been retrieved. Specifically, this information will be leveraged in a subsequent PR to address https://github.com/cilium/cilium/issues/24740.

At the moment, "synced" canaries are enabled only for service entries. The introduction for the other resources depends on https://github.com/cilium/cilium/pull/25049, and I temporarily removed that part to allow reviewing both in parallel.

Please, refer to the individual commits for more details.

I've tagged this PR as *release-note/minor* since it introduces a new metric.

<!-- Description of change -->

Related: #24740

```release-note
clustermesh-apiserver: expose information about completion of initial synchronization through etcd
```
