### PR TITLE
cmd: enhance cilium bpf policy list&get

### DIFF
--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -82,7 +82,8 @@ func listAllMaps() {
 		}
 	} else {
 		for _, m := range maps {
-			fmt.Printf("%s:\n", m.Path)
+			fmt.Printf("Endpoint ID: %s\n", m.EndpointID)
+			fmt.Printf("Path: %s\n", m.Path)
 			fmt.Println()
 			printTable(m.Content)
 			fmt.Println()

--- a/cilium/cmd/bpf_policy_get.go
+++ b/cilium/cmd/bpf_policy_get.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	identitymodel "github.com/cilium/cilium/pkg/identity/model"
 	"github.com/cilium/cilium/pkg/maps/policymap"
+	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
@@ -149,6 +150,7 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 		labelsDesTitle        = "LABELS (source:key[=value])"
 		portTitle             = "PORT/PROTO"
 		proxyPortTitle        = "PROXY PORT"
+		authTypeTitle         = "AUTH TYPE"
 		bytesTitle            = "BYTES"
 		packetsTitle          = "PACKETS"
 		prefixTitle           = "PREFIX"
@@ -169,11 +171,11 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 	}
 
 	if printIDs {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
-			policyTitle, trafficDirectionTitle, labelsIDTitle, portTitle, proxyPortTitle, bytesTitle, packetsTitle, prefixTitle)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+			policyTitle, trafficDirectionTitle, labelsIDTitle, portTitle, proxyPortTitle, authTypeTitle, bytesTitle, packetsTitle, prefixTitle)
 	} else {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
-			policyTitle, trafficDirectionTitle, labelsDesTitle, portTitle, proxyPortTitle, bytesTitle, packetsTitle, prefixTitle)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t\n",
+			policyTitle, trafficDirectionTitle, labelsDesTitle, portTitle, proxyPortTitle, authTypeTitle, bytesTitle, packetsTitle, prefixTitle)
 	}
 	for _, stat := range statsMap {
 		prefixLen := stat.Key.Prefixlen - policymap.StaticPrefixBits
@@ -193,22 +195,22 @@ func formatMap(w io.Writer, statsMap []policymap.PolicyEntryDump) {
 			policyStr = "Allow"
 		}
 		if printIDs {
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%d\t%d\t%d\t\n",
-				policyStr, trafficDirectionString, id, port, proxyPort, stat.Bytes, stat.Packets, prefixLen)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%d\t%d\t%d\t\n",
+				policyStr, trafficDirectionString, id, port, proxyPort, policy.AuthType(stat.AuthType), stat.Bytes, stat.Packets, prefixLen)
 		} else if lbls := labelsID[id]; lbls != nil && len(lbls.Labels) > 0 {
 			first := true
 			for _, lbl := range lbls.Labels.GetPrintableModel() {
 				if first {
-					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t\n",
-						policyStr, trafficDirectionString, lbl, port, proxyPort, stat.Bytes, stat.Packets, prefixLen)
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%d\t\n",
+						policyStr, trafficDirectionString, lbl, port, proxyPort, policy.AuthType(stat.AuthType), stat.Bytes, stat.Packets, prefixLen)
 					first = false
 				} else {
-					fmt.Fprintf(w, "\t\t%s\t\t\t\t\t\t\n", lbl)
+					fmt.Fprintf(w, "\t\t%s\t\t\t\t\t\t\t\n", lbl)
 				}
 			}
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%d\t%d\t%d\t\n",
-				policyStr, trafficDirectionString, id, port, proxyPort, stat.Bytes, stat.Packets, prefixLen)
+			fmt.Fprintf(w, "%s\t%s\t%d\t%s\t%s\t%s\t%d\t%d\t%d\t\n",
+				policyStr, trafficDirectionString, id, port, proxyPort, policy.AuthType(stat.AuthType), stat.Bytes, stat.Packets, prefixLen)
 		}
 	}
 }


### PR DESCRIPTION
This PR introduces the following changes related to the cilium commands `cilium bpf policy get/list`:
* Fixing structured output (JSON/YAML) when listing all policy maps, by formatting the whole content - and not on a per map basis
* The Endpoint ID gets printed before the actual policy map content in addition to the path when listing in table form
* The recently introduced Auth Type (e.g. `mtls-spiffe`) gets printed when getting/listing in the table form

**Listing all policy maps as JSON/YAML**

Currently, when listing all policy maps with structured output (e.g. `cilium bpf policy list -o json`), the output as a whole isn't structured as JSON, only the individual policy maps per endpoint. This prevents piping its output into other tools - e.g. jq.

```
/sys/fs/bpf/tc/globals/cilium_policy_00035:

[
  {
    // map entry
  },
  {
    // map entry
  }
]

/sys/fs/bpf/tc/globals/cilium_policy_00038:

[
  {
    // map entry
  },
  {
    // map entry
  }
]
```

This commits changes this by formatting the full output as JSON/YAML with EndpointID, Path & Content.

```
[
  {
    "EndpointID": "35",
    "Path": "/sys/fs/bpf/tc/globals/cilium_policy_00035",
    "Content": [
      {
        // map entry
      },
      {
        // map entry
      }
    ]
  },
  {
    "EndpointID": "38",
    "Path": "/sys/fs/bpf/tc/globals/cilium_policy_00038",
    "Content": [
      {
        // map entry
      },
      {
        // map entry
      }
    ]
  },
...
]
```

**Endpoint ID**

Explicitly display Endpoint ID in addition to path (where it might not be that obvious that it contains the endpoint id)

before

```
...
/sys/fs/bpf/tc/globals/cilium_policy_03642:

POLICY   DIRECTION   LABELS (source:key[=value])                                                  PORT/PROTO   PROXY PORT   AUTH TYPE   BYTES   PACKETS   PREFIX   
Allow    Ingress     reserved:unknown                                                             ANY          NONE         none        0       0         0        
Allow    Ingress     reserved:host                                                                ANY          NONE         none        0       0         0        
...
```

after

```
...
Endpoint ID: 3642
Path: /sys/fs/bpf/tc/globals/cilium_policy_03642

POLICY   DIRECTION   LABELS (source:key[=value])                                                  PORT/PROTO   PROXY PORT   AUTH TYPE   BYTES   PACKETS   PREFIX   
Allow    Ingress     reserved:unknown                                                             ANY          NONE         none        0       0         0        
Allow    Ingress     reserved:host                                                                ANY          NONE         none        0       0         0        
...
```