### PR TITLE
ci-e2e-v1.13: Fix workflow

### DIFF
--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -64,7 +64,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate: datasource=github-releases depName=cilium/cilium-cli
+  # renovate is disabled in this workflow until https://github.com/cilium/cilium-cli/issues/1627 is resolved.
+  # renovate_disabled: datasource=github-releases depName=cilium/cilium-cli
   cilium_cli_version: v0.13.2
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -65,7 +65,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.14.2
+  cilium_cli_version: v0.13.2
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -248,6 +248,7 @@ jobs:
             tunnel: 'vxlan'
             encryption: 'ipsec'
             encryption-node: 'false'
+            ipv6: 'false' # https://github.com/cilium/cilium/issues/23461
 
           - name: '10'
             kernel: '5.4-main'
@@ -289,26 +290,6 @@ jobs:
             egress-gateway: 'true'
 
           - name: '14'
-            kernel: '6.0-main'
-            kube-proxy: 'none'
-            kpr: 'strict'
-            tunnel: 'vxlan'
-            encryption: 'wireguard'
-            encryption-node: 'true'
-            lb-mode: 'snat'
-            egress-gateway: 'true'
-
-          - name: '15'
-            kernel: 'bpf-next-main'
-            kube-proxy: 'none'
-            kpr: 'strict'
-            tunnel: 'disabled'
-            encryption: 'wireguard'
-            encryption-node: 'true'
-            lb-mode: 'snat'
-            egress-gateway: 'true'
-
-          - name: '16'
             kernel: 'bpf-next-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
@@ -346,9 +327,9 @@ jobs:
             --config monitor-aggregation=none \
             --nodes-without-cilium=kind-worker3 \
             --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
-          TUNNEL="--helm-set-string=tunnelProtocol=${{ matrix.tunnel }}"
+          TUNNEL="--helm-set-string=tunnel=${{ matrix.tunnel }}"
           if [ "${{ matrix.tunnel }}" == "disabled" ]; then
-            TUNNEL="--helm-set-string=routingMode=native --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16"
+            TUNNEL="--helm-set-string=tunnel=disabled --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16"
             TUNNEL="${TUNNEL} --helm-set-string=ipv6NativeRoutingCIDR=fd00:10:244::/56"
           fi
           LB_MODE=""
@@ -391,7 +372,12 @@ jobs:
             HOST_FW="--helm-set=hostFirewall.enabled=true"
           fi
 
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
+          L7=""
+          if [ "${{ matrix.egress-gateway }}" == "true" ] || [ "${{ matrix.encryption }}" == "wireguard" ]; then
+            L7="--helm-set=l7Proxy=false"
+          fi
+
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${L7}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
       - name: Checkout pull request for Helm chart
@@ -440,63 +426,9 @@ jobs:
             ./cilium-cli status --wait
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
-            # install static routes
-            EXTERNAL_FROM_CIDRS=(\$(kubectl get nodes -o jsonpath='{range .items[*]}{.spec.podCIDR}{"\n"}{end}'))
-            EXTERNAL_NODE_IPS=() # Nodes IPs are collected to be passed to the Cilium CLI later on.
-            NODES_WITHOUT_CILIUM=kind-worker3 # To add more elements, keep it comma-separated.
-
-            # Loop over each pod CIDR from all nodes.
-            for i in "\${!EXTERNAL_FROM_CIDRS[@]}"; do
-              EXTERNAL_FROM_CIDR=\${EXTERNAL_FROM_CIDRS[i]}
-
-              if [[ \$EXTERNAL_FROM_CIDR =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]; then
-                IP_FAMILY="v4"
-              elif [[ \$EXTERNAL_FROM_CIDR =~ ^[0-9a-fA-F:]+/[0-9]+$ ]]; then
-                IP_FAMILY="v6"
-              else
-                echo "ERROR: Malformed pod CIDR '\${EXTERNAL_FROM_CIDR}'" >&2
-                exit 1
-              fi
-
-              IFS=',' read -ra NODES_WITHOUT <<< "\$NODES_WITHOUT_CILIUM" # Split by comma into an array
-              for WITHOUT in "\${NODES_WITHOUT[@]}"; do
-                # Fetch node with a specific pod CIDR.
-                node=\$(kubectl get nodes -o jsonpath="{range .items[?(@.spec.podCIDR == '\$EXTERNAL_FROM_CIDR')]}{@.metadata.name}{end}")
-                if [[ -z "\$node" ]]; then
-                  echo "ERROR: Could not find node with .spec.podCIDR matching \${EXTERNAL_FROM_CIDR}" >&2
-                  exit 1
-                fi
-                for NODE_IP in \$(kubectl get node "\$node" -o jsonpath="{.status.addresses[?(@.type == 'InternalIP')].address}"); do
-                  # Skip if the node IP's family mismatches with pod CIDR's
-                  # family. Cannot create a route with the gateway IP family
-                  # mismatching the subnet.
-                  if [[ "\$IP_FAMILY" == "v4" && ! "\$NODE_IP" =~ \. ]]; then
-                    continue
-                  elif [[ "\$IP_FAMILY" == "v6" && ! "\$NODE_IP" =~ \: ]]; then
-                    continue
-                  fi
-                  # Install static route on the host, towards the pod CIDR via the node IP.
-                  docker exec "\$WITHOUT" ip route replace "\${EXTERNAL_FROM_CIDR}" via "\${NODE_IP}"
-                  EXTERNAL_NODE_IPS+=("\${NODE_IP}")
-                done
-              done
-            done
-
-            # Join the elements with a comma delimiter, or leave them unmodified
-            # if there's only one element so that it can be passed properly to
-            # the CLI.
-            if [[ \${#EXTERNAL_NODE_IPS[@]} -eq 1 ]]; then
-              EXTERNAL_NODE_IPS_PARAM="\${EXTERNAL_NODE_IPS[0]}"
-            else
-              EXTERNAL_NODE_IPS_PARAM=\$(IFS=','; echo "\${EXTERNAL_NODE_IPS[*]}")
-            fi
-            EXTERNAL_NODE_IPS_PARAM=\${EXTERNAL_NODE_IPS_PARAM}
-
             ./cilium-cli connectivity test --datapath --collect-sysdump-on-failure \
-              --external-from-cidrs="\${EXTERNAL_NODE_IPS_PARAM}" \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./cilium-cli connectivity test --collect-sysdump-on-failure \
-              --external-from-cidrs="\${EXTERNAL_NODE_IPS_PARAM}" \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
             ./contrib/scripts/kind-down.sh
 


### PR DESCRIPTION
 Unfortunately, 93baa34 was run against the latest Cilium, so it didn't catch v1.13 specific issues (limitations). This commit fixes:

* Use --tunnel instead of --tunnelProtocol. The latter was only introduced in v1.14 \[1\].
* Disable IPv6 for IPsec configuration.
* Downgrade CLI to v0.13.2 until \[2\] has been resolved.
* Remove external CIDRs, as they are not needed for v0.13.2 CLI.
* Disable L7 if EGW or WG is enabled (v1.13 limitation).
* Remove host-to-host encryption configurations (v1.13 doesn't support it).

\[1\]: https://github.com/cilium/cilium/pull/24561
\[2\]: https://github.com/cilium/cilium-cli/issues/1627

Successful run https://github.com/cilium/cilium/actions/runs/4959820195/jobs/8874465740.