### PR TITLE
images: scripts to update and check envoy image version

### DIFF
--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -38,3 +38,6 @@ jobs:
         with:
           entrypoint: make
           args: -C images check-runtime-image check-builder-image
+
+      - name: Check Cilium Envoy image
+        run: make -C images check-envoy-image

--- a/images/Makefile
+++ b/images/Makefile
@@ -50,3 +50,6 @@ operator-image: .buildx_builder
 
 hubble-relay-image: .buildx_builder
 	ROOT_CONTEXT=true scripts/build-image.sh hubble-relay-dev images/hubble-relay $(PLATFORMS) $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+
+check-envoy-image:
+	scripts/check-cilium-envoy-image.sh

--- a/images/Makefile
+++ b/images/Makefile
@@ -51,5 +51,8 @@ operator-image: .buildx_builder
 hubble-relay-image: .buildx_builder
 	ROOT_CONTEXT=true scripts/build-image.sh hubble-relay-dev images/hubble-relay $(PLATFORMS) $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
 
+update-envoy-image:
+	scripts/update-cilium-envoy-image.sh
+
 check-envoy-image:
 	scripts/check-cilium-envoy-image.sh

--- a/images/scripts/check-cilium-envoy-image.sh
+++ b/images/scripts/check-cilium-envoy-image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+root_dir="$(git rev-parse --show-toplevel)"
+
+cd "${root_dir}"
+
+image="quay.io/cilium/cilium-envoy"
+image_tag="$(yq '.envoy.image.tag' ./install/kubernetes/cilium/values.yaml.tmpl)"
+image_sha256="$(yq '.envoy.image.digest' ./install/kubernetes/cilium/values.yaml.tmpl)"
+
+sed -i -E "s|(FROM ${image}:)(.*)(@sha256:[0-9a-z]*)( as cilium-envoy)|\1${image_tag}@${image_sha256}\4|" ./images/cilium/Dockerfile
+
+echo "Checking for different Cilium Envoy images"
+git diff --exit-code ./images/cilium/Dockerfile

--- a/images/scripts/update-cilium-envoy-image.sh
+++ b/images/scripts/update-cilium-envoy-image.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+root_dir="$(git rev-parse --show-toplevel)"
+
+cd "${root_dir}"
+
+github_repo="cilium/proxy"
+github_branch="main"
+image="quay.io/cilium/cilium-envoy"
+
+latest_commit_sha="$(curl -s https://api.github.com/repos/${github_repo}/commits/${github_branch} | jq -r '.sha')"
+envoy_version="$(curl -s https://raw.githubusercontent.com/${github_repo}/"${latest_commit_sha}"/ENVOY_VERSION)"
+
+image_tag="${envoy_version//envoy-/v}-${latest_commit_sha}"
+
+image_full="${image}:${image_tag}"
+image_sha256=$("${script_dir}/get-image-digest.sh" "${image_full}" || echo "")
+if [ -n "${image_sha256}" ]; then
+  image_full="${image_full}@${image_sha256}"
+fi
+
+echo "Latest image from branch ${github_branch}: ${image_full}"
+
+echo "Updating image in ./images/cilium/Dockerfile"
+sed -i -E "s|(FROM ${image}:)(.*)(@sha256:[0-9a-z]*)( as cilium-envoy)|\1${image_tag}@${image_sha256}\4|" ./images/cilium/Dockerfile
+
+echo "Updating image in ./install/kubernetes/cilium/values.yaml.tmpl"
+# Using tr to workaround matching the multiline regex with sed
+# yq would change formatting: https://github.com/mikefarah/yq/issues/465
+# use of envoy.image.override (which would allow match in one line) isn't optimal either
+< ./install/kubernetes/cilium/values.yaml.tmpl tr '\n' '\f' |
+  sed -E "s|(# -- Envoy container image\..*tag: \")(v[0-9a-zA-Z\.-]*)(\")|\1${image_tag}\3|" |
+  sed -E "s|(# -- Envoy container image\..*digest: \")(sha256:[0-9a-z]*)(\")|\1${image_sha256}\3|" |
+  tr '\f' '\n' > ./install/kubernetes/cilium/values.yaml.tmpl_tmp &&
+  mv ./install/kubernetes/cilium/values.yaml.tmpl_tmp ./install/kubernetes/cilium/values.yaml.tmpl
+
+echo "Please don't forget to execute 'make -C Documentation update-helm-values && make -C install/kubernetes'"


### PR DESCRIPTION
**check**

This commit introduces a linter which checks for differences of the Cilium Envoy image version between the Cilium Dockerfile (embedded) and the Cilium Helm Chart (DaemonSet).

In addition, the linter gets added to the CI GH Action lint-images-base.

**update**

This commit introduces the script `update-cilium-envoy-image.sh` (and corresponding make target) which fetches the latest cilium-envoy image by getting the relevant data from its github repo.

It updates the cilium Dockerfile (embedded) and the Helm values.yaml.tmpl (DaemonSet).

-> This script is executed manually on demand