### PR TITLE
cilium-health: feat: responder server can listen on specific IPs

### DIFF
--- a/cilium-health/responder/main.go
+++ b/cilium-health/responder/main.go
@@ -31,7 +31,7 @@ func main() {
 	// Shutdown gracefully to halt server and remove pidfile
 	ctx, cancel := signal.NotifyContext(context.Background(), unix.SIGINT, unix.SIGHUP, unix.SIGTERM, unix.SIGQUIT)
 
-	srv := responder.NewServer(listen)
+	srv := responder.NewServer(fmt.Sprintf(":%d", listen))
 	defer srv.Shutdown()
 	go func() {
 		if err := srv.Serve(); !errors.Is(err, http.ErrServerClosed) {

--- a/pkg/health/probe/responder/responder.go
+++ b/pkg/health/probe/responder/responder.go
@@ -7,7 +7,6 @@ package responder
 // as this package typically runs in its own process
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 )
@@ -20,11 +19,11 @@ type Server struct {
 	httpServer http.Server
 }
 
-// NewServer creates a new server listening on the given port
-func NewServer(port int) *Server {
+// NewServer creates a new server listening on the given address
+func NewServer(addr string) *Server {
 	return &Server{
 		http.Server{
-			Addr:    fmt.Sprintf(":%d", port),
+			Addr:    addr,
 			Handler: http.HandlerFunc(serverRequests),
 		},
 	}


### PR DESCRIPTION
Now cilium-health's responder server listens on `0:4240`, it means at all interfaces and all IPs.
Which may cause the following error in cilium-agent log:
```
Failed to serve cilium-health API" error="listen tcp :4240: bind: address already in use" subsys=cilium-health-launcher
```

This PR adds the possibility to define specific IPs the responder server listens on.
A new command line option `--cluster-health-addrs` has been added as an extension of `--cluster-health-port`.