### PR TITLE
docs: Remove non-x86 restriction

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -81,18 +81,7 @@ copy-api:
 	@$(ECHO_GEN)_api
 	$(QUIET)cp -r ../api/. _api
 
-# $(HELM_DOCS_IMAGE), necessary to update the reference for Helm values,
-# attempts to run a Go binary compiled for x86_64. Skip the update on other
-# architectures by making update-helm-values an empty target, unless the user
-# passes a compatible image.
-HELM_VALUES_DEP := $(HELM_VALUES)
-ifneq ($(shell uname -m),x86_64)
-  ifeq ($(origin HELM_DOCS_IMAGE), file)
-    $(info Documentation: skipping update for the Helm reference (image needs x86_64))
-    HELM_VALUES_DEP :=
-  endif
-endif
-update-helm-values: $(HELM_VALUES_DEP) ## Update the Helm reference documentation.
+update-helm-values: $(HELM_VALUES) ## Update the Helm reference documentation.
 
 HELM_DOCS_ROOT_PATH := $(DOCKER_CTR_ROOT_DIR)
 HELM_DOCS_CHARTS_DIR := $(HELM_DOCS_ROOT_PATH)/install/kubernetes


### PR DESCRIPTION
Remove logic from Documentation/Makefile that skips building 'update-helm-values' on non-x86 platforms. This limitation is no longer needed as we use the helm toolbox image, which is available for multiple architectures.

Note to backporter: This change depends on #20236, which needs to be backported first.

Fixes: #20236

```release-note
Updating documentation helm values now works also on arm64.
```
