### PR TITLE
v1.13 backports 2023-05-12

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -543,6 +543,21 @@ ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 	ct_flip_tuple_dir4(tuple);
 }
 
+static __always_inline void
+ipv4_ct_tuple_swap_ports(struct ipv4_ct_tuple *tuple)
+{
+	__be16 tmp;
+
+	/* Conntrack code uses tuples that have source and destination ports in
+	 * the reversed order. Other code, such as BPF helpers and NAT, requires
+	 * normal tuples that match the actual packet contents. This function
+	 * converts between these two formats.
+	 */
+	tmp = tuple->sport;
+	tuple->sport = tuple->dport;
+	tuple->dport = tmp;
+}
+
 static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 						    int off,
 						    enum ct_dir dir __maybe_unused,

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -327,6 +327,21 @@ ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
 	ct_flip_tuple_dir6(tuple);
 }
 
+static __always_inline void
+ipv6_ct_tuple_swap_ports(struct ipv6_ct_tuple *tuple)
+{
+	__be16 tmp;
+
+	/* Conntrack code uses tuples that have source and destination ports in
+	 * the reversed order. Other code, such as BPF helpers and NAT, requires
+	 * normal tuples that match the actual packet contents. This function
+	 * converts between these two formats.
+	 */
+	tmp = tuple->sport;
+	tuple->sport = tuple->dport;
+	tuple->dport = tmp;
+}
+
 static __always_inline int
 __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ctx,
 	     int l4_off, int action, enum ct_dir dir, struct ct_state *ct_state,

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -375,13 +375,11 @@ out:
 	return ret;
 }
 
-/* Like an IPv6 version of ct_lazy_lookup4, but also assumes that the L4
- * protocol is a service protocol (SCTP, UDP or TCP).
- */
+/* An IPv6 version of ct_lazy_lookup4. */
 static __always_inline int
-ct_lb_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
-	      struct __ctx_buff *ctx, int l4_off, enum ct_dir dir,
-	      struct ct_state *ct_state, __u32 *monitor)
+ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
+		struct __ctx_buff *ctx, int l4_off, int action, enum ct_dir dir,
+		struct ct_state *ct_state, __u32 *monitor)
 {
 	/* The tuple is created in reverse order initially to find a
 	 * potential reverse flow. This is required because the RELATED
@@ -399,7 +397,7 @@ ct_lb_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
 	else
 		return DROP_CT_INVALID_HDR;
 
-	return __ct_lookup6(map, tuple, ctx, l4_off, ACTION_CREATE, dir,
+	return __ct_lookup6(map, tuple, ctx, l4_off, action, dir,
 			    ct_state, monitor);
 }
 

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -375,6 +375,9 @@ out:
 	return ret;
 }
 
+/* Like an IPv6 version of ct_lazy_lookup4, but also assumes that the L4
+ * protocol is a service protocol (SCTP, UDP or TCP).
+ */
 static __always_inline int
 ct_lb_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
 	      struct __ctx_buff *ctx, int l4_off, enum ct_dir dir,
@@ -714,15 +717,21 @@ out:
  * @arg dir		lookup direction
  * @arg ct_state	returned CT entry
  * @arg monitor		monitor feedback for trace aggregation
+ * @arg action          ACTION_CREATE or ACTION_UNSPEC for __ct_lookup
  *
- * This differs from ct_lookup4(), as here we expect that
- * - the CT tuple has its L4 ports populated,
- * - the L4 protocol is a SVC protocol (ie SCTP / UDP / TCP)
+ * This differs from ct_lookup4(), as here we expect that the CT tuple has its
+ * L4 ports populated.
+ *
+ * Note that certain ICMP types are not supported by this function (see cases
+ * where ct_extract_ports4 sets tuple->flags), because it overwrites
+ * tuple->flags, but this works well in LB and NAT flows that don't pass these
+ * ICMP types to ct_lazy_lookup4.
  */
 static __always_inline int
-ct_lb_lookup4(const void *map, struct ipv4_ct_tuple *tuple,
-	      struct __ctx_buff *ctx, int l4_off, bool has_l4_header,
-	      enum ct_dir dir, struct ct_state *ct_state, __u32 *monitor)
+ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple,
+		struct __ctx_buff *ctx, int l4_off, bool has_l4_header,
+		int action, enum ct_dir dir, struct ct_state *ct_state,
+		__u32 *monitor)
 {
 	/* The tuple is created in reverse order initially to find a
 	 * potential reverse flow. This is required because the RELATED
@@ -741,7 +750,7 @@ ct_lb_lookup4(const void *map, struct ipv4_ct_tuple *tuple,
 		return DROP_CT_INVALID_HDR;
 
 	return __ct_lookup4(map, tuple, ctx, l4_off, has_l4_header,
-			    ACTION_CREATE, dir, ct_state, monitor);
+			    action, dir, ct_state, monitor);
 }
 
 /* Offset must point to IPv4 header */

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1544,8 +1544,8 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 	if (unlikely(svc->count == 0))
 		return DROP_NO_SERVICE;
 
-	ret = ct_lb_lookup4(map, tuple, ctx, l4_off, has_l4_header, CT_SERVICE,
-			    state, &monitor);
+	ret = ct_lazy_lookup4(map, tuple, ctx, l4_off, has_l4_header, ACTION_CREATE,
+			      CT_SERVICE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -852,7 +852,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		return DROP_NO_SERVICE;
 
 	/* See lb4_local comments re svc endpoint lookup process */
-	ret = ct_lb_lookup6(map, tuple, ctx, l4_off, CT_SERVICE, state, &monitor);
+	ret = ct_lazy_lookup6(map, tuple, ctx, l4_off, ACTION_CREATE, CT_SERVICE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -29,7 +29,7 @@ enum  nat_dir {
 
 struct nat_entry {
 	__u64 created;
-	__u64 host_local;	/* Only single bit used. */
+	__u64 needs_ct;		/* Only single bit used. */
 	__u64 pad1;		/* Future use. */
 	__u64 pad2;		/* Future use. */
 };
@@ -236,8 +236,9 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 	rtuple.daddr = target->addr;
 
 	if (otuple->saddr == target->addr) {
-		ostate->common.host_local = 1;
-		rstate.common.host_local = ostate->common.host_local;
+		/* Host-local connection. */
+		ostate->common.needs_ct = 1;
+		rstate.common.needs_ct = ostate->common.needs_ct;
 	}
 
 #pragma unroll
@@ -277,7 +278,7 @@ static __always_inline int snat_v4_track_connection(struct __ctx_buff *ctx,
 	enum ct_dir where;
 	int ret;
 
-	if (state && state->common.host_local) {
+	if (state && state->common.needs_ct) {
 		needs_ct = true;
 #if defined(ENABLE_EGRESS_GATEWAY)
 	/* Track egress gateway connections, but only if they are related to a
@@ -1016,8 +1017,9 @@ static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 	rtuple.daddr = target->addr;
 
 	if (!ipv6_addrcmp(&otuple->saddr, &rtuple.daddr)) {
-		ostate->common.host_local = 1;
-		rstate.common.host_local = ostate->common.host_local;
+		/* Host-local connection. */
+		ostate->common.needs_ct = 1;
+		rstate.common.needs_ct = ostate->common.needs_ct;
 	}
 
 #pragma unroll
@@ -1057,7 +1059,7 @@ static __always_inline int snat_v6_track_connection(struct __ctx_buff *ctx,
 	enum ct_dir where;
 	int ret;
 
-	if (state && state->common.host_local) {
+	if (state && state->common.needs_ct) {
 		needs_ct = true;
 	} else if (!state && dir == NAT_DIR_EGRESS) {
 		if (!ipv6_addrcmp(&tuple->saddr, (void *)&target->addr))

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -241,6 +241,16 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 		rstate.common.needs_ct = ostate->common.needs_ct;
 	}
 
+#if defined(ENABLE_EGRESS_GATEWAY)
+	if (target->egress_gateway && !target->from_local_endpoint) {
+		/* Track established egress gateway connections to extend the
+		 * CT entry expiration timeout.
+		 */
+		ostate->common.needs_ct = 1;
+		rstate.common.needs_ct = ostate->common.needs_ct;
+	}
+#endif
+
 #pragma unroll
 	for (retries = 0; retries < SNAT_COLLISION_RETRIES; retries++) {
 		if (!snat_v4_lookup(&rtuple)) {
@@ -283,8 +293,11 @@ static __always_inline int snat_v4_track_connection(struct __ctx_buff *ctx,
 #if defined(ENABLE_EGRESS_GATEWAY)
 	/* Track egress gateway connections, but only if they are related to a
 	 * remote endpoint (if the endpoint is local then the connection is
-	 * already tracked). NAT_DIR_EGRESS is implied. Do ct_lookup4 also for
-	 * established connections to extend the expiration timeout.
+	 * already tracked). NAT_DIR_EGRESS is implied.
+	 * This check is only relevant for the first packet; the subsequent ones
+	 * will have state->common.needs_ct set, therefore, both egress and
+	 * ingress packets will trigger ct_lookup4 and extend the expiration
+	 * timeout.
 	 */
 	} else if (target->egress_gateway && !target->from_local_endpoint) {
 		needs_ct = true;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -364,10 +364,18 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       __u32 off,
 			       const struct ipv4_nat_target *target)
 {
+	struct ipv4_ct_tuple tuple_revsnat;
 	int ret;
 
 	*state = snat_v4_lookup(tuple);
-	ret = snat_v4_track_connection(ctx, tuple, *state, has_l4_header, ct_action,
+
+	memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
+	if (*state) {
+		tuple_revsnat.daddr = (*state)->to_daddr;
+		tuple_revsnat.dport = (*state)->to_dport;
+	}
+
+	ret = snat_v4_track_connection(ctx, &tuple_revsnat, *state, has_l4_header, ct_action,
 				       NAT_DIR_INGRESS, off, target);
 	if (ret < 0)
 		return ret;
@@ -1135,10 +1143,18 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       __u32 off,
 			       const struct ipv6_nat_target *target)
 {
+	struct ipv6_ct_tuple tuple_revsnat;
 	int ret;
 
 	*state = snat_v6_lookup(tuple);
-	ret = snat_v6_track_connection(ctx, tuple, *state, ct_action,
+
+	memcpy(&tuple_revsnat, tuple, sizeof(tuple_revsnat));
+	if (*state) {
+		ipv6_addr_copy(&tuple_revsnat.daddr, &(*state)->to_daddr);
+		tuple_revsnat.dport = (*state)->to_dport;
+	}
+
+	ret = snat_v6_track_connection(ctx, &tuple_revsnat, *state, ct_action,
 				       NAT_DIR_INGRESS, off, target);
 	if (ret < 0)
 		return ret;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1903,8 +1903,8 @@ int tail_nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-			    has_l4_header, CT_EGRESS, &ct_state, &monitor);
+	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
+			      has_l4_header, ACTION_CREATE, CT_EGRESS, &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	/* Maybe we can be a bit more selective about CT_REOPENED?
@@ -2290,8 +2290,8 @@ skip_service_lookup:
 	if (backend_local || !nodeport_uses_dsr4(&tuple)) {
 		struct ct_state ct_state = {};
 
-		ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-				    has_l4_header, CT_EGRESS, &ct_state, &monitor);
+		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
+				      ACTION_CREATE, CT_EGRESS, &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
 redo:
@@ -2371,8 +2371,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 					   is_defined(ENABLE_DSR)))
 		return CTX_ACT_OK;
 
-	ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-			    has_l4_header, CT_INGRESS, &ct_state, &trace->monitor);
+	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
+			      ACTION_CREATE, CT_INGRESS, &ct_state, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -2456,9 +2456,8 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __u32 *ifind
 
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
-	ret = ct_lb_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-			    has_l4_header, CT_INGRESS, &ct_state, &monitor);
-
+	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
+			      ACTION_CREATE, CT_INGRESS, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		reason = TRACE_REASON_CT_REPLY;
 		ret2 = lb4_rev_nat(ctx, l3_off, l4_off, &csum_off,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -605,8 +605,8 @@ int tail_nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
-			    CT_EGRESS, &ct_state, &monitor);
+	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+			      CT_EGRESS, &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	case CT_REOPENED:
@@ -1042,8 +1042,8 @@ skip_service_lookup:
 	if (backend_local || !nodeport_uses_dsr6(&tuple)) {
 		struct ct_state ct_state = {};
 
-		ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
-				    CT_EGRESS, &ct_state, &monitor);
+		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+				      CT_EGRESS, &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
 redo:
@@ -1132,8 +1132,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 					   is_defined(ENABLE_DSR)))
 		return CTX_ACT_OK;
 
-	ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
-			    &ct_state, &trace->monitor);
+	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+			      CT_INGRESS, &ct_state, &trace->monitor);
 
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
@@ -1195,8 +1195,8 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __u32 *ifind
 
 	csum_l4_offset_and_flags(tuple.nexthdr, &csum_off);
 
-	ret = ct_lb_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
-			    &ct_state, &monitor);
+	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+			      CT_INGRESS, &ct_state, &monitor);
 
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		ret2 = lb6_rev_nat(ctx, l4_off, &csum_off, ct_state.rev_nat_index,

--- a/bpf/tests/nat_test.c
+++ b/bpf/tests/nat_test.c
@@ -105,8 +105,6 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 
 	struct __ctx_buff ctx_buff;
 	struct ipv4_ct_tuple tuple;
-	struct ipv4_nat_entry state;
-	struct ipv4_nat_target target;
 
 	/* If there is an error in ct_lazy_lookup4, it will return a negative value. We */
 	/* can simply assume it to be -1 because the actually value does not matter. */
@@ -115,8 +113,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return exactly the same value which means */
 	/* an error occurs when snat_v4_track_connection is looking for the ipv4_ct_tuple. */
 	TEST("return -1 on error", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
-					     NAT_DIR_EGRESS, 0, &target) != -1) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0) != -1) {
 			test_fail();
 		}
 	});
@@ -128,8 +126,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return 0 which means snat_v4_track_connection */
 	/* successfully tracks ipv4_ct_tuple. */
 	TEST("return 0 on track", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
-					     NAT_DIR_EGRESS, 0, &target) != 0) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0) != 0) {
 			test_fail();
 		}
 	});
@@ -144,8 +142,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return that value which means an error occurs */
 	/* when snat_v4_track_connection is trying to create the ipv4_ct_tuple. */
 	TEST("return -1 on create error", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
-					     NAT_DIR_EGRESS, 0, &target) != -1) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0) != -1) {
 			test_fail();
 		}
 	});
@@ -159,8 +157,8 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	/* So snat_v4_track_connection will return 0 which means snat_v4_track_connection */
 	/* successfully creates the ipv4_ct_tuple. */
 	TEST("return 0 on create success", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
-					     NAT_DIR_EGRESS, 0, &target) != 0) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0) != 0) {
 			test_fail();
 		}
 	});

--- a/bpf/tests/nat_test.c
+++ b/bpf/tests/nat_test.c
@@ -45,7 +45,7 @@
 
 #include "lib/conntrack.h"
 
-#define ct_lookup4 mock_ct_lookup4
+#define ct_lazy_lookup4 mock_ct_lazy_lookup4
 #define ct_create4 mock_ct_create4
 
 #include "lib/common.h"
@@ -54,16 +54,18 @@
 
 #define __LIB_CONNTRACK_H_
 
-static int mock_ct_lookup4_response = -1;
-static __always_inline int mock_ct_lookup4(__maybe_unused const void *map,
-					   __maybe_unused struct ipv4_ct_tuple *tuple,
-					   __maybe_unused struct __ctx_buff *ctx,
-					   __maybe_unused int off,
-					   __maybe_unused enum ct_dir dir,
-					   __maybe_unused struct ct_state *ct_state,
-					   __maybe_unused __u32 *monitor)
+static int mock_ct_lazy_lookup4_response = -1;
+static __always_inline int mock_ct_lazy_lookup4(__maybe_unused const void *map,
+						__maybe_unused struct ipv4_ct_tuple *tuple,
+						__maybe_unused struct __ctx_buff *ctx,
+						__maybe_unused int off,
+						__maybe_unused bool has_l4_header,
+						__maybe_unused int action,
+						__maybe_unused enum ct_dir dir,
+						__maybe_unused struct ct_state *ct_state,
+						__maybe_unused __u32 *monitor)
 {
-	return mock_ct_lookup4_response;
+	return mock_ct_lazy_lookup4_response;
 }
 
 static int mock_ct_create4_response = 1;
@@ -106,59 +108,59 @@ int bpf_test(__maybe_unused struct xdp_md *ctx)
 	struct ipv4_nat_entry state;
 	struct ipv4_nat_target target;
 
-	/* If there is an error in ct_lookup4, it will return a negative value. We */
+	/* If there is an error in ct_lazy_lookup4, it will return a negative value. We */
 	/* can simply assume it to be -1 because the actually value does not matter. */
-	mock_ct_lookup4_response = -1;
+	mock_ct_lazy_lookup4_response = -1;
 
 	/* So snat_v4_track_connection will return exactly the same value which means */
 	/* an error occurs when snat_v4_track_connection is looking for the ipv4_ct_tuple. */
 	TEST("return -1 on error", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS, 0, &target)
-		    != -1){
+		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0, &target) != -1) {
 			test_fail();
 		}
 	});
 
-	/* If ct_lookup4 finds an entry, it will return a positive value. We can */
+	/* If ct_lazy_lookup4 finds an entry, it will return a positive value. We can */
 	/* also assume it to be 1 because the actually value does not matter. */
-	mock_ct_lookup4_response = 1;
+	mock_ct_lazy_lookup4_response = 1;
 
 	/* So snat_v4_track_connection will return 0 which means snat_v4_track_connection */
 	/* successfully tracks ipv4_ct_tuple. */
 	TEST("return 0 on track", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS, 0, &target)
-		    != 0){
+		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0, &target) != 0) {
 			test_fail();
 		}
 	});
 
-	/* If ct_lookup4 does not find an entry, it will return CT_NEW which equals */
+	/* If ct_lazy_lookup4 does not find an entry, it will return CT_NEW which equals */
 	/* to zero. Then if ct_create4 fails creating the entry, it will return a */
 	/* negative value which is assumed as -1 since the actual value does not */
 	/* matter. */
-	mock_ct_lookup4_response = CT_NEW;
+	mock_ct_lazy_lookup4_response = CT_NEW;
 	mock_ct_create4_response = -1;
 
 	/* So snat_v4_track_connection will return that value which means an error occurs */
 	/* when snat_v4_track_connection is trying to create the ipv4_ct_tuple. */
 	TEST("return -1 on create error", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS, 0, &target)
-		    != -1){
+		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0, &target) != -1) {
 			test_fail();
 		}
 	});
 
-	/* If ct_lookup4 does not find an entry, it will return CT_NEW which equals */
+	/* If ct_lazy_lookup4 does not find an entry, it will return CT_NEW which equals */
 	/* to zero. Then if ct_create4 successfully creates the entry, it will */
 	/* return 0. */
-	mock_ct_lookup4_response = CT_NEW;
+	mock_ct_lazy_lookup4_response = CT_NEW;
 	mock_ct_create4_response = 0;
 
 	/* So snat_v4_track_connection will return 0 which means snat_v4_track_connection */
 	/* successfully creates the ipv4_ct_tuple. */
 	TEST("return 0 on create success", {
-		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, NAT_DIR_EGRESS, 0, &target)
-		    != 0) {
+		if (snat_v4_track_connection(&ctx_buff, &tuple, &state, true, ACTION_CREATE,
+					     NAT_DIR_EGRESS, 0, &target) != 0) {
 			test_fail();
 		}
 	});

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -195,15 +195,8 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, boo
 		test_fatal("bad TX packet count (expected %u, actual %u)",
 			   tx_packets, ct_entry->tx_packets)
 	if (ct_entry->rx_packets != rx_packets)
-#ifdef ISSUE_25110_FIXED
-		/* This test fails until this issue is fixed:
-		 * https://github.com/cilium/cilium/issues/25110
-		 */
 		test_fatal("bad RX packet count (expected %u, actual %u)",
 			   rx_packets, ct_entry->rx_packets)
-#else
-		;
-#endif
 
 	tuple.saddr = CLIENT_IP;
 	tuple.daddr = EXTERNAL_SVC_IP;

--- a/cilium/cmd/bpf_nat_list_test.go
+++ b/cilium/cmd/bpf_nat_list_test.go
@@ -46,16 +46,16 @@ var (
 		},
 	}
 	natValue4 = nat.NatEntry4{
-		Created:   12345,
-		HostLocal: 6789,
-		Addr:      types.IPv4{10, 10, 10, 3},
-		Port:      byteorder.HostToNetwork16(53),
+		Created: 12345,
+		NeedsCT: 6789,
+		Addr:    types.IPv4{10, 10, 10, 3},
+		Port:    byteorder.HostToNetwork16(53),
 	}
 	natValue6 = nat.NatEntry6{
-		Created:   12345,
-		HostLocal: 6789,
-		Addr:      types.IPv6{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53},
-		Port:      byteorder.HostToNetwork16(53),
+		Created: 12345,
+		NeedsCT: 6789,
+		Addr:    types.IPv6{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53},
+		Port:    byteorder.HostToNetwork16(53),
 	}
 )
 

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -151,10 +151,10 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 		},
 	}
 	natVal := &nat.NatEntry4{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv4{192, 168, 61, 11},
-		Port:      0x3195,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{192, 168, 61, 11},
+		Port:    0x3195,
 	}
 	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
 		unsafe.Pointer(natVal), 0)
@@ -172,10 +172,10 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 		},
 	}
 	natVal = &nat.NatEntry4{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv4{192, 168, 61, 11},
-		Port:      0x3195,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{192, 168, 61, 11},
+		Port:    0x3195,
 	}
 	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
 		unsafe.Pointer(natVal), 0)
@@ -287,10 +287,10 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		},
 	}
 	natVal := &nat.NatEntry4{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv4{10, 23, 32, 45},
-		Port:      0x51d6,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{10, 23, 32, 45},
+		Port:    0x51d6,
 	}
 	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
 		unsafe.Pointer(natVal), 0)
@@ -308,10 +308,10 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		},
 	}
 	natVal = &nat.NatEntry4{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv4{10, 23, 32, 45},
-		Port:      0x50d6,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{10, 23, 32, 45},
+		Port:    0x50d6,
 	}
 	err = bpf.UpdateElement(natMap.Map.GetFd(), natMap.Map.Name(), unsafe.Pointer(natKey),
 		unsafe.Pointer(natVal), 0)
@@ -543,10 +543,10 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		},
 	}
 	natValV6 := &nat.NatEntry6{
-		Created:   37400,
-		HostLocal: 1,
-		Addr:      types.IPv6{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
-		Port:      0x51d6,
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv6{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2},
+		Port:    0x51d6,
 	}
 	err = bpf.UpdateElement(natMapV6.Map.GetFd(), natMapV6.Map.Name(), unsafe.Pointer(natKeyV6),
 		unsafe.Pointer(natValV6), 0)

--- a/pkg/maps/nat/ipv4.go
+++ b/pkg/maps/nat/ipv4.go
@@ -16,12 +16,12 @@ import (
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
 type NatEntry4 struct {
-	Created   uint64     `align:"created"`
-	HostLocal uint64     `align:"host_local"`
-	Pad1      uint64     `align:"pad1"`
-	Pad2      uint64     `align:"pad2"`
-	Addr      types.IPv4 `align:"to_saddr"`
-	Port      uint16     `align:"to_sport"`
+	Created uint64     `align:"created"`
+	NeedsCT uint64     `align:"needs_ct"`
+	Pad1    uint64     `align:"pad1"`
+	Pad2    uint64     `align:"pad2"`
+	Addr    types.IPv4 `align:"to_saddr"`
+	Port    uint16     `align:"to_sport"`
 }
 
 // SizeofNatEntry4 is the size of the NatEntry4 type in bytes.
@@ -32,11 +32,11 @@ func (n *NatEntry4) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(n) }
 
 // String returns the readable format.
 func (n *NatEntry4) String() string {
-	return fmt.Sprintf("Addr=%s Port=%d Created=%d HostLocal=%d\n",
+	return fmt.Sprintf("Addr=%s Port=%d Created=%d NeedsCT=%d\n",
 		n.Addr,
 		n.Port,
 		n.Created,
-		n.HostLocal)
+		n.NeedsCT)
 }
 
 // Dump dumps NAT entry to string.
@@ -48,12 +48,12 @@ func (n *NatEntry4) Dump(key NatKey, start uint64) string {
 	} else {
 		which = "SRC"
 	}
-	return fmt.Sprintf("XLATE_%s %s:%d Created=%s HostLocal=%d\n",
+	return fmt.Sprintf("XLATE_%s %s:%d Created=%s NeedsCT=%d\n",
 		which,
 		n.Addr,
 		n.Port,
 		NatDumpCreated(start, n.Created),
-		n.HostLocal)
+		n.NeedsCT)
 }
 
 // ToHost converts NatEntry4 ports to host byte order.

--- a/pkg/maps/nat/ipv6.go
+++ b/pkg/maps/nat/ipv6.go
@@ -16,12 +16,12 @@ import (
 // +k8s:deepcopy-gen=true
 // +k8s:deepcopy-gen:interfaces=github.com/cilium/cilium/pkg/bpf.MapValue
 type NatEntry6 struct {
-	Created   uint64     `align:"created"`
-	HostLocal uint64     `align:"host_local"`
-	Pad1      uint64     `align:"pad1"`
-	Pad2      uint64     `align:"pad2"`
-	Addr      types.IPv6 `align:"to_saddr"`
-	Port      uint16     `align:"to_sport"`
+	Created uint64     `align:"created"`
+	NeedsCT uint64     `align:"needs_ct"`
+	Pad1    uint64     `align:"pad1"`
+	Pad2    uint64     `align:"pad2"`
+	Addr    types.IPv6 `align:"to_saddr"`
+	Port    uint16     `align:"to_sport"`
 }
 
 // SizeofNatEntry6 is the size of the NatEntry6 type in bytes.
@@ -32,11 +32,11 @@ func (n *NatEntry6) GetValuePtr() unsafe.Pointer { return unsafe.Pointer(n) }
 
 // String returns the readable format.
 func (n *NatEntry6) String() string {
-	return fmt.Sprintf("Addr=%s Port=%d Created=%d HostLocal=%d\n",
+	return fmt.Sprintf("Addr=%s Port=%d Created=%d NeedsCT=%d\n",
 		n.Addr,
 		n.Port,
 		n.Created,
-		n.HostLocal)
+		n.NeedsCT)
 }
 
 // Dump dumps NAT entry to string.
@@ -48,12 +48,12 @@ func (n *NatEntry6) Dump(key NatKey, start uint64) string {
 	} else {
 		which = "SRC"
 	}
-	return fmt.Sprintf("XLATE_%s [%s]:%d Created=%s HostLocal=%d\n",
+	return fmt.Sprintf("XLATE_%s [%s]:%d Created=%s NeedsCT=%d\n",
 		which,
 		n.Addr,
 		n.Port,
 		NatDumpCreated(start, n.Created),
-		n.HostLocal)
+		n.NeedsCT)
 }
 
 // ToHost converts NatEntry4 ports to host byte order.


### PR DESCRIPTION
- [ ] #25112 -- bpf: Track reply packets of egress gateway and SNATed host-local connections (@gentoo-root)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25112; do contrib/backporting/set-labels.py $pr done 1.13; done
```