### PR TITLE
Issue #22527 - bpf_lxc.c: do drop notifications at drop source

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -195,6 +195,38 @@ select_ct_map4(struct __ctx_buff *ctx __maybe_unused, int dir __maybe_unused,
 }
 #endif
 
+#if defined ENABLE_IPV4 || defined ENABLE_IPV6
+static __always_inline int drop_for_direction(struct __ctx_buff *ctx,
+					      enum ct_dir dir, __u32 reason)
+{
+	__u32 dst = 0;
+	__u32 dst_id = 0;
+	enum metric_dir m_dir = METRIC_EGRESS;
+	__u32 src_label = 0;
+
+	switch (dir) {
+	case CT_EGRESS:
+		dst_id = 0;
+		dst = 0;
+		src_label = SECLABEL;
+		m_dir = METRIC_EGRESS;
+		break;
+	case CT_INGRESS:
+		dst = SECLABEL;
+		dst_id = LXC_ID;
+		src_label = ctx_load_meta(ctx, CB_SRC_LABEL);
+		m_dir = METRIC_INGRESS;
+		break;
+	/* ingress/egress only for now */
+	default:
+		__throw_build_bug();
+	}
+
+	return send_drop_notify(ctx, src_label, dst, dst_id, reason,
+				CTX_ACT_DROP, m_dir);
+}
+#endif /* ENABLE_IPV4 || ENABLE_IPV6 */
+
 #define TAIL_CT_LOOKUP4(ID, NAME, DIR, CONDITION, TARGET_ID, TARGET_NAME)	\
 declare_tailcall_if(CONDITION, ID)						\
 int NAME(struct __ctx_buff *ctx)						\
@@ -206,13 +238,13 @@ int NAME(struct __ctx_buff *ctx)						\
 	void *data, *data_end;							\
 	struct iphdr *ip4;							\
 	__u32 zero = 0;								\
-	void *map;									\
+	void *map;								\
 										\
 	ct_state = (struct ct_state *)&ct_buffer.ct_state;			\
 	tuple = (struct ipv4_ct_tuple *)&ct_buffer.tuple;			\
 										\
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))			\
-		return DROP_INVALID;						\
+		return drop_for_direction(ctx, DIR, DROP_INVALID);		\
 										\
 	tuple->nexthdr = ip4->protocol;						\
 	tuple->daddr = ip4->daddr;						\
@@ -220,17 +252,16 @@ int NAME(struct __ctx_buff *ctx)						\
 										\
 	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);					\
 										\
-	map = select_ct_map4(ctx, DIR, tuple);				\
-	if (!map)									\
-		return DROP_CT_NO_MAP_FOUND;					\
-											\
-	ct_buffer.ret = ct_lookup4(map, tuple, ctx, l4_off,		\
+	map = select_ct_map4(ctx, DIR, tuple);					\
+	if (!map)								\
+		return drop_for_direction(ctx, DIR, DROP_CT_NO_MAP_FOUND);	\
+										\
+	ct_buffer.ret = ct_lookup4(map, tuple, ctx, l4_off,			\
 				   DIR, ct_state, &ct_buffer.monitor);		\
 	if (ct_buffer.ret < 0)							\
-		return ct_buffer.ret;						\
-										\
+		return drop_for_direction(ctx, DIR, ct_buffer.ret);		\
 	if (map_update_elem(&CT_TAIL_CALL_BUFFER4, &zero, &ct_buffer, 0) < 0)	\
-		return DROP_INVALID_TC_BUFFER;					\
+		return drop_for_direction(ctx, DIR, DROP_INVALID_TC_BUFFER);	\
 										\
 	invoke_tailcall_if(CONDITION, TARGET_ID, TARGET_NAME);			\
 	return ret;								\
@@ -252,7 +283,7 @@ int NAME(struct __ctx_buff *ctx)						\
 	tuple = (struct ipv6_ct_tuple *)&ct_buffer.tuple;			\
 										\
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))			\
-		return DROP_INVALID;						\
+		return drop_for_direction(ctx, DIR, DROP_INVALID);		\
 										\
 	tuple->nexthdr = ip6->nexthdr;						\
 	ipv6_addr_copy(&tuple->daddr, (union v6addr *)&ip6->daddr);		\
@@ -267,10 +298,11 @@ int NAME(struct __ctx_buff *ctx)						\
 	ct_buffer.ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, l4_off,	\
 				   DIR, ct_state, &ct_buffer.monitor);		\
 	if (ct_buffer.ret < 0)							\
-		return ct_buffer.ret;						\
+		return drop_for_direction(ctx, DIR, ct_buffer.ret);		\
 										\
 	if (map_update_elem(&CT_TAIL_CALL_BUFFER6, &zero, &ct_buffer, 0) < 0)	\
-		return DROP_INVALID_TC_BUFFER;					\
+		return drop_for_direction(ctx, DIR,				\
+			DROP_INVALID_TC_BUFFER);				\
 										\
 	invoke_tailcall_if(CONDITION, TARGET_ID, TARGET_NAME);			\
 	return ret;								\


### PR DESCRIPTION
Fixes: #22527


#22527 points out that there may be some corner cases where packet drops are not properly logged.

This is largely possible because a macro-defined func is reused in several places, and `send_drop_notify` is assumed to be deferred up the chain - but not all parents would actually invoke it, and by definition it seems clearer/less error prone to always explicitly issue drop notification at the source, where the drop is decided.

This is a smidge more verbose, but it avoids the problem of bad assumptions or hard-to-catch mistakes causing missing drop notifications.


~Additionally - I might be missing something - but I couldn't see that the macro expansions of `tail_ipv4_ct_ingress`/`tail_ipv6_ct_ingress` actually ever get invoked? Am I missing something there?~ was missing something

(I couldn't find any formal C style guidelines declared for this repo, so if I'm violating some understood assumption or doing something very dumb, please comment)

```release-note
Fix missing drop notifications on conntrack lookup failures when IPv4 and IPv6 are both enabled or socket-level load balancing is disabled.
```


