### PR TITLE
Fix external-contribution-label workflow renovate tag

### DIFF
--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -33,7 +33,7 @@ jobs:
         # permissions.
         if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' }}
         id: get_token
-        uses: cilium/actions-app-token@350a14155dd9be79227f081310f4d77fdf792e76 # v1.0.0
+        uses: cilium/actions-app-token@350a14155dd9be79227f081310f4d77fdf792e76 # v0.21.0
         with:
           APP_PEM: ${{ secrets.CHECK_TEAM_ORG_PEM }}
           APP_ID: ${{ secrets.CHECK_TEAM_ORG_APP_ID }}


### PR DESCRIPTION
Noticed this was a tag that doesn't exist and renovate is complaining about the workflow in the dependency dashboard https://github.com/cilium/cilium/issues/22100