### PR TITLE
Update push-chart workflow concurrency group

### DIFF
--- a/.github/workflows/push-chart-ci.yaml
+++ b/.github/workflows/push-chart-ci.yaml
@@ -29,7 +29,11 @@ permissions:
   statuses: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
+  group: |
+    ${{ github.workflow }}-${{ github.event_name }}-${{
+      (github.event_name == 'workflow_dispatch' && inputs.checkout_ref) ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha)
+    }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
I think we're seeing unintended cancellations of this workflow because it's a workflow_run event in most cases and github.event.after might not be working as we expect.

First, add the event name into the concurrency group and then use a different ref based on the event type based on the git SHA the image chart will use for the image tags. This ensures we'll get one build for each image build but if we re-run the same job with the same parameters it'll cancel any previous invocations with for the same ref and event type.