### PR TITLE
docs: Update gateway-api version to v0.6.1

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -10,8 +10,8 @@
 Gateway API Support
 *******************
 
-Cilium supports Gateway API v0.5.1 for below resources, all the Core conformance
-tests, plus the ReferenceGrant extended tests, are passed.
+Cilium supports Gateway API v0.6.1 for below resources, all the Core conformance
+tests are passed.
 
 - `GatewayClass <https://gateway-api.sigs.k8s.io/api-types/gatewayclass/>`_
 - `Gateway <https://gateway-api.sigs.k8s.io/api-types/gateway/>`_
@@ -33,4 +33,4 @@ Cilium's Gateway API features:
    http
    https
 
-More examples can be found `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v0.5.1/examples/v1beta1>`_.
+More examples can be found `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v0.6.1/examples/standard>`_.

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -327,7 +327,8 @@ Annotations:
 * Egress Gateway policies now drop matching traffic when no
   gateway nodes can be found. Previously, traffic would be allowed without
   being rerouted towards an Egress Gateway.
-
+* If Gateway API feature is enabled, please upgrade related CRDs to v0.6.x. This is
+  mainly for ReferenceGrant resource version change (i.e. from v1alpha2 to v1beta1).
 
 Removed Options
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
After PR #22680, the minimum Gateway API supported version is v0.6.x. The older version will not work due to changes in the API version of CRDs.

Relates: #22680
Fixes: #25377
