### PR TITLE
bpf: Don't encrypt on path `hostns -> remote pod`

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -372,15 +372,6 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		/* See IPv4 comment. */
 		return DROP_UNROUTABLE;
 	}
-
-#ifdef ENABLE_IPSEC
-	if (info->key && info->tunnel_endpoint) {
-		__u8 key = get_min_encrypt_key(info->key);
-
-		set_encrypt_key_meta(ctx, key, info->node_id);
-		set_identity_meta(ctx, secctx);
-	}
-#endif
 	return CTX_ACT_OK;
 }
 
@@ -800,15 +791,6 @@ skip_vtep:
 		 */
 		return DROP_UNROUTABLE;
 	}
-
-#ifdef ENABLE_IPSEC
-	if (info->key && info->tunnel_endpoint) {
-		__u8 key = get_min_encrypt_key(info->key);
-
-		set_encrypt_key_meta(ctx, key, info->node_id);
-		set_identity_meta(ctx, secctx);
-	}
-#endif
 	return CTX_ACT_OK;
 }
 

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -62,12 +62,6 @@ set_encrypt_key_mark(struct __sk_buff *ctx, __u8 key, __u32 node_id)
 	ctx->mark = or_encrypt_key(key) | node_id << 16;
 }
 
-static __always_inline __maybe_unused void
-set_encrypt_key_meta(struct __sk_buff *ctx, __u8 key, __u32 node_id)
-{
-	ctx->cb[CB_ENCRYPT_MAGIC] = or_encrypt_key(key) | node_id << 16;
-}
-
 /**
  * set_cluster_id_mark - sets the cluster_id mark.
  */

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -39,12 +39,6 @@ set_encrypt_key_mark(struct xdp_md *ctx __maybe_unused, __u8 key __maybe_unused,
 }
 
 static __always_inline __maybe_unused void
-set_encrypt_key_meta(struct xdp_md *ctx __maybe_unused, __u8 key __maybe_unused,
-		     __u32 node_id __maybe_unused)
-{
-}
-
-static __always_inline __maybe_unused void
 ctx_set_cluster_id_mark(struct xdp_md *ctx __maybe_unused, __u32 cluster_id __maybe_unused)
 {
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -343,13 +343,12 @@ func (m *manager) nodeAddressHasTunnelIP(address nodeTypes.Address) bool {
 }
 
 func (m *manager) nodeAddressHasEncryptKey(address nodeTypes.Address) bool {
-	return (m.conf.NodeEncryptionEnabled() ||
-		// If we are doing encryption, but not node based encryption, then do not
-		// add a key to the nodeIPs so that we avoid a trip through stack and attempting
-		// to encrypt something we know does not have an encryption policy installed
-		// in the datapath. By setting key=0 and tunnelIP this will result in traffic
-		// being sent unencrypted over overlay device.
-		(address.Type != addressing.NodeExternalIP && address.Type != addressing.NodeInternalIP)) &&
+	// If we are doing encryption, but not node based encryption, then do not
+	// add a key to the nodeIPs so that we avoid a trip through stack and attempting
+	// to encrypt something we know does not have an encryption policy installed
+	// in the datapath. By setting key=0 and tunnelIP this will result in traffic
+	// being sent unencrypted over overlay device.
+	return m.conf.NodeEncryptionEnabled() &&
 		// Also ignore any remote node's key if the local node opted to not perform
 		// node-to-node encryption
 		!node.GetOptOutNodeEncryption()


### PR DESCRIPTION
In pod-to-pod encryption with IPsec and tunneling, Cilium currently encrypts traffic on the path `hostns -> remote pod` even though traffic is in plain-text on the path `remote pod -> hostns`. When using native routing, neither of those paths is encrypted because traffic from the hostns doesn't go through the bpf_host BPF program.

Cilium's Transparent Encryption with IPsec aims at encrypting pod-to-pod traffic. It is therefore unclear why we are encrypting traffic from the hostns. The simple fact that only one direction of the connection is encrypted begs the question of its usefulness. It's possible that this traffic was encrypted by mistake: some of this logic is necessary for node-to-node encryption with IPsec (not supported anymore) and pod-to-pod encryption may have been somewhat simplified to encrypt `*-to-pod` traffic.

Encrypting traffic from the hostns nevertheless creates several issues. First, this situation creates a path asymmetry between the forward and reply paths of `hostns<>remote pod` connections. Path asymmetry issues are well known to be a source of bugs, from of `--ctstate INVALID -j DROP` iptables rules to NAT issues.

Second, Gray recently uncovered a separate bug which, when combined with this encryption from hostns, can prevent Cilium from starting. That separate bug is still being investigated but it seems to cause the reload of bpf_host to depend on Cilium connecting to etcd in a clustermesh context. If this etcd is a remote pod, Cilium connects to it on hostns -> remote pod path. The bpf_host program being unloaded[1], it fails. We end up in a cyclic dependency: bpf_host requires connectivity to etcd, connectivity to etcd requires bpf_host.

This pull request therefore removes encryption with IPsec for the path `hostns -> remote pod` when using tunneling (already unencrypted when using native routing).

1 - More specifically, in Gray's case, the bpf_host program is already loaded, but it needs to be reloaded because the IPsec XFRM  config changed. Without this reload, encryption fails.

```release-note
Fix path asymmetry when using pod-to-pod encryption with IPsec and tunnel mode.
```