### PR TITLE
Slim down Node handler interface

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -2002,7 +2002,7 @@ func (d *Daemon) instantiateAPI(swaggerSpec *server.Spec) *restapi.CiliumAPIAPI 
 	restAPI.PolicyGetIPHandler = NewGetIPHandler(d)
 
 	// /node/ids
-	restAPI.DaemonGetNodeIdsHandler = NewGetNodeIDsHandler(d.datapath.Node())
+	restAPI.DaemonGetNodeIdsHandler = NewGetNodeIDsHandler(d.datapath.NodeIDs())
 
 	// /bgp/peers
 	restAPI.BgpGetBgpPeersHandler = NewGetBGPHandler(d.bgpControlPlaneController)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1850,16 +1850,16 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 	}
 
 	if option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
-		if !d.datapath.Node().NodeNeighDiscoveryEnabled() {
+		if !d.datapath.NodeNeighbors().NodeNeighDiscoveryEnabled() {
 			// Remove all non-GC'ed neighbor entries that might have previously set
 			// by a Cilium instance.
-			d.datapath.Node().NodeCleanNeighbors(false)
+			d.datapath.NodeNeighbors().NodeCleanNeighbors(false)
 		} else {
 			// If we came from an agent upgrade, migrate entries.
-			d.datapath.Node().NodeCleanNeighbors(true)
+			d.datapath.NodeNeighbors().NodeCleanNeighbors(true)
 			// Start periodical refresh of the neighbor table from the agent if needed.
 			if option.Config.ARPPingRefreshPeriod != 0 && !option.Config.ARPPingKernelManaged {
-				d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.Node())
+				d.nodeDiscovery.Manager.StartNeighborRefresh(d.datapath.NodeNeighbors())
 			}
 		}
 	}

--- a/daemon/cmd/node_ids.go
+++ b/daemon/cmd/node_ids.go
@@ -11,14 +11,14 @@ import (
 )
 
 type getNodeIDHandler struct {
-	nodeHandler datapath.NodeHandler
+	nodeIDHandler datapath.NodeIDHandler
 }
 
-func NewGetNodeIDsHandler(h datapath.NodeHandler) GetNodeIdsHandler {
-	return &getNodeIDHandler{nodeHandler: h}
+func NewGetNodeIDsHandler(h datapath.NodeIDHandler) GetNodeIdsHandler {
+	return &getNodeIDHandler{nodeIDHandler: h}
 }
 
 func (h *getNodeIDHandler) Handle(_ GetNodeIdsParams) middleware.Responder {
-	dump := h.nodeHandler.DumpNodeIDs()
+	dump := h.nodeIDHandler.DumpNodeIDs()
 	return NewGetNodeIdsOK().WithPayload(dump)
 }

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -116,7 +116,7 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 		IdentityAllocator: idAlloc,
 		PolicyHandler:     iao.policy.GetSelectorCache(),
 		DatapathHandler:   params.EndpointManager,
-		NodeHandler:       params.Datapath.Node(),
+		NodeIDHandler:     params.Datapath.NodeIDs(),
 		CacheStatus:       params.CacheStatus,
 	})
 	idAlloc.ipcache = ipc

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"net"
 	"strings"
 	"time"
 
@@ -513,26 +512,6 @@ func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeT
 }
 
 func (c *clusterNodesClient) NodeCleanNeighbors(migrateOnly bool) {
-	// no-op
-	return
-}
-
-func (c *clusterNodesClient) AllocateNodeID(_ net.IP) uint16 {
-	// no-op
-	return 0
-}
-
-func (c *clusterNodesClient) GetNodeIP(_ uint16) string {
-	// no-op
-	return ""
-}
-
-func (c *clusterNodesClient) DumpNodeIDs() []*models.NodeID {
-	// no-op
-	return nil
-}
-
-func (c *clusterNodesClient) RestoreNodeIDs() {
 	// no-op
 	return
 }

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -501,21 +501,6 @@ func (c *clusterNodesClient) NodeConfigurationChanged(config datapath.LocalNodeC
 	return nil
 }
 
-func (c *clusterNodesClient) NodeNeighDiscoveryEnabled() bool {
-	// no-op
-	return false
-}
-
-func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
-	// no-op
-	return
-}
-
-func (c *clusterNodesClient) NodeCleanNeighbors(migrateOnly bool) {
-	// no-op
-	return
-}
-
 func (h *getNodes) cleanupClients() {
 	past := time.Now().Add(-clientGCTimeout)
 	for k, v := range h.clients {

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -40,8 +40,8 @@ var Cell = cell.Module(
 		newDatapath,
 	),
 
-	cell.Provide(func(dp types.Datapath) ipcache.NodeHandler {
-		return dp.Node()
+	cell.Provide(func(dp types.Datapath) ipcache.NodeIDHandler {
+		return dp.NodeIDs()
 	}),
 )
 
@@ -96,7 +96,7 @@ func newDatapath(params datapathParams) types.Datapath {
 
 	params.LC.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
-			datapath.Node().RestoreNodeIDs()
+			datapath.NodeIDs().RestoreNodeIDs()
 			return nil
 		},
 	})

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -36,6 +36,10 @@ func (f *FakeDatapath) Node() datapath.NodeHandler {
 	return f.node
 }
 
+func (f *FakeDatapath) NodeIDs() datapath.NodeIDHandler {
+	return f.node
+}
+
 func (f *FakeDatapath) FakeNode() *FakeNodeHandler {
 	return f.node
 }

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -40,6 +40,10 @@ func (f *FakeDatapath) NodeIDs() datapath.NodeIDHandler {
 	return f.node
 }
 
+func (f *FakeDatapath) NodeNeighbors() datapath.NodeNeighbors {
+	return f.node
+}
+
 func (f *FakeDatapath) FakeNode() *FakeNodeHandler {
 	return f.node
 }

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -22,7 +22,7 @@ type DatapathConfiguration struct {
 type linuxDatapath struct {
 	datapath.ConfigWriter
 	datapath.IptablesManager
-	node           datapath.NodeHandler
+	node           *linuxNodeHandler
 	nodeAddressing datapath.NodeAddressing
 	config         DatapathConfiguration
 	loader         *loader.Loader
@@ -48,6 +48,10 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 
 // Node returns the handler for node events
 func (l *linuxDatapath) Node() datapath.NodeHandler {
+	return l.node
+}
+
+func (l *linuxDatapath) NodeIDs() datapath.NodeIDHandler {
 	return l.node
 }
 

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -55,6 +55,10 @@ func (l *linuxDatapath) NodeIDs() datapath.NodeIDHandler {
 	return l.node
 }
 
+func (l *linuxDatapath) NodeNeighbors() datapath.NodeNeighbors {
+	return l.node
+}
+
 // LocalNodeAddressing returns the node addressing implementation of the local
 // node
 func (l *linuxDatapath) LocalNodeAddressing() datapath.NodeAddressing {

--- a/pkg/datapath/linux/fuzz_test.go
+++ b/pkg/datapath/linux/fuzz_test.go
@@ -23,7 +23,7 @@ func FuzzNodeHandler(f *testing.F) {
 		}
 		dpConfig := DatapathConfiguration{HostDevice: "veth0"}
 		fakeNodeAddressing := fake.NewNodeAddressing()
-		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil).(*linuxNodeHandler)
+		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil)
 		if linuxNodeHandler == nil {
 			panic("Should not be nil")
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -83,6 +83,7 @@ type linuxNodeHandler struct {
 var (
 	_ datapath.NodeHandler   = (*linuxNodeHandler)(nil)
 	_ datapath.NodeIDHandler = (*linuxNodeHandler)(nil)
+	_ datapath.NodeNeighbors = (*linuxNodeHandler)(nil)
 )
 
 // NewNodeHandler returns a new node handler to handle node events and

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -80,7 +80,10 @@ type linuxNodeHandler struct {
 	ipsecMetricOnce      sync.Once
 }
 
-var _ datapath.NodeHandler = (*linuxNodeHandler)(nil)
+var (
+	_ datapath.NodeHandler   = (*linuxNodeHandler)(nil)
+	_ datapath.NodeIDHandler = (*linuxNodeHandler)(nil)
+)
 
 // NewNodeHandler returns a new node handler to handle node events and
 // implement the implications in the Linux datapath

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -80,9 +80,11 @@ type linuxNodeHandler struct {
 	ipsecMetricOnce      sync.Once
 }
 
+var _ datapath.NodeHandler = (*linuxNodeHandler)(nil)
+
 // NewNodeHandler returns a new node handler to handle node events and
 // implement the implications in the Linux datapath
-func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapath.NodeAddressing, wgAgent datapath.WireguardAgent) datapath.NodeHandler {
+func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapath.NodeAddressing, wgAgent datapath.WireguardAgent) *linuxNodeHandler {
 	return &linuxNodeHandler{
 		nodeAddressing:         nodeAddressing,
 		datapathConfig:         datapathConfig,

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -201,7 +201,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4: s.enableIPv4,
@@ -249,7 +249,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	// enable as per test definition
@@ -315,7 +315,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	net2 := cidr.MustParseCIDR("cafe:f00d::/112")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:        s.enableIPv4,
@@ -389,7 +389,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	externalNodeIP2 := net.ParseIP("8.8.8.8")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:          s.enableIPv4,
@@ -679,7 +679,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateDirectRouting(c *check.C) {
 	defer removeDevice(externalNode2Device)
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:              s.enableIPv4,
@@ -894,7 +894,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 	underlayIP := net.ParseIP("4.4.4.4")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:          s.enableIPv4,
@@ -1001,7 +1001,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 	ip4Alloc1 := cidr.MustParseCIDR("5.5.5.0/24")
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
@@ -1166,7 +1166,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = time.Duration(1 * time.Nanosecond)
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -2055,7 +2055,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = 1 * time.Nanosecond
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -2336,7 +2336,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = time.Duration(1 * time.Nanosecond)
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -3226,7 +3226,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = 1 * time.Nanosecond
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -3425,7 +3425,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config da
 	ip6Alloc2 := cidr.MustParseCIDR("2001:bbbb::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)
@@ -3531,7 +3531,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdateNOP(c *check.C, config
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)
@@ -3600,7 +3600,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeValidateImplementation(c *ch
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil).(*linuxNodeHandler)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -70,7 +70,7 @@ func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {
 	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil)
 
 	c1 := cidr.MustParseCIDR("10.10.0.0/16")
-	generatedRoute, err := nodeHandler.(*linuxNodeHandler).createNodeRouteSpec(c1, false)
+	generatedRoute, err := nodeHandler.createNodeRouteSpec(c1, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(generatedRoute.Prefix, checker.DeepEquals, *c1.IPNet)
 	c.Assert(generatedRoute.Device, check.Equals, dpConfig.HostDevice)
@@ -78,7 +78,7 @@ func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {
 	c.Assert(generatedRoute.Local, checker.DeepEquals, fakeNodeAddressing.IPv4().Router())
 
 	c1 = cidr.MustParseCIDR("beef:beef::/48")
-	generatedRoute, err = nodeHandler.(*linuxNodeHandler).createNodeRouteSpec(c1, false)
+	generatedRoute, err = nodeHandler.createNodeRouteSpec(c1, false)
 	c.Assert(err, check.IsNil)
 	c.Assert(generatedRoute.Prefix, checker.DeepEquals, *c1.IPNet)
 	c.Assert(generatedRoute.Device, check.Equals, dpConfig.HostDevice)

--- a/pkg/datapath/types/datapath.go
+++ b/pkg/datapath/types/datapath.go
@@ -13,6 +13,8 @@ type Datapath interface {
 	// Node must return the handler for node events
 	Node() NodeHandler
 
+	NodeIDs() NodeIDHandler
+
 	// LocalNodeAddressing must return the node addressing implementation
 	// of the local node
 	LocalNodeAddressing() NodeAddressing

--- a/pkg/datapath/types/datapath.go
+++ b/pkg/datapath/types/datapath.go
@@ -15,6 +15,8 @@ type Datapath interface {
 
 	NodeIDs() NodeIDHandler
 
+	NodeNeighbors() NodeNeighbors
+
 	// LocalNodeAddressing must return the node addressing implementation
 	// of the local node
 	LocalNodeAddressing() NodeAddressing

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -135,7 +135,9 @@ type NodeHandler interface {
 	// NodeCleanNeighbors cleans all neighbor entries for the direct routing device
 	// and the encrypt interface.
 	NodeCleanNeighbors(migrateOnly bool)
+}
 
+type NodeIDHandler interface {
 	// AllocateNodeID allocates a new ID for the given node (by IP) if one wasn't
 	// already assigned.
 	AllocateNodeID(net.IP) uint16

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -125,7 +125,9 @@ type NodeHandler interface {
 	// NodeConfigurationChanged is called when the local node configuration
 	// has changed
 	NodeConfigurationChanged(config LocalNodeConfiguration) error
+}
 
+type NodeNeighbors interface {
 	// NodeNeighDiscoveryEnabled returns whether node neighbor discovery is enabled
 	NodeNeighDiscoveryEnabled() bool
 

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -5,10 +5,8 @@ package peer
 
 import (
 	"context"
-	"net"
 	"strings"
 
-	"github.com/cilium/cilium/api/v1/models"
 	peerpb "github.com/cilium/cilium/api/v1/peer"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	ciliumDefaults "github.com/cilium/cilium/pkg/defaults"
@@ -132,26 +130,6 @@ func (h handler) NodeCleanNeighbors(migrateOnly bool) {
 // Close frees handler resources.
 func (h *handler) Close() {
 	close(h.stop)
-}
-
-func (h *handler) AllocateNodeID(_ net.IP) uint16 {
-	// no-op
-	return 0
-}
-
-func (h *handler) GetNodeIP(_ uint16) string {
-	// no-op
-	return ""
-}
-
-func (h *handler) DumpNodeIDs() []*models.NodeID {
-	// no-op
-	return nil
-}
-
-func (h *handler) RestoreNodeIDs() {
-	// no-op
-	return
 }
 
 // newChangeNotification creates a new change notification with the provided

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -4,7 +4,6 @@
 package peer
 
 import (
-	"context"
 	"strings"
 
 	peerpb "github.com/cilium/cilium/api/v1/peer"
@@ -106,25 +105,6 @@ func (h handler) NodeValidateImplementation(_ types.Node) error {
 func (h handler) NodeConfigurationChanged(_ datapath.LocalNodeConfiguration) error {
 	// no-op
 	return nil
-}
-
-// NodeNeighDiscoveryEnabled implements
-// datapath.NodeHandler.NodeNeighDiscoveryEnabled. It is a no-op.
-func (h handler) NodeNeighDiscoveryEnabled() bool {
-	// no-op
-	return false
-}
-
-// NodeNeighborRefresh implements
-// datapath.NodeHandler.NodeNeighborRefresh. It is a no-op.
-func (h handler) NodeNeighborRefresh(_ context.Context, _ types.Node) {
-	// no-op
-	return
-}
-
-func (h handler) NodeCleanNeighbors(migrateOnly bool) {
-	// no-op
-	return
 }
 
 // Close frees handler resources.

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -85,7 +85,7 @@ type Configuration struct {
 	cache.IdentityAllocator
 	ipcacheTypes.PolicyHandler
 	ipcacheTypes.DatapathHandler
-	ipcacheTypes.NodeHandler
+	ipcacheTypes.NodeIDHandler
 	k8s.CacheStatus
 }
 

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -47,7 +47,7 @@ func (s *IPCacheTestSuite) SetUpTest(c *C) {
 		IdentityAllocator: allocator,
 		PolicyHandler:     &mockUpdater{},
 		DatapathHandler:   &mockTriggerer{},
-		NodeHandler:       &mockNodeHandler{},
+		NodeIDHandler:     &mockNodeIDHandler{},
 	})
 
 	s.cleanup = func() {
@@ -620,7 +620,7 @@ func benchmarkIPCacheUpsert(b *testing.B, num int) {
 			IdentityAllocator: allocator,
 			PolicyHandler:     &mockUpdater{},
 			DatapathHandler:   &mockTriggerer{},
-			NodeHandler:       &mockNodeHandler{},
+			NodeIDHandler:     &mockNodeIDHandler{},
 		})
 
 		// We only want to measure the calls to upsert.
@@ -727,12 +727,12 @@ func (s *IPCacheTestSuite) TestIPCacheShadowing(c *C) {
 	c.Assert(exists, Equals, false)
 }
 
-type mockNodeHandler struct{}
+type mockNodeIDHandler struct{}
 
-func (m *mockNodeHandler) AllocateNodeID(_ net.IP) uint16 {
+func (m *mockNodeIDHandler) AllocateNodeID(_ net.IP) uint16 {
 	return 0
 }
 
-func (m *mockNodeHandler) GetNodeIP(_ uint16) string {
+func (m *mockNodeIDHandler) GetNodeIP(_ uint16) string {
 	return ""
 }

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -402,7 +402,7 @@ func setupTest(t *testing.T) (cleanup func()) {
 		IdentityAllocator: allocator,
 		PolicyHandler:     &mockUpdater{},
 		DatapathHandler:   &mockTriggerer{},
-		NodeHandler:       &mockNodeHandler{},
+		NodeIDHandler:     &mockNodeIDHandler{},
 	})
 
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "kube-uid", labels.LabelKubeAPIServer)

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -62,8 +62,8 @@ func NewResourceID(kind ResourceKind, namespace, name string) ResourceID {
 	return ResourceID(str.String())
 }
 
-// NodeHandler is responsible for the management of node identities.
-type NodeHandler interface {
+// NodeIDHandler is responsible for the management of node identities.
+type NodeIDHandler interface {
 	AllocateNodeID(net.IP) uint16
 	GetNodeIP(uint16) string
 }

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -61,7 +61,7 @@ type NodeManager interface {
 
 	// StartNeighborRefresh spawns a controller which refreshes neighbor table
 	// by sending arping periodically.
-	StartNeighborRefresh(nh datapath.NodeHandler)
+	StartNeighborRefresh(nh datapath.NodeNeighbors)
 }
 
 func newAllNodeManager(lc hive.Lifecycle, ipCache *ipcache.IPCache) (NodeManager, error) {

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -675,7 +675,7 @@ func (m *manager) GetNodes() map[nodeTypes.Identity]nodeTypes.Node {
 
 // StartNeighborRefresh spawns a controller which refreshes neighbor table
 // by sending arping periodically.
-func (m *manager) StartNeighborRefresh(nh datapath.NodeHandler) {
+func (m *manager) StartNeighborRefresh(nh datapath.NodeNeighbors) {
 	ctx, cancel := context.WithCancel(context.Background())
 	controller.NewManager().UpdateController("neighbor-table-refresh",
 		controller.ControllerParams{

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -15,7 +15,6 @@ import (
 
 	"gopkg.in/check.v1"
 
-	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -186,22 +185,6 @@ func (n *signalNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTy
 }
 
 func (n *signalNodeHandler) NodeCleanNeighbors(migrateOnly bool) {
-	return
-}
-
-func (n *signalNodeHandler) AllocateNodeID(_ net.IP) uint16 {
-	return 0
-}
-
-func (n *signalNodeHandler) GetNodeIP(_ uint16) string {
-	return ""
-}
-
-func (n *signalNodeHandler) DumpNodeIDs() []*models.NodeID {
-	return nil
-}
-
-func (n *signalNodeHandler) RestoreNodeIDs() {
 	return
 }
 

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -176,18 +176,6 @@ func (n *signalNodeHandler) NodeConfigurationChanged(config datapath.LocalNodeCo
 	return nil
 }
 
-func (n *signalNodeHandler) NodeNeighDiscoveryEnabled() bool {
-	return false
-}
-
-func (n *signalNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
-	return
-}
-
-func (n *signalNodeHandler) NodeCleanNeighbors(migrateOnly bool) {
-	return
-}
-
 func (s *managerTestSuite) SetUpSuite(c *check.C) {
 }
 

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -81,8 +81,8 @@ func containsIP(allowedIPs []net.IPNet, ipnet *net.IPNet) bool {
 
 func newTestAgent(ctx context.Context) (*Agent, *ipcache.IPCache) {
 	ipCache := ipcache.NewIPCache(&ipcache.Configuration{
-		Context:     ctx,
-		NodeHandler: &mockNodeHandler{},
+		Context:       ctx,
+		NodeIDHandler: &mockNodeHandler{},
 	})
 	wgAgent := &Agent{
 		wgClient:         &fakeWgClient{},


### PR DESCRIPTION
Review commit by commit, though changes shouldn't be too large

I was looking into `NodeHandler` for a [related PR](https://github.com/cilium/cilium/pull/25419), and noticed that one has to stub out quite a few methods to implement the interface, even if the code is just interested in getting notifed on `Node{Add,Update,Delete}`. That seemed suboptimal, so this series splits the `NodeHandler` interface in three more focussed interfaces. Purely cosmetic change, no (intentional) functional changes.

A next step might be to look into breaking up the `linuxNodeHandler`, but that's stuff for another PR.

cc @gandro
