### PR TITLE
ci: fix Cilium CLI install in ConformanceKindEnvoyDaemonSet

### DIFF
--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -24,7 +24,8 @@ env:
   kind_version: v0.17.0
   kind_config: .github/kind-config.yaml
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.14.0
+  cilium_cli_version: v0.14.2
+  cilium_cli_ci_version:
 
 jobs:
   installation-and-connectivity:
@@ -78,12 +79,10 @@ jobs:
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
       - name: Install Cilium CLI
-        run: |
-          curl -sSL --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${{ env.cilium_cli_version }}/cilium-linux-amd64.tar.gz{,.sha256sum}
-          sha256sum --check cilium-linux-amd64.tar.gz.sha256sum
-          sudo tar xzvfC cilium-linux-amd64.tar.gz /usr/local/bin
-          rm cilium-linux-amd64.tar.gz{,.sha256sum}
-          cilium version
+        uses: cilium/cilium-cli@207512ce9e729d9b3cc1a59e92af5c8d50ce37c4 # v0.14.2
+        with:
+          release-version: ${{ env.cilium_cli_version }}
+          ci-version: ${{ env.cilium_cli_ci_version }}
 
       - name: Checkout code
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2


### PR DESCRIPTION
In cef9595361e970dbee47eed659bac56ea68d73cd we switched to using a cilium-cli GHA for installing the CLI, but this workflow was merged in main at a later point.

We edit the workflow to be consistent with the other workflows when installing the CLI.