### PR TITLE
test/k8s: add host firewall workaround for svc host policy test.

### DIFF
--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -625,6 +625,8 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 					"hostFirewall.enabled": "true",
 				})
 
+				prepareHostPolicyEnforcement(kubectl)
+
 				originalCCNPHostPolicy := helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
 				res := kubectl.ExecMiddle("mktemp")
 				res.ExpectSuccess()


### PR DESCRIPTION
Change 439a0a0 introduced workaround to common flake we've been seeing relating to issue #15455.

Any test enabling hostfw/host-policy will may suffer from the same issue.

Addresses: #25411