### PR TITLE
Compare annotations before discarding CiliumNode updates.

### DIFF
--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -68,8 +68,10 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 						if ciliumNode := k8s.ObjToCiliumNode(newObj); ciliumNode != nil {
 							valid = true
 							isLocal := k8s.IsLocalCiliumNode(ciliumNode)
+							// Comparing Annotations here since wg-pub-key annotation is used to exchange rotated Wireguard keys.
 							if oldCN.DeepEqual(ciliumNode) &&
-								comparator.MapStringEquals(oldCN.ObjectMeta.Labels, ciliumNode.ObjectMeta.Labels) {
+								comparator.MapStringEquals(oldCN.ObjectMeta.Labels, ciliumNode.ObjectMeta.Labels) &&
+								comparator.MapStringEquals(oldCN.ObjectMeta.Annotations, ciliumNode.ObjectMeta.Annotations) {
 								equal = true
 								if !isLocal {
 									// For remote nodes, we return early here to avoid unnecessary update events if


### PR DESCRIPTION
Currently we discard CiliumNode updates based on DeepEqual and labels. However DeepEqual is set to ignore Annotations, and the wg-pub-key annotation is used to exchange rotated Wireguard keys.


