### PR TITLE
dns proxy: Only reuse DNS proxy port when it's free

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -363,8 +363,12 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	if option.Config.ToFQDNsProxyPort != 0 {
 		port = uint16(option.Config.ToFQDNsProxyPort)
 	} else if port == 0 {
-		// Try locate old DNS proxy port number from the datapath
-		port = d.datapath.GetProxyPort(proxy.DNSProxyName)
+		// Try locate old DNS proxy port number from the datapath, and reuse it if it's not open
+		oldPort := d.datapath.GetProxyPort(proxy.DNSProxyName)
+		openLocalPorts := proxy.OpenLocalPorts()
+		if _, alreadyOpen := openLocalPorts[oldPort]; !alreadyOpen {
+			port = oldPort
+		}
 	}
 	if err := re.InitRegexCompileLRU(option.Config.FQDNRegexCompileLRUSize); err != nil {
 		return fmt.Errorf("could not initialize regex LRU cache: %w", err)

--- a/pkg/proxy/netstat.go
+++ b/pkg/proxy/netstat.go
@@ -65,3 +65,8 @@ func readOpenLocalPorts(procNetFiles []string) map[uint16]struct{} {
 
 	return openLocalPorts
 }
+
+// OpenLocalPorts returns the set of L4 ports currently open locally.
+func OpenLocalPorts() map[uint16]struct{} {
+	return readOpenLocalPorts(append(procNetTCPFiles, procNetUDPFiles...))
+}


### PR DESCRIPTION
When cilium-agent starts, it will allocate a free port for proxy to use, if users don't speicify in config. It also tries to recover previous allocation from iptables rules, but the recover doesn't check if the port is already open by other processes on the host. This change will check the recovered port is free before assign it to DNS proxy.


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #22465
