### PR TITLE
Add support for paginated lists in etcd, and propagate global config options

### DIFF
--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -45,8 +45,8 @@ const (
 	EtcdAddrOption               = "etcd.address"
 	isEtcdOperatorOption         = "etcd.operator"
 	EtcdOptionConfig             = "etcd.config"
-	etcdOptionKeepAliveHeartbeat = "etcd.keepaliveHeartbeat"
-	etcdOptionKeepAliveTimeout   = "etcd.keepaliveTimeout"
+	EtcdOptionKeepAliveHeartbeat = "etcd.keepaliveHeartbeat"
+	EtcdOptionKeepAliveTimeout   = "etcd.keepaliveTimeout"
 
 	// EtcdRateLimitOption specifies maximum kv operations per second
 	EtcdRateLimitOption = "etcd.qps"
@@ -112,14 +112,14 @@ func newEtcdModule() backendModule {
 			EtcdOptionConfig: &backendOption{
 				description: "Path to etcd configuration file",
 			},
-			etcdOptionKeepAliveTimeout: &backendOption{
+			EtcdOptionKeepAliveTimeout: &backendOption{
 				description: "Timeout after which an unanswered heartbeat triggers the connection to be closed",
 				validate: func(v string) error {
 					_, err := time.ParseDuration(v)
 					return err
 				},
 			},
-			etcdOptionKeepAliveHeartbeat: &backendOption{
+			EtcdOptionKeepAliveHeartbeat: &backendOption{
 				description: "Heartbeat interval to keep gRPC connection alive",
 				validate: func(v string) error {
 					_, err := time.ParseDuration(v)
@@ -204,11 +204,11 @@ func (e *etcdModule) newClient(ctx context.Context, opts *ExtraOptions) (Backend
 		clientOptions.ListBatchSize, _ = strconv.Atoi(o.value)
 	}
 
-	if o, ok := e.opts[etcdOptionKeepAliveTimeout]; ok && o.value != "" {
+	if o, ok := e.opts[EtcdOptionKeepAliveTimeout]; ok && o.value != "" {
 		clientOptions.KeepAliveTimeout, _ = time.ParseDuration(o.value)
 	}
 
-	if o, ok := e.opts[etcdOptionKeepAliveHeartbeat]; ok && o.value != "" {
+	if o, ok := e.opts[EtcdOptionKeepAliveHeartbeat]; ok && o.value != "" {
 		clientOptions.KeepAliveHeartbeat, _ = time.ParseDuration(o.value)
 	}
 

--- a/pkg/kvstore/logfields.go
+++ b/pkg/kvstore/logfields.go
@@ -38,6 +38,9 @@ const (
 	// fieldNumEntries is the number of entries in the result
 	fieldNumEntries = "numEntries"
 
+	// fieldRemainingEntries is the number of entries still to be retrieved
+	fieldRemainingEntries = "remainingEntries"
+
 	// fieldAttachLease is true if the key must be attached to a lease
 	fieldAttachLease = "attachLease"
 


### PR DESCRIPTION
This PR extends the ListAndWatch implementation of the etcd client with the support for pagination during the initial list operation. This allows to retrieve the initial state in batches, reducing the overall load in case a large number of entries needs to be obtained. Additionally, the global etcd-related options are applied also to the etcd clients targeting remote clusters, to enable better customization and for consistency with other configuration parameters.

Tagging as `release-note/minor` due to the slight behavioral change as etcd options are propagated also to clients targeting remote clusters.

<!-- Description of change -->

```release-note
Add support for paginated lists in etcd, and propagate config options
```
