### PR TITLE
Support externalTrafficPolicy=Local for BGP CPlane service VIP advertisement

### DIFF
--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -94,6 +94,8 @@ type ControlPlaneState struct {
 	IPv4 netip.Addr
 	// The current IPv6 address of the agent, reachable externally.
 	IPv6 netip.Addr
+	// The current node name
+	CurrentNodeName string
 }
 
 // ResolveRouterID resolves router ID, if we have an annotation and it can be
@@ -395,15 +397,21 @@ func (c *Controller) Reconcile(ctx context.Context) error {
 		return fmt.Errorf("failed to retrieve Node's pod CIDR ranges: %w", err)
 	}
 
+	currentNodeName, err := c.NodeSpec.CurrentNodeName()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve current node's name: %w", err)
+	}
+
 	ipv4, _ := ip.AddrFromIP(nodeaddr.GetIPv4())
 	ipv6, _ := ip.AddrFromIP(nodeaddr.GetIPv6())
 
 	// define our current point-in-time control plane state.
 	state := &ControlPlaneState{
-		PodCIDRs:    podCIDRs,
-		Annotations: annoMap,
-		IPv4:        ipv4,
-		IPv6:        ipv6,
+		PodCIDRs:        podCIDRs,
+		Annotations:     annoMap,
+		IPv4:            ipv4,
+		IPv6:            ipv6,
+		CurrentNodeName: currentNodeName,
 	}
 
 	// call bgp sub-systems required to apply this policy's BGP topology.

--- a/pkg/bgpv1/agent/controller_test.go
+++ b/pkg/bgpv1/agent/controller_test.go
@@ -47,6 +47,10 @@ func (f *fakeNodeSpecer) Annotations() (map[string]string, error) {
 	return f.Annotations_()
 }
 
+func (f *fakeNodeSpecer) CurrentNodeName() (string, error) {
+	return nodeName, nil
+}
+
 // TestControllerSanity ensures that the controller calls the correct methods,
 // with the correct arguments, during its Reconcile loop.
 func TestControllerSanity(t *testing.T) {

--- a/pkg/bgpv1/agent/nodespecer.go
+++ b/pkg/bgpv1/agent/nodespecer.go
@@ -25,6 +25,7 @@ type nodeSpecer interface {
 	Annotations() (map[string]string, error)
 	Labels() (map[string]string, error)
 	PodCIDRs() ([]string, error)
+	CurrentNodeName() (string, error)
 }
 
 type localNodeStoreSpecerParams struct {
@@ -140,6 +141,13 @@ func (s *kubernetesNodeSpecer) PodCIDRs() ([]string, error) {
 	return []string{}, nil
 }
 
+func (s *kubernetesNodeSpecer) CurrentNodeName() (string, error) {
+	if s.currentNode == nil {
+		return "", errors.New("node name is not yet available")
+	}
+	return s.currentNode.Name, nil
+}
+
 type ciliumNodeSpecer struct {
 	nodeResource k8s.LocalCiliumNodeResource
 
@@ -211,4 +219,11 @@ func (s *ciliumNodeSpecer) PodCIDRs() ([]string, error) {
 	}
 
 	return []string{}, nil
+}
+
+func (s *ciliumNodeSpecer) CurrentNodeName() (string, error) {
+	if s.currentNode == nil {
+		return "", errors.New("node name is not yet available")
+	}
+	return s.currentNode.Name, nil
 }

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/manager"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/k8s"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -34,6 +35,8 @@ var Cell = cell.Module(
 		manager.NewBGPRouterManager,
 		// Create a slim service DiffStore
 		manager.NewDiffStore[*slim_core_v1.Service],
+		// Create a endpoints DiffStore
+		manager.NewDiffStore[*k8s.Endpoints],
 	),
 	// Provides the reconcilers used by the route manager to update the config
 	manager.ConfigReconcilers,

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	k8sPkg "github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -137,6 +138,9 @@ func newFixture(conf fixtureConfig) *fixture {
 				),
 			)
 		}),
+
+		// endpoints
+		cell.Provide(k8sPkg.EndpointsResource),
 
 		// Provide the mocked client cells directly
 		cell.Provide(func() k8sClient.Clientset {


### PR DESCRIPTION
Support `externalTrafficPolicy=local` for BGP CPlane service VIP advertisement. Please see the commit message for more details.

You can test this PR in your environment with below lab. Thanks to the recently added `Chart CI Push` workflow, you don't have to build images.

[lab.tar.gz](https://github.com/cilium/cilium/files/11494605/lab.tar.gz)

```mermaid
flowchart TB
  Router0["Router0 (FRR)"]
  Router0---kind-control-plane["kind-control-plane (Cilium)"]
  Router0---kind-worker["kind-worker (Cilium)"]
```

```
$ tar xvf lab.tar.gz
$ cd lab
$ VERSION=1.14.0-dev-dev.55-HEAD-f00eeee626 make deploy

# Watch what's happening
$ watch -n 1 "docker exec -it clab-bgp-cplane-router0 vtysh -c 'show bgp all wide'"

# Make endpoints on one node empty. This should withdraw the route from kind-worker.
$ kubectl drain kind-worker --ignore-daemonsets

# Restore endpoints. This should restore the route as well.
$ kubectl uncordon kind-worker
```

```release-note
Support externalTrafficPolicy=local for BGP CPlane service VIP advertisement
```
