### PR TITLE
garp: Announce Pods with Gratuitous ARP

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -127,6 +127,7 @@ cilium-agent [flags]
       --enable-k8s-terminating-endpoint                         Enable auto-detect of terminating endpoint condition (default true)
       --enable-l2-announcements                                 Enable L2 announcements
       --enable-l2-neigh-discovery                               Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec (default true)
+      --enable-l2-pod-announcements                             Enable announcing Pod IPs with Gratuitous ARP
       --enable-l7-proxy                                         Enable L7 proxy for L7 policy enforcement (default true)
       --enable-local-node-route                                 Enable installation of the route which points the allocation prefix of the local node (default true)
       --enable-local-redirect-policy                            Enable Local Redirect Policy
@@ -235,6 +236,7 @@ cilium-agent [flags]
       --l2-announcements-lease-duration duration                Duration of inactivity after which a new leader is selected (default 15s)
       --l2-announcements-renew-deadline duration                Interval at which the leader renews a lease (default 5s)
       --l2-announcements-retry-period duration                  Timeout after a renew failure, before the next retry (default 2s)
+      --l2-pod-announcements-interface string                   Interface used for sending gratuitous arp messages
       --label-prefix-file string                                Valid label prefixes file path
       --labels strings                                          List of label prefixes used to determine identity of an endpoint
       --lib-dir string                                          Directory path to store runtime build environment (default "/var/lib/cilium")

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -23,6 +23,7 @@ cilium-agent hive [flags]
       --enable-cilium-health-api-server-access strings   List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                       Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                         Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-l2-pod-announcements                      Enable announcing Pod IPs with Gratuitous ARP
       --enable-monitor                                   Enable the monitor unix domain socket server (default true)
       --gops-port uint16                                 Port for gops server to listen on (default 9890)
   -h, --help                                             help for hive
@@ -32,6 +33,7 @@ cilium-agent hive [flags]
       --k8s-client-qps float32                           Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
+      --l2-pod-announcements-interface string            Interface used for sending gratuitous arp messages
       --mesh-auth-enabled                                Enable authentication processing & garbage collection (default true)
       --mesh-auth-expired-gc-interval duration           Interval in which expired auth entries are attempted to be garbage collected (default 15m0s)
       --mesh-auth-mutual-listener-port int               Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -29,6 +29,7 @@ cilium-agent hive dot-graph [flags]
       --enable-cilium-health-api-server-access strings   List of cilium health API APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                       Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                         Enable discovery of Kubernetes API groups and resources with the discovery API
+      --enable-l2-pod-announcements                      Enable announcing Pod IPs with Gratuitous ARP
       --enable-monitor                                   Enable the monitor unix domain socket server (default true)
       --gops-port uint16                                 Port for gops server to listen on (default 9890)
       --install-egress-gateway-routes                    Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
@@ -37,6 +38,7 @@ cilium-agent hive dot-graph [flags]
       --k8s-client-qps float32                           Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
+      --l2-pod-announcements-interface string            Interface used for sending gratuitous arp messages
       --mesh-auth-enabled                                Enable authentication processing & garbage collection (default true)
       --mesh-auth-expired-gc-interval duration           Interval in which expired auth entries are attempted to be garbage collected (default 15m0s)
       --mesh-auth-mutual-listener-port int               Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1936,6 +1936,18 @@
      - Enable L2 announcements
      - bool
      - ``false``
+   * - l2podAnnouncements
+     - Configure L2 pod announcements
+     - object
+     - ``{"enabled":false,"interface":"eth0"}``
+   * - l2podAnnouncements.enabled
+     - Enable L2 pod announcements
+     - bool
+     - ``false``
+   * - l2podAnnouncements.interface
+     - Interface used for sending Gratuitous ARP pod announcements
+     - string
+     - ``"eth0"``
    * - l7Proxy
      - Enable Layer 7 network policy.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -840,6 +840,7 @@ pmdabcc
 pmtuDiscovery
 png
 podAnnotations
+podAnnouncements
 podCIDR
 podDisruptionBudget
 podLabels

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -534,6 +534,9 @@ contributors across the globe, there is almost always someone available to help.
 | l2NeighDiscovery.refreshPeriod | string | `"30s"` | Override the agent's default neighbor resolution refresh period. |
 | l2announcements | object | `{"enabled":false}` | Configure L2 announcements |
 | l2announcements.enabled | bool | `false` | Enable L2 announcements |
+| l2podAnnouncements | object | `{"enabled":false,"interface":"eth0"}` | Configure L2 pod announcements |
+| l2podAnnouncements.enabled | bool | `false` | Enable L2 pod announcements |
+| l2podAnnouncements.interface | string | `"eth0"` | Interface used for sending Gratuitous ARP pod announcements |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -973,6 +973,11 @@ data:
   {{- end}}
 {{- end}}
 
+{{- if .Values.l2podAnnouncements.enabled }}
+  enable-l2-pod-announcements: {{ .Values.l2podAnnouncements.enabled | quote }}
+  l2-pod-announcements-interface: {{ .Values.l2podAnnouncements.interface | quote }}
+{{- end }}
+
 {{- if and .Values.bgp.enabled (and (not .Values.bgp.announce.loadbalancerIP) (not .Values.bgp.announce.podCIDR)) }}
   {{ fail "BGP was enabled, but no announcements were enabled. Please enable one or more announcements." }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -370,6 +370,13 @@ l2announcements:
   # -- The timeout between retries if renewal fails
   # leaseRetryPeriod: 2s
 
+# -- Configure L2 pod announcements
+l2podAnnouncements:
+  # -- Enable L2 pod announcements
+  enabled: false
+  # -- Interface used for sending Gratuitous ARP pod announcements
+  interface: "eth0"
+
 # -- Configure BGP
 bgp:
   # -- Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -367,6 +367,13 @@ l2announcements:
   # -- The timeout between retries if renewal fails
   # leaseRetryPeriod: 2s
 
+# -- Configure L2 pod announcements
+l2podAnnouncements:
+  # -- Enable L2 pod announcements
+  enabled: false
+  # -- Interface used for sending Gratuitous ARP pod announcements
+  interface: "eth0"
+
 # -- Configure BGP
 bgp:
   # -- Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/agentliveness"
+	"github.com/cilium/cilium/pkg/datapath/garp"
 	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/l2responder"
 	"github.com/cilium/cilium/pkg/datapath/link"
@@ -64,6 +65,9 @@ var Cell = cell.Module(
 	// This cell defines StateDB tables and their schemas for tables which are used to transfer information
 	// between datapath components and more high-level components.
 	tables.Cell,
+
+	// Gratuitous ARP event processor emits GARP packets on k8s pod creation events.
+	garp.Cell,
 
 	cell.Provide(func(dp types.Datapath) ipcache.NodeIDHandler {
 		return dp.NodeIDs()

--- a/pkg/datapath/garp/cells.go
+++ b/pkg/datapath/garp/cells.go
@@ -5,15 +5,8 @@ package garp
 
 import (
 	"github.com/spf13/pflag"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/fields"
 
-	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
-	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/resource"
-	"github.com/cilium/cilium/pkg/k8s/utils"
-	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
 
 const (
@@ -34,24 +27,12 @@ func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.Bool(EnableL2PodAnnouncements, def.EnableL2PodAnnouncements, "Enable announcing Pod IPs with Gratuitous ARP")
 }
 
-var localPodsCell = cell.ProvidePrivate(func(lc hive.Lifecycle, c k8sClient.Clientset) (resource.Resource[*corev1.Pod], error) {
-	if !c.IsEnabled() {
-		return nil, nil
-	}
-
-	lw := utils.ListerWatcherWithFields(utils.ListerWatcherFromTyped[*corev1.PodList](
-		c.CoreV1().Pods("")), fields.OneTermEqualSelector("spec.nodeName", nodeTypes.GetName()),
-	)
-	return resource.New[*corev1.Pod](lc, lw), nil
-})
-
 // Cell processes k8s pod events for the local node and determines if a
 // Gratuitous ARP packet needs to be sent.
 var Cell = cell.Module(
 	"l2-pod-announcements-garp",
 	"GARP processor sends gratuitous ARP packets for local pods",
 
-	localPodsCell,
 	cell.Provide(newGARPSender),
 
 	// This cell can't have a default config, it's entirely env dependent.

--- a/pkg/datapath/garp/cells.go
+++ b/pkg/datapath/garp/cells.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package garp
+
+import (
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+const (
+	// L2PodAnnouncementsInterface is the interface used to send Gratuitous ARP messages.
+	L2PodAnnouncementsInterface = "l2-pod-announcements-interface"
+
+	EnableL2PodAnnouncements = "enable-l2-pod-announcements"
+)
+
+// Config contains the configuration for the GARP cell.
+type Config struct {
+	L2PodAnnouncementsInterface string
+	EnableL2PodAnnouncements    bool
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.String(L2PodAnnouncementsInterface, def.L2PodAnnouncementsInterface, "Interface used for sending gratuitous arp messages")
+	flags.Bool(EnableL2PodAnnouncements, def.EnableL2PodAnnouncements, "Enable announcing Pod IPs with Gratuitous ARP")
+}
+
+var localPodsCell = cell.ProvidePrivate(func(lc hive.Lifecycle, c k8sClient.Clientset) (resource.Resource[*corev1.Pod], error) {
+	if !c.IsEnabled() {
+		return nil, nil
+	}
+
+	lw := utils.ListerWatcherWithFields(utils.ListerWatcherFromTyped[*corev1.PodList](
+		c.CoreV1().Pods("")), fields.OneTermEqualSelector("spec.nodeName", nodeTypes.GetName()),
+	)
+	return resource.New[*corev1.Pod](lc, lw), nil
+})
+
+// Cell processes k8s pod events for the local node and determines if a
+// Gratuitous ARP packet needs to be sent.
+var Cell = cell.Module(
+	"l2-pod-announcements-garp",
+	"GARP processor sends gratuitous ARP packets for local pods",
+
+	localPodsCell,
+	cell.Provide(newGARPSender),
+
+	// This cell can't have a default config, it's entirely env dependent.
+	cell.Config(Config{}),
+
+	cell.Invoke(newGARPProcessor),
+)

--- a/pkg/datapath/garp/garp_test.go
+++ b/pkg/datapath/garp/garp_test.go
@@ -56,10 +56,12 @@ func (s *garpSuite) TestGARPCell(c *C) {
 	h := hive.New(cell.Module(
 		"test-garp-cell",
 		"TestGARPCell",
-		Cell,
+
+		cell.Config(Config{}),
+		cell.Provide(newGARPSender),
 		cell.Invoke(testGARPCell),
 	))
-	hive.AddConfigOverride(h, func(cfg *Config) { cfg.GARPInterface = testIfaceName })
+	hive.AddConfigOverride(h, func(cfg *Config) { cfg.L2PodAnnouncementsInterface = testIfaceName })
 
 	if err := h.Populate(); err != nil {
 		c.Fatalf("Failed to populate: %s", err)

--- a/pkg/datapath/garp/processor.go
+++ b/pkg/datapath/garp/processor.go
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package garp
+
+import (
+	"context"
+	"net/netip"
+
+	"github.com/cilium/workerpool"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+type Processor interface {
+	Start(hive.HookContext) error
+	Stop(hive.HookContext) error
+}
+
+type processorParams struct {
+	cell.In
+
+	Logger     logrus.FieldLogger
+	Lifecycle  hive.Lifecycle
+	Pods       resource.Resource[*corev1.Pod]
+	GARPSender Sender
+	Config     Config
+}
+
+func newGARPProcessor(p processorParams) Processor {
+	if !p.Config.EnableL2PodAnnouncements {
+		return nil
+	}
+
+	if p.Pods == nil {
+		return nil
+	}
+
+	gp := &processor{
+		log:         p.Logger,
+		pods:        p.Pods,
+		garpSender:  p.GARPSender,
+		podIPsState: make(map[resource.Key]netip.Addr),
+	}
+
+	p.Lifecycle.Append(gp)
+
+	p.Logger.Info("initialised gratuitous arp processor")
+
+	return gp
+}
+
+type processor struct {
+	wp *workerpool.WorkerPool
+
+	log        logrus.FieldLogger
+	pods       resource.Resource[*corev1.Pod]
+	garpSender Sender
+
+	podIPsState map[resource.Key]netip.Addr
+}
+
+func (gp *processor) Start(hive.HookContext) error {
+	gp.wp = workerpool.New(1)
+	gp.wp.Submit("GARPProcessorLoop", gp.run)
+	return nil
+}
+
+func (gp *processor) Stop(hive.HookContext) error {
+	gp.wp.Close()
+	return nil
+}
+
+func (gp *processor) run(ctx context.Context) error {
+	pods := gp.pods.Events(ctx)
+
+	for pods != nil {
+		event, ok := <-pods
+		if !ok {
+			pods = nil
+			continue
+		}
+
+		if event.Kind == resource.Upsert {
+			if err := gp.upsert(&event); err != nil {
+				event.Done(err)
+				continue
+			}
+		}
+
+		if event.Kind == resource.Delete {
+			delete(gp.podIPsState, event.Key)
+		}
+
+		event.Done(nil)
+	}
+
+	return nil
+}
+
+func (gp *processor) upsert(event *resource.Event[*corev1.Pod]) error {
+	if event.Object.Status.PodIPs == nil {
+		return nil
+	}
+
+	newIP := getPodIPv4(event.Object.Status.PodIPs)
+	if !newIP.IsValid() {
+		return nil
+	}
+
+	oldIP, ok := gp.podIPsState[event.Key]
+	if ok && oldIP == newIP {
+		return nil
+	}
+
+	gp.podIPsState[event.Key] = newIP
+
+	if err := gp.garpSender.Send(newIP); err != nil {
+		return err
+	}
+
+	gp.log.WithFields(logrus.Fields{
+		logfields.K8sPodName: event.Key.Name,
+		logfields.IPAddr:     newIP,
+	}).Debug("pod upsert gratuitous arp sent")
+
+	return nil
+}
+
+// getPodIPv4 returns the IPv4 address from the given Pod IPs, if
+// available.
+func getPodIPv4(podIPs []corev1.PodIP) netip.Addr {
+	for _, podIP := range podIPs {
+		ip, err := netip.ParseAddr(podIP.IP)
+		if err != nil {
+			continue
+		}
+
+		ip = ip.Unmap()
+		if ip.Is4() {
+			// Valid v4 address found, return it.
+			return ip
+		}
+	}
+
+	// No valid v4 address found, return the zero value.
+	return netip.Addr{}
+}

--- a/pkg/datapath/garp/processor_test.go
+++ b/pkg/datapath/garp/processor_test.go
@@ -9,15 +9,12 @@ import (
 	"time"
 
 	. "github.com/cilium/checkmate"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientv1 "k8s.io/client-go/applyconfigurations/core/v1"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
-	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/resource"
 )
 
 // fakeSender mocks the GARP Sender, allowing for a feedback channel.
@@ -35,33 +32,24 @@ func (s *garpSuite) TestProcessorCell(c *C) {
 
 	// These allow us to inspect the state of the processor cell.
 	garpSent := make(chan netip.Addr)
-	var processorState *map[resource.Key]netip.Addr
-
-	_, cs := k8sClient.NewFakeClientset()
+	var processorState *processor
 
 	h := hive.New(cell.Module(
 		"test-garp-processor-cell",
 		"TestProcessorCell",
 
-		// Provide the mock k8s client cell.
-		cell.Provide(func() k8sClient.Clientset { return cs }),
+		cell.Config(Config{}),
 
 		// Provide the mock GARP Sender cell, passing in feedback
 		// channel.
 		cell.Provide(func() Sender { return &fakeSender{sent: garpSent} }),
-
-		cell.Config(Config{}),
-
-		localPodsCell,
+		cell.Provide(func() endpointmanager.EndpointManager { return nil }),
 		cell.Provide(newGARPProcessor),
 
 		// Force invocation.
-		cell.Invoke(func(ep Processor) {
-			e, _ := ep.(*processor)
-			c.Assert(e, NotNil)
-			// Here we keep a reference to the internal pod IP state in
-			// the parent scope so we can inspect later.
-			processorState = &e.podIPsState
+		cell.Invoke(func(p *processor) {
+			// Here we keep a reference to processor for inspection.
+			processorState = p
 		}),
 	))
 
@@ -91,87 +79,42 @@ func (s *garpSuite) TestProcessorCell(c *C) {
 
 	// checkState is a helper function that asserts that the GARP
 	// processor state matches the given desired state.
-	checkState := func(desired map[string]string) {
-		c.Assert(*processorState, HasLen, len(desired))
-		desiredState := make(map[resource.Key]netip.Addr)
-		for name, ip := range desired {
-			desiredState[resource.Key{Name: name, Namespace: "default"}] = netip.MustParseAddr(ip)
+	checkState := func(desired map[uint16]string) {
+		c.Assert(processorState.endpointIPs, HasLen, len(desired))
+		desiredState := make(map[uint16]netip.Addr)
+		for id, ip := range desired {
+			desiredState[id] = netip.MustParseAddr(ip)
 		}
-		c.Assert(*processorState, checker.DeepEquals, desiredState)
+		c.Assert(processorState.endpointIPs, checker.DeepEquals, desiredState)
 	}
 
-	// Create a Pod. This should sent a GARP packet, and should present
-	// an item in the state.
-	podOne := makePod(c, cs, "pod-1", "1.2.3.4")
+	// Create an endpoint. This should sent a GARP packet, and should
+	// present an item in the state.
+	go processorState.EndpointCreated(&endpoint.Endpoint{ID: 1, IPv4: netip.MustParseAddr("1.2.3.4")})
 	garpEvent := getGARPEvent()
 	c.Assert(garpEvent, NotNil) // GARP packet sent
 	c.Assert(garpEvent.String(), Equals, "1.2.3.4")
-	checkState(map[string]string{"pod-1": "1.2.3.4"})
+	checkState(map[uint16]string{1: "1.2.3.4"})
 
-	// Update the previous Pod with the same IP. This should not send
+	// Update the previous endpoint with the same IP. This should not send
 	// any GARP packets or change the state.
-	_ = updatePodIP(c, cs, podOne, "1.2.3.4")
+	go processorState.EndpointCreated(&endpoint.Endpoint{ID: 1, IPv4: netip.MustParseAddr("1.2.3.4")})
 	garpEvent = getGARPEvent()
 	c.Assert(garpEvent, IsNil) // NO GARP packet sent
-	checkState(map[string]string{"pod-1": "1.2.3.4"})
+	checkState(map[uint16]string{1: "1.2.3.4"})
 
-	// Update the previous Pod with a new IP. This should send a new
+	// Update the previous endpoint with a new IP. This should send a new
 	// GARP packet and the state should reflect the new IP.
-	_ = updatePodIP(c, cs, podOne, "4.3.2.1")
+	go processorState.EndpointCreated(&endpoint.Endpoint{ID: 1, IPv4: netip.MustParseAddr("4.3.2.1")})
 	garpEvent = getGARPEvent()
 	c.Assert(garpEvent, NotNil) // GARP packet sent
 	c.Assert(garpEvent.String(), Equals, "4.3.2.1")
-	checkState(map[string]string{"pod-1": "4.3.2.1"})
+	checkState(map[uint16]string{1: "4.3.2.1"})
 
 	// Delete the previous Pod. This should not send any GARP packets,
 	// and the pod should no longer be present in the state.
-	deletePod(c, cs, "pod-1")
+	go processorState.EndpointDeleted(&endpoint.Endpoint{ID: 1, IPv4: netip.MustParseAddr("4.3.2.1")}, endpoint.DeleteConfig{})
 	garpEvent = getGARPEvent()
 	c.Assert(garpEvent, IsNil) // NO GARP packet sent
-	checkState(map[string]string{})
-}
-
-func (s *garpSuite) TestPodIPv4ParseFunc(c *C) {
-	c.Assert(getPodIPv4([]corev1.PodIP{}), Equals, netip.Addr{})
-	c.Assert(getPodIPv4([]corev1.PodIP{{IP: "::1"}}), Equals, netip.Addr{})
-	c.Assert(getPodIPv4([]corev1.PodIP{{IP: "::1"}, {IP: "1.2.3.4"}}), Equals, netip.MustParseAddr("1.2.3.4"))
-	c.Assert(getPodIPv4([]corev1.PodIP{{IP: "1.2.3.4"}, {IP: "::1"}}), Equals, netip.MustParseAddr("1.2.3.4"))
-	c.Assert(getPodIPv4([]corev1.PodIP{{IP: "1.2.3.4"}}), Equals, netip.MustParseAddr("1.2.3.4"))
-}
-
-// makePod makes a test pod with the provided IP.
-func makePod(c *C, cs k8sClient.Clientset, name string, ip string) *corev1.Pod {
-	addr := netip.MustParseAddr(ip).String()
-
-	podDefinition := corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
-		Status:     corev1.PodStatus{PodIP: addr, PodIPs: []corev1.PodIP{{IP: addr}}},
-	}
-
-	pod, err := cs.CoreV1().Pods("default").Create(context.Background(), &podDefinition, metav1.CreateOptions{})
-	c.Assert(err, IsNil)
-
-	return pod
-}
-
-// updatePodIP updates the status field of given pod with a new IP and applies it.
-func updatePodIP(c *C, cs k8sClient.Clientset, pod *corev1.Pod, ip string) *corev1.Pod {
-	addr := netip.MustParseAddr(ip).String()
-
-	extractedPod, err := clientv1.ExtractPod(pod, "")
-	c.Assert(err, IsNil)
-
-	podStatusApply := clientv1.PodStatus().WithPodIP(addr).WithPodIPs(clientv1.PodIP().WithIP(addr))
-	podApply := extractedPod.WithStatus(podStatusApply)
-
-	updated, err := cs.CoreV1().Pods("default").ApplyStatus(context.Background(), podApply, metav1.ApplyOptions{})
-	c.Assert(err, IsNil)
-
-	return updated
-}
-
-// deletePod deletes the given pod.
-func deletePod(c *C, cs k8sClient.Clientset, pod string) {
-	err := cs.CoreV1().Pods("default").Delete(context.Background(), "pod-1", metav1.DeleteOptions{})
-	c.Assert(err, IsNil)
+	checkState(map[uint16]string{})
 }

--- a/pkg/datapath/garp/processor_test.go
+++ b/pkg/datapath/garp/processor_test.go
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package garp
+
+import (
+	"context"
+	"net/netip"
+	"time"
+
+	. "github.com/cilium/checkmate"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientv1 "k8s.io/client-go/applyconfigurations/core/v1"
+
+	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+)
+
+// fakeSender mocks the GARP Sender, allowing for a feedback channel.
+type fakeSender struct {
+	sent chan netip.Addr
+}
+
+func (ms *fakeSender) Send(ip netip.Addr) error {
+	ms.sent <- ip
+	return nil
+}
+
+func (s *garpSuite) TestProcessorCell(c *C) {
+	testIfaceName := "lo"
+
+	// These allow us to inspect the state of the processor cell.
+	garpSent := make(chan netip.Addr)
+	var processorState *map[resource.Key]netip.Addr
+
+	_, cs := k8sClient.NewFakeClientset()
+
+	h := hive.New(cell.Module(
+		"test-garp-processor-cell",
+		"TestProcessorCell",
+
+		// Provide the mock k8s client cell.
+		cell.Provide(func() k8sClient.Clientset { return cs }),
+
+		// Provide the mock GARP Sender cell, passing in feedback
+		// channel.
+		cell.Provide(func() Sender { return &fakeSender{sent: garpSent} }),
+
+		cell.Config(Config{}),
+
+		localPodsCell,
+		cell.Provide(newGARPProcessor),
+
+		// Force invocation.
+		cell.Invoke(func(ep Processor) {
+			e, _ := ep.(*processor)
+			c.Assert(e, NotNil)
+			// Here we keep a reference to the internal pod IP state in
+			// the parent scope so we can inspect later.
+			processorState = &e.podIPsState
+		}),
+	))
+
+	// Apply the config so that the GARP cell will initialise.
+	hive.AddConfigOverride(h, func(cfg *Config) {
+		cfg.L2PodAnnouncementsInterface = testIfaceName
+		cfg.EnableL2PodAnnouncements = true
+	})
+
+	// Everything is ready, start the cell.
+	if err := h.Start(context.Background()); err != nil {
+		c.Fatalf("Failed to start: %s", err)
+	}
+
+	// getGARPEvent is a helper func to see if a GARP packet would have
+	// been sent. This assumes that if a GARP event should have been
+	// sent, it would happen within the timeout window. Returns nil if
+	// no GARP packet is sent.
+	getGARPEvent := func() *netip.Addr {
+		select {
+		case e := <-garpSent:
+			return &e
+		case <-time.After(5 * time.Second):
+			return nil
+		}
+	}
+
+	// checkState is a helper function that asserts that the GARP
+	// processor state matches the given desired state.
+	checkState := func(desired map[string]string) {
+		c.Assert(*processorState, HasLen, len(desired))
+		desiredState := make(map[resource.Key]netip.Addr)
+		for name, ip := range desired {
+			desiredState[resource.Key{Name: name, Namespace: "default"}] = netip.MustParseAddr(ip)
+		}
+		c.Assert(*processorState, checker.DeepEquals, desiredState)
+	}
+
+	// Create a Pod. This should sent a GARP packet, and should present
+	// an item in the state.
+	podOne := makePod(c, cs, "pod-1", "1.2.3.4")
+	garpEvent := getGARPEvent()
+	c.Assert(garpEvent, NotNil) // GARP packet sent
+	c.Assert(garpEvent.String(), Equals, "1.2.3.4")
+	checkState(map[string]string{"pod-1": "1.2.3.4"})
+
+	// Update the previous Pod with the same IP. This should not send
+	// any GARP packets or change the state.
+	_ = updatePodIP(c, cs, podOne, "1.2.3.4")
+	garpEvent = getGARPEvent()
+	c.Assert(garpEvent, IsNil) // NO GARP packet sent
+	checkState(map[string]string{"pod-1": "1.2.3.4"})
+
+	// Update the previous Pod with a new IP. This should send a new
+	// GARP packet and the state should reflect the new IP.
+	_ = updatePodIP(c, cs, podOne, "4.3.2.1")
+	garpEvent = getGARPEvent()
+	c.Assert(garpEvent, NotNil) // GARP packet sent
+	c.Assert(garpEvent.String(), Equals, "4.3.2.1")
+	checkState(map[string]string{"pod-1": "4.3.2.1"})
+
+	// Delete the previous Pod. This should not send any GARP packets,
+	// and the pod should no longer be present in the state.
+	deletePod(c, cs, "pod-1")
+	garpEvent = getGARPEvent()
+	c.Assert(garpEvent, IsNil) // NO GARP packet sent
+	checkState(map[string]string{})
+}
+
+func (s *garpSuite) TestPodIPv4ParseFunc(c *C) {
+	c.Assert(getPodIPv4([]corev1.PodIP{}), Equals, netip.Addr{})
+	c.Assert(getPodIPv4([]corev1.PodIP{{IP: "::1"}}), Equals, netip.Addr{})
+	c.Assert(getPodIPv4([]corev1.PodIP{{IP: "::1"}, {IP: "1.2.3.4"}}), Equals, netip.MustParseAddr("1.2.3.4"))
+	c.Assert(getPodIPv4([]corev1.PodIP{{IP: "1.2.3.4"}, {IP: "::1"}}), Equals, netip.MustParseAddr("1.2.3.4"))
+	c.Assert(getPodIPv4([]corev1.PodIP{{IP: "1.2.3.4"}}), Equals, netip.MustParseAddr("1.2.3.4"))
+}
+
+// makePod makes a test pod with the provided IP.
+func makePod(c *C, cs k8sClient.Clientset, name string, ip string) *corev1.Pod {
+	addr := netip.MustParseAddr(ip).String()
+
+	podDefinition := corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status:     corev1.PodStatus{PodIP: addr, PodIPs: []corev1.PodIP{{IP: addr}}},
+	}
+
+	pod, err := cs.CoreV1().Pods("default").Create(context.Background(), &podDefinition, metav1.CreateOptions{})
+	c.Assert(err, IsNil)
+
+	return pod
+}
+
+// updatePodIP updates the status field of given pod with a new IP and applies it.
+func updatePodIP(c *C, cs k8sClient.Clientset, pod *corev1.Pod, ip string) *corev1.Pod {
+	addr := netip.MustParseAddr(ip).String()
+
+	extractedPod, err := clientv1.ExtractPod(pod, "")
+	c.Assert(err, IsNil)
+
+	podStatusApply := clientv1.PodStatus().WithPodIP(addr).WithPodIPs(clientv1.PodIP().WithIP(addr))
+	podApply := extractedPod.WithStatus(podStatusApply)
+
+	updated, err := cs.CoreV1().Pods("default").ApplyStatus(context.Background(), podApply, metav1.ApplyOptions{})
+	c.Assert(err, IsNil)
+
+	return updated
+}
+
+// deletePod deletes the given pod.
+func deletePod(c *C, cs k8sClient.Clientset, pod string) {
+	err := cs.CoreV1().Pods("default").Delete(context.Background(), "pod-1", metav1.DeleteOptions{})
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
garp: Announce Pods with Gratuitous ARP

This introduces a new feature that advertises Pod IPs on the L2 domain
using Gratuitous ARP packets.

When enabled, k8s Pod upsert and delete events are processed and GARP
packets are sent on the chosen interface, when required.

The EventProcessor cell introduced here is what processes the k8s Pod
events and maintains an internal state to make sure to only send GARP
packets when the Pod is created, or the IP is changed for some reason.
Pod deletion events simply erase the entry from the state.

There are new agent flags and helm values introduced to enable the
feature and to chose which interface to send GARP packets on.

Signed-off-by: Mark Pashmfouroush <mark@isovalent.com>
```release-note
Added Gratuitous ARP Pod Announcements
```
