### PR TITLE
backport (v1.11): policy: Fix Deny Precedence Bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	github.com/sasha-s/go-deadlock v0.3.1
 	github.com/servak/go-fastping v0.0.0-20160802140958-5718d12e20a0
 	github.com/shirou/gopsutil/v3 v3.21.10
-	github.com/sirupsen/logrus v1.8.1
+	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1228,8 +1228,9 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -1720,6 +1721,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211013075003-97ac67df715c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -21,6 +21,8 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
@@ -200,6 +202,21 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	return err
 }
 
+// policyIdentitiesLabelLookup is an implementation of the policy.Identites interface.
+type policyIdentitiesLabelLookup struct {
+	*Endpoint
+}
+
+// GetLabels implements the policy.Identites interface{} method GetLabels,
+// which allows Endpoint.addNewRedirectsFromDesiredPolicy to call `l4.ToMapState`
+// with a label cache. This enables `l4.ToMapstate` to look up CIDRs associated with
+// identites to make a final determination about whether they should even be inserted into
+// an Endpoint's policy map.
+func (p *policyIdentitiesLabelLookup) GetLabels(id identity.NumericIdentity) labels.LabelArray {
+	ident := p.allocator.LookupIdentityByID(context.Background(), id)
+	return ident.LabelArray
+}
+
 // addNewRedirectsFromDesiredPolicy must be called while holding the endpoint lock for
 // writing. On success, returns nil; otherwise, returns an error indicating the
 // problem that occurred while adding an l7 redirect for the specified policy.
@@ -299,7 +316,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				direction = trafficdirection.Egress
 			}
 
-			keysFromFilter := l4.ToMapState(e, direction)
+			keysFromFilter := l4.ToMapState(e, direction, &policyIdentitiesLabelLookup{e})
 
 			for keyFromFilter, entry := range keysFromFilter {
 				if oldEntry, ok := e.desiredPolicy.PolicyMapState[keyFromFilter]; ok {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -214,7 +214,10 @@ type policyIdentitiesLabelLookup struct {
 // an Endpoint's policy map.
 func (p *policyIdentitiesLabelLookup) GetLabels(id identity.NumericIdentity) labels.LabelArray {
 	ident := p.allocator.LookupIdentityByID(context.Background(), id)
-	return ident.LabelArray
+	if ident != nil {
+		return ident.LabelArray
+	}
+	return nil
 }
 
 // addNewRedirectsFromDesiredPolicy must be called while holding the endpoint lock for

--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -30,3 +30,23 @@ func ParseCIDRs(cidrs []string) (valid []*net.IPNet, invalid []string) {
 	}
 	return valid, invalid
 }
+
+// NetsContainsAny checks that any subnet in the `a` subnet group *fully*
+// contains any of the subnets in the `b` subnet group.
+func NetsContainsAny(a, b []*net.IPNet) bool {
+	for _, an := range a {
+		aMask, _ := an.Mask.Size()
+		aIsIPv4 := an.IP.To4() != nil
+		for _, bn := range b {
+			bIsIPv4 := bn.IP.To4() != nil
+			isSameFamily := aIsIPv4 == bIsIPv4
+			if isSameFamily {
+				bMask, _ := bn.Mask.Size()
+				if bMask >= aMask && an.Contains(bn.IP) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !privileged_tests
+// +build !privileged_tests
+
+package ip
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mustParseCIDR(t *testing.T, s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	assert.NoError(t, err)
+	return n
+}
+
+func TestNetsContainsAny(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []*net.IPNet
+		b    []*net.IPNet
+		ret  bool
+	}{
+		{
+			name: "a contains b",
+			a:    []*net.IPNet{mustParseCIDR(t, "0.0.0.0/0")},
+			b:    []*net.IPNet{mustParseCIDR(t, "192.0.0.1/32")},
+			ret:  true,
+		},
+		{
+			name: "b contains a",
+			a:    []*net.IPNet{mustParseCIDR(t, "192.0.0.1/32")},
+			b:    []*net.IPNet{mustParseCIDR(t, "0.0.0.0/0")},
+		},
+		{
+			name: "a equals b",
+			a:    []*net.IPNet{mustParseCIDR(t, "192.0.0.1/32")},
+			b:    []*net.IPNet{mustParseCIDR(t, "192.0.0.1/32")},
+			ret:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.ret, NetsContainsAny(tt.a, tt.b))
+		})
+	}
+}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -5,8 +5,10 @@ package policy
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -45,6 +47,10 @@ const (
 // MapState is a state of a policy map.
 type MapState map[Key]MapStateEntry
 
+type Identities interface {
+	GetLabels(identity.NumericIdentity) labels.LabelArray
+}
+
 // Key is the userspace representation of a policy key in BPF. It is
 // intentionally duplicated from pkg/maps/policymap to avoid pulling in the
 // BPF dependency to this package.
@@ -76,6 +82,21 @@ func (k Key) IsEgress() bool {
 	return k.TrafficDirection == trafficdirection.Egress.Uint8()
 }
 
+// PortProtoIsBroader returns true if the receiver Key has broader
+// port-protocol than the argument Key. That is a port-protocol
+// that covers the argument Key's port-protocol and is larger.
+// An equal port-protocol will return false.
+func (k Key) PortProtoIsBroader(c Key) bool {
+	return k.DestPort == 0 && c.DestPort != 0 ||
+		k.Nexthdr == 0 && c.Nexthdr != 0
+}
+
+// PortProtoIsEqual returns true if the port-protocols of the
+// two keys are exactly equal.
+func (k Key) PortProtoIsEqual(c Key) bool {
+	return k.DestPort == c.DestPort && k.Nexthdr == c.Nexthdr
+}
+
 type Keys map[Key]struct{}
 
 type MapStateOwner interface{}
@@ -101,6 +122,9 @@ type MapStateEntry struct {
 	// dependents contains the keys for entries create based on this entry. These entries
 	// will be deleted once all of the owners are deleted.
 	dependents Keys
+
+	// cachedNets caches the subnets (if any) associated with this MapStateEntry.
+	cachedNets []*net.IPNet
 }
 
 // NewMapStateEntry creates a map state entry. If redirect is true, the
@@ -141,6 +165,60 @@ func (e *MapStateEntry) RemoveDependent(key Key) {
 	if len(e.dependents) == 0 {
 		e.dependents = nil
 	}
+}
+
+// HasDependent returns true if the 'key' is contained
+// within the set of dependent keys
+func (e *MapStateEntry) HasDependent(key Key) bool {
+	if e.dependents == nil {
+		return false
+	}
+	_, ok := e.dependents[key]
+	return ok
+}
+
+// getNets returns the most specific CIDR for an identity. For the "World" identity
+// it returns both IPv4 and IPv6.
+func (e *MapStateEntry) getNets(identities Identities, ident uint32) []*net.IPNet {
+	// Caching results is not dangerous in this situation as the entry
+	// is ephemerally tied to the lifecycle of the MapState object that
+	// it will be in.
+	if e.cachedNets != nil {
+		return e.cachedNets
+	}
+	id := identity.NumericIdentity(ident)
+	if id == identity.ReservedIdentityWorld {
+		e.cachedNets = []*net.IPNet{
+			{IP: net.IPv4zero, Mask: net.CIDRMask(0, net.IPv4len*8)},
+			{IP: net.IPv6zero, Mask: net.CIDRMask(0, net.IPv6len*8)},
+		}
+		return e.cachedNets
+	}
+	if identities == nil {
+		return nil
+	}
+	lbls := identities.GetLabels(id)
+	nets := make([]*net.IPNet, 0, 1)
+	var (
+		maskSize         int
+		mostSpecificCidr *net.IPNet
+	)
+	for _, lbl := range lbls {
+		if lbl.Source == labels.LabelSourceCIDR {
+			_, netIP, err := net.ParseCIDR(lbl.Key)
+			if err == nil {
+				if ms, _ := netIP.Mask.Size(); ms > maskSize {
+					mostSpecificCidr = netIP
+					maskSize = ms
+				}
+			}
+		}
+	}
+	if mostSpecificCidr != nil {
+		nets = append(nets, mostSpecificCidr)
+	}
+	e.cachedNets = nets
+	return nets
 }
 
 // AddDependent adds 'key' to the set of dependent keys.
@@ -199,8 +277,8 @@ func (e MapStateEntry) String() string {
 // to deny entries, and L3-only deny entries over L3-L4 allows.
 // This form may be used when a full policy is computed and we are not yet interested
 // in accumulating incremental changes.
-func (keys MapState) DenyPreferredInsert(newKey Key, newEntry MapStateEntry) {
-	keys.denyPreferredInsertWithChanges(newKey, newEntry, nil, nil)
+func (keys MapState) DenyPreferredInsert(newKey Key, newEntry MapStateEntry, identities Identities) {
+	keys.denyPreferredInsertWithChanges(newKey, newEntry, nil, nil, identities)
 }
 
 // addKeyWithChanges adds a 'key' with value 'entry' to 'keys' keeping track of incremental changes in 'adds' and 'deletes'
@@ -285,107 +363,139 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, de
 	}
 }
 
-// denyPreferredInsertWithChanges inserts a key and entry into the map by giving preference
-// to deny entries, and L3-only deny entries over L3-L4 allows.
+// entryIdentityIsSupersetOf compares two entries and keys to see if the primary identity contains
+// the compared identity. This means that either that primary identity is 0 (i.e. it is a superset
+// of every other identity), or one of the subnets of the primary identity fully contains or is
+// equal to one of the subnets in the compared identity (note:this covers cases like "reserved:world").
+func entryIdentityIsSupersetOf(primaryKey Key, primaryEntry MapStateEntry, compareKey Key, compareEntry MapStateEntry, identities Identities) bool {
+	// If the identities are equal then neither is a superset (for the purposes of our business logic).
+	if primaryKey.Identity == compareKey.Identity {
+		return false
+	}
+	return primaryKey.Identity == 0 && compareKey.Identity != 0 ||
+		ip.NetsContainsAny(primaryEntry.getNets(identities, primaryKey.Identity),
+			compareEntry.getNets(identities, compareKey.Identity))
+}
+
+// protocolsMatch checks to see if two given keys match on protocol.
+// This means that either one of them covers all protocols or they
+// are equal.
+func protocolsMatch(a, b Key) bool {
+	return a.Nexthdr == 0 || b.Nexthdr == 0 || a.Nexthdr == b.Nexthdr
+}
+
+// denyPreferredInsertWithChanges contains the most important business logic for policy insertions. It inserts
+// a key and entry into the map by giving preference to deny entries, and L3-only deny entries over L3-L4 allows.
 // Incremental changes performed are recorded in 'adds' and 'deletes', if not nil.
-func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, adds, deletes Keys) {
+// See https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw#gid=2109052536 for details
+func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, adds, deletes Keys, identities Identities) {
 	allCpy := allKey
 	allCpy.TrafficDirection = newKey.TrafficDirection
-	// If we have a deny "all" we don't accept any kind of map entry
+	// If we have a deny "all" we don't accept any kind of map entry.
 	if v, ok := keys[allCpy]; ok && v.IsDeny {
 		return
 	}
-
 	if newEntry.IsDeny {
-		// case for an existing allow L4-only and we are inserting deny L3-only
-		switch {
-		case newKey.DestPort == 0 && newKey.Nexthdr == 0 && newKey.Identity != 0:
-			l4OnlyAllows := MapState{}
-			for k, v := range keys {
-				if newKey.TrafficDirection == k.TrafficDirection &&
-					!v.IsDeny &&
-					k.Identity == 0 && (k.DestPort != 0 || k.Nexthdr != 0) {
-					// create a deny L3-L4 with the same allowed L4 port and proto
-					newKeyCpy := newKey
-					newKeyCpy.DestPort = k.DestPort
-					newKeyCpy.Nexthdr = k.Nexthdr
-					l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, false, true)
-					keys.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, adds, deletes)
-					// L3-only entries can be deleted incrementally so we need to track their
-					// effects on other entries so that those effects can be reverted when the
-					// identity is removed.
-					newEntry.AddDependent(newKeyCpy)
-					l4OnlyAllows[k] = v
-				}
+		for k, v := range keys {
+			// Protocols and traffic directions that don't match ensure that the policies
+			// do not interact in anyway.
+			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
+				continue
 			}
-			// Delete all L3-L4 if we are inserting a deny L3-only and
-			// there aren't allow L4-only for the existing deny L3-L4
-			for k := range keys {
-				if k.TrafficDirection == newKey.TrafficDirection &&
-					k.DestPort != 0 && k.Nexthdr != 0 &&
-					k.Identity == newKey.Identity {
-
-					kCpy := k
-					kCpy.Identity = 0
-					if _, ok := l4OnlyAllows[kCpy]; !ok {
-						keys.deleteKeyWithChanges(k, nil, adds, deletes)
+			if !v.IsDeny {
+				if entryIdentityIsSupersetOf(k, v, newKey, newEntry, identities) {
+					if newKey.PortProtoIsBroader(k) {
+						// If this iterated-allow-entry is a superset of the new-entry
+						// and it has a more specific port-protocol than the new-entry
+						// then an additional copy of the new-entry with the more
+						// specific port-protocol of the iterated-allow-entry must be inserted.
+						newKeyCpy := newKey
+						newKeyCpy.DestPort = k.DestPort
+						newKeyCpy.Nexthdr = k.Nexthdr
+						l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, false, true)
+						keys.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, adds, deletes)
+						// L3-only entries can be deleted incrementally so we need to track their
+						// effects on other entries so that those effects can be reverted when the
+						// identity is removed.
+						newEntry.AddDependent(newKeyCpy)
 					}
-				}
-			}
-		case allCpy == newKey:
-			// If we adding a deny "all" entry, then we will remove all entries
-			// from the map state for that direction.
-			for k := range keys {
-				if k.TrafficDirection == allCpy.TrafficDirection {
+				} else if (newKey.Identity == k.Identity ||
+					entryIdentityIsSupersetOf(newKey, newEntry, k, v, identities)) &&
+					(newKey.PortProtoIsBroader(k) || newKey.PortProtoIsEqual(k)) {
+					// If the new-entry is a superset (or equal) of the iterated-allow-entry and
+					// the new-entry has a broader (or equal) port-protocol then we
+					// should delete the iterated-allow-entry
 					keys.deleteKeyWithChanges(k, nil, adds, deletes)
 				}
-			}
-		default:
-			// Do not insert 'newKey' if the map state already denies traffic
-			// which is a superset of (or equal to) 'newKey'
-			newKeyCpy := newKey
-			newKeyCpy.DestPort = 0
-			newKeyCpy.Nexthdr = 0
-			v, ok := keys[newKeyCpy]
-			if ok && v.IsDeny {
-				// Found a L3-only Deny so we won't accept any L3-L4 policies
+			} else if (newKey.Identity == k.Identity ||
+				entryIdentityIsSupersetOf(k, v, newKey, newEntry, identities)) &&
+				k.DestPort == 0 && k.Nexthdr == 0 &&
+				!v.HasDependent(newKey) {
+				// If this iterated-deny-entry is a supserset (or equal) of the new-entry and
+				// the iterated-deny-entry is an L3-only policy then we
+				// should not insert the new entry (as long as it is not one
+				// of the special L4-only denies we created to cover the special
+				// case of a superset-allow with a more specific port-protocol).
+				//
+				// NOTE: This condition could be broader to reject more deny entries,
+				// but there *may* be performance tradeoffs.
 				return
+			} else if (newKey.Identity == k.Identity ||
+				entryIdentityIsSupersetOf(newKey, newEntry, k, v, identities)) &&
+				newKey.DestPort == 0 && newKey.Nexthdr == 0 &&
+				!newEntry.HasDependent(k) {
+				// If this iterated-deny-entry is a subset (or equal) of the new-entry and
+				// the new-entry is an L3-only policy then we
+				// should delete the iterated-deny-entry (as long as it is not one
+				// of the special L4-only denies we created to cover the special
+				// case of a superset-allow with a more specific port-protocol).
+				//
+				// NOTE: This condition could be broader to reject more deny entries,
+				// but there *may* be performance tradeoffs.
+				keys.deleteKeyWithChanges(k, nil, adds, deletes)
 			}
 		}
-
 		keys.addKeyWithChanges(newKey, newEntry, adds, deletes)
-		return
-	} else if newKey.Identity == 0 && newKey.DestPort != 0 {
-		// case for an existing deny L3-only and we are inserting allow L4-only
+	} else {
 		for k, v := range keys {
-			if newKey.TrafficDirection == k.TrafficDirection {
-				if v.IsDeny && k.Identity != 0 && k.DestPort == 0 && k.Nexthdr == 0 {
-					// create a deny L3-L4 with the same deny L3
-					newKeyCpy := newKey
-					newKeyCpy.Identity = k.Identity
-					l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, false, true)
-					keys.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, adds, deletes)
-					// Mark the new entry as a dependent of 'v'
-					v.AddDependent(newKeyCpy)
-					keys[k] = v
+			// Protocols and traffic directions that don't match ensure that the policies
+			// do not interact in anyway.
+			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
+				continue
+			}
+			// NOTE: We do not delete redundant allow entries.
+			if v.IsDeny {
+				if entryIdentityIsSupersetOf(newKey, newEntry, k, v, identities) {
+					if k.PortProtoIsBroader(newKey) {
+						// If the new-entry is *only* superset of the iterated-deny-entry
+						// and the new-entry has a more specific port-protocol than the
+						// iterated-deny-entry then an additional copy of the iterated-deny-entry
+						// with the more specific port-porotocol of the new-entry must
+						// be added.
+						denyKeyCpy := k
+						denyKeyCpy.DestPort = newKey.DestPort
+						denyKeyCpy.Nexthdr = newKey.Nexthdr
+						l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, false, true)
+						keys.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, adds, deletes)
+						// L3-only entries can be deleted incrementally so we need to track their
+						// effects on other entries so that those effects can be reverted when the
+						// identity is removed.
+						v.AddDependent(denyKeyCpy)
+						keys[k] = v
+					}
+				} else if (k.Identity == newKey.Identity ||
+					entryIdentityIsSupersetOf(k, v, newKey, newEntry, identities)) &&
+					(k.PortProtoIsBroader(newKey) || k.PortProtoIsEqual(newKey)) &&
+					!v.HasDependent(newKey) {
+					// If the iterated-deny-entry is a superset (or equal) of the new-entry and has a
+					// broader (or equal) port-protocol than the new-entry then the new
+					// entry should not be inserted.
+					return
 				}
 			}
 		}
-		keys.addKeyWithChanges(newKey, newEntry, adds, deletes)
-		return
+		keys.redirectPreferredInsert(newKey, newEntry, adds, deletes)
 	}
-	// branch for adding a new allow L3-L4
-
-	newKeyCpy := newKey
-	newKeyCpy.DestPort = 0
-	newKeyCpy.Nexthdr = 0
-	v, ok := keys[newKeyCpy]
-	if ok && v.IsDeny {
-		// Found a L3-only Deny so we won't accept any L3-L4 allow policies
-		return
-	}
-
-	keys.redirectPreferredInsert(newKey, newEntry, adds, deletes)
 }
 
 // redirectPreferredInsert inserts a new entry giving priority to L7-redirects by
@@ -437,23 +547,23 @@ func (keys MapState) insertIfNotExists(key Key, entry MapStateEntry) {
 //
 // The above can be accomplished by:
 //
-// 1. Change existing L4-only ALLOW key on matching port that does not already
-//    redirect to redirect.
-//    - e.g., 0:80=allow,0 -> 0:80=allow,<proxyport>
-// 2. If allow-all policy exists, add L4-only visibility redirect key if the L4-only
-//    key does not already exist.
-//    - e.g., 0:0=allow,0 -> add 0:80=allow,<proxyport> if 0:80 does not exist
-//      - this allows all traffic on port 80, but see step 5 below.
-// 3. Change all L3/L4 ALLOW keys on matching port that do not already redirect to
-//    redirect.
-//    - e.g, <ID1>:80=allow,0 -> <ID1>:80=allow,<proxyport>
-// 4. For each L3-only ALLOW key add the corresponding L3/L4 ALLOW redirect if no
-//    L3/L4 key already exists and no L4-only key already exists and one is not added.
-//    - e.g., <ID2>:0=allow,0 -> add <ID2>:80=allow,<proxyport> if <ID2>:80
-//      and 0:80 do not exist
-// 5. If a new L4-only key was added: For each L3-only DENY key add the
-//    corresponding L3/L4 DENY key if no L3/L4 key already exists.
-//    - e.g., <ID3>:0=deny,0 -> add <ID3>:80=deny,0 if <ID3>:80 does not exist
+//  1. Change existing L4-only ALLOW key on matching port that does not already
+//     redirect to redirect.
+//     - e.g., 0:80=allow,0 -> 0:80=allow,<proxyport>
+//  2. If allow-all policy exists, add L4-only visibility redirect key if the L4-only
+//     key does not already exist.
+//     - e.g., 0:0=allow,0 -> add 0:80=allow,<proxyport> if 0:80 does not exist
+//     - this allows all traffic on port 80, but see step 5 below.
+//  3. Change all L3/L4 ALLOW keys on matching port that do not already redirect to
+//     redirect.
+//     - e.g, <ID1>:80=allow,0 -> <ID1>:80=allow,<proxyport>
+//  4. For each L3-only ALLOW key add the corresponding L3/L4 ALLOW redirect if no
+//     L3/L4 key already exists and no L4-only key already exists and one is not added.
+//     - e.g., <ID2>:0=allow,0 -> add <ID2>:80=allow,<proxyport> if <ID2>:80
+//     and 0:80 do not exist
+//  5. If a new L4-only key was added: For each L3-only DENY key add the
+//     corresponding L3/L4 DENY key if no L3/L4 key already exists.
+//     - e.g., <ID3>:0=deny,0 -> add <ID3>:80=deny,0 if <ID3>:80 does not exist
 //
 // With the above we only change/expand existing allow keys to redirect, and
 // expand existing drop keys to also drop on the port of interest, if a new
@@ -605,7 +715,7 @@ func (keys MapState) DetermineAllowLocalhostIngress() {
 			},
 		}
 		es := NewMapStateEntry(nil, derivedFrom, false, false)
-		keys.DenyPreferredInsert(localHostKey, es)
+		keys.DenyPreferredInsert(localHostKey, es, nil)
 		if !option.Config.EnableRemoteNodeIdentity {
 			var isHostDenied bool
 			v, ok := keys[localHostKey]
@@ -616,7 +726,7 @@ func (keys MapState) DetermineAllowLocalhostIngress() {
 				},
 			}
 			es := NewMapStateEntry(nil, derivedFrom, false, isHostDenied)
-			keys.DenyPreferredInsert(localRemoteNodeKey, es)
+			keys.DenyPreferredInsert(localRemoteNodeKey, es, nil)
 		}
 	}
 }
@@ -792,7 +902,7 @@ func (mc *MapChanges) AccumulateMapChanges(cs CachedSelector, adds, deletes []id
 
 // consumeMapChanges transfers the incremental changes from MapChanges to the caller,
 // while applying the changes to PolicyMapState.
-func (mc *MapChanges) consumeMapChanges(policyMapState MapState) (adds, deletes Keys) {
+func (mc *MapChanges) consumeMapChanges(policyMapState MapState, identities Identities) (adds, deletes Keys) {
 	mc.mutex.Lock()
 	adds = make(Keys, len(mc.changes))
 	deletes = make(Keys, len(mc.changes))
@@ -802,7 +912,7 @@ func (mc *MapChanges) consumeMapChanges(policyMapState MapState) (adds, deletes 
 			// insert but do not allow non-redirect entries to overwrite a redirect entry,
 			// nor allow non-deny entries to overwrite deny entries.
 			// Collect the incremental changes to the overall state in 'mc.adds' and 'mc.deletes'.
-			policyMapState.denyPreferredInsertWithChanges(mc.changes[i].Key, mc.changes[i].Value, adds, deletes)
+			policyMapState.denyPreferredInsertWithChanges(mc.changes[i].Key, mc.changes[i].Value, adds, deletes, identities)
 		} else {
 			// Delete the contribution of this cs to the key and collect incremental changes
 			for cs := range mc.changes[i].Value.owners { // get the sole selector

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -727,7 +729,7 @@ func (ds *PolicyTestSuite) TestMapState_DenyPreferredInsert(c *check.C) {
 		},
 	}
 	for _, tt := range tests {
-		tt.keys.DenyPreferredInsert(tt.args.key, tt.args.entry)
+		tt.keys.DenyPreferredInsert(tt.args.key, tt.args.entry, nil)
 		c.Assert(tt.keys, checker.DeepEquals, tt.want, check.Commentf(tt.name))
 	}
 }
@@ -1140,7 +1142,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			}
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, nil)
 		}
-		adds, deletes := policyMaps.consumeMapChanges(policyMapState)
+		adds, deletes := policyMaps.consumeMapChanges(policyMapState, nil)
 		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
 		c.Assert(adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))
 		c.Assert(deletes, checker.DeepEquals, tt.deletes, check.Commentf(tt.name+" (deletes)"))
@@ -1377,7 +1379,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			}
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, nil)
 		}
-		adds, deletes := policyMaps.consumeMapChanges(policyMapState)
+		adds, deletes := policyMaps.consumeMapChanges(policyMapState, nil)
 		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
 		c.Assert(adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))
 		c.Assert(deletes, checker.DeepEquals, tt.deletes, check.Commentf(tt.name+" (deletes)"))
@@ -1935,7 +1937,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			}
 			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, nil)
 		}
-		adds, deletes = policyMaps.consumeMapChanges(policyMapState)
+		adds, deletes = policyMaps.consumeMapChanges(policyMapState, nil)
 		// Visibilty redirects need to be re-applied after consumeMapChanges()
 		visOld = make(MapState)
 		for _, arg := range tt.visArgs {
@@ -1947,5 +1949,133 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
 		c.Assert(adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))
 		c.Assert(deletes, checker.DeepEquals, tt.deletes, check.Commentf(tt.name+" (deletes)"))
+	}
+}
+
+func (ds *PolicyTestSuite) TestMapState_DenyPreferredInsertWithSubnets(c *check.C) {
+	identityCache := cache.IdentityCache{
+		identity.ReservedIdentityWorld: labels.LabelWorld.LabelArray(),
+		worldIPIdentity:                lblWorldIP,                  // "192.0.2.3/32"
+		worldSubnetIdentity:            lblWorldSubnet.LabelArray(), // "192.0.2.0/24"
+	}
+
+	reservedWorldID := identity.ReservedIdentityWorld.Uint32()
+	worldIPID := worldIPIdentity.Uint32()
+	worldSubnetID := worldSubnetIdentity.Uint32()
+	selectorCache := testNewSelectorCache(identityCache)
+	type action uint16
+	const (
+		noAction = action(iota)
+		insertA  = action(1 << iota)
+		insertB
+		insertAWithBProto
+		insertBWithAProto
+
+		insertBoth            = insertA | insertB
+		canDeleteAInsertsBoth = insertBoth
+		canDeleteBInsertsBoth = insertBoth
+	)
+	// these tests are based on the sheet https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw#gid=2109052536
+	tests := []struct {
+		name                 string
+		aIdentity, bIdentity uint32
+		aIsDeny, bIsDeny     bool
+		aPort                uint16
+		aProto               uint8
+		bPort                uint16
+		bProto               uint8
+		outcome              action
+	}{
+		// deny-allow insertions
+		{"deny-allow: a superset a|b L3-only", reservedWorldID, worldSubnetID, true, false, 0, 0, 0, 0, insertA},
+		{"deny-allow: b superset a|b L3-only", worldIPID, worldSubnetID, true, false, 0, 0, 0, 0, insertBoth},
+		{"deny-allow: a superset a L3-only, b L4", reservedWorldID, worldSubnetID, true, false, 0, 0, 0, 6, insertA},
+		{"deny-allow: b superset a L3-only, b L4", worldIPID, worldSubnetID, true, false, 0, 0, 0, 6, insertBoth | insertAWithBProto},
+		{"deny-allow: a superset a L3-only, b L3L4", reservedWorldID, worldSubnetID, true, false, 0, 0, 80, 6, insertA},
+		{"deny-allow: b superset a L3-only, b L3L4", worldIPID, worldSubnetID, true, false, 0, 0, 80, 6, insertBoth | insertAWithBProto},
+		{"deny-allow: a superset a L4, b L3-only", reservedWorldID, worldSubnetID, true, false, 0, 6, 0, 0, insertBoth},
+		{"deny-allow: b superset a L4, b L3-only", worldIPID, worldSubnetID, true, false, 0, 6, 0, 0, insertBoth},
+		{"deny-allow: a superset a L4, b L4", reservedWorldID, worldSubnetID, true, false, 0, 6, 0, 6, insertA},
+		{"deny-allow: b superset a L4, b L4", worldIPID, worldSubnetID, true, false, 0, 6, 0, 6, insertBoth},
+		{"deny-allow: a superset a L4, b L3L4", reservedWorldID, worldSubnetID, true, false, 0, 6, 80, 6, insertA},
+		{"deny-allow: b superset a L4, b L3L4", worldIPID, worldSubnetID, true, false, 0, 6, 80, 6, insertBoth | insertAWithBProto},
+		{"deny-allow: a superset a L3L4, b L3-only", reservedWorldID, worldSubnetID, true, false, 80, 6, 0, 0, insertBoth},
+		{"deny-allow: b superset a L3L4, b L3-only", worldIPID, worldSubnetID, true, false, 80, 6, 0, 0, insertBoth},
+		{"deny-allow: a superset a L3L4, b L4", reservedWorldID, worldSubnetID, true, false, 80, 6, 0, 6, insertBoth},
+		{"deny-allow: b superset a L3L4, b L4", worldIPID, worldSubnetID, true, false, 80, 6, 0, 6, insertBoth},
+		{"deny-allow: a superset a L3L4, b L3L4", reservedWorldID, worldSubnetID, true, false, 80, 6, 80, 6, insertA},
+		{"deny-allow: b superset a L3L4, b L3L4", worldIPID, worldSubnetID, true, false, 80, 6, 80, 6, insertBoth},
+
+		// deny-deny insertions: Note: We do not delete all redundant deny-deny insertions that we could.
+		// We only delete entries redundant to L3-only port protocols, all other port-protocol supersets
+		// *do not* have this effect.
+		{"deny-deny: a superset a|b L3-only", worldSubnetID, worldIPID, true, true, 0, 0, 0, 0, insertA},
+		{"deny-deny: b superset a|b L3-only", worldSubnetID, reservedWorldID, true, true, 0, 0, 0, 0, insertB},
+		{"deny-deny: a superset a L3-only, b L4", worldSubnetID, worldIPID, true, true, 0, 0, 0, 6, insertA},
+		{"deny-deny: b superset a L3-only, b L4", worldSubnetID, reservedWorldID, true, true, 0, 0, 0, 6, insertBoth},
+		{"deny-deny: a superset a L3-only, b L3L4", worldSubnetID, worldIPID, true, true, 0, 0, 80, 6, insertA},
+		{"deny-deny: b superset a L3-only, b L3L4", worldSubnetID, reservedWorldID, true, true, 0, 0, 80, 6, insertBoth},
+		{"deny-deny: a superset a L4, b L3-only", worldSubnetID, worldIPID, true, true, 0, 6, 0, 0, insertBoth},
+		{"deny-deny: b superset a L4, b L3-only", worldSubnetID, reservedWorldID, true, true, 0, 6, 0, 0, insertB},
+		{"deny-deny: a superset a L4, b L4", worldSubnetID, worldIPID, true, true, 0, 6, 0, 6, canDeleteBInsertsBoth},
+		{"deny-deny: b superset a L4, b L4", worldSubnetID, reservedWorldID, true, true, 0, 6, 0, 6, canDeleteAInsertsBoth},
+		{"deny-deny: a superset a L4, b L3L4", worldSubnetID, worldIPID, true, true, 0, 6, 80, 6, canDeleteBInsertsBoth},
+		{"deny-deny: b superset a L4, b L3L4", worldSubnetID, reservedWorldID, true, true, 0, 6, 80, 6, insertBoth},
+		{"deny-deny: a superset a L3L4, b L3-only", worldSubnetID, worldIPID, true, true, 80, 6, 0, 0, insertBoth},
+		{"deny-deny: b superset a L3L4, b L3-only", worldSubnetID, reservedWorldID, true, true, 80, 6, 0, 0, insertB},
+		{"deny-deny: a superset a L3L4, b L4", worldSubnetID, worldIPID, true, true, 80, 6, 0, 6, insertBoth},
+		{"deny-deny: b superset a L3L4, b L4", worldSubnetID, reservedWorldID, true, true, 80, 6, 0, 6, canDeleteAInsertsBoth},
+		{"deny-deny: a superset a L3L4, b L3L4", worldSubnetID, worldIPID, true, true, 80, 6, 80, 6, canDeleteBInsertsBoth},
+		{"deny-deny: b superset a L3L4, b L3L4", worldSubnetID, reservedWorldID, true, true, 80, 6, 80, 6, canDeleteAInsertsBoth},
+		// allow-allow insertions do not need to be tests as they will all be inserted
+	}
+	for _, tt := range tests {
+		aKey := Key{Identity: tt.aIdentity, DestPort: tt.aPort, Nexthdr: tt.aProto}
+		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
+		bKey := Key{Identity: tt.bIdentity, DestPort: tt.bPort, Nexthdr: tt.bProto}
+		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
+		expectedKeys := MapState{}
+		if tt.outcome&insertA > 0 {
+			expectedKeys[aKey] = aEntry
+		}
+		if tt.outcome&insertB > 0 {
+			expectedKeys[bKey] = bEntry
+		}
+		if tt.outcome&insertAWithBProto > 0 {
+			aKeyWithBProto := Key{Identity: tt.aIdentity, DestPort: tt.bPort, Nexthdr: tt.bProto}
+			aEntryCpy := MapStateEntry{IsDeny: tt.aIsDeny}
+			aEntryCpy.owners = map[MapStateOwner]struct{}{aKey: {}}
+			aEntry.AddDependent(aKeyWithBProto)
+			expectedKeys[aKey] = aEntry
+			expectedKeys[aKeyWithBProto] = aEntryCpy
+		}
+		if tt.outcome&insertBWithAProto > 0 {
+			bKeyWithBProto := Key{Identity: tt.bIdentity, DestPort: tt.aPort, Nexthdr: tt.aProto}
+			bEntryCpy := MapStateEntry{IsDeny: tt.bIsDeny}
+			bEntryCpy.owners = map[MapStateOwner]struct{}{bKey: {}}
+			bEntry.AddDependent(bKeyWithBProto)
+			expectedKeys[bKey] = bEntry
+			expectedKeys[bKeyWithBProto] = bEntryCpy
+		}
+		outcomeKeys := MapState{}
+		outcomeKeys.DenyPreferredInsert(aKey, aEntry, selectorCache)
+		outcomeKeys.DenyPreferredInsert(bKey, bEntry, selectorCache)
+		c.Assert(outcomeKeys, checker.DeepEquals, expectedKeys, check.Commentf(tt.name))
+	}
+	// Now test all cases with different traffic directions.
+	// This should result in both entries being inserted with
+	// no changes, as they do not affect one another anymore.
+	for _, tt := range tests {
+		aKey := Key{Identity: tt.aIdentity, DestPort: tt.aPort, Nexthdr: tt.aProto}
+		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
+		bKey := Key{Identity: tt.bIdentity, DestPort: tt.bPort, Nexthdr: tt.bProto, TrafficDirection: 1}
+		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
+		expectedKeys := MapState{}
+		expectedKeys[aKey] = aEntry
+		expectedKeys[bKey] = bEntry
+		outcomeKeys := MapState{}
+		outcomeKeys.DenyPreferredInsert(aKey, aEntry, selectorCache)
+		outcomeKeys.DenyPreferredInsert(bKey, bEntry, selectorCache)
+		c.Assert(outcomeKeys, checker.DeepEquals, expectedKeys, check.Commentf("different traffic directions %s", tt.name))
 	}
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -141,10 +141,12 @@ func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *En
 	// Must come after the 'insertUser()' above to guarantee
 	// PolicyMapChanges will contain all changes that are applied
 	// after the computation of PolicyMapState has started.
+	p.SelectorCache.mutex.RLock()
 	calculatedPolicy.computeDesiredL4PolicyMapEntries()
 	if !isHost {
 		calculatedPolicy.PolicyMapState.DetermineAllowLocalhostIngress()
 	}
+	p.SelectorCache.mutex.RUnlock()
 
 	return calculatedPolicy
 }

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -171,7 +171,7 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(policyMapState MapSt
 	for _, filter := range l4PolicyMap {
 		lookupDone := false
 		proxyport := uint16(0)
-		keysFromFilter := filter.ToMapState(p.PolicyOwner, direction)
+		keysFromFilter := filter.ToMapState(p.PolicyOwner, direction, p.SelectorCache)
 		for keyFromFilter, entry := range keysFromFilter {
 			// Fix up the proxy port for entries that need proxy redirection
 			if entry.IsRedirectEntry() {
@@ -191,7 +191,7 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(policyMapState MapSt
 					continue
 				}
 			}
-			policyMapState.DenyPreferredInsert(keyFromFilter, entry)
+			policyMapState.DenyPreferredInsert(keyFromFilter, entry, p.SelectorCache)
 		}
 	}
 }
@@ -203,7 +203,7 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(policyMapState MapSt
 func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
 	p.selectorPolicy.SelectorCache.mutex.Lock()
 	defer p.selectorPolicy.SelectorCache.mutex.Unlock()
-	return p.policyMapChanges.consumeMapChanges(p.PolicyMapState)
+	return p.policyMapChanges.consumeMapChanges(p.PolicyMapState, p.SelectorCache)
 }
 
 // AllowsIdentity returns whether the specified policy allows

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -1079,3 +1079,11 @@ func (sc *SelectorCache) RemoveIdentitiesFQDNSelectors(fqdnSels []api.FQDNSelect
 	sc.mutex.Unlock()
 	sc.releaseIdentityMappings(identitiesToRelease)
 }
+
+func (sc *SelectorCache) GetLabels(id identity.NumericIdentity) labels.LabelArray {
+	ident, ok := sc.idCache[id]
+	if !ok {
+		return labels.LabelArray{}
+	}
+	return ident.lbls
+}

--- a/vendor/github.com/sirupsen/logrus/README.md
+++ b/vendor/github.com/sirupsen/logrus/README.md
@@ -1,4 +1,4 @@
-# Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/> [![Build Status](https://travis-ci.org/sirupsen/logrus.svg?branch=master)](https://travis-ci.org/sirupsen/logrus) [![GoDoc](https://godoc.org/github.com/sirupsen/logrus?status.svg)](https://godoc.org/github.com/sirupsen/logrus)
+# Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:"/> [![Build Status](https://github.com/sirupsen/logrus/workflows/CI/badge.svg)](https://github.com/sirupsen/logrus/actions?query=workflow%3ACI) [![Build Status](https://travis-ci.org/sirupsen/logrus.svg?branch=master)](https://travis-ci.org/sirupsen/logrus) [![Go Reference](https://pkg.go.dev/badge/github.com/sirupsen/logrus.svg)](https://pkg.go.dev/github.com/sirupsen/logrus)
 
 Logrus is a structured logger for Go (golang), completely API compatible with
 the standard library logger.
@@ -341,7 +341,7 @@ import (
   log "github.com/sirupsen/logrus"
 )
 
-init() {
+func init() {
   // do something here to set environment depending on an environment variable
   // or command-line flag
   if Environment == "production" {

--- a/vendor/github.com/sirupsen/logrus/buffer_pool.go
+++ b/vendor/github.com/sirupsen/logrus/buffer_pool.go
@@ -26,15 +26,6 @@ func (p *defaultPool) Get() *bytes.Buffer {
 	return p.pool.Get().(*bytes.Buffer)
 }
 
-func getBuffer() *bytes.Buffer {
-	return bufferPool.Get()
-}
-
-func putBuffer(buf *bytes.Buffer) {
-	buf.Reset()
-	bufferPool.Put(buf)
-}
-
 // SetBufferPool allows to replace the default logrus buffer pool
 // to better meets the specific needs of an application.
 func SetBufferPool(bp BufferPool) {

--- a/vendor/github.com/sirupsen/logrus/logger.go
+++ b/vendor/github.com/sirupsen/logrus/logger.go
@@ -44,6 +44,9 @@ type Logger struct {
 	entryPool sync.Pool
 	// Function to exit the application, defaults to `os.Exit()`
 	ExitFunc exitFunc
+	// The buffer pool used to format the log. If it is nil, the default global
+	// buffer pool will be used.
+	BufferPool BufferPool
 }
 
 type exitFunc func(int)
@@ -192,6 +195,9 @@ func (logger *Logger) Panicf(format string, args ...interface{}) {
 	logger.Logf(PanicLevel, format, args...)
 }
 
+// Log will log a message at the level given as parameter.
+// Warning: using Log at Panic or Fatal level will not respectively Panic nor Exit.
+// For this behaviour Logger.Panic or Logger.Fatal should be used instead.
 func (logger *Logger) Log(level Level, args ...interface{}) {
 	if logger.IsLevelEnabled(level) {
 		entry := logger.newEntry()
@@ -401,4 +407,11 @@ func (logger *Logger) ReplaceHooks(hooks LevelHooks) LevelHooks {
 	logger.Hooks = hooks
 	logger.mu.Unlock()
 	return oldHooks
+}
+
+// SetBufferPool sets the logger buffer pool.
+func (logger *Logger) SetBufferPool(pool BufferPool) {
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+	logger.BufferPool = pool
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -718,7 +718,7 @@ github.com/shirou/gopsutil/v3/load
 github.com/shirou/gopsutil/v3/mem
 github.com/shirou/gopsutil/v3/net
 github.com/shirou/gopsutil/v3/process
-# github.com/sirupsen/logrus v1.8.1
+# github.com/sirupsen/logrus v1.9.0
 ## explicit; go 1.13
 github.com/sirupsen/logrus
 github.com/sirupsen/logrus/hooks/syslog


### PR DESCRIPTION
- Add Tests for Deny Precedence Bug:

  Currently, when a broad "Deny" policy is paired with a specific "Unmanaged CIDR" policy, then the "Unmanaged CIDR" policy will still be inserted into the policy map for an endpoint. This results in "Deny" policies not always taking precedence over "Allow" policies. This test confirms the bugs existence.

- Fix Deny Precedence Bug:

  When the policy map state is created CIDRs are now checked against one another to ensure that deny-rules that supersede allow-rules when they should.

  `DenyPreferredInsert` has been refactored to use utility methods that make the complex boolean logic of policy precedence more atomic.

  Add `NetsContainsAny` method to `pkg/ip` to compare cases where one set of networks conatins or is equal to any network in another set.

- endpoint: Add policy.Identity Implementation

  A `policy.Identity` implementation is necessary for the incremental update to the endpoint's policy map that can occur with L7 changes. Valid deny-policy entries may prohibit these L7 changes based on CIDR rules, which are only obtainable by looking up all potentially conflicting policies' labels. Thus `l4.ToMapState` needs access to the identity allocater to lookup "random" identity labels.

- Additional commit from @joestringer to fix concurrent access to the SelectorCache, a bug the original work introduced.

- Additional commit from @nathanjsweet to prevent a potential nil pointer dereference in the endpoint code.

```release-note
policy: Promote Deny Policies from Beta to Stable
```