### PR TITLE
nodehandler: register node-id restore as hive lifecycle hook

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -743,10 +743,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		log.WithField(logfields.Ingress, restoredIngressIPs).Info("Restored ingress IPs")
 	}
 
-	// Now that BPF maps are opened, we can restore node IDs to the node
-	// manager.
-	d.datapath.Node().RestoreNodeIDs()
-
 	// Read the service IDs of existing services from the BPF map and
 	// reserve them. This must be done *before* connecting to the
 	// Kubernetes apiserver and serving the API to ensure service IDs are

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -92,7 +92,16 @@ func newDatapath(params datapathParams) types.Datapath {
 			return nil
 		}})
 
-	return linuxdatapath.NewDatapath(datapathConfig, iptablesManager, params.WgAgent)
+	datapath := linuxdatapath.NewDatapath(datapathConfig, iptablesManager, params.WgAgent)
+
+	params.LC.Append(hive.Hook{
+		OnStart: func(hive.HookContext) error {
+			datapath.Node().RestoreNodeIDs()
+			return nil
+		},
+	})
+
+	return datapath
 }
 
 type datapathParams struct {


### PR DESCRIPTION
This commit moves the node id restore from the daemon to the datapath hive cell (which instantiates the `linuxNodeHandler`) - where it's implemented as hive lifecycle hook.

Otherwise, dependent components are trying to lookup node ids before the actual restoration - which results in unnecessary newly allocated node ids.