### PR TITLE
Fix missed deletion events when reconnecting to/disconnecting from remote clusters (nodes and services)

### DIFF
--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -68,7 +68,7 @@ func (n *testNode) Marshal() ([]byte, error) {
 	return json.Marshal(n)
 }
 
-func (n *testNode) Unmarshal(data []byte) error {
+func (n *testNode) Unmarshal(_ string, data []byte) error {
 	return json.Unmarshal(data, n)
 }
 

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
-	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -58,18 +57,16 @@ type remoteCluster struct {
 
 	// mutex protects the following variables
 	// - backend
-	// - store
-	// - remoteNodes
 	// - ipCacheWatcher
 	// - remoteIdentityCache
 	mutex lock.RWMutex
 
 	// store is the shared store representing all nodes in the remote cluster
-	remoteNodes *store.SharedStore
+	remoteNodes store.WatchStore
 
 	// remoteServices is the shared store representing services in remote
 	// clusters
-	remoteServices *store.SharedStore
+	remoteServices store.WatchStore
 
 	// ipCacheWatcher is the watcher that notifies about IP<->identity
 	// changes in the remote cluster
@@ -120,21 +117,14 @@ func (rc *remoteCluster) releaseOldConnection() {
 	ipCacheWatcher := rc.ipCacheWatcher
 	rc.ipCacheWatcher = nil
 
-	remoteNodes := rc.remoteNodes
-	rc.remoteNodes = nil
-
 	remoteIdentityCache := rc.remoteIdentityCache
 	rc.remoteIdentityCache = nil
-
-	remoteServices := rc.remoteServices
-	rc.remoteServices = nil
 
 	backend := rc.backend
 	rc.backend = nil
 
 	rc.config = nil
 
-	rc.mesh.metricTotalNodes.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(0.0)
 	rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
 
 	rc.mutex.Unlock()
@@ -146,14 +136,8 @@ func (rc *remoteCluster) releaseOldConnection() {
 		if ipCacheWatcher != nil {
 			ipCacheWatcher.Close()
 		}
-		if remoteNodes != nil {
-			remoteNodes.Close(context.TODO())
-		}
 		if remoteIdentityCache != nil {
 			remoteIdentityCache.Close()
-		}
-		if remoteServices != nil {
-			remoteServices.Close(context.TODO())
 		}
 		if backend != nil {
 			backend.Close(context.TODO())
@@ -204,43 +188,28 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 					return err
 				}
 
-				remoteNodes, err := store.JoinSharedStore(store.Configuration{
-					Prefix:                  path.Join(nodeStore.NodeStorePrefix, rc.name),
-					KeyCreator:              rc.mesh.conf.NodeKeyCreator,
-					SynchronizationInterval: time.Minute,
-					SharedKeyDeleteDelay:    defaults.NodeDeleteDelay,
-					Backend:                 backend,
-					Observer:                rc.mesh.conf.NodeObserver,
-				})
-				if err != nil {
-					backend.Close(ctx)
-					return err
+				var capabilities types.CiliumClusterConfigCapabilities
+				if config != nil {
+					capabilities = config.Capabilities
 				}
 
-				remoteServices, err := store.JoinSharedStore(store.Configuration{
-					Prefix: path.Join(serviceStore.ServiceStorePrefix, rc.name),
-					KeyCreator: func() store.Key {
-						svc := serviceStore.ClusterService{}
-						return &svc
-					},
-					SynchronizationInterval: time.Minute,
-					Backend:                 backend,
-					Observer: &remoteServiceObserver{
-						remoteCluster: rc,
-						swg:           rc.swg,
-					},
-				})
-				if err != nil {
-					remoteNodes.Close(ctx)
-					backend.Close(ctx)
-					return err
+				var mgr store.WatchStoreManager
+				if capabilities.SyncedCanaries {
+					mgr = store.NewWatchStoreManagerSync(backend, rc.name)
+				} else {
+					mgr = store.NewWatchStoreManagerImmediate(rc.name)
 				}
-				rc.swg.Stop()
+
+				mgr.Register(nodeStore.NodeStorePrefix, func(ctx context.Context) {
+					rc.remoteNodes.Watch(ctx, backend, path.Join(nodeStore.NodeStorePrefix, rc.name))
+				})
+
+				mgr.Register(serviceStore.ServiceStorePrefix, func(ctx context.Context) {
+					rc.remoteServices.Watch(ctx, backend, path.Join(serviceStore.ServiceStorePrefix, rc.name))
+				})
 
 				remoteIdentityCache, err := allocator.WatchRemoteIdentities(rc.name, backend)
 				if err != nil {
-					remoteServices.Close(ctx)
-					remoteNodes.Close(ctx)
 					backend.Close(ctx)
 					return err
 				}
@@ -249,23 +218,21 @@ func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher
 				go ipCacheWatcher.Watch(ctx)
 
 				rc.mutex.Lock()
-				rc.remoteNodes = remoteNodes
-				rc.remoteServices = remoteServices
 				rc.backend = backend
 				rc.config = config
 				rc.ipCacheWatcher = ipCacheWatcher
 				rc.remoteIdentityCache = remoteIdentityCache
-				rc.mesh.metricTotalNodes.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(float64(rc.remoteNodes.NumEntries()))
 				rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
 				rc.mutex.Unlock()
 
 				rc.getLogger().Info("Established connection to remote etcd")
+				mgr.Run(ctx)
 
 				return nil
 			},
 			StopFunc: func(ctx context.Context) error {
 				rc.releaseOldConnection()
-				rc.mesh.metricTotalNodes.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(float64(rc.remoteNodes.NumEntries()))
+
 				rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
 				allocator.RemoveRemoteIdentities(rc.name)
 				rc.getLogger().Info("All resources of remote cluster cleaned up")
@@ -409,7 +376,6 @@ func (rc *remoteCluster) onInsert(allocator RemoteIdentityWatcher) {
 				rc.lastFailure = time.Now()
 				rc.mesh.metricLastFailureTimestamp.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).SetToCurrentTime()
 				rc.mesh.metricTotalFailures.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(float64(rc.failures))
-				rc.mesh.metricTotalNodes.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(float64(rc.remoteNodes.NumEntries()))
 				rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
 				rc.mutex.Unlock()
 				rc.restartRemoteConnection(allocator)
@@ -419,9 +385,23 @@ func (rc *remoteCluster) onInsert(allocator RemoteIdentityWatcher) {
 
 }
 
-func (rc *remoteCluster) onRemove() {
+// onStop is executed when the clustermesh subsystem is being stopped.
+// In this case, we don't want to drain the known entries, otherwise
+// we would break existing connections when the agent gets restarted.
+func (rc *remoteCluster) onStop() {
 	rc.controllers.RemoveAllAndWait()
 	close(rc.changed)
+}
+
+// onRemove is executed when a remote cluster is explicitly disconnected
+// (i.e., its configuration is removed). In this case, we need to drain
+// all known entries, to properly cleanup the status without requiring to
+// restart the agent.
+func (rc *remoteCluster) onRemove() {
+	rc.onStop()
+
+	rc.remoteNodes.Drain()
+	rc.remoteServices.Drain()
 
 	rc.getLogger().Info("Remote cluster disconnected")
 }
@@ -434,7 +414,7 @@ func (rc *remoteCluster) isReady() bool {
 }
 
 func (rc *remoteCluster) isReadyLocked() bool {
-	return rc.backend != nil && rc.remoteNodes != nil && rc.ipCacheWatcher != nil
+	return rc.backend != nil && rc.ipCacheWatcher != nil
 }
 
 func (rc *remoteCluster) status() *models.RemoteCluster {

--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -304,7 +304,7 @@ func (c *CNPNSWithMeta) Marshal() ([]byte, error) {
 }
 
 // Unmarshal unmarshals the CNPNSWithMeta from JSON form.
-func (c *CNPNSWithMeta) Unmarshal(data []byte) error {
+func (c *CNPNSWithMeta) Unmarshal(_ string, data []byte) error {
 	newCNPNS := CNPNSWithMeta{}
 	if err := json.Unmarshal(data, &newCNPNS); err != nil {
 		return err

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -182,6 +182,24 @@ type LocalKey interface {
 	DeepKeyCopy() LocalKey
 }
 
+// KVPair represents a basic implementation of the LocalKey interface
+type KVPair struct{ Key, Value string }
+
+func NewKVPair(key, value string) *KVPair { return &KVPair{Key: key, Value: value} }
+func KVPairCreator() Key                  { return &KVPair{} }
+
+func (kv *KVPair) GetKeyName() string       { return kv.Key }
+func (kv *KVPair) Marshal() ([]byte, error) { return []byte(kv.Value), nil }
+
+func (kv *KVPair) Unmarshal(key string, data []byte) error {
+	kv.Key, kv.Value = key, string(data)
+	return nil
+}
+
+func (kv *KVPair) DeepKeyCopy() LocalKey {
+	return NewKVPair(kv.Key, kv.Value)
+}
+
 // JoinSharedStore creates a new shared store based on the provided
 // configuration. An error is returned if the configuration is invalid. The
 // store is initialized with the contents of the kvstore. An error is returned

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -166,11 +166,12 @@ type Key interface {
 	Marshal() ([]byte, error)
 
 	// Unmarshal is called when an update from the kvstore is received. The
+	// prefix configured for the store is removed from the key, and the
 	// byte slice passed to the function is coming from the Marshal
 	// function from another collaborator. The function must unmarshal and
 	// update the underlying data type. It is typically a good idea to use
 	// json.Unmarshal to implement this function.
-	Unmarshal(data []byte) error
+	Unmarshal(key string, data []byte) error
 }
 
 // LocalKey is a Key owned by the local store instance
@@ -391,7 +392,7 @@ func (s *SharedStore) getLogger() *logrus.Entry {
 
 func (s *SharedStore) updateKey(name string, value []byte) error {
 	newKey := s.conf.KeyCreator()
-	if err := newKey.Unmarshal(value); err != nil {
+	if err := newKey.Unmarshal(name, value); err != nil {
 		return err
 	}
 

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -80,10 +80,10 @@ type TestType struct {
 
 var _ = TestType{}
 
-func (t *TestType) GetKeyName() string          { return t.Name }
-func (t *TestType) DeepKeyCopy() LocalKey       { return &TestType{Name: t.Name} }
-func (t *TestType) Marshal() ([]byte, error)    { return json.Marshal(t) }
-func (t *TestType) Unmarshal(data []byte) error { return json.Unmarshal(data, t) }
+func (t *TestType) GetKeyName() string                    { return t.Name }
+func (t *TestType) DeepKeyCopy() LocalKey                 { return &TestType{Name: t.Name} }
+func (t *TestType) Marshal() ([]byte, error)              { return json.Marshal(t) }
+func (t *TestType) Unmarshal(_ string, data []byte) error { return json.Unmarshal(data, t) }
 
 type opCounter struct {
 	deleted int

--- a/pkg/kvstore/store/syncstore.go
+++ b/pkg/kvstore/store/syncstore.go
@@ -128,7 +128,7 @@ func NewWorkqueueSyncStore(backend SyncStoreBackend, prefix string, opts ...WSSO
 		limiter:   workqueue.DefaultControllerRateLimiter(),
 		syncedKey: prefix,
 
-		log: log.WithField("prefix", prefix),
+		log: log.WithField(logfields.Prefix, prefix),
 	}
 
 	for _, opt := range opts {

--- a/pkg/kvstore/store/syncstore_test.go
+++ b/pkg/kvstore/store/syncstore_test.go
@@ -24,13 +24,6 @@ var (
 	timeout = 5 * time.Second
 )
 
-type KVPair struct{ Key, Value string }
-
-func NewKVPair(key, value string) *KVPair      { return &KVPair{Key: key, Value: value} }
-func (kv *KVPair) GetKeyName() string          { return kv.Key }
-func (kv *KVPair) Marshal() ([]byte, error)    { return []byte(kv.Value), nil }
-func (kv *KVPair) Unmarshal(data []byte) error { return nil /* not used */ }
-
 type fakeBackend struct {
 	t           *testing.T
 	expectLease bool

--- a/pkg/kvstore/store/watchstore.go
+++ b/pkg/kvstore/store/watchstore.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package store
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+)
+
+// WatchStore abstracts the operations allowing to synchronize key/value pairs
+// from a kvstore, emitting the corresponding events.
+type WatchStore interface {
+	// Watch starts watching the specified kvstore prefix, blocking until the context is closed.
+	// Depending on the implementation, it might be executed multiple times.
+	Watch(ctx context.Context, backend WatchStoreBackend, prefix string)
+
+	// NumEntries returns the number of entries synchronized from the store.
+	NumEntries() uint64
+
+	// Drain emits a deletion event for each known key. It shall be called only
+	// when no watch operation is in progress.
+	Drain()
+}
+
+// WatchStoreBackend represents the subset of kvstore.BackendOperations leveraged
+// by WatchStore implementations.
+type WatchStoreBackend interface {
+	// ListAndWatch creates a new watcher for the given prefix after listing the existing keys.
+	ListAndWatch(ctx context.Context, name, prefix string, chanSize int) *kvstore.Watcher
+}
+
+type RWSOpt func(*restartableWatchStore)
+
+// WSWithOnSyncCallback registers a function to be executed after
+// listing all keys from the kvstore for the first time. Multiple
+// callback functions can be registered.
+func RWSWithOnSyncCallback(callback func(ctx context.Context)) RWSOpt {
+	return func(rws *restartableWatchStore) {
+		rws.onSyncCallbacks = append(rws.onSyncCallbacks, callback)
+	}
+}
+
+// WSWithEntriesGauge registers a Prometheus gauge metric that is kept
+// in sync with the number of entries synchronized from the kvstore.
+func RWSWithEntriesMetric(gauge prometheus.Gauge) RWSOpt {
+	return func(rws *restartableWatchStore) {
+		rws.entriesMetric = gauge
+	}
+}
+
+type rwsEntry struct {
+	key   Key
+	stale bool
+}
+
+// restartableWatchStore implements the WatchStore interface, supporting
+// multiple executions of the Watch() operation (granted that the previous one
+// already terminated). This allows to transparently handle the case in which
+// we had to create a new etcd connection (for instance following a failure)
+// which refers to the same remote cluster.
+type restartableWatchStore struct {
+	source     string
+	keyCreator KeyCreator
+	observer   Observer
+
+	watching        atomic.Bool
+	synced          bool
+	onSyncCallbacks []func(ctx context.Context)
+
+	// Using a separate entries counter avoids the need for synchronizing the
+	// access to the state map, since the only concurrent reader is represented
+	// by the NumEntries() function.
+	state      map[string]*rwsEntry
+	numEntries atomic.Uint64
+
+	log           *logrus.Entry
+	entriesMetric prometheus.Gauge
+}
+
+// NewRestartableWatchStore returns a WatchStore instance which supports
+// restarting the watch operation multiple times, automatically handling
+// the emission of deletion events for all stale entries (if enabled). It
+// shall be restarted only once the previous Watch execution terminated.
+func NewRestartableWatchStore(clusterName string, keyCreator KeyCreator, observer Observer, opts ...RWSOpt) WatchStore {
+	rws := &restartableWatchStore{
+		source:     clusterName,
+		keyCreator: keyCreator,
+		observer:   observer,
+
+		state: make(map[string]*rwsEntry),
+
+		log:           log,
+		entriesMetric: metrics.NoOpGauge,
+	}
+
+	for _, opt := range opts {
+		opt(rws)
+	}
+
+	rws.log = rws.log.WithField(logfields.ClusterName, rws.source)
+	return rws
+}
+
+// Watch starts watching the specified kvstore prefix, blocking until the context is closed.
+// It might be executed multiple times, granted that the previous execution already terminated.
+func (rws *restartableWatchStore) Watch(ctx context.Context, backend WatchStoreBackend, prefix string) {
+	// Append a trailing "/" to the prefix, to make sure that we watch only
+	// sub-elements belonging to that prefix, and not to sibling prefixes
+	// (for instance in case the last part of the prefix is the cluster name,
+	// and one is the substring of another).
+	if !strings.HasSuffix(prefix, "/") {
+		prefix = prefix + "/"
+	}
+
+	rws.log = rws.log.WithField(logfields.Prefix, prefix)
+	syncedMetric := metrics.KVStoreInitialSyncCompleted.WithLabelValues(
+		kvstore.GetScopeFromKey(prefix), rws.source, "read")
+
+	rws.log.Info("Starting restartable watch store")
+	syncedMetric.Set(metrics.BoolToFloat64(false))
+
+	if rws.watching.Swap(true) {
+		rws.log.Panic("Cannot start the watch store while still running")
+	}
+
+	defer func() {
+		rws.log.Info("Stopped restartable watch store")
+		syncedMetric.Set(metrics.BoolToFloat64(false))
+		rws.watching.Store(false)
+	}()
+
+	// Mark all known keys as stale.
+	for _, entry := range rws.state {
+		entry.stale = true
+	}
+
+	// The events channel is closed when the context is closed.
+	watcher := backend.ListAndWatch(ctx, prefix, prefix, 0)
+	for event := range watcher.Events {
+		if event.Typ == kvstore.EventTypeListDone {
+			rws.log.Debug("Initial synchronization completed")
+			rws.drainKeys(true)
+			syncedMetric.Set(metrics.BoolToFloat64(true))
+
+			if !rws.synced {
+				rws.synced = true
+				for _, callback := range rws.onSyncCallbacks {
+					callback(ctx)
+				}
+			}
+
+			continue
+		}
+
+		key := strings.TrimPrefix(event.Key, prefix)
+		rws.log.WithFields(logrus.Fields{
+			logfields.Key:   key,
+			logfields.Event: event.Typ,
+		}).Debug("Received event from kvstore")
+
+		switch event.Typ {
+		case kvstore.EventTypeCreate, kvstore.EventTypeModify:
+			rws.handleUpsert(key, event.Value)
+		case kvstore.EventTypeDelete:
+			rws.handleDelete(key)
+		}
+	}
+}
+
+// NumEntries returns the number of entries synchronized from the store.
+func (rws *restartableWatchStore) NumEntries() uint64 {
+	return rws.numEntries.Load()
+}
+
+// Drain emits a deletion event for each known key. It shall be called only
+// when no watch operation is in progress.
+func (rws *restartableWatchStore) Drain() {
+	if rws.watching.Swap(true) {
+		rws.log.Panic("Cannot drain the watch store while still running")
+	}
+	defer rws.watching.Store(false)
+
+	rws.log.Info("Draining restartable watch store")
+	rws.drainKeys(false)
+	rws.log.Info("Drained restartable watch store")
+}
+
+// drainKeys emits synthetic deletion events:
+// * staleOnly == true: for all keys marked as stale;
+// * staleOnly == false: for all known keys;
+func (rws *restartableWatchStore) drainKeys(staleOnly bool) {
+	for key, entry := range rws.state {
+		if !staleOnly || entry.stale {
+			rws.log.WithField(logfields.Key, key).Debug("Emitting deletion event for stale key")
+			rws.handleDelete(key)
+		}
+	}
+}
+
+func (rws *restartableWatchStore) handleUpsert(key string, value []byte) {
+	entry := &rwsEntry{key: rws.keyCreator()}
+	if err := entry.key.Unmarshal(key, value); err != nil {
+		rws.log.WithFields(logrus.Fields{
+			logfields.Key:   key,
+			logfields.Value: string(value),
+		}).WithError(err).Warning("Unable to unmarshal value")
+		return
+	}
+
+	rws.state[key] = entry
+	rws.numEntries.Store(uint64(len(rws.state)))
+	rws.entriesMetric.Set(float64(len(rws.state)))
+	rws.observer.OnUpdate(entry.key)
+}
+
+func (rws *restartableWatchStore) handleDelete(key string) {
+	entry, ok := rws.state[key]
+	if !ok {
+		rws.log.WithField(logfields.Key, key).Warning("Received deletion event for unknown key")
+		return
+	}
+
+	delete(rws.state, key)
+	rws.numEntries.Store(uint64(len(rws.state)))
+	rws.entriesMetric.Set(float64(len(rws.state)))
+	rws.observer.OnDelete(entry.key)
+}

--- a/pkg/kvstore/store/watchstore_test.go
+++ b/pkg/kvstore/store/watchstore_test.go
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package store
+
+import (
+	"context"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type fakeLWBackend struct {
+	t      *testing.T
+	prefix string
+	events []kvstore.KeyValueEvent
+}
+
+func NewFakeLWBackend(t *testing.T, prefix string, events []kvstore.KeyValueEvent) *fakeLWBackend {
+	return &fakeLWBackend{
+		t:      t,
+		prefix: prefix,
+		events: events,
+	}
+}
+
+func (fb *fakeLWBackend) ListAndWatch(ctx context.Context, _, prefix string, _ int) *kvstore.Watcher {
+	ch := make(kvstore.EventChan)
+
+	go func() {
+		defer close(ch)
+		require.Equal(fb.t, fb.prefix, prefix)
+
+		for _, event := range fb.events {
+			event.Key = path.Join(fb.prefix, event.Key)
+			select {
+			case ch <- event:
+			case <-ctx.Done():
+				require.Fail(fb.t, "Context closed before propagating all events", "pending: %#v", event)
+			}
+		}
+
+		<-ctx.Done()
+	}()
+
+	return &kvstore.Watcher{Events: ch}
+}
+
+type fakeObserver struct {
+	t       *testing.T
+	updated chan *KVPair
+	deleted chan *KVPair
+}
+
+func NewFakeObserver(t *testing.T) *fakeObserver {
+	return &fakeObserver{
+		t:       t,
+		updated: make(chan *KVPair),
+		deleted: make(chan *KVPair),
+	}
+}
+
+func (fo *fakeObserver) OnUpdate(k Key) {
+	select {
+	case fo.updated <- k.(*KVPair):
+	case <-time.After(timeout):
+		require.Failf(fo.t, "Failed observing update event", "key: %s", k.GetKeyName())
+	}
+}
+func (fo *fakeObserver) OnDelete(k NamedKey) {
+	select {
+	case fo.deleted <- k.(*KVPair):
+	case <-time.After(timeout):
+		require.Failf(fo.t, "Failed observing delete event", "key: %s", k.GetKeyName())
+	}
+}
+
+func rwsRun(store WatchStore, prefix string, body func(), backend WatchStoreBackend) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		store.Watch(ctx, backend, prefix)
+	}()
+
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	body()
+}
+
+func rwsDrain(t *testing.T, store WatchStore, observer *fakeObserver, expected []*KVPair) {
+	drainDone := make(chan struct{})
+	go func() {
+		store.Drain()
+		close(drainDone)
+	}()
+
+	var actual []*KVPair
+	for range expected {
+		actual = append(actual, eventually(observer.deleted))
+	}
+
+	// Since the drained elements are spilled out of a map, there's no ordering guarantee.
+	require.ElementsMatch(t, expected, actual)
+
+	select {
+	case <-drainDone:
+	case <-time.After(timeout):
+		require.Fail(t, "The drain operation did not complete when expected")
+	}
+}
+
+func TestRestartableWatchStore(t *testing.T) {
+	observer := NewFakeObserver(t)
+	store := NewRestartableWatchStore("qux", KVPairCreator, observer)
+	require.Equal(t, uint64(0), store.NumEntries())
+
+	// Watch the kvstore once, and assert that the expected events are propagated
+	rwsRun(store, "foo/bar", func() {
+		require.Equal(t, NewKVPair("key1", "value1A"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key2", "value2A"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key2", "value2B"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key3", "value3A"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key3", "value3A"), eventually(observer.deleted))
+		require.Equal(t, uint64(2), store.NumEntries())
+	}, NewFakeLWBackend(t, "foo/bar/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1A")},
+		{Typ: kvstore.EventTypeCreate, Key: "key2", Value: []byte("value2A")},
+		{Typ: kvstore.EventTypeListDone},
+		{Typ: kvstore.EventTypeModify, Key: "key2", Value: []byte("value2B")},
+		{Typ: kvstore.EventTypeCreate, Key: "key3", Value: []byte("value3A")},
+		{Typ: kvstore.EventTypeDelete, Key: "key4"}, // The key is not known locally -> no event
+		{Typ: kvstore.EventTypeDelete, Key: "key3"},
+	}))
+
+	// Watch the kvstore a second time, and assert that the expected events (including
+	// stale keys deletions) are propagated, even though the watcher prefix changed.
+	rwsRun(store, "foo/baz", func() {
+		require.Equal(t, NewKVPair("key1", "value1C"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key4", "value4A"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key2", "value2B"), eventually(observer.deleted))
+		require.Equal(t, NewKVPair("key2", "value2C"), eventually(observer.updated))
+		require.Equal(t, uint64(3), store.NumEntries())
+	}, NewFakeLWBackend(t, "foo/baz/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1C")},
+		{Typ: kvstore.EventTypeCreate, Key: "key4", Value: []byte("value4A")},
+		{Typ: kvstore.EventTypeListDone},
+		{Typ: kvstore.EventTypeCreate, Key: "key2", Value: []byte("value2C")},
+	}))
+}
+
+func TestRestartableWatchStoreDrain(t *testing.T) {
+	observer := NewFakeObserver(t)
+	store := NewRestartableWatchStore("qux", KVPairCreator, observer)
+
+	// Watch a few keys through the watch store
+	rwsRun(store, "foo/bar", func() {
+		require.Equal(t, NewKVPair("key1", "value1A"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key2", "value2A"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key3", "value3A"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key2", "value2A"), eventually(observer.deleted))
+	}, NewFakeLWBackend(t, "foo/bar/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1A")},
+		{Typ: kvstore.EventTypeCreate, Key: "key2", Value: []byte("value2A")},
+		{Typ: kvstore.EventTypeListDone},
+		{Typ: kvstore.EventTypeModify, Key: "key3", Value: []byte("value3A")},
+		{Typ: kvstore.EventTypeDelete, Key: "key2"},
+	}))
+
+	// Drain the store, and assert that a deletion event is emitted for all keys
+	rwsDrain(t, store, observer, []*KVPair{
+		NewKVPair("key1", "value1A"),
+		NewKVPair("key3", "value3A"),
+	})
+
+	// Make sure that it is possible to restart the watch store
+	rwsRun(store, "foo/bar", func() {
+		require.Equal(t, NewKVPair("key1", "value1A"), eventually(observer.updated))
+	}, NewFakeLWBackend(t, "foo/bar/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1A")},
+	}))
+
+	// And to drain it again
+	rwsDrain(t, store, observer, []*KVPair{
+		NewKVPair("key1", "value1A"),
+	})
+}
+
+func TestRestartableWatchStoreSyncCallback(t *testing.T) {
+	observer := NewFakeObserver(t)
+	callback := func(value string) func(context.Context) {
+		return func(context.Context) {
+			observer.OnUpdate(NewKVPair("callback/executed", value))
+		}
+	}
+
+	store := NewRestartableWatchStore("qux", KVPairCreator, observer,
+		RWSWithOnSyncCallback(callback("1")), RWSWithOnSyncCallback(callback("2")))
+
+	// The watcher is closed before receiving the list done event, the sync callbacks should not be executed
+	rwsRun(store, "foo/bar", func() {
+		require.Equal(t, NewKVPair("key1", "value1A"), eventually(observer.updated))
+	}, NewFakeLWBackend(t, "foo/bar/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1A")},
+	}))
+
+	// Assert that the callback are executed when the list done event is received
+	rwsRun(store, "foo/bar", func() {
+		require.Equal(t, NewKVPair("key1", "value1A"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("callback/executed", "1"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("callback/executed", "2"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key2", "value2A"), eventually(observer.updated))
+	}, NewFakeLWBackend(t, "foo/bar/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1A")},
+		{Typ: kvstore.EventTypeListDone},
+		{Typ: kvstore.EventTypeCreate, Key: "key2", Value: []byte("value2A")},
+	}))
+
+	// Assert that the callbacks are not executed a second time
+	rwsRun(store, "foo/bar", func() {
+		require.Equal(t, NewKVPair("key1", "value1A"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key2", "value2A"), eventually(observer.deleted))
+		require.Equal(t, NewKVPair("key3", "value3A"), eventually(observer.updated))
+	}, NewFakeLWBackend(t, "foo/bar/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1A")},
+		{Typ: kvstore.EventTypeListDone},
+		{Typ: kvstore.EventTypeCreate, Key: "key3", Value: []byte("value3A")},
+	}))
+}
+
+func TestRestartableWatchStoreConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
+
+	backend := NewFakeLWBackend(t, "foo/bar/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1")},
+	})
+	observer := NewFakeObserver(t)
+	store := NewRestartableWatchStore("qux", KVPairCreator, observer)
+
+	wg.Add(1)
+	go func() {
+		store.Watch(ctx, backend, "foo/bar/")
+		wg.Done()
+	}()
+
+	// Ensure that the Watch operation running in the goroutine has started
+	require.Equal(t, NewKVPair("key1", "value1"), eventually(observer.updated))
+
+	require.Panics(t, func() { store.Watch(ctx, backend, "foo/bar/") }, "store.Watch should panic when already running")
+	require.Panics(t, store.Drain, "store.Drain should panic when store.Watch is running")
+}
+
+func TestRestartableWatchStoreMetrics(t *testing.T) {
+	defer func(name string, metric metrics.GaugeVec) {
+		metrics.KVStoreInitialSyncCompleted = metric
+	}(option.Config.ClusterName, metrics.KVStoreInitialSyncCompleted)
+
+	cfg, collectors := metrics.CreateConfiguration([]string{"cilium_kvstore_initial_sync_completed"})
+	require.True(t, cfg.KVStoreInitialSyncCompletedEnabled)
+	require.Len(t, collectors, 1)
+
+	entries := prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_elements_metric"})
+	synced := metrics.KVStoreInitialSyncCompleted.WithLabelValues("nodes/v1", "qux", "read")
+
+	observer := NewFakeObserver(t)
+	store := NewRestartableWatchStore("qux", KVPairCreator, observer, RWSWithEntriesMetric(entries))
+
+	require.Equal(t, float64(0), testutil.ToFloat64(entries))
+	require.Equal(t, metrics.BoolToFloat64(false), testutil.ToFloat64(synced))
+
+	rwsRun(store, "cilium/state/nodes/v1", func() {
+		require.Equal(t, NewKVPair("key1", "value1A"), eventually(observer.updated))
+		require.Equal(t, metrics.BoolToFloat64(false), testutil.ToFloat64(synced))
+		require.Equal(t, NewKVPair("key2", "value2A"), eventually(observer.updated))
+
+		require.Eventually(t, func() bool {
+			return metrics.BoolToFloat64(true) == testutil.ToFloat64(synced)
+		}, timeout, tick)
+
+		require.Equal(t, NewKVPair("key1", "value1A"), eventually(observer.deleted))
+		require.Equal(t, NewKVPair("key2", "value2B"), eventually(observer.updated))
+		require.Equal(t, NewKVPair("key3", "value3A"), eventually(observer.updated))
+	}, NewFakeLWBackend(t, "cilium/state/nodes/v1/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1A")},
+		{Typ: kvstore.EventTypeCreate, Key: "key2", Value: []byte("value2A")},
+		{Typ: kvstore.EventTypeListDone},
+		{Typ: kvstore.EventTypeDelete, Key: "key1"},
+		{Typ: kvstore.EventTypeCreate, Key: "key2", Value: []byte("value2B")},
+		{Typ: kvstore.EventTypeCreate, Key: "key3", Value: []byte("value3A")},
+	}))
+
+	// The metric should reflect the number of elements.
+	require.Equal(t, float64(2), testutil.ToFloat64(entries))
+	require.Equal(t, metrics.BoolToFloat64(false), testutil.ToFloat64(synced))
+
+	rwsRun(store, "cilium/state/nodes/v1", func() {
+		require.Equal(t, NewKVPair("key3", "value3A"), eventually(observer.updated))
+		require.Equal(t, metrics.BoolToFloat64(false), testutil.ToFloat64(synced))
+		require.Equal(t, NewKVPair("key2", "value2B"), eventually(observer.deleted))
+
+		require.Eventually(t, func() bool {
+			return metrics.BoolToFloat64(true) == testutil.ToFloat64(synced)
+		}, timeout, tick)
+
+		require.Equal(t, NewKVPair("key1", "value1A"), eventually(observer.updated))
+	}, NewFakeLWBackend(t, "cilium/state/nodes/v1/", []kvstore.KeyValueEvent{
+		{Typ: kvstore.EventTypeCreate, Key: "key3", Value: []byte("value3A")},
+		{Typ: kvstore.EventTypeListDone},
+		{Typ: kvstore.EventTypeCreate, Key: "key1", Value: []byte("value1A")},
+	}))
+}

--- a/pkg/kvstore/store/watchstoremgr.go
+++ b/pkg/kvstore/store/watchstoremgr.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package store
+
+import (
+	"context"
+	"path"
+	"sync"
+	"sync/atomic"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+// WSMFunc if a function which can be registered in the WatchStoreManager.
+type WSMFunc func(context.Context)
+
+// WatchStoreManager enables to register a set of functions to be asynchronously
+// executed when the corresponding kvstore prefixes are synchronized (based on
+// the implementation).
+type WatchStoreManager interface {
+	// Register registers a function associated with a given kvstore prefix.
+	// It cannot be called once Run() has started.
+	Register(prefix string, function WSMFunc)
+	// Run starts the manager, blocking until the context is closed and all
+	// started functions terminated.
+	Run(ctx context.Context)
+}
+
+// wsmCommon implements the common logic shared by WatchStoreManager implementations.
+type wsmCommon struct {
+	wg        sync.WaitGroup
+	functions map[string]WSMFunc
+
+	running atomic.Bool
+	log     *logrus.Entry
+}
+
+func newWSMCommon(clusterName string) wsmCommon {
+	return wsmCommon{
+		functions: make(map[string]WSMFunc),
+		log:       log.WithField(logfields.ClusterName, clusterName),
+	}
+}
+
+// Register registers a function associated with a given kvstore prefix.
+// It cannot be called once Run() has started.
+func (mgr *wsmCommon) Register(prefix string, function WSMFunc) {
+	if mgr.running.Load() {
+		mgr.log.Panic("Cannot call Register while the watch store manager is running")
+	}
+
+	mgr.functions[prefix] = function
+}
+
+func (mgr *wsmCommon) ready(ctx context.Context, prefix string) {
+	if fn := mgr.functions[prefix]; fn != nil {
+		mgr.log.WithField(logfields.Prefix, prefix).Debug("Starting function for kvstore prefix")
+		delete(mgr.functions, prefix)
+
+		mgr.wg.Add(1)
+		go func() {
+			defer mgr.wg.Done()
+			fn(ctx)
+			mgr.log.WithField(logfields.Prefix, prefix).Debug("Function terminated for kvstore prefix")
+		}()
+	} else {
+		mgr.log.WithField(logfields.Prefix, prefix).Debug("Received sync event for unregistered prefix")
+	}
+}
+
+func (mgr *wsmCommon) run() {
+	mgr.log.Info("Starting watch store manager")
+	if mgr.running.Swap(true) {
+		mgr.log.Panic("Cannot start the watch store manager twice")
+	}
+}
+
+func (mgr *wsmCommon) wait() {
+	mgr.wg.Wait()
+	mgr.log.Info("Stopped watch store manager")
+}
+
+type wsmSync struct {
+	wsmCommon
+
+	clusterName string
+	backend     WatchStoreBackend
+	store       WatchStore
+	onUpdate    func(prefix string)
+}
+
+// NewWatchStoreManagerSync implements the WatchStoreManager interface, starting the
+// registered functions only once the corresponding prefix sync canary has been received.
+// This ensures that the synchronization of the keys hosted under the given prefix
+// have been successfully synchronized from the external source, even in case an
+// ephemeral kvstore is used.
+func NewWatchStoreManagerSync(backend WatchStoreBackend, clusterName string) WatchStoreManager {
+	mgr := wsmSync{
+		wsmCommon:   newWSMCommon(clusterName),
+		clusterName: clusterName,
+		backend:     backend,
+	}
+
+	mgr.store = NewRestartableWatchStore(clusterName, KVPairCreator, &mgr)
+	return &mgr
+}
+
+// Run starts the manager, blocking until the context is closed and all
+// started functions terminated.
+func (mgr *wsmSync) Run(ctx context.Context) {
+	mgr.run()
+	mgr.onUpdate = func(prefix string) { mgr.ready(ctx, prefix) }
+	mgr.store.Watch(ctx, mgr.backend, path.Join(kvstore.SyncedPrefix, mgr.clusterName))
+	mgr.wait()
+}
+
+func (mgr *wsmSync) OnUpdate(k Key)      { mgr.onUpdate(k.GetKeyName()) }
+func (mgr *wsmSync) OnDelete(k NamedKey) {}
+
+type wsmImmediate struct {
+	wsmCommon
+}
+
+// NewWatchStoreManagerImmediate implements the WatchStoreManager interface,
+// immediately starting the registered functions once Run() is executed.
+func NewWatchStoreManagerImmediate(clusterName string) WatchStoreManager {
+	return &wsmImmediate{
+		wsmCommon: newWSMCommon(clusterName),
+	}
+}
+
+// Run starts the manager, blocking until the context is closed and all
+// started functions terminated.
+func (mgr *wsmImmediate) Run(ctx context.Context) {
+	mgr.run()
+	for prefix := range mgr.functions {
+		mgr.ready(ctx, prefix)
+	}
+	mgr.wait()
+}

--- a/pkg/kvstore/store/watchstoremgr_test.go
+++ b/pkg/kvstore/store/watchstoremgr_test.go
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/kvstore"
+)
+
+func TestWatchStoreManager(t *testing.T) {
+	runnable := func(mgr func() WatchStoreManager) func(t *testing.T) {
+		return func(t *testing.T) {
+			ch := make(chan *KVPair, 3)
+			run := func(ctx context.Context, str string) {
+				ch <- NewKVPair(str, "")
+				<-ctx.Done()
+			}
+
+			mgr := mgr()
+			mgr.Register("bar", func(ctx context.Context) { run(ctx, "bar") })
+			mgr.Register("bax", func(ctx context.Context) { run(ctx, "baz") })
+			mgr.Register("qux", func(ctx context.Context) { run(ctx, "qux") })
+
+			ctx, cancel := context.WithCancel(context.Background())
+			completed := make(chan struct{})
+			go func() {
+				mgr.Run(ctx)
+				close(completed)
+			}()
+
+			defer func() {
+				cancel()
+
+				select {
+				case <-completed:
+				case <-time.After(100 * time.Millisecond):
+					require.Fail(t, "Manager didn't stop properly after closing the context")
+				}
+			}()
+
+			var started []string
+			started = append(started, eventually(ch).Key)
+			started = append(started, eventually(ch).Key)
+			started = append(started, eventually(ch).Key)
+
+			require.ElementsMatch(t, started, []string{"bar", "baz", "qux"})
+		}
+	}
+
+	t.Run("sync", runnable(func() WatchStoreManager {
+		backend := NewFakeLWBackend(t, kvstore.SyncedPrefix+"/foo/", []kvstore.KeyValueEvent{
+			{Typ: kvstore.EventTypeListDone},
+			{Typ: kvstore.EventTypeCreate, Key: "not-registered"},
+			{Typ: kvstore.EventTypeCreate, Key: "bar"},
+			{Typ: kvstore.EventTypeCreate, Key: "bax"},
+			{Typ: kvstore.EventTypeCreate, Key: "qux"},
+		})
+
+		return NewWatchStoreManagerSync(backend, "foo")
+	}))
+
+	t.Run("immediate", runnable(func() WatchStoreManager {
+		return NewWatchStoreManagerImmediate("foo")
+	}))
+}
+
+func TestWatchStoreManagerPanic(t *testing.T) {
+	runnable := func(mgr func() WatchStoreManager) func(t *testing.T) {
+		return func(t *testing.T) {
+			mgr := mgr()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			mgr.Run(ctx)
+
+			require.Panics(t, func() { mgr.Register("foo", func(ctx context.Context) {}) },
+				"mgr.Register should panic after Run was called")
+			require.Panics(t, func() { mgr.Run(ctx) }, "mgr.Run should panic when already started")
+		}
+	}
+
+	t.Run("sync", runnable(func() WatchStoreManager {
+		backend := NewFakeLWBackend(t, kvstore.SyncedPrefix+"/foo/", nil)
+		return NewWatchStoreManagerSync(backend, "foo")
+	}))
+
+	t.Run("immediate", runnable(func() WatchStoreManager {
+		return NewWatchStoreManagerImmediate("foo")
+	}))
+}

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -717,4 +717,13 @@ const (
 
 	// Workers represents the number of workers.
 	Workers = "workers"
+
+	// Event identifies the type of an event.
+	Event = "event"
+
+	// Prefix identifies a given prefix.
+	Prefix = "prefix"
+
+	// Value identifies a generic value (e.g., of a key/value pair).
+	Value = "value"
 )

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -609,7 +609,7 @@ func (n *Node) Marshal() ([]byte, error) {
 }
 
 // Unmarshal parses the JSON byte slice and updates the node receiver
-func (n *Node) Unmarshal(data []byte) error {
+func (n *Node) Unmarshal(_ string, data []byte) error {
 	newNode := Node{}
 	if err := json.Unmarshal(data, &newNode); err != nil {
 		return err

--- a/pkg/service/store/store.go
+++ b/pkg/service/store/store.go
@@ -104,7 +104,7 @@ func (s *ClusterService) Marshal() ([]byte, error) {
 }
 
 // Unmarshal parses the JSON byte slice and updates the global service receiver
-func (s *ClusterService) Unmarshal(data []byte) error {
+func (s *ClusterService) Unmarshal(_ string, data []byte) error {
 	newService := NewClusterService("", "")
 
 	if err := json.Unmarshal(data, &newService); err != nil {

--- a/pkg/service/store/store_test.go
+++ b/pkg/service/store/store_test.go
@@ -32,7 +32,7 @@ func (s *ServiceGenericSuite) TestClusterService(c *check.C) {
 	c.Assert(err, check.IsNil)
 
 	unmarshal := ClusterService{}
-	err = unmarshal.Unmarshal(b)
+	err = unmarshal.Unmarshal("", b)
 	c.Assert(err, check.IsNil)
 	c.Assert(svc, checker.DeepEquals, unmarshal)
 


### PR DESCRIPTION
Currently, restarting the connection to remote clusters leaves a time window in which possible deletion events are missed, and never recovered once the new watchers are started. Similarly, the status is not properly cleaned-up when removing one remote cluster from the clustermesh configuration. 

This PR builds on top of https://github.com/cilium/cilium/pull/25388 and addresses this issue for nodes and services (identities and ipcache entries will be handled in a followup PR). When connecting to a remote cluster that supports synced canaries, the initial prefix list is postponed until that prefix is known to be synchronized. This ensures that we observe an up-to-date state (which would not be otherwise guaranteed when the remote etcd instance is ephemeral). 

Differently, when synced canaries are not supported (e.g., because the remote cluster is running an older version of the clustermesh-apiserver), we perform listing immediately.  In this case, there is the possibility that non-stale keys are temporarily removed upon reconnection, causing brief connectivity disruptions. Yet, this is not different from what already happens today if the agent is restarted when the remote kvstore has not yet been fully synchronized. Additionally, this is not an issue when the remote kvstore is backed by persistent storage, since it is already synchronized. Alternatively, we might disable the deletion of stale entries if sync canaries are not supported, at the cost of leaking those entries until the agent is restarted. This behavior (if agreed upon) will be further detailed updating the release notes in a subsequent commit (it can be prevented upgrading first all clustermesh-apiservers and then the agents) after addressing the same problem affecting the ipcache and identity entries.

<!-- Description of change -->

Related: https://github.com/cilium/cilium/pull/25388
Related: https://github.com/cilium/cilium/issues/24740

```release-note
Fix missed deletion events when reconnecting to/disconnecting from remote clusters (nodes and services)
```
