### PR TITLE
v1.13 Backports 2023-05-16

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1513,7 +1513,7 @@ The fixes to clean up leaked duplicate backend entries were backported to older
 releases, and are available as part of Cilium versions v1.11.16, v1.12.9 and v1.13.2.
 Fresh clusters deploying Cilium versions 1.11.15 or later don't experience this leak issue.
 
-For more information, see `this GitHub issue <https://github.com/cilium/cilium/issues/235514>`__.
+For more information, see `this GitHub issue <https://github.com/cilium/cilium/issues/23551>`__.
 
 Limitations
 ###########

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -68,6 +68,7 @@ run Cilium.
 Distribution               Minimum Version
 ========================== ====================
 `Amazon Linux 2`_          all
+`Bottlerocket OS`_         all
 `CentOS`_                  >= 8.0
 `Container-Optimized OS`_  all
 `CoreOS`_                  all
@@ -89,6 +90,7 @@ Ubuntu_                    >= 18.04.3
 .. _RedHat Enterprise Linux: https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux
 .. _Ubuntu: https://wiki.ubuntu.com/YakketyYak/ReleaseNotes#Linux_kernel_4.8
 .. _Opensuse: https://www.opensuse.org/
+.. _Bottlerocket OS: https://github.com/bottlerocket-os/bottlerocket
 
 .. note:: The above list is based on feedback by users. If you find an unlisted
           Linux distribution that works well, please let us know by opening a

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -737,9 +737,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 # endif /* ENABLE_IPV4 */
 	}
 	if (!ep)
-		return send_drop_notify_error(ctx, src_id,
-					      DROP_NO_TUNNEL_ENDPOINT,
-					      CTX_ACT_DROP, METRIC_EGRESS);
+		return DROP_NO_TUNNEL_ENDPOINT;
 
 	ctx->mark = 0;
 	bpf_clear_meta(ctx);
@@ -795,7 +793,11 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 			send_trace_notify(ctx, TRACE_FROM_STACK, identity, 0, 0,
 					  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
 					  TRACE_PAYLOAD_LEN);
-			return do_netdev_encrypt(ctx, identity);
+			ret = do_netdev_encrypt(ctx, identity);
+			if (IS_ERR(ret))
+				return send_drop_notify_error(ctx, identity, ret,
+							      CTX_ACT_DROP, METRIC_EGRESS);
+			return ret;
 		}
 #endif
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -771,7 +771,8 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 
 			ctx->mark = 0;
 			tail_call_dynamic(ctx, &POLICY_EGRESSCALL_MAP, lxc_id);
-			return DROP_MISSED_TAIL_CALL;
+			return send_drop_notify_error(ctx, identity, DROP_MISSED_TAIL_CALL,
+						      CTX_ACT_DROP, METRIC_EGRESS);
 		}
 	}
 #endif

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -736,7 +736,7 @@ static __always_inline int do_netdev_encrypt_encap(struct __ctx_buff *ctx, __u32
 		break;
 # endif /* ENABLE_IPV4 */
 	}
-	if (!ep)
+	if (!ep || !ep->tunnel_endpoint)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
 	ctx->mark = 0;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -379,15 +379,19 @@ int tail_handle_arp(struct __ctx_buff *ctx)
 	ret = arp_prepare_response(ctx, &mac, tip, &smac, sip);
 	if (unlikely(ret != 0))
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
-	if (info->tunnel_endpoint)
-		return __encap_and_redirect_with_nodeid(ctx,
-							info->tunnel_endpoint,
-							LOCAL_NODE_ID,
-							WORLD_ID,
-							WORLD_ID,
-							&trace);
+	if (info->tunnel_endpoint) {
+		ret = __encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
+						       LOCAL_NODE_ID, WORLD_ID,
+						       WORLD_ID, &trace);
+		if (IS_ERR(ret))
+			goto drop_err;
 
-	return send_drop_notify_error(ctx, 0, DROP_UNKNOWN_L3, CTX_ACT_DROP, METRIC_EGRESS);
+		return ret;
+	}
+
+	ret = DROP_UNKNOWN_L3;
+drop_err:
+	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 
 pass_to_stack:
 	send_trace_notify(ctx, TRACE_TO_STACK, 0, 0, 0, ctx->ingress_ifindex,

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1248,7 +1248,7 @@ static __always_inline int snat_v6_rewrite_ingress(struct __ctx_buff *ctx,
 
 			if (ctx_load_bytes(ctx, off, &type, 1) < 0)
 				return DROP_INVALID;
-			if (type == ICMP_ECHO || type == ICMP_ECHOREPLY) {
+			if (type == ICMPV6_ECHO_REQUEST || type == ICMPV6_ECHO_REPLY) {
 				if (ctx_store_bytes(ctx, off +
 						    offsetof(struct icmp6hdr,
 							     icmp6_dataun.u_echo.identifier),

--- a/test/k8s/manifests/host-policies.yaml
+++ b/test/k8s/manifests/host-policies.yaml
@@ -93,3 +93,19 @@ specs:
     - toEntities:
       - health
       - world
+  - description: "Allow ICMP/ICMPv6 traffic on all nodes"
+    nodeSelector: {}
+    ingress:
+    - icmps:
+      - fields:
+        - type: 8
+          family: IPv4
+        - type: 128
+          family: IPv6
+    egress:
+    - icmps:
+      - fields:
+        - type: 8
+          family: IPv4
+        - type: 128
+          family: IPv6

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/asaskevich/govalidator"
@@ -89,9 +90,19 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sDatapathServicesTest", func()
 		})
 
 		AfterAll(func() {
+			wg := sync.WaitGroup{}
 			for _, yaml := range yamls {
-				kubectl.Delete(yaml)
+				wg.Add(1)
+				go func(yaml string) {
+					defer wg.Done()
+					// Ensure that all deployments are fully cleaned up before
+					// proceeding to the next test.
+					res := kubectl.DeleteAndWait(yaml, true)
+
+					Expect(res.WasSuccessful()).Should(BeTrue(), "Unable to cleanup yaml: %s", yaml)
+				}(yaml)
 			}
+			wg.Wait()
 			ExpectAllPodsTerminated(kubectl)
 		})
 


### PR DESCRIPTION
 * [ ] #25341 (@tommyp1ckles)
 * [ ] #25352 (@jrajahalme)
 * [x] #25183 (@julianwiedmann)
   * :warning: quite some conflicts here in `bpf/bpf_host.c`, documented in the individual commits, review it carefully
   * dropped 83268f4b4181a4634a4542389c94aa4432303c0a and 218d0092bf02c569664424c4b3d212e37746f91b as those resulted in an empty commits
 * [x] #25374 (@tommyp1ckles)
 * [x] #25306 (@julianwiedmann)
 * [x] #25390 (@nebril)
 * [x] #25278 (@akhilles)

PRs skipped due to conflicts:

 * #25159 (@julianwiedmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 25341 25352 25183 25374 25306 25390 25278; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=25341,25352,25183,25374,25306,25390,25278
```
