### PR TITLE
multi-pool: Determine IP pool based on `ipam.cilium.io/ip-pool` annotation

### DIFF
--- a/api/v1/client/ipam/delete_ipam_ip_parameters.go
+++ b/api/v1/client/ipam/delete_ipam_ip_parameters.go
@@ -66,7 +66,7 @@ type DeleteIpamIPParams struct {
 
 	/* IP.
 
-	   IP address or owner name
+	   IP address
 	*/
 	IP string
 

--- a/api/v1/models/address_pair.go
+++ b/api/v1/models/address_pair.go
@@ -26,11 +26,17 @@ type AddressPair struct {
 	// UUID of IPv4 expiration timer
 	IPV4ExpirationUUID string `json:"ipv4-expiration-uuid,omitempty"`
 
+	// IPAM pool from which this IPv4 address was allocated
+	IPV4PoolName string `json:"ipv4-pool-name,omitempty"`
+
 	// IPv6 address
 	IPV6 string `json:"ipv6,omitempty"`
 
 	// UUID of IPv6 expiration timer
 	IPV6ExpirationUUID string `json:"ipv6-expiration-uuid,omitempty"`
+
+	// IPAM pool from which this IPv6 address was allocated
+	IPV6PoolName string `json:"ipv6-pool-name,omitempty"`
 }
 
 // Validate validates this address pair

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1686,11 +1686,17 @@ definitions:
       ipv4-expiration-uuid:
         description: UUID of IPv4 expiration timer
         type: string
+      ipv4-pool-name:
+        description: IPAM pool from which this IPv4 address was allocated
+        type: string
       ipv6:
         description: IPv6 address
         type: string
       ipv6-expiration-uuid:
         description: UUID of IPv6 expiration timer
+        type: string
+      ipv6-pool-name:
+        description: IPAM pool from which this IPv6 address was allocated
         type: string
   Address:
     description: IP address

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -469,7 +469,7 @@ paths:
       tags:
       - ipam
       parameters:
-      - "$ref": "#/parameters/ipam-release-arg"
+      - "$ref": "#/parameters/ipam-ip"
       - "$ref": "#/parameters/ipam-pool"
       responses:
         '200':
@@ -1112,12 +1112,6 @@ parameters:
   ipam-ip:
     name: ip
     description: IP address
-    in: path
-    required: true
-    type: string
-  ipam-release-arg:
-    name: ip
-    description: IP address or owner name
     in: path
     required: true
     type: string

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1566,12 +1566,20 @@ func init() {
           "description": "UUID of IPv4 expiration timer",
           "type": "string"
         },
+        "ipv4-pool-name": {
+          "description": "IPAM pool from which this IPv4 address was allocated",
+          "type": "string"
+        },
         "ipv6": {
           "description": "IPv6 address",
           "type": "string"
         },
         "ipv6-expiration-uuid": {
           "description": "UUID of IPv6 expiration timer",
+          "type": "string"
+        },
+        "ipv6-pool-name": {
+          "description": "IPAM pool from which this IPv6 address was allocated",
           "type": "string"
         }
       }
@@ -6431,12 +6439,20 @@ func init() {
           "description": "UUID of IPv4 expiration timer",
           "type": "string"
         },
+        "ipv4-pool-name": {
+          "description": "IPAM pool from which this IPv4 address was allocated",
+          "type": "string"
+        },
         "ipv6": {
           "description": "IPv6 address",
           "type": "string"
         },
         "ipv6-expiration-uuid": {
           "description": "UUID of IPv6 expiration timer",
+          "type": "string"
+        },
+        "ipv6-pool-name": {
+          "description": "IPAM pool from which this IPv6 address was allocated",
           "type": "string"
         }
       }

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -938,7 +938,7 @@ func init() {
         "summary": "Release an allocated IP address",
         "parameters": [
           {
-            "$ref": "#/parameters/ipam-release-arg"
+            "$ref": "#/parameters/ipam-ip"
           },
           {
             "$ref": "#/parameters/ipam-pool"
@@ -4598,13 +4598,6 @@ func init() {
       "name": "pool",
       "in": "query"
     },
-    "ipam-release-arg": {
-      "type": "string",
-      "description": "IP address or owner name",
-      "name": "ip",
-      "in": "path",
-      "required": true
-    },
     "labels": {
       "description": "List of labels\n",
       "name": "labels",
@@ -5741,7 +5734,7 @@ func init() {
         "parameters": [
           {
             "type": "string",
-            "description": "IP address or owner name",
+            "description": "IP address",
             "name": "ip",
             "in": "path",
             "required": true
@@ -9989,13 +9982,6 @@ func init() {
       "type": "string",
       "name": "pool",
       "in": "query"
-    },
-    "ipam-release-arg": {
-      "type": "string",
-      "description": "IP address or owner name",
-      "name": "ip",
-      "in": "path",
-      "required": true
     },
     "labels": {
       "description": "List of labels\n",

--- a/api/v1/server/restapi/ipam/delete_ipam_ip_parameters.go
+++ b/api/v1/server/restapi/ipam/delete_ipam_ip_parameters.go
@@ -34,7 +34,7 @@ type DeleteIpamIPParams struct {
 	// HTTP Request Object
 	HTTPRequest *http.Request `json:"-"`
 
-	/*IP address or owner name
+	/*IP address
 	  Required: true
 	  In: path
 	*/

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -245,11 +245,13 @@ func LaunchAsEndpoint(baseCtx context.Context,
 
 	if healthIPv6 := node.GetEndpointHealthIPv6(); healthIPv6 != nil {
 		info.Addressing.IPV6 = healthIPv6.String()
+		info.Addressing.IPV6PoolName = ipamOption.PoolDefault
 		ip6Address = &net.IPNet{IP: healthIPv6, Mask: defaults.ContainerIPv6Mask}
 		healthIP = healthIPv6
 	}
 	if healthIPv4 := node.GetEndpointHealthIPv4(); healthIPv4 != nil {
 		info.Addressing.IPV4 = healthIPv4.String()
+		info.Addressing.IPV4PoolName = ipamOption.PoolDefault
 		ip4Address = &net.IPNet{IP: healthIPv4, Mask: defaults.ContainerIPv4Mask}
 		healthIP = healthIPv4
 	}

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/node"
@@ -108,6 +109,9 @@ var (
 
 		// IPCache, policy.Repository and CachingIdentityAllocator.
 		cell.Provide(newPolicyTrifecta),
+
+		// IPAM metadata manager, determines which IPAM pool a pod should allocate from
+		ipamMetadata.Cell,
 
 		// Egress Gateway allows originating traffic from specific IPv4 addresses.
 		egressgateway.Cell,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -188,6 +189,8 @@ type Daemon struct {
 	egressGatewayManager *egressgateway.Manager
 
 	cgroupManager *manager.CgroupManager
+
+	ipamMetadata *ipamMetadata.Manager
 
 	apiLimiterSet *rate.APILimiterSet
 
@@ -533,6 +536,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		policy:               params.Policy,
 		policyUpdater:        params.PolicyUpdater,
 		egressGatewayManager: params.EgressGatewayManager,
+		ipamMetadata:         params.IPAMMetadataManager,
 		cniConfigManager:     params.CNIConfigManager,
 		clustermesh:          params.ClusterMesh,
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -55,6 +55,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
+	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/ipmasq"
@@ -1622,6 +1623,7 @@ type daemonParams struct {
 	PolicyUpdater        *policy.Updater
 	IPCache              *ipcache.IPCache
 	EgressGatewayManager *egressgateway.Manager
+	IPAMMetadataManager  *ipamMetadata.Manager
 	CNIConfigManager     cni.CNIConfigManager
 	SwaggerSpec          *server.Spec
 	HealthAPISpec        *healthApi.Spec

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -541,14 +541,16 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 	if addressing := epTemplate.Addressing; addressing != nil {
 		if uuid := addressing.IPV4ExpirationUUID; uuid != "" {
 			if ip := net.ParseIP(addressing.IPV4); ip != nil {
-				if err := d.ipam.StopExpirationTimer(ip, ipam.PoolDefault, uuid); err != nil {
+				pool := ipam.PoolOrDefault(addressing.IPV4PoolName)
+				if err := d.ipam.StopExpirationTimer(ip, pool, uuid); err != nil {
 					return d.errorDuringCreation(ep, err)
 				}
 			}
 		}
 		if uuid := addressing.IPV6ExpirationUUID; uuid != "" {
 			if ip := net.ParseIP(addressing.IPV6); ip != nil {
-				if err := d.ipam.StopExpirationTimer(ip, ipam.PoolDefault, uuid); err != nil {
+				pool := ipam.PoolOrDefault(addressing.IPV4PoolName)
+				if err := d.ipam.StopExpirationTimer(ip, pool, uuid); err != nil {
 					return d.errorDuringCreation(ep, err)
 				}
 			}
@@ -758,13 +760,13 @@ func (d *Daemon) EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConf
 
 	if !conf.NoIPRelease {
 		if option.Config.EnableIPv4 {
-			if err := d.ipam.ReleaseIP(ep.IPv4.AsSlice(), ipam.PoolDefault); err != nil {
+			if err := d.ipam.ReleaseIP(ep.IPv4.AsSlice(), ipam.PoolOrDefault(ep.IPv4IPAMPool)); err != nil {
 				scopedLog := ep.Logger(daemonSubsys).WithError(err)
 				scopedLog.Warning("Unable to release IPv4 address during endpoint deletion")
 			}
 		}
 		if option.Config.EnableIPv6 {
-			if err := d.ipam.ReleaseIP(ep.IPv6.AsSlice(), ipam.PoolDefault); err != nil {
+			if err := d.ipam.ReleaseIP(ep.IPv6.AsSlice(), ipam.PoolOrDefault(ep.IPv6IPAMPool)); err != nil {
 				scopedLog := ep.Logger(daemonSubsys).WithError(err)
 				scopedLog.Warning("Unable to release IPv6 address during endpoint deletion")
 			}

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -123,8 +123,13 @@ func (h *deleteIPAMIP) Handle(params ipamapi.DeleteIpamIPParams) middleware.Resp
 		return api.Error(ipamapi.DeleteIpamIPFailureCode, fmt.Errorf("IP is in use by endpoint %d", ep.ID))
 	}
 
+	ip := net.ParseIP(params.IP)
+	if ip == nil {
+		return api.Error(ipamapi.DeleteIpamIPInvalidCode, fmt.Errorf("Invalid IP address: %s", params.IP))
+	}
+
 	pool := ipam.PoolOrDefault(swag.StringValue(params.Pool))
-	if err := h.daemon.ipam.ReleaseIPString(params.IP, pool); err != nil {
+	if err := h.daemon.ipam.ReleaseIP(ip, pool); err != nil {
 		return api.Error(ipamapi.DeleteIpamIPFailureCode, err)
 	}
 

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -359,9 +359,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 	return
 }
 
-func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
-	var err error
-
+func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 	if option.Config.EnableIPv6 && ep.IPv6.IsValid() {
 		ipv6Pool := ipam.PoolOrDefault(ep.IPv6IPAMPool)
 		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanStringLocked()+" [restored]", ipv6Pool)

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -363,20 +363,22 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	var err error
 
 	if option.Config.EnableIPv6 && ep.IPv6.IsValid() {
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanStringLocked()+" [restored]", ipam.PoolDefault)
+		ipv6Pool := ipam.PoolOrDefault(ep.IPv6IPAMPool)
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanStringLocked()+" [restored]", ipv6Pool)
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6, err)
 		}
 
 		defer func() {
 			if err != nil {
-				d.ipam.ReleaseIP(ep.IPv6.AsSlice(), ipam.PoolDefault)
+				d.ipam.ReleaseIP(ep.IPv6.AsSlice(), ipv6Pool)
 			}
 		}()
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4.IsValid() {
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanStringLocked()+" [restored]", ipam.PoolDefault)
+		ipv4Pool := ipam.PoolOrDefault(ep.IPv4IPAMPool)
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanStringLocked()+" [restored]", ipv4Pool)
 		switch {
 		// We only check for BypassIPAllocUponRestore for IPv4 because we
 		// assume that this flag is only turned on for IPv4-only IPAM modes

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -24,6 +24,9 @@ const (
 	// ServicePrefix is the common prefix for service related annotations.
 	ServicePrefix = "service.cilium.io"
 
+	// IPAMPrefix is the common prefix for IPAM related annotations.
+	IPAMPrefix = "ipam.cilium.io"
+
 	// PolicyName / PolicyNameAlias is an optional annotation to the NetworkPolicy
 	// resource which specifies the name of the policy node to which all
 	// rules should be applied to.
@@ -119,6 +122,10 @@ const (
 	// BGPVRouterAnnoPrefix is the prefix used for all Virtual Router annotations
 	// Its just a prefix, because the ASN of the Router is part of the annotation itself
 	BGPVRouterAnnoPrefix = "cilium.io/bgp-virtual-router."
+
+	// IPAMPoolKey is the annotation name used to store the IPAM pool name from
+	// which workloads should allocate their IP from
+	IPAMPoolKey = IPAMPrefix + "/ip-pool"
 )
 
 // Get returns the annotation value associated with the given key, or any of

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -98,6 +98,7 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 				return nil, fmt.Errorf("invalid IPv6 address %q", ip)
 			}
 			ep.IPv6 = ip6
+			ep.IPv6IPAMPool = base.Addressing.IPV6PoolName
 		}
 
 		if ip := base.Addressing.IPV4; ip != "" {
@@ -109,6 +110,7 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 				return nil, fmt.Errorf("invalid IPv4 address %q", ip)
 			}
 			ep.IPv4 = ip4
+			ep.IPv4IPAMPool = base.Addressing.IPV4PoolName
 		}
 	}
 
@@ -145,8 +147,10 @@ func (e *Endpoint) getModelEndpointIdentitiersRLocked() *models.EndpointIdentifi
 func (e *Endpoint) getModelNetworkingRLocked() *models.EndpointNetworking {
 	return &models.EndpointNetworking{
 		Addressing: []*models.AddressPair{{
-			IPV4: e.GetIPv4Address(),
-			IPV6: e.GetIPv6Address(),
+			IPV4:         e.GetIPv4Address(),
+			IPV4PoolName: e.IPv4IPAMPool,
+			IPV6:         e.GetIPv6Address(),
+			IPV6PoolName: e.IPv6IPAMPool,
 		}},
 		InterfaceIndex: int64(e.ifIndex),
 		InterfaceName:  e.ifName,
@@ -499,11 +503,13 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 
 	if newEp.IPv6.IsValid() && e.IPv6 != newEp.IPv6 {
 		e.IPv6 = newEp.IPv6
+		e.IPv6IPAMPool = newEp.IPv6IPAMPool
 		changed = true
 	}
 
 	if newEp.IPv4.IsValid() && e.IPv4 != newEp.IPv4 {
 		e.IPv4 = newEp.IPv4
+		e.IPv4IPAMPool = newEp.IPv4IPAMPool
 		changed = true
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -166,8 +166,14 @@ type Endpoint struct {
 	// IPv6 is the IPv6 address of the endpoint
 	IPv6 netip.Addr
 
+	// IPv6IPAMPool is the IPAM address pool from which the IPv6 address has been allocated from
+	IPv6IPAMPool string
+
 	// IPv4 is the IPv4 address of the endpoint
 	IPv4 netip.Addr
+
+	// IPv4IPAMPool is the IPAM address pool from which the IPv4 address has been allocated from
+	IPv4IPAMPool string
 
 	// nodeMAC is the MAC of the node (agent). The MAC is different for every endpoint.
 	nodeMAC mac.MAC

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -373,7 +373,9 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		OpLabels:              e.OpLabels,
 		LXCMAC:                e.mac,
 		IPv6:                  e.IPv6,
+		IPv6IPAMPool:          e.IPv6IPAMPool,
 		IPv4:                  e.IPv4,
+		IPv4IPAMPool:          e.IPv4IPAMPool,
 		NodeMAC:               e.nodeMAC,
 		SecurityIdentity:      e.SecurityIdentity,
 		Options:               e.Options,
@@ -435,8 +437,14 @@ type serializableEndpoint struct {
 	// IPv6 is the IPv6 address of the endpoint
 	IPv6 netip.Addr
 
+	// IPv6IPAMPool is the IPAM address pool from which the IPv6 address was allocated
+	IPv6IPAMPool string
+
 	// IPv4 is the IPv4 address of the endpoint
 	IPv4 netip.Addr
+
+	// IPv4IPAMPool is the IPAM address pool from which the IPv4 address was allocated
+	IPv4IPAMPool string
 
 	// nodeMAC is the MAC of the node (agent). The MAC is different for every endpoint.
 	NodeMAC mac.MAC
@@ -513,7 +521,9 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.OpLabels = r.OpLabels
 	ep.mac = r.LXCMAC
 	ep.IPv6 = r.IPv6
+	ep.IPv6IPAMPool = r.IPv6IPAMPool
 	ep.IPv4 = r.IPv4
+	ep.IPv4IPAMPool = r.IPv4IPAMPool
 	ep.nodeMAC = r.NodeMAC
 	ep.SecurityIdentity = r.SecurityIdentity
 	ep.DNSRules = r.DNSRules

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -30,6 +30,19 @@ var (
 	ErrIPv6Disabled = errors.New("IPv6 allocation disabled")
 )
 
+func (ipam *IPAM) determineIPAMPool(owner string) (Pool, error) {
+	if ipam.metadata == nil {
+		return PoolDefault, nil
+	}
+
+	pool, err := ipam.metadata.GetIPPoolForPod(owner)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine IPAM pool for owner %q: %w", owner, err)
+	}
+
+	return Pool(pool), nil
+}
+
 // AllocateIP allocates a IP address.
 func (ipam *IPAM) AllocateIP(ip net.IP, owner string, pool Pool) error {
 	needSyncUpstream := true
@@ -55,6 +68,10 @@ func (ipam *IPAM) AllocateIPString(ipAddr, owner string, pool Pool) error {
 func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstream bool) (result *AllocationResult, err error) {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()
+
+	if pool == "" {
+		return nil, fmt.Errorf("unable to restore IP %s for %q: pool name must be provided", ip, owner)
+	}
 
 	if ownedBy, ok := ipam.isIPExcluded(ip, pool); ok {
 		err = fmt.Errorf("IP %s is excluded, owned by %s", ip, ownedBy)
@@ -85,19 +102,26 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 		}
 
 		if needSyncUpstream {
-			if _, err = ipam.IPv6Allocator.Allocate(ip, owner, pool); err != nil {
+			if result, err = ipam.IPv6Allocator.Allocate(ip, owner, pool); err != nil {
 				return
 			}
 		} else {
-			if _, err = ipam.IPv6Allocator.AllocateWithoutSyncUpstream(ip, owner, pool); err != nil {
+			if result, err = ipam.IPv6Allocator.AllocateWithoutSyncUpstream(ip, owner, pool); err != nil {
 				return
 			}
 		}
 	}
 
+	// If the allocator did not populate the pool, we assume it does not
+	// support IPAM pools and assign the default pool instead
+	if result.IPPoolName == "" {
+		result.IPPoolName = PoolDefault
+	}
+
 	log.WithFields(logrus.Fields{
 		"ip":    ip.String(),
 		"owner": owner,
+		"pool":  result.IPPoolName,
 	}).Debugf("Allocated specific IP")
 
 	ipam.registerIPOwner(ip, owner, pool)
@@ -123,6 +147,13 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 		return
 	}
 
+	if pool == "" {
+		pool, err = ipam.determineIPAMPool(owner)
+		if err != nil {
+			return
+		}
+	}
+
 	for {
 		if needSyncUpstream {
 			result, err = allocator.AllocateNext(owner, pool)
@@ -133,10 +164,16 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 			return
 		}
 
+		// If the allocator did not populate the pool, we assume it does not
+		// support IPAM pools and assign the default pool instead
+		if result.IPPoolName == "" {
+			result.IPPoolName = PoolDefault
+		}
+
 		if _, ok := ipam.isIPExcluded(result.IP, pool); !ok {
 			log.WithFields(logrus.Fields{
 				"ip":    result.IP.String(),
-				"pool":  pool.String(),
+				"pool":  result.IPPoolName,
 				"owner": owner,
 			}).Debugf("Allocated random IP")
 			ipam.registerIPOwner(result.IP, owner, pool)
@@ -189,7 +226,7 @@ func (ipam *IPAM) AllocateNext(family, owner string, pool Pool) (ipv4Result, ipv
 		ipv4Result, err = ipam.AllocateNextFamily(IPv4, owner, pool)
 		if err != nil {
 			if ipv6Result != nil {
-				ipam.ReleaseIP(ipv6Result.IP, pool)
+				ipam.ReleaseIP(ipv6Result.IP, ipv6Result.IPPoolName)
 			}
 			return
 		}
@@ -213,10 +250,10 @@ func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, pool Pool, ti
 				result.ExpirationUUID, err = ipam.StartExpirationTimer(result.IP, pool, timeout)
 				if err != nil {
 					if ipv4Result != nil {
-						ipam.ReleaseIP(ipv4Result.IP, pool)
+						ipam.ReleaseIP(ipv4Result.IP, ipv4Result.IPPoolName)
 					}
 					if ipv6Result != nil {
-						ipam.ReleaseIP(ipv6Result.IP, pool)
+						ipam.ReleaseIP(ipv6Result.IP, ipv6Result.IPPoolName)
 					}
 					return
 				}
@@ -228,6 +265,10 @@ func (ipam *IPAM) AllocateNextWithExpiration(family, owner string, pool Pool, ti
 }
 
 func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
+	if pool == "" {
+		return fmt.Errorf("no IPAM pool provided for IP release of %s", ip)
+	}
+
 	family := IPv4
 	if ip.To4() != nil {
 		if ipam.IPv4Allocator == nil {
@@ -255,7 +296,9 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 	return nil
 }
 
-// ReleaseIP release a IP address.
+// ReleaseIP release a IP address. The pool argument must not be empty, it
+// must be set to the pool name returned by the `Allocate*` functions when
+// the IP was allocated.
 func (ipam *IPAM) ReleaseIP(ip net.IP, pool Pool) error {
 	ipam.allocatorMutex.Lock()
 	defer ipam.allocatorMutex.Unlock()

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -102,6 +102,10 @@ type MtuConfiguration interface {
 	GetDeviceMTU() int
 }
 
+type Metadata interface {
+	GetIPPoolForPod(owner string) (pool string, err error)
+}
+
 // NewIPAM returns a new IP address manager
 func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, k8sEventReg K8sEventRegister, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
 	ipam := &IPAM{
@@ -167,6 +171,12 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 	}
 
 	return ipam
+}
+
+// WithMetadata sets an optional Metadata provider, which IPAM will use to
+// determine what IPAM pool an IP owner should allocate its IP from
+func (ipam *IPAM) WithMetadata(m Metadata) {
+	ipam.metadata = m
 }
 
 // getIPOwner returns the owner for an IP in a particular pool or the empty

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -95,28 +95,3 @@ func (s *IPAMSuite) TestDeriveFamily(c *C) {
 	c.Assert(DeriveFamily(net.ParseIP("1.1.1.1")), Equals, IPv4)
 	c.Assert(DeriveFamily(net.ParseIP("f00d::1")), Equals, IPv6)
 }
-
-func (s *IPAMSuite) TestOwnerRelease(c *C) {
-	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
-
-	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
-	ipv4 = ipv4.Next()
-	err := ipam.AllocateIP(ipv4.AsSlice(), "default/test", PoolDefault)
-	c.Assert(err, IsNil)
-
-	ipv6 := fakeIPv6AllocCIDRIP(fakeAddressing)
-	ipv6 = ipv6.Next()
-	err = ipam.AllocateIP(ipv6.AsSlice(), "default/test", PoolDefault)
-	c.Assert(err, IsNil)
-
-	// unknown owner, must fail
-	err = ipam.ReleaseIPString("default/test2", PoolDefault)
-	c.Assert(err, Not(IsNil))
-	// 1st release by correct owner, must succeed
-	err = ipam.ReleaseIPString("default/test", PoolDefault)
-	c.Assert(err, IsNil)
-	// 2nd release by owner, must now fail
-	err = ipam.ReleaseIPString("default/test", PoolDefault)
-	c.Assert(err, Not(IsNil))
-}

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -4,8 +4,10 @@
 package ipam
 
 import (
+	"fmt"
 	"net"
 	"net/netip"
+	"strings"
 	"testing"
 
 	. "github.com/cilium/checkmate"
@@ -42,6 +44,83 @@ func (t *testConfiguration) UnreachableRoutesEnabled() bool           { return f
 func (t *testConfiguration) IPAMMode() string                         { return ipamOption.IPAMClusterPool }
 func (t *testConfiguration) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
 func (t *testConfiguration) GetIPv4NativeRoutingCIDR() *cidr.CIDR     { return nil }
+
+type fakeMetadataFunc func(owner string) (pool string, err error)
+
+func (f fakeMetadataFunc) GetIPPoolForPod(owner string) (pool string, err error) {
+	return f(owner)
+}
+
+type fakePoolAllocator struct {
+	pools map[string]Allocator
+}
+
+func newFakePoolAllocator(poolMap map[string]string) *fakePoolAllocator {
+	pools := make(map[string]Allocator, len(poolMap))
+	for name, cidr := range poolMap {
+		_, ipnet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Sprintf("failed to parse test cidr %s for pool %s", cidr, name))
+		}
+		pools[name] = newHostScopeAllocator(ipnet)
+	}
+	return &fakePoolAllocator{pools: pools}
+}
+
+func (f *fakePoolAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
+	alloc, ok := f.pools[pool.String()]
+	if !ok {
+		return nil, fmt.Errorf("unknown pool %s", pool)
+	}
+	result, err := alloc.Allocate(ip, owner, pool)
+	if err != nil {
+		return nil, err
+	}
+	result.IPPoolName = pool
+	return result, nil
+}
+
+func (f fakePoolAllocator) AllocateWithoutSyncUpstream(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {
+	return f.Allocate(ip, owner, pool)
+}
+
+func (f fakePoolAllocator) Release(ip net.IP, pool Pool) error {
+	alloc, ok := f.pools[pool.String()]
+	if !ok {
+		return fmt.Errorf("unknown pool %s", pool)
+	}
+	return alloc.Release(ip, pool)
+}
+
+func (f fakePoolAllocator) AllocateNext(owner string, pool Pool) (*AllocationResult, error) {
+	alloc, ok := f.pools[pool.String()]
+	if !ok {
+		return nil, fmt.Errorf("unknown pool %s", pool)
+	}
+	result, err := alloc.AllocateNext(owner, pool)
+	if err != nil {
+		return nil, err
+	}
+	result.IPPoolName = pool
+	return result, nil
+}
+
+func (f fakePoolAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error) {
+	return f.AllocateNext(owner, pool)
+}
+
+func (f fakePoolAllocator) Dump() (map[string]string, string) {
+	result := map[string]string{}
+	for name, alloc := range f.pools {
+		dump, _ := alloc.Dump()
+		for k, v := range dump {
+			result[name+":"+k] = v
+		}
+	}
+	return result, fmt.Sprintf("%d pools", len(f.pools))
+}
+
+func (f fakePoolAllocator) RestoreFinished() {}
 
 func (s *IPAMSuite) TestLock(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
@@ -94,4 +173,125 @@ func (s *IPAMSuite) TestExcludeIP(c *C) {
 func (s *IPAMSuite) TestDeriveFamily(c *C) {
 	c.Assert(DeriveFamily(net.ParseIP("1.1.1.1")), Equals, IPv4)
 	c.Assert(DeriveFamily(net.ParseIP("f00d::1")), Equals, IPv6)
+}
+
+func (s *IPAMSuite) TestIPAMMetadata(c *C) {
+	fakeAddressing := fake.NewNodeAddressing()
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
+	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
+		"default": "10.10.0.0/16",
+		"test":    "192.168.178.0/24",
+		"special": "172.18.19.0/24",
+	})
+	ipam.IPv6Allocator = newFakePoolAllocator(map[string]string{
+		"default": "fd00:100::/80",
+		"test":    "fc00:100::/96",
+		"special": "fe00:100::/80",
+	})
+
+	// Without metadata, should always return PoolDefault
+	resIPv4, resIPv6, err := ipam.AllocateNext("", "test/some-pod", "")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
+
+	ipam.WithMetadata(fakeMetadataFunc(func(owner string) (pool string, err error) {
+		// use namespace to determine pool name
+		namespace, _, _ := strings.Cut(owner, "/")
+		switch namespace {
+		case "test":
+			return "test", nil
+		case "special":
+			return "special", nil
+		case "error":
+			return "", fmt.Errorf("unable to determine pool for %s", owner)
+		default:
+			return PoolDefault.String(), nil
+		}
+	}))
+
+	// Checks AllocateIP
+	specialIP := net.ParseIP("172.18.19.20")
+	_, err = ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "")
+	c.Assert(err, Not(IsNil)) // pool required
+	resIPv4, err = ipam.AllocateIPWithoutSyncUpstream(specialIP, "special/wants-special-ip", "special")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, Pool("special"))
+	c.Assert(resIPv4.IP.Equal(specialIP), Equals, true)
+
+	// Checks ReleaseIP
+	err = ipam.ReleaseIP(specialIP, "")
+	c.Assert(err, Not(IsNil)) // pool required
+	err = ipam.ReleaseIP(specialIP, "special")
+	c.Assert(err, IsNil)
+
+	// Checks if pool metadata is used if pool is empty
+	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/some-other-pod", "")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, Pool("test"))
+	c.Assert(resIPv6.IPPoolName, Equals, Pool("test"))
+
+	// Checks if pool can be overwritten
+	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/special-pod", "special")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, Pool("special"))
+	c.Assert(resIPv6.IPPoolName, Equals, Pool("special"))
+
+	// Checks if fallback to default works
+	resIPv4, resIPv6, err = ipam.AllocateNext("", "other/special-pod", "")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
+
+	// Checks if metadata errors are propagated
+	_, _, err = ipam.AllocateNext("", "error/special-value", "")
+	c.Assert(err, Not(IsNil))
+}
+
+func (s *IPAMSuite) TestLegacyAllocatorIPAMMetadata(c *C) {
+	// This test uses a regular hostScope allocator which does not support
+	// IPAM pools. We assert that in this scenario, the pool returned in the
+	// AllocationResult is always set to PoolDefault, regardless of the requested
+	// pool
+	fakeAddressing := fake.NewNodeAddressing()
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
+	ipam.WithMetadata(fakeMetadataFunc(func(owner string) (pool string, err error) {
+		return "some-pool", nil
+	}))
+
+	// AllocateIP requires explicit pool
+	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
+	ipv4 = ipv4.Next()
+	_, err := ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "")
+	c.Assert(err, Not(IsNil))
+
+	// AllocateIP with specific pool
+	ipv4 = ipv4.Next()
+	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "override")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
+
+	// AllocateIP with default pool
+	ipv4 = ipv4.Next()
+	resIPv4, err = ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "default")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
+
+	// AllocateNext with empty pool
+	resIPv4, resIPv6, err := ipam.AllocateNext("", "test/some-pod", "")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
+
+	// AllocateNext with specific pool
+	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/some-other-pod", "override")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
+
+	// AllocateNext with default pool
+	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/some-other-pod", "default")
+	c.Assert(err, IsNil)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
 }

--- a/pkg/ipam/metadata/cell.go
+++ b/pkg/ipam/metadata/cell.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metadata
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var Cell = cell.Module(
+	"ipam-metadata-manager",
+	"Provides IPAM metadata",
+
+	cell.Provide(newIPAMMetadataManager),
+)
+
+type managerParams struct {
+	cell.In
+
+	Lifecycle    hive.Lifecycle
+	DaemonConfig *option.DaemonConfig
+
+	NamespaceResource resource.Resource[*slim_core_v1.Namespace]
+	PodResource       k8s.LocalPodResource
+}
+
+func newIPAMMetadataManager(params managerParams) *Manager {
+	if params.DaemonConfig.IPAM != ipamOption.IPAMMultiPool {
+		return nil
+	}
+
+	manager := &Manager{
+		namespaceResource: params.NamespaceResource,
+		podResource:       params.PodResource,
+	}
+	params.Lifecycle.Append(manager)
+
+	return manager
+}

--- a/pkg/ipam/metadata/manager.go
+++ b/pkg/ipam/metadata/manager.go
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metadata
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	"github.com/cilium/cilium/pkg/hive"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-metadata-manager")
+)
+
+type ManagerStoppedError struct{}
+
+func (m *ManagerStoppedError) Error() string {
+	return "ipam-metadata-manager has been stopped"
+}
+
+type ResourceNotFound struct {
+	Resource  string
+	Name      string
+	Namespace string
+}
+
+func (r *ResourceNotFound) Error() string {
+	name := r.Name
+	if r.Namespace != "" {
+		name = r.Namespace + "/" + r.Name
+	}
+	return fmt.Sprintf("resource %s %q not found", r.Resource, name)
+}
+
+func (r *ResourceNotFound) Is(target error) bool {
+	targetErr, ok := target.(*ResourceNotFound)
+	if !ok {
+		return false
+	}
+	if r != nil && targetErr.Resource != "" {
+		return r.Resource == targetErr.Resource
+	}
+	return true
+}
+
+type Manager struct {
+	namespaceResource resource.Resource[*slim_core_v1.Namespace]
+	namespaceStore    resource.Store[*slim_core_v1.Namespace]
+	podResource       k8s.LocalPodResource
+	podStore          resource.Store[*slim_core_v1.Pod]
+}
+
+func (m *Manager) Start(ctx hive.HookContext) (err error) {
+	m.namespaceStore, err = m.namespaceResource.Store(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to obtain namespace store: %w", err)
+	}
+
+	m.podStore, err = m.podResource.Store(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to obtain pod store: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) Stop(ctx hive.HookContext) error {
+	m.namespaceStore = nil
+	m.podStore = nil
+	return nil
+}
+
+func splitK8sPodName(owner string) (namespace, name string, ok bool) {
+	// Require namespace/name format
+	s := strings.SplitN(owner, "/", 2)
+	if len(s) != 2 {
+		return "", "", false
+	}
+	// Check if components are a valid namespace name and pod name
+	if validation.IsDNS1123Subdomain(s[0]) != nil ||
+		validation.IsDNS1123Subdomain(s[1]) != nil {
+		return "", "", false
+	}
+	return s[0], s[1], true
+}
+
+func (m *Manager) GetIPPoolForPod(owner string) (pool string, err error) {
+	if m.namespaceStore == nil || m.podStore == nil {
+		return "", &ManagerStoppedError{}
+	}
+
+	namespace, name, ok := splitK8sPodName(owner)
+	if !ok {
+		log.WithField("owner", owner).
+			Debug("IPAM metadata request for invalid pod name, falling back to default pool")
+		return ipamOption.PoolDefault, nil
+	}
+
+	// Check annotation on pod
+	pod, ok, err := m.podStore.GetByKey(resource.Key{
+		Name:      name,
+		Namespace: namespace,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup pod %q: %w", namespace+"/"+name, err)
+	} else if !ok {
+		return "", &ResourceNotFound{Resource: "Pod", Namespace: namespace, Name: name}
+	} else if ipPool, hasAnnotation := pod.Annotations[annotation.IPAMPoolKey]; hasAnnotation {
+		return ipPool, nil
+	}
+
+	// Check annotation on namespace
+	podNamespace, ok, err := m.namespaceStore.GetByKey(resource.Key{
+		Name: namespace,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup namespace %q: %w", namespace, err)
+	} else if !ok {
+		return "", &ResourceNotFound{Resource: "Namespace", Name: namespace}
+	} else if ipPool, hasAnnotation := podNamespace.Annotations[annotation.IPAMPoolKey]; hasAnnotation {
+		return ipPool, nil
+	}
+
+	// Fallback to default pool
+	return ipamOption.PoolDefault, nil
+}

--- a/pkg/ipam/metadata/manager.go
+++ b/pkg/ipam/metadata/manager.go
@@ -83,16 +83,16 @@ func (m *Manager) Stop(ctx hive.HookContext) error {
 
 func splitK8sPodName(owner string) (namespace, name string, ok bool) {
 	// Require namespace/name format
-	s := strings.SplitN(owner, "/", 2)
-	if len(s) != 2 {
+	namespace, name, ok = strings.Cut(owner, "/")
+	if !ok {
 		return "", "", false
 	}
 	// Check if components are a valid namespace name and pod name
-	if validation.IsDNS1123Subdomain(s[0]) != nil ||
-		validation.IsDNS1123Subdomain(s[1]) != nil {
+	if validation.IsDNS1123Subdomain(namespace) != nil ||
+		validation.IsDNS1123Subdomain(name) != nil {
 		return "", "", false
 	}
-	return s[0], s[1], true
+	return namespace, name, true
 }
 
 func (m *Manager) GetIPPoolForPod(owner string) (pool string, err error) {

--- a/pkg/ipam/metadata/manager_test.go
+++ b/pkg/ipam/metadata/manager_test.go
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metadata
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/cilium/cilium/pkg/annotation"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+type mockStore[T comparable] map[resource.Key]T
+
+func (m mockStore[T]) GetByKey(key resource.Key) (item T, exists bool, err error) {
+	item, exists = m[key]
+	return item, exists, nil
+}
+
+func (m mockStore[T]) Get(obj T) (item T, exists bool, err error) {
+	panic("not implemented")
+}
+
+func (m mockStore[T]) List() []T {
+	panic("not implemented")
+}
+
+func (m mockStore[T]) IterKeys() resource.KeyIter {
+	panic("not implemented")
+}
+
+func (m mockStore[T]) CacheStore() cache.Store {
+	panic("not implemented")
+}
+
+func podKey(ns, name string) resource.Key {
+	return resource.Key{
+		Namespace: ns,
+		Name:      name,
+	}
+}
+
+func namespaceKey(name string) resource.Key {
+	return resource.Key{
+		Name: name,
+	}
+}
+
+func TestManager_GetIPPoolForPod(t *testing.T) {
+	m := &Manager{
+		namespaceStore: mockStore[*slim_core_v1.Namespace]{
+			namespaceKey("default"): &slim_core_v1.Namespace{},
+			namespaceKey("special"): &slim_core_v1.Namespace{
+				ObjectMeta: slim_meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.IPAMPoolKey: "namespace-pool",
+					},
+				},
+			},
+		},
+		podStore: mockStore[*slim_core_v1.Pod]{
+			podKey("default", "client"): &slim_core_v1.Pod{},
+			podKey("default", "custom-workload"): &slim_core_v1.Pod{
+				ObjectMeta: slim_meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.IPAMPoolKey: "custom-pool",
+					},
+				},
+			},
+
+			podKey("special", "server"): &slim_core_v1.Pod{},
+			podKey("special", "server2"): &slim_core_v1.Pod{
+				ObjectMeta: slim_meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						annotation.IPAMPoolKey: "pod-pool",
+					},
+				},
+			},
+
+			podKey("missing-ns", "pod"): &slim_core_v1.Pod{},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		owner    string
+		wantPool string
+		wantErr  error
+	}{
+		{
+			name:     "no annotations",
+			owner:    "default/client",
+			wantPool: ipamOption.PoolDefault,
+		},
+		{
+			name:     "not a pod name",
+			owner:    "router",
+			wantPool: ipamOption.PoolDefault,
+		},
+		{
+			name:     "also not a pod name (due to underline)",
+			owner:    "default/xwing_net2",
+			wantPool: ipamOption.PoolDefault,
+		},
+		{
+			name:     "pod annotation",
+			owner:    "default/custom-workload",
+			wantPool: "custom-pool",
+		},
+		{
+			name:     "namespace annotation",
+			owner:    "special/server",
+			wantPool: "namespace-pool",
+		},
+		{
+			name:     "pod annotation in namespace with annotation",
+			owner:    "special/server2",
+			wantPool: "pod-pool",
+		},
+		{
+			name:    "missing pod",
+			owner:   "does-not/exist",
+			wantErr: &ResourceNotFound{Resource: "Pod"},
+		},
+		{
+			name:    "missing namespace",
+			owner:   "missing-ns/pod",
+			wantErr: &ResourceNotFound{Resource: "Namespace"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPool, err := m.GetIPPoolForPod(tt.owner)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("GetIPPoolForPod() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotPool != tt.wantPool {
+				t.Errorf("GetIPPoolForPod() gotPool = %v, want %v", gotPool, tt.wantPool)
+			}
+		})
+	}
+}

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -430,7 +430,7 @@ func (m *multiPoolManager) allocateNext(owner string, poolName Pool, family Fami
 	if syncUpstream {
 		m.k8sUpdater.TriggerWithReason("allocation of next IP")
 	}
-	return &AllocationResult{IP: ip}, nil
+	return &AllocationResult{IP: ip, IPPoolName: poolName}, nil
 }
 
 func (m *multiPoolManager) allocateIP(ip net.IP, owner string, poolName Pool, family Family, syncUpstream bool) (*AllocationResult, error) {
@@ -450,7 +450,7 @@ func (m *multiPoolManager) allocateIP(ip net.IP, owner string, poolName Pool, fa
 	if syncUpstream {
 		m.k8sUpdater.TriggerWithReason("allocation of IP")
 	}
-	return &AllocationResult{IP: ip}, nil
+	return &AllocationResult{IP: ip, IPPoolName: poolName}, nil
 }
 
 func (m *multiPoolManager) releaseIP(ip net.IP, poolName Pool, family Family, upstreamSync bool) error {

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -19,6 +19,9 @@ type AllocationResult struct {
 	// IP is the allocated IP
 	IP net.IP
 
+	// IPPoolName is the IPAM pool from which the above IP was allocated from
+	IPPoolName Pool
+
 	// CIDRs is a list of all CIDRs to which the IP has direct access to.
 	// This is primarily useful if the IP has been allocated out of a VPC
 	// subnet range and the VPC provides routing to a set of CIDRs in which
@@ -82,6 +85,10 @@ type IPAM struct {
 
 	IPv6Allocator Allocator
 	IPv4Allocator Allocator
+
+	// metadata provides information about a particular IP owner.
+	// May be nil.
+	metadata Metadata
 
 	// owner maps an IP to the owner per pool.
 	owner map[Pool]map[string]string

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -546,6 +546,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	if ipv6IsEnabled(ipam) {
 		ep.Addressing.IPV6 = ipam.Address.IPV6
+		ep.Addressing.IPV6PoolName = ipam.Address.IPV6PoolName
 		ep.Addressing.IPV6ExpirationUUID = ipam.IPV6.ExpirationUUID
 
 		ipConfig, routes, err = prepareIP(ep.Addressing.IPV6, &state, int(conf.RouteMTU))
@@ -559,6 +560,7 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 
 	if ipv4IsEnabled(ipam) {
 		ep.Addressing.IPV4 = ipam.Address.IPV4
+		ep.Addressing.IPV4PoolName = ipam.Address.IPV4PoolName
 		ep.Addressing.IPV4ExpirationUUID = ipam.IPV4.ExpirationUUID
 
 		ipConfig, routes, err = prepareIP(ep.Addressing.IPV4, &state, int(conf.RouteMTU))

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -119,9 +119,8 @@ func getConfigFromCiliumAgent(client *client.Client) (*models.DaemonConfiguratio
 
 func allocateIPsWithCiliumAgent(client *client.Client, cniArgs types.ArgsSpec) (*models.IPAMResponse, func(context.Context), error) {
 	podName := string(cniArgs.K8S_POD_NAMESPACE) + "/" + string(cniArgs.K8S_POD_NAME)
-	// TODO: this will be configurable e.g. by pod annotations when using multi-homing
-	pool := ""
-	ipam, err := client.IPAMAllocate("", podName, pool, true)
+
+	ipam, err := client.IPAMAllocate("", podName, "", true)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to allocate IP via local cilium agent: %w", err)
 	}
@@ -132,8 +131,8 @@ func allocateIPsWithCiliumAgent(client *client.Client, cniArgs types.ArgsSpec) (
 
 	releaseFunc := func(context.Context) {
 		if ipam.Address != nil {
-			releaseIP(client, ipam.Address.IPV4, pool)
-			releaseIP(client, ipam.Address.IPV6, pool)
+			releaseIP(client, ipam.Address.IPV4, ipam.Address.IPV4PoolName)
+			releaseIP(client, ipam.Address.IPV6, ipam.Address.IPV6PoolName)
 		}
 	}
 


### PR DESCRIPTION
This adds a mechanism which allows workloads to specify what IP pool their IP should be allocated from in multi-pool IPAM mode (see https://github.com/cilium/cilium/pull/22762 for details).

It will do that by first checking if the pod has a `ipam.cilium.io/ip-pool`  annotation, and if present, will return that pool to be used for IP allocation. If the pod does not have such an annotation, it will then check for the same annotation on the pod's namespace. If that is also not present, we fall back on the `default` pool.

:bulb: **Review per commit**

I have manually tested this on kind as follows:

```console
$ helm upgrade --install cilium ./install/kubernetes/cilium --namespace kube-system \
    --set debug.enabled=true \
    --set image.override=localhost:5000/cilium/cilium-dev:local \
    --set image.pullPolicy=IfNotPresent \
    --set operator.image.override=localhost:5000/cilium/operator-generic:local \
    --set operator.image.pullPolicy=IfNotPresent \
    --set operator.replicas=1 \
    --set hubble.relay.enabled=true \
    --set ipam.mode=multi-pool \
    --set "ipam.operator.multiPoolMap.default.ipv4CIDRs[0]=10.10.0.0/16" \
    --set "ipam.operator.multiPoolMap.default.ipv4MaskSize=27" \
    --set "ipam.operator.multiPoolMap.mars.ipv4CIDRs[0]=10.20.0.0/16" \
    --set "ipam.operator.multiPoolMap.mars.ipv4MaskSize=24" \
    --set "extraConfig.multi-pool-node-pre-alloc=default=64\,mars=64" \
    --set tunnel=disabled \
    --set autoDirectNodeRoutes=true \
    --set ipv4NativeRoutingCIDR=10.0.0.0/8 \
    --set endpointRoutes.enabled=true \
    --set-string extraConfig.enable-local-node-route=false \
    --set kubeProxyReplacement=strict \
    --set bpf.masquerade=true
$ k create ns cilium-test
$ k annotate ns cilium-test ipam.cilium.io/ip-pool=mars
$ cilium connectivity test
...
✅ All 41 tests (291 actions) successful, 8 tests skipped, 0 scenarios skipped.
$ k -n default get pods -o wide
NAME                         READY   STATUS    RESTARTS   AGE   IP            NODE           NOMINATED NODE   READINESS GATES
deathstar-54bb8475cc-89hwl   1/1     Running   0          9m    10.10.1.77    kind-worker2   <none>           <none>
deathstar-54bb8475cc-8gfdd   1/1     Running   0          9m    10.10.0.83    kind-worker    <none>           <none>
tiefighter                   1/1     Running   0          9m    10.10.1.103   kind-worker    <none>           <none>
xwing                        1/1     Running   0          9m    10.10.1.101   kind-worker    <none>           <none>
$ k -n cilium-test get pods -o wide
NAME                               READY   STATUS    RESTARTS   AGE     IP            NODE           NOMINATED NODE   READINESS GATES
client-7b78db77d5-dkzh6            1/1     Running   0          7m59s   10.20.0.94    kind-worker    <none>           <none>
client2-78f748dd67-j2qhg           1/1     Running   0          7m59s   10.20.0.103   kind-worker    <none>           <none>
echo-other-node-8689b5dd4f-6pk5l   2/2     Running   0          7m59s   10.20.2.182   kind-worker2   <none>           <none>
echo-same-node-5b55d8bdd7-jdb66    2/2     Running   0          7m59s   10.20.0.225   kind-worker    <none>           <none>
$ # note the different IP range for the cilium-test pods                ⬆️
```

CI and documentation will be added in a separate PR. See meta issue #25470 