### PR TITLE
Updates endpoint pkg to use netip.Addr

### DIFF
--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -5,7 +5,7 @@ package cmd
 
 import (
 	"context"
-	"net"
+	"net/netip"
 	"runtime"
 	"time"
 
@@ -96,7 +96,9 @@ func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 		labels.IDNameInit: labels.NewLabel(labels.IDNameInit, "", labels.LabelSourceReserved),
 	}
 	// Check that the endpoint has the reserved:init label.
-	ep, err := ds.d.endpointManager.Lookup(endpointid.NewIPPrefixID(net.ParseIP(epTemplate.Addressing.IPV4)))
+	v4ip, err := netip.ParseAddr(epTemplate.Addressing.IPV4)
+	c.Assert(err, IsNil)
+	ep, err := ds.d.endpointManager.Lookup(endpointid.NewIPPrefixID(v4ip))
 	c.Assert(err, IsNil)
 	c.Assert(ep.OpLabels.IdentityLabels(), checker.DeepEquals, expectedLabels)
 

--- a/pkg/endpoint/id/id.go
+++ b/pkg/endpoint/id/id.go
@@ -6,7 +6,7 @@ package id
 import (
 	"fmt"
 	"math"
-	"net"
+	"net/netip"
 	"strconv"
 	"strings"
 )
@@ -70,13 +70,16 @@ func NewID(prefix PrefixType, id string) string {
 	return string(prefix) + ":" + id
 }
 
-// NewIPPrefixID returns an identifier based on the IP address specified
-func NewIPPrefixID(ip net.IP) string {
-	if ip.To4() != nil {
-		return NewID(IPv4Prefix, ip.String())
+// NewIPPrefixID returns an identifier based on the IP address specified. If ip
+// is invalid, an empty string is returned.
+func NewIPPrefixID(ip netip.Addr) string {
+	if ip.IsValid() {
+		if ip.Is4() {
+			return NewID(IPv4Prefix, ip.String())
+		}
+		return NewID(IPv6Prefix, ip.String())
 	}
-
-	return NewID(IPv6Prefix, ip.String())
+	return ""
 }
 
 // splitID splits ID into prefix and id. No validation is performed on prefix.

--- a/pkg/endpoint/id/id_test.go
+++ b/pkg/endpoint/id/id_test.go
@@ -4,7 +4,7 @@
 package id
 
 import (
-	"net"
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -202,6 +202,6 @@ func (s *IDSuite) TestParse(c *C) {
 }
 
 func (s *IDSuite) TestNewIPPrefix(c *C) {
-	c.Assert(strings.HasPrefix(NewIPPrefixID(net.ParseIP("1.1.1.1")), string(IPv4Prefix)), Equals, true)
-	c.Assert(strings.HasPrefix(NewIPPrefixID(net.ParseIP("f00d::1")), string(IPv6Prefix)), Equals, true)
+	c.Assert(strings.HasPrefix(NewIPPrefixID(netip.MustParseAddr("1.1.1.1")), string(IPv4Prefix)), Equals, true)
+	c.Assert(strings.HasPrefix(NewIPPrefixID(netip.MustParseAddr("f00d::1")), string(IPv6Prefix)), Equals, true)
 }

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/netip"
 	"path"
 	"sort"
 	"strings"
@@ -97,7 +98,7 @@ func newKVReferenceCounter(s store) *kvReferenceCounter {
 
 // UpsertIPToKVStore updates / inserts the provided IP->Identity mapping into the
 // kvstore, which will subsequently trigger an event in NewIPIdentityWatcher().
-func UpsertIPToKVStore(ctx context.Context, IP, hostIP net.IP, ID identity.NumericIdentity, key uint8,
+func UpsertIPToKVStore(ctx context.Context, IP, hostIP netip.Addr, ID identity.NumericIdentity, key uint8,
 	metadata, k8sNamespace, k8sPodName string, npm types.NamedPortMap) error {
 	// Sort named ports into a slice
 	namedPorts := make([]identity.NamedPort, 0, len(npm))
@@ -114,10 +115,10 @@ func UpsertIPToKVStore(ctx context.Context, IP, hostIP net.IP, ID identity.Numer
 
 	ipKey := path.Join(IPIdentitiesPath, AddressSpace, IP.String())
 	ipIDPair := identity.IPIdentityPair{
-		IP:           IP,
+		IP:           IP.AsSlice(),
 		ID:           ID,
 		Metadata:     metadata,
-		HostIP:       hostIP,
+		HostIP:       hostIP.AsSlice(),
 		Key:          key,
 		K8sNamespace: k8sNamespace,
 		K8sPodName:   k8sPodName,


### PR DESCRIPTION
Updates the endpoint pkg to use `netip.Addr` type instead of `net.IP`.

Related: #24246

