### PR TITLE
ci-l4lb-v1.1{1,2}: Remove helm charts

### DIFF
--- a/.github/workflows/tests-l4lb-v1.11.yaml
+++ b/.github/workflows/tests-l4lb-v1.11.yaml
@@ -209,13 +209,6 @@ jobs:
           ref: v1.11
           persist-credentials: false
 
-      - name: Checkout pull request for Helm chart
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          ref: ${{ steps.vars.outputs.sha }}
-          persist-credentials: false
-          path: pull-request
-
       - name: Wait for image to be available
         timeout-minutes: 10
         shell: bash
@@ -224,7 +217,7 @@ jobs:
 
       - name: Run LoadBalancing test
         run: |
-          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request/install/kubernetes/cilium
+          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }}
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}

--- a/.github/workflows/tests-l4lb-v1.12.yaml
+++ b/.github/workflows/tests-l4lb-v1.12.yaml
@@ -209,13 +209,6 @@ jobs:
           ref: v1.12
           persist-credentials: false
 
-      - name: Checkout pull request for Helm chart
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-        with:
-          ref: ${{ steps.vars.outputs.sha }}
-          persist-credentials: false
-          path: pull-request
-
       - name: Wait for image to be available
         timeout-minutes: 10
         shell: bash
@@ -224,11 +217,11 @@ jobs:
 
       - name: Run LoadBalancing test
         run: |
-          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request/install/kubernetes/cilium
+          cd ${{ github.workspace }}/test/l4lb && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }}
 
       - name: Run NAT46x64 test
         run: |
-          cd ${{ github.workspace }}/test/nat46x64 && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }} ${{ github.workspace }}/pull-request/install/kubernetes/cilium
+          cd ${{ github.workspace }}/test/nat46x64 && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }}
 
       - name: Fetch cilium-sysdump
         if: ${{ !success() }}


### PR DESCRIPTION
They are no longer needed, as thanks to \[1\] \[2\] we started to run the L4LB in DinD instead of Kind.

\[1\]: https://github.com/cilium/cilium/pull/25528
\[2\]: https://github.com/cilium/cilium/pull/25523