### PR TITLE
endpoint: Remove the duplicate ENABLE_SIP_VERIFICATION in ep_config.h

### DIFF
--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -985,10 +985,6 @@ func (h *HeaderfileWriter) writeTemplateConfig(fw *bufio.Writer, e datapath.Endp
 		fmt.Fprintf(fw, "#define ENABLE_ROUTING 1\n")
 	}
 
-	if !e.DisableSIPVerification() {
-		fmt.Fprintf(fw, "#define ENABLE_SIP_VERIFICATION 1\n")
-	}
-
 	if !option.Config.EnableHostLegacyRouting && option.Config.DirectRoutingDevice != "" {
 		directRoutingIface := option.Config.DirectRoutingDevice
 		directRoutingIfIndex, err := link.GetIfIndex(directRoutingIface)

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -80,10 +80,6 @@ type CompileTimeConfiguration interface {
 
 	// IsHost returns true if the endpoint is the host endpoint.
 	IsHost() bool
-
-	// DisableSIPVerification returns true if the endpoint wishes to skip
-	// source IP verification
-	DisableSIPVerification() bool
 }
 
 // EndpointConfiguration provides datapath implementations a clean interface

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -116,6 +116,11 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 
 	if base.DatapathConfiguration != nil {
 		ep.DatapathConfiguration = *base.DatapathConfiguration
+		// We need to make sure DatapathConfiguration.DisableSipVerification value
+		// overrides the value of SourceIPVerification runtime option of the endpoint.
+		if ep.DatapathConfiguration.DisableSipVerification {
+			ep.updateAndOverrideEndpointOptions(option.OptionMap{option.SourceIPVerification: option.OptionDisabled})
+		}
 	}
 
 	if base.Labels != nil {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1455,12 +1455,6 @@ func (e *Endpoint) RequireEndpointRoute() bool {
 	return e.DatapathConfiguration.InstallEndpointRoute
 }
 
-// DisableSIPVerification returns true if the endpoint wants to skip
-// srcIP verification
-func (e *Endpoint) DisableSIPVerification() bool {
-	return e.DatapathConfiguration.DisableSipVerification
-}
-
 // GetPolicyVerdictLogFilter returns the PolicyVerdictLogFilter that would control
 // the creation of policy verdict logs. Value of VerdictLogFilter needs to be
 // consistent with how it is used in policy_verdict_filter_allow() in bpf/lib/policy_log.h

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -38,7 +38,6 @@ type epInfoCache struct {
 	requireEgressProg                      bool
 	requireRouting                         bool
 	requireEndpointRoute                   bool
-	disableSIPVerification                 bool
 	policyVerdictLogFilter                 uint32
 	cidr4PrefixLengths, cidr6PrefixLengths []int
 	options                                *option.IntOptions
@@ -73,7 +72,6 @@ func (e *Endpoint) createEpInfoCache(epdir string) *epInfoCache {
 		requireEgressProg:      e.RequireEgressProg(),
 		requireRouting:         e.RequireRouting(),
 		requireEndpointRoute:   e.RequireEndpointRoute(),
-		disableSIPVerification: e.DisableSIPVerification(),
 		policyVerdictLogFilter: e.GetPolicyVerdictLogFilter(),
 		cidr4PrefixLengths:     cidr4,
 		cidr6PrefixLengths:     cidr6,
@@ -172,12 +170,6 @@ func (ep *epInfoCache) RequireRouting() bool {
 // RequireEndpointRoute returns if the endpoint wants a per endpoint route
 func (ep *epInfoCache) RequireEndpointRoute() bool {
 	return ep.requireEndpointRoute
-}
-
-// DisableSIPVerification returns true if the endpoint wants to skip
-// srcIP verification
-func (ep *epInfoCache) DisableSIPVerification() bool {
-	return ep.disableSIPVerification
 }
 
 func (ep *epInfoCache) GetPolicyVerdictLogFilter() uint32 {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/cilium/checkmate"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -253,6 +254,16 @@ func (s *EndpointSuite) TestEndpointStatus(c *C) {
 	}
 	eps.addStatusLog(sts)
 	c.Assert(eps.String(), Equals, "OK")
+}
+
+func (s *EndpointSuite) TestEndpointDatapathOptions(c *C) {
+	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
+		DatapathConfiguration: &models.EndpointDatapathConfiguration{
+			DisableSipVerification: true,
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Assert(e.Options.GetValue(option.SourceIPVerification), Equals, option.OptionDisabled)
 }
 
 func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -603,8 +603,6 @@ func (mgr *endpointManager) RestoreEndpoint(ep *endpoint.Endpoint) error {
 
 // AddEndpoint takes the prepared endpoint object and starts managing it.
 func (mgr *endpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.Endpoint, reason string) (err error) {
-	ep.SetDefaultConfiguration(false)
-
 	if ep.ID != 0 {
 		return fmt.Errorf("Endpoint ID is already set to %d", ep.ID)
 	}

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -56,7 +56,6 @@ func (e *TestEndpoint) RequireARPPassthrough() bool                 { return fal
 func (e *TestEndpoint) RequireEgressProg() bool                     { return false }
 func (e *TestEndpoint) RequireRouting() bool                        { return false }
 func (e *TestEndpoint) RequireEndpointRoute() bool                  { return false }
-func (e *TestEndpoint) DisableSIPVerification() bool                { return false }
 func (e *TestEndpoint) GetPolicyVerdictLogFilter() uint32           { return 0xffff }
 func (e *TestEndpoint) GetCIDRPrefixLengths() ([]int, []int)        { return nil, nil }
 func (e *TestEndpoint) GetID() uint64                               { return e.Id }


### PR DESCRIPTION
Currently ENABLE_SIP_VERIFICATION runtime option can define ENABLE_SIP_VERIFICATION macro just like DisableSIPVerification endpoint datapath option can. If DatapathConfiguration.DisableSipVerification value is not inline with SourceIPVerification, the two macros in ep_config.h may conflict.

Related slack thread https://cilium.slack.com/archives/C2B917YHE/p1680518197957369

```release-note
Fix a bug where datapath option DisableSipVerification can no longer be used.
```

This completes the PR https://github.com/cilium/cilium/pull/24150 (i.e. 24150 can be closed, original author is honored here...)