### PR TITLE
Disable the Hubble before starting with UI via cilium-cli.

### DIFF
--- a/Documentation/gettingstarted/hubble.rst
+++ b/Documentation/gettingstarted/hubble.rst
@@ -18,20 +18,22 @@ service map.
 
 .. note::
 
-   This guide assumes that Cilium has been correctly installed in your
-   Kubernetes cluster and that Hubble has been enabled. Please see
-   :ref:`k8s_quick_install` and :ref:`hubble_setup` for more information. If
-   unsure, run ``cilium status`` and validate that Cilium and Hubble are up and
-   running.
+   This guide assumes that Cilium and Hubble have been correctly installed in your
+   Kubernetes cluster. Please see :ref:`k8s_quick_install` and :ref:`hubble_setup`
+   for more information. If unsure, run ``cilium status`` and validate that Cilium
+   and Hubble are installed.
 
 Enable the Hubble UI
 ====================
 
-If you have not done so already, enable the Hubble UI by running the following command:
+Enable the Hubble UI by running the following command:
 
 .. tabs::
 
     .. group-tab:: Cilium CLI 
+
+        If Hubble is already enabled with ``cilium hubble enable``, you must first temporarily disable Hubble with ``cilium hubble disable``.
+        This is because the Hubble UI cannot be added at runtime.
 
         .. code-block:: shell-session
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #24587

```release-note
docs: Add steps to start Hubble UI with cilium-cli, but only after Hubble itself has started
```