### PR TITLE
daemon: Don't register monitor listener for auth required events

### DIFF
--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -18,8 +18,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/api"
-	"github.com/cilium/cilium/pkg/auth"
-	authMonitor "github.com/cilium/cilium/pkg/auth/monitor"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -64,8 +62,6 @@ func (d *Daemon) initPolicy(epMgr *endpointmanager.EndpointManager) error {
 	if err != nil {
 		return fmt.Errorf("failed to create policy update trigger: %w", err)
 	}
-
-	d.monitorAgent.RegisterNewConsumer(authMonitor.AddAuthManager(auth.NewAuthManager(epMgr)))
 
 	return nil
 }


### PR DESCRIPTION
Auth required events are not handled in v1.13, so don't add the monitor listener to avoid the associated overhead.

```release-note
CPU overhead regression introduced in v1.13 is fixed.
```
