### PR TITLE
gateway-api: Skip reconciliation for non-matching controller routes

### DIFF
--- a/operator/pkg/gateway-api/httproute.go
+++ b/operator/pkg/gateway-api/httproute.go
@@ -95,7 +95,9 @@ func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to Gateways and enqueue HTTPRoutes that reference them,
 		// only if there is a change in the spec
 		Watches(&source.Kind{Type: &gatewayv1beta1.Gateway{}}, r.enqueueRequestForGateway(),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			builder.WithPredicates(
+				predicate.GenerationChangedPredicate{},
+				predicate.NewPredicateFuncs(hasMatchingController(context.Background(), mgr.GetClient(), controllerName)))).
 		Complete(r)
 }
 

--- a/operator/pkg/gateway-api/httproute_reconcile.go
+++ b/operator/pkg/gateway-api/httproute_reconcile.go
@@ -138,6 +138,10 @@ func validateGateway(ctx context.Context, c client.Client, hr *gatewayv1beta1.HT
 			continue
 		}
 
+		if !hasMatchingController(ctx, c, controllerName)(gw) {
+			continue
+		}
+
 		if !isAllowed(ctx, c, gw, hr) {
 			// Gateway is not attachable, update the status for this HTTPRoute
 			mergeHTTPRouteStatusConditions(hr, parent, []metav1.Condition{

--- a/operator/pkg/gateway-api/httproute_reconcile_test.go
+++ b/operator/pkg/gateway-api/httproute_reconcile_test.go
@@ -21,6 +21,15 @@ import (
 )
 
 var httpRouteFixture = []client.Object{
+	// GatewayClass
+	&gatewayv1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cilium",
+		},
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: "io.cilium/gateway-controller",
+		},
+	},
 	// Gateway for valid HTTPRoute
 	&gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
@@ -28,7 +37,7 @@ var httpRouteFixture = []client.Object{
 			Namespace: "default",
 		},
 		Spec: gatewayv1beta1.GatewaySpec{
-			GatewayClassName: "io.cilium/gateway-controller",
+			GatewayClassName: "cilium",
 			Listeners: []gatewayv1beta1.Listener{
 				{
 					Name:     "http",
@@ -47,7 +56,7 @@ var httpRouteFixture = []client.Object{
 			Namespace: "another-namespace",
 		},
 		Spec: gatewayv1beta1.GatewaySpec{
-			GatewayClassName: "io.cilium/gateway-controller",
+			GatewayClassName: "cilium",
 			Listeners: []gatewayv1beta1.Listener{
 				{
 					Name: "http",

--- a/operator/pkg/gateway-api/tlsroute.go
+++ b/operator/pkg/gateway-api/tlsroute.go
@@ -89,7 +89,10 @@ func (r *tlsRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to Gateways and enqueue TLSRoutes that reference them,
 		// only if there is a change in the spec
 		Watches(&source.Kind{Type: &gatewayv1beta1.Gateway{}}, r.enqueueRequestForGateway(),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			builder.WithPredicates(
+				predicate.GenerationChangedPredicate{},
+				predicate.NewPredicateFuncs(hasMatchingController(context.Background(), mgr.GetClient(), controllerName)),
+			)).
 		Complete(r)
 }
 


### PR DESCRIPTION
This commit is to make sure that only gateways matching cilium pre-defined controller are re-queued for reconciliation.

Testing was done with the below spec, the expected behavior is no-op as the controllerName of GatewayClass of Gateway of underlying HTTPRoute is not same as pre-defined cilium controller name value (e.g. io.cilium-gateway-controller)

```yaml
apiVersion: gateway.networking.k8s.io/v1beta1
kind: GatewayClass
metadata:
  name: cilium
spec:
  controllerName: io.cilium/gateway-controller-non-matching
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: Gateway
metadata:
  name: my-gateway
spec:
  gatewayClassName: cilium
  listeners:
  - protocol: HTTP
    port: 80
    name: prod-web-gw
    allowedRoutes:
      namespaces:
        from: Same
---
apiVersion: gateway.networking.k8s.io/v1beta1
kind: HTTPRoute
metadata:
  name: http-app-1
spec:
  parentRefs:
  - name: my-gateway
    namespace: default
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /details
    backendRefs:
    - name: details
      port: 9080
```

Status of resources

````
# Ignore Gateway as it's not matching controller name in cilium
$ kg gateway my-gateway -o json | jqs
{
  "conditions": [
    {
      "lastTransitionTime": "1970-01-01T00:00:00Z",
      "message": "Waiting for controller",
      "reason": "NotReconciled",
      "status": "Unknown",
      "type": "Accepted"
    }
  ]
}

# Ignore HTTP Route as it's under cilium controller
$ kg httproute http-app-1 -o json | jqs
null

```
