### PR TITLE
pkg/endpoint: fix comment about Delete

### DIFF
--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -2139,7 +2139,6 @@ func (e *Endpoint) SyncEndpointHeaderFile() {
 // * removal from the endpointmanager, resulting in new events not taking effect
 // on this endpoint
 // * cleanup of datapath state (BPF maps, proxy configuration, directories)
-// * releasing IP addresses allocated for the endpoint
 // * releasing of the reference to its allocated security identity
 func (e *Endpoint) Delete(conf DeleteConfig) []error {
 	errs := []error{}


### PR DESCRIPTION
This is a new submission of PR #25132, which was inadvertently merged into the `master` branch although the repo had switched to `main`.

The commit was already approved by Joe.

```release-note
docs: Fix a comment: the endpoint's IP is not released in function `Delete`, but in function `EndpointDeleted`.
```
