### PR TITLE
clustermesh-apiserver: extract kvstore client initialization and heartbeat logic in separate cells

### DIFF
--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -43,11 +43,14 @@ type VMManager struct {
 
 	ciliumExternalWorkloadStore    cache.Store
 	ciliumExternalWorkloadInformer cache.Controller
+
+	backend kvstore.BackendOperations
 }
 
-func NewVMManager(clientset k8sClient.Clientset) *VMManager {
+func NewVMManager(clientset k8sClient.Clientset, backend kvstore.BackendOperations) *VMManager {
 	m := &VMManager{
 		ciliumClient: clientset,
+		backend:      backend,
 	}
 	m.identityAllocator = identityCache.NewCachingIdentityAllocator(m)
 
@@ -449,7 +452,7 @@ func (m *VMManager) syncKVStoreKey(ctx context.Context, key store.LocalKey) erro
 	// Update key in kvstore, overwrite an eventual existing key, attach
 	// lease to expire entry when agent dies and never comes back up.
 	k := path.Join(nodeStore.NodeRegisterStorePrefix, key.GetKeyName())
-	if _, err := kvstore.Client().UpdateIfDifferent(ctx, k, jsonValue, true); err != nil {
+	if _, err := m.backend.UpdateIfDifferent(ctx, k, jsonValue, true); err != nil {
 		return err
 	}
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -479,7 +479,13 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 		})
 
 		if legacy.clientset.IsEnabled() && operatorOption.Config.SyncK8sServices {
-			operatorWatchers.StartSynchronizingServices(legacy.ctx, &legacy.wg, legacy.clientset, legacy.resources.Services, true, option.Config)
+			operatorWatchers.StartSynchronizingServices(legacy.ctx, &legacy.wg, operatorWatchers.ServiceSyncParameters{
+				ServiceSyncConfiguration: option.Config,
+
+				Clientset:  legacy.clientset,
+				Services:   legacy.resources.Services,
+				SharedOnly: true,
+			})
 			// If K8s is enabled we can do the service translation automagically by
 			// looking at services from k8s and retrieve the service IP from that.
 			// This makes cilium to not depend on kube dns to interact with etcd

--- a/pkg/kvstore/cell.go
+++ b/pkg/kvstore/cell.go
@@ -4,13 +4,119 @@
 package kvstore
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"sync"
+	"time"
 
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
 )
+
+// Cell returns a cell which provides a promise for the global kvstore client.
+// The parameter allows to customize the default backend, which can be either
+// set to a specific value (e.g., in the case of clustermesh-apiserver) or
+// left unset.
+var Cell = func(defaultBackend string) cell.Cell {
+	return cell.Module(
+		"kvstore-client",
+		"KVStore Client",
+
+		cell.Config(config{
+			KVStore:                    defaultBackend,
+			KVStoreConnectivityTimeout: defaults.KVstoreConnectivityTimeout,
+			KVStoreLeaseTTL:            defaults.KVstoreLeaseTTL,
+			KVStorePeriodicSync:        defaults.KVstorePeriodicSync,
+		}),
+
+		cell.Provide(func(lc hive.Lifecycle, shutdowner hive.Shutdowner, cfg config, opts *ExtraOptions) promise.Promise[BackendOperations] {
+			resolver, promise := promise.New[BackendOperations]()
+			if cfg.KVStore == "" {
+				log.Info("Skipping connection to kvstore, as not configured")
+				resolver.Reject(errors.New("kvstore not configured"))
+				return promise
+			}
+
+			// Propagate the options to the global variables for backward compatibility
+			option.Config.KVStore = cfg.KVStore
+			option.Config.KVStoreOpt = cfg.KVStoreOpt
+			option.Config.KVstoreConnectivityTimeout = cfg.KVStoreConnectivityTimeout
+			option.Config.KVstoreLeaseTTL = cfg.KVStoreLeaseTTL
+			option.Config.KVstorePeriodicSync = cfg.KVStorePeriodicSync
+
+			ctx, cancel := context.WithCancel(context.Background())
+			var wg sync.WaitGroup
+
+			lc.Append(hive.Hook{
+				OnStart: func(hive.HookContext) error {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+
+						log := log.WithField(logfields.BackendName, cfg.KVStore)
+						log.Info("Establishing connection to kvstore")
+						backend, errCh := NewClient(ctx, cfg.KVStore, cfg.KVStoreOpt, opts)
+
+						if err, isErr := <-errCh; isErr {
+							log.WithError(err).Error("Failed to establish connection to kvstore")
+							resolver.Reject(fmt.Errorf("failed connecting to kvstore: %w", err))
+							shutdowner.Shutdown(hive.ShutdownWithError(err))
+							return
+						}
+
+						log.Info("Connection to kvstore successfully established")
+						resolver.Resolve(backend)
+					}()
+					return nil
+				},
+				OnStop: func(hive.HookContext) error {
+					cancel()
+					wg.Wait()
+
+					// We don't explicitly close the backend here, because that would
+					// attempt to revoke the lease, causing all entries associated
+					// with that lease to be deleted. This would not be the
+					// behavior expected by the consumers of this cell.
+					return nil
+				},
+			})
+
+			return promise
+		}),
+	)
+}
+
+type config struct {
+	KVStore                    string
+	KVStoreOpt                 map[string]string
+	KVStoreConnectivityTimeout time.Duration
+	KVStoreLeaseTTL            time.Duration
+	KVStorePeriodicSync        time.Duration
+}
+
+func (def config) Flags(flags *pflag.FlagSet) {
+	flags.String(option.KVStore, def.KVStore, "Key-value store type")
+
+	flags.StringToString(option.KVStoreOpt, def.KVStoreOpt,
+		"Key-value store options e.g. etcd.address=127.0.0.1:4001")
+
+	flags.Duration(option.KVstoreConnectivityTimeout, def.KVStoreConnectivityTimeout,
+		"Time after which an incomplete kvstore operation is considered failed")
+
+	flags.Duration(option.KVstoreLeaseTTL, def.KVStoreLeaseTTL,
+		"Time-to-live for the KVstore lease.")
+	flags.MarkHidden(option.KVstoreLeaseTTL)
+
+	flags.Duration(option.KVstorePeriodicSync, def.KVStorePeriodicSync,
+		"Periodic KVstore synchronization interval")
+}
 
 // GlobalUserMgmtClientPromiseCell provides a promise returning the global kvstore client to perform users
 // management operations, once it has been initialized. Note: client initialization must be handled separately.

--- a/pkg/kvstore/heartbeat/cell.go
+++ b/pkg/kvstore/heartbeat/cell.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package heartbeat
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+// Cell creates a cell responsible for periodically updating the heartbeat key
+// in the kvstore.
+var Cell = cell.Module(
+	"kvstore-heartbeat-updater",
+	"KVStore Heartbeat Updater",
+
+	cell.Invoke(func(lc hive.Lifecycle, backendPromise promise.Promise[kvstore.BackendOperations]) {
+		ctx, cancel := context.WithCancel(context.Background())
+		var wg sync.WaitGroup
+
+		lc.Append(hive.Hook{
+			OnStart: func(hive.HookContext) error {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					backend, err := backendPromise.Await(ctx)
+					if err != nil {
+						// There's nothing we can actually do here. We are already shutting down
+						// (either user-requested or caused by the backend initialization failure).
+						return
+					}
+
+					Heartbeat(ctx, backend)
+				}()
+				return nil
+			},
+
+			OnStop: func(ctx hive.HookContext) error {
+				cancel()
+				wg.Wait()
+				return nil
+			},
+		})
+	}),
+)

--- a/pkg/kvstore/heartbeat/heartbeat.go
+++ b/pkg/kvstore/heartbeat/heartbeat.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package heartbeat
+
+import (
+	"context"
+	"time"
+
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "kvstore-heartbeat")
+
+// Heartbeat periodically updates the heatbeat path through the given client,
+// blocking until the context is canceled.
+func Heartbeat(ctx context.Context, backend kvstore.BackendOperations) {
+	log.WithField(logfields.Interval, kvstore.HeartbeatWriteInterval).Info("Starting to update heartbeat key")
+	timer, timerDone := inctimer.New()
+	defer timerDone()
+	for {
+		log.Debug("Updating heartbeat key")
+		tctx, cancel := context.WithTimeout(ctx, defaults.LockLeaseTTL)
+		err := backend.Update(tctx, kvstore.HeartbeatPath, []byte(time.Now().Format(time.RFC3339)), true)
+		if err != nil {
+			log.WithError(err).Warning("Unable to update heartbeat key")
+		}
+		cancel()
+
+		select {
+		case <-timer.After(kvstore.HeartbeatWriteInterval):
+		case <-ctx.Done():
+			log.Info("Stopping to update heartbeat key")
+			return
+		}
+	}
+}


### PR DESCRIPTION
This PR extracts the kvstore client initialization and heartbeat logic from the clustermesh-apiserver in two separate cells, to better integrate in the hive paradigm and allow them to be reused by other components. In this phase, the clustermesh-apiserver still relies on a global variable for the kvstore client, which is planned to be removed with subsequent refactoring (in particular, it involves much less changes once https://github.com/cilium/cilium/pull/25049 is in).

<!-- Description of change -->

```release-note
clustermesh-apiserver: extract kvstore client initialization and heartbeat logic in separate cells
```
