### PR TITLE
metrics: Add k8s client rate limiter latency metric

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -450,6 +450,17 @@ Name                                        Labels                              
 ``k8s_terminating_endpoints_events_total``                                                     Enabled    Number of terminating endpoint events received from Kubernetes
 =========================================== ================================================== ========== ========================================================
 
+Kubernetes Rest Client
+~~~~~~~~~~~~~~~~~~~~~~
+
+============================================= ============================================= ========== ===========================================================
+Name                                          Labels                                        Default    Description
+============================================= ============================================= ========== ===========================================================
+``k8s_client_api_latency_time_seconds``       ``path``, ``method``                          Enabled    Duration of processed API calls labeled by path and method
+``k8s_client_rate_limiter_duration_seconds``  ``path``, ``method``                          Enabled    Kubernetes client rate limiter latency in seconds. Broken down by path and method
+``k8s_client_api_calls_total``                ``host``, ``method``, ``return_code``         Enabled    Number of API calls made to kube-apiserver labeled by host, method and return code
+============================================= ============================================= ========== ===========================================================
+
 IPAM
 ~~~~
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -96,9 +96,9 @@ func init() {
 	k8s_metrics.Register(k8s_metrics.RegisterOpts{
 		ClientCertExpiry:      nil,
 		ClientCertRotationAge: nil,
-		RequestLatency:        &k8sMetrics{},
-		RateLimiterLatency:    nil,
-		RequestResult:         &k8sMetrics{},
+		RequestLatency:        &requestLatencyAdapter{},
+		RateLimiterLatency:    &rateLimiterLatencyAdapter{},
+		RequestResult:         &resultAdapter{},
 	})
 }
 
@@ -320,15 +320,24 @@ func NewK8sWatcher(
 	}
 }
 
-// k8sMetrics implements the LatencyMetric and ResultMetric interface from
-// k8s client-go package
-type k8sMetrics struct{}
+// requestLatencyAdapter implements the LatencyMetric interface from k8s client-go package
+type requestLatencyAdapter struct{}
 
-func (*k8sMetrics) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
+func (*requestLatencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
 	metrics.KubernetesAPIInteractions.WithLabelValues(u.Path, verb).Observe(latency.Seconds())
 }
 
-func (*k8sMetrics) Increment(_ context.Context, code string, method string, host string) {
+// rateLimiterLatencyAdapter implements the LatencyMetric interface from k8s client-go package
+type rateLimiterLatencyAdapter struct{}
+
+func (c *rateLimiterLatencyAdapter) Observe(_ context.Context, verb string, u url.URL, latency time.Duration) {
+	metrics.KubernetesAPIRateLimiterLatency.WithLabelValues(u.Path, verb).Observe(latency.Seconds())
+}
+
+// resultAdapter implements the ResultMetric interface from k8s client-go package
+type resultAdapter struct{}
+
+func (r *resultAdapter) Increment(_ context.Context, code, method, host string) {
 	metrics.KubernetesAPICallsTotal.WithLabelValues(host, method, code).Inc()
 	// The 'code' is set to '<error>' in case an error is returned from k8s
 	// more info:

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -444,6 +444,9 @@ var (
 	// to the kube-apiserver
 	KubernetesAPIInteractions = NoOpObserverVec
 
+	// KubernetesAPIRateLimiterLatency is the client side rate limiter latency metric
+	KubernetesAPIRateLimiterLatency = NoOpObserverVec
+
 	// KubernetesAPICallsTotal is the counter for all API calls made to
 	// kube-apiserver.
 	KubernetesAPICallsTotal = NoOpCounterVec
@@ -613,6 +616,7 @@ type LegacyMetrics struct {
 	KubernetesEventProcessed         metric.Vec[metric.Counter]
 	KubernetesEventReceived          metric.Vec[metric.Counter]
 	KubernetesAPIInteractions        metric.Vec[metric.Observer]
+	KubernetesAPIRateLimiterLatency  metric.Vec[metric.Observer]
 	KubernetesAPICallsTotal          metric.Vec[metric.Counter]
 	KubernetesCNPStatusCompletion    metric.Vec[metric.Observer]
 	TerminatingEndpointsEvents       metric.Counter
@@ -1001,6 +1005,15 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Help:       "Duration of processed API calls labeled by path and method.",
 		}, []string{LabelPath, LabelMethod}),
 
+		KubernetesAPIRateLimiterLatency: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: Namespace + "_" + SubsystemK8sClient + "_rate_limiter_duration_seconds",
+			Namespace:  Namespace,
+			Subsystem:  SubsystemK8sClient,
+			Name:       "rate_limiter_duration_seconds",
+			Help:       "Kubernetes client rate limiter latency in seconds. Broken down by path and method.",
+			Buckets:    []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 60.0},
+		}, []string{LabelPath, LabelMethod}),
+
 		KubernetesAPICallsTotal: metric.NewCounterVec(metric.CounterOpts{
 			ConfigName: Namespace + "_" + SubsystemK8sClient + "_api_calls_total",
 			Namespace:  Namespace,
@@ -1331,6 +1344,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	KubernetesEventProcessed = lm.KubernetesEventProcessed
 	KubernetesEventReceived = lm.KubernetesEventReceived
 	KubernetesAPIInteractions = lm.KubernetesAPIInteractions
+	KubernetesAPIRateLimiterLatency = lm.KubernetesAPIRateLimiterLatency
 	KubernetesAPICallsTotal = lm.KubernetesAPICallsTotal
 	KubernetesCNPStatusCompletion = lm.KubernetesCNPStatusCompletion
 	TerminatingEndpointsEvents = lm.TerminatingEndpointsEvents


### PR DESCRIPTION
The rate limiter metrics visualize the extent of delays caused by the k8s client-side rate limit, providing valuable insights for making decisions on configuration adjustments.

~~Also, this commit fixes a conflict with controller-runtime on the metrics registration.~~

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!
