### PR TITLE
Convert the clustermesh subsystem into a hive.Cell

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -12,6 +12,7 @@ cilium-agent hive [flags]
 
 ```
       --certificates-directory string                    Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --clustermesh-config string                        Path to the ClusterMesh configuration directory
       --cni-chaining-mode string                         Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                       CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                    Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -18,6 +18,7 @@ cilium-agent hive dot-graph [flags]
 
 ```
       --certificates-directory string                    Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --clustermesh-config string                        Path to the ClusterMesh configuration directory
       --cni-chaining-mode string                         Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                       CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                    Whether to remove other CNI configurations

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/datapath"
+	dptypes "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/egressgateway"
 	"github.com/cilium/cilium/pkg/endpointmanager"
@@ -109,5 +110,8 @@ var (
 
 		// Egress Gateway allows originating traffic from specific IPv4 addresses.
 		egressgateway.Cell,
+
+		// ServiceCache holds the list of known services correlated with the matching endpoints.
+		cell.Provide(func(dp dptypes.Datapath) *k8s.ServiceCache { return k8s.NewServiceCache(dp.LocalNodeAddressing()) }),
 	)
 )

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/daemon/cmd/cni"
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bgpv1"
+	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/datapath"
 	dptypes "github.com/cilium/cilium/pkg/datapath/types"
@@ -113,5 +114,8 @@ var (
 
 		// ServiceCache holds the list of known services correlated with the matching endpoints.
 		cell.Provide(func(dp dptypes.Datapath) *k8s.ServiceCache { return k8s.NewServiceCache(dp.LocalNodeAddressing()) }),
+
+		// ClusterMesh is the Cilium's multicluster implementation.
+		clustermesh.Cell,
 	)
 )

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -679,6 +679,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		d.ipcache,
 		d.cgroupManager,
 		params.SharedResources,
+		params.ServiceCache,
 	)
 	nd.RegisterK8sGetters(d.k8sWatcher)
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -692,16 +692,16 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		}
 	}
 	if option.Config.EnableServiceTopology {
-		d.k8sWatcher.RegisterNodeSubscriber(&d.k8sWatcher.K8sSvcCache)
+		d.k8sWatcher.RegisterNodeSubscriber(d.k8sWatcher.K8sSvcCache)
 	}
 
 	// watchers.NewCiliumNodeUpdater needs to be registered *after* d.endpointManager
 	d.k8sWatcher.RegisterNodeSubscriber(watchers.NewCiliumNodeUpdater(d.nodeDiscovery))
 
-	d.redirectPolicyManager.RegisterSvcCache(&d.k8sWatcher.K8sSvcCache)
+	d.redirectPolicyManager.RegisterSvcCache(d.k8sWatcher.K8sSvcCache)
 	d.redirectPolicyManager.RegisterGetStores(d.k8sWatcher)
 	if option.Config.BGPAnnounceLBIP {
-		d.bgpSpeaker.RegisterSvcCache(&d.k8sWatcher.K8sSvcCache)
+		d.bgpSpeaker.RegisterSvcCache(d.k8sWatcher.K8sSvcCache)
 	}
 
 	bootstrapStats.daemonInit.End(true)
@@ -768,7 +768,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		bootstrapStats.restore.End(true)
 	}
 
-	debug.RegisterStatusObject("k8s-service-cache", &d.k8sWatcher.K8sSvcCache)
+	debug.RegisterStatusObject("k8s-service-cache", d.k8sWatcher.K8sSvcCache)
 	debug.RegisterStatusObject("ipam", d.ipam)
 	debug.RegisterStatusObject("ongoing-endpoint-creations", d.endpointCreations)
 
@@ -1102,7 +1102,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		d.nodeDiscovery.JoinCluster(nodeTypes.GetName())
 
 		// Start services watcher
-		serviceStore.JoinClusterServices(&d.k8sWatcher.K8sSvcCache, option.Config)
+		serviceStore.JoinClusterServices(d.k8sWatcher.K8sSvcCache, option.Config)
 	}
 
 	// Start IPAM
@@ -1292,7 +1292,7 @@ func (d *Daemon) bootstrapClusterMesh(nodeMngr nodemanager.NodeManager) {
 				NodeName:              nodeTypes.GetName(),
 				ConfigDirectory:       path,
 				NodeKeyCreator:        nodeStore.KeyCreator,
-				ServiceMerger:         &d.k8sWatcher.K8sSvcCache,
+				ServiceMerger:         d.k8sWatcher.K8sSvcCache,
 				NodeManager:           nodeMngr,
 				RemoteIdentityWatcher: d.identityAllocator,
 				IPCache:               d.ipcache,

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -74,8 +74,6 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node"
-	nodemanager "github.com/cilium/cilium/pkg/node/manager"
-	nodeStore "github.com/cilium/cilium/pkg/node/store"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
@@ -541,6 +539,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		policyUpdater:        params.PolicyUpdater,
 		egressGatewayManager: params.EgressGatewayManager,
 		cniConfigManager:     params.CNIConfigManager,
+		clustermesh:          params.ClusterMesh,
 	}
 
 	if option.Config.RunMonitorAgent {
@@ -1182,8 +1181,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		// identity allocator to run asynchronously.
 		realIdentityAllocator := d.identityAllocator
 		realIdentityAllocator.InitIdentityAllocator(params.Clientset)
-
-		d.bootstrapClusterMesh(params.NodeManager)
 	}
 
 	// Must be done at least after initializing BPF LB-related maps
@@ -1279,33 +1276,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	return &d, restoredEndpoints, nil
-}
-
-func (d *Daemon) bootstrapClusterMesh(nodeMngr nodemanager.NodeManager) {
-	bootstrapStats.clusterMeshInit.Start()
-	if path := option.Config.ClusterMeshConfig; path != "" {
-		if option.Config.ClusterID == 0 {
-			log.Info("Cluster-ID is not specified, skipping ClusterMesh initialization")
-		} else {
-			log.WithField("path", path).Info("Initializing ClusterMesh routing")
-			clustermesh, err := clustermesh.NewClusterMesh(clustermesh.Configuration{
-				Name:                  option.Config.ClusterName,
-				NodeName:              nodeTypes.GetName(),
-				ConfigDirectory:       path,
-				NodeKeyCreator:        nodeStore.KeyCreator,
-				ServiceMerger:         d.k8sWatcher.K8sSvcCache,
-				NodeManager:           nodeMngr,
-				RemoteIdentityWatcher: d.identityAllocator,
-				IPCache:               d.ipcache,
-			})
-			if err != nil {
-				log.WithError(err).Fatal("Unable to initialize ClusterMesh")
-			}
-
-			d.clustermesh = clustermesh
-		}
-	}
-	bootstrapStats.clusterMeshInit.End(true)
 }
 
 // ReloadOnDeviceChange regenerates device related information and reloads the datapath.

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -33,6 +33,7 @@ import (
 	bgpv1 "github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
+	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
@@ -191,9 +192,6 @@ func initializeFlags() {
 
 	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")
 	option.BindEnv(Vp, option.ClusterName)
-
-	flags.String(option.ClusterMeshConfigName, "", "Path to the ClusterMesh configuration directory")
-	option.BindEnv(Vp, option.ClusterMeshConfigName)
 
 	flags.StringSlice(option.CompilerFlags, []string{}, "Extra CFLAGS for BPF compilation")
 	flags.MarkHidden(option.CompilerFlags)
@@ -1621,6 +1619,7 @@ type daemonParams struct {
 	SwaggerSpec          *server.Spec
 	HealthAPISpec        *healthApi.Spec
 	ServiceCache         *k8s.ServiceCache
+	ClusterMesh          *clustermesh.ClusterMesh
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1620,6 +1620,7 @@ type daemonParams struct {
 	CNIConfigManager     cni.CNIConfigManager
 	SwaggerSpec          *server.Spec
 	HealthAPISpec        *healthApi.Spec
+	ServiceCache         *k8s.ServiceCache
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1569,7 +1569,7 @@ func (d *Daemon) initKVStore() {
 		)
 		log := log.WithField(logfields.LogSubsys, "etcd")
 		goopts.DialOption = []grpc.DialOption{
-			grpc.WithContextDialer(k8s.CreateCustomDialer(&d.k8sWatcher.K8sSvcCache, log)),
+			grpc.WithContextDialer(k8s.CreateCustomDialer(d.k8sWatcher.K8sSvcCache, log)),
 		}
 	}
 

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -79,6 +80,7 @@ type policyOut struct {
 
 	IdentityAllocator      CachingIdentityAllocator
 	CacheIdentityAllocator cache.IdentityAllocator
+	RemoteIdentityWatcher  clustermesh.RemoteIdentityWatcher
 	Repository             *policy.Repository
 	Updater                *policy.Updater
 	IPCache                *ipcache.IPCache
@@ -142,6 +144,7 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 	return policyOut{
 		IdentityAllocator:      idAlloc,
 		CacheIdentityAllocator: idAlloc,
+		RemoteIdentityWatcher:  idAlloc,
 		Repository:             iao.policy,
 		Updater:                policyUpdater,
 		IPCache:                ipc,

--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -1306,7 +1306,7 @@ func (ds *DaemonSuite) Test_addCiliumNetworkPolicyV2(c *C) {
 		rules, policyImportErr := args.cnp.Parse()
 		c.Assert(policyImportErr, checker.DeepEquals, want.err)
 
-		policyImportErr = k8s.PreprocessRules(rules, &ds.d.k8sWatcher.K8sSvcCache)
+		policyImportErr = k8s.PreprocessRules(rules, ds.d.k8sWatcher.K8sSvcCache)
 		c.Assert(policyImportErr, IsNil)
 
 		// Only add policies if we have successfully parsed them. Otherwise, if

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -488,7 +488,7 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 				if isETCDOperator {
 					scopedLog.Infof("%s running with service synchronization: automatic etcd service translation enabled", binaryName)
 
-					svcGetter := k8s.ServiceIPGetter(&operatorWatchers.K8sSvcCache)
+					svcGetter := k8s.ServiceIPGetter(operatorWatchers.K8sSvcCache)
 
 					name, namespace, err := kvstore.SplitK8sServiceURL(svcURL)
 					if err != nil {
@@ -519,7 +519,7 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 								scopedLog.Warnf("BUG: invalid k8s service: %s", slimSvcObj)
 							}
 							sc.UpdateService(slimSvc, nil)
-							svcGetter = operatorWatchers.NewServiceGetter(&sc)
+							svcGetter = operatorWatchers.NewServiceGetter(sc)
 						case k8sErrors.IsNotFound(err):
 							scopedLog.Error("Service not found in k8s")
 						default:

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -371,7 +371,7 @@ type ServiceGetter struct {
 func NewServiceGetter(sc *k8s.ServiceCache) *ServiceGetter {
 	return &ServiceGetter{
 		shortCutK8sCache: sc,
-		k8sCache:         &K8sSvcCache,
+		k8sCache:         K8sSvcCache,
 	}
 }
 

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/k8s"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	nodemanager "github.com/cilium/cilium/pkg/node/manager"
+	nodeStore "github.com/cilium/cilium/pkg/node/store"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var Cell = cell.Module(
+	"clustermesh",
+	"ClusterMesh is the Cilium multicluster implementation",
+
+	cell.Provide(NewClusterMesh),
+
+	// Convert concrete objects into more restricted interfaces used by clustermesh.
+	cell.ProvidePrivate(func(sc *k8s.ServiceCache) ServiceMerger { return sc }),
+	cell.ProvidePrivate(func(ipcache *ipcache.IPCache) ipcache.IPCacher { return ipcache }),
+	cell.ProvidePrivate(func(mgr nodemanager.NodeManager) (store.Observer, kvstore.ClusterSizeDependantIntervalFunc) {
+		return nodeStore.NewNodeObserver(mgr), mgr.ClusterSizeDependantInterval
+	}),
+	cell.ProvidePrivate(func() store.KeyCreator { return nodeStore.KeyCreator }),
+	cell.ProvidePrivate(func(cfg *option.DaemonConfig) types.ClusterIDName {
+		return types.ClusterIDName{ClusterID: cfg.ClusterID, ClusterName: cfg.ClusterName}
+	}),
+
+	cell.Config(Config{}),
+)
+
+type Config struct {
+	// ClusterMeshConfig is the path to the clustermesh configuration directory.
+	ClusterMeshConfig string
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.String("clustermesh-config", def.ClusterMeshConfig, "Path to the ClusterMesh configuration directory")
+}

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -41,7 +41,7 @@ func (s *ClusterMeshServicesTestSuite) prepareServiceUpdate(clusterSuffix, backe
 }
 
 type ClusterMeshServicesTestSuite struct {
-	svcCache   k8s.ServiceCache
+	svcCache   *k8s.ServiceCache
 	testDir    string
 	mesh       *ClusterMesh
 	randomName string
@@ -98,7 +98,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 		ConfigDirectory:       dir,
 		NodeKeyCreator:        testNodeCreator,
 		nodeObserver:          &testObserver{},
-		ServiceMerger:         &s.svcCache,
+		ServiceMerger:         s.svcCache,
 		RemoteIdentityWatcher: mgr,
 		IPCache:               ipc,
 	})

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -59,3 +59,9 @@ func (c0 *CiliumClusterConfig) IsCompatible(c1 *CiliumClusterConfig) error {
 	}
 	return nil
 }
+
+// ClusterIDName groups together the ClusterID and the ClusterName
+type ClusterIDName struct {
+	ClusterID   uint32
+	ClusterName string
+}

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -340,7 +340,7 @@ func (s *K8sSuite) TestPreprocessRules(c *C) {
 
 	rules := api.Rules{&rule1}
 
-	err := PreprocessRules(rules, &cache)
+	err := PreprocessRules(rules, cache)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(rule1.Egress[0].ToCIDRSet), Equals, 1)

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -95,8 +95,8 @@ type ServiceCache struct {
 }
 
 // NewServiceCache returns a new ServiceCache
-func NewServiceCache(nodeAddressing types.NodeAddressing) ServiceCache {
-	return ServiceCache{
+func NewServiceCache(nodeAddressing types.NodeAddressing) *ServiceCache {
+	return &ServiceCache{
 		services:          map[ServiceID]*Service{},
 		endpoints:         map[ServiceID]*EndpointSlices{},
 		externalEndpoints: map[ServiceID]externalEndpoints{},

--- a/pkg/k8s/service_cache_test.go
+++ b/pkg/k8s/service_cache_test.go
@@ -216,7 +216,7 @@ func testServiceCache(c *check.C,
 	}
 
 	swgEps := lock.NewStoppableWaitGroup()
-	updateEndpointsCB(&svcCache, swgEps)
+	updateEndpointsCB(svcCache, swgEps)
 
 	// The service should be ready as both service and endpoints have been
 	// imported
@@ -262,7 +262,7 @@ func testServiceCache(c *check.C,
 	}, 2*time.Second), check.IsNil)
 
 	// Deleting the endpoints will result in a service update event
-	deleteEndpointsCB(&svcCache, swgEps)
+	deleteEndpointsCB(svcCache, swgEps)
 	c.Assert(testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
 		defer event.SWG.Done()
@@ -276,7 +276,7 @@ func testServiceCache(c *check.C,
 	c.Assert(endpoints.String(), check.Equals, "")
 
 	// Reinserting the endpoints should re-match with the still existing service
-	updateEndpointsCB(&svcCache, swgEps)
+	updateEndpointsCB(svcCache, swgEps)
 	c.Assert(testutils.WaitUntil(func() bool {
 		event := <-svcCache.Events
 		defer event.SWG.Done()
@@ -301,7 +301,7 @@ func testServiceCache(c *check.C,
 
 	// Deleting the endpoints will not emit an event as the notification
 	// was sent out when the service was deleted.
-	deleteEndpointsCB(&svcCache, swgEps)
+	deleteEndpointsCB(svcCache, swgEps)
 	time.Sleep(100 * time.Millisecond)
 	select {
 	case <-svcCache.Events:

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -319,7 +319,7 @@ func (k *K8sWatcher) addCiliumNetworkPolicyV2(ciliumNPClient clientset.Interface
 
 	rules, policyImportErr := cnp.Parse()
 	if policyImportErr == nil {
-		policyImportErr = k8s.PreprocessRules(rules, &k.K8sSvcCache)
+		policyImportErr = k8s.PreprocessRules(rules, k.K8sSvcCache)
 		// Replace all rules with the same name, namespace and
 		// resourceTypeCiliumNetworkPolicy
 		if policyImportErr == nil {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -297,10 +297,11 @@ func NewK8sWatcher(
 	ipcache ipcacheManager,
 	cgroupManager cgroupManager,
 	sharedResources k8s.SharedResources,
+	serviceCache *k8s.ServiceCache,
 ) *K8sWatcher {
 	return &K8sWatcher{
 		clientset:             clientset,
-		K8sSvcCache:           k8s.NewServiceCache(datapath.LocalNodeAddressing()),
+		K8sSvcCache:           serviceCache,
 		endpointManager:       endpointManager,
 		nodeDiscoverManager:   nodeDiscoverManager,
 		policyManager:         policyManager,

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -219,7 +219,7 @@ type K8sWatcher struct {
 	k8sAPIGroups synced.APIGroups
 
 	// K8sSvcCache is a cache of all Kubernetes services and endpoints
-	K8sSvcCache k8s.ServiceCache
+	K8sSvcCache *k8s.ServiceCache
 
 	// NodeChain is the root of a notification chain for k8s Node events.
 	// This NodeChain allows registration of subscriber.Node implementations.

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -185,6 +185,7 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		},
 	}
 
+	dp := fakeDatapath.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -192,7 +193,7 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		policyManager,
 		policyRepository,
 		nil,
-		fakeDatapath.NewDatapath(),
+		dp,
 		nil,
 		nil,
 		nil,
@@ -201,6 +202,7 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		testipcache.NewMockIPCache(),
 		nil,
 		emptySharedResources,
+		k8s.NewServiceCache(dp.LocalNodeAddressing()),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -508,6 +510,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		},
 	}
 
+	dp := fakeDatapath.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -515,7 +518,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
-		fakeDatapath.NewDatapath(),
+		dp,
 		nil,
 		nil,
 		nil,
@@ -524,6 +527,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		testipcache.NewMockIPCache(),
 		nil,
 		emptySharedResources,
+		k8s.NewServiceCache(dp.LocalNodeAddressing()),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -660,6 +664,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		},
 	}
 
+	dp := fakeDatapath.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -667,7 +672,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
-		fakeDatapath.NewDatapath(),
+		dp,
 		nil,
 		nil,
 		nil,
@@ -676,6 +681,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		testipcache.NewMockIPCache(),
 		nil,
 		emptySharedResources,
+		k8s.NewServiceCache(dp.LocalNodeAddressing()),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1141,6 +1147,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		},
 	}
 
+	dp := fakeDatapath.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -1148,7 +1155,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
-		fakeDatapath.NewDatapath(),
+		dp,
 		nil,
 		nil,
 		nil,
@@ -1157,6 +1164,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		testipcache.NewMockIPCache(),
 		nil,
 		emptySharedResources,
+		k8s.NewServiceCache(dp.LocalNodeAddressing()),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1456,6 +1464,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		},
 	}
 
+	dp := fakeDatapath.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -1463,7 +1472,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
-		fakeDatapath.NewDatapath(),
+		dp,
 		nil,
 		nil,
 		nil,
@@ -1472,6 +1481,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		testipcache.NewMockIPCache(),
 		nil,
 		emptySharedResources,
+		k8s.NewServiceCache(dp.LocalNodeAddressing()),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1764,6 +1774,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		},
 	}
 
+	dp := fakeDatapath.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -1771,7 +1782,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
-		fakeDatapath.NewDatapath(),
+		dp,
 		nil,
 		nil,
 		nil,
@@ -1780,6 +1791,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		testipcache.NewMockIPCache(),
 		nil,
 		emptySharedResources,
+		k8s.NewServiceCache(dp.LocalNodeAddressing()),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -2686,6 +2698,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		},
 	}
 
+	dp := fakeDatapath.NewDatapath()
 	w := NewK8sWatcher(
 		nil,
 		nil,
@@ -2693,7 +2706,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		policyManager,
 		policyRepository,
 		svcManager,
-		fakeDatapath.NewDatapath(),
+		dp,
 		nil,
 		nil,
 		nil,
@@ -2702,6 +2715,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		testipcache.NewMockIPCache(),
 		nil,
 		emptySharedResources,
+		k8s.NewServiceCache(dp.LocalNodeAddressing()),
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -23,6 +23,8 @@ type backendOption struct {
 
 type backendOptions map[string]*backendOption
 
+type ClusterSizeDependantIntervalFunc func(baseInterval time.Duration) time.Duration
+
 // ExtraOptions represents any options that can not be represented in a textual
 // format and need to be set programmatically.
 type ExtraOptions struct {
@@ -30,7 +32,7 @@ type ExtraOptions struct {
 
 	// ClusterSizeDependantInterval defines the function to calculate
 	// intervals based on cluster size
-	ClusterSizeDependantInterval func(baseInterval time.Duration) time.Duration
+	ClusterSizeDependantInterval ClusterSizeDependantIntervalFunc
 
 	// NoLockQuorumCheck disables the lock acquisition quorum check
 	NoLockQuorumCheck bool

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -547,9 +547,6 @@ const (
 	// ClusterIDName is the name of the ClusterID option
 	ClusterIDName = "cluster-id"
 
-	// ClusterMeshConfigName is the name of the ClusterMeshConfig option
-	ClusterMeshConfigName = "clustermesh-config"
-
 	// CNIChainingMode configures which CNI plugin Cilium is chained with.
 	CNIChainingMode = "cni-chaining-mode"
 
@@ -1475,9 +1472,6 @@ type DaemonConfig struct {
 
 	// ClusterID is the unique identifier of the cluster
 	ClusterID uint32
-
-	// ClusterMeshConfig is the path to the clustermesh configuration directory
-	ClusterMeshConfig string
 
 	// CTMapEntriesGlobalTCP is the maximum number of conntrack entries
 	// allowed in each TCP CT table for IPv4/IPv6.
@@ -2920,7 +2914,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.CGroupRoot = vp.GetString(CGroupRoot)
 	c.ClusterID = vp.GetUint32(ClusterIDName)
 	c.ClusterName = vp.GetString(ClusterName)
-	c.ClusterMeshConfig = vp.GetString(ClusterMeshConfigName)
 	c.DatapathMode = vp.GetString(DatapathMode)
 	c.Debug = vp.GetBool(DebugArg)
 	c.DebugVerbose = vp.GetStringSlice(DebugVerbose)


### PR DESCRIPTION
This PR refactors the clustermesh subsystem into a cell, which is registered in the controlplane module. Please refer to the individual commit messages for more details about the preliminary steps.

<!-- Description of change -->

```release-note
Convert the clustermesh subsystem into a hive.Cell
```
