### PR TITLE
Updates egressgateway pkg to use netip.Addr

### DIFF
--- a/cilium/cmd/bpf_egress_list.go
+++ b/cilium/cmd/bpf_egress_list.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net"
+	"net/netip"
 	"os"
 	"text/tabwriter"
 
@@ -79,11 +79,11 @@ var bpfEgressListCmd = &cobra.Command{
 
 // This function attempt to translate gatewayIP to special values if they exist
 // or return the IP as a string otherwise.
-func mapGatewayIP(ip net.IP) string {
-	if ip.Equal(egressgateway.GatewayNotFoundIPv4) {
+func mapGatewayIP(ip netip.Addr) string {
+	if ip.Compare(egressgateway.GatewayNotFoundIPv4) == 0 {
 		return "Not Found"
 	}
-	if ip.Equal(egressgateway.ExcludedCIDRIPv4) {
+	if ip.Compare(egressgateway.ExcludedCIDRIPv4) == 0 {
 		return "Excluded CIDR"
 	}
 	return ip.String()

--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -5,7 +5,7 @@ package egressgateway
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -21,14 +21,14 @@ type endpointMetadata struct {
 	// Endpoint ID
 	id endpointID
 	// ips are endpoint's unique IPs
-	ips []net.IP
+	ips []netip.Addr
 }
 
 // endpointID includes endpoint name and namespace
 type endpointID = types.NamespacedName
 
 func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels labels.Labels) (*endpointMetadata, error) {
-	var ipv4s []net.IP
+	var ipv4s []netip.Addr
 	id := types.NamespacedName{
 		Name:      endpoint.GetName(),
 		Namespace: endpoint.GetNamespace(),
@@ -40,7 +40,9 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels label
 
 	for _, pair := range endpoint.Networking.Addressing {
 		if pair.IPV4 != "" {
-			ipv4s = append(ipv4s, net.ParseIP(pair.IPV4).To4())
+			if ip := netip.MustParseAddr(pair.IPV4); ip.Is4() {
+				ipv4s = append(ipv4s, ip)
+			}
 		}
 	}
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -6,12 +6,13 @@ package egressgateway
 import (
 	"context"
 	"fmt"
-	"net"
+	"net/netip"
 	"sort"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/probes"
@@ -34,10 +35,10 @@ var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "egressgateway")
 	// GatewayNotFoundIPv4 is a special IP value used as gatewayIP in the BPF policy
 	// map to indicate no gateway was found for the given policy
-	GatewayNotFoundIPv4 = net.ParseIP("0.0.0.0")
+	GatewayNotFoundIPv4 = netip.MustParseAddr("0.0.0.0")
 	// ExcludedCIDRIPv4 is a special IP value used as gatewayIP in the BPF policy map
 	// to indicate the entry is for an excluded CIDR and should skip egress gateway
-	ExcludedCIDRIPv4 = net.ParseIP("0.0.0.1")
+	ExcludedCIDRIPv4 = netip.MustParseAddr("0.0.0.1")
 )
 
 // Cell provides a [Manager] for consumption with hive.
@@ -344,15 +345,15 @@ func (manager *Manager) updatePoliciesBySourceIP() {
 // - the given endpoint
 // - the destination CIDR
 // - a boolean value indicating if the CIDR belongs to the excluded ones
-// - the gatewayConfig of the  policy
+// - the gatewayConfig of the policy
 //
 // This method returns true whenever the f callback matches one of the endpoint
 // and CIDR tuples (i.e. whenever one callback invocation returns true)
-func (manager *Manager) policyMatches(sourceIP net.IP, f func(net.IP, *net.IPNet, bool, *gatewayConfig) bool) bool {
+func (manager *Manager) policyMatches(sourceIP netip.Addr, f func(netip.Addr, netip.Prefix, bool, *gatewayConfig) bool) bool {
 	for _, policy := range manager.policyConfigsBySourceIP[sourceIP.String()] {
 		for _, ep := range policy.matchedEndpoints {
 			for _, endpointIP := range ep.ips {
-				if !endpointIP.Equal(sourceIP) {
+				if endpointIP.Compare(sourceIP) != 0 {
 					continue
 				}
 
@@ -394,13 +395,13 @@ func (manager *Manager) policyMatches(sourceIP net.IP, f func(net.IP, *net.IPNet
 //
 // This method returns true whenever the f callback matches one of the endpoint
 // and CIDR tuples (i.e. whenever one callback invocation returns true)
-func (manager *Manager) policyMatchesMinusExcludedCIDRs(sourceIP net.IP, f func(net.IP, *net.IPNet, *gatewayConfig) bool) bool {
+func (manager *Manager) policyMatchesMinusExcludedCIDRs(sourceIP netip.Addr, f func(netip.Addr, netip.Prefix, *gatewayConfig) bool) bool {
 	for _, policy := range manager.policyConfigsBySourceIP[sourceIP.String()] {
 		cidrs := policy.destinationMinusExcludedCIDRs()
 
 		for _, ep := range policy.matchedEndpoints {
 			for _, endpointIP := range ep.ips {
-				if !endpointIP.Equal(sourceIP) {
+				if endpointIP.Compare(sourceIP) != 0 {
 					continue
 				}
 
@@ -427,7 +428,7 @@ func (manager *Manager) addMissingIpRulesAndRoutes(isRetry bool) (shouldRetry bo
 		return false
 	}
 
-	addIPRulesAndRoutesForConfig := func(endpointIP net.IP, dstCIDR *net.IPNet, gwc *gatewayConfig) {
+	addIPRulesAndRoutesForConfig := func(endpointIP netip.Addr, dstCIDR netip.Prefix, gwc *gatewayConfig) {
 		if !gwc.localNodeConfiguredAsGateway {
 			return
 		}
@@ -435,11 +436,11 @@ func (manager *Manager) addMissingIpRulesAndRoutes(isRetry bool) (shouldRetry bo
 		logger := log.WithFields(logrus.Fields{
 			logfields.SourceIP:        endpointIP,
 			logfields.DestinationCIDR: dstCIDR.String(),
-			logfields.EgressIP:        gwc.egressIP.IP,
+			logfields.EgressIP:        gwc.egressIP.Addr(),
 			logfields.LinkIndex:       gwc.ifaceIndex,
 		})
 
-		if err := addEgressIpRule(endpointIP, dstCIDR, gwc.egressIP.IP, gwc.ifaceIndex); err != nil {
+		if err := addEgressIpRule(endpointIP, dstCIDR, gwc.egressIP.Addr(), gwc.ifaceIndex); err != nil {
 			if isRetry {
 				logger.WithError(err).Warn("Can't add IP rule")
 			} else {
@@ -476,7 +477,7 @@ func (manager *Manager) removeUnusedIpRulesAndRoutes() {
 	// Delete all IP rules that don't have a matching egress gateway rule
 nextIpRule:
 	for _, ipRule := range ipRules {
-		matchFunc := func(endpointIP net.IP, dstCIDR *net.IPNet, gwc *gatewayConfig) bool {
+		matchFunc := func(endpointIP netip.Addr, dstCIDR netip.Prefix, gwc *gatewayConfig) bool {
 			if !manager.installRoutes {
 				return false
 			}
@@ -491,8 +492,10 @@ nextIpRule:
 			return ipRule.Dst.String() == dstCIDR.String()
 		}
 
-		if manager.policyMatchesMinusExcludedCIDRs(ipRule.Src.IP, matchFunc) {
-			continue nextIpRule
+		if srcIP, ok := netipx.FromStdIP(ipRule.Src.IP); ok {
+			if manager.policyMatchesMinusExcludedCIDRs(srcIP, matchFunc) {
+				continue nextIpRule
+			}
 		}
 
 		deleteIpRule(ipRule)
@@ -534,8 +537,8 @@ func (manager *Manager) addMissingEgressRules() {
 			egressPolicies[*key] = *val
 		})
 
-	addEgressRule := func(endpointIP net.IP, dstCIDR *net.IPNet, excludedCIDR bool, gwc *gatewayConfig) {
-		policyKey := egressmap.NewEgressPolicyKey4(endpointIP, dstCIDR.IP, dstCIDR.Mask)
+	addEgressRule := func(endpointIP netip.Addr, dstCIDR netip.Prefix, excludedCIDR bool, gwc *gatewayConfig) {
+		policyKey := egressmap.NewEgressPolicyKey4(endpointIP, dstCIDR.Addr(), dstCIDR)
 		policyVal, policyPresent := egressPolicies[policyKey]
 
 		gatewayIP := gwc.gatewayIP
@@ -543,18 +546,19 @@ func (manager *Manager) addMissingEgressRules() {
 			gatewayIP = ExcludedCIDRIPv4
 		}
 
-		if policyPresent && policyVal.Match(gwc.egressIP.IP, gatewayIP) {
+		egressIP := gwc.egressIP.Addr()
+		if policyPresent && policyVal.Match(egressIP, gatewayIP) {
 			return
 		}
 
 		logger := log.WithFields(logrus.Fields{
 			logfields.SourceIP:        endpointIP,
 			logfields.DestinationCIDR: dstCIDR.String(),
-			logfields.EgressIP:        gwc.egressIP.IP,
+			logfields.EgressIP:        egressIP,
 			logfields.GatewayIP:       gatewayIP,
 		})
 
-		if err := manager.policyMap.Update(endpointIP, *dstCIDR, gwc.egressIP.IP, gatewayIP); err != nil {
+		if err := manager.policyMap.Update(endpointIP, dstCIDR, egressIP, gatewayIP); err != nil {
 			logger.WithError(err).Error("Error applying egress gateway policy")
 		} else {
 			logger.Debug("Egress gateway policy applied")
@@ -577,16 +581,16 @@ func (manager *Manager) removeUnusedEgressRules() {
 
 nextPolicyKey:
 	for policyKey, policyVal := range egressPolicies {
-		matchPolicy := func(endpointIP net.IP, dstCIDR *net.IPNet, excludedCIDR bool, gwc *gatewayConfig) bool {
+		matchPolicy := func(endpointIP netip.Addr, dstCIDR netip.Prefix, excludedCIDR bool, gwc *gatewayConfig) bool {
 			gatewayIP := gwc.gatewayIP
 			if excludedCIDR {
 				gatewayIP = ExcludedCIDRIPv4
 			}
 
-			return policyKey.Match(endpointIP, dstCIDR) && policyVal.Match(gwc.egressIP.IP, gatewayIP)
+			return policyKey.Match(endpointIP, dstCIDR) && policyVal.Match(gwc.egressIP.Addr(), gatewayIP)
 		}
 
-		if manager.policyMatches(policyKey.SourceIP.IP(), matchPolicy) {
+		if manager.policyMatches(policyKey.GetSourceIP(), matchPolicy) {
 			continue nextPolicyKey
 		}
 

--- a/pkg/egressgateway/net.go
+++ b/pkg/egressgateway/net.go
@@ -6,9 +6,11 @@ package egressgateway
 import (
 	"fmt"
 	"net"
+	"net/netip"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	"go4.org/netipx"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -16,46 +18,50 @@ import (
 
 var zeroIPv4Net = &net.IPNet{IP: net.ParseIP("0.0.0.0"), Mask: net.CIDRMask(0, 32)}
 
-func getIfaceFirstIPv4Address(ifaceName string) (net.IPNet, int, error) {
+func getIfaceFirstIPv4Address(ifaceName string) (netip.Prefix, int, error) {
 	dev, err := netlink.LinkByName(ifaceName)
 	if err != nil {
-		return net.IPNet{}, 0, err
+		return netip.Prefix{}, 0, err
 	}
 
 	addrs, err := netlink.AddrList(dev, netlink.FAMILY_V4)
 	if err != nil {
-		return net.IPNet{}, 0, err
+		return netip.Prefix{}, 0, err
 	}
 
 	for _, addr := range addrs {
 		if addr.IP.To4() != nil {
-			return *addr.IPNet, dev.Attrs().Index, nil
+			if prefix, ok := netipx.FromStdIPNet(addr.IPNet); ok {
+				return prefix, dev.Attrs().Index, nil
+			}
 		}
 	}
 
-	return net.IPNet{}, 0, fmt.Errorf("no IPv4 address assigned to interface")
+	return netip.Prefix{}, 0, fmt.Errorf("no IPv4 address assigned to interface")
 }
 
-func getIfaceWithIPv4Address(ip net.IP) (string, int, net.IPMask, error) {
+func getIfaceWithIPv4Address(ip netip.Addr) (string, int, netip.Prefix, error) {
 	links, err := netlink.LinkList()
 	if err != nil {
-		return "", 0, nil, err
+		return "", 0, netip.Prefix{}, err
 	}
 
 	for _, l := range links {
 		addrs, err := netlink.AddrList(l, netlink.FAMILY_V4)
 		if err != nil {
-			return "", 0, nil, err
+			return "", 0, netip.Prefix{}, err
 		}
 
 		for _, addr := range addrs {
-			if addr.IP.Equal(ip) {
-				return l.Attrs().Name, l.Attrs().Index, addr.Mask, nil
+			if addr.IP.Equal(ip.AsSlice()) {
+				if prefix, ok := netipx.FromStdIPNet(addr.IPNet); ok {
+					return l.Attrs().Name, l.Attrs().Index, prefix, nil
+				}
 			}
 		}
 	}
 
-	return "", 0, nil, fmt.Errorf("no interface with %s IPv4 assigned to", ip)
+	return "", 0, netip.Prefix{}, fmt.Errorf("no interface with %s IPv4 assigned to", ip)
 }
 
 // egressGatewayRoutingTableIdx returns the index of the routing table that
@@ -90,13 +96,13 @@ func listEgressIpRules() ([]netlink.Rule, error) {
 	return rules, nil
 }
 
-func addEgressIpRule(endpointIP net.IP, dstCIDR *net.IPNet, egressIP net.IP, ifaceIndex int) error {
+func addEgressIpRule(endpointIP netip.Addr, dstCIDR netip.Prefix, egressIP netip.Addr, ifaceIndex int) error {
 	routingTableIdx := egressGatewayRoutingTableIdx(ifaceIndex)
 
 	ipRule := route.Rule{
 		Priority: linux_defaults.RulePriorityEgressGateway,
-		From:     &net.IPNet{IP: endpointIP, Mask: net.CIDRMask(32, 32)},
-		To:       dstCIDR,
+		From:     &net.IPNet{IP: endpointIP.AsSlice(), Mask: net.CIDRMask(32, 32)},
+		To:       netipx.PrefixIPNet(dstCIDR),
 		Table:    routingTableIdx,
 		Protocol: linux_defaults.RTProto,
 	}
@@ -104,26 +110,38 @@ func addEgressIpRule(endpointIP net.IP, dstCIDR *net.IPNet, egressIP net.IP, ifa
 	return route.ReplaceRule(ipRule)
 }
 
-func getFirstIPInHostRange(ip net.IPNet) net.IP {
-	out := make(net.IP, net.IPv4len)
-	copy(out, ip.IP.To4())
-	out = out.Mask(ip.Mask)
-	out[3] += 1
+func getFirstIPInHostRange(prefix netip.Prefix) (netip.Addr, error) {
+	if !prefix.IsValid() {
+		return netip.Addr{}, fmt.Errorf("invalid prefix %v", prefix)
+	}
 
-	return out
+	if prefix.IsSingleIP() {
+		return prefix.Addr(), nil
+	}
+
+	nextIP := prefix.Addr().Next()
+	// If no addresses are available, the zero address is returned.
+	if nextIP.Compare(GatewayNotFoundIPv4) == 0 {
+		return netip.Addr{}, fmt.Errorf("no available IPs for prefix %v", prefix)
+	}
+
+	return nextIP, nil
 }
 
-func addEgressIpRoutes(egressIP net.IPNet, ifaceIndex int) error {
+func addEgressIpRoutes(egressIP netip.Prefix, ifaceIndex int) error {
 	routingTableIdx := egressGatewayRoutingTableIdx(ifaceIndex)
 
 	// The gateway for a subnet and VPC should always be the first IP of the
 	// host address range.
-	eniGatewayIP := getFirstIPInHostRange(egressIP)
+	eniGatewayIP, err := getFirstIPInHostRange(egressIP)
+	if err != nil {
+		return fmt.Errorf("unable to get first IP from egress prefix %v: %w", egressIP, err)
+	}
 
 	// Nexthop route to the VPC or subnet gateway
 	if err := netlink.RouteReplace(&netlink.Route{
 		LinkIndex: ifaceIndex,
-		Dst:       &net.IPNet{IP: eniGatewayIP, Mask: net.CIDRMask(32, 32)},
+		Dst:       &net.IPNet{IP: eniGatewayIP.AsSlice(), Mask: net.CIDRMask(32, 32)},
 		Scope:     netlink.SCOPE_LINK,
 		Table:     routingTableIdx,
 		Protocol:  linux_defaults.RTProto,
@@ -136,7 +154,7 @@ func addEgressIpRoutes(egressIP net.IPNet, ifaceIndex int) error {
 		LinkIndex: ifaceIndex,
 		Dst:       &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
 		Table:     routingTableIdx,
-		Gw:        eniGatewayIP,
+		Gw:        eniGatewayIP.AsSlice(),
 		Protocol:  linux_defaults.RTProto,
 	}); err != nil {
 		return fmt.Errorf("unable to add L2 nexthop route: %w", err)


### PR DESCRIPTION
Updates the egressgateway pkg to use `netip.Addr` type instead of `net.IP`.

__Note:__ The `net` pkg can be removed from `pkg/egressgateway/manager_privileged_test.go` after node/type and netlink pkgs support `netip.Addr`.

Partially Fixes: https://github.com/cilium/cilium/issues/24246