### PR TITLE
ipsec: Attach to new ENI interfaces as they are added

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1187,6 +1187,13 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		return nil, restoredEndpoints, fmt.Errorf("error while initializing daemon: %w", err)
 	}
 
+	// Register the datapath loader as a CiliumNode subscriber if running IPsec
+	// and ENI mode so that we can attach the IPsec BPF program on new ENIs as
+	// they are added.
+	if option.Config.EnableIPSec && option.Config.IPAM == ipamOption.IPAMENI {
+		d.k8sWatcher.RegisterCiliumNodeSubscriber(d.Datapath().Loader())
+	}
+
 	// iptables rules can be updated only after d.init() intializes the iptables above.
 	err = d.updateDNSDatapathRules(d.ctx)
 	if err != nil {

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/testutils/mockmaps"
 )
 
@@ -143,5 +145,17 @@ func (f *fakeLoader) CustomCallsMapPath(id uint16) string {
 
 // Reinitialize does nothing.
 func (f *fakeLoader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+	return nil
+}
+
+func (f *fakeLoader) OnUpdateCiliumNode(oldNode, newNode *ciliumv2.CiliumNode, _ *lock.StoppableWaitGroup) error {
+	return nil
+}
+
+func (f *fakeLoader) OnAddCiliumNode(node *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error {
+	return nil
+}
+
+func (f *fakeLoader) OnDeleteCiliumNode(node *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error {
 	return nil
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -184,18 +184,16 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 		// IPAMENI mode supports multiple network facing interfaces that
 		// will all need Encrypt logic applied in order to decrypt any
 		// received encrypted packets. This logic will attach to all
-		// !veth devices. Only use if user has not configured interfaces.
-		if len(interfaces) == 0 {
-			if links, err := netlink.LinkList(); err == nil {
-				for _, link := range links {
-					isVirtual, err := ethtool.IsVirtualDriver(link.Attrs().Name)
-					if err == nil && !isVirtual {
-						interfaces = append(interfaces, link.Attrs().Name)
-					}
+		// !veth devices.
+		if links, err := netlink.LinkList(); err == nil {
+			for _, link := range links {
+				isVirtual, err := ethtool.IsVirtualDriver(link.Attrs().Name)
+				if err == nil && !isVirtual {
+					interfaces = append(interfaces, link.Attrs().Name)
 				}
 			}
-			option.Config.EncryptInterface = interfaces
 		}
+		option.Config.EncryptInterface = interfaces
 	}
 
 	// No interfaces is valid in tunnel disabled case

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -9,6 +9,7 @@ import (
 	"net"
 
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -22,6 +23,9 @@ type Loader interface {
 	EndpointHash(cfg EndpointConfiguration) (string, error)
 	Unload(ep Endpoint)
 	Reinitialize(ctx context.Context, o BaseProgramOwner, deviceMTU int, iptMgr IptablesManager, p Proxy) error
+	OnUpdateCiliumNode(oldNode, newNode *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error
+	OnAddCiliumNode(node *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error
+	OnDeleteCiliumNode(node *ciliumv2.CiliumNode, swg *lock.StoppableWaitGroup) error
 }
 
 // BaseProgramOwner is any type for which a loader is building base programs.

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -614,6 +614,9 @@ const (
 	// MissingENIs are the ENIs that we expected to be available but were not found.
 	MissingENIs = "missingENIs"
 
+	// NewENIs are ENIs that have been added to the CiliumNode.
+	NewENIs = "newENIs"
+
 	// Hint helps nudge the user in the right direction when troubleshooting.
 	Hint = "hint"
 

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -611,11 +611,8 @@ const (
 	// NewNode refers to the node after the update
 	NewNode = "newNode"
 
-	// AttachedENIs are the ENIs which have been attached to the node
-	AttachedENIs = "attachedENIs"
-
-	// ExpectedENIs are the ENIs which are expected to be available
-	ExpectedENIs = "expectedENIs"
+	// MissingENIs are the ENIs that we expected to be available but were not found.
+	MissingENIs = "missingENIs"
 
 	// Hint helps nudge the user in the right direction when troubleshooting.
 	Hint = "hint"


### PR DESCRIPTION
This pull request ensures that we rerun the detection and attachment of bpf_network to new ENI interfaces whenever they are added. See commits for details.

```release-note
Fix bug where Cilium wouldn't attach its IPsec BPF program to new ENI interfaces, resulting in connectivity loss between pods on remote nodes.  
```