### PR TITLE
contrib/scripts: Ignore all vendor sub-directories

### DIFF
--- a/contrib/scripts/check-fmt.sh
+++ b/contrib/scripts/check-fmt.sh
@@ -6,7 +6,7 @@ set -o pipefail
 _goroot=$(${GO:-go} env GOROOT)
 
 diff="$(find . ! \( -path './contrib' -prune \) \
-        ! \( -path './vendor' -prune \) \
+        ! \( -regex '.*/vendor/.*' -prune \) \
         ! \( -path './_build' -prune \) \
         ! \( -path './.git' -prune \) \
         ! \( -path '*.validate.go' -prune \) \

--- a/contrib/scripts/check-k8s-code-gen.sh
+++ b/contrib/scripts/check-k8s-code-gen.sh
@@ -4,12 +4,12 @@ set -e
 set -o pipefail
 
 # Delete all zz_generated.deepcopy.go files
-find . -not -path "./vendor/*" -not -path "./_build/*" -name "zz_generated.deepcopy.go" -exec rm  {} \;
+find . -not -regex ".*/vendor/.*" -not -path "./_build/*" -name "zz_generated.deepcopy.go" -exec rm  {} \;
 # Delete all zz_generated.deepequal.go files
-find . -not -path "./vendor/*" -not -path "./_build/*" -name "zz_generated.deepequal.go" -exec rm  {} \;
+find . -not -regex ".*/vendor/.*" -not -path "./_build/*" -name "zz_generated.deepequal.go" -exec rm  {} \;
 # Delete all generated proto and proto go files
-find . -not -path "./vendor/*" -not -path "./_build/*" -name "generated.pb.go" -exec rm  {} \;
-find . -not -path "./vendor/*" -not -path "./_build/*" -name "generated.proto" -exec rm  {} \;
+find . -not -regex ".*/vendor/.*" -not -path "./_build/*" -name "generated.pb.go" -exec rm  {} \;
+find . -not -regex ".*/vendor/.*" -not -path "./_build/*" -name "generated.proto" -exec rm  {} \;
 # Delete cilium clientsets, informers & listers
 rm -rf ./pkg/k8s/client/{clientset,informers,listers}
 # Delete k8s slim clients

--- a/contrib/scripts/rand-check.sh
+++ b/contrib/scripts/rand-check.sh
@@ -12,7 +12,7 @@ for l in rand\.NewSource; do
 	  -not -path "./_build/*" \
 	  -not -path "./contrib/*" \
 	  -not -path "./pkg/rand/*" \
-	  -not -path "./vendor/*" \
+	  -not -regex ".*/vendor/.*" \
 	  -not -path "./test/*" \
 	  -print0 \
 	  | xargs -0 grep --exclude NewSafeSource "$l")


### PR DESCRIPTION
Make these check scripts slightly more future-proof by ignoring all sub-directories named vendor.