### PR TITLE
docs: disable host dns resolver for minikube installation guide

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -149,6 +149,9 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
           ``minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf`` in order to mount the BPF filesystem
           ``bpffs`` to ``/sys/fs/bpf``.
 
+          It might be necessary to add ``--host-dns-resolver=false`` if using the Virtualbox provider,
+          otherwise DNS resolution may not work after Cilium installation.
+
     .. group-tab:: Rancher Desktop
 
        Install Rancher Desktop >= v1.1.0 as per Rancher Desktop documentation:


### PR DESCRIPTION
When `virtualbox` provider is used as minikube driver, all the VM instances are going to have `10.0.2.3` as dns server (inspected by looking at `/etc/resolv.conf`). This seems to have collapsed with cilium cni cidr. This is going to fail the `cilium connectivity test` because image pulling are going to fail due to dns resolution failure to image registry.

The fix here is to specify `--host-dns-resolver=false` so that such problem doesn't occur. The new dns resolver will be `192.168.0.1` (all with default configurations).

I also thought about customizing cilium cni cidr, but that may involve more changes to the doc. It might not be worthwhile in this *quick* installation guide.

```release-note
docs: Disable host DNS resolver with Virtualbox for Minikube quick installation guide
```
