### PR TITLE
helm: Correct typo in Ingress validation

### DIFF
--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -47,9 +47,9 @@
 {{- end }}
 
 {{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled }}
-  {{- if hasKey .Values "l7proxy" }}
-    {{- if not .Values.l7proxy }}
-      {{ fail "Ingress or Gateway API controller requires .Values.l7proxy to be set to 'true'" }}
+  {{- if hasKey .Values "l7Proxy" }}
+    {{- if not .Values.l7Proxy }}
+      {{ fail "Ingress or Gateway API controller requires .Values.l7Proxy to be set to 'true'" }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This is to correct the typo (i.e. l7Proxy instead of l7proxy) in helm validation if Ingress or Gateway API is enabled. Negative testing is done as per below

```
$ helm template --namespace kube-system cilium "./install/kubernetes/cilium" --set ingressController.enabled=true --set l7Proxy=false
Error: execution error at (cilium/templates/validate.yaml:52:9): Ingress or Gateway API controller requires .Values.l7Proxy to be set to 'true'

$ helm template --namespace kube-system cilium "./install/kubernetes/cilium" --set gatewayAPI.enabled=true --set l7Proxy=false
Error: execution error at (cilium/templates/validate.yaml:52:9): Ingress or Gateway API controller requires .Values.l7Proxy to be set to 'true'

```

Fixes: ea404cf458aeed02bbaad27326838b9b135ec892

Reported-By: Yutaro Hayakawa <yutaro.hayakawa@isovalent.com>

