### PR TITLE
gateway-api: Race condition between routes and Gateway

### DIFF
--- a/operator/pkg/gateway-api/httproute.go
+++ b/operator/pkg/gateway-api/httproute.go
@@ -88,15 +88,13 @@ func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		// Watch for changes to HTTPRoute, but not the status
-		For(&gatewayv1beta1.HTTPRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		// Watch for changes to HTTPRoute
+		For(&gatewayv1beta1.HTTPRoute{}).
 		// Watch for changes to Backend services
 		Watches(&source.Kind{Type: &corev1.Service{}}, r.enqueueRequestForBackendService()).
 		// Watch for changes to Gateways and enqueue HTTPRoutes that reference them,
-		// only if there is a change in the spec
 		Watches(&source.Kind{Type: &gatewayv1beta1.Gateway{}}, r.enqueueRequestForGateway(),
 			builder.WithPredicates(
-				predicate.GenerationChangedPredicate{},
 				predicate.NewPredicateFuncs(hasMatchingController(context.Background(), mgr.GetClient(), controllerName)))).
 		Complete(r)
 }

--- a/operator/pkg/gateway-api/tlsroute.go
+++ b/operator/pkg/gateway-api/tlsroute.go
@@ -82,15 +82,15 @@ func (r *tlsRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		// Watch for changes to TLSRoute, but not the status
-		For(&gatewayv1alpha2.TLSRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		// Watch for changes to TLSRoute
+		For(&gatewayv1alpha2.TLSRoute{}).
 		// Watch for changes to Backend services
 		Watches(&source.Kind{Type: &corev1.Service{}}, r.enqueueRequestForBackendService()).
+		// Watch for changes to Gateways and enqueue TLSRoutes that reference them
+		Watches(&source.Kind{Type: &gatewayv1beta1.Gateway{}}, r.enqueueRequestForGateway()).
 		// Watch for changes to Gateways and enqueue TLSRoutes that reference them,
-		// only if there is a change in the spec
 		Watches(&source.Kind{Type: &gatewayv1beta1.Gateway{}}, r.enqueueRequestForGateway(),
 			builder.WithPredicates(
-				predicate.GenerationChangedPredicate{},
 				predicate.NewPredicateFuncs(hasMatchingController(context.Background(), mgr.GetClient(), controllerName)),
 			)).
 		Complete(r)


### PR DESCRIPTION
There was a race condition between http/tls routes and the underlying Gateway resource. Basically, if the HTTP or TLS Route resource is created before Gateway resource, its status will be updated with the value `gateway not found`. However, the reconciliation for HTTP or TLS routes is not triggered even after mentioned Gateway is created. The issue is due to an unnecessary predicate on GenerationChangedPredicate, which only checks for changes in spec.

This commit is to remove GenerationChangedPredicate predicate in HTTP and TLS routes.

Status for gateway not found

```json
{
  "lastTransitionTime": "2023-05-22T05:24:01Z",
  "message": "Gateway.gateway.networking.k8s.io \"gateway-tlsroute\" not found",
  "observedGeneration": 1,
  "reason": "InvalidTLSRoute",
  "status": "False",
  "type": "Accepted"
}
```

Testing was done before and after the changes with below step:

- Create one TLSRoute with a non-existent Gateway. This TLSRoute status should say `gateway not found`
- Create mentioned Gateway Resource with a valid GatewayClass
- Verify the TLSRoute status, which should be updated to Accepted.

Fixes: #25487

