### PR TITLE
nodeid map: provide map via hive cell

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
-	"github.com/cilium/cilium/pkg/maps/nodemap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/srv6map"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
@@ -323,10 +322,6 @@ func (d *Daemon) initMaps() error {
 	// are re-allocated on startup.
 	if err := ipcachemap.IPCacheMap().Recreate(); err != nil {
 		return fmt.Errorf("initializing ipcache map: %w", err)
-	}
-
-	if err := nodemap.NodeMap().OpenOrCreate(); err != nil {
-		return err
 	}
 
 	if err := metricsmap.Metrics.OpenOrCreate(); err != nil {

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -19,6 +19,7 @@ import (
 	ipcache "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/maps"
 	"github.com/cilium/cilium/pkg/maps/eventsmap"
+	"github.com/cilium/cilium/pkg/maps/nodemap"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/option"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
@@ -100,7 +101,7 @@ func newDatapath(params datapathParams) types.Datapath {
 			return nil
 		}})
 
-	datapath := linuxdatapath.NewDatapath(datapathConfig, iptablesManager, params.WgAgent)
+	datapath := linuxdatapath.NewDatapath(datapathConfig, iptablesManager, params.WgAgent, params.NodeMap)
 
 	params.LC.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
@@ -121,4 +122,6 @@ type datapathParams struct {
 	// Force map initialisation before loader. You should not use these otherwise.
 	// Some of the entries in this slice may be nil.
 	BpfMaps []bpf.BpfMap `group:"bpf-maps"`
+
+	NodeMap nodemap.Map
 }

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
+	"github.com/cilium/cilium/pkg/maps/nodemap"
 )
 
 // DatapathConfiguration is the static configuration of the datapath. The
@@ -31,7 +32,7 @@ type linuxDatapath struct {
 }
 
 // NewDatapath creates a new Linux datapath
-func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager, wgAgent datapath.WireguardAgent) datapath.Datapath {
+func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager, wgAgent datapath.WireguardAgent, nodeMap nodemap.Map) datapath.Datapath {
 	dp := &linuxDatapath{
 		ConfigWriter:    &config.HeaderfileWriter{},
 		IptablesManager: ruleManager,
@@ -42,7 +43,7 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 		lbmap:           lbmap.New(),
 	}
 
-	dp.node = NewNodeHandler(cfg, dp.nodeAddressing)
+	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, nodeMap)
 	return dp
 }
 

--- a/pkg/datapath/linux/datapath_test.go
+++ b/pkg/datapath/linux/datapath_test.go
@@ -18,7 +18,7 @@ type linuxTestSuite struct{}
 var _ = check.Suite(&linuxTestSuite{})
 
 func (s *linuxTestSuite) TestNewDatapath(c *check.C) {
-	dp := NewDatapath(DatapathConfiguration{}, nil, nil)
+	dp := NewDatapath(DatapathConfiguration{}, nil, nil, nil)
 	c.Assert(dp, check.Not(check.IsNil))
 
 	c.Assert(dp.Node(), check.Not(check.IsNil))

--- a/pkg/datapath/linux/fuzz_test.go
+++ b/pkg/datapath/linux/fuzz_test.go
@@ -23,7 +23,7 @@ func FuzzNodeHandler(f *testing.F) {
 		}
 		dpConfig := DatapathConfiguration{HostDevice: "veth0"}
 		fakeNodeAddressing := fake.NewNodeAddressing()
-		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing)
+		linuxNodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil)
 		if linuxNodeHandler == nil {
 			panic("Should not be nil")
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -32,6 +32,7 @@ import (
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/nodemap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
@@ -68,6 +69,7 @@ type linuxNodeHandler struct {
 	neighByNextHop         map[string]*netlink.Neigh // key = string(net.IP)
 	neighLastPingByNextHop map[string]time.Time      // key = string(net.IP)
 
+	nodeMap nodemap.Map
 	// Pool of available IDs for nodes.
 	nodeIDs idpool.IDPool
 	// Node-scoped unique IDs for the nodes.
@@ -87,7 +89,7 @@ var (
 
 // NewNodeHandler returns a new node handler to handle node events and
 // implement the implications in the Linux datapath
-func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapath.NodeAddressing) *linuxNodeHandler {
+func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapath.NodeAddressing, nodeMap nodemap.Map) *linuxNodeHandler {
 	return &linuxNodeHandler{
 		nodeAddressing:         nodeAddressing,
 		datapathConfig:         datapathConfig,
@@ -97,6 +99,7 @@ func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapat
 		neighNextHopRefCount:   counter.StringCounter{},
 		neighByNextHop:         map[string]*netlink.Neigh{},
 		neighLastPingByNextHop: map[string]time.Time{},
+		nodeMap:                nodeMap,
 		nodeIDs:                idpool.NewIDPool(minNodeID, maxNodeID),
 		nodeIDsByIPs:           map[string]uint16{},
 		nodeIPsByIDs:           map[uint16]string{},

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -172,7 +172,7 @@ func (n *linuxNodeHandler) mapNodeID(ip string, id uint16) error {
 		return fmt.Errorf("invalid node IP %s", ip)
 	}
 
-	if err := nodemap.NodeMap().Update(nodeIP, id); err != nil {
+	if err := n.nodeMap.Update(nodeIP, id); err != nil {
 		return err
 	}
 
@@ -197,7 +197,7 @@ func (n *linuxNodeHandler) unmapNodeID(ip string) error {
 		return fmt.Errorf("invalid node IP %s", ip)
 	}
 
-	if err := nodemap.NodeMap().Delete(nodeIP); err != nil {
+	if err := n.nodeMap.Delete(nodeIP); err != nil {
 		return err
 	}
 	if id, exists := n.nodeIDsByIPs[ip]; exists {
@@ -246,7 +246,7 @@ func (n *linuxNodeHandler) RestoreNodeIDs() {
 		}
 		nodeIDs[address] = val.NodeID
 	}
-	if err := nodemap.NodeMap().IterateWithCallback(parse); err != nil {
+	if err := n.nodeMap.IterateWithCallback(parse); err != nil {
 		log.WithError(err).Error("Failed to dump content of node map")
 		return
 	}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/maps/nodemap"
+	nodemapfake "github.com/cilium/cilium/pkg/maps/nodemap/fake"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/netns"
@@ -112,10 +112,6 @@ func (s *linuxPrivilegedBaseTestSuite) SetUpTest(c *check.C, addressing datapath
 	tunnel.SetTunnelMap(tunnel.NewTunnelMap("test_cilium_tunnel_map"))
 	err = tunnel.TunnelMap().OpenOrCreate()
 	c.Assert(err, check.IsNil)
-
-	nodemap.SetNodeMap(nodemap.NewNodeMap("test_cilium_node_map"))
-	err = nodemap.NodeMap().OpenOrCreate()
-	c.Assert(err, check.IsNil)
 }
 
 func (s *linuxPrivilegedIPv6OnlyTestSuite) SetUpTest(c *check.C) {
@@ -201,7 +197,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4: s.enableIPv4,
@@ -249,7 +245,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestUpdateNodeRoute(c *check.C) {
 func (s *linuxPrivilegedBaseTestSuite) TestSingleClusterPrefix(c *check.C) {
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	// enable as per test definition
@@ -315,7 +311,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAuxiliaryPrefixes(c *check.C) {
 	net2 := cidr.MustParseCIDR("cafe:f00d::/112")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:        s.enableIPv4,
@@ -389,7 +385,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 	externalNodeIP2 := net.ParseIP("8.8.8.8")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap())
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:          s.enableIPv4,
@@ -679,7 +675,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateDirectRouting(c *check.C) {
 	defer removeDevice(externalNode2Device)
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:              s.enableIPv4,
@@ -894,7 +890,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestAgentRestartOptionChanges(c *check.C)
 	underlayIP := net.ParseIP("4.4.4.4")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nodemapfake.NewFakeNodeMap())
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 	nodeConfig := datapath.LocalNodeConfiguration{
 		EnableIPv4:          s.enableIPv4,
@@ -1001,7 +997,7 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeValidationDirectRouting(c *check.
 	ip4Alloc1 := cidr.MustParseCIDR("5.5.5.0/24")
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	if s.enableIPv4 {
@@ -1166,7 +1162,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = time.Duration(1 * time.Nanosecond)
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -2055,7 +2051,7 @@ func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = 1 * time.Nanosecond
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -2336,7 +2332,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandling(c *check.C) {
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = time.Duration(1 * time.Nanosecond)
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -3226,7 +3222,7 @@ func (s *linuxPrivilegedIPv4OnlyTestSuite) TestArpPingHandlingForMultiDevice(c *
 	defer func() { option.Config.ARPPingRefreshPeriod = prevARPPeriod }()
 	option.Config.ARPPingRefreshPeriod = 1 * time.Nanosecond
 
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err = linuxNodeHandler.NodeConfigurationChanged(datapath.LocalNodeConfiguration{
@@ -3425,7 +3421,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdate(c *check.C, config da
 	ip6Alloc2 := cidr.MustParseCIDR("2001:bbbb::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)
@@ -3531,7 +3527,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeUpdateNOP(c *check.C, config
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)
@@ -3600,7 +3596,7 @@ func (s *linuxPrivilegedBaseTestSuite) benchmarkNodeValidateImplementation(c *ch
 	ip6Alloc1 := cidr.MustParseCIDR("2001:aaaa::/96")
 
 	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
-	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing)
+	linuxNodeHandler := NewNodeHandler(dpConfig, s.nodeAddressing, nil)
 	c.Assert(linuxNodeHandler, check.Not(check.IsNil))
 
 	err := linuxNodeHandler.NodeConfigurationChanged(config)

--- a/pkg/datapath/linux/node_test.go
+++ b/pkg/datapath/linux/node_test.go
@@ -67,7 +67,7 @@ func (s *linuxTestSuite) TestCreateNodeRoute(c *check.C) {
 
 	fakeNodeAddressing := fake.NewNodeAddressing()
 
-	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing)
+	nodeHandler := NewNodeHandler(dpConfig, fakeNodeAddressing, nil)
 
 	c1 := cidr.MustParseCIDR("10.10.0.0/16")
 	generatedRoute, err := nodeHandler.createNodeRouteSpec(c1, false)

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -31,7 +31,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 	testutils.IntegrationTest(b)
 
 	e := NewEndpointWithState(&suite, &suite, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
-	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil)
+	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil, nil)
 
 	targetComments := func(w io.Writer) error {
 		return e.writeInformationalComments(w)

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -81,7 +81,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil)
+	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil)
 
 	epsWanted, _ := ds.createEndpoints()
 	tmpDir, err := os.MkdirTemp("", "cilium-tests")
@@ -151,7 +151,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNamesWithRestoreFailure(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil)
+	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil)
 
 	eps, _ := ds.createEndpoints()
 	ep := eps[0]
@@ -217,7 +217,7 @@ func (ds *EndpointSuite) BenchmarkReadEPsFromDirNames(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil)
+	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil)
 
 	epsWanted, _ := ds.createEndpoints()
 	tmpDir, err := os.MkdirTemp("", "cilium-tests")

--- a/pkg/maps/cells.go
+++ b/pkg/maps/cells.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/configmap"
 	"github.com/cilium/cilium/pkg/maps/ctmap/gc"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
+	"github.com/cilium/cilium/pkg/maps/nodemap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
 )
 
@@ -32,4 +33,7 @@ var Cell = cell.Module(
 
 	// Provides signalmap for datapath signals
 	signalmap.Cell,
+
+	// Provides the node map which contains information about node IDs and their IP addresses.
+	nodemap.Cell,
 )

--- a/pkg/maps/nodemap/cell.go
+++ b/pkg/maps/nodemap/cell.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodemap
+
+import (
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+// Cell provides the nodemap.Map which contains information about node IDs and their IP addresses.
+var Cell = cell.Module(
+	"node-map",
+	"eBPF map which contains information about node IDs and their IP addresses",
+
+	cell.Provide(newNodeMap),
+)
+
+func newNodeMap(lifecycle hive.Lifecycle) bpf.MapOut[Map] {
+	nodeMap := newMap()
+
+	lifecycle.Append(hive.Hook{
+		OnStart: func(context hive.HookContext) error {
+			return nodeMap.init()
+		},
+		OnStop: func(context hive.HookContext) error {
+			return nodeMap.close()
+		},
+	})
+
+	return bpf.NewMapOut(Map(nodeMap))
+}

--- a/pkg/maps/nodemap/fake/node_map.go
+++ b/pkg/maps/nodemap/fake/node_map.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fake
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/maps/nodemap"
+)
+
+type fakeNodeMap struct {
+}
+
+var _ nodemap.Map = &fakeNodeMap{}
+
+func NewFakeNodeMap() *fakeNodeMap {
+	return &fakeNodeMap{}
+}
+
+func (f fakeNodeMap) Update(ip net.IP, nodeID uint16) error {
+	return nil
+}
+
+func (f fakeNodeMap) Delete(ip net.IP) error {
+	return nil
+}
+
+func (f fakeNodeMap) IterateWithCallback(cb nodemap.NodeIterateCallback) error {
+	return nil
+}

--- a/pkg/maps/nodemap/node_map.go
+++ b/pkg/maps/nodemap/node_map.go
@@ -4,8 +4,8 @@
 package nodemap
 
 import (
+	"fmt"
 	"net"
-	"sync"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -20,25 +20,37 @@ const (
 	MaxEntries = 16384
 )
 
-var (
-	nodeMap     *Map
-	nodeMapInit = &sync.Once{}
-)
+// Map provides access to the eBPF map node.
+type Map interface {
+	// Update inserts or updates the node map object associated with the provided
+	// IP and node id.
+	Update(ip net.IP, nodeID uint16) error
 
-// SetNodeMap sets the node map. Only used for testing.
-func SetNodeMap(m *Map) {
-	nodeMap = m
+	// Delete deletes the node map object associated with the provided
+	// IP.
+	Delete(ip net.IP) error
+
+	// IterateWithCallback iterates through all the keys/values of a node map,
+	// passing each key/value pair to the cb callback.
+	IterateWithCallback(cb NodeIterateCallback) error
 }
 
-func NodeMap() *Map {
-	nodeMapInit.Do(func() {
-		nodeMap = NewNodeMap(MapName)
-	})
-	return nodeMap
+type nodeMap struct {
+	bpfMap *ebpf.Map
 }
 
-type Map struct {
-	*ebpf.Map
+func newMap() *nodeMap {
+	return &nodeMap{
+		bpfMap: ebpf.NewMap(&ebpf.MapSpec{
+			Name:       MapName,
+			Type:       ebpf.Hash,
+			KeySize:    uint32(unsafe.Sizeof(NodeKey{})),
+			ValueSize:  uint32(unsafe.Sizeof(NodeValue{})),
+			MaxEntries: uint32(MaxEntries),
+			Flags:      unix.BPF_F_NO_PREALLOC,
+			Pinning:    ebpf.PinByName,
+		}),
+	}
 }
 
 type NodeKey struct {
@@ -75,27 +87,15 @@ type NodeValue struct {
 	NodeID uint16
 }
 
-func NewNodeMap(mapName string) *Map {
-	return &Map{Map: ebpf.NewMap(&ebpf.MapSpec{
-		Name:       mapName,
-		Type:       ebpf.Hash,
-		KeySize:    uint32(unsafe.Sizeof(NodeKey{})),
-		ValueSize:  uint32(unsafe.Sizeof(NodeValue{})),
-		MaxEntries: uint32(MaxEntries),
-		Flags:      unix.BPF_F_NO_PREALLOC,
-		Pinning:    ebpf.PinByName,
-	})}
-}
-
-func (m *Map) Update(ip net.IP, nodeID uint16) error {
+func (m *nodeMap) Update(ip net.IP, nodeID uint16) error {
 	key := newNodeKey(ip)
 	val := NodeValue{NodeID: nodeID}
-	return m.Map.Update(key, val, 0)
+	return m.bpfMap.Update(key, val, 0)
 }
 
-func (m *Map) Delete(ip net.IP) error {
+func (m *nodeMap) Delete(ip net.IP) error {
 	key := newNodeKey(ip)
-	return m.Map.Delete(key)
+	return m.bpfMap.Map.Delete(key)
 }
 
 // NodeIterateCallback represents the signature of the callback function
@@ -103,14 +103,40 @@ func (m *Map) Delete(ip net.IP) error {
 // all the keys/values of a node map.
 type NodeIterateCallback func(*NodeKey, *NodeValue)
 
-// IterateWithCallback iterates through all the keys/values of a node map,
-// passing each key/value pair to the cb callback.
-func (m Map) IterateWithCallback(cb NodeIterateCallback) error {
-	return m.Map.IterateWithCallback(&NodeKey{}, &NodeValue{},
+func (m *nodeMap) IterateWithCallback(cb NodeIterateCallback) error {
+	return m.bpfMap.IterateWithCallback(&NodeKey{}, &NodeValue{},
 		func(k, v interface{}) {
 			key := k.(*NodeKey)
 			value := v.(*NodeValue)
 
 			cb(key, value)
 		})
+}
+
+// LoadNodeMap loads the pre-initialized node map for access.
+// This should only be used from components which aren't capable of using hive - mainly the Cilium CLI.
+// It needs to initialized beforehand via the Cilium Agent.
+func LoadNodeMap() (Map, error) {
+	bpfMap, err := ebpf.LoadRegisterMap(MapName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load bpf map: %w", err)
+	}
+
+	return &nodeMap{bpfMap: bpfMap}, nil
+}
+
+func (m *nodeMap) init() error {
+	if err := m.bpfMap.OpenOrCreate(); err != nil {
+		return fmt.Errorf("failed to init bpf map: %w", err)
+	}
+
+	return nil
+}
+
+func (m *nodeMap) close() error {
+	if err := m.bpfMap.Close(); err != nil {
+		return fmt.Errorf("failed to close bpf map: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/maps/nodemap/node_map_privileged_test.go
+++ b/pkg/maps/nodemap/node_map_privileged_test.go
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nodemap
+
+import (
+	"net"
+	"testing"
+
+	. "github.com/cilium/checkmate"
+
+	"github.com/cilium/ebpf/rlimit"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+// Hook up gocheck into the "go test" runner.
+type NodeMapTestSuite struct{}
+
+var _ = Suite(&NodeMapTestSuite{})
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
+
+func (k *NodeMapTestSuite) SetUpSuite(c *C) {
+	testutils.PrivilegedTest(c)
+
+	bpf.CheckOrMountFS("")
+	err := rlimit.RemoveMemlock()
+	c.Assert(err, IsNil)
+}
+
+func (k *NodeMapTestSuite) TestNodeMap(c *C) {
+	nodeMap := newMap()
+	err := nodeMap.init()
+	c.Assert(err, IsNil)
+	defer nodeMap.bpfMap.Unpin()
+
+	bpfNodeIDMap := map[uint16]string{}
+	toMap := func(key *NodeKey, val *NodeValue) {
+		address := key.IP.String()
+		if key.Family == bpf.EndpointKeyIPv4 {
+			address = net.IP(key.IP[:net.IPv4len]).String()
+		}
+		bpfNodeIDMap[val.NodeID] = address
+	}
+
+	err = nodeMap.IterateWithCallback(toMap)
+	c.Assert(err, IsNil)
+	c.Assert(bpfNodeIDMap, HasLen, 0)
+
+	err = nodeMap.Update(net.ParseIP("10.1.0.0"), 10)
+	c.Assert(err, IsNil)
+	err = nodeMap.Update(net.ParseIP("10.1.0.1"), 20)
+	c.Assert(err, IsNil)
+
+	bpfNodeIDMap = map[uint16]string{}
+	err = nodeMap.IterateWithCallback(toMap)
+	c.Assert(err, IsNil)
+	c.Assert(bpfNodeIDMap, HasLen, 2)
+
+	err = nodeMap.Delete(net.ParseIP("10.1.0.0"))
+	c.Assert(err, IsNil)
+
+	bpfNodeIDMap = map[uint16]string{}
+	err = nodeMap.IterateWithCallback(toMap)
+	c.Assert(err, IsNil)
+	c.Assert(bpfNodeIDMap, HasLen, 1)
+}


### PR DESCRIPTION
This commit introduces a hive cell for the nodeid map.

The datapath cell has been refactored to depend on the nodeid map - which introduces explicit dependencies with a proper init order. 

This way, the map is properly initialized when accessing it for nodeid restoration. Currently this is only working due to the fact, that the map gets implicitly opened when iterating over its entries.

Follow up of https://github.com/cilium/cilium/pull/25497
