### PR TITLE
Controller clean up

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -130,7 +130,7 @@ func NoopFunc(ctx context.Context) error {
 //     owner dies. It is the responsibility of the owner to either lock the owner
 //     in a way that will delay destruction throughout the controller run or to
 //     check for the destruction throughout the run.
-type Controller struct {
+type controller struct {
 	// Constant after creation, safe to access without locking
 	name string
 	uuid string
@@ -155,7 +155,7 @@ type Controller struct {
 }
 
 // GetSuccessCount returns the number of successful controller runs
-func (c *Controller) GetSuccessCount() int {
+func (c *controller) GetSuccessCount() int {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
@@ -163,7 +163,7 @@ func (c *Controller) GetSuccessCount() int {
 }
 
 // GetFailureCount returns the number of failed controller runs
-func (c *Controller) GetFailureCount() int {
+func (c *controller) GetFailureCount() int {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
@@ -171,7 +171,7 @@ func (c *Controller) GetFailureCount() int {
 }
 
 // GetLastError returns the last error returned
-func (c *Controller) GetLastError() error {
+func (c *controller) GetLastError() error {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
@@ -179,14 +179,14 @@ func (c *Controller) GetLastError() error {
 }
 
 // GetLastErrorTimestamp returns the last error returned
-func (c *Controller) GetLastErrorTimestamp() time.Time {
+func (c *controller) GetLastErrorTimestamp() time.Time {
 	c.mutex.RLock()
 	defer c.mutex.RUnlock()
 
 	return c.lastErrorStamp
 }
 
-func (c *Controller) runController(params ControllerParams) {
+func (c *controller) runController(params ControllerParams) {
 	errorRetries := 1
 
 	runTimer, timerDone := inctimer.New()
@@ -303,7 +303,7 @@ shutdown:
 }
 
 // logger returns a logrus object with controllerName and UUID fields.
-func (c *Controller) getLogger() *logrus.Entry {
+func (c *controller) getLogger() *logrus.Entry {
 	return log.WithFields(logrus.Fields{
 		fieldControllerName: c.name,
 		fieldUUID:           c.uuid,
@@ -312,7 +312,7 @@ func (c *Controller) getLogger() *logrus.Entry {
 
 // recordError updates all statistic collection variables on error
 // c.mutex must be held.
-func (c *Controller) recordError(err error) {
+func (c *controller) recordError(err error) {
 	c.lastError = err
 	c.lastErrorStamp = time.Now()
 	c.failureCount++
@@ -323,7 +323,7 @@ func (c *Controller) recordError(err error) {
 
 // recordSuccess updates all statistic collection variables on success
 // c.mutex must be held.
-func (c *Controller) recordSuccess() {
+func (c *controller) recordSuccess() {
 	c.lastError = nil
 	c.lastSuccessStamp = time.Now()
 	c.successCount++

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -97,9 +97,9 @@ func (m *Manager) updateController(name string, params ControllerParams) *Contro
 		ctrl.getLogger().Debug("Starting new controller")
 
 		if params.Context == nil {
-			ctrl.ctxDoFunc, ctrl.cancelDoFunc = context.WithCancel(context.Background())
+			ctrl.params.Context, ctrl.cancelDoFunc = context.WithCancel(context.Background())
 		} else {
-			ctrl.ctxDoFunc, ctrl.cancelDoFunc = context.WithCancel(params.Context)
+			ctrl.params.Context, ctrl.cancelDoFunc = context.WithCancel(params.Context)
 		}
 		m.controllers[ctrl.name] = ctrl
 		m.mutex.Unlock()
@@ -266,7 +266,7 @@ func FakeManager(failingControllers int) *Manager {
 			consecutiveErrors: 1,
 		}
 
-		ctrl.ctxDoFunc, ctrl.cancelDoFunc = context.WithCancel(context.Background())
+		ctrl.params.Context, ctrl.cancelDoFunc = context.WithCancel(context.Background())
 		m.controllers[ctrl.name] = ctrl
 	}
 

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -158,18 +158,6 @@ func (m *Manager) RemoveControllerAndWait(name string) error {
 	return err
 }
 
-// TerminationChannel returns a channel that is closed after the controller has
-// been terminated
-func (m *Manager) TerminationChannel(name string) chan struct{} {
-	if c := m.lookup(name); c != nil {
-		return c.terminated
-	}
-
-	c := make(chan struct{})
-	close(c)
-	return c
-}
-
 func (m *Manager) removeAll() []*managedController {
 	ctrls := []*managedController{}
 

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -75,7 +75,7 @@ func (m *Manager) updateController(name string, params ControllerParams) *manage
 		ctrl.getLogger().Debug("Controller update time: ", time.Since(start))
 	} else {
 		ctrl = &managedController{
-			Controller: Controller{
+			controller: controller{
 				name:       name,
 				uuid:       uuid.New().String(),
 				stop:       make(chan struct{}),
@@ -225,6 +225,7 @@ func (m *Manager) TriggerController(name string) {
 // FakeManager returns a fake controller manager with the specified number of
 // failing controllers. The returned manager is identical in any regard except
 // for internal pointers.
+// Used for testing only.
 func FakeManager(failingControllers int) *Manager {
 	m := &Manager{
 		controllers: controllerMap{},
@@ -232,7 +233,7 @@ func FakeManager(failingControllers int) *Manager {
 
 	for i := 0; i < failingControllers; i++ {
 		ctrl := &managedController{
-			Controller: Controller{
+			controller: controller{
 				name:              fmt.Sprintf("controller-%d", i),
 				uuid:              fmt.Sprintf("%d", i),
 				stop:              make(chan struct{}),
@@ -253,7 +254,7 @@ func FakeManager(failingControllers int) *Manager {
 }
 
 type managedController struct {
-	Controller
+	controller
 
 	params       ControllerParams
 	cancelDoFunc context.CancelFunc

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -19,7 +21,7 @@ var (
 	globalStatus = NewManager()
 )
 
-type controllerMap map[string]*Controller
+type controllerMap map[string]*managedController
 
 // Manager is a list of controllers
 type Manager struct {
@@ -49,18 +51,8 @@ func (m *Manager) UpdateController(name string, params ControllerParams) {
 	m.updateController(name, params)
 }
 
-func (m *Manager) updateController(name string, params ControllerParams) *Controller {
+func (m *Manager) updateController(name string, params ControllerParams) *managedController {
 	start := time.Now()
-
-	// ensure the callbacks are valid
-	if params.DoFunc == nil {
-		params.DoFunc = func(ctx context.Context) error {
-			return undefinedDoFunc(name)
-		}
-	}
-	if params.StopFunc == nil {
-		params.StopFunc = NoopFunc
-	}
 
 	m.mutex.Lock()
 
@@ -82,22 +74,19 @@ func (m *Manager) updateController(name string, params ControllerParams) *Contro
 
 		ctrl.getLogger().Debug("Controller update time: ", time.Since(start))
 	} else {
-		ctrl = &Controller{
-			name:       name,
-			uuid:       uuid.New().String(),
-			stop:       make(chan struct{}),
-			update:     make(chan ControllerParams, 1),
-			trigger:    make(chan struct{}, 1),
-			terminated: make(chan struct{}),
+		ctrl = &managedController{
+			Controller: Controller{
+				name:       name,
+				uuid:       uuid.New().String(),
+				stop:       make(chan struct{}),
+				update:     make(chan ControllerParams, 1),
+				trigger:    make(chan struct{}, 1),
+				terminated: make(chan struct{}),
+			},
 		}
 		ctrl.updateParamsLocked(params)
 		ctrl.getLogger().Debug("Starting new controller")
 
-		if params.Context == nil {
-			ctrl.params.Context, ctrl.cancelDoFunc = context.WithCancel(context.Background())
-		} else {
-			ctrl.params.Context, ctrl.cancelDoFunc = context.WithCancel(params.Context)
-		}
 		m.controllers[ctrl.name] = ctrl
 		m.mutex.Unlock()
 
@@ -111,7 +100,7 @@ func (m *Manager) updateController(name string, params ControllerParams) *Contro
 	return ctrl
 }
 
-func (m *Manager) removeController(ctrl *Controller) {
+func (m *Manager) removeController(ctrl *managedController) {
 	ctrl.stopController()
 	delete(m.controllers, ctrl.name)
 
@@ -122,7 +111,7 @@ func (m *Manager) removeController(ctrl *Controller) {
 	ctrl.getLogger().Debug("Removed controller")
 }
 
-func (m *Manager) lookup(name string) *Controller {
+func (m *Manager) lookup(name string) *managedController {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
 
@@ -133,7 +122,7 @@ func (m *Manager) lookup(name string) *Controller {
 	return nil
 }
 
-func (m *Manager) removeAndReturnController(name string) (*Controller, error) {
+func (m *Manager) removeAndReturnController(name string) (*managedController, error) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
@@ -181,8 +170,8 @@ func (m *Manager) TerminationChannel(name string) chan struct{} {
 	return c
 }
 
-func (m *Manager) removeAll() []*Controller {
-	ctrls := []*Controller{}
+func (m *Manager) removeAll() []*managedController {
+	ctrls := []*managedController{}
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
@@ -234,12 +223,15 @@ func (m *Manager) GetStatusModel() models.ControllerStatuses {
 
 // TriggerController triggers the controller with the specified name.
 func (m *Manager) TriggerController(name string) {
-	controller := m.lookup(name)
-	if controller == nil {
+	ctrl := m.lookup(name)
+	if ctrl == nil {
 		return
 	}
 
-	controller.Trigger()
+	select {
+	case ctrl.trigger <- struct{}{}:
+	default:
+	}
 }
 
 // FakeManager returns a fake controller manager with the specified number of
@@ -251,16 +243,18 @@ func FakeManager(failingControllers int) *Manager {
 	}
 
 	for i := 0; i < failingControllers; i++ {
-		ctrl := &Controller{
-			name:              fmt.Sprintf("controller-%d", i),
-			uuid:              fmt.Sprintf("%d", i),
-			stop:              make(chan struct{}),
-			update:            make(chan ControllerParams, 1),
-			trigger:           make(chan struct{}, 1),
-			terminated:        make(chan struct{}),
-			lastError:         fmt.Errorf("controller failed"),
-			failureCount:      1,
-			consecutiveErrors: 1,
+		ctrl := &managedController{
+			Controller: Controller{
+				name:              fmt.Sprintf("controller-%d", i),
+				uuid:              fmt.Sprintf("%d", i),
+				stop:              make(chan struct{}),
+				update:            make(chan ControllerParams, 1),
+				trigger:           make(chan struct{}, 1),
+				terminated:        make(chan struct{}),
+				lastError:         fmt.Errorf("controller failed"),
+				failureCount:      1,
+				consecutiveErrors: 1,
+			},
 		}
 
 		ctrl.params.Context, ctrl.cancelDoFunc = context.WithCancel(context.Background())
@@ -268,4 +262,93 @@ func FakeManager(failingControllers int) *Manager {
 	}
 
 	return m
+}
+
+type managedController struct {
+	Controller
+
+	params       ControllerParams
+	cancelDoFunc context.CancelFunc
+}
+
+// updateParamsLocked sanitizes and sets the controller's parameters.
+//
+// If the RunInterval exceeds ControllerMaxInterval, it will be capped.
+//
+// Manager's mutex must be held
+func (c *managedController) updateParamsLocked(params ControllerParams) {
+	// ensure the callbacks are valid
+	if params.DoFunc == nil {
+		params.DoFunc = func(ctx context.Context) error {
+			return undefinedDoFunc(c.name)
+		}
+	}
+	if params.StopFunc == nil {
+		params.StopFunc = NoopFunc
+	}
+
+	// Enforce max controller interval
+	maxInterval := time.Duration(option.Config.MaxControllerInterval) * time.Second
+	if maxInterval > 0 && params.RunInterval > maxInterval {
+		c.getLogger().Infof("Limiting interval to %s", maxInterval)
+		params.RunInterval = maxInterval
+	}
+
+	// Save current context on update if not canceling
+	ctx := c.params.Context
+	// Check if the current context needs to be cancelled
+	if c.params.CancelDoFuncOnUpdate && c.cancelDoFunc != nil {
+		c.cancelDoFunc()
+		c.params.Context = nil
+	}
+
+	// (re)set the context as the previous might have been cancelled
+	if c.params.Context == nil {
+		if params.Context == nil {
+			ctx, c.cancelDoFunc = context.WithCancel(context.Background())
+		} else {
+			ctx, c.cancelDoFunc = context.WithCancel(params.Context)
+		}
+	}
+
+	c.params = params
+	c.params.Context = ctx
+}
+
+func (c *managedController) stopController() {
+	if c.cancelDoFunc != nil {
+		c.cancelDoFunc()
+	}
+
+	close(c.stop)
+}
+
+// GetStatusModel returns a models.ControllerStatus representing the
+// controller's configuration & status
+func (c *managedController) GetStatusModel() *models.ControllerStatus {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+
+	status := &models.ControllerStatus{
+		Name: c.name,
+		UUID: strfmt.UUID(c.uuid),
+		Configuration: &models.ControllerStatusConfiguration{
+			ErrorRetry:     !c.params.NoErrorRetry,
+			ErrorRetryBase: strfmt.Duration(c.params.ErrorRetryBaseDuration),
+			Interval:       strfmt.Duration(c.params.RunInterval),
+		},
+		Status: &models.ControllerStatusStatus{
+			SuccessCount:            int64(c.successCount),
+			LastSuccessTimestamp:    strfmt.DateTime(c.lastSuccessStamp),
+			FailureCount:            int64(c.failureCount),
+			LastFailureTimestamp:    strfmt.DateTime(c.lastErrorStamp),
+			ConsecutiveFailureCount: int64(c.consecutiveErrors),
+		},
+	}
+
+	if c.lastError != nil {
+		status.Status.LastFailureMsg = c.lastError.Error()
+	}
+
+	return status
 }


### PR DESCRIPTION
Clean up internals of `pkg/controller` by:
- Simplify by using an infinite interval
- Organize fields by access type
- Use params.Context
- Pass parameter updates in the update channel
- Introduce 'managedController' to simplify field access contract
- Move TerminationChannel to test
- Un-export Controller type