### PR TITLE
[WIP] policy: allocate identity for CIDR selectors on first use

### DIFF
--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -122,6 +122,7 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 		CacheStatus:       params.CacheStatus,
 	})
 	idAlloc.ipcache = ipc
+	iao.policy.GetSelectorCache().SetIPCache(ipc)
 
 	params.Lifecycle.Append(hive.Hook{
 		OnStart: func(hc hive.HookContext) error {
@@ -375,10 +376,11 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 		epsToBumpRevision: endpointsToBumpRevision,
 		endpointsToRegen:  endpointsToRegen,
 		newRev:            newRev,
-		upsertPrefixes:    prefixes,
-		releasePrefixes:   removedPrefixes,
-		source:            opts.Source,
-		resource:          opts.Resource,
+		// XXX: these are commented out for debugging
+		//upsertPrefixes:    prefixes,
+		//releasePrefixes:   removedPrefixes,
+		source:   opts.Source,
+		resource: opts.Resource,
 	}
 
 	ev := eventqueue.NewEvent(r)
@@ -438,7 +440,7 @@ func (r *PolicyReactionEvent) reactToRuleUpdates(epsToBumpRevision, epsToRegen *
 	//   this operation completes regardless of whether the BPF ipcache or
 	//   policymap gets updated first, so the ordering is not consequential.
 	if len(releasePrefixes) != 0 {
-		r.d.ipcache.RemovePrefixes(releasePrefixes, r.source, r.resource)
+		//r.d.ipcache.RemovePrefixes(releasePrefixes, r.source, r.resource)
 	}
 
 	// Bump revision of endpoints which don't need to be regenerated.
@@ -482,7 +484,7 @@ func (r *PolicyReactionEvent) reactToRuleUpdates(epsToBumpRevision, epsToRegen *
 	// SelectorCache / Endpoints to do an incremental identity update to
 	// the datapath maps (if necessary).
 	if len(upsertPrefixes) != 0 {
-		r.d.ipcache.UpsertPrefixes(upsertPrefixes, r.source, r.resource)
+		//r.d.ipcache.UpsertPrefixes(upsertPrefixes, r.source, r.resource)
 	}
 }
 

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -187,3 +187,20 @@ func addrsToCIDRRules(addrs []netip.Addr) []CIDRRule {
 // A CIDR Group is a list of CIDRs whose IP addresses should be considered as a
 // same entity when applying fromCIDRGroupRefs policies on incoming network traffic.
 type CIDRGroupRef string
+
+func CIDRSFromSelector(n EndpointSelector) []netip.Prefix {
+	labels := n.GetKeysWithPrefix(labels.LabelSourceCIDR)
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]netip.Prefix, 0, len(labels))
+	for _, label := range labels {
+		// label has "cidr:" prefix
+		pfx, err := netip.ParsePrefix(label[5:])
+		if err != nil { // skip invalid prefixes
+			continue
+		}
+		out = append(out, pfx)
+	}
+	return out
+}

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -126,6 +126,22 @@ func (n EndpointSelector) HasKeyPrefix(prefix string) bool {
 	return false
 }
 
+func (n EndpointSelector) GetKeysWithPrefix(prefix string) []string {
+	var out []string
+	for k := range n.MatchLabels {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, k)
+		}
+	}
+	for _, v := range n.MatchExpressions {
+		if strings.HasPrefix(v.Key, prefix) {
+			out = append(out, v.Key)
+		}
+	}
+
+	return out
+}
+
 // HasKey checks if the endpoint selector contains the given key in
 // its MatchLabels map or in its MatchExpressions slice.
 func (n EndpointSelector) HasKey(key string) bool {


### PR DESCRIPTION
This moves allocation of local identities for CIDRs from policy ingestion to selector parsing.

See individual commits for more detailed commentary.

### TODO:
- [ ] Get soft consensus that this is a good approach
- [ ] Fix existing unit tests
- [ ] Write more tests