### PR TITLE
daemon: Separate endpoint API handlers from daemon and add tests

### DIFF
--- a/api/v1/server.gotmpl
+++ b/api/v1/server.gotmpl
@@ -13,6 +13,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"strconv"
 	"sync"
@@ -40,10 +41,14 @@ var Cell = cell.Module(
 	"{{ dasherize .Name }}-server",
 	"{{ humanize .Name }} server",
 
-	cell.Provide(newForCell),
+	cell.Provide(
+		apiObject,
+		realServer,
+		testServer,
+	),
 )
 
-type serverParams struct {
+type apiParams struct {
 	cell.In
 
 	Lifecycle  hive.Lifecycle
@@ -53,12 +58,13 @@ type serverParams struct {
 
 	{{- $package := .Package }}
 	{{ range .Operations }}
-		{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler {{ .PackageAlias }}.{{ pascalize .Name }}Handler
+		{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler {{ .PackageAlias }}.{{ pascalize .Name }}Handler `optional:"true"`
 	{{- end }}
 }
 
-func newForCell(p serverParams) (*Server, error) {
-	api := {{ .Package }}.New{{pascalize .Name}}API(p.Spec.Document)
+func apiObject(p apiParams) (*{{ .Package }}.{{ pascalize .Name}}API, error) {
+	// Construct the API from the provided handlers
+	api := {{ .Package }}.New{{ pascalize .Name}}API(p.Spec.Document)
 
 	// Construct the API from the provided handlers
 	{{- $package := .Package }}
@@ -66,14 +72,31 @@ func newForCell(p serverParams) (*Server, error) {
 	  api.{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler = p.{{ if ne  .Package $package }}{{ pascalize .Package }}{{ end }}{{ pascalize .Name }}Handler
 	{{- end }}
 
-	s := NewServer(api)
+	return api, nil
+}
+
+type serverParams struct {
+	cell.In
+
+	Lifecycle  hive.Lifecycle
+	Shutdowner hive.Shutdowner
+	Logger     logrus.FieldLogger
+	API        *{{ .Package }}.{{ pascalize .Name }}API
+}
+
+func realServer(p serverParams) (*Server, error) {
+	s := NewServer(p.API)
 	s.shutdowner = p.Shutdowner
 	s.logger = p.Logger
 	p.Lifecycle.Append(s)
-
 	return s, nil
 }
 
+type TestServer *httptest.Server
+
+func testServer(p serverParams) TestServer {
+	return httptest.NewServer(p.API.Serve(nil))
+}
 
 const (
 	schemeHTTP  = "http"
@@ -137,11 +160,11 @@ func (cfg ServerConfig) Flags(flags *pflag.FlagSet) {
 }
 
 var SpecCell = cell.Module(
-	"{{ dasherize .Name }}-spec",
-	"{{ humanize .Name }} Specification",
+       "{{ dasherize .Name }}-spec",
+       "{{ humanize .Name }} Specification",
 
-	cell.Config(defaultServerConfig),
-	cell.Provide(newSpec),
+       cell.Config(defaultServerConfig),
+       cell.Provide(newSpec),
 )
 
 type Spec struct {

--- a/daemon/cmd/api_handlers.go
+++ b/daemon/cmd/api_handlers.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cilium/cilium/api/v1/server/restapi/bgp"
 	"github.com/cilium/cilium/api/v1/server/restapi/daemon"
-	"github.com/cilium/cilium/api/v1/server/restapi/endpoint"
 	"github.com/cilium/cilium/api/v1/server/restapi/ipam"
 	"github.com/cilium/cilium/api/v1/server/restapi/metrics"
 	"github.com/cilium/cilium/api/v1/server/restapi/policy"
@@ -39,18 +38,6 @@ type handlersOut struct {
 	DaemonGetMapNameHandler            daemon.GetMapNameHandler
 	DaemonGetNodeIdsHandler            daemon.GetNodeIdsHandler
 	DaemonPatchConfigHandler           daemon.PatchConfigHandler
-
-	EndpointDeleteEndpointIDHandler      endpoint.DeleteEndpointIDHandler
-	EndpointGetEndpointHandler           endpoint.GetEndpointHandler
-	EndpointGetEndpointIDConfigHandler   endpoint.GetEndpointIDConfigHandler
-	EndpointGetEndpointIDHandler         endpoint.GetEndpointIDHandler
-	EndpointGetEndpointIDHealthzHandler  endpoint.GetEndpointIDHealthzHandler
-	EndpointGetEndpointIDLabelsHandler   endpoint.GetEndpointIDLabelsHandler
-	EndpointGetEndpointIDLogHandler      endpoint.GetEndpointIDLogHandler
-	EndpointPatchEndpointIDConfigHandler endpoint.PatchEndpointIDConfigHandler
-	EndpointPatchEndpointIDHandler       endpoint.PatchEndpointIDHandler
-	EndpointPatchEndpointIDLabelsHandler endpoint.PatchEndpointIDLabelsHandler
-	EndpointPutEndpointIDHandler         endpoint.PutEndpointIDHandler
 
 	IpamDeleteIpamIPHandler ipam.DeleteIpamIPHandler
 	IpamPostIpamHandler     ipam.PostIpamHandler
@@ -139,29 +126,6 @@ func ciliumAPIHandlers(dp promise.Promise[*Daemon], cfg *option.DaemonConfig, _ 
 	out.DaemonPatchConfigHandler = wrapAPIHandler(dp, patchConfigHandler)
 
 	if cfg.DatapathMode != datapathOption.DatapathModeLBOnly {
-		// /endpoint/
-		out.EndpointGetEndpointHandler = wrapAPIHandler(dp, getEndpointHandler)
-
-		// /endpoint/{id}
-		out.EndpointGetEndpointIDHandler = wrapAPIHandler(dp, getEndpointIDHandler)
-		out.EndpointPutEndpointIDHandler = wrapAPIHandler(dp, putEndpointIDHandler)
-		out.EndpointPatchEndpointIDHandler = wrapAPIHandler(dp, patchEndpointIDHandler)
-		out.EndpointDeleteEndpointIDHandler = wrapAPIHandler(dp, deleteEndpointIDHandler)
-
-		// /endpoint/{id}config/
-		out.EndpointGetEndpointIDConfigHandler = wrapAPIHandler(dp, getEndpointIDConfigHandler)
-		out.EndpointPatchEndpointIDConfigHandler = wrapAPIHandler(dp, patchEndpointIDConfigHandler)
-
-		// /endpoint/{id}/labels/
-		out.EndpointGetEndpointIDLabelsHandler = wrapAPIHandler(dp, getEndpointIDLabelsHandler)
-		out.EndpointPatchEndpointIDLabelsHandler = wrapAPIHandler(dp, putEndpointIDLabelsHandler)
-
-		// /endpoint/{id}/log/
-		out.EndpointGetEndpointIDLogHandler = wrapAPIHandler(dp, getEndpointIDLogHandler)
-
-		// /endpoint/{id}/healthz
-		out.EndpointGetEndpointIDHealthzHandler = wrapAPIHandler(dp, getEndpointIDHealthzHandler)
-
 		// /identity/
 		out.PolicyGetIdentityHandler = wrapAPIHandler(dp, getIdentityHandler)
 		out.PolicyGetIdentityIDHandler = wrapAPIHandler(dp, getIdentityIDHandler)

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -34,6 +34,7 @@ import (
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pprof"
+	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/signal"
 	"github.com/cilium/cilium/pkg/statedb"
@@ -141,6 +142,11 @@ var (
 
 		// Cilium REST API handlers
 		restapi.Cell,
+
+		// Provide the endpoint API handlers the ability to create endpoints via the daemon.
+		cell.Provide(func(dp promise.Promise[*Daemon]) promise.Promise[restapi.EndpointModifier] {
+			return promise.Map(dp, func(d *Daemon) restapi.EndpointModifier { return d })
+		}),
 
 		// The BGP Control Plane which enables various BGP related interop.
 		bgpv1.Cell,

--- a/daemon/cmd/debuginfo.go
+++ b/daemon/cmd/debuginfo.go
@@ -11,15 +11,15 @@ import (
 	"github.com/spf13/cast"
 
 	"github.com/cilium/cilium/api/v1/models"
-	restapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
-	"github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	daemonapi "github.com/cilium/cilium/api/v1/server/restapi/daemon"
+	"github.com/cilium/cilium/daemon/restapi"
 	"github.com/cilium/cilium/pkg/debug"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/version"
 )
 
-func getDebugInfoHandler(d *Daemon, params restapi.GetDebuginfoParams) middleware.Responder {
+func getDebugInfoHandler(d *Daemon, params daemonapi.GetDebuginfoParams) middleware.Responder {
 	dr := models.DebugInfo{}
 
 	dr.CiliumVersion = version.Version
@@ -32,9 +32,7 @@ func getDebugInfoHandler(d *Daemon, params restapi.GetDebuginfoParams) middlewar
 	status := d.getStatus(false)
 	dr.CiliumStatus = &status
 
-	var p endpoint.GetEndpointParams
-
-	dr.EndpointList = d.getEndpointList(p)
+	dr.EndpointList = restapi.GetEndpointList(d.endpointManager, nil)
 	dr.Policy = d.policy.GetRulesList()
 	dr.Subsystem = debug.CollectSubsystemStatus()
 	dr.CiliumMemoryMap = memoryMap(os.Getpid())
@@ -53,7 +51,7 @@ func getDebugInfoHandler(d *Daemon, params restapi.GetDebuginfoParams) middlewar
 		}
 	}
 
-	return restapi.NewGetDebuginfoOK().WithPayload(&dr)
+	return daemonapi.NewGetDebuginfoOK().WithPayload(&dr)
 }
 
 func memoryMap(pid int) string {

--- a/daemon/restapi/cell.go
+++ b/daemon/restapi/cell.go
@@ -10,4 +10,8 @@ var Cell = cell.Module(
 	"Cilium Agent API handlers",
 
 	rateLimiterCell, // Request rate-limiting
+
+	cell.Provide(
+		newEndpointHandlers,
+	),
 )

--- a/daemon/restapi/cell.go
+++ b/daemon/restapi/cell.go
@@ -3,7 +3,9 @@
 
 package restapi
 
-import "github.com/cilium/cilium/pkg/hive/cell"
+import (
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
 
 var Cell = cell.Module(
 	"cilium-restapi",
@@ -11,7 +13,5 @@ var Cell = cell.Module(
 
 	rateLimiterCell, // Request rate-limiting
 
-	cell.Provide(
-		newEndpointHandlers,
-	),
+	endpointHandlersCell,
 )

--- a/daemon/restapi/endpoint.go
+++ b/daemon/restapi/endpoint.go
@@ -1,0 +1,503 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package restapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime"
+	"sync"
+
+	"github.com/go-openapi/runtime/middleware"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/api/v1/models"
+	endpointapi "github.com/cilium/cilium/api/v1/server/restapi/endpoint"
+	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/rate"
+)
+
+var errEndpointNotFound = errors.New("endpoint not found")
+
+// endpointGetHandlerParams are the common set of parameters shared
+// by the endpoint GET handlers.
+type endpointGetHandlerParams struct {
+	cell.In
+
+	Log       logrus.FieldLogger
+	Endpoints endpointmanager.EndpointsLookup
+	RateLimit *rate.APILimiterSet
+}
+
+// endpointModifyHandlerParams are the common set of parameters shared
+// by the endpoint POST/PATCH/PUT handlers.
+type endpointModifyHandlerParams struct {
+	cell.In
+
+	Log             logrus.FieldLogger
+	EndpointManager endpointmanager.EndpointManager
+	RateLimit       *rate.APILimiterSet
+
+	EndpointModifierPromise promise.Promise[EndpointModifier]
+}
+
+// EndpointModifier is implemented by the daemon to create or modify an endpoint.
+// These operations still have many dependencies to daemon-owned components so
+// the code cannot yet easily be migrated here.
+type EndpointModifier interface {
+	CreateEndpoint(ctx context.Context, epTemplate *models.EndpointChangeRequest) (int, error)
+	PatchEndpoint(ctx context.Context, ID string, epTemplate *models.EndpointChangeRequest) (int, error)
+	DeleteEndpoint(id string) (int, error)
+}
+
+type endpointHandlersOut struct {
+	cell.Out
+
+	GetEndpointHandler          endpointapi.GetEndpointHandler          // GET /endpoint (with labels)
+	GetEndpointIDHandler        endpointapi.GetEndpointIDHandler        // GET /endpoint/{id}
+	GetEndpointIDConfigHandler  endpointapi.GetEndpointIDConfigHandler  // GET /endpoint/{id}/config
+	GetEndpointIDLabelsHandler  endpointapi.GetEndpointIDLabelsHandler  // GET /endpoint/{id}/labels
+	GetEndpointIDLogHandler     endpointapi.GetEndpointIDLogHandler     // GET /endpoint/{id}/log
+	GetEndpointIDHealthzHandler endpointapi.GetEndpointIDHealthzHandler // GET /endpoint/{id}/healthz
+
+	DeleteEndpointIDHandler      endpointapi.DeleteEndpointIDHandler      // DELETE /endpoint/{id}
+	PutEndpointIDHandler         endpointapi.PutEndpointIDHandler         // PUT /endpoint/{id}
+	PatchEndpointIDHandler       endpointapi.PatchEndpointIDHandler       // PATCH /endpoint/{id}
+	PatchEndpointIDLabelsHandler endpointapi.PatchEndpointIDLabelsHandler // PATCH /endpoint/{id}/labels
+	PatchEndpointIDConfigHandler endpointapi.PatchEndpointIDConfigHandler // PATCH /endpoint/{id}/config
+}
+
+// Since all the handlers share the same set of parameters and hold
+// no state, we can just new type around the input parameters to
+// implement Handle() for each of them.
+type (
+	getEndpointHandler          endpointGetHandlerParams
+	getEndpointIDHandler        endpointGetHandlerParams
+	getEndpointIDConfigHandler  endpointGetHandlerParams
+	getEndpointIDLabelsHandler  endpointGetHandlerParams
+	getEndpointIDLogHandler     endpointGetHandlerParams
+	getEndpointIDHealthzHandler endpointGetHandlerParams
+
+	deleteEndpointHandler        endpointModifyHandlerParams
+	putEndpointIDHandler         endpointModifyHandlerParams
+	patchEndpointIDHandler       endpointModifyHandlerParams
+	patchEndpointIDLabelsHandler endpointModifyHandlerParams
+	patchEndpointIDConfigHandler endpointModifyHandlerParams
+)
+
+func newEndpointHandlers(getP endpointGetHandlerParams, postP endpointModifyHandlerParams) endpointHandlersOut {
+	return endpointHandlersOut{
+		GetEndpointHandler:          getEndpointHandler(getP),
+		GetEndpointIDHandler:        getEndpointIDHandler(getP),
+		GetEndpointIDConfigHandler:  getEndpointIDConfigHandler(getP),
+		GetEndpointIDLabelsHandler:  getEndpointIDLabelsHandler(getP),
+		GetEndpointIDLogHandler:     getEndpointIDLogHandler(getP),
+		GetEndpointIDHealthzHandler: getEndpointIDHealthzHandler(getP),
+
+		DeleteEndpointIDHandler:      deleteEndpointHandler(postP),
+		PutEndpointIDHandler:         putEndpointIDHandler(postP),
+		PatchEndpointIDHandler:       patchEndpointIDHandler(postP),
+		PatchEndpointIDLabelsHandler: patchEndpointIDLabelsHandler(postP),
+		PatchEndpointIDConfigHandler: patchEndpointIDConfigHandler(postP),
+	}
+}
+
+func (h getEndpointHandler) Handle(params endpointapi.GetEndpointParams) middleware.Responder {
+	h.Log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint request")
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointList)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	resEPs := GetEndpointList(h.Endpoints, params.Labels)
+
+	if params.Labels != nil && len(resEPs) == 0 {
+		r.Error(errEndpointNotFound)
+		return endpointapi.NewGetEndpointNotFound()
+	}
+
+	return endpointapi.NewGetEndpointOK().WithPayload(resEPs)
+}
+
+// GetEndpointList retrieves endpoints matching the given (optional) label set. Returns
+// endpoint as REST API models.
+// Exported for use in cmd.getDebugInfoHandler. Unexport once debuginfo handler moves here.
+func GetEndpointList(endpoints endpointmanager.EndpointsLookup, modelLabels models.Labels) []*models.Endpoint {
+	maxGoroutines := runtime.NumCPU()
+	var (
+		epWorkersWg, epsAppendWg sync.WaitGroup
+		convertedLabels          labels.Labels
+		resEPs                   []*models.Endpoint
+	)
+
+	if modelLabels != nil {
+		// Convert params.Labels to model that we can compare with the endpoint's labels.
+		convertedLabels = labels.NewLabelsFromModel(modelLabels)
+	}
+
+	eps := endpoints.GetEndpoints()
+	if len(eps) < maxGoroutines {
+		maxGoroutines = len(eps)
+	}
+	epsCh := make(chan *endpoint.Endpoint, maxGoroutines)
+	epModelsCh := make(chan *models.Endpoint, maxGoroutines)
+
+	epWorkersWg.Add(maxGoroutines)
+	for i := 0; i < maxGoroutines; i++ {
+		// Run goroutines to process each endpoint and the corresponding model.
+		// The obtained endpoint model is sent to the endpoint models channel from
+		// where it will be aggregated later.
+		go func(wg *sync.WaitGroup, epModelsChan chan<- *models.Endpoint, epsChan <-chan *endpoint.Endpoint) {
+			for ep := range epsChan {
+				if ep.HasLabels(convertedLabels) {
+					epModelsChan <- ep.GetModel()
+				}
+			}
+			wg.Done()
+		}(&epWorkersWg, epModelsCh, epsCh)
+	}
+
+	// Send the endpoints to be aggregated a models to the endpoint channel.
+	go func(epsChan chan<- *endpoint.Endpoint, eps []*endpoint.Endpoint) {
+		for _, ep := range eps {
+			epsChan <- ep
+		}
+		close(epsChan)
+	}(epsCh, eps)
+
+	epsAppendWg.Add(1)
+	// This needs to be done over channels since we might not receive all
+	// the existing endpoints since not all endpoints contain the list of
+	// labels that we will use to filter in `ep.HasLabels(convertedLabels)`
+	go func(epsAppended *sync.WaitGroup) {
+		for ep := range epModelsCh {
+			resEPs = append(resEPs, ep)
+		}
+		epsAppended.Done()
+	}(&epsAppendWg)
+
+	epWorkersWg.Wait()
+	close(epModelsCh)
+	epsAppendWg.Wait()
+
+	return resEPs
+}
+
+func (h getEndpointIDHandler) Handle(params endpointapi.GetEndpointIDParams) middleware.Responder {
+	h.Log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id} request")
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointGet)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	ep, err := h.Endpoints.Lookup(params.ID)
+
+	if err != nil {
+		r.Error(err)
+		return api.Error(endpointapi.GetEndpointIDInvalidCode, err)
+	} else if ep == nil {
+		r.Error(errEndpointNotFound)
+		return endpointapi.NewGetEndpointIDNotFound()
+	} else {
+		return endpointapi.NewGetEndpointIDOK().WithPayload(ep.GetModel())
+	}
+}
+
+func (h getEndpointIDConfigHandler) Handle(params endpointapi.GetEndpointIDConfigParams) middleware.Responder {
+	h.Log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/config")
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointGet)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	ep, err := h.Endpoints.Lookup(params.ID)
+	if err != nil {
+		r.Error(err)
+		return api.Error(endpointapi.GetEndpointIDInvalidCode, err)
+	} else if ep == nil {
+		r.Error(errEndpointNotFound)
+		return endpointapi.NewGetEndpointIDConfigNotFound()
+	} else {
+		cfgStatus := ep.GetConfigurationStatus()
+
+		return endpointapi.NewGetEndpointIDConfigOK().WithPayload(cfgStatus)
+	}
+}
+
+func (h getEndpointIDLabelsHandler) Handle(params endpointapi.GetEndpointIDLabelsParams) middleware.Responder {
+	h.Log.WithField(logfields.Params, logfields.Repr(params)).Debug("GET /endpoint/{id}/labels")
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointGet)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	ep, err := h.Endpoints.Lookup(params.ID)
+	if err != nil {
+		r.Error(err)
+		return api.Error(endpointapi.GetEndpointIDInvalidCode, err)
+	}
+	if ep == nil {
+		r.Error(errEndpointNotFound)
+		return endpointapi.NewGetEndpointIDLabelsNotFound()
+	}
+
+	cfg, err := ep.GetLabelsModel()
+	if err != nil {
+		r.Error(err)
+		return api.Error(endpointapi.GetEndpointIDInvalidCode, err)
+	}
+
+	return endpointapi.NewGetEndpointIDLabelsOK().WithPayload(cfg)
+}
+
+func (h getEndpointIDLogHandler) Handle(params endpointapi.GetEndpointIDLogParams) middleware.Responder {
+	h.Log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id}/log request")
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointGet)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	ep, err := h.Endpoints.Lookup(params.ID)
+
+	if err != nil {
+		r.Error(err)
+		return api.Error(endpointapi.GetEndpointIDLogInvalidCode, err)
+	} else if ep == nil {
+		r.Error(errEndpointNotFound)
+		return endpointapi.NewGetEndpointIDLogNotFound()
+	} else {
+		return endpointapi.NewGetEndpointIDLogOK().WithPayload(ep.GetStatusModel())
+	}
+}
+
+func (h getEndpointIDHealthzHandler) Handle(params endpointapi.GetEndpointIDHealthzParams) middleware.Responder {
+	h.Log.WithField(logfields.EndpointID, params.ID).Debug("GET /endpoint/{id}/log request")
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointGet)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	ep, err := h.Endpoints.Lookup(params.ID)
+
+	if err != nil {
+		r.Error(err)
+		return api.Error(endpointapi.GetEndpointIDHealthzInvalidCode, err)
+	} else if ep == nil {
+		r.Error(errEndpointNotFound)
+		return endpointapi.NewGetEndpointIDHealthzNotFound()
+	} else {
+		return endpointapi.NewGetEndpointIDHealthzOK().WithPayload(ep.GetHealthModel())
+	}
+}
+
+func (h deleteEndpointHandler) Handle(params endpointapi.DeleteEndpointIDParams) middleware.Responder {
+	h.Log.WithField(logfields.Params, logfields.Repr(params)).Debug("DELETE /endpoint/{id} request")
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointDelete)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	creator, err := h.EndpointModifierPromise.Await(params.HTTPRequest.Context())
+	if err != nil {
+		return api.Error(http.StatusServiceUnavailable, err)
+	}
+
+	nerr, err := creator.DeleteEndpoint(params.ID)
+	if err != nil {
+		r.Error(err)
+		if apierr, ok := err.(*api.APIError); ok {
+			return apierr
+		}
+		return api.Error(endpointapi.DeleteEndpointIDErrorsCode, err)
+	} else if nerr > 0 {
+		return endpointapi.NewDeleteEndpointIDErrors().WithPayload(int64(nerr))
+	} else {
+
+		return endpointapi.NewDeleteEndpointIDOK()
+	}
+}
+
+func (h putEndpointIDHandler) Handle(params endpointapi.PutEndpointIDParams) (resp middleware.Responder) {
+	epTemplate := params.Endpoint
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointCreate)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	creator, err := h.EndpointModifierPromise.Await(params.HTTPRequest.Context())
+	if err != nil {
+		return api.Error(http.StatusServiceUnavailable, err)
+	}
+
+	code, err := creator.CreateEndpoint(params.HTTPRequest.Context(), epTemplate)
+	if err != nil {
+		r.Error(err)
+		return api.Error(code, err)
+	}
+
+	return endpointapi.NewPutEndpointIDCreated()
+}
+
+func (h patchEndpointIDHandler) Handle(params endpointapi.PatchEndpointIDParams) middleware.Responder {
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointPatch)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	epTemplate := params.Endpoint
+
+	creator, err := h.EndpointModifierPromise.Await(params.HTTPRequest.Context())
+	if err != nil {
+		return api.Error(http.StatusServiceUnavailable, err)
+	}
+
+	code, err := creator.PatchEndpoint(params.HTTPRequest.Context(), params.ID, epTemplate)
+	if err != nil {
+		r.Error(err)
+		return api.Error(code, err)
+	}
+
+	return endpointapi.NewPatchEndpointIDOK()
+}
+
+// modifyEndpointIdentityLabelsFromAPI adds and deletes the given labels on given endpoint ID.
+// Performs checks for whether the endpoint may be modified by an API call.
+// The received `add` and `del` labels will be filtered with the valid label prefixes.
+// The `add` labels take precedence over `del` labels, this means if the same
+// label is set on both `add` and `del`, that specific label will exist in the
+// endpoint's labels.
+// Returns an HTTP response code and an error msg (or nil on success).
+func (h patchEndpointIDLabelsHandler) modifyEndpointIdentityLabelsFromAPI(id string, add, del labels.Labels) (int, error) {
+	addLabels, _ := labelsfilter.Filter(add)
+	delLabels, _ := labelsfilter.Filter(del)
+	if lbls := addLabels.FindReserved(); lbls != nil {
+		return endpointapi.PatchEndpointIDLabelsUpdateFailedCode, fmt.Errorf("Not allowed to add reserved labels: %s", lbls)
+	} else if lbls := delLabels.FindReserved(); lbls != nil {
+		return endpointapi.PatchEndpointIDLabelsUpdateFailedCode, fmt.Errorf("Not allowed to delete reserved labels: %s", lbls)
+	}
+
+	ep, err := h.EndpointManager.Lookup(id)
+	if err != nil {
+		return endpointapi.PatchEndpointIDInvalidCode, err
+	}
+	if ep == nil {
+		return endpointapi.PatchEndpointIDLabelsNotFoundCode, fmt.Errorf("Endpoint ID %s not found", id)
+	}
+	if err = endpoint.APICanModify(ep); err != nil {
+		return endpointapi.PatchEndpointIDInvalidCode, err
+	}
+
+	if err := ep.ModifyIdentityLabels(addLabels, delLabels); err != nil {
+		return endpointapi.PatchEndpointIDLabelsNotFoundCode, err
+	}
+
+	return endpointapi.PatchEndpointIDLabelsOKCode, nil
+}
+
+func (h patchEndpointIDLabelsHandler) Handle(params endpointapi.PatchEndpointIDLabelsParams) middleware.Responder {
+	h.Log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id}/labels request")
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointPatch)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	mod := params.Configuration
+	lbls := labels.NewLabelsFromModel(mod.User)
+
+	ep, err := h.EndpointManager.Lookup(params.ID)
+	if err != nil {
+		r.Error(err)
+		return api.Error(endpointapi.PutEndpointIDInvalidCode, err)
+	} else if ep == nil {
+		r.Error(errEndpointNotFound)
+		return endpointapi.NewPatchEndpointIDLabelsNotFound()
+	}
+
+	add, del, err := ep.ApplyUserLabelChanges(lbls)
+	if err != nil {
+		r.Error(err)
+		return api.Error(endpointapi.PutEndpointIDInvalidCode, err)
+	}
+
+	code, err := h.modifyEndpointIdentityLabelsFromAPI(params.ID, add, del)
+	if err != nil {
+		r.Error(err)
+		return api.Error(code, err)
+	}
+	return endpointapi.NewPatchEndpointIDLabelsOK()
+}
+
+func (h patchEndpointIDConfigHandler) Handle(params endpointapi.PatchEndpointIDConfigParams) middleware.Responder {
+	h.Log.WithField(logfields.Params, logfields.Repr(params)).Debug("PATCH /endpoint/{id}/config request")
+
+	r, err := h.RateLimit.Wait(params.HTTPRequest.Context(), APIRequestEndpointPatch)
+	if err != nil {
+		return api.Error(http.StatusTooManyRequests, err)
+	}
+	defer r.Done()
+
+	if err := h.endpointUpdate(params.ID, params.EndpointConfiguration); err != nil {
+		r.Error(err)
+		if apierr, ok := err.(*api.APIError); ok {
+			return apierr
+		}
+		return api.Error(endpointapi.PatchEndpointIDFailedCode, err)
+	}
+
+	return endpointapi.NewPatchEndpointIDConfigOK()
+}
+
+// endpointUpdate updates the options of the given endpoint and regenerates the endpoint
+func (h patchEndpointIDConfigHandler) endpointUpdate(id string, cfg *models.EndpointConfigurationSpec) error {
+	ep, err := h.EndpointManager.Lookup(id)
+	if err != nil {
+		return api.Error(endpointapi.PatchEndpointIDInvalidCode, err)
+	} else if ep == nil {
+		return api.New(endpointapi.PatchEndpointIDConfigNotFoundCode, "endpoint %s not found", id)
+	} else if err := ep.APICanModifyConfig(cfg.Options); err != nil {
+		return api.Error(endpointapi.PatchEndpointIDInvalidCode, err)
+	}
+
+	if err := ep.Update(cfg); err != nil {
+		switch err.(type) {
+		case endpoint.UpdateValidationError:
+			return api.Error(endpointapi.PatchEndpointIDConfigInvalidCode, err)
+		default:
+			return api.Error(endpointapi.PatchEndpointIDConfigFailedCode, err)
+		}
+	}
+	if err := h.EndpointManager.UpdateReferences(ep); err != nil {
+		return api.Error(endpointapi.PatchEndpointIDNotFoundCode, err)
+	}
+
+	return nil
+}

--- a/daemon/restapi/endpoint_test.go
+++ b/daemon/restapi/endpoint_test.go
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package restapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/exp/maps"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/api/v1/server"
+	"github.com/cilium/cilium/pkg/client"
+	"github.com/cilium/cilium/pkg/endpoint"
+	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/promise"
+	identitymock "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+type endpointTestContext struct {
+	endpoints        *fakeEndpoints
+	endpointModifier *fakeEndpointModifier
+	client           *client.Client
+}
+
+type endpointTestCase struct {
+	name string
+	test func(t *testing.T, ctx endpointTestContext)
+}
+
+var endpointTestCases = []endpointTestCase{
+	{"ListEndpoints", testListEndpoints},
+	{"GetEndpointID", testGetEndpointID},
+	{"GetEndpointIDConfig", testGetEndpointIDConfig},
+	{"GetEndpointIDLabels", testGetEndpointIDLabels},
+	{"GetEndpointIDLog", testGetEndpointIDLog},
+	{"GetEndpointIDHealthz", testGetEndpointIDHealthz},
+	{"PutEndpointID", testPutEndpointID},
+	{"PatchEndpointID", testPatchEndpointID},
+	{"PatchEndpointIDLabels", testPatchEndpointIDLabels},
+}
+
+func TestEndpointHandlers(t *testing.T) {
+	err := labelsfilter.ParseLabelPrefixCfg(nil, "")
+	if err != nil {
+		panic("ParseLabelPrefixCfg() failed")
+	}
+
+	// The test context is populated by an invoke function.
+	var ctx endpointTestContext
+
+	h := hive.New(
+		rateLimiterCell, // *api.APILimiterSet
+		cell.Provide(
+			func() *testing.T { return t },
+			func() cache.IdentityAllocator {
+				return identitymock.NewMockIdentityAllocator(nil)
+			},
+			newFakeEndpoints,        // endpointLookup
+			newFakeEndpointModifier, // Promise[EndpointModifier]
+		),
+
+		// Provide the handlers for /endpoint and pull in the server cell,
+		// which provides server.TestServer for testing.
+		cell.Provide(newEndpointHandlers),
+
+		server.SpecCell,
+		server.Cell,
+
+		// Provide the client against the test server.
+		cell.Provide(
+			func(s server.TestServer) (*client.Client, error) {
+				return client.NewClient(s.URL)
+			},
+		),
+
+		// Extract the fake endpoints and the API client
+		cell.Invoke(func(client *client.Client, endpoints *fakeEndpoints, fem *fakeEndpointModifier) {
+			ctx = endpointTestContext{
+				endpoints:        endpoints,
+				endpointModifier: fem,
+				client:           client,
+			}
+		}),
+	)
+
+	if assert.NoError(t, h.Start(context.TODO())) {
+		for _, testCase := range endpointTestCases {
+			t.Run(testCase.name, func(t *testing.T) {
+				testCase.test(t, ctx)
+			})
+		}
+
+		assert.NoError(t, h.Stop(context.TODO()))
+	}
+}
+
+var (
+	testEndpointIDs = []uint16{123, 234}
+
+	testEndpointOrchLabels = map[uint16]string{
+		123: "foo=bar",
+		234: "baz=quux",
+	}
+
+	testEndpointUserLabel = "custom=test"
+)
+
+func newFakeEndpoints(ia cache.IdentityAllocator) (*fakeEndpoints, endpointLookup) {
+	newEndpointForTest := func(numID uint16, lbls string) *endpoint.Endpoint {
+		ep := endpoint.NewEndpointWithState(nil, fakePolicyGetter{}, nil, nil, ia, numID, endpoint.StateReady)
+		ep.OpLabels.OrchestrationIdentity = labels.NewLabelsFromSortedList(lbls)
+		ep.OpLabels.Custom = labels.NewLabelsFromSortedList(testEndpointUserLabel)
+		ep.Options.SetValidated(
+			option.DebugPolicy,
+			option.OptionEnabled,
+		)
+		ep.LogStatusOK(endpoint.BPF, "hello")
+		return ep
+	}
+
+	endpoints := map[string]*endpoint.Endpoint{}
+	for numID, lbl := range testEndpointOrchLabels {
+		ep := newEndpointForTest(numID, lbl)
+		defer ep.Stop()
+		id := endpointid.NewCiliumID(int64(numID))
+		endpoints[id] = ep
+	}
+
+	f := &fakeEndpoints{endpoints}
+	return f, f
+}
+
+func testListEndpoints(t *testing.T, ctx endpointTestContext) {
+	endpoints, err := ctx.client.EndpointList()
+	assert.Nil(t, err)
+	assert.NotNil(t, endpoints)
+	assert.Len(t, endpoints, 2)
+
+	for _, ep := range endpoints {
+		assert.Contains(t, testEndpointIDs, uint16(ep.ID))
+	}
+}
+
+// clientResponseStatus unfolds the error to find an implementation for ClientResponseStatus,
+// which all the normal error responses implement.
+func clientResponseStatus(t *testing.T, err error) (runtime.ClientResponseStatus, bool) {
+	orig := err
+	for err != nil {
+		s, ok := err.(runtime.ClientResponseStatus)
+		if ok {
+			return s, true
+		}
+		fmt.Printf("%T did not implement ClientResponseStatus (%s)\n", err, err)
+		err = errors.Unwrap(err)
+	}
+	assert.Fail(t, "ClientResponseStatus not implemented by error", orig)
+	return nil, false
+}
+
+func testGetEndpointID(t *testing.T, ctx endpointTestContext) {
+	t.Run("404", func(t *testing.T) {
+		ok, err := ctx.client.EndpointGet("non-existing")
+		assert.Nil(t, ok)
+		if s, ok := clientResponseStatus(t, err); ok {
+			assert.True(t, s.IsCode(404))
+		}
+	})
+	t.Run("200", func(t *testing.T) {
+		for _, epNumID := range testEndpointIDs {
+			epID := endpointid.NewCiliumID(int64(epNumID))
+			ok, err := ctx.client.EndpointGet(epID)
+			assert.NoError(t, err)
+			if assert.NotNil(t, ok) {
+				assert.EqualValues(t, epNumID, ok.ID)
+			}
+			// TODO what else to assert?
+			// Do we want golden tests here instead of manually asserting every field?
+		}
+	})
+}
+
+func testGetEndpointIDConfig(t *testing.T, ctx endpointTestContext) {
+	t.Run("404", func(t *testing.T) {
+		ok, err := ctx.client.EndpointGet("non-existing")
+		assert.Nil(t, ok)
+		if s, ok := clientResponseStatus(t, err); ok {
+			assert.True(t, s.IsCode(404))
+		}
+	})
+	t.Run("200", func(t *testing.T) {
+		for _, epNumID := range testEndpointIDs {
+			epID := endpointid.NewCiliumID(int64(epNumID))
+			conf, err := ctx.client.EndpointConfigGet(epID)
+			assert.Nil(t, err)
+			if assert.NotNil(t, conf) {
+				// TODO what to assert here
+				actual := conf.Realized.LabelConfiguration.User
+				expected := []string{"unspec:" + testEndpointUserLabel}
+				assert.EqualValues(t, expected, actual)
+			}
+		}
+	})
+}
+
+func testGetEndpointIDLabels(t *testing.T, ctx endpointTestContext) {
+	t.Run("404", func(t *testing.T) {
+		ok, err := ctx.client.EndpointLabelsGet("non-existing")
+		assert.Nil(t, ok)
+		assert.Error(t, err)
+		// Due to use of client.Hint() in EndpointLabelsGet() we don't have
+		// the original error to type-match on. Revisit use of Hint()?
+		assert.Contains(t, err.Error(), "getEndpointIdLabelsNotFound")
+	})
+
+	t.Run("200", func(t *testing.T) {
+		for _, epNumID := range testEndpointIDs {
+			epID := endpointid.NewCiliumID(int64(epNumID))
+			labelConf, err := ctx.client.EndpointLabelsGet(epID)
+			assert.NoError(t, err)
+			if assert.NotNil(t, labelConf) {
+				actual := labelConf.Status.Realized.User
+				expected := []string{"unspec:" + testEndpointUserLabel}
+				assert.EqualValues(t, expected, actual)
+			}
+		}
+	})
+}
+
+func testGetEndpointIDLog(t *testing.T, ctx endpointTestContext) {
+	t.Run("404", func(t *testing.T) {
+		ok, err := ctx.client.EndpointLogGet("non-existing")
+		assert.Nil(t, ok)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "getEndpointIdLogNotFound")
+	})
+
+	t.Run("200", func(t *testing.T) {
+		for _, epNumID := range testEndpointIDs {
+			epID := endpointid.NewCiliumID(int64(epNumID))
+			log, err := ctx.client.EndpointLogGet(epID)
+			assert.NoError(t, err)
+			if assert.Len(t, log, 1) {
+				assert.Equal(t, "hello", log[0].Message)
+			}
+		}
+	})
+}
+
+func testGetEndpointIDHealthz(t *testing.T, ctx endpointTestContext) {
+	t.Run("404", func(t *testing.T) {
+		ok, err := ctx.client.EndpointHealthGet("non-existing")
+		assert.Nil(t, ok)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "getEndpointIdHealthzNotFound")
+	})
+
+	t.Run("200", func(t *testing.T) {
+		for _, epNumID := range testEndpointIDs {
+			epID := endpointid.NewCiliumID(int64(epNumID))
+			health, err := ctx.client.EndpointHealthGet(epID)
+			assert.NoError(t, err)
+			assert.EqualValues(t, "OK", health.Bpf)
+		}
+	})
+}
+
+func testPutEndpointID(t *testing.T, ctx endpointTestContext) {
+	t.Run("200", func(t *testing.T) {
+		contID := "test-container-id"
+		ep := &models.EndpointChangeRequest{
+			ContainerID:           contID,
+			Labels:                []string{"test=true"},
+			State:                 models.EndpointStateWaitingDashForDashIdentity.Pointer(),
+			Addressing:            &models.AddressPair{},
+			K8sPodName:            "pod-name",
+			K8sNamespace:          "pod-namespace",
+			DatapathConfiguration: &models.EndpointDatapathConfiguration{},
+		}
+		err := ctx.client.EndpointCreate(ep)
+		if assert.NoError(t, err) {
+			assert.Equal(t, contID, ctx.endpointModifier.lastCreate.ContainerID)
+			assert.Equal(t, "pod-name", ctx.endpointModifier.lastCreate.K8sPodName)
+			assert.EqualValues(t, []string{"test=true"}, ctx.endpointModifier.lastCreate.Labels)
+		}
+	})
+}
+
+func testPatchEndpointID(t *testing.T, ctx endpointTestContext) {
+	t.Run("200", func(t *testing.T) {
+		epNumID := testEndpointIDs[0]
+		epID := endpointid.NewCiliumID(int64(epNumID))
+		contID := "test-container-id"
+		p := &models.EndpointChangeRequest{
+			ContainerID: contID,
+			State:       models.EndpointStateReady.Pointer(),
+		}
+		err := ctx.client.EndpointPatch(epID, p)
+
+		if assert.NoError(t, err) {
+			assert.Equal(t, contID, ctx.endpointModifier.lastPatch.ContainerID)
+		}
+	})
+}
+
+func testPatchEndpointIDLabels(t *testing.T, ctx endpointTestContext) {
+	epNumID := testEndpointIDs[0]
+	epID := endpointid.NewCiliumID(int64(epNumID))
+	t.Run("200", func(t *testing.T) {
+		err := ctx.client.EndpointLabelsPatch(epID, []string{"user-label=test"}, nil)
+		ep := ctx.endpoints.eps[epID]
+		if assert.NoError(t, err) {
+			assert.Equal(t,
+				ep.OpLabels.Custom.String(),
+				"unspec:custom=test,unspec:user-label=test",
+			)
+			// Revert the modification.
+			err = ctx.client.EndpointLabelsPatch(epID, nil, []string{"user-label=test"})
+			if assert.NoError(t, err) {
+				assert.Equal(t,
+					ep.OpLabels.Custom.String(),
+					"unspec:custom=test",
+				)
+			}
+		}
+	})
+
+	t.Run("reserved:world", func(t *testing.T) {
+		// Use of reserved:world as user label not allowed.
+		err := ctx.client.EndpointLabelsPatch(epID, []string{"reserved:world"}, nil)
+		assert.Error(t, err, "adding reserved:world label results in error")
+		assert.Contains(t, err.Error(), "Not allowed to add reserved labels")
+	})
+}
+
+//
+// Fakes
+//
+
+type fakeEndpoints struct {
+	eps map[string]*endpoint.Endpoint
+}
+
+func (f *fakeEndpoints) GetEndpoints() []*endpoint.Endpoint           { return maps.Values(f.eps) }
+func (f *fakeEndpoints) Lookup(id string) (*endpoint.Endpoint, error) { return f.eps[id], nil }
+func (f *fakeEndpoints) UpdateReferences(ep *endpoint.Endpoint) error { return nil }
+
+var _ endpointLookup = &fakeEndpoints{}
+
+type fakeEndpointModifier struct {
+	lastCreate *models.EndpointChangeRequest
+	lastDelete *string
+	lastPatch  *models.EndpointChangeRequest
+}
+
+func (f *fakeEndpointModifier) CreateEndpoint(ctx context.Context, epTemplate *models.EndpointChangeRequest) (int, error) {
+	f.lastCreate = epTemplate
+	return 0, nil
+}
+
+func (f *fakeEndpointModifier) DeleteEndpoint(id string) (int, error) {
+	f.lastDelete = &id
+	return 0, nil
+}
+
+func (f *fakeEndpointModifier) PatchEndpoint(ctx context.Context, ID string, epTemplate *models.EndpointChangeRequest) (int, error) {
+	f.lastPatch = epTemplate
+	return 0, nil
+}
+
+func newFakeEndpointModifier() (*fakeEndpointModifier, promise.Promise[EndpointModifier]) {
+	fem := &fakeEndpointModifier{}
+	return fem, promise.Resolved(EndpointModifier(fem))
+}
+
+var _ EndpointModifier = &fakeEndpointModifier{}
+
+type fakePolicyGetter struct{}
+
+func (fakePolicyGetter) GetPolicyRepository() *policy.Repository {
+	return policy.NewPolicyRepository(nil, nil, nil, nil)
+}

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -183,9 +183,12 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 	// This returns the most recent log entry for this endpoint. It is backwards
 	// compatible with the json from before we added `cilium endpoint log` but it
 	// only returns 1 entry.
-	statusLog := e.status.GetModel()
-	if len(statusLog) > 0 {
-		statusLog = statusLog[:1]
+	var statusLog []*models.EndpointStatusChange
+	if e.status != nil {
+		statusLog = e.status.GetModel()
+		if len(statusLog) > 0 {
+			statusLog = statusLog[:1]
+		}
 	}
 
 	lblMdl := model.NewModel(&e.OpLabels)

--- a/pkg/promise/promise.go
+++ b/pkg/promise/promise.go
@@ -39,6 +39,14 @@ func New[T any]() (Resolver[T], Promise[T]) {
 	return promise, promise
 }
 
+// Resolved creates a new resolved promise.
+func Resolved[T any](v T) Promise[T] {
+	promise := &promise[T]{}
+	promise.cond = sync.NewCond(promise)
+	promise.Resolve(v)
+	return promise
+}
+
 const (
 	promiseUnresolved = iota
 	promiseResolved

--- a/pkg/promise/promise_test.go
+++ b/pkg/promise/promise_test.go
@@ -63,3 +63,14 @@ func TestPromiseCancelled(t *testing.T) {
 		t.Fatalf("expected %s error, got %s", context.Canceled, err)
 	}
 }
+
+func TestPromiseResolved(t *testing.T) {
+	promise := Resolved(123)
+	i, err := promise.Await(context.TODO())
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if i != 123 {
+		t.Fatalf("expected 123, got %d", i)
+	}
+}


### PR DESCRIPTION
This moves the handlers for `/endpoint` to `daemon/restapi/endpoint.go` and thus decouples them from `type Daemon struct` which reduces their dependencies and allows to easily test them.

While most of the handlers now only require access to `EndpointManager` API, the endpoint creation still need to go through `Daemon` as not everything it depends on has been modularized (it is close though!). For creation `Daemon` implements `EndpointModifier` API which the endpoint handlers can depend on.

For testing the handlers this PR also introduces the `server.TestServer` which runs the API server using `httptest`.