### PR TITLE
crd: Refactor RegisterCRDsCell to be extensible

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -43,7 +43,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipam/allocator"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
+	"github.com/cilium/cilium/pkg/k8s/apis"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -124,7 +124,7 @@ var (
 		// These cells are started only after the operator is elected leader.
 		WithLeaderLifecycle(
 			// The CRDs registration should be the first operation to be invoked after the operator is elected leader.
-			client.RegisterCRDsCell,
+			apis.RegisterCRDsCell,
 			k8s.SharedResourcesCell,
 
 			lbipam.Cell,

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
+	"github.com/cilium/cilium/pkg/k8s/apis"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -168,7 +168,7 @@ func (cpt *ControlPlaneTest) StartOperator(modCellConfig func(vp *viper.Viper)) 
 		),
 	}
 
-	cpt.operatorHandle.hive.Viper().Set(client.SkipCRDCreation, true)
+	cpt.operatorHandle.hive.Viper().Set(apis.SkipCRDCreation, true)
 
 	// Apply the test specific cells configuration
 	//


### PR DESCRIPTION
Current implementation of RegisterCRDsCell is strictly tied to the registration of the CRDs belonging to the "cilium.io" group.

This PR refactors the cell to make it easily extendable if other groups needs to register their CRDs at operator startup.
