### PR TITLE
High-scale IPcache: Chapter 4

### DIFF
--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -41,6 +41,9 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #endif
 
 #define TUNNEL_PORT 8472
+#define TUNNEL_PROTOCOL_VXLAN 1
+#define TUNNEL_PROTOCOL_GENEVE 2
+#define TUNNEL_PROTOCOL 1
 
 #define HOST_ID 1
 #define WORLD_ID 2

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -361,13 +361,9 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initArgMode] = string(mode)
 
 	if !option.Config.TunnelingEnabled() {
-		if option.Config.EnableIPv4EgressGateway {
+		if option.Config.EnableIPv4EgressGateway || option.Config.EnableHighScaleIPcache {
 			// Tunnel is required for egress traffic under this config
 			encapProto = option.Config.TunnelProtocol
-		}
-		if option.Config.EnableHighScaleIPcache {
-			// The high-scale ipcache only supports VXLAN for now.
-			encapProto = option.TunnelVXLAN
 		}
 	}
 


### PR DESCRIPTION
This is in the context of the high-scale ipcache feature described at https://github.com/cilium/design-cfps/pull/7.

This pull request adds support for GENEVE encapsulation in addition to the existing VXLAN support.

Updates: https://github.com/cilium/cilium/issues/25243.
```release-note
Support GENEVE encapsulation with high-scale ipcache.
```