### PR TITLE
Removes IngressBandwidth Annotation

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -42,6 +42,9 @@ import (
 	"github.com/cilium/cilium/pkg/proxy"
 )
 
+// ingressBandwidth represents the K8s ingress bandwidth Pod annotation (currently unsupported).
+const ingressBandwidth = "kubernetes.io/ingress-bandwidth"
+
 var errEndpointNotFound = errors.New("endpoint not found")
 
 type getEndpoint struct {
@@ -430,12 +433,12 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 			}
 			addLabels.MergeLabels(identityLabels)
 			infoLabels.MergeLabels(info)
-			if _, ok := annotations[bandwidth.IngressBandwidth]; ok {
+			if _, ok := annotations[ingressBandwidth]; ok {
 				log.WithFields(logrus.Fields{
 					logfields.K8sPodName:  epTemplate.K8sNamespace + "/" + epTemplate.K8sPodName,
 					logfields.Annotations: logfields.Repr(annotations),
 				}).Warningf("Endpoint has %s annotation which is unsupported. This annotation is ignored.",
-					bandwidth.IngressBandwidth)
+					ingressBandwidth)
 			}
 			if _, ok := annotations[bandwidth.EgressBandwidth]; ok && !option.Config.EnableBandwidthManager {
 				log.WithFields(logrus.Fields{

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -25,8 +25,6 @@ const (
 
 	// EgressBandwidth is the K8s Pod annotation.
 	EgressBandwidth = "kubernetes.io/egress-bandwidth"
-	// IngressBandwidth is the K8s Pod annotation.
-	IngressBandwidth = "kubernetes.io/ingress-bandwidth"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsystem)


### PR DESCRIPTION
The IngressBandwidth is unimplemented but is represented as an exportable constant. This PR removes the IngressBandwidth annotation to avoid potential confusion and misuse.

Fixes: #25532
