### PR TITLE
Remove unused parameter from NewCachingIdentityAllocator

### DIFF
--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -54,7 +54,7 @@ func NewVMManager(clientset k8sClient.Clientset) *VMManager {
 	if option.Config.EnableWellKnownIdentities {
 		identity.InitWellKnownIdentities(option.Config)
 	}
-	m.identityAllocator.InitIdentityAllocator(clientset, identityStore)
+	m.identityAllocator.InitIdentityAllocator(clientset)
 	m.startCiliumExternalWorkloadWatcher(clientset)
 	return m
 }

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1173,7 +1173,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		// Ignore the channel returned by this function, as we want the global
 		// identity allocator to run asynchronously.
 		realIdentityAllocator := d.identityAllocator
-		realIdentityAllocator.InitIdentityAllocator(params.Clientset, nil)
+		realIdentityAllocator.InitIdentityAllocator(params.Clientset)
 
 		d.bootstrapClusterMesh(params.NodeManager)
 	}

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -13,7 +13,6 @@ import (
 
 	miekgdns "github.com/miekg/dns"
 	. "gopkg.in/check.v1"
-	k8sCache "k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/checker"
@@ -111,7 +110,7 @@ func (f *FakeRefcountingIdentityAllocator) IdentityReferenceCounter() counter.In
 
 func (f *FakeRefcountingIdentityAllocator) Close() {
 }
-func (f *FakeRefcountingIdentityAllocator) InitIdentityAllocator(versioned.Interface, k8sCache.Store) <-chan struct{} {
+func (f *FakeRefcountingIdentityAllocator) InitIdentityAllocator(versioned.Interface) <-chan struct{} {
 	return nil
 }
 func (f *FakeRefcountingIdentityAllocator) WatchRemoteIdentities(string, kvstore.BackendOperations) (*allocator.RemoteCache, error) {

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -9,7 +9,6 @@ import (
 	"net/netip"
 
 	"github.com/go-openapi/runtime/middleware"
-	k8sCache "k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
@@ -95,7 +94,7 @@ type CachingIdentityAllocator interface {
 	cache.IdentityAllocator
 	clustermesh.RemoteIdentityWatcher
 
-	InitIdentityAllocator(versioned.Interface, k8sCache.Store) <-chan struct{}
+	InitIdentityAllocator(versioned.Interface) <-chan struct{}
 	Close()
 }
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -98,7 +98,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 
 	dir, err := os.MkdirTemp("", "multicluster")

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -66,7 +66,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 	dir, err := os.MkdirTemp("", "multicluster")
 	s.testDir = dir
 	c.Assert(err, IsNil)

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -151,7 +151,7 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 	s.mgr = mgr
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -138,7 +138,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
 
 	mgr := NewCachingIdentityAllocator(idAllocatorOwner)
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 
 	do := &DummyOwner{

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -35,7 +35,7 @@ func (s *IdentityCacheTestSuite) TestAllocateIdentityReserved(c *C) {
 	}
 
 	mgr := NewCachingIdentityAllocator(newDummyOwner())
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 
 	c.Assert(identity.IdentityAllocationIsLocal(lbls), Equals, true)
 	i, isNew, err = mgr.AllocateIdentity(context.Background(), lbls, false, identity.InvalidIdentity)
@@ -239,7 +239,7 @@ func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(newDummyOwner())
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()
 
@@ -257,7 +257,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(owner)
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()
 
@@ -342,7 +342,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(owner)
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 	defer mgr.Close()
 	defer mgr.IdentityAllocator.DeleteAllKeys()
 
@@ -414,10 +414,10 @@ func (s *IdentityCacheTestSuite) TestAllocatorReset(c *C) {
 		c.Assert(queued, Equals, id1a.ID)
 	}
 
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 	testAlloc()
 	mgr.Close()
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 	testAlloc()
 	mgr.Close()
 }

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -41,7 +41,7 @@ func (s *IdentityCacheTestSuite) SetUpSuite(c *C) {
 
 func (s *IdentityCacheTestSuite) TestLookupReservedIdentity(c *C) {
 	mgr := NewCachingIdentityAllocator(newDummyOwner())
-	<-mgr.InitIdentityAllocator(nil, nil)
+	<-mgr.InitIdentityAllocator(nil)
 
 	hostID := identity.GetReservedID("host")
 	c.Assert(mgr.LookupIdentityByID(context.TODO(), hostID), Not(IsNil))


### PR DESCRIPTION
The `NewCachingIdentityAllocator` used to take a `cache.Store` as parameter. Yet, it is ignored since 78cbaf05b7bb ("Optimize identity allocation with CRD backend."). Hence, let's drop it and remove the remaining occurrences.

Suggested by @tklauser: https://github.com/cilium/cilium/pull/25049#discussion_r1200594589

```release-note
Remove unused parameter from NewCachingIdentityAllocator
```
