### PR TITLE
ci: fix gke network starvation

### DIFF
--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -256,7 +256,10 @@ jobs:
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
+            --enable-ip-alias \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -256,7 +256,10 @@ jobs:
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
+            --enable-ip-alias \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -256,7 +256,10 @@ jobs:
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
+            --enable-ip-alias \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -250,7 +250,10 @@ jobs:
           gcloud container clusters create ${{ env.clusterName }} \
             --labels "usage=${{ github.repository_owner }}-${{ github.event.repository.name }},owner=${{ steps.vars.outputs.owner }}" \
             --zone ${{ env.zone }} \
+            --enable-ip-alias \
             --node-taints node.cilium.io/agent-not-ready=true:NoExecute \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -232,7 +232,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -232,7 +232,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -233,7 +233,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -231,7 +231,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -236,7 +236,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
@@ -253,7 +255,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-multicluster-v1.12.yaml
+++ b/.github/workflows/conformance-multicluster-v1.12.yaml
@@ -236,7 +236,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
@@ -253,7 +255,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \

--- a/.github/workflows/conformance-multicluster-v1.13.yaml
+++ b/.github/workflows/conformance-multicluster-v1.13.yaml
@@ -236,7 +236,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \
@@ -253,7 +255,9 @@ jobs:
             --zone ${{ env.zone }} \
             --cluster-version ${{ env.k8s_version }} \
             --enable-ip-alias \
-            --create-subnetwork="" \
+            --create-subnetwork="range=/26" \
+            --cluster-ipv4-cidr="/21" \
+            --services-ipv4-cidr="/24" \
             --image-type COS_CONTAINERD \
             --num-nodes 2 \
             --machine-type e2-custom-2-4096 \


### PR DESCRIPTION
There are 10 workflows that provision a new GKE cluster, and 3 workflows provision 2 GKE clusters.
Also other repositories, like `cilium-cli` use the same project for provisioning GKE clusters.
If the number of simultaneously provisioned clusters is high enough we get an error like below,
```
The network "default" does not have available private IP space in 10.0.0.0/9 to reserve a /14 block for pods for cluster {Zone=us-west2-a, ProjectNum=185287498374, ProjectName=*** ....
```

This became more apparent with a recent change 4a92f1afac85005f1bb68439ce887f1c6bab1e26 which runs `conformance-gke` workflows in matrix strategy.

With current defaults, which are below, the number of clusters that can be provisioned simultaneously is around 31.
- subnetwork (used by nodes) : /22 
- pod cidr :  /14
- service cidr : /20

The current default network ranges are too big for our use cases, per cluster only 2 nodes are provisioned.
Below are the max number of pods, and services created by workflow.
|Worfflows | Max pod count | Max service count |
|----------|----------|----------|
| externalworkloads    | 28  | 8  |
| gke    | 28 | 9  |
| multicluster    | 28  |  8  |

In accordance with network range requirements, changes below have been made. 
- subnetwork : /26  **it is not used in externalworkloads** 
- pod cidr :  /21 **this is the max allowed range**
- service cidr : /24

With these changes, the number of clusters that can be provisioned simultaneously is more than 3500. 

Successful run links are below,

[conformance-externalworkloads-v1.11.yaml](https://github.com/cilium/cilium/actions/runs/5050179350?pr=25597) [conformance-externalworkloads-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5050179351?pr=25597) [conformance-externalworkloads-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5050179349?pr=25597) [conformance-externalworkloads.yaml](https://github.com/cilium/cilium/actions/runs/5050179337?pr=25597)

[conformance-gke-v1.11.yaml](https://github.com/cilium/cilium/actions/runs/5049388717?pr=25597) [conformance-gke-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5049388719?pr=25597) [conformance-gke-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5049388741?pr=25597) [conformance-gke.yaml](https://github.com/cilium/cilium/actions/runs/5049388735?pr=25597)

[conformance-multicluster-v1.11.yaml](https://github.com/cilium/cilium/actions/runs/5049388771?pr=25597) [conformance-multicluster-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5049388728?pr=25597) [conformance-multicluster-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5049388730?pr=25597)