### PR TITLE
probes: use veth device for probing managed neighbor support

### DIFF
--- a/pkg/datapath/linux/probes/managed_neighbors.go
+++ b/pkg/datapath/linux/probes/managed_neighbors.go
@@ -70,17 +70,22 @@ func haveManagedNeighbors() (outer error) {
 		runtime.UnlockOSThread()
 	}()
 
-	la := netlink.NewLinkAttrs()
-	la.Name = "cilium-dummy"
+	// Use a veth device instead of a dummy to avoid the kernel having to modprobe
+	// the dummy kmod, which could potentially be compiled out. veth is currently
+	// a hard dependency for Cilium, so safe to assume the module is available if
+	// not already loaded.
+	veth := &netlink.Veth{
+		LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+		PeerName:  "veth1",
+	}
 
-	dummy := &netlink.Dummy{LinkAttrs: la}
-	if err := netlink.LinkAdd(dummy); err != nil {
-		return fmt.Errorf("failed to add dummy link: %w", err)
+	if err := netlink.LinkAdd(veth); err != nil {
+		return fmt.Errorf("failed to add dummy veth: %w", err)
 	}
 
 	neigh := netlink.Neigh{
-		LinkIndex: dummy.Index,
-		IP:        net.IPv4(10, 1, 1, 1),
+		LinkIndex: veth.Index,
+		IP:        net.IPv4(0, 0, 0, 1),
 		Flags:     netlink.NTF_EXT_LEARNED,
 		FlagsExt:  netlink.NTF_EXT_MANAGED,
 	}
@@ -89,15 +94,23 @@ func haveManagedNeighbors() (outer error) {
 		return fmt.Errorf("failed to add neighbor: %w", err)
 	}
 
-	nl, err := netlink.NeighList(dummy.Index, 0)
+	nl, err := netlink.NeighList(veth.Index, 0)
 	if err != nil {
 		return fmt.Errorf("failed to list neighbors: %w", err)
 	}
 
 	for _, n := range nl {
-		if n.IP.Equal(neigh.IP) && n.Flags == netlink.NTF_EXT_LEARNED && n.FlagsExt == netlink.NTF_EXT_MANAGED {
-			return nil
+		if !n.IP.Equal(neigh.IP) {
+			continue
 		}
+		if n.Flags != netlink.NTF_EXT_LEARNED {
+			continue
+		}
+		if n.FlagsExt != netlink.NTF_EXT_MANAGED {
+			continue
+		}
+
+		return nil
 	}
 
 	return ErrNotSupported


### PR DESCRIPTION
Some distributions don't ship with dummy device support/module, leading to the following error when probing for managed neighbors:

```
level=fatal msg="failed to probe managed neighbor support"
error="failed to add dummy link: operation not supported" subsys=probes
```

This patch uses a veth device instead, which should be available on nodes running Cilium, if it's not already loaded.

```release-note
Use veth device for probing managed neighbor support
```
