### PR TITLE
pkg/ipam: Update histogram buckets for trigger metrics

### DIFF
--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -290,12 +290,16 @@ func NewTriggerMetrics(namespace, name string) *triggerMetrics {
 			Subsystem: ipamSubsystem,
 			Name:      name + "_duration_seconds",
 			Help:      "Duration of trigger runs",
+			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
 		}),
 		latency: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: ipamSubsystem,
 			Name:      name + "_latency_seconds",
 			Help:      "Latency between queue and trigger run",
+			Buckets: []float64{0.005, 0.025, 0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.25, 1.5, 2, 3,
+				4, 5, 6, 8, 10, 15, 20, 30, 45, 60},
 		}),
 	}
 }


### PR DESCRIPTION
Currently, trigger related histogram metrics in `pgk/ipam` use the default prometheus histogram buckets. Resync operation in cloud providers like Azure tend to take a long time and the current buckets are inadequate to track changes in behavior. This commit extends the buckets to allow for measuring longer durations.

Currently, some metrics plateau at 10 secs
<img width="394" alt="image" src="https://github.com/cilium/cilium/assets/3775612/7bd6355b-8d58-4b01-84cd-d81d01ef83ed">

Reusing buckets [defined in Kubernetes API server to measure request duration](https://github.com/kubernetes/kubernetes/blob/ce05a4f7fcc234dd3132a4e40e6afdf0b2ebc94e/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go#L96-L100 )
