### PR TITLE
High-scale IPcache: Chapter 5

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1307,8 +1307,8 @@ int cil_from_host(struct __ctx_buff *ctx)
 
 	ret = decapsulate_overlay(ctx, &src_id);
 	if (IS_ERR(ret))
-		send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
-				       METRIC_INGRESS);
+		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
+					      METRIC_INGRESS);
 	if (ret == CTX_ACT_REDIRECT)
 		return ret;
 #endif /* ENABLE_HIGH_SCALE_IPCACHE */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2184,7 +2184,6 @@ int cil_to_container(struct __ctx_buff *ctx)
 	}
 #endif /* ENABLE_HOST_FIREWALL && !ENABLE_ROUTING */
 
-	ctx_store_meta(ctx, CB_SRC_LABEL, identity);
 
 	switch (proto) {
 #if defined(ENABLE_ARP_PASSTHROUGH) || defined(ENABLE_ARP_RESPONDER)
@@ -2194,12 +2193,42 @@ int cil_to_container(struct __ctx_buff *ctx)
 #endif
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
+# ifdef ENABLE_HIGH_SCALE_IPCACHE
+	if (identity == WORLD_ID) {
+		struct endpoint_info *ep;
+		void *data, *data_end;
+		struct ipv6hdr *ip6;
+
+		if (!revalidate_data(ctx, &data, &data_end, &ip6))
+			return DROP_INVALID;
+
+		ep = __lookup_ip6_endpoint((union v6addr *)&ip6->saddr);
+		if (ep)
+			identity = ep->sec_id;
+	}
+# endif /* ENABLE_HIGH_SCALE_IPCACHE */
+		ctx_store_meta(ctx, CB_SRC_LABEL, identity);
 		ep_tail_call(ctx, CILIUM_CALL_IPV6_CT_INGRESS);
 		ret = DROP_MISSED_TAIL_CALL;
 		break;
 #endif /* ENABLE_IPV6 */
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
+# ifdef ENABLE_HIGH_SCALE_IPCACHE
+	if (identity == WORLD_ID) {
+		struct endpoint_info *ep;
+		void *data, *data_end;
+		struct iphdr *ip4;
+
+		if (!revalidate_data(ctx, &data, &data_end, &ip4))
+			return DROP_INVALID;
+
+		ep = __lookup_ip4_endpoint(ip4->saddr);
+		if (ep)
+			identity = ep->sec_id;
+	}
+# endif /* ENABLE_HIGH_SCALE_IPCACHE */
+		ctx_store_meta(ctx, CB_SRC_LABEL, identity);
 		ep_tail_call(ctx, CILIUM_CALL_IPV4_CT_INGRESS);
 		ret = DROP_MISSED_TAIL_CALL;
 		break;

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -290,11 +290,12 @@ struct tunnel_value {
 struct endpoint_info {
 	__u32		ifindex;
 	__u16		unused; /* used to be sec_label, no longer used */
-	__u16           lxc_id;
+	__u16		lxc_id;
 	__u32		flags;
 	mac_t		mac;
 	mac_t		node_mac;
-	__u32		pad[4];
+	__u32		sec_id;
+	__u32		pad[3];
 };
 
 struct edt_id {

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -171,12 +171,7 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx,
 	struct tunnel_value *tunnel __maybe_unused;
 
 #ifdef ENABLE_HIGH_SCALE_IPCACHE
-	/* If the destination doesn't match one of the world CIDRs, we assume
-	 * it's destined to a remote pod. In that case, since the high-scale
-	 * ipcache is enabled, we want to encapsulate with the remote pod's IP
-	 * itself.
-	 */
-	if (!world_cidrs_lookup4(dst_ip))
+	if (needs_encapsulation(dst_ip))
 		return __encap_and_redirect_with_nodeid(ctx, src_ip, dst_ip,
 							seclabel, dstid,
 							NOT_VTEP_DST, trace);

--- a/bpf/lib/high_scale_ipcache.h
+++ b/bpf/lib/high_scale_ipcache.h
@@ -29,6 +29,27 @@ world_cidrs_lookup4(__u32 addr)
 	return matches != NULL;
 }
 
+static __always_inline bool
+needs_encapsulation(__u32 addr)
+{
+# ifndef ENABLE_ROUTING
+	/* If endpoint routes are enabled, we need to check if the destination
+	 * is a local endpoint, in which case we don't want to encapsulate. If
+	 * endpoint routes are disabled, we don't need to check this because we
+	 * will never reach this point and the packet will be redirected to the
+	 * destination endpoint directly.
+	 */
+	if (__lookup_ip4_endpoint(addr))
+		return false;
+# endif /* ENABLE_ROUTING */
+	/* If the destination doesn't match one of the world CIDRs, we assume
+	 * it's destined to a remote pod. In that case, since the high-scale
+	 * ipcache is enabled, we want to encapsulate with the remote pod's IP
+	 * itself.
+	 */
+	return !world_cidrs_lookup4(addr);
+}
+
 static __always_inline int
 decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1018,10 +1018,17 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			return nil, nil, fmt.Errorf("BPF ip-masq-agent needs kernel 4.16 or newer")
 		}
 	}
-	if option.Config.EnableHostFirewall && len(option.Config.GetDevices()) == 0 {
-		msg := "host firewall's external facing device could not be determined. Use --%s to specify."
-		log.WithError(err).Errorf(msg, option.Devices)
-		return nil, nil, fmt.Errorf(msg, option.Devices)
+	if len(option.Config.GetDevices()) == 0 {
+		if option.Config.EnableHostFirewall {
+			msg := "Host firewall's external facing device could not be determined. Use --%s to specify."
+			log.WithError(err).Errorf(msg, option.Devices)
+			return nil, nil, fmt.Errorf(msg, option.Devices)
+		}
+		if option.Config.EnableHighScaleIPcache {
+			msg := "External facing device for high-scale IPcache could not be determined. Use --%s to specify."
+			log.WithError(err).Errorf(msg, option.Devices)
+			return nil, nil, fmt.Errorf(msg, option.Devices)
+		}
 	}
 	if option.Config.EnableSCTP {
 		if probes.HaveLargeInstructionLimit() != nil {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2529,7 +2529,8 @@ func (c *DaemonConfig) TunnelExists() bool {
 // AreDevicesRequired returns true if the agent needs to attach to the native
 // devices to implement some features.
 func (c *DaemonConfig) AreDevicesRequired() bool {
-	return c.EnableNodePort || c.EnableHostFirewall || c.EnableBandwidthManager || c.EnableWireguard
+	return c.EnableNodePort || c.EnableHostFirewall || c.EnableBandwidthManager ||
+		c.EnableWireguard || c.EnableHighScaleIPcache
 }
 
 // MasqueradingEnabled returns true if either IPv4 or IPv6 masquerading is enabled.
@@ -4124,7 +4125,7 @@ func EndpointStatusValuesMap() (values map[string]struct{}) {
 // place.
 func MightAutoDetectDevices() bool {
 	devices := Config.GetDevices()
-	return ((Config.EnableHostFirewall || Config.EnableWireguard) && len(devices) == 0) ||
+	return ((Config.EnableHostFirewall || Config.EnableWireguard || Config.EnableHighScaleIPcache) && len(devices) == 0) ||
 		(Config.KubeProxyReplacement != KubeProxyReplacementDisabled &&
 			(len(devices) == 0 || Config.DirectRoutingDevice == ""))
 }

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -484,7 +484,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"highScaleIPcache.enabled":    "true",
 				"routingMode":                 "native",
 				"bpf.monitorAggregation":      "none",
-				"devices":                     "",
 				"ipv6.enabled":                "false",
 				"wellKnownIdentities.enabled": "true",
 				"tunnelProtocol":              tunnelProto,

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -479,7 +479,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			_ = kubectl.Delete(hsIPcacheYAML)
 		})
 
-		testHighScaleIPcache := func(tunnelProto string) {
+		testHighScaleIPcache := func(tunnelProto string, epRoutesConfig string) {
 			options := map[string]string{
 				"highScaleIPcache.enabled":    "true",
 				"routingMode":                 "native",
@@ -487,6 +487,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 				"ipv6.enabled":                "false",
 				"wellKnownIdentities.enabled": "true",
 				"tunnelProtocol":              tunnelProto,
+				"endpointRoutes.enabled":      epRoutesConfig,
 			}
 			if !helpers.RunsOnGKE() {
 				options["autoDirectNodeRoutes"] = "true"
@@ -508,12 +509,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 			Expect(err).ToNot(HaveOccurred(), "Client pods not ready after timeout")
 		}
 
-		It("Test ingress policy enforcement with VXLAN", func() {
-			testHighScaleIPcache("vxlan")
+		It("Test ingress policy enforcement with VXLAN and no endpoint routes", func() {
+			testHighScaleIPcache("vxlan", "false")
 		})
 
-		It("Test ingress policy enforcement with GENEVE", func() {
-			testHighScaleIPcache("geneve")
+		It("Test ingress policy enforcement with GENEVE and endpoint routes", func() {
+			testHighScaleIPcache("geneve", "true")
 		})
 	})
 


### PR DESCRIPTION
This is in the context of the high-scale ipcache feature described at https://github.com/cilium/design-cfps/pull/7.

This pull request adds support for endpoint routes in high-scale ipcache mode. See commits for details.

Updates: https://github.com/cilium/cilium/issues/25243.
```release-note
Support `enable-endpoint-routes` with `enable-high-scale-ipcache`.
```