### PR TITLE
Updates informer pkg to use TransformFunc()

### DIFF
--- a/clustermesh-apiserver/vmmanager.go
+++ b/clustermesh-apiserver/vmmanager.go
@@ -89,7 +89,7 @@ func (m *VMManager) startCiliumExternalWorkloadWatcher(clientset k8sClient.Clien
 				}
 			},
 		},
-		k8s.ConvertToCiliumExternalWorkload,
+		k8s.TransformToCiliumExternalWorkload,
 	)
 
 	go m.ciliumExternalWorkloadInformer.Run(wait.NeverStop)

--- a/operator/cmd/ccnp_event.go
+++ b/operator/cmd/ccnp_event.go
@@ -114,7 +114,7 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 				}
 			},
 		},
-		k8s.ConvertToCCNP,
+		k8s.TransformToCCNP,
 		ccnpStore,
 	)
 	mgr := controller.NewManager()

--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -78,7 +78,7 @@ func (s *ciliumNodeSynchronizer) Start(ctx context.Context, wg *sync.WaitGroup) 
 		connectedToKVStore     = make(chan struct{})
 
 		resourceEventHandler   = cache.ResourceEventHandlerFuncs{}
-		ciliumNodeConvertFunc  = k8s.ConvertToCiliumNode
+		ciliumNodeConvertFunc  = k8s.TransformToCiliumNode
 		ciliumNodeManagerQueue = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 		kvStoreQueue           = workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 	)

--- a/operator/cmd/cnp_event.go
+++ b/operator/cmd/cnp_event.go
@@ -119,7 +119,7 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 				}
 			},
 		},
-		k8s.ConvertToCNP,
+		k8s.TransformToCNP,
 		cnpStore,
 	)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -520,14 +520,24 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 							// k8s service for etcd. As soon the k8s caches are
 							// synced, this hijack will stop happening.
 							sc := k8s.NewServiceCache(nil)
-							slimSvcObj := k8s.ConvertToK8sService(k8sSvc)
-							slimSvc := k8s.ObjToV1Services(slimSvcObj)
-							if slimSvc == nil {
-								// This will never happen but still log it
-								scopedLog.Warnf("BUG: invalid k8s service: %s", slimSvcObj)
+							slimSvcObj, err := k8s.TransformToK8sService(k8sSvc)
+							if err != nil {
+								scopedLog.WithFields(logrus.Fields{
+									logfields.ServiceName:      k8sSvc.Name,
+									logfields.ServiceNamespace: k8sSvc.Namespace,
+								}).Error("Failed to transform k8s service")
+							} else {
+								slimSvc := k8s.ObjToV1Services(slimSvcObj)
+								if slimSvc == nil {
+									// This will never happen but still log it
+									scopedLog.WithFields(logrus.Fields{
+										logfields.ServiceName:      k8sSvc.Name,
+										logfields.ServiceNamespace: k8sSvc.Namespace,
+									}).Warn("BUG: invalid k8s service")
+								}
+								sc.UpdateService(slimSvc, nil)
+								svcGetter = operatorWatchers.NewServiceGetter(sc)
 							}
-							sc.UpdateService(slimSvc, nil)
-							svcGetter = operatorWatchers.NewServiceGetter(sc)
 						case k8sErrors.IsNotFound(err):
 							scopedLog.Error("Service not found in k8s")
 						default:

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -281,10 +281,10 @@ func setupCiliumEndpointWatcher(
 				&v2.CiliumEndpoint{},
 				0,
 				cache.ResourceEventHandlerFuncs{},
-				func(obj interface{}) interface{} {
+				func(obj interface{}) (interface{}, error) {
 					endpointObj, ok := obj.(*v2.CiliumEndpoint)
 					if !ok {
-						return errors.New("failed to convert cilium endpoint")
+						return nil, errors.New("failed to convert cilium endpoint")
 					}
 					return &v2.CiliumEndpoint{
 						TypeMeta: endpointObj.TypeMeta,
@@ -294,7 +294,7 @@ func setupCiliumEndpointWatcher(
 						Status: v2.EndpointStatus{
 							Identity: endpointObj.Status.Identity,
 						},
-					}
+					}, nil
 				},
 				watchers.CiliumEndpointStore,
 			)

--- a/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
+++ b/pkg/k8s/informer/benchmarks/informer_benchmarks_test.go
@@ -466,7 +466,7 @@ func (k *K8sIntegrationSuite) benchmarkInformer(ctx context.Context, nCycles int
 					wg.Done()
 				},
 			},
-			k8s.ConvertToNode,
+			k8s.TransformToNode,
 		)
 		go controller.Run(ctx.Done())
 	} else {

--- a/pkg/k8s/init_test.go
+++ b/pkg/k8s/init_test.go
@@ -66,14 +66,15 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 				return true, n1copy, nil
 			})
 
-		node1Slim := ConvertToNode(node1.DeepCopy()).(*slim_corev1.Node)
-		node1Cilium := ParseNode(node1Slim, source.Unspec)
+		node1Slim, err := TransformToNode(node1.DeepCopy())
+		c.Assert(err, checker.Equals, nil)
+		node1Cilium := ParseNode(node1Slim.(*slim_corev1.Node), source.Unspec)
 		node1Cilium.SetCiliumInternalIP(net.ParseIP("10.254.0.1"))
 		useNodeCIDR(node1Cilium)
 		c.Assert(node.GetIPv4AllocRange().String(), Equals, "10.2.0.0/16")
 		// IPv6 Node range is not checked because it shouldn't be changed.
 
-		_, err := AnnotateNode(fakeK8sClient, "node1", *node1Cilium, 0)
+		_, err = AnnotateNode(fakeK8sClient, "node1", *node1Cilium, 0)
 
 		c.Assert(err, IsNil)
 
@@ -123,8 +124,9 @@ func (s *K8sSuite) TestUseNodeCIDR(c *C) {
 				return true, n2Copy, nil
 			})
 
-		node2Slim := ConvertToNode(node2.DeepCopy()).(*slim_corev1.Node)
-		node2Cilium := ParseNode(node2Slim, source.Unspec)
+		node2Slim, err := TransformToNode(node2.DeepCopy())
+		c.Assert(err, checker.Equals, nil)
+		node2Cilium := ParseNode(node2Slim.(*slim_corev1.Node), source.Unspec)
 		node2Cilium.SetCiliumInternalIP(net.ParseIP("10.254.0.1"))
 		useNodeCIDR(node2Cilium)
 

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -234,6 +234,6 @@ func CiliumSlimEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...
 	return resource.New[*types.CiliumEndpoint](lc, lw,
 		resource.WithLazyTransform(func() runtime.Object {
 			return &cilium_api_v2.CiliumEndpoint{}
-		}, ConvertToCiliumEndpointOrError),
+		}, TransformToCiliumEndpoint),
 	), nil
 }

--- a/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_clusterwide_envoy_config.go
@@ -66,7 +66,7 @@ func (k *K8sWatcher) ciliumClusterwideEnvoyConfigInit(ctx context.Context, clien
 				k.K8sEventProcessed(metricCCEC, resources.MetricDelete, err == nil)
 			},
 		},
-		k8s.ConvertToCiliumClusterwideEnvoyConfig,
+		k8s.TransformToCiliumClusterwideEnvoyConfig,
 	)
 
 	k.blockWaitGroupToSyncResources(

--- a/pkg/k8s/watchers/cilium_egress_gateway_policy.go
+++ b/pkg/k8s/watchers/cilium_egress_gateway_policy.go
@@ -59,7 +59,7 @@ func (k *K8sWatcher) ciliumEgressGatewayPolicyInit(ciliumNPClient client.Clients
 				k.K8sEventProcessed(metricCEGP, resources.MetricDelete, true)
 			},
 		},
-		k8s.ConvertToCiliumEgressGatewayPolicy,
+		k8s.TransformToCiliumEgressGatewayPolicy,
 	)
 
 	k.blockWaitGroupToSyncResources(

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -77,7 +77,7 @@ func (k *K8sWatcher) ciliumEndpointsInit(ciliumNPClient client.Clientset, asyncC
 					k.endpointDeleted(ciliumEndpoint)
 				},
 			},
-			k8s.ConvertToCiliumEndpoint,
+			k8s.TransformToCiliumEndpoint,
 			cache.Indexers{
 				"localNode": CreateCiliumEndpointLocalPodIndexFunc(),
 			},

--- a/pkg/k8s/watchers/cilium_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_envoy_config.go
@@ -70,7 +70,7 @@ func (k *K8sWatcher) ciliumEnvoyConfigInit(ctx context.Context, ciliumNPClient c
 				k.K8sEventProcessed(metricCEC, resources.MetricDelete, err == nil)
 			},
 		},
-		k8s.ConvertToCiliumEnvoyConfig,
+		k8s.TransformToCiliumEnvoyConfig,
 	)
 
 	k.blockWaitGroupToSyncResources(

--- a/pkg/k8s/watchers/cilium_local_redirect_policy.go
+++ b/pkg/k8s/watchers/cilium_local_redirect_policy.go
@@ -52,7 +52,7 @@ func (k *K8sWatcher) ciliumLocalRedirectPolicyInit(ciliumLRPClient client.Client
 				k.K8sEventProcessed(metricCLRP, resources.MetricDelete, err == nil)
 			},
 		},
-		k8s.ConvertToCiliumLocalRedirectPolicy,
+		k8s.TransformToCiliumLocalRedirectPolicy,
 	)
 
 	k.blockWaitGroupToSyncResources(

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -114,7 +114,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 					k.nodeDiscoverManager.NodeDeleted(n)
 				},
 			},
-			k8s.ConvertToCiliumNode,
+			k8s.TransformToCiliumNode,
 		)
 		isConnected := make(chan struct{})
 		// once isConnected is closed, it will stop waiting on caches to be

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
-	k8sTypes "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -418,7 +417,7 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 	// as this was added in sufficiently earlier versions of Cilium (v1.6).
 	// Source:
 	// https://github.com/cilium/cilium/commit/5c365f2c6d7930dcda0b8f0d5e6b826a64022a4f
-	k8sNode, err := n.k8sGetters.GetK8sNode(
+	slimNode, err := n.k8sGetters.GetK8sNode(
 		context.TODO(),
 		nodeTypes.GetName(),
 	)
@@ -440,15 +439,13 @@ func (n *NodeDiscovery) mutateNodeResource(nodeResource *ciliumv2.CiliumNode) er
 		APIVersion: "v1",
 		Kind:       "Node",
 		Name:       nodeTypes.GetName(),
-		UID:        k8sNode.UID,
+		UID:        slimNode.UID,
 	}}
-	providerID = k8sNode.Spec.ProviderID
+	providerID = slimNode.Spec.ProviderID
 
 	// Get the addresses from k8s node and add them as part of Cilium Node.
 	// Cilium Node should contain all addresses from k8s.
-	nodeInterface := k8s.ConvertToNode(k8sNode)
-	typesNode := nodeInterface.(*k8sTypes.Node)
-	k8sNodeParsed := k8s.ParseNode(typesNode, source.Unspec)
+	k8sNodeParsed := k8s.ParseNode(slimNode, source.Unspec)
 	k8sNodeAddresses = k8sNodeParsed.IPAddresses
 
 	nodeResource.ObjectMeta.Labels = k8sNodeParsed.Labels


### PR DESCRIPTION
- Removes `ConvertFunc` in favor of [TransformFunc](https://pkg.go.dev/k8s.io/client-go@v0.26.0/tools/cache#TransformFunc) for object transformation. Informers are now created with `TransformFunc` instead of `ConvertFunc` to mutate certain resources in K8s Caches.
- Renames ConvertXXX functions to TransformXXX.
- Adds tests to `pkg/k8s/init_test.go` to improve test coverage of transformer functions.

Fixes: #24923 
