### PR TITLE
daemon: Update code comment regarding PolicyReactionEvent

### DIFF
--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -421,7 +421,7 @@ func (r *PolicyReactionEvent) Handle(res chan interface{}) {
 //   - regenerate all endpoints in epsToRegen
 //   - bump the policy revision of all endpoints not in epsToRegen, but which are
 //     in allEps, to revision rev.
-//   - wait for the regenerations to be finished
+//   - wait for the all endpoint regenerations to be _queued_.
 //   - upsert or delete CIDR identities to the ipcache, as needed.
 func (r *PolicyReactionEvent) reactToRuleUpdates(epsToBumpRevision, epsToRegen *policy.EndpointSet, rev uint64, upsertPrefixes, releasePrefixes []netip.Prefix) {
 	var enqueueWaitGroup sync.WaitGroup


### PR DESCRIPTION
This code comment is confusing because it states that
reactToRuleUpdates() waits until all endpoints have been regenerated.

Upon code inspection, this is incorrect and not necessary either. It is
not necessary because 2820a1fc72 ("daemon: Switch policy over to new
IPCache interface") fixed the previously buggy behavior where prefixes
were pushed into the ipcache BPF map before the policy recalculation
(i.e. endpoint regeneration) has completed (endpoint policymap entries).
This buggy behavior likely caused CI flakes of some sort when new
policies were added.

The 8f20d3bfd7 commit mistakenly asserted this, so fix it in this
commit.

Fixes: 8f20d3bfd7 ("daemon: Postpone ipcache upserts until after policy
changes have been regenerated by endpoints.")

Reported-by: Joe Stringer <joe@cilium.io>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
