### PR TITLE
add a verdict before use the pointer variable

### DIFF
--- a/pkg/cidr/cidr.go
+++ b/pkg/cidr/cidr.go
@@ -89,6 +89,14 @@ func (n *CIDR) Equal(o *CIDR) bool {
 	return Equal(n.IPNet, o.IPNet)
 }
 
+// String returns the string about the CIDR like "192.0.2.0/24"
+func (in *CIDR) String() string {
+	if in == nil {
+		return "<nil>"
+	}
+	return in.IPNet.String()
+}
+
 // Equal returns true if the n and o net.IPNet CIDRs arr Equal.
 func Equal(n, o *net.IPNet) bool {
 	if n == nil || o == nil {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- I have deploy the cilium on my cluster,and the cilium-agent ds is crashed. I have checked the err log and discovered the function _getIPv4NativeRouting_   maybe return nil, so add the judge before use the pointer variable, i think return err when the pointer is nil is more gracefuly than crashed -->
```
