### PR TITLE
bgpv1: Fix use of k8s.LocalNodeResource and LocalCiliumNodeResource types

### DIFF
--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -119,15 +119,15 @@ func newFixture(conf fixtureConfig) *fixture {
 	// Construct a new Hive with mocked out dependency cells.
 	f.hive = hive.New(
 		// node resource
-		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) *k8s.LocalNodeResource {
-			lw := utils.ListerWatcherFromTyped[*corev1.NodeList](c.CoreV1().Nodes())
-			return &k8s.LocalNodeResource{Resource: resource.New[*corev1.Node](lc, lw)}
+		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) k8s.LocalNodeResource {
+			lw := utils.ListerWatcherFromTyped[*slim_core_v1.NodeList](c.Slim().CoreV1().Nodes())
+			return k8s.LocalNodeResource(resource.New[*slim_core_v1.Node](lc, lw))
 		}),
 
 		// cilium node resource
-		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) *k8s.LocalCiliumNodeResource {
+		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) k8s.LocalCiliumNodeResource {
 			lw := utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumNodeList](c.CiliumV2().CiliumNodes())
-			return &k8s.LocalCiliumNodeResource{Resource: resource.New[*cilium_api_v2.CiliumNode](lc, lw)}
+			return k8s.LocalCiliumNodeResource(resource.New[*cilium_api_v2.CiliumNode](lc, lw))
 		}),
 
 		// service


### PR DESCRIPTION
Due to a merge race the new tests in pkg/bgpv1 broke after 69dca4b53b was merged. Fix the types in the tests.

Fixes: 69dca4b53b ("k8s: Remove unnecessary boxing in Local(Cilium)NodeResource")
