### PR TITLE
Fix CIDR json tag in CNP CIDRRule

### DIFF
--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -39,7 +39,7 @@ type CIDRRule struct {
 	// CIDR is a CIDR prefix / IP Block.
 	//
 	// +kubebuilder:validation:OneOf
-	Cidr CIDR `json:"cidr"`
+	Cidr CIDR `json:"cidr,omitempty"`
 
 	// CIDRGroupRef is a reference to a CiliumCIDRGroup object.
 	// A CiliumCIDRGroup contains a list of CIDRs that the endpoint, subject to


### PR DESCRIPTION
Without the omitempty tag, the following valid policy:

```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "echo-ingress-from-cidr-group-ref"
  namespace: "default"
spec:
  description: "Allow echo pods to receive ingress traffic from a specific CIDR Group"
  endpointSelector:
    matchLabels:
      kind: echo
  ingress:
  - fromCIDRSet:
    - cidrGroupRef: "connectivity-test-cidr-group"
```

cannot be correctly decoded from YAML using an `UniversalDeserializer` from `runtime/serializer`.
