### PR TITLE
ipam,alibabacloud: Improve event driven instance resync

### DIFF
--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -212,6 +212,11 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 	return resyncStart
 }
 
+func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) time.Time {
+	// Resync for a separate instance is not implemented yet, fallback to full resync.
+	return m.Resync(ctx)
+}
+
 // UpdateENI updates the ENI definition of an ENI for a particular instance. If
 // the ENI is already known, the definition is updated, otherwise the ENI is
 // added to the instance.

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -99,6 +99,11 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 	return resyncStart
 }
 
+func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) time.Time {
+	// Resync for a separate instance is not implemented yet, fallback to full resync.
+	return m.Resync(ctx)
+}
+
 // DeleteInstance delete instance from m.instances
 func (m *InstancesManager) DeleteInstance(instanceID string) {
 	m.mutex.Lock()

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -113,6 +113,10 @@ type Node struct {
 	// limiting.
 	k8sSync *trigger.Trigger
 
+	// instanceSync is the trigger used to fetch instance information
+	// with external APIs or systems.
+	instanceSync *trigger.Trigger
+
 	// ops is the IPAM implementation to used for this node
 	ops NodeOperations
 
@@ -367,6 +371,12 @@ func (n *Node) InstanceID() (id string) {
 	}
 	n.mutex.RUnlock()
 	return
+}
+
+func (n *Node) instanceAPISync(ctx context.Context, instanceID string) (time.Time, bool) {
+	syncTime := n.manager.instancesAPI.InstanceSync(ctx, instanceID)
+	success := !syncTime.IsZero()
+	return syncTime, success
 }
 
 // UpdatedResource is called when an update to the CiliumNode has been
@@ -955,7 +965,7 @@ func (n *Node) MaintainIPPool(ctx context.Context) error {
 	n.poolMaintenanceComplete()
 	n.recalculate()
 	if instanceMutated || err != nil {
-		n.manager.resyncTrigger.Trigger()
+		n.instanceSync.Trigger()
 	}
 	return err
 }

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -59,6 +59,10 @@ func (a *allocationImplementationMock) Resync(ctx context.Context) time.Time {
 	return time.Now()
 }
 
+func (a *allocationImplementationMock) InstanceSync(ctx context.Context, instanceID string) time.Time {
+	return time.Now()
+}
+
 func (a *allocationImplementationMock) HasInstance(instanceID string) bool {
 	return true
 }
@@ -452,19 +456,19 @@ func (e *IPAMSuite) TestNodeManagerReleaseAddress(c *check.C) {
 	// Trigger resync manually, excess IPs should be released down to 18
 	// (10 used + 4 prealloc + 4 max-above-watermark)
 	// Excess timestamps should be registered after this trigger
-	mngr.resyncTrigger.Trigger()
+	node.instanceSync.Trigger()
 
 	// Acknowledge release IPs after 3 secs
 	time.AfterFunc(3*time.Second, func() {
 		// Excess delay duration should have elapsed by now, trigger resync again.
 		// IPs should be marked as excess
-		mngr.resyncTrigger.Trigger()
+		node.instanceSync.Trigger()
 		time.Sleep(1 * time.Second)
 		node.PopulateIPReleaseStatus(node.resource)
 		// Fake acknowledge IPs for release like agent would.
 		testutils.FakeAcknowledgeReleaseIps(node.resource)
 		// Resync one more time to process acknowledgements.
-		mngr.resyncTrigger.Trigger()
+		node.instanceSync.Trigger()
 	})
 
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
@@ -511,7 +515,7 @@ func (e *IPAMSuite) TestNodeManagerAbortRelease(c *check.C) {
 
 	// Trigger resync manually, excess IPs should be released down to 3
 	// Excess timestamps should be registered after this trigger
-	mngr.resyncTrigger.Trigger()
+	node.instanceSync.Trigger()
 	wg.Add(1)
 
 	// Acknowledge release IPs after 3 secs
@@ -519,7 +523,7 @@ func (e *IPAMSuite) TestNodeManagerAbortRelease(c *check.C) {
 		defer wg.Done()
 		// Excess delay duration should have elapsed by now, trigger resync again.
 		// IPs should be marked as excess
-		mngr.resyncTrigger.Trigger()
+		node.instanceSync.Trigger()
 		time.Sleep(1 * time.Second)
 		node.PopulateIPReleaseStatus(node.resource)
 
@@ -532,7 +536,7 @@ func (e *IPAMSuite) TestNodeManagerAbortRelease(c *check.C) {
 		mngr.Upsert(updateCiliumNode(node.resource, 3))
 		node.poolMaintainer.Trigger()
 		// Resync one more time to process acknowledgements.
-		mngr.resyncTrigger.Trigger()
+		node.instanceSync.Trigger()
 
 		time.Sleep(1 * time.Second)
 		node.PopulateIPReleaseStatus(node.resource)

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -410,6 +410,13 @@ func NewInstanceMap() *InstanceMap {
 	return &InstanceMap{data: map[string]*Instance{}}
 }
 
+// UpdateInstance updates the interfaces map for a particular instance.
+func (m *InstanceMap) UpdateInstance(instanceID string, instance *Instance) {
+	m.mutex.Lock()
+	m.data[instanceID] = instance
+	m.mutex.Unlock()
+}
+
 // Update updates the definition of an interface for a particular instance. If
 // the interface is already known, the definition is updated, otherwise the
 // interface is added to the instance.


### PR DESCRIPTION
Currently in AWS/Alibabacloud ipam modes, every time the IP allocation/release event happens, the cilium operator triggers a resync and fetches all the ENIs from instance API. In a large and frequently changing cluster, the full sync might take several tens of seconds. This slows down the IP allocation process severely and also imposes a lot of pressure on the instance API. The full sync here should be unnecessary since we only need to update the ENIs of the instance that triggered the event.

This patch introduces a new `Node.instanceSync` trigger to replace `NodeManager.resyncTrigger`. Whenever an instance is mutated due to IP pool maintenance, the trigger attempts to incrementally resynchronize the corresponding instance to the local cache. This is achieved through the newly introduced `InstanceSync` method of the `AllocationImplementation` interface.
While this feature is implemented for Alibabacloud, AWS and Azure still fall back to full resynchronization.

Here are some time cost data from an Alibabacloud cluster during different periods:

                                  full sync    InstanceSync
    time cost with ~8000  ENIs    ~20s         ~2s
    time cost with ~13000 ENIs    ~35s         ~2s

Related: #25073

```release-note
ipam,alibabacloud: Improve event driven instance resync
```
