### PR TITLE
cilium, hf, 1.10: test setting prio

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1025,6 +1025,7 @@ out:
 					      METRIC_EGRESS);
 #endif /* ENABLE_HOST_FIREWALL */
 
+	bwm_xfer_prio(ctx);
 #if defined(ENABLE_BANDWIDTH_MANAGER)
 	ret = edt_sched_departure(ctx);
 	/* No send_drop_notify_error() here given we're rate-limiting. */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -981,6 +981,7 @@ int handle_xgress(struct __ctx_buff *ctx)
 	switch (proto) {
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
+		bwm_save_prio(ctx);
 		edt_set_aggregate(ctx, LXC_ID);
 		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
 					is_defined(DEBUG)),
@@ -989,6 +990,7 @@ int handle_xgress(struct __ctx_buff *ctx)
 #endif /* ENABLE_IPV6 */
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
+		bwm_save_prio(ctx);
 		edt_set_aggregate(ctx, LXC_ID);
 		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
 					is_defined(DEBUG)),

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -354,6 +354,7 @@ int to_overlay(struct __ctx_buff *ctx)
 	if (unlikely(ret < 0))
 		goto out;
 
+	bwm_xfer_prio(ctx);
 #ifdef ENABLE_BANDWIDTH_MANAGER
 	/* In tunneling mode, we should do this as close as possible to the
 	 * phys dev where FQ runs, but the issue is that the aggregate state

--- a/bpf/include/bpf/helpers_skb.h
+++ b/bpf/include/bpf/helpers_skb.h
@@ -40,6 +40,8 @@ static int BPF_FUNC(skb_change_tail, struct __sk_buff *skb, __u32 nlen,
 static int BPF_FUNC(skb_change_head, struct __sk_buff *skb, __u32 head_room,
 		    __u64 flags);
 
+static __u32 BPF_FUNC(skb_cgroup_classid, struct __sk_buff *skb);
+
 static int BPF_FUNC(skb_pull_data, struct __sk_buff *skb, __u32 len);
 
 /* Packet tunnel encap/decap */

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -10,6 +10,23 @@
 #include "time.h"
 #include "maps.h"
 
+static __always_inline void bwm_save_prio(struct __ctx_buff *ctx __maybe_unused)
+{
+#if __ctx_is == __ctx_skb
+	/* queue mapping is retained, upper stack orhpans skb->sk */
+	/* note: 16 bit only retained */
+	ctx->queue_mapping = skb_cgroup_classid(ctx);
+#endif
+}
+
+static __always_inline void bwm_xfer_prio(struct __ctx_buff *ctx __maybe_unused)
+{
+#if __ctx_is == __ctx_skb
+	ctx->priority = ctx->queue_mapping;
+	ctx->queue_mapping = 0;
+#endif
+}
+
 /* From XDP layer, we neither go through an egress hook nor qdisc
  * from here, hence nothing to be set.
  */


### PR DESCRIPTION
the prio can be pushed into Pod's net_cls cgroup: `echo 123 > net_cls.classid`