### PR TITLE
bgpv1: use slim_core_v1 node instead of corev1 in test fixtures

### DIFF
--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -145,7 +145,7 @@ func Test_PodCIDRAdvert(t *testing.T) {
 	err = gobgpPeers[0].waitForSessionState(testCtx, []string{"ESTABLISHED"})
 	require.NoError(t, err)
 
-	tracker := fixture.fakeClientSet.KubernetesFakeClientset.Tracker()
+	tracker := fixture.fakeClientSet.SlimFakeClientset.Tracker()
 
 	for _, step := range steps {
 		t.Run(step.description, func(t *testing.T) {

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -26,7 +26,6 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -95,7 +94,7 @@ type fixture struct {
 }
 
 type fixtureConfig struct {
-	node      corev1.Node
+	node      slim_core_v1.Node
 	policy    cilium_api_v2alpha1.CiliumBGPPeeringPolicy
 	ipam      string
 	bgpEnable bool
@@ -110,8 +109,8 @@ func newFixture(conf fixtureConfig) *fixture {
 	f.policyClient = f.fakeClientSet.CiliumFakeClientset.CiliumV2alpha1().CiliumBGPPeeringPolicies()
 
 	// create default base node
-	f.fakeClientSet.KubernetesFakeClientset.Tracker().Create(
-		corev1.SchemeGroupVersion.WithResource("nodes"), conf.node.DeepCopy(), "")
+	f.fakeClientSet.SlimFakeClientset.Tracker().Create(
+		slim_core_v1.SchemeGroupVersion.WithResource("nodes"), conf.node.DeepCopy(), "")
 
 	// create initial bgp policy
 	f.fakeClientSet.CiliumFakeClientset.Tracker().Add(&conf.policy)

--- a/pkg/bgpv1/test/objects.go
+++ b/pkg/bgpv1/test/objects.go
@@ -8,7 +8,6 @@ import (
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -55,9 +54,9 @@ type nodeConfig struct {
 }
 
 // newNodeObj creates new corev1.Node object based on passed config
-func newNodeObj(conf nodeConfig) corev1.Node {
-	nodeObj := corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
+func newNodeObj(conf nodeConfig) slim_core_v1.Node {
+	nodeObj := slim_core_v1.Node{
+		ObjectMeta: slim_meta_v1.ObjectMeta{
 			Name:        "base-node",
 			Labels:      map[string]string{},
 			Annotations: map[string]string{},


### PR DESCRIPTION
BGP tests : use slim_core_v1 node instead of corev1 kubernetes node objects. 

Follow up of https://github.com/cilium/cilium/pull/25615 