### PR TITLE
hubble: replace deprecated usage of grpc.WithInsecure.

### DIFF
--- a/pkg/hubble/peer/types/client.go
+++ b/pkg/hubble/peer/types/client.go
@@ -52,8 +52,11 @@ type LocalClientBuilder struct {
 func (b LocalClientBuilder) Client(target string) (Client, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), b.DialTimeout)
 	defer cancel()
-	// the connection is local so we assume WithInsecure() is safe in this context
-	conn, err := grpc.DialContext(ctx, target, grpc.WithInsecure(), grpc.WithBlock())
+	// The connection is local, so we assume using insecure connection is safe in
+	// this context.
+	conn, err := grpc.DialContext(ctx, target,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hubble/relay/pool/client.go
+++ b/pkg/hubble/relay/pool/client.go
@@ -11,6 +11,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/cilium/cilium/pkg/crypto/certloader"
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
@@ -27,7 +28,7 @@ type GRPCClientConnBuilder struct {
 	Options []grpc.DialOption
 
 	// TLSConfig is used to build transport credentials for the connection.
-	// If not provided, grpc.WithInsecure() is added to Options before creating
+	// If not provided, insecure credentials are added to Options before creating
 	// a new ClientConn.
 	TLSConfig certloader.ClientConfigBuilder
 }
@@ -50,7 +51,7 @@ func (b GRPCClientConnBuilder) ClientConn(target, hostname string) (poolTypes.Cl
 	copy(opts, b.Options)
 
 	if b.TLSConfig == nil {
-		opts = append(opts, grpc.WithInsecure())
+		opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	} else {
 		// NOTE: gosec is unable to resolve the constant and warns about "TLS
 		// MinVersion too low".

--- a/pkg/hubble/relay/pool/option.go
+++ b/pkg/hubble/relay/pool/option.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/cilium/cilium/pkg/backoff"
 	peerTypes "github.com/cilium/cilium/pkg/hubble/peer/types"
@@ -26,7 +27,7 @@ var defaultOptions = options{
 	clientConnBuilder: GRPCClientConnBuilder{
 		DialTimeout: defaults.DialTimeout,
 		Options: []grpc.DialOption{
-			grpc.WithInsecure(),
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
 			grpc.WithBlock(),
 			grpc.FailOnNonTempDialError(true),
 			grpc.WithReturnConnectionError(),


### PR DESCRIPTION
[Current method is to use `grpc.WithTransportCredentials(insecure.NewCredentials())`](https://pkg.go.dev/google.golang.org/grpc#WithInsecure)

