### PR TITLE
hive/jobs: fix enqueueing of multiple jobs via variadic func

### DIFF
--- a/pkg/hive/job/job.go
+++ b/pkg/hive/job/job.go
@@ -169,13 +169,13 @@ func (jg *group) Add(jobs ...Job) {
 	jg.mu.Lock()
 	defer jg.mu.Unlock()
 
-	for _, j := range jobs {
-		// The context is only set once the group has been started. If we have not yet started, queue the job.
-		if jg.ctx == nil {
-			jg.queuedJobs = append(jg.queuedJobs, j)
-			return
-		}
+	// The context is only set once the group has been started. If we have not yet started, queue the jobs.
+	if jg.ctx == nil {
+		jg.queuedJobs = append(jg.queuedJobs, jobs...)
+		return
+	}
 
+	for _, j := range jobs {
 		jg.wg.Add(1)
 		pprof.Do(jg.ctx, jg.options.pprofLabels, func(ctx context.Context) {
 			go j.start(ctx, jg.wg, jg.options)

--- a/pkg/hive/job/job_test.go
+++ b/pkg/hive/job/job_test.go
@@ -676,10 +676,15 @@ func TestRegistry(t *testing.T) {
 func TestGroup_JobQueue(t *testing.T) {
 	h := fixture(func(r Registry, l hive.Lifecycle) {
 		g := r.NewGroup()
-		g.Add(OneShot("queued", func(ctx context.Context) error {
-			return nil
-		}))
-		if len(g.(*group).queuedJobs) != 1 {
+		g.Add(
+			OneShot("queued1", func(ctx context.Context) error { return nil }),
+			OneShot("queued2", func(ctx context.Context) error { return nil }),
+		)
+		g.Add(
+			OneShot("queued3", func(ctx context.Context) error { return nil }),
+			OneShot("queued4", func(ctx context.Context) error { return nil }),
+		)
+		if len(g.(*group).queuedJobs) != 4 {
 			t.Fatal()
 		}
 		l.Append(g)


### PR DESCRIPTION
Currently, when registering multiple jobs to the hive job queue at once via the variadic function, only the first job gets enqueued.

This PR fixes this by adding all jobs to the queue of the job group.