### PR TITLE
command/exec: remove unused (*Cmd).WithFilters method

### DIFF
--- a/pkg/command/exec/exec_test.go
+++ b/pkg/command/exec/exec_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	. "gopkg.in/check.v1"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/logging"
 )
 
@@ -88,37 +87,4 @@ func (h *LoggingHook) Fire(entry *logrus.Entry) error {
 	}
 	h.Lines = append(h.Lines, serializedEntry)
 	return nil
-}
-
-func (s *ExecTestSuite) TestWithFilters(c *C) {
-	hook := &LoggingHook{}
-	logging.DefaultLogger.Hooks.Add(hook)
-	logging.SetLogLevel(logrus.WarnLevel)
-	defer logging.SetDefaultLogLevel()
-
-	// This command will print the following output to stderr:
-	//
-	// cat: /some/non/existing/file: No such file or directory
-	// cat: /non/existing/file/filtered/out: No such file or directory
-	//
-	// But the second message should be filtered out from logging.
-	cmd := CommandContext(context.Background(),
-		"cat",
-		"/non/existing/file",
-		"/non/existing/file/filtered/out").WithFilters("/filtered/out")
-	scopedLog := logging.DefaultLogger.WithField("foo", "bar")
-	out, err := cmd.CombinedOutput(scopedLog, true)
-	c.Assert(err, ErrorMatches, "exit status 1")
-
-	// Both errors be returned by CombinedOutput.
-	expectedOut := `cat: /non/existing/file: No such file or directory
-cat: /non/existing/file/filtered/out: No such file or directory
-`
-	c.Assert(string(out), Equals, expectedOut)
-
-	// The last error message should be filtered out from logging.
-	logLines := []string{
-		"level=warning msg=\"cat: /non/existing/file: No such file or directory\" foo=bar\n",
-	}
-	c.Assert(hook.Lines, checker.DeepEquals, logLines)
 }


### PR DESCRIPTION
It's unused since commit bf2602b552b1 ("bpf,datapath: switch to cilium/ebpf loader and native netlink calls").