### PR TITLE
hive: add support for map[string]string flags

### DIFF
--- a/Documentation/contributing/development/hive.rst
+++ b/Documentation/contributing/development/hive.rst
@@ -403,12 +403,25 @@ returns a cell that "provides" the parsed configuration to the application:
 
     type MyConfig struct {
         MyOption string
+
+        SliceOption []string
+        MapOption map[string]string
     }
 
     func (def MyConfig) Flags(flags *pflag.FlagSet) {
         // Register the "my-option" flag. This matched against the MyOption field
         // by removing any dashes and doing case insensitive comparison.
         flags.String("my-option", def.MyOption, "My config option")
+
+        // Flags are supported for representing complex types such as slices and maps.
+        // * Slices are obtained splitting the input string on commas.
+        // * Maps support different formats based on how they are provided:
+        //   - CLI: key=value format, separated by commas; the flag can be
+        //     repeated multiple times.
+        //   - Environment variable or configuration file: either JSON encoded
+        //     or comma-separated key=value format.
+        flags.StringSlice("slice-option", def.SliceOption, "My slice config option")
+        flags.StringToString("map-option", def.MapOption, "My map config option")
     }
 
     var defaultMyConfig = MyConfig{

--- a/pkg/command/map_string.go
+++ b/pkg/command/map_string.go
@@ -32,10 +32,17 @@ func GetStringMapString(vp *viper.Viper, key string) map[string]string {
 
 // GetStringMapStringE is same as GetStringMapString, but with error
 func GetStringMapStringE(vp *viper.Viper, key string) (map[string]string, error) {
-	data := vp.Get(key)
+	return ToStringMapStringE(vp.Get(key))
+}
+
+// ToStringMapStringE casts an interface to a map[string]string type. The underlying
+// interface type might be a map or string. In the latter case, it is attempted to be
+// json decoded, falling back to the k1=v2,k2=v2 format in case it doesn't look like json.
+func ToStringMapStringE(data interface{}) (map[string]string, error) {
 	if data == nil {
 		return map[string]string{}, nil
 	}
+
 	v, err := cast.ToStringMapStringE(data)
 	if err != nil {
 		var syntaxErr *json.SyntaxError

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1354,9 +1354,16 @@ func LogRegisteredOptions(vp *viper.Viper, entry *logrus.Entry) {
 	keys := vp.AllKeys()
 	sort.Strings(keys)
 	for _, k := range keys {
-		v := vp.GetStringSlice(k)
-		if len(v) > 0 {
-			entry.Infof("  --%s='%s'", k, strings.Join(v, ","))
+		ss := vp.GetStringSlice(k)
+		if len(ss) == 0 {
+			sm := vp.GetStringMap(k)
+			for k, v := range sm {
+				ss = append(ss, fmt.Sprintf("%s=%s", k, v))
+			}
+		}
+
+		if len(ss) > 0 {
+			entry.Infof("  --%s='%s'", k, strings.Join(ss, ","))
 		} else {
 			entry.Infof("  --%s='%s'", k, vp.GetString(k))
 		}


### PR DESCRIPTION
Reporting the description of the main commit for convenience:

```
Introduce a decoding hook to convert from a string to the corresponding
map[string]string representation when the target configuration entry is
of the corresponding type. It reuses the same logic already adopted
today outside of hive, assuming initially that the string is json
encoded, and falling back to the KV format in case of errors. This
allows to have a config struct contain map[string]string options,
registering the corresponding flag through flags.StringToString.
```

<!-- Description of change -->

```release-note
hive: add support for map[string]string flags
```
