### PR TITLE
.github: add renovate/stop-updating label on renovate's PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -53,6 +53,7 @@
     "enabled": true
   },
   "labels": [
+    "renovate/stop-updating",
     "kind/enhancement",
     "release-note/misc"
   ],


### PR DESCRIPTION
When renovate opens a PR, it will keep updating the dependencies until the PR is open. This makes it difficult have a green CI run since some dependencies are being updated frequently and we aren't able to merge the PR. Thus, we will add this label to prevent renovate from updating PRs after opening them.
