### PR TITLE
backporting: Fix pattern to handle commit subjects that begin with a space

### DIFF
--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -151,10 +151,9 @@ generate_commit_list_for_pr () {
   echo "                 ----------                          -------------------"
   echo "     v (start)"
   while read entry; do
-    entry_array=($entry)
-    entry_id=${entry_array[0]}
-    entry_sha=${entry_array[1]}
-    entry_sub=${entry_array[@]:2}
+    entry_id=$(echo "$entry" | cut -d ' ' -f 1)
+    entry_sha=$(echo "$entry" | cut -d ' ' -f 2)
+    entry_sub=$(echo "$entry" | cut -d ' ' -f 3-)
     entry_sub_re="^$(sed 's/[.^$*+?()[{\|]/\\&/g' <<< "$entry_sub")$" # adds backslashes for extended regex
     related_commits="$(git log --since="1year" --pretty="%H" --no-merges --extended-regexp --grep "$entry_sub_re" $REMOTE/main)"
     found_commit=0


### PR DESCRIPTION
Commit da04e683fa (" bpf/nat: introduce snat_v*_handle_mapping() nat and rev_nat") has a subject that starts with a space, which results in this warning when trying to backport it:

     |  Warning: No commit correlation found!    via b968e9db2a58aaa9ad5e68a470d52bc2357a4f15 ("bpf/nat: introduce snat_v*_handle_mapping() nat and rev_nat")

Fix parsing so that it doesn't trim leading and trailing spaces from the commit subject.