### PR TITLE
Add workload context to hubble context labels.

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -620,6 +620,7 @@ Option Value          Description
 ``dns``               All known DNS names of the source or destination (comma-separated)
 ``ip``                The IPv4 or IPv6 address
 ``reserved-identity`` Reserved identity label.
+``workload``          Kubernetes pod's workload name and namespace in the form of ``namespace/workload-name``.
 ``workload-name``     Kubernetes pod's workload name (workloads are: Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift), etc).
 ``app``               Kubernetes pod's app name, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
 ===================== ===================================================================================

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -39,6 +39,8 @@ const (
 	// purpose. It uses "reserved:kube-apiserver" label if it's present in the identity label list.
 	// Otherwise, it uses the first label in the identity label list with "reserved:" prefix.
 	ContextReservedIdentity
+	// ContextWorkload uses the namespace and the pod's workload name for identification.
+	ContextWorkload
 	// ContextWorkloadName uses the pod's workload name for identification.
 	ContextWorkloadName
 	// ContextApp uses the pod's app label for identification.
@@ -54,7 +56,7 @@ const ContextOptionsHelp = `
  destinationEgressContext  ::= identifier , { "|", identifier }
  destinationIngressContext ::= identifier , { "|", identifier }
  labels                    ::= label , { ",", label }
- identifier             ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload-name | app
+ identifier             ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
  label                     ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 
@@ -105,6 +107,8 @@ func (c ContextIdentifier) String() string {
 		return "ip"
 	case ContextReservedIdentity:
 		return "reserved-identity"
+	case ContextWorkload:
+		return "workload"
 	case ContextWorkloadName:
 		return "workload-name"
 	case ContextApp:
@@ -165,6 +169,8 @@ func parseContextIdentifier(s string) (ContextIdentifier, error) {
 		return ContextIP, nil
 	case "reserved-identity":
 		return ContextReservedIdentity, nil
+	case "workload":
+		return ContextWorkload, nil
 	case "workload-name":
 		return ContextWorkloadName, nil
 	case "app":
@@ -468,6 +474,13 @@ func getContextIDLabelValue(contextID ContextIdentifier, flow *pb.Flow, source b
 		}
 	case ContextReservedIdentity:
 		labelValue = handleReservedIdentityLabels(ep.GetLabels())
+	case ContextWorkload:
+		if workloads := ep.GetWorkloads(); len(workloads) != 0 {
+			labelValue = workloads[0].Name
+		}
+		if labelValue != "" && ep.GetNamespace() != "" {
+			labelValue = ep.GetNamespace() + "/" + labelValue
+		}
 	case ContextWorkloadName:
 		if workloads := ep.GetWorkloads(); len(workloads) != 0 {
 			labelValue = workloads[0].Name

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -289,6 +289,19 @@ func Test_reservedIdentityContext(t *testing.T) {
 	}), []string{"reserved:host", "reserved:remote-node"})
 }
 
+func Test_workloadContext(t *testing.T) {
+	opts, err := ParseContextOptions(Options{"sourceContext": "workload", "destinationContext": "workload"})
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{
+		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod"},
+		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod"}}), []string{"", ""})
+	assert.EqualValues(t, mustGetLabelValues(opts, &pb.Flow{
+		Source:      &pb.Endpoint{Namespace: "foo-ns", PodName: "foo-deploy-pod", Workloads: []*pb.Workload{{Name: "foo-deploy", Kind: "Deployment"}}},
+		Destination: &pb.Endpoint{Namespace: "bar-ns", PodName: "bar-deploy-pod", Workloads: []*pb.Workload{{Name: "bar-deploy", Kind: "Deployment"}}},
+	}), []string{"foo-ns/foo-deploy", "bar-ns/bar-deploy"})
+}
+
 func Test_workloadNameContext(t *testing.T) {
 	opts, err := ParseContextOptions(Options{"sourceContext": "workload-name", "destinationContext": "workload-name"})
 	assert.NoError(t, err)

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -27,7 +27,7 @@ Options:
  destinationEgressContext  ::= identifier , { "|", identifier }
  destinationIngressContext ::= identifier , { "|", identifier }
  labels                    ::= label , { ",", label }
- identifier             ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload-name | app
+ identifier             ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
  label                     ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())


### PR DESCRIPTION
Workload context labels hubble metrics with namespace and workload name.


Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.

As `pod-short` is deprecated and going to be removed in 1.14, current `workload-name` isn't a sufficient replacement as it misses the namespace.


```release-note
Add workload label context (hubble metrics).
```
