### PR TITLE
test/k8s: quarantine High-scale IPcache test

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -471,7 +471,9 @@ var _ = Describe("K8sDatapathConfig", func() {
 		})
 	})
 
-	SkipContextIf(helpers.DoesNotRunOnNetNextKernel, "High-scale IPcache", func() {
+	SkipContextIf(func() bool {
+		return helpers.SkipQuarantined() || helpers.DoesNotRunOnNetNextKernel()
+	}, "High-scale IPcache", func() {
 		const hsIPcacheFile = "high-scale-ipcache.yaml"
 
 		AfterEach(func() {


### PR DESCRIPTION
This test has been failing more than 75% of the test runs, thus it will be quarantined.

Test runs with the failures:

 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/19
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/20
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/21
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/23
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/24
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/25
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/26
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/27
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/28
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/29
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/30
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/31
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/32
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/33
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/34
