### PR TITLE
test/k8s: quarantine K8sDatapathServicesTest

### DIFF
--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -617,7 +617,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			testIPv4FragmentSupport(kubectl, ni)
 		})
 
-		SkipContextIf(func() bool { return helpers.RunsOnGKE() }, "With host policy", func() {
+		SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
 			var ccnpHostPolicy string
 
 			BeforeAll(func() {


### PR DESCRIPTION
The "K8sDatapathServicesTest Checks N/S loadbalancing With host policy Tests NodePort" test has been failing more than 75% of the test runs, thus it will be quarantined.

Test runs with the failures:

 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/25
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/26
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/27
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/28
 - https://jenkins.cilium.io/view/all/job/cilium-main-k8s-1.26-kernel-net-next/33

Issue tracking the flake #25524