### PR TITLE
clustermesh: allow waiting for the CiliumClusterConfig to appear when required

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -584,7 +584,7 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, servi
 		ID: cfg.clusterID,
 	}
 
-	if err := clustermesh.SetClusterConfig(cfg.clusterName, &config, kvstore.Client()); err != nil {
+	if err := clustermesh.SetClusterConfig(context.Background(), cfg.clusterName, &config, kvstore.Client()); err != nil {
 		log.WithError(err).Fatal("Unable to set local cluster config on kvstore")
 	}
 

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -51,6 +51,11 @@ spec:
         - |
           rm -rf /var/run/etcd/*;
           /usr/local/bin/etcd --data-dir=/var/run/etcd --name=clustermesh-apiserver --listen-client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster-token=clustermesh-apiserver --initial-cluster-state=new --auto-compaction-retention=1 &
+
+          # The following key needs to be created before that the cilium agents
+          # have the possibility of connecting to etcd.
+          etcdctl put cilium/.has-cluster-config true
+
           etcdctl user add root --no-password;
           etcdctl user grant-role root root;
           etcdctl user add admin-{{ .Values.cluster.name }} --no-password;

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -66,7 +66,7 @@ type Configuration struct {
 	ClusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc `optional:"true"`
 }
 
-func SetClusterConfig(clusterName string, config *cmtypes.CiliumClusterConfig, backend kvstore.BackendOperations) error {
+func SetClusterConfig(ctx context.Context, clusterName string, config *cmtypes.CiliumClusterConfig, backend kvstore.BackendOperations) error {
 	key := path.Join(kvstore.ClusterConfigPrefix, clusterName)
 
 	val, err := json.Marshal(config)
@@ -74,7 +74,7 @@ func SetClusterConfig(clusterName string, config *cmtypes.CiliumClusterConfig, b
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	_, err = backend.UpdateIfDifferent(ctx, key, val, true)
@@ -85,10 +85,10 @@ func SetClusterConfig(clusterName string, config *cmtypes.CiliumClusterConfig, b
 	return nil
 }
 
-func GetClusterConfig(clusterName string, backend kvstore.BackendOperations) (*cmtypes.CiliumClusterConfig, error) {
+func GetClusterConfig(ctx context.Context, clusterName string, backend kvstore.BackendOperations) (*cmtypes.CiliumClusterConfig, error) {
 	var config cmtypes.CiliumClusterConfig
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	val, err := backend.Get(ctx, path.Join(kvstore.ClusterConfigPrefix, clusterName))

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -108,6 +108,16 @@ func GetClusterConfig(clusterName string, backend kvstore.BackendOperations) (*c
 	return &config, nil
 }
 
+// IsClusterConfigRequired returns whether the remote kvstore guarantees that the
+// cilium cluster config will be eventually created.
+func IsClusterConfigRequired(ctx context.Context, backend kvstore.BackendOperations) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	val, err := backend.Get(ctx, kvstore.HasClusterConfigPath)
+	return val != nil, err
+}
+
 // RemoteIdentityWatcher is any type which provides identities that have been
 // allocated on a remote cluster.
 type RemoteIdentityWatcher interface {

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -306,7 +306,7 @@ func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.B
 	rc.controllers.UpdateController(ctrlname, controller.ControllerParams{
 		DoFunc: func(ctx context.Context) error {
 			rc.getLogger().Debug("Retrieving cluster configuration from remote kvstore")
-			config, err := GetClusterConfig(rc.name, backend)
+			config, err := GetClusterConfig(ctx, rc.name, backend)
 			if err != nil {
 				return err
 			}

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -56,6 +56,9 @@ func (s *ClusterMeshServicesTestSuite) SetUpSuite(c *C) {
 }
 
 func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	kvstore.SetupDummy("etcd")
 
 	s.randomName = rand.RandomString()
@@ -77,7 +80,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 		config := cmtypes.CiliumClusterConfig{
 			ID: uint32(i),
 		}
-		err := SetClusterConfig(cluster, &config, kvstore.Client())
+		err := SetClusterConfig(ctx, cluster, &config, kvstore.Client())
 		c.Assert(err, IsNil)
 	}
 
@@ -89,8 +92,6 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	err = os.WriteFile(config2, etcdConfig, 0644)
 	c.Assert(err, IsNil)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	ipc := ipcache.NewIPCache(&ipcache.Configuration{
 		Context: ctx,
 	})

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -39,6 +39,15 @@ const (
 	// the heartbeat
 	HeartbeatPath = BaseKeyPrefix + "/.heartbeat"
 
+	// HasClusterConfigPath is the path to the key used to convey that the cluster
+	// configuration will be eventually created, and remote cilium agents shall
+	// wait until it is present. If this key is not set, the cilium configuration
+	// might, or might not, be configured, but the agents will continue regardless,
+	// falling back to the backward compatible behavior. It must be set before that
+	// the agents have the possibility to connect to the kvstore (that is, when
+	// it is not yet exposed). The corresponding values is ignored.
+	HasClusterConfigPath = BaseKeyPrefix + "/.has-cluster-config"
+
 	// ClusterConfigPrefix is the kvstore prefix to cluster configuration
 	ClusterConfigPrefix = BaseKeyPrefix + "/cluster-config"
 


### PR DESCRIPTION
Reporting the description of the first commit for convenience:

```
857060bbcf07 ("clustermesh: Introduce CiliumClusterConfig") introduced
the CiliumClusterConfig, which the clustermesh-apiserver stores into the
kvstore during startup, and the remote cilium agents read when connecting
to new clusters. Cilium agents tolerate the possible lack of the cluster
configuration, to account for backward compatibility.

This process currently suffers from the possibility of a race condition,
because the agents might connect to the kvstore before that the cluster
configuration has been actually written. Although as of today it doesn't
raise particular concerns given that it is only used for sanity checks,
the issue will be more serious when depending on the information therein
contained to tune the behavior. One such case concerns the upcoming
kvstoremesh approach (caching the information of remote clusters in
the local kvstore), which leverages different prefixes for separation
(hence requiring the cluster config to be present for disambiguation)
and increases the race condition window (since the cluster configuration
of new clusters would be written at runtime rather than on startup).

This commit introduces a new well-known key (`cilium/.has-cilium-config`)
that, when present, conveys that the cluster configuration will be
eventually created, and remote clusters shall wait until it is present
rather than falling back to the legacy approach. This key will be
created by the clustermesh-apiserver init container, ensuring that it is
always present when etcd is exposed to the remote agents.

Alternative approaches that have been considered, but discarded because
they would solve the problem for vanilla clustermesh but not for
kvstoremesh include:
* Setting the CiliumClusterConfig in the clustermesh-apiserver init
  container rather than during the initialization phase.
* Leveraging a readiness probe to set the clustermesh-apiserver as ready
  only once the initialization phase completed, and the configuration
  has been written.
```

Another possibility might involve being strict and making the cluster configuration mandatory starting from v1.14. This looks a no-go to me though, because:
* It would prevent a cluster Cilium v1.14 to mesh with another running Cilium v1.12 (I couldn't find any official documentation about the maximum supported skew in the clustermesh scenario to say whether this is acceptable or not).
* AFAIK. we are not currently setting the cluster configuration when the clustermesh-apiserver is not used (i.e., Cilium is run with the kvstore backend). In this scenario, even a cluster running Cilium v1.13 would be incompatible (unless the cluster config is created manually before upgrading the other clusters).  

/cc @YutaroHayakawa, @marseel, @aanm, @joestringer for opinions.

<!-- Description of change -->

```release-note
clustermesh: allow waiting for the CiliumClusterConfig to appear when required
```
