### PR TITLE
envoy: Never use x-forwarded-for header, add for Cilium Ingress

### DIFF
--- a/examples/kubernetes/servicemesh/envoy/envoy-admin-listener.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-admin-listener.yaml
@@ -27,5 +27,7 @@ spec:
                   prefix: "/"
                 route:
                   cluster: "envoy-admin"
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router

--- a/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
@@ -19,6 +19,8 @@ spec:
           stat_prefix: envoy-prometheus-metrics-listener
           rds:
             route_config_name: prometheus_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
   - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration

--- a/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
@@ -19,6 +19,8 @@ spec:
                 stat_prefix: envoy-lb-listener
                 rds:
                   route_config_name: lb_route
+                use_remote_address: true
+                skip_xff_append: true
                 http_filters:
                   - name: envoy.filters.http.router
     - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -267,7 +267,7 @@ func (m *Manager) getConnectionManager(svc *slim_corev1.Service) (ciliumv2.XDSRe
 			},
 		},
 		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
-		SkipXffAppend:    true,
+		SkipXffAppend:    false,
 		HttpFilters: []*envoy_extensions_filters_network_http_connection_manager_v3.HttpFilter{
 			{
 				Name: "envoy.filters.http.router",

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -266,6 +266,8 @@ func (m *Manager) getConnectionManager(svc *slim_corev1.Service) (ciliumv2.XDSRe
 				RouteConfigName: getName(svc),
 			},
 		},
+		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+		SkipXffAppend:    true,
 		HttpFilters: []*envoy_extensions_filters_network_http_connection_manager_v3.HttpFilter{
 			{
 				Name: "envoy.filters.http.router",

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -8,6 +8,7 @@ import (
 	httpConnectionManagerv3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -23,6 +24,8 @@ func NewHTTPConnectionManager(name, routeName string, mutationFunc ...HttpConnec
 		RouteSpecifier: &httpConnectionManagerv3.HttpConnectionManager_Rds{
 			Rds: &httpConnectionManagerv3.Rds{RouteConfigName: routeName},
 		},
+		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+		SkipXffAppend:    true,
 		HttpFilters: []*httpConnectionManagerv3.HttpFilter{
 			{
 				Name: "envoy.filters.http.router",

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -25,7 +25,7 @@ func NewHTTPConnectionManager(name, routeName string, mutationFunc ...HttpConnec
 			Rds: &httpConnectionManagerv3.Rds{RouteConfigName: routeName},
 		},
 		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
-		SkipXffAppend:    true,
+		SkipXffAppend:    false,
 		HttpFilters: []*httpConnectionManagerv3.HttpFilter{
 			{
 				Name: "envoy.filters.http.router",

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -54,7 +54,7 @@ var httpInsecureListenerXDSResource = toAny(&envoy_config_listener.Listener{
 								{UpgradeType: "websocket"},
 							},
 							UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
-							SkipXffAppend:    true,
+							SkipXffAppend:    false,
 							HttpFilters: []*http_connection_manager_v3.HttpFilter{
 								{
 									Name: "envoy.filters.http.router",

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -52,6 +53,8 @@ var httpInsecureListenerXDSResource = toAny(&envoy_config_listener.Listener{
 							UpgradeConfigs: []*http_connection_manager_v3.HttpConnectionManager_UpgradeConfig{
 								{UpgradeType: "websocket"},
 							},
+							UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+							SkipXffAppend:    true,
 							HttpFilters: []*http_connection_manager_v3.HttpFilter{
 								{
 									Name: "envoy.filters.http.router",

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -148,6 +148,8 @@ func toListenerFilter(name string) *envoy_config_listener.Filter {
 				UpgradeConfigs: []*http_connection_manager_v3.HttpConnectionManager_UpgradeConfig{
 					{UpgradeType: "websocket"},
 				},
+				UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+				SkipXffAppend:    true,
 				HttpFilters: []*http_connection_manager_v3.HttpFilter{
 					{
 						Name: "envoy.filters.http.router",

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -149,7 +149,7 @@ func toListenerFilter(name string) *envoy_config_listener.Filter {
 					{UpgradeType: "websocket"},
 				},
 				UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
-				SkipXffAppend:    true,
+				SkipXffAppend:    false,
 				HttpFilters: []*http_connection_manager_v3.HttpFilter{
 					{
 						Name: "envoy.filters.http.router",

--- a/pkg/envoy/ciliumenvoyconfig_test.go
+++ b/pkg/envoy/ciliumenvoyconfig_test.go
@@ -100,6 +100,8 @@ resources:
               route:
                 cluster: "envoy-admin"
                 prefix_rewrite: "/stats/prometheus"
+        use_remote_address: true
+        skip_xff_append: true
         http_filters:
         - name: envoy.filters.http.router
 `
@@ -138,6 +140,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
       transport_socket:
@@ -236,6 +240,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
 `
@@ -306,6 +312,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
 `
@@ -378,6 +386,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
   - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
@@ -687,6 +697,8 @@ spec:
                   - upgrade_type: CONNECT
                     connect_config:
                       allow_post: true
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
           http2_protocol_options:

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -270,7 +270,9 @@ func (s *XDSServer) getHttpFilterChainProto(clusterName string, tls bool) *envoy
 	retryTimeout := int64(option.Config.HTTPRetryTimeout) //seconds
 
 	hcmConfig := &envoy_config_http.HttpConnectionManager{
-		StatPrefix: "proxy",
+		StatPrefix:       "proxy",
+		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+		SkipXffAppend:    true,
 		HttpFilters: []*envoy_config_http.HttpFilter{
 			getCiliumHttpFilter(),
 			{
@@ -525,7 +527,9 @@ func (s *XDSServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
 
 	s.addListener(metricsListenerName, func() *envoy_config_listener.Listener {
 		hcmConfig := &envoy_config_http.HttpConnectionManager{
-			StatPrefix: metricsListenerName,
+			StatPrefix:       metricsListenerName,
+			UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+			SkipXffAppend:    true,
 			HttpFilters: []*envoy_config_http.HttpFilter{{
 				Name: "envoy.filters.http.router",
 				ConfigType: &envoy_config_http.HttpFilter_TypedConfig{

--- a/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
@@ -38,6 +38,8 @@ var (
               route:
                 cluster: "envoy-admin"
                 prefix_rewrite: "/stats/prometheus"
+        use_remote_address: true
+        skip_xff_append: true
         http_filters:
         - name: envoy.filters.http.router
 `)

--- a/pkg/k8s/watchers/cilium_envoy_config_test.go
+++ b/pkg/k8s/watchers/cilium_envoy_config_test.go
@@ -46,6 +46,8 @@ spec:
                 route:
                   cluster: "envoy-admin"
                   prefix_rewrite: "/stats/prometheus"
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
 `)


### PR DESCRIPTION
Envoy by default gets the source address from the x-forwarded-for header, if present. Always add an explicit `use_remote_address: true` for Envoy HTTP Connection Manager configuration to disable the default behavior.

Also add `skip_xff_append: true` config to keep the existing behavior of not adding `x-forwarded-for` headers, except for Cilium Ingress, where we now use `skip_xff_append: false` to explicitly append the source IP to `x-forwarded-for` header so that Hubble flow records have a trace for the original source of the traffic traversing Cilium Ingress.

Fixes: #25630

```release-note
Fix incorrect hubble flow data when HTTP requests contain an `x-forwarded-for` header by adding an explicit `use_remote_address: true` config to Envoy HTTP configuration to always use the actual remote address of the incoming connection rather than the value of `x-forwarded-for` header, which may originate from an untrusted source. This change has no effect on Cilium policy enforcement where the source security identity is always resolved before HTTP headers are parsed. Previous Cilium behavior of not adding `x-forwarded-for` headers is retained via an explicit `skip_xff_append: true` config setting, except for Cilium Ingress where the source IP address is now appended to `x-forwarded-for` header.
```
