### PR TITLE
Fix missed deletion events when reconnecting to/disconnecting from remote clusters (identities)

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -148,6 +148,9 @@ type Allocator struct {
 	// disableGC disables the garbage collector
 	disableGC bool
 
+	// disableAutostart prevents starting the allocator when it is initialized
+	disableAutostart bool
+
 	// backend is the upstream, shared, backend to which we syncronize local
 	// information
 	backend Backend
@@ -316,6 +319,14 @@ func NewAllocator(typ AllocatorKey, backend Backend, opts ...AllocatorOption) (*
 
 	a.idPool = idpool.NewIDPool(a.min, a.max)
 
+	if !a.disableAutostart {
+		a.start()
+	}
+
+	return a, nil
+}
+
+func (a *Allocator) start() {
 	a.initialListDone = a.mainCache.start()
 	if !a.disableGC {
 		go func() {
@@ -327,8 +338,6 @@ func NewAllocator(typ AllocatorKey, backend Backend, opts ...AllocatorOption) (*
 			a.startLocalKeySync()
 		}()
 	}
-
-	return a, nil
 }
 
 // WithBackend sets this allocator to use backend. It is expected to be used at
@@ -376,6 +385,11 @@ func WithMasterKeyProtection() AllocatorOption {
 // WithoutGC disables the use of the garbage collector
 func WithoutGC() AllocatorOption {
 	return func(a *Allocator) { a.disableGC = true }
+}
+
+// WithoutAutostart prevents starting the allocator when it is initialized
+func WithoutAutostart() AllocatorOption {
+	return func(a *Allocator) { a.disableAutostart = true }
 }
 
 // GetEvents returns the events channel given to the allocator when
@@ -887,7 +901,22 @@ type AllocatorEvent struct {
 // identities. The contents are not directly accessible but will be merged into
 // the ForeachCache() function.
 type RemoteCache struct {
-	cache *cache
+	name string
+
+	allocator *Allocator
+	cache     *cache
+
+	watchFunc func(ctx context.Context, remote *RemoteCache)
+}
+
+func (a *Allocator) NewRemoteCache(remoteName string, remoteAlloc *Allocator) *RemoteCache {
+	return &RemoteCache{
+		name:      remoteName,
+		allocator: remoteAlloc,
+		cache:     &remoteAlloc.mainCache,
+
+		watchFunc: a.WatchRemoteKVStore,
+	}
 }
 
 // WatchRemoteKVStore starts watching an allocator base prefix the kvstore
@@ -895,16 +924,66 @@ type RemoteCache struct {
 // kvstore will be maintained in the RemoteCache structure returned and will
 // start being reported in the identities returned by the ForeachCache()
 // function. RemoteName should be unique per logical "remote".
-func (a *Allocator) WatchRemoteKVStore(remoteName string, remoteAlloc *Allocator) *RemoteCache {
-	rc := &RemoteCache{
-		cache: &remoteAlloc.mainCache,
+func (a *Allocator) WatchRemoteKVStore(ctx context.Context, rc *RemoteCache) {
+	scopedLog := log.WithField(logfields.ClusterName, rc.name)
+	scopedLog.Info("Starting remote kvstore watcher")
+
+	rc.allocator.start()
+
+	select {
+	case <-ctx.Done():
+		scopedLog.Debug("Context canceled before remote kvstore watcher synchronization completed: stale identities will now be drained")
+		rc.close()
+
+		a.remoteCachesMutex.RLock()
+		old := a.remoteCaches[rc.name]
+		a.remoteCachesMutex.RUnlock()
+
+		if old != nil {
+			old.cache.mutex.RLock()
+			defer old.cache.mutex.RUnlock()
+		}
+
+		// Drain all entries that might have been received until now, and that
+		// are not present in the current cache (if any). This ensures we do not
+		// leak any stale identity, and at the same time we do not invalidate the
+		// current state.
+		rc.cache.drainIf(func(id idpool.ID) bool {
+			if old == nil {
+				return true
+			}
+
+			_, ok := old.cache.nextCache[id]
+			return !ok
+		})
+		return
+
+	case <-rc.cache.listDone:
+		scopedLog.Info("Remote kvstore watcher successfully synchronized and registered")
 	}
 
 	a.remoteCachesMutex.Lock()
-	a.remoteCaches[remoteName] = rc
+	old := a.remoteCaches[rc.name]
+	a.remoteCaches[rc.name] = rc
 	a.remoteCachesMutex.Unlock()
 
-	return rc
+	if old != nil {
+		// In case of reconnection, let's emit a deletion event for all stale identities
+		// that are no longer present in the kvstore. We take the lock of the new cache
+		// to ensure that we observe a stable state during this process (i.e., no keys
+		// are added/removed in the meanwhile).
+		scopedLog.Debug("Another kvstore watcher was already registered: deleting stale identities")
+		rc.cache.mutex.RLock()
+		old.cache.drainIf(func(id idpool.ID) bool {
+			_, ok := rc.cache.nextCache[id]
+			return !ok
+		})
+		rc.cache.mutex.RUnlock()
+	}
+
+	<-ctx.Done()
+	rc.close()
+	scopedLog.Info("Stopped remote kvstore watcher")
 }
 
 // RemoveRemoteKVStore removes any reference to a remote allocator / kvstore.
@@ -912,6 +991,12 @@ func (a *Allocator) RemoveRemoteKVStore(remoteName string) {
 	a.remoteCachesMutex.Lock()
 	delete(a.remoteCaches, remoteName)
 	a.remoteCachesMutex.Unlock()
+}
+
+// Watch starts watching the remote kvstore and synchronize the identities in
+// the local cache. It blocks until the context is closed.
+func (rc *RemoteCache) Watch(ctx context.Context) {
+	rc.watchFunc(ctx, rc)
 }
 
 // NumEntries returns the number of entries in the remote cache
@@ -923,8 +1008,8 @@ func (rc *RemoteCache) NumEntries() int {
 	return rc.cache.numEntries()
 }
 
-// Close stops watching for identities in the kvstore associated with the
+// close stops watching for identities in the kvstore associated with the
 // remote cache.
-func (rc *RemoteCache) Close() {
+func (rc *RemoteCache) close() {
 	rc.cache.allocator.Delete()
 }

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -200,6 +200,19 @@ func (c *cache) stop() {
 	c.stopWatchWg.Wait()
 }
 
+// drain emits a deletion event for all known IDs. It must be called after the
+// cache has been stopped, to ensure that no new events can be received afterwards.
+func (c *cache) drain() {
+	// Make sure we wait until the watch loop has been properly stopped.
+	c.stopWatchWg.Wait()
+
+	c.mutex.Lock()
+	for id, key := range c.nextCache {
+		c.onDeleteLocked(id, key)
+	}
+	c.mutex.Unlock()
+}
+
 // drainIf emits a deletion event for all known IDs that are stale according to
 // the isStale function. It must be called after the cache has been stopped, to
 // ensure that no new events can be received afterwards.

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -64,9 +64,10 @@ type Configuration struct {
 // RemoteIdentityWatcher is any type which provides identities that have been
 // allocated on a remote cluster.
 type RemoteIdentityWatcher interface {
-	// WatchRemoteIdentities starts watching for identities in another kvstore and
-	// syncs all identities to the local identity cache. RemoteName should be unique
-	// unless replacing an existing remote's backend.
+	// WatchRemoteIdentities returns a RemoteCache instance which can be later
+	// started to watch identities in another kvstore and sync them to the local
+	// identity cache. remoteName should be unique unless replacing an existing
+	// remote's backend.
 	WatchRemoteIdentities(remoteName string, backend kvstore.BackendOperations) (*allocator.RemoteCache, error)
 
 	// RemoveRemoteIdentities removes any reference to a remote identity source.

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -70,7 +70,8 @@ type RemoteIdentityWatcher interface {
 	// remote's backend.
 	WatchRemoteIdentities(remoteName string, backend kvstore.BackendOperations) (*allocator.RemoteCache, error)
 
-	// RemoveRemoteIdentities removes any reference to a remote identity source.
+	// RemoveRemoteIdentities removes any reference to a remote identity source,
+	// emitting a deletion event for all previously known identities.
 	RemoveRemoteIdentities(name string)
 }
 

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -71,9 +71,6 @@ type RemoteIdentityWatcher interface {
 
 	// RemoveRemoteIdentities removes any reference to a remote identity source.
 	RemoveRemoteIdentities(name string)
-
-	// Close stops the watcher.
-	Close()
 }
 
 // ClusterMesh is a cache of multiple remote clusters

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/internal"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
@@ -74,8 +75,6 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		return err
 	}
 
-	defer remoteIdentityCache.Close()
-
 	rc.mutex.Lock()
 	rc.config = config
 	rc.remoteIdentityCache = remoteIdentityCache
@@ -98,6 +97,10 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 
 	mgr.Register(ipcache.IPIdentitiesPath, func(ctx context.Context) {
 		rc.ipCacheWatcher.Watch(ctx, backend)
+	})
+
+	mgr.Register(identityCache.IdentitiesPath, func(ctx context.Context) {
+		rc.remoteIdentityCache.Watch(ctx)
 	})
 
 	mgr.Run(ctx)


### PR DESCRIPTION
Follow up of https://github.com/cilium/cilium/pull/25499 targeting identities synchronization. Please refer to the above PR and the commit descriptions for additional information.

Related: https://github.com/cilium/cilium/issues/24740
Related: https://github.com/cilium/cilium/pull/25499

Fix missed deletion events when reconnecting to/disconnecting from remote clusters (identities)
