### PR TITLE
[v1.11] Reinitialize IPsec on device changes

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -173,6 +173,10 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 		return nil
 	}
 
+	// Guard against concurrent calls from Reinitialize() and reloadIPSecOnLinkChanges()
+	l.ipsecMu.Lock()
+	defer l.ipsecMu.Unlock()
+
 	interfaces := option.Config.EncryptInterface
 	if option.Config.IPAM == ipamOption.IPAMENI {
 		// IPAMENI mode supports multiple network facing interfaces that

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -178,18 +178,17 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 		// IPAMENI mode supports multiple network facing interfaces that
 		// will all need Encrypt logic applied in order to decrypt any
 		// received encrypted packets. This logic will attach to all
-		// !veth devices. Only use if user has not configured interfaces.
-		if len(interfaces) == 0 {
-			if links, err := netlink.LinkList(); err == nil {
-				for _, link := range links {
-					isVirtual, err := ethtool.IsVirtualDriver(link.Attrs().Name)
-					if err == nil && !isVirtual {
-						interfaces = append(interfaces, link.Attrs().Name)
-					}
+		// !veth devices.
+		interfaces = nil
+		if links, err := netlink.LinkList(); err == nil {
+			for _, link := range links {
+				isVirtual, err := ethtool.IsVirtualDriver(link.Attrs().Name)
+				if err == nil && !isVirtual {
+					interfaces = append(interfaces, link.Attrs().Name)
 				}
 			}
-			option.Config.EncryptInterface = interfaces
 		}
+		option.Config.EncryptInterface = interfaces
 	}
 
 	// No interfaces is valid in tunnel disabled case


### PR DESCRIPTION
A custom fix for v1.11 to reload IPsec when the network devices change. This is required when IPsec is enabled
and used with IPAM ENI mode where new network devices may be added at runtime.

Since v1.11 does not contain the "runtime-device-detection" feature, this fixes the issue by subscribing to
link updates directly in loader.