### PR TITLE
clustermesh: fix SyncedCanaries capability name mismatch

### DIFF
--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -35,7 +35,7 @@ type CiliumClusterConfig struct {
 
 type CiliumClusterConfigCapabilities struct {
 	// Supports per-prefix "synced" canaries
-	SyncedCanaries bool `json:"syncedFlags,omitempty"`
+	SyncedCanaries bool `json:"syncedCanaries,omitempty"`
 }
 
 func (c0 *CiliumClusterConfig) IsCompatible(c1 *CiliumClusterConfig) error {


### PR DESCRIPTION
8ed956c14620 ("clustermesh: extend CiliumClusterConfig with capabilities") just introduced the SyncedCanaries capability. Yet, there was a mismatch between the variable name and the JSON field name, which is now fixed.

<!-- Description of change -->

Fixes: #issue-number

```release-note
clustermesh: fix SyncedCanaries capability name mismatch
```
