### PR TITLE
Fix bug with `toServices` policy where service backend churn left stale CIDR identities

### DIFF
--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -63,7 +63,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, false)
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, map[string]string{}, false)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -77,7 +77,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epAddrCluster.Addr().String()+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, map[string]string{}, false)
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, endpointInfo, true, map[string]string{}, false)
 	result, err = repo.TranslateRules(translator)
 	c.Assert(result.NumToServicesRules, Equals, 1)
 
@@ -119,7 +119,7 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 		},
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false)
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, svcLabels, false)
 	c.Assert(translator.serviceMatches(service), Equals, true)
 }
 
@@ -169,7 +169,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, svcLabels, false)
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, svcLabels, false)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -183,7 +183,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epAddrCluster.Addr().String()+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, true, svcLabels, false)
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, endpointInfo, true, svcLabels, false)
 	result, err = repo.TranslateRules(translator)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
@@ -224,7 +224,7 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 		Namespace: "default",
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, false)
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, map[string]string{}, false)
 	prefixesToAllocate, err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 	c.Assert(len(prefixesToAllocate), Equals, 0, Commentf("if allocatePrefixes is false, then it should return nothing"))
@@ -378,7 +378,7 @@ func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
 		Namespace: "default",
 	}
 
-	translator := NewK8sTranslator(serviceInfo, endpointInfo, false, map[string]string{}, false)
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, map[string]string{}, false)
 	_, err := translator.generateToCidrFromEndpoint(rule, endpointInfo, false)
 	c.Assert(err, IsNil)
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -616,7 +616,7 @@ func (k *K8sWatcher) k8sServiceHandler() {
 			if event.OldEndpoints != nil {
 				oldEP = *event.OldEndpoints
 			}
-			translator := k8s.NewK8sTranslator(event.ID, oldEP, *event.Endpoints, false, svc.Labels, true)
+			translator := k8s.NewK8sTranslator(event.ID, oldEP, *event.Endpoints, false, svc.Labels)
 			result, err := k.policyRepository.TranslateRules(translator)
 			if err != nil {
 				log.WithError(err).Error("Unable to repopulate egress policies from ToService rules")
@@ -644,7 +644,7 @@ func (k *K8sWatcher) k8sServiceHandler() {
 
 			// Use the current Endpoints object as the "old" object and "new"
 			// object due to deletion.
-			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, *event.Endpoints, true, svc.Labels, true)
+			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, *event.Endpoints, true, svc.Labels)
 			result, err := k.policyRepository.TranslateRules(translator)
 			if err != nil {
 				log.WithError(err).Error("Unable to depopulate egress policies from ToService rules")

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -171,10 +171,10 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 			switch policyRepositoryCalls {
 			case 0:
 				parsedEPs := k8s.ParseEndpoints(ep1stApply)
-				c.Assert(rt.Endpoint.Backends, checker.DeepEquals, parsedEPs.Backends)
+				c.Assert(rt.NewEndpoint.Backends, checker.DeepEquals, parsedEPs.Backends)
 			case 1:
 				parsedEPs := k8s.ParseEndpoints(ep2ndApply)
-				c.Assert(rt.Endpoint.Backends, checker.DeepEquals, parsedEPs.Backends)
+				c.Assert(rt.NewEndpoint.Backends, checker.DeepEquals, parsedEPs.Backends)
 			default:
 				c.Assert(policyRepositoryCalls, Not(Equals), 0, Commentf("policy repository was called more times than expected!"))
 			}
@@ -1172,7 +1172,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 	w.K8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
 	// Running a 2nd update should also trigger a new upsert service
 	w.K8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
-	// Running a 3rd update should not trigger anything because the
+	// Running a 3rd update should also not trigger anything because the
 	// endpoints are the same
 	w.K8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 
@@ -2723,7 +2723,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 	w.K8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep1stApply), swg)
 	// Running a 2nd update should also trigger a new upsert service
 	w.K8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
-	// Running a 3rd update should not trigger anything because the
+	// Running a 3rd update should also not trigger anything because the
 	// endpoints are the same
 	w.K8sSvcCache.UpdateEndpoints(k8s.ParseEndpoints(ep2ndApply), swg)
 


### PR DESCRIPTION
- k8s: Plumb old Endpoints object through handlers
- k8s: Fix toServices rule translation cleanup
- k8s: Add test for RuleTranslator.Translate()
- k8s: Remove unnecessary AllocatePrefixes from RuleTranslator

Fixes: #20477

---

Main commit "k8s: Fix toServices rule translation cleanup" will be pasted below for ease of review:
> Previously, toServices-based rules did not properly cleanup CIDR
identities. When service backends were removed or changed, the deletion
logic acted on the new object rather than on the old object, thus
the entries that were supposed to be deleted were simply added back in
generateToCidrFromEndpoint().
>
> Fix this by passing the deletion logic the old endpoint object state
and performing a diff between the old and new states.
