### PR TITLE
gh/workflows: Pin LVH VMs to v0.3

### DIFF
--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -179,26 +179,26 @@ jobs:
         include:
           # See https://github.com/cilium/cilium/issues/20606 for configuration table
           - name: '1'
-            kernel: '4.19-20230420.212204'
+            kernel: '4.19-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'
 
           - name: '2'
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
 
           - name: '3'
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
             endpoint-routes: 'true'
 
           - name: '4'
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-v0.3'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -207,7 +207,7 @@ jobs:
             egress-gateway: 'true'
 
           - name: '5'
-            kernel: '5.15-20230420.212204'
+            kernel: '5.15-v0.3'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
@@ -217,7 +217,7 @@ jobs:
             host-fw: 'true'
 
           - name: '6'
-            kernel: '6.0-20230420.212204'
+            kernel: '6.0-v0.3'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -227,7 +227,7 @@ jobs:
             lb-acceleration: 'testing-only'
 
           - name: '7'
-            kernel: 'bpf-next-20230420.212204'
+            kernel: 'bpf-next-main'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'disabled'
@@ -236,14 +236,14 @@ jobs:
             lb-acceleration: 'testing-only'
 
           - name: '8'
-            kernel: 'bpf-next-20230420.212204'
+            kernel: 'bpf-next-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'geneve'
             endpoint-routes: 'true'
 
           - name: '9'
-            kernel: '4.19-20230420.212204'
+            kernel: '4.19-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'
@@ -252,7 +252,7 @@ jobs:
             ipv6: 'false' # https://github.com/cilium/cilium/issues/23461
 
           - name: '10'
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -260,7 +260,7 @@ jobs:
             encryption-node: 'false'
 
           - name: '11'
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -269,7 +269,7 @@ jobs:
             endpoint-routes: 'true'
 
           - name: '12'
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-v0.3'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -280,7 +280,7 @@ jobs:
             egress-gateway: 'true'
 
           - name: '13'
-            kernel: '5.15-20230420.212204'
+            kernel: '5.15-v0.3'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
@@ -291,7 +291,7 @@ jobs:
             egress-gateway: 'true'
 
           - name: '14'
-            kernel: 'bpf-next-20230420.212204'
+            kernel: 'bpf-next-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'geneve'

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -176,26 +176,26 @@ jobs:
           # See https://github.com/cilium/cilium/issues/20606 for configuration table
 
           - name: '1'
-            kernel: '4.19-20230420.212204'
+            kernel: '4.19-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'
 
           - name: '2'
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
 
           - name: '3'
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
             endpoint-routes: 'true'
 
           - name: '4'
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-v0.3'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -204,7 +204,7 @@ jobs:
             egress-gateway: 'true'
 
           - name: '5'
-            kernel: '5.15-20230420.212204'
+            kernel: '5.15-v0.3'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
@@ -214,7 +214,7 @@ jobs:
             host-fw: 'true'
 
           - name: '6'
-            kernel: '6.0-20230420.212204'
+            kernel: '6.0-v0.3'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -224,7 +224,7 @@ jobs:
             lb-acceleration: 'testing-only'
 
           - name: '7'
-            kernel: 'bpf-next-20230420.212204'
+            kernel: 'bpf-next-main'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'disabled'
@@ -233,14 +233,14 @@ jobs:
             lb-acceleration: 'testing-only'
 
           - name: '8'
-            kernel: 'bpf-next-20230420.212204'
+            kernel: 'bpf-next-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'geneve'
             endpoint-routes: 'true'
 
           - name: '9'
-            kernel: '4.19-20230420.212204'
+            kernel: '4.19-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'
@@ -248,7 +248,7 @@ jobs:
             encryption-node: 'false'
 
           - name: '10'
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -256,7 +256,7 @@ jobs:
             encryption-node: 'false'
 
           - name: '11'
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-v0.3'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -265,7 +265,7 @@ jobs:
             endpoint-routes: 'true'
 
           - name: '12'
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-v0.3'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -276,7 +276,7 @@ jobs:
             egress-gateway: 'true'
 
           - name: '13'
-            kernel: '5.15-20230420.212204'
+            kernel: '5.15-v0.3'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
@@ -287,7 +287,7 @@ jobs:
             egress-gateway: 'true'
 
           - name: '14'
-            kernel: '6.0-20230420.212204'
+            kernel: '6.0-v0.3'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -297,7 +297,7 @@ jobs:
             egress-gateway: 'true'
 
           - name: '15'
-            kernel: 'bpf-next-20230420.212204'
+            kernel: 'bpf-next-main'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'disabled'
@@ -307,7 +307,7 @@ jobs:
             egress-gateway: 'true'
 
           - name: '16'
-            kernel: 'bpf-next-20230420.212204'
+            kernel: 'bpf-next-main'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'geneve'

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -169,15 +169,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - kernel: '4.19-20230420.212204'
+          - kernel: '4.19-v0.3'
             ci-kernel: '419'
-          - kernel: '5.4-20230420.212204'
+          - kernel: '5.4-v0.3'
             ci-kernel: '54'
-          - kernel: '5.10-20230420.212204'
+          - kernel: '5.10-v0.3'
             ci-kernel: '510'
-          - kernel: '5.15-20230420.212204'
+          - kernel: '5.15-v0.3'
             ci-kernel: '510'
-          - kernel: 'bpf-next-20230420.212204'
+          - kernel: 'bpf-next-main'
             ci-kernel: 'netnext'
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
This commit pins LVH VMs version to the v0.3 to avoid situations when a
new VM version is not working (-main) or the temp tag gets deleted
(-20230420.212204).

For bpf-next stick to -main, as we want to test any potential
regressions of new bpf-next kernels.

Fix #25682 