### PR TITLE
helm: add extraArgs to clustermesh-apiserver

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -348,6 +348,10 @@
      - Security context to be added to clustermesh-apiserver etcd containers
      - object
      - ``{}``
+   * - clustermesh.apiserver.extraArgs
+     - Additional clustermesh-apiserver arguments.
+     - list
+     - ``[]``
    * - clustermesh.apiserver.extraEnv
      - Additional clustermesh-apiserver environment variables.
      - list

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -137,6 +137,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.etcd.init.resources | object | `{}` | Specifies the resources for etcd init container in the apiserver |
 | clustermesh.apiserver.etcd.resources | object | `{}` | Specifies the resources for etcd container in the apiserver |
 | clustermesh.apiserver.etcd.securityContext | object | `{}` | Security context to be added to clustermesh-apiserver etcd containers |
+| clustermesh.apiserver.extraArgs | list | `[]` | Additional clustermesh-apiserver arguments. |
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
 | clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -162,6 +162,9 @@ spec:
         {{- if .Values.clustermesh.apiserver.metrics.enabled }}
         - --prometheus-serve-addr=:{{ .Values.clustermesh.apiserver.metrics.port }}
         {{- end }}
+        {{- with .Values.clustermesh.apiserver.extraArgs }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
         env:
         - name: CLUSTER_NAME
           valueFrom:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2644,6 +2644,9 @@ clustermesh:
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
 
+    # -- Additional clustermesh-apiserver arguments.
+    extraArgs: []
+
     # -- Additional clustermesh-apiserver environment variables.
     extraEnv: []
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2641,6 +2641,9 @@ clustermesh:
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
 
+    # -- Additional clustermesh-apiserver arguments.
+    extraArgs: []
+
     # -- Additional clustermesh-apiserver environment variables.
     extraEnv: []
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
This adds `extraArgs` to clustermesh-apiserver in the helm chart. This will allow users to increase `kvstore-opt` such as `etcd.qps` which can't be overriden via env variables since args take precedence.

```release-note
helm: add extraArgs to clustermesh-apiserver
```
