### PR TITLE
Add missing LB IPAM description in the operator document

### DIFF
--- a/Documentation/internals/cilium_operator.rst
+++ b/Documentation/internals/cilium_operator.rst
@@ -50,6 +50,14 @@ Cilium. The following custom resources are registered by the Cilium Operator:
 -  CiliumExternalWorkload
 -  CiliumIdentity
 -  CiliumLocalRedirectPolicy
+-  CiliumEgressGatewayPolicy
+-  CiliumEndpointSlice
+-  CiliumClusterwideEnvoyConfig
+-  CiliumEnvoyConfig
+-  CiliumBGPPeeringPolicy
+-  CiliumLoadBalancerIPPool
+-  CiliumNodeConfig
+-  CiliumCIDRGroup
 
 IPAM
 ~~~~

--- a/Documentation/internals/cilium_operator.rst
+++ b/Documentation/internals/cilium_operator.rst
@@ -85,6 +85,12 @@ mode:
 
 For more information on IPAM visit :ref:`address_management`.
 
+Load Balancer IP Address Management
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When :ref:`lb_ipam` is used, Cilium Operator manages IP address
+for ``type: LoadBalancer`` services.
+
 KVStore operations
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
LB IPAM description was missing from the operator document. Also, the list of CRDs was out-of-date. 

```release-note
Add missing LB IPAM description in the operator document
```
