### PR TITLE
ipcache: Handle error during label injection

### DIFF
--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -286,6 +286,10 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 	// Don't hold lock while calling UpdateIdentities, as it will otherwise run into a deadlock
 	ipc.metadata.RUnlock()
 
+	if err != nil {
+		return remainingPrefixes, err
+	}
+
 	// Recalculate policy first before upserting into the ipcache.
 	if len(idsToAdd) > 0 {
 		ipc.UpdatePolicyMaps(ctx, idsToAdd, idsToDelete)


### PR DESCRIPTION
There was an error case that was not handled, namely when
resolveIdentity() fails. Found by code inspection. Unclear whether this
was having further ramifications.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
