### PR TITLE
Add BPF unit tests for IPsec

### DIFF
--- a/bpf/tests/ipsec_from_host_test.c
+++ b/bpf/tests/ipsec_from_host_test.c
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define ROUTER_IP
+#include "config_replacement.h"
+#undef ROUTER_IP
+
+#define NODE_ID 2333
+#define ENCRYPT_KEY 3
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_IPSEC
+#define TUNNEL_MODE
+#define HAVE_ENCAP
+#define ENCAP_IFINDEX 4
+#define SECCTX_FROM_IPCACHE 1
+
+#define skb_set_tunnel_key mock_skb_set_tunnel_key
+#define ctx_redirect mock_ctx_redirect
+
+int mock_skb_set_tunnel_key(__maybe_unused struct __sk_buff *skb,
+			    const struct bpf_tunnel_key *from,
+			    __maybe_unused __u32 size,
+			    __maybe_unused __u32 flags)
+{
+	/* 0xfffff is the default SECLABEL */
+	if (from->tunnel_id != 0xfffff)
+		return -1;
+	if (from->local_ipv4 != 0)
+		return -2;
+	if (from->remote_ipv4 != bpf_htonl(v4_node_two))
+		return -3;
+	return 0;
+}
+
+int mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused, int ifindex, __u32 flags)
+{
+	if (ifindex != ENCAP_IFINDEX)
+		return -1;
+	if (flags != 0)
+		return -2;
+	return CTX_ACT_REDIRECT;
+}
+
+#include "bpf_host.c"
+
+#define FROM_HOST 0
+#define ESP_SEQUENCE 69865
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_HOST] = &cil_from_host,
+	},
+};
+
+PKTGEN("tc", "ipv4_ipsec_from_host")
+int ipv4_ipsec_from_host_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct ip_esp_hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+	l3->saddr = v4_pod_one;
+	l3->daddr = v4_pod_two;
+
+	l4 = pktgen__push_default_esphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+	l4->spi = ENCRYPT_KEY;
+	l4->seq_no = ESP_SEQUENCE;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv4_ipsec_from_host")
+int ipv4_ipsec_from_host_setup(struct __ctx_buff *ctx)
+{
+	struct ipcache_key cache_key = {};
+	struct remote_endpoint_info cache_value = {};
+
+	cache_key.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(32);
+	cache_key.family = ENDPOINT_KEY_IPV4;
+	cache_key.ip4 = v4_pod_two;
+	cache_value.sec_identity = 233;
+	cache_value.tunnel_endpoint = v4_node_two;
+	cache_value.node_id = NODE_ID;
+	cache_value.key = ENCRYPT_KEY;
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
+	set_encrypt_key_mark(ctx, ENCRYPT_KEY, NODE_ID);
+	set_identity_meta(ctx, SECLABEL);
+	tail_call_static(ctx, &entry_call_map, FROM_HOST);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv4_ipsec_from_host")
+int ipv4_ipsec_from_host_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct ip_esp_hdr *l4;
+	__u8 *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	assert(ctx->mark == 0);
+	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == 0);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != v4_pod_one)
+		test_fatal("src IP was changed");
+
+	if (l3->daddr != v4_pod_two)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct ip_esp_hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->spi != ENCRYPT_KEY)
+		test_fatal("ESP spi was changed");
+
+	if (l4->seq_no != ESP_SEQUENCE)
+		test_fatal("ESP seq was changed");
+
+	payload = (void *)l4 + sizeof(struct ip_esp_hdr);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("paylaod out of bounds\n");
+
+	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
+		test_fatal("tcp payload was changed");
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_ipsec_from_host")
+int ipv6_ipsec_from_host_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct ip_esp_hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+	ipv6hdr__set_addrs(l3, (__u8 *)v6_pod_one, (__u8 *)v6_pod_two);
+
+	l4 = pktgen__push_default_esphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+	l4->spi = ENCRYPT_KEY;
+	l4->seq_no = ESP_SEQUENCE;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv6_ipsec_from_host")
+int ipv6_ipsec_from_host_setup(struct __ctx_buff *ctx)
+{
+	struct ipcache_key cache_key = {};
+	struct remote_endpoint_info cache_value = {};
+
+	cache_key.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(128);
+	cache_key.family = ENDPOINT_KEY_IPV6;
+	memcpy(&cache_key.ip6, (__u8 *)v6_pod_two, 16);
+	cache_value.sec_identity = 233;
+	cache_value.tunnel_endpoint = v4_node_two;
+	cache_value.node_id = NODE_ID;
+	cache_value.key = ENCRYPT_KEY;
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
+	set_encrypt_key_mark(ctx, ENCRYPT_KEY, NODE_ID);
+	set_identity_meta(ctx, SECLABEL);
+	tail_call_static(ctx, &entry_call_map, FROM_HOST);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv6_ipsec_from_host")
+int ipv6_ipsec_from_host_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct ip_esp_hdr *l4;
+	__u8 *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	assert(ctx->mark == 0);
+	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == 0);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("src IP was changed");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_two, 16) != 0)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct ip_esp_hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->spi != ENCRYPT_KEY)
+		test_fatal("ESP spi was changed");
+
+	if (l4->seq_no != ESP_SEQUENCE)
+		test_fatal("ESP seq was changed");
+
+	payload = (void *)l4 + sizeof(struct ip_esp_hdr);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("paylaod out of bounds\n");
+
+	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
+		test_fatal("tcp payload was changed");
+
+	test_finish();
+}

--- a/bpf/tests/ipsec_from_lxc_test.c
+++ b/bpf/tests/ipsec_from_lxc_test.c
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define ROUTER_IP
+#include "config_replacement.h"
+#undef ROUTER_IP
+
+#define NODE_ID 2333
+#define ENCRYPT_KEY 3
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_IPSEC
+#define TUNNEL_MODE
+#define HAVE_ENCAP
+#define ENCAP_IFINDEX 4
+
+#include "bpf_lxc.c"
+
+#define FROM_CONTAINER 0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_CONTAINER] = &cil_from_container,
+	},
+};
+
+PKTGEN("tc", "ipv4_ipsec_from_lxc")
+int ipv4_ipsec_from_lxc_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+	l3->saddr = v4_pod_one;
+	l3->daddr = v4_pod_two;
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+	l4->source = tcp_src_one;
+	l4->dest = tcp_svc_one;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv4_ipsec_from_lxc")
+int ipv4_ipsec_from_lxc_setup(struct __ctx_buff *ctx)
+{
+	struct policy_key policy_key = { .egress = 1 };
+	struct policy_entry policy_value = {};
+
+	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+
+	struct ipcache_key cache_key = {};
+	struct remote_endpoint_info cache_value = {};
+
+	cache_key.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(32);
+	cache_key.family = ENDPOINT_KEY_IPV4;
+	cache_key.ip4 = v4_pod_two;
+	cache_value.sec_identity = 233;
+	cache_value.tunnel_endpoint = v4_node_two;
+	cache_value.node_id = NODE_ID;
+	cache_value.key = ENCRYPT_KEY;
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
+	__u32 encrypt_key = 0;
+	struct encrypt_config encrypt_value = { .encrypt_key = 3 };
+
+	map_update_elem(&ENCRYPT_MAP, &encrypt_key, &encrypt_value, BPF_ANY);
+
+	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv4_ipsec_from_lxc")
+int ipv4_ipsec_from_lxc_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+	__u8 *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+	assert(ctx->mark == (NODE_ID << 16 | ENCRYPT_KEY << 12 | MARK_MAGIC_ENCRYPT));
+	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == SECLABEL);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != v4_pod_one)
+		test_fatal("src IP was changed");
+
+	if (l3->daddr != v4_pod_two)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_src_one)
+		test_fatal("src TCP port was changed");
+
+	if (l4->dest != tcp_svc_one)
+		test_fatal("dst TCP port was changed");
+
+	payload = (void *)l4 + sizeof(struct tcphdr);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("paylaod out of bounds\n");
+
+	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
+		test_fatal("tcp payload was changed");
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_ipsec_from_lxc")
+int ipv6_ipsec_from_lxc_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+	ipv6hdr__set_addrs(l3, (__u8 *)v6_pod_one, (__u8 *)v6_pod_two);
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+	l4->source = tcp_src_one;
+	l4->dest = tcp_svc_one;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv6_ipsec_from_lxc")
+int ipv6_ipsec_from_lxc_setup(struct __ctx_buff *ctx)
+{
+	struct policy_key policy_key = { .egress = 1 };
+	struct policy_entry policy_value = {};
+
+	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+
+	struct ipcache_key cache_key = {};
+	struct remote_endpoint_info cache_value = {};
+
+	cache_key.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(128);
+	cache_key.family = ENDPOINT_KEY_IPV6;
+	memcpy(&cache_key.ip6, (__u8 *)v6_pod_two, 16);
+	cache_value.sec_identity = 233;
+	cache_value.tunnel_endpoint = v4_node_two;
+	cache_value.node_id = NODE_ID;
+	cache_value.key = ENCRYPT_KEY;
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
+	__u32 encrypt_key = 0;
+	struct encrypt_config encrypt_value = { .encrypt_key = 3 };
+
+	map_update_elem(&ENCRYPT_MAP, &encrypt_key, &encrypt_value, BPF_ANY);
+
+	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv6_ipsec_from_lxc")
+int ipv6_ipsec_from_lxc_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+	__u8 *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+	assert(ctx->mark == (NODE_ID << 16 | ENCRYPT_KEY << 12 | MARK_MAGIC_ENCRYPT));
+	assert(ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY) == SECLABEL);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IPV6");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("src IP was changed");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_two, 16) != 0)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_src_one)
+		test_fatal("src TCP port was changed");
+
+	if (l4->dest != tcp_svc_one)
+		test_fatal("dst TCP port was changed");
+
+	payload = (void *)l4 + sizeof(struct tcphdr);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("paylaod out of bounds\n");
+
+	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
+		test_fatal("tcp payload was changed");
+	test_finish();
+}

--- a/bpf/tests/ipsec_from_overlay_test.c
+++ b/bpf/tests/ipsec_from_overlay_test.c
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+#define ROUTER_IP
+#define SECLABEL
+#include "config_replacement.h"
+#undef ROUTER_IP
+#undef SECLABEL
+
+#define NODE_ID 2333
+#define ENCRYPT_KEY 3
+#define ENABLE_IPV4
+#define ENABLE_IPV6
+#define ENABLE_IPSEC
+#define TUNNEL_MODE
+#define HAVE_ENCAP
+#define ENCAP_IFINDEX 4
+#define DEST_IFINDEX 5
+#define DEST_LXC_ID 200
+
+#define skb_change_type mock_skb_change_type
+int mock_skb_change_type(__maybe_unused struct __sk_buff *skb, __u32 type)
+{
+	if (type != PACKET_HOST)
+		return -1;
+	return 0;
+}
+
+#define skb_get_tunnel_key mock_skb_get_tunnel_key
+int mock_skb_get_tunnel_key(__maybe_unused struct __sk_buff *skb,
+			    struct bpf_tunnel_key *to,
+			    __maybe_unused __u32 size,
+			    __maybe_unused __u32 flags)
+{
+	to->remote_ipv4 = v4_node_one;
+	/* 0xfffff is the default SECLABEL */
+	to->tunnel_id = 0xfffff;
+	return 0;
+}
+
+__section("mock-handle-policy")
+int mock_handle_policy(struct __ctx_buff *ctx __maybe_unused)
+{
+	return TC_ACT_REDIRECT;
+}
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 256);
+	__array(values, int());
+} mock_policy_call_map __section(".maps") = {
+	.values = {
+		[DEST_LXC_ID] = &mock_handle_policy,
+	},
+};
+
+#define tail_call_dynamic mock_tail_call_dynamic
+static __always_inline __maybe_unused void
+mock_tail_call_dynamic(struct __ctx_buff *ctx __maybe_unused,
+		       const void *map __maybe_unused, __u32 slot __maybe_unused)
+{
+	tail_call(ctx, &mock_policy_call_map, slot);
+}
+
+static volatile const __u8 *DEST_EP_MAC = mac_three;
+static volatile const __u8 *DEST_NODE_MAC = mac_four;
+
+#include "bpf_overlay.c"
+
+#define FROM_OVERLAY 0
+#define ESP_SEQUENCE 69865
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_OVERLAY] = &cil_from_overlay,
+	},
+};
+
+PKTGEN("tc", "ipv4_with_encrypt_ipsec_from_overlay")
+int ipv4_with_encrypt_ipsec_from_overlay_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct ip_esp_hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+	l3->saddr = v4_pod_one;
+	l3->daddr = v4_pod_two;
+
+	l4 = pktgen__push_default_esphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+	l4->spi = ENCRYPT_KEY;
+	l4->seq_no = ESP_SEQUENCE;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv4_with_encrypt_ipsec_from_overlay")
+int ipv4_with_encrypt_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, &entry_call_map, FROM_OVERLAY);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv4_with_encrypt_ipsec_from_overlay")
+int ipv4_with_encrypt_ipsec_from_overlay_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct ip_esp_hdr *l4;
+	__u8 *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+	assert(ctx->mark == MARK_MAGIC_DECRYPT);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != v4_pod_one)
+		test_fatal("src IP was changed");
+
+	if (l3->daddr != v4_pod_two)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct ip_esp_hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->spi != ENCRYPT_KEY)
+		test_fatal("ESP spi was changed");
+
+	if (l4->seq_no != ESP_SEQUENCE)
+		test_fatal("ESP seq was changed");
+
+	payload = (void *)l4 + sizeof(struct ip_esp_hdr);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("paylaod out of bounds\n");
+
+	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
+		test_fatal("tcp payload was changed");
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_with_encrypt_ipsec_from_overlay")
+int ipv6_with_encrypt_ipsec_from_overlay_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct ip_esp_hdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+	ipv6hdr__set_addrs(l3, (__u8 *)v6_pod_one, (__u8 *)v6_pod_two);
+
+	l4 = pktgen__push_default_esphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+	l4->spi = ENCRYPT_KEY;
+	l4->seq_no = ESP_SEQUENCE;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv6_with_encrypt_ipsec_from_overlay")
+int ipv6_with_encrypt_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
+{
+	tail_call_static(ctx, &entry_call_map, FROM_OVERLAY);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv6_with_encrypt_ipsec_from_overlay")
+int ipv6_with_encrypt_ipsec_from_overlay_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct ip_esp_hdr *l4;
+	__u8 *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_OK);
+	assert(ctx->mark == MARK_MAGIC_DECRYPT);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)mac_one, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)mac_two, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("src IP was changed");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_two, 16) != 0)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct ip_esp_hdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->spi != ENCRYPT_KEY)
+		test_fatal("ESP spi was changed");
+
+	if (l4->seq_no != ESP_SEQUENCE)
+		test_fatal("ESP seq was changed");
+
+	payload = (void *)l4 + sizeof(struct ip_esp_hdr);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("paylaod out of bounds\n");
+
+	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
+		test_fatal("tcp payload was changed");
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv4_without_encrypt_ipsec_from_overlay")
+int ipv4_without_encrypt_ipsec_from_overlay_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+	l3->saddr = v4_pod_one;
+	l3->daddr = v4_pod_two;
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+	l4->source = tcp_src_one;
+	l4->dest = tcp_svc_one;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv4_without_encrypt_ipsec_from_overlay")
+int ipv4_without_encrypt_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
+{
+	struct endpoint_info ep_value = {
+		.ifindex = DEST_IFINDEX,
+		.lxc_id = DEST_LXC_ID,
+
+	};
+
+	memcpy(&ep_value.mac, (__u8 *)DEST_EP_MAC, ETH_ALEN);
+	memcpy(&ep_value.node_mac, (__u8 *)DEST_NODE_MAC, ETH_ALEN);
+
+	struct endpoint_key ep_key = {
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = v4_pod_two,
+	};
+
+	map_update_elem(&ENDPOINTS_MAP, &ep_key, &ep_value, BPF_ANY);
+
+	ctx->mark = MARK_MAGIC_DECRYPT;
+	tail_call_static(ctx, &entry_call_map, FROM_OVERLAY);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv4_without_encrypt_ipsec_from_overlay")
+int ipv4_without_encrypt_ipsec_from_overlay_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+	__u8 *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+	assert(ctx->mark == 0);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)DEST_NODE_MAC, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)DEST_EP_MAC, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != v4_pod_one)
+		test_fatal("src IP was changed");
+
+	if (l3->daddr != v4_pod_two)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_src_one)
+		test_fatal("src TCP port was changed");
+
+	if (l4->dest != tcp_svc_one)
+		test_fatal("dst TCP port was changed");
+
+	payload = (void *)l4 + sizeof(struct tcphdr);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("paylaod out of bounds\n");
+
+	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
+		test_fatal("tcp payload was changed");
+
+	test_finish();
+}
+
+PKTGEN("tc", "ipv6_without_encrypt_ipsec_from_overlay")
+int ipv6_without_encrypt_ipsec_from_overlay_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+	void *data;
+
+	pktgen__init(&builder, ctx);
+
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+	ethhdr__set_macs(l2, (__u8 *)mac_one, (__u8 *)mac_two);
+
+	l3 = pktgen__push_default_ipv6hdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+	ipv6hdr__set_addrs(l3, (__u8 *)v6_pod_one, (__u8 *)v6_pod_two);
+
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+	l4->source = tcp_src_one;
+	l4->dest = tcp_svc_one;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	pktgen__finish(&builder);
+	return 0;
+}
+
+SETUP("tc", "ipv6_without_encrypt_ipsec_from_overlay")
+int ipv6_without_encrypt_ipsec_from_overlay_setup(struct __ctx_buff *ctx)
+{
+	struct endpoint_info ep_value = {
+		.ifindex = DEST_IFINDEX,
+		.lxc_id = DEST_LXC_ID,
+
+	};
+
+	memcpy(&ep_value.mac, (__u8 *)DEST_EP_MAC, ETH_ALEN);
+	memcpy(&ep_value.node_mac, (__u8 *)DEST_NODE_MAC, ETH_ALEN);
+
+	struct endpoint_key ep_key = {
+		.family = ENDPOINT_KEY_IPV6,
+	};
+
+	memcpy(&ep_key.ip6, (__u8 *)v6_pod_two, 16);
+	map_update_elem(&ENDPOINTS_MAP, &ep_key, &ep_value, BPF_ANY);
+
+	ctx->mark = MARK_MAGIC_DECRYPT;
+	tail_call_static(ctx, &entry_call_map, FROM_OVERLAY);
+	return TEST_ERROR;
+}
+
+CHECK("tc", "ipv6_without_encrypt_ipsec_from_overlay")
+int ipv6_without_encrypt_ipsec_from_overlay_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct ethhdr *l2;
+	struct ipv6hdr *l3;
+	struct tcphdr *l4;
+	__u8 *payload;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(*status_code) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+	assert(*status_code == CTX_ACT_REDIRECT);
+	assert(ctx->mark == 0);
+
+	l2 = data + sizeof(*status_code);
+
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IPV6))
+		test_fatal("l2 proto hasn't been set to ETH_P_IP");
+
+	if (memcmp(l2->h_source, (__u8 *)DEST_NODE_MAC, ETH_ALEN) != 0)
+		test_fatal("src mac hasn't been set to source ep's mac");
+
+	if (memcmp(l2->h_dest, (__u8 *)DEST_EP_MAC, ETH_ALEN) != 0)
+		test_fatal("dest mac hasn't been set to dest ep's mac");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct ipv6hdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (memcmp((__u8 *)&l3->saddr, (__u8 *)v6_pod_one, 16) != 0)
+		test_fatal("src IP was changed");
+
+	if (memcmp((__u8 *)&l3->daddr, (__u8 *)v6_pod_two, 16) != 0)
+		test_fatal("dest IP was changed");
+
+	l4 = (void *)l3 + sizeof(struct ipv6hdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_src_one)
+		test_fatal("src TCP port was changed");
+
+	if (l4->dest != tcp_svc_one)
+		test_fatal("dst TCP port was changed");
+
+	payload = (void *)l4 + sizeof(struct tcphdr);
+	if ((void *)payload + sizeof(default_data) > data_end)
+		test_fatal("paylaod out of bounds\n");
+
+	if (memcmp(payload, default_data, sizeof(default_data)) != 0)
+		test_fatal("tcp payload was changed");
+
+	test_finish();
+}


### PR DESCRIPTION
A typical datapath for pod to pod ipsec connection is:

local host:
1\. ingress on lxc, where skb->mark is for encryption;
2. stack, xfrm encrypts skb data;
3. egress on cilium_host, where tunnel key is set and skb is redirected to cilium_vxlan;
4. egress on cilium_vxlan
5. egress on eth0

remote host:
6. ingress on eth0
7. ingress on cilium_vxlan (1st), where skb->mark is set for decryption;
8. stack: xfrm decrypts skb data
9. ingress on cilium_vxlan (2nd), skb is redirected to lxc
10. egress on lxc

This PR checks step 1 (`from-container`), step 3 (`from-host`), step 7 (1st `from-overlay`), and step 9 (2nd `from-overlay`). All the tests are done with `TUNNEL_MODE` enabled, both IPv6 and IPv4 are covered.

Step 2 and step 8 will be covered by control plane test mentioned by https://github.com/cilium/cilium/issues/20707

Step 4, 5, 6, 10 have nothing special for IPSec, so I'll leave them aside.

Corner cases and failure cases are to be tested in a separate PR. 
