### PR TITLE
test: delete ginkgo test "NodePort with L7 Policy from outside"

### DIFF
--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -656,29 +656,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			})
 		})
 
-		SkipContextIf(func() bool {
-			return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.RunsOnAKS() || helpers.DoesNotExistNodeWithoutCilium() ||
-				helpers.SkipQuarantined()
-		}, "with L7 policy", func() {
-			var demoPolicyL7 string
-
-			BeforeAll(func() {
-				demoPolicyL7 = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-demo.yaml")
-			})
-
-			AfterAll(func() {
-				kubectl.Delete(demoPolicyL7)
-				// Same reason as in other L7 test above
-				kubectl.CiliumExecMustSucceedOnAll(context.TODO(),
-					"cilium bpf ct flush global", "Unable to flush CT maps")
-			})
-
-			It("Tests NodePort with L7 Policy from outside", func() {
-				applyPolicy(kubectl, demoPolicyL7)
-				testNodePort(kubectl, ni, false, true, 0)
-			})
-		})
-
 		It("ClusterIP cannot be accessed externally when access is disabled",
 			func() {
 				Expect(curlClusterIPFromExternalHost(kubectl, ni)).


### PR DESCRIPTION
The test case was introduced to cover issue #21954, but it turned out the test is buggy and caused a number of CI flakes (#25119). Consequently, PR #25236 put the test case under quarantine.

This commit removes that problematic test, as the target scenario has been covered by connectivity test in cilium-cli
(https://github.com/cilium/cilium-cli/pull/1547).

Fixes: #25119
