### PR TITLE
bgpv1: Add support for eBGP-multihop in BGP control plane

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -77,6 +77,7 @@ The policy in ``yaml`` form is defined below:
       neighbors: # []CiliumBGPNeighbor
        - peerAddress: 'fc00:f853:ccd:e793::50/128'
          peerASN: 64512
+         eBGPMultihopTTL: 10
          gracefulRestart:
             enabled: true
             restartTime: "20s"
@@ -99,6 +100,7 @@ Fields
        virtualRouters[*].neighbors: A list of neighbors to peer with
            neighbors[*].peerAddress: The address of the peer neighbor
            neighbors[*].peerASN: The ASN of the peer
+           neighbors[*].eBGPMultihopTTL: (optional) Time To Live (TTL) value used in BGP packets. 0 if eBGP multi-hop feature is disabled.
            neighbors[*].gracefulRestart.enabled: The flag to enable graceful restart capability.
            neighbors[*].gracefulRestart.restartTime: The restart time advertised to the peer (RFC 4724 section 4.2).
 

--- a/api/v1/models/bgp_peer.go
+++ b/api/v1/models/bgp_peer.go
@@ -47,6 +47,11 @@ type BgpPeer struct {
 	// Initial value for the BGP ConnectRetryTimer (RFC 4271, Section 8) in seconds
 	ConnectRetryTimeSeconds int64 `json:"connect-retry-time-seconds,omitempty"`
 
+	// Time To Live (TTL) value used in BGP packets sent to the eBGP neighbor.
+	// 0 if eBGP multi-hop feature is disabled.
+	//
+	EbgpMultihopTTL int64 `json:"ebgp-multihop-ttl,omitempty"`
+
 	// BGP peer address family state
 	Families []*BgpPeerFamilies `json:"families"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -3529,6 +3529,11 @@ definitions:
       peer-address:
         description: IP Address of peer
         type: string
+      ebgp-multihop-ttl:
+        description: |
+          Time To Live (TTL) value used in BGP packets sent to the eBGP neighbor.
+          0 if eBGP multi-hop feature is disabled.
+        type: integer
       session-state:
         description: |
           BGP peer operational state as described here

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1834,6 +1834,10 @@ func init() {
           "description": "Initial value for the BGP ConnectRetryTimer (RFC 4271, Section 8) in seconds",
           "type": "integer"
         },
+        "ebgp-multihop-ttl": {
+          "description": "Time To Live (TTL) value used in BGP packets sent to the eBGP neighbor.\n0 if eBGP multi-hop feature is disabled.\n",
+          "type": "integer"
+        },
         "families": {
           "description": "BGP peer address family state",
           "type": "array",
@@ -6769,6 +6773,10 @@ func init() {
         },
         "connect-retry-time-seconds": {
           "description": "Initial value for the BGP ConnectRetryTimer (RFC 4271, Section 8) in seconds",
+          "type": "integer"
+        },
+        "ebgp-multihop-ttl": {
+          "description": "Time To Live (TTL) value used in BGP packets sent to the eBGP neighbor.\n0 if eBGP multi-hop feature is disabled.\n",
           "type": "integer"
         },
         "families": {

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.27.6
-	github.com/osrg/gobgp/v3 v3.14.0
+	github.com/osrg/gobgp/v3 v3.15.1-0.20230605074248-03982e597eac
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.15.1
 	github.com/prometheus/client_model v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -744,8 +744,8 @@ github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b h1:FfH+VrHHk6Lxt9HdVS0PXzSXFyS2NbZKXv33FYPol0A=
 github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b/go.mod h1:AC62GU6hc0BrNm+9RK9VSiwa/EUe1bkIeFORAMcHvJU=
 github.com/osrg/gobgp v2.0.0+incompatible h1:91ARQbE1AtO0U4TIxHPJ7wYVZIqduyBwS1+FjlHlmrY=
-github.com/osrg/gobgp/v3 v3.14.0 h1:zfXhM8+QSfAPUkzWYTbH8pMkvxkcUfvQEKnBU7ikk4g=
-github.com/osrg/gobgp/v3 v3.14.0/go.mod h1:tSUXn/s9uggSRTKP3IBeT5zI4ayOUX3O7fG5+n+SHPc=
+github.com/osrg/gobgp/v3 v3.15.1-0.20230605074248-03982e597eac h1:92rwa6xL1qlnmaW4KrWQgX/mpjOorjtwc3ioe1SCVn4=
+github.com/osrg/gobgp/v3 v3.15.1-0.20230605074248-03982e597eac/go.mod h1:tSUXn/s9uggSRTKP3IBeT5zI4ayOUX3O7fG5+n+SHPc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=

--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -189,6 +189,14 @@ func (g *GoBGPServer) getPeerConfig(ctx context.Context, n *v2alpha1api.CiliumBG
 		peer.Transport = &gobgp.Transport{LocalAddress: wildcardIPv6Addr}
 	}
 
+	// Enable multi-hop for eBGP if non-zero TTL is provided
+	if g.asn != uint32(n.PeerASN) && n.EBGPMultihopTTL > 0 {
+		peer.EbgpMultihop = &gobgp.EbgpMultihop{
+			Enabled:     true,
+			MultihopTtl: uint32(n.EBGPMultihopTTL),
+		}
+	}
+
 	if peer.Timers == nil {
 		peer.Timers = &gobgp.Timers{}
 	}

--- a/pkg/bgpv1/gobgp/state.go
+++ b/pkg/bgpv1/gobgp/state.go
@@ -74,6 +74,10 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context) (types.GetPeerStateRespo
 			peerState.Families = append(peerState.Families, toAgentAfiSafiState(afiSafi.State))
 		}
 
+		if peer.EbgpMultihop != nil && peer.EbgpMultihop.Enabled {
+			peerState.EbgpMultihopTTL = int64(peer.EbgpMultihop.MultihopTtl)
+		}
+
 		if peer.Timers != nil {
 			tConfig := peer.Timers.Config
 			tState := peer.Timers.State

--- a/pkg/bgpv1/gobgp/state_test.go
+++ b/pkg/bgpv1/gobgp/state_test.go
@@ -84,6 +84,24 @@ var (
 
 	neighbor64127 = &v2alpha1api.CiliumBGPNeighbor{
 		PeerASN:          64127,
+		PeerAddress:      "192.168.88.1/32",
+		ConnectRetryTime: metav1.Duration{Duration: 99 * time.Second},
+		HoldTime:         metav1.Duration{Duration: 9 * time.Second},
+		KeepAliveTime:    metav1.Duration{Duration: 3 * time.Second},
+	}
+
+	// changed EBGPMultihopTTL
+	neighbor64127Update = &v2alpha1api.CiliumBGPNeighbor{
+		PeerASN:          64127,
+		PeerAddress:      "192.168.88.1/32",
+		ConnectRetryTime: metav1.Duration{Duration: 99 * time.Second},
+		HoldTime:         metav1.Duration{Duration: 9 * time.Second},
+		KeepAliveTime:    metav1.Duration{Duration: 3 * time.Second},
+		EBGPMultihopTTL:  10,
+	}
+
+	neighbor64128 = &v2alpha1api.CiliumBGPNeighbor{
+		PeerASN:          64128,
 		PeerAddress:      "192.168.77.1/32",
 		ConnectRetryTime: metav1.Duration{Duration: 99 * time.Second},
 		HoldTime:         metav1.Duration{Duration: 9 * time.Second},
@@ -119,14 +137,17 @@ func TestGetPeerState(t *testing.T) {
 				neighbor64125,
 				neighbor64126,
 				neighbor64127,
+				neighbor64128,
 			},
 			neighborsAfterUpdate: []*v2alpha1api.CiliumBGPNeighbor{
 				// changed ConnectRetryTime
 				neighbor64125Update,
 				// changed HoldTime & KeepAliveTime
 				neighbor64126Update,
+				// changed EBGPMultihopTTL
+				neighbor64127Update,
 				// no change
-				neighbor64127,
+				neighbor64128,
 			},
 			localASN: 64124,
 			errStr:   "",
@@ -270,6 +291,10 @@ func validatePeers(t *testing.T, localASN uint32, neighbors []*v2alpha1api.Ciliu
 
 		require.EqualValues(t, n.GracefulRestart.Enabled, p.GracefulRestart.Enabled)
 		require.EqualValues(t, n.GracefulRestart.RestartTime.Seconds(), p.GracefulRestart.RestartTimeSeconds)
+
+		if n.EBGPMultihopTTL > 0 {
+			require.EqualValues(t, n.EBGPMultihopTTL, p.EbgpMultihopTTL)
+		}
 
 		// since there is no real neighbor, bgp session state will be either idle or active.
 		require.Contains(t, []string{"idle", "active"}, p.SessionState)

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -132,6 +132,15 @@ spec:
                               whole second.
                             format: duration
                             type: string
+                          eBGPMultihopTTL:
+                            description: EBGPMultihopTTL controls the multi-hop feature
+                              for eBGP peers. Its value defines the Time To Live (TTL)
+                              value used in BGP packets sent to the neighbor. When
+                              empty or zero, eBGP multi-hop feature is disabled. The
+                              value is ignored for iBGP peers.
+                            maximum: 255
+                            minimum: 0
+                            type: integer
                           gracefulRestart:
                             description: GracefulRestart defines graceful restart
                               parameters which are negotiated with this neighbor.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -97,6 +97,14 @@ type CiliumBGPNeighbor struct {
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=4294967295
 	PeerASN int `json:"peerASN"`
+	// EBGPMultihopTTL controls the multi-hop feature for eBGP peers.
+	// Its value defines the Time To Live (TTL) value used in BGP packets sent to the neighbor.
+	// When empty or zero, eBGP multi-hop feature is disabled. The value is ignored for iBGP peers.
+	//
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=255
+	EBGPMultihopTTL int `json:"eBGPMultihopTTL,omitempty"`
 	// ConnectRetryTime defines the initial value for the BGP ConnectRetryTimer (RFC 4271, Section 8).
 	// The default value for the ConnectRetryTime (if empty or zero) is 120 seconds.
 	// Rounded internally to the nearest whole second.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -21,6 +21,9 @@ func (in *CiliumBGPNeighbor) DeepEqual(other *CiliumBGPNeighbor) bool {
 	if in.PeerASN != other.PeerASN {
 		return false
 	}
+	if in.EBGPMultihopTTL != other.EBGPMultihopTTL {
+		return false
+	}
 	if in.ConnectRetryTime != other.ConnectRetryTime {
 		return false
 	}

--- a/vendor/github.com/osrg/gobgp/v3/internal/pkg/config/util.go
+++ b/vendor/github.com/osrg/gobgp/v3/internal/pkg/config/util.go
@@ -554,6 +554,8 @@ func NewPeerFromConfigStruct(pconf *Neighbor) *api.Peer {
 			NotificationEnabled: pconf.GracefulRestart.Config.NotificationEnabled,
 			LonglivedEnabled:    pconf.GracefulRestart.Config.LongLivedEnabled,
 			LocalRestarting:     pconf.GracefulRestart.State.LocalRestarting,
+			PeerRestartTime:     uint32(pconf.GracefulRestart.State.PeerRestartTime),
+			PeerRestarting:      pconf.GracefulRestart.State.PeerRestarting,
 		},
 		Transport: &api.Transport{
 			RemotePort:    uint32(pconf.Transport.Config.RemotePort),

--- a/vendor/github.com/osrg/gobgp/v3/internal/pkg/version/version.go
+++ b/vendor/github.com/osrg/gobgp/v3/internal/pkg/version/version.go
@@ -18,7 +18,7 @@ package version
 import "fmt"
 
 const MAJOR uint = 3
-const MINOR uint = 14
+const MINOR uint = 15
 const PATCH uint = 0
 
 var COMMIT string = ""

--- a/vendor/github.com/osrg/gobgp/v3/pkg/packet/bgp/bgp.go
+++ b/vendor/github.com/osrg/gobgp/v3/pkg/packet/bgp/bgp.go
@@ -4374,12 +4374,9 @@ func NewFlowSpecComponentItem(op uint8, value uint64) *FlowSpecComponentItem {
 					return uint32(i)
 				}
 			}
-			// return invalid order
-			return 4
+			// Return 8 octet order
+			return 3
 		}()
-	}
-	if order > 3 {
-		return nil
 	}
 	v.Op = uint8(uint32(v.Op) | order<<4)
 	return v
@@ -6917,8 +6914,14 @@ func (l *LsTLVBgpRouterID) DecodeFromBytes(data []byte) error {
 }
 
 func (l *LsTLVBgpRouterID) Serialize() ([]byte, error) {
-	var buf [4]byte
-	copy(buf[:], l.RouterID)
+	tmpaddr := l.RouterID
+	if tmpaddr.To4() != nil {
+		var buf [4]byte
+		copy(buf[:], l.RouterID.To4())
+		return l.LsTLV.Serialize(buf[:])
+	}
+	var buf [16]byte
+	copy(buf[:], l.RouterID.To16())
 	return l.LsTLV.Serialize(buf[:])
 }
 
@@ -7937,7 +7940,7 @@ func NewLsTLVAdjacencySID(l *uint32) *LsTLVAdjacencySID {
 	var flags uint8
 	return &LsTLVAdjacencySID{
 		LsTLV: LsTLV{
-			Type:   BGP_ASPATH_ATTR_TYPE_SET,
+			Type:   LS_TLV_ADJACENCY_SID,
 			Length: 7, // TODO: Implementation to judge 7 octets or 8 octets
 		},
 		Flags:  flags,
@@ -8069,7 +8072,7 @@ type LsTLVPeerNodeSID struct {
 func NewLsTLVPeerNodeSID(l *LsBgpPeerSegmentSID) *LsTLVPeerNodeSID {
 	return &LsTLVPeerNodeSID{
 		LsTLV: LsTLV{
-			Type:   BGP_ASPATH_ATTR_TYPE_SET,
+			Type:   LS_TLV_PEER_NODE_SID,
 			Length: l.Flags.SidLen(),
 		},
 		Flags:  l.Flags.FlagBits(),
@@ -8160,7 +8163,7 @@ type LsTLVPeerAdjacencySID struct {
 func NewLsTLVPeerAdjacencySID(l *LsBgpPeerSegmentSID) *LsTLVPeerAdjacencySID {
 	return &LsTLVPeerAdjacencySID{
 		LsTLV: LsTLV{
-			Type:   BGP_ASPATH_ATTR_TYPE_SET,
+			Type:   LS_TLV_ADJACENCY_SID,
 			Length: l.Flags.SidLen(),
 		},
 		Flags:  l.Flags.FlagBits(),
@@ -8251,7 +8254,7 @@ type LsTLVPeerSetSID struct {
 func NewLsTLVPeerSetSID(l *LsBgpPeerSegmentSID) *LsTLVPeerSetSID {
 	return &LsTLVPeerSetSID{
 		LsTLV: LsTLV{
-			Type:   BGP_ASPATH_ATTR_TYPE_SET,
+			Type:   LS_TLV_PEER_SET_SID,
 			Length: l.Flags.SidLen(),
 		},
 		Flags:  l.Flags.FlagBits(),

--- a/vendor/github.com/osrg/gobgp/v3/pkg/server/grpc_server.go
+++ b/vendor/github.com/osrg/gobgp/v3/pkg/server/grpc_server.go
@@ -697,6 +697,7 @@ func newNeighborFromAPIStruct(a *api.Peer) (*config.Neighbor, error) {
 			pconf.Timers.Config.HoldTime = float64(a.Timers.Config.HoldTime)
 			pconf.Timers.Config.KeepaliveInterval = float64(a.Timers.Config.KeepaliveInterval)
 			pconf.Timers.Config.MinimumAdvertisementInterval = float64(a.Timers.Config.MinimumAdvertisementInterval)
+			pconf.Timers.Config.IdleHoldTimeAfterReset = float64(a.Timers.Config.IdleHoldTimeAfterReset)
 		}
 		if a.Timers.State != nil {
 			pconf.Timers.State.KeepaliveInterval = float64(a.Timers.State.KeepaliveInterval)
@@ -806,6 +807,7 @@ func newPeerGroupFromAPIStruct(a *api.PeerGroup) (*config.PeerGroup, error) {
 			pconf.Timers.Config.HoldTime = float64(a.Timers.Config.HoldTime)
 			pconf.Timers.Config.KeepaliveInterval = float64(a.Timers.Config.KeepaliveInterval)
 			pconf.Timers.Config.MinimumAdvertisementInterval = float64(a.Timers.Config.MinimumAdvertisementInterval)
+			pconf.Timers.Config.IdleHoldTimeAfterReset = float64(a.Timers.Config.IdleHoldTimeAfterReset)
 		}
 		if a.Timers.State != nil {
 			pconf.Timers.State.KeepaliveInterval = float64(a.Timers.State.KeepaliveInterval)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -747,7 +747,7 @@ github.com/opencontainers/image-spec/specs-go/v1
 github.com/opentracing/opentracing-go
 github.com/opentracing/opentracing-go/ext
 github.com/opentracing/opentracing-go/log
-# github.com/osrg/gobgp/v3 v3.14.0
+# github.com/osrg/gobgp/v3 v3.15.1-0.20230605074248-03982e597eac
 ## explicit; go 1.20
 github.com/osrg/gobgp/v3/api
 github.com/osrg/gobgp/v3/internal/pkg/config


### PR DESCRIPTION
Extends the `CiliumBGPNeighbor` configuration in the `CiliumBGPPeeringPolicy` CRD with a new configuration option: `EBGPMultihopTTL`. This can be used to enable multihop feature for eBGP peers, with explicit TTL hop limit count.

Example Configuration:
```yaml
apiVersion: "cilium.io/v2alpha1"
kind: CiliumBGPPeeringPolicy
metadata:
  name: tor
spec:
  virtualRouters:
  - localASN: 65001
    exportPodCIDR: true
    neighbors:
    - peerAddress: "172.0.0.1/32"
      peerASN: 65000
      eBGPMultihopTTL: 10   # >=1 means enabled, 0 means disabled, default=0.
```

Example state dump of peers after configuring:
```
# cilium bgp peers -o json
[
  {
    "applied-hold-time-seconds": 90,
    "applied-keep-alive-time-seconds": 30,
    "configured-hold-time-seconds": 90,
    "configured-keep-alive-time-seconds": 30,
    "connect-retry-time-seconds": 60,
    "ebgp-multihop-ttl": 10,
    "families": [
      {
        "advertised": 1,
        "afi": "ipv4",
        "received": 1,
        "safi": "unicast"
      },
      {
        "afi": "ipv6",
        "safi": "unicast"
      }
    ],
    "local-asn": 65001,
    "peer-address": "172.0.0.1",
    "peer-asn": 65000,
    "session-state": "established",
    "uptime-nanoseconds": 53443700101
  }
]
```

Example dump of a keepalive packet:

![Screenshot from 2023-05-25 15-50-17](https://github.com/cilium/cilium/assets/15926980/575e8a4f-7c17-4474-9f73-72637de6a81b)


Fixes: #21753

```release-note
Add support for eBGP-multihop configuration for CiliumBGPNeighbor in CiliumBGPPeeringPolicy CRD
```
