### PR TITLE
docs: Slack updates

### DIFF
--- a/Documentation/community/community.rst
+++ b/Documentation/community/community.rst
@@ -41,6 +41,8 @@ Name                 Purpose
 #kubernetes          Kubernetes-specific questions
 #networkpolicy       Questions on network policies
 #release             Release announcements only
+#service-mesh        Questions on Cilium Service Mesh
+#tetragon            Questions on Tetragon
 ==================== ==========================================================
 
 You can join the following channels if you are looking to contribute to
@@ -72,6 +74,27 @@ Name                 Purpose
 .. _eBPF Go library: https://github.com/cilium/ebpf
 .. _eCHO News: https://cilium.io/newsletter/
 
+Our Slack hosts channels for eBPF and Cilium-related events online and in
+person.
+
+==================== ==========================================================
+Name                 Purpose
+==================== ==========================================================
+#ciliumcon           CiliumCon
+#ctf                 Cilium and eBPF capture-the-flag challenges
+#ebpf-summit         eBPF Summit
+==================== ==========================================================
+
+How to create a Slack channel
+-----------------------------
+
+1. Open a new `GitHub issue in the cilium/community repo <https://github.com/cilium/community/issues>`_
+2. Specify the title "Slack: <Name>"
+3. Provide a description
+4. Find two Cilium committers to comment in the issue that they approve the
+   creation of the Slack channel
+5. Not all Slack channels need to be listed on this page, but you can submit a
+   PR if you would like to include it here. 
 
 Special Interest Groups
 =======================
@@ -97,9 +120,10 @@ Release Management     None                                  #launchpad    Relea
 How to create a SIG
 -------------------
 
-1. Open a new `GitHub issue <https://github.com/cilium/cilium/issues>`_
+1. Open a new `GitHub issue in the cilium/cilium repo <https://github.com/cilium/cilium/issues>`_
 2. Specify the title "SIG-Request: <Name>"
 3. Provide a description
 4. Find two Cilium committers to support the SIG.
 5. Ask on #development to get the Slack channel and Zoom meeting created
 6. Submit a PR to update the documentation to get your new SIG listed
+

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -280,6 +280,7 @@ cidrs
 ciliumAgent
 ciliumNodeUpdateRate
 ciliumOperator
+ciliumcon
 ciliumnode
 classful
 classid
@@ -340,6 +341,7 @@ crypto
 cryptographic
 ctAnyMax
 ctTcpMax
+ctf
 curl
 customCalls
 customConf
@@ -1039,6 +1041,7 @@ terminatingTLS
 terminationGracePeriodSeconds
 terminationGracePeriods
 testsuite
+tetragon
 th
 thunderx
 tiefighter


### PR DESCRIPTION
Changes to the Slack docs page:
- List some more of the existing Slack channels
- Clarify that not all Slack channels have to be listed in the docs 
- Document how to request a new Slack channel

Note: I've suggested that for simply creating a Slack channel this issue could be filed in the cilium/community repo. There is a very similar process for creating a SIG, which gets a Slack channel and regular Zoom meeting, and currently is requested via an issue in cilium/cilium. Should we move that to cilium/community as well? 