### PR TITLE
operator: fix crash that occurs when cep CRD is disabled with etcd.

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -623,13 +623,15 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 	}
 
 	if legacy.clientset.IsEnabled() {
-		if operatorOption.Config.EndpointGCInterval != 0 {
-			enableCiliumEndpointSyncGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer, false)
-		} else {
-			// Even if the EndpointGC is disabled we still want it to run at least
-			// once. This is to prevent leftover CEPs from populating ipcache with
-			// stale entries.
-			enableCiliumEndpointSyncGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer, true)
+		if !option.Config.EnableCiliumEndpointSlice {
+			if operatorOption.Config.EndpointGCInterval != 0 {
+				enableCiliumEndpointSyncGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer, false)
+			} else {
+				// Even if the EndpointGC is disabled we still want it to run at least
+				// once. This is to prevent leftover CEPs from populating ipcache with
+				// stale entries.
+				enableCiliumEndpointSyncGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer, true)
+			}
 		}
 
 		err = enableCNPWatcher(legacy.ctx, &legacy.wg, legacy.clientset)


### PR DESCRIPTION
When using identityAllocationMode=kvstore, disableEndpointCRD=true, enabledCiliumEndpointSlice=true then operator crashes due to attempting to access unitialized CES controller watcher.

For the CEP GC, we probably don't need that running if CEP CRD is disabled, therefore this prevents starting GC controller if that option is set.

Fixes: #24396
