### PR TITLE
v1.13 backports 2023-05-28

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -80,18 +80,7 @@ copy-api:
 	@$(ECHO_GEN)_api
 	$(QUIET)cp -r ../api/. _api
 
-# $(HELM_DOCS_IMAGE), necessary to update the reference for Helm values,
-# attempts to run a Go binary compiled for x86_64. Skip the update on other
-# architectures by making update-helm-values an empty target, unless the user
-# passes a compatible image.
-HELM_VALUES_DEP := $(HELM_VALUES)
-ifneq ($(shell uname -m),x86_64)
-  ifeq ($(origin HELM_DOCS_IMAGE), file)
-    $(info Documentation: skipping update for the Helm reference (image needs x86_64))
-    HELM_VALUES_DEP :=
-  endif
-endif
-update-helm-values: $(HELM_VALUES_DEP) ## Update the Helm reference documentation.
+update-helm-values: $(HELM_VALUES) ## Update the Helm reference documentation.
 
 HELM_DOCS_ROOT_PATH := $(DOCKER_CTR_ROOT_DIR)
 HELM_DOCS_CHARTS_DIR := $(HELM_DOCS_ROOT_PATH)/install/kubernetes

--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -101,7 +101,7 @@ Fields
 
    Setting unique configuration details of a particular
    instantiated virtual router on a particular Cilium node is explained
-   in `Virtual Router Attributes <#Virtual%20Router%20Attributes>`__
+   in `Virtual Router Attributes`_
 
 Creating a BGP Topology
 -----------------------
@@ -140,8 +140,7 @@ apply to a node.
       generate a unique 32 bit BGP router ID, as it defines no unique
       IPv4 addresses for the node. The administrator must define these
       IDs manually or an error applying the policy will occur.
-   -  This is explained further in `Virtual Router
-      Attributes <#Virtual%20Router%20Attributes>`__
+   -  This is explained further in `Virtual Router Attributes`_
 
 Defining Topology
 ~~~~~~~~~~~~~~~~~

--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -26,6 +26,13 @@ If using Helm charts instead, the relevant values are the following:
    bgpControlPlane:
      enabled: true
 
+.. note::
+
+   The BGP Control Plane feature is mutually exclusive with the MetalLB-based :ref:`bgp`
+   feature. To use the Control Plane, the older BGP feature has to be disabled.
+   In other words, this feature does _not_ switch the BGP implementation
+   from MetalLB to GoBGP.
+
 When set to ``true`` the ``BGP Control Plane`` ``Controllers`` will be
 instantiated and will begin listening for ``CiliumBGPPeeringPolicy``
 events.

--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -19,6 +19,13 @@ Currently a single flag in the ``Cilium Agent`` exists to turn on the
 
    --enable-bgp-control-plane=true
 
+If using Helm charts instead, the relevant values are the following:
+
+.. code-block:: yaml
+
+   bgpControlPlane:
+     enabled: true
+
 When set to ``true`` the ``BGP Control Plane`` ``Controllers`` will be
 instantiated and will begin listening for ``CiliumBGPPeeringPolicy``
 events.

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -329,6 +329,10 @@ kube-apiserver
     The kube-apiserver entity represents the kube-apiserver in a Kubernetes
     cluster. This entity represents both deployments of the kube-apiserver:
     within the cluster and outside of the cluster.
+ingress
+    The ingress entity represents the Cilium Envoy instance that handles ingress
+    L7 traffic. Be aware that this also applies for pod-to-pod traffic within
+    the same cluster when using ingress endpoints (also known as *hairpinning*).
 cluster
     Cluster is the logical group of all network endpoints inside of the local
     cluster. This includes all Cilium-managed endpoints of the local cluster,

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -481,6 +481,7 @@ grafana
 graphviz
 grep
 hairpinned
+hairpinning
 hardcode
 hardcoded
 hardcoding

--- a/examples/kubernetes/servicemesh/envoy/envoy-admin-listener.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-admin-listener.yaml
@@ -27,5 +27,7 @@ spec:
                   prefix: "/"
                 route:
                   cluster: "envoy-admin"
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router

--- a/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
@@ -19,6 +19,8 @@ spec:
           stat_prefix: envoy-prometheus-metrics-listener
           rds:
             route_config_name: prometheus_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
   - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration

--- a/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
@@ -19,6 +19,8 @@ spec:
                 stat_prefix: envoy-lb-listener
                 rds:
                   route_config_name: lb_route
+                use_remote_address: true
+                skip_xff_append: true
                 http_filters:
                   - name: envoy.filters.http.router
     - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -47,6 +47,14 @@
 {{- end }}
 
 {{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled }}
+  {{- if hasKey .Values "l7Proxy" }}
+    {{- if not .Values.l7Proxy }}
+      {{ fail "Ingress or Gateway API controller requires .Values.l7Proxy to be set to 'true'" }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled }}
   {{- if hasKey .Values "kubeProxyReplacement" }}
     {{- if and (ne .Values.kubeProxyReplacement "partial") (ne .Values.kubeProxyReplacement "strict") }}
       {{ fail "Ingress/Gateway API controller requires .Values.kubeProxyReplacement to be set to either 'partial' or 'strict'" }}

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -267,7 +267,7 @@ func (m *Manager) getConnectionManager(svc *slim_corev1.Service) (ciliumv2.XDSRe
 			},
 		},
 		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
-		SkipXffAppend:    true,
+		SkipXffAppend:    false,
 		HttpFilters: []*envoy_extensions_filters_network_http_connection_manager_v3.HttpFilter{
 			{
 				Name: "envoy.filters.http.router",

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -266,6 +266,8 @@ func (m *Manager) getConnectionManager(svc *slim_corev1.Service) (ciliumv2.XDSRe
 				RouteConfigName: getName(svc),
 			},
 		},
+		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+		SkipXffAppend:    true,
 		HttpFilters: []*envoy_extensions_filters_network_http_connection_manager_v3.HttpFilter{
 			{
 				Name: "envoy.filters.http.router",

--- a/operator/pkg/gateway-api/httproute.go
+++ b/operator/pkg/gateway-api/httproute.go
@@ -95,7 +95,9 @@ func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch for changes to Gateways and enqueue HTTPRoutes that reference them,
 		// only if there is a change in the spec
 		Watches(&source.Kind{Type: &gatewayv1beta1.Gateway{}}, r.enqueueRequestForGateway(),
-			builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+			builder.WithPredicates(
+				predicate.GenerationChangedPredicate{},
+				predicate.NewPredicateFuncs(hasMatchingController(context.Background(), mgr.GetClient(), controllerName)))).
 		Complete(r)
 }
 

--- a/operator/pkg/gateway-api/httproute.go
+++ b/operator/pkg/gateway-api/httproute.go
@@ -88,15 +88,13 @@ func (r *httpRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		// Watch for changes to HTTPRoute, but not the status
-		For(&gatewayv1beta1.HTTPRoute{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		// Watch for changes to HTTPRoute
+		For(&gatewayv1beta1.HTTPRoute{}).
 		// Watch for changes to Backend services
 		Watches(&source.Kind{Type: &corev1.Service{}}, r.enqueueRequestForBackendService()).
 		// Watch for changes to Gateways and enqueue HTTPRoutes that reference them,
-		// only if there is a change in the spec
 		Watches(&source.Kind{Type: &gatewayv1beta1.Gateway{}}, r.enqueueRequestForGateway(),
 			builder.WithPredicates(
-				predicate.GenerationChangedPredicate{},
 				predicate.NewPredicateFuncs(hasMatchingController(context.Background(), mgr.GetClient(), controllerName)))).
 		Complete(r)
 }

--- a/operator/pkg/gateway-api/httproute_reconcile.go
+++ b/operator/pkg/gateway-api/httproute_reconcile.go
@@ -138,6 +138,10 @@ func validateGateway(ctx context.Context, c client.Client, hr *gatewayv1beta1.HT
 			continue
 		}
 
+		if !hasMatchingController(ctx, c, controllerName)(gw) {
+			continue
+		}
+
 		if !isAllowed(ctx, c, gw, hr) {
 			// Gateway is not attachable, update the status for this HTTPRoute
 			mergeHTTPRouteStatusConditions(hr, parent, []metav1.Condition{

--- a/operator/pkg/gateway-api/httproute_reconcile_test.go
+++ b/operator/pkg/gateway-api/httproute_reconcile_test.go
@@ -21,6 +21,15 @@ import (
 )
 
 var httpRouteFixture = []client.Object{
+	// GatewayClass
+	&gatewayv1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cilium",
+		},
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: "io.cilium/gateway-controller",
+		},
+	},
 	// Gateway for valid HTTPRoute
 	&gatewayv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
@@ -28,7 +37,7 @@ var httpRouteFixture = []client.Object{
 			Namespace: "default",
 		},
 		Spec: gatewayv1beta1.GatewaySpec{
-			GatewayClassName: "io.cilium/gateway-controller",
+			GatewayClassName: "cilium",
 			Listeners: []gatewayv1beta1.Listener{
 				{
 					Name:     "http",
@@ -47,7 +56,7 @@ var httpRouteFixture = []client.Object{
 			Namespace: "another-namespace",
 		},
 		Spec: gatewayv1beta1.GatewaySpec{
-			GatewayClassName: "io.cilium/gateway-controller",
+			GatewayClassName: "cilium",
 			Listeners: []gatewayv1beta1.Listener{
 				{
 					Name: "http",

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -8,6 +8,7 @@ import (
 	httpConnectionManagerv3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -23,6 +24,8 @@ func NewHTTPConnectionManager(name, routeName string, mutationFunc ...HttpConnec
 		RouteSpecifier: &httpConnectionManagerv3.HttpConnectionManager_Rds{
 			Rds: &httpConnectionManagerv3.Rds{RouteConfigName: routeName},
 		},
+		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+		SkipXffAppend:    true,
 		HttpFilters: []*httpConnectionManagerv3.HttpFilter{
 			{
 				Name: "envoy.filters.http.router",

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -25,7 +25,7 @@ func NewHTTPConnectionManager(name, routeName string, mutationFunc ...HttpConnec
 			Rds: &httpConnectionManagerv3.Rds{RouteConfigName: routeName},
 		},
 		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
-		SkipXffAppend:    true,
+		SkipXffAppend:    false,
 		HttpFilters: []*httpConnectionManagerv3.HttpFilter{
 			{
 				Name: "envoy.filters.http.router",

--- a/pkg/envoy/ciliumenvoyconfig_test.go
+++ b/pkg/envoy/ciliumenvoyconfig_test.go
@@ -100,6 +100,8 @@ resources:
               route:
                 cluster: "envoy-admin"
                 prefix_rewrite: "/stats/prometheus"
+        use_remote_address: true
+        skip_xff_append: true
         http_filters:
         - name: envoy.filters.http.router
 `
@@ -138,6 +140,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
       transport_socket:
@@ -236,6 +240,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
 `
@@ -306,6 +312,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
 `
@@ -378,6 +386,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
   - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
@@ -687,6 +697,8 @@ spec:
                   - upgrade_type: CONNECT
                     connect_config:
                       allow_post: true
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
           http2_protocol_options:

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -277,7 +277,9 @@ func (s *XDSServer) getHttpFilterChainProto(clusterName string, tls bool) *envoy
 	retryTimeout := int64(option.Config.HTTPRetryTimeout) //seconds
 
 	hcmConfig := &envoy_config_http.HttpConnectionManager{
-		StatPrefix: "proxy",
+		StatPrefix:       "proxy",
+		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+		SkipXffAppend:    true,
 		HttpFilters: []*envoy_config_http.HttpFilter{
 			getCiliumHttpFilter(),
 			{
@@ -494,7 +496,9 @@ func (s *XDSServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
 
 	s.addListener(metricsListenerName, func() *envoy_config_listener.Listener {
 		hcmConfig := &envoy_config_http.HttpConnectionManager{
-			StatPrefix: metricsListenerName,
+			StatPrefix:       metricsListenerName,
+			UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+			SkipXffAppend:    true,
 			HttpFilters: []*envoy_config_http.HttpFilter{{
 				Name: "envoy.filters.http.router",
 				ConfigType: &envoy_config_http.HttpFilter_TypedConfig{

--- a/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
@@ -38,6 +38,8 @@ var (
               route:
                 cluster: "envoy-admin"
                 prefix_rewrite: "/stats/prometheus"
+        use_remote_address: true
+        skip_xff_append: true
         http_filters:
         - name: envoy.filters.http.router
 `)

--- a/pkg/k8s/watchers/cilium_envoy_config_test.go
+++ b/pkg/k8s/watchers/cilium_envoy_config_test.go
@@ -46,6 +46,8 @@ spec:
                 route:
                   cluster: "envoy-admin"
                   prefix_rewrite: "/stats/prometheus"
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
 `)

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -578,7 +578,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			testIPv4FragmentSupport(kubectl, ni)
 		})
 
-		SkipContextIf(func() bool { return helpers.RunsOnGKE() }, "With host policy", func() {
+		SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
 			var ccnpHostPolicy string
 
 			BeforeAll(func() {

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -609,28 +609,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			})
 		})
 
-		SkipContextIf(func() bool {
-			return helpers.DoesNotRunWithKubeProxyReplacement() || helpers.RunsOnAKS() || helpers.DoesNotExistNodeWithoutCilium()
-		}, "with L7 policy", func() {
-			var demoPolicyL7 string
-
-			BeforeAll(func() {
-				demoPolicyL7 = helpers.ManifestGet(kubectl.BasePath(), "l7-policy-demo.yaml")
-			})
-
-			AfterAll(func() {
-				kubectl.Delete(demoPolicyL7)
-				// Same reason as in other L7 test above
-				kubectl.CiliumExecMustSucceedOnAll(context.TODO(),
-					"cilium bpf ct flush global", "Unable to flush CT maps")
-			})
-
-			It("Tests NodePort with L7 Policy from outside", func() {
-				applyPolicy(kubectl, demoPolicyL7)
-				testNodePort(kubectl, ni, false, true, 0)
-			})
-		})
-
 		It("ClusterIP cannot be accessed externally when access is disabled",
 			func() {
 				Expect(curlClusterIPFromExternalHost(kubectl, ni)).


### PR DESCRIPTION
- [ ] ~#25350 -- Revert and fix ip rules~ (@NikAleksandrov)
  - :warning: minor conflict, please help to double check 
  - Dropped this PR in favour of manual backport as per offline discussion with datapath team.
- [ ] #25422 -- docs: Remove non-x86 restriction (@jrajahalme)
- [ ] #23939 -- docs: Improve BGP Control Plane page (@krouma)
- [x] #25549 -- gateway-api: Skip reconciliation for non-matching controller routes (@sayboras)
- [x] #25570 -- helm: Correct typo in Ingress validation (@sayboras)
- [x] #25670 -- test/k8s: quarantine K8sDatapathServicesTest (@aanm)
- [x] #25573 -- gateway-api: Race condition between routes and Gateway (@sayboras)
- [x] #25665 -- docs: document missing entity 'ingress' (@mhofstetter)
- [x] #25702 -- test: delete ginkgo test "NodePort with L7 Policy from outside" (@jschwinger233)
- [ ] #25674 -- envoy: Never use x-forwarded-for header, add for Cilium Ingress (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25422 23939 25549 25570 25670 25573 25665 25702 25674; do contrib/backporting/set-labels.py $pr done 1.13; done
```