### PR TITLE
v1.12 backports 2023-05-28

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -66,18 +66,7 @@ copy-api:
 	@$(ECHO_GEN)_api
 	$(QUIET)cp -T -r ../api _api
 
-# $(HELM_DOCS_IMAGE), necessary to update the reference for Helm values,
-# attempts to run a Go binary compiled for x86_64. Skip the update on other
-# architectures by making update-helm-values an empty target, unless the user
-# passes a compatible image.
-HELM_VALUES_DEP := $(HELM_VALUES)
-ifneq ($(shell uname -m),x86_64)
-  ifeq ($(origin HELM_DOCS_IMAGE), file)
-    $(info Documentation: skipping update for the Helm reference (image needs x86_64))
-    HELM_VALUES_DEP :=
-  endif
-endif
-update-helm-values: $(HELM_VALUES_DEP) ## Update the Helm reference documentation.
+update-helm-values: $(HELM_VALUES) ## Update the Helm reference documentation.
 
 HELM_DOCS_ROOT_PATH := $(DOCKER_CTR_ROOT_DIR)
 HELM_DOCS_CHARTS_DIR := $(HELM_DOCS_ROOT_PATH)/install/kubernetes

--- a/Documentation/policy/language.rst
+++ b/Documentation/policy/language.rst
@@ -329,6 +329,9 @@ kube-apiserver
     The kube-apiserver entity represents the kube-apiserver in a Kubernetes
     cluster. This entity represents both deployments of the kube-apiserver:
     within the cluster and outside of the cluster.
+ingress
+    The ingress entity represents the Cilium Envoy instance that handles ingress
+    L7 traffic.
 cluster
     Cluster is the logical group of all network endpoints inside of the local
     cluster. This includes all Cilium-managed endpoints of the local cluster,

--- a/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
@@ -19,6 +19,8 @@ spec:
           stat_prefix: envoy-prometheus-metrics-listener
           rds:
             route_config_name: prometheus_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
   - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration

--- a/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
@@ -19,6 +19,8 @@ spec:
                 stat_prefix: envoy-lb-listener
                 rds:
                   route_config_name: lb_route
+                use_remote_address: true
+                skip_xff_append: true
                 http_filters:
                   - name: envoy.filters.http.router
     - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -45,3 +45,11 @@
     {{ fail "Hubble UI requires hubble.ui.frontend.image.tag to be '>=v0.9.0'" }}
   {{- end }}
 {{- end }}
+
+{{- if .Values.ingressController.enabled }}
+  {{- if hasKey .Values "l7Proxy" }}
+    {{- if not .Values.l7Proxy }}
+      {{ fail "Ingress or Gateway API controller requires .Values.l7Proxy to be set to 'true'" }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/pkg/envoy/ciliumenvoyconfig_test.go
+++ b/pkg/envoy/ciliumenvoyconfig_test.go
@@ -99,6 +99,8 @@ resources:
               route:
                 cluster: "envoy-admin"
                 prefix_rewrite: "/stats/prometheus"
+        use_remote_address: true
+        skip_xff_append: true
         http_filters:
         - name: envoy.filters.http.router
 `
@@ -137,6 +139,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
       transport_socket:
@@ -233,6 +237,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
 `
@@ -301,6 +307,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
 `
@@ -371,6 +379,8 @@ spec:
           codec_type: AUTO
           rds:
             route_config_name: local_route
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
   - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -278,7 +278,9 @@ func (s *XDSServer) getHttpFilterChainProto(clusterName string, tls bool) *envoy
 	retryTimeout := int64(option.Config.HTTPRetryTimeout) //seconds
 
 	hcmConfig := &envoy_config_http.HttpConnectionManager{
-		StatPrefix: "proxy",
+		StatPrefix:       "proxy",
+		UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+		SkipXffAppend:    true,
 		HttpFilters: []*envoy_config_http.HttpFilter{
 			getCiliumHttpFilter(),
 			{
@@ -481,7 +483,9 @@ func (s *XDSServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
 
 	s.addListener(metricsListenerName, func() *envoy_config_listener.Listener {
 		hcmConfig := &envoy_config_http.HttpConnectionManager{
-			StatPrefix: metricsListenerName,
+			StatPrefix:       metricsListenerName,
+			UseRemoteAddress: &wrapperspb.BoolValue{Value: true},
+			SkipXffAppend:    true,
 			HttpFilters: []*envoy_config_http.HttpFilter{{
 				Name: "envoy.filters.http.router",
 				ConfigType: &envoy_config_http.HttpFilter_TypedConfig{

--- a/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
@@ -41,6 +41,8 @@ var (
               route:
                 cluster: "envoy-admin"
                 prefix_rewrite: "/stats/prometheus"
+        use_remote_address: true
+        skip_xff_append: true
         http_filters:
         - name: envoy.filters.http.router
 `)

--- a/pkg/k8s/watchers/cilium_envoy_config_test.go
+++ b/pkg/k8s/watchers/cilium_envoy_config_test.go
@@ -49,6 +49,8 @@ spec:
                 route:
                   cluster: "envoy-admin"
                   prefix_rewrite: "/stats/prometheus"
+          use_remote_address: true
+          skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
 `)


### PR DESCRIPTION
- [ ] ~#20410 -- service: Improve memory usage when handling update of a big service. (@alan-kut)~
  - :warning: there are minor conflicts
  - Dropped this PR as per below discussion
- [ ] #25422 -- docs: Remove non-x86 restriction (@jrajahalme)
- [x] #25570 -- helm: Correct typo in Ingress validation (@sayboras)
- [x] #25665 -- docs: document missing entity 'ingress' (@mhofstetter)
- [ ] #25674 -- envoy: Never use x-forwarded-for header, add for Cilium Ingress (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25422 25570 25665 25674; do contrib/backporting/set-labels.py $pr done 1.12; done
```