### PR TITLE
v1.11 backports 2023-05-28

### DIFF
--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -209,7 +209,9 @@ func (s *XDSServer) getHttpFilterChainProto(clusterName string, tls bool) *envoy
 	retryTimeout := int64(option.Config.HTTPRetryTimeout) //seconds
 
 	hcmConfig := &envoy_config_http.HttpConnectionManager{
-		StatPrefix: "proxy",
+		StatPrefix:       "proxy",
+		UseRemoteAddress: &wrappers.BoolValue{Value: true},
+		SkipXffAppend:    true,
 		HttpFilters: []*envoy_config_http.HttpFilter{{
 			Name: "cilium.l7policy",
 			ConfigType: &envoy_config_http.HttpFilter_TypedConfig{
@@ -404,7 +406,9 @@ func (s *XDSServer) AddMetricsListener(port uint16, wg *completion.WaitGroup) {
 
 	s.addListener(metricsListenerName, port, func() *envoy_config_listener.Listener {
 		hcmConfig := &envoy_config_http.HttpConnectionManager{
-			StatPrefix: metricsListenerName,
+			StatPrefix:       metricsListenerName,
+			UseRemoteAddress: &wrappers.BoolValue{Value: true},
+			SkipXffAppend:    true,
 			HttpFilters: []*envoy_config_http.HttpFilter{{
 				Name: "envoy.filters.http.router",
 				ConfigType: &envoy_config_http.HttpFilter_TypedConfig{


### PR DESCRIPTION
- [ ] #25674 -- envoy: Never use x-forwarded-for header, add for Cilium Ingress (@jrajahalme)
   - :warning: skip files (and whole 2nd commit) not relevant to 1.11 

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25674; do contrib/backporting/set-labels.py $pr done 1.11; done
```