### PR TITLE
[v1.13] bpf: improve handling for short packets

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -122,7 +122,7 @@ resolve_srcid_ipv6(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	union v6addr *src;
 	int ret;
 
-	if (!revalidate_data_maybe_pull(ctx, &data, &data_end, &ip6, !from_host))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
 	if (!from_host) {
@@ -410,11 +410,11 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	struct iphdr *ip4;
 
 	/* This is the first time revalidate_data() is going to be called in
-	 * the "from-netdev" path. Make sure that we don't legitimately drop
-	 * the packet if the skb arrived with the header not being not in the
-	 * linear data.
+	 * the "from-netdev" and "from-host" paths. Make sure that we don't
+	 * legitimately drop the packet if the skb arrived with the header
+	 * not being not in the linear data.
 	 */
-	if (!revalidate_data_maybe_pull(ctx, &data, &data_end, &ip4, !from_host))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
 	/* Packets from the proxy will already have a real identity. */

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -410,7 +410,7 @@ resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
 	struct iphdr *ip4;
 
 	/* This is the first time revalidate_data() is going to be called in
-	 * the "to-netdev" path. Make sure that we don't legitimately drop
+	 * the "from-netdev" path. Make sure that we don't legitimately drop
 	 * the packet if the skb arrived with the header not being not in the
 	 * linear data.
 	 */
@@ -682,10 +682,10 @@ handle_to_netdev_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_HOST)
 		src_id = HOST_ID;
 
-	src_id = resolve_srcid_ipv4(ctx, src_id, &ipcache_srcid, true);
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
+
+	src_id = resolve_srcid_ipv4(ctx, src_id, &ipcache_srcid, true);
 
 	/* We need to pass the srcid from ipcache to host firewall. See
 	 * comment in ipv4_host_policy_egress() for details.

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -112,18 +112,13 @@ derive_src_id(const union v6addr *node_ip, struct ipv6hdr *ip6, __u32 *identity)
 }
 
 static __always_inline __u32
-resolve_srcid_ipv6(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
-		   const bool from_host)
+resolve_srcid_ipv6(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
+		   __u32 srcid_from_proxy, const bool from_host)
 {
 	__u32 src_id = WORLD_ID, srcid_from_ipcache = srcid_from_proxy;
 	struct remote_endpoint_info *info = NULL;
-	void *data, *data_end;
-	struct ipv6hdr *ip6;
 	union v6addr *src;
 	int ret;
-
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
 
 	if (!from_host) {
 		union v6addr node_ip = {};
@@ -391,7 +386,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 
 	if ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_HOST)
 		src_id = HOST_ID;
-	src_id = resolve_srcid_ipv6(ctx, src_id, true);
+	src_id = resolve_srcid_ipv6(ctx, ip6, src_id, true);
 
 	/* to-netdev is attached to the egress path of the native device. */
 	return ipv6_host_policy_egress(ctx, src_id, trace, ext_err);
@@ -401,21 +396,12 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 
 #ifdef ENABLE_IPV4
 static __always_inline __u32
-resolve_srcid_ipv4(struct __ctx_buff *ctx, __u32 srcid_from_proxy,
-		   __u32 *sec_label, const bool from_host)
+resolve_srcid_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4,
+		   __u32 srcid_from_proxy, __u32 *sec_label,
+		   const bool from_host)
 {
 	__u32 src_id = WORLD_ID, srcid_from_ipcache = srcid_from_proxy;
 	struct remote_endpoint_info *info = NULL;
-	void *data, *data_end;
-	struct iphdr *ip4;
-
-	/* This is the first time revalidate_data() is going to be called in
-	 * the "from-netdev" and "from-host" paths. Make sure that we don't
-	 * legitimately drop the packet if the skb arrived with the header
-	 * not being not in the linear data.
-	 */
-	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
 
 	/* Packets from the proxy will already have a real identity. */
 	if (identity_is_reserved(srcid_from_ipcache)) {
@@ -685,7 +671,7 @@ handle_to_netdev_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 
-	src_id = resolve_srcid_ipv4(ctx, src_id, &ipcache_srcid, true);
+	src_id = resolve_srcid_ipv4(ctx, ip4, src_id, &ipcache_srcid, true);
 
 	/* We need to pass the srcid from ipcache to host firewall. See
 	 * comment in ipv4_host_policy_egress() for details.
@@ -820,6 +806,9 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 {
 	__u32 __maybe_unused identity = 0;
 	__u32 __maybe_unused ipcache_srcid = 0;
+	void __maybe_unused *data, *data_end;
+	struct ipv6hdr __maybe_unused *ip6;
+	struct iphdr __maybe_unused *ip4;
 	int ret;
 
 #if defined(ENABLE_L7_LB)
@@ -883,7 +872,11 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 # endif
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		identity = resolve_srcid_ipv6(ctx, identity, from_host);
+		if (!revalidate_data_pull(ctx, &data, &data_end, &ip6))
+			return send_drop_notify_error(ctx, identity, DROP_INVALID,
+						      CTX_ACT_DROP, METRIC_INGRESS);
+
+		identity = resolve_srcid_ipv6(ctx, ip6, identity, from_host);
 		ctx_store_meta(ctx, CB_SRC_LABEL, identity);
 		if (from_host)
 			ep_tail_call(ctx, CILIUM_CALL_IPV6_FROM_HOST);
@@ -895,7 +888,15 @@ do_netdev(struct __ctx_buff *ctx, __u16 proto, const bool from_host)
 #endif
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		identity = resolve_srcid_ipv4(ctx, identity, &ipcache_srcid,
+		/* This is the first time revalidate_data() is going to be called.
+		 * Make sure that we don't legitimately drop the packet if the skb
+		 * arrived with the header not being not in the linear data.
+		 */
+		if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
+			return send_drop_notify_error(ctx, identity, DROP_INVALID,
+						      CTX_ACT_DROP, METRIC_INGRESS);
+
+		identity = resolve_srcid_ipv4(ctx, ip4, identity, &ipcache_srcid,
 					      from_host);
 		ctx_store_meta(ctx, CB_SRC_LABEL, identity);
 		if (from_host) {

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -211,13 +211,6 @@ __revalidate_data_pull(struct __ctx_buff *ctx, void **data, void **data_end,
 #define revalidate_data_pull(ctx, data, data_end, ip)			\
 	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), true)
 
-/* revalidate_data_maybe_pull() does the same as revalidate_data_pull()
- * except that the skb data pull is controlled by the "pull" argument.
- */
-#define revalidate_data_maybe_pull(ctx, data, data_end, ip, pull)	\
-	__revalidate_data_pull(ctx, data, data_end, (void **)ip, sizeof(**ip), pull)
-
-
 /* revalidate_data() initializes the provided pointers from the ctx.
  * Returns true if 'ctx' is long enough for an IP header of the provided type,
  * false otherwise.


### PR DESCRIPTION
Manual backport for

* [x] https://github.com/cilium/cilium/pull/25159

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 25159; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=25159
```
