### PR TITLE
bpf: nat: tolerate unhandled protocol types in revSNAT path

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1152,7 +1152,7 @@ snat_v4_rev_nat_handle_icmp_frag_needed(struct __ctx_buff *ctx, __u64 off)
 		tuple.dport = identifier;
 		break;
 	default:
-		return DROP_UNKNOWN_L4;
+		return NAT_PUNT_TO_STACK;
 	}
 	state = snat_v4_lookup(&tuple);
 	if (!state)
@@ -1225,7 +1225,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target, __
 			break;
 		case ICMP_DEST_UNREACH:
 			if (icmphdr.code != ICMP_FRAG_NEEDED)
-				return DROP_UNKNOWN_ICMP_CODE;
+				return NAT_PUNT_TO_STACK;
 			return snat_v4_rev_nat_handle_icmp_frag_needed(ctx, off);
 		default:
 			return NAT_PUNT_TO_STACK;
@@ -1951,7 +1951,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx, __u32 off)
 		tuple.dport = identifier;
 		break;
 	default:
-		return DROP_UNKNOWN_L4;
+		return NAT_PUNT_TO_STACK;
 	}
 	state = snat_v6_lookup(&tuple);
 	if (!state)


### PR DESCRIPTION
In the past we would just pass up packets with unknown protocols, and let the next layer (or the stack) deal with them.

https://github.com/cilium/cilium/pull/19753 recently added error handling for the revSNAT paths, so that we can catch errors while eg. rewriting the packet headers.

But we want to preserve the old behaviour of tolerating unknown protocol types. So return NAT_PUNT_TO_STACK from a few additional ICMP paths.