### PR TITLE
slices: Introduce slices.UniqueFunc()

### DIFF
--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -49,6 +49,29 @@ func Unique[S ~[]T, T comparable](s S) S {
 	return s[:last]
 }
 
+// UniqueFunc deduplicates the elements in the input slice like Unique, but takes a
+// function to extract the comparable "key" to compare T. This is slower than Unique,
+// but can be used with non-comparable elements.
+func UniqueFunc[S ~[]T, T any, K comparable](s S, key func(i int) K) S {
+	if len(s) < 2 {
+		return s
+	}
+
+	last := 0
+
+	set := make(map[K]struct{}, len(s))
+	for i := 0; i < len(s); i++ {
+		if _, ok := set[key(i)]; ok {
+			continue
+		}
+		set[key(i)] = struct{}{}
+		s[last] = s[i]
+		last++
+	}
+
+	return s[:last]
+}
+
 // SortedUnique sorts and dedup the input slice in place.
 // It uses the < operator to compare the elements in the slice and thus requires
 // the elements to satisfies contraints.Ordered.

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -59,6 +59,20 @@ func TestUnique(t *testing.T) {
 	}
 }
 
+func TestUniqueFunc(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := UniqueFunc(
+				tc.input,
+				func(i int) int {
+					return tc.input[i]
+				},
+			)
+			assert.ElementsMatch(t, tc.expected, got)
+		})
+	}
+}
+
 func TestSortedUnique(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -143,6 +157,14 @@ func TestUniqueKeepOrdering(t *testing.T) {
 // The relevant differences between the two approaches in terms of memory are shown in the previous
 // two columns.
 func BenchmarkUnique(b *testing.B) {
+	benchmarkUnique(b, false)
+}
+
+func BenchmarkUniqueFunc(b *testing.B) {
+	benchmarkUnique(b, true)
+}
+
+func benchmarkUnique(b *testing.B, benchUniqueFunc bool) {
 	var benchCases = [...]int{96, 128, 160, 192, 256, 512, 1024}
 
 	r := rand.New(rand.NewSource(time.Now().Unix()))
@@ -162,6 +184,11 @@ func BenchmarkUnique(b *testing.B) {
 				orig = append(orig, next)
 			}
 			values := make([]int, len(orig))
+
+			key := func(i int) int {
+				return values[i]
+			}
+
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
@@ -171,9 +198,13 @@ func BenchmarkUnique(b *testing.B) {
 				rand.Shuffle(len(orig), func(i, j int) {
 					orig[i], orig[j] = orig[j], orig[i]
 				})
-				b.StartTimer()
-
-				Unique(values)
+				if benchUniqueFunc {
+					b.StartTimer()
+					UniqueFunc(values, key)
+				} else {
+					b.StartTimer()
+					Unique(values)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
This commit is extracted from https://github.com/cilium/cilium/pull/25477 since it is an independent change.

Add a new function UniqueFunc() that deduplicates given slice like Unique(), but users can pass function to extract comparable key to compare the elements.

We didn't applied the optimization applied for Unique in UniqueFunc, because when we measure the performance, a simple map-based deduplication showed a good performance in terms of the deduplication speed (but has extra allocation).

Unique

```
cpu: 11th Gen Intel(R) Core(TM) i7-1195G7 @ 2.90GHz
BenchmarkUnique
BenchmarkUnique/96
BenchmarkUnique/96-8         	  576111	      1877 ns/op	       0 B/op	       0 allocs/op
BenchmarkUnique/128
BenchmarkUnique/128-8        	  376249	      3162 ns/op	       0 B/op	       0 allocs/op
BenchmarkUnique/160
BenchmarkUnique/160-8        	  267973	      4758 ns/op	       0 B/op	       0 allocs/op
BenchmarkUnique/192
BenchmarkUnique/192-8        	  205845	      5518 ns/op	    3134 B/op	       4 allocs/op
BenchmarkUnique/256
BenchmarkUnique/256-8        	  165156	      6981 ns/op	    6177 B/op	       2 allocs/op
BenchmarkUnique/512
BenchmarkUnique/512-8        	   89644	     13566 ns/op	   10927 B/op	       3 allocs/op
BenchmarkUnique/1024
BenchmarkUnique/1024-8       	   46180	     26177 ns/op	   21819 B/op	       4 allocs/op
```

UniqueFunc with the Unique-like optimization (compare elements like `key(i) == key(j)`)

```
cpu: 11th Gen Intel(R) Core(TM) i7-1195G7 @ 2.90GHz
BenchmarkUniqueFunc
BenchmarkUniqueFunc/96
BenchmarkUniqueFunc/96-8         	  109359	     11018 ns/op	       0 B/op	       0 allocs/op
BenchmarkUniqueFunc/128
BenchmarkUniqueFunc/128-8        	   63355	     17134 ns/op	       0 B/op	       0 allocs/op
BenchmarkUniqueFunc/160
BenchmarkUniqueFunc/160-8        	   42169	     26700 ns/op	       0 B/op	       0 allocs/op
BenchmarkUniqueFunc/192
BenchmarkUniqueFunc/192-8        	  192640	      6253 ns/op	    3143 B/op	       4 allocs/op
BenchmarkUniqueFunc/256
BenchmarkUniqueFunc/256-8        	  150264	      7652 ns/op	    6176 B/op	       2 allocs/op
BenchmarkUniqueFunc/512
BenchmarkUniqueFunc/512-8        	   79173	     15185 ns/op	   10927 B/op	       3 allocs/op
BenchmarkUniqueFunc/1024
BenchmarkUniqueFunc/1024-8       	   41577	     29245 ns/op	   21821 B/op	       4 allocs/op
```

UniqueFunc with simple map-based deduplication

```
cpu: 11th Gen Intel(R) Core(TM) i7-1195G7 @ 2.90GHz
BenchmarkUniqueFunc
BenchmarkUniqueFunc/96
BenchmarkUniqueFunc/96-8         	  393656	      3258 ns/op	    1474 B/op	       3 allocs/op
BenchmarkUniqueFunc/128
BenchmarkUniqueFunc/128-8        	  272712	      4091 ns/op	    3099 B/op	       2 allocs/op
BenchmarkUniqueFunc/160
BenchmarkUniqueFunc/160-8        	  232684	      5242 ns/op	    3118 B/op	       3 allocs/op
BenchmarkUniqueFunc/192
BenchmarkUniqueFunc/192-8        	  191180	      6159 ns/op	    3132 B/op	       4 allocs/op
BenchmarkUniqueFunc/256
BenchmarkUniqueFunc/256-8        	  148922	      7928 ns/op	    6179 B/op	       2 allocs/op
BenchmarkUniqueFunc/512
BenchmarkUniqueFunc/512-8        	   78356	     15101 ns/op	   10923 B/op	       3 allocs/op
BenchmarkUniqueFunc/1024
BenchmarkUniqueFunc/1024-8       	   41091	     29386 ns/op	   21821 B/op	       4 allocs/op
```

```release-note
slices: Introduce slices.UniqueFunc()
```
