### PR TITLE
ipsec: Reinitialize IPsec for new devices in ENI mode

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -198,18 +198,17 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 		// IPAMENI mode supports multiple network facing interfaces that
 		// will all need Encrypt logic applied in order to decrypt any
 		// received encrypted packets. This logic will attach to all
-		// !veth devices. Only use if user has not configured interfaces.
-		if len(interfaces) == 0 {
-			if links, err := netlink.LinkList(); err == nil {
-				for _, link := range links {
-					isVirtual, err := ethtool.IsVirtualDriver(link.Attrs().Name)
-					if err == nil && !isVirtual {
-						interfaces = append(interfaces, link.Attrs().Name)
-					}
+		// !veth devices.
+		interfaces = nil
+		if links, err := netlink.LinkList(); err == nil {
+			for _, link := range links {
+				isVirtual, err := ethtool.IsVirtualDriver(link.Attrs().Name)
+				if err == nil && !isVirtual {
+					interfaces = append(interfaces, link.Attrs().Name)
 				}
 			}
-			option.Config.EncryptInterface = interfaces
 		}
+		option.Config.EncryptInterface = interfaces
 	}
 
 	// No interfaces is valid in tunnel disabled case


### PR DESCRIPTION
In ENI mode new network devices are added as more IPs are requested. For IPsec support we
require the bpf_network program to be loaded on any device that receives the IPsec traffic
to mark the packets for decryption. 

Since Cilium uses the IP of the `cilium_host` device for the IPsec traffic the ENI device hosting
the IP requires bpf_network to be loaded onto it and since the `cilium_host` IP can change, this
PR watches for new network devices and reinitializes IPsec to make sure the `bpf_network` program
is loaded onto all used non-virtual devices.

```release-note
Fix bug affecting EKS installations with IPsec encryption enabled, where Cilium wouldn't attach its IPsec BPF program to new ENI interfaces, resulting in connectivity loss between pods on remote nodes.  
```
