### PR TITLE
High-scale IPCache: Nodeport LB support Part 1

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -617,6 +617,30 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 
 	case bpf_htons(ETH_P_IP):
 #ifdef ENABLE_IPV4
+# ifdef ENABLE_HIGH_SCALE_IPCACHE
+#  if defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+		if (ctx_load_meta(ctx, CB_HSIPC_ADDR_V4)) {
+			struct geneve_dsr_opt4 dsr_opt;
+			struct bpf_tunnel_key key = {};
+
+			set_geneve_dsr_opt4((__be16)ctx_load_meta(ctx, CB_HSIPC_PORT),
+					    ctx_load_meta(ctx, CB_HSIPC_ADDR_V4),
+					    &dsr_opt);
+
+			/* Needed to create the metadata_dst for storing tunnel opts: */
+			if (ctx_set_tunnel_key(ctx, &key, sizeof(key), BPF_F_ZERO_CSUM_TX) < 0) {
+				ret = DROP_WRITE_ERROR;
+				goto out;
+			}
+
+			if (ctx_set_tunnel_opt(ctx, &dsr_opt, sizeof(dsr_opt)) < 0) {
+				ret = DROP_WRITE_ERROR;
+				goto out;
+			}
+		}
+#  endif
+# endif
+
 		ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_OVERLAY);
 		ret = DROP_MISSED_TAIL_CALL;
 #else

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -775,10 +775,12 @@ enum {
 #define	CB_IPCACHE_SRC_LABEL	CB_IFINDEX	/* Alias, non-overlapping */
 #define CB_SRV6_SID_2		CB_IFINDEX	/* Alias, non-overlapping */
 #define CB_CLUSTER_ID_EGRESS	CB_IFINDEX	/* Alias, non-overlapping */
+#define CB_HSIPC_ADDR_V4	CB_IFINDEX	/* Alias, non-overlapping */
 	CB_POLICY,
 #define	CB_ADDR_V6_2		CB_POLICY	/* Alias, non-overlapping */
 #define CB_SRV6_SID_3		CB_POLICY	/* Alias, non-overlapping */
 #define	CB_CLUSTER_ID_INGRESS	CB_POLICY	/* Alias, non-overlapping */
+#define CB_HSIPC_PORT		CB_POLICY	/* Alias, non-overlapping */
 	CB_NAT,
 #define	CB_ADDR_V6_3		CB_NAT		/* Alias, non-overlapping */
 #define	CB_FROM_HOST		CB_NAT		/* Alias, non-overlapping */

--- a/bpf/lib/high_scale_ipcache.h
+++ b/bpf/lib/high_scale_ipcache.h
@@ -83,7 +83,7 @@ decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 	case TUNNEL_PROTOCOL_GENEVE:
 		off = ((void *)ip4 - data) + ipv4_hdrlen(ip4) + sizeof(struct udphdr);
 		if (ctx_load_bytes(ctx, off, &geneve, sizeof(geneve)) < 0)
-			return CTX_ACT_DROP;
+			return DROP_INVALID;
 
 		opt_len = geneve.opt_len * 4;
 		memcpy(src_id, &geneve.vni, sizeof(__u32));
@@ -100,7 +100,7 @@ decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 		      offsetof(struct vxlanhdr, vx_vni);
 
 		if (ctx_load_bytes(ctx, off, src_id, sizeof(__u32)) < 0)
-			return CTX_ACT_DROP;
+			return DROP_INVALID;
 		break;
 	default:
 		/* If the tunnel type is neither VXLAN nor GENEVE, we have an issue. */
@@ -111,7 +111,7 @@ decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 	ctx_store_meta(ctx, CB_SRC_LABEL, *src_id);
 
 	if (ctx_adjust_hroom(ctx, -shrink, BPF_ADJ_ROOM_MAC, ctx_adjust_hroom_flags()))
-		return CTX_ACT_DROP;
+		return DROP_INVALID;
 	return ctx_redirect(ctx, ENCAP_IFINDEX, BPF_F_INGRESS);
 }
 #endif /* ENABLE_HIGH_SCALE_IPCACHE */


### PR DESCRIPTION
This PR is in the context of the high-scale ipcache feature described at https://github.com/cilium/design-cfps/pull/7.

It enables the nodeport LB to handle an unencapsulated service request, and forward the request to the backend using GENEVE-DSR. It also adds handling for reply traffic.

In detail:

- the request enters the LB in `from-netdev` (either XDP or TC), and `nodeport_lb4()` selects a backend.
- the DNATed packet goes down the DSR egress code path, and has GENEVE encapsulation added (+ DSR option as needed). In the context of hs-ipcache, we use the backend's IP address as OuterDstIP (same as if it was a pod-to-pod connection). If the load-balancing is done in XDP, we punt up to TC for adding the tunnel headers.
 - the packet is sent to the backend node
 - at the backend node, the `from-netdev` program strips off the encapsulation and redirects it to `from-overlay`. We manually transfer the DSR info across this redirect. The `from-overlay` program processes the DSR info and creates a corresponding SNAT entry.
 - replies are revDNATed in `to-overlay` (when they go to a destination inside the Clustermesh), or `to-netdev` (when the client belongs to one of the configured WorldCIDRs).


```release-note
Add support for load-balancing unencapsulated requests in a configuration with high-scale ipcache.
```
