### PR TITLE
Hubble: Add option to remove query from HTTP flows

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -181,6 +181,7 @@ cilium-agent [flags]
       --hubble-prefer-ipv6                                      Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-recorder-sink-queue-size int                     Queue size of each Hubble recorder sink (default 1024)
       --hubble-recorder-storage-path string                     Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")
+      --hubble-redact strings                                   List of Hubble redact options
       --hubble-skip-unknown-cgroup-ids                          Skip Hubble events with unknown cgroup ids (default true)
       --hubble-socket-path string                               Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
       --hubble-tls-cert-file string                             Path to the public key file for the Hubble server. The file must contain PEM encoded data.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1301,7 +1301,7 @@
      - bool
      - ``false``
    * - hubble.metrics.enabled
-     - Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
+     - Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
      - string
      - ``nil``
    * - hubble.metrics.port
@@ -1348,6 +1348,10 @@
      - Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
      - bool
      - ``false``
+   * - hubble.redact
+     - Configures the list of redact options for Hubble. Example:    redact:   - http-url-query  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query}"
+     - string
+     - ``nil``
    * - hubble.relay.affinity
      - Affinity for hubble-replay
      - object

--- a/Documentation/observability/visibility.rst
+++ b/Documentation/observability/visibility.rst
@@ -66,6 +66,26 @@ In order for Cilium to populate the ``INGRESS ENFORCEMENT``, ``EGRESS ENFORCEMEN
 and ``VISIBILITY POLICY`` fields, it must run with ``--endpoint-status=policy``
 to make field values visible.
 
+Security Implications
+---------------------
+
+Monitoring Layer 7 traffic involves security considerations for handling
+potentially sensitive information, such as usernames, passwords, query
+parameters, API keys, and others.
+
+.. warning::
+
+   By default, Hubble does not redact potentially sensitive information
+   present in `Layer 7 Hubble Flows <https://github.com/cilium/cilium/tree/master/api/v1/flow#flow-Layer7>`_.
+
+To harden security, Cilium provides the ``--hubble-redact`` option to control
+how Hubble handles sensitive information present in Layer 7 flows. More
+specifically, it offers the following features for supported Layer 7 protocols:
+
+* For HTTP: redacting URL query (GET) parameters
+
+For more information on configuring Cilium, see :ref:`Cilium Configuration <configuration>`.
+
 Troubleshooting
 ---------------
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -553,6 +553,7 @@ hostonlyifs
 hostport
 hostscope
 hq
+http
 httpd
 https
 hubble

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -968,6 +968,9 @@ func initializeFlags() {
 	)
 	option.BindEnv(Vp, option.HubbleMonitorEvents)
 
+	flags.StringSlice(option.HubbleRedact, []string{}, "List of Hubble redact options")
+	option.BindEnv(Vp, option.HubbleRedact)
+
 	flags.StringSlice(option.DisableIptablesFeederRules, []string{}, "Chains to ignore when installing feeder rules.")
 	option.BindEnv(Vp, option.DisableIptablesFeederRules)
 

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/observer"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/hubble/parser"
+	parserOptions "github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/hubble/peer"
 	"github.com/cilium/cilium/pkg/hubble/peer/serviceoption"
 	"github.com/cilium/cilium/pkg/hubble/recorder"
@@ -97,6 +98,7 @@ func (d *Daemon) launchHubble() {
 	var (
 		observerOpts []observeroption.Option
 		localSrvOpts []serveroption.Option
+		parserOpts   []parserOptions.Option
 	)
 
 	if len(option.Config.HubbleMonitorEvents) > 0 {
@@ -137,8 +139,12 @@ func (d *Daemon) launchHubble() {
 		)
 	}
 
+	if len(option.Config.HubbleRedact) > 0 {
+		parserOpts = append(parserOpts, parserOptions.Redact(logger, option.Config.HubbleRedact))
+	}
+
 	d.linkCache = link.NewLinkCache()
-	payloadParser, err := parser.New(logger, d, d, d, d, d, d.linkCache, d.cgroupManager)
+	payloadParser, err := parser.New(logger, d, d, d, d, d, d.linkCache, d.cgroupManager, parserOpts...)
 	if err != nil {
 		logger.WithError(err).Error("Failed to initialize Hubble")
 		return

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -375,7 +375,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics | object | `{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
 | hubble.metrics.dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null}` | Grafana dashboards for hubble grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | hubble.metrics.enableOpenMetrics | bool | `false` | Enables exporting hubble metrics in OpenMetrics format. |
-| hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"  |
+| hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"  |
 | hubble.metrics.port | int | `9965` | Configure the port the hubble metric server listens on. |
 | hubble.metrics.serviceAnnotations | object | `{}` | Annotations to be added to hubble-metrics service. |
 | hubble.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble |
@@ -387,6 +387,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service, must match the hubble.listenAddress' port. |
 | hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. |
+| hubble.redact | string | `nil` | Configures the list of redact options for Hubble. Example:    redact:   - http-url-query  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query}"  |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -829,6 +829,12 @@ data:
 {{- end }}
   enable-hubble-open-metrics: {{ .Values.hubble.metrics.enableOpenMetrics | quote }}
 {{- end }}
+{{- if .Values.hubble.redact }}
+  # A space separated list of redact options for Hubble.
+  hubble-redact: {{- range .Values.hubble.redact }}
+    {{.}}
+{{- end }}
+{{- end }}
 {{- if hasKey .Values.hubble "listenAddress" }}
   # An additional address for Hubble server to listen to (e.g. ":4244").
   hubble-listen-address: {{ .Values.hubble.listenAddress | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -960,7 +960,7 @@ hubble:
     #
     # You can specify the list of metrics from the helm CLI:
     #
-    #   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
+    #   --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
     #
     enabled: ~
     # -- Enables exporting hubble metrics in OpenMetrics format.
@@ -1000,6 +1000,18 @@ hubble:
 
   # -- Unix domain socket path to listen to when Hubble is enabled.
   socketPath: /var/run/cilium/hubble.sock
+
+  # -- Configures the list of redact options for Hubble.
+  # Example:
+  #
+  #   redact:
+  #   - http-url-query
+  #
+  # You can specify the list of options from the helm CLI:
+  #
+  #   --set hubble.redact="{http-url-query}"
+  #
+  redact: ~
 
   # -- An additional address for Hubble to listen to.
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -957,7 +957,7 @@ hubble:
     #
     # You can specify the list of metrics from the helm CLI:
     #
-    #   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
+    #   --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
     #
     enabled: ~
     # -- Enables exporting hubble metrics in OpenMetrics format.
@@ -997,6 +997,18 @@ hubble:
 
   # -- Unix domain socket path to listen to when Hubble is enabled.
   socketPath: /var/run/cilium/hubble.sock
+
+  # -- Configures the list of redact options for Hubble.
+  # Example:
+  #
+  #   redact:
+  #   - http-url-query
+  #
+  # You can specify the list of options from the helm CLI:
+  #
+  #   --set hubble.redact="{http-url-query}"
+  #
+  redact: ~
 
   # -- An additional address for Hubble to listen to.
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -3,17 +3,48 @@
 
 package options
 
+import (
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	HttpUrlQuery = "http-url-query"
+)
+
 // Option is used to configure parsers
 type Option func(*Options)
 
 // Options contains all parser options
 type Options struct {
-	CacheSize int
+	CacheSize       int
+	RedactHTTPQuery bool
 }
 
 // CacheSize configures the amount of L7 requests cached for latency calculation
 func CacheSize(size int) Option {
 	return func(opt *Options) {
 		opt.CacheSize = size
+	}
+}
+
+// Redact configures which data Hubble will redact.
+func Redact(logger logrus.FieldLogger, hubbleRedactOptions []string) Option {
+	return func(opt *Options) {
+		validOpts := []string{}
+		for _, option := range hubbleRedactOptions {
+			switch option {
+			case HttpUrlQuery:
+				opt.RedactHTTPQuery = true
+			default:
+				if logger != nil {
+					logger.WithField("option", option).Warn("ignoring unknown Hubble redact option")
+				}
+				continue
+			}
+			validOpts = append(validOpts, option)
+		}
+		if logger != nil {
+			logger.WithField("options", validOpts).Info("configured Hubble with redact options")
+		}
 	}
 }

--- a/pkg/hubble/parser/seven/http.go
+++ b/pkg/hubble/parser/seven/http.go
@@ -25,15 +25,16 @@ func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP) *flo
 			headers = append(headers, &flowpb.HTTPHeader{Key: key, Value: value})
 		}
 	}
+	uri, _ := url.Parse(http.URL.String())
 	var urlString string
-	if http.URL != nil {
-		if http.URL.User != nil {
+	if uri != nil {
+		if uri.User != nil {
 			// Don't include the password in the flow.
-			if _, ok := http.URL.User.Password(); ok {
-				http.URL.User = url.UserPassword(http.URL.User.Username(), "HUBBLE_REDACTED")
+			if _, ok := uri.User.Password(); ok {
+				uri.User = url.UserPassword(uri.User.Username(), "HUBBLE_REDACTED")
 			}
 		}
-		urlString = http.URL.String()
+		urlString = uri.String()
 	}
 	if flowType == accesslog.TypeRequest {
 		// Set only fields that are relevant for requests.

--- a/pkg/hubble/parser/seven/http.go
+++ b/pkg/hubble/parser/seven/http.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
-func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP) *flowpb.Layer7_Http {
+func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts *options.Options) *flowpb.Layer7_Http {
 	var headers []*flowpb.HTTPHeader
 	keys := make([]string, 0, len(http.Headers))
 	for key := range http.Headers {
@@ -33,6 +34,10 @@ func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP) *flo
 			if _, ok := uri.User.Password(); ok {
 				uri.User = url.UserPassword(uri.User.Username(), "HUBBLE_REDACTED")
 			}
+		}
+		if opts.RedactHTTPQuery {
+			uri.RawQuery = ""
+			uri.Fragment = ""
 		}
 		urlString = uri.String()
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1003,6 +1003,10 @@ const (
 	// By default, Hubble observes all monitor events.
 	HubbleMonitorEvents = "hubble-monitor-events"
 
+	// HubbleRedact controls which values Hubble will redact in network flows.
+	// By default, Hubble does not redact any values.
+	HubbleRedact = "hubble-redact"
+
 	// DisableIptablesFeederRules specifies which chains will be excluded
 	// when installing the feeder rules
 	DisableIptablesFeederRules = "disable-iptables-feeder-rules"
@@ -2203,6 +2207,10 @@ type DaemonConfig struct {
 	// HubbleMonitorEvents specifies Cilium monitor events for Hubble to observe.
 	// By default, Hubble observes all monitor events.
 	HubbleMonitorEvents []string
+
+	// HubbleRedact controls which values Hubble will redact in network flows.
+	// By default, Hubble does not redact any values.
+	HubbleRedact []string
 
 	// EndpointStatus enables population of information in the
 	// CiliumEndpoint.Status resource
@@ -3427,6 +3435,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.HubbleRecorderSinkQueueSize = vp.GetInt(HubbleRecorderSinkQueueSize)
 	c.HubbleSkipUnknownCGroupIDs = vp.GetBool(HubbleSkipUnknownCGroupIDs)
 	c.HubbleMonitorEvents = vp.GetStringSlice(HubbleMonitorEvents)
+	c.HubbleRedact = vp.GetStringSlice(HubbleRedact)
 
 	c.DisableIptablesFeederRules = vp.GetStringSlice(DisableIptablesFeederRules)
 


### PR DESCRIPTION
This PR adds `--hubble-redact` flag for cilium agent with only accepted value the `http-url-query` for now. This is to provide the option to remove the Query and Fragment part from the URL in http flows.

Part of: https://github.com/cilium/cilium/issues/23887

```release-note
Add option to remove query from HTTP flows
```

#### TODOS
- [x] Add unit tests
- [x] Allign naming with https://github.com/cilium/cilium/pull/25844

### How to test this manually

1. In the root directory of the project edit https://github.com/cilium/cilium/blob/23bac97b3aa7a34e9d03f7d901bd77a124378446/contrib/testing/kind-values.yaml to add the following lines:
```yaml
extraArgs: ["--hubble-redact=rand1,http-url-query,rand2"]
```
2. Deploy cilium from source with `make kind-image && make kind-install-cilium`
3. Enable hubble with `cilium hubble enable --chart-directory=/home/chrismark/go/src/github.com/cilium/cilium/install/kubernetes/cilium`
4. Apply a L7 example endpoint with `kubectl apply -f https://raw.githubusercontent.com/cilium/cilium/1.13.3/examples/minikube/sw_l3_l4_l7_policy.yaml`
5. Port forward hubble relay svc with `kubectl port-forward -n kube-system svc/hubble-relay --address 0.0.0.0 --address :: 4245:80`
6. Deploy the sample app with `kubectl create -f https://raw.githubusercontent.com/cilium/cilium/1.13.3/examples/minikube/http-sw-app.yaml`. From https://docs.cilium.io/en/stable/gettingstarted/demo/#starwars-demo
7. Observe the flows with `hubble observe --pod deathstar --protocol http -f`
8. Execute a curl request with `kubectl exec tiefighter -- curl -s -XPOST "http://deathstar.default.svc.cluster.local/v1/request-landing#v2?foo=bar"`
9. Verify that sensitive parts are removed from the URL in the flows' observe output. 

### Screenshot
![cilium-working](https://github.com/cilium/cilium/assets/11754898/6bb0779b-a9ba-410b-a3eb-b8bbdd7d6160)

