### PR TITLE
test: prevent panic on k8s services host fw test on some runs.

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -396,6 +396,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 		BeforeAll(func() {
 			kubectl.Exec("kubectl label nodes --all status=lockdown")
 
+			// Need to install Cilium w/ host fw prior to the host policy preparation
+			// step.
+			deploymentManager.DeployCilium(map[string]string{
+				"hostFirewall.enabled": "true",
+			}, DeployCiliumOptionsAndDNS)
+
 			prepareHostPolicyEnforcement(kubectl)
 		})
 
@@ -589,10 +595,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 // termination of those connections.
 // This function implements that process.
 func prepareHostPolicyEnforcement(kubectl *helpers.Kubectl) {
-	deploymentManager.DeployCilium(map[string]string{
-		"hostFirewall.enabled": "true",
-	}, DeployCiliumOptionsAndDNS)
-
 	demoHostPolicies := helpers.ManifestGet(kubectl.BasePath(), "host-policies.yaml")
 	By(fmt.Sprintf("Applying policies %s for 1min", demoHostPolicies))
 	_, err := kubectl.CiliumClusterwidePolicyAction(demoHostPolicies, helpers.KubectlApply, helpers.HelperTimeout)


### PR DESCRIPTION
Change introduced 0e20d30e70b938e530c848dc00da359656740fa0 in order to provide workaround fix for flake can panic depending on the order which tests are run if the deploymentManager is not setup with a kubectl object.

k8s/services already deploys Cilium with the hostfirewall enabled, so this moves installing Cilium out of the host-few preperation step and defers that to the caller (such as in datapath_configuration).

Fixes #25775
