### PR TITLE
Convert daemon ipcache usages to new ipcache async API

### DIFF
--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -71,6 +71,21 @@ func PrefixToIPNet(prefix netip.Prefix) *net.IPNet {
 	}
 }
 
+// IPNetToPrefix is a convenience helper for migrating from the older 'net'
+// standard library types to the newer 'netip' types. Use this to plug the
+// new types in newer code into older types in older code during the migration.
+func IPNetToPrefix(prefix *net.IPNet) netip.Prefix {
+	if prefix == nil {
+		return netip.Prefix{}
+	}
+	addr, ok := AddrFromIP(prefix.IP)
+	if !ok {
+		return netip.Prefix{}
+	}
+	ones, _ := prefix.Mask.Size()
+	return netip.PrefixFrom(addr, ones)
+}
+
 // AddrToIPNet is a convenience helper to convert a netip.Addr to a *net.IPNet
 // with a mask corresponding to the addresses's bit length.
 func AddrToIPNet(addr netip.Addr) *net.IPNet {

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -90,3 +90,19 @@ func TestNetsContainsAny(t *testing.T) {
 		})
 	}
 }
+
+func TestIPNetToPrefix(t *testing.T) {
+	_, v4CIDR, err := net.ParseCIDR("1.1.1.1/32")
+	assert.NoError(t, err)
+	_, v6CIDR, err := net.ParseCIDR("::ff/128")
+	assert.NoError(t, err)
+	assert.Equal(t, netip.MustParsePrefix(v4CIDR.String()), IPNetToPrefix(v4CIDR))
+	assert.Equal(t, netip.MustParsePrefix(v6CIDR.String()), IPNetToPrefix(v6CIDR))
+
+	_, v4CIDR, err = net.ParseCIDR("1.1.1.1/1")
+	assert.NoError(t, err)
+	assert.Equal(t, netip.MustParsePrefix(v4CIDR.String()), IPNetToPrefix(v4CIDR))
+
+	assert.Equal(t, netip.Prefix{}, IPNetToPrefix(nil))
+	assert.Equal(t, netip.Prefix{}, IPNetToPrefix(&net.IPNet{}))
+}

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -42,6 +42,7 @@ type ResourceKind string
 var (
 	ResourceKindCNP      = ResourceKind("cnp")
 	ResourceKindCCNP     = ResourceKind("ccnp")
+	ResourceKindDaemon   = ResourceKind("daemon")
 	ResourceKindEndpoint = ResourceKind("ep")
 	ResourceKindNetpol   = ResourceKind("netpol")
 	ResourceKindNode     = ResourceKind("node")


### PR DESCRIPTION
- daemon: Convert host IP sync to async ipcache API
- ip: Add IPNetToPrefix() helper
- dameon: Convert ingress restoration code to async ipcache API

Related: https://github.com/cilium/cilium/issues/21142
