### PR TITLE
Improve Hubble decoding performance for drop, debug, policy and tracesock events

### DIFF
--- a/pkg/hubble/parser/debug/parser.go
+++ b/pkg/hubble/parser/debug/parser.go
@@ -4,15 +4,12 @@
 package debug
 
 import (
-	"bytes"
-	"encoding/binary"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
 	"github.com/cilium/cilium/pkg/monitor"
@@ -47,7 +44,7 @@ func (p *Parser) Decode(data []byte, cpu int) (*flowpb.DebugEvent, error) {
 	}
 
 	dbg := &monitor.DebugMsg{}
-	if err := binary.Read(bytes.NewReader(data), byteorder.Native, dbg); err != nil {
+	if err := monitor.DecodeDebugMsg(data, dbg); err != nil {
 		return nil, fmt.Errorf("failed to parse debug event: %w", err)
 	}
 

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -4,8 +4,6 @@
 package sock
 
 import (
-	"bytes"
-	"encoding/binary"
 	"fmt"
 	"net"
 	"net/netip"
@@ -14,7 +12,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
-	"github.com/cilium/cilium/pkg/byteorder"
 	"github.com/cilium/cilium/pkg/hubble/parser/common"
 	"github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/getters"
@@ -74,7 +71,7 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	}
 
 	sock := &monitor.TraceSockNotify{}
-	if err := binary.Read(bytes.NewReader(data), byteorder.Native, sock); err != nil {
+	if err := monitor.DecodeTraceSockNotify(data, sock); err != nil {
 		return fmt.Errorf("failed to parse sock trace event: %w", err)
 	}
 

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -4,8 +4,6 @@
 package threefour
 
 import (
-	"bytes"
-	"encoding/binary"
 	"fmt"
 	"net/netip"
 	"strings"
@@ -111,7 +109,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	case monitorAPI.MessageTypeDrop:
 		packetOffset = monitor.DropNotifyLen
 		dn = &monitor.DropNotify{}
-		if err := binary.Read(bytes.NewReader(data), byteorder.Native, dn); err != nil {
+		if err := monitor.DecodeDropNotify(data, dn); err != nil {
 			return fmt.Errorf("failed to parse drop: %v", err)
 		}
 		eventSubType = dn.SubType
@@ -133,7 +131,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		packetOffset = (int)(tn.DataOffset())
 	case monitorAPI.MessageTypePolicyVerdict:
 		pvn = &monitor.PolicyVerdictNotify{}
-		if err := binary.Read(bytes.NewReader(data), byteorder.Native, pvn); err != nil {
+		if err := monitor.DecodePolicyVerdictNotify(data, pvn); err != nil {
 			return fmt.Errorf("failed to parse policy verdict: %v", err)
 		}
 		eventSubType = pvn.SubType
@@ -141,7 +139,7 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		authType = flow.AuthType(pvn.GetAuthType())
 	case monitorAPI.MessageTypeCapture:
 		dbg = &monitor.DebugCapture{}
-		if err := binary.Read(bytes.NewReader(data), byteorder.Native, dbg); err != nil {
+		if err := monitor.DecodeDebugCapture(data, dbg); err != nil {
 			return fmt.Errorf("failed to parse debug capture: %w", err)
 		}
 		eventSubType = dbg.SubType

--- a/pkg/monitor/datapath_debug_test.go
+++ b/pkg/monitor/datapath_debug_test.go
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package monitor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	. "github.com/cilium/checkmate"
+
+	"github.com/cilium/cilium/pkg/byteorder"
+)
+
+func (s *MonitorSuite) TestDecodeDebugCapture(c *C) {
+	// This check on the struct length constant is there to ensure that this
+	// test is updated when the struct changes.
+	c.Assert(DebugCaptureLen, Equals, 24)
+
+	input := DebugCapture{
+		Type:    0x00,
+		SubType: 0x01,
+		Source:  0x02_03,
+		Hash:    0x04_05_06_07,
+		OrigLen: 0x08_09_0a_0b,
+		Arg1:    0x0c_0d_0e_10,
+		Arg2:    0x11_12_13_14,
+	}
+
+	buf := bytes.NewBuffer(nil)
+	err := binary.Write(buf, byteorder.Native, input)
+	c.Assert(err, IsNil)
+
+	output := &DebugCapture{}
+	err = DecodeDebugCapture(buf.Bytes(), output)
+	c.Assert(err, IsNil)
+
+	c.Assert(output.Type, Equals, input.Type)
+	c.Assert(output.SubType, Equals, input.SubType)
+	c.Assert(output.Source, Equals, input.Source)
+	c.Assert(output.Hash, Equals, input.Hash)
+	c.Assert(output.OrigLen, Equals, input.OrigLen)
+	c.Assert(output.Arg1, Equals, input.Arg1)
+	c.Assert(output.Arg2, Equals, input.Arg2)
+}
+
+func BenchmarkNewDecodeDebugCapture(b *testing.B) {
+	input := &DebugCapture{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		dbg := &DebugCapture{}
+		if err := DecodeDebugCapture(buf.Bytes(), dbg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkOldDecodeDebugCapture(b *testing.B) {
+	input := &DebugCapture{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		dbg := &DebugCapture{}
+		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, dbg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func (s *MonitorSuite) TestDecodeDebugMsg(c *C) {
+	// This check on the struct length constant is there to ensure that this
+	// test is updated when the struct changes.
+	c.Assert(DebugMsgLen, Equals, 20)
+
+	input := DebugMsg{
+		Type:    0x00,
+		SubType: 0x01,
+		Source:  0x02_03,
+		Hash:    0x04_05_06_07,
+		Arg1:    0x08_09_0a_0b,
+		Arg2:    0x0c_0d_0e_10,
+		Arg3:    0x11_12_13_14,
+	}
+
+	buf := bytes.NewBuffer(nil)
+	err := binary.Write(buf, byteorder.Native, input)
+	c.Assert(err, IsNil)
+
+	output := &DebugMsg{}
+	err = DecodeDebugMsg(buf.Bytes(), output)
+	c.Assert(err, IsNil)
+
+	c.Assert(output.Type, Equals, input.Type)
+	c.Assert(output.SubType, Equals, input.SubType)
+	c.Assert(output.Source, Equals, input.Source)
+	c.Assert(output.Hash, Equals, input.Hash)
+	c.Assert(output.Arg1, Equals, input.Arg1)
+	c.Assert(output.Arg2, Equals, input.Arg2)
+	c.Assert(output.Arg3, Equals, input.Arg3)
+}
+
+func BenchmarkNewDecodeDebugMsg(b *testing.B) {
+	input := &DebugMsg{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		dbg := &DebugMsg{}
+		if err := DecodeDebugMsg(buf.Bytes(), dbg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkOldDecodeDebugMsg(b *testing.B) {
+	input := &DebugMsg{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		dbg := &DebugMsg{}
+		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, dbg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/monitor/datapath_drop_test.go
+++ b/pkg/monitor/datapath_drop_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package monitor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	. "github.com/cilium/checkmate"
+
+	"github.com/cilium/cilium/pkg/byteorder"
+)
+
+func (s *MonitorSuite) TestDecodeDropNotify(c *C) {
+	// This check on the struct length constant is there to ensure that this
+	// test is updated when the struct changes.
+	c.Assert(DropNotifyLen, Equals, 36)
+
+	input := DropNotify{
+		Type:     0x00,
+		SubType:  0x01,
+		Source:   0x02_03,
+		Hash:     0x04_05_06_07,
+		OrigLen:  0x08_09_0a_0b,
+		CapLen:   0x0c_0d_0e_10,
+		SrcLabel: 0x11_12_13_14,
+		DstLabel: 0x15_16_17_18,
+		DstID:    0x19_1a_1b_1c,
+		Line:     0x1d_1e,
+		File:     0x20,
+		ExtError: 0x21,
+		Ifindex:  0x22_23_24_25,
+	}
+	buf := bytes.NewBuffer(nil)
+	err := binary.Write(buf, byteorder.Native, input)
+	c.Assert(err, IsNil)
+
+	output := &DropNotify{}
+	err = DecodeDropNotify(buf.Bytes(), output)
+	c.Assert(err, IsNil)
+
+	c.Assert(output.Type, Equals, input.Type)
+	c.Assert(output.SubType, Equals, input.SubType)
+	c.Assert(output.Source, Equals, input.Source)
+	c.Assert(output.Hash, Equals, input.Hash)
+	c.Assert(output.OrigLen, Equals, input.OrigLen)
+	c.Assert(output.CapLen, Equals, input.CapLen)
+	c.Assert(output.SrcLabel, Equals, input.SrcLabel)
+	c.Assert(output.DstLabel, Equals, input.DstLabel)
+	c.Assert(output.DstID, Equals, input.DstID)
+	c.Assert(output.Line, Equals, input.Line)
+	c.Assert(output.File, Equals, input.File)
+	c.Assert(output.ExtError, Equals, input.ExtError)
+	c.Assert(output.Ifindex, Equals, input.Ifindex)
+}
+
+func BenchmarkNewDecodeDropNotify(b *testing.B) {
+	input := DropNotify{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		dn := &DropNotify{}
+		if err := DecodeDropNotify(buf.Bytes(), dn); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkOldDecodeDropNotify(b *testing.B) {
+	input := DropNotify{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		dn := &DropNotify{}
+		if err := binary.Read(bytes.NewReader(buf.Bytes()), byteorder.Native, dn); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/monitor/datapath_policy_test.go
+++ b/pkg/monitor/datapath_policy_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package monitor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	. "github.com/cilium/checkmate"
+
+	"github.com/cilium/cilium/pkg/byteorder"
+)
+
+func (s *MonitorSuite) TestDecodePolicyVerdicyNotify(c *C) {
+	// This check on the struct length constant is there to ensure that this
+	// test is updated when the struct changes.
+	c.Assert(PolicyVerdictNotifyLen, Equals, 32)
+
+	input := PolicyVerdictNotify{
+		Type:        0x00,
+		SubType:     0x01,
+		Source:      0x02_03,
+		Hash:        0x04_05_06_07,
+		OrigLen:     0x08_09_0a_0b,
+		CapLen:      0x0c_0d,
+		Version:     0x0e_10,
+		RemoteLabel: 0x11_12_13_14,
+		Verdict:     0x15_16_17_18,
+		DstPort:     0x19_1a,
+		Proto:       0x1b,
+		Flags:       0x1c,
+		AuthType:    0x1d,
+		Pad1:        0x1e,
+		Pad2:        0x20_21,
+	}
+	buf := bytes.NewBuffer(nil)
+	err := binary.Write(buf, byteorder.Native, input)
+	c.Assert(err, IsNil)
+
+	output := &PolicyVerdictNotify{}
+	err = DecodePolicyVerdictNotify(buf.Bytes(), output)
+	c.Assert(err, IsNil)
+
+	c.Assert(output.Type, Equals, input.Type)
+	c.Assert(output.SubType, Equals, input.SubType)
+	c.Assert(output.Source, Equals, input.Source)
+	c.Assert(output.Hash, Equals, input.Hash)
+	c.Assert(output.OrigLen, Equals, input.OrigLen)
+	c.Assert(output.CapLen, Equals, input.CapLen)
+	c.Assert(output.Version, Equals, input.Version)
+	c.Assert(output.RemoteLabel, Equals, input.RemoteLabel)
+	c.Assert(output.Verdict, Equals, input.Verdict)
+	c.Assert(output.DstPort, Equals, input.DstPort)
+	c.Assert(output.Proto, Equals, input.Proto)
+	c.Assert(output.Flags, Equals, input.Flags)
+	c.Assert(output.AuthType, Equals, input.AuthType)
+	c.Assert(output.Pad1, Equals, input.Pad1)
+	c.Assert(output.Pad2, Equals, input.Pad2)
+}
+
+func BenchmarkNewDecodePolicyVerdictNotify(b *testing.B) {
+	input := &PolicyVerdictNotify{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		pvn := &PolicyVerdictNotify{}
+		if err := DecodePolicyVerdictNotify(buf.Bytes(), pvn); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkOldDecodePolicyVerdictNotify(b *testing.B) {
+	input := &PolicyVerdictNotify{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		pvn := &PolicyVerdictNotify{}
+		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, pvn); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/monitor/datapath_sock_trace_test.go
+++ b/pkg/monitor/datapath_sock_trace_test.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package monitor
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	. "github.com/cilium/checkmate"
+
+	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+func (s *MonitorSuite) TestDecodeTraceSockNotify(c *C) {
+	// This check on the struct length constant is there to ensure that this
+	// test is updated when the struct changes.
+	c.Assert(TraceSockNotifyLen, Equals, 38)
+
+	input := TraceSockNotify{
+		Type:       0x00,
+		XlatePoint: 0x01,
+		DstIP: types.IPv6{
+			0x02, 0x03,
+			0x04, 0x05,
+			0x06, 0x07,
+			0x08, 0x09,
+			0x0a, 0x0b,
+			0x0c, 0x0d,
+			0x0e, 0x10,
+			0x11, 0x12,
+		},
+		DstPort:    0x13_14,
+		SockCookie: 0x15_16_17_18,
+		L4Proto:    0x19,
+		Flags:      0x1a,
+	}
+
+	buf := bytes.NewBuffer(nil)
+	err := binary.Write(buf, byteorder.Native, input)
+	c.Assert(err, IsNil)
+
+	output := &TraceSockNotify{}
+	err = DecodeTraceSockNotify(buf.Bytes(), output)
+	c.Assert(err, IsNil)
+
+	c.Assert(output.Type, Equals, input.Type)
+	c.Assert(output.XlatePoint, Equals, input.XlatePoint)
+	c.Assert(output.DstIP, Equals, input.DstIP)
+	c.Assert(output.DstPort, Equals, input.DstPort)
+	c.Assert(output.SockCookie, Equals, input.SockCookie)
+	c.Assert(output.L4Proto, Equals, input.L4Proto)
+	c.Assert(output.Flags, Equals, input.Flags)
+}
+
+func BenchmarkNewDecodeTraceSockNotify(b *testing.B) {
+	input := &TraceSockNotify{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tsn := &TraceSockNotify{}
+		if err := DecodeTraceSockNotify(buf.Bytes(), tsn); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkOldDecodeTraceSockNotify(b *testing.B) {
+	input := &TraceSockNotify{}
+	buf := bytes.NewBuffer(nil)
+
+	if err := binary.Write(buf, byteorder.Native, input); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		tsn := &TraceSockNotify{}
+		if err := binary.Read(bytes.NewBuffer(buf.Bytes()), byteorder.Native, tsn); err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
I implemented the function by referencing #24162.
reduced CPU usage.

DecodeDropNotify Benchmark Result
```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/monitor
cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
=== RUN   BenchmarkNewDecodeDropNotify
BenchmarkNewDecodeDropNotify
BenchmarkNewDecodeDropNotify-4   	45821463	        27.00 ns/op	       0 B/op	       0 allocs/op
=== RUN   BenchmarkOldDecodeDropNotify
BenchmarkOldDecodeDropNotify
BenchmarkOldDecodeDropNotify-4   	 3343834	       368.0 ns/op	     144 B/op	       3 allocs/op
PASS
ok  	github.com/cilium/cilium/pkg/monitor	2.925s
```

DecodePolicyVerdictNotify
```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/monitor
cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
=== RUN   BenchmarkNewDecodePolicyVerdictNotify
BenchmarkNewDecodePolicyVerdictNotify
BenchmarkNewDecodePolicyVerdictNotify-4         42731541                26.72 ns/op            0 B/op          0 allocs/op
=== RUN   BenchmarkOldDecodePolicyVerdictNotify
BenchmarkOldDecodePolicyVerdictNotify
BenchmarkOldDecodePolicyVerdictNotify-4          2977009               405.1 ns/op           112 B/op          3 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/monitor    2.863s
```

DecodeDebugCapture/DecodeDebugMsg
```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/monitor
cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
=== RUN   BenchmarkNewDecodeDebugCapture
BenchmarkNewDecodeDebugCapture
BenchmarkNewDecodeDebugCapture-4        64555694                18.92 ns/op            0 B/op          0 allocs/op
=== RUN   BenchmarkOldDecodeDebugCapture
BenchmarkOldDecodeDebugCapture
BenchmarkOldDecodeDebugCapture-4         4329416               272.1 ns/op            96 B/op          3 allocs/op
=== RUN   BenchmarkNewDecodeDebugMsg
BenchmarkNewDecodeDebugMsg
BenchmarkNewDecodeDebugMsg-4            74855434                16.42 ns/op            0 B/op          0 allocs/op
=== RUN   BenchmarkOldDecodeDebugMsg
BenchmarkOldDecodeDebugMsg
BenchmarkOldDecodeDebugMsg-4             4504531               264.1 ns/op            96 B/op          3 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/monitor    5.501s
```

DecodeTraceSockNotify
```
goos: linux
goarch: amd64
pkg: github.com/cilium/cilium/pkg/monitor
cpu: Intel(R) Xeon(R) Platinum 8272CL CPU @ 2.60GHz
=== RUN   BenchmarkNewDecodeTraceSockNotify
BenchmarkNewDecodeTraceSockNotify
BenchmarkNewDecodeTraceSockNotify-4     92002668                12.99 ns/op            0 B/op          0 allocs/op
=== RUN   BenchmarkOldDecodeTraceSockNotify
BenchmarkOldDecodeTraceSockNotify
BenchmarkOldDecodeTraceSockNotify-4      2426386               439.2 ns/op           144 B/op          3 allocs/op
PASS
ok      github.com/cilium/cilium/pkg/monitor    2.862s
```
Fixes: #25657 
