### PR TITLE
Auth Map: Initial Garbage Collection

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -243,6 +243,7 @@ cilium-agent [flags]
       --log-driver strings                                      Logging endpoints to use for example syslog
       --log-opt map                                             Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
       --log-system-load                                         Enable periodic logging of system load
+      --mesh-auth-expired-gc-interval duration                  Interval in which expired auth entries are attempted to be garbage collected (default 15m0s)
       --mesh-auth-mutual-listener-port int                      Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                                Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int             The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -32,6 +32,7 @@ cilium-agent hive [flags]
       --k8s-client-qps float32                           Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-expired-gc-interval duration           Interval in which expired auth entries are attempted to be garbage collected (default 15m0s)
       --mesh-auth-mutual-listener-port int               Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                         Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int      The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -37,6 +37,7 @@ cilium-agent hive dot-graph [flags]
       --k8s-client-qps float32                           Queries per second limit for the K8s client
       --k8s-heartbeat-timeout duration                   Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
+      --mesh-auth-expired-gc-interval duration           Interval in which expired auth entries are attempted to be garbage collected (default 15m0s)
       --mesh-auth-mutual-listener-port int               Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                         Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int      The size of the queue for signaling rotated identities. (default 1024)

--- a/pkg/auth/authmap.go
+++ b/pkg/auth/authmap.go
@@ -15,6 +15,7 @@ import (
 type authMap interface {
 	Update(key authKey, info authInfo) error
 	Delete(key authKey) error
+	DeleteIf(predicate func(key authKey, info authInfo) bool) error
 	Get(key authKey) (authInfo, error)
 	All() (map[authKey]authInfo, error)
 }

--- a/pkg/auth/authmap_cache_test.go
+++ b/pkg/auth/authmap_cache_test.go
@@ -33,4 +33,46 @@ func Test_authMapCache_restoreCache(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Len(t, am.cacheEntries, 1)
+
+	val, err := am.Get(authKey{
+		localIdentity:  1,
+		remoteIdentity: 2,
+		remoteNodeID:   10,
+		authType:       policy.AuthTypeDisabled,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, val)
+}
+
+func Test_authMapCache_allReturnsCopy(t *testing.T) {
+	am := authMapCache{
+		authmap: &fakeAuthMap{
+			entries: map[authKey]authInfo{},
+		},
+		cacheEntries: map[authKey]authInfo{
+			{
+				localIdentity:  1,
+				remoteIdentity: 2,
+				remoteNodeID:   10,
+				authType:       policy.AuthTypeDisabled,
+			}: {
+				expiration: time.Now().Add(10 * time.Minute),
+			},
+		},
+	}
+
+	all, err := am.All()
+	assert.NoError(t, err)
+	assert.Len(t, all, 1)
+
+	all[authKey{
+		localIdentity:  10,
+		remoteIdentity: 20,
+		remoteNodeID:   100,
+		authType:       policy.AuthTypeDisabled,
+	}] = authInfo{
+		expiration: time.Now().Add(10 * time.Minute),
+	}
+	assert.Len(t, all, 2)
+	assert.Len(t, am.cacheEntries, 1)
 }

--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/cilium/cilium/pkg/identity"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/node/addressing"
+)
+
+type authMapGarbageCollector struct {
+	authmap authMap
+	ipCache ipCache
+
+	discoveredCiliumNodeIDs    map[uint16]struct{}
+	discoveredCiliumIdentities map[identity.NumericIdentity]struct{}
+}
+
+func newAuthMapGC(authmap authMap, ipCache ipCache) *authMapGarbageCollector {
+	return &authMapGarbageCollector{
+		authmap: authmap,
+		ipCache: ipCache,
+		discoveredCiliumNodeIDs: map[uint16]struct{}{
+			0: {}, // Local node 0 is always available
+		},
+		discoveredCiliumIdentities: map[identity.NumericIdentity]struct{}{},
+	}
+}
+
+func (r *authMapGarbageCollector) handleCiliumNodeEvent(_ context.Context, e resource.Event[*ciliumv2.CiliumNode]) (err error) {
+	defer func() { e.Done(err) }()
+
+	switch e.Kind {
+	case resource.Upsert:
+		if r.discoveredCiliumNodeIDs != nil {
+			log.Debug("auth: nodes discovered - getting node id")
+			remoteNodeIDs := r.remoteNodeIDs(e.Object)
+			for _, rID := range remoteNodeIDs {
+				r.discoveredCiliumNodeIDs[rID] = struct{}{}
+			}
+		}
+	case resource.Sync:
+		log.Debug("auth: nodes synced - cleaning up missing nodes")
+		if err = r.cleanupMissingNodes(); err != nil {
+			return fmt.Errorf("failed to cleanup missing nodes: %w", err)
+		}
+		r.discoveredCiliumNodeIDs = nil
+	case resource.Delete:
+		log.Debugf("auth: node deleted - cleaning up: %s", e.Key.Name)
+		if err = r.cleanupDeletedNode(e.Object); err != nil {
+			return fmt.Errorf("failed to cleanup deleted node: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *authMapGarbageCollector) handleCiliumIdentityEvent(_ context.Context, e resource.Event[*ciliumv2.CiliumIdentity]) (err error) {
+	defer func() { e.Done(err) }()
+
+	switch e.Kind {
+	case resource.Upsert:
+		if r.discoveredCiliumIdentities != nil {
+			log.Debug("auth: identities discovered")
+			var id identity.NumericIdentity
+			id, err = identity.ParseNumericIdentity(e.Object.Name)
+			if err != nil {
+				return fmt.Errorf("failed to parse identity: %w", err)
+			}
+			r.discoveredCiliumIdentities[id] = struct{}{}
+		}
+	case resource.Sync:
+		log.Debug("auth: identities synced - cleaning up missing identities")
+		if err = r.cleanupMissingIdentities(); err != nil {
+			return fmt.Errorf("failed to cleanup missing identities: %w", err)
+		}
+	case resource.Delete:
+		log.Debugf("auth: identity deleted - cleaning up: %s", e.Key.Name)
+		if err = r.cleanupDeletedIdentity(e.Object); err != nil {
+			return fmt.Errorf("failed to cleanup deleted identity: %w", err)
+		}
+		r.discoveredCiliumIdentities = nil
+	}
+	return nil
+}
+
+func (r *authMapGarbageCollector) cleanupMissingNodes() error {
+	return r.authmap.DeleteIf(func(key authKey, info authInfo) bool {
+		if _, ok := r.discoveredCiliumNodeIDs[key.remoteNodeID]; !ok {
+			log.Debugf("auth: deleting entry due to removed remote node: %d", key.remoteNodeID)
+			return true
+		}
+		return false
+	})
+}
+
+func (r *authMapGarbageCollector) cleanupMissingIdentities() error {
+	return r.authmap.DeleteIf(func(key authKey, info authInfo) bool {
+		if _, ok := r.discoveredCiliumIdentities[key.localIdentity]; !ok {
+			log.Debugf("auth: deleting entry due to removed local identity: %d", key.localIdentity)
+			return true
+		}
+		if _, ok := r.discoveredCiliumIdentities[key.remoteIdentity]; !ok {
+			log.Debugf("auth: deleting entry due to removed remote identity: %d", key.remoteIdentity)
+			return true
+		}
+		return false
+	})
+}
+
+func (r *authMapGarbageCollector) cleanupDeletedNode(node *ciliumv2.CiliumNode) error {
+	remoteNodeIDs := r.remoteNodeIDs(node)
+
+	return r.authmap.DeleteIf(func(key authKey, info authInfo) bool {
+		for _, id := range remoteNodeIDs {
+			if key.remoteNodeID == id {
+				log.Debugf("auth: deleting entry due to removed node: %d", id)
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func (r *authMapGarbageCollector) cleanupDeletedIdentity(id *ciliumv2.CiliumIdentity) error {
+	idNumeric, err := identity.ParseNumericIdentity(id.Name)
+	if err != nil {
+		return fmt.Errorf("failed to parse deleted identity: %w", err)
+	}
+
+	return r.authmap.DeleteIf(func(key authKey, info authInfo) bool {
+		if key.localIdentity == idNumeric || key.remoteIdentity == idNumeric {
+			log.Debugf("auth: deleting entry due to removed identity: %d", idNumeric)
+			return true
+		}
+		return false
+	})
+}
+
+func (r *authMapGarbageCollector) CleanupExpiredEntries(_ context.Context) error {
+	log.Debug("auth: cleaning up expired entries")
+	now := time.Now()
+	err := r.authmap.DeleteIf(func(key authKey, info authInfo) bool {
+		if info.expiration.Before(now) {
+			log.Debugf("auth: deleting entry due to expiration: %s", info.expiration)
+			return true
+		}
+		return false
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to cleanup expired entries: %w", err)
+	}
+	return nil
+}
+
+func (r *authMapGarbageCollector) remoteNodeIDs(node *ciliumv2.CiliumNode) []uint16 {
+	var remoteNodeIDs []uint16
+
+	for _, addr := range node.Spec.Addresses {
+		if addr.Type == addressing.NodeInternalIP {
+			remoteNodeIDs = append(remoteNodeIDs, r.ipCache.AllocateNodeID(net.ParseIP(addr.IP)))
+		}
+	}
+
+	return remoteNodeIDs
+}

--- a/pkg/auth/authmap_gc_test.go
+++ b/pkg/auth/authmap_gc_test.go
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/identity"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+func Test_authMapGarbageCollector_initialSync(t *testing.T) {
+	authMap := &fakeAuthMap{
+		entries: map[authKey]authInfo{
+			{localIdentity: identity.NumericIdentity(1), remoteIdentity: identity.NumericIdentity(2), remoteNodeID: 10, authType: policy.AuthTypeDisabled}:  {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: identity.NumericIdentity(2), remoteIdentity: identity.NumericIdentity(4), remoteNodeID: 0, authType: policy.AuthTypeDisabled}:   {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: identity.NumericIdentity(10), remoteIdentity: identity.NumericIdentity(11), remoteNodeID: 0, authType: policy.AuthTypeDisabled}: {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: identity.NumericIdentity(2), remoteIdentity: identity.NumericIdentity(3), remoteNodeID: 11, authType: policy.AuthTypeDisabled}:  {expiration: time.Now().Add(-5 * time.Minute)},
+		},
+	}
+	am := newAuthMapGC(authMap,
+		newFakeIPCache(map[uint16]string{
+			10: "172.18.0.3",
+		}),
+	)
+
+	err := am.handleCiliumNodeEvent(context.Background(), ciliumNodeEvent(resource.Upsert, "172.18.0.3"))
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 4) // no modification at upsert
+
+	err = am.handleCiliumNodeEvent(context.Background(), ciliumNodeEvent(resource.Sync, ""))
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 3) // deleted all entries where remote node id doesn't match existing (10) or local node (0)
+
+	err = am.handleCiliumIdentityEvent(context.Background(), ciliumIdentityEvent(resource.Upsert, "11"))
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 3) // no modification at upsert
+
+	err = am.handleCiliumIdentityEvent(context.Background(), ciliumIdentityEvent(resource.Upsert, "10"))
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 3) // no modification at upsert
+
+	err = am.handleCiliumIdentityEvent(context.Background(), ciliumIdentityEvent(resource.Sync, ""))
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 1) // deleted all entries where local and remote identity are no longer existing
+}
+
+func Test_authMapGarbageCollector_gc(t *testing.T) {
+	authMap := &fakeAuthMap{
+		entries: map[authKey]authInfo{
+			{localIdentity: identity.NumericIdentity(1), remoteIdentity: identity.NumericIdentity(2), remoteNodeID: 10, authType: policy.AuthTypeDisabled}:  {expiration: time.Now().Add(5 * time.Minute)},  // deleted remote node
+			{localIdentity: identity.NumericIdentity(2), remoteIdentity: identity.NumericIdentity(4), remoteNodeID: 0, authType: policy.AuthTypeDisabled}:   {expiration: time.Now().Add(5 * time.Minute)},  // deleted remote id
+			{localIdentity: identity.NumericIdentity(10), remoteIdentity: identity.NumericIdentity(11), remoteNodeID: 0, authType: policy.AuthTypeDisabled}: {expiration: time.Now().Add(5 * time.Minute)},  // deleted local id
+			{localIdentity: identity.NumericIdentity(2), remoteIdentity: identity.NumericIdentity(3), remoteNodeID: 11, authType: policy.AuthTypeDisabled}:  {expiration: time.Now().Add(-5 * time.Minute)}, // expired
+		},
+	}
+	am := authMapGarbageCollector{
+		authmap: authMap,
+		ipCache: newFakeIPCache(map[uint16]string{
+			10: "172.18.0.3",
+		}),
+	}
+
+	assert.Len(t, authMap.entries, 4)
+
+	err := am.handleCiliumNodeEvent(context.Background(), ciliumNodeEvent(resource.Delete, "172.18.0.3"))
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 3)
+
+	err = am.handleCiliumIdentityEvent(context.Background(), ciliumIdentityEvent(resource.Delete, "4"))
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 2)
+
+	err = am.handleCiliumIdentityEvent(context.Background(), ciliumIdentityEvent(resource.Delete, "10"))
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 1)
+
+	err = am.CleanupExpiredEntries(context.Background())
+	assert.NoError(t, err)
+	assert.Empty(t, authMap.entries)
+}
+
+func Test_authMapGarbageCollector_HandleNodeEventError(t *testing.T) {
+	authMap := &fakeAuthMap{
+		entries:    map[authKey]authInfo{},
+		failDelete: true,
+	}
+	am := authMapGarbageCollector{
+		authmap: authMap,
+		ipCache: newFakeIPCache(map[uint16]string{}),
+	}
+
+	event := ciliumNodeEvent(resource.Delete, "172.18.0.3")
+	var eventErr error
+	event.Done = func(err error) {
+		eventErr = err
+	}
+	err := am.handleCiliumNodeEvent(context.Background(), event)
+	assert.ErrorContains(t, err, "failed to cleanup deleted node: failed to delete entry")
+	assert.ErrorContains(t, eventErr, "failed to cleanup deleted node: failed to delete entry")
+}
+
+func Test_authMapGarbageCollector_HandleIdentityEventError(t *testing.T) {
+	authMap := &fakeAuthMap{
+		entries:    map[authKey]authInfo{},
+		failDelete: true,
+	}
+	am := authMapGarbageCollector{
+		authmap: authMap,
+		ipCache: newFakeIPCache(map[uint16]string{}),
+	}
+
+	event := ciliumIdentityEvent(resource.Delete, "4")
+	var eventErr error
+	event.Done = func(err error) {
+		eventErr = err
+	}
+	err := am.handleCiliumIdentityEvent(context.Background(), event)
+	assert.ErrorContains(t, err, "failed to cleanup deleted identity: failed to delete entry")
+	assert.ErrorContains(t, eventErr, "failed to cleanup deleted identity: failed to delete entry")
+}
+
+func ciliumNodeEvent(eventType resource.EventKind, nodeInternalIP string) resource.Event[*ciliumv2.CiliumNode] {
+	return resource.Event[*ciliumv2.CiliumNode]{
+		Kind: eventType,
+		Done: func(err error) {},
+		Object: &ciliumv2.CiliumNode{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-ns",
+				Name:      "test-node",
+			},
+			Spec: ciliumv2.NodeSpec{
+				Addresses: []ciliumv2.NodeAddress{
+					{
+						Type: addressing.NodeInternalIP,
+						IP:   nodeInternalIP,
+					},
+				},
+			},
+		},
+		Key: resource.Key{Namespace: "test-ns", Name: "test-node"},
+	}
+}
+
+func ciliumIdentityEvent(eventType resource.EventKind, id string) resource.Event[*ciliumv2.CiliumIdentity] {
+	return resource.Event[*ciliumv2.CiliumIdentity]{
+		Kind: eventType,
+		Done: func(err error) {},
+		Object: &ciliumv2.CiliumIdentity{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "test-ns",
+				Name:      id,
+			},
+		},
+		Key: resource.Key{Namespace: "test-ns", Name: id},
+	}
+}

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/signal"
 )
@@ -35,6 +36,15 @@ var Cell = cell.Module(
 		newMutualAuthHandler,
 		// Always fail auth handler provides support for auth type "always-fail" - which always fails.
 		newAlwaysFailAuthHandler,
+	),
+	// Providing k8s resource Node & Identity privately to avoid further usage of them in other agent components
+	cell.ProvidePrivate(
+		// TODO: use node manager to get events of all nodes, including the ones of other clusters (ClusterMesh)
+		// https://github.com/cilium/cilium/issues/25899
+		k8s.CiliumNodeResource,
+		// TODO: add support for KVStore. K8s identity events are only provided for CRD based identity backend.
+		// https://github.com/cilium/cilium/issues/25898
+		k8s.CiliumIdentityResource,
 	),
 	cell.Config(config{MeshAuthQueueSize: 1024}),
 	cell.Config(MutualAuthConfig{}),

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -4,17 +4,25 @@
 package auth
 
 import (
+	"context"
 	"fmt"
+	"runtime/pprof"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/auth/spire"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/signal"
+	"github.com/cilium/cilium/pkg/stream"
 )
 
 // Cell invokes authManager which is responsible for request authentication.
@@ -46,16 +54,21 @@ var Cell = cell.Module(
 		// https://github.com/cilium/cilium/issues/25898
 		k8s.CiliumIdentityResource,
 	),
-	cell.Config(config{MeshAuthQueueSize: 1024}),
+	cell.Config(config{
+		MeshAuthQueueSize:         1024,
+		MeshAuthExpiredGCInterval: 15 * time.Minute,
+	}),
 	cell.Config(MutualAuthConfig{}),
 )
 
 type config struct {
-	MeshAuthQueueSize int
+	MeshAuthQueueSize         int
+	MeshAuthExpiredGCInterval time.Duration
 }
 
 func (r config) Flags(flags *pflag.FlagSet) {
 	flags.Int("mesh-auth-queue-size", r.MeshAuthQueueSize, "Queue size for the auth manager")
+	flags.Duration("mesh-auth-expired-gc-interval", r.MeshAuthExpiredGCInterval, "Interval in which expired auth entries are attempted to be garbage collected")
 }
 
 func newSignalRegistration(sm signal.SignalManager, config config) (<-chan signalAuthKey, error) {
@@ -73,12 +86,16 @@ func newSignalRegistration(sm signal.SignalManager, config config) (<-chan signa
 type authManagerParams struct {
 	cell.In
 
-	Lifecycle     hive.Lifecycle
-	Config        config
-	IPCache       *ipcache.IPCache
-	AuthHandlers  []authHandler `group:"authHandlers"`
-	AuthMap       authmap.Map
-	SignalChannel <-chan signalAuthKey
+	Lifecycle        hive.Lifecycle
+	Config           config
+	IPCache          *ipcache.IPCache
+	AuthHandlers     []authHandler `group:"authHandlers"`
+	AuthMap          authmap.Map
+	SignalChannel    <-chan signalAuthKey
+	CiliumIdentities resource.Resource[*ciliumv2.CiliumIdentity]
+	CiliumNodes      resource.Resource[*ciliumv2.CiliumNode]
+	Logger           logrus.FieldLogger
+	JobRegistry      job.Registry
 }
 
 func newManager(params authManagerParams) error {
@@ -107,7 +124,41 @@ func newManager(params authManagerParams) error {
 		},
 	})
 
+	mapGC := newAuthMapGC(mapCache, params.IPCache)
+
+	jobGroup := params.JobRegistry.NewGroup(
+		job.WithLogger(params.Logger),
+		job.WithPprofLabels(pprof.Labels("cell", "auth")),
+	)
+
+	registerGCJobs(jobGroup, mapGC, params)
+
+	params.Lifecycle.Append(jobGroup)
+
 	return nil
+}
+
+func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params authManagerParams) {
+	// Add identities based auth gc if k8s client is enabled
+	if params.CiliumIdentities != nil {
+		jobGroup.Add(job.Observer("auth identities gc",
+			mapGC.handleCiliumIdentityEvent,
+			stream.FromChannel(params.CiliumIdentities.Events(context.Background())),
+		))
+	}
+
+	// Add node based auth gc if k8s client is enabled
+	if params.CiliumNodes != nil {
+		jobGroup.Add(job.Observer("auth nodes gc",
+			mapGC.handleCiliumNodeEvent,
+			stream.FromChannel(params.CiliumNodes.Events(context.Background())),
+		))
+	}
+
+	jobGroup.Add(job.Timer("auth expiration gc",
+		mapGC.CleanupExpiredEntries,
+		params.Config.MeshAuthExpiredGCInterval,
+	))
 }
 
 type authHandlerResult struct {

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/cilium/cilium/pkg/auth/certs"
@@ -35,6 +36,7 @@ type authManager struct {
 // ipCache is the set of interactions the auth manager performs with the IPCache
 type ipCache interface {
 	GetNodeIP(uint16) string
+	AllocateNodeID(net.IP) uint16
 }
 
 // authHandler is responsible to handle authentication for a specific auth type


### PR DESCRIPTION
This PR introduces garbage collection for the auth map based on the following events:

* deleted cilium node: all auth map entries which belong to the deleted node will be deleted
* deleted cilium identity: all auth map entries which belong to the deleted identity will be deleted
* timer (configurable - defaults to every 15m): expired auth map entries will be deleted

The implementation uses the [hive job framework](https://docs.cilium.io/en/latest/contributing/development/hive/#job-groups).

Known Limitations:

* Garbage Collection based on deleted Cilium Identities is currently only supported if Cilium Identities are backed by the CRD storage. Eventually the expired entries will be cleaned up by the periodic timer based run.
* Currently no GC based on deleted policies
 
Fixes: #25213