### PR TITLE
workflows: e2e: bump max-parallel to 16

### DIFF
--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -174,7 +174,7 @@ jobs:
       github.event_name == 'pull_request'
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 16
       matrix:
         include:
           # See https://github.com/cilium/cilium/issues/20606 for configuration table

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -170,7 +170,7 @@ jobs:
       github.event_name == 'pull_request'
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: 16
       matrix:
         include:
           # See https://github.com/cilium/cilium/issues/20606 for configuration table


### PR DESCRIPTION
This will allow to run the entire test suite in one batch rather than waiting for the first 8 jobs to finish before starting the remaining ones.