### PR TITLE
multi-pool: Support allocating from new IPAM pools on demand

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -193,6 +193,7 @@ cilium-agent [flags]
       --ip-masq-agent-config-path string                        ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
       --ipam string                                             Backend to use for IPAM (default "cluster-pool")
       --ipam-cilium-node-update-rate duration                   Maximum rate at which the CiliumNode custom resource is updated (default 15s)
+      --ipam-multi-pool-pre-allocation map                      Defines how the minimum number of IPs a node should pre-allocate from each pool (default default=8)
       --ipsec-key-file string                                   Path to IPSec key file
       --ipsec-key-rotation-duration duration                    Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. (default 5m0s)
       --iptables-lock-timeout duration                          Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -289,10 +289,11 @@ func initializeFlags() {
 	flags.StringSlice(option.IPv6PodSubnets, []string{}, "List of IPv6 pod subnets to preconfigure for encryption")
 	option.BindEnv(Vp, option.IPv6PodSubnets)
 
-	flags.Var(option.NewNamedMapOptions(option.IPAMMultiPoolNodePreAlloc, &option.Config.IPAMMultiPoolNodePreAlloc, nil),
-		option.IPAMMultiPoolNodePreAlloc, "List of IP pools which should be pre-allocated on this node")
-	flags.MarkHidden(option.IPAMMultiPoolNodePreAlloc)
-	option.BindEnv(Vp, option.IPAMMultiPoolNodePreAlloc)
+	flags.Var(option.NewNamedMapOptions(option.IPAMMultiPoolPreAllocation, &option.Config.IPAMMultiPoolPreAllocation, nil),
+		option.IPAMMultiPoolPreAllocation,
+		fmt.Sprintf("Defines how the minimum number of IPs a node should pre-allocate from each pool (default %s)", defaults.IPAMMultiPoolPreAllocation))
+	Vp.SetDefault(option.IPAMMultiPoolPreAllocation, defaults.IPAMMultiPoolPreAllocation)
+	option.BindEnv(Vp, option.IPAMMultiPoolPreAllocation)
 
 	flags.StringSlice(option.ExcludeLocalAddress, []string{}, "Exclude CIDR from being recognized as local address")
 	option.BindEnv(Vp, option.ExcludeLocalAddress)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -366,6 +366,10 @@ const (
 	// CiliumNode.Spec.IPAM.PreAllocate if no value is set
 	IPAMPreAllocation = 8
 
+	// IPAMMultiPoolPreAllocation is the default value for multi-pool IPAM
+	// pre-allocations
+	IPAMMultiPoolPreAllocation = "default=8"
+
 	// ENIFirstInterfaceIndex is the default value for
 	// CiliumNode.Spec.ENI.FirstInterfaceIndex if no value is set.
 	ENIFirstInterfaceIndex = 0

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -279,10 +279,10 @@ func (m *multiPoolManager) updateCiliumNode(ctx context.Context) error {
 	}
 
 	sort.Slice(requested, func(i, j int) bool {
-		return requested[i].Pool > requested[j].Pool
+		return requested[i].Pool < requested[j].Pool
 	})
 	sort.Slice(allocated, func(i, j int) bool {
-		return allocated[i].Pool > allocated[j].Pool
+		return allocated[i].Pool < allocated[j].Pool
 	})
 	newNode.Spec.IPAM.Pools.Requested = requested
 	newNode.Spec.IPAM.Pools.Allocated = allocated

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -65,8 +65,8 @@ func Test_MultiPoolManager(t *testing.T) {
 		Spec: ciliumv2.NodeSpec{IPAM: types.IPAMSpec{
 			Pools: types.IPAMPoolSpec{
 				Requested: []types.IPAMPoolRequest{
-					{Pool: "mars", Needed: types.IPAMPoolDemand{IPv4Addrs: 8, IPv6Addrs: 8}},
 					{Pool: "default", Needed: types.IPAMPoolDemand{IPv4Addrs: 16, IPv6Addrs: 16}},
+					{Pool: "mars", Needed: types.IPAMPoolDemand{IPv4Addrs: 8, IPv6Addrs: 8}},
 				},
 				Allocated: []types.IPAMPoolAllocation{},
 			},
@@ -81,17 +81,17 @@ func Test_MultiPoolManager(t *testing.T) {
 	// Assign CIDR to pools (i.e. this simulates the operator logic)
 	currentNode.Spec.IPAM.Pools.Allocated = []types.IPAMPoolAllocation{
 		{
-			Pool: "mars",
-			CIDRs: []types.IPAMPodCIDR{
-				types.IPAMPodCIDR(marsIPv6CIDR1.String()),
-				types.IPAMPodCIDR(marsIPv4CIDR1.String()),
-			},
-		},
-		{
 			Pool: "default",
 			CIDRs: []types.IPAMPodCIDR{
 				types.IPAMPodCIDR(defaultIPv6CIDR1.String()),
 				types.IPAMPodCIDR(defaultIPv4CIDR1.String()),
+			},
+		},
+		{
+			Pool: "mars",
+			CIDRs: []types.IPAMPodCIDR{
+				types.IPAMPodCIDR(marsIPv6CIDR1.String()),
+				types.IPAMPodCIDR(marsIPv4CIDR1.String()),
 			},
 		},
 	}
@@ -139,16 +139,17 @@ func Test_MultiPoolManager(t *testing.T) {
 	currentNode = fakeK8sCiliumNodeAPI.currentNode()
 	assert.Equal(t, []types.IPAMPoolRequest{
 		{
-			Pool: "mars",
-			Needed: types.IPAMPoolDemand{
-				IPv4Addrs: 40, // 30 allocated + 8 pre-allocate, rounded up to multiple of 8
-				IPv6Addrs: 8,
-			}},
-		{
 			Pool: "default",
 			Needed: types.IPAMPoolDemand{
 				IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
 				IPv6Addrs: 16,
+			},
+		},
+		{
+			Pool: "mars",
+			Needed: types.IPAMPoolDemand{
+				IPv4Addrs: 40, // 30 allocated + 8 pre-allocate, rounded up to multiple of 8
+				IPv6Addrs: 8,
 			},
 		},
 	}, currentNode.Spec.IPAM.Pools.Requested)
@@ -158,18 +159,18 @@ func Test_MultiPoolManager(t *testing.T) {
 	// Assign additional mars IPv4 CIDR
 	currentNode.Spec.IPAM.Pools.Allocated = []types.IPAMPoolAllocation{
 		{
+			Pool: "default",
+			CIDRs: []types.IPAMPodCIDR{
+				types.IPAMPodCIDR(defaultIPv6CIDR1.String()),
+				types.IPAMPodCIDR(defaultIPv4CIDR1.String()),
+			},
+		},
+		{
 			Pool: "mars",
 			CIDRs: []types.IPAMPodCIDR{
 				types.IPAMPodCIDR(marsIPv6CIDR1.String()),
 				types.IPAMPodCIDR(marsIPv4CIDR1.String()),
 				types.IPAMPodCIDR(marsIPv4CIDR2.String()),
-			},
-		},
-		{
-			Pool: "default",
-			CIDRs: []types.IPAMPodCIDR{
-				types.IPAMPodCIDR(defaultIPv6CIDR1.String()),
-				types.IPAMPodCIDR(defaultIPv4CIDR1.String()),
 			},
 		},
 	}
@@ -190,16 +191,17 @@ func Test_MultiPoolManager(t *testing.T) {
 	currentNode = fakeK8sCiliumNodeAPI.currentNode()
 	assert.Equal(t, []types.IPAMPoolRequest{
 		{
-			Pool: "mars",
-			Needed: types.IPAMPoolDemand{
-				IPv4Addrs: 16, // 1 allocated + 8 pre-allocate, rounded up to multiple of 8
-				IPv6Addrs: 8,
-			}},
-		{
 			Pool: "default",
 			Needed: types.IPAMPoolDemand{
 				IPv4Addrs: 32, // 1 allocated + 16 pre-allocate, rounded up to multiple of 16
 				IPv6Addrs: 16,
+			},
+		},
+		{
+			Pool: "mars",
+			Needed: types.IPAMPoolDemand{
+				IPv4Addrs: 16, // 1 allocated + 8 pre-allocate, rounded up to multiple of 8
+				IPv6Addrs: 8,
 			},
 		},
 	}, currentNode.Spec.IPAM.Pools.Requested)
@@ -207,17 +209,17 @@ func Test_MultiPoolManager(t *testing.T) {
 	// Initial mars CIDR should have been marked as released now
 	assert.Equal(t, []types.IPAMPoolAllocation{
 		{
-			Pool: "mars",
-			CIDRs: []types.IPAMPodCIDR{
-				types.IPAMPodCIDR(marsIPv4CIDR2.String()),
-				types.IPAMPodCIDR(marsIPv6CIDR1.String()),
-			},
-		},
-		{
 			Pool: "default",
 			CIDRs: []types.IPAMPodCIDR{
 				types.IPAMPodCIDR(defaultIPv4CIDR1.String()),
 				types.IPAMPodCIDR(defaultIPv6CIDR1.String()),
+			},
+		},
+		{
+			Pool: "mars",
+			CIDRs: []types.IPAMPodCIDR{
+				types.IPAMPodCIDR(marsIPv4CIDR2.String()),
+				types.IPAMPodCIDR(marsIPv6CIDR1.String()),
 			},
 		},
 	}, currentNode.Spec.IPAM.Pools.Allocated)

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -35,7 +35,7 @@ func Test_MultiPoolManager(t *testing.T) {
 	}
 	c := newMultiPoolManager(fakeConfig, fakeK8sCiliumNodeAPI, fakeOwner, fakeK8sCiliumNodeAPI)
 	// set custom preAllocMap to not rely on option.Config in unit tests
-	c.preallocMap = preAllocMap{
+	c.preallocatedIPsPerPool = preAllocatePerPool{
 		"default": 16,
 		"mars":    8,
 	}

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -83,15 +83,15 @@ func Test_MultiPoolManager(t *testing.T) {
 		{
 			Pool: "default",
 			CIDRs: []types.IPAMPodCIDR{
-				types.IPAMPodCIDR(defaultIPv6CIDR1.String()),
 				types.IPAMPodCIDR(defaultIPv4CIDR1.String()),
+				types.IPAMPodCIDR(defaultIPv6CIDR1.String()),
 			},
 		},
 		{
 			Pool: "mars",
 			CIDRs: []types.IPAMPodCIDR{
-				types.IPAMPodCIDR(marsIPv6CIDR1.String()),
 				types.IPAMPodCIDR(marsIPv4CIDR1.String()),
+				types.IPAMPodCIDR(marsIPv6CIDR1.String()),
 			},
 		},
 	}
@@ -161,16 +161,16 @@ func Test_MultiPoolManager(t *testing.T) {
 		{
 			Pool: "default",
 			CIDRs: []types.IPAMPodCIDR{
-				types.IPAMPodCIDR(defaultIPv6CIDR1.String()),
 				types.IPAMPodCIDR(defaultIPv4CIDR1.String()),
+				types.IPAMPodCIDR(defaultIPv6CIDR1.String()),
 			},
 		},
 		{
 			Pool: "mars",
 			CIDRs: []types.IPAMPodCIDR{
-				types.IPAMPodCIDR(marsIPv6CIDR1.String()),
 				types.IPAMPodCIDR(marsIPv4CIDR1.String()),
 				types.IPAMPodCIDR(marsIPv4CIDR2.String()),
+				types.IPAMPodCIDR(marsIPv6CIDR1.String()),
 			},
 		},
 	}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -842,8 +842,8 @@ const (
 	// IPAM is the IPAM method to use
 	IPAM = "ipam"
 
-	// IPAMMultiPoolNodePreAlloc contains the list of IP pools which should be pre-allocated on this node
-	IPAMMultiPoolNodePreAlloc = "multi-pool-node-pre-alloc"
+	// IPAMMultiPoolPreAllocation defines the pre-allocation value for each IPAM pool
+	IPAMMultiPoolPreAllocation = "ipam-multi-pool-pre-allocation"
 
 	// XDPModeNative for loading progs with XDPModeLinkDriver
 	XDPModeNative = "native"
@@ -2057,8 +2057,8 @@ type DaemonConfig struct {
 	// IPAM is the IPAM method to use
 	IPAM string
 
-	// IPAMMultiPoolNodePreAlloc contains the list of IP pools which should be pre-allocated on this node
-	IPAMMultiPoolNodePreAlloc map[string]string
+	// IPAMMultiPoolPreAllocation defines the pre-allocation value for each IPAM pool
+	IPAMMultiPoolPreAllocation map[string]string
 
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
@@ -3378,10 +3378,10 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 			c.K8sRequireIPv6PodCIDR = true
 		}
 	}
-	if m, err := command.GetStringMapStringE(vp, IPAMMultiPoolNodePreAlloc); err != nil {
-		log.Fatalf("unable to parse %s: %s", IPAMMultiPoolNodePreAlloc, err)
+	if m, err := command.GetStringMapStringE(vp, IPAMMultiPoolPreAllocation); err != nil {
+		log.Fatalf("unable to parse %s: %s", IPAMMultiPoolPreAllocation, err)
 	} else {
-		c.IPAMMultiPoolNodePreAlloc = m
+		c.IPAMMultiPoolPreAllocation = m
 	}
 
 	c.KubeProxyReplacementHealthzBindAddr = vp.GetString(KubeProxyReplacementHealthzBindAddr)


### PR DESCRIPTION
This PR adds support for dynamically allocating IPs from a new pool. Previously, we required the user to specify in advance what pool the agent would allocate from. This however is very limiting, since it's often not known in advance what workload a particular node will run.

Therefore, this PR adds a mechanism where upon observing a allocation attempt for a new pool, we update the local CiliumNode CRD to request additional IPs for that pool. This then allows the allocation request to be successful upon retry. This retry mechanism is similar to how Cilium IPAM also works e.g. in ENI mode (where if the local node is out of IPs, we fail the CNI ADD request and expect kubelet to re-try again later).

This PR also implicitly adds support for allocating from pools without a "pre-allocate" value. This allows users to configure very small pools for specific workloads and assign those few IPs only if they are actually used.

:information_source: **Review per commit**. The first few commits are mainly cleanup, the main logic is contained in the last two commits

For further context, see:

- https://github.com/cilium/cilium/pull/22762
- https://github.com/cilium/cilium/pull/25511
- https://github.com/cilium/cilium/issues/25470

CI and documentation will be added in a separate PR. See meta issue https://github.com/cilium/cilium/issues/25470