### PR TITLE
helm: Avoid error in IDE due to .range keyword

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -650,7 +650,7 @@ data:
   enable-node-port: {{ .Values.nodePort.enabled | quote }}
 {{- end }}
 {{- if hasKey .Values.nodePort "range" }}
-  node-port-range: {{ .Values.nodePort.range | quote }}
+  node-port-range: {{ get .Values.nodePort "range" | quote }}
 {{- end }}
 {{- if hasKey .Values.nodePort "directRoutingDevice" }}
   direct-routing-device: {{ .Values.nodePort.directRoutingDevice | quote }}


### PR DESCRIPTION
### Description 

As range is a keyword in jinja template, using the expression with usual attribute name (e.g. .Values.nodePort.range) will cause the error in IDE. This issue makes it hard for deployment helm for normal operation like checking where the flag is used.

This commit is to use alternative way to get around the issue with get function.

Testing was done as per below

```
$ cat temp_values.yaml
nodePort:
  range: "30000,32767"
$ helm template cilium install/kubernetes/cilium -f temp_values.yaml | grep node-port-range
  node-port-range: "30000,32767"
  enable-auto-protect-node-port-range: "true"
```

![image](https://github.com/cilium/cilium/assets/9019229/815f2c7c-c193-4f3c-b850-08da45bf8655)

