### PR TITLE
helm: `nodeEncryption` is only supported with WireGuard

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -797,7 +797,7 @@
      - string
      - ``"/etc/ipsec"``
    * - encryption.nodeEncryption
-     - Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to ipsec.
+     - Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to "wireguard".
      - bool
      - ``false``
    * - encryption.secretName

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -249,7 +249,7 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.ipsec.secretName | string | `""` | Name of the Kubernetes secret containing the encryption keys. |
 | encryption.keyFile | string | `"keys"` | Deprecated in favor of encryption.ipsec.keyFile. To be removed in 1.15. Name of the key file inside the Kubernetes secret configured via secretName. This option is only effective when encryption.type is set to ipsec. |
 | encryption.mountPath | string | `"/etc/ipsec"` | Deprecated in favor of encryption.ipsec.mountPath. To be removed in 1.15. Path to mount the secret inside the Cilium pod. This option is only effective when encryption.type is set to ipsec. |
-| encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to ipsec. |
+| encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to "wireguard". |
 | encryption.secretName | string | `"cilium-ipsec-keys"` | Deprecated in favor of encryption.ipsec.secretName. To be removed in 1.15. Name of the Kubernetes secret containing the encryption keys. This option is only effective when encryption.type is set to ipsec. |
 | encryption.type | string | `"ipsec"` | Encryption method. Can be either ipsec or wireguard. |
 | encryption.wireguard.userspaceFallback | bool | `false` | Enables the fallback to the user-space implementation. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -728,7 +728,7 @@ encryption:
   type: ipsec
 
   # -- Enable encryption for pure node to node traffic.
-  # This option is only effective when encryption.type is set to ipsec.
+  # This option is only effective when encryption.type is set to "wireguard".
   nodeEncryption: false
 
   ipsec:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -725,7 +725,7 @@ encryption:
   type: ipsec
 
   # -- Enable encryption for pure node to node traffic.
-  # This option is only effective when encryption.type is set to ipsec.
+  # This option is only effective when encryption.type is set to "wireguard".
   nodeEncryption: false
 
   ipsec:


### PR DESCRIPTION
This commit fixes an outdated comment in our Helm `values.yaml` file. Originally, node-to-node encryption was a beta feature only supported with IPSec. However, since then, we have removed the IPSec support (#21333), but have added support in WireGuard instead (#19401).

Fixes: 5e980372f3d6 ("cmd: Unhide node-encryption flag")
