### PR TITLE
Remove ip assignments for cilium_host from init.sh

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -181,15 +181,6 @@ function encap_fail()
 	exit 1
 }
 
-	# If the host does not have an IPv6 address assigned, assign our generated host
-	# IP to make the host accessible to endpoints
-	if [ "$IP6_HOST" != "<nil>" ]; then
-		[ -n "$(ip -6 addr show to $IP6_HOST dev $HOST_DEV1)" ] || ip -6 addr add $IP6_HOST dev $HOST_DEV1
-	fi
-	if [ "$IP4_HOST" != "<nil>" ]; then
-		[ -n "$(ip -4 addr show to $IP4_HOST dev $HOST_DEV1)" ] || ip -4 addr add $IP4_HOST dev $HOST_DEV1
-	fi
-
 if [ "$PROXY_RULE" = "true" ]; then
 # Decrease priority of the rule to identify local addresses
 move_local_rules

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -319,6 +319,20 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 	args[initArgMode] = string(mode)
 
+	args[initArgIPv4NodeIP] = "<nil>"
+	args[initArgIPv6NodeIP] = "<nil>"
+	if option.Config.EnableIPv4 {
+		args[initArgIPv4NodeIP] = node.GetInternalIPv4Router().String()
+	}
+	if option.Config.EnableIPv6 {
+		args[initArgIPv6NodeIP] = node.GetIPv6Router().String()
+		// Docker <17.05 has an issue which causes IPv6 to be disabled in the initns for all
+		// interface (https://github.com/docker/libnetwork/issues/1720)
+		// Enable IPv6 for now
+		sysSettings = append(sysSettings,
+			sysctl.Setting{Name: "net.ipv6.conf.all.disable_ipv6", Val: "0", IgnoreErr: false})
+	}
+
 	// Datapath initialization
 	hostDev1, hostDev2, err := SetupBaseDevice(deviceMTU)
 	if err != nil {
@@ -326,6 +340,16 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 	args[initArgHostDev1] = hostDev1.Attrs().Name
 	args[initArgHostDev2] = hostDev2.Attrs().Name
+
+	if option.Config.IPAM == ipamOption.IPAMENI {
+		var err error
+		if sysSettings, err = addENIRules(sysSettings, o.Datapath().LocalNodeAddressing()); err != nil {
+			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
+		}
+	}
+
+	// Any code that relies on sysctl settings being applied needs to be called after this.
+	sysctl.ApplySettings(sysSettings)
 
 	if err := l.writeNodeConfigHeader(o); err != nil {
 		log.WithError(err).Error("Unable to write node config header")
@@ -358,23 +382,6 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 
 	args[initArgLib] = "<nil>"
 	args[initArgRundir] = option.Config.StateDir
-
-	if option.Config.EnableIPv4 {
-		args[initArgIPv4NodeIP] = node.GetInternalIPv4Router().String()
-	} else {
-		args[initArgIPv4NodeIP] = "<nil>"
-	}
-
-	if option.Config.EnableIPv6 {
-		args[initArgIPv6NodeIP] = node.GetIPv6Router().String()
-		// Docker <17.05 has an issue which causes IPv6 to be disabled in the initns for all
-		// interface (https://github.com/docker/libnetwork/issues/1720)
-		// Enable IPv6 for now
-		sysSettings = append(sysSettings,
-			sysctl.Setting{Name: "net.ipv6.conf.all.disable_ipv6", Val: "0", IgnoreErr: false})
-	} else {
-		args[initArgIPv6NodeIP] = "<nil>"
-	}
 
 	args[initArgMTU] = fmt.Sprintf("%d", deviceMTU)
 
@@ -433,15 +440,6 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		logfields.BPFInsnSet:     args[initBPFCPU],
 		logfields.BPFClockSource: clockSource[option.Config.ClockSource],
 	}).Info("Setting up BPF datapath")
-
-	if option.Config.IPAM == ipamOption.IPAMENI {
-		var err error
-		if sysSettings, err = addENIRules(sysSettings, o.Datapath().LocalNodeAddressing()); err != nil {
-			return fmt.Errorf("unable to install ip rule for ENI multi-node NodePort: %w", err)
-		}
-	}
-
-	sysctl.ApplySettings(sysSettings)
 
 	if option.Config.InstallIptRules && option.Config.EnableL7Proxy {
 		args[initArgProxyRule] = "true"

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -414,3 +414,33 @@ func (l *Loader) reloadIPSecOnLinkChanges() {
 		}
 	}()
 }
+
+// addHostDeviceAddr add internal ipv4 and ipv6 addresses to the cilium_host device.
+func addHostDeviceAddr(hostDev netlink.Link, ipv4, ipv6 net.IP) error {
+	if ipv4 != nil {
+		addr := netlink.Addr{
+			IPNet: &net.IPNet{
+				IP:   ipv4,
+				Mask: net.CIDRMask(32, 32), // corresponds to /32
+			},
+		}
+
+		if err := netlink.AddrReplace(hostDev, &addr); err != nil {
+			return err
+		}
+	}
+	if ipv6 != nil {
+		addr := netlink.Addr{
+			IPNet: &net.IPNet{
+				IP:   ipv6,
+				Mask: net.CIDRMask(64, 128), // corresponds to /64
+			},
+		}
+
+		if err := netlink.AddrReplace(hostDev, &addr); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -7,71 +7,75 @@ package loader
 
 import (
 	"fmt"
+	"testing"
 
-	. "github.com/cilium/checkmate"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
-type NetlinkTestSuite struct {
-	prevConfigEnableIPv4 bool
-	prevConfigEnableIPv6 bool
-}
+func TestSetupDev(t *testing.T) {
+	testutils.PrivilegedTest(t)
 
-var _ = Suite(&NetlinkTestSuite{})
-
-func (s *NetlinkTestSuite) SetUpSuite(c *C) {
-	testutils.PrivilegedTest(c)
-
-	s.prevConfigEnableIPv4 = option.Config.EnableIPv4
-	s.prevConfigEnableIPv6 = option.Config.EnableIPv6
-
+	prevConfigEnableIPv4 := option.Config.EnableIPv4
+	prevConfigEnableIPv6 := option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4 = prevConfigEnableIPv4
+		option.Config.EnableIPv6 = prevConfigEnableIPv6
+	})
 	option.Config.EnableIPv4 = true
 	option.Config.EnableIPv6 = true
-}
 
-func (s *NetlinkTestSuite) TearDownSuite(c *C) {
-	option.Config.EnableIPv4 = s.prevConfigEnableIPv4
-	option.Config.EnableIPv6 = s.prevConfigEnableIPv6
-}
+	netnsName := "test-setup-dev"
+	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+	require.NoError(t, err)
+	require.NotNil(t, netns0)
+	t.Cleanup(func() {
+		netns0.Close()
+		netns.RemoveNetNSWithName(netnsName)
+	})
 
-func (s *NetlinkTestSuite) TestSetupDev(c *C) {
-	ifName := "dummy9"
+	netns0.Do(func(_ ns.NetNS) error {
+		ifName := "dummy"
+		dummy := &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name: ifName,
+			},
+		}
+		err := netlink.LinkAdd(dummy)
+		require.NoError(t, err)
 
-	dummy := &netlink.Dummy{
-		LinkAttrs: netlink.LinkAttrs{
-			Name: ifName,
-		},
-	}
-	err := netlink.LinkAdd(dummy)
-	c.Assert(err, IsNil)
+		err = setupDev(dummy)
+		require.NoError(t, err)
 
-	err = setupDev(dummy)
-	c.Assert(err, IsNil)
+		enabledSettings := []string{
+			fmt.Sprintf("net.ipv6.conf.%s.forwarding", ifName),
+			fmt.Sprintf("net.ipv4.conf.%s.forwarding", ifName),
+			fmt.Sprintf("net.ipv4.conf.%s.accept_local", ifName),
+		}
+		disabledSettings := []string{
+			fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifName),
+			fmt.Sprintf("net.ipv4.conf.%s.send_redirects", ifName),
+		}
+		for _, setting := range enabledSettings {
+			s, err := sysctl.Read(setting)
+			require.NoError(t, err)
+			require.Equal(t, s, "1")
+		}
+		for _, setting := range disabledSettings {
+			s, err := sysctl.Read(setting)
+			require.NoError(t, err)
+			require.Equal(t, s, "0")
+		}
 
-	enabledSettings := []string{
-		fmt.Sprintf("net.ipv6.conf.%s.forwarding", ifName),
-		fmt.Sprintf("net.ipv4.conf.%s.forwarding", ifName),
-		fmt.Sprintf("net.ipv4.conf.%s.accept_local", ifName),
-	}
-	disabledSettings := []string{
-		fmt.Sprintf("net.ipv4.conf.%s.rp_filter", ifName),
-		fmt.Sprintf("net.ipv4.conf.%s.send_redirects", ifName),
-	}
-	for _, setting := range enabledSettings {
-		s, err := sysctl.Read(setting)
-		c.Assert(err, IsNil)
-		c.Assert(s, Equals, "1")
-	}
-	for _, setting := range disabledSettings {
-		s, err := sysctl.Read(setting)
-		c.Assert(err, IsNil)
-		c.Assert(s, Equals, "0")
-	}
+		err = netlink.LinkDel(dummy)
+		require.NoError(t, err)
 
-	err = netlink.LinkDel(dummy)
-	c.Assert(err, IsNil)
+		return nil
+	})
 }


### PR DESCRIPTION
This PR continues to remove code from init.sh and ports it to Go, which for now means it will have to live in the `Reinitialize()`.

Fixes: #25486 
