### PR TITLE
pkg/aws: leverage the API rate limiter through a middleware

### DIFF
--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ec2"
-
 	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	apiMetrics "github.com/cilium/cilium/pkg/api/metrics"
@@ -91,7 +89,7 @@ func (a *AllocatorAWS) Init(ctx context.Context) error {
 		eniCreationTags = ec2shim.MergeTags(eniCreationTags, a.eniGCTags)
 	}
 
-	a.client = ec2shim.NewClient(ec2.NewFromConfig(cfg), aMetrics, operatorOption.Config.IPAMAPIQPSLimit,
+	a.client = ec2shim.NewClient(cfg, aMetrics, operatorOption.Config.IPAMAPIQPSLimit,
 		operatorOption.Config.IPAMAPIBurst, subnetsFilters, instancesFilters, eniCreationTags,
 		operatorOption.Config.AWSUsePrimaryAddress)
 


### PR DESCRIPTION
This change factorizes the implementation of the rate limiter for AWS API calls into a unique instantiation. It makes it less prone to omissions, ensuring that any operation is actually rate limited.

```release-note
Use a middleware to implement the rate limiting of AWS EC2 operations
```
