### PR TITLE
workflows: e2e: enable debug logs

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -441,7 +441,8 @@ jobs:
 
             ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+              --debug=true
 
             ./contrib/scripts/kind-down.sh
 


### PR DESCRIPTION
temporary enable debug logs in e2e conformance test to help debug a flake.