### PR TITLE
egressgateway: implement NodeHandler interface

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1100,7 +1100,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	// Start IPAM
-	d.startIPAM()
+	d.startIPAM(params.SharedResources.LocalCiliumNode)
 	// After the IPAM is started, in particular IPAM modes (CRD, ENI, Alibaba)
 	// which use the VPC CIDR as the pod CIDR, we must attempt restoring the
 	// router IPs from the K8s resources if we weren't able to restore them

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -22,6 +22,7 @@ import (
 	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -556,11 +557,11 @@ func (d *Daemon) configureIPAM() {
 	}
 }
 
-func (d *Daemon) startIPAM() {
+func (d *Daemon) startIPAM(localNode k8s.LocalCiliumNodeResource) {
 	bootstrapStats.ipam.Start()
 	log.Info("Initializing node addressing")
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), option.Config, d.nodeDiscovery, d.k8sWatcher, &d.mtuConfig, d.clientset)
+	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), option.Config, d.nodeDiscovery, d.k8sWatcher, localNode, &d.mtuConfig, d.clientset)
 	if d.ipamMetadata != nil {
 		d.ipam.WithMetadata(d.ipamMetadata)
 	}

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -561,7 +561,7 @@ func (d *Daemon) startIPAM(localNode k8s.LocalCiliumNodeResource) {
 	bootstrapStats.ipam.Start()
 	log.Info("Initializing node addressing")
 	// Set up ipam conf after init() because we might be running d.conf.KVStoreIPv4Registration
-	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), option.Config, d.nodeDiscovery, d.k8sWatcher, localNode, &d.mtuConfig, d.clientset)
+	d.ipam = ipam.NewIPAM(d.datapath.LocalNodeAddressing(), option.Config, d.nodeDiscovery, localNode, &d.mtuConfig, d.clientset)
 	if d.ipamMetadata != nil {
 		d.ipam.WithMetadata(d.ipamMetadata)
 	}

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -165,10 +165,10 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	close(k.cacheStatus)
 
 	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
-	egressGatewayManager.OnUpdateNode(node1)
+	egressGatewayManager.NodeAdd(node1)
 
 	node2 := newCiliumNode(node2, node2IP, nodeGroup2Labels)
-	egressGatewayManager.OnUpdateNode(node2)
+	egressGatewayManager.NodeAdd(node2)
 
 	// Create a new policy
 	policy1 := newEgressPolicyConfigWithNodeSelector("policy-1", ep1Labels, destCIDR, []string{}, nodeGroup1Selector, testInterface1)

--- a/pkg/ipam/clusterpool_test.go
+++ b/pkg/ipam/clusterpool_test.go
@@ -650,6 +650,7 @@ func TestNewCRDWatcher(t *testing.T) {
 
 			fakeConfig := &testConfiguration{}
 			fakeK8sEventRegister := &ownerMock{}
+			fakeResource := &resourceMock{}
 			events := make(chan string, 1)
 			fakeK8sCiliumNodeAPI := &fakeK8sCiliumNodeAPI{
 				node: &ciliumv2.CiliumNode{},
@@ -662,7 +663,7 @@ func TestNewCRDWatcher(t *testing.T) {
 			}
 
 			// Test that the watcher updates the CiliumNode CRD.
-			c := newCRDWatcher(fakeConfig, fakeK8sCiliumNodeAPI, fakeK8sEventRegister, fakeK8sCiliumNodeAPI)
+			c := newCRDWatcher(fakeConfig, fakeResource, fakeK8sEventRegister, fakeK8sCiliumNodeAPI)
 			c.localNodeUpdated(&ciliumv2.CiliumNode{
 				Spec: ciliumv2.NodeSpec{
 					IPAM: types.IPAMSpec{
@@ -785,6 +786,7 @@ func TestNewCRDWatcher_restoreFinished(t *testing.T) {
 
 	fakeConfig := &testConfiguration{}
 	fakeK8sEventRegister := &ownerMock{}
+	fakeResource := &resourceMock{}
 	events := make(chan string, 1)
 	fakeK8sCiliumNodeAPI := &fakeK8sCiliumNodeAPI{
 		node: &ciliumv2.CiliumNode{},
@@ -796,7 +798,7 @@ func TestNewCRDWatcher_restoreFinished(t *testing.T) {
 		},
 	}
 
-	c := newCRDWatcher(fakeConfig, fakeK8sEventRegister, fakeK8sEventRegister, fakeK8sCiliumNodeAPI)
+	c := newCRDWatcher(fakeConfig, fakeResource, fakeK8sEventRegister, fakeK8sCiliumNodeAPI)
 	c.localNodeUpdated(&ciliumv2.CiliumNode{
 		Spec: ciliumv2.NodeSpec{
 			IPAM: types.IPAMSpec{

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -100,7 +100,7 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 		sharedNodeStore = newFakeNodeStore(conf, c)
 		sharedNodeStore.ownNode = cn
 	})
-	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, conf, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 	sharedNodeStore.updateLocalNodeResource(cn)
 
 	// Allocate the first 3 IPs

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -142,7 +142,7 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 		}
 	case ipamOption.IPAMMultiPool:
 		log.Info("Initializing MultiPool IPAM")
-		manager := newMultiPoolManager(c, k8sEventReg, owner, clientset.CiliumV2().CiliumNodes())
+		manager := newMultiPoolManager(c, localNode, owner, clientset.CiliumV2().CiliumNodes())
 
 		if c.IPv6Enabled() {
 			ipam.IPv6Allocator = manager.Allocator(IPv6)

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/logging"
@@ -107,7 +108,7 @@ type Metadata interface {
 }
 
 // NewIPAM returns a new IP address manager
-func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, k8sEventReg K8sEventRegister, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
+func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, k8sEventReg K8sEventRegister, localNode k8s.LocalCiliumNodeResource, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
 	ipam := &IPAM{
 		nodeAddressing:   nodeAddressing,
 		config:           c,
@@ -134,10 +135,10 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 		log.Info("Initializing ClusterPool v2 IPAM")
 
 		if c.IPv6Enabled() {
-			ipam.IPv6Allocator = newClusterPoolAllocator(IPv6, c, owner, k8sEventReg, clientset)
+			ipam.IPv6Allocator = newClusterPoolAllocator(IPv6, c, owner, localNode, clientset)
 		}
 		if c.IPv4Enabled() {
-			ipam.IPv4Allocator = newClusterPoolAllocator(IPv4, c, owner, k8sEventReg, clientset)
+			ipam.IPv4Allocator = newClusterPoolAllocator(IPv4, c, owner, localNode, clientset)
 		}
 	case ipamOption.IPAMMultiPool:
 		log.Info("Initializing MultiPool IPAM")

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -108,7 +108,7 @@ type Metadata interface {
 }
 
 // NewIPAM returns a new IP address manager
-func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, k8sEventReg K8sEventRegister, localNode k8s.LocalCiliumNodeResource, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
+func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, localNode k8s.LocalCiliumNodeResource, mtuConfig MtuConfiguration, clientset client.Clientset) *IPAM {
 	ipam := &IPAM{
 		nodeAddressing:   nodeAddressing,
 		config:           c,
@@ -153,11 +153,11 @@ func NewIPAM(nodeAddressing types.NodeAddressing, c Configuration, owner Owner, 
 	case ipamOption.IPAMCRD, ipamOption.IPAMENI, ipamOption.IPAMAzure, ipamOption.IPAMAlibabaCloud:
 		log.Info("Initializing CRD-based IPAM")
 		if c.IPv6Enabled() {
-			ipam.IPv6Allocator = newCRDAllocator(IPv6, c, owner, clientset, k8sEventReg, mtuConfig)
+			ipam.IPv6Allocator = newCRDAllocator(IPv6, c, owner, clientset, localNode, mtuConfig)
 		}
 
 		if c.IPv4Enabled() {
-			ipam.IPv4Allocator = newCRDAllocator(IPv4, c, owner, clientset, k8sEventReg, mtuConfig)
+			ipam.IPv4Allocator = newCRDAllocator(IPv4, c, owner, clientset, localNode, mtuConfig)
 		}
 	case ipamOption.IPAMDelegatedPlugin:
 		log.Info("Initializing no-op IPAM since we're using a CNI delegated plugin")

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -124,7 +124,7 @@ func (f fakePoolAllocator) RestoreFinished() {}
 
 func (s *IPAMSuite) TestLock(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	// Since the IPs we have allocated to the endpoints might or might not
 	// be in the allocrange specified in cilium, we need to specify them
@@ -146,7 +146,7 @@ func (s *IPAMSuite) TestLock(c *C) {
 
 func (s *IPAMSuite) TestExcludeIP(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
@@ -177,7 +177,7 @@ func (s *IPAMSuite) TestDeriveFamily(c *C) {
 
 func (s *IPAMSuite) TestIPAMMetadata(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 	ipam.IPv4Allocator = newFakePoolAllocator(map[string]string{
 		"default": "10.10.0.0/16",
 		"test":    "192.168.178.0/24",
@@ -254,7 +254,7 @@ func (s *IPAMSuite) TestLegacyAllocatorIPAMMetadata(c *C) {
 	// AllocationResult is always set to PoolDefault, regardless of the requested
 	// pool
 	fakeAddressing := fake.NewNodeAddressing()
-	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
+	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 	ipam.WithMetadata(fakeMetadataFunc(func(owner string) (pool string, err error) {
 		return "some-pool", nil
 	}))

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -22,6 +22,7 @@ import (
 
 func Test_MultiPoolManager(t *testing.T) {
 	fakeConfig := &testConfiguration{}
+	fakeResource := &resourceMock{}
 	fakeOwner := &ownerMock{}
 	events := make(chan string, 1)
 	fakeK8sCiliumNodeAPI := &fakeK8sCiliumNodeAPI{
@@ -33,7 +34,7 @@ func Test_MultiPoolManager(t *testing.T) {
 			events <- "upsert"
 		},
 	}
-	c := newMultiPoolManager(fakeConfig, fakeK8sCiliumNodeAPI, fakeOwner, fakeK8sCiliumNodeAPI)
+	c := newMultiPoolManager(fakeConfig, fakeResource, fakeOwner, fakeK8sCiliumNodeAPI)
 	// set custom preAllocMap to not rely on option.Config in unit tests
 	c.preallocMap = preAllocMap{
 		"default": 16,

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -51,9 +51,6 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 						valid = true
 						n := nodeTypes.ParseCiliumNode(ciliumNode)
 						errs := k.CiliumNodeChain.OnAddCiliumNode(ciliumNode, swgNodes)
-						if k.egressGatewayManager != nil {
-							k.egressGatewayManager.OnUpdateNode(n)
-						}
 						if n.IsLocal() {
 							return
 						}
@@ -84,9 +81,6 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 							}
 							n := nodeTypes.ParseCiliumNode(ciliumNode)
 							errs := k.CiliumNodeChain.OnUpdateCiliumNode(oldCN, ciliumNode, swgNodes)
-							if k.egressGatewayManager != nil {
-								k.egressGatewayManager.OnUpdateNode(n)
-							}
 							if isLocal {
 								return
 							}
@@ -104,9 +98,6 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 					}
 					valid = true
 					n := nodeTypes.ParseCiliumNode(ciliumNode)
-					if k.egressGatewayManager != nil {
-						k.egressGatewayManager.OnDeleteNode(n)
-					}
 					errs := k.CiliumNodeChain.OnDeleteCiliumNode(ciliumNode, swgNodes)
 					if errs != nil {
 						valid = false

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -171,8 +171,6 @@ type EgressGatewayManager interface {
 	OnDeleteEgressPolicy(configID types.NamespacedName)
 	OnUpdateEndpoint(endpoint *k8sTypes.CiliumEndpoint)
 	OnDeleteEndpoint(endpoint *k8sTypes.CiliumEndpoint)
-	OnUpdateNode(node nodeTypes.Node)
-	OnDeleteNode(node nodeTypes.Node)
 }
 
 type envoyConfigManager interface {


### PR DESCRIPTION
Instead of subscribing to node updates in a somewhat ad-hoc way in the k8s/watchers pkg, implement the NodeHandler interface made for this purpose, and subscribe to the node discovery manager.

Since the node discovery manager is clustermesh aware, but egw isn't (yet), we need to take care to only process updates from the current cluster. (This was not previously an issue, as we got updates only for our cluster when watching through k8s/watchers.)