### PR TITLE
bpf,datapath: read jiffies from /proc/schedstat

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -2044,11 +2044,11 @@ func initClockSourceOption() {
 
 	if option.Config.EnableBPFClockProbe {
 		if probes.HaveProgramHelper(ebpf.XDP, asm.FnJiffies64) == nil {
-			t, err := bpf.GetJtime()
+			t, err := probes.Jiffies()
 			if err == nil && t > 0 {
 				option.Config.ClockSource = option.ClockSourceJiffies
 			} else {
-				log.WithError(err).Warningf("Auto-disabling %q feature since kernel doesn't expose %q.", option.EnableBPFClockProbe, bpf.TimerInfoFilepath)
+				log.WithError(err).Warningf("Auto-disabling %q feature since kernel doesn't expose jiffies", option.EnableBPFClockProbe)
 				option.Config.EnableBPFClockProbe = false
 			}
 		} else {

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -6,7 +6,6 @@
 package bpf
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -172,32 +171,4 @@ func GetMtime() (uint64, error) {
 	}
 
 	return uint64(unix.TimespecToNsec(ts)), nil
-}
-
-const (
-	TimerInfoFilepath = "/proc/timer_list"
-)
-
-// GetJtime returns a close-enough approximation of kernel jiffies
-// that can be used to compare against jiffies BPF helper. We parse
-// it from /proc/timer_list. GetJtime() should be invoked only at
-// mid-low frequencies.
-func GetJtime() (uint64, error) {
-	jiffies := uint64(0)
-	scaler := uint64(8)
-	timers, err := os.Open(TimerInfoFilepath)
-	if err != nil {
-		return 0, err
-	}
-	defer timers.Close()
-	scanner := bufio.NewScanner(timers)
-	for scanner.Scan() {
-		tmp := uint64(0)
-		n, _ := fmt.Sscanf(scanner.Text(), "jiffies: %d\n", &tmp)
-		if n == 1 {
-			jiffies = tmp
-			break
-		}
-	}
-	return jiffies >> scaler, scanner.Err()
 }

--- a/pkg/datapath/linux/probes/kernel_hz.go
+++ b/pkg/datapath/linux/probes/kernel_hz.go
@@ -53,6 +53,23 @@ func KernelHZ() (uint16, error) {
 	return nearest(hz, hzValues)
 }
 
+// Jiffies returns the kernel's internal timestamp in jiffies read from
+// /proc/schedstat.
+func Jiffies() (uint64, error) {
+	f, err := os.Open("/proc/schedstat")
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	k, err := readSchedstat(f)
+	if err != nil {
+		return 0, err
+	}
+
+	return k.k, nil
+}
+
 // readSchedstat expects to read /proc/schedstat and returns the first line
 // matching 'timestamp %d'. Upon return, f is rewound to allow reuse.
 //

--- a/pkg/datapath/linux/probes/kernel_hz_test.go
+++ b/pkg/datapath/linux/probes/kernel_hz_test.go
@@ -14,6 +14,16 @@ func TestKernelHZ(t *testing.T) {
 	}
 }
 
+func TestJiffies(t *testing.T) {
+	j, err := Jiffies()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == 0 {
+		t.Fatal("unexpected zero jiffies reading")
+	}
+}
+
 func TestNearest(t *testing.T) {
 	var tests = []struct {
 		name   string

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -266,7 +267,7 @@ func DumpEntriesWithTimeDiff(m CtMap, clockSource *models.ClockSource) (string, 
 			return fmt.Sprintf("remaining: %d sec(s)", diff)
 		}
 	} else if clockSource.Mode == models.ClockSourceModeJiffies {
-		now, err := bpf.GetJtime()
+		now, err := probes.Jiffies()
 		if err != nil {
 			return "", err
 		}
@@ -580,7 +581,7 @@ func GC(m *Map, filter *GCFilter) int {
 			t, _ = bpf.GetMtime()
 			t = t / 1000000000
 		} else {
-			t, _ = bpf.GetJtime()
+			t, _ = probes.Jiffies()
 		}
 		filter.Time = uint32(t)
 	}


### PR DESCRIPTION
The Cilium agent has been throwing the 'Auto-disabling "enable-bpf-clock-probe" feature since kernel doesn't expose /proc/timer_list' warning for a while now.

Since /proc/timer_list is not available under the default k8s SecurityContext and Docker also masks the file by default, read it from /proc/schedstat instead.

Reuse the existing parsing code from probes.KernelHZ to obtain the value.

Fixes: https://github.com/cilium/cilium/issues/25463

Backporting to 1.13 only since 1.12 doesn't have the new /proc/schedstat reader infra yet.

```release-note
bpf,datapath: read jiffies from /proc/schedstat
```
