### PR TITLE
Change wording on toServices limitations (see #20067)

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -304,8 +304,9 @@ have ``external:yes`` set as the label.
 Limitations
 ~~~~~~~~~~~
 
-``toServices`` statements cannot be combined with ``toPorts`` statements in the
-same rule.
+``toServices`` statements must not be combined with ``toPorts`` statements in the
+same rule. In the presence of a ``toPorts`` statement, ``toServices`` does nothing
+and as a result all egress traffic to port(s) specified by ``toPorts`` is allowed.
 
 .. _Entities based:
 

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -305,8 +305,7 @@ Limitations
 ~~~~~~~~~~~
 
 ``toServices`` statements must not be combined with ``toPorts`` statements in the
-same rule. In the presence of a ``toPorts`` statement, ``toServices`` does nothing
-and as a result all egress traffic to port(s) specified by ``toPorts`` is allowed.
+same rule. If a rule combines both these statements, the policy is rejected.
 
 .. _Entities based:
 

--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -190,7 +190,7 @@ func (e *EgressRule) sanitize() error {
 		"ToCIDRSet":   true,
 		"ToEndpoints": true,
 		"ToEntities":  true,
-		"ToServices":  true,
+		"ToServices":  false, // see https://github.com/cilium/cilium/issues/20067
 		"ToFQDNs":     true,
 		"ToGroups":    true,
 	}

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -627,7 +627,7 @@ func (s *PolicyAPITestSuite) TestToServicesSanitize(c *C) {
 	}
 
 	err := toServicesL3L4.Sanitize()
-	c.Assert(err, IsNil)
+	c.Assert(err, NotNil)
 
 }
 


### PR DESCRIPTION
#21052 updated Cilium documentation to say that, in network policy rules, `toServices` statements _cannot_ be combined with `toPorts` statements. I believe it would be more informative for users of Cilium to say (following RFC 2119) that `toServices` _must not_ be combined with `toPorts`, as technically Cilium accepts such a configuration as valid but handles it in the unexpected and unuseful manner described in #20067.