### PR TITLE
Add improvements in Conformance Runtime

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -358,3 +358,9 @@ jobs:
           path: |
             cilium-junits/*.xml
           retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@86789108ea0fd9be947a4232dd560e2fa3b9467a # v0.0.1
+        with:
+          junit-directory: "cilium-junits"

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -321,6 +321,18 @@ jobs:
             export GOTEST_FORMATTER="/root/go/bin/go-junit-report -set-exit-code -iocopy -out test/runtime.xml"
             make tests-privileged NO_COLOR=1
 
+      - name: Debug failure on VM
+        # Only debug the failure on the LVH that have Cilium running as a service,
+        # which is 'agent' and 'datapath' focus.
+        if:  ${{ !success() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
+        timeout-minutes: 10
+        uses: cilium/little-vm-helper@0b7d7157dae56a44dc531c852e7756dc671071af # v0.0.3
+        with:
+          provision: 'false'
+          cmd: |
+            journalctl --no-pager -xeu cilium.service
+            systemctl status cilium.service
+
       - name: Fetch artifacts
         if: ${{ !success() && (matrix.focus == 'agent' || matrix.focus == 'datapath') }}
         shell: bash

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -64,7 +64,6 @@ env:
   # RuntimeDatapathMonitorTest With Sample Containers cilium monitor check --related-to
   # RuntimeDatapathMonitorTest With Sample Containers cilium monitor check --to
   # RuntimeDatapathMonitorTest With Sample Containers Cilium monitor event types
-  # RuntimeDatapathMonitorTest With Sample Containers Cilium monitor verbose mode
   # RuntimeDatapathMonitorTest With Sample Containers delivers the same information to multiple monitors
   ###
   privileged: "RuntimeDatapathPrivilegedUnitTests"


### PR DESCRIPTION
Add some improvements in the Conformance runtime tests to make it easier to understand which test failed.

An example of such output can be found [here](https://github.com/cilium/cilium/actions/runs/5133502410)

![image](https://github.com/cilium/cilium/assets/5714066/44201ccd-4310-4c93-8af6-ff0f9e1602f9)
