### PR TITLE
docs: Add missing backslash in Helm command

### DIFF
--- a/Documentation/installation/cni-chaining-aws-cni.rst
+++ b/Documentation/installation/cni-chaining-aws-cni.rst
@@ -68,7 +68,7 @@ Deploy Cilium via Helm:
      --set cni.chainingMode=aws-cni \\
      --set cni.exclusive=false \\
      --set enableIPv4Masquerade=false \\
-     --set routingMode=native
+     --set routingMode=native \\
      --set endpointRoutes.enabled=true
 
 This will enable chaining with the AWS VPC CNI plugin. It will also disable


### PR DESCRIPTION
Adds missing backslash to Helm command in the AWS CNI-chaining documentation.