### PR TITLE
CI: Add JUnit reports upload

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -117,6 +117,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -127,6 +128,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -267,9 +270,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Clean up Cilium
         run: |
@@ -295,9 +303,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Run connectivity test with IPSec
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --junit-file "cilium-junits/${{ env.job_name }} - 2.xml" --junit-property github_job_step="Run connectivity test with IPSec"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -320,6 +329,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -117,6 +117,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -127,6 +128,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -269,9 +272,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Clean up Cilium
         run: |
@@ -297,9 +305,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Run connectivity test with IPSec
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --junit-file "cilium-junits/${{ env.job_name }} - 2.xml" --junit-property github_job_step="Run connectivity test with IPSec"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -322,6 +331,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -117,6 +117,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -127,6 +128,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -269,9 +272,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Clean up Cilium
         run: |
@@ -297,9 +305,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Run connectivity test with IPSec
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --junit-file "cilium-junits/${{ env.job_name }} - 2.xml" --junit-property github_job_step="Run connectivity test with IPSec"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -322,6 +331,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -116,6 +116,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -126,6 +127,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -265,9 +268,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Clean up Cilium
         run: |
@@ -293,9 +301,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Run connectivity test with IPSec
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --junit-file "cilium-junits/${{ env.job_name }} - 2.xml" --junit-property github_job_step="Run connectivity test with IPSec"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -318,6 +327,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -116,6 +116,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -126,6 +127,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -275,9 +278,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -300,6 +308,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -116,6 +116,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -126,6 +127,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -275,9 +278,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -300,6 +308,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -116,6 +116,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -126,6 +127,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -275,9 +278,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -300,6 +308,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -115,6 +115,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -125,6 +126,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -262,9 +265,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -287,6 +295,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -168,8 +168,8 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test-backport-1.11`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: setup-report
-    name: Setup & Test
     if: |
       ((github.event_name == 'issue_comment' &&
         ((github.event.comment.body == '/ci-multicluster-1.11') ||
@@ -178,6 +178,8 @@ jobs:
       github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
 
     strategy:
       fail-fast: false
@@ -496,9 +498,15 @@ jobs:
         sleep 10s
         [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-    - name: Run connectivity test
+    - name: Make JUnit report directory
       run: |
-        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+        mkdir -p cilium-junits
+
+    - name: Run connectivity test (${{ join(matrix.*, ', ') }})
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+        --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+        --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
     - name: Post-test information gathering
       if: ${{ !success() }}
@@ -524,6 +532,20 @@ jobs:
         name: cilium-sysdumps-${{ matrix.name }}
         path: cilium-sysdump-*.zip
         retention-days: 5
+
+    - name: Upload JUnits
+      if: ${{ always() }}
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: cilium-junits
+        path: cilium-junits/*.xml
+        retention-days: 2
+
+    - name: Publish Test Results As GitHub Summary
+      if: ${{ always() }}
+      uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+      with:
+        junit-directory: "cilium-junits"
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -168,8 +168,8 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test-backport-1.12`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: setup-report
-    name: Setup & Test
     if: |
       ((github.event_name == 'issue_comment' &&
         ((github.event.comment.body == '/ci-multicluster-1.12') ||
@@ -178,6 +178,8 @@ jobs:
       github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
 
     strategy:
       fail-fast: false
@@ -491,9 +493,15 @@ jobs:
         sleep 10s
         [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-    - name: Run connectivity test
+    - name: Make JUnit report directory
       run: |
-        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+        mkdir -p cilium-junits
+
+    - name: Run connectivity test (${{ join(matrix.*, ', ') }})
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+        --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+        --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
     - name: Post-test information gathering
       if: ${{ !success() }}
@@ -519,6 +527,20 @@ jobs:
         name: cilium-sysdumps-${{ matrix.name }}
         path: cilium-sysdump-*.zip
         retention-days: 5
+
+    - name: Upload JUnits
+      if: ${{ always() }}
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: cilium-junits
+        path: cilium-junits/*.xml
+        retention-days: 2
+
+    - name: Publish Test Results As GitHub Summary
+      if: ${{ always() }}
+      uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+      with:
+        junit-directory: "cilium-junits"
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -168,8 +168,8 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test-backport-1.13`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: setup-report
-    name: Setup & Test
     if: |
       ((github.event_name == 'issue_comment' &&
         ((github.event.comment.body == '/ci-multicluster-1.13') ||
@@ -178,6 +178,8 @@ jobs:
       github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
 
     strategy:
       fail-fast: false
@@ -491,9 +493,15 @@ jobs:
         sleep 10s
         [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-    - name: Run connectivity test
+    - name: Make JUnit report directory
       run: |
-        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+        mkdir -p cilium-junits
+
+    - name: Run connectivity test (${{ join(matrix.*, ', ') }})
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+        --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+        --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
     - name: Post-test information gathering
       if: ${{ !success() }}
@@ -519,6 +527,20 @@ jobs:
         name: cilium-sysdumps-${{ matrix.name }}
         path: cilium-sysdump-*.zip
         retention-days: 5
+
+    - name: Upload JUnits
+      if: ${{ always() }}
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: cilium-junits
+        path: cilium-junits/*.xml
+        retention-days: 2
+
+    - name: Publish Test Results As GitHub Summary
+      if: ${{ always() }}
+      uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+      with:
+        junit-directory: "cilium-junits"
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -165,8 +165,8 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: setup-report
-    name: Setup & Test
     if: |
       ((github.event_name == 'issue_comment' &&
         ((github.event.comment.body == '/ci-multicluster') ||
@@ -175,6 +175,8 @@ jobs:
       github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
 
     strategy:
       fail-fast: false
@@ -482,9 +484,15 @@ jobs:
         sleep 10s
         [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-    - name: Run connectivity test
+    - name: Make JUnit report directory
       run: |
-        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+        mkdir -p cilium-junits
+
+    - name: Run connectivity test (${{ join(matrix.*, ', ') }})
+      run: |
+        cilium --context ${{ env.contextName1 }} connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+        --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+        --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
     - name: Post-test information gathering
       if: ${{ !success() }}
@@ -510,6 +518,21 @@ jobs:
         name: cilium-sysdumps-${{ matrix.name }}
         path: cilium-sysdump-*.zip
         retention-days: 5
+
+    - name: Upload JUnits
+      if: ${{ always() }}
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      with:
+        name: cilium-junits
+        path: cilium-junits/*.xml
+        retention-days: 2
+
+    - name: Publish Test Results As GitHub Summary
+      if: ${{ always() }}
+      uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+      with:
+        junit-directory: "cilium-junits"
+
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -172,6 +172,8 @@ jobs:
       )) ||
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
+    env:
+      job_name: "Setup & Test"
     strategy:
       fail-fast: false
       max-parallel: 16
@@ -381,6 +383,20 @@ jobs:
           CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${L7}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
+          JUNIT=""
+          for NAME in ${{ matrix.kube-proxy }} ${{ matrix.tunnel }} ${{ matrix.lb-mode }} ${{ matrix.encryption }} ${{ matrix.endpoint-routes }}; do
+            if [[ "${NAME}" != "" ]] && [[ "${NAME}" != "disabled" ]] && [[ "${NAME}" != "none" ]]; then
+              if [[ "${JUNIT}" != "" ]]; then
+                JUNIT+="-"
+              fi
+              if [[ "${NAME}" == "true" ]];then
+                NAME="endpoint-routes"
+              fi
+              JUNIT+="${NAME}"
+            fi
+          done
+          echo junit_type="${JUNIT}" >> $GITHUB_OUTPUT
+
       - name: Checkout pull request for Helm chart
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
@@ -415,7 +431,7 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ needs.setup-report.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
-      - name: Run tests
+      - name: Run tests (${{ join(matrix.*, ', ') }})
         uses: cilium/little-vm-helper@657fd0df35e4edfd7815efdae14ca44ea1e74897 # v0.0.4
         with:
           provision: 'false'
@@ -434,9 +450,13 @@ jobs:
             ./cilium-cli status --wait
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
+            mkdir -p cilium-junits
+
             ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})"
 
             ./contrib/scripts/kind-down.sh
 
@@ -459,6 +479,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -168,6 +168,8 @@ jobs:
       )) ||
       github.event_name == 'schedule' ||
       github.event_name == 'pull_request'
+    env:
+      job_name: 'Setup & Test'
     strategy:
       fail-fast: false
       max-parallel: 16
@@ -392,6 +394,20 @@ jobs:
           CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
+          JUNIT=""
+          for NAME in ${{ matrix.kube-proxy }} ${{ matrix.tunnel }} ${{ matrix.lb-mode }} ${{ matrix.encryption }} ${{ matrix.endpoint-routes }}; do
+            if [[ "${NAME}" != "" ]] && [[ "${NAME}" != "disabled" ]] && [[ "${NAME}" != "none" ]]; then
+              if [[ "${JUNIT}" != "" ]]; then
+                JUNIT+="-"
+              fi
+              if [[ "${NAME}" == "true" ]];then
+                NAME="endpoint-routes"
+              fi
+              JUNIT+="${NAME}"
+            fi
+          done
+          echo junit_type="${JUNIT}" >> $GITHUB_OUTPUT
+
       - name: Checkout pull request for Helm chart
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
@@ -426,7 +442,7 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ needs.setup-report.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
-      - name: Run tests
+      - name: Run tests (${{ join(matrix.*, ', ') }})
         uses: cilium/little-vm-helper@657fd0df35e4edfd7815efdae14ca44ea1e74897 # v0.0.4
         with:
           provision: 'false'
@@ -445,9 +461,13 @@ jobs:
             ./cilium-cli status --wait
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
+            mkdir -p cilium-junits
+
             ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>"
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})"
 
             ./contrib/scripts/kind-down.sh
 
@@ -470,6 +490,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -116,6 +116,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -126,6 +127,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -264,9 +267,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Clean up Cilium
         run: |
@@ -294,9 +302,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Run connectivity test with IPSec
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --junit-file "cilium-junits/${{ env.job_name }} - 2.xml" --junit-property github_job_step="Run connectivity test with IPSec"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -319,6 +328,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -116,6 +116,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -126,6 +127,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -264,9 +267,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Clean up Cilium
         run: |
@@ -294,9 +302,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Run connectivity test with IPSec
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --junit-file "cilium-junits/${{ env.job_name }} - 2.xml" --junit-property github_job_step="Run connectivity test with IPSec"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -319,6 +328,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -116,6 +116,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -126,6 +127,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -264,9 +267,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Clean up Cilium
         run: |
@@ -294,9 +302,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Run connectivity test with IPSec
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --junit-file "cilium-junits/${{ env.job_name }} - 2.xml" --junit-property github_job_step="Run connectivity test with IPSec"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -319,6 +328,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -115,6 +115,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -125,6 +126,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -255,9 +258,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Clean up Cilium
         run: |
@@ -284,9 +292,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Run connectivity test with IPSec
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy \
+          --junit-file "cilium-junits/${{ env.job_name }} - 2.xml" --junit-property github_job_step="Run connectivity test with IPSec"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -309,6 +318,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -117,6 +117,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -127,6 +128,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -317,9 +320,14 @@ jobs:
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} \
             --command "ping -c 3 \$(sudo cilium service list get -o jsonpath='{[?(@.spec.flags.name==\"clustermesh-apiserver\")].spec.backend-addresses[0].ip}')"
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -352,6 +360,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -117,6 +117,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -127,6 +128,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -317,9 +320,14 @@ jobs:
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} \
             --command "ping -c 3 \$(sudo cilium service list get -o jsonpath='{[?(@.spec.flags.name==\"clustermesh-apiserver\")].spec.backend-addresses[0].ip}')"
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -352,6 +360,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -117,6 +117,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -127,6 +128,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -317,9 +320,14 @@ jobs:
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} \
             --command "ping -c 3 \$(sudo cilium service list get -o jsonpath='{[?(@.spec.flags.name==\"clustermesh-apiserver\")].spec.backend-addresses[0].ip}')"
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -352,6 +360,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -116,6 +116,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -126,6 +127,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -311,9 +314,14 @@ jobs:
           gcloud compute ssh ${{ env.vmName }} --zone ${{ env.zone }} \
             --command "ping -c 3 \$(sudo cilium service list get -o jsonpath='{[?(@.spec.flags.name==\"clustermesh-apiserver\")].spec.backend-addresses[0].ip}')"
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -346,6 +354,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -172,6 +172,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: [check_changes, setup-report]
     if: |
       (github.event_name == 'issue_comment' && (
@@ -182,6 +183,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      job_name: "Installation and Connectivity Test"
     strategy:
       matrix:
         include:
@@ -197,7 +200,6 @@ jobs:
         - type: "tunnel-ipsec"
           index: "4"
           cilium-install-opts: "--encryption=ipsec --datapath-mode=tunnel"
-    name: installation-and-connectivity ${{ matrix.type }}
 
     steps:
       - name: Checkout main branch to access local actions
@@ -321,9 +323,15 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Make JUnit report directory
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          mkdir -p cilium-junits
+
+      - name: Run connectivity test (${{ matrix.index }}, ${{ matrix.type }})
+        run: |
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.index }}, ${{ matrix.type }}).xml" \
+          --junit-property github_job_step="Run connectivity test (${{ matrix.index }}, ${{ matrix.type }})"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -346,9 +354,23 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: cilium-sysdump-${{ matrix.type }}
+          name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -172,6 +172,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: [check_changes, setup-report]
     if: |
       (github.event_name == 'issue_comment' && (
@@ -182,6 +183,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 75
+    env:
+      job_name: "Installation and Connectivity Test"
     strategy:
       matrix:
         include:
@@ -197,7 +200,6 @@ jobs:
         - type: "tunnel-ipsec"
           index: "4"
           cilium-install-opts: "--encryption=ipsec --datapath-mode=tunnel"
-    name: installation-and-connectivity ${{ matrix.type }}
 
     steps:
       - name: Checkout main branch to access local actions
@@ -321,9 +323,15 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Make JUnit report directory
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          mkdir -p cilium-junits
+
+      - name:  Run connectivity test (${{ matrix.index }}, ${{ matrix.type }})
+        run: |
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.index }}, ${{ matrix.type }}).xml" \
+          --junit-property github_job_step="Run connectivity test (${{ matrix.index }}, ${{ matrix.type }})"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -346,9 +354,23 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: cilium-sysdump-${{ matrix.type }}
+          name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -172,6 +172,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: [check_changes, setup-report]
     if: |
       (github.event_name == 'issue_comment' && (
@@ -182,6 +183,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 75
+    env:
+      job_name: "Installation and Connectivity Test"
     strategy:
       matrix:
         include:
@@ -197,7 +200,6 @@ jobs:
         - type: "tunnel-ipsec"
           index: "4"
           cilium-install-opts: "--encryption=ipsec --datapath-mode=tunnel"
-    name: installation-and-connectivity ${{ matrix.type }}
 
     steps:
       - name: Checkout main branch to access local actions
@@ -322,9 +324,15 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Make JUnit report directory
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          mkdir -p cilium-junits
+
+      - name: Run connectivity test (${{ matrix.index }}, ${{ matrix.type }})
+        run: |
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.index }}, ${{ matrix.type }}).xml" \
+          --junit-property github_job_step="Run connectivity test (${{ matrix.index }}, ${{ matrix.type }})"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -347,9 +355,23 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: cilium-sysdump-${{ matrix.type }}
+          name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -168,6 +168,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: [check_changes, setup-report]
     if: |
       (github.event_name == 'issue_comment' && (
@@ -178,6 +179,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 75
+    env:
+      job_name: "Installation and Connectivity Test"
     strategy:
       matrix:
         include:
@@ -193,7 +196,6 @@ jobs:
         - type: "tunnel-ipsec"
           index: "4"
           cilium-install-opts: "--helm-set=encryption.enabled=true --helm-set=encryption.type=ipsec --datapath-mode=tunnel"
-    name: installation-and-connectivity ${{ matrix.type }}
 
     steps:
       - name: Checkout main branch to access local actions
@@ -318,9 +320,15 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
-      - name: Run connectivity test
+      - name: Make JUnit report directory
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          mkdir -p cilium-junits
+
+      - name: Run connectivity test (${{ matrix.index }}, ${{ matrix.type }})
+        run: |
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ matrix.index }}, ${{ matrix.type }}).xml" \
+          --junit-property github_job_step="Run connectivity test (${{ matrix.index }}, ${{ matrix.type }})"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -343,9 +351,23 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: cilium-sysdump-${{ matrix.type }}
+          name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
   report-success:
     runs-on: ubuntu-latest

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -29,8 +29,11 @@ env:
 
 jobs:
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -119,9 +122,14 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
-          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }}
+          cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
+          --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
         if: ${{ !success() }}
@@ -138,3 +146,17 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -118,6 +118,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -128,6 +129,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -350,6 +353,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
           cilium connectivity test \
@@ -360,7 +367,8 @@ jobs:
             --test '!/pod-to-.*-nodeport' \
             --test '!no-policies/pod-to-service' \
             --external-target google.com \
-            --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4
+            --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4 \
+            --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
         # TODO: Remove `no-policies/pod-to-service` test exception (unreliable
         # on clustermesh) once https://github.com/cilium/cilium-cli/issues/600
         # is fixed.
@@ -401,6 +409,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-multicluster-v1.12.yaml
+++ b/.github/workflows/conformance-multicluster-v1.12.yaml
@@ -118,6 +118,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -128,6 +129,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -350,6 +353,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
           cilium connectivity test \
@@ -360,7 +367,8 @@ jobs:
             --test '!/pod-to-.*-nodeport' \
             --test '!no-policies/pod-to-service' \
             --external-target google.com \
-            --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4
+            --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4 \
+            --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
         # TODO: Remove `no-policies/pod-to-service` test exception (unreliable
         # on clustermesh) once https://github.com/cilium/cilium-cli/issues/600
         # is fixed.
@@ -401,6 +409,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}

--- a/.github/workflows/conformance-multicluster-v1.13.yaml
+++ b/.github/workflows/conformance-multicluster-v1.13.yaml
@@ -118,6 +118,7 @@ jobs:
   # This job is skipped when the workflow was triggered with the generic `/test`
   # trigger if the only modified files were under `test/` or `Documentation/`.
   installation-and-connectivity:
+    name: "Installation and Connectivity Test"
     needs: check_changes
     if: |
       (github.event_name == 'issue_comment' && (
@@ -128,6 +129,8 @@ jobs:
       github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      job_name: "Installation and Connectivity Test"
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -350,6 +353,10 @@ jobs:
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
+      - name: Make JUnit report directory
+        run: |
+          mkdir -p cilium-junits
+
       - name: Run connectivity test
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
@@ -359,7 +366,8 @@ jobs:
             --test '!/pod-to-.*-nodeport' \
             --test '!no-policies/pod-to-service' \
             --external-target google.com \
-            --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4
+            --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4 \
+            --junit-file "cilium-junits/${{ env.job_name }} - 1.xml" --junit-property github_job_step="Run connectivity test"
         # TODO: Remove `no-policies/pod-to-service` test exception (unreliable
         # on clustermesh) once https://github.com/cilium/cilium-cli/issues/600
         # is fixed.
@@ -387,7 +395,8 @@ jobs:
             --test '!client-egress-l7,!echo-ingress-l7,!to-fqdns,!dns-only' \
             --test '!no-policies/pod-to-service' \
             --external-target google.com \
-            --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4
+            --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4 \
+            --junit-file "cilium-junits/${{ env.job_name }} - 2.xml" --junit-property github_job_step="Run connectivity test with WireGuard"
         # TODO: Once WireGuard supports the L7 proxy, the L7 tests can be
         # included here. See cilium/cilium#15462
         # TODO: Remove `no-policies/pod-to-service` test exception (unreliable
@@ -430,6 +439,20 @@ jobs:
           name: cilium-sysdumps
           path: cilium-sysdump-*.zip
           retention-days: 5
+
+      - name: Upload JUnits
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
 
       - name: Set commit status to success
         if: ${{ success() }}


### PR DESCRIPTION
This PR adds the generation and uploading of `connectivity test` Junit reports.
In order the distinguish Junit reports in CI reporting two metadata items are added to the reports.

`workflow` shows the workflow it was run on, and `type` indicates the configuration of the `cilium` installation.

Workflows run results:
:white_check_mark: [conformance-aks-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5157044551)
:white_check_mark: [conformance-aks-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5157044513)
:x: [conformance-aws-cni-v1.11.yaml](https://github.com/cilium/cilium/actions/runs/5157044528) Cilium installation failed, not related to these changes
:x: [conformance-aws-cni-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5157044538) Cilium installation failed, not related to these changes
:white_check_mark: [conformance-aws-cni-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5157044520)
:white_check_mark: [conformance-aws-cni.yaml](https://github.com/cilium/cilium/actions/runs/5157044511)
:white_check_mark: [conformance-clustermesh-v1.11.yaml](https://github.com/cilium/cilium/actions/runs/5157044544)
:x: [conformance-clustermesh-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5157044553) One of the connectivity tests failed. It shows the failure correctly in the summary.
:white_check_mark: [conformance-clustermesh-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5157044525)
:white_check_mark: [conformance-clustermesh.yaml](https://github.com/cilium/cilium/actions/runs/5157044523)
:white_check_mark: [conformance-e2e-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5157044518)
:x: [conformance-e2e.yaml](https://github.com/cilium/cilium/actions/runs/5157044546) One of the connectivity tests failed. It shows the failure correctly in the summary.
:white_check_mark: [conformance-eks-v1.11.yaml](https://github.com/cilium/cilium/actions/runs/5157044522)
:x: [conformance-eks-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5157044543) Test exceeded the run time, so it is canceled. No reports were generated.
:white_check_mark: [conformance-eks-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5157044554)
:white_check_mark: [conformance-eks.yaml](https://github.com/cilium/cilium/actions/runs/5157044529)
:white_check_mark: [conformance-externalworkloads-v1.11.yaml](https://github.com/cilium/cilium/actions/runs/5157044527)
:white_check_mark: [conformance-externalworkloads-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5157044539)
:white_check_mark: [conformance-externalworkloads-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5157044532)
:white_check_mark: [conformance-externalworkloads.yaml](https://github.com/cilium/cilium/actions/runs/5157044550)
:white_check_mark: [conformance-gke-v1.11.yaml](https://github.com/cilium/cilium/actions/runs/5157044552)
:white_check_mark: [conformance-gke-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5157044556)
:white_check_mark: [conformance-gke-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5157044542)
:white_check_mark: [conformance-gke.yaml](https://github.com/cilium/cilium/actions/runs/5157044537)
:white_check_mark: [conformance-kind-proxy-daemonset.yaml](https://github.com/cilium/cilium/actions/runs/5157044555)
:white_check_mark: [conformance-multicluster-v1.11.yaml](https://github.com/cilium/cilium/actions/runs/5157044531)
:white_check_mark: [conformance-multicluster-v1.12.yaml](https://github.com/cilium/cilium/actions/runs/5157044530)
:white_check_mark: [conformance-multicluster-v1.13.yaml](https://github.com/cilium/cilium/actions/runs/5157044524)
