### PR TITLE
daemon: Reject BPF Host Routing without KPR=strict

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -394,6 +394,9 @@ func finishKubeProxyReplacementInit() error {
 		// Non-BPF masquerade requires netfilter and hence CT.
 		case option.Config.IptablesMasqueradingEnabled():
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
+		// KPR=strict is needed or we might rely on netfilter.
+		case option.Config.KubeProxyReplacement != option.KubeProxyReplacementStrict:
+			msg = fmt.Sprintf("BPF host routing requires %s=%s.", option.KubeProxyReplacement, option.KubeProxyReplacementStrict)
 		// All cases below still need to be implemented ...
 		case option.Config.EnableEndpointRoutes && option.Config.EnableIPv6:
 			msg = fmt.Sprintf("BPF host routing is currently not supported with %s when IPv6 is enabled.", option.EnableEndpointRoutes)


### PR DESCRIPTION
It's currently possible to enable BPF Host Routing with KPR=partial if masquerading is disabled. If masquerading is enabled, then we will require it to be BPF masquerading, which itself requires KPR. But if masquerading is disabled, then we currently don't have a check that prevents KPR=partial from being enabled at the same time as BPF Host Routing.

```release-note
Reject incorrect configuration enable-host-legacy-routing=false kube-proxy-replacement=partial.
```