### PR TITLE
Increase the max wait time for EndpointCreate API requests

### DIFF
--- a/daemon/cmd/api_limits.go
+++ b/daemon/cmd/api_limits.go
@@ -25,8 +25,9 @@ var apiRateLimitDefaults = map[string]rate.APILimiterParameters{
 		RateLimit:                   0.5,
 		RateBurst:                   4,
 		ParallelRequests:            4,
+		MinParallelRequests:         2,
 		SkipInitial:                 4,
-		MaxWaitDuration:             15 * time.Second,
+		MaxWaitDuration:             60 * time.Second, // Kubelet has a PodSandbox creation timeout of 4 minutes, in total.
 		Log:                         false,
 	},
 	// DELETE /endpoint/{id}


### PR DESCRIPTION
In the event that a node has a burst of PodSanboxCreate requests, API requests will pile up. However, we should wait longer for the queue to clear before short-circuting and returing failure.

This is because the kubelet has a relatively relaxed timeout for PodSandbox creation -- 4 minutes. Furthermore, if we return a failure here, it is propagated all the way back through containerd to kubelet, which will tear down the entire PodSandbox and try again, which can be expensive.

So, increase the maximum queue duration time to 1 minute. That should hopefully give enough time for the queue to clear.

Fixes: #24361

```release-note
Cilium now waits longer before returning a failure in the event of a pod creation burst.
```
