### PR TITLE
renovate: do not update 'github.com/mdlayher/arp'

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -125,6 +125,8 @@
         // want to update them automatically.
         "go.universe.tf/metallb",
         "github.com/cilium/metallb",
+        // metallb is still using an old version of "github.com/mdlayher/arp"
+        "github.com/mdlayher/arp",
         "github.com/miekg/dns",
         "github.com/cilium/dns",
         "sigs.k8s.io/controller-tools",


### PR DESCRIPTION
We are still using an old version of this dependency in github.com/cilium/metallb so we should avoid updating it in the meanwhile.

It will fix PR https://github.com/cilium/cilium/pull/25539