### PR TITLE
Makefile: use CLI options to set local images for kind-install-cilium-clustermesh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -463,6 +463,8 @@ kind-install-cilium-clustermesh: kind-clustermesh-ready ## Install a local Ciliu
 	$(CILIUM_CLI) install \
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
 		--helm-values=$(ROOT_DIR)/contrib/testing/kind-clustermesh1.yaml \
+		--agent-image=$(LOCAL_AGENT_IMAGE) \
+		--operator-image=$(LOCAL_OPERATOR_IMAGE) \
 		--version=
 	@echo "  INSTALL cilium on clustermesh2 cluster"
 	kubectl config use kind-clustermesh2
@@ -471,6 +473,8 @@ kind-install-cilium-clustermesh: kind-clustermesh-ready ## Install a local Ciliu
 		--inherit-ca kind-clustermesh1 \
 		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
 		--helm-values=$(ROOT_DIR)/contrib/testing/kind-clustermesh2.yaml \
+		--agent-image=$(LOCAL_AGENT_IMAGE) \
+		--operator-image=$(LOCAL_OPERATOR_IMAGE) \
 		--version=
 	@echo "  Enabling clustermesh"
 	$(CILIUM_CLI) clustermesh enable --context kind-clustermesh1 --service-type NodePort --apiserver-image $(LOCAL_CLUSTERMESH_IMAGE)

--- a/contrib/testing/kind-clustermesh1.yaml
+++ b/contrib/testing/kind-clustermesh1.yaml
@@ -4,13 +4,10 @@ cluster:
 debug:
   enabled: true
 image:
-  override: "localhost:5000/cilium/cilium-dev:local"
   pullPolicy: Never
 operator:
   image:
-    override: "localhost:5000/cilium/operator-generic:local"
     pullPolicy: Never
-    suffix: ""
 ipam:
   mode: kubernetes
 ipv6:

--- a/contrib/testing/kind-clustermesh2.yaml
+++ b/contrib/testing/kind-clustermesh2.yaml
@@ -4,13 +4,10 @@ cluster:
 debug:
   enabled: true
 image:
-  override: "localhost:5000/cilium/cilium-dev:local"
   pullPolicy: Never
 operator:
   image:
-    override: "localhost:5000/cilium/operator-generic:local"
     pullPolicy: Never
-    suffix: ""
 ipam:
   mode: kubernetes
 ipv6:


### PR DESCRIPTION
Makefile: use CLI options to set local images for kind-install-cilium-clustermesh

`make-kind-clustermesh-images` uses `KIND_ENV` to set image repositories for local images to be pushed to kind clusters, however these are not actually used when installing Cilium on the kind clusters in `kind-install-cilium-clustermesh`.

The hardcoded image overrides have been removed from the helm values for these clusters and replaced with CLI flags to specify using the local images for Agent and Operator.

Fixes: #issue-number

```release-note
Makefile: use CLI options to set local images for kind-install-cilium-clustermesh
```
