### PR TITLE
ci-e2e: Add DSR Geneve dispatch test cases

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -234,12 +234,22 @@ jobs:
 
           - name: '8'
             kernel: 'bpf-next-20230420.212204'
+            kube-proxy: 'none'
+            kpr: 'strict'
+            tunnel: 'disabled'
+            lb-mode: 'dsr'
+            lb-dsr-dispatch: 'geneve'
+            egress-gateway: 'true'
+            lb-acceleration: 'testing-only'
+
+          - name: '9'
+            kernel: 'bpf-next-20230420.212204'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'geneve'
             endpoint-routes: 'true'
 
-          - name: '9'
+          - name: '10'
             kernel: '4.19-20230420.212204'
             kube-proxy: 'iptables'
             kpr: 'disabled'
@@ -247,7 +257,7 @@ jobs:
             encryption: 'ipsec'
             encryption-node: 'false'
 
-          - name: '10'
+          - name: '11'
             kernel: '5.4-20230420.212204'
             kube-proxy: 'iptables'
             kpr: 'disabled'
@@ -255,7 +265,7 @@ jobs:
             encryption: 'ipsec'
             encryption-node: 'false'
 
-          - name: '11'
+          - name: '12'
             kernel: '5.10-20230420.212204'
             kube-proxy: 'iptables'
             kpr: 'disabled'
@@ -264,7 +274,7 @@ jobs:
             encryption-node: 'false'
             endpoint-routes: 'true'
 
-          - name: '12'
+          - name: '13'
             kernel: '5.10-20230420.212204'
             kube-proxy: 'iptables'
             kpr: 'strict'
@@ -275,7 +285,7 @@ jobs:
             endpoint-routes: 'true'
             egress-gateway: 'true'
 
-          - name: '13'
+          - name: '14'
             kernel: '5.15-20230420.212204'
             kube-proxy: 'iptables'
             kpr: 'strict'
@@ -286,7 +296,7 @@ jobs:
             endpoint-routes: 'true'
             egress-gateway: 'true'
 
-          - name: '14'
+          - name: '15'
             kernel: '6.0-20230420.212204'
             kube-proxy: 'none'
             kpr: 'strict'
@@ -296,7 +306,7 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
 
-          - name: '15'
+          - name: '16'
             kernel: 'bpf-next-20230420.212204'
             kube-proxy: 'none'
             kpr: 'strict'
@@ -306,7 +316,18 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
 
-          - name: '16'
+          - name: '17'
+            kernel: 'bpf-next-20230420.212204'
+            kube-proxy: 'none'
+            kpr: 'strict'
+            tunnel: 'geneve'
+            encryption: 'wireguard'
+            encryption-node: 'false'
+            lb-mode: 'dsr'
+            lb-dsr-dispatch: 'geneve'
+            egress-gateway: 'true'
+
+          - name: '18'
             kernel: 'bpf-next-20230420.212204'
             kube-proxy: 'iptables'
             kpr: 'disabled'
@@ -353,6 +374,10 @@ jobs:
           if [ "${{ matrix.lb-mode }}" != "" ]; then
             LB_MODE="--helm-set-string=loadBalancer.mode=${{ matrix.lb-mode }}"
           fi
+          LB_DSR_DISPATCH=""
+          if [ "${{ matrix.lb-dsr-dispatch }}" != "" ]; then
+            LB_DSR_DISPATCH="--helm-set-string=loadBalancer.dsrDispatch=${{ matrix.lb-dsr-dispatch }}"
+          fi
           ENDPOINT_ROUTES=""
           if [ "${{ matrix.endpoint-routes }}" == "true" ]; then
             ENDPOINT_ROUTES="--helm-set-string=endpointRoutes.enabled=true"
@@ -389,7 +414,7 @@ jobs:
             HOST_FW="--helm-set=hostFirewall.enabled=true"
           fi
 
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${LB_DSR_DISPATCH} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
 
       - name: Checkout pull request for Helm chart


### PR DESCRIPTION
This commit adds two test cases for DSR Geneve dispatch (lb-mode: 'dsr', lb-dsr-dispatch: 'geneve')

- kernel: bpf-next, kpr: strict, tunnel: disable, lb-acceleration: testing-only, egress-gateway: true
- kernel: bpf-next, kpr: strict, tunnel: geneve,  lb-acceleration: disabled, encryption: wireguard, egress-gateway: true

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!