### PR TITLE
etcd: extend rate limiting to consider the number of inflight requests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -469,6 +469,7 @@ jenkinsfiles @cilium/ci-structure
 /pkg/promise @cilium/sig-foundations
 /pkg/proxy/ @cilium/proxy
 /pkg/proxy/accesslog @cilium/api
+/pkg/rate/metrics @cilium/metrics
 /pkg/recorder @cilium/sig-datapath
 /pkg/redirectpolicy @cilium/sig-lb
 /pkg/safeio @cilium/sig-agent

--- a/clustermesh-apiserver/metrics/metrics.go
+++ b/clustermesh-apiserver/metrics/metrics.go
@@ -73,6 +73,11 @@ func (mm *metricsManager) Start(hive.HookContext) error {
 		metrics.KVStoreQuorumErrors,
 		metrics.KVStoreSyncQueueSize,
 		metrics.KVStoreInitialSyncCompleted,
+		metrics.APILimiterProcessingDuration,
+		metrics.APILimiterWaitDuration,
+		metrics.APILimiterRequestsInFlight,
+		metrics.APILimiterRateLimit,
+		metrics.APILimiterAdjustmentFactor,
 	)
 
 	mux := http.NewServeMux()

--- a/daemon/cmd/api_limits.go
+++ b/daemon/cmd/api_limits.go
@@ -6,7 +6,6 @@ package cmd
 import (
 	"time"
 
-	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/rate"
 )
 
@@ -93,26 +92,4 @@ var apiRateLimitDefaults = map[string]rate.APILimiterParameters{
 		ParallelRequests:            2,
 		MinParallelRequests:         2,
 	},
-}
-
-type apiRateLimitingMetrics struct{}
-
-func (a *apiRateLimitingMetrics) ProcessedRequest(name string, v rate.MetricsValues) {
-	metrics.APILimiterProcessingDuration.WithLabelValues(name, "mean").Set(v.MeanProcessingDuration)
-	metrics.APILimiterProcessingDuration.WithLabelValues(name, "estimated").Set(v.EstimatedProcessingDuration)
-	metrics.APILimiterWaitDuration.WithLabelValues(name, "mean").Set(v.MeanWaitDuration)
-	metrics.APILimiterWaitDuration.WithLabelValues(name, "max").Set(v.MaxWaitDuration.Seconds())
-	metrics.APILimiterWaitDuration.WithLabelValues(name, "min").Set(v.MinWaitDuration.Seconds())
-	metrics.APILimiterRequestsInFlight.WithLabelValues(name, "in-flight").Set(float64(v.CurrentRequestsInFlight))
-	metrics.APILimiterRequestsInFlight.WithLabelValues(name, "limit").Set(float64(v.ParallelRequests))
-	metrics.APILimiterRateLimit.WithLabelValues(name, "limit").Set(float64(v.Limit))
-	metrics.APILimiterRateLimit.WithLabelValues(name, "burst").Set(float64(v.Burst))
-	metrics.APILimiterAdjustmentFactor.WithLabelValues(name).Set(v.AdjustmentFactor)
-
-	if v.Outcome == "" {
-		metrics.APILimiterWaitHistoryDuration.WithLabelValues(name).Observe(v.WaitDuration.Seconds())
-		v.Outcome = metrics.Error2Outcome(v.Error)
-	}
-
-	metrics.APILimiterProcessedRequests.WithLabelValues(name, v.Outcome).Inc()
 }

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -85,6 +85,7 @@ import (
 	policyAPI "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
+	ratemetrics "github.com/cilium/cilium/pkg/rate/metrics"
 	"github.com/cilium/cilium/pkg/recorder"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
@@ -418,7 +419,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		log.WithField("mtu", configuredMTU).Info("Overwriting MTU based on CNI configuration")
 	}
 
-	apiLimiterSet, err := rate.NewAPILimiterSet(option.Config.APIRateLimit, apiRateLimitDefaults, &apiRateLimitingMetrics{})
+	apiLimiterSet, err := rate.NewAPILimiterSet(option.Config.APIRateLimit, apiRateLimitDefaults, ratemetrics.APILimiterObserver())
 	if err != nil {
 		log.WithError(err).Error("unable to configure API rate limiting")
 		return nil, nil, fmt.Errorf("unable to configure API rate limiting: %w", err)

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -300,7 +300,7 @@ func (rc *remoteCluster) makeEtcdOpts() map[string]string {
 
 	for key, value := range option.Config.KVStoreOpt {
 		switch key {
-		case kvstore.EtcdRateLimitOption, kvstore.EtcdListLimitOption,
+		case kvstore.EtcdRateLimitOption, kvstore.EtcdMaxInflightOption, kvstore.EtcdListLimitOption,
 			kvstore.EtcdOptionKeepAliveHeartbeat, kvstore.EtcdOptionKeepAliveTimeout:
 			opts[key] = value
 		}

--- a/pkg/rate/metrics/metrics.go
+++ b/pkg/rate/metrics/metrics.go
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/rate"
+)
+
+func APILimiterObserver() rate.MetricsObserver {
+	return &apiRateLimitingMetrics{}
+}
+
+type apiRateLimitingMetrics struct{}
+
+func (a *apiRateLimitingMetrics) ProcessedRequest(name string, v rate.MetricsValues) {
+	metrics.APILimiterProcessingDuration.WithLabelValues(name, "mean").Set(v.MeanProcessingDuration)
+	metrics.APILimiterProcessingDuration.WithLabelValues(name, "estimated").Set(v.EstimatedProcessingDuration)
+	metrics.APILimiterWaitDuration.WithLabelValues(name, "mean").Set(v.MeanWaitDuration)
+	metrics.APILimiterWaitDuration.WithLabelValues(name, "max").Set(v.MaxWaitDuration.Seconds())
+	metrics.APILimiterWaitDuration.WithLabelValues(name, "min").Set(v.MinWaitDuration.Seconds())
+	metrics.APILimiterRequestsInFlight.WithLabelValues(name, "in-flight").Set(float64(v.CurrentRequestsInFlight))
+	metrics.APILimiterRequestsInFlight.WithLabelValues(name, "limit").Set(float64(v.ParallelRequests))
+	metrics.APILimiterRateLimit.WithLabelValues(name, "limit").Set(float64(v.Limit))
+	metrics.APILimiterRateLimit.WithLabelValues(name, "burst").Set(float64(v.Burst))
+	metrics.APILimiterAdjustmentFactor.WithLabelValues(name).Set(v.AdjustmentFactor)
+
+	if v.Outcome == "" {
+		metrics.APILimiterWaitHistoryDuration.WithLabelValues(name).Observe(v.WaitDuration.Seconds())
+		v.Outcome = metrics.Error2Outcome(v.Error)
+	}
+
+	metrics.APILimiterProcessedRequests.WithLabelValues(name, v.Outcome).Inc()
+}


### PR DESCRIPTION
Reporting the description of the last commit for convenience:

```
Currently, the etcd rate limiter operates based on a token bucket of a
fixed size. Yet, this is problematic when etcd is overloaded, since we
may continue to issue new requests even if it cannot keep up. Hence,
let's start using the custom APILimiter, which also takes into account
the number of currently inflight requests. The maximum amount of
inflight requests can configured through the etcd.maxInflight parameter,
and defaults to the same value as etcd.qps if unset.
```

<!-- Description of change -->

```release-note
etcd: extend rate limiting to consider the number of inflight requests
```
