### PR TITLE
bpf: nodeport: reduce CT lookup scope

### DIFF
--- a/bpf/lib/dbg.h
+++ b/bpf/lib/dbg.h
@@ -60,7 +60,7 @@ enum {
 				 */
 	DBG_CT_LOOKUP4_2,       /* arg1: (nexthdr << 8) | flags
 				 * arg2: direction
-				 * arg3: unused
+				 * arg3: scope
 				 */
 	DBG_CT_CREATED4,        /* arg1: (unused << 16) | rev_nat_index
 				 * arg2: src sec-id
@@ -72,7 +72,7 @@ enum {
 				 */
 	DBG_CT_LOOKUP6_2,       /* arg1: (nexthdr << 8) | flags
 				 * arg2: direction
-				 * arg3: unused
+				 * arg3: scope
 				 */
 	DBG_CT_CREATED6,        /* arg1: (unused << 16) | rev_nat_index
 				 * arg2: src sec-id

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -854,7 +854,8 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		return DROP_NO_SERVICE;
 
 	/* See lb4_local comments re svc endpoint lookup process */
-	ret = ct_lazy_lookup6(map, tuple, ctx, l4_off, ACTION_CREATE, CT_SERVICE, state, &monitor);
+	ret = ct_lazy_lookup6(map, tuple, ctx, l4_off, ACTION_CREATE, CT_SERVICE,
+			      SCOPE_REVERSE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY
@@ -1531,7 +1532,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		return DROP_NO_SERVICE;
 
 	ret = ct_lazy_lookup4(map, tuple, ctx, l4_off, has_l4_header, ACTION_CREATE,
-			      CT_SERVICE, state, &monitor);
+			      CT_SERVICE, SCOPE_REVERSE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -350,7 +350,7 @@ static __always_inline int snat_v4_track_connection(struct __ctx_buff *ctx,
 	ipv4_ct_tuple_swap_ports(&tmp);
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tmp), &tmp, ctx, off, has_l4_header,
-			      ct_action, where, &ct_state, &monitor);
+			      ct_action, where, SCOPE_BIDIR, &ct_state, &monitor);
 	if (ret < 0) {
 		return ret;
 	} else if (ret == CT_NEW) {
@@ -1479,7 +1479,7 @@ static __always_inline int snat_v6_track_connection(struct __ctx_buff *ctx,
 	ipv6_ct_tuple_swap_ports(&tmp);
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tmp), &tmp, ctx, off, ct_action,
-			      where, &ct_state, &monitor);
+			      where, SCOPE_BIDIR, &ct_state, &monitor);
 	if (ret < 0) {
 		return ret;
 	} else if (ret == CT_NEW) {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1153,7 +1153,7 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 		return CTX_ACT_OK;
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
-			      CT_INGRESS, SCOPE_BIDIR, &ct_state, &trace->monitor);
+			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -1216,7 +1216,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __s8 *ext_er
 		goto out;
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
-			      CT_INGRESS, SCOPE_BIDIR, &ct_state, &monitor);
+			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index,
 				  &tuple, REV_NAT_F_TUPLE_SADDR);
@@ -2428,7 +2428,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 		return CTX_ACT_OK;
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      ACTION_CREATE, CT_INGRESS, SCOPE_BIDIR, &ct_state,
+			      ACTION_CREATE, CT_INGRESS, SCOPE_REVERSE, &ct_state,
 			      &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
@@ -2527,7 +2527,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 		goto out;
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      ACTION_CREATE, CT_INGRESS, SCOPE_BIDIR, &ct_state, &monitor);
+			      ACTION_CREATE, CT_INGRESS, SCOPE_REVERSE, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		reason = TRACE_REASON_CT_REPLY;
 		ret = lb4_rev_nat(ctx, l3_off, l4_off, &ct_state, &tuple,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -680,7 +680,7 @@ int tail_nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx)
 	}
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
-			      CT_EGRESS, &ct_state, &monitor);
+			      CT_EGRESS, SCOPE_BIDIR, &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	case CT_REOPENED:
@@ -1061,7 +1061,7 @@ skip_service_lookup:
 		struct ct_state ct_state = {};
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
-				      CT_EGRESS, &ct_state, &monitor);
+				      CT_EGRESS, SCOPE_BIDIR, &ct_state, &monitor);
 		switch (ret) {
 		case CT_REPLY:
 			ipv6_ct_tuple_reverse(&tuple);
@@ -1153,7 +1153,7 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 		return CTX_ACT_OK;
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
-			      CT_INGRESS, &ct_state, &trace->monitor);
+			      CT_INGRESS, SCOPE_BIDIR, &ct_state, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -1216,7 +1216,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __s8 *ext_er
 		goto out;
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
-			      CT_INGRESS, &ct_state, &monitor);
+			      CT_INGRESS, SCOPE_BIDIR, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index,
 				  &tuple, REV_NAT_F_TUPLE_SADDR);
@@ -1972,7 +1972,8 @@ int tail_nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx)
 	}
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-			      has_l4_header, ACTION_CREATE, CT_EGRESS, &ct_state, &monitor);
+			      has_l4_header, ACTION_CREATE, CT_EGRESS, SCOPE_BIDIR,
+			      &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	/* Maybe we can be a bit more selective about CT_REOPENED?
@@ -2338,7 +2339,8 @@ skip_service_lookup:
 		struct ct_state ct_state = {};
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-				      ACTION_CREATE, CT_EGRESS, &ct_state, &monitor);
+				      ACTION_CREATE, CT_EGRESS, SCOPE_BIDIR,
+				      &ct_state, &monitor);
 		switch (ret) {
 		case CT_REPLY:
 			/* SVC request should never be considered a reply, so this
@@ -2426,7 +2428,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 		return CTX_ACT_OK;
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      ACTION_CREATE, CT_INGRESS, &ct_state, &trace->monitor);
+			      ACTION_CREATE, CT_INGRESS, SCOPE_BIDIR, &ct_state,
+			      &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -2524,7 +2527,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 		goto out;
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      ACTION_CREATE, CT_INGRESS, &ct_state, &monitor);
+			      ACTION_CREATE, CT_INGRESS, SCOPE_BIDIR, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		reason = TRACE_REASON_CT_REPLY;
 		ret = lb4_rev_nat(ctx, l3_off, l4_off, &ct_state, &tuple,

--- a/bpf/tests/nat_test.c
+++ b/bpf/tests/nat_test.c
@@ -62,6 +62,7 @@ static __always_inline int mock_ct_lazy_lookup4(__maybe_unused const void *map,
 						__maybe_unused bool has_l4_header,
 						__maybe_unused int action,
 						__maybe_unused enum ct_dir dir,
+						__maybe_unused enum ct_scope scope,
 						__maybe_unused struct ct_state *ct_state,
 						__maybe_unused __u32 *monitor)
 {


### PR DESCRIPTION
The standard behaviour for a CT lookup is that we first check whether the packet is a **reply** for some tracked connection. If that doesn't return a match, we do an additional lookup for the packet's actual direction (which might either find a match, or return `CT_NEW`). The exception is when we look for entries of type `CT_SERVICE` - here we already avoid the second lookup.

But we have some additional code paths that would benefit from excluding the second lookup
- nodeport RevDNAT only wants to handle a `CT_REPLY` lookup result (as it only  wants to reverse-translate the replies for nodeport connections). This PR converts those users.
- the inbound nodeport code only cares about the forward direction, but currently needs to tolerate results from the reverse direction (treating them as stale CT entries that need to be re-created). All of this can go away if we switch to `SCOPE_FORWARD`.
- the SNAT and RevSNAT paths should only care about their respective direction (I'll convert those in a follow-on, they need a bit more cleanup before).
 
Make the needed changes so that we can avoid the second lookup. This reduces code size / complexity, and offers more robust behaviour (as we no longer have to consider "impossible" CT results).