### PR TITLE
bgpv1: Reset BGP session in UpdateNeighbor if necessary

### DIFF
--- a/pkg/bgpv1/gobgp/state_test.go
+++ b/pkg/bgpv1/gobgp/state_test.go
@@ -35,8 +35,8 @@ var (
 		PeerASN:          64125,
 		PeerAddress:      "192.168.0.1/32",
 		ConnectRetryTime: metav1.Duration{Duration: 101 * time.Second},
-		HoldTime:         metav1.Duration{Duration: 30 * time.Second},
-		KeepAliveTime:    metav1.Duration{Duration: 10 * time.Second},
+		HoldTime:         metav1.Duration{Duration: 9 * time.Second},
+		KeepAliveTime:    metav1.Duration{Duration: 3 * time.Second},
 	}
 
 	// enabled graceful restart

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -18,6 +18,12 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	// maxNeighborTestDuration is allowed time for the Neighbor tests execution
+	// (on average we need about 20 - 25s to finish the tests due to BGP timers etc.)
+	maxNeighborTestDuration = 40 * time.Second
+)
+
 // peeringState helper struct containing peering information of BGP neighbor
 type peeringState struct {
 	peerASN         uint32
@@ -44,7 +50,7 @@ func Test_NeighborAddDel(t *testing.T) {
 				{
 					PeerAddress: dummies[instance1Link].ipv4.String(),
 					PeerASN:     int(gobgpASN),
-					HoldTime:    meta_v1.Duration{Duration: 3 * time.Second}, // must be lower than default (90s) to be applied on the peer
+					HoldTime:    meta_v1.Duration{Duration: 9 * time.Second}, // must be lower than default (90s) to be applied on the peer
 				},
 				{
 					PeerAddress: dummies[instance2Link].ipv4.String(),
@@ -58,13 +64,43 @@ func Test_NeighborAddDel(t *testing.T) {
 					peerASN:         gobgpASN,
 					peerAddr:        dummies[instance1Link].ipv4.Addr().String(),
 					peerSession:     types.SessionEstablished.String(),
-					holdTimeSeconds: 3,
+					holdTimeSeconds: 9,
 				},
 				{
 					peerASN:         gobgpASN2,
 					peerAddr:        dummies[instance2Link].ipv4.Addr().String(),
 					peerSession:     types.SessionEstablished.String(),
 					holdTimeSeconds: 6,
+				},
+			},
+		},
+		{
+			description: "update both neighbors",
+			neighbors: []cilium_api_v2alpha1.CiliumBGPNeighbor{
+				{
+					PeerAddress: dummies[instance1Link].ipv4.String(),
+					PeerASN:     int(gobgpASN),
+					HoldTime:    meta_v1.Duration{Duration: 6 * time.Second}, // updated, must be lower than the previous value to be applied on the peer
+				},
+				{
+					PeerAddress: dummies[instance2Link].ipv4.String(),
+					PeerASN:     int(gobgpASN2),
+					HoldTime:    meta_v1.Duration{Duration: 3 * time.Second}, // updated, must be lower than the previous value to be applied on the peer
+				},
+			},
+			waitState: []string{"ESTABLISHED"},
+			expectedPeerStates: []peeringState{
+				{
+					peerASN:         gobgpASN,
+					peerAddr:        dummies[instance1Link].ipv4.Addr().String(),
+					peerSession:     types.SessionEstablished.String(),
+					holdTimeSeconds: 6,
+				},
+				{
+					peerASN:         gobgpASN2,
+					peerAddr:        dummies[instance2Link].ipv4.Addr().String(),
+					peerSession:     types.SessionEstablished.String(),
+					holdTimeSeconds: 3,
 				},
 			},
 		},
@@ -76,7 +112,7 @@ func Test_NeighborAddDel(t *testing.T) {
 		},
 	}
 
-	testCtx, testDone := context.WithTimeout(context.Background(), maxTestDuration)
+	testCtx, testDone := context.WithTimeout(context.Background(), maxNeighborTestDuration)
 	defer testDone()
 
 	// test setup, we configure two gobgp instances here.

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -154,7 +154,8 @@ spec:
                             description: HoldTime defines the initial value for the
                               BGP HoldTimer (RFC 4271, Section 4.2). The default value
                               for the HoldTime (if empty or zero) is 90 seconds. Rounded
-                              internally to the nearest whole second.
+                              internally to the nearest whole second. Updating this
+                              value will cause a session reset.
                             format: duration
                             type: string
                           keepAliveTime:
@@ -162,7 +163,7 @@ spec:
                               the BGP KeepaliveTimer (RFC 4271, Section 8). The default
                               value for the KeepaliveTime (if empty or zero) is 1/3
                               of the HoldTime. Rounded internally to the nearest whole
-                              second.
+                              second. Updating this value will cause a session reset.
                             format: duration
                             type: string
                           peerASN:

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -106,14 +106,14 @@ type CiliumBGPNeighbor struct {
 	ConnectRetryTime metav1.Duration `json:"connectRetryTime,omitempty"`
 	// HoldTime defines the initial value for the BGP HoldTimer (RFC 4271, Section 4.2).
 	// The default value for the HoldTime (if empty or zero) is 90 seconds.
-	// Rounded internally to the nearest whole second.
+	// Rounded internally to the nearest whole second. Updating this value will cause a session reset.
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Format=duration
 	HoldTime metav1.Duration `json:"holdTime,omitempty"`
 	// KeepaliveTime defines the initial value for the BGP KeepaliveTimer (RFC 4271, Section 8).
 	// The default value for the KeepaliveTime (if empty or zero) is 1/3 of the HoldTime.
-	// Rounded internally to the nearest whole second.
+	// Rounded internally to the nearest whole second. Updating this value will cause a session reset.
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Format=duration


### PR DESCRIPTION
As Cilium's user-facing API based on CRDs is intent-based, this PR ensures that updated BGP peer configuration is always applied also on existing BGP sessions immediately, even if it requires a session reset. If the underlying BGP implementation (GoBGP at the moment) does not reset the session for particular configuration items automatically, we enforce the session reset explicitly.

For example, changing `HoldTime` for a peer will cause the following `NOTIFICATION` message:

![image](https://github.com/cilium/cilium/assets/15926980/154b6182-5437-44e1-ae1a-3f7d90b67217)

Followed by a session re-establishment and the new timer interval exchanged in the `OPEN` message:

![image](https://github.com/cilium/cilium/assets/15926980/bc2a5cb2-5e88-4740-a328-0c0c221d01b6)
