### PR TITLE
tests: replace more incorrect DeepEquals uses

### DIFF
--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -40,7 +41,7 @@ func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
 	})
 
 	c.Assert(ep.visibilityPolicy, check.Not(check.Equals), nil)
-	c.Assert(ep.visibilityPolicy.Ingress["80/TCP"], check.DeepEquals, &policy.VisibilityMetadata{
+	c.Assert(ep.visibilityPolicy.Ingress["80/TCP"], checker.DeepEquals, &policy.VisibilityMetadata{
 		Parser:  policy.ParserTypeHTTP,
 		Port:    uint16(80),
 		Proto:   u8proto.TCP,

--- a/pkg/k8s/service_test.go
+++ b/pkg/k8s/service_test.go
@@ -1007,7 +1007,7 @@ func (s *K8sSuite) TestNewClusterService(c *check.C) {
 	})
 
 	clusterService := NewClusterService(id, svc, endpoints)
-	c.Assert(clusterService, check.DeepEquals, serviceStore.ClusterService{
+	c.Assert(clusterService, checker.DeepEquals, serviceStore.ClusterService{
 		Name:      "foo",
 		Namespace: "bar",
 		Labels:    map[string]string{"foo": "bar"},

--- a/pkg/policy/visibility_test.go
+++ b/pkg/policy/visibility_test.go
@@ -40,7 +40,7 @@ func (ds *PolicyTestSuite) TestVisibilityPolicyCreation(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(len(vp.Ingress), Equals, 1)
-	c.Assert(vp.Ingress["80/TCP"], DeepEquals, &VisibilityMetadata{
+	c.Assert(vp.Ingress["80/TCP"], checker.DeepEquals, &VisibilityMetadata{
 		Proto:   u8proto.TCP,
 		Port:    uint16(80),
 		Parser:  ParserTypeHTTP,
@@ -53,13 +53,13 @@ func (ds *PolicyTestSuite) TestVisibilityPolicyCreation(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(len(vp.Ingress), Equals, 2)
-	c.Assert(vp.Ingress["80/TCP"], DeepEquals, &VisibilityMetadata{
+	c.Assert(vp.Ingress["80/TCP"], checker.DeepEquals, &VisibilityMetadata{
 		Proto:   u8proto.TCP,
 		Port:    uint16(80),
 		Parser:  ParserTypeHTTP,
 		Ingress: true,
 	})
-	c.Assert(vp.Ingress["8080/TCP"], DeepEquals, &VisibilityMetadata{
+	c.Assert(vp.Ingress["8080/TCP"], checker.DeepEquals, &VisibilityMetadata{
 		Proto:   u8proto.TCP,
 		Port:    uint16(8080),
 		Parser:  ParserTypeHTTP,
@@ -72,7 +72,7 @@ func (ds *PolicyTestSuite) TestVisibilityPolicyCreation(c *C) {
 	c.Assert(err, IsNil)
 
 	c.Assert(len(vp.Ingress), Equals, 1)
-	c.Assert(vp.Ingress["80/TCP"], DeepEquals, &VisibilityMetadata{
+	c.Assert(vp.Ingress["80/TCP"], checker.DeepEquals, &VisibilityMetadata{
 		Proto:   u8proto.TCP,
 		Port:    uint16(80),
 		Parser:  ParserTypeHTTP,


### PR DESCRIPTION
The current script used to locate the wrong DeepEquals is incapable of finding all instances. Fix the remaining.

I used the following rule with `go-ruleguard` to find these instances. But I'm not entirely confident in introducing it into the CI yet.
```go
func checkAssertDeepEquals(m dsl.Matcher) {
	m.Match(
		`c.Assert($*_, check.DeepEquals, $*_)`,
		`c.Assert($*_, DeepEquals, $*_)`,
	).Report(`Found tests which use DeepEquals checker imported from github.com/cilium/checkmate.
		Cilium implements its own DeepEquals checker which can be imported from:
		github.com/cilium/cilium/pkg/checker
		It gives a more detailed trace when the assertion fails.`)
}
```
