### PR TITLE
gha: use Cilium CLI Helm mode for conformance-clustermesh 

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -69,6 +69,7 @@ env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
   cilium_cli_version: v0.14.5
   cilium_cli_ci_version:
+  CILIUM_CLI_MODE: helm
   clusterName1: cluster1-${{ github.run_id }}
   clusterName2: cluster2-${{ github.run_id }}
   contextName1: kind-cluster1-${{ github.run_id }}
@@ -271,9 +272,15 @@ jobs:
           --helm-set=operator.image.tag=${SHA} \
           --helm-set=operator.image.useDigest=false \
           --helm-set=bpf.masquerade=false \
-          --config monitor-aggregation=none \
-          --rollback=false \
-          --version="
+          --helm-set=bpf.monitorAggregation=none \
+          --helm-set=hubble.enabled=true \
+          --helm-set=hubble.relay.enabled=true \
+          --helm-set=hubble.relay.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci:${SHA} \
+          --helm-set=hubble.relay.image.useDigest=false \
+          --helm-set=clustermesh.useAPIServer=true \
+          --helm-set=clustermesh.apiserver.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci:${SHA} \
+          --helm-set=clustermesh.apiserver.image.useDigest=false \
+          "
 
         CILIUM_INSTALL_TUNNEL="--helm-set=tunnel=vxlan"
         if [ "${{ matrix.tunnel }}" == "disabled" ]; then
@@ -310,11 +317,11 @@ jobs:
             ;;
         esac
 
-        HUBBLE_ENABLE_DEFAULTS="--chart-directory=install/kubernetes/cilium \
-          --helm-set=hubble.relay.image.override=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci:${SHA} \
-          --helm-set=hubble.relay.image.useDigest=false"
-        CLUSTERMESH_ENABLE_DEFAULTS="--apiserver-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
-          --apiserver-version=${SHA} --service-type=NodePort"
+        CILIUM_INSTALL_ENCRYPTION=""
+        if [ "${{ matrix.encryption }}" != "none" ]; then
+          CILIUM_INSTALL_ENCRYPTION="--helm-set=encryption.enabled=true \
+            --helm-set=encryption.type=${{ matrix.encryption }}"
+        fi
 
         CONNECTIVITY_TEST_DEFAULTS="--hubble=false \
           --flow-validation=disabled \
@@ -330,10 +337,9 @@ jobs:
             --test='!/pod-to-cidr'"
         fi
 
-        echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} ${CILIUM_INSTALL_IPFAMILY}" >> $GITHUB_OUTPUT
-        echo hubble_enable_defaults=${HUBBLE_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
+        echo cilium_install_defaults="${CILIUM_INSTALL_DEFAULTS} ${CILIUM_INSTALL_TUNNEL} \
+          ${CILIUM_INSTALL_IPFAMILY} ${CILIUM_INSTALL_ENCRYPTION}" >> $GITHUB_OUTPUT
         echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
-        echo clustermesh_enable_defaults=${CLUSTERMESH_ENABLE_DEFAULTS} >> $GITHUB_OUTPUT
 
         echo kind_pod_cidr_1=${KIND_POD_CIDR_1} >> $GITHUB_OUTPUT
         echo kind_svc_cidr_1=${KIND_SVC_CIDR_1} >> $GITHUB_OUTPUT
@@ -419,44 +425,37 @@ jobs:
         ref: ${{ needs.setup-report.outputs.sha }}
         persist-credentials: false
 
-    - name: Install Cilium in cluster1
-      run: |
-        # Using the deprecated flag --cluster-name due to cilium/cilium-cli#1347
-        # --helm-set cluster.name ${{ env.clusterName1 }}
-        cilium --context ${{ env.contextName1 }} install \
-          ${{ steps.vars.outputs.cilium_install_defaults }} \
-          --encryption ${{ matrix.encryption }} \
-          --cluster-name ${{ env.clusterName1 }} \
-          --helm-set cluster.id=1
-
-    - name: Copy the IPsec secret to cluster2, as they must match
+    - name: Create the IPSec secret in both clusters
       if: matrix.encryption == 'ipsec'
       run: |
-        kubectl --context ${{ env.contextName1 }} get secret -n kube-system cilium-ipsec-keys -o yaml |
+        SECRET="3 rfc4106(gcm(aes)) $(openssl rand -hex 20) 128"
+        kubectl --context ${{ env.contextName1 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
+        kubectl --context ${{ env.contextName2 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
+
+    - name: Install Cilium in cluster1
+      run: |
+        # Explicitly configure the NodePort to make sure that it is different in
+        # each cluster, to workaround #24692
+        cilium --context ${{ env.contextName1 }} install \
+          ${{ steps.vars.outputs.cilium_install_defaults }} \
+          --helm-set cluster.name=${{ env.clusterName1 }} \
+          --helm-set cluster.id=1 \
+          --helm-set clustermesh.apiserver.service.nodePort=32379
+
+    - name: Copy the Cilium CA secret to cluster2, as they must match
+      run: |
+        kubectl --context ${{ env.contextName1 }} get secret -n kube-system cilium-ca -o yaml |
           kubectl --context ${{ env.contextName2 }} create -f -
 
     - name: Install Cilium in cluster2
       run: |
-        # Using the deprecated form --cluster-name due to cilium/cilium-cli#1347
-        # --helm-set cluster.name ${{ env.clusterName2 }}
+        # Explicitly configure the NodePort to make sure that it is different in
+        # each cluster, to workaround #24692
         cilium --context ${{ env.contextName2 }} install \
           ${{ steps.vars.outputs.cilium_install_defaults }} \
-          --encryption ${{ matrix.encryption }} \
-          --cluster-name ${{ env.clusterName2 }} \
+          --helm-set cluster.name=${{ env.clusterName2 }} \
           --helm-set cluster.id=255 \
-          --inherit-ca ${{ env.contextName1 }}
-
-    - name: Enable Hubble
-      run: |
-        cilium --context ${{ env.contextName1 }} hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false
-        cilium --context ${{ env.contextName2 }} hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }} --wait=false --relay=false
-        cilium --context ${{ env.contextName1 }} status --wait
-        cilium --context ${{ env.contextName2 }} status --wait
-
-    - name: Enable Cluster Mesh
-      run: |
-        cilium --context ${{ env.contextName1 }} clustermesh enable ${{ steps.vars.outputs.clustermesh_enable_defaults }}
-        cilium --context ${{ env.contextName2 }} clustermesh enable ${{ steps.vars.outputs.clustermesh_enable_defaults }}
+          --helm-set clustermesh.apiserver.service.nodePort=32380
 
     - name: Wait for cluster mesh status to be ready
       run: |


### PR DESCRIPTION
Let's convert the conformance-clustermesh workflow to leverage the new Helm mode of the Cilium CLI. Both hubble and clustermesh are now enabled at install time, to configure the image versions and speedup the whole process.

The connect operation is still performed with the legacy approach, but the new helm mode will be automatically used once https://github.com/cilium/cilium-cli/pull/1628 gets merged and released.

Link to successful run: https://github.com/cilium/cilium/actions/runs/5174733271?pr=25834

Related: https://github.com/cilium/cilium/issues/25156

<!-- Description of change -->

```release-note
gha: use Cilium CLI Helm mode for conformance-clustermesh 
```
