### PR TITLE
ci: Wait for hubble-relay to be ready before port-forward

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -261,6 +261,10 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -288,6 +292,10 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
+
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -263,6 +263,10 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -290,6 +294,10 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
+
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -263,6 +263,10 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -290,6 +294,10 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
+
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -259,6 +259,10 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&
@@ -286,6 +290,10 @@ jobs:
       - name: Enable Relay
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
+
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
 
       - name: Port forward Relay
         run: |

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -315,6 +315,10 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -315,6 +315,10 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -316,6 +316,10 @@ jobs:
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -312,6 +312,10 @@ jobs:
           cilium status --wait
           kubectl get pods -n kube-system
 
+      - name: Wait for Cilium status to be ready
+        run: |
+          cilium status --wait
+
       - name: Port forward Relay
         run: |
           cilium hubble port-forward&


### PR DESCRIPTION
This commit adds calls to `cilium status --wait` between places where hubble is enabled and hubble-relay is port forwarded. Flakes in CI were occurring due to a race conditition, where an attempt to forward the hubble-relay port was occurring before the hubble-relay pod was ready.

<!-- Description of change -->

Related: https://github.com/cilium/cilium-cli/pull/986

Fixes: https://github.com/cilium/cilium/issues/25560

```release-note
CI: wait for cilium to become ready in conformance-{aks,gke} before port forward relay 
```