### PR TITLE
pkg/datapath: skip TestArpPingHandling due flakiness

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -1074,6 +1074,7 @@ func neighStateOk(n netlink.Neigh) (bool, bool) {
 }
 
 func (s *linuxPrivilegedIPv6OnlyTestSuite) TestArpPingHandling(c *check.C) {
+	c.Skip("Skipping due flakiness. See https://github.com/cilium/cilium/issues/22373 for more info")
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 


### PR DESCRIPTION
This test has been flaky in the last couple days, skipping it for now since we have an assignee to fix it.

Follow up of: 5a12f1916f40 ("pkg/datapath: skip TestArpPingHandlingForMultiDevice due flakiness")