### PR TITLE
test/provisioning: prevent simultaneous job conflicts of cilium.service

### DIFF
--- a/contrib/systemd/cilium.service-with-docker
+++ b/contrib/systemd/cilium.service-with-docker
@@ -4,13 +4,11 @@ Documentation=http://docs.cilium.io
 Requires=docker.service cilium-consul.service cilium-docker.service
 
 [Service]
-Type=oneshot
-RemainAfterExit=yes
-TimeoutStartSec=0
+Type=simple
 LimitCORE=infinity
 EnvironmentFile=-/etc/sysconfig/cilium
 ExecStart=/usr/bin/docker-run-cilium $CILIUM_OPTS
-ExecStop=-/usr/bin/docker-run-cilium uninstall
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/test/provision/docker-run-cilium.sh
+++ b/test/provision/docker-run-cilium.sh
@@ -32,7 +32,7 @@ if [ "$1" = "uninstall" ] ; then
     exit 0
 fi
 
-DOCKER_OPTS=" -d --log-driver local --restart always"
+DOCKER_OPTS=" --rm -ti --log-driver local"
 DOCKER_OPTS+=" --privileged --network host --cap-add NET_ADMIN --cap-add SYS_MODULE"
 # Run cilium agent in the host's cgroup namespace so that
 # socket-based load balancing works as expected.
@@ -52,7 +52,7 @@ if [ -n "$(${SUDO} docker ps -a -q -f label=app=cilium)" ]; then
 fi
 
 echo "Launching Cilium agent $CILIUM_IMAGE with params $CILIUM_OPTS"
-${SUDO} docker run --name cilium $DOCKER_OPTS $CILIUM_IMAGE /bin/bash -c "groupadd -f cilium && cilium-agent $CILIUM_OPTS"
+${SUDO} docker create --name cilium $DOCKER_OPTS $CILIUM_IMAGE /bin/bash -c "groupadd -f cilium && cilium-agent $CILIUM_OPTS"
 
 # Copy Cilium CLI
 ${SUDO} docker cp cilium:/usr/bin/cilium /usr/bin/
@@ -65,3 +65,5 @@ if ! command -v "clang" >/dev/null 2>&1; then
   ${SUDO} docker cp cilium:/usr/local/bin/llc /usr/bin/
   ${SUDO} docker cp cilium:/usr/local/bin/tc /usr/bin/
 fi
+
+${SUDO} docker start -ai cilium


### PR DESCRIPTION
Altered the `docker-run-cilium.sh` so that it can be used as a "simple" systemd service unit. With a combination of docker create and docker start we are able to have the same functionality as before and run the Cilium container in the foreground.

This should prevent the multiple executions of the Cilium systemd service unit which was causing the CI to fail with the following error:

```
Jun 01 16:09:25 kind-bpf-next docker-run-cilium[2013]: Launching Cilium
 agent quay.io/cilium/cilium-ci:a68ea4088c9ceba1fa99be6211964fff3deeed77
 with params --debug --pprof=true --log-system-load --enable-hubble
 --kvstore consul --kvstore-opt consul.address=127.0.0.1:8500
 --exclude-local-address=172.17.0.1/32
 --exclude-local-address=192.168.254.254/32
 --exclude-local-address=fdff::ff/128
Jun 01 16:09:25 kind-bpf-next docker-run-cilium[2022]: docker: Error
 response from daemon: Conflict. The container name "/cilium" is already
 in use by container
 "4d79de8d0315c4cd011707253852a0c039996050a883237de60ac2be252db7b1". You
 have to remove (or rename) that container to be able to reuse that name.
Jun 01 16:09:25 kind-bpf-next docker-run-cilium[2022]: See 'docker run
 --help'.
```