### PR TITLE
Hubble: improve security by adding an option to redact API key in Kafka requests (L7)

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1401,7 +1401,7 @@
      - bool
      - ``false``
    * - hubble.redact
-     - Configures the list of redact options for Hubble. Example:    redact:   - http-url-query  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query}"
+     - Configures the list of redact options for Hubble. Example:    redact:   - http-url-query   - kafka-api-key  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query,kafka-api-key}"
      - string
      - ``nil``
    * - hubble.relay.affinity

--- a/Documentation/observability/visibility.rst
+++ b/Documentation/observability/visibility.rst
@@ -78,11 +78,13 @@ parameters, API keys, and others.
    By default, Hubble does not redact potentially sensitive information
    present in `Layer 7 Hubble Flows <https://github.com/cilium/cilium/tree/master/api/v1/flow#flow-Layer7>`_.
 
-To harden security, Cilium provides the ``--hubble-redact`` option to control
-how Hubble handles sensitive information present in Layer 7 flows. More
-specifically, it offers the following features for supported Layer 7 protocols:
+To harden security, Cilium provides the ``--hubble-redact`` option which
+accepts a comma-separated list of values that control how Hubble handles
+sensitive information present in Layer 7 flows. More specifically, it offers
+the following features and values for supported Layer 7 protocols:
 
-* For HTTP: redacting URL query (GET) parameters
+* For HTTP: redacting URL query (GET) parameters (``--hubble-redact=http-url-query``)
+* For Kafka: redacting API key (``--hubble-redact=kafka-api-key``)
 
 For more information on configuring Cilium, see :ref:`Cilium Configuration <configuration>`.
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -400,7 +400,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service, must match the hubble.listenAddress' port. |
 | hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. |
-| hubble.redact | string | `nil` | Configures the list of redact options for Hubble. Example:    redact:   - http-url-query  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query}"  |
+| hubble.redact | string | `nil` | Configures the list of redact options for Hubble. Example:    redact:   - http-url-query   - kafka-api-key  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query,kafka-api-key}"  |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -806,7 +806,7 @@ data:
 
 {{- if .Values.hubble.enabled }}
   # Enable Hubble gRPC service.
-  enable-hubble: {{ .Values.hubble.enabled  | quote }}
+  enable-hubble: {{ .Values.hubble.enabled | quote }}
   # UNIX domain socket for Hubble server to listen to.
   hubble-socket-path: {{ .Values.hubble.socketPath | quote }}
 {{- if hasKey .Values.hubble "eventQueueSize" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1013,10 +1013,11 @@ hubble:
   #
   #   redact:
   #   - http-url-query
+  #   - kafka-api-key
   #
   # You can specify the list of options from the helm CLI:
   #
-  #   --set hubble.redact="{http-url-query}"
+  #   --set hubble.redact="{http-url-query,kafka-api-key}"
   #
   redact: ~
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1010,10 +1010,11 @@ hubble:
   #
   #   redact:
   #   - http-url-query
+  #   - kafka-api-key
   #
   # You can specify the list of options from the helm CLI:
   #
-  #   --set hubble.redact="{http-url-query}"
+  #   --set hubble.redact="{http-url-query,kafka-api-key}"
   #
   redact: ~
 

--- a/pkg/hubble/defaults/defaults.go
+++ b/pkg/hubble/defaults/defaults.go
@@ -17,4 +17,8 @@ const (
 	// DomainName specifies the domain name to use when constructing the server
 	// name for peer change notifications.
 	DomainName = "cilium.io"
+
+	// SensitiveValueRedacted is the string constant that is used to redact
+	// sensitive information.
+	SensitiveValueRedacted = "HUBBLE_REDACTED"
 )

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	HttpUrlQuery = "http-url-query"
+	KafkaApiKey  = "kafka-api-key"
 )
 
 // Option is used to configure parsers
@@ -16,8 +17,9 @@ type Option func(*Options)
 
 // Options contains all parser options
 type Options struct {
-	CacheSize       int
-	RedactHTTPQuery bool
+	CacheSize         int
+	RedactHTTPQuery   bool
+	RedactKafkaAPIKey bool
 }
 
 // CacheSize configures the amount of L7 requests cached for latency calculation
@@ -35,6 +37,8 @@ func Redact(logger logrus.FieldLogger, hubbleRedactOptions []string) Option {
 			switch option {
 			case HttpUrlQuery:
 				opt.RedactHTTPQuery = true
+			case KafkaApiKey:
+				opt.RedactKafkaAPIKey = true
 			default:
 				if logger != nil {
 					logger.WithField("option", option).Warn("ignoring unknown Hubble redact option")

--- a/pkg/hubble/parser/seven/http.go
+++ b/pkg/hubble/parser/seven/http.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/defaults"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
@@ -32,7 +33,7 @@ func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts
 		if uri.User != nil {
 			// Don't include the password in the flow.
 			if _, ok := uri.User.Password(); ok {
-				uri.User = url.UserPassword(uri.User.Username(), "HUBBLE_REDACTED")
+				uri.User = url.UserPassword(uri.User.Username(), defaults.SensitiveValueRedacted)
 			}
 		}
 		if opts.RedactHTTPQuery {

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -46,8 +46,9 @@ func New(
 	opts ...options.Option,
 ) (*Parser, error) {
 	args := &options.Options{
-		CacheSize:       10000,
-		RedactHTTPQuery: false,
+		CacheSize:         10000,
+		RedactHTTPQuery:   false,
+		RedactKafkaAPIKey: false,
 	}
 
 	for _, opt := range opts {
@@ -353,7 +354,7 @@ func decodeLayer7(r *accesslog.LogRecord, opts *options.Options) *flowpb.Layer7 
 	case r.Kafka != nil:
 		return &flowpb.Layer7{
 			Type:   flowType,
-			Record: decodeKafka(r.Type, r.Kafka),
+			Record: decodeKafka(r.Type, r.Kafka, opts),
 		}
 	default:
 		return &flowpb.Layer7{


### PR DESCRIPTION
Add option to redact API key in Kafka requests.

### TODOS

- [X] Accept option to redact Kafka API key
- [X] Add business logic to L7 parser
- [X] Add unit tests
- [X] Update Helm charts
- [X] Update docs 

Refs: https://github.com/cilium/cilium/issues/23887

Depends on: https://github.com/cilium/cilium/pull/25746
