### PR TITLE
v1.13 backports 2023-06-02

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1584,7 +1584,7 @@
    * - nodeinit.image
      - node-init image.
      - object
-     - ``{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"d69851597ea019af980891a4628fb36b7880ec26"}``
+     - ``{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"62093c5c233ea914bfa26a10ba41f8780d9b737f"}``
    * - nodeinit.nodeSelector
      - Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector
      - object

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1886,7 +1886,7 @@ int tail_nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	has_l4_header = ipv4_has_l4_header(ip4),
+	has_l4_header = ipv4_has_l4_header(ip4);
 
 	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
 	if (IS_ERR(ret))

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -2078,7 +2078,7 @@ func initClockSourceOption() {
 
 	if option.Config.EnableBPFClockProbe {
 		if probes.HaveProgramHelper(ebpf.XDP, asm.FnJiffies64) == nil {
-			t, err := bpf.GetJtime()
+			t, err := probes.Jiffies()
 			if err == nil && t > 0 {
 				option.Config.ClockSource = option.ClockSourceJiffies
 			}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -446,6 +446,9 @@ func finishKubeProxyReplacementInit() error {
 		// Non-BPF masquerade requires netfilter and hence CT.
 		case option.Config.IptablesMasqueradingEnabled():
 			msg = fmt.Sprintf("BPF host routing requires %s.", option.EnableBPFMasquerade)
+		// KPR=strict is needed or we might rely on netfilter.
+		case option.Config.KubeProxyReplacement != option.KubeProxyReplacementStrict:
+			msg = fmt.Sprintf("BPF host routing requires %s=%s.", option.KubeProxyReplacement, option.KubeProxyReplacementStrict)
 		// All cases below still need to be implemented ...
 		case option.Config.EnableEndpointRoutes:
 			msg = fmt.Sprintf("BPF host routing is currently not supported with %s.", option.EnableEndpointRoutes)

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -32,7 +32,7 @@ export CERTGEN_VERSION:=v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d66517
 export CILIUM_ETCD_OPERATOR_REPO:=quay.io/cilium/cilium-etcd-operator
 export CILIUM_ETCD_OPERATOR_VERSION:=v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
 export CILIUM_NODEINIT_REPO:=quay.io/cilium/startup-script
-export CILIUM_NODEINIT_VERSION:=d69851597ea019af980891a4628fb36b7880ec26
+export CILIUM_NODEINIT_VERSION:=62093c5c233ea914bfa26a10ba41f8780d9b737f
 export CILIUM_OPERATOR_BASE_REPO:=quay.io/cilium/operator
 
 export ETCD_REPO:=quay.io/coreos/etcd

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -446,7 +446,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap.d/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |
 | nodeinit.enabled | bool | `false` | Enable the node initialization DaemonSet |
 | nodeinit.extraEnv | list | `[]` | Additional nodeinit environment variables. |
-| nodeinit.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"d69851597ea019af980891a4628fb36b7880ec26"}` | node-init image. |
+| nodeinit.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"62093c5c233ea914bfa26a10ba41f8780d9b737f"}` | node-init image. |
 | nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2031,7 +2031,7 @@ nodeinit:
   image:
     override: ~
     repository: "quay.io/cilium/startup-script"
-    tag: "d69851597ea019af980891a4628fb36b7880ec26"
+    tag: "62093c5c233ea914bfa26a10ba41f8780d9b737f"
     pullPolicy: "IfNotPresent"
 
   # -- The priority class to use for the nodeinit pod.

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -6,7 +6,6 @@
 package bpf
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -617,34 +616,6 @@ func GetMtime() (uint64, error) {
 	}
 
 	return uint64(unix.TimespecToNsec(ts)), nil
-}
-
-const (
-	timerInfoFilepath = "/proc/timer_list"
-)
-
-// GetJtime returns a close-enough approximation of kernel jiffies
-// that can be used to compare against jiffies BPF helper. We parse
-// it from /proc/timer_list. GetJtime() should be invoked only at
-// mid-low frequencies.
-func GetJtime() (uint64, error) {
-	jiffies := uint64(0)
-	scaler := uint64(8)
-	timers, err := os.Open(timerInfoFilepath)
-	if err != nil {
-		return 0, err
-	}
-	defer timers.Close()
-	scanner := bufio.NewScanner(timers)
-	for scanner.Scan() {
-		tmp := uint64(0)
-		n, _ := fmt.Sscanf(scanner.Text(), "jiffies: %d\n", &tmp)
-		if n == 1 {
-			jiffies = tmp
-			break
-		}
-	}
-	return jiffies >> scaler, scanner.Err()
 }
 
 type bpfAttrProg struct {

--- a/pkg/datapath/linux/probes/kernel_hz.go
+++ b/pkg/datapath/linux/probes/kernel_hz.go
@@ -53,6 +53,23 @@ func KernelHZ() (uint16, error) {
 	return nearest(hz, hzValues)
 }
 
+// Jiffies returns the kernel's internal timestamp in jiffies read from
+// /proc/schedstat.
+func Jiffies() (uint64, error) {
+	f, err := os.Open("/proc/schedstat")
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	k, err := readSchedstat(f)
+	if err != nil {
+		return 0, err
+	}
+
+	return k.k, nil
+}
+
 // readSchedstat expects to read /proc/schedstat and returns the first line
 // matching 'timestamp %d'. Upon return, f is rewound to allow reuse.
 //

--- a/pkg/datapath/linux/probes/kernel_hz_test.go
+++ b/pkg/datapath/linux/probes/kernel_hz_test.go
@@ -14,6 +14,16 @@ func TestKernelHZ(t *testing.T) {
 	}
 }
 
+func TestJiffies(t *testing.T) {
+	j, err := Jiffies()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if j == 0 {
+		t.Fatal("unexpected zero jiffies reading")
+	}
+}
+
 func TestNearest(t *testing.T) {
 	var tests = []struct {
 		name   string

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
@@ -262,7 +263,7 @@ func DumpEntriesWithTimeDiff(m CtMap, clockSource *models.ClockSource) (string, 
 			return fmt.Sprintf("remaining: %d sec(s)", diff)
 		}
 	} else if clockSource.Mode == models.ClockSourceModeJiffies {
-		now, err := bpf.GetJtime()
+		now, err := probes.Jiffies()
 		if err != nil {
 			return "", err
 		}
@@ -544,7 +545,7 @@ func GC(m *Map, filter *GCFilter) int {
 			t, _ = bpf.GetMtime()
 			t = t / 1000000000
 		} else {
-			t, _ = bpf.GetJtime()
+			t, _ = probes.Jiffies()
 		}
 		filter.Time = uint32(t)
 	}

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -3296,7 +3296,7 @@ func (kub *Kubectl) CiliumReport(commands ...string) {
 	defer cancel()
 
 	var wg sync.WaitGroup
-	wg.Add(2)
+	wg.Add(3)
 
 	go func() {
 		defer wg.Done()
@@ -3306,6 +3306,11 @@ func (kub *Kubectl) CiliumReport(commands ...string) {
 	go func() {
 		defer wg.Done()
 		kub.DumpCiliumCommandOutput(ctx, CiliumNamespace)
+	}()
+
+	go func() {
+		defer wg.Done()
+		kub.CollectSysdump(ctx)
 	}()
 
 	kub.CiliumCheckReport(ctx)
@@ -3331,6 +3336,24 @@ func (kub *Kubectl) CiliumReport(commands ...string) {
 	for _, res := range results {
 		res.WaitUntilFinish()
 		ginkgoext.GinkgoPrint(res.GetDebugMessage())
+	}
+}
+
+func (kub *Kubectl) CollectSysdump(ctx context.Context) {
+	testPath, err := CreateReportDirectory()
+	if err != nil {
+		log.WithError(err).Errorf("cannot create test result path '%s'", testPath)
+		return
+	}
+
+	logsPath := filepath.Join(kub.BasePath(), testPath)
+
+	// We need to get into the root directory because the CLI doesn't yet
+	// support absolute path. Once https://github.com/cilium/cilium-cli/pull/1552
+	// is installed in test VM images, we can remove this.
+	res := kub.ExecContext(ctx, fmt.Sprintf("cd / && cilium-cli sysdump --output-filename %s/cilium-sysdump", logsPath))
+	if !res.WasSuccessful() {
+		log.WithError(res.GetError()).Errorf("failed to collect sysdump")
 	}
 }
 

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -401,6 +401,12 @@ var _ = Describe("K8sDatapathConfig", func() {
 		BeforeAll(func() {
 			kubectl.Exec("kubectl label nodes --all status=lockdown")
 
+			// Need to install Cilium w/ host fw prior to the host policy preparation
+			// step.
+			deploymentManager.DeployCilium(map[string]string{
+				"hostFirewall.enabled": "true",
+			}, DeployCiliumOptionsAndDNS)
+
 			prepareHostPolicyEnforcement(kubectl)
 		})
 
@@ -545,10 +551,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 // termination of those connections.
 // This function implements that process.
 func prepareHostPolicyEnforcement(kubectl *helpers.Kubectl) {
-	deploymentManager.DeployCilium(map[string]string{
-		"hostFirewall.enabled": "true",
-	}, DeployCiliumOptionsAndDNS)
-
 	demoHostPolicies := helpers.ManifestGet(kubectl.BasePath(), "host-policies.yaml")
 	By(fmt.Sprintf("Applying policies %s for 1min", demoHostPolicies))
 	_, err := kubectl.CiliumClusterwidePolicyAction(demoHostPolicies, helpers.KubectlApply, helpers.HelperTimeout)


### PR DESCRIPTION
- [x] #25079 -- test: Collect sysdump as part of artifacts (@pchaigno)
 - [x] #25742 -- bpf: dsr: fix typo in tail_nodeport_dsr_ingress_ipv4() (@julianwiedmann)
 - [ ] #25795 -- bpf,datapath: read jiffies from /proc/schedstat (@ti-mo)
    - :warning: minor conflicts
 - [x] #25774 -- Pick up the latest startup-script image (@michi-covalent)
 - [ ] #25747 -- test: prevent panic on k8s services host fw test on some runs. (@tommyp1ckles)
 - [x] #25803 -- daemon: Reject BPF Host Routing without KPR=strict (@pchaigno)

Skipped due to major conflicts:

 - [ ] ~#25450 -- Slim down Node handler interface (@bimmlerd)~
    - :loudspeaker: major conflicts due to hive and cell changes
 - [ ] ~#25419 -- wireguard, linuxnodehandler: untangle WireGuard agent from the linux node handler (@bimmlerd)~
     - :loudspeaker: skipped as dependent PRs are not backported (e.g. https://github.com/cilium/cilium/pull/24016)


Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25450 25419 25742 25795 25774 25747 25803; do contrib/backporting/set-labels.py $pr done 1.13; done
```