### PR TITLE
wireguard: Always unset fwMark

### DIFF
--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -217,10 +217,12 @@ func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.Configuration) erro
 		}
 	}
 
+	fwMark := 0
 	cfg := wgtypes.Config{
 		PrivateKey:   &a.privKey,
 		ListenPort:   &a.listenPort,
 		ReplacePeers: false,
+		FirewallMark: &fwMark,
 	}
 	if err := a.wgClient.ConfigureDevice(types.IfaceName, cfg); err != nil {
 		return fmt.Errorf("failed to configure wireguard device: %w", err)


### PR DESCRIPTION
Previously, when doing a downgrade from v1.14 (unreleased yet) to v1.13, the fwMark of cilium_wg0 set by v1.14 was not cleared by v1.13 which resulted in WireGuard peer's handshake failures.

No need to run full CI, ci-e2e is enough.