### PR TITLE
CI: Verifier tests: Keep generated object files and logs on test failure

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -230,7 +230,7 @@ jobs:
         if: ${{ !success() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
-          name: datapath-verifier
+          name: datapath-verifier_${{ matrix.kernel }}
           path: datapath-verifier
           retention-days: 5
 

--- a/test/verifier/verifier_test.go
+++ b/test/verifier/verifier_test.go
@@ -87,6 +87,12 @@ func TestVerifier(t *testing.T) {
 	kernelVersion, source := getCIKernelVersion(t)
 	t.Logf("CI kernel version: %s (%s)", kernelVersion, source)
 
+	cmd := exec.Command("make", "-C", "bpf/", "clean")
+	cmd.Dir = *ciliumBasePath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("Failed to clean bpf objects: %v\ncommand output: %s", err, out)
+	}
+
 	for _, bpfProgram := range []struct {
 		name      string
 		macroName string
@@ -124,12 +130,6 @@ func TestVerifier(t *testing.T) {
 
 			name := fmt.Sprintf("%s_%d", bpfProgram.name, i)
 			t.Run(name, func(t *testing.T) {
-				cmd := exec.Command("make", "-C", "bpf/", "clean")
-				cmd.Dir = *ciliumBasePath
-				if out, err := cmd.CombinedOutput(); err != nil {
-					t.Fatalf("Failed to clean bpf objects: %v\ncommand output: %s", err, out)
-				}
-
 				cmd = exec.Command("make", "-C", "bpf", fmt.Sprintf("%s.o", bpfProgram.name))
 				cmd.Dir = *ciliumBasePath
 				cmd.Env = append(cmd.Env,


### PR DESCRIPTION
The CI workflow for testing Cilium's programs against the verifier is supposed to upload its log files and the generated files on failures. However, we lose some of this data, because:

- Multiple jobs (for different kernel versions) upload their log and object files to the same artifact, overwriting previous uploads in the process, so that we only keep the files uploaded by the last job to complete. We can address that by using different artifact names for the different jobs.

- The test itself runs `make -C bpf/ clean` before testing the programs of each source file, thus removing the object files previously generated. Instead, we can clean up the directory just once before running the tests, not between two tests.

- At last, each source file is compiled multiple times with different sets of options, resulting in only the last version of this object file being kept. The solution implemented here consists in renaming these object files (on test failure) to make sure we keep them around.
