### PR TITLE
service: Handle backend with initial state set to Terminating

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1660,8 +1660,6 @@ func (s *Service) updateBackendsCacheLocked(svc *svcInfo, backends []lb.Backend)
 						backend.L3n4Addr, err)
 				}
 				backends[i].ID = id
-				// Default backend state is active.
-				backends[i].State = lb.BackendStateActive
 				newBackends = append(newBackends, backends[i])
 				// TODO make backendByHash by value not by ref
 				s.backendByHash[hash] = &backends[i]


### PR DESCRIPTION
Backends were previously set by default with BackendStateActive as
initial state. Even though it seems strange you can have endpointslices
starting in a terminating state.

When the EnableK8sTerminatingEndpoint knob is activated in
pkg/k8s/endpoints.go:ParseEndpointSlice, endpoints in terminating state
aren't skipped. Now moving forward in the logic, in UpsertService
we construct the backends list without considering its initial state.
With these two conditions, a new backend even in BackendTerminatingState
was considered active b/c of the default BackendStateActive and thus
mechanically added to the bpf backends map.
This was resulting in packets sent to a remote not accepting any
connections.

This patch fixes this situation by not setting a default state to the
backend.



---
### Here the proof that endpointslice in terminating mode (as initial state) was considered active

Below the output of a homemade tool subscribed to a specific endpointslice's events.
1. A new endpoint `chazam-78bcf8785c-769zv` added with ready, serving & terminating set to false.
2. Without waiting its readiness I deleted it right after which resulted in an endpoint with ready, serving set to false **but** terminating set to **true**
```csv
action, ip, pod_name, node_name, ready, serving, terminating
newEndpoint,100.97.232.213,chazam-78bcf8785c-769zv,i-0e9b6f012192efa19,false,false,false      
updateCondition,100.97.232.213,chazam-78bcf8785c-769zv,i-0e9b6f012192efa19,false,false,true
```

Now below the output of `cilium service list`, **before** `kubectl delete pod chazam-78bcf8785c-769zv`
```
36    100.68.110.241:80      ClusterIP      1 => 100.96.90.103:80 (active)                                                                                                                                                       
                                            2 => 100.98.105.156:80 (active)                                                                                                                                                      
                                            3 => 100.96.251.251:80 (active)                                                                                                                                                      
                                            4 => 100.98.119.199:80 (active)                                                                                                                                                      
                                            5 => 100.98.127.136:80 (active)                                                                                                                                                      
                                            6 => 100.96.153.171:80 (active)                                                                                                                                                      
                                            7 => 100.98.134.176:80 (active)                                                                                                                                                      
                                            8 => 100.98.135.206:80 (active)                                                                                                                                                      
                                            9 => 100.98.143.190:80 (active)                                                                                                                                                      
                                            10 => 100.98.144.191:80 (active)
```

Now, after executing `kubectl delete pod chazam-78bcf8785c-769zv` we can see that the `100.97.232.213` ip was added as an active backend.

```
36    100.68.110.241:80      ClusterIP      1 => 100.96.90.103:80 (active)                                                                                                                                                       
                                            2 => 100.98.105.156:80 (active)                                                                                                                                                      
                                            3 => 100.96.251.251:80 (active)                                                                                                                                                      
                                            4 => 100.98.119.199:80 (active)                                                                                                                                                      
                                            5 => 100.98.127.136:80 (active)                                                                                                                                                      
                                            6 => 100.96.153.171:80 (active)                                                                                                                                                      
                                            7 => 100.98.134.176:80 (active)                                                                                                                                                      
                                            8 => 100.98.135.206:80 (active)                                                                                                                                                      
                                            9 => 100.98.143.190:80 (active)                                     
                                            10 => 100.98.144.191:80 (active)                                    
                        --->              11 => 100.97.232.213:80 (active)
```
---
This issue is gone in v1.13 b/c of this specific commit https://github.com/cilium/cilium/commit/ed118b430a70d50bd5cd3fbfeb2f7f472e77e3f9#diff-2b655ba613ca8386fd9f4c383200480492ee25711e24a575f3fc8b33531b4672L1468 where basically no more default state is set to backends.
