### PR TITLE
k8s: Update comment about rule preprocessing

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -284,8 +284,8 @@ namespace ``default``.
         .. literalinclude:: ../../../examples/policies/l3/service/service.json
 
 This example shows how to allow all endpoints with the label ``id=app2``
-to talk to all endpoints of all kubernetes headless services which
-have ``head:none`` set as the label.
+to talk to all endpoints of all kubernetes services without selectors which
+have ``external:yes`` set as the label.
 
 .. only:: html
 

--- a/examples/policies/l3/service/service-labels.json
+++ b/examples/policies/l3/service/service-labels.json
@@ -12,7 +12,7 @@
                     "k8sServiceSelector": {
                         "selector": {
                             "matchLabels": {
-                                "head": "none"
+                                "external": "yes"
                             }
                         }
                     }

--- a/examples/policies/l3/service/service-labels.yaml
+++ b/examples/policies/l3/service/service-labels.yaml
@@ -11,4 +11,4 @@ spec:
     - k8sServiceSelector:
         selector:
           matchLabels:
-            head: none
+            external: yes

--- a/pkg/k8s/rule_translate.go
+++ b/pkg/k8s/rule_translate.go
@@ -221,7 +221,7 @@ func (k RuleTranslator) deleteToCidrFromEndpoint(
 	return toReleasePrefixes, nil
 }
 
-// PreprocessRules translates rules that apply to headless services
+// PreprocessRules translates egress rules that apply to external services (ToServices)
 func PreprocessRules(r api.Rules, cache *ServiceCache) error {
 
 	cache.mutex.Lock()


### PR DESCRIPTION
There is a difference between headless services, and services without a selector (sometimes referred to as external services in cilium). Those services without a selector can be headless or have a ClusterIP; but the important thing, is that this function care about services without a selector, independent on the ClusterIP. See commit messages for more context.


