### PR TITLE
[WIP] bpf: modularize lib/fib.h

### DIFF
--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -40,50 +40,63 @@ static __always_inline bool fib_ok(int ret)
 	return likely(ret == CTX_ACT_TX || ret == CTX_ACT_REDIRECT);
 }
 
-/* fib_redirect() is common helper code which performs fib lookup, populates
- * the corresponding hardware addresses and pushes the packet to a target
- * device for the next hop. Calling fib_redirect_v{4,6} is preferred unless
- * due to NAT46x64 struct bpf_fib_lookup_padded needs to be prepared at the
- * callsite. oif must be 0 if otherwise not passed in from the BPF CT. The
- * needs_l2_check must be true if the packet could transition between L2->L3
- * or L3->L2 device.
- */
+ /* fib_do_redirect will redirect the ctx to a particular output interface.
+  *
+  * the redirect can occur with or without a previous call to fib_lookup.
+  *
+  * if a previous fib_lookup was performed, this function will attempt to redirect
+  * to the output interface in the provided 'fib_params', as long as 'fib_ret'
+  * is set to 'BPF_FIB_LKUP_RET_SUCCESS'
+  *
+  * if a previous fib_lookup was performed and the return was 'BPF_FIB_LKUP_NO_NEIGH'
+  * this function will then attempt to copy the af_family and destination address
+  * out of 'fib_params' and into 'redir_neigh' struct then perform a
+  * 'redirect_neigh'.
+  *
+  * if no previous fib_lookup was performed, and the desire is to simply use
+  * 'redirect_neigh' then set 'fib_params' to nil and 'fib_ret' to
+  * 'BPF_FIB_LKUP_RET_NO_NEIGH'.
+  * in this case, the 'oif' value will be used for the 'redirect_neigh' call.
+  *
+  * in a special case, if a previous fib_lookup was performed, and the return
+  * was 'BPF_FIB_LKUP_RET_NO_NEIGH', and we are on a kernel version where
+  * the target interface for the fib lookup is not returned
+  * (due to ARP failing, see Kernel commit d1c362e1dd68) the provided 'oif'
+  * will be used as output interface for redirect.
+  */
 static __always_inline int
-fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
-	     struct bpf_fib_lookup_padded *fib_params, __s8 *fib_err, int *oif)
+fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
+		const struct bpf_fib_lookup_padded *fib_params, __s8 *fib_ret,
+		int *oif)
 {
 	struct bpf_redir_neigh nh_params;
 	struct bpf_redir_neigh *nh = NULL;
-	bool no_neigh = is_defined(ENABLE_SKIP_FIB);
 	int ret;
 
-#ifndef ENABLE_SKIP_FIB
-	ret = fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), 0);
-	if (ret != BPF_FIB_LKUP_RET_SUCCESS) {
-		*fib_err = (__s8)ret;
-		if (likely(ret == BPF_FIB_LKUP_RET_NO_NEIGH)) {
-			nh_params.nh_family = fib_params->l.family;
-			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
-					     &fib_params->l.ipv6_dst,
-					     sizeof(nh_params.ipv6_nh));
-			nh = &nh_params;
-			no_neigh = true;
+	/* sanity check, we only enter this function with these two fib lookup
+	 * return codes.
+	 */
+	if (*fib_ret && (*fib_ret != BPF_FIB_LKUP_RET_NO_NEIGH))
+		return DROP_NO_FIB;
+
+	/* determine which oif to use before needs_l2_check determines if layer 2
+	 * header needs to be pushed.
+	 */
+	if (fib_params) {
+		if (*fib_ret == BPF_FIB_LKUP_RET_NO_NEIGH &&
+		    !is_defined(HAVE_FIB_IFINDEX) && *oif) {
 			/* For kernels without d1c362e1dd68 ("bpf: Always
-			 * return target ifindex in bpf_fib_lookup") we
-			 * fall back to use the caller-provided oif when
-			 * necessary.
-			 */
-			if (!is_defined(HAVE_FIB_IFINDEX) && *oif > 0)
-				goto skip_oif;
+			* return target ifindex in bpf_fib_lookup") we
+			* fall back to use the caller-provided oif when
+			* necessary.
+			* no-op
+			*/
 		} else {
-			return DROP_NO_FIB;
+			*oif = fib_params->l.ifindex;
 		}
 	}
-	*oif = fib_params->l.ifindex;
-skip_oif:
-#else
-	*oif = DIRECT_ROUTING_DEV_IFINDEX;
-#endif /* ENABLE_SKIP_FIB */
+
+	/* determine if we need to append layer 2 header */
 	if (needs_l2_check) {
 		bool l2_hdr_required = true;
 
@@ -93,7 +106,27 @@ skip_oif:
 		if (!l2_hdr_required)
 			goto out_send;
 	}
-	if (no_neigh) {
+
+	/* determine if we are performing redirect or redirect_neigh*/
+	switch (*fib_ret) {
+	case BPF_FIB_LKUP_RET_SUCCESS:
+		if (eth_store_daddr(ctx, fib_params->l.dmac, 0) < 0)
+			return DROP_WRITE_ERROR;
+		if (eth_store_saddr(ctx, fib_params->l.smac, 0) < 0)
+			return DROP_WRITE_ERROR;
+		break;
+	case BPF_FIB_LKUP_RET_NO_NEIGH:
+		/* previous fib_lookup was done, copy fib params into
+		 * neigh params to provide lookup details to redirect_neigh
+		 */
+		if (fib_params) {
+			nh_params.nh_family = fib_params->l.family;
+			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
+					     &fib_params->l.ipv6_dst,
+					     sizeof(nh_params.ipv6_nh));
+			nh = &nh_params;
+		}
+
 		/* If we are able to resolve neighbors on demand, always
 		 * prefer that over the BPF neighbor map since the latter
 		 * might be less accurate in some asymmetric corner cases.
@@ -101,7 +134,7 @@ skip_oif:
 		if (neigh_resolver_available()) {
 			if (nh)
 				return redirect_neigh(*oif, &nh_params,
-						      sizeof(nh_params), 0);
+						sizeof(nh_params), 0);
 			else
 				return redirect_neigh(*oif, NULL, 0, 0);
 		} else {
@@ -112,10 +145,10 @@ skip_oif:
 			 * know that replies need to go back to them.
 			 */
 			dmac = fib_params->l.family == AF_INET ?
-			       neigh_lookup_ip4(&fib_params->l.ipv4_dst) :
-			       neigh_lookup_ip6((void *)&fib_params->l.ipv6_dst);
+			neigh_lookup_ip4(&fib_params->l.ipv4_dst) :
+			neigh_lookup_ip6((void *)&fib_params->l.ipv6_dst);
 			if (!dmac) {
-				*fib_err = BPF_FIB_MAP_NO_NEIGH;
+				*fib_ret = BPF_FIB_MAP_NO_NEIGH;
 				return DROP_NO_FIB;
 			}
 			if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0)
@@ -123,64 +156,124 @@ skip_oif:
 			if (eth_store_saddr_aligned(ctx, smac.addr, 0) < 0)
 				return DROP_WRITE_ERROR;
 		}
-	} else {
-		if (eth_store_daddr(ctx, fib_params->l.dmac, 0) < 0)
-			return DROP_WRITE_ERROR;
-		if (eth_store_saddr(ctx, fib_params->l.smac, 0) < 0)
-			return DROP_WRITE_ERROR;
-	}
+	};
 out_send:
 	return ctx_redirect(ctx, *oif, 0);
 }
 
+static __always_inline int
+fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
+	     struct bpf_fib_lookup_padded *fib_params __maybe_unused,
+	     __s8 *fib_err __maybe_unused, int *oif)
+{
+#ifndef ENABLE_SKIP_FIB
+	int ret;
+	ret = fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), 0);
+	*fib_err = (__s8)ret;
+	return fib_do_redirect(ctx, needs_l2_check, fib_params, fib_err, oif);
+#else
+	__s8 skip_fib = BPF_FIB_LKUP_RET_NO_NEIGH;
+	*oif = DIRECT_ROUTING_DEV_IFINDEX;
+	return fib_do_redirect(ctx, needs_l2_check, NULL, &skip_fib, oif);
+#endif
+}
+
 #ifdef ENABLE_IPV6
+/* fib_lookup_v6 will take a ctx along with a ipv6 header and parameters, perform
+ * a fib lookup with the src and dest addresses in the ipv6 header and return
+ * the code.
+ *
+ * after the function returns 'fib_params' will have the results of the fib lookup
+ * if successful.
+ */
+static __always_inline int
+fib_lookup_v6(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
+	      struct ipv6hdr *ip6, int flags)
+{
+	fib_params->l.family	= AF_INET6;
+	fib_params->l.ifindex	= ctx_get_ifindex(ctx);
+
+	ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_src,
+		       (union v6addr *)&ip6->saddr);
+	ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_dst,
+		       (union v6addr *)&ip6->daddr);
+
+	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
+};
+
 static __always_inline int
 fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
-		struct ipv6hdr *ip6, const bool needs_l2_check,
-		__s8 *fib_err, int iif, int *oif)
+		struct ipv6hdr *ip6 __maybe_unused, const bool needs_l2_check,
+		__s8 *fib_err __maybe_unused, int iif, int *oif)
 {
-	struct bpf_fib_lookup_padded fib_params = {
-		.l = {
-			.family		= AF_INET6,
-			.ifindex	= iif,
-		},
-	};
+	struct bpf_fib_lookup_padded fib_params __maybe_unused = {0};
+	void *data_end;
+	void *data;
+	__s8 skip_fib __maybe_unused = BPF_FIB_LKUP_RET_NO_NEIGH;
 	int ret;
 
-	ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_src,
-		       (union v6addr *)&ip6->saddr);
-	ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
-		       (union v6addr *)&ip6->daddr);
+	/* TODO: Fix this*/
+	(void)iif;
 
 	ret = ipv6_l3(ctx, l3_off, NULL, NULL, METRIC_EGRESS);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 
-	return fib_redirect(ctx, needs_l2_check, &fib_params, fib_err, oif);
+	/* we touched ttl above, revalidate for any header reads/writes */
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+		return DROP_INVALID;
+
+#ifndef ENABLE_SKIP_FIB
+	ret = fib_lookup_v6(ctx, &fib_params, ip6, 0);
+	*fib_err = (__s8)ret;
+	return fib_do_redirect(ctx, needs_l2_check, &fib_params, fib_err, oif);
+#else
+	*oif = DIRECT_ROUTING_DEV_IFINDEX;
+	return fib_do_redirect(ctx, needs_l2_check, NULL, &skip_fib, oif);
+#endif
 }
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
 static __always_inline int
+fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
+	      const struct iphdr *ip4, int flags) {
+	fib_params->l.family	= AF_INET;
+	fib_params->l.ifindex	= ctx_get_ifindex(ctx);
+	fib_params->l.ipv4_src	= ip4->saddr;
+	fib_params->l.ipv4_dst	= ip4->daddr;
+
+	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
+}
+
+static __always_inline int
 fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
-		struct iphdr *ip4, const bool needs_l2_check,
-		__s8 *fib_err, int iif, int *oif)
+		struct iphdr *ip4 __maybe_unused, const bool needs_l2_check,
+		__s8 *fib_err __maybe_unused, int iif __maybe_unused, int *oif)
 {
-	struct bpf_fib_lookup_padded fib_params = {
-		.l = {
-			.family		= AF_INET,
-			.ifindex	= iif,
-			.ipv4_src	= ip4->saddr,
-			.ipv4_dst	= ip4->daddr,
-		},
-	};
+	struct bpf_fib_lookup_padded fib_params __maybe_unused = {0};
+	void *data_end;
+	void *data;
+	__s8 skip_fib __maybe_unused = BPF_FIB_LKUP_RET_NO_NEIGH;
 	int ret;
 
 	ret = ipv4_l3(ctx, l3_off, NULL, NULL, ip4);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 
-	return fib_redirect(ctx, needs_l2_check, &fib_params, fib_err, oif);
+	/* we touched ttl above, revalidate for any header reads/writes. */
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+#ifndef ENABLE_SKIP_FIB
+	ret = fib_lookup_v4(ctx, &fib_params, ip4, 0);
+	*fib_err = (__s8)ret;
+	return fib_do_redirect(ctx, needs_l2_check, &fib_params, fib_err, oif);
+#else
+	*oif = DIRECT_ROUTING_DEV_IFINDEX;
+	return fib_do_redirect(ctx, needs_l2_check, NULL, &skip_fib, oif);
+#endif
+
 }
 #endif /* ENABLE_IPV4 */
 #endif /* __LIB_FIB_H_ */

--- a/bpf/tests/session_affinity_test.c
+++ b/bpf/tests/session_affinity_test.c
@@ -21,8 +21,8 @@ static const char fib_dmac[6] = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37};
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)
 {
-	memcpy(params->smac, fib_smac, sizeof(fib_smac));
-	memcpy(params->dmac, fib_dmac, sizeof(fib_dmac));
+	__bpf_memcpy_builtin(params->smac, fib_smac, ETH_ALEN);
+	__bpf_memcpy_builtin(params->dmac, fib_dmac, ETH_ALEN);
 	return 0;
 }
 
@@ -187,7 +187,7 @@ int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	__u32 *status_code = data;
 
-	if (*status_code != XDP_TX) test_fatal("status code != XDP_TX");
+	if (*status_code != XDP_TX) test_fatal("status code != XDP_TX %d", *status_code);
 
 	data += sizeof(__u32);
 

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -17,8 +17,8 @@ static const char fib_dmac[6] = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37};
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)
 {
-	memcpy(params->smac, fib_smac, sizeof(fib_smac));
-	memcpy(params->dmac, fib_dmac, sizeof(fib_dmac));
+	__bpf_memcpy_builtin(params->smac, fib_smac, ETH_ALEN);
+	__bpf_memcpy_builtin(params->dmac, fib_dmac, ETH_ALEN);
 	return 0;
 }
 


### PR DESCRIPTION
This commit has further modularized fib.h, making it possible to perform a fib lookup independently from a redirect. As a result of this refactor, two new functions have been created: fib_lookup_v4 and fib_lookup_v6.

This is a WIP PR which will not merge. 

Opening to get an initial view on the split refactor. 

This work ties into an SRv6 related fix and will be ultimately incorporated into a PR which includes SRv6 fix. 