### PR TITLE
spire: Add identity GC capability

### DIFF
--- a/operator/auth/identity/identity_provider.go
+++ b/operator/auth/identity/identity_provider.go
@@ -9,4 +9,5 @@ import "context"
 type Provider interface {
 	Upsert(ctx context.Context, id string) error
 	Delete(ctx context.Context, id string) error
+	List(ctx context.Context) ([]string, error)
 }

--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -47,6 +47,13 @@ var Cell = cell.Module(
 	cell.Provide(NewClient),
 )
 
+var FakeCellClient = cell.Module(
+	"fake-spire-client",
+	"Fake Spire Server API Client",
+	cell.Config(ClientConfig{}),
+	cell.Provide(NewFakeClient),
+)
+
 // ClientConfig contains the configuration for the SPIRE client.
 type ClientConfig struct {
 	AuthMTLSEnabled              bool          `mapstructure:"mesh-auth-mtls-enabled"`

--- a/operator/auth/spire/fake_client.go
+++ b/operator/auth/spire/fake_client.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package spire
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/operator/auth/identity"
+)
+
+// NewFakeClient creates a new fake SPIRE client.
+func NewFakeClient() identity.Provider {
+	return fakeClient{
+		ids: map[string]struct{}{},
+	}
+}
+
+type fakeClient struct {
+	ids map[string]struct{}
+}
+
+func (n fakeClient) Upsert(_ context.Context, id string) error {
+	n.ids[id] = struct{}{}
+	return nil
+}
+
+func (n fakeClient) Delete(_ context.Context, id string) error {
+	delete(n.ids, id)
+	return nil
+}
+
+func (n fakeClient) List(_ context.Context) ([]string, error) {
+	ids := make([]string, 0, len(n.ids))
+	for id := range n.ids {
+		ids = append(ids, id)
+	}
+	return ids, nil
+}

--- a/operator/auth/spire/noop.go
+++ b/operator/auth/spire/noop.go
@@ -15,3 +15,7 @@ func (n noopClient) Upsert(_ context.Context, _ string) error {
 func (n noopClient) Delete(_ context.Context, _ string) error {
 	return nil
 }
+
+func (n noopClient) List(_ context.Context) ([]string, error) {
+	return nil, nil
+}

--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -158,6 +158,11 @@ func (igc *GC) deleteIdentity(ctx context.Context, identity *v2.CiliumIdentity) 
 		return err
 	}
 
+	// Delete the identity from the auth identity store
+	if err := igc.authIdentityClient.Delete(ctx, identity.Name); err != nil {
+		return err
+	}
+
 	if err := igc.clientset.Delete(
 		ctx,
 		identity.Name,


### PR DESCRIPTION
### Description

The same mechanism with life sign is used, if mutual auth feature is not
enabled, no-op client will be injected and eventually do nothing.

In CRD mode, the auth identity GC is performed first, so that if there is
any intermittent failures, retry will be done automatically as stale CR is
still not removed. However, auth identity GC is best-effort right now due
to how allocator is implemented currently.

Fixes: #25227
