### PR TITLE
Allow users to ignore links when enabling XDP

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1543,6 +1543,13 @@ func initEnv(vp *viper.Viper) {
 			)
 		}
 	}
+
+	// Ensure the xdp-ignore-device-regex compiles
+	if len(option.Config.XDPIgnoreDeviceNameRegex) > 0 {
+		if _, err := regexp.Compile(option.Config.XDPIgnoreDeviceNameRegex); err != nil {
+			log.WithError(err).Fatal("Invalid xdp-ignore-device-regex regular expression")
+		}
+	}
 }
 
 func (d *Daemon) initKVStore() {

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -732,6 +732,9 @@ data:
 {{- if hasKey .Values.loadBalancer "serviceTopology" }}
   enable-service-topology: {{ .Values.loadBalancer.serviceTopology | quote }}
 {{- end }}
+{{- if hasKey .Values.loadBalancer "xdpIgnoreDeviceRegex" }}
+  xdp-ignore-device-regex: {{ .Values.loadBalancer.xdpIgnoreDeviceRegex | quote }}
+{{- end }}
 
 {{- end }}
 {{- if hasKey .Values.maglev "tableSize" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1737,6 +1737,11 @@ loadBalancer:
   # e.g. native, disabled
   # acceleration: disabled
 
+  # -- xdpIgnoreDeviceRegex is the option to selectively ignore devices that would
+  # otherwise have xdp enabled on them. Useful if you have devices that do not yet
+  # have driver support for XDP
+  # xdpIgnoreDeviceRegex:
+
   # -- dsrDispatch configures whether IP option or IPIP encapsulation is
   # used to pass a service IP and port to remote backend
   # dsrDispatch: opt

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1734,6 +1734,11 @@ loadBalancer:
   # e.g. native, disabled
   # acceleration: disabled
 
+  # -- xdpIgnoreDeviceRegex is the option to selectively ignore devices that would
+  # otherwise have xdp enabled on them. Useful if you have devices that do not yet
+  # have driver support for XDP
+  # xdpIgnoreDeviceRegex:
+
   # -- dsrDispatch configures whether IP option or IPIP encapsulation is
   # used to pass a service IP and port to remote backend
   # dsrDispatch: opt

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -191,7 +191,7 @@ func attachProgram(link netlink.Link, prog *ebpf.Program, progName string, qdisc
 	}
 
 	if err := netlink.FilterReplace(filter); err != nil {
-		return fmt.Errorf("replacing tc filter: %w", err)
+		return fmt.Errorf("replacing tc filter for interface %s: %w", link.Attrs().Name, err)
 	}
 
 	return nil

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -154,6 +154,9 @@ const (
 	// EncryptNode enables node IP encryption
 	EncryptNode = "encrypt-node"
 
+	// XDPIgnoreDeviceNameRegex allows devices to be skipped when XDP is enabled
+	XDPIgnoreDeviceNameRegex = "xdp-ignore-device-regex"
+
 	// EnvoyLog sets the path to a separate Envoy log file, if any
 	EnvoyLog = "envoy-log"
 
@@ -1438,6 +1441,9 @@ type DaemonConfig struct {
 	HostV6Addr          net.IP       // Host v6 address of the snooping device
 	EncryptInterface    []string     // Set of network facing interface to encrypt over
 	EncryptNode         bool         // Set to true for encrypting node IP traffic
+
+	// Set to ignore devices when enabling XDP
+	XDPIgnoreDeviceNameRegex string
 
 	// If set to true the daemon will detect new and deleted datapath devices
 	// at runtime and reconfigure the datapath to load programs onto the new
@@ -3092,6 +3098,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnableLocalRedirectPolicy = vp.GetBool(EnableLocalRedirectPolicy)
 	c.EncryptInterface = vp.GetStringSlice(EncryptInterface)
 	c.EncryptNode = vp.GetBool(EncryptNode)
+	c.XDPIgnoreDeviceNameRegex = vp.GetString(XDPIgnoreDeviceNameRegex)
 	c.EnvoyLogPath = vp.GetString(EnvoyLog)
 	c.HTTPNormalizePath = vp.GetBool(HTTPNormalizePath)
 	c.HTTPIdleTimeout = vp.GetInt(HTTPIdleTimeout)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [?] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [?] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

This allows a user to specify a regex that will cause a link to be ignored when enabling XDP. We need this ability since we are running physical hosts where the primary NICs do support XDP, but have additional `vlan` devices that _do not_ have XDP support in the driver.

More background can be found in #24768, but to summarize we have 1 physical device (ens785np0) per host and due to network design we need an additional `vlan` type interface (ens785np0.3). Regrettably the `vlan` driver in the kernel does not support XDP. When enabling XDP without this change Cilium enters a crashloop with this error:

```
Failed to compile XDP program" error="program cil_xdp_entry: attaching XDP program to interface ens785np0.3: operation not supported" subsys=datapath-loader
```

With this change applied and by specifying `xdp-ignore-device-name-regex` in the Cilium config we now get XDP enabled on the device and `tc` for the vlan device:

```
$ sudo bpftool net
xdp:
ens785np0(2) driver id 22899

tc:
ens785np0(2) clsact/ingress cil_from_netdev-ens785np0 id 23063
ens785np0(2) clsact/egress cil_to_netdev-ens785np0 id 23077
cilium_net(4) clsact/ingress cil_to_host-cilium_net id 23052
cilium_host(5) clsact/ingress cil_to_host-cilium_host id 23005
cilium_host(5) clsact/egress cil_from_host-cilium_host id 23051
cilium_vxlan(6) clsact/ingress cil_from_overlay-cilium_vxlan id 22907
cilium_vxlan(6) clsact/egress cil_to_overlay-cilium_vxlan id 22903
lxc4ecafafd804a(10) clsact/ingress cil_from_container-lxc4ecafafd804a id 23022
lxc9e4006f5d109(12) clsact/ingress cil_from_container-lxc9e4006f5d109 id 22950
lxcb6797ab24b31(14) clsact/ingress cil_from_container-lxcb6797ab24b31 id 22914
lxc22d432e999bb(16) clsact/ingress cil_from_container-lxc22d432e999bb id 22913
lxcecd9c72cbc66(18) clsact/ingress cil_from_container-lxcecd9c72cbc66 id 22983
lxc123aaba50ec5(20) clsact/ingress cil_from_container-lxc123aaba50ec5 id 22937
lxc602295b67e63(22) clsact/ingress cil_from_container-lxc602295b67e63 id 23028
lxcd5f791798257(24) clsact/ingress cil_from_container-lxcd5f791798257 id 22917
lxc3bd4bca11864(26) clsact/ingress cil_from_container-lxc3bd4bca11864 id 23017
lxc1ecd38cdf625(28) clsact/ingress cil_from_container-lxc1ecd38cdf625 id 23039
lxcb36787663030(30) clsact/ingress cil_from_container-lxcb36787663030 id 22922
ens785np0.3(57) clsact/ingress cil_from_netdev-ens785np0.3 id 23090
ens785np0.3(57) clsact/egress cil_to_netdev-ens785np0.3 id 23103
lxc_health(79) clsact/ingress cil_from_container-lxc_health id 23008

flow_dissector:
```

@borkmann indicated in https://github.com/cilium/cilium/issues/24768#issuecomment-1568942302 that a regex to filter out a device name would be acceptable.

Happy to make any adjustments and I am looking forward to getting this merged!

Note: I have not yet added support for this option to the Helm chart. Happy to do so in this PR or in a follow up if desired. I am holding off on it just to ensure that the variable names I chose are acceptable.

Fixes: #24768

```release-note
Adds ability to filter out device names via regex when enabling XDP
```
