### PR TITLE
Makefile: Fix kind deployment in quiet mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ microk8s: check-microk8s ## Build cilium-dev docker image and import to microk8s
 	$(QUIET)./contrib/scripts/microk8s-import.sh $(LOCAL_OPERATOR_IMAGE)
 
 kind: ## Create a kind cluster for Cilium development.
-	SED=$(SED) $(QUIET)./contrib/scripts/kind.sh
+	$(QUIET)SED=$(SED) ./contrib/scripts/kind.sh
 
 kind-down: ## Destroy a kind cluster for Cilium development.
 	$(QUIET)./contrib/scripts/kind-down.sh


### PR DESCRIPTION
The "$(QUIET)" directive is a Makefile syntax converting to something
like "@" when env V=0, so as a Makefile directive it must be at the
beginning of the line, or "make kind" will fail. Fix it.

Fixes: cb2b1124e57d ("Set SED binary from Makefile in kind.sh")
