### PR TITLE
BGP CP: Updates docs for PeerPort

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -95,6 +95,7 @@ Fields
 
        virtualRouters[*].neighbors: A list of neighbors to peer with
            neighbors[*].peerAddress: The address of the peer neighbor
+           neighbors[*].peerPort: Optional TCP port number of the neighbor. 1-65535 are valid values and defaults to 179 when unspecified.
            neighbors[*].peerASN: The ASN of the peer
 
 .. note::

--- a/pkg/bgpv1/README.md
+++ b/pkg/bgpv1/README.md
@@ -53,6 +53,7 @@ nodeSelector: Nodes which are selected by this label selector will apply the giv
 	
 	virtualRouters[*].neighbors: A list of neighbors to peer with
 		neighbors[*].peerAddress: The address of the peer neighbor
+		neighbors[*].peerPort: Optional TCP port number of the neighbor. 1-65535 are valid values and defaults to 179 when unspecified.
 		neighbors[*].peerASN: The ASN of the peer	
 ```
 


### PR DESCRIPTION
Updates BGP CP docs for the newly added PeerPort field of `CiliumBGPPeeringPolicy`.

Requires: #25809
Fixes: #25869
