### PR TITLE
bpf: lb: have lb4_extract_tuple() pass direction for IPv4 fragment metrics

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -90,7 +90,7 @@ static __always_inline int __per_packet_lb_svc_xlate_4(void *ctx, struct iphdr *
 
 	has_l4_header = ipv4_has_l4_header(ip4);
 
-	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
+	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, CT_SERVICE, &tuple);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
 			goto skip_service_lookup;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1147,6 +1147,7 @@ lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
  * @arg ip4		Pointer to L3 header
  * @arg l3_off		Offset to L3 header
  * @arg l4_off		Offset to L4 header
+ * @arg dir		CT direction
  * @arg tuple		CT tuple
  *
  * Returns:
@@ -1156,7 +1157,7 @@ lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
  */
 static __always_inline int
 lb4_extract_tuple(struct __ctx_buff *ctx, struct iphdr *ip4, int l3_off, int *l4_off,
-		  struct ipv4_ct_tuple *tuple)
+		  enum ct_dir dir __maybe_unused, struct ipv4_ct_tuple *tuple)
 {
 	int ret;
 
@@ -1173,8 +1174,7 @@ lb4_extract_tuple(struct __ctx_buff *ctx, struct iphdr *ip4, int l3_off, int *l4
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
 #ifdef ENABLE_IPV4_FRAGMENTS
-		ret = ipv4_handle_fragmentation(ctx, ip4, *l4_off,
-						CT_EGRESS,
+		ret = ipv4_handle_fragmentation(ctx, ip4, *l4_off, dir,
 						(struct ipv4_frag_l4ports *)&tuple->dport,
 						NULL);
 #else

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1951,7 +1951,7 @@ int tail_nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx)
 
 	has_l4_header = ipv4_has_l4_header(ip4);
 
-	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
+	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, CT_SERVICE, &tuple);
 	if (IS_ERR(ret))
 		goto drop_err;
 
@@ -2195,7 +2195,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 
 	has_l4_header = ipv4_has_l4_header(ip4);
 
-	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
+	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, CT_SERVICE, &tuple);
 	if (IS_ERR(ret)) {
 		if (ret == DROP_NO_SERVICE) {
 			is_svc_proto = false;
@@ -2397,7 +2397,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 
 	has_l4_header = ipv4_has_l4_header(ip4);
 
-	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
+	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, CT_SERVICE, &tuple);
 	if (ret < 0) {
 		/* If it's not a SVC protocol, we don't need to check for RevDNAT: */
 		if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)
@@ -2497,7 +2497,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 
 	has_l4_header = ipv4_has_l4_header(ip4);
 
-	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
+	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, CT_SERVICE, &tuple);
 	if (ret < 0) {
 		/* If it's not a SVC protocol, we don't need to check for RevDNAT: */
 		if (ret == DROP_NO_SERVICE || ret == DROP_UNKNOWN_L4)

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -211,7 +211,7 @@ int nodeport_dsr_backend_check(struct __ctx_buff *ctx)
 	int l4_off, ret;
 
 	ret = lb4_extract_tuple(ctx, l3, sizeof(*status_code) + ETH_HLEN,
-				&l4_off, &tuple);
+				&l4_off, CT_INGRESS, &tuple);
 	assert(!IS_ERR(ret));
 
 	tuple.flags = TUPLE_F_IN;


### PR DESCRIPTION
When introducing lb4_extract_tuple() a while back, we just hard-coded
the CT direction as CT_EGRESS (as that's what the previous code was doing).
This is currently only used for updating IPv4 fragmentation-related metrics
in ipv4_handle_fragmentation().

But as we now use the helper in all kinds of code paths, it's time to
revisit. The more accurate value is actually CT_SERVICE, as all these
fragment lookups are service-related.

```release-note
Set correct direction in IPv4 fragmentation metrics.
```
