### PR TITLE
bpf: nat: report detailed error from map_update_elem() for NAT entries

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -678,7 +678,7 @@ snat_v4_rev_nat_can_skip(const struct ipv4_nat_target *target, const struct ipv4
  */
 static __always_inline __maybe_unused int
 snat_v4_create_dsr(const struct ipv4_ct_tuple *tuple,
-		   __be32 to_saddr, __be16 to_sport)
+		   __be32 to_saddr, __be16 to_sport, __s8 *ext_err)
 {
 	struct ipv4_ct_tuple tmp = *tuple;
 	struct ipv4_nat_entry state = {};
@@ -695,8 +695,10 @@ snat_v4_create_dsr(const struct ipv4_ct_tuple *tuple,
 	state.to_sport = to_sport;
 
 	ret = map_update_elem(&SNAT_MAPPING_IPV4, &tmp, &state, 0);
-	if (ret)
-		return ret;
+	if (ret) {
+		*ext_err = (__s8)ret;
+		return DROP_NAT_NO_MAPPING;
+	}
 
 	return CTX_ACT_OK;
 }
@@ -1648,7 +1650,7 @@ snat_v6_rev_nat_can_skip(const struct ipv6_nat_target *target, const struct ipv6
 
 static __always_inline __maybe_unused int
 snat_v6_create_dsr(const struct ipv6_ct_tuple *tuple, union v6addr *to_saddr,
-		   __be16 to_sport)
+		   __be16 to_sport, __s8 *ext_err)
 {
 	struct ipv6_ct_tuple tmp = *tuple;
 	struct ipv6_nat_entry state = {};
@@ -1665,8 +1667,10 @@ snat_v6_create_dsr(const struct ipv6_ct_tuple *tuple, union v6addr *to_saddr,
 	state.to_sport = to_sport;
 
 	ret = map_update_elem(&SNAT_MAPPING_IPV6, &tmp, &state, 0);
-	if (ret)
-		return ret;
+	if (ret) {
+		*ext_err = (__s8)ret;
+		return DROP_NAT_NO_MAPPING;
+	}
 
 	return CTX_ACT_OK;
 }

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -197,7 +197,7 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 					       struct ipv4_ct_tuple *otuple,
 					       struct ipv4_nat_entry *ostate,
 					       const struct ipv4_nat_target *target,
-					       bool needs_ct)
+					       bool needs_ct, __s8 *ext_err)
 {
 	int ret = DROP_NAT_NO_MAPPING, retries;
 	struct ipv4_nat_entry rstate;
@@ -248,7 +248,14 @@ static __always_inline int snat_v4_new_mapping(struct __ctx_buff *ctx,
 
 	if (retries > SNAT_SIGNAL_THRES)
 		send_signal_nat_fill_up(ctx, SIGNAL_PROTO_V4);
-	return !ret ? 0 : DROP_NAT_NO_MAPPING;
+
+	if (ret < 0) {
+		if (ext_err)
+			*ext_err = (__s8)ret;
+		return DROP_NAT_NO_MAPPING;
+	}
+
+	return 0;
 }
 
 static __always_inline bool
@@ -328,7 +335,8 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 	if (*state)
 		return NAT_CONTINUE_XLATE;
 	else
-		return snat_v4_new_mapping(ctx, tuple, (*state = tmp), target, needs_ct);
+		return snat_v4_new_mapping(ctx, tuple, (*state = tmp), target, needs_ct,
+					   ext_err);
 }
 
 static __always_inline int
@@ -1292,7 +1300,7 @@ static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 					       struct ipv6_ct_tuple *otuple,
 					       struct ipv6_nat_entry *ostate,
 					       const struct ipv6_nat_target *target,
-					       bool needs_ct)
+					       bool needs_ct, __s8 *ext_err)
 {
 	int ret = DROP_NAT_NO_MAPPING, retries;
 	struct ipv6_nat_entry rstate;
@@ -1338,7 +1346,14 @@ static __always_inline int snat_v6_new_mapping(struct __ctx_buff *ctx,
 
 	if (retries > SNAT_SIGNAL_THRES)
 		send_signal_nat_fill_up(ctx, SIGNAL_PROTO_V6);
-	return !ret ? 0 : DROP_NAT_NO_MAPPING;
+
+	if (ret < 0) {
+		if (ext_err)
+			*ext_err = (__s8)ret;
+		return DROP_NAT_NO_MAPPING;
+	}
+
+	return 0;
 }
 
 static __always_inline bool
@@ -1398,7 +1413,8 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 	if (*state)
 		return NAT_CONTINUE_XLATE;
 	else
-		return snat_v6_new_mapping(ctx, tuple, (*state = tmp), target, needs_ct);
+		return snat_v6_new_mapping(ctx, tuple, (*state = tmp), target, needs_ct,
+					   ext_err);
 }
 
 static __always_inline int

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -693,7 +693,7 @@ create_ct:
 		ret = ct_create6(get_ct_map6(&tuple), NULL, &tuple, ctx,
 				 CT_EGRESS, &ct_state_new, false, false, &ext_err);
 		if (!IS_ERR(ret))
-			ret = snat_v6_create_dsr(&tuple, &addr, port);
+			ret = snat_v6_create_dsr(&tuple, &addr, port, &ext_err);
 
 		if (IS_ERR(ret))
 			goto drop_err;
@@ -2057,7 +2057,7 @@ create_ct:
 		ret = ct_create4(get_ct_map4(&tuple), NULL, &tuple, ctx,
 				 CT_EGRESS, &ct_state_new, false, false, &ext_err);
 		if (!IS_ERR(ret))
-			ret = snat_v4_create_dsr(&tuple, addr, port);
+			ret = snat_v4_create_dsr(&tuple, addr, port, &ext_err);
 
 		if (IS_ERR(ret))
 			goto drop_err;

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -189,7 +189,8 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target));
+				  snat_v4_needs_ct(&tuple, &target),
+				  NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -298,7 +299,8 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target));
+				  snat_v4_needs_ct(&tuple, &target),
+				  NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -406,7 +408,8 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target));
+				  snat_v4_needs_ct(&tuple, &target),
+				  NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -503,7 +506,8 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target));
+				  snat_v4_needs_ct(&tuple, &target),
+				  NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -564,7 +568,8 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target));
+				  snat_v4_needs_ct(&tuple, &target),
+				  NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -673,7 +678,8 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target));
+				  snat_v4_needs_ct(&tuple, &target),
+				  NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -781,7 +787,8 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target));
+				  snat_v4_needs_ct(&tuple, &target),
+				  NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -878,7 +885,8 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target));
+				  snat_v4_needs_ct(&tuple, &target),
+				  NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling


### PR DESCRIPTION
Continuing from https://github.com/cilium/cilium/pull/24716, also report an `ext_err` when inserting entries into the NAT map fails.

```release-note
Report the kernel error code in case of packet drops due to failures to create NAT map entries.
```
