### PR TITLE
node: Replace node managers dynamic metrics with modular metrics

### DIFF
--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -35,7 +35,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.New("", &fakeConfig.Config{}, nil)
+	nm, err = manager.New(&fakeConfig.Config{}, nil, manager.NewNodeMetrics())
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -20,6 +20,7 @@ var Cell = cell.Module(
 	"node-manager",
 	"Manages the collection of Cilium nodes",
 	cell.Provide(newAllNodeManager),
+	cell.Metric(NewNodeMetrics),
 )
 
 // Notifier is the interface the wraps Subscribe and Unsubscribe. An
@@ -64,8 +65,8 @@ type NodeManager interface {
 	StartNeighborRefresh(nh datapath.NodeNeighbors)
 }
 
-func newAllNodeManager(lc hive.Lifecycle, ipCache *ipcache.IPCache) (NodeManager, error) {
-	mngr, err := New("all", option.Config, ipCache)
+func newAllNodeManager(lc hive.Lifecycle, ipCache *ipcache.IPCache, nodeMetrics *nodeMetrics) (NodeManager, error) {
+	mngr, err := New(option.Config, ipCache, nodeMetrics)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/cilium/workerpool"
-	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/backoff"
@@ -26,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -109,21 +109,8 @@ type manager struct {
 	// workerpool manages background workers
 	workerpool *workerpool.WorkerPool
 
-	// name is the name of the manager. It must be unique and feasibility
-	// to be used a prometheus metric name.
-	name string
-
-	// metricEventsReceived is the prometheus metric to track the number of
-	// node events received
-	metricEventsReceived *prometheus.CounterVec
-
-	// metricNumNodes is the prometheus metric to track the number of nodes
-	// being managed
-	metricNumNodes prometheus.Gauge
-
-	// metricDatapathValidations is the prometheus metric to track the
-	// number of datapath node validation calls
-	metricDatapathValidations prometheus.Counter
+	// metrics to track information about the node manager
+	metrics *nodeMetrics
 
 	// conf is the configuration of the caller passed in via NewManager.
 	// This field is immutable after NewManager()
@@ -169,41 +156,57 @@ func (m *manager) Iter(f func(nh datapath.NodeHandler)) {
 	}
 }
 
+type nodeMetrics struct {
+	// metricEventsReceived is the prometheus metric to track the number of
+	// node events received
+	EventsReceived metric.Vec[metric.Counter]
+
+	// metricNumNodes is the prometheus metric to track the number of nodes
+	// being managed
+	NumNodes metric.Gauge
+
+	// metricDatapathValidations is the prometheus metric to track the
+	// number of datapath node validation calls
+	DatapathValidations metric.Counter
+}
+
+func NewNodeMetrics() *nodeMetrics {
+	return &nodeMetrics{
+		EventsReceived: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_" + "nodes_all_events_received_total",
+			Namespace:  metrics.Namespace,
+			Subsystem:  "nodes",
+			Name:       "all_events_received_total",
+			Help:       "Number of node events received",
+		}, []string{"event_type", "source"}),
+
+		NumNodes: metric.NewGauge(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_" + "nodes_all_num",
+			Namespace:  metrics.Namespace,
+			Subsystem:  "nodes",
+			Name:       "all_num",
+			Help:       "Number of nodes managed",
+		}),
+
+		DatapathValidations: metric.NewCounter(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_" + "nodes_all_datapath_validations_total",
+			Namespace:  metrics.Namespace,
+			Subsystem:  "nodes",
+			Name:       "all_datapath_validations_total",
+			Help:       "Number of validation calls to implement the datapath implementation of a node",
+		}),
+	}
+}
+
 // New returns a new node manager
-func New(name string, c Configuration, ipCache IPCache) (*manager, error) {
+func New(c Configuration, ipCache IPCache, nodeMetrics *nodeMetrics) (*manager, error) {
 	m := &manager{
-		name:              name,
 		nodes:             map[nodeTypes.Identity]*nodeEntry{},
 		conf:              c,
 		controllerManager: controller.NewManager(),
 		nodeHandlers:      map[datapath.NodeHandler]struct{}{},
 		ipcache:           ipCache,
-	}
-
-	m.metricEventsReceived = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: "nodes",
-		Name:      name + "_events_received_total",
-		Help:      "Number of node events received",
-	}, []string{"event_type", "source"})
-
-	m.metricNumNodes = prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: "nodes",
-		Name:      name + "_num",
-		Help:      "Number of nodes managed",
-	})
-
-	m.metricDatapathValidations = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: "nodes",
-		Name:      name + "_datapath_validations_total",
-		Help:      "Number of validation calls to implement the datapath implementation of a node",
-	})
-
-	err := metrics.RegisterList([]prometheus.Collector{m.metricDatapathValidations, m.metricEventsReceived, m.metricNumNodes})
-	if err != nil {
-		return nil, err
+		metrics:           nodeMetrics,
 	}
 
 	return m, nil
@@ -224,10 +227,6 @@ func (m *manager) Stop(hive.HookContext) error {
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-
-	metrics.Unregister(m.metricNumNodes)
-	metrics.Unregister(m.metricEventsReceived)
-	metrics.Unregister(m.metricDatapathValidations)
 
 	return nil
 }
@@ -297,7 +296,7 @@ func (m *manager) backgroundSync(ctx context.Context) error {
 			})
 			entry.mutex.Unlock()
 
-			m.metricDatapathValidations.Inc()
+			m.metrics.DatapathValidations.Inc()
 		}
 
 		select {
@@ -480,7 +479,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 	m.mutex.Lock()
 	entry, oldNodeExists := m.nodes[nodeIdentifier]
 	if oldNodeExists {
-		m.metricEventsReceived.WithLabelValues("update", string(n.Source)).Inc()
+		m.metrics.EventsReceived.WithLabelValues("update", string(n.Source)).Inc()
 
 		if !source.AllowOverwrite(entry.node.Source, n.Source) {
 			// Done; skip node-handler updates and label injection
@@ -505,8 +504,8 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 
 		entry.mutex.Unlock()
 	} else {
-		m.metricEventsReceived.WithLabelValues("add", string(n.Source)).Inc()
-		m.metricNumNodes.Inc()
+		m.metrics.EventsReceived.WithLabelValues("add", string(n.Source)).Inc()
+		m.metrics.NumNodes.Inc()
 
 		entry = &nodeEntry{node: n}
 		entry.mutex.Lock()
@@ -601,7 +600,7 @@ func (m *manager) removeNodeFromIPCache(oldNode nodeTypes.Node, resource ipcache
 // origins from. If the node was removed, NodeDelete() is invoked of the
 // datapath interface.
 func (m *manager) NodeDeleted(n nodeTypes.Node) {
-	m.metricEventsReceived.WithLabelValues("delete", string(n.Source)).Inc()
+	m.metrics.EventsReceived.WithLabelValues("delete", string(n.Source)).Inc()
 
 	log.Debugf("Received node delete event from %s", n.Source)
 
@@ -633,7 +632,7 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 
 	m.removeNodeFromIPCache(entry.node, resource, nil, nil, nil)
 
-	m.metricNumNodes.Dec()
+	m.metrics.NumNodes.Dec()
 
 	entry.mutex.Lock()
 	delete(m.nodes, nodeIdentifier)

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -185,7 +185,7 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)
 
@@ -257,7 +257,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -339,7 +339,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -360,7 +360,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -392,7 +392,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
 	mngr.Subscribe(signalNodeHandler)
 	c.Assert(err, check.IsNil)
 	defer mngr.Stop(context.TODO())
@@ -436,7 +436,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 func (s *managerTestSuite) TestIpcache(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -484,7 +484,7 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -560,7 +560,7 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{RemoteNodeIdentity: true}, ipcacheMock)
+	mngr, err := New(&configMock{RemoteNodeIdentity: true}, ipcacheMock, NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -636,7 +636,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{NodeEncryption: true, Encryption: true}, ipcacheMock)
+	mngr, err := New(&configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -731,7 +731,7 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())

--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
 	fakesignalmap "github.com/cilium/cilium/pkg/maps/signalmap/fake"
+	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
@@ -87,6 +88,7 @@ func startCiliumAgent(t *testing.T, clientset k8sClient.Clientset) (*fakeDatapat
 		tables.Cell,
 		statedb.Cell,
 		job.Cell,
+		metrics.Cell,
 		cmd.ControlPlane,
 		cell.Invoke(func(p promise.Promise[*cmd.Daemon]) {
 			daemonPromise = p


### PR DESCRIPTION
The node manager does dynamic metrics registration and cleanup. This PR replaces it with modular metrics to remove the usage of the global registry functions.

```release-note
converted node manager dynamic metrics into modular metrics
```
