### PR TITLE
envoy: Bump envoy version to v1.23.10

### DIFF
--- a/images/Makefile
+++ b/images/Makefile
@@ -57,3 +57,6 @@ operator-image: .buildx_builder
 
 hubble-relay-image: .buildx_builder
 	ROOT_CONTEXT=true scripts/build-image.sh hubble-relay-dev images/hubble-relay linux/amd64,linux/arm64 $(OUTPUT) "$$(cat .buildx_builder)" $(REGISTRIES)
+
+update-envoy-image:
+	scripts/update-cilium-envoy-image.sh

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -9,7 +9,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:26167abd7b6518f8f61423002
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.23-0c056b5821621f5407fd4844a333f25b1157556f@sha256:61a274f0beebc84fb0d752e8847353e697203bd851237f2d11090115c48e4e8e as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.23-ca87bee70e40bfa681d5859e7da4cba6b8ba4e8c@sha256:10bed2f6236efff7e2b3026f466a13600f46f0edad19b09e5eeb38340bdfef98 as cilium-envoy
 
 #
 # Hubble CLI

--- a/images/scripts/update-cilium-envoy-image.sh
+++ b/images/scripts/update-cilium-envoy-image.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+root_dir="$(git rev-parse --show-toplevel)"
+
+cd "${root_dir}"
+
+github_repo="cilium/proxy"
+github_branch="v1.23"
+image="quay.io/cilium/cilium-envoy"
+
+latest_commit_sha="$(curl -s https://api.github.com/repos/${github_repo}/commits/${github_branch} | jq -r '.sha')"
+envoy_version="${github_branch}"
+
+image_tag="${envoy_version//envoy-/v}-${latest_commit_sha}"
+
+image_full="${image}:${image_tag}"
+image_sha256=$("${script_dir}/get-image-digest.sh" "${image_full}" || echo "")
+if [ -n "${image_sha256}" ]; then
+  image_full="${image_full}@${image_sha256}"
+fi
+
+echo "Latest image from branch ${github_branch}: ${image_full}"
+
+echo "Updating image in ./images/cilium/Dockerfile"
+sed -i -E "s|(FROM ${image}:)(.*)(@sha256:[0-9a-z]*)( as cilium-envoy)|\1${image_tag}@${image_sha256}\4|" ./images/cilium/Dockerfile


### PR DESCRIPTION
This is for latest patch release from upstream

https://github.com/envoyproxy/envoy/releases/tag/v1.23.10
https://www.envoyproxy.io/docs/envoy/v1.23.10/version_history/v1.23/v1.23.10