### PR TITLE
Sensible defaults for Cilium Envoy Config

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -86,6 +86,15 @@ func initKubeProxyReplacementOptions() error {
 		option.Config.EnableSessionAffinity = true
 	}
 
+	if option.Config.KubeProxyReplacement != option.KubeProxyReplacementDisabled &&
+		option.Config.EnableEnvoyConfig && !option.Config.EnableIPSec &&
+		!option.Config.EnableNodePort {
+		// CiliumEnvoyConfig L7 LB only works with bpf node port enabled
+		log.Infof("Auto-enabling %s for %s",
+			option.EnableNodePort, option.EnableEnvoyConfig)
+		option.Config.EnableNodePort = true
+	}
+
 	if option.Config.EnableNodePort {
 		if option.Config.EnableIPSec {
 			return fmt.Errorf("IPSec cannot be used with BPF NodePort")

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -50,6 +50,12 @@
   {{- $defaultKubeProxyReplacement = "disabled" -}}
 {{- end -}}
 
+{{- /* Default values when 1.14 was initially deployed */ -}}
+{{- if semverCompare ">=1.14" (default "1.14" .Values.upgradeCompatibility) -}}
+  {{- /* KPR default for 1.14 needed to override earlier version defaults set above when upgradeCompatibility is not specified */ -}}
+  {{- $defaultKubeProxyReplacement = "false" -}}
+{{- end -}}
+
 {{- $ipam := (coalesce .Values.ipam.mode $defaultIPAM) -}}
 {{- $bpfCtTcpMax := (coalesce .Values.bpf.ctTcpMax $defaultBpfCtTcpMax) -}}
 {{- $bpfCtAnyMax := (coalesce .Values.bpf.ctAnyMax $defaultBpfCtAnyMax) -}}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -56,13 +56,9 @@
   {{- end }}
 {{- end }}
 
-{{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled }}
-  {{- if hasKey .Values "kubeProxyReplacement" }}
-    {{- if and (ne (toString .Values.kubeProxyReplacement) "strict") (ne (toString .Values.kubeProxyReplacement) "true") (not .Values.nodePort.enabled) }}
-      {{ fail "Ingress/Gateway API controller requires either .Values.kubeProxyReplacement to be set to 'true' or .Values.nodePort.enabled to 'true'" }}
-    {{- end }}
-  {{- else }}
-    {{ fail "Ingress/Gateway API controller requires either .Values.kubeProxyReplacement to be set to 'true' or .Values.nodePort.enabled to 'true'" }}
+{{- if or .Values.envoyConfig.enabled .Values.ingressController.enabled .Values.gatewayAPI.enabled }}
+  {{- if or (eq (toString .Values.kubeProxyReplacement) "disabled") (and (not (hasKey .Values "kubeProxyReplacement")) (not (semverCompare ">=1.14" (default "1.14" .Values.upgradeCompatibility)))) }}
+    {{ fail "Ingress/Gateway API controller and EnvoyConfig require .Values.kubeProxyReplacement to be explicitly set to 'false' or 'true'" }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
CiliumEnvoyConfig needs BPF NodePort to function properly in most cases. Enable this by default if CEC is enabled, and kubeproxy replacement is not explicitly disabled.
    
For this to work, helm chart is made to default to KPR=false starting on 1.14. Validation will now fail only if KPR=disabled is explicitly configured or if KPR option is not given and upgradeCompatibility is < 1.14, when KPR will default to a disabled or probe.

```release-note
BPF NodePort is now enabled by default if CiliumEnvoyConfig is configured.
```
