### PR TITLE
build: Avoid cross compilation issue on Windows

### DIFF
--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"reflect"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -17,7 +18,6 @@ import (
 	"github.com/spf13/viper"
 	"go.uber.org/dig"
 	"go.uber.org/multierr"
-	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/logging"
@@ -213,7 +213,7 @@ func (h *Hive) Run() error {
 func (h *Hive) waitForSignalOrShutdown() error {
 	signals := make(chan os.Signal, 1)
 	defer signal.Stop(signals)
-	signal.Notify(signals, os.Interrupt, unix.SIGINT, unix.SIGTERM)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 	select {
 	case sig := <-signals:
 		log.WithField("signal", sig).Info("Signal received")


### PR DESCRIPTION
Happens in cilium-cli PR when trying to import the latest cilium/cilium main hash.

```
Error: vendor/github.com/cilium/cilium/pkg/hive/hive.go:202:44: undefined: unix.SIGINT
Error: vendor/github.com/cilium/cilium/pkg/hive/hive.go:202:57: undefined: unix.SIGTERM
Error: Process completed with exit code 1.
```
