### PR TITLE
bpf unit tests: Run tests on changes to pks/bpf/**

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -42,6 +42,7 @@ jobs:
               - 'contrib/coccinelle/**'
             bpf-tests-runner:
               - 'test/bpf_tests/**'
+              - 'pkg/bpf/**'
 
   checkpatch:
     name: checkpatch


### PR DESCRIPTION
The Go program used to run the BPF unit tests has a few dependencies on other Cilium packages, namely:

  - pkg/bpf
  - pkg/byteorder
  - pkg/datapath/link
  - pkg/monitor

In the past, we nearly merged a change that would break the unit tests, because the CI skipped the unit tests job for the related PR. The reason was that the changes didn't touch BPF files (or the runner's sources), but the way we collect programs and perform relocations from an ELF file in pkg/bpf/collection.go.

To avoid repeating this in the future, let's mark `pkg/bpf/**` updates as a trigger for the unit tests. The other dependency packages could be added too, but they seem less critical (and less likely to break the tests), so we leave them aside for now.

Reference: https://github.com/cilium/cilium/pull/25837#pullrequestreview-1462953072