### PR TITLE
Module health node manager

### DIFF
--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -446,6 +446,10 @@ type clusterNodesClient struct {
 	*models.ClusterNodeStatus
 }
 
+func (c *clusterNodesClient) Name() string {
+	return "cluster-node"
+}
+
 func (c *clusterNodesClient) NodeAdd(newNode nodeTypes.Node) error {
 	c.Lock()
 	c.NodesAdded = append(c.NodesAdded, newNode.GetModel())

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/hive/hivetest"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -35,7 +36,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.New("", &fakeConfig.Config{}, nil)
+	nm, err = manager.New("", &fakeConfig.Config{}, nil, &hivetest.MockHealthReporter{})
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -24,6 +24,10 @@ func NewNodeHandler() *FakeNodeHandler {
 	return &FakeNodeHandler{Nodes: make(map[string]nodeTypes.Node)}
 }
 
+func (n *FakeNodeHandler) Name() string {
+	return "fake-node-handler"
+}
+
 func (n *FakeNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -47,6 +47,10 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 	return dp
 }
 
+func (l *linuxDatapath) Name() string {
+	return "linux-datapath"
+}
+
 // Node returns the handler for node events
 func (l *linuxDatapath) Node() datapath.NodeHandler {
 	return l.node

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -107,6 +107,10 @@ func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapat
 	}
 }
 
+func (l *linuxNodeHandler) Name() string {
+	return "linux-node-datapath"
+}
+
 // updateTunnelMapping is called when a node update is received while running
 // with encapsulation mode enabled. The CIDR and IP of both the old and new
 // node are provided as context. The caller expects the tunnel mapping in the

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1238,6 +1238,14 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		// assumptions:
 		// 1. newNode is accessed only by reads.
 		// 2. It is safe to invoke insertNeighbor for the same node.
+		//
+		// Because neighbor inserts is not synced, we do not currently
+		// collect/ bubble up errors.
+		// Instead we just rely on logging errors as they come up in the
+		// neighbor update procedure.
+		//
+		// In v1.15, we will have the neighbor sync component report its own
+		// health via stored errors. 
 		go n.insertNeighbor(context.Background(), newNode, false)
 	}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -158,7 +158,7 @@ func updateTunnelMapping(oldCIDR, newCIDR cmtypes.PrefixCluster, oldIP, newIP ne
 	case oldCIDR.IsValid() && newCIDR.IsValid() && !oldCIDR.Equal(newCIDR):
 		if err := deleteTunnelMapping(oldCIDR, false); err != nil {
 			acc = errors.Join(acc,
-				fmt.Errorf("delete tunnel mapping (oldCIDR: %s): %w", oldCIDR, newIP))
+				fmt.Errorf("delete tunnel mapping (oldCIDR: %s, newIP: %s): %w", oldCIDR, newIP, err))
 		}
 	}
 	return acc
@@ -707,7 +707,7 @@ type NextHop struct {
 func (n *linuxNodeHandler) insertNeighborCommon(scopedLog *logrus.Entry, ctx context.Context, nextHop NextHop, link netlink.Link, refresh bool) {
 	if refresh {
 		if lastPing, found := n.neighLastPingByNextHop[nextHop.Name]; found &&
-			time.Now().Sub(lastPing) < option.Config.ARPPingRefreshPeriod {
+			time.Since(lastPing) < option.Config.ARPPingRefreshPeriod {
 			// Last ping was issued less than option.Config.ARPPingRefreshPeriod
 			// ago, so skip it (e.g. to avoid ddos'ing the same GW if nodes are
 			// L3 connected)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -410,7 +410,7 @@ func (n *linuxNodeHandler) createNodeRouteSpec(prefix *cidr.CIDR, isLocalNode bo
 		}
 
 		if n.nodeAddressing.IPv6().PrimaryExternal() == nil {
-			return route.Route{}, fmt.Errorf("External IPv6 address unavailable")
+			return route.Route{}, fmt.Errorf("external IPv6 address unavailable")
 		}
 
 		// For ipv6, kernel will reject "ip r a $cidr via $ipv6_cilium_host dev cilium_host"
@@ -1531,14 +1531,14 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRule(netlink.FAMILY_V4, rule); err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("Delete previous IPv4 decrypt rule failed: %s", err)
+			return fmt.Errorf("delete previous IPv4 decrypt rule failed: %w", err)
 		}
 	}
 
 	rule.Mark = linux_defaults.RouteMarkEncrypt
 	if err := route.DeleteRule(netlink.FAMILY_V4, rule); err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("Delete previousa IPv4 encrypt rule failed: %s", err)
+			return fmt.Errorf("delete previousa IPv4 encrypt rule failed: %w", err)
 		}
 	}
 
@@ -1549,14 +1549,14 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRule(netlink.FAMILY_V6, rule); err != nil {
 		if !os.IsNotExist(err) && !errors.Is(err, unix.EAFNOSUPPORT) {
-			return fmt.Errorf("Delete previous IPv6 decrypt rule failed: %s", err)
+			return fmt.Errorf("delete previous IPv6 decrypt rule failed: %w", err)
 		}
 	}
 
 	rule.Mark = linux_defaults.RouteMarkEncrypt
 	if err := route.DeleteRule(netlink.FAMILY_V6, rule); err != nil {
 		if !os.IsNotExist(err) && !errors.Is(err, unix.EAFNOSUPPORT) {
-			return fmt.Errorf("Delete previous IPv6 encrypt rule failed: %s", err)
+			return fmt.Errorf("delete previous IPv6 encrypt rule failed: %w", err)
 		}
 	}
 	return nil
@@ -2188,7 +2188,7 @@ func deleteOldLocalRule(family int, rule route.Rule) error {
 		}
 	}
 
-	if found == true {
+	if found {
 		err := route.DeleteRule(family, rule)
 		if err != nil {
 			return fmt.Errorf("could not delete old %s local rule: %w", familyStr, err)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -460,18 +460,24 @@ func (n *linuxNodeHandler) familyEnabled(c *cidr.CIDR) bool {
 	return (c.IP.To4() != nil && n.nodeConfig.EnableIPv4) || (c.IP.To4() == nil && n.nodeConfig.EnableIPv6)
 }
 
-func (n *linuxNodeHandler) updateOrRemoveNodeRoutes(old, new []*cidr.CIDR, isLocalNode bool) {
+func (n *linuxNodeHandler) updateOrRemoveNodeRoutes(old, new []*cidr.CIDR, isLocalNode bool) error {
+	var acc error
 	addedAuxRoutes, removedAuxRoutes := cidr.DiffCIDRLists(old, new)
 	for _, prefix := range addedAuxRoutes {
 		if prefix != nil {
-			n.updateNodeRoute(prefix, n.familyEnabled(prefix), isLocalNode)
+			if err := n.updateNodeRoute(prefix, n.familyEnabled(prefix), isLocalNode); err != nil {
+				acc = errors.Join(acc, fmt.Errorf("add aux route %q: %w", prefix, err))
+			}
 		}
 	}
 	for _, prefix := range removedAuxRoutes {
 		if rt, _ := n.lookupNodeRoute(prefix, isLocalNode); rt != nil {
-			n.deleteNodeRoute(prefix, isLocalNode)
+			if err := n.deleteNodeRoute(prefix, isLocalNode); err != nil {
+				acc = errors.Join(acc, fmt.Errorf("remove aux route %q: %w", prefix, err))
+			}
 		}
 	}
+	return acc
 }
 
 func (n *linuxNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
@@ -1241,11 +1247,16 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		}
 	}
 
+	// Local node update
 	if newNode.IsLocal() {
 		isLocalNode = true
 		if n.nodeConfig.EnableLocalNodeRoute {
-			n.updateOrRemoveNodeRoutes(oldAllIP4AllocCidrs, newAllIP4AllocCidrs, isLocalNode)
-			n.updateOrRemoveNodeRoutes(oldAllIP6AllocCidrs, newAllIP6AllocCidrs, isLocalNode)
+			if err := n.updateOrRemoveNodeRoutes(oldAllIP4AllocCidrs, newAllIP4AllocCidrs, isLocalNode); err != nil {
+				acc = errors.Join(acc, fmt.Errorf("enable local node route: update ipv4 routes: %w", err))
+			}
+			if err := n.updateOrRemoveNodeRoutes(oldAllIP6AllocCidrs, newAllIP6AllocCidrs, isLocalNode); err != nil {
+				acc = errors.Join(acc, fmt.Errorf("enable local node route: update ipv6 routes: %w", err))
+			}
 		}
 		if n.subnetEncryption() {
 			n.enableSubnetIPsec(n.nodeConfig.IPv4PodSubnets, n.nodeConfig.IPv6PodSubnets)
@@ -1253,7 +1264,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		if firstAddition && n.nodeConfig.EnableIPSec {
 			n.registerIpsecMetricOnce()
 		}
-		return nil
+		return acc
 	}
 
 	if n.nodeConfig.EnableAutoDirectRouting {
@@ -1292,20 +1303,28 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		updateTunnelMapping(oldPrefixCluster6, newPrefixCluster6, oldIP4, newIP4, firstAddition, n.nodeConfig.EnableIPv6, oldKey, newKey, nodeID)
 
 		if !n.nodeConfig.UseSingleClusterRoute {
-			n.updateOrRemoveNodeRoutes(oldAllIP4AllocCidrs, newAllIP4AllocCidrs, isLocalNode)
-			n.updateOrRemoveNodeRoutes(oldAllIP6AllocCidrs, newAllIP6AllocCidrs, isLocalNode)
+			if err := n.updateOrRemoveNodeRoutes(oldAllIP4AllocCidrs, newAllIP4AllocCidrs, isLocalNode); err != nil {
+				acc = errors.Join(acc, fmt.Errorf("encapsulation: single cluster routes: ipv4: %w", err))
+			}
+			if err := n.updateOrRemoveNodeRoutes(oldAllIP6AllocCidrs, newAllIP6AllocCidrs, isLocalNode); err != nil {
+				acc = errors.Join(acc, fmt.Errorf("encapsulation: single cluster routes: ipv6: %w", err))
+			}
 		}
 
-		return nil
+		return acc
 	} else if firstAddition {
 		for _, ipv4AllocCIDR := range newAllIP4AllocCidrs {
 			if rt, _ := n.lookupNodeRoute(ipv4AllocCIDR, isLocalNode); rt != nil {
-				n.deleteNodeRoute(ipv4AllocCIDR, isLocalNode)
+				if err := n.deleteNodeRoute(ipv4AllocCIDR, isLocalNode); err != nil {
+					acc = errors.Join(acc, fmt.Errorf("initial sync: delete ipv4 route: %w", err))
+				}
 			}
 		}
 		for _, ipv6AllocCIDR := range newAllIP6AllocCidrs {
 			if rt, _ := n.lookupNodeRoute(ipv6AllocCIDR, isLocalNode); rt != nil {
-				n.deleteNodeRoute(ipv6AllocCIDR, isLocalNode)
+				if err := n.deleteNodeRoute(ipv6AllocCIDR, isLocalNode); err != nil {
+					acc = errors.Join(acc, fmt.Errorf("initial sync: delete ipv6 route: %w", err))
+				}
 			}
 		}
 	}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -298,7 +298,7 @@ func (n *linuxNodeHandler) updateDirectRoutes(oldCIDRs, newCIDRs []*cidr.CIDR, o
 		if firstAddition {
 			acc = errors.Join(acc, n.deleteAllDirectRoutes(newCIDRs, newIP))
 		}
-		return nil
+		return acc
 	}
 
 	var addedCIDRs, removedCIDRs []*cidr.CIDR

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -239,13 +239,13 @@ func Upsert(route Route) error {
 
 	link, err := netlink.LinkByName(route.Device)
 	if err != nil {
-		return fmt.Errorf("unable to lookup interface %s: %s", route.Device, err)
+		return fmt.Errorf("unable to lookup interface %s: %w", route.Device, err)
 	}
 
 	routerNet := route.getNexthopAsIPNet()
 	if routerNet != nil {
 		if _, err := replaceNexthopRoute(route, link, routerNet); err != nil {
-			return fmt.Errorf("unable to add nexthop route: %s", err)
+			return fmt.Errorf("unable to add nexthop route: %w", err)
 		}
 
 		nexthopRouteCreated = true
@@ -267,7 +267,11 @@ func Upsert(route Route) error {
 
 	if err != nil {
 		if nexthopRouteCreated {
-			deleteNexthopRoute(route, link, routerNet)
+			if err2 := deleteNexthopRoute(route, link, routerNet); err2 != nil {
+				// TODO: If this fails, we may want to add some retry logic.
+				log.WithError(err2).
+					Errorf("unable to clean up nexthop route following failure to replace route")
+			}
 		}
 		return err
 	}

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -106,6 +106,10 @@ type LocalNodeConfiguration struct {
 // implementation can differ between the own local node and remote nodes by
 // calling node.IsLocal().
 type NodeHandler interface {
+	// Name identifies the handler, this is used in logging/reporting handler
+	// reconciliation errors.
+	Name() string
+
 	// NodeAdd is called when a node is discovered for the first time.
 	NodeAdd(newNode nodeTypes.Node) error
 

--- a/pkg/hive/hivetest/health.go
+++ b/pkg/hive/hivetest/health.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hivetest
+
+import "github.com/cilium/cilium/pkg/lock"
+
+type MockHealthReporter struct {
+	lock.Mutex
+	m       string
+	stopped bool
+	err     error
+}
+
+func (m *MockHealthReporter) Msg() string {
+	m.Lock()
+	defer m.Unlock()
+	return m.m
+}
+
+func (m *MockHealthReporter) Err() error {
+	m.Lock()
+	defer m.Unlock()
+	return m.err
+}
+
+func (m *MockHealthReporter) IsStopped() bool {
+	m.Lock()
+	defer m.Unlock()
+	return m.stopped
+}
+
+func (m *MockHealthReporter) OK(msg string) {
+	m.Lock()
+	defer m.Unlock()
+	m.m = msg
+	m.err = nil
+}
+
+func (m *MockHealthReporter) Degraded(msg string, err error) {
+	m.Lock()
+	defer m.Unlock()
+	m.m = msg
+	m.err = err
+}
+
+func (m *MockHealthReporter) Stopped(msg string) {
+	m.Lock()
+	defer m.Unlock()
+	m.m = msg
+	m.stopped = true
+}

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -37,6 +37,10 @@ func newHandler(withoutTLSInfo bool, addressPref serviceoption.AddressFamilyPref
 	}
 }
 
+func (h *handler) Name() string {
+	return "hubble-peer"
+}
+
 // Ensure that Service implements the NodeHandler interface so that it can be
 // notified of nodes updates by the daemon's node manager.
 var _ datapath.NodeHandler = (*handler)(nil)

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -64,8 +64,8 @@ type NodeManager interface {
 	StartNeighborRefresh(nh datapath.NodeNeighbors)
 }
 
-func newAllNodeManager(lc hive.Lifecycle, ipCache *ipcache.IPCache) (NodeManager, error) {
-	mngr, err := New("all", option.Config, ipCache)
+func newAllNodeManager(lc hive.Lifecycle, ipCache *ipcache.IPCache, hr cell.HealthReporter) (NodeManager, error) {
+	mngr, err := New("all", option.Config, ipCache, hr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -145,6 +145,10 @@ func newSignalNodeHandler() *signalNodeHandler {
 	}
 }
 
+func (s *signalNodeHandler) Name() string {
+	return "manager_test:signalNodeHandler"
+}
+
 func (n *signalNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
 	if n.EnableNodeAddEvent {
 		n.NodeAddEvent <- newNode

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -10,14 +10,17 @@ import (
 	"net/netip"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	check "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/hive/hivetest"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -128,11 +131,15 @@ func (i *ipcacheMock) RemoveIdentityOverride(prefix netip.Prefix, identityLabels
 type signalNodeHandler struct {
 	EnableNodeAddEvent                    bool
 	NodeAddEvent                          chan nodeTypes.Node
+	NodeAddEventError                     error
 	NodeUpdateEvent                       chan nodeTypes.Node
+	NodeUpdateEventError                  error
 	EnableNodeUpdateEvent                 bool
 	NodeDeleteEvent                       chan nodeTypes.Node
+	NodeDeleteEventError                  error
 	EnableNodeDeleteEvent                 bool
 	NodeValidateImplementationEvent       chan nodeTypes.Node
+	NodeValidateImplementationEventError  error
 	EnableNodeValidateImplementationEvent bool
 }
 
@@ -153,28 +160,28 @@ func (n *signalNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
 	if n.EnableNodeAddEvent {
 		n.NodeAddEvent <- newNode
 	}
-	return nil
+	return n.NodeAddEventError
 }
 
 func (n *signalNodeHandler) NodeUpdate(oldNode, newNode nodeTypes.Node) error {
 	if n.EnableNodeUpdateEvent {
 		n.NodeUpdateEvent <- newNode
 	}
-	return nil
+	return n.NodeUpdateEventError
 }
 
 func (n *signalNodeHandler) NodeDelete(node nodeTypes.Node) error {
 	if n.EnableNodeDeleteEvent {
 		n.NodeDeleteEvent <- node
 	}
-	return nil
+	return n.NodeDeleteEventError
 }
 
 func (n *signalNodeHandler) NodeValidateImplementation(node nodeTypes.Node) error {
 	if n.EnableNodeValidateImplementationEvent {
 		n.NodeValidateImplementationEvent <- node
 	}
-	return nil
+	return n.NodeValidateImplementationEventError
 }
 
 func (n *signalNodeHandler) NodeConfigurationChanged(config datapath.LocalNodeConfiguration) error {
@@ -198,7 +205,7 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock, &hivetest.MockHealthReporter{})
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)
 
@@ -270,7 +277,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock, &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -352,7 +359,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock, &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -373,7 +380,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock, &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -405,7 +412,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock, &hivetest.MockHealthReporter{})
 	mngr.Subscribe(signalNodeHandler)
 	c.Assert(err, check.IsNil)
 	defer mngr.Stop(context.TODO())
@@ -449,7 +456,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 func (s *managerTestSuite) TestIpcache(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock, &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -497,7 +504,7 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock, &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -573,7 +580,7 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{RemoteNodeIdentity: true}, ipcacheMock)
+	mngr, err := New("test", &configMock{RemoteNodeIdentity: true}, ipcacheMock, &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -649,7 +656,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New("test", &configMock{NodeEncryption: true, Encryption: true}, ipcacheMock)
+	mngr, err := New("test", &configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -744,7 +751,7 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := New("test", &configMock{}, ipcacheMock)
+	mngr, err := New("test", &configMock{}, ipcacheMock, &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -832,4 +839,52 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 	// Needs to be the same as n2
 	c.Assert(n, checker.DeepEquals, *n1V2)
+}
+
+func TestNodeManagerEmitStatus(t *testing.T) {
+	// Tests health reporting on node manager.
+	assert := assert.New(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	baseBackgroundSyncInterval = time.Millisecond * 10
+	hr := &hivetest.MockHealthReporter{}
+	m, err := New("test", &configMock{}, newIPcacheMock(), hr)
+	assert.NoError(err)
+
+	m.nodes[nodeTypes.Identity{
+		Name:    "node1",
+		Cluster: "c1",
+	}] = &nodeEntry{node: nodeTypes.Node{Name: "node1", Cluster: "c1"}}
+	m.nodeHandlers = make(map[datapath.NodeHandler]struct{})
+	nh1 := newSignalNodeHandler()
+	nh1.EnableNodeValidateImplementationEvent = true
+	nh1.NodeValidateImplementationEventError = fmt.Errorf("test error")
+	m.nodeHandlers[nh1] = struct{}{}
+
+	// Start the manager
+	assert.NoError(m.Start(context.Background()))
+	time.Sleep(time.Millisecond * 100)
+	ch := make(chan struct{})
+	var tc atomic.Pointer[chan struct{}]
+	tc.Store(&ch)
+	m.syncObs.Observe(ctx, func(_ any) {
+		nch := make(chan struct{})
+		tc.Swap(&nch)
+		close(ch)
+		ch = nch
+	}, func(err error) {})
+	tick := func() {
+		<-*tc.Load()
+	}
+	defer func() {
+		tick()
+		m.Stop(context.Background())
+	}()
+
+	tick()
+	assert.Error(hr.Err())
+	nh1.NodeValidateImplementationEventError = nil
+	tick()
+	assert.NoError(hr.Err(), "following a successful validation, the error should be cleared")
 }

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -113,6 +113,10 @@ func NewAgent(privKeyPath string, localNodeStore *node.LocalNodeStore) (*Agent, 
 	}, nil
 }
 
+func (a *Agent) Name() string {
+	return "wireguard-agent"
+}
+
 // Close is called when the agent stops
 func (a *Agent) Close() error {
 	a.RLock()


### PR DESCRIPTION
This PR seeks to provide modular health status checking on the "node manager" component of the Agent. Specifically the goals are:

## Intentions of this PR:

### Bubble-up all errors in Linux node handler code

Node Manager related code relies heavily on logging (or just ignoring) errors far down the stack, instead of bubbling them up.

The result of this is:
* Logged errors have little context on the root event causing them to be invoked.
* It's hard to trace failure from a particular event relating to all reconcile procedures that need to run.
* It's hard to definitively to say if reconciliation for a Node Event was successfully.

The changes in this PR seek to address this by handling and bubbling up all relevant errors that may be encountered while doing Linux Node update reconciliation logic.

As well, this PR seeks to **avoid** any changes to the control-flow logic of the reconciliation by _not_ immediately returning at places where errors may occur.
Rather, this follows a pattern of combining lists of errors into relevant/scoped multi errors (using the multierr library). All code will execute as before, with the difference being that errors are handled up the stack.

### Use Hive's Modular Health Reporter to report status of node manager.

This is a first attempt at trying to manage health status for a module. 

#### Follow up work:
* Investigate Reconciliation: Break Linux node logic into atomic and idempotent tasks that can be executed and retried (+ reported on more easily).