### PR TITLE
bgpv1: graceful restart component test

### DIFF
--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -21,6 +21,9 @@ import (
 var (
 	// maxTestDuration is allowed time for test execution
 	maxTestDuration = 15 * time.Second
+
+	// maxGracefulRestartTestDuration is max allowed time for graceful restart test
+	maxGracefulRestartTestDuration = 1 * time.Minute
 )
 
 // Test_PodCIDRAdvert validates pod IPv4/v6 subnet is advertised, withdrawn and modified on node addresses change.

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -27,10 +27,12 @@ var (
 
 // peeringState helper struct containing peering information of BGP neighbor
 type peeringState struct {
-	peerASN         uint32
-	peerAddr        string
-	peerSession     string
-	holdTimeSeconds int64 // applied hold time, as negotiated with the peer during the session setup
+	peerASN                uint32
+	peerAddr               string
+	peerSession            string
+	holdTimeSeconds        int64 // applied hold time, as negotiated with the peer during the session setup
+	gracefulRestartEnabled bool
+	gracefulRestartTime    int64 // configured restart time
 }
 
 // Test_NeighborAddDel validates neighbor add and delete are working as expected. Test validates this using
@@ -174,6 +176,148 @@ func Test_NeighborAddDel(t *testing.T) {
 			// session state (e.g. peer may be already in Established but we still in OpenConfirm
 			// until we receive a Keepalive from the peer).
 			require.Eventually(t, peerStatesMatch, outstanding, 1*time.Second, step.description)
+		})
+	}
+}
+
+// Test_NeighborGracefulRestart tests graceful restart configuration knobs with single peer.
+func Test_NeighborGracefulRestart(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	node.SetTestLocalNodeStore()
+	defer node.UnsetTestLocalNodeStore()
+
+	var steps = []struct {
+		description       string
+		neighbor          cilium_api_v2alpha1.CiliumBGPNeighbor
+		waitState         []string
+		expectedPeerState peeringState
+	}{
+		{
+			description: "add neighbor with defaults",
+			neighbor: cilium_api_v2alpha1.CiliumBGPNeighbor{
+				PeerAddress: dummies[instance1Link].ipv4.String(),
+				PeerASN:     int(gobgpASN),
+			},
+			waitState: []string{"ESTABLISHED"},
+			expectedPeerState: peeringState{
+				peerASN:     gobgpASN,
+				peerAddr:    dummies[instance1Link].ipv4.Addr().String(),
+				peerSession: types.SessionEstablished.String(),
+			},
+		},
+		{
+			description: "update graceful restart with defaults",
+			neighbor: cilium_api_v2alpha1.CiliumBGPNeighbor{
+				PeerAddress: dummies[instance1Link].ipv4.String(),
+				PeerASN:     int(gobgpASN),
+				GracefulRestart: cilium_api_v2alpha1.CiliumBGPNeighborGracefulRestart{
+					Enabled: true,
+				},
+			},
+			waitState: []string{"ESTABLISHED"},
+			expectedPeerState: peeringState{
+				peerASN:                gobgpASN,
+				peerAddr:               dummies[instance1Link].ipv4.Addr().String(),
+				peerSession:            types.SessionEstablished.String(),
+				gracefulRestartEnabled: true,
+				gracefulRestartTime:    int64(types.DefaultGRRestartTime.Seconds()),
+			},
+		},
+		{
+			description: "update graceful restart, restart time",
+			neighbor: cilium_api_v2alpha1.CiliumBGPNeighbor{
+				PeerAddress: dummies[instance1Link].ipv4.String(),
+				PeerASN:     int(gobgpASN),
+				GracefulRestart: cilium_api_v2alpha1.CiliumBGPNeighborGracefulRestart{
+					Enabled:     true,
+					RestartTime: meta_v1.Duration{Duration: 20 * time.Second},
+				},
+			},
+			waitState: []string{"ESTABLISHED"},
+			expectedPeerState: peeringState{
+				peerASN:                gobgpASN,
+				peerAddr:               dummies[instance1Link].ipv4.Addr().String(),
+				peerSession:            types.SessionEstablished.String(),
+				gracefulRestartEnabled: true,
+				gracefulRestartTime:    20,
+			},
+		},
+		{
+			description: "disable graceful restart",
+			neighbor: cilium_api_v2alpha1.CiliumBGPNeighbor{
+				PeerAddress: dummies[instance1Link].ipv4.String(),
+				PeerASN:     int(gobgpASN),
+				GracefulRestart: cilium_api_v2alpha1.CiliumBGPNeighborGracefulRestart{
+					Enabled: false,
+				},
+			},
+			waitState: []string{"ESTABLISHED"},
+			expectedPeerState: peeringState{
+				peerASN:                gobgpASN,
+				peerAddr:               dummies[instance1Link].ipv4.Addr().String(),
+				peerSession:            types.SessionEstablished.String(),
+				gracefulRestartEnabled: false,
+			},
+		},
+	}
+
+	// This test run can take upto a minute
+	testCtx, testDone := context.WithTimeout(context.Background(), maxGracefulRestartTestDuration)
+	defer testDone()
+
+	// test setup, we configure single gobgp instance here.
+	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, fixtureConf)
+	require.NoError(t, err)
+	require.Len(t, gobgpInstances, 1)
+	defer cleanup()
+
+	for _, step := range steps {
+		t.Run(step.description, func(t *testing.T) {
+			// update bgp policy with neighbors defined in test step
+			policyObj := newPolicyObj(policyConfig{
+				nodeSelector: labels,
+				virtualRouters: []cilium_api_v2alpha1.CiliumBGPVirtualRouter{
+					{
+						LocalASN:      int(ciliumASN),
+						ExportPodCIDR: true,
+						Neighbors:     []cilium_api_v2alpha1.CiliumBGPNeighbor{step.neighbor},
+					},
+				},
+			})
+			_, err = fixture.policyClient.Update(testCtx, &policyObj, meta_v1.UpdateOptions{})
+			require.NoError(t, err)
+
+			// wait for peers to reach expected state
+			err = gobgpInstances[0].waitForSessionState(testCtx, step.waitState)
+			require.NoError(t, err)
+
+			deadline, _ := testCtx.Deadline()
+			outstanding := deadline.Sub(time.Now())
+			require.Greater(t, outstanding, 0*time.Second, "test context deadline exceeded")
+
+			peerStatesMatch := func() bool {
+				// validate expected state vs state reported by BGP CP
+				var peers []*models.BgpPeer
+				peers, err = fixture.bgp.BGPMgr.GetPeers(testCtx)
+				require.NoError(t, err, step.description)
+				require.Len(t, peers, 1)
+
+				runningPeerState := peeringState{
+					peerASN:                uint32(peers[0].PeerAsn),
+					peerAddr:               peers[0].PeerAddress,
+					peerSession:            peers[0].SessionState,
+					gracefulRestartEnabled: peers[0].GracefulRestart.Enabled,
+					gracefulRestartTime:    peers[0].GracefulRestart.RestartTimeSeconds,
+				}
+				return assert.Equal(t, step.expectedPeerState, runningPeerState)
+			}
+
+			// Retry peerStatesMatch once per second until the test context deadline.
+			// We may need to retry as remote peer's session state does not have to immediately match our
+			// session state (e.g. peer may be already in Established but we still in OpenConfirm
+			// until we receive a Keepalive from the peer).
+			require.Eventually(t, peerStatesMatch, outstanding, 1*time.Second)
 		})
 	}
 }


### PR DESCRIPTION
Added component test for BGP graceful restart configuration knobs and corresponding get peer state validation.