### PR TITLE
clustermesh: split the generic logic from the specific part

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -25,8 +25,8 @@ import (
 	cmmetrics "github.com/cilium/cilium/clustermesh-apiserver/metrics"
 	apiserverOption "github.com/cilium/cilium/clustermesh-apiserver/option"
 	operatorWatchers "github.com/cilium/cilium/operator/watchers"
-	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive"
@@ -538,7 +538,7 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, backe
 		},
 	}
 
-	if err := clustermesh.SetClusterConfig(context.Background(), cfg.clusterName, &config, backend); err != nil {
+	if err := cmutils.SetClusterConfig(context.Background(), cfg.clusterName, &config, backend); err != nil {
 		log.WithError(err).Fatal("Unable to set local cluster config on kvstore")
 	}
 

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -4,8 +4,7 @@
 package clustermesh
 
 import (
-	"github.com/spf13/pflag"
-
+	"github.com/cilium/cilium/pkg/clustermesh/internal"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -34,14 +33,8 @@ var Cell = cell.Module(
 		return types.ClusterIDName{ClusterID: cfg.ClusterID, ClusterName: cfg.ClusterName}
 	}),
 
-	cell.Config(Config{}),
+	cell.Config(internal.Config{}),
+
+	cell.Metric(newMetrics),
+	cell.Metric(internal.MetricsProvider(subsystem)),
 )
-
-type Config struct {
-	// ClusterMeshConfig is the path to the clustermesh configuration directory.
-	ClusterMeshConfig string
-}
-
-func (def Config) Flags(flags *pflag.FlagSet) {
-	flags.String("clustermesh-config", def.ClusterMeshConfig, "Path to the ClusterMesh configuration directory")
-}

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -5,43 +5,34 @@ package clustermesh
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"path"
-	"time"
-
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/clustermesh/internal"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 )
 
-const (
-	// configNotificationsChannelSize is the size of the channel used to
-	// notify a clustermesh of configuration changes
-	configNotificationsChannelSize = 512
+const subsystem = "clustermesh"
 
-	subsystem = "clustermesh"
-)
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsystem)
 
 // Configuration is the configuration that must be provided to
 // NewClusterMesh()
 type Configuration struct {
 	cell.In
 
-	Config
+	internal.Config
 
 	// ClusterIDName is the id/name of the local cluster. This is used for logging and metrics
 	types.ClusterIDName
@@ -64,59 +55,10 @@ type Configuration struct {
 	IPCache ipcache.IPCacher
 
 	// ClusterSizeDependantInterval allows to calculate intervals based on cluster size.
-	ClusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc `optional:"true"`
-}
+	ClusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc
 
-func SetClusterConfig(ctx context.Context, clusterName string, config *cmtypes.CiliumClusterConfig, backend kvstore.BackendOperations) error {
-	key := path.Join(kvstore.ClusterConfigPrefix, clusterName)
-
-	val, err := json.Marshal(config)
-	if err != nil {
-		return err
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	_, err = backend.UpdateIfDifferent(ctx, key, val, true)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func GetClusterConfig(ctx context.Context, clusterName string, backend kvstore.BackendOperations) (*cmtypes.CiliumClusterConfig, error) {
-	var config cmtypes.CiliumClusterConfig
-
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	val, err := backend.Get(ctx, path.Join(kvstore.ClusterConfigPrefix, clusterName))
-	if err != nil {
-		return nil, err
-	}
-
-	// Cluster configuration missing, but it's not an error
-	if val == nil {
-		return nil, nil
-	}
-
-	if err := json.Unmarshal(val, &config); err != nil {
-		return nil, err
-	}
-
-	return &config, nil
-}
-
-// IsClusterConfigRequired returns whether the remote kvstore guarantees that the
-// cilium cluster config will be eventually created.
-func IsClusterConfigRequired(ctx context.Context, backend kvstore.BackendOperations) (bool, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-
-	val, err := backend.Get(ctx, kvstore.HasClusterConfigPath)
-	return val != nil, err
+	Metrics         Metrics
+	InternalMetrics internal.Metrics
 }
 
 // RemoteIdentityWatcher is any type which provides identities that have been
@@ -139,9 +81,8 @@ type ClusterMesh struct {
 	// conf is the configuration, it is immutable after NewClusterMesh()
 	conf Configuration
 
-	mutex         lock.RWMutex
-	clusters      map[string]*remoteCluster
-	configWatcher *configDirectoryWatcher
+	// internal implements the common logic to connect to remote clusters.
+	internal internal.ClusterMesh
 
 	// globalServices is a list of all global services. The datastructure
 	// is protected by its own mutex inside the structure.
@@ -149,144 +90,50 @@ type ClusterMesh struct {
 
 	// nodeName is the name of the local node. This is used for logging and metrics
 	nodeName string
-
-	// metricTotalRemoteClusters is gauge metric keeping track of total number
-	// of remote clusters.
-	metricTotalRemoteClusters *prometheus.GaugeVec
-
-	// metricLastFailureTimestamp is a gauge metric tracking the last failure timestamp
-	metricLastFailureTimestamp *prometheus.GaugeVec
-
-	// metricReadinessStatus is a gauge metric tracking the readiness status of a remote cluster
-	metricReadinessStatus *prometheus.GaugeVec
-
-	// metricTotalFailure is a gauge metric tracking the number of failures when connecting to a remote cluster
-	metricTotalFailures *prometheus.GaugeVec
-
-	// metricTotalNodes is a gauge metric tracking the number of total nodes in a remote cluster
-	metricTotalNodes *prometheus.GaugeVec
 }
 
 // NewClusterMesh creates a new remote cluster cache based on the
 // provided configuration
 func NewClusterMesh(lifecycle hive.Lifecycle, c Configuration) *ClusterMesh {
-	if c.ClusterID == 0 {
-		return nil
-	}
-
-	if c.ClusterMeshConfig == "" {
+	if c.ClusterID == 0 || c.ClusterMeshConfig == "" {
 		return nil
 	}
 
 	nodeName := nodeTypes.GetName()
 	cm := &ClusterMesh{
 		conf:           c,
-		clusters:       map[string]*remoteCluster{},
-		globalServices: newGlobalServiceCache(c.ClusterName, nodeName),
 		nodeName:       nodeName,
-
-		metricTotalRemoteClusters: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: metrics.Namespace,
-			Subsystem: subsystem,
-			Name:      "remote_clusters",
-			Help:      "The total number of remote clusters meshed with the local cluster",
-		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName}),
-
-		metricLastFailureTimestamp: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: metrics.Namespace,
-			Subsystem: subsystem,
-			Name:      "remote_cluster_last_failure_ts",
-			Help:      "The timestamp of the last failure of the remote cluster",
-		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
-
-		metricReadinessStatus: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: metrics.Namespace,
-			Subsystem: subsystem,
-			Name:      "remote_cluster_readiness_status",
-			Help:      "The readiness status of the remote cluster",
-		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
-
-		metricTotalFailures: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: metrics.Namespace,
-			Subsystem: subsystem,
-			Name:      "remote_cluster_failures",
-			Help:      "The total number of failures related to the remote cluster",
-		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
-
-		metricTotalNodes: prometheus.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: metrics.Namespace,
-			Subsystem: subsystem,
-			Name:      "remote_cluster_nodes",
-			Help:      "The total number of nodes in the remote cluster",
-		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
+		globalServices: newGlobalServiceCache(c.ClusterName, nodeName),
 	}
 
-	lifecycle.Append(cm)
+	cm.internal = internal.NewClusterMesh(internal.Configuration{
+		Config:                       c.Config,
+		ClusterIDName:                c.ClusterIDName,
+		ClusterSizeDependantInterval: c.ClusterSizeDependantInterval,
+
+		NewRemoteCluster: cm.newRemoteCluster,
+
+		NodeName: nodeName,
+		Metrics:  c.InternalMetrics,
+	})
+
+	lifecycle.Append(&cm.internal)
 	return cm
 }
 
-func (cm *ClusterMesh) Start(hive.HookContext) error {
-	w, err := createConfigDirectoryWatcher(cm.conf.ClusterMeshConfig, cm)
-	if err != nil {
-		return fmt.Errorf("unable to create config directory watcher: %w", err)
-	}
-
-	cm.configWatcher = w
-
-	if err := cm.configWatcher.watch(); err != nil {
-		return fmt.Errorf("unable to start config directory watcher: %w", err)
-	}
-
-	_ = metrics.RegisterList([]prometheus.Collector{
-		cm.metricTotalRemoteClusters,
-		cm.metricLastFailureTimestamp,
-		cm.metricReadinessStatus,
-		cm.metricTotalFailures,
-		cm.metricTotalNodes,
-	})
-
-	return nil
-}
-
-// Close stops watching for remote cluster configuration files to appear and
-// will close all connections to remote clusters
-func (cm *ClusterMesh) Stop(hive.HookContext) error {
-	cm.mutex.Lock()
-	defer cm.mutex.Unlock()
-
-	if cm.configWatcher != nil {
-		cm.configWatcher.close()
-	}
-
-	for name, cluster := range cm.clusters {
-		cluster.onStop()
-		delete(cm.clusters, name)
-	}
-
-	metrics.Unregister(cm.metricTotalRemoteClusters)
-	metrics.Unregister(cm.metricLastFailureTimestamp)
-	metrics.Unregister(cm.metricReadinessStatus)
-	metrics.Unregister(cm.metricTotalFailures)
-	metrics.Unregister(cm.metricTotalNodes)
-
-	return nil
-}
-
-func (cm *ClusterMesh) newRemoteCluster(name, path string) *remoteCluster {
+func (cm *ClusterMesh) newRemoteCluster(name string, status internal.StatusFunc) internal.RemoteCluster {
 	rc := &remoteCluster{
-		name:        name,
-		configPath:  path,
-		mesh:        cm,
-		changed:     make(chan bool, configNotificationsChannelSize),
-		controllers: controller.NewManager(),
-		swg:         lock.NewStoppableWaitGroup(),
+		name:   name,
+		mesh:   cm,
+		status: status,
+		swg:    lock.NewStoppableWaitGroup(),
 	}
 
 	rc.remoteNodes = store.NewRestartableWatchStore(
 		name,
 		cm.conf.NodeKeyCreator,
 		cm.conf.NodeObserver,
-		store.RWSWithEntriesMetric(rc.mesh.metricTotalNodes.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name)),
+		store.RWSWithEntriesMetric(cm.conf.Metrics.TotalNodes.WithLabelValues(cm.conf.ClusterName, cm.nodeName, rc.name)),
 	)
 
 	rc.remoteServices = store.NewRestartableWatchStore(
@@ -301,98 +148,40 @@ func (cm *ClusterMesh) newRemoteCluster(name, path string) *remoteCluster {
 	return rc
 }
 
-func (cm *ClusterMesh) add(name, path string) {
-	if name == cm.conf.ClusterName {
-		log.WithField(fieldClusterName, name).Debug("Ignoring configuration for own cluster")
-		return
-	}
+func (cm *ClusterMesh) canConnect(name string, config *cmtypes.CiliumClusterConfig) error {
+	return cm.internal.ForEachRemoteCluster(func(rci internal.RemoteCluster) error {
+		rc := rci.(*remoteCluster)
 
-	inserted := false
-	cm.mutex.Lock()
-	cluster, ok := cm.clusters[name]
-	if !ok {
-		cluster = cm.newRemoteCluster(name, path)
-		cm.clusters[name] = cluster
-		inserted = true
-	}
+		rc.mutex.RLock()
+		defer rc.mutex.RUnlock()
 
-	cm.metricTotalRemoteClusters.WithLabelValues(cm.conf.ClusterName, cm.nodeName).Set(float64(len(cm.clusters)))
-	cm.mutex.Unlock()
+		if rc.name == name || rc.config == nil {
+			return nil
+		}
 
-	log.WithField(fieldClusterName, name).Debug("Remote cluster configuration added")
+		if err := rc.config.IsCompatible(config); err != nil {
+			return err
+		}
 
-	if inserted {
-		cluster.onInsert(cm.conf.RemoteIdentityWatcher)
-	} else {
-		// signal a change in configuration
-		cluster.changed <- true
-	}
-}
-
-func (cm *ClusterMesh) remove(name string) {
-	cm.mutex.Lock()
-	if cluster, ok := cm.clusters[name]; ok {
-		cluster.onRemove()
-		delete(cm.clusters, name)
-		cm.metricTotalRemoteClusters.WithLabelValues(cm.conf.ClusterName, cm.nodeName).Set(float64(len(cm.clusters)))
-		cm.globalServices.onClusterDelete(name)
-	}
-	cm.mutex.Unlock()
-
-	log.WithField(fieldClusterName, name).Debug("Remote cluster configuration removed")
+		return nil
+	})
 }
 
 // NumReadyClusters returns the number of remote clusters to which a connection
 // has been established
 func (cm *ClusterMesh) NumReadyClusters() int {
-	cm.mutex.RLock()
-	defer cm.mutex.RUnlock()
-
-	nready := 0
-	for _, cm := range cm.clusters {
-		if cm.isReady() {
-			nready++
-		}
-	}
-
-	return nready
-}
-
-func (cm *ClusterMesh) canConnect(name string, config *cmtypes.CiliumClusterConfig) error {
-	cm.mutex.RLock()
-	defer cm.mutex.RUnlock()
-
-	for n, rc := range cm.clusters {
-		if err := func() error {
-			rc.mutex.RLock()
-			defer rc.mutex.RUnlock()
-
-			if rc.name == name || !rc.isReadyLocked() || rc.config == nil {
-				return nil
-			}
-
-			if err := rc.config.IsCompatible(config); err != nil {
-				return err
-			}
-
-			return nil
-		}(); err != nil {
-			return fmt.Errorf("configuration of %s is not compatible with %s: %w", name, n, err)
-		}
-	}
-
-	return nil
+	return cm.internal.NumReadyClusters()
 }
 
 // ClustersSynced returns after all clusters were synchronized with the bpf
 // datapath.
 func (cm *ClusterMesh) ClustersSynced(ctx context.Context) error {
-	cm.mutex.RLock()
-	swgs := make([]*lock.StoppableWaitGroup, 0, len(cm.clusters))
-	for _, cluster := range cm.clusters {
-		swgs = append(swgs, cluster.swg)
-	}
-	cm.mutex.RUnlock()
+	swgs := make([]*lock.StoppableWaitGroup, 0)
+	cm.internal.ForEachRemoteCluster(func(rci internal.RemoteCluster) error {
+		rc := rci.(*remoteCluster)
+		swgs = append(swgs, rc.swg)
+		return nil
+	})
 
 	for _, swg := range swgs {
 		select {
@@ -406,16 +195,15 @@ func (cm *ClusterMesh) ClustersSynced(ctx context.Context) error {
 
 // Status returns the status of the ClusterMesh subsystem
 func (cm *ClusterMesh) Status() (status *models.ClusterMeshStatus) {
-	cm.mutex.RLock()
-	defer cm.mutex.RUnlock()
-
 	status = &models.ClusterMeshStatus{
 		NumGlobalServices: int64(cm.globalServices.size()),
 	}
 
-	for _, cm := range cm.clusters {
-		status.Clusters = append(status.Clusters, cm.status())
-	}
+	cm.internal.ForEachRemoteCluster(func(rci internal.RemoteCluster) error {
+		rc := rci.(*remoteCluster)
+		status.Clusters = append(status.Clusters, rc.Status())
+		return nil
+	})
 
 	return
 }

--- a/pkg/clustermesh/internal/clustermesh.go
+++ b/pkg/clustermesh/internal/clustermesh.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package internal
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+const (
+	// configNotificationsChannelSize is the size of the channel used to
+	// notify a clustermesh of configuration changes
+	configNotificationsChannelSize = 512
+)
+
+type Config struct {
+	// ClusterMeshConfig is the path to the clustermesh configuration directory.
+	ClusterMeshConfig string
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.String("clustermesh-config", def.ClusterMeshConfig, "Path to the ClusterMesh configuration directory")
+}
+
+type StatusFunc func() *models.RemoteCluster
+type RemoteClusterCreatorFunc func(name string, status StatusFunc) RemoteCluster
+
+// Configuration is the configuration that must be provided to
+// NewClusterMesh()
+type Configuration struct {
+	Config
+
+	// ClusterIDName is the id/name of the local cluster. This is used for logging and metrics
+	types.ClusterIDName
+
+	// NewRemoteCluster is a function returning a new implementation of the remote cluster business logic.
+	NewRemoteCluster RemoteClusterCreatorFunc
+
+	// nodeName is the name of the local node. This is used for logging and metrics
+	NodeName string
+
+	// ClusterSizeDependantInterval allows to calculate intervals based on cluster size.
+	ClusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc
+
+	// Metrics holds the different clustermesh metrics.
+	Metrics Metrics
+}
+
+// ClusterMesh is a cache of multiple remote clusters
+type ClusterMesh struct {
+	// conf is the configuration, it is immutable after NewClusterMesh()
+	conf Configuration
+
+	mutex         lock.RWMutex
+	clusters      map[string]*remoteCluster
+	configWatcher *configDirectoryWatcher
+}
+
+// NewClusterMesh creates a new remote cluster cache based on the
+// provided configuration
+func NewClusterMesh(c Configuration) ClusterMesh {
+	return ClusterMesh{
+		conf:     c,
+		clusters: map[string]*remoteCluster{},
+	}
+}
+
+func (cm *ClusterMesh) Start(hive.HookContext) error {
+	w, err := createConfigDirectoryWatcher(cm.conf.ClusterMeshConfig, cm)
+	if err != nil {
+		return fmt.Errorf("unable to create config directory watcher: %w", err)
+	}
+
+	cm.configWatcher = w
+
+	if err := cm.configWatcher.watch(); err != nil {
+		return fmt.Errorf("unable to start config directory watcher: %w", err)
+	}
+
+	return nil
+}
+
+// Close stops watching for remote cluster configuration files to appear and
+// will close all connections to remote clusters
+func (cm *ClusterMesh) Stop(hive.HookContext) error {
+	cm.mutex.Lock()
+	defer cm.mutex.Unlock()
+
+	if cm.configWatcher != nil {
+		cm.configWatcher.close()
+	}
+
+	for name, cluster := range cm.clusters {
+		cluster.onStop()
+		delete(cm.clusters, name)
+	}
+
+	return nil
+}
+
+func (cm *ClusterMesh) newRemoteCluster(name, path string) *remoteCluster {
+	rc := &remoteCluster{
+		name:                         name,
+		configPath:                   path,
+		clusterSizeDependantInterval: cm.conf.ClusterSizeDependantInterval,
+
+		changed:     make(chan bool, configNotificationsChannelSize),
+		controllers: controller.NewManager(),
+
+		metricLastFailureTimestamp: cm.conf.Metrics.LastFailureTimestamp.WithLabelValues(cm.conf.ClusterName, cm.conf.NodeName, name),
+		metricReadinessStatus:      cm.conf.Metrics.ReadinessStatus.WithLabelValues(cm.conf.ClusterName, cm.conf.NodeName, name),
+		metricTotalFailures:        cm.conf.Metrics.TotalFailures.WithLabelValues(cm.conf.ClusterName, cm.conf.NodeName, name),
+	}
+
+	rc.RemoteCluster = cm.conf.NewRemoteCluster(name, rc.status)
+	return rc
+}
+
+func (cm *ClusterMesh) add(name, path string) {
+	if name == cm.conf.ClusterName {
+		log.WithField(fieldClusterName, name).Debug("Ignoring configuration for own cluster")
+		return
+	}
+
+	inserted := false
+	cm.mutex.Lock()
+	cluster, ok := cm.clusters[name]
+	if !ok {
+		cluster = cm.newRemoteCluster(name, path)
+		cm.clusters[name] = cluster
+		inserted = true
+	}
+
+	cm.conf.Metrics.TotalRemoteClusters.WithLabelValues(cm.conf.ClusterName, cm.conf.NodeName).Set(float64(len(cm.clusters)))
+	cm.mutex.Unlock()
+
+	log.WithField(fieldClusterName, name).Debug("Remote cluster configuration added")
+
+	if inserted {
+		cluster.onInsert()
+	} else {
+		// signal a change in configuration
+		cluster.changed <- true
+	}
+}
+
+func (cm *ClusterMesh) remove(name string) {
+	cm.mutex.Lock()
+	if cluster, ok := cm.clusters[name]; ok {
+		cluster.onRemove()
+		delete(cm.clusters, name)
+		cm.conf.Metrics.TotalRemoteClusters.WithLabelValues(cm.conf.ClusterName, cm.conf.NodeName).Set(float64(len(cm.clusters)))
+	}
+	cm.mutex.Unlock()
+
+	log.WithField(fieldClusterName, name).Debug("Remote cluster configuration removed")
+}
+
+// NumReadyClusters returns the number of remote clusters to which a connection
+// has been established
+func (cm *ClusterMesh) NumReadyClusters() int {
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
+
+	nready := 0
+	for _, cm := range cm.clusters {
+		if cm.isReady() {
+			nready++
+		}
+	}
+
+	return nready
+}
+
+func (cm *ClusterMesh) ForEachRemoteCluster(fn func(RemoteCluster) error) error {
+	cm.mutex.RLock()
+	defer cm.mutex.RUnlock()
+
+	for _, cluster := range cm.clusters {
+		if err := fn(cluster.RemoteCluster); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/clustermesh/internal/config.go
+++ b/pkg/clustermesh/internal/config.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package clustermesh
+package internal
 
 import (
 	"crypto/sha256"

--- a/pkg/clustermesh/internal/logfields.go
+++ b/pkg/clustermesh/internal/logfields.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package clustermesh
+package internal
 
 import (
 	"github.com/cilium/cilium/pkg/logging"

--- a/pkg/clustermesh/internal/metrics.go
+++ b/pkg/clustermesh/internal/metrics.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package internal
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type Metrics struct {
+	// TotalRemoteClusters tracks the total number of remote clusters.
+	TotalRemoteClusters metric.Vec[metric.Gauge]
+	// LastFailureTimestamp tracks the last failure timestamp.
+	LastFailureTimestamp metric.Vec[metric.Gauge]
+	// ReadinessStatus tracks the readiness status of remote clusters.
+	ReadinessStatus metric.Vec[metric.Gauge]
+	// TotalFailure tracks the number of failures when connecting to remote clusters.
+	TotalFailures metric.Vec[metric.Gauge]
+}
+
+func MetricsProvider(subsystem string) func() Metrics {
+	return func() Metrics {
+		return Metrics{
+			TotalRemoteClusters: metric.NewGaugeVec(metric.GaugeOpts{
+				ConfigName: metrics.Namespace + "_" + subsystem + "_remote_clusters",
+				Namespace:  metrics.Namespace,
+				Subsystem:  subsystem,
+				Name:       "remote_clusters",
+				Help:       "The total number of remote clusters meshed with the local cluster",
+			}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName}),
+
+			LastFailureTimestamp: metric.NewGaugeVec(metric.GaugeOpts{
+				ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_last_failure_ts",
+				Namespace:  metrics.Namespace,
+				Subsystem:  subsystem,
+				Name:       "remote_cluster_last_failure_ts",
+				Help:       "The timestamp of the last failure of the remote cluster",
+			}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
+
+			ReadinessStatus: metric.NewGaugeVec(metric.GaugeOpts{
+				ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_readiness_status",
+				Namespace:  metrics.Namespace,
+				Subsystem:  subsystem,
+				Name:       "remote_cluster_readiness_status",
+				Help:       "The readiness status of the remote cluster",
+			}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
+
+			TotalFailures: metric.NewGaugeVec(metric.GaugeOpts{
+				ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_failures",
+				Namespace:  metrics.Namespace,
+				Subsystem:  subsystem,
+				Name:       "remote_cluster_failures",
+				Help:       "The total number of failures related to the remote cluster",
+			}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
+		}
+	}
+}

--- a/pkg/clustermesh/internal/remote_cluster.go
+++ b/pkg/clustermesh/internal/remote_cluster.go
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+type RemoteCluster interface {
+	Run(ctx context.Context, backend kvstore.BackendOperations, config *types.CiliumClusterConfig) error
+
+	Stop()
+	Remove()
+}
+
+// remoteCluster represents another cluster other than the cluster the agent is
+// running in
+type remoteCluster struct {
+	RemoteCluster
+
+	// name is the name of the cluster
+	name string
+
+	// configPath is the path to the etcd configuration to be used to
+	// connect to the etcd cluster of the remote cluster
+	configPath string
+
+	// clusterSizeDependantInterval allows to calculate intervals based on cluster size.
+	clusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc
+
+	// changed receives an event when the remote cluster configuration has
+	// changed and is closed when the configuration file was removed
+	changed chan bool
+
+	controllers *controller.Manager
+
+	// remoteConnectionControllerName is the name of the backing controller
+	// that maintains the remote connection
+	remoteConnectionControllerName string
+
+	// mutex protects the following variables
+	// - backend
+	// - failures
+	// - lastFailure
+	mutex lock.RWMutex
+
+	// backend is the kvstore backend being used
+	backend kvstore.BackendOperations
+
+	// failures is the number of observed failures
+	failures int
+
+	// lastFailure is the timestamp of the last failure
+	lastFailure time.Time
+
+	metricLastFailureTimestamp prometheus.Gauge
+	metricReadinessStatus      prometheus.Gauge
+	metricTotalFailures        prometheus.Gauge
+}
+
+var (
+	// skipKvstoreConnection skips the etcd connection, used for testing
+	skipKvstoreConnection bool
+)
+
+func (rc *remoteCluster) getLogger() *logrus.Entry {
+	var (
+		status string
+		err    error
+	)
+
+	if rc.backend != nil {
+		status, err = rc.backend.Status()
+	}
+
+	return log.WithFields(logrus.Fields{
+		fieldClusterName:   rc.name,
+		fieldConfig:        rc.configPath,
+		fieldKVStoreStatus: status,
+		fieldKVStoreErr:    err,
+	})
+}
+
+// releaseOldConnection releases the etcd connection to a remote cluster
+func (rc *remoteCluster) releaseOldConnection() {
+	rc.mutex.Lock()
+	backend := rc.backend
+	rc.backend = nil
+	rc.mutex.Unlock()
+
+	// Release resources asynchronously in the background. Many of these
+	// operations may time out if the connection was closed due to an error
+	// condition.
+	go func() {
+		if backend != nil {
+			backend.Close(context.Background())
+		}
+	}()
+}
+
+func (rc *remoteCluster) restartRemoteConnection() {
+	rc.controllers.UpdateController(rc.remoteConnectionControllerName,
+		controller.ControllerParams{
+			DoFunc: func(ctx context.Context) error {
+				rc.releaseOldConnection()
+
+				extraOpts := rc.makeExtraOpts()
+
+				backend, errChan := kvstore.NewClient(ctx, kvstore.EtcdBackendName,
+					rc.makeEtcdOpts(), &extraOpts)
+
+				// Block until either an error is returned or
+				// the channel is closed due to success of the
+				// connection
+				rc.getLogger().Debugf("Waiting for connection to be established")
+				err, isErr := <-errChan
+				if isErr {
+					if backend != nil {
+						backend.Close(ctx)
+					}
+					rc.getLogger().WithError(err).Warning("Unable to establish etcd connection to remote cluster")
+					return err
+				}
+
+				rc.getLogger().Info("Connection to remote cluster established")
+
+				config, err := rc.getClusterConfig(ctx, backend, false)
+				if err == nil && config == nil {
+					rc.getLogger().Warning("Remote cluster doesn't have cluster configuration, falling back to the old behavior. This is expected when connecting to the old cluster running Cilium without cluster configuration feature.")
+				} else if err == nil {
+					rc.getLogger().Info("Found remote cluster configuration")
+				} else {
+					rc.getLogger().WithError(err).Warning("Unable to get remote cluster configuration")
+					backend.Close(ctx)
+					return err
+				}
+
+				rc.mutex.Lock()
+				rc.backend = backend
+				rc.mutex.Unlock()
+
+				rc.metricReadinessStatus.Set(metrics.BoolToFloat64(true))
+				defer rc.metricReadinessStatus.Set(metrics.BoolToFloat64(false))
+
+				if err := rc.Run(ctx, backend, config); err != nil {
+					rc.getLogger().WithError(err).Error("Connection to remote cluster failed")
+					return err
+				}
+
+				return nil
+			},
+			StopFunc: func(ctx context.Context) error {
+				rc.releaseOldConnection()
+				rc.getLogger().Info("Connection to remote cluster stopped")
+				return nil
+			},
+			CancelDoFuncOnUpdate: true,
+		},
+	)
+}
+
+func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.BackendOperations, forceRequired bool) (*cmtypes.CiliumClusterConfig, error) {
+	var (
+		err                           error
+		requireConfig                 = forceRequired
+		clusterConfigRetrievalTimeout = 3 * time.Minute
+	)
+
+	ctx, cancel := context.WithTimeout(ctx, clusterConfigRetrievalTimeout)
+	defer cancel()
+
+	if !requireConfig {
+		// Let's check whether the kvstore states that the cluster configuration should be always present.
+		requireConfig, err = cmutils.IsClusterConfigRequired(ctx, backend)
+		if err != nil {
+			return nil, fmt.Errorf("failed to detect whether the cluster configuration is required: %w", err)
+		}
+	}
+
+	cfgch := make(chan *types.CiliumClusterConfig)
+	defer close(cfgch)
+
+	// We retry here rather than simply returning an error and relying on the external
+	// controller backoff period to avoid recreating every time a new connection to the remote
+	// kvstore, which would introduce an unnecessary overhead. Still, we do return in case of
+	// consecutive failures, to ensure that we do not retry forever if something strange happened.
+	ctrlname := rc.remoteConnectionControllerName + "-cluster-config"
+	defer rc.controllers.RemoveControllerAndWait(ctrlname)
+	rc.controllers.UpdateController(ctrlname, controller.ControllerParams{
+		DoFunc: func(ctx context.Context) error {
+			rc.getLogger().Debug("Retrieving cluster configuration from remote kvstore")
+			config, err := cmutils.GetClusterConfig(ctx, rc.name, backend)
+			if err != nil {
+				return err
+			}
+
+			if config == nil && requireConfig {
+				return errors.New("cluster configuration expected to be present but not found")
+			}
+
+			// We should stop retrying in case we either successfully retrieved the cluster
+			// configuration, or we are not required to wait for it.
+			cfgch <- config
+			return nil
+		},
+		Context:          ctx,
+		MaxRetryInterval: 30 * time.Second,
+	})
+
+	// Wait until either the configuration is retrieved, or the context expires
+	select {
+	case config := <-cfgch:
+		return config, nil
+	case <-ctx.Done():
+		return nil, fmt.Errorf("failed to retrieve cluster configuration")
+	}
+}
+
+func (rc *remoteCluster) makeEtcdOpts() map[string]string {
+	opts := map[string]string{
+		kvstore.EtcdOptionConfig: rc.configPath,
+	}
+
+	for key, value := range option.Config.KVStoreOpt {
+		switch key {
+		case kvstore.EtcdRateLimitOption, kvstore.EtcdMaxInflightOption, kvstore.EtcdListLimitOption,
+			kvstore.EtcdOptionKeepAliveHeartbeat, kvstore.EtcdOptionKeepAliveTimeout:
+			opts[key] = value
+		}
+	}
+
+	return opts
+}
+
+func (rc *remoteCluster) makeExtraOpts() kvstore.ExtraOptions {
+	return kvstore.ExtraOptions{
+		NoLockQuorumCheck:            true,
+		ClusterName:                  rc.name,
+		ClusterSizeDependantInterval: rc.clusterSizeDependantInterval,
+	}
+}
+
+func (rc *remoteCluster) onInsert() {
+	rc.getLogger().Info("New remote cluster configuration")
+
+	if skipKvstoreConnection {
+		return
+	}
+
+	rc.remoteConnectionControllerName = fmt.Sprintf("remote-etcd-%s", rc.name)
+	rc.restartRemoteConnection()
+
+	go func() {
+		for {
+			val := <-rc.changed
+			if val {
+				rc.getLogger().Info("etcd configuration has changed, re-creating connection")
+				rc.restartRemoteConnection()
+			} else {
+				rc.getLogger().Info("Closing connection to remote etcd")
+				return
+			}
+		}
+	}()
+
+	go func() {
+		for {
+			select {
+			// terminate routine when remote cluster is removed
+			case _, ok := <-rc.changed:
+				if !ok {
+					return
+				}
+			default:
+			}
+
+			// wait for backend to appear
+			rc.mutex.RLock()
+			if rc.backend == nil {
+				rc.mutex.RUnlock()
+				time.Sleep(10 * time.Millisecond)
+				continue
+			}
+			statusCheckErrors := rc.backend.StatusCheckErrors()
+			rc.mutex.RUnlock()
+
+			err, ok := <-statusCheckErrors
+			if ok && err != nil {
+				rc.getLogger().WithError(err).Warning("Error observed on etcd connection, reconnecting etcd")
+				rc.mutex.Lock()
+				rc.failures++
+				rc.lastFailure = time.Now()
+				rc.metricLastFailureTimestamp.SetToCurrentTime()
+				rc.metricTotalFailures.Set(float64(rc.failures))
+				rc.metricReadinessStatus.Set(metrics.BoolToFloat64(rc.isReadyLocked()))
+				rc.mutex.Unlock()
+				rc.restartRemoteConnection()
+			}
+		}
+	}()
+
+}
+
+// onStop is executed when the clustermesh subsystem is being stopped.
+// In this case, we don't want to drain the known entries, otherwise
+// we would break existing connections when the agent gets restarted.
+func (rc *remoteCluster) onStop() {
+	rc.controllers.RemoveAllAndWait()
+	close(rc.changed)
+	rc.Stop()
+}
+
+// onRemove is executed when a remote cluster is explicitly disconnected
+// (i.e., its configuration is removed). In this case, we need to drain
+// all known entries, to properly cleanup the status without requiring to
+// restart the agent.
+func (rc *remoteCluster) onRemove() {
+	rc.onStop()
+	rc.Remove()
+
+	rc.getLogger().Info("Remote cluster disconnected")
+}
+
+func (rc *remoteCluster) isReady() bool {
+	rc.mutex.RLock()
+	defer rc.mutex.RUnlock()
+
+	return rc.isReadyLocked()
+}
+
+func (rc *remoteCluster) isReadyLocked() bool {
+	return rc.backend != nil
+}
+
+func (rc *remoteCluster) status() *models.RemoteCluster {
+	rc.mutex.RLock()
+	defer rc.mutex.RUnlock()
+
+	// This can happen when the controller in restartRemoteConnection is waiting
+	// for the first connection to succeed.
+	var backendStatus = "Waiting for initial connection to be established"
+	if rc.backend != nil {
+		var backendError error
+		backendStatus, backendError = rc.backend.Status()
+		if backendError != nil {
+			backendStatus = backendError.Error()
+		}
+	}
+
+	status := &models.RemoteCluster{
+		Name:        rc.name,
+		Ready:       rc.isReadyLocked(),
+		Status:      backendStatus,
+		NumFailures: int64(rc.failures),
+		LastFailure: strfmt.DateTime(rc.lastFailure),
+	}
+
+	return status
+}

--- a/pkg/clustermesh/metrics.go
+++ b/pkg/clustermesh/metrics.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type Metrics struct {
+	// TotalNodes tracks the number of total nodes in a remote cluster.
+	TotalNodes metric.Vec[metric.Gauge]
+}
+
+func newMetrics() Metrics {
+	return Metrics{
+		TotalNodes: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_nodes",
+			Namespace:  metrics.Namespace,
+			Subsystem:  subsystem,
+			Name:       "remote_cluster_nodes",
+			Help:       "The total number of nodes in the remote cluster",
+		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
+	}
+}

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -5,31 +5,23 @@ package clustermesh
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"path"
-	"time"
-
-	"github.com/go-openapi/strfmt"
-	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
+	"github.com/cilium/cilium/pkg/clustermesh/internal"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
-	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/metrics"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
-	"github.com/cilium/cilium/pkg/option"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 )
 
-// remoteCluster represents another cluster other than the cluster the agent is
-// running in
+// remoteCluster implements the clustermesh business logic on top of
+// internal.RemoteCluster.
 type remoteCluster struct {
 	// name is the name of the cluster
 	name string
@@ -38,25 +30,11 @@ type remoteCluster struct {
 	// from remote kvstore.
 	config *cmtypes.CiliumClusterConfig
 
-	// configPath is the path to the etcd configuration to be used to
-	// connect to the etcd cluster of the remote cluster
-	configPath string
-
-	// changed receives an event when the remote cluster configuration has
-	// changed and is closed when the configuration file was removed
-	changed chan bool
-
 	// mesh is the cluster mesh this remote cluster belongs to
 	mesh *ClusterMesh
 
-	controllers *controller.Manager
-
-	// remoteConnectionControllerName is the name of the backing controller
-	// that maintains the remote connection
-	remoteConnectionControllerName string
-
-	// mutex protects the following variables
-	// - backend
+	// mutex protects the following variables:
+	// - config
 	// - remoteIdentityCache
 	mutex lock.RWMutex
 
@@ -75,365 +53,79 @@ type remoteCluster struct {
 	// allocations in the remote cluster
 	remoteIdentityCache *allocator.RemoteCache
 
-	// backend is the kvstore backend being used
-	backend kvstore.BackendOperations
+	// status is the function which fills the internal part of the status.
+	status internal.StatusFunc
 
 	swg *lock.StoppableWaitGroup
-
-	// failures is the number of observed failures
-	failures int
-
-	// lastFailure is the timestamp of the last failure
-	lastFailure time.Time
 }
 
-var (
-	// skipKvstoreConnection skips the etcd connection, used for testing
-	skipKvstoreConnection bool
-)
-
-func (rc *remoteCluster) getLogger() *logrus.Entry {
-	var (
-		status string
-		err    error
-	)
-
-	if rc.backend != nil {
-		status, err = rc.backend.Status()
+func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperations, config *cmtypes.CiliumClusterConfig) error {
+	if err := rc.mesh.canConnect(rc.name, config); err != nil {
+		return err
 	}
 
-	return log.WithFields(logrus.Fields{
-		fieldClusterName:   rc.name,
-		fieldConfig:        rc.configPath,
-		fieldKVStoreStatus: status,
-		fieldKVStoreErr:    err,
-	})
-}
+	var capabilities types.CiliumClusterConfigCapabilities
+	if config != nil {
+		capabilities = config.Capabilities
+	}
 
-// releaseOldConnection releases the etcd connection to a remote cluster
-func (rc *remoteCluster) releaseOldConnection() {
+	remoteIdentityCache, err := rc.mesh.conf.RemoteIdentityWatcher.WatchRemoteIdentities(rc.name, backend)
+	if err != nil {
+		return err
+	}
+
+	defer remoteIdentityCache.Close()
+
 	rc.mutex.Lock()
-	remoteIdentityCache := rc.remoteIdentityCache
-	rc.remoteIdentityCache = nil
-
-	backend := rc.backend
-	rc.backend = nil
-
-	rc.config = nil
-
-	rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
-
+	rc.config = config
+	rc.remoteIdentityCache = remoteIdentityCache
 	rc.mutex.Unlock()
 
-	// Release resources asynchronously in the background. Many of these
-	// operations may time out if the connection was closed due to an error
-	// condition.
-	go func() {
-		if remoteIdentityCache != nil {
-			remoteIdentityCache.Close()
-		}
-		if backend != nil {
-			backend.Close(context.TODO())
-		}
-	}()
-}
-
-func (rc *remoteCluster) restartRemoteConnection(allocator RemoteIdentityWatcher) {
-	rc.controllers.UpdateController(rc.remoteConnectionControllerName,
-		controller.ControllerParams{
-			DoFunc: func(ctx context.Context) error {
-				rc.releaseOldConnection()
-
-				extraOpts := rc.makeExtraOpts()
-
-				backend, errChan := kvstore.NewClient(ctx, kvstore.EtcdBackendName,
-					rc.makeEtcdOpts(), &extraOpts)
-
-				// Block until either an error is returned or
-				// the channel is closed due to success of the
-				// connection
-				rc.getLogger().Debugf("Waiting for connection to be established")
-				err, isErr := <-errChan
-				if isErr {
-					if backend != nil {
-						backend.Close(ctx)
-					}
-					rc.getLogger().WithError(err).Warning("Unable to establish etcd connection to remote cluster")
-					return err
-				}
-
-				rc.getLogger().Info("Connection to remote cluster established")
-
-				config, err := rc.getClusterConfig(ctx, backend, false)
-				if err == nil && config == nil {
-					rc.getLogger().Warning("Remote cluster doesn't have cluster configuration, falling back to the old behavior. This is expected when connecting to the old cluster running Cilium without cluster configuration feature.")
-				} else if err == nil {
-					rc.getLogger().Info("Found remote cluster configuration")
-				} else {
-					rc.getLogger().WithError(err).Warning("Unable to get remote cluster configuration")
-					backend.Close(ctx)
-					return err
-				}
-
-				if err := rc.mesh.canConnect(rc.name, config); err != nil {
-					rc.getLogger().WithError(err).Error("Unable to connect to the remote cluster")
-					backend.Close(ctx)
-					return err
-				}
-
-				var capabilities types.CiliumClusterConfigCapabilities
-				if config != nil {
-					capabilities = config.Capabilities
-				}
-
-				var mgr store.WatchStoreManager
-				if capabilities.SyncedCanaries {
-					mgr = store.NewWatchStoreManagerSync(backend, rc.name)
-				} else {
-					mgr = store.NewWatchStoreManagerImmediate(rc.name)
-				}
-
-				mgr.Register(nodeStore.NodeStorePrefix, func(ctx context.Context) {
-					rc.remoteNodes.Watch(ctx, backend, path.Join(nodeStore.NodeStorePrefix, rc.name))
-				})
-
-				mgr.Register(serviceStore.ServiceStorePrefix, func(ctx context.Context) {
-					rc.remoteServices.Watch(ctx, backend, path.Join(serviceStore.ServiceStorePrefix, rc.name))
-				})
-
-				mgr.Register(ipcache.IPIdentitiesPath, func(ctx context.Context) {
-					rc.ipCacheWatcher.Watch(ctx, backend)
-				})
-
-				remoteIdentityCache, err := allocator.WatchRemoteIdentities(rc.name, backend)
-				if err != nil {
-					backend.Close(ctx)
-					return err
-				}
-
-				rc.mutex.Lock()
-				rc.backend = backend
-				rc.config = config
-				rc.remoteIdentityCache = remoteIdentityCache
-				rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
-				rc.mutex.Unlock()
-
-				rc.getLogger().Info("Established connection to remote etcd")
-				mgr.Run(ctx)
-
-				return nil
-			},
-			StopFunc: func(ctx context.Context) error {
-				rc.releaseOldConnection()
-
-				rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
-				allocator.RemoveRemoteIdentities(rc.name)
-				rc.getLogger().Info("All resources of remote cluster cleaned up")
-				return nil
-			},
-			CancelDoFuncOnUpdate: true,
-		},
-	)
-}
-
-func (rc *remoteCluster) getClusterConfig(ctx context.Context, backend kvstore.BackendOperations, forceRequired bool) (*cmtypes.CiliumClusterConfig, error) {
-	var (
-		err                           error
-		requireConfig                 = forceRequired
-		clusterConfigRetrievalTimeout = 3 * time.Minute
-	)
-
-	ctx, cancel := context.WithTimeout(ctx, clusterConfigRetrievalTimeout)
-	defer cancel()
-
-	if !requireConfig {
-		// Let's check whether the kvstore states that the cluster configuration should be always present.
-		requireConfig, err = IsClusterConfigRequired(ctx, backend)
-		if err != nil {
-			return nil, fmt.Errorf("failed to detect whether the cluster configuration is required: %w", err)
-		}
+	var mgr store.WatchStoreManager
+	if capabilities.SyncedCanaries {
+		mgr = store.NewWatchStoreManagerSync(backend, rc.name)
+	} else {
+		mgr = store.NewWatchStoreManagerImmediate(rc.name)
 	}
 
-	cfgch := make(chan *types.CiliumClusterConfig)
-	defer close(cfgch)
-
-	// We retry here rather than simply returning an error and relying on the external
-	// controller backoff period to avoid recreating every time a new connection to the remote
-	// kvstore, which would introduce an unnecessary overhead. Still, we do return in case of
-	// consecutive failures, to ensure that we do not retry forever if something strange happened.
-	ctrlname := rc.remoteConnectionControllerName + "-cluster-config"
-	defer rc.controllers.RemoveControllerAndWait(ctrlname)
-	rc.controllers.UpdateController(ctrlname, controller.ControllerParams{
-		DoFunc: func(ctx context.Context) error {
-			rc.getLogger().Debug("Retrieving cluster configuration from remote kvstore")
-			config, err := GetClusterConfig(ctx, rc.name, backend)
-			if err != nil {
-				return err
-			}
-
-			if config == nil && requireConfig {
-				return errors.New("cluster configuration expected to be present but not found")
-			}
-
-			// We should stop retrying in case we either successfully retrieved the cluster
-			// configuration, or we are not required to wait for it.
-			cfgch <- config
-			return nil
-		},
-		Context:          ctx,
-		MaxRetryInterval: 30 * time.Second,
+	mgr.Register(nodeStore.NodeStorePrefix, func(ctx context.Context) {
+		rc.remoteNodes.Watch(ctx, backend, path.Join(nodeStore.NodeStorePrefix, rc.name))
 	})
 
-	// Wait until either the configuration is retrieved, or the context expires
-	select {
-	case config := <-cfgch:
-		return config, nil
-	case <-ctx.Done():
-		return nil, fmt.Errorf("failed to retrieve cluster configuration")
-	}
+	mgr.Register(serviceStore.ServiceStorePrefix, func(ctx context.Context) {
+		rc.remoteServices.Watch(ctx, backend, path.Join(serviceStore.ServiceStorePrefix, rc.name))
+	})
+
+	mgr.Register(ipcache.IPIdentitiesPath, func(ctx context.Context) {
+		rc.ipCacheWatcher.Watch(ctx, backend)
+	})
+
+	mgr.Run(ctx)
+	return nil
 }
 
-func (rc *remoteCluster) makeEtcdOpts() map[string]string {
-	opts := map[string]string{
-		kvstore.EtcdOptionConfig: rc.configPath,
-	}
+func (rc *remoteCluster) Stop() {}
 
-	for key, value := range option.Config.KVStoreOpt {
-		switch key {
-		case kvstore.EtcdRateLimitOption, kvstore.EtcdMaxInflightOption, kvstore.EtcdListLimitOption,
-			kvstore.EtcdOptionKeepAliveHeartbeat, kvstore.EtcdOptionKeepAliveTimeout:
-			opts[key] = value
-		}
-	}
-
-	return opts
-}
-
-func (rc *remoteCluster) makeExtraOpts() kvstore.ExtraOptions {
-	return kvstore.ExtraOptions{
-		NoLockQuorumCheck:            true,
-		ClusterName:                  rc.name,
-		ClusterSizeDependantInterval: rc.mesh.conf.ClusterSizeDependantInterval,
-	}
-}
-
-func (rc *remoteCluster) onInsert(allocator RemoteIdentityWatcher) {
-	rc.getLogger().Info("New remote cluster configuration")
-
-	if skipKvstoreConnection {
-		return
-	}
-
-	rc.remoteConnectionControllerName = fmt.Sprintf("remote-etcd-%s", rc.name)
-	rc.restartRemoteConnection(allocator)
-
-	go func() {
-		for {
-			val := <-rc.changed
-			if val {
-				rc.getLogger().Info("etcd configuration has changed, re-creating connection")
-				rc.restartRemoteConnection(allocator)
-			} else {
-				rc.getLogger().Info("Closing connection to remote etcd")
-				return
-			}
-		}
-	}()
-
-	go func() {
-		for {
-			select {
-			// terminate routine when remote cluster is removed
-			case _, ok := <-rc.changed:
-				if !ok {
-					return
-				}
-			default:
-			}
-
-			// wait for backend to appear
-			rc.mutex.RLock()
-			if rc.backend == nil {
-				rc.mutex.RUnlock()
-				time.Sleep(10 * time.Millisecond)
-				continue
-			}
-			statusCheckErrors := rc.backend.StatusCheckErrors()
-			rc.mutex.RUnlock()
-
-			err, ok := <-statusCheckErrors
-			if ok && err != nil {
-				rc.getLogger().WithError(err).Warning("Error observed on etcd connection, reconnecting etcd")
-				rc.mutex.Lock()
-				rc.failures++
-				rc.lastFailure = time.Now()
-				rc.mesh.metricLastFailureTimestamp.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).SetToCurrentTime()
-				rc.mesh.metricTotalFailures.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(float64(rc.failures))
-				rc.mesh.metricReadinessStatus.WithLabelValues(rc.mesh.conf.ClusterName, rc.mesh.nodeName, rc.name).Set(metrics.BoolToFloat64(rc.isReadyLocked()))
-				rc.mutex.Unlock()
-				rc.restartRemoteConnection(allocator)
-			}
-		}
-	}()
-
-}
-
-// onStop is executed when the clustermesh subsystem is being stopped.
-// In this case, we don't want to drain the known entries, otherwise
-// we would break existing connections when the agent gets restarted.
-func (rc *remoteCluster) onStop() {
-	rc.controllers.RemoveAllAndWait()
-	close(rc.changed)
-}
-
-// onRemove is executed when a remote cluster is explicitly disconnected
-// (i.e., its configuration is removed). In this case, we need to drain
-// all known entries, to properly cleanup the status without requiring to
-// restart the agent.
-func (rc *remoteCluster) onRemove() {
-	rc.onStop()
-
+func (rc *remoteCluster) Remove() {
+	// Draining shall occur only when the configuration for the remote cluster
+	// is removed, and not in case the agent is shutting down, otherwise we
+	// would break existing connections on restart.
 	rc.remoteNodes.Drain()
 	rc.remoteServices.Drain()
 	rc.ipCacheWatcher.Drain()
 
-	rc.getLogger().Info("Remote cluster disconnected")
+	rc.mesh.conf.RemoteIdentityWatcher.RemoveRemoteIdentities(rc.name)
+	rc.mesh.globalServices.onClusterDelete(rc.name)
 }
 
-func (rc *remoteCluster) isReady() bool {
+func (rc *remoteCluster) Status() *models.RemoteCluster {
+	status := rc.status()
+
 	rc.mutex.RLock()
 	defer rc.mutex.RUnlock()
 
-	return rc.isReadyLocked()
-}
-
-func (rc *remoteCluster) isReadyLocked() bool {
-	return rc.backend != nil
-}
-
-func (rc *remoteCluster) status() *models.RemoteCluster {
-	rc.mutex.RLock()
-	defer rc.mutex.RUnlock()
-
-	// This can happen when the controller in restartRemoteConnection is waiting
-	// for the first connection to succeed.
-	var backendStatus = "Waiting for initial connection to be established"
-	if rc.backend != nil {
-		var backendError error
-		backendStatus, backendError = rc.backend.Status()
-		if backendError != nil {
-			backendStatus = backendError.Error()
-		}
-	}
-
-	return &models.RemoteCluster{
-		Name:              rc.name,
-		Ready:             rc.isReadyLocked(),
-		NumNodes:          int64(rc.remoteNodes.NumEntries()),
-		NumSharedServices: int64(rc.remoteServices.NumEntries()),
-		NumIdentities:     int64(rc.remoteIdentityCache.NumEntries()),
-		Status:            backendStatus,
-		NumFailures:       int64(rc.failures),
-		LastFailure:       strfmt.DateTime(rc.lastFailure),
-	}
+	status.NumNodes = int64(rc.remoteNodes.NumEntries())
+	status.NumSharedServices = int64(rc.remoteServices.NumEntries())
+	status.NumIdentities = int64(rc.remoteIdentityCache.NumEntries())
+	return status
 }

--- a/pkg/clustermesh/utils/clustercfg.go
+++ b/pkg/clustermesh/utils/clustercfg.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"path"
+	"time"
+
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/kvstore"
+)
+
+func SetClusterConfig(ctx context.Context, clusterName string, config *cmtypes.CiliumClusterConfig, backend kvstore.BackendOperations) error {
+	key := path.Join(kvstore.ClusterConfigPrefix, clusterName)
+
+	val, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	_, err = backend.UpdateIfDifferent(ctx, key, val, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func GetClusterConfig(ctx context.Context, clusterName string, backend kvstore.BackendOperations) (*cmtypes.CiliumClusterConfig, error) {
+	var config cmtypes.CiliumClusterConfig
+
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	val, err := backend.Get(ctx, path.Join(kvstore.ClusterConfigPrefix, clusterName))
+	if err != nil {
+		return nil, err
+	}
+
+	// Cluster configuration missing, but it's not an error
+	if val == nil {
+		return nil, nil
+	}
+
+	if err := json.Unmarshal(val, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// IsClusterConfigRequired returns whether the remote kvstore guarantees that the
+// cilium cluster config will be eventually created.
+func IsClusterConfigRequired(ctx context.Context, backend kvstore.BackendOperations) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	val, err := backend.Get(ctx, kvstore.HasClusterConfigPath)
+	return val != nil, err
+}


### PR DESCRIPTION
This PR refactors the clustermesh subsystem, splitting it into a generic part (`pkg/clustermesh`), which is responsible for watching the configuration directory and establishing the connections to remote etcd endpoints, and a clustermesh specific part (`pkg/clustermesh/clustermesh`), which handles the actual synchronization of the required information). This is a preparatory change to allow reusing the generic part for the upcoming kvstoremesh implementation, reducing code duplication and maintenance burden.