### PR TITLE
auth: implement re-authentication in case of rotated certificates

### DIFF
--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -29,8 +29,9 @@ type authManager struct {
 	authHandlers map[policy.AuthType]authHandler
 	authmap      authMap
 
-	mutex   lock.Mutex
-	pending map[authKey]struct{}
+	mutex                    lock.Mutex
+	pending                  map[authKey]struct{}
+	handleAuthenticationFunc func(a *authManager, k authKey, reAuth bool)
 }
 
 // ipCache is the set of interactions the auth manager performs with the IPCache
@@ -56,11 +57,7 @@ type authResponse struct {
 	expirationTime time.Time
 }
 
-func newAuthManager(
-	authHandlers []authHandler,
-	authmap authMap,
-	ipCache ipCache,
-) (*authManager, error) {
+func newAuthManager(authHandlers []authHandler, authmap authMap, ipCache ipCache) (*authManager, error) {
 	ahs := map[policy.AuthType]authHandler{}
 	for _, ah := range authHandlers {
 		if ah == nil {
@@ -73,10 +70,11 @@ func newAuthManager(
 	}
 
 	return &authManager{
-		authHandlers: ahs,
-		authmap:      authmap,
-		ipCache:      ipCache,
-		pending:      make(map[authKey]struct{}),
+		authHandlers:             ahs,
+		authmap:                  authmap,
+		ipCache:                  ipCache,
+		pending:                  make(map[authKey]struct{}),
+		handleAuthenticationFunc: handleAuthentication,
 	}, nil
 }
 
@@ -89,16 +87,43 @@ func (a *authManager) handleAuthRequest(_ context.Context, key signalAuthKey) er
 		authType:       policy.AuthType(key.AuthType),
 	}
 
+	log.Debugf("auth: Handle authentication request for key %s", k)
+
+	a.handleAuthenticationFunc(a, k, false)
+
+	return nil
+}
+
+func (a *authManager) handleCertificateRotationEvent(_ context.Context, event certs.CertificateRotationEvent) error {
+	log.Debugf("auth: Handle certificate rotation event for identity %s", event.Identity)
+
+	all, err := a.authmap.All()
+	if err != nil {
+		return fmt.Errorf("failed to get all auth map entries: %w", err)
+	}
+
+	for k := range all {
+		if k.localIdentity == event.Identity || k.remoteIdentity == event.Identity {
+			a.handleAuthenticationFunc(a, k, true)
+		}
+	}
+
+	return nil
+}
+
+func handleAuthentication(a *authManager, k authKey, reAuth bool) {
 	if a.markPendingAuth(k) {
 		go func(key authKey) {
 			defer a.clearPendingAuth(key)
 
-			// Check if the auth is actually required, as we might have
-			// updated the authmap since the datapath issued the auth
-			// required signal.
-			if i, err := a.authmap.Get(key); err == nil && i.expiration.After(time.Now()) {
-				log.Debugf("auth: Already authenticated, skipped authentication for key %v", key)
-				return
+			if !reAuth {
+				// Check if the auth is actually required, as we might have
+				// updated the authmap since the datapath issued the auth
+				// required signal.
+				if i, err := a.authmap.Get(key); err == nil && i.expiration.After(time.Now()) {
+					log.Debugf("auth: Already authenticated, skipped authentication for key %v", key)
+					return
+				}
 			}
 
 			if err := a.authenticate(key); err != nil {
@@ -106,8 +131,6 @@ func (a *authManager) handleAuthRequest(_ context.Context, key signalAuthKey) er
 			}
 		}(k)
 	}
-
-	return nil
 }
 
 // markPendingAuth checks if there is a pending authentication for the given key.

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -21,7 +21,7 @@ func Test_newAuthManager_clashingAuthHandlers(t *testing.T) {
 		&alwaysFailAuthHandler{},
 	}
 
-	am, err := newAuthManager(nil, authHandlers, nil, nil)
+	am, err := newAuthManager(authHandlers, nil, nil)
 	assert.ErrorContains(t, err, "multiple handlers for auth type: test-always-fail")
 	assert.Nil(t, am)
 }
@@ -32,7 +32,7 @@ func Test_newAuthManager(t *testing.T) {
 		&fakeAuthHandler{},
 	}
 
-	am, err := newAuthManager(make(<-chan signalAuthKey, 100), authHandlers, nil, nil)
+	am, err := newAuthManager(authHandlers, nil, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, am)
 
@@ -87,7 +87,6 @@ func Test_authManager_authenticate(t *testing.T) {
 				entries: map[authKey]authInfo{},
 			}
 			am, err := newAuthManager(
-				make(<-chan signalAuthKey, 100),
 				[]authHandler{&alwaysFailAuthHandler{}, &alwaysPassAuthHandler{}},
 				authMap,
 				newFakeIPCache(map[uint16]string{


### PR DESCRIPTION
This PR introduces mutual auth re-authentication. Whenever an
authhandler is emiting CertificateRotatedEvents, an authentication will
be triggered.

In addition, the existing authentication flow has been refactored to use the hive job framework.

Fixes https://github.com/cilium/cilium/issues/25475