### PR TITLE
bpf: nodeport: don't reset aggregate ID when revDNAT is called by bpf_lxc

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1313,7 +1313,10 @@ int tail_rev_nodeport_lb6(struct __ctx_buff *ctx)
 	ret = rev_nodeport_lb6(ctx, &ext_err);
 	if (IS_ERR(ret))
 		goto drop;
+
+#ifndef IS_BPF_LXC
 	edt_set_aggregate(ctx, 0);
+#endif
 	cilium_capture_out(ctx);
 	return ret;
 drop:
@@ -2664,7 +2667,10 @@ int tail_rev_nodeport_lb4(struct __ctx_buff *ctx)
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
 						  CTX_ACT_DROP, METRIC_EGRESS);
+
+#ifndef IS_BPF_LXC
 	edt_set_aggregate(ctx, 0);
+#endif
 	cilium_capture_out(ctx);
 	return ret;
 }


### PR DESCRIPTION
tail_rev_nodeport_lb*() is typically used for RevDNAT of replies by a remote service backend, on a NAT connection. To avoid accidental rate-limiting in to-netdev, we need to clear the EDT aggregate-ID (which is stored in skb->queue_mapping).

But in the "legacy" path for replies by local service backends, from-container also tail-calls to CILIUM_CALL_IPV*_NODEPORT_REVNAT for RevDNAT handling. Current code would then accidentally clear the aggregate-ID that was previously set by bpf_lxc, and the traffic would pass through to-netdev without rate-limiting.

Fix this by excluding the relevant code for bpf_lxc.