### PR TITLE
.github/workflows: add JUnit tag on workflows that have JUnits

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -330,7 +330,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -332,7 +332,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -332,7 +332,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -328,7 +328,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -309,7 +309,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -309,7 +309,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -309,7 +309,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -296,7 +296,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -533,7 +533,7 @@ jobs:
         path: cilium-sysdump-*.zip
         retention-days: 5
 
-    - name: Upload JUnits
+    - name: Upload JUnits [junit]
       if: ${{ always() }}
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -528,7 +528,7 @@ jobs:
         path: cilium-sysdump-*.zip
         retention-days: 5
 
-    - name: Upload JUnits
+    - name: Upload JUnits [junit]
       if: ${{ always() }}
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -528,7 +528,7 @@ jobs:
         path: cilium-sysdump-*.zip
         retention-days: 5
 
-    - name: Upload JUnits
+    - name: Upload JUnits [junit]
       if: ${{ always() }}
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -518,7 +518,7 @@ jobs:
         path: cilium-sysdump-*.zip
         retention-days: 5
 
-    - name: Upload JUnits
+    - name: Upload JUnits [junit]
       if: ${{ always() }}
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:

--- a/.github/workflows/conformance-e2e-v1.13.yaml
+++ b/.github/workflows/conformance-e2e-v1.13.yaml
@@ -480,7 +480,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -491,7 +491,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -329,7 +329,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -329,7 +329,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -329,7 +329,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -319,7 +319,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -361,7 +361,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -361,7 +361,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -361,7 +361,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -355,7 +355,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -617,7 +617,7 @@ jobs:
           cd test/
           tar -xf /tmp/.ginkgo-build/test.tgz
 
-      - name: Run tests [junit]
+      - name: Run tests
         timeout-minutes: 40
         uses: cilium/little-vm-helper@d04a0cf0ee684b1b249a320a0a6030ffda5eef30 # v0.0.5
         with:
@@ -710,7 +710,7 @@ jobs:
           junit_filename="${{ env.job_name }}.xml"
           for filename in *.xml; do cp "${filename}" "../cilium-junits/${junit_filename}"; done;
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -358,7 +358,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -358,7 +358,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -359,7 +359,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -355,7 +355,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -245,9 +245,16 @@ jobs:
           path: ./_artifacts/logs
           retention-days: 5
 
-      - name: Upload Kubernetes e2e Junit Reports
+      - name: Upload Kubernetes e2e Junit Reports [junit]
         if: ${{ success() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
         with:
           name: kubernetes-e2e-junit
           path: './_artifacts/*.xml'
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "_artifacts"
+

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -147,7 +147,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-multicluster-v1.11.yaml
+++ b/.github/workflows/conformance-multicluster-v1.11.yaml
@@ -410,7 +410,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-multicluster-v1.12.yaml
+++ b/.github/workflows/conformance-multicluster-v1.12.yaml
@@ -410,7 +410,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-multicluster-v1.13.yaml
+++ b/.github/workflows/conformance-multicluster-v1.13.yaml
@@ -440,7 +440,7 @@ jobs:
           path: cilium-sysdump-*.zip
           retention-days: 5
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -249,7 +249,7 @@ jobs:
             /tmp/provision/runtime_install.sh
             service docker restart
 
-      - name: Runtime tests [junit]
+      - name: Runtime tests
         if: ${{ matrix.focus == 'agent' || matrix.focus == 'datapath' }}
         timeout-minutes: 20
         shell: bash
@@ -281,7 +281,7 @@ jobs:
           -cilium.operator-suffix=-ci \
           -cilium.SSHConfig="cat ./cilium-ssh-config.txt"
 
-      - name: Runtime privileged tests [junit]
+      - name: Runtime privileged tests
         if: ${{ matrix.focus == 'privileged' }}
         timeout-minutes: 20
         uses: cilium/little-vm-helper@d04a0cf0ee684b1b249a320a0a6030ffda5eef30 # v0.0.5
@@ -335,7 +335,7 @@ jobs:
           junit_filename="${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml"
           for filename in *.xml; do cp "${filename}" "../cilium-junits/${junit_filename}"; done;
 
-      - name: Upload JUnits
+      - name: Upload JUnits [junit]
         if: ${{ always() }}
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:


### PR DESCRIPTION
In order for the CI dashboard backend to know that a workflow provides JUnits we need to tag any of the workflow steps with the `[junit]` string.