### PR TITLE
Add gARP capability to L2 announcer feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/kr/pretty v0.3.1
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/mdlayher/arp v0.0.0-20220221190821-c37aaafac7f9
+	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118
 	github.com/miekg/dns v1.1.43
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/ginkgo v1.16.5
@@ -201,7 +202,6 @@ require (
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
-	github.com/mdlayher/ethernet v0.0.0-20220221185849-529eae5b6118 // indirect
 	github.com/mdlayher/genetlink v1.3.2 // indirect
 	github.com/mdlayher/ndp v0.0.0-20200602162440-17ab9e3e5567 // indirect
 	github.com/mdlayher/netlink v1.7.2 // indirect


### PR DESCRIPTION
When failover occurs a different node will start responding to ARP.
But other nodes on the network will not know this has happened and thus
keep using the ARP entry from their local cache.

This PR makes it so we broadcast a gARP reply with the new MAC
address of the IP any time we reconcile a IP+ifidx tuple that was not
yet present in the L2 responder map.

Nodes that honor gARP replies will update their ARP cache to minimize
downtime. Those who do not honer these replies will have more downtime
until their ARP cache entry expires and they perform a ARP request
themselves.

```release-note
Added gARP capability to L2 announcer feature
```
