### PR TITLE
resource: implement stream.Observable

### DIFF
--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -4,7 +4,6 @@
 package auth
 
 import (
-	"context"
 	"fmt"
 	"runtime/pprof"
 	"time"
@@ -22,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/signal"
-	"github.com/cilium/cilium/pkg/stream"
 )
 
 // Cell invokes authManager which is responsible for request authentication.
@@ -141,24 +139,15 @@ func newManager(params authManagerParams) error {
 func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params authManagerParams) {
 	// Add identities based auth gc if k8s client is enabled
 	if params.CiliumIdentities != nil {
-		jobGroup.Add(job.Observer("auth identities gc",
-			mapGC.handleCiliumIdentityEvent,
-			stream.FromChannel(params.CiliumIdentities.Events(context.Background())),
-		))
+		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumIdentity]]("auth identities gc", mapGC.handleCiliumIdentityEvent, params.CiliumIdentities))
 	}
 
 	// Add node based auth gc if k8s client is enabled
 	if params.CiliumNodes != nil {
-		jobGroup.Add(job.Observer("auth nodes gc",
-			mapGC.handleCiliumNodeEvent,
-			stream.FromChannel(params.CiliumNodes.Events(context.Background())),
-		))
+		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumNode]]("auth nodes gc", mapGC.handleCiliumNodeEvent, params.CiliumNodes))
 	}
 
-	jobGroup.Add(job.Timer("auth expiration gc",
-		mapGC.CleanupExpiredEntries,
-		params.Config.MeshAuthExpiredGCInterval,
-	))
+	jobGroup.Add(job.Timer("auth expiration gc", mapGC.CleanupExpiredEntries, params.Config.MeshAuthExpiredGCInterval))
 }
 
 type authHandlerResult struct {

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -123,6 +123,10 @@ type fakeResource[T runtime.Object] struct {
 	store resource.Store[T]
 }
 
+func (fr *fakeResource[T]) Observe(ctx context.Context, next func(event resource.Event[T]), complete func(error)) {
+
+}
+
 func (fr *fakeResource[T]) Events(ctx context.Context, opts ...resource.EventsOpt) <-chan resource.Event[T] {
 	return make(<-chan resource.Event[T])
 }


### PR DESCRIPTION
This commit lets resource.Resource implement stream.Observable to easily use k8s resources as observable without wrapping them with stream.FromChannel.

This is especially useful with hive jobs and make direct use of the context handling.

thanks @joamaki for recommending this