### PR TITLE
bpf: don't build all bpf when making containers (fix)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ debug: all
 
 include Makefile.defs
 
-SUBDIRS_CILIUM_CONTAINER := envoy bpf cilium daemon cilium-health bugtool tools/mount tools/sysctlfix
+SUBDIRS_CILIUM_CONTAINER := envoy cilium daemon cilium-health bugtool tools/mount tools/sysctlfix
 SUBDIR_OPERATOR_CONTAINER := operator
 
 # Add the ability to override variables
 -include Makefile.override
 
-SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) $(SUBDIR_OPERATOR_CONTAINER) plugins tools hubble-relay
+SUBDIRS := $(SUBDIRS_CILIUM_CONTAINER) $(SUBDIR_OPERATOR_CONTAINER) plugins tools hubble-relay bpf
 
 SUBDIRS_CILIUM_CONTAINER += plugins/cilium-cni
 ifdef LIBNETWORK_PLUGIN


### PR DESCRIPTION
We used to skip bpf builds by setting PKG_BUILD=1 deep in the docker build rules, but that check was removed. That variable is undocumented and obscure anyways, so let's not bring it back.
    
 Rather, don't set bpf for building when making container images, just when doing a top-level "make build".


Fixes: 4b78c1e60d