### PR TITLE
conformance-runtime: Bump timeout to wait for images

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -139,7 +139,7 @@ jobs:
           fi
 
       - name: Waiting for images
-        timeout-minutes: 10
+        timeout-minutes: 20
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do


### PR DESCRIPTION
There have been some timeouts.