### PR TITLE
cilium/cmd: Deprecate `cilium endpoint regenerate` command

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -359,6 +359,12 @@ Deprecated Options
   options are deprecated and will be removed in v1.15. There is no replacement for these
   flags as enabling them causes scalability and performance issues even in small clusters.
 
+Deprecated Commands
+~~~~~~~~~~~~~~~~~~~
+
+* The ``cilium endpoint regenerate`` command is deprecated and will be removed
+  in v1.15.
+
 Added Metrics
 ~~~~~~~~~~~~~
 

--- a/cilium/cmd/endpoint_regenerate.go
+++ b/cilium/cmd/endpoint_regenerate.go
@@ -6,16 +6,24 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 // endpointRegenerateCmd represents the endpoint_regenerate command
 var endpointRegenerateCmd = &cobra.Command{
-	Use:    "regenerate <endpoint-id>",
-	Short:  "Force regeneration of endpoint program",
-	PreRun: requireEndpointID,
+	Use:   "regenerate <endpoint-id>",
+	Short: "Force regeneration of endpoint program",
+	PreRun: func(cmd *cobra.Command, args []string) {
+		log.WithFields(logrus.Fields{
+			logfields.URL:         "https://github.com/cilium/cilium/issues/25948",
+			logfields.HelpMessage: "For more information, see the linked URL.",
+		}).Warn("This command is deprecated and will be removed in Cilium v1.15.")
+		requireEndpointID(cmd, args)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		id := args[0]
 		cfg := &models.EndpointConfigurationSpec{}


### PR DESCRIPTION
As mentioned in GH-25948, let's deprecate this command and queue it for
removal in v1.15.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
