### PR TITLE
.github: simplify conformance-runtime workflow

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -18,58 +18,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.after }}
   cancel-in-progress: true
 
-env:
-  # List of Runtime tests
-  # <description>: <Regex that matches the tests in the section>
-  ###
-  agent: "RuntimeAgent|RuntimeSSHTests"
-  # RuntimeAgentChaos Cilium agent Checking for file-descriptor leak
-  # RuntimeAgentChaos Cilium agent removing leftover Cilium interfaces
-  # RuntimeAgentChaos Connectivity over restarts Checking that during restart no traffic is dropped using Egress + Ingress Traffic
-  # RuntimeAgentChaos Endpoint Endpoint recovery on restart
-  # RuntimeAgentChaos KVStore Delete event on KVStore with CIDR identities
-  # RuntimeAgentChaos KVStore Validate that delete events on KVStore do not release in use identities
-  # RuntimeAgentFQDNPolicies Can update L7 DNS policy rules
-  # RuntimeAgentFQDNPolicies CNAME follow
-  # RuntimeAgentFQDNPolicies DNS proxy policy works if Cilium stops
-  # RuntimeAgentFQDNPolicies Enforces L3 policy even when no IPs are inserted
-  # RuntimeAgentFQDNPolicies Enforces ToFQDNs policy
-  # RuntimeAgentFQDNPolicies Implements matchPattern: *
-  # RuntimeAgentFQDNPolicies Interaction with other ToCIDR rules
-  # RuntimeAgentFQDNPolicies Roundrobin DNS
-  # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) L3-dependent L7/HTTP with toFQDN updates proxy policy
-  # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) Policy addition after DNS lookup
-  # RuntimeAgentFQDNPolicies Validate dns-proxy monitor information
-  # RuntimeAgentFQDNPolicies With verbose policy logs Validates DNSSEC responses
-  # RuntimeAgentKVStoreTest KVStore tests Consul KVStore
-  # RuntimeAgentKVStoreTest KVStore tests Etcd KVStore
-  # RuntimeAgentPolicies Init Policy Default Drop Test tests egress
-  # RuntimeAgentPolicies Init Policy Default Drop Test tests ingress
-  # RuntimeAgentPolicies Init Policy Default Drop Test With PolicyAuditMode tests egress
-  # RuntimeAgentPolicies Init Policy Default Drop Test With PolicyAuditMode tests ingress
-  # RuntimeAgentPolicies Init Policy Test Init Egress Policy Test
-  # RuntimeAgentPolicies Init Policy Test Init Ingress Policy Test
-  # RuntimeAgentPolicies TestsEgressToHost Tests Egress To Host
-  # RuntimeAgentPolicies TestsEgressToHost Tests egress with CIDR+L4 policy
-  # RuntimeAgentPolicies TestsEgressToHost Tests egress with CIDR+L4 policy to external https service
-  # RuntimeAgentPolicies TestsEgressToHost Tests egress with CIDR+L7 policy
-  # RuntimeAgentPolicies Tests Endpoint Connectivity Functions After Daemon Configuration Is Updated
-  # RuntimeAgentPolicies Tests EntityNone as a deny-all
-  # RuntimeSSHTests Should fail when context times out
-  ###
-  datapath: "RuntimeDatapathConntrackInVethModeTest|RuntimeDatapathMonitorTest"
-  # RuntimeDatapathConntrackInVethModeTest Conntrack-related configuration options for endpoints
-  # RuntimeDatapathMonitorTest With Sample Containers checks container ids match monitor output
-  # RuntimeDatapathMonitorTest With Sample Containers cilium monitor check --from
-  # RuntimeDatapathMonitorTest With Sample Containers cilium monitor check --related-to
-  # RuntimeDatapathMonitorTest With Sample Containers cilium monitor check --to
-  # RuntimeDatapathMonitorTest With Sample Containers Cilium monitor event types
-  # RuntimeDatapathMonitorTest With Sample Containers delivers the same information to multiple monitors
-  ###
-  privileged: "RuntimeDatapathPrivilegedUnitTests"
-  # RuntimeDatapathPrivilegedUnitTests Run Tests
-  ###
-
 jobs:
   # Pre-build the ginkgo binary so that we don't have to build it for all
   # runners.
@@ -150,11 +98,11 @@ jobs:
     needs: build-ginkgo-binary
     runs-on:
       group: ginkgo-runners
-    name: Runtime Test
+    name: "Runtime Test (${{matrix.focus}})"
     env:
-      # GitHub doesn't provide a way to retrieve the name of a job so we have
+      # GitHub doesn't provide a way to retrieve the name of a job, so we have
       # to repeated it here.
-      job_name: "Runtime Test"
+      job_name: "Runtime Test (${{matrix.focus}})"
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -163,6 +111,60 @@ jobs:
           - "agent"
           - "datapath"
           - "privileged"
+
+        include:
+          ###
+          # RuntimeAgentChaos Cilium agent Checking for file-descriptor leak
+          # RuntimeAgentChaos Cilium agent removing leftover Cilium interfaces
+          # RuntimeAgentChaos Connectivity over restarts Checking that during restart no traffic is dropped using Egress + Ingress Traffic
+          # RuntimeAgentChaos Endpoint Endpoint recovery on restart
+          # RuntimeAgentChaos KVStore Delete event on KVStore with CIDR identities
+          # RuntimeAgentChaos KVStore Validate that delete events on KVStore do not release in use identities
+          # RuntimeAgentFQDNPolicies Can update L7 DNS policy rules
+          # RuntimeAgentFQDNPolicies CNAME follow
+          # RuntimeAgentFQDNPolicies DNS proxy policy works if Cilium stops
+          # RuntimeAgentFQDNPolicies Enforces L3 policy even when no IPs are inserted
+          # RuntimeAgentFQDNPolicies Enforces ToFQDNs policy
+          # RuntimeAgentFQDNPolicies Implements matchPattern: *
+          # RuntimeAgentFQDNPolicies Interaction with other ToCIDR rules
+          # RuntimeAgentFQDNPolicies Roundrobin DNS
+          # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) L3-dependent L7/HTTP with toFQDN updates proxy policy
+          # RuntimeAgentFQDNPolicies toFQDNs populates toCIDRSet (data from proxy) Policy addition after DNS lookup
+          # RuntimeAgentFQDNPolicies Validate dns-proxy monitor information
+          # RuntimeAgentFQDNPolicies With verbose policy logs Validates DNSSEC responses
+          # RuntimeAgentKVStoreTest KVStore tests Consul KVStore
+          # RuntimeAgentKVStoreTest KVStore tests Etcd KVStore
+          # RuntimeAgentPolicies Init Policy Default Drop Test tests egress
+          # RuntimeAgentPolicies Init Policy Default Drop Test tests ingress
+          # RuntimeAgentPolicies Init Policy Default Drop Test With PolicyAuditMode tests egress
+          # RuntimeAgentPolicies Init Policy Default Drop Test With PolicyAuditMode tests ingress
+          # RuntimeAgentPolicies Init Policy Test Init Egress Policy Test
+          # RuntimeAgentPolicies Init Policy Test Init Ingress Policy Test
+          # RuntimeAgentPolicies TestsEgressToHost Tests Egress To Host
+          # RuntimeAgentPolicies TestsEgressToHost Tests egress with CIDR+L4 policy
+          # RuntimeAgentPolicies TestsEgressToHost Tests egress with CIDR+L4 policy to external https service
+          # RuntimeAgentPolicies TestsEgressToHost Tests egress with CIDR+L7 policy
+          # RuntimeAgentPolicies Tests Endpoint Connectivity Functions After Daemon Configuration Is Updated
+          # RuntimeAgentPolicies Tests EntityNone as a deny-all
+          # RuntimeSSHTests Should fail when context times out
+          - focus: "agent"
+            cliFocus: "RuntimeAgent|RuntimeSSHTests"
+
+          ###
+          # RuntimeDatapathConntrackInVethModeTest Conntrack-related configuration options for endpoints
+          # RuntimeDatapathMonitorTest With Sample Containers checks container ids match monitor output
+          # RuntimeDatapathMonitorTest With Sample Containers cilium monitor check --from
+          # RuntimeDatapathMonitorTest With Sample Containers cilium monitor check --related-to
+          # RuntimeDatapathMonitorTest With Sample Containers cilium monitor check --to
+          # RuntimeDatapathMonitorTest With Sample Containers Cilium monitor event types
+          # RuntimeDatapathMonitorTest With Sample Containers delivers the same information to multiple monitors
+          - focus: "datapath"
+            cliFocus: "RuntimeDatapathConntrackInVethModeTest|RuntimeDatapathMonitorTest"
+
+          ###
+          # RuntimeDatapathPrivilegedUnitTests Run Tests
+          - focus: "privileged"
+            cliFocus: "RuntimeDatapathPrivilegedUnitTests"
 
     timeout-minutes: 20
     steps:
@@ -176,23 +178,6 @@ jobs:
           fi
 
           echo "sha=${SHA}" >> $GITHUB_OUTPUT
-
-          case ${{ matrix.focus }} in
-              agent)
-                  focus="${{ env.agent }}"
-                  ;;
-              datapath)
-                  focus="${{ env.datapath }}"
-                  ;;
-              privileged)
-                  focus="${{ env.privileged }}"
-                  ;;
-              *)
-                  echo "focus group not found!"
-                  ;;
-          esac
-
-          echo "focus=${focus}" >> $GITHUB_OUTPUT
 
       - name: Checkout pull request for tests
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -267,8 +252,8 @@ jobs:
           cd test
           export INTEGRATION_TESTS=true
           ./test.test \
-          --ginkgo.focus="${{ steps.vars.outputs.focus }}" \
-          --ginkgo.skip="${{ matrix.skip }}" \
+          --ginkgo.focus="${{ matrix.cliFocus }}" \
+          --ginkgo.skip="${{ matrix.cliSkip }}" \
           --ginkgo.seed=1679952881 \
           --ginkgo.v -- \
           -cilium.provision=false \
@@ -332,7 +317,7 @@ jobs:
           # GH web UI - In the Summary page of a workflow run, left column
           # "Jobs" - so that we can map the junit file to the right job - step
           # pair on datastudio.
-          junit_filename="${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml"
+          junit_filename="${{ env.job_name }}.xml"
           for filename in *.xml; do cp "${filename}" "../cilium-junits/${junit_filename}"; done;
 
       - name: Upload JUnits [junit]


### PR DESCRIPTION
Suggested by Nicolas, the workflows can have more matrix dimensions associated with them and so we don't need to define the CLI regex as environment variables.

Suggested-by: Nicolas Busseneau <nicolas@isovalent.com>