### PR TITLE
docs: Add externalTrafficPolicy=Local description to BGP CPlane doc

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -291,6 +291,13 @@ io.kubernetes.service.namespace ``.meta.namespace``
 io.kubernetes.service.name      ``.meta.name``
 =============================== ===================
 
+Semantics of the externalTrafficPolicy: Local
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the service has ``externalTrafficPolicy: Local``, ``BGP Control Plane`` keeps track
+of the endpoints for the service on the local node and stops advertisement when there's
+no local endpoint.
+
 Architecture
 ------------
 


### PR DESCRIPTION
As we now implemented the support for externalTrafficPolicy in 24e37ed4f42916333335e678db1ae78022ac3e4c.

```release-note
docs: Add externalTrafficPolicy=Local description to BGP CPlane doc
```
