### PR TITLE
proxy: Do not panic on local error

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -579,7 +579,8 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 		if nRetry > 0 {
 			// an error occurred and we can retry
 			scopedLog.WithError(err).Warningf("Unable to create %s proxy, retrying", ppName)
-			if option.Config.ToFQDNsProxyPort == 0 {
+			// Do not increment port for DNS when the port is set in config
+			if pp.proxyType != ProxyTypeDNS || option.Config.ToFQDNsProxyPort == 0 {
 				pp.proxyPort++
 			}
 		}


### PR DESCRIPTION
CreateOrUpdateRedirect called nil revertFunc when any local error was returned. This was done using the pattern `return 0, err, nil, nil` which sets the revertFunc return variable as nil, but this was called on a deferred function to revert any changes on a local error.

Fix this by calling ReverStack.Revert() directly on the deferred function, and setting the return variable if there was no local error.

Another panic was possible when updating an existing redirect the proxy port of which had been released. Check that the proxy port is initialized before reusing the (possibly stale) redirect.

This was hit any time a CiliumNetworkPolicy referred to a non-existing listener.

Add a test case that reproduced the panic and works after the fix.

Increment proxy port on failure for non-DNS ports, even if DNS has been configured with a static port.

```release-note
Fixed Cilium agent crash when policy refers to a non-existing Envoy listener.
```
