### PR TITLE
bgpv1: Extend the timeout for the Test_NeighborAddDel test

### DIFF
--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -21,8 +21,8 @@ import (
 
 var (
 	// maxNeighborTestDuration is allowed time for the Neighbor tests execution
-	// (on average we need about 20 - 25s to finish the tests due to BGP timers etc.)
-	maxNeighborTestDuration = 40 * time.Second
+	// (on average we need about 35-40s to finish the tests due to BGP timers etc.)
+	maxNeighborTestDuration = 1 * time.Minute
 )
 
 // peeringState helper struct containing peering information of BGP neighbor


### PR DESCRIPTION
After the recent GoBGP version upgrade the `Test_NeighborAddDel` test takes a bit longer than it used to.

Still analyzing why exactly, but extending the timeout to 1 min should be enough to avoid CI issues.

Fixes: #25968
