### PR TITLE
auth: add missing config values to helm values

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -40,6 +40,10 @@
      - Annotate k8s node upon initialization with Cilium's metadata.
      - bool
      - ``false``
+   * - authentication.expiredGCInterval
+     - Interval for garbage collection of expired auth map entries.
+     - string
+     - ``"15m0s"``
    * - authentication.mutual.port
      - Port on the agent where mutual authentication handshakes between agents will be performed
      - int
@@ -144,6 +148,14 @@
      - SPIFFE trust domain to use for fetching certificates
      - string
      - ``"spiffe.cilium"``
+   * - authentication.queueSize
+     - Buffer size of the channel Cilium uses to receive authentication events from the signal map.
+     - int
+     - ``1024``
+   * - authentication.rotatedIdentitiesQueueSize
+     - Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers.
+     - int
+     - ``1024``
    * - autoDirectNodeRoutes
      - Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment.
      - bool

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -441,6 +441,7 @@ ethernet
 ethtool
 eventBufferCapacity
 eventQueueSize
+expiredGCInterval
 extTrafficPolicy
 extendable
 extensibility
@@ -879,6 +880,7 @@ qede
 qemu
 quantiles
 queryable
+queueSize
 queueing
 rbac
 rc
@@ -920,6 +922,7 @@ roadmap
 rollOutCiliumPods
 rollOutPods
 rollout
+rotatedIdentitiesQueueSize
 routable
 routingMode
 rst

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -60,6 +60,7 @@ contributors across the globe, there is almost always someone available to help.
 | aksbyocni.enabled | bool | `false` | Enable AKS BYOCNI integration. Note that this is incompatible with AKS clusters not created in BYOCNI mode: use Azure integration (`azure.enabled`) instead. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
+| authentication.expiredGCInterval | string | `"15m0s"` | Interval for garbage collection of expired auth map entries. |
 | authentication.mutual.port | int | `4250` | Port on the agent where mutual authentication handshakes between agents will be performed |
 | authentication.mutual.spire.adminSocketPath | string | `"/run/spire/sockets/admin.sock"` | SPIRE socket path where the SPIRE delegated api agent is listening |
 | authentication.mutual.spire.agentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE socket path where the SPIRE workload agent is listening. Applies to both the Cilium Agent and Operator |
@@ -86,6 +87,8 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.install.server.serviceAccount | object | `{"create":true,"name":"spire-server"}` | SPIRE server service account |
 | authentication.mutual.spire.serverAddress | string | `"spire-server.cilium-spire.svc:8081"` | SPIRE server address |
 | authentication.mutual.spire.trustDomain | string | `"spiffe.cilium"` | SPIFFE trust domain to use for fetching certificates |
+| authentication.queueSize | int | `1024` | Buffer size of the channel Cilium uses to receive authentication events from the signal map. |
+| authentication.rotatedIdentitiesQueueSize | int | `1024` | Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers. |
 | autoDirectNodeRoutes | bool | `false` | Enable installation of PodCIDR routes between worker nodes if worker nodes share a common L2 network segment. |
 | azure.enabled | bool | `false` | Enable Azure integration. Note that this is incompatible with AKS clusters created in BYOCNI mode: use AKS BYOCNI integration (`aksbyocni.enabled`) instead. |
 | bandwidthManager | object | `{"bbr":false,"enabled":false}` | Enable bandwidth manager to optimize TCP and UDP workloads and allow for rate-limiting traffic from individual Pods with EDT (Earliest Departure Time) through the "kubernetes.io/egress-bandwidth" Pod annotation. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1086,6 +1086,10 @@ data:
   agent-not-ready-taint-key: {{ .Values.agentNotReadyTaintKey | quote }}
 {{- end }}
 
+  mesh-auth-queue-size: {{ .Values.authentication.queueSize | quote }}
+  mesh-auth-rotated-identities-queue-size: {{ .Values.authentication.rotatedIdentitiesQueueSize | quote }}
+  mesh-auth-expired-gc-interval: {{ include "validateDuration" .Values.authentication.expiredGCInterval | quote }}
+
 {{- if .Values.authentication.mutual.spire.enabled }}
   mesh-auth-mutual-enabled: "true"
   mesh-auth-mutual-listener-port: {{ .Values.authentication.mutual.port | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2950,6 +2950,12 @@ sctp:
 
 # Configuration for types of authentication for Cilium
 authentication:
+  # -- Buffer size of the channel Cilium uses to receive authentication events from the signal map.
+  queueSize: 1024
+  # -- Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers.
+  rotatedIdentitiesQueueSize: 1024
+    # -- Interval for garbage collection of expired auth map entries.
+  expiredGCInterval: "15m0s"
   # Configuration for Cilium's service-to-service mutual authentication using TLS handshakes.
   # Note that this is not full mTLS support without also enabling encryption of some form.
   # Current encryption options are Wireguard or IPSec, configured in encryption block above.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2947,6 +2947,12 @@ sctp:
 
 # Configuration for types of authentication for Cilium
 authentication:
+  # -- Buffer size of the channel Cilium uses to receive authentication events from the signal map.
+  queueSize: 1024
+  # -- Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers.
+  rotatedIdentitiesQueueSize: 1024
+    # -- Interval for garbage collection of expired auth map entries.
+  expiredGCInterval: "15m0s"
   # Configuration for Cilium's service-to-service mutual authentication using TLS handshakes.
   # Note that this is not full mTLS support without also enabling encryption of some form.
   # Current encryption options are Wireguard or IPSec, configured in encryption block above.


### PR DESCRIPTION
Currently, some auth-related config properties are not exposed/configurable via Helm Chart.

This PR adds the missing properties to the Helm Chart.