### PR TITLE
ipcache: fix not waiting for k8s caches to sync

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -118,8 +118,6 @@ type IPCache struct {
 	// interface.
 	namedPorts namedPortMultiMapUpdater
 
-	cacheStatus k8s.CacheStatus
-
 	// Configuration provides pointers towards other agent components that
 	// the IPCache relies upon at runtime.
 	*Configuration

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -171,7 +171,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 		return modifiedPrefixes, ErrLocalIdentityAllocatorUninitialized
 	}
 
-	if !ipc.cacheStatus.Synchronized() {
+	if !ipc.Configuration.CacheStatus.Synchronized() {
 		return modifiedPrefixes, errors.New("k8s cache not fully synced")
 	}
 


### PR DESCRIPTION
This variable was refactored, but we missed reading from the new source.

Fixes: c12cbe426