### PR TITLE
k8s: fix ciliumpodippools CRD controller-gen version

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumpodippools.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumpodippools.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.11.4
   creationTimestamp: null
   name: ciliumpodippools.cilium.io
 spec:


### PR DESCRIPTION
This commit fixes the outdated version in the annotation `controller-gen.kubebuilder.io/version` of the CRD ciliumpodippools by updating it to `v0.11.4`.

Fixes: https://github.com/cilium/cilium/issues/25974