### PR TITLE
policy: allocate identity for CIDR selectors on first use (v2)

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -395,7 +395,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 	if option.Config.EnableIPv6 && ep.IPv6.IsValid() {
 		ipv6Pool := ipam.PoolOrDefault(ep.IPv6IPAMPool)
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanStringLocked()+" [restored]", ipv6Pool)
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanString()+" [restored]", ipv6Pool)
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6, err)
 		}
@@ -409,7 +409,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 
 	if option.Config.EnableIPv4 && ep.IPv4.IsValid() {
 		ipv4Pool := ipam.PoolOrDefault(ep.IPv4IPAMPool)
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanStringLocked()+" [restored]", ipv4Pool)
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanString()+" [restored]", ipv4Pool)
 		switch {
 		// We only check for BypassIPAllocUponRestore for IPv4 because we
 		// assume that this flag is only turned on for IPv4-only IPAM modes

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -293,10 +294,12 @@ func (e *Endpoint) GetHealthModel() *models.EndpointHealth {
 }
 
 // getNamedPortsModel returns the endpoint's NamedPorts object.
-//
-// Must be called with e.mutex RLock()ed.
 func (e *Endpoint) getNamedPortsModel() (np models.NamedPorts) {
-	k8sPorts := e.k8sPorts
+	var k8sPorts types.NamedPortMap
+	if p := e.k8sPorts.Load(); p != nil {
+		k8sPorts = *p
+	}
+
 	// keep named ports ordered to avoid the unnecessary updates to
 	// kube-apiserver
 	names := make([]string, 0, len(k8sPorts))

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -459,6 +459,9 @@ func (e *Endpoint) policyStatus() models.EndpointPolicyEnabled {
 // purposes should a caller choose to try to regenerate this endpoint, as well
 // as an error if the Endpoint is being deleted, since there is no point in
 // changing an Endpoint if it is going to be deleted.
+//
+// Before adding any new fields here, check to see if they are assumed to be mutable after
+// endpoint creation!
 func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionState bool) (string, error) {
 	var (
 		changed bool

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -735,7 +735,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 
 	// regenerate policy without holding the lock
 	stats.policyCalculation.Start()
-	err := e.regeneratePolicy()
+	err := e.regeneratePolicy(regenContext.parentContext)
 	stats.policyCalculation.End(err == nil)
 	if err != nil {
 		return false, fmt.Errorf("unable to regenerate policy for '%s': %s", e.StringID(), err)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -239,13 +239,10 @@ type Endpoint struct {
 
 	// k8sPorts contains container ports associated in the pod.
 	// It is used to enforce k8s network policies with port names.
-	k8sPorts types.NamedPortMap
+	k8sPorts atomic.Pointer[types.NamedPortMap]
 
 	// logLimiter rate limits potentially repeating warning logs
 	logLimiter logging.Limiter
-
-	// k8sPortsSet keep track when k8sPorts was set at least one time.
-	hasK8sMetadata bool
 
 	// policyRevision is the policy revision this endpoint is currently on
 	// to modify this field please use endpoint.setPolicyRevision instead
@@ -1211,7 +1208,6 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 // SetK8sMetadata sets the k8s container ports specified by kubernetes.
 // Note that once put in place, the new k8sPorts is never changed,
 // so that the map can be used concurrently without keeping locks.
-// Reading the 'e.k8sPorts' member (the "map pointer") *itself* requires the endpoint lock!
 // Can't really error out as that might break backwards compatibility.
 func (e *Endpoint) SetK8sMetadata(containerPorts []slim_corev1.ContainerPort) error {
 	k8sPorts := make(types.NamedPortMap, len(containerPorts))
@@ -1225,33 +1221,22 @@ func (e *Endpoint) SetK8sMetadata(containerPorts []slim_corev1.ContainerPort) er
 			continue
 		}
 	}
-	if len(k8sPorts) == 0 {
-		k8sPorts = nil // nil map with no storage
-	}
-	e.mutex.Lock()
-	e.hasK8sMetadata = true
-	e.k8sPorts = k8sPorts
-	e.mutex.Unlock()
+	e.k8sPorts.Store(&k8sPorts)
 	return nil
 }
 
 // GetK8sPorts returns the k8sPorts, which must not be modified by the caller
-func (e *Endpoint) GetK8sPorts() (k8sPorts types.NamedPortMap, err error) {
-	err = e.rlockAlive()
-	if err != nil {
-		return nil, err
+func (e *Endpoint) GetK8sPorts() (k8sPorts types.NamedPortMap) {
+	if p := e.k8sPorts.Load(); p != nil {
+		k8sPorts = *p
 	}
-	k8sPorts = e.k8sPorts
-	e.mutex.RUnlock()
-	return k8sPorts, nil
+	return k8sPorts
 }
 
 // HaveK8sMetadata returns true once hasK8sMetadata was set
 func (e *Endpoint) HaveK8sMetadata() (metadataSet bool) {
-	e.mutex.RLock()
-	metadataSet = e.hasK8sMetadata
-	e.mutex.RUnlock()
-	return
+	p := e.k8sPorts.Load()
+	return p != nil
 }
 
 // K8sNamespaceAndPodNameIsSet returns true if the pod name is set

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -302,7 +303,7 @@ type Endpoint struct {
 	// successfully added into a proxy for this endpoint, to the redirect's
 	// proxy port number.
 	// You must hold Endpoint.mutex to read or write it.
-	realizedRedirects map[string]uint16
+	realizedRedirects sync.Map
 
 	// ctCleaned indicates whether the conntrack table has already been
 	// cleaned when this endpoint was first created
@@ -1118,7 +1119,7 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 	// Remove restored rules of cleaned endpoint
 	e.owner.RemoveRestoredDNSRules(e.ID)
 
-	if e.SecurityIdentity != nil && len(e.realizedRedirects) > 0 {
+	if e.SecurityIdentity != nil {
 		// Passing a new map of nil will purge all redirects
 		finalize, _ := e.removeOldRedirects(nil, proxyWaitGroup)
 		if finalize != nil {

--- a/pkg/endpoint/identifiers.go
+++ b/pkg/endpoint/identifiers.go
@@ -17,25 +17,22 @@ func (e *Endpoint) GetContainerName() string {
 	return e.containerName
 }
 
-// SetContainerName modifies the endpoint's container name
-func (e *Endpoint) SetContainerName(name string) {
-	e.unconditionalLock()
+// SetContainerNameLocked modifies the endpoint's container name
+// Only used during tests.
+func (e *Endpoint) SetContainerNameLocked(name string) {
 	e.containerName = name
-	e.unlock()
 }
 
 // GetK8sPodName returns the name of the pod if the endpoint represents a
 // Kubernetes pod
 func (e *Endpoint) GetK8sPodName() string {
-	e.unconditionalRLock()
 	k8sPodName := e.K8sPodName
-	e.runlock()
 
 	return k8sPodName
 }
 
-// HumanStringLocked returns the endpoint's most human readable identifier as string
-func (e *Endpoint) HumanStringLocked() string {
+// HumanString returns the endpoint's most human readable identifier as string
+func (e *Endpoint) HumanString() string {
 	if pod := e.getK8sNamespaceAndPodName(); pod != "" {
 		return pod
 	}
@@ -46,9 +43,6 @@ func (e *Endpoint) HumanStringLocked() string {
 // GetK8sNamespaceAndPodName returns the corresponding namespace and pod
 // name for this endpoint.
 func (e *Endpoint) GetK8sNamespaceAndPodName() string {
-	e.unconditionalRLock()
-	defer e.runlock()
-
 	return e.getK8sNamespaceAndPodName()
 }
 
@@ -56,24 +50,22 @@ func (e *Endpoint) getK8sNamespaceAndPodName() string {
 	return e.K8sNamespace + "/" + e.K8sPodName
 }
 
-// SetK8sPodName modifies the endpoint's pod name
-func (e *Endpoint) SetK8sPodName(name string) {
-	e.unconditionalLock()
+// SetK8sPodNameLocked modifies the endpoint's pod name
+// Only used for tests.
+func (e *Endpoint) SetK8sPodNameLocked(name string) {
 	e.K8sPodName = name
 	e.UpdateLogger(map[string]interface{}{
 		logfields.K8sPodName: e.getK8sNamespaceAndPodName(),
 	})
-	e.unlock()
 }
 
-// SetContainerID modifies the endpoint's container ID
-func (e *Endpoint) SetContainerID(id string) {
-	e.unconditionalLock()
+// SetContainerIDLocked modifies the endpoint's container ID
+// Only used for tests
+func (e *Endpoint) SetContainerIDLocked(id string) {
 	e.containerID = id
 	e.UpdateLogger(map[string]interface{}{
-		logfields.ContainerID: e.getShortContainerID(),
+		logfields.ContainerID: e.getShortContainerIDLocked(),
 	})
-	e.unlock()
 }
 
 // GetContainerID returns the endpoint's container ID
@@ -88,50 +80,33 @@ func (e *Endpoint) GetContainerID() string {
 func (e *Endpoint) GetShortContainerID() string {
 	e.unconditionalRLock()
 	defer e.runlock()
-
-	return e.getShortContainerID()
+	return e.getShortContainerIDLocked()
 }
 
-func (e *Endpoint) getShortContainerID() string {
+func (e *Endpoint) getShortContainerIDLocked() string {
 	if e == nil {
 		return ""
 	}
 
+	cid := e.containerID
+
 	caplen := 10
-	if len(e.containerID) <= caplen {
-		return e.containerID
+	if len(cid) <= caplen {
+		return cid
 	}
 
-	return e.containerID[:caplen]
+	return cid[:caplen]
 
 }
 
-// SetDockerEndpointID modifies the endpoint's Docker Endpoint ID
-func (e *Endpoint) SetDockerEndpointID(id string) {
-	e.unconditionalLock()
+// SetDockerEndpointIDLocked modifies the endpoint's Docker Endpoint ID
+// Only used during tests
+func (e *Endpoint) SetDockerEndpointIDLocked(id string) {
 	e.dockerEndpointID = id
-	e.unlock()
 }
 
 func (e *Endpoint) GetDockerEndpointID() string {
-	e.unconditionalRLock()
-	defer e.runlock()
 	return e.dockerEndpointID
-}
-
-// SetDockerNetworkID modifies the endpoint's Docker Endpoint ID
-func (e *Endpoint) SetDockerNetworkID(id string) {
-	e.unconditionalLock()
-	e.dockerNetworkID = id
-	e.unlock()
-}
-
-// GetDockerNetworkID returns the endpoint's Docker Endpoint ID
-func (e *Endpoint) GetDockerNetworkID() string {
-	e.unconditionalRLock()
-	defer e.runlock()
-
-	return e.dockerNetworkID
 }
 
 // IdentifiersLocked fetches the set of attributes that uniquely identify the

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -66,7 +66,7 @@ func (e *Endpoint) Logger(subsystem string) *logrus.Entry {
 //
 // Note: You must hold Endpoint.mutex.Lock() to synchronize logger pointer
 // updates if the endpoint is already exposed. Callers that create new
-// endopoints do not need locks to call this.
+// endpoints do not need locks to call this.
 func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	e.updatePolicyLogger(fields)
 	epLogger := e.logger.Load()
@@ -109,7 +109,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	l := baseLogger.WithFields(logrus.Fields{
 		logfields.LogSubsys:              subsystem,
 		logfields.EndpointID:             e.ID,
-		logfields.ContainerID:            e.getShortContainerID(),
+		logfields.ContainerID:            e.getShortContainerIDLocked(),
 		logfields.DatapathPolicyRevision: e.policyRevision,
 		logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 		logfields.IPv4:                   e.GetIPv4Address(),
@@ -167,7 +167,7 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
 		policyLogger = policyLogger.WithFields(logrus.Fields{
 			logfields.LogSubsys:              subsystem,
 			logfields.EndpointID:             e.ID,
-			logfields.ContainerID:            e.getShortContainerID(),
+			logfields.ContainerID:            e.getShortContainerIDLocked(),
 			logfields.DatapathPolicyRevision: e.policyRevision,
 			logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 			logfields.IPv4:                   e.GetIPv4Address(),

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -114,9 +114,12 @@ func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
 // lookupRedirectPort returns the redirect L4 proxy port for the given L4
 // policy map key, in host byte order. Returns 0 if not found or the
 // filter doesn't require a redirect.
-// Must be called with Endpoint.mutex held.
-func (e *Endpoint) LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16 {
-	return e.realizedRedirects[policy.ProxyID(e.ID, ingress, protocol, port)]
+func (e *Endpoint) LookupRedirectPort(ingress bool, protocol string, port uint16) uint16 {
+	pp, ok := e.realizedRedirects.Load(policy.ProxyID(e.ID, ingress, protocol, port))
+	if !ok {
+		return 0
+	}
+	return pp.(uint16)
 }
 
 // Note that this function assumes that endpoint policy has already been generated!

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -44,29 +44,7 @@ import (
 func (e *Endpoint) GetNamedPort(ingress bool, name string, proto uint8) uint16 {
 	if ingress {
 		// Ingress only needs the ports of the POD itself
-		k8sPorts, err := e.GetK8sPorts()
-		if err != nil {
-			if e.logLimiter.Allow() {
-				e.getLogger().WithFields(logrus.Fields{
-					logfields.PortName:         name,
-					logfields.Protocol:         u8proto.U8proto(proto).String(),
-					logfields.TrafficDirection: "ingress",
-				}).WithError(err).Warning("Skipping named port")
-			}
-			return 0
-		}
-		return e.getNamedPortIngress(k8sPorts, name, proto)
-	}
-	// egress needs named ports of all the pods
-	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto)
-}
-
-// GetNamedPortLocked returns port for the given name. May return an invalid (0) port
-// Must be called with e.mutex held.
-func (e *Endpoint) GetNamedPortLocked(ingress bool, name string, proto uint8) uint16 {
-	if ingress {
-		// Ingress only needs the ports of the POD itself
-		return e.getNamedPortIngress(e.k8sPorts, name, proto)
+		return e.getNamedPortIngress(e.GetK8sPorts(), name, proto)
 	}
 	// egress needs named ports of all the pods
 	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto)
@@ -103,7 +81,7 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
 	port := uint16(l4.Port)
 	if port == 0 && l4.PortName != "" {
-		port = e.GetNamedPortLocked(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+		port = e.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 		if port == 0 {
 			return ""
 		}
@@ -736,13 +714,12 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				metadata := e.FormatGlobalEndpointID()
 				k8sNamespace := e.K8sNamespace
 				k8sPodName := e.K8sPodName
-				namedPorts := e.k8sPorts
 
 				// Release lock as we do not want to have long-lasting key-value
 				// store operations resulting in lock being held for a long time.
 				e.runlock()
 
-				if err := ipcache.UpsertIPToKVStore(ctx, endpointIP, hostIP, ID, key, metadata, k8sNamespace, k8sPodName, namedPorts); err != nil {
+				if err := ipcache.UpsertIPToKVStore(ctx, endpointIP, hostIP, ID, key, metadata, k8sNamespace, k8sPodName, e.GetK8sPorts()); err != nil {
 					return fmt.Errorf("unable to add endpoint IP mapping '%s'->'%d': %s", endpointIP.String(), ID, err)
 				}
 				return nil

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -173,7 +173,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return firstAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	err = ep.regeneratePolicy(context.Background())
 	c.Assert(err, check.IsNil)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -196,7 +196,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return secondAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	err = ep.regeneratePolicy(context.Background())
 	c.Assert(err, check.IsNil)
 	d, err, _, _ := ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
@@ -216,7 +216,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return thirdAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	err = ep.regeneratePolicy(context.Background())
 	c.Assert(err, check.IsNil)
 	_, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
@@ -263,7 +263,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return noAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	err = ep.regeneratePolicy(context.Background())
 	c.Assert(err, check.IsNil)
 	d, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1432,7 +1432,7 @@ func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4Poli
 
 		port := uint16(l4.Port)
 		if port == 0 && l4.PortName != "" {
-			port = ep.GetNamedPortLocked(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 			if port == 0 {
 				continue
 			}

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -4,6 +4,7 @@
 package dnsproxy
 
 import (
+	"context"
 	"regexp"
 	"testing"
 
@@ -228,4 +229,7 @@ func (m MockCachedSelector) IsNone() bool {
 
 func (m MockCachedSelector) String() string {
 	return m.key
+}
+
+func (m MockCachedSelector) AwaitIdentities(_ context.Context) {
 }

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1116,6 +1116,9 @@ func (t selectorMock) String() string {
 	return t.key
 }
 
+func (t selectorMock) AwaitIdentities(_ context.Context) {
+}
+
 func Benchmark_perEPAllow_setPortRulesForID(b *testing.B) {
 	const (
 		nEPs              = 10000

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -187,3 +187,20 @@ func addrsToCIDRRules(addrs []netip.Addr) []CIDRRule {
 // A CIDR Group is a list of CIDRs whose IP addresses should be considered as a
 // same entity when applying fromCIDRGroupRefs policies on incoming network traffic.
 type CIDRGroupRef string
+
+func CIDRSFromSelector(n EndpointSelector) []netip.Prefix {
+	labels := n.GetKeysWithPrefix(labels.LabelSourceCIDR)
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make([]netip.Prefix, 0, len(labels))
+	for _, label := range labels {
+		// label has "cidr:" prefix
+		pfx, err := netip.ParsePrefix(label[5:])
+		if err != nil { // skip invalid prefixes
+			continue
+		}
+		out = append(out, pfx)
+	}
+	return out
+}

--- a/pkg/policy/api/selector.go
+++ b/pkg/policy/api/selector.go
@@ -126,6 +126,22 @@ func (n EndpointSelector) HasKeyPrefix(prefix string) bool {
 	return false
 }
 
+func (n EndpointSelector) GetKeysWithPrefix(prefix string) []string {
+	var out []string
+	for k := range n.MatchLabels {
+		if strings.HasPrefix(k, prefix) {
+			out = append(out, k)
+		}
+	}
+	for _, v := range n.MatchExpressions {
+		if strings.HasPrefix(v.Key, prefix) {
+			out = append(out, v.Key)
+		}
+	}
+
+	return out
+}
+
 // HasKey checks if the endpoint selector contains the given key in
 // its MatchLabels map or in its MatchExpressions slice.
 func (n EndpointSelector) HasKey(key string) bool {

--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -4,6 +4,7 @@
 package policy
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 
@@ -19,6 +20,8 @@ type SelectorPolicy interface {
 	// Consume returns the policy in terms of connectivity to peer
 	// Identities.
 	Consume(owner PolicyOwner) *EndpointPolicy
+
+	AwaitIdentities(context.Context)
 }
 
 // PolicyCache represents a cache of resolved policies for identities.
@@ -199,4 +202,8 @@ func (cip *cachedSelectorPolicy) Consume(owner PolicyOwner) *EndpointPolicy {
 	// EndpointPolicy for this Identity and emit datapath deltas instead.
 	isHost := cip.identity.ID == identityPkg.ReservedIdentityHost
 	return cip.getPolicy().DistillPolicy(owner, isHost)
+}
+
+func (cip *cachedSelectorPolicy) AwaitIdentities(ctx context.Context) {
+	cip.getPolicy().awaitIdentities(ctx)
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -502,7 +502,7 @@ func (l4Filter *L4Filter) ToMapState(policyOwner PolicyOwner, direction trafficd
 
 	// resolve named port
 	if port == 0 && l4Filter.PortName != "" {
-		port = policyOwner.GetNamedPortLocked(l4Filter.Ingress, l4Filter.PortName, proto)
+		port = policyOwner.GetNamedPort(l4Filter.Ingress, l4Filter.PortName, proto)
 		if port == 0 {
 			return keysToAdd
 		}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -775,7 +775,7 @@ func (keys MapState) AllowsL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 
 	// resolve named port
 	if port == 0 && l4.PortName != "" {
-		port = policyOwner.GetNamedPortLocked(l4.Ingress, l4.PortName, proto)
+		port = policyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
 		if port == 0 {
 			return false
 		}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -66,7 +66,7 @@ type EndpointPolicy struct {
 // PolicyOwner is anything which consumes a EndpointPolicy.
 type PolicyOwner interface {
 	GetID() uint64
-	LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16
+	LookupRedirectPort(ingress bool, protocol string, port uint16) uint16
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
 	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
 	PolicyDebug(fields logrus.Fields, msg string)
@@ -178,7 +178,7 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(policyMapState MapSt
 					// only lookup once for each filter
 					// Use 'destPort' from the key as it is already resolved
 					// from a named port if needed.
-					proxyport = p.PolicyOwner.LookupRedirectPortLocked(filter.Ingress, string(filter.Protocol), keyFromFilter.DestPort)
+					proxyport = p.PolicyOwner.LookupRedirectPort(filter.Ingress, string(filter.Protocol), keyFromFilter.DestPort)
 					lookupDone = true
 				}
 				entry.ProxyPort = proxyport

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -4,6 +4,8 @@
 package policy
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/identity"
@@ -37,6 +39,10 @@ func (p *selectorPolicy) Attach(ctx PolicyContext) {
 	if p.L4Policy != nil {
 		p.L4Policy.Attach(ctx)
 	}
+}
+
+func (p *selectorPolicy) awaitIdentities(ctx context.Context) {
+	p.L4Policy.awaitIdentities(ctx)
 }
 
 // EndpointPolicy is a structure which contains the resolved policy across all

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -68,7 +68,6 @@ type PolicyOwner interface {
 	GetID() uint64
 	LookupRedirectPort(ingress bool, protocol string, port uint16) uint16
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
-	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
 	PolicyDebug(fields logrus.Fields, msg string)
 }
 

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -169,7 +169,7 @@ func GenerateCIDRRules(numRules int) api.Rules {
 
 type DummyOwner struct{}
 
-func (d DummyOwner) LookupRedirectPortLocked(bool, string, uint16) uint16 {
+func (d DummyOwner) LookupRedirectPort(bool, string, uint16) uint16 {
 	return 4242
 }
 

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -4,6 +4,7 @@
 package policy
 
 import (
+	"context"
 	"sync"
 
 	. "github.com/cilium/checkmate"
@@ -227,6 +228,9 @@ func (cs *testCachedSelector) IsNone() bool {
 
 func (cs *testCachedSelector) String() string {
 	return cs.name
+}
+
+func (cs *testCachedSelector) AwaitIdentities(_ context.Context) {
 }
 
 func (ds *SelectorCacheTestSuite) SetUpTest(c *C) {

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -17,15 +17,7 @@ type EndpointInfoSource interface {
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string
-	GetIdentityLocked() identity.NumericIdentity
-	GetLabels() []string
 	HasSidecarProxy() bool
-	// ConntrackName assumes that the caller has *not* acquired any mutexes
-	// that may be associated with this EndpointInfoSource. It is (unfortunately)
-	// up to the caller to know when to use this vs. ConntrackNameLocked, which
-	// assumes that the caller has acquired any needed mutexes of the
-	// implementation.
-	ConntrackName() string
 	ConntrackNameLocked() string
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
 }

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -27,7 +27,7 @@ type EndpointInfoSource interface {
 	// implementation.
 	ConntrackName() string
 	ConntrackNameLocked() string
-	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
+	GetNamedPort(ingress bool, name string, proto uint8) uint16
 }
 
 // EndpointUpdater returns information about an endpoint being proxied and

--- a/pkg/proxy/logger/test/epinfo.go
+++ b/pkg/proxy/logger/test/epinfo.go
@@ -23,17 +23,17 @@ type ProxyUpdaterMock struct {
 func (m *ProxyUpdaterMock) UnconditionalRLock() { m.RWMutex.RLock() }
 func (m *ProxyUpdaterMock) RUnlock()            { m.RWMutex.RUnlock() }
 
-func (m *ProxyUpdaterMock) GetID() uint64                                 { return m.Id }
-func (m *ProxyUpdaterMock) GetIPv4Address() string                        { return m.Ipv4 }
-func (m *ProxyUpdaterMock) GetIPv6Address() string                        { return m.Ipv6 }
-func (m *ProxyUpdaterMock) GetLabels() []string                           { return m.Labels }
-func (m *ProxyUpdaterMock) GetEgressPolicyEnabledLocked() bool            { return true }
-func (m *ProxyUpdaterMock) GetIngressPolicyEnabledLocked() bool           { return true }
-func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity   { return m.Identity }
-func (m *ProxyUpdaterMock) GetNamedPortLocked(bool, string, uint8) uint16 { return 0 }
-func (m *ProxyUpdaterMock) HasSidecarProxy() bool                         { return m.SidecarProxy }
-func (m *ProxyUpdaterMock) ConntrackName() string                         { return m.ConntrackNameLocked() }
-func (m *ProxyUpdaterMock) ConntrackNameLocked() string                   { return "global" }
+func (m *ProxyUpdaterMock) GetID() uint64                               { return m.Id }
+func (m *ProxyUpdaterMock) GetIPv4Address() string                      { return m.Ipv4 }
+func (m *ProxyUpdaterMock) GetIPv6Address() string                      { return m.Ipv6 }
+func (m *ProxyUpdaterMock) GetLabels() []string                         { return m.Labels }
+func (m *ProxyUpdaterMock) GetEgressPolicyEnabledLocked() bool          { return true }
+func (m *ProxyUpdaterMock) GetIngressPolicyEnabledLocked() bool         { return true }
+func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity { return m.Identity }
+func (m *ProxyUpdaterMock) GetNamedPort(bool, string, uint8) uint16     { return 0 }
+func (m *ProxyUpdaterMock) HasSidecarProxy() bool                       { return m.SidecarProxy }
+func (m *ProxyUpdaterMock) ConntrackName() string                       { return m.ConntrackNameLocked() }
+func (m *ProxyUpdaterMock) ConntrackNameLocked() string                 { return "global" }
 
 func (m *ProxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}
 func (m *ProxyUpdaterMock) UpdateProxyStatistics(l4Protocol string, port uint16, ingress, request bool,


### PR DESCRIPTION
This is a rewrite #25581 after @joestringer had some suggestions. I'm leaving that PR as-is to preserve the discussion.

**TODO:**

- [ ] Get consensus that this is the right direction
- [ ] Write some unit tests
- [ ] Consider rewriting existing unit tests

This PR consists of two basic changes:
1: Make policy not rely on the endpoint lock
2: Allocate CIDR identities inside the SelectorCache

### Part 1: The endpoint lock
The endpoint lock is just used to protect access to a number of fields against concurrent writers. It is not used to serialize disparate operations - for that, there are other locks (e.g. the bpf lock). To that end, there are a number of small commits that either remove unnecessary locking (because a field is actually immutable after creation) or switch to atomic pointers. 

An additional commit changes `regeneratePolicy()` to not hold the endpoint lock until it is time to commit. This is necessary to prepare for part 2.

### Part 2: CIDR allocation
Before this change, we would allocate CIDR identities as soon as a policy was ingested - on every node. This meant that nodes would have entries in the ipcache and potentially unnecessary identities, because this was done even if no pods relied on those selectors. This change moves allocation in to the SelectorCache, which is similar to how FQDN policies work.

The interesting bit is that allocation is asynchronous, so we need to wait for the ipcache to make progress and update back in to the SelectorCache that the requested identities exist. As part of genernal paranoia, I added a timeout. This is ultimately safe since we will "eventually" coalesce on the desired state. I tried to find a way to reflect this waiting back to the caller, but the tree was very deep, so I couldn't find a good way.


```release-note
TODO
```
