### PR TITLE
Modular daemon and operator

### DIFF
--- a/api/v1/client/daemon/daemon_client.go
+++ b/api/v1/client/daemon/daemon_client.go
@@ -174,7 +174,7 @@ func (a *Client) GetConfig(params *GetConfigParams, opts ...ClientOption) (*GetC
 }
 
 /*
-GetDebuginfo retrieves information about the agent and evironment for debugging
+GetDebuginfo retrieves information about the agent and environment for debugging
 */
 func (a *Client) GetDebuginfo(params *GetDebuginfoParams, opts ...ClientOption) (*GetDebuginfoOK, error) {
 	// TODO: Validate the params before sending

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -833,7 +833,7 @@ paths:
             "$ref": "#/definitions/Error"
   "/debuginfo":
     get:
-      summary: Retrieve information about the agent and evironment for debugging
+      summary: Retrieve information about the agent and environment for debugging
       tags:
       - daemon
       responses:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -162,7 +162,7 @@ func init() {
         "tags": [
           "daemon"
         ],
-        "summary": "Retrieve information about the agent and evironment for debugging",
+        "summary": "Retrieve information about the agent and environment for debugging",
         "responses": {
           "200": {
             "description": "Success",
@@ -4986,7 +4986,7 @@ func init() {
         "tags": [
           "daemon"
         ],
-        "summary": "Retrieve information about the agent and evironment for debugging",
+        "summary": "Retrieve information about the agent and environment for debugging",
         "responses": {
           "200": {
             "description": "Success",

--- a/api/v1/server/restapi/daemon/get_debuginfo.go
+++ b/api/v1/server/restapi/daemon/get_debuginfo.go
@@ -35,7 +35,7 @@ func NewGetDebuginfo(ctx *middleware.Context, handler GetDebuginfoHandler) *GetD
 /*
 	GetDebuginfo swagger:route GET /debuginfo daemon getDebuginfo
 
-Retrieve information about the agent and evironment for debugging
+Retrieve information about the agent and environment for debugging
 */
 type GetDebuginfo struct {
 	Context *middleware.Context

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -405,11 +405,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	bootstrapStats.daemonInit.Start()
 
-	// Validate the daemon-specific global options.
-	if err := option.Config.Validate(Vp); err != nil {
-		return nil, nil, fmt.Errorf("invalid daemon configuration: %s", err)
-	}
-
 	// Validate configuration options that depend on other cells.
 	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !params.Clientset.IsEnabled() &&
 		option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -219,6 +219,9 @@ type Daemon struct {
 
 	// statedb for implementing /statedb/dump
 	db statedb.DB
+
+	// read-only map of all the hive settings
+	settings cellSettings
 }
 
 func (d *Daemon) initDNSProxyContext(size int) {
@@ -541,6 +544,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		l2announcer:          params.L2Announcer,
 		l7Proxy:              params.L7Proxy,
 		db:                   params.DB,
+		settings:             params.Settings,
 	}
 
 	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1590,6 +1590,9 @@ var daemonCell = cell.Module(
 
 	cell.Provide(newDaemonPromise),
 	cell.Provide(func() k8s.CacheStatus { return make(k8s.CacheStatus) }),
+	// Provide a read-only copy of the current daemon settings to be consumed
+	// by the debuginfo API
+	cell.ProvidePrivate(daemonSettings),
 	cell.Invoke(func(promise.Promise[*Daemon]) {}), // Force instantiation.
 )
 
@@ -1625,6 +1628,7 @@ type daemonParams struct {
 	L7Proxy              *proxy.Proxy
 	DB                   statedb.DB
 	APILimiterSet        *rate.APILimiterSet
+	Settings             cellSettings
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/ebpf/asm"
 	"github.com/cilium/ebpf/rlimit"
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 
@@ -107,16 +108,14 @@ const (
 )
 
 var (
-	Vp *viper.Viper
-
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, daemonSubsys)
 
 	bootstrapTimestamp = time.Now()
 	bootstrapStats     = bootstrapStatistics{}
 )
 
-func initializeFlags() {
-	flags := RootCmd.Flags()
+func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
+	flags := cmd.Flags()
 
 	// Validators
 	option.Config.FixedIdentityMappingValidator = option.Validator(func(val string) (string, error) {
@@ -154,821 +153,821 @@ func initializeFlags() {
 
 	// Env bindings
 	flags.Int(option.AgentHealthPort, defaults.AgentHealthPort, "TCP port for agent health status API")
-	option.BindEnv(Vp, option.AgentHealthPort)
+	option.BindEnv(vp, option.AgentHealthPort)
 
 	flags.Int(option.ClusterHealthPort, defaults.ClusterHealthPort, "TCP port for cluster-wide network connectivity health API")
-	option.BindEnv(Vp, option.ClusterHealthPort)
+	option.BindEnv(vp, option.ClusterHealthPort)
 
 	flags.StringSlice(option.AgentLabels, []string{}, "Additional labels to identify this agent")
-	option.BindEnv(Vp, option.AgentLabels)
+	option.BindEnv(vp, option.AgentLabels)
 
 	flags.Bool(option.AllowICMPFragNeeded, defaults.AllowICMPFragNeeded, "Allow ICMP Fragmentation Needed type packets for purposes like TCP Path MTU.")
-	option.BindEnv(Vp, option.AllowICMPFragNeeded)
+	option.BindEnv(vp, option.AllowICMPFragNeeded)
 
 	flags.String(option.AllowLocalhost, option.AllowLocalhostAuto, "Policy when to allow local stack to reach local endpoints { auto | always | policy }")
-	option.BindEnv(Vp, option.AllowLocalhost)
+	option.BindEnv(vp, option.AllowLocalhost)
 
 	flags.Bool(option.AnnotateK8sNode, defaults.AnnotateK8sNode, "Annotate Kubernetes node")
-	option.BindEnv(Vp, option.AnnotateK8sNode)
+	option.BindEnv(vp, option.AnnotateK8sNode)
 
 	flags.Duration(option.ARPPingRefreshPeriod, defaults.ARPBaseReachableTime, "Period for remote node ARP entry refresh (set 0 to disable)")
-	option.BindEnv(Vp, option.ARPPingRefreshPeriod)
+	option.BindEnv(vp, option.ARPPingRefreshPeriod)
 
 	flags.Bool(option.EnableL2NeighDiscovery, true, "Enables L2 neighbor discovery used by kube-proxy-replacement and IPsec")
-	option.BindEnv(Vp, option.EnableL2NeighDiscovery)
+	option.BindEnv(vp, option.EnableL2NeighDiscovery)
 
 	flags.Bool(option.AutoCreateCiliumNodeResource, defaults.AutoCreateCiliumNodeResource, "Automatically create CiliumNode resource for own node on startup")
-	option.BindEnv(Vp, option.AutoCreateCiliumNodeResource)
+	option.BindEnv(vp, option.AutoCreateCiliumNodeResource)
 
 	flags.String(option.BPFRoot, "", "Path to BPF filesystem")
-	option.BindEnv(Vp, option.BPFRoot)
+	option.BindEnv(vp, option.BPFRoot)
 
 	flags.Bool(option.EnableBPFClockProbe, false, "Enable BPF clock source probing for more efficient tick retrieval")
-	option.BindEnv(Vp, option.EnableBPFClockProbe)
+	option.BindEnv(vp, option.EnableBPFClockProbe)
 
 	flags.String(option.CGroupRoot, "", "Path to Cgroup2 filesystem")
-	option.BindEnv(Vp, option.CGroupRoot)
+	option.BindEnv(vp, option.CGroupRoot)
 
 	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")
-	option.BindEnv(Vp, option.ClusterIDName)
+	option.BindEnv(vp, option.ClusterIDName)
 
 	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")
-	option.BindEnv(Vp, option.ClusterName)
+	option.BindEnv(vp, option.ClusterName)
 
 	flags.StringSlice(option.CompilerFlags, []string{}, "Extra CFLAGS for BPF compilation")
 	flags.MarkHidden(option.CompilerFlags)
-	option.BindEnv(Vp, option.CompilerFlags)
+	option.BindEnv(vp, option.CompilerFlags)
 
 	flags.String(option.ConfigFile, "", `Configuration file (default "$HOME/ciliumd.yaml")`)
-	option.BindEnv(Vp, option.ConfigFile)
+	option.BindEnv(vp, option.ConfigFile)
 
 	flags.String(option.ConfigDir, "", `Configuration directory that contains a file for each option`)
-	option.BindEnv(Vp, option.ConfigDir)
+	option.BindEnv(vp, option.ConfigDir)
 
 	flags.Duration(option.ConntrackGCInterval, time.Duration(0), "Overwrite the connection-tracking garbage collection interval")
-	option.BindEnv(Vp, option.ConntrackGCInterval)
+	option.BindEnv(vp, option.ConntrackGCInterval)
 
 	flags.BoolP(option.DebugArg, "D", false, "Enable debugging mode")
-	option.BindEnv(Vp, option.DebugArg)
+	option.BindEnv(vp, option.DebugArg)
 
 	flags.StringSlice(option.DebugVerbose, []string{}, "List of enabled verbose debug groups")
-	option.BindEnv(Vp, option.DebugVerbose)
+	option.BindEnv(vp, option.DebugVerbose)
 
 	flags.StringSlice(option.Devices, []string{}, "List of devices facing cluster/external network (used for BPF NodePort, BPF masquerading and host firewall); supports '+' as wildcard in device name, e.g. 'eth+'")
-	option.BindEnv(Vp, option.Devices)
+	option.BindEnv(vp, option.Devices)
 
 	flags.String(option.DirectRoutingDevice, "", "Device name used to connect nodes in direct routing mode (used by BPF NodePort, BPF host routing; if empty, automatically set to a device with k8s InternalIP/ExternalIP or with a default route)")
-	option.BindEnv(Vp, option.DirectRoutingDevice)
+	option.BindEnv(vp, option.DirectRoutingDevice)
 
 	flags.Bool(option.EnableRuntimeDeviceDetection, false, "Enable runtime device detection and datapath reconfiguration (experimental)")
-	option.BindEnv(Vp, option.EnableRuntimeDeviceDetection)
+	option.BindEnv(vp, option.EnableRuntimeDeviceDetection)
 
 	flags.String(option.LBDevInheritIPAddr, "", fmt.Sprintf("Device name which IP addr is inherited by devices running LB BPF program (--%s)", option.Devices))
-	option.BindEnv(Vp, option.LBDevInheritIPAddr)
+	option.BindEnv(vp, option.LBDevInheritIPAddr)
 
 	flags.String(option.DatapathMode, defaults.DatapathMode, "Datapath mode name")
-	option.BindEnv(Vp, option.DatapathMode)
+	option.BindEnv(vp, option.DatapathMode)
 
 	flags.Bool(option.EnableEndpointRoutes, defaults.EnableEndpointRoutes, "Use per endpoint routes instead of routing via cilium_host")
-	option.BindEnv(Vp, option.EnableEndpointRoutes)
+	option.BindEnv(vp, option.EnableEndpointRoutes)
 
 	flags.Bool(option.EnableHealthChecking, defaults.EnableHealthChecking, "Enable connectivity health checking")
-	option.BindEnv(Vp, option.EnableHealthChecking)
+	option.BindEnv(vp, option.EnableHealthChecking)
 
 	flags.Bool(option.EnableHealthCheckNodePort, defaults.EnableHealthCheckNodePort, "Enables a healthcheck nodePort server for NodePort services with 'healthCheckNodePort' being set")
-	option.BindEnv(Vp, option.EnableHealthCheckNodePort)
+	option.BindEnv(vp, option.EnableHealthCheckNodePort)
 
 	flags.StringSlice(option.EndpointStatus, []string{},
 		"Enable additional CiliumEndpoint status features ("+strings.Join(option.EndpointStatusValues(), ",")+")")
-	option.BindEnv(Vp, option.EndpointStatus)
+	option.BindEnv(vp, option.EndpointStatus)
 
 	flags.Bool(option.EnableEndpointHealthChecking, defaults.EnableEndpointHealthChecking, "Enable connectivity health checking between virtual endpoints")
-	option.BindEnv(Vp, option.EnableEndpointHealthChecking)
+	option.BindEnv(vp, option.EnableEndpointHealthChecking)
 
 	flags.Bool(option.EnableLocalNodeRoute, defaults.EnableLocalNodeRoute, "Enable installation of the route which points the allocation prefix of the local node")
-	option.BindEnv(Vp, option.EnableLocalNodeRoute)
+	option.BindEnv(vp, option.EnableLocalNodeRoute)
 
 	flags.Bool(option.EnableIPv4Name, defaults.EnableIPv4, "Enable IPv4 support")
-	option.BindEnv(Vp, option.EnableIPv4Name)
+	option.BindEnv(vp, option.EnableIPv4Name)
 
 	flags.Bool(option.EnableIPv6Name, defaults.EnableIPv6, "Enable IPv6 support")
-	option.BindEnv(Vp, option.EnableIPv6Name)
+	option.BindEnv(vp, option.EnableIPv6Name)
 
 	flags.Bool(option.EnableNat46X64Gateway, false, "Enable NAT46 and NAT64 gateway")
-	option.BindEnv(Vp, option.EnableNat46X64Gateway)
+	option.BindEnv(vp, option.EnableNat46X64Gateway)
 
 	flags.Bool(option.EnableIPv6NDPName, defaults.EnableIPv6NDP, "Enable IPv6 NDP support")
-	option.BindEnv(Vp, option.EnableIPv6NDPName)
+	option.BindEnv(vp, option.EnableIPv6NDPName)
 
 	flags.Bool(option.EnableSRv6, defaults.EnableSRv6, "Enable SRv6 support (beta)")
 	flags.MarkHidden(option.EnableSRv6)
-	option.BindEnv(Vp, option.EnableSRv6)
+	option.BindEnv(vp, option.EnableSRv6)
 
 	flags.String(option.SRv6EncapModeName, defaults.SRv6EncapMode, "Encapsulation mode for SRv6 (\"srh\" or \"reduced\")")
 	flags.MarkHidden(option.SRv6EncapModeName)
-	option.BindEnv(Vp, option.SRv6EncapModeName)
+	option.BindEnv(vp, option.SRv6EncapModeName)
 
 	flags.Bool(option.EnableSCTPName, defaults.EnableSCTP, "Enable SCTP support (beta)")
-	option.BindEnv(Vp, option.EnableSCTPName)
+	option.BindEnv(vp, option.EnableSCTPName)
 
 	flags.String(option.IPv6MCastDevice, "", "Device that joins a Solicited-Node multicast group for IPv6")
-	option.BindEnv(Vp, option.IPv6MCastDevice)
+	option.BindEnv(vp, option.IPv6MCastDevice)
 
 	flags.Bool(option.EnableRemoteNodeIdentity, defaults.EnableRemoteNodeIdentity, "Enable use of remote node identity")
-	option.BindEnv(Vp, option.EnableRemoteNodeIdentity)
+	option.BindEnv(vp, option.EnableRemoteNodeIdentity)
 
 	flags.String(option.EncryptInterface, "", "Transparent encryption interface")
-	option.BindEnv(Vp, option.EncryptInterface)
+	option.BindEnv(vp, option.EncryptInterface)
 
 	flags.Bool(option.EncryptNode, defaults.EncryptNode, "Enables encrypting traffic from non-Cilium pods and host networking (only supported with WireGuard, beta)")
-	option.BindEnv(Vp, option.EncryptNode)
+	option.BindEnv(vp, option.EncryptNode)
 
 	flags.StringSlice(option.IPv4PodSubnets, []string{}, "List of IPv4 pod subnets to preconfigure for encryption")
-	option.BindEnv(Vp, option.IPv4PodSubnets)
+	option.BindEnv(vp, option.IPv4PodSubnets)
 
 	flags.StringSlice(option.IPv6PodSubnets, []string{}, "List of IPv6 pod subnets to preconfigure for encryption")
-	option.BindEnv(Vp, option.IPv6PodSubnets)
+	option.BindEnv(vp, option.IPv6PodSubnets)
 
 	flags.Var(option.NewNamedMapOptions(option.IPAMMultiPoolPreAllocation, &option.Config.IPAMMultiPoolPreAllocation, nil),
 		option.IPAMMultiPoolPreAllocation,
 		fmt.Sprintf("Defines the minimum number of IPs a node should pre-allocate from each pool (default %s)", defaults.IPAMMultiPoolPreAllocation))
-	Vp.SetDefault(option.IPAMMultiPoolPreAllocation, defaults.IPAMMultiPoolPreAllocation)
-	option.BindEnv(Vp, option.IPAMMultiPoolPreAllocation)
+	vp.SetDefault(option.IPAMMultiPoolPreAllocation, defaults.IPAMMultiPoolPreAllocation)
+	option.BindEnv(vp, option.IPAMMultiPoolPreAllocation)
 
 	flags.StringSlice(option.ExcludeLocalAddress, []string{}, "Exclude CIDR from being recognized as local address")
-	option.BindEnv(Vp, option.ExcludeLocalAddress)
+	option.BindEnv(vp, option.ExcludeLocalAddress)
 
 	flags.Bool(option.DisableCiliumEndpointCRDName, false, "Disable use of CiliumEndpoint CRD")
-	option.BindEnv(Vp, option.DisableCiliumEndpointCRDName)
+	option.BindEnv(vp, option.DisableCiliumEndpointCRDName)
 
 	flags.String(option.EgressMasqueradeInterfaces, "", "Limit egress masquerading to interface selector")
-	option.BindEnv(Vp, option.EgressMasqueradeInterfaces)
+	option.BindEnv(vp, option.EgressMasqueradeInterfaces)
 
 	flags.Bool(option.BPFSocketLBHostnsOnly, false, "Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).")
-	option.BindEnv(Vp, option.BPFSocketLBHostnsOnly)
+	option.BindEnv(vp, option.BPFSocketLBHostnsOnly)
 
 	flags.Bool(option.EnableSocketLB, false, "Enable socket-based LB for E/W traffic")
-	option.BindEnv(Vp, option.EnableSocketLB)
+	option.BindEnv(vp, option.EnableSocketLB)
 
 	flags.Bool(option.EnableSocketLBTracing, true, "Enable tracing for socket-based LB")
-	option.BindEnv(Vp, option.EnableSocketLBTracing)
+	option.BindEnv(vp, option.EnableSocketLBTracing)
 
 	flags.Bool(option.EnableAutoDirectRoutingName, defaults.EnableAutoDirectRouting, "Enable automatic L2 routing between nodes")
-	option.BindEnv(Vp, option.EnableAutoDirectRoutingName)
+	option.BindEnv(vp, option.EnableAutoDirectRoutingName)
 
 	flags.Bool(option.EnableBPFTProxy, defaults.EnableBPFTProxy, "Enable BPF-based proxy redirection, if support available")
-	option.BindEnv(Vp, option.EnableBPFTProxy)
+	option.BindEnv(vp, option.EnableBPFTProxy)
 
 	flags.Bool(option.EnableHostLegacyRouting, defaults.EnableHostLegacyRouting, "Enable the legacy host forwarding model which does not bypass upper stack in host namespace")
-	option.BindEnv(Vp, option.EnableHostLegacyRouting)
+	option.BindEnv(vp, option.EnableHostLegacyRouting)
 
 	flags.Bool(option.EnableXTSocketFallbackName, defaults.EnableXTSocketFallback, "Enable fallback for missing xt_socket module")
-	option.BindEnv(Vp, option.EnableXTSocketFallbackName)
+	option.BindEnv(vp, option.EnableXTSocketFallbackName)
 
 	flags.String(option.EnablePolicy, option.DefaultEnforcement, "Enable policy enforcement")
-	option.BindEnv(Vp, option.EnablePolicy)
+	option.BindEnv(vp, option.EnablePolicy)
 
 	flags.Bool(option.EnableExternalIPs, false, fmt.Sprintf("Enable k8s service externalIPs feature (requires enabling %s)", option.EnableNodePort))
-	option.BindEnv(Vp, option.EnableExternalIPs)
+	option.BindEnv(vp, option.EnableExternalIPs)
 
 	flags.Bool(option.K8sEnableEndpointSlice, defaults.K8sEnableEndpointSlice, "Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it")
-	option.BindEnv(Vp, option.K8sEnableEndpointSlice)
+	option.BindEnv(vp, option.K8sEnableEndpointSlice)
 
 	flags.Bool(option.EnableL7Proxy, defaults.EnableL7Proxy, "Enable L7 proxy for L7 policy enforcement")
-	option.BindEnv(Vp, option.EnableL7Proxy)
+	option.BindEnv(vp, option.EnableL7Proxy)
 
 	flags.Bool(option.EnableTracing, false, "Enable tracing while determining policy (debugging)")
-	option.BindEnv(Vp, option.EnableTracing)
+	option.BindEnv(vp, option.EnableTracing)
 
 	flags.Bool(option.EnableUnreachableRoutes, false, "Add unreachable routes on pod deletion")
-	option.BindEnv(Vp, option.EnableUnreachableRoutes)
+	option.BindEnv(vp, option.EnableUnreachableRoutes)
 
 	flags.Bool(option.EnableWellKnownIdentities, defaults.EnableWellKnownIdentities, "Enable well-known identities for known Kubernetes components")
-	option.BindEnv(Vp, option.EnableWellKnownIdentities)
+	option.BindEnv(vp, option.EnableWellKnownIdentities)
 
 	flags.String(option.EnvoyLog, "", "Path to a separate Envoy log file, if any")
-	option.BindEnv(Vp, option.EnvoyLog)
+	option.BindEnv(vp, option.EnvoyLog)
 
 	flags.Bool(option.EnableIPSecName, defaults.EnableIPSec, "Enable IPSec support")
-	option.BindEnv(Vp, option.EnableIPSecName)
+	option.BindEnv(vp, option.EnableIPSecName)
 
 	flags.String(option.IPSecKeyFileName, "", "Path to IPSec key file")
-	option.BindEnv(Vp, option.IPSecKeyFileName)
+	option.BindEnv(vp, option.IPSecKeyFileName)
 
 	flags.Duration(option.IPsecKeyRotationDuration, defaults.IPsecKeyRotationDuration, "Maximum duration of the IPsec key rotation. The previous key will be removed after that delay.")
-	option.BindEnv(Vp, option.IPsecKeyRotationDuration)
+	option.BindEnv(vp, option.IPsecKeyRotationDuration)
 
 	flags.Bool(option.EnableIPsecKeyWatcher, defaults.EnableIPsecKeyWatcher, "Enable watcher for IPsec key. If disabled, a restart of the agent will be necessary on key rotations.")
-	option.BindEnv(Vp, option.EnableIPsecKeyWatcher)
+	option.BindEnv(vp, option.EnableIPsecKeyWatcher)
 
 	flags.Bool(option.EnableWireguard, false, "Enable wireguard")
-	option.BindEnv(Vp, option.EnableWireguard)
+	option.BindEnv(vp, option.EnableWireguard)
 
 	flags.Bool(option.EnableL2Announcements, false, "Enable L2 announcements")
-	option.BindEnv(Vp, option.EnableL2Announcements)
+	option.BindEnv(vp, option.EnableL2Announcements)
 
 	flags.Duration(option.L2AnnouncerLeaseDuration, 15*time.Second, "Duration of inactivity after which a new leader is selected")
-	option.BindEnv(Vp, option.L2AnnouncerLeaseDuration)
+	option.BindEnv(vp, option.L2AnnouncerLeaseDuration)
 
 	flags.Duration(option.L2AnnouncerRenewDeadline, 5*time.Second, "Interval at which the leader renews a lease")
-	option.BindEnv(Vp, option.L2AnnouncerRenewDeadline)
+	option.BindEnv(vp, option.L2AnnouncerRenewDeadline)
 
 	flags.Duration(option.L2AnnouncerRetryPeriod, 2*time.Second, "Timeout after a renew failure, before the next retry")
-	option.BindEnv(Vp, option.L2AnnouncerRetryPeriod)
+	option.BindEnv(vp, option.L2AnnouncerRetryPeriod)
 
 	flags.Bool(option.EnableWireguardUserspaceFallback, false, "Enables the fallback to the wireguard userspace implementation")
-	option.BindEnv(Vp, option.EnableWireguardUserspaceFallback)
+	option.BindEnv(vp, option.EnableWireguardUserspaceFallback)
 
 	flags.String(option.NodeEncryptionOptOutLabels, defaults.NodeEncryptionOptOutLabels, "Label selector for nodes which will opt-out of node-to-node encryption")
-	option.BindEnv(Vp, option.NodeEncryptionOptOutLabels)
+	option.BindEnv(vp, option.NodeEncryptionOptOutLabels)
 
 	flags.Bool(option.EnableEncryptionStrictMode, false, "Enable encryption strict mode")
-	option.BindEnv(Vp, option.EnableEncryptionStrictMode)
+	option.BindEnv(vp, option.EnableEncryptionStrictMode)
 
 	flags.String(option.EncryptionStrictModeCIDR, "", "In strict-mode encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped")
-	option.BindEnv(Vp, option.EncryptionStrictModeCIDR)
+	option.BindEnv(vp, option.EncryptionStrictModeCIDR)
 
 	flags.Bool(option.EncryptionStrictModeAllowRemoteNodeIdentities, false, "Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.")
-	option.BindEnv(Vp, option.EncryptionStrictModeAllowRemoteNodeIdentities)
+	option.BindEnv(vp, option.EncryptionStrictModeAllowRemoteNodeIdentities)
 
 	flags.Bool(option.HTTPNormalizePath, true, "Use Envoy HTTP path normalization options, which currently includes RFC 3986 path normalization, Envoy merge slashes option, and unescaping and redirecting for paths that contain escaped slashes. These are necessary to keep path based access control functional, and should not interfere with normal operation. Set this to false only with caution.")
-	option.BindEnv(Vp, option.HTTPNormalizePath)
+	option.BindEnv(vp, option.HTTPNormalizePath)
 
 	flags.String(option.HTTP403Message, "", "Message returned in proxy L7 403 body")
 	flags.MarkHidden(option.HTTP403Message)
-	option.BindEnv(Vp, option.HTTP403Message)
+	option.BindEnv(vp, option.HTTP403Message)
 
 	flags.Uint(option.HTTPRequestTimeout, 60*60, "Time after which a forwarded HTTP request is considered failed unless completed (in seconds); Use 0 for unlimited")
-	option.BindEnv(Vp, option.HTTPRequestTimeout)
+	option.BindEnv(vp, option.HTTPRequestTimeout)
 
 	flags.Uint(option.HTTPIdleTimeout, 0, "Time after which a non-gRPC HTTP stream is considered failed unless traffic in the stream has been processed (in seconds); defaults to 0 (unlimited)")
-	option.BindEnv(Vp, option.HTTPIdleTimeout)
+	option.BindEnv(vp, option.HTTPIdleTimeout)
 
 	flags.Uint(option.HTTPMaxGRPCTimeout, 0, "Time after which a forwarded gRPC request is considered failed unless completed (in seconds). A \"grpc-timeout\" header may override this with a shorter value; defaults to 0 (unlimited)")
-	option.BindEnv(Vp, option.HTTPMaxGRPCTimeout)
+	option.BindEnv(vp, option.HTTPMaxGRPCTimeout)
 
 	flags.Uint(option.HTTPRetryCount, 3, "Number of retries performed after a forwarded request attempt fails")
-	option.BindEnv(Vp, option.HTTPRetryCount)
+	option.BindEnv(vp, option.HTTPRetryCount)
 
 	flags.Uint(option.HTTPRetryTimeout, 0, "Time after which a forwarded but uncompleted request is retried (connection failures are retried immediately); defaults to 0 (never)")
-	option.BindEnv(Vp, option.HTTPRetryTimeout)
+	option.BindEnv(vp, option.HTTPRetryTimeout)
 
 	flags.Uint(option.ProxyConnectTimeout, 2, "Time after which a TCP connect attempt is considered failed unless completed (in seconds)")
-	option.BindEnv(Vp, option.ProxyConnectTimeout)
+	option.BindEnv(vp, option.ProxyConnectTimeout)
 
 	flags.Uint(option.ProxyGID, 1337, "Group ID for proxy control plane sockets.")
-	option.BindEnv(Vp, option.ProxyGID)
+	option.BindEnv(vp, option.ProxyGID)
 
 	flags.Int(option.ProxyPrometheusPort, 0, "Port to serve Envoy metrics on. Default 0 (disabled).")
-	option.BindEnv(Vp, option.ProxyPrometheusPort)
+	option.BindEnv(vp, option.ProxyPrometheusPort)
 
 	flags.Int(option.ProxyMaxRequestsPerConnection, 0, "Set Envoy HTTP option max_requests_per_connection. Default 0 (disable)")
-	option.BindEnv(Vp, option.ProxyMaxRequestsPerConnection)
+	option.BindEnv(vp, option.ProxyMaxRequestsPerConnection)
 
 	flags.Int64(option.ProxyMaxConnectionDuration, 0, "Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)")
-	option.BindEnv(Vp, option.ProxyMaxConnectionDuration)
+	option.BindEnv(vp, option.ProxyMaxConnectionDuration)
 
 	flags.Int64(option.ProxyIdleTimeout, 60, "Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s")
-	option.BindEnv(Vp, option.ProxyIdleTimeout)
+	option.BindEnv(vp, option.ProxyIdleTimeout)
 
 	flags.Bool(option.DisableEnvoyVersionCheck, false, "Do not perform Envoy binary version check on startup")
 	flags.MarkHidden(option.DisableEnvoyVersionCheck)
 	// Disable version check if Envoy build is disabled
-	option.BindEnvWithLegacyEnvFallback(Vp, option.DisableEnvoyVersionCheck, "CILIUM_DISABLE_ENVOY_BUILD")
+	option.BindEnvWithLegacyEnvFallback(vp, option.DisableEnvoyVersionCheck, "CILIUM_DISABLE_ENVOY_BUILD")
 
 	flags.Var(option.NewNamedMapOptions(option.FixedIdentityMapping, &option.Config.FixedIdentityMapping, option.Config.FixedIdentityMappingValidator),
 		option.FixedIdentityMapping, "Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns")
-	option.BindEnv(Vp, option.FixedIdentityMapping)
+	option.BindEnv(vp, option.FixedIdentityMapping)
 
 	flags.Duration(option.IdentityChangeGracePeriod, defaults.IdentityChangeGracePeriod, "Time to wait before using new identity on endpoint identity change")
-	option.BindEnv(Vp, option.IdentityChangeGracePeriod)
+	option.BindEnv(vp, option.IdentityChangeGracePeriod)
 
 	flags.Duration(option.IdentityRestoreGracePeriod, defaults.IdentityRestoreGracePeriod, "Time to wait before releasing unused restored CIDR identities during agent restart")
-	option.BindEnv(Vp, option.IdentityRestoreGracePeriod)
+	option.BindEnv(vp, option.IdentityRestoreGracePeriod)
 
 	flags.String(option.IdentityAllocationMode, option.IdentityAllocationModeKVstore, "Method to use for identity allocation")
-	option.BindEnv(Vp, option.IdentityAllocationMode)
+	option.BindEnv(vp, option.IdentityAllocationMode)
 
 	flags.String(option.IPAM, ipamOption.IPAMClusterPool, "Backend to use for IPAM")
-	option.BindEnv(Vp, option.IPAM)
+	option.BindEnv(vp, option.IPAM)
 
 	flags.String(option.IPv4Range, AutoCIDR, "Per-node IPv4 endpoint prefix, e.g. 10.16.0.0/16")
-	option.BindEnv(Vp, option.IPv4Range)
+	option.BindEnv(vp, option.IPv4Range)
 
 	flags.String(option.IPv6Range, AutoCIDR, "Per-node IPv6 endpoint prefix, e.g. fd02:1:1::/96")
-	option.BindEnv(Vp, option.IPv6Range)
+	option.BindEnv(vp, option.IPv6Range)
 
 	flags.String(option.IPv6ClusterAllocCIDRName, defaults.IPv6ClusterAllocCIDR, "IPv6 /64 CIDR used to allocate per node endpoint /96 CIDR")
-	option.BindEnv(Vp, option.IPv6ClusterAllocCIDRName)
+	option.BindEnv(vp, option.IPv6ClusterAllocCIDRName)
 
 	flags.String(option.IPv4ServiceRange, AutoCIDR, "Kubernetes IPv4 services CIDR if not inside cluster prefix")
-	option.BindEnv(Vp, option.IPv4ServiceRange)
+	option.BindEnv(vp, option.IPv4ServiceRange)
 
 	flags.String(option.IPv6ServiceRange, AutoCIDR, "Kubernetes IPv6 services CIDR if not inside cluster prefix")
-	option.BindEnv(Vp, option.IPv6ServiceRange)
+	option.BindEnv(vp, option.IPv6ServiceRange)
 
 	flags.Bool(option.K8sEventHandover, defaults.K8sEventHandover, "Enable k8s event handover to kvstore for improved scalability")
-	option.BindEnv(Vp, option.K8sEventHandover)
+	option.BindEnv(vp, option.K8sEventHandover)
 
 	flags.String(option.K8sNamespaceName, "", "Name of the Kubernetes namespace in which Cilium is deployed in")
-	option.BindEnv(Vp, option.K8sNamespaceName)
+	option.BindEnv(vp, option.K8sNamespaceName)
 
 	flags.String(option.AgentNotReadyNodeTaintKeyName, defaults.AgentNotReadyNodeTaint, "Key of the taint indicating that Cilium is not ready on the node")
-	option.BindEnv(Vp, option.AgentNotReadyNodeTaintKeyName)
+	option.BindEnv(vp, option.AgentNotReadyNodeTaintKeyName)
 
 	flags.Bool(option.JoinClusterName, false, "Join a Cilium cluster via kvstore registration")
-	option.BindEnv(Vp, option.JoinClusterName)
+	option.BindEnv(vp, option.JoinClusterName)
 
 	flags.Bool(option.K8sRequireIPv4PodCIDRName, false, "Require IPv4 PodCIDR to be specified in node resource")
-	option.BindEnv(Vp, option.K8sRequireIPv4PodCIDRName)
+	option.BindEnv(vp, option.K8sRequireIPv4PodCIDRName)
 
 	flags.Bool(option.K8sRequireIPv6PodCIDRName, false, "Require IPv6 PodCIDR to be specified in node resource")
-	option.BindEnv(Vp, option.K8sRequireIPv6PodCIDRName)
+	option.BindEnv(vp, option.K8sRequireIPv6PodCIDRName)
 
 	flags.Uint(option.K8sServiceCacheSize, defaults.K8sServiceCacheSize, "Cilium service cache size for kubernetes")
-	option.BindEnv(Vp, option.K8sServiceCacheSize)
+	option.BindEnv(vp, option.K8sServiceCacheSize)
 	flags.MarkHidden(option.K8sServiceCacheSize)
 
 	flags.String(option.K8sWatcherEndpointSelector, defaults.K8sWatcherEndpointSelector, "K8s endpoint watcher will watch for these k8s endpoints")
-	option.BindEnv(Vp, option.K8sWatcherEndpointSelector)
+	option.BindEnv(vp, option.K8sWatcherEndpointSelector)
 
 	flags.Bool(option.KeepConfig, false, "When restoring state, keeps containers' configuration in place")
-	option.BindEnv(Vp, option.KeepConfig)
+	option.BindEnv(vp, option.KeepConfig)
 
 	flags.String(option.KVStore, "", "Key-value store type")
-	option.BindEnv(Vp, option.KVStore)
+	option.BindEnv(vp, option.KVStore)
 
 	flags.Duration(option.KVstoreLeaseTTL, defaults.KVstoreLeaseTTL, "Time-to-live for the KVstore lease.")
 	flags.MarkHidden(option.KVstoreLeaseTTL)
-	option.BindEnv(Vp, option.KVstoreLeaseTTL)
+	option.BindEnv(vp, option.KVstoreLeaseTTL)
 
 	flags.Int(option.KVstoreMaxConsecutiveQuorumErrorsName, defaults.KVstoreMaxConsecutiveQuorumErrors, "Max acceptable kvstore consecutive quorum errors before the agent assumes permanent failure")
-	option.BindEnv(Vp, option.KVstoreMaxConsecutiveQuorumErrorsName)
+	option.BindEnv(vp, option.KVstoreMaxConsecutiveQuorumErrorsName)
 
 	flags.Duration(option.KVstorePeriodicSync, defaults.KVstorePeriodicSync, "Periodic KVstore synchronization interval")
-	option.BindEnv(Vp, option.KVstorePeriodicSync)
+	option.BindEnv(vp, option.KVstorePeriodicSync)
 
 	flags.Duration(option.KVstoreConnectivityTimeout, defaults.KVstoreConnectivityTimeout, "Time after which an incomplete kvstore operation  is considered failed")
-	option.BindEnv(Vp, option.KVstoreConnectivityTimeout)
+	option.BindEnv(vp, option.KVstoreConnectivityTimeout)
 
 	flags.Duration(option.IPAllocationTimeout, defaults.IPAllocationTimeout, "Time after which an incomplete CIDR allocation is considered failed")
-	option.BindEnv(Vp, option.IPAllocationTimeout)
+	option.BindEnv(vp, option.IPAllocationTimeout)
 
 	flags.Var(option.NewNamedMapOptions(option.KVStoreOpt, &option.Config.KVStoreOpt, nil),
 		option.KVStoreOpt, "Key-value store options e.g. etcd.address=127.0.0.1:4001")
-	option.BindEnv(Vp, option.KVStoreOpt)
+	option.BindEnv(vp, option.KVStoreOpt)
 
 	flags.Duration(option.K8sSyncTimeoutName, defaults.K8sSyncTimeout, "Timeout after last K8s event for synchronizing k8s resources before exiting")
 	flags.MarkHidden(option.K8sSyncTimeoutName)
-	option.BindEnv(Vp, option.K8sSyncTimeoutName)
+	option.BindEnv(vp, option.K8sSyncTimeoutName)
 
 	flags.Duration(option.AllocatorListTimeoutName, defaults.AllocatorListTimeout, "Timeout for listing allocator state before exiting")
-	option.BindEnv(Vp, option.AllocatorListTimeoutName)
+	option.BindEnv(vp, option.AllocatorListTimeoutName)
 
 	flags.String(option.LabelPrefixFile, "", "Valid label prefixes file path")
-	option.BindEnv(Vp, option.LabelPrefixFile)
+	option.BindEnv(vp, option.LabelPrefixFile)
 
 	flags.StringSlice(option.Labels, []string{}, "List of label prefixes used to determine identity of an endpoint")
-	option.BindEnv(Vp, option.Labels)
+	option.BindEnv(vp, option.Labels)
 
 	flags.String(option.KubeProxyReplacement, option.KubeProxyReplacementFalse, fmt.Sprintf(
 		"Enable only selected features (will panic if any selected feature cannot be enabled) (%q), "+
 			"or enable all features (will panic if any feature cannot be enabled) (%q)",
 		option.KubeProxyReplacementFalse, option.KubeProxyReplacementTrue))
-	option.BindEnv(Vp, option.KubeProxyReplacement)
+	option.BindEnv(vp, option.KubeProxyReplacement)
 
 	flags.String(option.KubeProxyReplacementHealthzBindAddr, defaults.KubeProxyReplacementHealthzBindAddr, "The IP address with port for kube-proxy replacement health check server to serve on (set to '0.0.0.0:10256' for all IPv4 interfaces and '[::]:10256' for all IPv6 interfaces). Set empty to disable.")
-	option.BindEnv(Vp, option.KubeProxyReplacementHealthzBindAddr)
+	option.BindEnv(vp, option.KubeProxyReplacementHealthzBindAddr)
 
 	flags.Bool(option.EnableHostPort, false, fmt.Sprintf("Enable k8s hostPort mapping feature (requires enabling %s)", option.EnableNodePort))
-	option.BindEnv(Vp, option.EnableHostPort)
+	option.BindEnv(vp, option.EnableHostPort)
 
 	flags.Bool(option.EnableNodePort, false, "Enable NodePort type services by Cilium")
-	option.BindEnv(Vp, option.EnableNodePort)
+	option.BindEnv(vp, option.EnableNodePort)
 
 	flags.Bool(option.EnableSVCSourceRangeCheck, true, "Enable check of service source ranges (currently, only for LoadBalancer)")
-	option.BindEnv(Vp, option.EnableSVCSourceRangeCheck)
+	option.BindEnv(vp, option.EnableSVCSourceRangeCheck)
 
 	flags.String(option.AddressScopeMax, fmt.Sprintf("%d", defaults.AddressScopeMax), "Maximum local address scope for ipcache to consider host addresses")
 	flags.MarkHidden(option.AddressScopeMax)
-	option.BindEnv(Vp, option.AddressScopeMax)
+	option.BindEnv(vp, option.AddressScopeMax)
 
 	flags.Bool(option.EnableBandwidthManager, false, "Enable BPF bandwidth manager")
-	option.BindEnv(Vp, option.EnableBandwidthManager)
+	option.BindEnv(vp, option.EnableBandwidthManager)
 
 	flags.Bool(option.EnableBBR, false, "Enable BBR for the bandwidth manager")
-	option.BindEnv(Vp, option.EnableBBR)
+	option.BindEnv(vp, option.EnableBBR)
 
 	flags.Bool(option.EnableRecorder, false, "Enable BPF datapath pcap recorder")
-	option.BindEnv(Vp, option.EnableRecorder)
+	option.BindEnv(vp, option.EnableRecorder)
 
 	flags.Bool(option.EnableLocalRedirectPolicy, false, "Enable Local Redirect Policy")
-	option.BindEnv(Vp, option.EnableLocalRedirectPolicy)
+	option.BindEnv(vp, option.EnableLocalRedirectPolicy)
 
 	flags.Bool(option.EnableMKE, false, "Enable BPF kube-proxy replacement for MKE environments")
 	flags.MarkHidden(option.EnableMKE)
-	option.BindEnv(Vp, option.EnableMKE)
+	option.BindEnv(vp, option.EnableMKE)
 
 	flags.String(option.CgroupPathMKE, "", "Cgroup v1 net_cls mount path for MKE environments")
 	flags.MarkHidden(option.CgroupPathMKE)
-	option.BindEnv(Vp, option.CgroupPathMKE)
+	option.BindEnv(vp, option.CgroupPathMKE)
 
 	flags.String(option.NodePortMode, option.NodePortModeSNAT, "BPF NodePort mode (\"snat\", \"dsr\", \"hybrid\")")
 	flags.MarkHidden(option.NodePortMode)
-	option.BindEnv(Vp, option.NodePortMode)
+	option.BindEnv(vp, option.NodePortMode)
 
 	flags.String(option.NodePortAlg, option.NodePortAlgRandom, "BPF load balancing algorithm (\"random\", \"maglev\")")
 	flags.MarkHidden(option.NodePortAlg)
-	option.BindEnv(Vp, option.NodePortAlg)
+	option.BindEnv(vp, option.NodePortAlg)
 
 	flags.String(option.NodePortAcceleration, option.NodePortAccelerationDisabled, fmt.Sprintf(
 		"BPF NodePort acceleration via XDP (\"%s\", \"%s\")",
 		option.NodePortAccelerationNative, option.NodePortAccelerationDisabled))
 	flags.MarkHidden(option.NodePortAcceleration)
-	option.BindEnv(Vp, option.NodePortAcceleration)
+	option.BindEnv(vp, option.NodePortAcceleration)
 
 	flags.String(option.LoadBalancerMode, option.NodePortModeSNAT, "BPF load balancing mode (\"snat\", \"dsr\", \"hybrid\")")
-	option.BindEnv(Vp, option.LoadBalancerMode)
+	option.BindEnv(vp, option.LoadBalancerMode)
 
 	flags.String(option.LoadBalancerAlg, option.NodePortAlgRandom, "BPF load balancing algorithm (\"random\", \"maglev\")")
-	option.BindEnv(Vp, option.LoadBalancerAlg)
+	option.BindEnv(vp, option.LoadBalancerAlg)
 
 	flags.String(option.LoadBalancerDSRDispatch, option.DSRDispatchOption, "BPF load balancing DSR dispatch method (\"opt\", \"ipip\", \"geneve\")")
-	option.BindEnv(Vp, option.LoadBalancerDSRDispatch)
+	option.BindEnv(vp, option.LoadBalancerDSRDispatch)
 
 	flags.String(option.LoadBalancerDSRL4Xlate, option.DSRL4XlateFrontend, "BPF load balancing DSR L4 DNAT method for IPIP (\"frontend\", \"backend\")")
-	option.BindEnv(Vp, option.LoadBalancerDSRL4Xlate)
+	option.BindEnv(vp, option.LoadBalancerDSRL4Xlate)
 
 	flags.String(option.LoadBalancerRSSv4CIDR, "", "BPF load balancing RSS outer source IPv4 CIDR prefix for IPIP")
-	option.BindEnv(Vp, option.LoadBalancerRSSv4CIDR)
+	option.BindEnv(vp, option.LoadBalancerRSSv4CIDR)
 
 	flags.String(option.LoadBalancerRSSv6CIDR, "", "BPF load balancing RSS outer source IPv6 CIDR prefix for IPIP")
-	option.BindEnv(Vp, option.LoadBalancerRSSv6CIDR)
+	option.BindEnv(vp, option.LoadBalancerRSSv6CIDR)
 
 	flags.String(option.LoadBalancerAcceleration, option.NodePortAccelerationDisabled, fmt.Sprintf(
 		"BPF load balancing acceleration via XDP (\"%s\", \"%s\")",
 		option.NodePortAccelerationNative, option.NodePortAccelerationDisabled))
-	option.BindEnv(Vp, option.LoadBalancerAcceleration)
+	option.BindEnv(vp, option.LoadBalancerAcceleration)
 
 	flags.Uint(option.MaglevTableSize, maglev.DefaultTableSize, "Maglev per service backend table size (parameter M)")
-	option.BindEnv(Vp, option.MaglevTableSize)
+	option.BindEnv(vp, option.MaglevTableSize)
 
 	flags.String(option.MaglevHashSeed, maglev.DefaultHashSeed, "Maglev cluster-wide hash seed (base64 encoded)")
-	option.BindEnv(Vp, option.MaglevHashSeed)
+	option.BindEnv(vp, option.MaglevHashSeed)
 
 	flags.Bool(option.EnableAutoProtectNodePortRange, true,
 		"Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps "+
 			"with ephemeral port range (net.ipv4.ip_local_port_range)")
-	option.BindEnv(Vp, option.EnableAutoProtectNodePortRange)
+	option.BindEnv(vp, option.EnableAutoProtectNodePortRange)
 
 	flags.StringSlice(option.NodePortRange, []string{fmt.Sprintf("%d", option.NodePortMinDefault), fmt.Sprintf("%d", option.NodePortMaxDefault)}, "Set the min/max NodePort port range")
-	option.BindEnv(Vp, option.NodePortRange)
+	option.BindEnv(vp, option.NodePortRange)
 
 	flags.Bool(option.NodePortBindProtection, true, "Reject application bind(2) requests to service ports in the NodePort range")
-	option.BindEnv(Vp, option.NodePortBindProtection)
+	option.BindEnv(vp, option.NodePortBindProtection)
 
 	flags.Bool(option.EnableSessionAffinity, false, "Enable support for service session affinity")
-	option.BindEnv(Vp, option.EnableSessionAffinity)
+	option.BindEnv(vp, option.EnableSessionAffinity)
 
 	flags.Bool(option.EnableServiceTopology, false, "Enable support for service topology aware hints")
-	option.BindEnv(Vp, option.EnableServiceTopology)
+	option.BindEnv(vp, option.EnableServiceTopology)
 
 	flags.Bool(option.EnableIdentityMark, true, "Enable setting identity mark for local traffic")
-	option.BindEnv(Vp, option.EnableIdentityMark)
+	option.BindEnv(vp, option.EnableIdentityMark)
 
 	flags.Bool(option.EnableHighScaleIPcache, defaults.EnableHighScaleIPcache, "Enable the high scale mode for ipcache")
-	option.BindEnv(Vp, option.EnableHighScaleIPcache)
+	option.BindEnv(vp, option.EnableHighScaleIPcache)
 
 	flags.Bool(option.EnableHostFirewall, false, "Enable host network policies")
-	option.BindEnv(Vp, option.EnableHostFirewall)
+	option.BindEnv(vp, option.EnableHostFirewall)
 
 	flags.String(option.IPv4NativeRoutingCIDR, "", "Allows to explicitly specify the IPv4 CIDR for native routing. "+
 		"When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. "+
 		"Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. "+
 		"To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag.")
-	option.BindEnv(Vp, option.IPv4NativeRoutingCIDR)
+	option.BindEnv(vp, option.IPv4NativeRoutingCIDR)
 
 	flags.String(option.IPv6NativeRoutingCIDR, "", "Allows to explicitly specify the IPv6 CIDR for native routing. "+
 		"When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. "+
 		"Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. "+
 		"To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag.")
-	option.BindEnv(Vp, option.IPv6NativeRoutingCIDR)
+	option.BindEnv(vp, option.IPv6NativeRoutingCIDR)
 
 	flags.String(option.LibDir, defaults.LibraryPath, "Directory path to store runtime build environment")
-	option.BindEnv(Vp, option.LibDir)
+	option.BindEnv(vp, option.LibDir)
 
 	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use for example syslog")
-	option.BindEnv(Vp, option.LogDriver)
+	option.BindEnv(vp, option.LogDriver)
 
 	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil),
 		option.LogOpt, `Log driver options for cilium-agent, `+
 			`configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}`)
-	option.BindEnv(Vp, option.LogOpt)
+	option.BindEnv(vp, option.LogOpt)
 
 	flags.Bool(option.LogSystemLoadConfigName, false, "Enable periodic logging of system load")
-	option.BindEnv(Vp, option.LogSystemLoadConfigName)
+	option.BindEnv(vp, option.LogSystemLoadConfigName)
 
 	flags.String(option.LoopbackIPv4, defaults.LoopbackIPv4, "IPv4 address for service loopback SNAT")
-	option.BindEnv(Vp, option.LoopbackIPv4)
+	option.BindEnv(vp, option.LoopbackIPv4)
 
 	flags.Bool(option.EnableIPv4Masquerade, true, "Masquerade IPv4 traffic from endpoints leaving the host")
-	option.BindEnv(Vp, option.EnableIPv4Masquerade)
+	option.BindEnv(vp, option.EnableIPv4Masquerade)
 
 	flags.Bool(option.EnableIPv6Masquerade, true, "Masquerade IPv6 traffic from endpoints leaving the host")
-	option.BindEnv(Vp, option.EnableIPv6Masquerade)
+	option.BindEnv(vp, option.EnableIPv6Masquerade)
 
 	flags.Bool(option.EnableBPFMasquerade, false, "Masquerade packets from endpoints leaving the host with BPF instead of iptables")
-	option.BindEnv(Vp, option.EnableBPFMasquerade)
+	option.BindEnv(vp, option.EnableBPFMasquerade)
 
 	flags.String(option.DeriveMasqIPAddrFromDevice, "", "Device name from which Cilium derives the IP addr for BPF masquerade")
 	flags.MarkHidden(option.DeriveMasqIPAddrFromDevice)
-	option.BindEnv(Vp, option.DeriveMasqIPAddrFromDevice)
+	option.BindEnv(vp, option.DeriveMasqIPAddrFromDevice)
 
 	flags.Bool(option.EnableIPMasqAgent, false, "Enable BPF ip-masq-agent")
-	option.BindEnv(Vp, option.EnableIPMasqAgent)
+	option.BindEnv(vp, option.EnableIPMasqAgent)
 
 	flags.Bool(option.EnableIPv6BIGTCP, false, "Enable IPv6 BIG TCP option which increases device's maximum GRO/GSO limits for IPv6")
-	option.BindEnv(Vp, option.EnableIPv6BIGTCP)
+	option.BindEnv(vp, option.EnableIPv6BIGTCP)
 
 	flags.Bool(option.EnableIPv4BIGTCP, false, "Enable IPv4 BIG TCP option which increases device's maximum GRO/GSO limits for IPv4")
-	option.BindEnv(Vp, option.EnableIPv4BIGTCP)
+	option.BindEnv(vp, option.EnableIPv4BIGTCP)
 
 	flags.Bool(option.EnableIPv4EgressGateway, false, "Enable egress gateway for IPv4")
-	option.BindEnv(Vp, option.EnableIPv4EgressGateway)
+	option.BindEnv(vp, option.EnableIPv4EgressGateway)
 
 	flags.Bool(option.EnableEnvoyConfig, false, "Enable Envoy Config CRDs")
-	option.BindEnv(Vp, option.EnableEnvoyConfig)
+	option.BindEnv(vp, option.EnableEnvoyConfig)
 
 	flags.Duration(option.EnvoyConfigTimeout, defaults.EnvoyConfigTimeout, "Timeout duration for Envoy Config acknowledgements")
-	option.BindEnv(Vp, option.EnvoyConfigTimeout)
+	option.BindEnv(vp, option.EnvoyConfigTimeout)
 
 	flags.String(option.IPMasqAgentConfigPath, "/etc/config/ip-masq-agent", "ip-masq-agent configuration file path")
-	option.BindEnv(Vp, option.IPMasqAgentConfigPath)
+	option.BindEnv(vp, option.IPMasqAgentConfigPath)
 
 	flags.Bool(option.InstallIptRules, true, "Install base iptables rules for cilium to mainly interact with kube-proxy (and masquerading)")
 	flags.MarkHidden(option.InstallIptRules)
-	option.BindEnv(Vp, option.InstallIptRules)
+	option.BindEnv(vp, option.InstallIptRules)
 
 	flags.Duration(option.IPTablesLockTimeout, 5*time.Second, "Time to pass to each iptables invocation to wait for xtables lock acquisition")
-	option.BindEnv(Vp, option.IPTablesLockTimeout)
+	option.BindEnv(vp, option.IPTablesLockTimeout)
 
 	flags.Bool(option.IPTablesRandomFully, false, "Set iptables flag random-fully on masquerading rules")
-	option.BindEnv(Vp, option.IPTablesRandomFully)
+	option.BindEnv(vp, option.IPTablesRandomFully)
 
 	flags.Int(option.MaxCtrlIntervalName, 0, "Maximum interval (in seconds) between controller runs. Zero is no limit.")
 	flags.MarkHidden(option.MaxCtrlIntervalName)
-	option.BindEnv(Vp, option.MaxCtrlIntervalName)
+	option.BindEnv(vp, option.MaxCtrlIntervalName)
 
 	flags.String(option.MonitorAggregationName, "None",
 		"Level of monitor aggregation for traces from the datapath")
-	option.BindEnvWithLegacyEnvFallback(Vp, option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
+	option.BindEnvWithLegacyEnvFallback(vp, option.MonitorAggregationName, "CILIUM_MONITOR_AGGREGATION_LEVEL")
 
 	flags.Int(option.MTUName, 0, "Overwrite auto-detected MTU of underlying network")
-	option.BindEnv(Vp, option.MTUName)
+	option.BindEnv(vp, option.MTUName)
 
 	flags.String(option.ProcFs, "/proc", "Root's proc filesystem path")
-	option.BindEnv(Vp, option.ProcFs)
+	option.BindEnv(vp, option.ProcFs)
 
 	flags.Int(option.RouteMetric, 0, "Overwrite the metric used by cilium when adding routes to its 'cilium_host' device")
-	option.BindEnv(Vp, option.RouteMetric)
+	option.BindEnv(vp, option.RouteMetric)
 
 	flags.Bool(option.PrependIptablesChainsName, true, "Prepend custom iptables chains instead of appending")
-	option.BindEnvWithLegacyEnvFallback(Vp, option.PrependIptablesChainsName, "CILIUM_PREPEND_IPTABLES_CHAIN")
+	option.BindEnvWithLegacyEnvFallback(vp, option.PrependIptablesChainsName, "CILIUM_PREPEND_IPTABLES_CHAIN")
 
 	flags.String(option.IPv6NodeAddr, "auto", "IPv6 address of node")
-	option.BindEnv(Vp, option.IPv6NodeAddr)
+	option.BindEnv(vp, option.IPv6NodeAddr)
 
 	flags.String(option.IPv4NodeAddr, "auto", "IPv4 address of node")
-	option.BindEnv(Vp, option.IPv4NodeAddr)
+	option.BindEnv(vp, option.IPv4NodeAddr)
 
 	flags.Bool(option.Restore, true, "Restores state, if possible, from previous daemon")
-	option.BindEnv(Vp, option.Restore)
+	option.BindEnv(vp, option.Restore)
 
 	flags.String(option.SidecarIstioProxyImage, k8s.DefaultSidecarIstioProxyImageRegexp,
 		"Regular expression matching compatible Istio sidecar istio-proxy container image names")
-	option.BindEnv(Vp, option.SidecarIstioProxyImage)
+	option.BindEnv(vp, option.SidecarIstioProxyImage)
 
 	flags.Bool(option.SingleClusterRouteName, false,
 		"Use a single cluster route instead of per node routes")
-	option.BindEnv(Vp, option.SingleClusterRouteName)
+	option.BindEnv(vp, option.SingleClusterRouteName)
 
 	flags.String(option.SocketPath, defaults.SockPath, "Sets daemon's socket path to listen for connections")
-	option.BindEnv(Vp, option.SocketPath)
+	option.BindEnv(vp, option.SocketPath)
 
 	flags.String(option.StateDir, defaults.RuntimePath, "Directory path to store runtime state")
-	option.BindEnv(Vp, option.StateDir)
+	option.BindEnv(vp, option.StateDir)
 
 	flags.Bool(option.ExternalEnvoyProxy, false, "whether the Envoy is deployed externally in form of a DaemonSet or not")
-	option.BindEnv(Vp, option.ExternalEnvoyProxy)
+	option.BindEnv(vp, option.ExternalEnvoyProxy)
 
 	flags.StringP(option.TunnelName, "t", "", fmt.Sprintf("Tunnel mode {%s} (default \"vxlan\" for the \"veth\" datapath mode)", option.GetTunnelModes()))
-	option.BindEnv(Vp, option.TunnelName)
+	option.BindEnv(vp, option.TunnelName)
 	flags.MarkDeprecated(option.TunnelName,
 		fmt.Sprintf("This option will be removed in v1.15. Please use --%s and --%s instead.", option.RoutingMode, option.TunnelProtocol))
 
 	flags.String(option.RoutingMode, defaults.RoutingMode, fmt.Sprintf("Routing mode (%q or %q)", option.RoutingModeNative, option.RoutingModeTunnel))
-	option.BindEnv(Vp, option.RoutingMode)
+	option.BindEnv(vp, option.RoutingMode)
 
 	flags.String(option.TunnelProtocol, defaults.TunnelProtocol, "Encapsulation protocol to use for the overlay (\"vxlan\" or \"geneve\")")
-	option.BindEnv(Vp, option.TunnelProtocol)
+	option.BindEnv(vp, option.TunnelProtocol)
 
 	flags.Int(option.TunnelPortName, 0, fmt.Sprintf("Tunnel port (default %d for \"vxlan\" and %d for \"geneve\")", defaults.TunnelPortVXLAN, defaults.TunnelPortGeneve))
-	option.BindEnv(Vp, option.TunnelPortName)
+	option.BindEnv(vp, option.TunnelPortName)
 
 	flags.Int(option.TracePayloadlen, 128, "Length of payload to capture when tracing")
-	option.BindEnv(Vp, option.TracePayloadlen)
+	option.BindEnv(vp, option.TracePayloadlen)
 
 	flags.Bool(option.Version, false, "Print version information")
-	option.BindEnv(Vp, option.Version)
+	option.BindEnv(vp, option.Version)
 
 	flags.Bool(option.EnableXDPPrefilter, false, "Enable XDP prefiltering")
-	option.BindEnv(Vp, option.EnableXDPPrefilter)
+	option.BindEnv(vp, option.EnableXDPPrefilter)
 
 	flags.Bool(option.PreAllocateMapsName, defaults.PreAllocateMaps, "Enable BPF map pre-allocation")
-	option.BindEnv(Vp, option.PreAllocateMapsName)
+	option.BindEnv(vp, option.PreAllocateMapsName)
 
 	flags.Int(option.AuthMapEntriesName, option.AuthMapEntriesDefault, "Maximum number of entries in auth map")
-	option.BindEnv(Vp, option.AuthMapEntriesName)
+	option.BindEnv(vp, option.AuthMapEntriesName)
 
 	flags.Int(option.CTMapEntriesGlobalTCPName, option.CTMapEntriesGlobalTCPDefault, "Maximum number of entries in TCP CT table")
-	option.BindEnvWithLegacyEnvFallback(Vp, option.CTMapEntriesGlobalTCPName, "CILIUM_GLOBAL_CT_MAX_TCP")
+	option.BindEnvWithLegacyEnvFallback(vp, option.CTMapEntriesGlobalTCPName, "CILIUM_GLOBAL_CT_MAX_TCP")
 
 	flags.Int(option.CTMapEntriesGlobalAnyName, option.CTMapEntriesGlobalAnyDefault, "Maximum number of entries in non-TCP CT table")
-	option.BindEnvWithLegacyEnvFallback(Vp, option.CTMapEntriesGlobalAnyName, "CILIUM_GLOBAL_CT_MAX_ANY")
+	option.BindEnvWithLegacyEnvFallback(vp, option.CTMapEntriesGlobalAnyName, "CILIUM_GLOBAL_CT_MAX_ANY")
 
 	flags.Duration(option.CTMapEntriesTimeoutTCPName, 21600*time.Second, "Timeout for established entries in TCP CT table")
-	option.BindEnv(Vp, option.CTMapEntriesTimeoutTCPName)
+	option.BindEnv(vp, option.CTMapEntriesTimeoutTCPName)
 
 	flags.Duration(option.CTMapEntriesTimeoutAnyName, 60*time.Second, "Timeout for entries in non-TCP CT table")
-	option.BindEnv(Vp, option.CTMapEntriesTimeoutAnyName)
+	option.BindEnv(vp, option.CTMapEntriesTimeoutAnyName)
 
 	flags.Duration(option.CTMapEntriesTimeoutSVCTCPName, 21600*time.Second, "Timeout for established service entries in TCP CT table")
-	option.BindEnv(Vp, option.CTMapEntriesTimeoutSVCTCPName)
+	option.BindEnv(vp, option.CTMapEntriesTimeoutSVCTCPName)
 
 	flags.Duration(option.CTMapEntriesTimeoutSVCTCPGraceName, 60*time.Second, "Timeout for graceful shutdown of service entries in TCP CT table")
-	option.BindEnv(Vp, option.CTMapEntriesTimeoutSVCTCPGraceName)
+	option.BindEnv(vp, option.CTMapEntriesTimeoutSVCTCPGraceName)
 
 	flags.Duration(option.CTMapEntriesTimeoutSVCAnyName, 60*time.Second, "Timeout for service entries in non-TCP CT table")
-	option.BindEnv(Vp, option.CTMapEntriesTimeoutSVCAnyName)
+	option.BindEnv(vp, option.CTMapEntriesTimeoutSVCAnyName)
 
 	flags.Duration(option.CTMapEntriesTimeoutSYNName, 60*time.Second, "Establishment timeout for entries in TCP CT table")
-	option.BindEnv(Vp, option.CTMapEntriesTimeoutSYNName)
+	option.BindEnv(vp, option.CTMapEntriesTimeoutSYNName)
 
 	flags.Duration(option.CTMapEntriesTimeoutFINName, 10*time.Second, "Teardown timeout for entries in TCP CT table")
-	option.BindEnv(Vp, option.CTMapEntriesTimeoutFINName)
+	option.BindEnv(vp, option.CTMapEntriesTimeoutFINName)
 
 	flags.Duration(option.MonitorAggregationInterval, 5*time.Second, "Monitor report interval when monitor aggregation is enabled")
-	option.BindEnv(Vp, option.MonitorAggregationInterval)
+	option.BindEnv(vp, option.MonitorAggregationInterval)
 
 	flags.StringSlice(option.MonitorAggregationFlags, option.MonitorAggregationFlagsDefault, "TCP flags that trigger monitor reports when monitor aggregation is enabled")
-	option.BindEnv(Vp, option.MonitorAggregationFlags)
+	option.BindEnv(vp, option.MonitorAggregationFlags)
 
 	flags.Int(option.NATMapEntriesGlobalName, option.NATMapEntriesGlobalDefault, "Maximum number of entries for the global BPF NAT table")
-	option.BindEnv(Vp, option.NATMapEntriesGlobalName)
+	option.BindEnv(vp, option.NATMapEntriesGlobalName)
 
 	flags.Int(option.NeighMapEntriesGlobalName, option.NATMapEntriesGlobalDefault, "Maximum number of entries for the global BPF neighbor table")
-	option.BindEnv(Vp, option.NeighMapEntriesGlobalName)
+	option.BindEnv(vp, option.NeighMapEntriesGlobalName)
 
 	flags.Int(option.PolicyMapEntriesName, policymap.MaxEntries, "Maximum number of entries in endpoint policy map (per endpoint)")
-	option.BindEnv(Vp, option.PolicyMapEntriesName)
+	option.BindEnv(vp, option.PolicyMapEntriesName)
 
 	flags.Int(option.SockRevNatEntriesName, option.SockRevNATMapEntriesDefault, "Maximum number of entries for the SockRevNAT BPF map")
-	option.BindEnv(Vp, option.SockRevNatEntriesName)
+	option.BindEnv(vp, option.SockRevNatEntriesName)
 
 	flags.Float64(option.MapEntriesGlobalDynamicSizeRatioName, 0.0025, "Ratio (0.0-1.0] of total system memory to use for dynamic sizing of CT, NAT and policy BPF maps")
-	option.BindEnv(Vp, option.MapEntriesGlobalDynamicSizeRatioName)
+	option.BindEnv(vp, option.MapEntriesGlobalDynamicSizeRatioName)
 
 	flags.String(option.CMDRef, "", "Path to cmdref output directory")
 	flags.MarkHidden(option.CMDRef)
-	option.BindEnv(Vp, option.CMDRef)
+	option.BindEnv(vp, option.CMDRef)
 
 	flags.Int(option.ToFQDNsMinTTL, defaults.ToFQDNsMinTTL, "The minimum time, in seconds, to use DNS data for toFQDNs policies")
-	option.BindEnv(Vp, option.ToFQDNsMinTTL)
+	option.BindEnv(vp, option.ToFQDNsMinTTL)
 
 	flags.Int(option.ToFQDNsProxyPort, 0, "Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port.")
-	option.BindEnv(Vp, option.ToFQDNsProxyPort)
+	option.BindEnv(vp, option.ToFQDNsProxyPort)
 
 	flags.StringVar(&option.Config.FQDNRejectResponse, option.FQDNRejectResponseCode, option.FQDNProxyDenyWithRefused, fmt.Sprintf("DNS response code for rejecting DNS requests, available options are '%v'", option.FQDNRejectOptions))
-	option.BindEnv(Vp, option.FQDNRejectResponseCode)
+	option.BindEnv(vp, option.FQDNRejectResponseCode)
 
 	flags.Int(option.ToFQDNsMaxIPsPerHost, defaults.ToFQDNsMaxIPsPerHost, "Maximum number of IPs to maintain per FQDN name for each endpoint")
-	option.BindEnv(Vp, option.ToFQDNsMaxIPsPerHost)
+	option.BindEnv(vp, option.ToFQDNsMaxIPsPerHost)
 
 	flags.Int(option.DNSMaxIPsPerRestoredRule, defaults.DNSMaxIPsPerRestoredRule, "Maximum number of IPs to maintain for each restored DNS rule")
-	option.BindEnv(Vp, option.DNSMaxIPsPerRestoredRule)
+	option.BindEnv(vp, option.DNSMaxIPsPerRestoredRule)
 
 	flags.Bool(option.DNSPolicyUnloadOnShutdown, false, "Unload DNS policy rules on graceful shutdown")
-	option.BindEnv(Vp, option.DNSPolicyUnloadOnShutdown)
+	option.BindEnv(vp, option.DNSPolicyUnloadOnShutdown)
 
 	flags.Int(option.ToFQDNsMaxDeferredConnectionDeletes, defaults.ToFQDNsMaxDeferredConnectionDeletes, "Maximum number of IPs to retain for expired DNS lookups with still-active connections")
-	option.BindEnv(Vp, option.ToFQDNsMaxDeferredConnectionDeletes)
+	option.BindEnv(vp, option.ToFQDNsMaxDeferredConnectionDeletes)
 
 	flags.Duration(option.ToFQDNsIdleConnectionGracePeriod, defaults.ToFQDNsIdleConnectionGracePeriod, "Time during which idle but previously active connections with expired DNS lookups are still considered alive (default 0s)")
-	option.BindEnv(Vp, option.ToFQDNsIdleConnectionGracePeriod)
+	option.BindEnv(vp, option.ToFQDNsIdleConnectionGracePeriod)
 
 	flags.Duration(option.FQDNProxyResponseMaxDelay, defaults.FQDNProxyResponseMaxDelay, "The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.")
-	option.BindEnv(Vp, option.FQDNProxyResponseMaxDelay)
+	option.BindEnv(vp, option.FQDNProxyResponseMaxDelay)
 
 	flags.Int(option.FQDNRegexCompileLRUSize, defaults.FQDNRegexCompileLRUSize, "Size of the FQDN regex compilation LRU. Useful for heavy but repeated DNS L7 rules with MatchName or MatchPattern")
 	flags.MarkHidden(option.FQDNRegexCompileLRUSize)
-	option.BindEnv(Vp, option.FQDNRegexCompileLRUSize)
+	option.BindEnv(vp, option.FQDNRegexCompileLRUSize)
 
 	flags.String(option.ToFQDNsPreCache, defaults.ToFQDNsPreCache, "DNS cache data at this path is preloaded on agent startup")
-	option.BindEnv(Vp, option.ToFQDNsPreCache)
+	option.BindEnv(vp, option.ToFQDNsPreCache)
 
 	flags.Bool(option.ToFQDNsEnableDNSCompression, defaults.ToFQDNsEnableDNSCompression, "Allow the DNS proxy to compress responses to endpoints that are larger than 512 Bytes or the EDNS0 option, if present")
-	option.BindEnv(Vp, option.ToFQDNsEnableDNSCompression)
+	option.BindEnv(vp, option.ToFQDNsEnableDNSCompression)
 
 	flags.Int(option.DNSProxyConcurrencyLimit, 0, "Limit concurrency of DNS message processing")
-	option.BindEnv(Vp, option.DNSProxyConcurrencyLimit)
+	option.BindEnv(vp, option.DNSProxyConcurrencyLimit)
 
 	flags.Duration(option.DNSProxyConcurrencyProcessingGracePeriod, 0, "Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing")
-	option.BindEnv(Vp, option.DNSProxyConcurrencyProcessingGracePeriod)
+	option.BindEnv(vp, option.DNSProxyConcurrencyProcessingGracePeriod)
 
 	flags.Int(option.DNSProxyLockCount, 128, "Array size containing mutexes which protect against parallel handling of DNS response IPs")
 	flags.MarkHidden(option.DNSProxyLockCount)
-	option.BindEnv(Vp, option.DNSProxyLockCount)
+	option.BindEnv(vp, option.DNSProxyLockCount)
 
 	flags.Duration(option.DNSProxyLockTimeout, 500*time.Millisecond, fmt.Sprintf("Timeout when acquiring the locks controlled by --%s", option.DNSProxyLockCount))
 	flags.MarkHidden(option.DNSProxyLockTimeout)
-	option.BindEnv(Vp, option.DNSProxyLockTimeout)
+	option.BindEnv(vp, option.DNSProxyLockTimeout)
 
 	flags.Int(option.PolicyQueueSize, defaults.PolicyQueueSize, "Size of queues for policy-related events")
-	option.BindEnv(Vp, option.PolicyQueueSize)
+	option.BindEnv(vp, option.PolicyQueueSize)
 
 	flags.Int(option.EndpointQueueSize, defaults.EndpointQueueSize, "Size of EventQueue per-endpoint")
-	option.BindEnv(Vp, option.EndpointQueueSize)
+	option.BindEnv(vp, option.EndpointQueueSize)
 
 	flags.Duration(option.PolicyTriggerInterval, defaults.PolicyTriggerInterval, "Time between triggers of policy updates (regenerations for all endpoints)")
 	flags.MarkHidden(option.PolicyTriggerInterval)
-	option.BindEnv(Vp, option.PolicyTriggerInterval)
+	option.BindEnv(vp, option.PolicyTriggerInterval)
 
 	flags.Bool(option.DisableCNPStatusUpdates, true, `Do not send CNP NodeStatus updates to the Kubernetes api-server (recommended to run with "cnp-node-status-gc-interval=0" in cilium-operator)`)
 	flags.MarkDeprecated(option.DisableCNPStatusUpdates, "This option will be removed in v1.15 (disabled CNP Status Updates by default)")
-	option.BindEnv(Vp, option.DisableCNPStatusUpdates)
+	option.BindEnv(vp, option.DisableCNPStatusUpdates)
 
 	flags.Bool(option.PolicyAuditModeArg, false, "Enable policy audit (non-drop) mode")
-	option.BindEnv(Vp, option.PolicyAuditModeArg)
+	option.BindEnv(vp, option.PolicyAuditModeArg)
 
 	flags.Bool(option.EnableHubble, false, "Enable hubble server")
-	option.BindEnv(Vp, option.EnableHubble)
+	option.BindEnv(vp, option.EnableHubble)
 
 	flags.String(option.HubbleSocketPath, defaults.HubbleSockPath, "Set hubble's socket path to listen for connections")
-	option.BindEnv(Vp, option.HubbleSocketPath)
+	option.BindEnv(vp, option.HubbleSocketPath)
 
 	flags.String(option.HubbleListenAddress, "", `An additional address for Hubble server to listen to, e.g. ":4244"`)
-	option.BindEnv(Vp, option.HubbleListenAddress)
+	option.BindEnv(vp, option.HubbleListenAddress)
 
 	flags.Bool(option.HubblePreferIpv6, false, "Prefer IPv6 addresses for announcing nodes when both address types are available.")
-	option.BindEnv(Vp, option.HubblePreferIpv6)
+	option.BindEnv(vp, option.HubblePreferIpv6)
 
 	flags.Bool(option.HubbleTLSDisabled, false, "Allow Hubble server to run on the given listen address without TLS.")
-	option.BindEnv(Vp, option.HubbleTLSDisabled)
+	option.BindEnv(vp, option.HubbleTLSDisabled)
 
 	flags.String(option.HubbleTLSCertFile, "", "Path to the public key file for the Hubble server. The file must contain PEM encoded data.")
-	option.BindEnv(Vp, option.HubbleTLSCertFile)
+	option.BindEnv(vp, option.HubbleTLSCertFile)
 
 	flags.String(option.HubbleTLSKeyFile, "", "Path to the private key file for the Hubble server. The file must contain PEM encoded data.")
-	option.BindEnv(Vp, option.HubbleTLSKeyFile)
+	option.BindEnv(vp, option.HubbleTLSKeyFile)
 
 	flags.StringSlice(option.HubbleTLSClientCAFiles, []string{}, "Paths to one or more public key files of client CA certificates to use for TLS with mutual authentication (mTLS). The files must contain PEM encoded data. When provided, this option effectively enables mTLS.")
-	option.BindEnv(Vp, option.HubbleTLSClientCAFiles)
+	option.BindEnv(vp, option.HubbleTLSClientCAFiles)
 
 	flags.Int(option.HubbleEventBufferCapacity, observeroption.Default.MaxFlows.AsInt(), "Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535)")
-	option.BindEnv(Vp, option.HubbleEventBufferCapacity)
+	option.BindEnv(vp, option.HubbleEventBufferCapacity)
 
 	flags.Int(option.HubbleEventQueueSize, 0, "Buffer size of the channel to receive monitor events.")
-	option.BindEnv(Vp, option.HubbleEventQueueSize)
+	option.BindEnv(vp, option.HubbleEventQueueSize)
 
 	flags.String(option.HubbleMetricsServer, "", "Address to serve Hubble metrics on.")
-	option.BindEnv(Vp, option.HubbleMetricsServer)
+	option.BindEnv(vp, option.HubbleMetricsServer)
 
 	flags.StringSlice(option.HubbleMetrics, []string{}, "List of Hubble metrics to enable.")
-	option.BindEnv(Vp, option.HubbleMetrics)
+	option.BindEnv(vp, option.HubbleMetrics)
 
 	flags.String(option.HubbleExportFilePath, exporteroption.Default.Path, "Filepath to write Hubble events to.")
-	option.BindEnv(Vp, option.HubbleExportFilePath)
+	option.BindEnv(vp, option.HubbleExportFilePath)
 
 	flags.Int(option.HubbleExportFileMaxSizeMB, exporteroption.Default.MaxSizeMB, "Size in MB at which to rotate Hubble export file.")
-	option.BindEnv(Vp, option.HubbleExportFileMaxSizeMB)
+	option.BindEnv(vp, option.HubbleExportFileMaxSizeMB)
 
 	flags.Int(option.HubbleExportFileMaxBackups, exporteroption.Default.MaxBackups, "Number of rotated Hubble export files to keep.")
-	option.BindEnv(Vp, option.HubbleExportFileMaxBackups)
+	option.BindEnv(vp, option.HubbleExportFileMaxBackups)
 
 	flags.Bool(option.HubbleExportFileCompress, exporteroption.Default.Compress, "Compress rotated Hubble export files.")
-	option.BindEnv(Vp, option.HubbleExportFileCompress)
+	option.BindEnv(vp, option.HubbleExportFileCompress)
 
 	flags.Bool(option.EnableHubbleRecorderAPI, true, "Enable the Hubble recorder API")
-	option.BindEnv(Vp, option.EnableHubbleRecorderAPI)
+	option.BindEnv(vp, option.EnableHubbleRecorderAPI)
 
 	flags.String(option.HubbleRecorderStoragePath, defaults.HubbleRecorderStoragePath, "Directory in which pcap files created via the Hubble Recorder API are stored")
-	option.BindEnv(Vp, option.HubbleRecorderStoragePath)
+	option.BindEnv(vp, option.HubbleRecorderStoragePath)
 
 	flags.Int(option.HubbleRecorderSinkQueueSize, defaults.HubbleRecorderSinkQueueSize, "Queue size of each Hubble recorder sink")
-	option.BindEnv(Vp, option.HubbleRecorderSinkQueueSize)
+	option.BindEnv(vp, option.HubbleRecorderSinkQueueSize)
 
 	flags.Bool(option.HubbleSkipUnknownCGroupIDs, true, "Skip Hubble events with unknown cgroup ids")
-	option.BindEnv(Vp, option.HubbleSkipUnknownCGroupIDs)
+	option.BindEnv(vp, option.HubbleSkipUnknownCGroupIDs)
 
 	flags.StringSlice(option.HubbleMonitorEvents, []string{},
 		fmt.Sprintf(
@@ -976,144 +975,144 @@ func initializeFlags() {
 			strings.Join(monitorAPI.AllMessageTypeNames(), " "),
 		),
 	)
-	option.BindEnv(Vp, option.HubbleMonitorEvents)
+	option.BindEnv(vp, option.HubbleMonitorEvents)
 
 	flags.StringSlice(option.HubbleRedact, []string{}, "List of Hubble redact options")
-	option.BindEnv(Vp, option.HubbleRedact)
+	option.BindEnv(vp, option.HubbleRedact)
 
 	flags.StringSlice(option.DisableIptablesFeederRules, []string{}, "Chains to ignore when installing feeder rules.")
-	option.BindEnv(Vp, option.DisableIptablesFeederRules)
+	option.BindEnv(vp, option.DisableIptablesFeederRules)
 
 	flags.Bool(option.EnableIPv4FragmentsTrackingName, defaults.EnableIPv4FragmentsTracking, "Enable IPv4 fragments tracking for L4-based lookups")
-	option.BindEnv(Vp, option.EnableIPv4FragmentsTrackingName)
+	option.BindEnv(vp, option.EnableIPv4FragmentsTrackingName)
 
 	flags.Int(option.FragmentsMapEntriesName, defaults.FragmentsMapEntries, "Maximum number of entries in fragments tracking map")
-	option.BindEnv(Vp, option.FragmentsMapEntriesName)
+	option.BindEnv(vp, option.FragmentsMapEntriesName)
 
 	flags.Int(option.LBMapEntriesName, lbmap.DefaultMaxEntries, "Maximum number of entries in Cilium BPF lbmap")
-	option.BindEnv(Vp, option.LBMapEntriesName)
+	option.BindEnv(vp, option.LBMapEntriesName)
 
 	flags.Int(option.LBServiceMapMaxEntries, 0, fmt.Sprintf("Maximum number of entries in Cilium BPF lbmap for services (if this isn't set, the value of --%s will be used.)", option.LBMapEntriesName))
 	flags.MarkHidden(option.LBServiceMapMaxEntries)
-	option.BindEnv(Vp, option.LBServiceMapMaxEntries)
+	option.BindEnv(vp, option.LBServiceMapMaxEntries)
 
 	flags.Int(option.LBBackendMapMaxEntries, 0, fmt.Sprintf("Maximum number of entries in Cilium BPF lbmap for service backends (if this isn't set, the value of --%s will be used.)", option.LBMapEntriesName))
 	flags.MarkHidden(option.LBBackendMapMaxEntries)
-	option.BindEnv(Vp, option.LBBackendMapMaxEntries)
+	option.BindEnv(vp, option.LBBackendMapMaxEntries)
 
 	flags.Int(option.LBRevNatMapMaxEntries, 0, fmt.Sprintf("Maximum number of entries in Cilium BPF lbmap for reverse NAT (if this isn't set, the value of --%s will be used.)", option.LBMapEntriesName))
 	flags.MarkHidden(option.LBRevNatMapMaxEntries)
-	option.BindEnv(Vp, option.LBRevNatMapMaxEntries)
+	option.BindEnv(vp, option.LBRevNatMapMaxEntries)
 
 	flags.Int(option.LBAffinityMapMaxEntries, 0, fmt.Sprintf("Maximum number of entries in Cilium BPF lbmap for session affinities (if this isn't set, the value of --%s will be used.)", option.LBMapEntriesName))
 	flags.MarkHidden(option.LBAffinityMapMaxEntries)
-	option.BindEnv(Vp, option.LBAffinityMapMaxEntries)
+	option.BindEnv(vp, option.LBAffinityMapMaxEntries)
 
 	flags.Int(option.LBSourceRangeMapMaxEntries, 0, fmt.Sprintf("Maximum number of entries in Cilium BPF lbmap for source ranges (if this isn't set, the value of --%s will be used.)", option.LBMapEntriesName))
 	flags.MarkHidden(option.LBSourceRangeMapMaxEntries)
-	option.BindEnv(Vp, option.LBSourceRangeMapMaxEntries)
+	option.BindEnv(vp, option.LBSourceRangeMapMaxEntries)
 
 	flags.Int(option.LBMaglevMapMaxEntries, 0, fmt.Sprintf("Maximum number of entries in Cilium BPF lbmap for maglev (if this isn't set, the value of --%s will be used.)", option.LBMapEntriesName))
 	flags.MarkHidden(option.LBMaglevMapMaxEntries)
-	option.BindEnv(Vp, option.LBMaglevMapMaxEntries)
+	option.BindEnv(vp, option.LBMaglevMapMaxEntries)
 
 	flags.String(option.LocalRouterIPv4, "", "Link-local IPv4 used for Cilium's router devices")
-	option.BindEnv(Vp, option.LocalRouterIPv4)
+	option.BindEnv(vp, option.LocalRouterIPv4)
 
 	flags.String(option.LocalRouterIPv6, "", "Link-local IPv6 used for Cilium's router devices")
-	option.BindEnv(Vp, option.LocalRouterIPv6)
+	option.BindEnv(vp, option.LocalRouterIPv6)
 
 	flags.String(option.K8sServiceProxyName, "", "Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)")
-	option.BindEnv(Vp, option.K8sServiceProxyName)
+	option.BindEnv(vp, option.K8sServiceProxyName)
 
 	flags.Var(option.NewNamedMapOptions(option.BPFMapEventBuffers, &option.Config.BPFMapEventBuffers, option.Config.BPFMapEventBuffersValidator), option.BPFMapEventBuffers, "Configuration for BPF map event buffers: (example: --bpf-map-event-buffers cilium_ipcache=true,1024,1h)")
 	flags.MarkHidden(option.BPFMapEventBuffers)
 
 	flags.Duration(option.CRDWaitTimeout, 5*time.Minute, "Cilium will exit if CRDs are not available within this duration upon startup")
-	option.BindEnv(Vp, option.CRDWaitTimeout)
+	option.BindEnv(vp, option.CRDWaitTimeout)
 
 	flags.Bool(option.EgressMultiHomeIPRuleCompat, false,
 		"Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.")
-	option.BindEnv(Vp, option.EgressMultiHomeIPRuleCompat)
+	option.BindEnv(vp, option.EgressMultiHomeIPRuleCompat)
 
 	flags.Bool(option.InstallNoConntrackIptRules, defaults.InstallNoConntrackIptRules, "Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup.")
-	option.BindEnv(Vp, option.InstallNoConntrackIptRules)
+	option.BindEnv(vp, option.InstallNoConntrackIptRules)
 
 	flags.Bool(option.EnableCustomCallsName, false, "Enable tail call hooks for custom eBPF programs")
-	option.BindEnv(Vp, option.EnableCustomCallsName)
+	option.BindEnv(vp, option.EnableCustomCallsName)
 
 	flags.Bool(option.BGPAnnounceLBIP, false, "Announces service IPs of type LoadBalancer via BGP")
-	option.BindEnv(Vp, option.BGPAnnounceLBIP)
+	option.BindEnv(vp, option.BGPAnnounceLBIP)
 
 	flags.Bool(option.BGPAnnouncePodCIDR, false, "Announces the node's pod CIDR via BGP")
-	option.BindEnv(Vp, option.BGPAnnouncePodCIDR)
+	option.BindEnv(vp, option.BGPAnnouncePodCIDR)
 
 	flags.String(option.BGPConfigPath, "/var/lib/cilium/bgp/config.yaml", "Path to file containing the BGP configuration")
-	option.BindEnv(Vp, option.BGPConfigPath)
+	option.BindEnv(vp, option.BGPConfigPath)
 
 	flags.Bool(option.ExternalClusterIPName, false, "Enable external access to ClusterIP services (default false)")
-	option.BindEnv(Vp, option.ExternalClusterIPName)
+	option.BindEnv(vp, option.ExternalClusterIPName)
 
 	// flags.IntSlice cannot be used due to missing support for appropriate conversion in Viper.
 	// See https://github.com/cilium/cilium/pull/20282 for more information.
 	flags.StringSlice(option.VLANBPFBypass, []string{}, "List of explicitly allowed VLAN IDs, '0' id will allow all VLAN IDs")
-	option.BindEnv(Vp, option.VLANBPFBypass)
+	option.BindEnv(vp, option.VLANBPFBypass)
 
 	flags.Bool(option.EnableICMPRules, true, "Enable ICMP-based rule support for Cilium Network Policies")
 	flags.MarkHidden(option.EnableICMPRules)
-	option.BindEnv(Vp, option.EnableICMPRules)
+	option.BindEnv(vp, option.EnableICMPRules)
 
 	flags.Bool(option.UseCiliumInternalIPForIPsec, defaults.UseCiliumInternalIPForIPsec, "Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation")
 	flags.MarkHidden(option.UseCiliumInternalIPForIPsec)
-	option.BindEnv(Vp, option.UseCiliumInternalIPForIPsec)
+	option.BindEnv(vp, option.UseCiliumInternalIPForIPsec)
 
 	flags.Bool(option.BypassIPAvailabilityUponRestore, false, "Bypasses the IP availability error within IPAM upon endpoint restore")
 	flags.MarkHidden(option.BypassIPAvailabilityUponRestore)
-	option.BindEnv(Vp, option.BypassIPAvailabilityUponRestore)
+	option.BindEnv(vp, option.BypassIPAvailabilityUponRestore)
 
 	flags.Bool(option.EnableCiliumEndpointSlice, false, "Enable the CiliumEndpointSlice watcher in place of the CiliumEndpoint watcher (beta)")
-	option.BindEnv(Vp, option.EnableCiliumEndpointSlice)
+	option.BindEnv(vp, option.EnableCiliumEndpointSlice)
 
 	flags.Bool(option.EnableK8sTerminatingEndpoint, true, "Enable auto-detect of terminating endpoint condition")
-	option.BindEnv(Vp, option.EnableK8sTerminatingEndpoint)
+	option.BindEnv(vp, option.EnableK8sTerminatingEndpoint)
 
 	flags.Bool(option.EnableVTEP, defaults.EnableVTEP, "Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)")
-	option.BindEnv(Vp, option.EnableVTEP)
+	option.BindEnv(vp, option.EnableVTEP)
 
 	flags.StringSlice(option.VtepEndpoint, []string{}, "List of VTEP IP addresses")
-	option.BindEnv(Vp, option.VtepEndpoint)
+	option.BindEnv(vp, option.VtepEndpoint)
 
 	flags.StringSlice(option.VtepCIDR, []string{}, "List of VTEP CIDRs that will be routed towards VTEPs for traffic cluster egress")
-	option.BindEnv(Vp, option.VtepCIDR)
+	option.BindEnv(vp, option.VtepCIDR)
 
 	flags.String(option.VtepMask, "255.255.255.0", "VTEP CIDR Mask for all VTEP CIDRs")
-	option.BindEnv(Vp, option.VtepMask)
+	option.BindEnv(vp, option.VtepMask)
 
 	flags.StringSlice(option.VtepMAC, []string{}, "List of VTEP MAC addresses for forwarding traffic outside the cluster")
-	option.BindEnv(Vp, option.VtepMAC)
+	option.BindEnv(vp, option.VtepMAC)
 
 	flags.Int(option.TCFilterPriority, 1, "Priority of TC BPF filter")
 	flags.MarkHidden(option.TCFilterPriority)
-	option.BindEnv(Vp, option.TCFilterPriority)
+	option.BindEnv(vp, option.TCFilterPriority)
 
 	flags.Bool(option.EnableBGPControlPlane, false, "Enable the BGP control plane.")
-	option.BindEnv(Vp, option.EnableBGPControlPlane)
+	option.BindEnv(vp, option.EnableBGPControlPlane)
 
 	flags.Bool(option.EnablePMTUDiscovery, false, "Enable path MTU discovery to send ICMP fragmentation-needed replies to the client")
-	option.BindEnv(Vp, option.EnablePMTUDiscovery)
+	option.BindEnv(vp, option.EnablePMTUDiscovery)
 
 	flags.Bool(option.EnableStaleCiliumEndpointCleanup, true, "Enable running cleanup init procedure of local CiliumEndpoints which are not being managed.")
 	flags.MarkHidden(option.EnableStaleCiliumEndpointCleanup)
-	option.BindEnv(Vp, option.EnableStaleCiliumEndpointCleanup)
+	option.BindEnv(vp, option.EnableStaleCiliumEndpointCleanup)
 
 	flags.Duration(option.IPAMCiliumNodeUpdateRate, 15*time.Second, "Maximum rate at which the CiliumNode custom resource is updated")
-	option.BindEnv(Vp, option.IPAMCiliumNodeUpdateRate)
+	option.BindEnv(vp, option.IPAMCiliumNodeUpdateRate)
 
 	flags.Bool(option.EnableK8sNetworkPolicy, defaults.EnableK8sNetworkPolicy, "Enable support for K8s NetworkPolicy")
 	flags.MarkHidden(option.EnableK8sNetworkPolicy)
-	option.BindEnv(Vp, option.EnableK8sNetworkPolicy)
+	option.BindEnv(vp, option.EnableK8sNetworkPolicy)
 
-	if err := Vp.BindPFlags(flags); err != nil {
+	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}
 }
@@ -1152,7 +1151,7 @@ func initLogging() {
 	}
 }
 
-func initDaemonConfig() {
+func initDaemonConfig(vp *viper.Viper) {
 	option.Config.SetMapElementSizes(
 		// for the conntrack and NAT element size we assume the largest possible
 		// key size, i.e. IPv6 keys
@@ -1161,16 +1160,16 @@ func initDaemonConfig() {
 		neighborsmap.SizeofNeighKey6+neighborsmap.SizeOfNeighValue,
 		lbmap.SizeofSockRevNat6Key+lbmap.SizeofSockRevNat6Value)
 
-	option.Config.Populate(Vp)
+	option.Config.Populate(vp)
 }
 
-func initEnv() {
+func initEnv(vp *viper.Viper) {
 	bootstrapStats.earlyInit.Start()
 	defer bootstrapStats.earlyInit.End(true)
 
 	var debugDatapath bool
 
-	option.LogRegisteredOptions(Vp, log)
+	option.LogRegisteredOptions(vp, log)
 
 	sysctl.SetProcfs(option.Config.ProcFs)
 
@@ -1635,10 +1634,9 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 	daemonCtx, cancelDaemonCtx := context.WithCancel(context.Background())
 	cleaner := NewDaemonCleanup()
 
-	if Vp.GetString(option.DatapathMode) == datapathOption.DatapathModeLBOnly {
+	if option.Config.DatapathMode == datapathOption.DatapathModeLBOnly {
 		// In lb-only mode the k8s client is not used, even if its configuration
-		// is available, so disable it here before it starts. Using GetString
-		// directly as option.Config not populated yet.
+		// is available, so disable it here before it starts.
 		params.Clientset.Disable()
 	}
 

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/cilium/checkmate"
+	"github.com/spf13/cobra"
+
 	"github.com/cilium/cilium/api/v1/models"
 	cnicell "github.com/cilium/cilium/daemon/cmd/cni"
 	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
@@ -44,8 +47,6 @@ import (
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/types"
-
-	. "github.com/cilium/checkmate"
 )
 
 type DaemonSuite struct {
@@ -66,7 +67,7 @@ type DaemonSuite struct {
 	OnGetCIDRPrefixLengths func() ([]int, []int)
 }
 
-func setupTestDirectories() {
+func setupTestDirectories() string {
 	tempRunDir, err := os.MkdirTemp("", "cilium-test-run")
 	if err != nil {
 		panic("TempDir() failed.")
@@ -77,14 +78,13 @@ func setupTestDirectories() {
 		panic("Mkdir failed")
 	}
 
-	option.Config.RunDir = tempRunDir
-	option.Config.StateDir = tempRunDir
-
 	socketDir := envoy.GetSocketDir(tempRunDir)
 	err = os.MkdirAll(socketDir, 0700)
 	if err != nil {
 		panic("creating envoy socket directory failed")
 	}
+
+	return tempRunDir
 }
 
 func TestMain(m *testing.M) {
@@ -96,9 +96,30 @@ func TestMain(m *testing.M) {
 
 	proxy.DefaultDNSProxy = fqdnproxy.MockFQDNProxy{}
 
+	time.Local = time.UTC
+
+	os.Exit(m.Run())
+}
+
+type dummyEpSyncher struct{}
+
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
+}
+
+func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
+}
+
+func (ds *DaemonSuite) SetUpSuite(c *C) {
+	testutils.IntegrationTest(c)
+}
+
+func (s *DaemonSuite) setupConfigOptions() {
 	// Set up all configuration options which are global to the entire test
 	// run.
-	option.Config.Populate(Vp)
+	mockCmd := &cobra.Command{}
+	s.hive.RegisterFlags(mockCmd.Flags())
+	InitGlobalFlags(mockCmd, s.hive.Viper())
+	option.Config.Populate(s.hive.Viper())
 	option.Config.IdentityAllocationMode = option.IdentityAllocationModeKVstore
 	option.Config.DryMode = true
 	option.Config.Opts = option.NewIntOptions(&option.DaemonMutableOptionLibrary)
@@ -119,28 +140,10 @@ func TestMain(m *testing.M) {
 	// which requires root privileges. This would require marking the test suite
 	// as privileged.
 	option.Config.KubeProxyReplacement = option.KubeProxyReplacementFalse
-
-	time.Local = time.UTC
-
-	os.Exit(m.Run())
-}
-
-type dummyEpSyncher struct{}
-
-func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
-}
-
-func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
-}
-
-func (ds *DaemonSuite) SetUpSuite(c *C) {
-	testutils.IntegrationTest(c)
 }
 
 func (ds *DaemonSuite) SetUpTest(c *C) {
 	ctx := context.Background()
-
-	setupTestDirectories()
 
 	ds.oldPolicyEnabled = policy.GetPolicyEnabled()
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
@@ -169,6 +172,14 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 			daemonPromise = p
 		}),
 	)
+
+	// bootstrap global config
+	ds.setupConfigOptions()
+
+	// create temporary test directories and update global config accordingly
+	testRunDir := setupTestDirectories()
+	option.Config.RunDir = testRunDir
+	option.Config.StateDir = testRunDir
 
 	err := ds.hive.Start(ctx)
 	c.Assert(err, IsNil)

--- a/daemon/cmd/debuginfo.go
+++ b/daemon/cmd/debuginfo.go
@@ -38,11 +38,14 @@ func getDebugInfoHandler(d *Daemon, params restapi.GetDebuginfoParams) middlewar
 	dr.CiliumMemoryMap = memoryMap(os.Getpid())
 
 	dr.EnvironmentVariables = []string{}
-	for _, k := range Vp.AllKeys() {
-		// Assuming we are only getting strings
-		v := fmt.Sprintf("%s:%s", k, Vp.GetString(k))
-		dr.EnvironmentVariables = append(dr.EnvironmentVariables, v)
-	}
+	// The debuginfo handler relies on the global Viper instance to list
+	// the agent settings and their values. Thus, this is temporarily commented
+	// out and will be fixed in a subsequent commit.
+	// for _, k := range Vp.AllKeys() {
+	// 	// Assuming we are only getting strings
+	// 	v := fmt.Sprintf("%s:%s", k, Vp.GetString(k))
+	// 	dr.EnvironmentVariables = append(dr.EnvironmentVariables, v)
+	// }
 
 	dr.ServiceList = getServiceList(d.svc)
 

--- a/daemon/cmd/kube_proxy_replacement_test.go
+++ b/daemon/cmd/kube_proxy_replacement_test.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 
 	. "github.com/cilium/checkmate"
+	"github.com/spf13/cobra"
 
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -83,7 +85,12 @@ func (cfg *kprConfig) verify(c *C) {
 }
 
 func (s *KPRSuite) SetUpTest(c *C) {
-	option.Config.Populate(Vp)
+	mockCmd := &cobra.Command{}
+
+	h := hive.New(Agent)
+	h.RegisterFlags(mockCmd.Flags())
+	InitGlobalFlags(mockCmd, h.Viper())
+	option.Config.Populate(h.Viper())
 	option.Config.DryMode = true
 }
 

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -3,8 +3,13 @@
 
 package main
 
-import "github.com/cilium/cilium/daemon/cmd"
+import (
+	"github.com/cilium/cilium/daemon/cmd"
+	"github.com/cilium/cilium/pkg/hive"
+)
 
 func main() {
-	cmd.Execute()
+	agentHive := hive.New(cmd.Agent)
+
+	cmd.Execute(cmd.NewAgentCmd(agentHive))
 }

--- a/operator/cmd/flags_providers.go
+++ b/operator/cmd/flags_providers.go
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+type ProviderFlagsHooks interface {
+	RegisterProviderFlag(cmd *cobra.Command, vp *viper.Viper)
+}

--- a/operator/cmd/provider_alibabacloud_flags.go
+++ b/operator/cmd/provider_alibabacloud_flags.go
@@ -6,15 +6,24 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/option"
 )
 
 func init() {
-	flags := rootCmd.Flags()
+	FlagsHooks = append(FlagsHooks, &alibabaFlagsHooks{})
+}
+
+type alibabaFlagsHooks struct{}
+
+func (hook *alibabaFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.Viper) {
+	flags := cmd.Flags()
 
 	flags.String(operatorOption.AlibabaCloudVPCID, "", "Specific VPC ID for AlibabaCloud ENI. If not set use same VPC as operator")
-	option.BindEnv(Vp, operatorOption.AlibabaCloudVPCID)
+	option.BindEnv(vp, operatorOption.AlibabaCloudVPCID)
 
-	Vp.BindPFlags(flags)
+	vp.BindPFlags(flags)
 }

--- a/operator/cmd/provider_aws_flags.go
+++ b/operator/cmd/provider_aws_flags.go
@@ -6,13 +6,22 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/option"
 )
 
 func init() {
-	flags := rootCmd.Flags()
+	FlagsHooks = append(FlagsHooks, &awsFlagsHooks{})
+}
+
+type awsFlagsHooks struct{}
+
+func (hook *awsFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.Viper) {
+	flags := cmd.Flags()
 
 	flags.Var(option.NewNamedMapOptions(operatorOption.AWSInstanceLimitMapping, &operatorOption.Config.AWSInstanceLimitMapping, nil),
 		operatorOption.AWSInstanceLimitMapping,
@@ -22,37 +31,37 @@ func init() {
 			`--aws-instance-limit-mapping=a1.medium=2,4,4 `+
 			`--aws-instance-limit-mapping=a2.somecustomflavor=4,5,6 `+
 			`configmap example: {"a1.medium": "2,4,4", "a2.somecustomflavor": "4,5,6"}`)
-	option.BindEnv(Vp, operatorOption.AWSInstanceLimitMapping)
+	option.BindEnv(vp, operatorOption.AWSInstanceLimitMapping)
 
 	flags.Bool(operatorOption.AWSReleaseExcessIPs, false, "Enable releasing excess free IP addresses from AWS ENI.")
-	option.BindEnv(Vp, operatorOption.AWSReleaseExcessIPs)
+	option.BindEnv(vp, operatorOption.AWSReleaseExcessIPs)
 
 	flags.Int(operatorOption.ExcessIPReleaseDelay, 180, "Number of seconds operator would wait before it releases an IP previously marked as excess")
-	option.BindEnv(Vp, operatorOption.ExcessIPReleaseDelay)
+	option.BindEnv(vp, operatorOption.ExcessIPReleaseDelay)
 
 	flags.Bool(operatorOption.AWSEnablePrefixDelegation, false, "Allows operator to allocate prefixes to ENIs instead of individual IP addresses")
-	option.BindEnv(Vp, operatorOption.AWSEnablePrefixDelegation)
+	option.BindEnv(vp, operatorOption.AWSEnablePrefixDelegation)
 
 	flags.Var(option.NewNamedMapOptions(operatorOption.ENITags, &operatorOption.Config.ENITags, nil),
 		operatorOption.ENITags, "ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)")
-	option.BindEnv(Vp, operatorOption.ENITags)
+	option.BindEnv(vp, operatorOption.ENITags)
 
 	flags.Var(option.NewNamedMapOptions(operatorOption.ENIGarbageCollectionTags, &operatorOption.Config.ENIGarbageCollectionTags, nil),
 		operatorOption.ENIGarbageCollectionTags, "Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected")
-	option.BindEnv(Vp, operatorOption.ENIGarbageCollectionTags)
+	option.BindEnv(vp, operatorOption.ENIGarbageCollectionTags)
 
 	flags.Duration(operatorOption.ENIGarbageCollectionInterval, defaults.ENIGarbageCollectionInterval,
 		"Interval for garbage collection of unattached ENIs. Set to 0 to disable")
-	option.BindEnv(Vp, operatorOption.ENIGarbageCollectionInterval)
+	option.BindEnv(vp, operatorOption.ENIGarbageCollectionInterval)
 
 	flags.Bool(operatorOption.UpdateEC2AdapterLimitViaAPI, true, "Use the EC2 API to update the instance type to adapter limits")
-	option.BindEnv(Vp, operatorOption.UpdateEC2AdapterLimitViaAPI)
+	option.BindEnv(vp, operatorOption.UpdateEC2AdapterLimitViaAPI)
 
 	flags.Bool(operatorOption.AWSUsePrimaryAddress, false, "Allows for using primary address of the ENI for allocations on the node")
-	option.BindEnv(Vp, operatorOption.AWSUsePrimaryAddress)
+	option.BindEnv(vp, operatorOption.AWSUsePrimaryAddress)
 
 	flags.String(operatorOption.EC2APIEndpoint, "", "AWS API endpoint for the EC2 service")
-	option.BindEnv(Vp, operatorOption.EC2APIEndpoint)
+	option.BindEnv(vp, operatorOption.EC2APIEndpoint)
 
-	Vp.BindPFlags(flags)
+	vp.BindPFlags(flags)
 }

--- a/operator/cmd/provider_azure_flags.go
+++ b/operator/cmd/provider_azure_flags.go
@@ -6,24 +6,33 @@
 package cmd
 
 import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/option"
 )
 
 func init() {
-	flags := rootCmd.Flags()
+	FlagsHooks = append(FlagsHooks, &azureFlagsHooks{})
+}
+
+type azureFlagsHooks struct{}
+
+func (hook *azureFlagsHooks) RegisterProviderFlag(cmd *cobra.Command, vp *viper.Viper) {
+	flags := cmd.Flags()
 
 	flags.String(operatorOption.AzureSubscriptionID, "", "Subscription ID to access Azure API")
-	option.BindEnvWithLegacyEnvFallback(Vp, operatorOption.AzureSubscriptionID, "AZURE_SUBSCRIPTION_ID")
+	option.BindEnvWithLegacyEnvFallback(vp, operatorOption.AzureSubscriptionID, "AZURE_SUBSCRIPTION_ID")
 
 	flags.String(operatorOption.AzureResourceGroup, "", "Resource group to use for Azure IPAM")
-	option.BindEnvWithLegacyEnvFallback(Vp, operatorOption.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
+	option.BindEnvWithLegacyEnvFallback(vp, operatorOption.AzureResourceGroup, "AZURE_RESOURCE_GROUP")
 
 	flags.String(operatorOption.AzureUserAssignedIdentityID, "", "ID of the user assigned identity used to auth with the Azure API")
-	option.BindEnvWithLegacyEnvFallback(Vp, operatorOption.AzureUserAssignedIdentityID, "AZURE_USER_ASSIGNED_IDENTITY_ID")
+	option.BindEnvWithLegacyEnvFallback(vp, operatorOption.AzureUserAssignedIdentityID, "AZURE_USER_ASSIGNED_IDENTITY_ID")
 
 	flags.Bool(operatorOption.AzureUsePrimaryAddress, false, "Use Azure IP address from interface's primary IPConfigurations")
-	option.BindEnvWithLegacyEnvFallback(Vp, operatorOption.AzureUsePrimaryAddress, "AZURE_USE_PRIMARY_ADDRESS")
+	option.BindEnvWithLegacyEnvFallback(vp, operatorOption.AzureUsePrimaryAddress, "AZURE_USE_PRIMARY_ADDRESS")
 
-	Vp.BindPFlags(flags)
+	vp.BindPFlags(flags)
 }

--- a/operator/cmd/provider_operator_flags.go
+++ b/operator/cmd/provider_operator_flags.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build ipam_provider_operator
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	FlagsHooks = append(FlagsHooks, &operatorFlagsHooks{})
+}
+
+type operatorFlagsHooks struct{}
+
+func (hook *operatorFlagsHooks) RegisterProviderFlag(_ *cobra.Command, _ *viper.Viper) {
+}

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -58,31 +58,43 @@ import (
 )
 
 var (
-	binaryName = filepath.Base(os.Args[0])
-
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, binaryName)
-
-	rootCmd = &cobra.Command{
-		Use:   binaryName,
-		Short: "Run " + binaryName,
-	}
-
-	leaderElectionResourceLockName = "cilium-operator-resource-lock"
-
-	// Use a Go context so we can tell the leaderelection code when we
-	// want to step down
-	leaderElectionCtx       context.Context
-	leaderElectionCtxCancel context.CancelFunc
-
-	// isLeader is an atomic boolean value that is true when the Operator is
-	// elected leader. Otherwise, it is false.
-	isLeader atomic.Bool
-
-	// OperatorCell are the operator specific cells without infrastructure cells.
-	// Used also in tests.
-	OperatorCell = cell.Module(
+	Operator = cell.Module(
 		"operator",
 		"Cilium Operator",
+
+		Infrastructure,
+		ControlPlane,
+	)
+
+	Infrastructure = cell.Module(
+		"operator-infra",
+		"Operator Infrastructure",
+
+		// Register the pprof HTTP handlers, to get runtime profiling data.
+		pprof.Cell,
+		cell.ProvidePrivate(func(cfg operatorPprofConfig) pprof.Config {
+			return pprof.Config{
+				Pprof:        cfg.OperatorPprof,
+				PprofAddress: cfg.OperatorPprofAddress,
+				PprofPort:    cfg.OperatorPprofPort,
+			}
+		}),
+		cell.Config(operatorPprofConfig{
+			OperatorPprofAddress: operatorOption.PprofAddressOperator,
+			OperatorPprofPort:    operatorOption.PprofPortOperator,
+		}),
+
+		// Runs the gops agent, a tool to diagnose Go processes.
+		gops.Cell(defaults.GopsPortOperator),
+
+		// Provides Clientset, API for accessing Kubernetes objects.
+		k8sClient.Cell,
+	)
+
+	// ControlPlane implements the control functions.
+	ControlPlane = cell.Module(
+		"operator-controlplane",
+		"Operator Control Plane",
 
 		cell.Invoke(
 			registerOperatorHooks,
@@ -140,13 +152,66 @@ var (
 		),
 	)
 
-	operatorHive *hive.Hive = newOperatorHive()
+	binaryName = filepath.Base(os.Args[0])
 
-	Vp *viper.Viper = operatorHive.Viper()
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, binaryName)
+
+	FlagsHooks []ProviderFlagsHooks
+
+	leaderElectionResourceLockName = "cilium-operator-resource-lock"
+
+	// Use a Go context so we can tell the leaderelection code when we
+	// want to step down
+	leaderElectionCtx       context.Context
+	leaderElectionCtxCancel context.CancelFunc
+
+	// isLeader is an atomic boolean value that is true when the Operator is
+	// elected leader. Otherwise, it is false.
+	isLeader atomic.Bool
 )
 
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
+func NewOperatorCmd(h *hive.Hive) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   binaryName,
+		Short: "Run " + binaryName,
+		Run: func(cobraCmd *cobra.Command, args []string) {
+			cmdRefDir := h.Viper().GetString(option.CMDRef)
+			if cmdRefDir != "" {
+				genMarkdown(cobraCmd, cmdRefDir)
+				os.Exit(0)
+			}
+
+			initEnv(h.Viper())
+
+			if err := h.Run(); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
+
+	h.RegisterFlags(cmd.Flags())
+
+	// Enable fallback to direct API probing to check for support of Leases in
+	// case Discovery API fails.
+	h.Viper().Set(option.K8sEnableAPIDiscovery, true)
+
+	cmd.AddCommand(
+		MetricsCmd,
+		h.Command(),
+	)
+
+	InitGlobalFlags(cmd, h.Viper())
+	for _, hook := range FlagsHooks {
+		hook.RegisterProviderFlag(cmd, h.Viper())
+	}
+
+	cobra.OnInitialize(option.InitConfig(cmd, "Cilium-Operator", "cilium-operators", h.Viper()))
+
+	return cmd
+}
+
+func Execute(cmd *cobra.Command) {
+	if err := cmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
@@ -174,55 +239,7 @@ func registerOperatorHooks(lc hive.Lifecycle, llc *LeaderLifecycle, clientset k8
 	})
 }
 
-func newOperatorHive() *hive.Hive {
-	h := hive.New(
-		pprof.Cell,
-		cell.ProvidePrivate(func(cfg operatorPprofConfig) pprof.Config {
-			return pprof.Config{
-				Pprof:        cfg.OperatorPprof,
-				PprofAddress: cfg.OperatorPprofAddress,
-				PprofPort:    cfg.OperatorPprofPort,
-			}
-		}),
-		cell.Config(operatorPprofConfig{
-			OperatorPprofAddress: operatorOption.PprofAddressOperator,
-			OperatorPprofPort:    operatorOption.PprofPortOperator,
-		}),
-
-		gops.Cell(defaults.GopsPortOperator),
-		k8sClient.Cell,
-		OperatorCell,
-	)
-	h.RegisterFlags(rootCmd.Flags())
-
-	// Enable fallback to direct API probing to check for support of Leases in
-	// case Discovery API fails.
-	h.Viper().Set(option.K8sEnableAPIDiscovery, true)
-
-	return h
-}
-
-func init() {
-	rootCmd.AddCommand(MetricsCmd)
-	rootCmd.AddCommand(operatorHive.Command())
-
-	rootCmd.Run = func(cobraCmd *cobra.Command, args []string) {
-		cmdRefDir := operatorHive.Viper().GetString(option.CMDRef)
-		if cmdRefDir != "" {
-			genMarkdown(cobraCmd, cmdRefDir)
-			os.Exit(0)
-		}
-
-		initEnv()
-
-		if err := operatorHive.Run(); err != nil {
-			log.Fatal(err)
-		}
-	}
-}
-
-func initEnv() {
-	vp := operatorHive.Viper()
+func initEnv(vp *viper.Viper) {
 	// Prepopulate option.Config with options from CLI.
 	option.Config.Populate(vp)
 	operatorOption.Config.Populate(vp)

--- a/operator/cmd/root_test.go
+++ b/operator/cmd/root_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/hive"
 )
 
 // TestOperatorHive verifies that the Operator hive can be instantiated with
@@ -21,6 +23,6 @@ func TestOperatorHive(t *testing.T) {
 		goleak.IgnoreCurrent(),
 	)
 
-	err := operatorHive.Populate()
+	err := hive.New(Operator).Populate()
 	assert.NoError(t, err, "Populate()")
 }

--- a/operator/main.go
+++ b/operator/main.go
@@ -3,8 +3,13 @@
 
 package main
 
-import "github.com/cilium/cilium/operator/cmd"
+import (
+	"github.com/cilium/cilium/operator/cmd"
+	"github.com/cilium/cilium/pkg/hive"
+)
 
 func main() {
-	cmd.Execute()
+	operatorHive := hive.New(cmd.Operator)
+
+	cmd.Execute(cmd.NewOperatorCmd(operatorHive))
 }

--- a/test/controlplane/controlplane_test.go
+++ b/test/controlplane/controlplane_test.go
@@ -12,11 +12,9 @@ import (
 	_ "github.com/cilium/cilium/test/controlplane/services/dualstack"
 	_ "github.com/cilium/cilium/test/controlplane/services/graceful-termination"
 	_ "github.com/cilium/cilium/test/controlplane/services/nodeport"
+	"github.com/cilium/cilium/test/controlplane/suite"
 )
 
 func TestControlPlane(t *testing.T) {
-	// Controlplane tests rely on the removed global Viper instance.
-	// Thus, we temporarily disable them.
-	// This will be fixed in a subsequent commit.
-	// suite.RunSuite(t)
+	suite.RunSuite(t)
 }

--- a/test/controlplane/controlplane_test.go
+++ b/test/controlplane/controlplane_test.go
@@ -12,9 +12,11 @@ import (
 	_ "github.com/cilium/cilium/test/controlplane/services/dualstack"
 	_ "github.com/cilium/cilium/test/controlplane/services/graceful-termination"
 	_ "github.com/cilium/cilium/test/controlplane/services/nodeport"
-	"github.com/cilium/cilium/test/controlplane/suite"
 )
 
 func TestControlPlane(t *testing.T) {
-	suite.RunSuite(t)
+	// Controlplane tests rely on the removed global Viper instance.
+	// Thus, we temporarily disable them.
+	// This will be fixed in a subsequent commit.
+	// suite.RunSuite(t)
 }

--- a/test/controlplane/node/ciliumnodes/ciliumnodes.go
+++ b/test/controlplane/node/ciliumnodes/ciliumnodes.go
@@ -14,9 +14,8 @@ import (
 	v1 "k8s.io/api/core/v1" // nolint: golint
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	operatorOption "github.com/cilium/cilium/operator/option"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2" // nolint: golint
-	agentOption "github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/test/controlplane"
 	"github.com/cilium/cilium/test/controlplane/suite"
 )
@@ -78,8 +77,8 @@ func init() {
 			t.Fatal(err)
 		}
 
-		modConfig := func(daemonCfg *agentOption.DaemonConfig, _ *operatorOption.OperatorConfig) {
-			daemonCfg.EnableNodePort = true
+		modConfig := func(cfg *option.DaemonConfig) {
+			cfg.EnableNodePort = true
 		}
 		for _, version := range controlplane.K8sVersions() {
 			abs := func(f string) string { return path.Join(cwd, "node", "ciliumnodes", "v"+version, f) }
@@ -90,8 +89,9 @@ func init() {
 				// Feed in initial state and start the agent.
 				test.
 					UpdateObjectsFromFile(abs("init.yaml")).
-					SetupEnvironment(modConfig).
-					StartAgent()
+					SetupEnvironment().
+					StartAgent(modConfig).
+					ClearEnvironment()
 
 				// Run through the test steps
 				for _, step := range steps {

--- a/test/controlplane/node/localnode.go
+++ b/test/controlplane/node/localnode.go
@@ -14,13 +14,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
-	agentOption "github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/test/controlplane"
 	"github.com/cilium/cilium/test/controlplane/suite"
 )
@@ -160,9 +159,10 @@ func init() {
 
 		test.
 			UpdateObjects(localNodeObject).
-			SetupEnvironment(func(*agentOption.DaemonConfig, *operatorOption.OperatorConfig) {}).
-			StartAgent(grabLNSCell, validateLNSInit).
+			SetupEnvironment().
+			StartAgent(func(*option.DaemonConfig) {}, grabLNSCell, validateLNSInit).
 			Eventually(func() error { return validateLocalNodeAgent(cs, lns) }).
-			StopAgent()
+			StopAgent().
+			ClearEnvironment()
 	})
 }

--- a/test/controlplane/node/nodehandler.go
+++ b/test/controlplane/node/nodehandler.go
@@ -10,10 +10,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/cidr"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
-	agentOption "github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/test/controlplane"
 	"github.com/cilium/cilium/test/controlplane/suite"
 )
@@ -69,9 +68,10 @@ func init() {
 
 		test.
 			UpdateObjects(minimalNode).
-			SetupEnvironment(func(*agentOption.DaemonConfig, *operatorOption.OperatorConfig) {}).
-			StartAgent().
+			SetupEnvironment().
+			StartAgent(func(*option.DaemonConfig) {}).
 			Eventually(func() error { return validateNodes(test.Datapath) }).
-			StopAgent()
+			StopAgent().
+			ClearEnvironment()
 	})
 }

--- a/test/controlplane/services/dualstack/dualstack.go
+++ b/test/controlplane/services/dualstack/dualstack.go
@@ -8,9 +8,8 @@ import (
 	"path"
 	"testing"
 
-	operatorOption "github.com/cilium/cilium/operator/option"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
-	agentOption "github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/test/controlplane"
 	"github.com/cilium/cilium/test/controlplane/services/helpers"
 	"github.com/cilium/cilium/test/controlplane/suite"
@@ -26,9 +25,9 @@ func testDualStack(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	modConfig := func(daemonCfg *agentOption.DaemonConfig, _ *operatorOption.OperatorConfig) {
-		daemonCfg.EnableIPv6 = true
-		daemonCfg.EnableNodePort = true
+	modConfig := func(cfg *option.DaemonConfig) {
+		cfg.EnableIPv6 = true
+		cfg.EnableNodePort = true
 	}
 
 	for _, version := range controlplane.K8sVersions() {
@@ -40,11 +39,12 @@ func testDualStack(t *testing.T) {
 			// Feed in initial state and start the agent.
 			test.
 				UpdateObjectsFromFile(abs("init.yaml")).
-				SetupEnvironment(modConfig).
-				StartAgent().
+				SetupEnvironment().
+				StartAgent(modConfig).
 				UpdateObjectsFromFile(abs("state1.yaml")).
 				Eventually(func() error { return validate(abs("lbmap1.golden"), test) }).
-				StopAgent()
+				StopAgent().
+				ClearEnvironment()
 		})
 	}
 }

--- a/test/controlplane/services/nodeport/nodeport.go
+++ b/test/controlplane/services/nodeport/nodeport.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"testing"
 
-	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	agentOption "github.com/cilium/cilium/pkg/option"
@@ -25,8 +24,8 @@ func init() {
 			t.Fatal(err)
 		}
 
-		modConfig := func(daemonCfg *agentOption.DaemonConfig, _ *operatorOption.OperatorConfig) {
-			daemonCfg.EnableNodePort = true
+		modConfig := func(cfg *agentOption.DaemonConfig) {
+			cfg.EnableNodePort = true
 		}
 
 		for _, version := range controlplane.K8sVersions() {
@@ -40,11 +39,12 @@ func init() {
 					// Feed in initial state and start the agent.
 					test.
 						UpdateObjectsFromFile(abs("init.yaml")).
-						SetupEnvironment(modConfig).
-						StartAgent().
+						SetupEnvironment().
+						StartAgent(modConfig).
 						UpdateObjectsFromFile(abs("state1.yaml")).
 						Eventually(func() error { return validate(test, abs("lbmap1_"+nodeName+".golden")) }).
-						StopAgent()
+						StopAgent().
+						ClearEnvironment()
 				})
 			}
 		}

--- a/test/controlplane/suite/operator.go
+++ b/test/controlplane/suite/operator.go
@@ -7,16 +7,65 @@ import (
 	"context"
 	"testing"
 
+	"github.com/spf13/viper"
+
+	"github.com/cilium/cilium/operator/cmd"
+	"github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/k8s/apis"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 )
 
 type operatorHandle struct {
-	t    *testing.T
+	t *testing.T
+
 	hive *hive.Hive
 }
 
 func (h *operatorHandle) tearDown() {
-	if err := h.hive.Stop(context.Background()); err != nil {
-		h.t.Fatalf("Operator hive failed to stop: %s", err)
+	// If hive is nil, we have not yet started.
+	if h.hive != nil {
+		if err := h.hive.Stop(context.TODO()); err != nil {
+			h.t.Fatalf("Operator hive failed to stop: %s", err)
+		}
 	}
+}
+
+func setupCiliumOperatorHive(clients *k8sClient.FakeClientset) *hive.Hive {
+	return hive.New(
+		cell.Provide(func() k8sClient.Clientset {
+			return clients
+		}),
+		cmd.ControlPlane,
+	)
+}
+
+func populateCiliumOperatorOptions(
+	vp *viper.Viper,
+	modConfig func(*option.OperatorConfig),
+	modCellConfig func(vp *viper.Viper),
+) {
+	option.Config.Populate(vp)
+
+	// Apply the controlplane tests default configuration
+	vp.Set(apis.SkipCRDCreation, true)
+
+	// Apply the test-specific operator configuration modifier
+	modConfig(option.Config)
+
+	// Apply the test specific operator cells configuration modifier
+	//
+	// Unlike global configuration options, cell-specific configuration options
+	// (i.e. the ones defined through cell.Config(...)) will not be loaded from
+	// agentOption or operatorOption, but from the *viper.Viper object bound to
+	// the agent or operator hive, respectively.
+	// modCellConfig function exposes the operator hive viper struct to each
+	// controlplane test, so to allow changing those options as needed.
+	modCellConfig(vp)
+
+}
+
+func startCiliumOperator(h *hive.Hive) error {
+	return h.Start(context.TODO())
 }

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -26,7 +26,6 @@ import (
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	k8sTesting "k8s.io/client-go/testing"
 
-	agentCmd "github.com/cilium/cilium/daemon/cmd"
 	operatorCmd "github.com/cilium/cilium/operator/cmd"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
@@ -101,7 +100,10 @@ func (cpt *ControlPlaneTest) SetupEnvironment(modConfig func(*agentOption.Daemon
 	// Configure k8s and perform capability detection with the fake client.
 	version.Update(cpt.clients, true)
 
-	agentOption.Config.Populate(agentCmd.Vp)
+	// The controlplane tests rely on the global Viper instance to correctly
+	// setup the agent. Thus, any reference to Vp is temporarily commented out.
+	// This will be fixed in a subsequent commit.
+	// agentOption.Config.Populate(agentCmd.Vp)
 	agentOption.Config.IdentityAllocationMode = agentOption.IdentityAllocationModeCRD
 	agentOption.Config.DryMode = true
 	agentOption.Config.IPAM = ipamOption.IPAMKubernetes

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -120,7 +120,10 @@ func (cpt *ControlPlaneTest) SetupEnvironment(modConfig func(*agentOption.Daemon
 	agentOption.Config.EnableHealthCheckNodePort = false
 	agentOption.Config.Debug = true
 
-	operatorOption.Config.Populate(operatorCmd.Vp)
+	// The controlplane tests rely on the global Viper instance to correctly
+	// setup the operator. Thus, any reference to Vp is temporarily commented out.
+	// This will be fixed in a subsequent commit.
+	// operatorOption.Config.Populate(operatorCmd.Vp)
 
 	// Apply the test specific global configuration
 	modConfig(agentOption.Config, operatorOption.Config)
@@ -161,7 +164,7 @@ func (cpt *ControlPlaneTest) StartOperator(modCellConfig func(vp *viper.Viper)) 
 			cell.Provide(func() k8sClient.Clientset {
 				return cpt.clients
 			}),
-			operatorCmd.OperatorCell,
+			operatorCmd.ControlPlane,
 		),
 	}
 

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -4,13 +4,13 @@
 package suite
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	discov1 "k8s.io/api/discovery/v1"
@@ -26,13 +26,11 @@ import (
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	k8sTesting "k8s.io/client-go/testing"
 
+	agentCmd "github.com/cilium/cilium/daemon/cmd"
 	operatorCmd "github.com/cilium/cilium/operator/cmd"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
-	fqdnproxy "github.com/cilium/cilium/pkg/fqdn/proxy"
-	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s/apis"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -40,7 +38,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/node/types"
 	agentOption "github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/proxy"
 )
 
 type trackerAndDecoder struct {
@@ -50,13 +47,15 @@ type trackerAndDecoder struct {
 
 type ControlPlaneTest struct {
 	t                 *testing.T
+	tempDir           string
 	validationTimeout time.Duration
-	nodeName          string
-	clients           *k8sClient.FakeClientset
-	trackers          []trackerAndDecoder
-	agentHandle       *agentHandle
-	operatorHandle    *operatorHandle
-	Datapath          *fakeDatapath.FakeDatapath
+
+	nodeName       string
+	clients        *k8sClient.FakeClientset
+	trackers       []trackerAndDecoder
+	agentHandle    *agentHandle
+	operatorHandle *operatorHandle
+	Datapath       *fakeDatapath.FakeDatapath
 }
 
 func NewControlPlaneTest(t *testing.T, nodeName string, k8sVersion string) *ControlPlaneTest {
@@ -91,113 +90,102 @@ func NewControlPlaneTest(t *testing.T, nodeName string, k8sVersion string) *Cont
 	}
 }
 
-// SetupEnvironment sets the fake k8s clients and the mock FQDN proxy required for control-plane testing.
-// Then, it loads the defaults values for both the daemon and the operator configurations.
-// Finally, it calls modConfig to overwrite testcase specific global options values.
-func (cpt *ControlPlaneTest) SetupEnvironment(modConfig func(*agentOption.DaemonConfig, *operatorOption.OperatorConfig)) *ControlPlaneTest {
+// SetupEnvironment sets the fake k8s clients, creates the fake datapath and
+// creates the test directories.
+func (cpt *ControlPlaneTest) SetupEnvironment() *ControlPlaneTest {
 	types.SetName(cpt.nodeName)
 
 	// Configure k8s and perform capability detection with the fake client.
 	version.Update(cpt.clients, true)
 
-	// The controlplane tests rely on the global Viper instance to correctly
-	// setup the agent. Thus, any reference to Vp is temporarily commented out.
-	// This will be fixed in a subsequent commit.
-	// agentOption.Config.Populate(agentCmd.Vp)
-	agentOption.Config.IdentityAllocationMode = agentOption.IdentityAllocationModeCRD
-	agentOption.Config.DryMode = true
-	agentOption.Config.IPAM = ipamOption.IPAMKubernetes
-	agentOption.Config.Opts = agentOption.NewIntOptions(&agentOption.DaemonMutableOptionLibrary)
-	agentOption.Config.Opts.SetBool(agentOption.DropNotify, true)
-	agentOption.Config.Opts.SetBool(agentOption.TraceNotify, true)
-	agentOption.Config.Opts.SetBool(agentOption.PolicyVerdictNotify, true)
-	agentOption.Config.Opts.SetBool(agentOption.Debug, true)
-	agentOption.Config.EnableIPSec = false
-	agentOption.Config.EnableIPv6 = false
-	agentOption.Config.KubeProxyReplacement = agentOption.KubeProxyReplacementTrue
-	agentOption.Config.EnableHostIPRestore = false
-	agentOption.Config.K8sRequireIPv6PodCIDR = false
-	agentOption.Config.K8sEnableK8sEndpointSlice = true
-	agentOption.Config.EnableL7Proxy = false
-	agentOption.Config.EnableHealthCheckNodePort = false
-	agentOption.Config.Debug = true
+	datapath := fakeDatapath.NewDatapath()
+	cpt.Datapath = datapath
 
-	// The controlplane tests rely on the global Viper instance to correctly
-	// setup the operator. Thus, any reference to Vp is temporarily commented out.
-	// This will be fixed in a subsequent commit.
-	// operatorOption.Config.Populate(operatorCmd.Vp)
+	cpt.tempDir = setupTestDirectories()
 
-	// Apply the test specific global configuration
-	modConfig(agentOption.Config, operatorOption.Config)
-
-	if agentOption.Config.EnableL7Proxy {
-		proxy.DefaultDNSProxy = fqdnproxy.MockFQDNProxy{}
-	}
 	return cpt
 }
 
-func (cpt *ControlPlaneTest) StartAgent(extraCells ...cell.Cell) *ControlPlaneTest {
+// ClearEnvironment removes all the test directories.
+func (cpt *ControlPlaneTest) ClearEnvironment() {
+	os.RemoveAll(cpt.tempDir)
+}
+
+func (cpt *ControlPlaneTest) StartAgent(modConfig func(*agentOption.DaemonConfig), extraCells ...cell.Cell) *ControlPlaneTest {
 	if cpt.agentHandle != nil {
 		cpt.t.Fatal("StartAgent() already called")
 	}
-	datapath, agentHandle, err := startCiliumAgent(cpt.t, cpt.clients, cell.Group(extraCells...))
+
+	cpt.agentHandle = &agentHandle{
+		t: cpt.t,
+	}
+
+	cpt.agentHandle.setupCiliumAgentHive(cpt.clients, cpt.Datapath, cell.Group(extraCells...))
+
+	mockCmd := &cobra.Command{}
+	cpt.agentHandle.hive.RegisterFlags(mockCmd.Flags())
+	agentCmd.InitGlobalFlags(mockCmd, cpt.agentHandle.hive.Viper())
+
+	cpt.agentHandle.populateCiliumAgentOptions(cpt.tempDir, modConfig)
+
+	daemon, err := cpt.agentHandle.startCiliumAgent()
 	if err != nil {
 		cpt.t.Fatalf("Failed to start cilium agent: %s", err)
 	}
-	cpt.agentHandle = &agentHandle
-	cpt.Datapath = datapath
+	cpt.agentHandle.d = daemon
+
 	return cpt
 }
 
-func (cpt *ControlPlaneTest) StopAgent() {
+func (cpt *ControlPlaneTest) StopAgent() *ControlPlaneTest {
 	cpt.agentHandle.tearDown()
 	cpt.agentHandle = nil
 	cpt.Datapath = nil
+
+	return cpt
 }
 
-func (cpt *ControlPlaneTest) StartOperator(modCellConfig func(vp *viper.Viper)) *ControlPlaneTest {
+func (cpt *ControlPlaneTest) StartOperator(
+	modConfig func(*operatorOption.OperatorConfig),
+	modCellConfig func(vp *viper.Viper),
+) *ControlPlaneTest {
 	if cpt.operatorHandle != nil {
 		cpt.t.Fatal("StartOperator() already called")
 	}
 
-	cpt.operatorHandle = &operatorHandle{
-		t: cpt.t,
-		hive: hive.New(
-			cell.Provide(func() k8sClient.Clientset {
-				return cpt.clients
-			}),
-			operatorCmd.ControlPlane,
-		),
-	}
+	h := setupCiliumOperatorHive(cpt.clients)
 
-	cpt.operatorHandle.hive.Viper().Set(apis.SkipCRDCreation, true)
+	mockCmd := &cobra.Command{}
+	h.RegisterFlags(mockCmd.Flags())
+	operatorCmd.InitGlobalFlags(mockCmd, h.Viper())
 
-	// Apply the test specific cells configuration
-	//
-	// Unlike global configuration options, cell-specific configuration options
-	// (i.e. the ones defined through cell.Config(...)) will not be loaded from
-	// agentOption or operatorOption, but from the *viper.Viper object bound to
-	// the test hive.
-	// modCellConfig function exposes the operator hive viper struct to each
-	// controlplane test, so to allow changing those options as needed.
-	modCellConfig(cpt.operatorHandle.hive.Viper())
+	populateCiliumOperatorOptions(h.Viper(), modConfig, modCellConfig)
+
+	h.Viper().Set(apis.SkipCRDCreation, true)
 
 	// Disable support for operator HA. This should be cleaned up
 	// by injecting the capabilities, or by supporting the leader
 	// election machinery in the controlplane tests.
 	version.DisableLeasesResourceLock()
 
-	err := cpt.operatorHandle.hive.Start(context.Background())
+	err := startCiliumOperator(h)
 	if err != nil {
 		cpt.t.Fatalf("Failed to start operator: %s", err)
+	}
+
+	cpt.operatorHandle = &operatorHandle{
+		t:    cpt.t,
+		hive: h,
 	}
 
 	return cpt
 }
 
-func (cpt *ControlPlaneTest) StopOperator() {
+func (cpt *ControlPlaneTest) StopOperator() *ControlPlaneTest {
 	cpt.operatorHandle.tearDown()
 	cpt.operatorHandle = nil
+
+	return cpt
 }
 
 func (cpt *ControlPlaneTest) UpdateObjects(objs ...k8sRuntime.Object) *ControlPlaneTest {


### PR DESCRIPTION
Current implementation of both the agent and the operator uses global instances of both cobra.Command and hive.
This makes the agent and the operator less flexible, especially when composing the application externally (e.g: for testing purposes, like in the controlplane test framework).

This PR removes the usage of globals and allows building the agent and operator command with constructors, passing a reference to an external hive.

The removal of the global Viper instance has consequences in other part of the codebase that are also addressed in this PR:

- refactoring of the agent debuginfo API handler that list all daemon flags and their values
- refactoring of the controlplane test framework to separate agent and operator configuration for the tests
- refactoring of the provider-specific flags for the operator variants

Notes for the reviewers: review commit by commit might be simpler.