### PR TITLE
Module Health: Node Manager: First Iteration

### DIFF
--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -464,6 +464,10 @@ type clusterNodesClient struct {
 	*models.ClusterNodeStatus
 }
 
+func (c *clusterNodesClient) Name() string {
+	return "cluster-node"
+}
+
 func (c *clusterNodesClient) NodeAdd(newNode nodeTypes.Node) error {
 	c.Lock()
 	c.NodesAdded = append(c.NodesAdded, newNode.GetModel())

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/hive/hivetest"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -35,7 +36,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.New(&fakeConfig.Config{}, nil, manager.NewNodeMetrics(), nil)
+	nm, err = manager.New(&fakeConfig.Config{}, nil, manager.NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -38,6 +38,10 @@ type authMapGarbageCollector struct {
 	ciliumIdentitiesDeleted    map[identity.NumericIdentity]struct{}
 }
 
+func (r *authMapGarbageCollector) Name() string {
+	return "authmap-gc"
+}
+
 type policyRepository interface {
 	GetAuthTypes(localID, remoteID identity.NumericIdentity) policy.AuthTypes
 }

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -28,6 +28,10 @@ func NewNodeHandler() *FakeNodeHandler {
 	return &FakeNodeHandler{Nodes: make(map[string]nodeTypes.Node)}
 }
 
+func (n *FakeNodeHandler) Name() string {
+	return "fake-node-handler"
+}
+
 func (n *FakeNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
 	n.mu.Lock()
 	defer n.mu.Unlock()

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -47,6 +47,10 @@ func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager
 	return dp
 }
 
+func (l *linuxDatapath) Name() string {
+	return "linux-datapath"
+}
+
 // Node returns the handler for node events
 func (l *linuxDatapath) Node() datapath.NodeHandler {
 	return l.node

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -9,6 +9,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -536,7 +537,8 @@ func matchesOnNodeID(mark *netlink.XfrmMark) bool {
 		mark.Mask&linux_defaults.IPsecMarkMaskNodeID == linux_defaults.IPsecMarkMaskNodeID
 }
 
-func ipsecDeleteXfrmState(nodeID uint16) {
+func ipsecDeleteXfrmState(nodeID uint16) error {
+	var errs error
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.NodeID: nodeID,
 	})
@@ -544,18 +546,20 @@ func ipsecDeleteXfrmState(nodeID uint16) {
 	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
 	if err != nil {
 		scopedLog.WithError(err).Warning("Failed to list XFRM states for deletion")
-		return
+		return err
 	}
 	for _, s := range xfrmStateList {
 		if matchesOnNodeID(s.Mark) && getNodeIDFromXfrmMark(s.Mark) == nodeID {
 			if err := netlink.XfrmStateDel(&s); err != nil {
 				scopedLog.WithError(err).Warning("Failed to delete XFRM state")
+				errs = errors.Join(errs, fmt.Errorf("failed to delete xfrm state (%s): %w", s.String(), err))
 			}
 		}
 	}
+	return errs
 }
 
-func ipsecDeleteXfrmPolicy(nodeID uint16) {
+func ipsecDeleteXfrmPolicy(nodeID uint16) error {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.NodeID: nodeID,
 	})
@@ -563,15 +567,18 @@ func ipsecDeleteXfrmPolicy(nodeID uint16) {
 	xfrmPolicyList, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	if err != nil {
 		scopedLog.WithError(err).Warning("Failed to list XFRM policies for deletion")
-		return
+		return fmt.Errorf("failed to list xfrm policies: %w", err)
 	}
+	var errs error
 	for _, p := range xfrmPolicyList {
 		if matchesOnNodeID(p.Mark) && getNodeIDFromXfrmMark(p.Mark) == nodeID {
 			if err := netlink.XfrmPolicyDel(&p); err != nil {
 				scopedLog.WithError(err).Warning("Failed to delete XFRM policy")
+				errs = errors.Join(errs, fmt.Errorf("failed to delete xfrm policy (%s): %w", p.String(), err))
 			}
 		}
 	}
+	return errs
 }
 
 /* UpsertIPsecEndpoint updates the IPSec context for a new endpoint inserted in
@@ -670,9 +677,8 @@ func UpsertIPsecEndpointPolicy(local, remote *net.IPNet, localTmpl, remoteTmpl n
 }
 
 // DeleteIPsecEndpoint deletes a endpoint associated with the remote IP address
-func DeleteIPsecEndpoint(nodeID uint16) {
-	ipsecDeleteXfrmState(nodeID)
-	ipsecDeleteXfrmPolicy(nodeID)
+func DeleteIPsecEndpoint(nodeID uint16) error {
+	return errors.Join(ipsecDeleteXfrmState(nodeID), ipsecDeleteXfrmPolicy(nodeID))
 }
 
 func isXfrmPolicyCilium(policy netlink.XfrmPolicy) bool {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1232,6 +1232,14 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		// assumptions:
 		// 1. newNode is accessed only by reads.
 		// 2. It is safe to invoke insertNeighbor for the same node.
+		//
+		// Because neighbor inserts is not synced, we do not currently
+		// collect/ bubble up errors.
+		// Instead we just rely on logging errors as they come up in the
+		// neighbor update procedure.
+		//
+		// In v1.15, we will have the neighbor sync component report its own
+		// health via stored errors. 
 		go n.insertNeighbor(context.Background(), newNode, false)
 	}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1207,8 +1207,11 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		newIP6                                   = newNode.GetNodeIP(true)
 		oldKey, newKey                           uint8
 		isLocalNode                              = false
-		remoteNodeID                             = n.allocateIDForNode(newNode)
 	)
+	remoteNodeID, err := n.allocateIDForNode(newNode)
+	if err != nil {
+		errs = errors.Join(errs, fmt.Errorf("failed to allocate ID for node %s: %w", newNode.Name, err))
+	}
 
 	if oldNode != nil {
 		oldIP4Cidr = oldNode.IPv4AllocCIDR
@@ -1239,7 +1242,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		// neighbor update procedure.
 		//
 		// In v1.15, we will have the neighbor sync component report its own
-		// health via stored errors. 
+		// health via stored errors.
 		go n.insertNeighbor(context.Background(), newNode, false)
 	}
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -107,6 +107,10 @@ func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapat
 	}
 }
 
+func (l *linuxNodeHandler) Name() string {
+	return "linux-node-datapath"
+}
+
 // updateTunnelMapping is called when a node update is received while running
 // with encapsulation mode enabled. The CIDR and IP of both the old and new
 // node are provided as context. The caller expects the tunnel mapping in the

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1400,6 +1400,7 @@ func (n *linuxNodeHandler) NodeDelete(oldNode nodeTypes.Node) error {
 
 // Must be called with linuxNodeHandler.mutex held.
 func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
+	var errs error
 	if oldNode.IsLocal() {
 		return nil
 	}
@@ -1408,19 +1409,31 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 	oldIP6 := oldNode.GetNodeIP(true)
 
 	if n.nodeConfig.EnableAutoDirectRouting {
-		n.deleteDirectRoute(oldNode.IPv4AllocCIDR, oldIP4)
-		n.deleteDirectRoute(oldNode.IPv6AllocCIDR, oldIP6)
+		if err := n.deleteDirectRoute(oldNode.IPv4AllocCIDR, oldIP4); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to remove old direct routing: deleting old routes %w", err))
+		}
+		if err := n.deleteDirectRoute(oldNode.IPv6AllocCIDR, oldIP6); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to remove old direct routing: deleting old routes %w", err))
+		}
 	}
 
 	if n.nodeConfig.EnableEncapsulation {
 		oldPrefix4 := cmtypes.PrefixClusterFromCIDR(oldNode.IPv4AllocCIDR, oldNode.ClusterID)
 		oldPrefix6 := cmtypes.PrefixClusterFromCIDR(oldNode.IPv6AllocCIDR, oldNode.ClusterID)
-		deleteTunnelMapping(oldPrefix4, false)
-		deleteTunnelMapping(oldPrefix6, false)
+		if err := deleteTunnelMapping(oldPrefix4, false); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to remove old encapsulation config: deleting tunnel mapping for ipv4: %w", err))
+		}
+		if err := deleteTunnelMapping(oldPrefix6, false); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to remove old encapsulation config: deleting tunnel mapping for ipv6: %w", err))
+		}
 
 		if !n.nodeConfig.UseSingleClusterRoute {
-			n.deleteNodeRoute(oldNode.IPv4AllocCIDR, false)
-			n.deleteNodeRoute(oldNode.IPv6AllocCIDR, false)
+			if err := n.deleteNodeRoute(oldNode.IPv4AllocCIDR, false); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to remove old encapsulation config: deleting old single cluster node route for ipv4: %w", err))
+			}
+			if err := n.deleteNodeRoute(oldNode.IPv6AllocCIDR, false); err != nil {
+				errs = errors.Join(errs, fmt.Errorf("failed to remove old encapsulation config: deleting old single cluster node route for ipv6: %w", err))
+			}
 		}
 	}
 
@@ -1429,12 +1442,16 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 	}
 
 	if n.nodeConfig.EnableIPSec {
-		n.deleteIPsec(oldNode)
+		if err := n.deleteIPsec(oldNode); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("failed to delete old ipsec config: %w", err))
+		}
 	}
 
-	n.deallocateIDForNode(oldNode)
+	if err := n.deallocateIDForNode(oldNode); err != nil {
+		errs = errors.Join(errs, fmt.Errorf("failed to deallocate old node ID: %w", err))
+	}
 
-	return nil
+	return errs
 }
 
 func (n *linuxNodeHandler) updateOrRemoveClusterRoute(addressing datapath.NodeAddressingFamily, addressFamilyEnabled bool) {
@@ -1625,41 +1642,47 @@ func (n *linuxNodeHandler) replaceNodeExternalIPSecOutRoute(ip *net.IPNet) error
 }
 
 // The caller must ensure that the CIDR passed in must be non-nil.
-func (n *linuxNodeHandler) deleteNodeIPSecOutRoute(ip *net.IPNet) {
+func (n *linuxNodeHandler) deleteNodeIPSecOutRoute(ip *net.IPNet) error {
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
-			return
+			return nil
 		}
 	} else {
 		if !n.nodeConfig.EnableIPv6 {
-			return
+			return nil
 		}
 	}
 
 	if err := route.Delete(n.createNodeIPSecOutRoute(ip)); err != nil {
 		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to delete the IPsec route OUT from the host routing table")
+		return fmt.Errorf("failed to delete ipsec host route out: %w", err)
 	}
+	return nil
 }
 
 // The caller must ensure that the CIDR passed in must be non-nil.
-func (n *linuxNodeHandler) deleteNodeExternalIPSecOutRoute(ip *net.IPNet) {
+func (n *linuxNodeHandler) deleteNodeExternalIPSecOutRoute(ip *net.IPNet) error {
+	var errs error
 	if ip.IP.To4() != nil {
 		if !n.nodeConfig.EnableIPv4 {
-			return
+			return nil
 		}
 	} else {
 		if !n.nodeConfig.EnableIPv6 {
-			return
+			return nil
 		}
 	}
 
 	if err := route.Delete(n.createNodeExternalIPSecOutRoute(ip, true)); err != nil {
 		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to delete the IPsec route External OUT from the ipsec routing table")
+		errs = errors.Join(errs, fmt.Errorf("failed to delete ipsec route out: %w", err))
 	}
 
 	if err := route.Delete(n.createNodeExternalIPSecOutRoute(ip, false)); err != nil {
 		log.WithError(err).WithField(logfields.CIDR, ip).Error("Unable to delete the IPsec route External OUT from the host routing table")
+		errs = errors.Join(errs, fmt.Errorf("failed to delete ipsec host route out: %w", err))
 	}
+	return errs
 }
 
 // replaceNodeIPSecoInRoute replace the in IPSec routes in the host routing
@@ -1683,7 +1706,8 @@ func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) error {
 	return nil
 }
 
-func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
+func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) error {
+	var errs error
 	scopedLog := log.WithField(logfields.NodeName, oldNode.Name)
 	scopedLog.Debugf("Removing IPsec configuration for node")
 
@@ -1691,7 +1715,7 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 	if nodeID == 0 {
 		scopedLog.Warning("No node ID found for node.")
 	} else {
-		ipsec.DeleteIPsecEndpoint(nodeID)
+		errs = errors.Join(errs, ipsec.DeleteIPsecEndpoint(nodeID))
 	}
 
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
@@ -1699,13 +1723,13 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 		// This is only needed in IPAM modes where we install one route per
 		// remote pod CIDR.
 		if !n.subnetEncryption() {
-			n.deleteNodeIPSecOutRoute(old4RouteNet)
+			errs = errors.Join(errs, n.deleteNodeIPSecOutRoute(old4RouteNet))
 		}
 		if n.nodeConfig.EncryptNode {
 			if remoteIPv4 := oldNode.GetNodeIP(false); remoteIPv4 != nil {
 				exactMask := net.IPv4Mask(255, 255, 255, 255)
 				ipsecRemote := &net.IPNet{IP: remoteIPv4, Mask: exactMask}
-				n.deleteNodeExternalIPSecOutRoute(ipsecRemote)
+				errs = errors.Join(errs, n.deleteNodeExternalIPSecOutRoute(ipsecRemote))
 			}
 		}
 	}
@@ -1720,10 +1744,11 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 			if remoteIPv6 := oldNode.GetNodeIP(true); remoteIPv6 != nil {
 				exactMask := net.CIDRMask(128, 128)
 				ipsecRemote := &net.IPNet{IP: remoteIPv6, Mask: exactMask}
-				n.deleteNodeExternalIPSecOutRoute(ipsecRemote)
+				errs = errors.Join(errs, n.deleteNodeExternalIPSecOutRoute(ipsecRemote))
 			}
 		}
 	}
+	return errs
 }
 
 // NodeConfigurationChanged is called when the LocalNodeConfiguration has changed

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -226,7 +226,7 @@ func createDirectRouteSpec(CIDR *cidr.CIDR, nodeIP net.IP) (routeSpec *netlink.R
 
 	routes, err = netlink.RouteGet(nodeIP)
 	if err != nil {
-		err = fmt.Errorf("unable to lookup route for node %s: %s", nodeIP, err)
+		err = fmt.Errorf("unable to lookup route for node %s: %w", nodeIP, err)
 		return
 	}
 
@@ -407,7 +407,7 @@ func (n *linuxNodeHandler) createNodeRouteSpec(prefix *cidr.CIDR, isLocalNode bo
 		}
 
 		if n.nodeAddressing.IPv6().PrimaryExternal() == nil {
-			return route.Route{}, fmt.Errorf("External IPv6 address unavailable")
+			return route.Route{}, fmt.Errorf("external IPv6 address unavailable")
 		}
 
 		// For ipv6, kernel will reject "ip r a $cidr via $ipv6_cilium_host dev cilium_host"
@@ -1513,14 +1513,14 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRule(netlink.FAMILY_V4, rule); err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("Delete previous IPv4 decrypt rule failed: %s", err)
+			return fmt.Errorf("delete previous IPv4 decrypt rule failed: %w", err)
 		}
 	}
 
 	rule.Mark = linux_defaults.RouteMarkEncrypt
 	if err := route.DeleteRule(netlink.FAMILY_V4, rule); err != nil {
 		if !os.IsNotExist(err) {
-			return fmt.Errorf("Delete previousa IPv4 encrypt rule failed: %s", err)
+			return fmt.Errorf("delete previousa IPv4 encrypt rule failed: %w", err)
 		}
 	}
 
@@ -1531,14 +1531,14 @@ func (n *linuxNodeHandler) removeEncryptRules() error {
 	rule.Mark = linux_defaults.RouteMarkDecrypt
 	if err := route.DeleteRule(netlink.FAMILY_V6, rule); err != nil {
 		if !os.IsNotExist(err) && !errors.Is(err, unix.EAFNOSUPPORT) {
-			return fmt.Errorf("Delete previous IPv6 decrypt rule failed: %s", err)
+			return fmt.Errorf("delete previous IPv6 decrypt rule failed: %w", err)
 		}
 	}
 
 	rule.Mark = linux_defaults.RouteMarkEncrypt
 	if err := route.DeleteRule(netlink.FAMILY_V6, rule); err != nil {
 		if !os.IsNotExist(err) && !errors.Is(err, unix.EAFNOSUPPORT) {
-			return fmt.Errorf("Delete previous IPv6 encrypt rule failed: %s", err)
+			return fmt.Errorf("delete previous IPv6 encrypt rule failed: %w", err)
 		}
 	}
 	return nil

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -239,13 +239,13 @@ func Upsert(route Route) error {
 
 	link, err := netlink.LinkByName(route.Device)
 	if err != nil {
-		return fmt.Errorf("unable to lookup interface %s: %s", route.Device, err)
+		return fmt.Errorf("unable to lookup interface %s: %w", route.Device, err)
 	}
 
 	routerNet := route.getNexthopAsIPNet()
 	if routerNet != nil {
 		if _, err := replaceNexthopRoute(route, link, routerNet); err != nil {
-			return fmt.Errorf("unable to add nexthop route: %s", err)
+			return fmt.Errorf("unable to add nexthop route: %w", err)
 		}
 
 		nexthopRouteCreated = true
@@ -267,7 +267,11 @@ func Upsert(route Route) error {
 
 	if err != nil {
 		if nexthopRouteCreated {
-			deleteNexthopRoute(route, link, routerNet)
+			if err2 := deleteNexthopRoute(route, link, routerNet); err2 != nil {
+				// TODO: If this fails, we may want to add some retry logic.
+				log.WithError(err2).
+					Errorf("unable to clean up nexthop route following failure to replace route")
+			}
 		}
 		return err
 	}

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -106,6 +106,10 @@ type LocalNodeConfiguration struct {
 // implementation can differ between the own local node and remote nodes by
 // calling node.IsLocal().
 type NodeHandler interface {
+	// Name identifies the handler, this is used in logging/reporting handler
+	// reconciliation errors.
+	Name() string
+
 	// NodeAdd is called when a node is discovered for the first time.
 	NodeAdd(newNode nodeTypes.Node) error
 

--- a/pkg/hive/hivetest/health.go
+++ b/pkg/hive/hivetest/health.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package hivetest
+
+import "github.com/cilium/cilium/pkg/lock"
+
+// MockHealthReporter is a mock implementation of cell.HealthReporter type.
+// It provides a minimal implementation that can notify on events via an unbuffered channel.
+// Further updates will block until all events are observed.
+//
+// Empty initialization provides an implementation that is a no-op and will not
+// notify on any updates.
+type MockHealthReporter struct {
+	lock.Mutex
+	notify chan Update
+}
+
+// NewMockHealthReporter creates a new mock health reporter which will block until
+// the event is consumed on the Wait channel.
+func NewMockHealthReporter() *MockHealthReporter {
+	return &MockHealthReporter{
+		notify: make(chan Update),
+	}
+}
+
+// Update is a single update to the health status. We don't use the cell.Update
+// type as it contains other fields that are not relevant to the test fixture.
+type Update struct {
+	Event string
+	Err   error
+}
+
+// OK updates with OK status.
+func (m *MockHealthReporter) OK(msg string) {
+	m.Lock()
+	defer m.Unlock()
+	if m.notify == nil {
+		return
+	}
+	m.notify <- Update{Event: "OK"}
+}
+
+// Degraded updates with Degraded status.
+func (m *MockHealthReporter) Degraded(msg string, err error) {
+	m.Lock()
+	defer m.Unlock()
+	if m.notify == nil {
+		return
+	}
+	m.notify <- Update{Event: "Degraded", Err: err}
+}
+
+// Degraded updates with Stopped status, but will not actually
+// stop the test reporter.
+func (m *MockHealthReporter) Stopped(msg string) {
+	m.Lock()
+	defer m.Unlock()
+	if m.notify == nil {
+		return
+	}
+	m.notify <- Update{Event: "Stopped"}
+}
+
+// Wait returns a channel that will receive updates on the health status.
+func (m *MockHealthReporter) Wait() <-chan Update {
+	return m.notify
+}

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -37,6 +37,10 @@ func newHandler(withoutTLSInfo bool, addressPref serviceoption.AddressFamilyPref
 	}
 }
 
+func (h *handler) Name() string {
+	return "hubble-peer"
+}
+
 // Ensure that Service implements the NodeHandler interface so that it can be
 // notified of nodes updates by the daemon's node manager.
 var _ datapath.NodeHandler = (*handler)(nil)

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -5,11 +5,14 @@ package manager
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/netip"
 	"time"
 
 	"github.com/cilium/workerpool"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/backoff"
@@ -136,7 +139,12 @@ func (m *manager) Subscribe(nh datapath.NodeHandler) {
 	m.mutex.RLock()
 	for _, v := range m.nodes {
 		v.mutex.Lock()
-		nh.NodeAdd(v.node)
+		if err := nh.NodeAdd(v.node); err != nil {
+			log.WithFields(logrus.Fields{
+				"handler": nh.Name(),
+				"node":    v.node.Name,
+			}).WithError(err).Error("Failed applying node handler following initial subscribe. Cilium may have degraded functionality. See error message for more details.")
+		}
 		v.mutex.Unlock()
 	}
 	m.mutex.RUnlock()
@@ -280,6 +288,7 @@ func (m *manager) backgroundSync(ctx context.Context) error {
 		syncInterval := m.backgroundSyncInterval()
 		log.WithField("syncInterval", syncInterval.String()).Debug("Performing regular background work")
 
+		var errs error
 		// get a copy of the node identities to avoid locking the entire manager
 		// throughout the process of running the datapath validation.
 		nodes := m.GetNodeIdentities()
@@ -296,11 +305,24 @@ func (m *manager) backgroundSync(ctx context.Context) error {
 			entry.mutex.Lock()
 			m.mutex.RUnlock()
 			m.Iter(func(nh datapath.NodeHandler) {
-				nh.NodeValidateImplementation(entry.node)
+				if err := nh.NodeValidateImplementation(entry.node); err != nil {
+					log.WithFields(logrus.Fields{
+						"handler": nh.Name(),
+						"node":    entry.node.Name,
+					}).WithError(err).
+						Error("Failed to apply node handler during background sync. Cilium may have degraded functionality. See error message for details.")
+					errs = errors.Join(errs, fmt.Errorf("failed while handling %s on node %s: %w", nh.Name(), entry.node.Name, err))
+				}
 			})
 			entry.mutex.Unlock()
 
 			m.metrics.DatapathValidations.Inc()
+		}
+
+		if errs != nil {
+			m.healthReporter.Degraded("Failed to apply node validation", errs)
+		} else {
+			m.healthReporter.OK("Node validation successful")
 		}
 
 		select {
@@ -495,7 +517,13 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		entry.node = n
 		if dpUpdate {
 			m.Iter(func(nh datapath.NodeHandler) {
-				nh.NodeUpdate(oldNode, entry.node)
+				if err := nh.NodeUpdate(oldNode, entry.node); err != nil {
+					log.WithFields(logrus.Fields{
+						"handler": nh.Name(),
+						"node":    entry.node.Name,
+					}).WithError(err).
+						Error("Failed to handle node update event while applying handler. Cilium may be have degraded functionality. See error message for details.")
+				}
 			})
 		}
 
@@ -512,7 +540,13 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		m.mutex.Unlock()
 		if dpUpdate {
 			m.Iter(func(nh datapath.NodeHandler) {
-				nh.NodeAdd(entry.node)
+				if err := nh.NodeAdd(entry.node); err != nil {
+					log.WithFields(logrus.Fields{
+						"node":    entry.node.Name,
+						"handler": nh.Name(),
+					}).WithError(err).
+						Error("Failed to handle node update event while applying handler. Cilium may be have degraded functionality. See error message for details.")
+				}
 			})
 		}
 		entry.mutex.Unlock()
@@ -637,7 +671,16 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 	delete(m.nodes, nodeIdentifier)
 	m.mutex.Unlock()
 	m.Iter(func(nh datapath.NodeHandler) {
-		nh.NodeDelete(n)
+		if err := nh.NodeDelete(n); err != nil {
+			// For now we log the error and continue. Eventually we will want to encorporate
+			// this into the node managers health status.
+			// However this is a bit tricky - as leftover node deletes are not retries so this will
+			// need to be accompanied by some kind of retry mechanism.
+			log.WithFields(logrus.Fields{
+				"handler": nh.Name(),
+				"node":    n.Name,
+			}).WithError(err).Error("Failed to handle node delete event while applying handler. Cilium may be have degraded functionality.")
+		}
 	})
 	entry.mutex.Unlock()
 }

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -145,6 +145,10 @@ func newSignalNodeHandler() *signalNodeHandler {
 	}
 }
 
+func (s *signalNodeHandler) Name() string {
+	return "manager_test:signalNodeHandler"
+}
+
 func (n *signalNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
 	if n.EnableNodeAddEvent {
 		n.NodeAddEvent <- newNode

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -14,10 +14,12 @@ import (
 	"time"
 
 	check "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/hive/hivetest"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
@@ -128,11 +130,15 @@ func (i *ipcacheMock) RemoveIdentityOverride(prefix netip.Prefix, identityLabels
 type signalNodeHandler struct {
 	EnableNodeAddEvent                    bool
 	NodeAddEvent                          chan nodeTypes.Node
+	NodeAddEventError                     error
 	NodeUpdateEvent                       chan nodeTypes.Node
+	NodeUpdateEventError                  error
 	EnableNodeUpdateEvent                 bool
 	NodeDeleteEvent                       chan nodeTypes.Node
+	NodeDeleteEventError                  error
 	EnableNodeDeleteEvent                 bool
 	NodeValidateImplementationEvent       chan nodeTypes.Node
+	NodeValidateImplementationEventError  error
 	EnableNodeValidateImplementationEvent bool
 }
 
@@ -153,28 +159,28 @@ func (n *signalNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
 	if n.EnableNodeAddEvent {
 		n.NodeAddEvent <- newNode
 	}
-	return nil
+	return n.NodeAddEventError
 }
 
 func (n *signalNodeHandler) NodeUpdate(oldNode, newNode nodeTypes.Node) error {
 	if n.EnableNodeUpdateEvent {
 		n.NodeUpdateEvent <- newNode
 	}
-	return nil
+	return n.NodeUpdateEventError
 }
 
 func (n *signalNodeHandler) NodeDelete(node nodeTypes.Node) error {
 	if n.EnableNodeDeleteEvent {
 		n.NodeDeleteEvent <- node
 	}
-	return nil
+	return n.NodeDeleteEventError
 }
 
 func (n *signalNodeHandler) NodeValidateImplementation(node nodeTypes.Node) error {
 	if n.EnableNodeValidateImplementationEvent {
 		n.NodeValidateImplementationEvent <- node
 	}
-	return nil
+	return n.NodeValidateImplementationEventError
 }
 
 func (n *signalNodeHandler) NodeConfigurationChanged(config datapath.LocalNodeConfiguration) error {
@@ -198,7 +204,7 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)
 
@@ -270,7 +276,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -352,7 +358,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -373,7 +379,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -405,7 +411,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	mngr.Subscribe(signalNodeHandler)
 	c.Assert(err, check.IsNil)
 	defer mngr.Stop(context.TODO())
@@ -449,7 +455,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 func (s *managerTestSuite) TestIpcache(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -497,7 +503,7 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -573,7 +579,7 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{RemoteNodeIdentity: true}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{RemoteNodeIdentity: true}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -649,7 +655,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -744,7 +750,7 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), nil)
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -832,4 +838,42 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	c.Assert(ok, check.Equals, true)
 	// Needs to be the same as n2
 	c.Assert(n, checker.DeepEquals, *n1V2)
+}
+
+func TestNodeManagerEmitStatus(t *testing.T) {
+	// Tests health reporting on node manager.
+	assert := assert.New(t)
+
+	baseBackgroundSyncInterval = 1 * time.Millisecond
+	hr := hivetest.NewMockHealthReporter()
+	m, err := New(&configMock{}, newIPcacheMock(), NewNodeMetrics(), hr)
+	assert.NoError(err)
+
+	m.nodes[nodeTypes.Identity{
+		Name:    "node1",
+		Cluster: "c1",
+	}] = &nodeEntry{node: nodeTypes.Node{Name: "node1", Cluster: "c1"}}
+	m.nodeHandlers = make(map[datapath.NodeHandler]struct{})
+	nh1 := newSignalNodeHandler()
+	nh1.EnableNodeValidateImplementationEvent = true
+	// By default this is a buffered channel, by making it a non-buffered
+	// channel we can sync up iterations of background sync.
+	nh1.NodeValidateImplementationEvent = make(chan nodeTypes.Node)
+	nh1.NodeValidateImplementationEventError = fmt.Errorf("test error")
+	m.nodeHandlers[nh1] = struct{}{}
+
+	done := make(chan struct{})
+	go func() {
+		<-nh1.NodeValidateImplementationEvent
+		s := <-hr.Wait()
+		assert.Error(s.Err)
+		nh1.NodeValidateImplementationEventError = nil
+		<-nh1.NodeValidateImplementationEvent
+		s = <-hr.Wait()
+		assert.NoError(s.Err)
+		close(done)
+	}()
+	// Start the manager
+	assert.NoError(m.Start(context.Background()))
+	<-done
 }

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -113,6 +113,10 @@ func NewAgent(privKeyPath string, localNodeStore *node.LocalNodeStore) (*Agent, 
 	}, nil
 }
 
+func (a *Agent) Name() string {
+	return "wireguard-agent"
+}
+
 // Close is called when the agent stops
 func (a *Agent) Close() error {
 	a.RLock()


### PR DESCRIPTION
This PR seeks to provide modular health status checking on the "node manager" component of the Agent. Specifically the goals are:

## Intentions of this PR:

### Bubble-up all errors in Linux node handler code

Node Manager related code relies heavily on logging (or just ignoring) errors far down the stack, instead of bubbling them up.

The result of this is:
* Logged errors have little context on the root event causing them to be invoked.
* It's hard to trace failure from a particular event relating to all reconcile procedures that need to run.
* It's hard to definitively to say if reconciliation for a Node Event was successfully.

The changes in this PR seek to address this by handling and bubbling up all relevant errors that may be encountered while doing Linux Node update reconciliation logic.

As well, this PR seeks to **avoid** any changes to the control-flow logic of the reconciliation by _not_ immediately returning at places where errors may occur.
Rather, this follows a pattern of combining lists of errors into relevant/scoped multi errors (using the multierr library). All code will execute as before, with the difference being that errors are handled up the stack.

### Use Hive's Modular Health Reporter to report status of node manager.

This is a first attempt at trying to manage health status for a module. 

#### Follow up work:
* Investigate Reconciliation: Break Linux node logic into atomic and idempotent tasks that can be executed and retried (+ reported on more easily).