### PR TITLE
contrib/kind: Add secondary iface to KIND network

### DIFF
--- a/contrib/scripts/kind-down.sh
+++ b/contrib/scripts/kind-down.sh
@@ -11,9 +11,11 @@ fi
 
 default_cluster_name="kind"
 default_network="kind-cilium"
+default_secondary_network="${default_network}-secondary"
 
 for cluster in "${@:-${default_cluster_name}}"; do
     kind delete cluster --name "$cluster"
 done
 
 docker network rm ${default_network}
+docker network rm ${default_secondary_network}


### PR DESCRIPTION
Add secondary iface to KIND network, so that we can test the NodePort via secondary iface.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

item2 of #18846
