### PR TITLE
auth: add missing stream package import

### DIFF
--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/signal"
+	"github.com/cilium/cilium/pkg/stream"
 )
 
 // Cell invokes authManager which is responsible for request authentication.


### PR DESCRIPTION
This PR adds back the stream package import, which appears to be missing due to a merge race between #25927 and #25934.

Fixes: eb653b60338e ("auth: use Resource.Observe for jobs")
Fixes: ebb6fc38803a ("auth: implement re-authentication in case of rotated certificates")
