### PR TITLE
.github: refactor job matrix generation into YAML files

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -1,0 +1,400 @@
+# This file contains the list of tests that should be included and excluded.
+#
+# To provide a better UX, the 'cliFocus' defined on each element from the
+#  "include" is expanded to the specific defined 'focus'. This way we can map
+#  which regex should be used on ginkgo --focus to an element from the "focus"
+#  list.
+#
+# Further down is a list of tests that can be excluded because they are ignored
+# by our constraints defined in the ginkgo tests. There is a justification, in
+# form of a comment, explaining why each test is excluded.
+#
+# More info: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
+---
+focus:
+- "f01-agent-chaos"
+- "f02-agent-fqdn"
+- "f03-agent-policy"
+- "f04-agent-policy-multi-node-1"
+- "f05-agent-policy-multi-node-2"
+- "f06-agent-policy-basic"
+- "f07-datapath-host"
+- "f08-datapath-misc-1"
+- "f09-datapath-misc-2"
+- "f10-agent-hubble-bandwidth"
+- "f11-datapath-service-ns-tc"
+- "f12-datapath-service-ns-misc"
+- "f13-datapath-service-ns-xdp-1"
+- "f14-datapath-service-ns-xdp-2"
+- "f15-datapath-service-ew-1"
+- "f16-datapath-service-ew-2"
+- "f17-datapath-service-ew-kube-proxy"
+- "f18-datapath-bgp-custom-lrp"
+- "f19-update"
+- "f20-kafka"
+include:
+  ###
+  # K8sAgentChaosTest Connectivity demo application Endpoint can still connect while Cilium is not running
+  # K8sAgentChaosTest Restart with long lived connections L3/L4 policies still work while Cilium is restarted
+  # K8sAgentChaosTest Restart with long lived connections TCP connection is not dropped when cilium restarts
+  - focus: "f01-agent-chaos"
+    cliFocus: "K8sAgentChaosTest"
+
+  ###
+  # K8sAgentFQDNTest Restart Cilium validate that FQDN is still working
+  # K8sAgentFQDNTest Validate that FQDN policy continues to work after being updated
+  # K8sAgentFQDNTest Validate that multiple specs are working correctly
+  # K8sAgentPerNodeConfigTest Correctly computes config overrides
+  - focus: "f02-agent-fqdn"
+    cliFocus: "K8sAgentFQDNTest|K8sAgentPerNodeConfigTest"
+
+  ###
+  # K8sAgentPolicyTest Clusterwide policies Test clusterwide connectivity with policies
+  # K8sAgentPolicyTest External services To Services first endpoint creation
+  # K8sAgentPolicyTest External services To Services first endpoint creation match service by labels
+  # K8sAgentPolicyTest External services To Services first policy
+  # K8sAgentPolicyTest External services To Services first policy, match service by labels
+  # K8sAgentPolicyTest Namespaces policies Cilium Network policy using namespace label and L7
+  # K8sAgentPolicyTest Namespaces policies Kubernetes Network Policy by namespace selector
+  # K8sAgentPolicyTest Namespaces policies Tests the same Policy in different namespaces
+  - focus: "f03-agent-policy"
+    cliFocus: "K8sAgentPolicyTest Clusterwide|K8sAgentPolicyTest External|K8sAgentPolicyTest Namespaces"
+
+  ###
+  # K8sAgentPolicyTest Multi-node policy test validates fromEntities policies Validates fromEntities all policy
+  # K8sAgentPolicyTest Multi-node policy test validates fromEntities policies Validates fromEntities cluster policy
+  # K8sAgentPolicyTest Multi-node policy test validates fromEntities policies with remote-node identity disabled Allows from all hosts with cnp fromEntities host policy
+  # K8sAgentPolicyTest Multi-node policy test validates fromEntities policies with remote-node identity enabled Validates fromEntities remote-node policy
+  # K8sAgentPolicyTest Multi-node policy test with L7 policy using connectivity-check to check datapath
+  - focus: "f04-agent-policy-multi-node-1"
+    cliFocus: "K8sAgentPolicyTest Multi-node policy test validates fromEntities|K8sAgentPolicyTest Multi-node policy test with"
+
+  ###
+  # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 connectivity is blocked after denying ingress
+  # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 connectivity is restored after importing ingress policy
+  # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 connectivity works from the outside before any policies
+  # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 With host policy Connectivity is restored after importing ingress policy
+  # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 With host policy Connectivity to hostns is blocked after denying ingress
+  - focus: "f05-agent-policy-multi-node-2"
+    cliFocus: "K8sAgentPolicyTest Multi-node policy test validates ingress"
+
+  ###
+  # K8sAgentPolicyTest Basic Test Invalid Policy report status correctly
+  # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests DNS proxy visibility without policy
+  # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests HTTP proxy visibility without policy
+  # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests proxy visibility interactions with policy lifecycle operations
+  # K8sPolicyTestExtended Validate toEntities KubeAPIServer Allows connection to KubeAPIServer
+  # K8sPolicyTestExtended Validate toEntities KubeAPIServer Denies connection to KubeAPIServer
+  # K8sPolicyTestExtended Validate toEntities KubeAPIServer Still allows connection to KubeAPIServer with a duplicate policy
+  - focus: "f06-agent-policy-basic"
+    cliFocus: "K8sAgentPolicyTest Basic|K8sPolicyTestExtended"
+
+  ###
+  # K8sDatapathConfig Host firewall Check connectivity with IPv6 disabled
+  # K8sDatapathConfig Host firewall With native routing
+  # K8sDatapathConfig Host firewall With native routing and endpoint routes
+  # K8sDatapathConfig Host firewall With VXLAN
+  # K8sDatapathConfig Host firewall With VXLAN and endpoint routes
+  - focus: "f07-datapath-host"
+    cliFocus: "K8sDatapathConfig Host"
+
+  ###
+  # K8sDatapathConfig Encapsulation Check iptables masquerading with random-fully
+  # K8sDatapathConfig Etcd Check connectivity
+  # K8sDatapathConfig MonitorAggregation Checks that monitor aggregation flags send notifications
+  # K8sDatapathConfig MonitorAggregation Checks that monitor aggregation restricts notifications
+  - focus: "f08-datapath-misc-1"
+    cliFocus: "K8sDatapathConfig Encapsulation|K8sDatapathConfig Etcd|K8sDatapathConfig Etcd|K8sDatapathConfig MonitorAggregation"
+
+  ###
+  # K8sDatapathConfig Check BPF masquerading with ip-masq-agent DirectRouting
+  # K8sDatapathConfig Check BPF masquerading with ip-masq-agent VXLAN
+  # K8sDatapathConfig High-scale IPcache Test ingress policy enforcement with GENEVE and endpoint routes
+  # K8sDatapathConfig High-scale IPcache Test ingress policy enforcement with VXLAN and no endpoint routes
+  # K8sDatapathConfig Iptables Skip conntrack for pod traffic
+  # K8sDatapathConfig IPv4Only Check connectivity with IPv6 disabled
+  # K8sDatapathConfig IPv6 masquerading across K8s nodes, skipped due to native routing CIDR
+  # K8sDatapathConfig Transparent encryption DirectRouting Check connectivity with transparent encryption and direct routing with bpf_host
+  - focus: "f09-datapath-misc-2"
+    cliFocus: "K8sDatapathConfig Check|K8sDatapathConfig IPv4Only|K8sDatapathConfig High-scale|K8sDatapathConfig Iptables|K8sDatapathConfig IPv4Only|K8sDatapathConfig IPv6|K8sDatapathConfig Transparent"
+
+  ###
+  # K8sAgentHubbleTest Hubble Observe Test FQDN Policy with Relay
+  # K8sAgentHubbleTest Hubble Observe Test L3/L4 Flow
+  # K8sAgentHubbleTest Hubble Observe Test L3/L4 Flow with hubble-relay
+  # K8sAgentHubbleTest Hubble Observe Test L7 Flow
+  # K8sAgentHubbleTest Hubble Observe Test L7 Flow with hubble-relay
+  # K8sAgentHubbleTest Hubble Observe Test TLS certificate
+  # K8sDatapathBandwidthTest Checks Bandwidth Rate-Limiting Checks Pod to Pod bandwidth, direct routing
+  # K8sDatapathBandwidthTest Checks Bandwidth Rate-Limiting Checks Pod to Pod bandwidth, geneve tunneling
+  # K8sDatapathBandwidthTest Checks Bandwidth Rate-Limiting Checks Pod to Pod bandwidth, vxlan tunneling
+  - focus: "f10-agent-hubble-bandwidth"
+    cliFocus: "K8sAgentHubbleTest|K8sDatapathBandwidthTest"
+
+  ###
+  # K8sDatapathServicesTest Checks N/S loadbalancing ClusterIP cannot be accessed externally when access is disabled
+  # K8sDatapathServicesTest Checks N/S loadbalancing Supports IPv4 fragments
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and dsr with geneve
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and Hybrid-DSR with Geneve
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, geneve tunnel, and Hybrid-DSR with Geneve
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and Hybrid
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, geneve tunnel, dsr and Maglev
+  - focus: "f11-datapath-service-ns-tc"
+    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing ClusterIP|K8sDatapathServicesTest Checks N/S loadbalancing Supports|K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC"
+
+  ###
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests GH#10983
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort with sessionAffinity from outside
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests security id propagation in N/S LB requests fwd-ed over tunnel
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct routing and DSR
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with secondary NodePort device
+  - focus: "f12-datapath-service-ns-misc"
+    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs|K8sDatapathServicesTest Checks N/S loadbalancing Tests GH|K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort|K8sDatapathServicesTest Checks N/S loadbalancing Tests security|K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct|K8sDatapathServicesTest Checks N/S loadbalancing Tests with secondary|K8sDatapathServicesTest Checks N/S loadbalancing with"
+
+  ###
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR and Maglev
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR and Random
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR with Geneve and Maglev
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, Hybrid and Maglev
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, Hybrid and Random
+  - focus: "f13-datapath-service-ns-xdp-1"
+    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR|K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, Hybrid"
+
+  ###
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, SNAT and Maglev
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, SNAT and Random
+  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, vxlan tunnel, SNAT and Random
+  # K8sDatapathServicesTest Checks N/S loadbalancing With ClusterIP external access ClusterIP can be accessed when external access is enabled
+  # K8sDatapathServicesTest Checks N/S loadbalancing With host policy Tests NodePort
+  - focus: "f14-datapath-service-ns-xdp-2"
+    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, SNAT|K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, vxlan|K8sDatapathServicesTest Checks N/S loadbalancing With"
+
+  ###
+  # K8sDatapathServicesTest Checks device reconfiguration Detects newly added device and reloads datapath
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Checks in-cluster KPR Tests HealthCheckNodePort
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Checks in-cluster KPR Tests that binding to NodePort port fails
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Checks in-cluster KPR with L7 policy Tests NodePort with L7 Policy
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Checks service accessing itself (hairpin flow)
+  - focus: "f15-datapath-service-ew-1"
+    cliFocus: 'K8sDatapathServicesTest Checks device|K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) Checks'
+
+  ###
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) TFTP with DNS Proxy port collision Tests TFTP from DNS Proxy Port
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) with L4 policy Tests NodePort with L4 Policy
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) with L7 policy Tests NodePort with L7 Policy
+  - focus: "f16-datapath-service-ew-2"
+    cliFocus: 'K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) TFTP|K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) with'
+
+  ###
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) 
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) with externalTrafficPolicy=Local
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) with IPSec and externalTrafficPolicy=Local
+  # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) with the host firewall and externalTrafficPolicy=Local
+  - focus: "f17-datapath-service-ew-kube-proxy"
+    cliFocus: 'K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) Tests'
+
+  ###
+  # K8sDatapathBGPTests Tests LoadBalancer Connectivity to endpoint via LB
+  # K8sDatapathCustomCalls Basic test with byte-counter Loads byte-counter and gets consistent values
+  # K8sDatapathCustomCalls Basic test with byte-counter Loads byte-counter and gets consistent values, with per-endpoint routes
+  # K8sDatapathLRPTests Checks local redirect policy LRP connectivity
+  # K8sDatapathLRPTests Checks local redirect policy LRP restores service when removed
+  - focus: "f18-datapath-bgp-custom-lrp"
+    cliFocus: "K8sDatapathBGPTests|K8sDatapathCustomCalls|K8sDatapathLRPTests"
+
+  ###
+  # K8sUpdates Tests upgrade and downgrade from a Cilium stable image to master
+  - focus: "f19-update"
+    cliFocus: "K8sUpdates"
+
+  ###
+  # K8sKafkaPolicyTest Kafka Policy Tests KafkaPolicies
+  - focus: "f20-kafka"
+    cliFocus: "K8sKafkaPolicyTest"
+
+exclude:
+  # The bandwidth test is disabled and hubble tests are not meant
+  # to run on net-next.
+  - k8s-version: "1.27"
+    focus: "f10-agent-hubble-bandwidth"
+
+  # Cilium "v1.13" is not supported in K8s "1.27". Skipping upgrade/downgrade tests.
+  - k8s-version: "1.27"
+    focus: "f19-update"
+
+  # These tests are meant to run with kube-proxy which is not available
+  # with net-next
+  - k8s-version: "1.27"
+    focus: "f16-datapath-service-ew-2"
+
+  # These tests are meant to run with kube-proxy which is not available
+  # with net-next
+  - k8s-version: "1.27"
+    focus: "f17-datapath-service-ew-kube-proxy"
+
+  # These tests require an external node which is only available on 1.27
+  # / net-next so there's no point on running them
+  - k8s-version: "1.26"
+    focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require kernel net-next so there's no point on running them
+  - k8s-version: "1.26"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.26"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.26"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.26"
+    focus: "f14-datapath-service-ns-xdp-2"
+
+  # These tests require are not intended to run on kernel 5.4, thus we can ignore them
+  - k8s-version: "1.25"
+    focus: "f01-agent-chaos"
+
+  - k8s-version: "1.25"
+    focus: "f03-agent-policy"
+
+  - k8s-version: "1.25"
+    focus: "f04-agent-policy-multi-node-1"
+
+  - k8s-version: "1.25"
+    focus: "f05-agent-policy-multi-node-2"
+
+  - k8s-version: "1.25"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.25"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.25"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.25"
+    focus: "f14-datapath-service-ns-xdp-2"
+
+  - k8s-version: "1.25"
+    focus: "f15-datapath-service-ew-1"
+
+  - k8s-version: "1.25"
+    focus: "f16-datapath-service-ew-2"
+
+  - k8s-version: "1.25"
+    focus: "f17-datapath-service-ew-kube-proxy"
+
+  - k8s-version: "1.25"
+    focus: "f18-datapath-bgp-custom-lrp"
+
+  - k8s-version: "1.25"
+    focus: "f20-kafka"
+
+  # These tests require an external node which is only available on 1.27
+  # / net-next so there's no point on running them
+  - k8s-version: "1.24"
+    focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require kernel net-next so there's no point on running them
+  - k8s-version: "1.24"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.24"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.24"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.24"
+    focus: "f14-datapath-service-ns-xdp-2"
+
+  # These tests require an external node which is only available on 1.27
+  # / net-next so there's no point on running them
+  - k8s-version: "1.23"
+    focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require kernel net-next so there's no point on running them
+  - k8s-version: "1.23"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.23"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.23"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.23"
+    focus: "f14-datapath-service-ns-xdp-2"
+
+  # These tests require an external node which is only available on 1.27
+  # / net-next so there's no point on running them
+  - k8s-version: "1.22"
+    focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require kernel net-next so there's no point on running them
+  - k8s-version: "1.22"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.22"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.22"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.22"
+    focus: "f14-datapath-service-ns-xdp-2"
+
+  # These tests require an external node which is only available on 1.27
+  # / net-next so there's no point on running them
+  - k8s-version: "1.21"
+    focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require kernel net-next so there's no point on running them
+  - k8s-version: "1.21"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.21"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.21"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.21"
+    focus: "f14-datapath-service-ns-xdp-2"
+
+  # These tests require an external node which is only available on 1.27
+  # / net-next so there's no point on running them
+  - k8s-version: "1.20"
+    focus: "f05-agent-policy-multi-node-2"
+
+  # These tests require kernel net-next so there's no point on running them
+  - k8s-version: "1.20"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.20"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.20"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.20"
+    focus: "f14-datapath-service-ns-xdp-2"
+
+  # These tests require an external node which is only available on 1.27
+  # / net-next so there's no point on running them
+  - k8s-version: "1.19"
+    focus: "f05-agent-policy-multi-node-2"
+
+  # These tests are always skipped so there's no point on running
+  - k8s-version: "1.19"
+    focus: "f11-datapath-service-ns-tc"
+
+  - k8s-version: "1.19"
+    focus: "f12-datapath-service-ns-misc"
+
+  - k8s-version: "1.19"
+    focus: "f13-datapath-service-ns-xdp-1"
+
+  - k8s-version: "1.19"
+    focus: "f14-datapath-service-ns-xdp-2"

--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -1,0 +1,47 @@
+# This file contains which kernel versions should be run with which k8s versions
+---
+include:
+  - k8s-version: "1.27"
+    ip-family: "dual"
+    kube-image: "kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b"
+    kernel: "bpf-next-20230526.105339@sha256:4133d4e09b1e86ac175df8d899873180281bb4220dc43e2566c47b0241637411"
+
+  - k8s-version: "1.26"
+    ip-family: "dual"
+    kube-image: "kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e"
+    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+
+  - k8s-version: "1.25"
+    ip-family: "dual"
+    kube-image: "kindest/node:v1.25.9@sha256:c08d6c52820aa42e533b70bce0c2901183326d86dcdcbedecc9343681db45161"
+    kernel: "5.4-20230526.105339@sha256:523ff0c81ed9be73a2d0d02a64c72655225efdd32e35220f530ca3eff3eada3c"
+
+  - k8s-version: "1.24"
+    ip-family: "dual"
+    kube-image: "kindest/node:v1.24.13@sha256:cea86276e698af043af20143f4bf0509e730ec34ed3b7fa790cc0bea091bc5dd"
+    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+
+  - k8s-version: "1.23"
+    ip-family: "dual"
+    kube-image: "kindest/node:v1.23.17@sha256:f77f8cf0b30430ca4128cc7cfafece0c274a118cd0cdb251049664ace0dee4ff"
+    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+
+  - k8s-version: "1.22"
+    ip-family: "dual"
+    kube-image: "kindest/node:v1.22.17@sha256:9af784f45a584f6b28bce2af84c494d947a05bd709151466489008f80a9ce9d5"
+    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+
+  - k8s-version: "1.21"
+    ip-family: "dual"
+    kube-image: "kindest/node:v1.21.14@sha256:220cfafdf6e3915fbce50e13d1655425558cb98872c53f802605aa2fb2d569cf"
+    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+
+  - k8s-version: "1.20"
+    ip-family: "dual"
+    kube-image: "kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394"
+    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+
+  - k8s-version: "1.19"
+    ip-family: "ipv4"
+    kube-image: "kindest/node:v1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7"
+    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"

--- a/.github/actions/ginkgo/main-prs.yaml
+++ b/.github/actions/ginkgo/main-prs.yaml
@@ -1,0 +1,7 @@
+# This file contain which k8s-versions should be executed for each PR
+---
+k8s-version:
+  - "1.27"
+  - "1.26"
+  - "1.25"
+  - "1.19"

--- a/.github/actions/ginkgo/main-scheduled.yaml
+++ b/.github/actions/ginkgo/main-scheduled.yaml
@@ -1,0 +1,12 @@
+# This file contain which k8s-versions should be executed for on a regular basis
+---
+k8s-version:
+  - "1.27"
+  - "1.26"
+  - "1.25"
+  - "1.24"
+  - "1.23"
+  - "1.22"
+  - "1.21"
+  - "1.20"
+  - "1.19"

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -79,7 +79,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tested: ${{ steps.tested-tree.outputs.src }}
+      matrix_sha: ${{ steps.sha.outputs.sha }}
+      base_branch: ${{ steps.sha.outputs.base_branch }}
       sha: ${{ steps.sha.outputs.sha }}
+      #
+      # For bisect uncomment the base_branch and 'sha' lines below and comment
+      # the two lines above this comment
+      #
+      #base_branch: <replace with the base branch name, should be 'main', not your branch name>
+      #sha: <replace with the SHA of an existing docker image tag that you want to bisect>
     steps:
       # Because we run on issue comments, we need to checkout the code for
       # paths-filter to work.
@@ -96,8 +104,10 @@ jobs:
             echo "base=$(jq -r '.base.sha' pr.json)" >> $GITHUB_OUTPUT
             echo "head=$(jq -r '.head.sha' pr.json)" >> $GITHUB_OUTPUT
             echo "sha=$(jq -r '.head.sha' pr.json)" >> $GITHUB_OUTPUT
+            echo "base_branch=${{ github.base_ref }}" >> $GITHUB_OUTPUT
           else
             echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "base_branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
       - name: Check code changes
         if: ${{ github.event.issue.pull_request }}
@@ -211,8 +221,61 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ needs.check_changes.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
+  generate-matrix:
+    name: Generate Job Matrix from YAMLs
+    needs: check_changes
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout PR code
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        with:
+          ref: ${{ needs.check_changes.outputs.matrix_sha }}
+          persist-credentials: false
+
+      - name: Convert YAML to JSON
+        run: |
+          work_dir=".github/actions/ginkgo"
+          destination_directory="/tmp/generated/ginkgo"
+          mkdir -p "${destination_directory}"
+          for file in "${work_dir}"/${{ needs.check_changes.outputs.base_branch }}*.yaml; do
+              if [[ -f "$file" ]]; then
+                  filename=$(basename "$file")
+                  new_filename="${filename%.yaml}.json"
+
+                  yq -o=json "${file}" | jq . > "${destination_directory}/${new_filename}"
+              fi
+          done
+
+      - name: Generate Matrix
+        id: set-matrix
+        run: |
+          if ${{ github.event_name == 'schedule' }}; then
+            k8s_versions_to_run='${{ needs.check_changes.outputs.base_branch }}-scheduled.json'
+          else
+            k8s_versions_to_run='${{ needs.check_changes.outputs.base_branch }}-prs.json'
+          fi
+
+          # Generate a Matrix from all k8s versions defined in '${k8s_versions_to_run}'
+          # combined with '${{ needs.check_changes.outputs.base_branch }}-focus.yaml'.
+          # Use '${{ needs.check_changes.outputs.base_branch }}-k8s-versions.yaml' to
+          # retrieve which kernel versions should be used for which k8s version.
+
+          dir="/tmp/generated/ginkgo"
+          cd ${dir}
+          jq --argjson prs "$(jq '.["k8s-version"]' ${k8s_versions_to_run})" \
+            --argfile focus ${{ needs.check_changes.outputs.base_branch }}-focus.json \
+            '.include |= map(select(.["k8s-version"] as $k | $prs[] | select($k == .))) + $focus.include |
+            . + {"k8s-version": $prs} |
+            .focus = $focus.focus | .exclude = $focus.exclude' \
+            ${{ needs.check_changes.outputs.base_branch }}-k8s-versions.json> /tmp/merged.json
+          echo "Generated matrix:"
+          cat /tmp/merged.json
+          echo "matrix=$(jq -c . < /tmp/merged.json)" >> $GITHUB_OUTPUT
+
   setup-and-test:
-    needs: [check_changes, build-ginkgo-binary]
+    needs: [check_changes, build-ginkgo-binary, generate-matrix]
     runs-on:
       group: ginkgo-runners
     timeout-minutes: 35
@@ -222,361 +285,7 @@ jobs:
     strategy:
       fail-fast: false
       max-parallel: 60
-      matrix:
-        k8s-version:
-          - "1.27"
-          - "1.26"
-          - "1.25"
-          - "1.19"
-        focus:
-          - "f01-agent-chaos"
-          - "f02-agent-fqdn"
-          - "f03-agent-policy"
-          - "f04-agent-policy-multi-node-1"
-          - "f05-agent-policy-multi-node-2"
-          - "f06-agent-policy-basic"
-          - "f07-datapath-host"
-          - "f08-datapath-misc-1"
-          - "f09-datapath-misc-2"
-          - "f10-agent-hubble-bandwidth"
-          - "f11-datapath-service-ns-tc"
-          - "f12-datapath-service-ns-misc"
-          - "f13-datapath-service-ns-xdp-1"
-          - "f14-datapath-service-ns-xdp-2"
-          - "f15-datapath-service-ew-1"
-          - "f16-datapath-service-ew-2"
-          - "f17-datapath-service-ew-kube-proxy"
-          - "f18-datapath-bgp-custom-lrp"
-          - "f19-update"
-          - "f20-kafka"
-
-        include:
-          - k8s-version: "1.27"
-            ip-family: "dual"
-            kube-image: "kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b"
-            kernel: "bpf-next-20230526.105339@sha256:4133d4e09b1e86ac175df8d899873180281bb4220dc43e2566c47b0241637411"
-
-          - k8s-version: "1.26"
-            ip-family: "dual"
-            kube-image: "kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e"
-            kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
-
-          - k8s-version: "1.25"
-            ip-family: "dual"
-            kube-image: "kindest/node:v1.25.9@sha256:c08d6c52820aa42e533b70bce0c2901183326d86dcdcbedecc9343681db45161"
-            kernel: "5.4-20230526.105339@sha256:523ff0c81ed9be73a2d0d02a64c72655225efdd32e35220f530ca3eff3eada3c"
-
-# Re-enable when necessary
-#          - k8s-version: "1.24"
-#            ip-family: "dual"
-#            kube-image: "kindest/node:v1.24.13@sha256:cea86276e698af043af20143f4bf0509e730ec34ed3b7fa790cc0bea091bc5dd"
-#            kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
-#
-#          - k8s-version: "1.23"
-#            ip-family: "dual"
-#            kube-image: "kindest/node:v1.23.17@sha256:f77f8cf0b30430ca4128cc7cfafece0c274a118cd0cdb251049664ace0dee4ff"
-#            kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
-#
-#          - k8s-version: "1.22"
-#            ip-family: "dual"
-#            kube-image: "kindest/node:v1.22.17@sha256:9af784f45a584f6b28bce2af84c494d947a05bd709151466489008f80a9ce9d5"
-#            kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
-#
-#          - k8s-version: "1.21"
-#            ip-family: "dual"
-#            kube-image: "kindest/node:v1.21.14@sha256:220cfafdf6e3915fbce50e13d1655425558cb98872c53f802605aa2fb2d569cf"
-#            kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
-#
-#          - k8s-version: "1.20"
-#            ip-family: "dual"
-#            kube-image: "kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394"
-#            kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
-
-          - k8s-version: "1.19"
-            ip-family: "ipv4"
-            kube-image: "kindest/node:v1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7"
-            kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
-
-          ###
-          # K8sAgentChaosTest Connectivity demo application Endpoint can still connect while Cilium is not running
-          # K8sAgentChaosTest Restart with long lived connections L3/L4 policies still work while Cilium is restarted
-          # K8sAgentChaosTest Restart with long lived connections TCP connection is not dropped when cilium restarts
-          - focus: "f01-agent-chaos"
-            cliFocus: "K8sAgentChaosTest"
-
-          ###
-          # K8sAgentFQDNTest Restart Cilium validate that FQDN is still working
-          # K8sAgentFQDNTest Validate that FQDN policy continues to work after being updated
-          # K8sAgentFQDNTest Validate that multiple specs are working correctly
-          # K8sAgentPerNodeConfigTest Correctly computes config overrides
-          - focus: "f02-agent-fqdn"
-            cliFocus: "K8sAgentFQDNTest|K8sAgentPerNodeConfigTest"
-
-          ###
-          # K8sAgentPolicyTest Clusterwide policies Test clusterwide connectivity with policies
-          # K8sAgentPolicyTest External services To Services first endpoint creation
-          # K8sAgentPolicyTest External services To Services first endpoint creation match service by labels
-          # K8sAgentPolicyTest External services To Services first policy
-          # K8sAgentPolicyTest External services To Services first policy, match service by labels
-          # K8sAgentPolicyTest Namespaces policies Cilium Network policy using namespace label and L7
-          # K8sAgentPolicyTest Namespaces policies Kubernetes Network Policy by namespace selector
-          # K8sAgentPolicyTest Namespaces policies Tests the same Policy in different namespaces
-          - focus: "f03-agent-policy"
-            cliFocus: "K8sAgentPolicyTest Clusterwide|K8sAgentPolicyTest External|K8sAgentPolicyTest Namespaces"
-
-          ###
-          # K8sAgentPolicyTest Multi-node policy test validates fromEntities policies Validates fromEntities all policy
-          # K8sAgentPolicyTest Multi-node policy test validates fromEntities policies Validates fromEntities cluster policy
-          # K8sAgentPolicyTest Multi-node policy test validates fromEntities policies with remote-node identity disabled Allows from all hosts with cnp fromEntities host policy
-          # K8sAgentPolicyTest Multi-node policy test validates fromEntities policies with remote-node identity enabled Validates fromEntities remote-node policy
-          # K8sAgentPolicyTest Multi-node policy test with L7 policy using connectivity-check to check datapath
-          - focus: "f04-agent-policy-multi-node-1"
-            cliFocus: "K8sAgentPolicyTest Multi-node policy test validates fromEntities|K8sAgentPolicyTest Multi-node policy test with"
-
-          ###
-          # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 connectivity is blocked after denying ingress
-          # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 connectivity is restored after importing ingress policy
-          # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 connectivity works from the outside before any policies
-          # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 With host policy Connectivity is restored after importing ingress policy
-          # K8sAgentPolicyTest Multi-node policy test validates ingress CIDR-dependent L4 With host policy Connectivity to hostns is blocked after denying ingress
-          - focus: "f05-agent-policy-multi-node-2"
-            cliFocus: "K8sAgentPolicyTest Multi-node policy test validates ingress"
-
-          ###
-          # K8sAgentPolicyTest Basic Test Invalid Policy report status correctly
-          # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests DNS proxy visibility without policy
-          # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests HTTP proxy visibility without policy
-          # K8sAgentPolicyTest Basic Test Traffic redirections to proxy Tests proxy visibility interactions with policy lifecycle operations
-          # K8sPolicyTestExtended Validate toEntities KubeAPIServer Allows connection to KubeAPIServer
-          # K8sPolicyTestExtended Validate toEntities KubeAPIServer Denies connection to KubeAPIServer
-          # K8sPolicyTestExtended Validate toEntities KubeAPIServer Still allows connection to KubeAPIServer with a duplicate policy
-          - focus: "f06-agent-policy-basic"
-            cliFocus: "K8sAgentPolicyTest Basic|K8sPolicyTestExtended"
-
-          ###
-          # K8sDatapathConfig Host firewall Check connectivity with IPv6 disabled
-          # K8sDatapathConfig Host firewall With native routing
-          # K8sDatapathConfig Host firewall With native routing and endpoint routes
-          # K8sDatapathConfig Host firewall With VXLAN
-          # K8sDatapathConfig Host firewall With VXLAN and endpoint routes
-          - focus: "f07-datapath-host"
-            cliFocus: "K8sDatapathConfig Host"
-
-          ###
-          # K8sDatapathConfig Encapsulation Check iptables masquerading with random-fully
-          # K8sDatapathConfig Etcd Check connectivity
-          # K8sDatapathConfig MonitorAggregation Checks that monitor aggregation flags send notifications
-          # K8sDatapathConfig MonitorAggregation Checks that monitor aggregation restricts notifications
-          - focus: "f08-datapath-misc-1"
-            cliFocus: "K8sDatapathConfig Encapsulation|K8sDatapathConfig Etcd|K8sDatapathConfig Etcd|K8sDatapathConfig MonitorAggregation"
-
-          ###
-          # K8sDatapathConfig Check BPF masquerading with ip-masq-agent DirectRouting
-          # K8sDatapathConfig Check BPF masquerading with ip-masq-agent VXLAN
-          # K8sDatapathConfig High-scale IPcache Test ingress policy enforcement with GENEVE and endpoint routes
-          # K8sDatapathConfig High-scale IPcache Test ingress policy enforcement with VXLAN and no endpoint routes
-          # K8sDatapathConfig Iptables Skip conntrack for pod traffic
-          # K8sDatapathConfig IPv4Only Check connectivity with IPv6 disabled
-          # K8sDatapathConfig IPv6 masquerading across K8s nodes, skipped due to native routing CIDR
-          # K8sDatapathConfig Transparent encryption DirectRouting Check connectivity with transparent encryption and direct routing with bpf_host
-          - focus: "f09-datapath-misc-2"
-            cliFocus: "K8sDatapathConfig Check|K8sDatapathConfig IPv4Only|K8sDatapathConfig High-scale|K8sDatapathConfig Iptables|K8sDatapathConfig IPv4Only|K8sDatapathConfig IPv6|K8sDatapathConfig Transparent"
-
-          ###
-          # K8sAgentHubbleTest Hubble Observe Test FQDN Policy with Relay
-          # K8sAgentHubbleTest Hubble Observe Test L3/L4 Flow
-          # K8sAgentHubbleTest Hubble Observe Test L3/L4 Flow with hubble-relay
-          # K8sAgentHubbleTest Hubble Observe Test L7 Flow
-          # K8sAgentHubbleTest Hubble Observe Test L7 Flow with hubble-relay
-          # K8sAgentHubbleTest Hubble Observe Test TLS certificate
-          # K8sDatapathBandwidthTest Checks Bandwidth Rate-Limiting Checks Pod to Pod bandwidth, direct routing
-          # K8sDatapathBandwidthTest Checks Bandwidth Rate-Limiting Checks Pod to Pod bandwidth, geneve tunneling
-          # K8sDatapathBandwidthTest Checks Bandwidth Rate-Limiting Checks Pod to Pod bandwidth, vxlan tunneling
-          - focus: "f10-agent-hubble-bandwidth"
-            cliFocus: "K8sAgentHubbleTest|K8sDatapathBandwidthTest"
-
-          ###
-          # K8sDatapathServicesTest Checks N/S loadbalancing ClusterIP cannot be accessed externally when access is disabled
-          # K8sDatapathServicesTest Checks N/S loadbalancing Supports IPv4 fragments
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and dsr with geneve
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and Hybrid-DSR with Geneve
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, geneve tunnel, and Hybrid-DSR with Geneve
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, direct routing and Hybrid
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC, geneve tunnel, dsr and Maglev
-          - focus: "f11-datapath-service-ns-tc"
-            cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing ClusterIP|K8sDatapathServicesTest Checks N/S loadbalancing Supports|K8sDatapathServicesTest Checks N/S loadbalancing Tests with TC"
-
-          ###
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests GH#10983
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort with sessionAffinity from outside
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests security id propagation in N/S LB requests fwd-ed over tunnel
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct routing and DSR
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with secondary NodePort device
-          - focus: "f12-datapath-service-ns-misc"
-            cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs|K8sDatapathServicesTest Checks N/S loadbalancing Tests GH|K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort|K8sDatapathServicesTest Checks N/S loadbalancing Tests security|K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct|K8sDatapathServicesTest Checks N/S loadbalancing Tests with secondary|K8sDatapathServicesTest Checks N/S loadbalancing with"
-
-          ###
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR and Maglev
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR and Random
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR with Geneve and Maglev
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, Hybrid and Maglev
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, Hybrid and Random
-          - focus: "f13-datapath-service-ns-xdp-1"
-            cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR|K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, Hybrid"
-
-          ###
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, SNAT and Maglev
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, SNAT and Random
-          # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, vxlan tunnel, SNAT and Random
-          # K8sDatapathServicesTest Checks N/S loadbalancing With ClusterIP external access ClusterIP can be accessed when external access is enabled
-          # K8sDatapathServicesTest Checks N/S loadbalancing With host policy Tests NodePort
-          - focus: "f14-datapath-service-ns-xdp-2"
-            cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, SNAT|K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, vxlan|K8sDatapathServicesTest Checks N/S loadbalancing With"
-
-          ###
-          # K8sDatapathServicesTest Checks device reconfiguration Detects newly added device and reloads datapath
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Checks in-cluster KPR Tests HealthCheckNodePort
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Checks in-cluster KPR Tests that binding to NodePort port fails
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Checks in-cluster KPR with L7 policy Tests NodePort with L7 Policy
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Checks service accessing itself (hairpin flow)
-          - focus: "f15-datapath-service-ew-1"
-            cliFocus: 'K8sDatapathServicesTest Checks device|K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) Checks'
-
-          ###
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) TFTP with DNS Proxy port collision Tests TFTP from DNS Proxy Port
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) with L4 policy Tests NodePort with L4 Policy
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) with L7 policy Tests NodePort with L7 Policy
-          - focus: "f16-datapath-service-ew-2"
-            cliFocus: 'K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) TFTP|K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) with'
-
-          ###
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) 
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) with externalTrafficPolicy=Local
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) with IPSec and externalTrafficPolicy=Local
-          # K8sDatapathServicesTest Checks E/W loadbalancing (ClusterIP, NodePort from inside cluster, etc) Tests NodePort inside cluster (kube-proxy) with the host firewall and externalTrafficPolicy=Local
-          - focus: "f17-datapath-service-ew-kube-proxy"
-            cliFocus: 'K8sDatapathServicesTest Checks E/W loadbalancing \\(ClusterIP, NodePort from inside cluster, etc\\) Tests'
-
-          ###
-          # K8sDatapathBGPTests Tests LoadBalancer Connectivity to endpoint via LB
-          # K8sDatapathCustomCalls Basic test with byte-counter Loads byte-counter and gets consistent values
-          # K8sDatapathCustomCalls Basic test with byte-counter Loads byte-counter and gets consistent values, with per-endpoint routes
-          # K8sDatapathLRPTests Checks local redirect policy LRP connectivity
-          # K8sDatapathLRPTests Checks local redirect policy LRP restores service when removed
-          - focus: "f18-datapath-bgp-custom-lrp"
-            cliFocus: "K8sDatapathBGPTests|K8sDatapathCustomCalls|K8sDatapathLRPTests"
-
-          ###
-          # K8sUpdates Tests upgrade and downgrade from a Cilium stable image to master
-          - focus: "f19-update"
-            cliFocus: "K8sUpdates"
-
-          ###
-          # K8sKafkaPolicyTest Kafka Policy Tests KafkaPolicies
-          - focus: "f20-kafka"
-            cliFocus: "K8sKafkaPolicyTest"
-
-        exclude:
-          # https://github.com/cilium/cilium/actions/runs/4914433266/jobs/8775742540
-          # Needs triage
-          - k8s-version: "1.19"
-            focus: "f20-kafka"
-
-          # The bandwidth test is disabled and hubble tests are not meant
-          # to run on net-next.
-          - k8s-version: "1.27"
-            focus: "f10-agent-hubble-bandwidth"
-
-          # Cilium "v1.13" is not supported in K8s "1.27". Skipping upgrade/downgrade tests.
-          - k8s-version: "1.27"
-            focus: "f19-update"
-
-          # These tests are meant to run with kube-proxy which is not available
-          # with net-next
-          - k8s-version: "1.27"
-            focus: "f16-datapath-service-ew-2"
-
-          # These tests are meant to run with kube-proxy which is not available
-          # with net-next
-          - k8s-version: "1.27"
-            focus: "f17-datapath-service-ew-kube-proxy"
-
-          # These tests require an external node which is only available on 1.27
-          # / net-next so there's no point on running them
-          - k8s-version: "1.26"
-            focus: "f05-agent-policy-multi-node-2"
-
-          # These tests require kernel net-next so there's no point on running them
-          - k8s-version: "1.26"
-            focus: "f11-datapath-service-ns-tc"
-
-          - k8s-version: "1.26"
-            focus: "f12-datapath-service-ns-misc"
-
-          - k8s-version: "1.26"
-            focus: "f13-datapath-service-ns-xdp-1"
-
-          - k8s-version: "1.26"
-            focus: "f14-datapath-service-ns-xdp-2"
-
-          # These tests require are not intended to run on kernel 5.4, thus we can ignore them
-          - k8s-version: "1.25"
-            focus: "f01-agent-chaos"
-
-          - k8s-version: "1.25"
-            focus: "f03-agent-policy"
-
-          - k8s-version: "1.25"
-            focus: "f04-agent-policy-multi-node-1"
-
-          - k8s-version: "1.25"
-            focus: "f05-agent-policy-multi-node-2"
-
-          - k8s-version: "1.25"
-            focus: "f11-datapath-service-ns-tc"
-
-          - k8s-version: "1.25"
-            focus: "f12-datapath-service-ns-misc"
-
-          - k8s-version: "1.25"
-            focus: "f13-datapath-service-ns-xdp-1"
-
-          - k8s-version: "1.25"
-            focus: "f14-datapath-service-ns-xdp-2"
-
-          - k8s-version: "1.25"
-            focus: "f15-datapath-service-ew-1"
-
-          - k8s-version: "1.25"
-            focus: "f16-datapath-service-ew-2"
-
-          - k8s-version: "1.25"
-            focus: "f17-datapath-service-ew-kube-proxy"
-
-          - k8s-version: "1.25"
-            focus: "f18-datapath-bgp-custom-lrp"
-
-          - k8s-version: "1.25"
-            focus: "f20-kafka"
-
-          # These tests require an external node which is only available on 1.27
-          # / net-next so there's no point on running them
-          - k8s-version: "1.19"
-            focus: "f05-agent-policy-multi-node-2"
-
-          # These tests are always skipped so there's no point on running
-          - k8s-version: "1.19"
-            focus: "f11-datapath-service-ns-tc"
-
-          - k8s-version: "1.19"
-            focus: "f12-datapath-service-ns-misc"
-
-          - k8s-version: "1.19"
-            focus: "f13-datapath-service-ns-xdp-1"
-
-          - k8s-version: "1.19"
-            focus: "f14-datapath-service-ns-xdp-2"
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout pull request for tests

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -190,7 +190,7 @@ jobs:
         run: |
           cd src/github.com/cilium/cilium
 
-          grep '# K8s' .github/workflows/conformance-ginkgo.yaml | \
+          grep '# K8s' .github/actions/ginkgo/main-focus.yaml | \
           sed -e 's/^[[:space:]]\+# //g' | \
           sort -u > /tmp/ginkgo-workflow-comments.txt
 
@@ -224,7 +224,7 @@ jobs:
             echo ""
             echo "Ginkgo tests out of sync with comments from GH workflow:"
             echo "$diff"
-            echo "Please fix the comments from .github/workflows/conformance-ginkgo.yaml accordingly"
+            echo "Please fix the comments from .github/actions/ginkgo/main-focus.yaml accordingly"
             echo ""
             exit 1
           fi


### PR DESCRIPTION
This commit addresses two main issues and introduces a more streamlined approach to generating job matrices for GitHub Actions. By migrating the job matrix definition into YAML files, we gain the ability to separate scheduled jobs and pull requests (PRs) into specific files, ensuring comprehensive testing coverage similar to what we have with Jenkins.

The first benefit of this approach is the improved organization of job definitions. With separate files for scheduled jobs and PRs, it becomes easier to manage and maintain testing configurations independently. This modular structure allows us to make changes to specific job types without impacting others, enhancing overall maintainability.

The second advantage is with help of jq, we can define kernel versions for all desired Kubernetes (k8s) versions to be tested without manually commenting out unwanted versions. Previously, when using the "include" mechanism, certain k8s versions like 1.24 had to be commented out to prevent their execution. However, with jq, we can selectively include only the desired k8s versions by mapping them with the definitions in main-prs.yaml or main-scheduled.yaml.

Lastly, this refactor enables per-branch configuration through prefixed filenames. By structuring configuration files with branch-specific prefixes, we can easily define and manage job configurations tailored to stable branches.