### PR TITLE
v1.11 backports 2023-06-08 (ipsec fixes)

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -673,9 +673,71 @@ handle_to_netdev_ipv4(struct __ctx_buff *ctx, __u32 *monitor)
 #ifdef ENABLE_IPSEC
 #ifndef TUNNEL_MODE
 static __always_inline int
+do_netdev_encrypt_pools(struct __ctx_buff *ctx __maybe_unused)
+{
+	int ret = 0;
+	__u32 tunnel_endpoint = 0;
+	void *data, *data_end;
+	__u32 tunnel_source = IPV4_ENCRYPT_IFACE;
+	struct iphdr *ip4;
+	__be32 sum;
+
+	tunnel_endpoint = ctx_load_meta(ctx, CB_ENCRYPT_DST);
+	ctx->mark = 0;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	/* We only need to replace the IPsec outer IP addresses if they are set to
+	 * 0.0.0.0 -> 192.168.0.0. In that case, it means the packet was
+	 * encapsulated by the old XFRM OUT state and we need this BPF logic.
+	 * Otherwise, it means the packet was encapsulated by the new XFRM OUT
+	 * states, which already set the proper outer IP addresses; nothing needed
+	 * here.
+	 * This whole function can be removed in 1.15.
+	 */
+	if (ip4->saddr != 0)
+		return 0;
+
+	/* When IP_POOLS is enabled ip addresses are not
+	 * assigned on a per node basis so lacking node
+	 * affinity we can not use IP address to assign the
+	 * destination IP. Instead rewrite it here from cb[].
+	 */
+	sum = csum_diff(&ip4->daddr, sizeof(__u32), &tunnel_endpoint,
+			sizeof(tunnel_endpoint), 0);
+	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, daddr),
+			    &tunnel_endpoint, sizeof(tunnel_endpoint), 0) < 0)
+		return DROP_WRITE_ERROR;
+	if (l3_csum_replace(ctx, ETH_HLEN + offsetof(struct iphdr, check),
+			    0, sum, 0) < 0)
+		return DROP_CSUM_L3;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	sum = csum_diff(&ip4->saddr, sizeof(__u32), &tunnel_source,
+			sizeof(tunnel_source), 0);
+	if (ctx_store_bytes(ctx, ETH_HLEN + offsetof(struct iphdr, saddr),
+			    &tunnel_source, sizeof(tunnel_source), 0) < 0)
+		return DROP_WRITE_ERROR;
+	if (l3_csum_replace(ctx, ETH_HLEN + offsetof(struct iphdr, check),
+			    0, sum, 0) < 0)
+		return DROP_CSUM_L3;
+
+	return ret;
+}
+
+static __always_inline int
 do_netdev_encrypt(struct __ctx_buff *ctx __maybe_unused,
 		  __u32 src_id __maybe_unused)
 {
+	int ret;
+
+	ret = do_netdev_encrypt_pools(ctx);
+	if (ret)
+		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_INGRESS);
+
 	return CTX_ACT_OK;
 }
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -620,6 +620,10 @@ enum {
 #define	CB_ENCRYPT_IDENTITY	CB_CT_STATE	/* Alias, non-overlapping,
 						 * Not used by xfrm.
 						 */
+#define	CB_ENCRYPT_DST		CB_CT_STATE	/* Alias, non-overlapping,
+						 * Not used by xfrm.
+						 * Can be removed in v1.15.
+						 */
 #define	CB_CUSTOM_CALLS		CB_CT_STATE	/* Alias, non-overlapping */
 };
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1066,6 +1066,10 @@ func initializeFlags() {
 	flags.MarkHidden(option.EnableICMPRules)
 	option.BindEnv(option.EnableICMPRules)
 
+	flags.Bool(option.UseCiliumInternalIPForIPsec, defaults.UseCiliumInternalIPForIPsec, "Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation")
+	flags.MarkHidden(option.UseCiliumInternalIPForIPsec)
+	option.BindEnv(option.UseCiliumInternalIPForIPsec)
+
 	flags.Bool(option.BypassIPAvailabilityUponRestore, false, "Bypasses the IP availability error within IPAM upon endpoint restore")
 	flags.MarkHidden(option.BypassIPAvailabilityUponRestore)
 	option.BindEnv(option.BypassIPAvailabilityUponRestore)

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ipam"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/labels"
@@ -275,7 +276,39 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		}
 	}
 
+	if option.Config.EnableIPSec &&
+		(option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) {
+		// If IPsec is enabled on EKS or AKS, we need to restore the host
+		// endpoint before any other endpoint, to ensure a dropless upgrade.
+		// This code can be removed in v1.15.
+		// This is necessary because we changed how the IPsec encapsulation is
+		// done. In older version, bpf_lxc would pass the outer destination IP
+		// via skb->cb to bpf_host which would write it to the outer header.
+		// In newer versions, the header is written by the kernel XFRM
+		// subsystem and bpf_host must therefore not write it. To allow for a
+		// smooth upgrade, bpf_host has been updated to handle both cases. But
+		// for that to succeed, it must be reloaded first, before the bpf_lxc
+		// programs stop writing the IP into skb->cb.
+		for _, ep := range state.restored {
+			if ep.IsHost() {
+				log.WithField(logfields.EndpointID, ep.ID).Info("Successfully restored endpoint. Scheduling regeneration")
+				if err := ep.RegenerateAfterRestore(); err != nil {
+					log.WithField(logfields.EndpointID, ep.ID).WithError(err).Debug("error regenerating restored host endpoint")
+					epRegenerated <- false
+				} else {
+					epRegenerated <- true
+				}
+				break
+			}
+		}
+	}
+
 	for _, ep := range state.restored {
+		if ep.IsHost() && option.Config.EnableIPSec &&
+			(option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) {
+			// The host endpoint was handled above.
+			continue
+		}
 		log.WithField(logfields.EndpointID, ep.ID).Info("Successfully restored endpoint. Scheduling regeneration")
 		go func(ep *endpoint.Endpoint, epRegenerated chan<- bool) {
 			if err := ep.RegenerateAfterRestore(); err != nil {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -175,6 +175,12 @@ func xfrmStateReplace(new *netlink.XfrmState) error {
 		return fmt.Errorf("Cannot get XFRM state: %s", err)
 	}
 
+	scopedLog := log.WithFields(logrus.Fields{
+		logfields.SPI:           new.Spi,
+		logfields.SourceIP:      new.Src,
+		logfields.DestinationIP: new.Dst,
+	})
+
 	// Check if the XFRM state already exists
 	for _, s := range states {
 		if xfrmIPEqual(s.Src, new.Src) && xfrmIPEqual(s.Dst, new.Dst) &&
@@ -184,16 +190,47 @@ func xfrmStateReplace(new *netlink.XfrmState) error {
 		}
 	}
 
+	oldXFRMMark := &netlink.XfrmMark{
+		Value: ipSecXfrmMarkSetSPI(linux_defaults.RouteMarkEncrypt, uint8(new.Spi)),
+		Mask:  linux_defaults.IPsecOldMarkMaskOut,
+	}
+	for _, s := range states {
+		// This is the XFRM OUT state from a previous Cilium version.
+		// Because its mark matches the new mark (0xXXXX3e00/0xffffff00 ∈
+		// 0x3e00/0xff00), the kernel considers the two states conflict and we
+		// won't be able to add the new one until the old one is removed.
+		//
+		// Thus, we temporarily remove the old, conflicting XFRM state and
+		// re-add it in a defer. In between the removal of the old state and
+		// the addition of the new, we can have a packet drops due to the
+		// missing state. These drops should be limited to the specific node
+		// pair we are handling here and the window during which they can
+		// happen should be really small. This is also specific to the upgrade
+		// and can be removed in v1.15. Finally, this shouldn't happen with ENI
+		// and Azure IPAM modes because they don't have such conflicting states.
+		if xfrmIPEqual(s.Src, new.Src) && xfrmIPEqual(s.Dst, new.Dst) &&
+			xfrmMarkEqual(s.OutputMark, new.OutputMark) &&
+			xfrmMarkEqual(s.Mark, oldXFRMMark) && s.Spi == new.Spi {
+			err := netlink.XfrmStateDel(&s)
+			if err != nil {
+				scopedLog.WithError(err).Error("Failed to remove old XFRM state")
+			} else {
+				scopedLog.Infof("Temporarily removed old XFRM state")
+				defer func(oldXFRMState netlink.XfrmState) {
+					if err := netlink.XfrmStateAdd(&oldXFRMState); err != nil {
+						scopedLog.WithError(err).Errorf("Failed to re-add old XFRM state")
+					}
+				}(s)
+			}
+		}
+	}
+
 	// It doesn't exist so let's attempt to add it.
 	firstAttemptErr := netlink.XfrmStateAdd(new)
 	if !os.IsExist(firstAttemptErr) {
 		return firstAttemptErr
 	}
-	log.WithFields(logrus.Fields{
-		logfields.SPI:           new.Spi,
-		logfields.SourceIP:      new.Src,
-		logfields.DestinationIP: new.Dst,
-	}).Warn("Failed to add XFRM state due to conflicting state")
+	scopedLog.Error("Failed to add XFRM state due to conflicting state")
 
 	// An existing state conflicts with this one. We need to remove the
 	// existing one first.

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -47,6 +47,8 @@ const (
 	// ipSecXfrmMarkSPIShift defines how many bits the SPI is shifted when
 	// encoded in a XfrmMark
 	ipSecXfrmMarkSPIShift = 12
+
+	defaultDropPriority = 100
 )
 
 type ipSecKey struct {
@@ -94,7 +96,7 @@ var (
 		Dst:      wildcardCIDRv4,
 		Mark:     defaultDropMark,
 		Action:   netlink.XFRM_POLICY_BLOCK,
-		Priority: 1,
+		Priority: defaultDropPriority,
 	}
 	defaultDropPolicyIPv6 = &netlink.XfrmPolicy{
 		Dir:      netlink.XFRM_DIR_OUT,
@@ -102,7 +104,7 @@ var (
 		Dst:      wildcardCIDRv6,
 		Mark:     defaultDropMark,
 		Action:   netlink.XFRM_POLICY_BLOCK,
-		Priority: 1,
+		Priority: defaultDropPriority,
 	}
 
 	// To attempt to remove any stale XFRM configs once at startup, after

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -84,7 +84,7 @@ var (
 	wildcardIPv6   = net.ParseIP("0::0")
 	wildcardCIDRv6 = &net.IPNet{
 		IP:   wildcardIPv6,
-		Mask: net.CIDRMask(128, 128),
+		Mask: net.CIDRMask(0, 128),
 	}
 
 	defaultDropMark = &netlink.XfrmMark{

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -48,7 +48,8 @@ const (
 	// encoded in a XfrmMark
 	ipSecXfrmMarkSPIShift = 12
 
-	defaultDropPriority = 100
+	defaultDropPriority      = 100
+	oldXFRMOutPolicyPriority = 50
 )
 
 type ipSecKey struct {
@@ -367,7 +368,7 @@ func IpSecReplacePolicyFwd(dst *net.IPNet, tmplDst net.IP) error {
 //
 // We do need to match on the mark because there is also traffic flowing
 // through XFRM that we don't want to encrypt (e.g., hostns traffic).
-func IPsecDefaultDropPolicy(ipv6 bool) (err error) {
+func IPsecDefaultDropPolicy(ipv6 bool) error {
 	defaultDropPolicy := defaultDropPolicyIPv4
 	family := netlink.FAMILY_V4
 	if ipv6 {
@@ -375,80 +376,36 @@ func IPsecDefaultDropPolicy(ipv6 bool) (err error) {
 		family = netlink.FAMILY_V6
 	}
 
-	// We call removeStaleStatesAndPolicies only if the catch-all default-drop
-	// policy was successfully installed. If it was not installed, then there's
-	// a danger of letting plain-text traffic leave the node if we remove stale
-	// XFRM configs.
-	// This code can be removed in Cilium v1.15.
-	defer func() {
-		if err == nil {
-			removeStaleStatesAndPolicies(family)
-		}
-	}()
+	err := netlink.XfrmPolicyUpdate(defaultDropPolicy)
 
-	return netlink.XfrmPolicyUpdate(defaultDropPolicy)
-}
-
-// Removes XFRM states and policies that are identified as installed by a
-// previous version of Cilium. We rely mainly on the mark mask to identify if
-// it was installed in a previous version. These states and policies need to be
-// removed for cross-node connectivity to work.
-func removeStaleStatesAndPolicies(family int) {
+	// We move the existing XFRM OUT policy to a lower priority to allow the
+	// new priorities to take precedence.
+	// This code can be removed in Cilium v1.15 to instead remove the old XFRM
+	// OUT policy and state.
 	removeStaleXFRMOnce.Do(func() {
-		removeStalePolicies(family)
-		removeStaleStates(family)
+		deprioritizeOldOutPolicy(family)
 	})
+
+	return err
 }
 
-func removeStalePolicies(family int) {
+// Lowers the priority of the old XFRM OUT policy. We rely on the mark mask to
+// identify it. By lowering the priority, we will allow the new XFRM OUT
+// policies to take precedence. We cannot simply remove and replace the old
+// XFRM OUT configs because that would cause traffic interruptions on upgrades.
+func deprioritizeOldOutPolicy(family int) {
 	policies, err := netlink.XfrmPolicyList(family)
 	if err != nil {
 		log.WithError(err).Error("Cannot get XFRM policies")
 	}
 	for _, p := range policies {
-		switch p.Dir {
-		case netlink.XFRM_DIR_OUT:
-			if isDefaultDropPolicy(&p) {
-				continue
-			}
-			if p.Mark.Mask != linux_defaults.IPsecOldMarkMaskOut {
-				// This XFRM OUT policy was not installed by a previous version of Cilium.
-				continue
-			}
-		case netlink.XFRM_DIR_IN:
-			// The XFRM IN policies didn't change so we don't want to remove them.
-			continue
-		default:
-			continue
-		}
-		if err := netlink.XfrmPolicyDel(&p); err != nil {
-			log.WithError(err).WithFields(logrus.Fields{
-				logfields.SourceCIDR:      p.Src,
-				logfields.DestinationCIDR: p.Dst,
-			}).Error("Failed to remove stale XFRM policy")
-		}
-	}
-}
-
-func removeStaleStates(family int) {
-	states, err := netlink.XfrmStateList(family)
-	if err != nil {
-		log.WithError(err).Error("Cannot get XFRM states")
-	}
-	for _, s := range states {
-		scopedLog := log.WithFields(logrus.Fields{
-			logfields.SPI:           s.Spi,
-			logfields.SourceIP:      s.Src,
-			logfields.DestinationIP: s.Dst,
-		})
-
-		if s.Mark.Mask == linux_defaults.IPsecOldMarkMaskOut &&
-			s.Mark.Value == ipSecXfrmMarkSetSPI(linux_defaults.RouteMarkEncrypt, uint8(s.Spi)) {
-			// This XFRM state was installed by a previous version of Cilium.
-			if err := netlink.XfrmStateDel(&s); err == nil {
-				scopedLog.Info("Removed stale XFRM OUT state")
-			} else {
-				scopedLog.WithError(err).Error("Failed to remove stale XFRM OUT state")
+		if p.Dir == netlink.XFRM_DIR_OUT && p.Mark.Mask == linux_defaults.IPsecOldMarkMaskOut {
+			p.Priority = oldXFRMOutPolicyPriority
+			if err := netlink.XfrmPolicyUpdate(&p); err != nil {
+				log.WithError(err).WithFields(logrus.Fields{
+					logfields.SourceCIDR:      p.Src,
+					logfields.DestinationCIDR: p.Dst,
+				}).Error("Failed to deprioritize old XFRM policy")
 			}
 		}
 	}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -414,11 +414,8 @@ func removeStalePolicies(family int) {
 				continue
 			}
 		case netlink.XFRM_DIR_IN:
-			if p.Src.String() != wildcardCIDRv4.String() ||
-				p.Mark.Mask != linux_defaults.IPsecMarkMaskIn {
-				// This XFRM IN policy was not installed by a previous version of Cilium.
-				continue
-			}
+			// The XFRM IN policies didn't change so we don't want to remove them.
+			continue
 		default:
 			continue
 		}
@@ -445,19 +442,11 @@ func removeStaleStates(family int) {
 
 		if s.Mark.Mask == linux_defaults.IPsecOldMarkMaskOut &&
 			s.Mark.Value == ipSecXfrmMarkSetSPI(linux_defaults.RouteMarkEncrypt, uint8(s.Spi)) {
-			// This XFRM state was installed by Cilium.
+			// This XFRM state was installed by a previous version of Cilium.
 			if err := netlink.XfrmStateDel(&s); err == nil {
 				scopedLog.Info("Removed stale XFRM OUT state")
 			} else {
 				scopedLog.WithError(err).Error("Failed to remove stale XFRM OUT state")
-			}
-		} else if s.Mark.Mask == linux_defaults.IPsecMarkMaskIn &&
-			s.Mark.Value == linux_defaults.RouteMarkDecrypt {
-			// This XFRM state was installed by Cilium.
-			if err := netlink.XfrmStateDel(&s); err == nil {
-				scopedLog.Info("Removed stale XFRM IN state")
-			} else {
-				scopedLog.WithError(err).Error("Failed to remove stale XFRM IN state")
 			}
 		}
 	}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -345,11 +345,18 @@ func _ipSecReplacePolicyInFwd(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, prox
 		return fmt.Errorf("IPSec key missing")
 	}
 
+	wildcardIP := wildcardIPv4
+	wildcardCIDR := wildcardCIDRv4
+	if tmplDst.To4() == nil {
+		wildcardIP = wildcardIPv6
+		wildcardCIDR = wildcardCIDRv6
+	}
+
 	policy := ipSecNewPolicy()
 	policy.Dir = dir
-	policy.Dst = dst
 	if dir == netlink.XFRM_DIR_IN {
 		policy.Src = src
+		policy.Dst = dst
 		policy.Mark = &netlink.XfrmMark{
 			Mask: linux_defaults.IPsecMarkMaskIn,
 		}
@@ -364,7 +371,7 @@ func _ipSecReplacePolicyInFwd(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, prox
 			optional = 1
 			// We set the source tmpl address to 0/0 to explicit that it
 			// doesn't matter.
-			tmplSrc = net.ParseIP("0.0.0.0")
+			tmplSrc = wildcardIP
 		} else {
 			policy.Mark.Value = linux_defaults.RouteMarkDecrypt
 		}
@@ -377,8 +384,8 @@ func _ipSecReplacePolicyInFwd(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, prox
 		policy.Priority = linux_defaults.IPsecFwdPriority
 		// In case of fwd policies, we should tell the kernel the tmpl src
 		// doesn't matter; we want all fwd packets to go through.
-		tmplSrc = net.ParseIP("0.0.0.0")
-		policy.Src = &net.IPNet{IP: tmplSrc, Mask: net.IPv4Mask(0, 0, 0, 0)}
+		policy.Src = wildcardCIDR
+		policy.Dst = wildcardCIDR
 	}
 	ipSecAttachPolicyTempl(policy, key, tmplSrc, tmplDst, false, optional)
 	return netlink.XfrmPolicyUpdate(policy)

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -471,6 +471,13 @@ func getSPIFromXfrmPolicy(policy *netlink.XfrmPolicy) uint8 {
 	return ipSecXfrmMarkGetSPI(policy.Mark.Value)
 }
 
+func getNodeIDFromXfrmMark(mark *netlink.XfrmMark) uint16 {
+	if mark == nil {
+		return 0
+	}
+	return uint16(mark.Value >> 16)
+}
+
 func generateEncryptMark(spi uint8, nodeID uint16) *netlink.XfrmMark {
 	val := ipSecXfrmMarkSetSPI(linux_defaults.RouteMarkEncrypt, spi)
 	val |= uint32(nodeID) << 16
@@ -501,38 +508,39 @@ func ipSecReplacePolicyOut(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, nodeID 
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
-func ipsecDeleteXfrmState(ip net.IP) {
+func ipsecDeleteXfrmState(nodeID uint16) {
 	scopedLog := log.WithFields(logrus.Fields{
-		"remote-ip": ip,
+		logfields.NodeID: nodeID,
 	})
 
 	xfrmStateList, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
 	if err != nil {
-		scopedLog.WithError(err).Warning("deleting xfrm state, xfrm state list error")
+		scopedLog.WithError(err).Warning("Failed to list XFRM states for deletion")
 		return
 	}
 	for _, s := range xfrmStateList {
-		if ip.Equal(s.Dst) {
+		if getNodeIDFromXfrmMark(s.Mark) == nodeID {
 			if err := netlink.XfrmStateDel(&s); err != nil {
-				scopedLog.WithError(err).Warning("deleting xfrm state failed")
+				scopedLog.WithError(err).Warning("Failed to delete XFRM state")
 			}
 		}
 	}
 }
 
-func ipsecDeleteXfrmPolicy(ip net.IP) {
+func ipsecDeleteXfrmPolicy(nodeID uint16) {
 	scopedLog := log.WithFields(logrus.Fields{
-		"remote-ip": ip,
+		logfields.NodeID: nodeID,
 	})
 
 	xfrmPolicyList, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
 	if err != nil {
-		scopedLog.WithError(err).Warning("deleting policy state, xfrm policy list error")
+		scopedLog.WithError(err).Warning("Failed to list XFRM policies for deletion")
+		return
 	}
 	for _, p := range xfrmPolicyList {
-		if ip.Equal(p.Dst.IP) {
+		if getNodeIDFromXfrmMark(p.Mark) == nodeID {
 			if err := netlink.XfrmPolicyDel(&p); err != nil {
-				scopedLog.WithError(err).Warning("deleting xfrm policy failed")
+				scopedLog.WithError(err).Warning("Failed to delete XFRM policy")
 			}
 		}
 	}
@@ -634,9 +642,9 @@ func UpsertIPsecEndpointPolicy(local, remote *net.IPNet, localTmpl, remoteTmpl n
 }
 
 // DeleteIPsecEndpoint deletes a endpoint associated with the remote IP address
-func DeleteIPsecEndpoint(remote net.IP) {
-	ipsecDeleteXfrmState(remote)
-	ipsecDeleteXfrmPolicy(remote)
+func DeleteIPsecEndpoint(nodeID uint16) {
+	ipsecDeleteXfrmState(nodeID)
+	ipsecDeleteXfrmPolicy(nodeID)
 }
 
 func isXfrmPolicyCilium(policy netlink.XfrmPolicy) bool {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -184,7 +184,6 @@ func xfrmStateReplace(new *netlink.XfrmState) error {
 	// Check if the XFRM state already exists
 	for _, s := range states {
 		if xfrmIPEqual(s.Src, new.Src) && xfrmIPEqual(s.Dst, new.Dst) &&
-			xfrmMarkEqual(s.OutputMark, new.OutputMark) &&
 			xfrmMarkEqual(s.Mark, new.Mark) && s.Spi == new.Spi {
 			return nil
 		}
@@ -209,7 +208,6 @@ func xfrmStateReplace(new *netlink.XfrmState) error {
 		// and can be removed in v1.15. Finally, this shouldn't happen with ENI
 		// and Azure IPAM modes because they don't have such conflicting states.
 		if xfrmIPEqual(s.Src, new.Src) && xfrmIPEqual(s.Dst, new.Dst) &&
-			xfrmMarkEqual(s.OutputMark, new.OutputMark) &&
 			xfrmMarkEqual(s.Mark, oldXFRMMark) && s.Spi == new.Spi {
 			err := netlink.XfrmStateDel(&s)
 			if err != nil {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -511,6 +511,13 @@ func ipSecReplacePolicyOut(src, dst *net.IPNet, tmplSrc, tmplDst net.IP, nodeID 
 	return netlink.XfrmPolicyUpdate(policy)
 }
 
+// Returns true if the given mark matches on the node ID. This works because
+// the node ID match is always in the first 16 bits.
+func matchesOnNodeID(mark *netlink.XfrmMark) bool {
+	return mark != nil &&
+		mark.Mask&linux_defaults.IPsecMarkMaskNodeID == linux_defaults.IPsecMarkMaskNodeID
+}
+
 func ipsecDeleteXfrmState(nodeID uint16) {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.NodeID: nodeID,
@@ -522,7 +529,7 @@ func ipsecDeleteXfrmState(nodeID uint16) {
 		return
 	}
 	for _, s := range xfrmStateList {
-		if getNodeIDFromXfrmMark(s.Mark) == nodeID {
+		if matchesOnNodeID(s.Mark) && getNodeIDFromXfrmMark(s.Mark) == nodeID {
 			if err := netlink.XfrmStateDel(&s); err != nil {
 				scopedLog.WithError(err).Warning("Failed to delete XFRM state")
 			}
@@ -541,7 +548,7 @@ func ipsecDeleteXfrmPolicy(nodeID uint16) {
 		return
 	}
 	for _, p := range xfrmPolicyList {
-		if getNodeIDFromXfrmMark(p.Mark) == nodeID {
+		if matchesOnNodeID(p.Mark) && getNodeIDFromXfrmMark(p.Mark) == nodeID {
 			if err := netlink.XfrmPolicyDel(&p); err != nil {
 				scopedLog.WithError(err).Warning("Failed to delete XFRM policy")
 			}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -975,7 +975,7 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 		}
 
 		if n.subnetEncryption() {
-			localIP, err = getV4LinkLocalIP()
+			localNodeInternalIP, err := getV4LinkLocalIP()
 			if err != nil {
 				log.WithError(err).Error("Failed to get local IPv4 for IPsec configuration")
 			}
@@ -987,7 +987,10 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 				}
 
 				spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
-				upsertIPsecLog(err, "in IPv4", wildcardCIDR, cidr, spi)
+				upsertIPsecLog(err, "in CiliumInternalIPv4", wildcardCIDR, cidr, spi)
+
+				spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localNodeInternalIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
+				upsertIPsecLog(err, "in NodeInternalIPv4", wildcardCIDR, cidr, spi)
 			}
 		} else {
 			localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
@@ -1052,14 +1055,17 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, zeroMark boo
 		}
 
 		if n.subnetEncryption() {
-			localIP, err = getV6LinkLocalIP()
+			localNodeInternalIP, err := getV6LinkLocalIP()
 			if err != nil {
 				log.WithError(err).Error("Failed to get local IPv6 for IPsec configuration")
 			}
 
 			for _, cidr := range n.nodeConfig.IPv6PodSubnets {
 				spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
-				upsertIPsecLog(err, "in IPv6", wildcardCIDR, cidr, spi)
+				upsertIPsecLog(err, "in CiliumInternalIPv6", wildcardCIDR, cidr, spi)
+
+				spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localNodeInternalIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
+				upsertIPsecLog(err, "in NodeInternalIPv6", wildcardCIDR, cidr, spi)
 			}
 		} else {
 			localCIDR := n.nodeAddressing.IPv6().AllocationCIDR().IPNet

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -920,57 +920,58 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 
 func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark bool) {
 	var spi uint8
-	var err error
 
-	if n.nodeConfig.EnableIPv4 && newNode.IPv4AllocCIDR != nil {
-		new4Net := newNode.IPv4AllocCIDR.IPNet
-		wildcardIP := net.ParseIP(wildcardIPv4)
-		wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
+	if !n.nodeConfig.EnableIPv4 || newNode.IPv4AllocCIDR == nil {
+		return
+	}
 
-		err = ipsec.IPsecDefaultDropPolicy(false)
-		upsertIPsecLog(err, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi)
+	new4Net := newNode.IPv4AllocCIDR.IPNet
+	wildcardIP := net.ParseIP(wildcardIPv4)
+	wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.IPv4Mask(0, 0, 0, 0)}
 
-		if newNode.IsLocal() {
-			n.replaceNodeIPSecInRoute(new4Net)
+	err := ipsec.IPsecDefaultDropPolicy(false)
+	upsertIPsecLog(err, "default-drop IPv4", wildcardCIDR, wildcardCIDR, spi)
 
-			if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
-				if n.subnetEncryption() {
-					for _, cidr := range n.nodeConfig.IPv4PodSubnets {
-						/* Insert wildcard policy rules for traffic skipping back through host */
-						if err = ipsec.IpSecReplacePolicyFwd(cidr, localIP); err != nil {
-							log.WithError(err).Warning("egress unable to replace policy fwd:")
-						}
+	if newNode.IsLocal() {
+		n.replaceNodeIPSecInRoute(new4Net)
 
-						spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
-						upsertIPsecLog(err, "in IPv4", wildcardCIDR, cidr, spi)
-					}
-				} else {
-					localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
-					spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
-					upsertIPsecLog(err, "in IPv4", localCIDR, wildcardCIDR, spi)
-				}
-			}
-		} else {
-			if remoteIP := newNode.GetCiliumInternalIP(false); remoteIP != nil {
-				localIP := n.nodeAddressing.IPv4().Router()
-				remoteNodeID := n.allocateIDForNode(newNode)
-
-				if n.subnetEncryption() {
-					for _, cidr := range n.nodeConfig.IPv4PodSubnets {
-						spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
-						upsertIPsecLog(err, "out IPv4", wildcardCIDR, cidr, spi)
-					}
-				} else {
-					localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
-					remoteCIDR := newNode.IPv4AllocCIDR.IPNet
-					n.replaceNodeIPSecOutRoute(new4Net)
-					spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
-					upsertIPsecLog(err, "out IPv4", localCIDR, remoteCIDR, spi)
-
+		if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
+			if n.subnetEncryption() {
+				for _, cidr := range n.nodeConfig.IPv4PodSubnets {
 					/* Insert wildcard policy rules for traffic skipping back through host */
-					if err = ipsec.IpSecReplacePolicyFwd(remoteCIDR, remoteIP); err != nil {
+					if err = ipsec.IpSecReplacePolicyFwd(cidr, localIP); err != nil {
 						log.WithError(err).Warning("egress unable to replace policy fwd:")
 					}
+
+					spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
+					upsertIPsecLog(err, "in IPv4", wildcardCIDR, cidr, spi)
+				}
+			} else {
+				localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
+				upsertIPsecLog(err, "in IPv4", localCIDR, wildcardCIDR, spi)
+			}
+		}
+	} else {
+		if remoteIP := newNode.GetCiliumInternalIP(false); remoteIP != nil {
+			localIP := n.nodeAddressing.IPv4().Router()
+			remoteNodeID := n.allocateIDForNode(newNode)
+
+			if n.subnetEncryption() {
+				for _, cidr := range n.nodeConfig.IPv4PodSubnets {
+					spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
+					upsertIPsecLog(err, "out IPv4", wildcardCIDR, cidr, spi)
+				}
+			} else {
+				localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
+				remoteCIDR := newNode.IPv4AllocCIDR.IPNet
+				n.replaceNodeIPSecOutRoute(new4Net)
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
+				upsertIPsecLog(err, "out IPv4", localCIDR, remoteCIDR, spi)
+
+				/* Insert wildcard policy rules for traffic skipping back through host */
+				if err = ipsec.IpSecReplacePolicyFwd(remoteCIDR, remoteIP); err != nil {
+					log.WithError(err).Warning("egress unable to replace policy fwd:")
 				}
 			}
 		}
@@ -979,48 +980,49 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 
 func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, zeroMark bool) {
 	var spi uint8
-	var err error
 
-	if n.nodeConfig.EnableIPv6 && newNode.IPv6AllocCIDR != nil {
-		new6Net := newNode.IPv6AllocCIDR.IPNet
-		wildcardIP := net.ParseIP(wildcardIPv6)
-		wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 128)}
+	if !n.nodeConfig.EnableIPv6 || newNode.IPv6AllocCIDR == nil {
+		return
+	}
 
-		err = ipsec.IPsecDefaultDropPolicy(true)
-		upsertIPsecLog(err, "default-drop IPv6", wildcardCIDR, wildcardCIDR, spi)
+	new6Net := newNode.IPv6AllocCIDR.IPNet
+	wildcardIP := net.ParseIP(wildcardIPv6)
+	wildcardCIDR := &net.IPNet{IP: wildcardIP, Mask: net.CIDRMask(0, 128)}
 
-		if newNode.IsLocal() {
-			n.replaceNodeIPSecInRoute(new6Net)
+	err := ipsec.IPsecDefaultDropPolicy(true)
+	upsertIPsecLog(err, "default-drop IPv6", wildcardCIDR, wildcardCIDR, spi)
 
-			if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
-				if n.subnetEncryption() {
-					for _, cidr := range n.nodeConfig.IPv6PodSubnets {
-						spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
-						upsertIPsecLog(err, "in IPv6", wildcardCIDR, cidr, spi)
-					}
-				} else {
-					localCIDR := n.nodeAddressing.IPv6().AllocationCIDR().IPNet
-					spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
-					upsertIPsecLog(err, "in IPv6", localCIDR, wildcardCIDR, spi)
+	if newNode.IsLocal() {
+		n.replaceNodeIPSecInRoute(new6Net)
+
+		if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
+			if n.subnetEncryption() {
+				for _, cidr := range n.nodeConfig.IPv6PodSubnets {
+					spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
+					upsertIPsecLog(err, "in IPv6", wildcardCIDR, cidr, spi)
 				}
+			} else {
+				localCIDR := n.nodeAddressing.IPv6().AllocationCIDR().IPNet
+				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
+				upsertIPsecLog(err, "in IPv6", localCIDR, wildcardCIDR, spi)
 			}
-		} else {
-			if remoteIP := newNode.GetCiliumInternalIP(true); remoteIP != nil {
-				localIP := n.nodeAddressing.IPv6().Router()
-				remoteNodeID := n.allocateIDForNode(newNode)
+		}
+	} else {
+		if remoteIP := newNode.GetCiliumInternalIP(true); remoteIP != nil {
+			localIP := n.nodeAddressing.IPv6().Router()
+			remoteNodeID := n.allocateIDForNode(newNode)
 
-				if n.subnetEncryption() {
-					for _, cidr := range n.nodeConfig.IPv6PodSubnets {
-						spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
-						upsertIPsecLog(err, "out IPv6", wildcardCIDR, cidr, spi)
-					}
-				} else {
-					localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
-					remoteCIDR := newNode.IPv6AllocCIDR.IPNet
-					n.replaceNodeIPSecOutRoute(new6Net)
-					spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
-					upsertIPsecLog(err, "out IPv6", localCIDR, remoteCIDR, spi)
+			if n.subnetEncryption() {
+				for _, cidr := range n.nodeConfig.IPv6PodSubnets {
+					spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
+					upsertIPsecLog(err, "out IPv6", wildcardCIDR, cidr, spi)
 				}
+			} else {
+				localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
+				remoteCIDR := newNode.IPv6AllocCIDR.IPNet
+				n.replaceNodeIPSecOutRoute(new6Net)
+				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
+				upsertIPsecLog(err, "out IPv6", localCIDR, remoteCIDR, spi)
 			}
 		}
 	}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -903,6 +903,40 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 	n.deleteNeighbor6(oldNode)
 }
 
+// getDefaultEncryptionInterface() is needed to find the interface used when
+// populating neighbor table and doing arpRequest. For most configurations
+// there is only a single interface so choosing [0] works by choosing the only
+// interface. However EKS, uses multiple interfaces, but fortunately for us
+// in EKS any interface would work so pick the [0] index here as well.
+func getDefaultEncryptionInterface() string {
+	iface := ""
+	if len(option.Config.EncryptInterface) > 0 {
+		iface = option.Config.EncryptInterface[0]
+	}
+	return iface
+}
+
+func getLinkLocalIP(family int) (net.IP, error) {
+	iface := getDefaultEncryptionInterface()
+	link, err := netlink.LinkByName(iface)
+	if err != nil {
+		return nil, err
+	}
+	addr, err := netlink.AddrList(link, family)
+	if err != nil {
+		return nil, err
+	}
+	return addr[0].IPNet.IP, nil
+}
+
+func getV4LinkLocalIP() (net.IP, error) {
+	return getLinkLocalIP(netlink.FAMILY_V4)
+}
+
+func getV6LinkLocalIP() (net.IP, error) {
+	return getLinkLocalIP(netlink.FAMILY_V6)
+}
+
 func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 	if newNode.IsLocal() {
 		n.replaceHostRules()
@@ -941,6 +975,11 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 		}
 
 		if n.subnetEncryption() {
+			localIP, err = getV4LinkLocalIP()
+			if err != nil {
+				log.WithError(err).Error("Failed to get local IPv4 for IPsec configuration")
+			}
+
 			for _, cidr := range n.nodeConfig.IPv4PodSubnets {
 				/* Insert wildcard policy rules for traffic skipping back through host */
 				if err = ipsec.IpSecReplacePolicyFwd(cidr, localIP); err != nil {
@@ -965,6 +1004,12 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 		remoteNodeID := n.allocateIDForNode(newNode)
 
 		if n.subnetEncryption() {
+			localIP, err = getV4LinkLocalIP()
+			if err != nil {
+				log.WithError(err).Error("Failed to get local IPv4 for IPsec configuration")
+			}
+			remoteIP = newNode.GetNodeIP(false)
+
 			for _, cidr := range n.nodeConfig.IPv4PodSubnets {
 				spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
 				upsertIPsecLog(err, "out IPv4", wildcardCIDR, cidr, spi)
@@ -1007,6 +1052,11 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, zeroMark boo
 		}
 
 		if n.subnetEncryption() {
+			localIP, err = getV6LinkLocalIP()
+			if err != nil {
+				log.WithError(err).Error("Failed to get local IPv6 for IPsec configuration")
+			}
+
 			for _, cidr := range n.nodeConfig.IPv6PodSubnets {
 				spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
 				upsertIPsecLog(err, "in IPv6", wildcardCIDR, cidr, spi)
@@ -1026,6 +1076,12 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, zeroMark boo
 		remoteNodeID := n.allocateIDForNode(newNode)
 
 		if n.subnetEncryption() {
+			localIP, err = getV6LinkLocalIP()
+			if err != nil {
+				log.WithError(err).Error("Failed to get local IPv6 for IPsec configuration")
+			}
+			remoteIP = newNode.GetNodeIP(true)
+
 			for _, cidr := range n.nodeConfig.IPv6PodSubnets {
 				spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
 				upsertIPsecLog(err, "out IPv6", wildcardCIDR, cidr, spi)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1504,8 +1504,9 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 	nodeID := n.getNodeIDForNode(oldNode)
 	if nodeID == 0 {
 		scopedLog.Warning("No node ID found for node.")
+	} else {
+		ipsec.DeleteIPsecEndpoint(nodeID)
 	}
-	ipsec.DeleteIPsecEndpoint(nodeID)
 
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
 		old4RouteNet := &net.IPNet{IP: oldNode.IPv4AllocCIDR.IP, Mask: oldNode.IPv4AllocCIDR.Mask}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -993,6 +993,11 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 				upsertIPsecLog(err, "in NodeInternalIPv4", wildcardCIDR, cidr, spi)
 			}
 		} else {
+			/* Insert wildcard policy rules for traffic skipping back through host */
+			if err = ipsec.IpSecReplacePolicyFwd(wildcardCIDR, localIP); err != nil {
+				log.WithError(err).Warning("egress unable to replace policy fwd:")
+			}
+
 			localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
 			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
 			upsertIPsecLog(err, "in IPv4", localCIDR, wildcardCIDR, spi)
@@ -1027,11 +1032,6 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 			n.replaceNodeIPSecOutRoute(new4Net)
 			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
 			upsertIPsecLog(err, "out IPv4", localCIDR, remoteCIDR, spi)
-
-			/* Insert wildcard policy rules for traffic skipping back through host */
-			if err = ipsec.IpSecReplacePolicyFwd(remoteCIDR, remoteIP); err != nil {
-				log.WithError(err).Warning("egress unable to replace policy fwd:")
-			}
 		}
 	}
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -935,44 +935,50 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 	if newNode.IsLocal() {
 		n.replaceNodeIPSecInRoute(new4Net)
 
-		if localIP := newNode.GetCiliumInternalIP(false); localIP != nil {
-			if n.subnetEncryption() {
-				for _, cidr := range n.nodeConfig.IPv4PodSubnets {
-					/* Insert wildcard policy rules for traffic skipping back through host */
-					if err = ipsec.IpSecReplacePolicyFwd(cidr, localIP); err != nil {
-						log.WithError(err).Warning("egress unable to replace policy fwd:")
-					}
-
-					spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
-					upsertIPsecLog(err, "in IPv4", wildcardCIDR, cidr, spi)
-				}
-			} else {
-				localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
-				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
-				upsertIPsecLog(err, "in IPv4", localCIDR, wildcardCIDR, spi)
-			}
+		localIP := newNode.GetCiliumInternalIP(false)
+		if localIP == nil {
+			return
 		}
-	} else {
-		if remoteIP := newNode.GetCiliumInternalIP(false); remoteIP != nil {
-			localIP := n.nodeAddressing.IPv4().Router()
-			remoteNodeID := n.allocateIDForNode(newNode)
 
-			if n.subnetEncryption() {
-				for _, cidr := range n.nodeConfig.IPv4PodSubnets {
-					spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
-					upsertIPsecLog(err, "out IPv4", wildcardCIDR, cidr, spi)
-				}
-			} else {
-				localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
-				remoteCIDR := newNode.IPv4AllocCIDR.IPNet
-				n.replaceNodeIPSecOutRoute(new4Net)
-				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
-				upsertIPsecLog(err, "out IPv4", localCIDR, remoteCIDR, spi)
-
+		if n.subnetEncryption() {
+			for _, cidr := range n.nodeConfig.IPv4PodSubnets {
 				/* Insert wildcard policy rules for traffic skipping back through host */
-				if err = ipsec.IpSecReplacePolicyFwd(remoteCIDR, remoteIP); err != nil {
+				if err = ipsec.IpSecReplacePolicyFwd(cidr, localIP); err != nil {
 					log.WithError(err).Warning("egress unable to replace policy fwd:")
 				}
+
+				spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
+				upsertIPsecLog(err, "in IPv4", wildcardCIDR, cidr, spi)
+			}
+		} else {
+			localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
+			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
+			upsertIPsecLog(err, "in IPv4", localCIDR, wildcardCIDR, spi)
+		}
+	} else {
+		remoteIP := newNode.GetCiliumInternalIP(false)
+		if remoteIP == nil {
+			return
+		}
+
+		localIP := n.nodeAddressing.IPv4().Router()
+		remoteNodeID := n.allocateIDForNode(newNode)
+
+		if n.subnetEncryption() {
+			for _, cidr := range n.nodeConfig.IPv4PodSubnets {
+				spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
+				upsertIPsecLog(err, "out IPv4", wildcardCIDR, cidr, spi)
+			}
+		} else {
+			localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
+			remoteCIDR := newNode.IPv4AllocCIDR.IPNet
+			n.replaceNodeIPSecOutRoute(new4Net)
+			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
+			upsertIPsecLog(err, "out IPv4", localCIDR, remoteCIDR, spi)
+
+			/* Insert wildcard policy rules for traffic skipping back through host */
+			if err = ipsec.IpSecReplacePolicyFwd(remoteCIDR, remoteIP); err != nil {
+				log.WithError(err).Warning("egress unable to replace policy fwd:")
 			}
 		}
 	}
@@ -995,35 +1001,41 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, zeroMark boo
 	if newNode.IsLocal() {
 		n.replaceNodeIPSecInRoute(new6Net)
 
-		if localIP := newNode.GetCiliumInternalIP(true); localIP != nil {
-			if n.subnetEncryption() {
-				for _, cidr := range n.nodeConfig.IPv6PodSubnets {
-					spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
-					upsertIPsecLog(err, "in IPv6", wildcardCIDR, cidr, spi)
-				}
-			} else {
-				localCIDR := n.nodeAddressing.IPv6().AllocationCIDR().IPNet
-				spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
-				upsertIPsecLog(err, "in IPv6", localCIDR, wildcardCIDR, spi)
+		localIP := newNode.GetCiliumInternalIP(true)
+		if localIP == nil {
+			return
+		}
+
+		if n.subnetEncryption() {
+			for _, cidr := range n.nodeConfig.IPv6PodSubnets {
+				spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, wildcardIP, 0, ipsec.IPSecDirIn, zeroMark)
+				upsertIPsecLog(err, "in IPv6", wildcardCIDR, cidr, spi)
 			}
+		} else {
+			localCIDR := n.nodeAddressing.IPv6().AllocationCIDR().IPNet
+			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
+			upsertIPsecLog(err, "in IPv6", localCIDR, wildcardCIDR, spi)
 		}
 	} else {
-		if remoteIP := newNode.GetCiliumInternalIP(true); remoteIP != nil {
-			localIP := n.nodeAddressing.IPv6().Router()
-			remoteNodeID := n.allocateIDForNode(newNode)
+		remoteIP := newNode.GetCiliumInternalIP(true)
+		if remoteIP == nil {
+			return
+		}
 
-			if n.subnetEncryption() {
-				for _, cidr := range n.nodeConfig.IPv6PodSubnets {
-					spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
-					upsertIPsecLog(err, "out IPv6", wildcardCIDR, cidr, spi)
-				}
-			} else {
-				localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
-				remoteCIDR := newNode.IPv6AllocCIDR.IPNet
-				n.replaceNodeIPSecOutRoute(new6Net)
-				spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
-				upsertIPsecLog(err, "out IPv6", localCIDR, remoteCIDR, spi)
+		localIP := n.nodeAddressing.IPv6().Router()
+		remoteNodeID := n.allocateIDForNode(newNode)
+
+		if n.subnetEncryption() {
+			for _, cidr := range n.nodeConfig.IPv6PodSubnets {
+				spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
+				upsertIPsecLog(err, "out IPv6", wildcardCIDR, cidr, spi)
 			}
+		} else {
+			localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
+			remoteCIDR := newNode.IPv6AllocCIDR.IPNet
+			n.replaceNodeIPSecOutRoute(new6Net)
+			spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
+			upsertIPsecLog(err, "out IPv6", localCIDR, remoteCIDR, spi)
 		}
 	}
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1510,7 +1510,11 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
 		old4RouteNet := &net.IPNet{IP: oldNode.IPv4AllocCIDR.IP, Mask: oldNode.IPv4AllocCIDR.Mask}
-		n.deleteNodeIPSecOutRoute(old4RouteNet)
+		// This is only needed in IPAM modes where we install one route per
+		// remote pod CIDR.
+		if !n.subnetEncryption() {
+			n.deleteNodeIPSecOutRoute(old4RouteNet)
+		}
 		if n.nodeConfig.EncryptNode {
 			if remoteIPv4 := oldNode.GetNodeIP(false); remoteIPv4 != nil {
 				exactMask := net.IPv4Mask(255, 255, 255, 255)
@@ -1522,7 +1526,10 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 
 	if n.nodeConfig.EnableIPv6 && oldNode.IPv6AllocCIDR != nil {
 		old6RouteNet := &net.IPNet{IP: oldNode.IPv6AllocCIDR.IP, Mask: oldNode.IPv6AllocCIDR.Mask}
-		n.deleteNodeIPSecOutRoute(old6RouteNet)
+		// See IPv4 case above.
+		if !n.subnetEncryption() {
+			n.deleteNodeIPSecOutRoute(old6RouteNet)
+		}
 		if n.nodeConfig.EncryptNode {
 			if remoteIPv6 := oldNode.GetNodeIP(true); remoteIPv6 != nil {
 				exactMask := net.CIDRMask(128, 128)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1498,11 +1498,18 @@ func (n *linuxNodeHandler) replaceNodeIPSecInRoute(ip *net.IPNet) {
 }
 
 func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
+	scopedLog := log.WithField(logfields.NodeName, oldNode.Name)
+	scopedLog.Debugf("Removing IPsec configuration for node")
+
+	nodeID := n.getNodeIDForNode(oldNode)
+	if nodeID == 0 {
+		scopedLog.Warning("No node ID found for node.")
+	}
+	ipsec.DeleteIPsecEndpoint(nodeID)
+
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
-		ciliumInternalIPv4 := oldNode.GetCiliumInternalIP(false)
 		old4RouteNet := &net.IPNet{IP: oldNode.IPv4AllocCIDR.IP, Mask: oldNode.IPv4AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old4RouteNet)
-		ipsec.DeleteIPsecEndpoint(ciliumInternalIPv4)
 		if n.nodeConfig.EncryptNode {
 			if remoteIPv4 := oldNode.GetNodeIP(false); remoteIPv4 != nil {
 				exactMask := net.IPv4Mask(255, 255, 255, 255)
@@ -1513,10 +1520,8 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 	}
 
 	if n.nodeConfig.EnableIPv6 && oldNode.IPv6AllocCIDR != nil {
-		ciliumInternalIPv6 := oldNode.GetCiliumInternalIP(true)
 		old6RouteNet := &net.IPNet{IP: oldNode.IPv6AllocCIDR.IP, Mask: oldNode.IPv6AllocCIDR.Mask}
 		n.deleteNodeIPSecOutRoute(old6RouteNet)
-		ipsec.DeleteIPsecEndpoint(ciliumInternalIPv6)
 		if n.nodeConfig.EncryptNode {
 			if remoteIPv6 := oldNode.GetNodeIP(true); remoteIPv6 != nil {
 				exactMask := net.CIDRMask(128, 128)

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -904,9 +904,6 @@ func (n *linuxNodeHandler) deleteNeighbor(oldNode *nodeTypes.Node) {
 }
 
 func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
-	var spi uint8
-	var err error
-
 	if newNode.IsLocal() {
 		n.replaceHostRules()
 	}
@@ -916,6 +913,14 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 	// to avoid confusion in netfilters and conntrack that may be using
 	// the mark fields. This uses XFRM_OUTPUT_MARK added in 4.14 kernels.
 	zeroMark := option.Config.EnableEndpointRoutes
+
+	n.enableIPsecIPv4(newNode, zeroMark)
+	n.enableIPsecIPv6(newNode, zeroMark)
+}
+
+func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark bool) {
+	var spi uint8
+	var err error
 
 	if n.nodeConfig.EnableIPv4 && newNode.IPv4AllocCIDR != nil {
 		new4Net := newNode.IPv4AllocCIDR.IPNet
@@ -970,6 +975,11 @@ func (n *linuxNodeHandler) enableIPsec(newNode *nodeTypes.Node) {
 			}
 		}
 	}
+}
+
+func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, zeroMark bool) {
+	var spi uint8
+	var err error
 
 	if n.nodeConfig.EnableIPv6 && newNode.IPv6AllocCIDR != nil {
 		new6Net := newNode.IPv6AllocCIDR.IPNet

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1007,11 +1007,15 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 		remoteNodeID := n.allocateIDForNode(newNode)
 
 		if n.subnetEncryption() {
-			localIP, err = getV4LinkLocalIP()
-			if err != nil {
-				log.WithError(err).Error("Failed to get local IPv4 for IPsec configuration")
+			// Check if we should use the NodeInternalIPs instead of the
+			// CiliumInternalIPs for the IPsec encapsulation.
+			if !option.Config.UseCiliumInternalIPForIPsec {
+				localIP, err = getV4LinkLocalIP()
+				if err != nil {
+					log.WithError(err).Error("Failed to get local IPv4 for IPsec configuration")
+				}
+				remoteIP = newNode.GetNodeIP(false)
 			}
-			remoteIP = newNode.GetNodeIP(false)
 
 			for _, cidr := range n.nodeConfig.IPv4PodSubnets {
 				spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)
@@ -1082,11 +1086,15 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, zeroMark boo
 		remoteNodeID := n.allocateIDForNode(newNode)
 
 		if n.subnetEncryption() {
-			localIP, err = getV6LinkLocalIP()
-			if err != nil {
-				log.WithError(err).Error("Failed to get local IPv6 for IPsec configuration")
+			// Check if we should use the NodeInternalIPs instead of the
+			// CiliumInternalIPs for the IPsec encapsulation.
+			if !option.Config.UseCiliumInternalIPForIPsec {
+				localIP, err = getV6LinkLocalIP()
+				if err != nil {
+					log.WithError(err).Error("Failed to get local IPv6 for IPsec configuration")
+				}
+				remoteIP = newNode.GetNodeIP(true)
 			}
-			remoteIP = newNode.GetNodeIP(true)
 
 			for _, cidr := range n.nodeConfig.IPv6PodSubnets {
 				spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, cidr, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, zeroMark)

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -65,19 +65,25 @@ func (n *linuxNodeHandler) AllocateNodeID(nodeIP net.IP) uint16 {
 	return nodeID
 }
 
-// allocateIDForNode allocates a new ID for the given node if one hasn't already
-// been assigned. If any of the node IPs have an ID associated, then all other
-// node IPs receive the same. This might happen if we allocated a node ID from
-// the ipcache, where we don't have all node IPs but only one.
-func (n *linuxNodeHandler) allocateIDForNode(node *nodeTypes.Node) uint16 {
+// getNodeIDForNode gets the node ID for the given node if one was allocated
+// for any of the node IP addresses. If none if found, 0 is returned.
+func (n *linuxNodeHandler) getNodeIDForNode(node *nodeTypes.Node) uint16 {
 	nodeID := uint16(0)
-
-	// Did we already allocate a node ID for any IP of that node?
 	for _, addr := range node.IPAddresses {
 		if id, exists := n.nodeIDsByIPs[addr.IP.String()]; exists {
 			nodeID = id
 		}
 	}
+	return nodeID
+}
+
+// allocateIDForNode allocates a new ID for the given node if one hasn't already
+// been assigned. If any of the node IPs have an ID associated, then all other
+// node IPs receive the same. This might happen if we allocated a node ID from
+// the ipcache, where we don't have all node IPs but only one.
+func (n *linuxNodeHandler) allocateIDForNode(node *nodeTypes.Node) uint16 {
+	// Did we already allocate a node ID for any IP of that node?
+	nodeID := n.getNodeIDForNode(node)
 
 	if nodeID == 0 {
 		nodeID = uint16(n.nodeIDs.AllocateID())

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -173,6 +173,9 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 		return nil
 	}
 
+	l.ipsecMu.Lock()
+	defer l.ipsecMu.Unlock()
+
 	interfaces := option.Config.EncryptInterface
 	if option.Config.IPAM == ipamOption.IPAMENI {
 		// IPAMENI mode supports multiple network facing interfaces that
@@ -446,8 +449,19 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		log.Warning("Cannot check matching of C and Go common struct alignments due to old LLVM/clang version")
 	}
 
-	if err := l.reinitializeIPSec(ctx); err != nil {
-		return err
+	if option.Config.EnableIPSec {
+		if err := compileNetwork(ctx); err != nil {
+			log.WithError(err).Fatal("failed to compile encryption programs")
+		}
+
+		if err := l.reinitializeIPSec(ctx); err != nil {
+			return err
+		}
+
+		if firstInitialization {
+			// Start a background worker to reinitialize IPsec if links change.
+			l.reloadIPSecOnLinkChanges()
+		}
 	}
 
 	if err := o.Datapath().Node().NodeConfigurationChanged(*o.LocalConfig()); err != nil {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -178,18 +178,17 @@ func (l *Loader) reinitializeIPSec(ctx context.Context) error {
 		// IPAMENI mode supports multiple network facing interfaces that
 		// will all need Encrypt logic applied in order to decrypt any
 		// received encrypted packets. This logic will attach to all
-		// !veth devices. Only use if user has not configured interfaces.
-		if len(interfaces) == 0 {
-			if links, err := netlink.LinkList(); err == nil {
-				for _, link := range links {
-					isVirtual, err := ethtool.IsVirtualDriver(link.Attrs().Name)
-					if err == nil && !isVirtual {
-						interfaces = append(interfaces, link.Attrs().Name)
-					}
+		// !veth devices.
+		interfaces = nil
+		if links, err := netlink.LinkList(); err == nil {
+			for _, link := range links {
+				isVirtual, err := ethtool.IsVirtualDriver(link.Attrs().Name)
+				if err == nil && !isVirtual {
+					interfaces = append(interfaces, link.Attrs().Name)
 				}
 			}
-			option.Config.EncryptInterface = interfaces
 		}
+		option.Config.EncryptInterface = interfaces
 	}
 
 	// No interfaces is valid in tunnel disabled case

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -7,10 +7,13 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/command/exec"
 	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/inctimer"
+	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
@@ -317,4 +320,75 @@ func setupBaseDevice(nativeDevs []netlink.Link, mode baseDeviceMode, mtu int) (n
 
 		return linkHost, linkNet, nil
 	}
+}
+
+// reloadIPSecOnLinkChanges subscribes to link changes to detect newly added devices
+// and reinitializes IPsec on changes. Only in effect for ENI mode in which we expect
+// new devices at runtime.
+func (l *Loader) reloadIPSecOnLinkChanges() {
+	// settleDuration is the amount of time to wait for further link updates
+	// before proceeding with reinitialization. This avoids back-to-back
+	// reinitialization when multiple link changes are made at once.
+	const settleDuration = 1 * time.Second
+
+	if !option.Config.EnableIPSec || option.Config.IPAM != ipamOption.IPAMENI {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	updates := make(chan netlink.LinkUpdate)
+
+	if err := netlink.LinkSubscribe(updates, ctx.Done()); err != nil {
+		log.WithError(err).Fatal("Failed to subscribe for link changes")
+	}
+
+	go func() {
+		defer cancel()
+
+		timer, stop := inctimer.New()
+		defer stop()
+
+		// If updates arrive during settle duration a single element
+		// is sent to this channel and we reinitialize right away
+		// without waiting for further updates.
+		trigger := make(chan struct{}, 1)
+
+		for {
+			// Wait for first update or trigger before reinitializing.
+			select {
+			case _, ok := <-updates:
+				if !ok {
+					return
+				}
+			case <-trigger:
+			}
+
+			log.Info("Reinitializing IPsec due to link changes")
+			err := l.reinitializeIPSec(ctx)
+			if err != nil {
+				// We may fail if links have been removed during the reload. In this case
+				// the updates channel will have queued updates which will retrigger the
+				// reinitialization.
+				log.WithError(err).Warn("Failed to reinitialize IPsec after device change")
+			}
+
+			// Avoid reinitializing repeatedly in short period of time
+			// by draining further updates for 'settleDuration'.
+			settled := timer.After(settleDuration)
+		settleLoop:
+			for {
+				select {
+				case <-settled:
+					break settleLoop
+				case <-updates:
+					select {
+					case trigger <- struct{}{}:
+					default:
+					}
+					break settleLoop
+				}
+
+			}
+		}
+	}()
 }

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -355,15 +355,20 @@ func (l *Loader) reloadIPSecOnLinkChanges() {
 
 		for {
 			// Wait for first update or trigger before reinitializing.
+		getUpdate:
 			select {
-			case _, ok := <-updates:
+			case u, ok := <-updates:
 				if !ok {
 					return
+				}
+				// Ignore veth devices
+				if u.Type() == "veth" {
+					goto getUpdate
 				}
 			case <-trigger:
 			}
 
-			log.Info("Reinitializing IPsec due to link changes")
+			log.Info("Reinitializing IPsec due to device changes")
 			err := l.reinitializeIPSec(ctx)
 			if err != nil {
 				// We may fail if links have been removed during the reload. In this case
@@ -380,12 +385,18 @@ func (l *Loader) reloadIPSecOnLinkChanges() {
 				select {
 				case <-settled:
 					break settleLoop
-				case <-updates:
+				case u := <-updates:
+					// Ignore veth devices
+					if u.Type() == "veth" {
+						continue
+					}
+
+					// Trigger reinit immediately after
+					// settle duration has passed.
 					select {
 					case trigger <- struct{}{}:
 					default:
 					}
-					break settleLoop
 				}
 
 			}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -455,6 +455,9 @@ const (
 	// EnableICMPRules enables ICMP-based rule support for Cilium Network Policies.
 	EnableICMPRules = false
 
+	// Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation.
+	UseCiliumInternalIPForIPsec = false
+
 	// TunnelPortVXLAN is the default VXLAN port
 	TunnelPortVXLAN = 8472
 	// TunnelPortGeneve is the default Geneve port

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1017,6 +1017,9 @@ const (
 	// EnableICMPRules enables ICMP-based rule support for Cilium Network Policies.
 	EnableICMPRules = "enable-icmp-rules"
 
+	// Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation.
+	UseCiliumInternalIPForIPsec = "use-cilium-internal-ip-for-ipsec"
+
 	// BypassIPAvailabilityUponRestore bypasses the IP availability error
 	// within IPAM upon endpoint restore and allows the use of the restored IP
 	// regardless of whether it's available in the pool.
@@ -2116,6 +2119,9 @@ type DaemonConfig struct {
 	// EnableICMPRules enables ICMP-based rule support for Cilium Network Policies.
 	EnableICMPRules bool
 
+	// Use the CiliumInternalIPs (vs. NodeInternalIPs) for IPsec encapsulation.
+	UseCiliumInternalIPForIPsec bool
+
 	// BypassIPAvailabilityUponRestore bypasses the IP availability error
 	// within IPAM upon endpoint restore and allows the use of the restored IP
 	// regardless of whether it's available in the pool.
@@ -2173,6 +2179,7 @@ var (
 		K8sEnableAPIDiscovery:        defaults.K8sEnableAPIDiscovery,
 		AllocatorListTimeout:         defaults.AllocatorListTimeout,
 		EnableICMPRules:              defaults.EnableICMPRules,
+		UseCiliumInternalIPForIPsec:  defaults.UseCiliumInternalIPForIPsec,
 
 		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 		APIRateLimit:                     make(map[string]string),
@@ -3024,6 +3031,7 @@ func (c *DaemonConfig) Populate() {
 	c.SelectiveRegeneration = viper.GetBool(SelectiveRegeneration)
 	c.DisableCNPStatusUpdates = viper.GetBool(DisableCNPStatusUpdates)
 	c.EnableICMPRules = viper.GetBool(EnableICMPRules)
+	c.UseCiliumInternalIPForIPsec = viper.GetBool(UseCiliumInternalIPForIPsec)
 	c.BypassIPAvailabilityUponRestore = viper.GetBool(BypassIPAvailabilityUponRestore)
 	c.EnableK8sTerminatingEndpoint = viper.GetBool(EnableK8sTerminatingEndpoint)
 	c.EnableStaleCiliumEndpointCleanup = viper.GetBool(EnableStaleCiliumEndpointCleanup)


### PR DESCRIPTION
 - [x] #25724 -- ipsec: Fix `XfrmInNoStates` drops on ESK & AKS upgrades (@pchaigno)
     - Minor conflicts in node.go due to https://github.com/cilium/cilium/pull/24208 not being in v1.11.
     - Trivial conflicts in config.go and daemon_main.go due to viper->vp change.
 - [x] #25744 -- ipsec: Reinitialize IPsec for new devices in ENI mode (@joamaki)
     - Trivial conflicts in includes and due to minor code movements in loader.go.
 - [x] #25784 -- ipsec: Fix leak of XFRM OUT policies (@pchaigno)
     - Trivial conflict in node_ids.go due to a new function added in main.
 - [x] #25735 -- ipsec: Fix `XfrmOutPolBlock` drops on upgrades (@pchaigno)
     - Minor conflict in includes of state.go.
 - [x] #25936 (@joamaki)
 - [x] #25953 (@pchaigno)
 - [x] #26072 (@pchaigno)
 - [x] #26093 (@pchaigno)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25724 25744 25784 25735 25936 25953 26072 26093; do contrib/backporting/set-labels.py $pr done 1.11; done
```