### PR TITLE
job,test: Improved reliability of `TestTimer_DoubleTrigger`

### DIFF
--- a/pkg/hive/job/job_test.go
+++ b/pkg/hive/job/job_test.go
@@ -442,11 +442,13 @@ func TestTimer_DoubleTrigger(t *testing.T) {
 
 		g.Add(
 			Timer("on-interval", func(ctx context.Context) error {
-				defer func() { close(ran) }()
+				defer func(iter int) {
+					if iter == 0 {
+						close(ran)
+					}
+				}(i)
 
 				i++
-
-				time.Sleep(100 * time.Millisecond)
 
 				return nil
 			}, 1*time.Hour, WithTrigger(trigger)),
@@ -455,13 +457,15 @@ func TestTimer_DoubleTrigger(t *testing.T) {
 		l.Append(g)
 	})
 
+	// Trigger a few times before we start consuming events, these should coalesce
+	trigger.Trigger()
+	trigger.Trigger()
+	trigger.Trigger()
+
 	if err := h.Start(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 
-	trigger.Trigger()
-	trigger.Trigger()
-	trigger.Trigger()
 	<-ran
 
 	if err := h.Stop(context.Background()); err != nil {


### PR DESCRIPTION
There existed an edge case in this test which caused it to flake:
```
panic: close of closed channel

goroutine 106 [running]:
github.com/cilium/cilium/pkg/hive/job.TestTimer_DoubleTrigger.func1()
	/home/runner/work/cilium/cilium/pkg/hive/job/job_test.go:445 +0x1d
```

This PR moves the triggering of the timer to before the hive starts to ensure they are all processes before the timer has a chance to start consuming them. Also added a guard around the closing of the channel so we don't panic if the test were to fail for another reason.

```release-note
Improved reliability of pkg/hive/job timer double trigger unit test
```
