### PR TITLE
mutual-auth: Support spire k8s service dns resolution

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -344,6 +344,8 @@ jobs:
             --helm-set=hubble.relay.image.tag=${SHA} \
             --helm-set=hubble.eventBufferCapacity=65535 \
             --helm-set=bpf.monitorAggregation=none \
+            --helm-set=authentication.mutual.spire.enabled=true \
+            --helm-set=authentication.mutual.spire.install.enabled=true \
             --nodes-without-cilium=kind-worker3 \
             --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
           TUNNEL="--helm-set-string=tunnelProtocol=${{ matrix.tunnel }}"
@@ -460,8 +462,11 @@ jobs:
             fi
 
             CILIUM_CLI_MODE=helm ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
+            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
+            kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
 
             ./cilium-cli status --wait
+            kubectl get pods --all-namespaces -o wide
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
             mkdir -p cilium-junits

--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -67,8 +67,8 @@ cilium-operator-alibabacloud [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -28,8 +28,8 @@ cilium-operator-alibabacloud hive [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -33,8 +33,8 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -75,8 +75,8 @@ cilium-operator-aws [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -28,8 +28,8 @@ cilium-operator-aws hive [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -33,8 +33,8 @@ cilium-operator-aws hive dot-graph [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -70,8 +70,8 @@ cilium-operator-azure [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -28,8 +28,8 @@ cilium-operator-azure hive [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -33,8 +33,8 @@ cilium-operator-azure hive dot-graph [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -66,8 +66,8 @@ cilium-operator-generic [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -28,8 +28,8 @@ cilium-operator-generic hive [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -33,8 +33,8 @@ cilium-operator-generic hive dot-graph [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -80,8 +80,8 @@ cilium-operator [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --nodes-gc-interval duration                           GC interval for CiliumNodes (default 5m0s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -28,8 +28,8 @@ cilium-operator hive [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -33,8 +33,8 @@ cilium-operator hive dot-graph [flags]
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server.
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")
-      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc.cluster.local:8081")
-      --mesh-auth-spire-server-connection-timeout duration   SPIRE server endpoint. (default 10s)
+      --mesh-auth-spire-server-address string                SPIRE server endpoint. (default "spire-server.spire.svc:8081")
+      --mesh-auth-spire-server-connection-timeout duration   SPIRE server connection timeout. (default 10s)
       --operator-api-serve-addr string                       Address to serve API requests (default "localhost:9234")
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -149,9 +149,9 @@
      - object
      - ``{"create":true,"name":"spire-server"}``
    * - authentication.mutual.spire.serverAddress
-     - SPIRE server address
+     - SPIRE server address used by Cilium Operator  If k8s Service DNS along with port number is used (e.g. :raw-html-m2r:`<service-name>`.\ :raw-html-m2r:`<namespace>`.svc(.*):\ :raw-html-m2r:`<port-number>` format), Cilium Operator will resolve its address by looking up the clusterIP from Service resource.  Example values: 10.0.0.1:8081, spire-server.cilium-spire.svc:8081
      - string
-     - ``"spire-server.cilium-spire.svc:8081"``
+     - ``nil``
    * - authentication.mutual.spire.trustDomain
      - SPIFFE trust domain to use for fetching certificates
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -296,6 +296,7 @@ clientsets
 clockProbe
 cls
 clusterDomain
+clusterIP
 clusterPoolIPv
 clusterSize
 clustermesh

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -87,7 +87,7 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.install.server.service.labels | object | `{}` | Labels to be added to the SPIRE server service |
 | authentication.mutual.spire.install.server.service.type | string | `"ClusterIP"` | Service type for the SPIRE server service |
 | authentication.mutual.spire.install.server.serviceAccount | object | `{"create":true,"name":"spire-server"}` | SPIRE server service account |
-| authentication.mutual.spire.serverAddress | string | `"spire-server.cilium-spire.svc:8081"` | SPIRE server address |
+| authentication.mutual.spire.serverAddress | string | `nil` | SPIRE server address used by Cilium Operator  If k8s Service DNS along with port number is used (e.g. <service-name>.<namespace>.svc(.*):<port-number> format), Cilium Operator will resolve its address by looking up the clusterIP from Service resource.  Example values: 10.0.0.1:8081, spire-server.cilium-spire.svc:8081 |
 | authentication.mutual.spire.trustDomain | string | `"spiffe.cilium"` | SPIFFE trust domain to use for fetching certificates |
 | authentication.queueSize | int | `1024` | Buffer size of the channel Cilium uses to receive authentication events from the signal map. |
 | authentication.rotatedIdentitiesQueueSize | int | `1024` | Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers. |

--- a/install/kubernetes/cilium/files/spire/wait-for-spire.bash
+++ b/install/kubernetes/cilium/files/spire/wait-for-spire.bash
@@ -2,7 +2,11 @@ set -e
 
 echo "Waiting for spire server to be reachable to start"
 
+{{- if .Values.authentication.mutual.spire.serverAddress }}
 ADDR="{{ .Values.authentication.mutual.spire.serverAddress }}"
+{{- else }}
+ADDR="spire-server.{{ .Values.authentication.mutual.spire.install.namespace}}.svc:8081"
+{{- end }}
 CONN_TIMEOUT="3"
 TIMEOUT="60"
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1098,7 +1098,11 @@ data:
   mesh-auth-mutual-enabled: "true"
   mesh-auth-mutual-listener-port: {{ .Values.authentication.mutual.port | quote }}
   mesh-auth-spire-agent-socket: {{ .Values.authentication.mutual.spire.agentSocketPath | quote }}
+  {{- if .Values.authentication.mutual.spire.serverAddress }}
   mesh-auth-spire-server-address: {{ .Values.authentication.mutual.spire.serverAddress | quote }}
+  {{- else }}
+  mesh-auth-spire-server-address: "spire-server.{{ .Values.authentication.mutual.spire.install.namespace}}.svc:8081"
+  {{- end }}
   mesh-auth-spire-server-connection-timeout: {{ .Values.authentication.mutual.spire.connectionTimeout }}
   mesh-auth-spire-admin-socket: {{ .Values.authentication.mutual.spire.adminSocketPath | quote }}
   mesh-auth-spiffe-trust-domain: {{ .Values.authentication.mutual.spire.trustDomain | quote }}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -239,9 +239,9 @@ spec:
         {{- end }}
         terminationMessagePolicy: FallbackToLogsOnError
       hostNetwork: true
-      {{- if or (and .Values.etcd.managed (not .Values.etcd.k8sService)) .Values.authentication.mutual.spire.enabled }}
-      # Cilium must be able to resolve the DNS name of the etcd service in managed etcd mode,
-      # and the DNS name of the SPIRE server in mTLS mode.
+      {{- if and .Values.etcd.managed (not .Values.etcd.k8sService) }}
+      # In managed etcd mode, Cilium must be able to resolve the DNS name of
+      # the etcd service
       dnsPolicy: ClusterFirstWithHostNet
       {{- else if .Values.operator.dnsPolicy }}
       dnsPolicy: {{ .Values.operator.dnsPolicy }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3051,8 +3051,13 @@ authentication:
               country: "US"
               organization: "SPIRE"
               commonName: "Cilium SPIRE CA"
-      # -- SPIRE server address
-      serverAddress: spire-server.cilium-spire.svc:8081
+      # -- SPIRE server address used by Cilium Operator
+      #
+      # If k8s Service DNS along with port number is used (e.g. <service-name>.<namespace>.svc(.*):<port-number> format),
+      # Cilium Operator will resolve its address by looking up the clusterIP from Service resource.
+      #
+      # Example values: 10.0.0.1:8081, spire-server.cilium-spire.svc:8081
+      serverAddress: ~
       # -- SPIFFE trust domain to use for fetching certificates
       trustDomain: spiffe.cilium
       # -- SPIRE socket path where the SPIRE delegated api agent is listening

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3048,8 +3048,13 @@ authentication:
               country: "US"
               organization: "SPIRE"
               commonName: "Cilium SPIRE CA"
-      # -- SPIRE server address
-      serverAddress: spire-server.cilium-spire.svc:8081
+      # -- SPIRE server address used by Cilium Operator
+      #
+      # If k8s Service DNS along with port number is used (e.g. <service-name>.<namespace>.svc(.*):<port-number> format),
+      # Cilium Operator will resolve its address by looking up the clusterIP from Service resource.
+      #
+      # Example values: 10.0.0.1:8081, spire-server.cilium-spire.svc:8081
+      serverAddress: ~
       # -- SPIFFE trust domain to use for fetching certificates
       trustDomain: spiffe.cilium
       # -- SPIRE socket path where the SPIRE delegated api agent is listening

--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -75,12 +75,12 @@ func (cfg ClientConfig) Flags(flags *pflag.FlagSet) {
 		"The path for the SPIRE admin agent Unix socket.")
 	flags.StringVar(&cfg.SpireServerAddress,
 		"mesh-auth-spire-server-address",
-		"spire-server.spire.svc.cluster.local:8081",
+		"spire-server.spire.svc:8081",
 		"SPIRE server endpoint.")
 	flags.DurationVar(&cfg.SpireServerConnectionTimeout,
 		"mesh-auth-spire-server-connection-timeout",
 		10*time.Second,
-		"SPIRE server endpoint.")
+		"SPIRE server connection timeout.")
 	flags.StringVar(&cfg.SpiffeTrustDomain,
 		"mesh-auth-spiffe-trust-domain",
 		"spiffe.cilium",

--- a/operator/auth/spire/client_test.go
+++ b/operator/auth/spire/client_test.go
@@ -6,12 +6,17 @@ package spire
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 
 	entryv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/server/entry/v1"
 	"github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/k8s/client"
 )
 
 type mockEntryClient struct {
@@ -399,4 +404,82 @@ func TestClient_Delete(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_resolvedK8sService(t *testing.T) {
+	_, c := client.NewFakeClientset()
+	_, _ = c.CoreV1().Services("dummy-namespace").Create(context.Background(), &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "valid-service",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "10.0.0.1",
+		},
+		Status: corev1.ServiceStatus{},
+	}, metav1.CreateOptions{})
+	type args struct {
+		client  client.Clientset
+		address string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      *string
+		wantedErr error
+	}{
+		{
+			name: "address not following <service-name>.<ns>.svc(.*) format",
+			args: args{
+				address: "192.168.0.1:8081",
+			},
+			want: addressOf("192.168.0.1:8081"),
+		},
+		{
+			name: "another address not following <service-name>.<ns>.svc(.*) format",
+			args: args{
+				address: "my-spire-server.com:8081",
+			},
+			want: addressOf("my-spire-server.com:8081"),
+		},
+		{
+			name: "invalid service dns",
+			args: args{
+				address: "dummy-service.ns.svc:8081",
+				client:  c,
+			},
+			wantedErr: fmt.Errorf("services \"dummy-service\" not found"),
+		},
+		{
+			name: "valid k8s service dns, but no port",
+			args: args{
+				address: "valid-service.dummy-namespace.svc",
+				client:  c,
+			},
+			wantedErr: fmt.Errorf("address valid-service.dummy-namespace.svc: missing port in address"),
+		},
+		{
+			name: "valid k8s service dns",
+			args: args{
+				address: "valid-service.dummy-namespace.svc:8081",
+				client:  c,
+			},
+			want: addressOf("10.0.0.1:8081"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolvedK8sService(context.Background(), tt.args.client, tt.args.address)
+			if tt.wantedErr != nil && (err == nil || !reflect.DeepEqual(err.Error(), tt.wantedErr.Error())) {
+				t.Errorf("resolvedK8sService() error = %v, wantErr %v", err, tt.wantedErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("resolvedK8sService() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func addressOf[T any](v T) *T {
+	return &v
 }

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -121,6 +121,9 @@ const (
 	// NextHop is an IPV4 or IPv6 address for the next hop
 	NextHop = "nextHop"
 
+	// Address is an IPV4, IPv6 or FQDN address
+	Address = "address"
+
 	// IPAddr is an IPV4 or IPv6 address
 	IPAddr = "ipAddr"
 


### PR DESCRIPTION
### Description

Please refer to individual commits for more details.

### Testing

Testing with the temp commit, the conformance-e2e is running successfully.

https://github.com/cilium/cilium/actions/runs/5220420030/jobs/9423492566?pr=26031
