### PR TITLE
Documentation: add CONFIG_SCHEDSTATS to required kconfigs

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -183,6 +183,7 @@ linked, either choice is valid.
         CONFIG_CGROUPS=y
         CONFIG_CGROUP_BPF=y
         CONFIG_PERF_EVENTS=y
+        CONFIG_SCHEDSTATS=y
 
 
 Requirements for Iptables-based Masquerading


### PR DESCRIPTION
This is a follow-up to https://github.com/cilium/cilium/pull/25795#issuecomment-1570929677.

Commit 8531c5a7da ("bpf,datapath: read jiffies from /proc/schedstat") changed the way the kernel jiffy value is obtained. This procfs file is gated behind CONFIG_SCHEDSTATS.

```release-note
Documentation: add CONFIG_SCHEDSTATS to required kconfigs
```
