### PR TITLE
Envoy resource namespacing

### DIFF
--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -256,24 +256,6 @@ func newTransportSocket(ciliumSecretNamespace string, tls []model.TLSSecret) (*e
 	for k := range tlsMap {
 		tlsSdsConfig = append(tlsSdsConfig, &envoy_extensions_transport_sockets_tls_v3.SdsSecretConfig{
 			Name: k,
-			SdsConfig: &envoy_config_core_v3.ConfigSource{
-				ConfigSourceSpecifier: &envoy_config_core_v3.ConfigSource_ApiConfigSource{
-					ApiConfigSource: &envoy_config_core_v3.ApiConfigSource{
-						ApiType:             envoy_config_core_v3.ApiConfigSource_GRPC,
-						TransportApiVersion: envoy_config_core_v3.ApiVersion_V3,
-						GrpcServices: []*envoy_config_core_v3.GrpcService{
-							{
-								TargetSpecifier: &envoy_config_core_v3.GrpcService_EnvoyGrpc_{
-									EnvoyGrpc: &envoy_config_core_v3.GrpcService_EnvoyGrpc{
-										ClusterName: envoy.CiliumXDSClusterName,
-									},
-								},
-							},
-						},
-					},
-				},
-				ResourceApiVersion: envoy_config_core_v3.ApiVersion_V3,
-			},
 		})
 	}
 

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -24,7 +24,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/pkg/model"
-	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
@@ -183,24 +182,6 @@ func toSecureListenerFilterChain(serverNames []string, certName string) *envoy_c
 						TlsCertificateSdsSecretConfigs: []*envoy_extensions_transport_sockets_tls_v3.SdsSecretConfig{
 							{
 								Name: certName,
-								SdsConfig: &envoy_config_core_v3.ConfigSource{
-									ConfigSourceSpecifier: &envoy_config_core_v3.ConfigSource_ApiConfigSource{
-										ApiConfigSource: &envoy_config_core_v3.ApiConfigSource{
-											ApiType:             envoy_config_core_v3.ApiConfigSource_GRPC,
-											TransportApiVersion: envoy_config_core_v3.ApiVersion_V3,
-											GrpcServices: []*envoy_config_core_v3.GrpcService{
-												{
-													TargetSpecifier: &envoy_config_core_v3.GrpcService_EnvoyGrpc_{
-														EnvoyGrpc: &envoy_config_core_v3.GrpcService_EnvoyGrpc{
-															ClusterName: envoy.CiliumXDSClusterName,
-														},
-													},
-												},
-											},
-										},
-									},
-									ResourceApiVersion: envoy_config_core_v3.ApiVersion_V3,
-								},
 							},
 						},
 					},

--- a/operator/pkg/model/translation/translator_test.go
+++ b/operator/pkg/model/translation/translator_test.go
@@ -244,7 +244,7 @@ func TestSharedIngressTranslator_getHTTPRouteListener(t *testing.T) {
 
 	require.Len(t, downStreamTLS.CommonTlsContext.TlsCertificateSdsSecretConfigs, 1)
 	require.Equal(t, downStreamTLS.CommonTlsContext.TlsCertificateSdsSecretConfigs[0].GetName(), "cilium-secrets/dummy-namespace-dummy-secret")
-	require.NotNil(t, downStreamTLS.CommonTlsContext.TlsCertificateSdsSecretConfigs[0].GetSdsConfig())
+	require.Nil(t, downStreamTLS.CommonTlsContext.TlsCertificateSdsSecretConfigs[0].GetSdsConfig())
 }
 
 func TestSharedIngressTranslator_getClusters(t *testing.T) {

--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -265,6 +265,11 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 			name := listener.Name
 			listener.Name = api.ResourceQualifiedName(cecNamespace, cecName, listener.Name, api.ForceNamespace)
 
+			if validate {
+				if err := listener.Validate(); err != nil {
+					return Resources{}, fmt.Errorf("ParseResources: Could not validate Listener (%s): %s", err, listener.String())
+				}
+			}
 			resources.Listeners = append(resources.Listeners, listener)
 
 			log.Debugf("ParseResources: Parsed listener %q: %v", name, listener)

--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -175,7 +175,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 							// Since we are prepending CEC namespace and name to Routes name,
 							// we must do the same here to point to the correct Route resource.
 							if rds.RouteConfigName != "" {
-								rds.RouteConfigName = api.ResourceQualifiedName(cecNamespace, cecName, rds.RouteConfigName)
+								rds.RouteConfigName = api.ResourceQualifiedName(cecNamespace, cecName, rds.RouteConfigName, api.ForceNamespace)
 								updated = true
 							}
 							if rds.ConfigSource == nil {
@@ -238,7 +238,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 			}
 
 			name := listener.Name
-			listener.Name = api.ResourceQualifiedName(cecNamespace, cecName, listener.Name)
+			listener.Name = api.ResourceQualifiedName(cecNamespace, cecName, listener.Name, api.ForceNamespace)
 			resources.Listeners = append(resources.Listeners, listener)
 
 			log.Debugf("ParseResources: Parsed listener %q: %v", name, listener)
@@ -264,7 +264,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 			}
 
 			name := route.Name
-			route.Name = api.ResourceQualifiedName(cecNamespace, cecName, route.Name)
+			route.Name = api.ResourceQualifiedName(cecNamespace, cecName, route.Name, api.ForceNamespace)
 			resources.Routes = append(resources.Routes, route)
 
 			log.Debugf("ParseResources: Parsed route %q: %v", name, route)

--- a/pkg/k8s/watchers/cilium_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_envoy_config.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -163,10 +164,15 @@ func getServiceName(resourceName loadbalancer.ServiceName, name, namespace strin
 func (k *K8sWatcher) addK8sServiceRedirects(resourceName loadbalancer.ServiceName, spec *cilium_v2.CiliumEnvoyConfigSpec, resources envoy.Resources) error {
 	// Redirect k8s services to an Envoy listener
 	for _, svc := range spec.Services {
+		svcListener := ""
+		if svc.Listener != "" {
+			// Listener names are qualified after parsing, so qualify the listener reference as well for it to match
+			svcListener = api.ResourceQualifiedName(resourceName.Namespace, resourceName.Name, svc.Listener)
+		}
 		// Find the listener the service is to be redirected to
 		var proxyPort uint16
 		for _, l := range resources.Listeners {
-			if svc.Listener == "" || l.Name == svc.Listener {
+			if svc.Listener == "" || l.Name == svcListener {
 				if addr := l.GetAddress(); addr != nil {
 					if sa := addr.GetSocketAddress(); sa != nil {
 						proxyPort = uint16(sa.GetPortValue())

--- a/pkg/k8s/watchers/cilium_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_envoy_config.go
@@ -167,7 +167,7 @@ func (k *K8sWatcher) addK8sServiceRedirects(resourceName loadbalancer.ServiceNam
 		svcListener := ""
 		if svc.Listener != "" {
 			// Listener names are qualified after parsing, so qualify the listener reference as well for it to match
-			svcListener = api.ResourceQualifiedName(resourceName.Namespace, resourceName.Name, svc.Listener)
+			svcListener = api.ResourceQualifiedName(resourceName.Namespace, resourceName.Name, svc.Listener, api.ForceNamespace)
 		}
 		// Find the listener the service is to be redirected to
 		var proxyPort uint16

--- a/pkg/k8s/watchers/cilium_envoy_config_test.go
+++ b/pkg/k8s/watchers/cilium_envoy_config_test.go
@@ -67,6 +67,7 @@ func (s *K8sWatcherSuite) TestParseEnvoySpec(c *C) {
 	c.Assert(resources.Listeners, HasLen, 1)
 	c.Assert(resources.Listeners[0].Address.GetSocketAddress().GetPortValue(), Equals, uint32(10000))
 	c.Assert(resources.Listeners[0].FilterChains, HasLen, 1)
+	c.Assert(resources.Listeners[0].Name, Equals, "namespace/name/envoy-prometheus-metrics-listener")
 	chain := resources.Listeners[0].FilterChains[0]
 	c.Assert(chain.Filters, HasLen, 1)
 	c.Assert(chain.Filters[0].Name, Equals, "envoy.filters.network.http_connection_manager")

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -802,7 +802,7 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints api.EndpointSelectorS
 				ns = ""
 			default:
 			}
-			l4.Listener = api.ResourceQualifiedName(ns, resource.Name, pr.Listener.Name)
+			l4.Listener = api.ResourceQualifiedName(ns, resource.Name, pr.Listener.Name, api.ForceNamespace)
 			forceRedirect = true
 		}
 	}

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -1143,7 +1143,7 @@ func (ds *PolicyTestSuite) TestMergeListenerPolicy(c *C) {
 				isRedirect:      true,
 			},
 		},
-		Listener: "shared-cec/test",
+		Listener: "/shared-cec/test",
 		Ingress:  false,
 		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
 			cachedSelectorA: {nil},
@@ -1308,7 +1308,7 @@ func (ds *PolicyTestSuite) TestMergeListenerPolicy(c *C) {
 				isRedirect:      true,
 			},
 		},
-		Listener: "shared-cec/test",
+		Listener: "/shared-cec/test",
 		Ingress:  false,
 		RuleOrigin: map[CachedSelector]labels.LabelArrayList{
 			cachedSelectorA: {nil},


### PR DESCRIPTION
Qualify cluster names that are not already qualified. This helps avoid
accidental resource name collision when multiple CiliumEnvoyConfigs are
defined.
