### PR TITLE
docs: cleanup SPIRE & Envoy values in helm reference

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -64,14 +64,6 @@
      - Enable SPIRE integration
      - bool
      - ``false``
-   * - authentication.mutual.spire.install
-     - Settings to control the SPIRE installation and configuration
-     - object
-     - ``{"agent":{"annotations":{},"image":"ghcr.io/spiffe/spire-agent:1.6.3@sha256:8eef9857bf223181ecef10d9bbcd2f7838f3689e9bd2445bede35066a732e823","labels":{},"serviceAccount":{"create":true,"name":"spire-agent"},"skipKubeletVerification":true},"enabled":false,"namespace":"cilium-spire","server":{"annotations":{},"ca":{"keyType":"rsa-4096","subject":{"commonName":"Cilium SPIRE CA","country":"US","organization":"SPIRE"}},"dataStorage":{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":null},"image":"ghcr.io/spiffe/spire-server:1.6.3@sha256:f4bc49fb0bd1d817a6c46204cc7ce943c73fb0a5496a78e0e4dc20c9a816ad7f","initContainers":[],"labels":{},"service":{"annotations":{},"labels":{},"type":"ClusterIP"},"serviceAccount":{"create":true,"name":"spire-server"}}}``
-   * - authentication.mutual.spire.install.agent
-     - SPIRE agent configuration
-     - object
-     - ``{"annotations":{},"image":"ghcr.io/spiffe/spire-agent:1.6.3@sha256:8eef9857bf223181ecef10d9bbcd2f7838f3689e9bd2445bede35066a732e823","labels":{},"serviceAccount":{"create":true,"name":"spire-agent"},"skipKubeletVerification":true}``
    * - authentication.mutual.spire.install.agent.annotations
      - SPIRE agent annotations
      - object
@@ -104,10 +96,6 @@
      - SPIRE server annotations
      - object
      - ``{}``
-   * - authentication.mutual.spire.install.server.ca
-     - SPIRE CA configuration
-     - object
-     - ``{"keyType":"rsa-4096","subject":{"commonName":"Cilium SPIRE CA","country":"US","organization":"SPIRE"}}``
    * - authentication.mutual.spire.install.server.ca.keyType
      - SPIRE CA key type AWS requires the use of RSA. EC cryptography is not supported
      - string
@@ -116,10 +104,22 @@
      - SPIRE CA Subject
      - object
      - ``{"commonName":"Cilium SPIRE CA","country":"US","organization":"SPIRE"}``
-   * - authentication.mutual.spire.install.server.dataStorage
-     - SPIRE server datastorage configuration
-     - object
-     - ``{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":null}``
+   * - authentication.mutual.spire.install.server.dataStorage.accessMode
+     - Access mode of the SPIRE server data storage
+     - string
+     - ``"ReadWriteOnce"``
+   * - authentication.mutual.spire.install.server.dataStorage.enabled
+     - Enable SPIRE server data storage
+     - bool
+     - ``true``
+   * - authentication.mutual.spire.install.server.dataStorage.size
+     - Size of the SPIRE server data storage
+     - string
+     - ``"1Gi"``
+   * - authentication.mutual.spire.install.server.dataStorage.storageClass
+     - StorageClass of the SPIRE server data storage
+     - string
+     - ``nil``
    * - authentication.mutual.spire.install.server.image
      - SPIRE server image
      - string
@@ -132,10 +132,18 @@
      - SPIRE server labels
      - object
      - ``{}``
-   * - authentication.mutual.spire.install.server.service
-     - SPIRE server service configuration
+   * - authentication.mutual.spire.install.server.service.annotations
+     - Annotations to be added to the SPIRE server service
      - object
-     - ``{"annotations":{},"labels":{},"type":"ClusterIP"}``
+     - ``{}``
+   * - authentication.mutual.spire.install.server.service.labels
+     - Labels to be added to the SPIRE server service
+     - object
+     - ``{}``
+   * - authentication.mutual.spire.install.server.service.type
+     - Service type for the SPIRE server service
+     - string
+     - ``"ClusterIP"``
    * - authentication.mutual.spire.install.server.serviceAccount
      - SPIRE server service account
      - object

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -904,18 +904,22 @@
      - Update ENI Adapter limits from the EC2 API
      - bool
      - ``true``
-   * - envoy
-     - Configure Cilium Envoy options.
-     - object
-     - ``{"affinity":{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium-envoy"}},"topologyKey":"kubernetes.io/hostname"}]}},"connectTimeoutSeconds":2,"dnsPolicy":null,"enabled":false,"extraArgs":[],"extraContainers":[],"extraEnv":[],"extraHostPathMounts":[],"extraVolumeMounts":[],"extraVolumes":[],"healthPort":9878,"idleTimeoutDurationSeconds":60,"image":{"digest":"sha256:f165787c05050a4d57c5940dcd59de03cafecff9c02965a1d076c2b2935505d8","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.25.7-384b5008dce426eba89af8ef17f52e4fb066ff40","useDigest":true},"livenessProbe":{"failureThreshold":10,"periodSeconds":30},"log":{"format":"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v","path":""},"maxConnectionDurationSeconds":0,"maxRequestsPerConnection":0,"nodeSelector":{"kubernetes.io/os":"linux"},"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"priorityClassName":null,"prometheus":{"enabled":true,"port":"9964","serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}},"readinessProbe":{"failureThreshold":3,"periodSeconds":30},"resources":{},"rollOutPods":false,"securityContext":{"capabilities":{"envoy":["NET_ADMIN","SYS_ADMIN"]},"privileged":false,"seLinuxOptions":{"level":"s0","type":"spc_t"}},"startupProbe":{"failureThreshold":105,"periodSeconds":2},"terminationGracePeriodSeconds":1,"tolerations":[{"operator":"Exists"}],"updateStrategy":{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}}``
    * - envoy.affinity
      - Affinity for cilium-envoy.
      - object
      - ``{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium-envoy"}},"topologyKey":"kubernetes.io/hostname"}]}}``
+   * - envoy.connectTimeoutSeconds
+     - Time in seconds after which a TCP connection attempt times out
+     - int
+     - ``2``
    * - envoy.dnsPolicy
      - DNS policy for Cilium envoy pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
      - string
      - ``nil``
+   * - envoy.enabled
+     - Enable Envoy Proxy in standalone DaemonSet.
+     - bool
+     - ``false``
    * - envoy.extraArgs
      - Additional envoy container arguments.
      - list
@@ -944,6 +948,10 @@
      - TCP port for the health API.
      - int
      - ``9878``
+   * - envoy.idleTimeoutDurationSeconds
+     - Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s
+     - int
+     - ``60``
    * - envoy.image
      - Envoy container image.
      - object
@@ -956,6 +964,22 @@
      - interval between checks of the liveness probe
      - int
      - ``30``
+   * - envoy.log.format
+     - The format string to use for laying out the log message metadata of Envoy.
+     - string
+     - ``"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"``
+   * - envoy.log.path
+     - Path to a separate Envoy log file, if any. Defaults to /dev/stdout.
+     - string
+     - ``""``
+   * - envoy.maxConnectionDurationSeconds
+     - Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
+     - int
+     - ``0``
+   * - envoy.maxRequestsPerConnection
+     - ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy
+     - int
+     - ``0``
    * - envoy.nodeSelector
      - Node selector for cilium-envoy.
      - object
@@ -976,6 +1000,14 @@
      - The priority class to use for cilium-envoy.
      - string
      - ``nil``
+   * - envoy.prometheus.enabled
+     - Enable prometheus metrics for cilium-envoy
+     - bool
+     - ``true``
+   * - envoy.prometheus.port
+     - Serve prometheus metrics for cilium-envoy on the configured port
+     - string
+     - ``"9964"``
    * - envoy.prometheus.serviceMonitor.annotations
      - Annotations to add to ServiceMonitor cilium-envoy
      - object
@@ -1044,6 +1076,10 @@
      - Node tolerations for envoy scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
      - list
      - ``[{"operator":"Exists"}]``
+   * - envoy.updateStrategy
+     - cilium-envoy update strategy ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#updating-a-daemonset
+     - object
+     - ``{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}``
    * - etcd.clusterDomain
      - Cluster domain for cilium-etcd-operator.
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -167,6 +167,7 @@ Zannoni
 Zhou
 Zookeeper
 aarch
+accessMode
 admin
 adminSocketPath
 agentNotReadyTaintKey
@@ -1005,6 +1006,7 @@ statefulset
 statelessNat
 statsd
 stdout
+storageClass
 structs
 subclasses
 subcommand

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -321,6 +321,7 @@ configSources
 configmap
 configs
 conformant
+connectTimeoutSeconds
 connectionTimeout
 conntrack
 conntrackGCInterval
@@ -561,6 +562,7 @@ identityChangeGracePeriod
 identityGCInterval
 identityHeartbeatTimeout
 idleConnectionGracePeriod
+idleTimeoutDurationSeconds
 ie
 ifindex
 imagePullSecrets
@@ -716,7 +718,9 @@ masqLinkLocal
 masterDevice
 matchLabels
 matchPattern
+maxConnectionDurationSeconds
 maxDeferredConnectionDeletes
+maxRequestsPerConnection
 maxUnavailable
 mc
 mediabot

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -66,8 +66,6 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.agentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE socket path where the SPIRE workload agent is listening. Applies to both the Cilium Agent and Operator |
 | authentication.mutual.spire.connectionTimeout | string | `"30s"` | SPIRE connection timeout |
 | authentication.mutual.spire.enabled | bool | `false` | Enable SPIRE integration |
-| authentication.mutual.spire.install | object | `{"agent":{"annotations":{},"image":"ghcr.io/spiffe/spire-agent:1.6.3@sha256:8eef9857bf223181ecef10d9bbcd2f7838f3689e9bd2445bede35066a732e823","labels":{},"serviceAccount":{"create":true,"name":"spire-agent"},"skipKubeletVerification":true},"enabled":false,"namespace":"cilium-spire","server":{"annotations":{},"ca":{"keyType":"rsa-4096","subject":{"commonName":"Cilium SPIRE CA","country":"US","organization":"SPIRE"}},"dataStorage":{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":null},"image":"ghcr.io/spiffe/spire-server:1.6.3@sha256:f4bc49fb0bd1d817a6c46204cc7ce943c73fb0a5496a78e0e4dc20c9a816ad7f","initContainers":[],"labels":{},"service":{"annotations":{},"labels":{},"type":"ClusterIP"},"serviceAccount":{"create":true,"name":"spire-server"}}}` | Settings to control the SPIRE installation and configuration |
-| authentication.mutual.spire.install.agent | object | `{"annotations":{},"image":"ghcr.io/spiffe/spire-agent:1.6.3@sha256:8eef9857bf223181ecef10d9bbcd2f7838f3689e9bd2445bede35066a732e823","labels":{},"serviceAccount":{"create":true,"name":"spire-agent"},"skipKubeletVerification":true}` | SPIRE agent configuration |
 | authentication.mutual.spire.install.agent.annotations | object | `{}` | SPIRE agent annotations |
 | authentication.mutual.spire.install.agent.image | string | `"ghcr.io/spiffe/spire-agent:1.6.3@sha256:8eef9857bf223181ecef10d9bbcd2f7838f3689e9bd2445bede35066a732e823"` | SPIRE agent image |
 | authentication.mutual.spire.install.agent.labels | object | `{}` | SPIRE agent labels |
@@ -76,14 +74,18 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.install.enabled | bool | `false` | Enable SPIRE installation. This will only take effect only if authentication.mutual.spire.enabled is true |
 | authentication.mutual.spire.install.namespace | string | `"cilium-spire"` | SPIRE namespace to install into |
 | authentication.mutual.spire.install.server.annotations | object | `{}` | SPIRE server annotations |
-| authentication.mutual.spire.install.server.ca | object | `{"keyType":"rsa-4096","subject":{"commonName":"Cilium SPIRE CA","country":"US","organization":"SPIRE"}}` | SPIRE CA configuration |
 | authentication.mutual.spire.install.server.ca.keyType | string | `"rsa-4096"` | SPIRE CA key type AWS requires the use of RSA. EC cryptography is not supported |
 | authentication.mutual.spire.install.server.ca.subject | object | `{"commonName":"Cilium SPIRE CA","country":"US","organization":"SPIRE"}` | SPIRE CA Subject |
-| authentication.mutual.spire.install.server.dataStorage | object | `{"accessMode":"ReadWriteOnce","enabled":true,"size":"1Gi","storageClass":null}` | SPIRE server datastorage configuration |
+| authentication.mutual.spire.install.server.dataStorage.accessMode | string | `"ReadWriteOnce"` | Access mode of the SPIRE server data storage |
+| authentication.mutual.spire.install.server.dataStorage.enabled | bool | `true` | Enable SPIRE server data storage |
+| authentication.mutual.spire.install.server.dataStorage.size | string | `"1Gi"` | Size of the SPIRE server data storage |
+| authentication.mutual.spire.install.server.dataStorage.storageClass | string | `nil` | StorageClass of the SPIRE server data storage |
 | authentication.mutual.spire.install.server.image | string | `"ghcr.io/spiffe/spire-server:1.6.3@sha256:f4bc49fb0bd1d817a6c46204cc7ce943c73fb0a5496a78e0e4dc20c9a816ad7f"` | SPIRE server image |
 | authentication.mutual.spire.install.server.initContainers | list | `[]` | SPIRE server init containers |
 | authentication.mutual.spire.install.server.labels | object | `{}` | SPIRE server labels |
-| authentication.mutual.spire.install.server.service | object | `{"annotations":{},"labels":{},"type":"ClusterIP"}` | SPIRE server service configuration |
+| authentication.mutual.spire.install.server.service.annotations | object | `{}` | Annotations to be added to the SPIRE server service |
+| authentication.mutual.spire.install.server.service.labels | object | `{}` | Labels to be added to the SPIRE server service |
+| authentication.mutual.spire.install.server.service.type | string | `"ClusterIP"` | Service type for the SPIRE server service |
 | authentication.mutual.spire.install.server.serviceAccount | object | `{"create":true,"name":"spire-server"}` | SPIRE server service account |
 | authentication.mutual.spire.serverAddress | string | `"spire-server.cilium-spire.svc:8081"` | SPIRE server address |
 | authentication.mutual.spire.trustDomain | string | `"spiffe.cilium"` | SPIFFE trust domain to use for fetching certificates |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1753,24 +1753,24 @@ proxy:
   # container image names
   sidecarImageRegex: "cilium/istio_proxy"
 
-# -- Configure Cilium Envoy options.
+# Configure Cilium Envoy options.
 envoy:
-  # Enable Envoy Proxy in standalone DaemonSet.
+  # -- Enable Envoy Proxy in standalone DaemonSet.
   enabled: false
 
   log:
-    # The format string to use for laying out the log message metadata of Envoy.
+    # -- The format string to use for laying out the log message metadata of Envoy.
     format: "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"
-    # Path to a separate Envoy log file, if any. Defaults to /dev/stdout.
+    # -- Path to a separate Envoy log file, if any. Defaults to /dev/stdout.
     path: ""
 
-  # Time in seconds after which a TCP connection attempt times out
+  # -- Time in seconds after which a TCP connection attempt times out
   connectTimeoutSeconds: 2
-  # ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy
+  # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy
   maxRequestsPerConnection: 0
-  # Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
+  # -- Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
   maxConnectionDurationSeconds: 0
-  # Set Envoy upstream HTTP idle connection timeout seconds.
+  # -- Set Envoy upstream HTTP idle connection timeout seconds.
   # Does not apply to connections with pending requests. Default 60s
   idleTimeoutDurationSeconds: 60
 
@@ -1813,6 +1813,8 @@ envoy:
   # -- TCP port for the health API.
   healthPort: 9878
 
+  # -- cilium-envoy update strategy
+  # ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#updating-a-daemonset
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -1913,6 +1915,7 @@ envoy:
   dnsPolicy: ~
 
   prometheus:
+    # -- Enable prometheus metrics for cilium-envoy
     enabled: true
     serviceMonitor:
       # -- Enable service monitors.
@@ -1935,6 +1938,7 @@ envoy:
           replacement: ${1}
       # -- Metrics relabeling configs for the ServiceMonitor cilium-envoy
       metricRelabelings: ~
+    # -- Serve prometheus metrics for cilium-envoy on the configured port
     port: "9964"
 
 # -- Enable use of the remote node identity.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2966,14 +2966,14 @@ authentication:
     spire:
       # -- Enable SPIRE integration
       enabled: false
-      # -- Settings to control the SPIRE installation and configuration
+      # Settings to control the SPIRE installation and configuration
       install:
         # -- Enable SPIRE installation.
         # This will only take effect only if authentication.mutual.spire.enabled is true
         enabled: false
         # -- SPIRE namespace to install into
         namespace: cilium-spire
-        # -- SPIRE agent configuration
+        # SPIRE agent configuration
         agent:
           # -- SPIRE agent image
           image: ghcr.io/spiffe/spire-agent:1.6.3@sha256:8eef9857bf223181ecef10d9bbcd2f7838f3689e9bd2445bede35066a732e823
@@ -3000,18 +3000,25 @@ authentication:
           annotations: {}
           # -- SPIRE server labels
           labels: {}
-          # -- SPIRE server service configuration
+          # SPIRE server service configuration
           service:
+            # -- Service type for the SPIRE server service
             type: ClusterIP
+            # -- Annotations to be added to the SPIRE server service
             annotations: {}
+            # -- Labels to be added to the SPIRE server service
             labels: {}
-          # -- SPIRE server datastorage configuration
+          # SPIRE server datastorage configuration
           dataStorage:
+            # -- Enable SPIRE server data storage
             enabled: true
+            # -- Size of the SPIRE server data storage
             size: 1Gi
+            # -- Access mode of the SPIRE server data storage
             accessMode: ReadWriteOnce
+            # -- StorageClass of the SPIRE server data storage
             storageClass: null
-          # -- SPIRE CA configuration
+          # SPIRE CA configuration
           ca:
             # -- SPIRE CA key type
             # AWS requires the use of RSA. EC cryptography is not supported

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2963,14 +2963,14 @@ authentication:
     spire:
       # -- Enable SPIRE integration
       enabled: false
-      # -- Settings to control the SPIRE installation and configuration
+      # Settings to control the SPIRE installation and configuration
       install:
         # -- Enable SPIRE installation.
         # This will only take effect only if authentication.mutual.spire.enabled is true
         enabled: false
         # -- SPIRE namespace to install into
         namespace: cilium-spire
-        # -- SPIRE agent configuration
+        # SPIRE agent configuration
         agent:
           # -- SPIRE agent image
           image: ghcr.io/spiffe/spire-agent:1.6.3@sha256:8eef9857bf223181ecef10d9bbcd2f7838f3689e9bd2445bede35066a732e823
@@ -2997,18 +2997,25 @@ authentication:
           annotations: {}
           # -- SPIRE server labels
           labels: {}
-          # -- SPIRE server service configuration
+          # SPIRE server service configuration
           service:
+            # -- Service type for the SPIRE server service
             type: ClusterIP
+            # -- Annotations to be added to the SPIRE server service
             annotations: {}
+            # -- Labels to be added to the SPIRE server service
             labels: {}
-          # -- SPIRE server datastorage configuration
+          # SPIRE server datastorage configuration
           dataStorage:
+            # -- Enable SPIRE server data storage
             enabled: true
+            # -- Size of the SPIRE server data storage
             size: 1Gi
+            # -- Access mode of the SPIRE server data storage
             accessMode: ReadWriteOnce
+            # -- StorageClass of the SPIRE server data storage
             storageClass: null
-          # -- SPIRE CA configuration
+          # SPIRE CA configuration
           ca:
             # -- SPIRE CA key type
             # AWS requires the use of RSA. EC cryptography is not supported

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1750,24 +1750,24 @@ proxy:
   # container image names
   sidecarImageRegex: "cilium/istio_proxy"
 
-# -- Configure Cilium Envoy options.
+# Configure Cilium Envoy options.
 envoy:
-  # Enable Envoy Proxy in standalone DaemonSet.
+  # -- Enable Envoy Proxy in standalone DaemonSet.
   enabled: false
 
   log:
-    # The format string to use for laying out the log message metadata of Envoy.
+    # -- The format string to use for laying out the log message metadata of Envoy.
     format: "[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"
-    # Path to a separate Envoy log file, if any. Defaults to /dev/stdout.
+    # -- Path to a separate Envoy log file, if any. Defaults to /dev/stdout.
     path: ""
 
-  # Time in seconds after which a TCP connection attempt times out
+  # -- Time in seconds after which a TCP connection attempt times out
   connectTimeoutSeconds: 2
-  # ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy
+  # -- ProxyMaxRequestsPerConnection specifies the max_requests_per_connection setting for Envoy
   maxRequestsPerConnection: 0
-  # Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
+  # -- Set Envoy HTTP option max_connection_duration seconds. Default 0 (disable)
   maxConnectionDurationSeconds: 0
-  # Set Envoy upstream HTTP idle connection timeout seconds.
+  # -- Set Envoy upstream HTTP idle connection timeout seconds.
   # Does not apply to connections with pending requests. Default 60s
   idleTimeoutDurationSeconds: 60
 
@@ -1810,6 +1810,8 @@ envoy:
   # -- TCP port for the health API.
   healthPort: 9878
 
+  # -- cilium-envoy update strategy
+  # ref: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#updating-a-daemonset
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -1910,6 +1912,7 @@ envoy:
   dnsPolicy: ~
 
   prometheus:
+    # -- Enable prometheus metrics for cilium-envoy
     enabled: true
     serviceMonitor:
       # -- Enable service monitors.
@@ -1932,6 +1935,7 @@ envoy:
           replacement: ${1}
       # -- Metrics relabeling configs for the ServiceMonitor cilium-envoy
       metricRelabelings: ~
+    # -- Serve prometheus metrics for cilium-envoy on the configured port
     port: "9964"
 
 # -- Enable use of the remote node identity.


### PR DESCRIPTION
This PR cleans up the helm reference documentation of the SPIRE & Envoy related values, by removing the comments of "objects" from the documentation and replacing them with comments on the object properties if not already present.

This removes objects like the following from the docu
![screenshot-2023-06-08-16-29-54](https://github.com/cilium/cilium/assets/6699311/94d68f18-c75e-4d66-a951-ed339dc102a7)
