### PR TITLE
daemon, maps/ipcache: Replace usage of `net.IP*` for ingress IPs

### DIFF
--- a/pkg/ip/cidr.go
+++ b/pkg/ip/cidr.go
@@ -57,21 +57,6 @@ func ParsePrefixes(cidrs []string) (valid []netip.Prefix, invalid []string, erro
 	return valid, invalid, errors
 }
 
-// IPNetToPrefix is a convenience helper for migrating from the older 'net'
-// standard library types to the newer 'netip' types. Use this to plug the
-// new types in newer code into older types in older code during the migration.
-func IPNetToPrefix(prefix *net.IPNet) netip.Prefix {
-	if prefix == nil {
-		return netip.Prefix{}
-	}
-	addr, ok := AddrFromIP(prefix.IP)
-	if !ok {
-		return netip.Prefix{}
-	}
-	ones, _ := prefix.Mask.Size()
-	return netip.PrefixFrom(addr, ones)
-}
-
 // AddrToIPNet is a convenience helper to convert a netip.Addr to a *net.IPNet
 // with a mask corresponding to the addresses's bit length.
 func AddrToIPNet(addr netip.Addr) *net.IPNet {

--- a/pkg/ip/cidr_test.go
+++ b/pkg/ip/cidr_test.go
@@ -78,19 +78,3 @@ func TestNetsContainsAny(t *testing.T) {
 		})
 	}
 }
-
-func TestIPNetToPrefix(t *testing.T) {
-	_, v4CIDR, err := net.ParseCIDR("1.1.1.1/32")
-	assert.NoError(t, err)
-	_, v6CIDR, err := net.ParseCIDR("::ff/128")
-	assert.NoError(t, err)
-	assert.Equal(t, netip.MustParsePrefix(v4CIDR.String()), IPNetToPrefix(v4CIDR))
-	assert.Equal(t, netip.MustParsePrefix(v6CIDR.String()), IPNetToPrefix(v6CIDR))
-
-	_, v4CIDR, err = net.ParseCIDR("1.1.1.1/1")
-	assert.NoError(t, err)
-	assert.Equal(t, netip.MustParsePrefix(v4CIDR.String()), IPNetToPrefix(v4CIDR))
-
-	assert.Equal(t, netip.Prefix{}, IPNetToPrefix(nil))
-	assert.Equal(t, netip.Prefix{}, IPNetToPrefix(&net.IPNet{}))
-}

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -71,20 +71,6 @@ func (k Key) String() string {
 
 func (k *Key) New() bpf.MapKey { return &Key{} }
 
-func (k Key) IPNet() *net.IPNet {
-	cidr := &net.IPNet{}
-	prefixLen := k.Prefixlen - getStaticPrefixBits()
-	switch k.Family {
-	case bpf.EndpointKeyIPv4:
-		cidr.IP = net.IP(k.IP[:net.IPv4len])
-		cidr.Mask = net.CIDRMask(int(prefixLen), 32)
-	case bpf.EndpointKeyIPv6:
-		cidr.IP = net.IP(k.IP[:net.IPv6len])
-		cidr.Mask = net.CIDRMask(int(prefixLen), 128)
-	}
-	return cidr
-}
-
 func (k Key) Prefix() netip.Prefix {
 	var addr netip.Addr
 	prefixLen := int(k.Prefixlen - getStaticPrefixBits())


### PR DESCRIPTION
- Revert "ip: Add IPNetToPrefix() helper"
- daemon, maps/ipcache: Replace usage of `net.IP*` for ingress IPs

---

> daemon, maps/ipcache: Replace usage of `net.IP*` for ingress IPs
> 
> Following the previously reverted commit, replace the ingress IP
> restoration to use netip types.
> 
> Towards https://github.com/cilium/cilium/issues/24246.
> 
> Reported-by: Tobias Klauser <tobias@cilium.io>
> Signed-off-by: Chris Tarazi <chris@isovalent.com>
