### PR TITLE
bpf: nodeport: wire up trace struct for IPv6 RevDNAT

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1400,7 +1400,7 @@ int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 	obs_point = TRACE_TO_NETWORK;
 #endif
 
-	ret = handle_nat_fwd_ipv6(ctx);
+	ret = __handle_nat_fwd_ipv6(ctx, &trace);
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
 


### PR DESCRIPTION
When the NAT path in `to-overlay/to-netdev` is included as `tail_handle_nat_fwd_ipv6()`, skip the hop through `handle_nat_fwd_ipv6()` and call the actual RevDNAT implementation straight away.

This allows us to pass through a `trace_ctx` struct, so that the RevDNAT can return precise trace information from its CT lookup.

The IPv4 path already does this, so we must have missed the boat at some point.