### PR TITLE
Ldelossa/srv6 encap fib

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -643,8 +643,7 @@ ct_recreate6:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 
-		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, ext_err,
-				      ctx_get_ifindex(ctx), &oif);
+		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, ext_err, &oif);
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_sec_identity, 0, oif,
@@ -1182,8 +1181,7 @@ skip_vtep:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 
-		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, ext_err,
-				      ctx_get_ifindex(ctx), &oif);
+		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, ext_err, &oif);
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL,
 					  *dst_sec_identity, 0, oif,

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -4,6 +4,7 @@
 #ifndef __LIB_EGRESS_POLICIES_H_
 #define __LIB_EGRESS_POLICIES_H_
 
+#include "lib/fib.h"
 #include "lib/identity.h"
 
 #include "maps.h"
@@ -579,6 +580,59 @@ srv6_store_meta_sid(struct __ctx_buff *ctx, const union v6addr *sid)
 	ctx_store_meta(ctx, CB_SRV6_SID_4, sid->p4);
 }
 
+#ifdef ENABLE_IPV6
+/* SRv6 encapsulation occurs at the native-dev currently.
+ * Its possible that after encapsulation a fib entry exists which would actually
+ * route the IPv6 destination somewhere else.
+ *
+ * Therefore, this function performs an additional fib lookup on the encap'd
+ * packet to ensure we transmit it via the correct link and with the correct
+ * l2 addresses.
+ */
+static __always_inline int
+srv6_refib(struct __ctx_buff *ctx)
+{
+	struct bpf_fib_lookup_padded params = {0};
+	__u32 old_oif = ctx_get_ifindex(ctx);
+	void *data, *data_end;
+	struct ipv6hdr *ip6;
+	__s8 fib_ret;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+		return DROP_INVALID;
+
+	fib_ret = (__s8)fib_lookup_v6(ctx, &params, ip6, BPF_FIB_LOOKUP_OUTPUT);
+
+	if (fib_ret && fib_ret != BPF_FIB_LKUP_RET_NO_NEIGH)
+		return DROP_NO_FIB;
+
+	switch (fib_ret) {
+	case BPF_FIB_LKUP_RET_SUCCESS:
+		/* We found an oif and ARP was successful.
+		 * We may need to redirect to the appropriate oif, if not
+		 * rewrite the layer 2 and continue processing.
+		 */
+		if (old_oif != params.l.ifindex)
+			return fib_do_redirect(ctx, true, &params, &fib_ret, (int *)&old_oif);
+
+		if (eth_store_daddr(ctx, params.l.dmac, 0) < 0)
+			return DROP_WRITE_ERROR;
+
+		break;
+	case BPF_FIB_LKUP_RET_NO_NEIGH:
+		/* In this case, we found an oif, but ARP failed.
+		 * We can't rule out that oif is a veth, in which ARP is not
+		 * strictly necessary to deliver the packet, since the kernel
+		 * can fill in the veth pair's dmac without it, we lets deliver
+		 * or redirect.
+		 */
+		if (old_oif != params.l.ifindex)
+			return fib_do_redirect(ctx, true, &params, &fib_ret, (int *)&old_oif);
+	};
+	return CTX_ACT_OK;
+}
+#endif /* ENABLE_IPV6 */
+
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SRV6_ENCAP)
 int tail_srv6_encap(struct __ctx_buff *ctx)
 {
@@ -590,14 +644,21 @@ int tail_srv6_encap(struct __ctx_buff *ctx)
 	vrf_id = ctx_load_meta(ctx, CB_SRV6_VRF_ID);
 
 	ret = srv6_handling(ctx, vrf_id, &dst_sid);
-
 	if (ret < 0)
 		return send_drop_notify_error(ctx, SECLABEL, ret, CTX_ACT_DROP,
 					      METRIC_EGRESS);
 
+#ifdef ENABLE_IPV6
+	ret = srv6_refib(ctx);
+	if (ret < 0)
+		return send_drop_notify_error(ctx, SECLABEL, ret, CTX_ACT_DROP,
+					      METRIC_EGRESS);
+#endif
+
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL, 0, 0, 0,
 			  TRACE_REASON_UNKNOWN, 0);
-	return CTX_ACT_OK;
+
+	return ret;
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SRV6_DECAP)

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -40,14 +40,127 @@ static __always_inline bool fib_ok(int ret)
 	return likely(ret == CTX_ACT_TX || ret == CTX_ACT_REDIRECT);
 }
 
-/* fib_redirect() is common helper code which performs fib lookup, populates
- * the corresponding hardware addresses and pushes the packet to a target
- * device for the next hop. Calling fib_redirect_v{4,6} is preferred unless
- * due to NAT46x64 struct bpf_fib_lookup_padded needs to be prepared at the
- * callsite. oif must be 0 if otherwise not passed in from the BPF CT. The
- * needs_l2_check must be true if the packet could transition between L2->L3
- * or L3->L2 device.
- */
+ /* fib_do_redirect will redirect the ctx to a particular output interface.
+  *
+  * the redirect can occur with or without a previous call to fib_lookup.
+  *
+  * if a previous fib_lookup was performed, this function will attempt to redirect
+  * to the output interface in the provided 'fib_params', as long as 'fib_ret'
+  * is set to 'BPF_FIB_LKUP_RET_SUCCESS'
+  *
+  * if a previous fib_lookup was performed and the return was 'BPF_FIB_LKUP_NO_NEIGH'
+  * this function will then attempt to copy the af_family and destination address
+  * out of 'fib_params' and into 'redir_neigh' struct then perform a
+  * 'redirect_neigh'.
+  *
+  * if no previous fib_lookup was performed, and the desire is to simply use
+  * 'redirect_neigh' then set 'fib_params' to nil and 'fib_ret' to
+  * 'BPF_FIB_LKUP_RET_NO_NEIGH'.
+  * in this case, the 'oif' value will be used for the 'redirect_neigh' call.
+  *
+  * in a special case, if a previous fib_lookup was performed, and the return
+  * was 'BPF_FIB_LKUP_RET_NO_NEIGH', and we are on a kernel version where
+  * the target interface for the fib lookup is not returned
+  * (due to ARP failing, see Kernel commit d1c362e1dd68) the provided 'oif'
+  * will be used as output interface for redirect.
+  */
+static __always_inline int
+fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
+		const struct bpf_fib_lookup_padded *fib_params, __s8 *fib_ret,
+		int *oif)
+{
+	struct bpf_redir_neigh nh_params;
+	struct bpf_redir_neigh *nh = NULL;
+	int ret;
+
+	/* sanity check, we only enter this function with these two fib lookup
+	 * return codes.
+	 */
+	if (*fib_ret && (*fib_ret != BPF_FIB_LKUP_RET_NO_NEIGH))
+		return DROP_NO_FIB;
+
+	/* determine which oif to use before needs_l2_check determines if layer 2
+	 * header needs to be pushed.
+	 */
+	if (fib_params) {
+		if (*fib_ret == BPF_FIB_LKUP_RET_NO_NEIGH &&
+		    !is_defined(HAVE_FIB_IFINDEX) && *oif) {
+			/* For kernels without d1c362e1dd68 ("bpf: Always
+			 * return target ifindex in bpf_fib_lookup") we
+			 * fall back to use the caller-provided oif when
+			 * necessary.
+			 * no-op
+			 */
+		} else {
+			*oif = fib_params->l.ifindex;
+		}
+	}
+
+	/* determine if we need to append layer 2 header */
+	if (needs_l2_check) {
+		bool l2_hdr_required = true;
+
+		ret = maybe_add_l2_hdr(ctx, *oif, &l2_hdr_required);
+		if (ret != 0)
+			return ret;
+		if (!l2_hdr_required)
+			goto out_send;
+	}
+
+	/* determine if we are performing redirect or redirect_neigh*/
+	switch (*fib_ret) {
+	case BPF_FIB_LKUP_RET_SUCCESS:
+		if (eth_store_daddr(ctx, fib_params->l.dmac, 0) < 0)
+			return DROP_WRITE_ERROR;
+		if (eth_store_saddr(ctx, fib_params->l.smac, 0) < 0)
+			return DROP_WRITE_ERROR;
+		break;
+	case BPF_FIB_LKUP_RET_NO_NEIGH:
+		/* previous fib_lookup was done, copy fib params into
+		 * neigh params to provide lookup details to redirect_neigh
+		 */
+		if (fib_params) {
+			nh_params.nh_family = fib_params->l.family;
+			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
+					     &fib_params->l.ipv6_dst,
+					     sizeof(nh_params.ipv6_nh));
+			nh = &nh_params;
+		}
+
+		/* If we are able to resolve neighbors on demand, always
+		 * prefer that over the BPF neighbor map since the latter
+		 * might be less accurate in some asymmetric corner cases.
+		 */
+		if (neigh_resolver_available()) {
+			if (nh)
+				return redirect_neigh(*oif, &nh_params,
+						sizeof(nh_params), 0);
+			else
+				return redirect_neigh(*oif, NULL, 0, 0);
+		} else {
+			union macaddr *dmac, smac = NATIVE_DEV_MAC_BY_IFINDEX(*oif);
+
+			/* The neigh_record_ip{4,6} locations are mainly from
+			 * inbound client traffic on the load-balancer where we
+			 * know that replies need to go back to them.
+			 */
+			dmac = fib_params->l.family == AF_INET ?
+			neigh_lookup_ip4(&fib_params->l.ipv4_dst) :
+			neigh_lookup_ip6((void *)&fib_params->l.ipv6_dst);
+			if (!dmac) {
+				*fib_ret = BPF_FIB_MAP_NO_NEIGH;
+				return DROP_NO_FIB;
+			}
+			if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0)
+				return DROP_WRITE_ERROR;
+			if (eth_store_saddr_aligned(ctx, smac.addr, 0) < 0)
+				return DROP_WRITE_ERROR;
+		}
+	};
+out_send:
+	return ctx_redirect(ctx, *oif, 0);
+}
+
 static __always_inline int
 fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 	     struct bpf_fib_lookup_padded *fib_params, __s8 *fib_err, int *oif)

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -163,87 +163,19 @@ out_send:
 
 static __always_inline int
 fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
-	     struct bpf_fib_lookup_padded *fib_params, __s8 *fib_err, int *oif)
+	     struct bpf_fib_lookup_padded *fib_params __maybe_unused,
+	     __s8 *fib_err __maybe_unused, int *oif)
 {
-	struct bpf_redir_neigh nh_params;
-	struct bpf_redir_neigh *nh = NULL;
-	bool no_neigh = is_defined(ENABLE_SKIP_FIB);
-	int ret;
-
 #ifndef ENABLE_SKIP_FIB
+	int ret;
 	ret = fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), 0);
-	if (ret != BPF_FIB_LKUP_RET_SUCCESS) {
-		*fib_err = (__s8)ret;
-		if (likely(ret == BPF_FIB_LKUP_RET_NO_NEIGH)) {
-			nh_params.nh_family = fib_params->l.family;
-			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
-					     &fib_params->l.ipv6_dst,
-					     sizeof(nh_params.ipv6_nh));
-			nh = &nh_params;
-			no_neigh = true;
-			/* For kernels without d1c362e1dd68 ("bpf: Always
-			 * return target ifindex in bpf_fib_lookup") we
-			 * fall back to use the caller-provided oif when
-			 * necessary.
-			 */
-			if (!is_defined(HAVE_FIB_IFINDEX) && *oif > 0)
-				goto skip_oif;
-		} else {
-			return DROP_NO_FIB;
-		}
-	}
-	*oif = fib_params->l.ifindex;
-skip_oif:
+	*fib_err = (__s8)ret;
+	return fib_do_redirect(ctx, needs_l2_check, fib_params, fib_err, oif);
 #else
+	__s8 skip_fib = BPF_FIB_LKUP_RET_NO_NEIGH;
 	*oif = DIRECT_ROUTING_DEV_IFINDEX;
-#endif /* ENABLE_SKIP_FIB */
-	if (needs_l2_check) {
-		bool l2_hdr_required = true;
-
-		ret = maybe_add_l2_hdr(ctx, *oif, &l2_hdr_required);
-		if (ret != 0)
-			return ret;
-		if (!l2_hdr_required)
-			goto out_send;
-	}
-	if (no_neigh) {
-		/* If we are able to resolve neighbors on demand, always
-		 * prefer that over the BPF neighbor map since the latter
-		 * might be less accurate in some asymmetric corner cases.
-		 */
-		if (neigh_resolver_available()) {
-			if (nh)
-				return redirect_neigh(*oif, &nh_params,
-						      sizeof(nh_params), 0);
-			else
-				return redirect_neigh(*oif, NULL, 0, 0);
-		} else {
-			union macaddr *dmac, smac = NATIVE_DEV_MAC_BY_IFINDEX(*oif);
-
-			/* The neigh_record_ip{4,6} locations are mainly from
-			 * inbound client traffic on the load-balancer where we
-			 * know that replies need to go back to them.
-			 */
-			dmac = fib_params->l.family == AF_INET ?
-			       neigh_lookup_ip4(&fib_params->l.ipv4_dst) :
-			       neigh_lookup_ip6((void *)&fib_params->l.ipv6_dst);
-			if (!dmac) {
-				*fib_err = BPF_FIB_MAP_NO_NEIGH;
-				return DROP_NO_FIB;
-			}
-			if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0)
-				return DROP_WRITE_ERROR;
-			if (eth_store_saddr_aligned(ctx, smac.addr, 0) < 0)
-				return DROP_WRITE_ERROR;
-		}
-	} else {
-		if (eth_store_daddr(ctx, fib_params->l.dmac, 0) < 0)
-			return DROP_WRITE_ERROR;
-		if (eth_store_saddr(ctx, fib_params->l.smac, 0) < 0)
-			return DROP_WRITE_ERROR;
-	}
-out_send:
-	return ctx_redirect(ctx, *oif, 0);
+	return fib_do_redirect(ctx, needs_l2_check, NULL, &skip_fib, oif);
+#endif
 }
 
 #ifdef ENABLE_IPV6

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -203,27 +203,31 @@ fib_lookup_v6(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 
 static __always_inline int
 fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
-		struct ipv6hdr *ip6, const bool needs_l2_check,
-		__s8 *fib_err, int iif, int *oif)
+		struct ipv6hdr *ip6 __maybe_unused, const bool needs_l2_check,
+		__s8 *fib_err __maybe_unused, int *oif)
 {
-	struct bpf_fib_lookup_padded fib_params = {
-		.l = {
-			.family		= AF_INET6,
-			.ifindex	= iif,
-		},
-	};
+	struct bpf_fib_lookup_padded fib_params __maybe_unused = {0};
+	void *data_end;
+	void *data;
+	__s8 skip_fib __maybe_unused = BPF_FIB_LKUP_RET_NO_NEIGH;
 	int ret;
-
-	ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_src,
-		       (union v6addr *)&ip6->saddr);
-	ipv6_addr_copy((union v6addr *)&fib_params.l.ipv6_dst,
-		       (union v6addr *)&ip6->daddr);
 
 	ret = ipv6_l3(ctx, l3_off, NULL, NULL, METRIC_EGRESS);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 
-	return fib_redirect(ctx, needs_l2_check, &fib_params, fib_err, oif);
+	/* we touched ttl above, revalidate for any header reads/writes */
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+		return DROP_INVALID;
+
+#ifndef ENABLE_SKIP_FIB
+	ret = fib_lookup_v6(ctx, &fib_params, ip6, 0);
+	*fib_err = (__s8)ret;
+	return fib_do_redirect(ctx, needs_l2_check, &fib_params, fib_err, oif);
+#else
+	*oif = DIRECT_ROUTING_DEV_IFINDEX;
+	return fib_do_redirect(ctx, needs_l2_check, NULL, &skip_fib, oif);
+#endif
 }
 #endif /* ENABLE_IPV6 */
 
@@ -248,24 +252,32 @@ fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
 
 static __always_inline int
 fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
-		struct iphdr *ip4, const bool needs_l2_check,
-		__s8 *fib_err, int iif, int *oif)
+		struct iphdr *ip4 __maybe_unused, const bool needs_l2_check,
+		__s8 *fib_err __maybe_unused, int *oif)
 {
-	struct bpf_fib_lookup_padded fib_params = {
-		.l = {
-			.family		= AF_INET,
-			.ifindex	= iif,
-			.ipv4_src	= ip4->saddr,
-			.ipv4_dst	= ip4->daddr,
-		},
-	};
+	struct bpf_fib_lookup_padded fib_params __maybe_unused = {0};
+	void *data_end;
+	void *data;
+	__s8 skip_fib __maybe_unused = BPF_FIB_LKUP_RET_NO_NEIGH;
 	int ret;
 
 	ret = ipv4_l3(ctx, l3_off, NULL, NULL, ip4);
 	if (unlikely(ret != CTX_ACT_OK))
 		return ret;
 
-	return fib_redirect(ctx, needs_l2_check, &fib_params, fib_err, oif);
+	/* we touched ttl above, revalidate for any header reads/writes. */
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+#ifndef ENABLE_SKIP_FIB
+	ret = fib_lookup_v4(ctx, &fib_params, ip4, 0);
+	*fib_err = (__s8)ret;
+	return fib_do_redirect(ctx, needs_l2_check, &fib_params, fib_err, oif);
+#else
+	*oif = DIRECT_ROUTING_DEV_IFINDEX;
+	return fib_do_redirect(ctx, needs_l2_check, NULL, &skip_fib, oif);
+#endif
+
 }
 #endif /* ENABLE_IPV4 */
 #endif /* __LIB_FIB_H_ */

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -179,6 +179,28 @@ fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 }
 
 #ifdef ENABLE_IPV6
+/* fib_lookup_v6 will take a ctx along with a ipv6 header and parameters, perform
+ * a fib lookup with the src and dest addresses in the ipv6 header and return
+ * the code.
+ *
+ * after the function returns 'fib_params' will have the results of the fib lookup
+ * if successful.
+ */
+static __always_inline int
+fib_lookup_v6(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
+	      struct ipv6hdr *ip6, int flags)
+{
+	fib_params->l.family	= AF_INET6;
+	fib_params->l.ifindex	= ctx_get_ifindex(ctx);
+
+	ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_src,
+		       (union v6addr *)&ip6->saddr);
+	ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_dst,
+		       (union v6addr *)&ip6->daddr);
+
+	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
+};
+
 static __always_inline int
 fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		struct ipv6hdr *ip6, const bool needs_l2_check,
@@ -206,6 +228,24 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
+/* fib_lookup_v4 will take a ctx along with a ipv4 header and parameters, perform
+ * a fib lookup with the src and dest addresses in the ipv4 header and return
+ * the code.
+ *
+ * after the function returns 'fib_params' will have the results of the fib lookup
+ * if successful.
+ */
+static __always_inline int
+fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
+	      const struct iphdr *ip4, int flags) {
+	fib_params->l.family	= AF_INET;
+	fib_params->l.ifindex	= ctx_get_ifindex(ctx);
+	fib_params->l.ipv4_src	= ip4->saddr;
+	fib_params->l.ipv4_dst	= ip4->daddr;
+
+	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
+}
+
 static __always_inline int
 fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		struct iphdr *ip4, const bool needs_l2_check,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -741,8 +741,7 @@ int tail_nat_ipv46(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v6(ctx, l3_off, ip6, false, &ext_err,
-			      ctx_get_ifindex(ctx), &oif);
+	ret = fib_redirect_v6(ctx, l3_off, ip6, false, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -773,8 +772,7 @@ int tail_nat_ipv64(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v4(ctx, l3_off, ip4, false, &ext_err,
-			      ctx_get_ifindex(ctx), &oif);
+	ret = fib_redirect_v4(ctx, l3_off, ip4, false, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -1993,8 +1991,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, &ext_err,
-			      ctx_get_ifindex(ctx), &oif);
+	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -2233,8 +2230,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
-	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, &ext_err,
-			      ctx_get_ifindex(ctx), &oif);
+	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -2635,8 +2631,7 @@ encap_redirect:
 #endif
 
 fib_lookup:
-	return fib_redirect_v4(ctx, l3_off, ip4, true, ext_err,
-			       ctx_get_ifindex(ctx), &ifindex);
+	return fib_redirect_v4(ctx, l3_off, ip4, true, ext_err, &ifindex);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_REVNAT)

--- a/bpf/tests/session_affinity_test.c
+++ b/bpf/tests/session_affinity_test.c
@@ -21,8 +21,8 @@ static const char fib_dmac[6] = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37};
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)
 {
-	memcpy(params->smac, fib_smac, sizeof(fib_smac));
-	memcpy(params->dmac, fib_dmac, sizeof(fib_dmac));
+	__bpf_memcpy_builtin(params->smac, fib_smac, ETH_ALEN);
+	__bpf_memcpy_builtin(params->dmac, fib_dmac, ETH_ALEN);
 	return 0;
 }
 
@@ -187,7 +187,7 @@ int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	__u32 *status_code = data;
 
-	if (*status_code != XDP_TX) test_fatal("status code != XDP_TX");
+	if (*status_code != XDP_TX) test_fatal("status code != XDP_TX %d", *status_code);
 
 	data += sizeof(__u32);
 

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -17,8 +17,8 @@ static const char fib_dmac[6] = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37};
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)
 {
-	memcpy(params->smac, fib_smac, sizeof(fib_smac));
-	memcpy(params->dmac, fib_dmac, sizeof(fib_dmac));
+	__bpf_memcpy_builtin(params->smac, fib_smac, ETH_ALEN);
+	__bpf_memcpy_builtin(params->dmac, fib_dmac, ETH_ALEN);
 	return 0;
 }
 


### PR DESCRIPTION
Original SRv6 encapsulation flow:

``` mermaid
 flowchart LR
p["pod"] 
v1["veth1"]
v2["veth2"]
hs["host stack"]
e["eth0"]
tx["tx"]

p-->|egress pkt|v1-->v2-->hs-->|fib lookup|e-->|SRv6 encap|tx
```
This results in the egress packet always choosing the output interface, source, and destination mac from the FIB lookup that occurred on the inner packet. 

SRv6 encapsulation flow corrected:

``` mermaid
 flowchart LR
p["pod"] 
v1["veth1"]
v2["veth2"]
hs["host stack"]
e["eth0"]
tx["tx"]

p-->|egress pkt|v1-->v2-->hs-->|fib lookup|e-->|SRv6 encap\n+\nfib lookup|tx
```

Now, we perform an additional fib lookup once the egress packet has been encapsulated, ensuring the encapsulated packet is forwarded correctly based on the host namespace's FIB.

To accomplish this a refactor of `lib/fib.h` was necessary. 
The fib library can now be used to perform a v4/v6 fib lookup and a redirect independently, where before the actions were coupled together. 

Performing these actions independently is currently necessary for this SRv6 datapath fix. 
This is because we perform the `fib_lookup` already at a egress interface and we **may or may not** need to redirect to a new interface for tx. 
This refactor does not change the semantics of the existing functions, they work exactly how they used to, sans removing the `iif` field from the `fib_redirect_v[4|6]` functions, as we can extract them from the passed `ctx` making the arguments redundant. 

It is obvious to see that two fib lookups are occurring here. 
It does seem to me that this can be reduced to one, however this involves changing where encapsulation occurs and will be a larger refactor, however I will also look into this. 

```release-note
Fixes an issue where SRv6 encapsulated packets are forwarded to the wrong layer 2 next hop.
```
