### PR TITLE
Only delete ipsec endpoint when node ID is not 0

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1575,8 +1575,9 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 	nodeID := n.getNodeIDForNode(oldNode)
 	if nodeID == 0 {
 		scopedLog.Warning("No node ID found for node.")
+	} else {
+		ipsec.DeleteIPsecEndpoint(nodeID)
 	}
-	ipsec.DeleteIPsecEndpoint(nodeID)
 
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
 		old4RouteNet := &net.IPNet{IP: oldNode.IPv4AllocCIDR.IP, Mask: oldNode.IPv4AllocCIDR.Mask}


### PR DESCRIPTION
After applying a backport of https://github.com/cilium/cilium/pull/25784 to 1.11.16 I noticed that we were getting occasional spikes of "no inbound state" xfrm errors (XfrmInNoStates). These lead to packet loss and brief outages for applications sending traffic to the node on which the spikes occur.

I noticed that the "No node ID found for node." logline would appear at the time of these spikes and from the code this is logged when the node ID cannot be resolved. Looking a bit further the call to `DeleteIPsecEndpoint` will end up deleting the xfrm state for any state that matches the node id as derived from the mark in the state. 

The problem seems to be that the inbound state for 0.0.0.0/0 -> node IP has a mark of `0xd00` which when shifted >> 16 in `getNodeIDFromXfrmMark` matches nodeID 0 and so the inbound state gets deleted and the kernel drops all the inbound traffic as it no longer matches a state.

I've updated the code to only call `DeleteIPsecEndpoint` when the nodeID != 0 as a first pass here. Initially wanted to return after the logline, but am not if we can skip the rest of the code below this call so raising this PR and looking for input from @pchaigno to see if any other changes are preferred/required.