### PR TITLE
auth: fix initial k8s events sync in auth map gc

### DIFF
--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -90,6 +90,7 @@ func (r *authMapGarbageCollector) handleCiliumIdentityEvent(_ context.Context, e
 		if err = r.cleanupMissingIdentities(); err != nil {
 			return fmt.Errorf("failed to cleanup missing identities: %w", err)
 		}
+		r.discoveredCiliumIdentities = nil
 	case resource.Delete:
 		r.logger.
 			WithField("key", e.Key).
@@ -97,7 +98,6 @@ func (r *authMapGarbageCollector) handleCiliumIdentityEvent(_ context.Context, e
 		if err = r.cleanupDeletedIdentity(e.Object); err != nil {
 			return fmt.Errorf("failed to cleanup deleted identity: %w", err)
 		}
-		r.discoveredCiliumIdentities = nil
 	}
 	return nil
 }


### PR DESCRIPTION
This PR fixes the issue where k8s resource upsert events of cilium identities are still triggering a cleanup of missing identities even though the sync event has already been received and processed.
