### PR TITLE
clustermesh-apiserver: add missing metrics and documentation

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -176,6 +176,8 @@ so this functionality is currently opt-in, though we believe all of the Hubble
 metrics conform to the OpenMetrics requirements.
 
 
+.. _clustermesh_apiserver_metrics:
+
 Cluster Mesh API Server Metrics
 ===============================
 
@@ -893,6 +895,8 @@ Options
 
 This metric supports :ref:`Context Options<hubble_context_options>`.
 
+.. _clustermesh_apiserver_metrics_reference:
+
 clustermesh-apiserver
 ---------------------
 
@@ -922,6 +926,19 @@ Name                                     Labels                                 
 ``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Number of elements queued for synchronization in the kvstore
 ``kvstore_initial_sync_completed``       ``scope``, ``source_cluster``, ``action``    Whether the initial synchronization from/to the kvstore has completed
 ======================================== ============================================ ========================================================
+
+API Rate Limiting
+~~~~~~~~~~~~~~~~~
+
+============================================== ================================ ========================================================
+Name                                           Labels                           Description
+============================================== ================================ ========================================================
+``api_limiter_processed_requests_total``       ``api_call``, ``outcome``        Total number of API requests processed
+``api_limiter_processing_duration_seconds``    ``api_call``, ``value``          Mean and estimated processing duration in seconds
+``api_limiter_rate_limit``                     ``api_call``, ``value``          Current rate limiting configuration (limit and burst)
+``api_limiter_requests_in_flight``             ``api_call``  ``value``          Current and maximum allowed number of requests in flight
+``api_limiter_wait_duration_seconds``          ``api_call``, ``value``          Mean, min, and max wait duration
+============================================== ================================ ========================================================
 
 .. _kvstoremesh_metrics_reference:
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -377,6 +377,14 @@ Added Metrics
 * ``cilium_operator_ipam_available_ips``
 * ``cilium_operator_ipam_used_ips``
 * ``cilium_operator_ipam_needed_ips``
+* ``kvstore_sync_queue_size``
+* ``kvstore_initial_sync_completed``
+
+You can now additionally configure the *clustermesh-apiserver* to expose a set
+of metrics about the synchronization process, kvstore operations, and the sidecar
+etcd instance. Please refer to :ref:`clustermesh_apiserver_metrics` and
+:ref:`the clustermesh-apiserver metrics reference<clustermesh_apiserver_metrics_reference>`
+for more information.
 
 Deprecated Metrics
 ~~~~~~~~~~~~~~~~~~

--- a/clustermesh-apiserver/metrics/metrics.go
+++ b/clustermesh-apiserver/metrics/metrics.go
@@ -77,7 +77,7 @@ func (mm *metricsManager) Start(hive.HookContext) error {
 		metrics.APILimiterWaitDuration,
 		metrics.APILimiterRequestsInFlight,
 		metrics.APILimiterRateLimit,
-		metrics.APILimiterAdjustmentFactor,
+		metrics.APILimiterProcessedRequests,
 	)
 
 	mux := http.NewServeMux()

--- a/clustermesh-apiserver/metrics/metrics.go
+++ b/clustermesh-apiserver/metrics/metrics.go
@@ -73,6 +73,7 @@ func (mm *metricsManager) Start(hive.HookContext) error {
 	// This is a hack until we can unify this metrics manager with the metrics.Registry.
 	metrics.NewLegacyMetrics()
 	mm.registry.MustRegister(
+		metrics.VersionMetric,
 		metrics.KVStoreOperationsDuration,
 		metrics.KVStoreEventsQueueDuration,
 		metrics.KVStoreQuorumErrors,

--- a/clustermesh-apiserver/metrics/metrics.go
+++ b/clustermesh-apiserver/metrics/metrics.go
@@ -6,6 +6,7 @@ package metrics
 import (
 	"errors"
 	"net/http"
+	"regexp"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
@@ -63,7 +64,11 @@ func (mm *metricsManager) Start(hive.HookContext) error {
 	log.Info("Registering metrics")
 
 	mm.registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
-	mm.registry.MustRegister(collectors.NewGoCollector())
+	mm.registry.MustRegister(collectors.NewGoCollector(
+		collectors.WithGoCollectorRuntimeMetrics(
+			collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile(`^/sched/latencies:seconds`)},
+		),
+	))
 	// Constructing the legacy metrics and register them at the metrics global variable.
 	// This is a hack until we can unify this metrics manager with the metrics.Registry.
 	metrics.NewLegacyMetrics()


### PR DESCRIPTION
This PR extends the documentation with information about clustermesh-apiserver metrics that have been overlooked in previous commits. It also corrects the selection of the rate limiter metrics exposed by the clustermesh-apiserver and adds a couple of missing metrics.