### PR TITLE
auth: temporarily disable node-based auth gc

### DIFF
--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -151,11 +151,6 @@ func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params a
 		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumIdentity]]("auth identities gc", mapGC.handleCiliumIdentityEvent, params.CiliumIdentities))
 	}
 
-	// Add node based auth gc if k8s client is enabled
-	if params.CiliumNodes != nil {
-		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumNode]]("auth nodes gc", mapGC.handleCiliumNodeEvent, params.CiliumNodes))
-	}
-
 	jobGroup.Add(job.Timer("auth expiration gc", mapGC.CleanupExpiredEntries, params.Config.MeshAuthExpiredGCInterval))
 }
 


### PR DESCRIPTION
Currently, auth map garbage collection based on deleted node events provokes issues in combination with enabled encryption.

The actual problem is that there are combinations where garbage collection unintentionally allocates node ids when trying to resolve the node IDs for a given node IP. This results in multiple node ids for the same ip, which breaks encryption.

Therefore, this commit temporarily disables auth map garbage collection based on deleted node events.

Fixes: #25964