### PR TITLE
hive,metrics: Add metrics for pkg/hive/job

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -419,6 +419,7 @@ jenkinsfiles @cilium/ci-structure
 /pkg/fswatcher/ @cilium/sig-datapath @cilium/sig-hubble
 /pkg/health/ @cilium/sig-agent
 /pkg/hive/ @cilium/sig-foundations
+/pkg/hive/job/metrics.go @cilium/sig-foundations @cilium/metrics
 /pkg/hubble/ @cilium/sig-hubble
 /pkg/hubble/metrics @cilium/sig-hubble @cilium/sig-hubble-api
 /pkg/identity @cilium/sig-policy

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -506,6 +506,18 @@ Name                               Labels                           Default     
 ``fqdn_alive_zombie_connections``  ``endpoint``                     Disabled     Number of IPs associated with domains that have expired (by TTL) yet still associated with an active connection (aka zombie), per endpoint
 ================================== ================================ ============ ========================================================
 
+Jobs
+~~~~
+
+================================== ================================ ============ ========================================================
+Name                               Labels                           Default      Description
+================================== ================================ ============ ========================================================
+``jobs_errors_total``              ``job``                          Enabled      Number of jobs runs that returned an error
+``jobs_one_shot_run_seconds``      ``job``                          Enabled      Histogram of one shot job run duration
+``jobs_timer_run_seconds``         ``job``                          Enabled      Histogram of timer job run duration
+``jobs_observer_run_seconds``      ``job``                          Enabled      Histogram of observer job run duration
+================================== ================================ ============ ========================================================
+
 .. _metrics_api_rate_limiting:
 
 API Rate Limiting

--- a/pkg/hive/job/job.go
+++ b/pkg/hive/job/job.go
@@ -5,7 +5,7 @@ package job
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"runtime/pprof"
 	"sync"
 	"time"
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/internal"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/spanstat"
 	"github.com/cilium/cilium/pkg/stream"
 )
 
@@ -25,7 +26,12 @@ import (
 // sure multiple goroutines properly shutdown takes a lot of boilerplate. Job groups make it easy to queue, spawn, and
 // collect jobs with minimal boilerplate. The registry maintains references to all groups which will allow us to add
 // automatic metrics collection and/or status reporting in the future.
-var Cell = cell.Provide(newRegistry)
+var Cell = cell.Module(
+	"jobs",
+	"Jobs",
+	cell.Provide(newRegistry),
+	cell.Metric(newJobMetrics),
+)
 
 // A Registry creates Groups, it maintains references to these groups for the purposes of collecting information
 // centralized like metrics.
@@ -37,14 +43,21 @@ type registry struct {
 	logger     logrus.FieldLogger
 	shutdowner hive.Shutdowner
 
+	metrics *jobMetrics
+
 	mu     lock.Mutex
 	groups []Group
 }
 
-func newRegistry(logger logrus.FieldLogger, shutdowner hive.Shutdowner) Registry {
+func newRegistry(
+	logger logrus.FieldLogger,
+	shutdowner hive.Shutdowner,
+	metrics *jobMetrics,
+) Registry {
 	return &registry{
 		logger:     logger,
 		shutdowner: shutdowner,
+		metrics:    metrics,
 	}
 }
 
@@ -57,6 +70,7 @@ func (c *registry) NewGroup(opts ...groupOpt) Group {
 	var options options
 	options.logger = c.logger
 	options.shutdowner = c.shutdowner
+	options.metrics = c.metrics
 
 	for _, opt := range opts {
 		opt(&options)
@@ -102,6 +116,7 @@ type options struct {
 	pprofLabels pprof.LabelSet
 	logger      logrus.FieldLogger
 	shutdowner  hive.Shutdowner
+	metrics     *jobMetrics
 }
 
 type groupOpt func(o *options)
@@ -191,6 +206,10 @@ func (jg *group) Add(jobs ...Job) {
 // The given function is expected to exit as soon as the context given to it expires, this is especially important for
 // blocking or long running jobs.
 func OneShot(name string, fn OneShotFunc, opts ...jobOneShotOpt) Job {
+	if fn == nil {
+		panic("`fn` must not be nil")
+	}
+
 	job := &jobOneShot{
 		name: name,
 		fn:   fn,
@@ -219,6 +238,15 @@ func WithShutdown() jobOneShotOpt {
 	}
 }
 
+// WithMetrics option enabled metrics collection for this one shot job. This option should only be used
+// for short running jobs. Metrics use the jobs name as label, so if jobs are spawned dynamically
+// make sure to use the same job name to keep metric cardinality low.
+func WithMetrics() jobOneShotOpt {
+	return func(jos *jobOneShot) {
+		jos.metrics = true
+	}
+}
+
 // OneShotFunc is the function type which is invoked by a one shot job. The given function is expected to exit as soon
 // as the context given to it expires, this is especially important for blocking or long running jobs.
 type OneShotFunc func(ctx context.Context) error
@@ -232,6 +260,7 @@ type jobOneShot struct {
 	retry           int
 	backoff         workqueue.RateLimiter
 	shutdownOnError bool
+	metrics         bool
 }
 
 func (jos *jobOneShot) start(ctx context.Context, wg *sync.WaitGroup, options options) {
@@ -246,10 +275,7 @@ func (jos *jobOneShot) start(ctx context.Context, wg *sync.WaitGroup, options op
 		"func": internal.FuncNameAndLocation(jos.fn),
 	})
 
-	if jos.fn == nil {
-		l.Error("can't start a nil one shot job")
-		return
-	}
+	stat := &spanstat.SpanStat{}
 
 	var err error
 	for i := 0; i <= jos.retry; i++ {
@@ -264,13 +290,24 @@ func (jos *jobOneShot) start(ctx context.Context, wg *sync.WaitGroup, options op
 
 		l.Debug("Starting one-shot job")
 
+		if jos.metrics {
+			stat.Start()
+		}
+
 		err = jos.fn(ctx)
+
+		if jos.metrics {
+			sec := stat.End(true).Seconds()
+			options.metrics.OneShotRunDuration.WithLabelValues(jos.name).Observe(sec)
+			stat.Reset()
+		}
 
 		if err == nil {
 			l.Debug("one-shot job finished")
 			return
-		} else {
+		} else if !errors.Is(err, context.Canceled) {
 			l.WithError(err).Error("one-shot job errored")
+			options.metrics.JobErrorsTotal.WithLabelValues(jos.name).Inc()
 		}
 	}
 
@@ -292,6 +329,10 @@ func (jos *jobOneShot) start(ctx context.Context, wg *sync.WaitGroup, options op
 // expires. This is especially important for long running functions. The signal created by a Trigger is coalesced so
 // multiple calls to trigger before the invocation takes place can result in just a single invocation.
 func Timer(name string, fn TimerFunc, interval time.Duration, opts ...timerOpt) Job {
+	if fn == nil {
+		panic("`fn` must not be nil")
+	}
+
 	job := &jobTimer{
 		name:     name,
 		fn:       fn,
@@ -365,11 +406,6 @@ func (jt *jobTimer) start(ctx context.Context, wg *sync.WaitGroup, options optio
 		"func": internal.FuncNameAndLocation(jt.fn),
 	})
 
-	if jt.fn == nil {
-		l.Error(fmt.Errorf("can't start a nil one timer job"))
-		return
-	}
-
 	timer := time.NewTicker(jt.interval)
 	defer timer.Stop()
 
@@ -379,6 +415,8 @@ func (jt *jobTimer) start(ctx context.Context, wg *sync.WaitGroup, options optio
 	}
 
 	l.Debug("Starting timer job")
+
+	stat := &spanstat.SpanStat{}
 
 	for {
 		select {
@@ -390,12 +428,19 @@ func (jt *jobTimer) start(ctx context.Context, wg *sync.WaitGroup, options optio
 
 		l.Debug("Timer job triggered")
 
+		stat.Start()
+
 		err := jt.fn(ctx)
+
+		sec := stat.End(true).Seconds()
+		options.metrics.TimerRunDuration.WithLabelValues(jt.name).Observe(sec)
+		stat.Reset()
 
 		if err == nil {
 			l.Debug("Timer job finished")
-		} else {
+		} else if !errors.Is(err, context.Canceled) {
 			l.WithError(err).Error("Timer job errored")
+			options.metrics.JobErrorsTotal.WithLabelValues(jt.name).Inc()
 			if jt.shutdown != nil {
 				jt.shutdown.Shutdown(hive.ShutdownWithError(err))
 			}
@@ -413,6 +458,10 @@ func (jt *jobTimer) start(ctx context.Context, wg *sync.WaitGroup, options optio
 // `observable`. If the `observable` completes, the job stops. The context given to the observable is also canceled
 // once the group stops.
 func Observer[T any](name string, fn ObserverFunc[T], observable stream.Observable[T], opts ...observerOpt[T]) Job {
+	if fn == nil {
+		panic("`fn` must not be nil")
+	}
+
 	job := &jobObserver[T]{
 		name:       name,
 		fn:         fn,
@@ -452,20 +501,26 @@ func (jo *jobObserver[T]) start(ctx context.Context, wg *sync.WaitGroup, options
 		"func": internal.FuncNameAndLocation(jo.fn),
 	})
 
-	if jo.fn == nil {
-		l.Error("can't start a nil observer job")
-		return
-	}
-
 	l.Debug("Observer job started")
 
 	done := make(chan struct{})
 
-	var err error
+	var (
+		stat = &spanstat.SpanStat{}
+		err  error
+	)
 	jo.observable.Observe(ctx, func(t T) {
+		stat.Start()
+
 		err := jo.fn(ctx, t)
-		if err != nil {
+
+		sec := stat.End(true).Seconds()
+		options.metrics.ObserverRunDuration.WithLabelValues(jo.name).Observe(sec)
+		stat.Reset()
+
+		if err != nil && !errors.Is(err, context.Canceled) {
 			l.WithError(err).Error("Observer job errored")
+			options.metrics.JobErrorsTotal.WithLabelValues(jo.name).Inc()
 			if jo.shutdown != nil {
 				jo.shutdown.Shutdown(hive.ShutdownWithError(
 					err,

--- a/pkg/hive/job/metrics.go
+++ b/pkg/hive/job/metrics.go
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package job
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type jobMetrics struct {
+	JobErrorsTotal      metric.Vec[metric.Counter]
+	OneShotRunDuration  metric.Vec[metric.Observer]
+	TimerRunDuration    metric.Vec[metric.Observer]
+	ObserverRunDuration metric.Vec[metric.Observer]
+}
+
+func newJobMetrics() *jobMetrics {
+	return &jobMetrics{
+		JobErrorsTotal: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "jobs_errors_total",
+			Namespace:  metrics.Namespace,
+			Subsystem:  "jobs",
+			Name:       "errors_total",
+			Help:       "The amount of errors encountered while running jobs",
+		}, []string{"job"}),
+		OneShotRunDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: metrics.Namespace + "jobs_one_shot_run_seconds",
+			Namespace:  metrics.Namespace,
+			Subsystem:  "jobs",
+			Name:       "one_shot_run_seconds",
+			Help:       "The run time of a one shot job",
+		}, []string{"job"}),
+		TimerRunDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: metrics.Namespace + "jobs_timer_run_seconds",
+			Namespace:  metrics.Namespace,
+			Subsystem:  "jobs",
+			Name:       "timer_run_seconds",
+			Help:       "The run time of a timer job",
+		}, []string{"job"}),
+		ObserverRunDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: metrics.Namespace + "jobs_observer_run_seconds",
+			Namespace:  metrics.Namespace,
+			Subsystem:  "jobs",
+			Name:       "observer_run_seconds",
+			Help:       "The run time of a observer job",
+		}, []string{"job"}),
+	}
+}


### PR DESCRIPTION
This PR adds a metric to that tracks error counts for job runs, a metric to track timer run performance and observer run performance.

For one shot jobs the metric collection is disabled by default, only jobs with the `WithMetrics` option will be measured. This way we can collect metrics for short running jobs and skip collection for high cardinality jobs or jobs that run forever.

```release-note
Added metrics for jobs
```
