### PR TITLE
metrics,endpointmanager: Register endpointmanager metrics via dependency

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -168,6 +168,7 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 		statedb.Cell,
 		tables.Cell,
 		job.Cell,
+		metrics.Cell,
 		cell.Invoke(func(p promise.Promise[*Daemon]) {
 			daemonPromise = p
 		}),

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 )
@@ -104,10 +105,6 @@ type EndpointManager interface {
 	subscriber.Node
 	EndpointResourceSynchronizer
 
-	// InitMetrics hooks the EndpointManager into the metrics subsystem. This can
-	// only be done once, globally, otherwise the metrics library will panic.
-	InitMetrics()
-
 	// Subscribe to endpoint events.
 	Subscribe(s Subscriber)
 
@@ -162,9 +159,10 @@ var (
 type endpointManagerParams struct {
 	cell.In
 
-	Lifecycle hive.Lifecycle
-	Config    EndpointManagerConfig
-	Clientset client.Clientset
+	Lifecycle       hive.Lifecycle
+	Config          EndpointManagerConfig
+	Clientset       client.Clientset
+	MetricsRegistry *metrics.Registry
 }
 
 type endpointManagerOut struct {
@@ -194,7 +192,7 @@ func newDefaultEndpointManager(p endpointManagerParams) endpointManagerOut {
 		})
 	}
 
-	mgr.InitMetrics()
+	mgr.InitMetrics(p.MetricsRegistry)
 
 	return endpointManagerOut{
 		Lookup:  mgr,

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -183,7 +183,7 @@ func (mgr *endpointManager) UpdatePolicyMaps(ctx context.Context, notifyWg *sync
 
 // InitMetrics hooks the endpointManager into the metrics subsystem. This can
 // only be done once, globally, otherwise the metrics library will panic.
-func (mgr *endpointManager) InitMetrics() {
+func (mgr *endpointManager) InitMetrics(registry *metrics.Registry) {
 	if option.Config.DryMode {
 		return
 	}
@@ -199,7 +199,7 @@ func (mgr *endpointManager) InitMetrics() {
 		},
 			func() float64 { return float64(len(mgr.GetEndpoints())) },
 		)
-		metrics.MustRegister(metrics.Endpoint)
+		registry.MustRegister(metrics.Endpoint)
 	})
 }
 

--- a/pkg/metrics/cell.go
+++ b/pkg/metrics/cell.go
@@ -6,7 +6,9 @@ package metrics
 import "github.com/cilium/cilium/pkg/hive/cell"
 
 var Cell = cell.Module("metrics", "Metrics",
-	cell.Invoke(NewRegistry),
+	// Provide registry to hive, but also invoke if case no cells decide to use as dependency
+	cell.Provide(NewRegistry),
+	cell.Invoke(func(_ *Registry) {}),
 	cell.Metric(NewLegacyMetrics),
 	cell.Config(defaultRegistryConfig),
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1442,15 +1442,6 @@ func Reinitialize() {
 	}
 }
 
-// MustRegister adds the collector to the registry, exposing this metric to
-// prometheus scrapes.
-// It will panic on error.
-func MustRegister(c ...prometheus.Collector) {
-	withRegistry(func(reg *Registry) {
-		reg.MustRegister(c...)
-	})
-}
-
 // Register registers a collector
 func Register(c prometheus.Collector) error {
 	withRegistry(func(reg *Registry) {


### PR DESCRIPTION
The endpointmanager was the last package to use the MustRegister package scope function in metrics. This PR replaces the access via global function by providing the registry via dependency injection. This allows us to get rid of the metrics.MustRegister function.

```release-note
Register endpointmanager metrics via dependency injected registry
```
