### PR TITLE
v1.13 backports 2023-06-09

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -97,7 +97,7 @@ var (
 	wildcardIPv6   = net.ParseIP("0::0")
 	wildcardCIDRv6 = &net.IPNet{
 		IP:   wildcardIPv6,
-		Mask: net.CIDRMask(128, 128),
+		Mask: net.CIDRMask(0, 128),
 	}
 
 	defaultDropMark = &netlink.XfrmMark{

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1532,8 +1532,9 @@ func (n *linuxNodeHandler) deleteIPsec(oldNode *nodeTypes.Node) {
 	nodeID := n.getNodeIDForNode(oldNode)
 	if nodeID == 0 {
 		scopedLog.Warning("No node ID found for node.")
+	} else {
+		ipsec.DeleteIPsecEndpoint(nodeID)
 	}
-	ipsec.DeleteIPsecEndpoint(nodeID)
 
 	if n.nodeConfig.EnableIPv4 && oldNode.IPv4AllocCIDR != nil {
 		old4RouteNet := &net.IPNet{IP: oldNode.IPv4AllocCIDR.IP, Mask: oldNode.IPv4AllocCIDR.Mask}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1019,6 +1019,11 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 				upsertIPsecLog(err, "in NodeInternalIPv4", wildcardCIDR, cidr, spi)
 			}
 		} else {
+			/* Insert wildcard policy rules for traffic skipping back through host */
+			if err = ipsec.IpSecReplacePolicyFwd(wildcardCIDR, localIP); err != nil {
+				log.WithError(err).Warning("egress unable to replace policy fwd:")
+			}
+
 			localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
 			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, wildcardCIDR, localIP, wildcardIP, 0, ipsec.IPSecDirIn, false)
 			upsertIPsecLog(err, "in IPv4", localCIDR, wildcardCIDR, spi)
@@ -1053,11 +1058,6 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 			n.replaceNodeIPSecOutRoute(new4Net)
 			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
 			upsertIPsecLog(err, "out IPv4", localCIDR, remoteCIDR, spi)
-
-			/* Insert wildcard policy rules for traffic skipping back through host */
-			if err = ipsec.IpSecReplacePolicyFwd(remoteCIDR, remoteIP); err != nil {
-				log.WithError(err).Warning("egress unable to replace policy fwd:")
-			}
 		}
 	}
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -500,7 +500,6 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 	scopedLog := log.WithField(fieldProxyRedirectID, id)
 
 	var revertStack revert.RevertStack
-	revertFunc = revertStack.Revert
 	defer func() {
 		if err != nil {
 			// We ignore errors while reverting. This is best-effort.
@@ -508,8 +507,12 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 			// some functions in the revert stack (like removeRevertFunc)
 			// require it
 			p.mutex.Unlock()
-			revertFunc()
+			revertStack.Revert()
 			p.mutex.Lock()
+			finalizeFunc = nil
+			revertFunc = nil
+		} else {
+			revertFunc = revertStack.Revert
 		}
 	}()
 

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -572,7 +572,8 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 		if nRetry > 0 {
 			// an error occurred and we can retry
 			scopedLog.WithError(err).Warningf("Unable to create %s proxy, retrying", ppName)
-			if option.Config.ToFQDNsProxyPort == 0 {
+			// Do not increment port for DNS when the port is set in config
+			if pp.proxyType != ProxyTypeDNS || option.Config.ToFQDNsProxyPort == 0 {
 				pp.proxyPort++
 			}
 		}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -516,10 +516,14 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 		}
 	}()
 
+	proxyPortsMutex.Lock()
+	defer proxyPortsMutex.Unlock()
+
 	if redir, ok := p.redirects[id]; ok {
 		redir.mutex.Lock()
 
-		if redir.listener.proxyType == ProxyType(l4.GetL7Parser()) {
+		// Only consider configured (but not necessarily acked) proxy ports for update
+		if redir.listener.configured && redir.listener.proxyType == ProxyType(l4.GetL7Parser()) {
 			updateRevertFunc := redir.updateRules(l4)
 			revertStack.Push(updateRevertFunc)
 			var implUpdateRevertFunc revert.RevertFunc
@@ -541,6 +545,7 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 			return
 		}
 
+		// Stale or incompatible redirects get removed before a new one is created below
 		var removeRevertFunc revert.RevertFunc
 		err, finalizeFunc, removeRevertFunc = p.removeRedirect(id, wg)
 		redir.mutex.Unlock()
@@ -553,8 +558,6 @@ func (p *Proxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolic
 		revertStack.Push(removeRevertFunc)
 	}
 
-	proxyPortsMutex.Lock()
-	defer proxyPortsMutex.Unlock()
 	ppName, pp := findProxyPortByType(ProxyType(l4.GetL7Parser()), l4.GetListener(), l4.GetIngress())
 	if pp == nil {
 		err = proxyTypeNotFoundError(ProxyType(l4.GetL7Parser()), l4.GetListener(), l4.GetIngress())

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -5,8 +5,15 @@ package proxy
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/proxy/logger"
+	"github.com/cilium/cilium/pkg/proxy/logger/test"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 
 	. "gopkg.in/check.v1"
@@ -165,4 +172,58 @@ func (s *ProxySuite) TestPortAllocator(c *C) {
 	c.Assert(pp.isStatic, Equals, false)
 	c.Assert(pp.nRedirects, Equals, 0)
 	c.Assert(pp.rulesPort, Equals, port3)
+}
+
+type fakeProxyPolicy struct{}
+
+func (p *fakeProxyPolicy) CopyL7RulesPerEndpoint() policy.L7DataMap {
+	return policy.L7DataMap{}
+}
+
+func (p *fakeProxyPolicy) GetL7Parser() policy.L7ParserType {
+	return policy.ParserTypeCRD
+}
+
+func (p *fakeProxyPolicy) GetIngress() bool {
+	return false
+}
+
+func (p *fakeProxyPolicy) GetPort() uint16 {
+	return uint16(80)
+}
+
+func (p *fakeProxyPolicy) GetListener() string {
+	return "nonexisting-listener"
+}
+
+func (s *ProxySuite) TestCreateOrUpdateRedirectMissingListener(c *C) {
+	mockDatapathUpdater := &MockDatapathUpdater{}
+
+	testRunDir := c.MkDir()
+	socketDir := filepath.Join(testRunDir, "envoy", "sockets")
+	err := os.MkdirAll(socketDir, 0700)
+	c.Assert(err, IsNil)
+
+	p := StartProxySupport(10000, 20000, testRunDir, nil, nil, mockDatapathUpdater, nil,
+		testipcache.NewMockIPCache())
+
+	Identity := identity.NumericIdentity(123)
+	var ep logger.EndpointUpdater = &test.ProxyUpdaterMock{
+		Id:       1000,
+		Ipv4:     "10.0.0.1",
+		Ipv6:     "f00d::1",
+		Labels:   []string{"id.foo", "id.bar"},
+		Identity: Identity,
+	}
+
+	l4 := &fakeProxyPolicy{}
+
+	ctx := context.TODO()
+	wg := completion.NewWaitGroup(ctx)
+
+	proxyPort, err, finalizeFunc, revertFunc := p.CreateOrUpdateRedirect(ctx, l4, "dummy-proxy-id", ep, wg)
+	c.Assert(proxyPort, Equals, uint16(0))
+	c.Assert(err, NotNil)
+	c.Assert(finalizeFunc, IsNil)
+	c.Assert(revertFunc, IsNil)
 }


### PR DESCRIPTION
 - [x] #25969 -- proxy: Do not panic on local error (@jrajahalme)
     - Trivial conflict in includes.
 - [x] #25953 -- ipsec: Change XFRM FWD policy to simplest wildcard (@pchaigno)
 - [x] #26072 -- ipsec: Fix cleanup of XFRM states and policies (@pchaigno)

Skipped to focus on the above release blocker:

 - [ ] #25908 -- docker: Detect default "desktop-linux" builder (@jrajahalme)
 - [ ] #26047 -- bpf: nodeport: wire up trace struct for IPv6 RevDNAT (@julianwiedmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25969 25953 26072; do contrib/backporting/set-labels.py $pr done 1.13; done
```
