### PR TITLE
Introduce kvstoremesh, a clustermesh-apiserver companion component

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -362,6 +362,7 @@ Makefile* @cilium/build
 /install/kubernetes/ @cilium/sig-k8s @cilium/helm
 /install/kubernetes/cilium/templates/hubble* @cilium/sig-k8s @cilium/helm @cilium/sig-hubble
 jenkinsfiles @cilium/ci-structure
+/kvstoremesh @cilium/sig-clustermesh
 /LICENSE @cilium/tophat
 /MAINTAINERS.md @cilium/contributing
 /netlify.toml @cilium/ci-structure

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -179,9 +179,11 @@ metrics conform to the OpenMetrics requirements.
 Cluster Mesh API Server Metrics
 ===============================
 
-Cluster Mesh API Server metrics provide insights into both the state of the
-``clustermesh-apiserver`` process and the sidecar etcd instance.
+Cluster Mesh API Server metrics provide insights into the state of the
+``clustermesh-apiserver`` process, the ``kvstoremesh`` process (if enabled),
+and the sidecar etcd instance.
 Cluster Mesh API Server metrics are exported under the ``cilium_clustermesh_apiserver_``
+Prometheus namespace. KVStoreMesh metrics are exported under the ``cilium_kvstoremesh_``
 Prometheus namespace. Etcd metrics are exported under the ``etcd_`` Prometheus namespace.
 
 
@@ -920,3 +922,59 @@ Name                                     Labels                                 
 ``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Number of elements queued for synchronization in the kvstore
 ``kvstore_initial_sync_completed``       ``scope``, ``source_cluster``, ``action``    Whether the initial synchronization from/to the kvstore has completed
 ======================================== ============================================ ========================================================
+
+.. _kvstoremesh_metrics_reference:
+
+kvstoremesh
+-----------
+
+Configuration
+^^^^^^^^^^^^^
+
+To expose any metrics, invoke ``kvstoremesh`` with the
+``--prometheus-serve-addr`` option. This option takes a ``IP:Port`` pair but
+passing an empty IP (e.g. ``:9964``) binds the server to all available
+interfaces (there is usually only one interface in a container).
+
+Exported Metrics
+^^^^^^^^^^^^^^^^
+
+All metrics are exported under the ``cilium_kvstoremesh_`` Prometheus namespace.
+
+Remote clusters
+~~~~~~~~~~~~~~~
+
+==================================== ======================================= =================================================================
+Name                                 Labels                                                       Description
+==================================== ======================================= =================================================================
+``remote_clusters``                  ``source_cluster``                      The total number of remote clusters meshed with the local cluster
+``remote_cluster_failures``          ``source_cluster``, ``target_cluster``  The total number of failures related to the remote cluster
+``remote_cluster_last_failure_ts``   ``source_cluster``, ``target_cluster``  The timestamp of the last failure of the remote cluster
+``remote_cluster_readiness_status``  ``source_cluster``, ``target_cluster``  The readiness status of the remote cluster
+==================================== ======================================= =================================================================
+
+KVstore
+~~~~~~~
+
+======================================== ============================================ ========================================================
+Name                                     Labels                                       Description
+======================================== ============================================ ========================================================
+``kvstore_operations_duration_seconds``  ``action``, ``kind``, ``outcome``, ``scope`` Duration of kvstore operation
+``kvstore_events_queue_seconds``         ``action``, ``scope``                        Seconds waited before a received event was queued
+``kvstore_quorum_errors_total``          ``error``                                    Number of quorum errors
+``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Number of elements queued for synchronization in the kvstore
+``kvstore_initial_sync_completed``       ``scope``, ``source_cluster``, ``action``    Whether the initial synchronization from/to the kvstore has completed
+======================================== ============================================ ========================================================
+
+API Rate Limiting
+~~~~~~~~~~~~~~~~~
+
+============================================== ================================ ========================================================
+Name                                           Labels                           Description
+============================================== ================================ ========================================================
+``api_limiter_processed_requests_total``       ``api_call``, ``outcome``        Total number of API requests processed
+``api_limiter_processing_duration_seconds``    ``api_call``, ``value``          Mean and estimated processing duration in seconds
+``api_limiter_rate_limit``                     ``api_call``, ``value``          Current rate limiting configuration (limit and burst)
+``api_limiter_requests_in_flight``             ``api_call``  ``value``          Current and maximum allowed number of requests in flight
+``api_limiter_wait_duration_seconds``          ``api_call``, ``value``          Mean, min, and max wait duration
+============================================== ================================ ========================================================

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -662,6 +662,7 @@ kubeproxy
 kubernetes
 kubespray
 kvstore
+kvstoremesh
 labelsContext
 latencies
 lbExternalClusterIP

--- a/kvstoremesh/.gitignore
+++ b/kvstoremesh/.gitignore
@@ -1,0 +1,1 @@
+kvstoremesh

--- a/kvstoremesh/Makefile
+++ b/kvstoremesh/Makefile
@@ -1,0 +1,32 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+include ../Makefile.defs
+
+TARGET := kvstoremesh
+
+.PHONY: all $(TARGET) clean install
+
+all: $(TARGET)
+
+$(TARGET):
+	@$(ECHO_GO)
+	$(QUIET)$(GO_BUILD) -o $@
+
+clean:
+	@$(ECHO_CLEAN)
+	-$(QUIET)rm -f $(TARGET)
+	$(QUIET)$(GO_CLEAN)
+
+install: install-binary install-bash-completion-only
+
+install-binary:
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(BINDIR)
+	$(QUIET)$(INSTALL) -m 0755 $(TARGET) $(DESTDIR)$(BINDIR)
+
+install-bash-completion: $(TARGET) install-bash-completion-only
+
+install-bash-completion-only:
+	$(QUIET)$(INSTALL) -m 0755 -d $(DESTDIR)$(CONFDIR)/bash_completion.d
+	./$(TARGET) completion bash > $(TARGET)_bash_completion
+	$(QUIET)$(INSTALL) -m 0644 -T $(TARGET)_bash_completion $(DESTDIR)$(CONFDIR)/bash_completion.d/$(TARGET)

--- a/kvstoremesh/main.go
+++ b/kvstoremesh/main.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	kmmetrics "github.com/cilium/cilium/kvstoremesh/metrics"
+	kmopt "github.com/cilium/cilium/kvstoremesh/option"
+	"github.com/cilium/cilium/pkg/clustermesh/kvstoremesh"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/gops"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/pprof"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "kvstoremesh")
+
+	rootHive *hive.Hive
+
+	rootCmd = &cobra.Command{
+		Use:   "kvstoremesh",
+		Short: "Run KVStoreMesh",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := rootHive.Run(); err != nil {
+				log.Fatal(err)
+			}
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			// Overwrite the metrics namespace with the one specific for KVStoreMesh
+			metrics.Namespace = metrics.CiliumKVStoreMeshNamespace
+			option.Config.Populate(rootHive.Viper())
+			if option.Config.Debug {
+				log.Logger.SetLevel(logrus.DebugLevel)
+			}
+			option.LogRegisteredOptions(rootHive.Viper(), log)
+		},
+	}
+)
+
+func init() {
+	rootHive = hive.New(
+		pprof.Cell,
+		cell.Config(pprof.Config{
+			PprofAddress: kmopt.PprofAddress,
+			PprofPort:    kmopt.PprofPort,
+		}),
+
+		gops.Cell(defaults.GopsPortKVStoreMesh),
+		kmmetrics.Cell,
+
+		cell.Config(kmopt.KVStoreMeshConfig{}),
+		cell.Provide(cfgAdapter),
+
+		kvstore.Cell(kvstore.EtcdBackendName),
+		cell.Provide(func() *kvstore.ExtraOptions { return nil }),
+		kvstoremesh.Cell,
+
+		cell.Invoke(func(*kvstoremesh.KVStoreMesh) {}),
+	)
+
+	rootHive.RegisterFlags(rootCmd.Flags())
+	rootCmd.AddCommand(rootHive.Command())
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func cfgAdapter(lc hive.Lifecycle, cfg kmopt.KVStoreMeshConfig) (types.ClusterIDName, error) {
+	lc.Append(hive.Hook{
+		OnStart: func(hive.HookContext) error {
+			if err := types.ValidateClusterID(cfg.ClusterID); err != nil {
+				return err
+			}
+
+			if cfg.ClusterName == "" {
+				return errors.New("ClusterName is unset")
+			}
+
+			return nil
+		},
+	})
+
+	return types.ClusterIDName{
+		ClusterID:   cfg.ClusterID,
+		ClusterName: cfg.ClusterName,
+	}, nil
+}

--- a/kvstoremesh/metrics/metrics.go
+++ b/kvstoremesh/metrics/metrics.go
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"errors"
+	"net/http"
+	"regexp"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+	"github.com/cilium/cilium/pkg/option"
+)
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "metrics")
+)
+
+var Cell = cell.Module(
+	"kvstoremesh-metrics",
+	"KVStoreMesh metrics",
+
+	cell.Config(MetricsConfig{}),
+	cell.Invoke(registerMetricsManager),
+)
+
+type MetricsConfig struct {
+	// PrometheusServeAddr IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off)
+	PrometheusServeAddr string
+}
+
+func (def MetricsConfig) Flags(flags *pflag.FlagSet) {
+	flags.String(option.PrometheusServeAddr, def.PrometheusServeAddr, "Address to serve Prometheus metrics")
+}
+
+type metricsManager struct {
+	registry *prometheus.Registry
+	server   http.Server
+
+	metrics []metric.WithMetadata
+}
+
+type params struct {
+	cell.In
+
+	MetricsConfig
+
+	Metrics []metric.WithMetadata `group:"hive-metrics"`
+}
+
+func registerMetricsManager(lc hive.Lifecycle, params params) error {
+	manager := metricsManager{
+		registry: prometheus.NewPedanticRegistry(),
+		server:   http.Server{Addr: params.PrometheusServeAddr},
+		metrics:  params.Metrics,
+	}
+
+	if params.PrometheusServeAddr != "" {
+		lc.Append(&manager)
+	} else {
+		log.Info("Prometheus metrics are disabled")
+	}
+
+	return nil
+}
+
+func (mm *metricsManager) Start(hive.HookContext) error {
+	log.Info("Registering metrics")
+
+	mm.registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
+	mm.registry.MustRegister(collectors.NewGoCollector(
+		collectors.WithGoCollectorRuntimeMetrics(
+			collectors.GoRuntimeMetricsRule{Matcher: regexp.MustCompile(`^/sched/latencies:seconds`)},
+		)))
+
+	// Constructing the legacy metrics and register them at the metrics global variable.
+	// This is a hack until we can unify this metrics manager with the metrics.Registry.
+	metrics.NewLegacyMetrics()
+	mm.registry.MustRegister(
+		metrics.VersionMetric,
+		metrics.KVStoreOperationsDuration,
+		metrics.KVStoreEventsQueueDuration,
+		metrics.KVStoreQuorumErrors,
+		metrics.KVStoreSyncQueueSize,
+		metrics.KVStoreInitialSyncCompleted,
+		metrics.APILimiterProcessingDuration,
+		metrics.APILimiterWaitDuration,
+		metrics.APILimiterRequestsInFlight,
+		metrics.APILimiterRateLimit,
+		metrics.APILimiterProcessedRequests,
+	)
+
+	for _, metric := range mm.metrics {
+		mm.registry.MustRegister(metric.(prometheus.Collector))
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(mm.registry, promhttp.HandlerOpts{}))
+	mm.server.Handler = mux
+
+	go func() {
+		log.WithField("address", mm.server.Addr).Info("Starting metrics server")
+		if err := mm.server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			log.WithError(err).Fatal("Unable to start metrics server")
+		}
+	}()
+
+	return nil
+}
+
+func (mm *metricsManager) Stop(ctx hive.HookContext) error {
+	log.Info("Stopping metrics server")
+
+	if err := mm.server.Shutdown(ctx); err != nil {
+		log.WithError(err).Error("Shutdown metrics server failed")
+		return err
+	}
+
+	return nil
+}

--- a/kvstoremesh/option/config.go
+++ b/kvstoremesh/option/config.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package option
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+const (
+	// PprofAddress is the default value for pprof in kvstoremesh
+	PprofAddress = "localhost"
+
+	// PprofPort is the default value for pprof in kvstoremesh
+	PprofPort = 6064
+)
+
+// Config is the KVStoreMeshConfig configuration.
+type KVStoreMeshConfig struct {
+	Debug bool
+
+	ClusterName string
+	ClusterID   uint32
+}
+
+func (def KVStoreMeshConfig) Flags(flags *pflag.FlagSet) {
+	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
+	flags.String(option.ClusterName, def.ClusterName, "Name of the cluster")
+	flags.Uint32(option.ClusterIDName, def.ClusterID, "Unique identifier of the cluster")
+}

--- a/pkg/clustermesh/kvstoremesh/cell.go
+++ b/pkg/clustermesh/kvstoremesh/cell.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstoremesh
+
+import (
+	"github.com/cilium/cilium/pkg/clustermesh/internal"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+var Cell = cell.Module(
+	"kvstoremesh",
+	"KVStoreMesh caches remote cluster information in a local kvstore",
+
+	cell.Provide(newKVStoreMesh),
+
+	cell.Config(internal.Config{}),
+
+	cell.Metric(internal.MetricsProvider("")),
+)

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh.go
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstoremesh
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/clustermesh/internal"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/kvstore"
+	nodeStore "github.com/cilium/cilium/pkg/node/store"
+	"github.com/cilium/cilium/pkg/promise"
+	serviceStore "github.com/cilium/cilium/pkg/service/store"
+)
+
+// KVStoreMesh is a cache of multiple remote clusters
+type KVStoreMesh struct {
+	internal internal.ClusterMesh
+
+	// backend is the interface to operate the local kvstore
+	backend        kvstore.BackendOperations
+	backendPromise promise.Promise[kvstore.BackendOperations]
+}
+
+type params struct {
+	cell.In
+
+	types.ClusterIDName
+	internal.Config
+
+	BackendPromise promise.Promise[kvstore.BackendOperations]
+
+	Metrics internal.Metrics
+}
+
+func newKVStoreMesh(lc hive.Lifecycle, params params) *KVStoreMesh {
+	km := KVStoreMesh{backendPromise: params.BackendPromise}
+	km.internal = internal.NewClusterMesh(internal.Configuration{
+		Config:           params.Config,
+		ClusterIDName:    params.ClusterIDName,
+		NewRemoteCluster: km.newRemoteCluster,
+		Metrics:          params.Metrics,
+	})
+
+	lc.Append(&km)
+
+	// The "internal" Start hook needs to be executed after that the kvstoremesh one
+	// terminated, to ensure that the backend promise has already been resolved.
+	lc.Append(&km.internal)
+
+	return &km
+}
+
+func (km *KVStoreMesh) Start(ctx hive.HookContext) error {
+	backend, err := km.backendPromise.Await(ctx)
+	if err != nil {
+		return err
+	}
+
+	km.backend = backend
+	return nil
+}
+
+func (km *KVStoreMesh) Stop(hive.HookContext) error {
+	return nil
+}
+
+func (km *KVStoreMesh) newRemoteCluster(name string, _ internal.StatusFunc) internal.RemoteCluster {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	rc := &remoteCluster{
+		name:         name,
+		localBackend: km.backend,
+
+		cancel: cancel,
+
+		nodes:      newReflector(km.backend, name, nodeStore.NodeStorePrefix),
+		services:   newReflector(km.backend, name, serviceStore.ServiceStorePrefix),
+		identities: newReflector(km.backend, name, identityCache.IdentitiesPath),
+		ipcache:    newReflector(km.backend, name, ipcache.IPIdentitiesPath),
+	}
+
+	run := func(fn func(context.Context)) {
+		rc.wg.Add(1)
+		go func() {
+			fn(ctx)
+			rc.wg.Done()
+		}()
+	}
+
+	run(rc.nodes.syncer.Run)
+	run(rc.services.syncer.Run)
+	run(rc.identities.syncer.Run)
+	run(rc.ipcache.syncer.Run)
+
+	return rc
+}

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstoremesh
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/clustermesh/utils"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+// Configure a generous timeout to prevent flakes when running in a noisy CI environment.
+var (
+	tick    = 10 * time.Millisecond
+	timeout = 5 * time.Second
+)
+
+type remoteEtcdClientWrapper struct {
+	kvstore.BackendOperations
+	name   string
+	cached bool
+
+	kvs map[string]string
+	mu  lock.Mutex
+
+	syncedCanariesWatched bool
+}
+
+// Override the ListAndWatch method so that we can propagate whatever event we want without key conflicts with
+// those eventually created by kvstoremesh. Additionally, this also allows to track which prefixes have been watched.
+func (w *remoteEtcdClientWrapper) ListAndWatch(ctx context.Context, name, prefix string, chanSize int) *kvstore.Watcher {
+	events := make(kvstore.EventChan, 10)
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if prefix == fmt.Sprintf("cilium/synced/%s/", w.name) {
+		state := "state"
+		if w.cached {
+			state = "cache"
+		}
+
+		w.syncedCanariesWatched = true
+		events <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeCreate, Key: fmt.Sprintf("cilium/synced/%s/cilium/%s/nodes/v1", w.name, state)}
+		events <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeCreate, Key: fmt.Sprintf("cilium/synced/%s/cilium/%s/services/v1", w.name, state)}
+		events <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeCreate, Key: fmt.Sprintf("cilium/synced/%s/cilium/%s/identities/v1", w.name, state)}
+		events <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeCreate, Key: fmt.Sprintf("cilium/synced/%s/cilium/%s/ip/v1", w.name, state)}
+	} else {
+		for key, value := range w.kvs {
+			var found bool
+			if strings.HasPrefix(key, prefix) {
+				events <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeCreate, Key: key, Value: []byte(value)}
+				found = true
+				delete(w.kvs, key)
+			}
+
+			if found {
+				events <- kvstore.KeyValueEvent{Typ: kvstore.EventTypeListDone}
+			}
+		}
+	}
+
+	go func() {
+		<-ctx.Done()
+		close(events)
+	}()
+
+	return &kvstore.Watcher{Events: events}
+}
+
+func TestRemoteClusterRun(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	kvstore.SetupDummyWithConfigOpts("etcd",
+		// Explicitly set higher QPS than the default to speedup the test
+		map[string]string{kvstore.EtcdRateLimitOption: "100"},
+	)
+	t.Cleanup(func() {
+		kvstore.Client().Close(context.Background())
+	})
+
+	tests := []struct {
+		name   string
+		srccfg *types.CiliumClusterConfig
+		dstcfg *types.CiliumClusterConfig
+		kvs    map[string]string
+	}{
+		{
+			name:   "remote cluster has no cluster config",
+			srccfg: nil,
+			dstcfg: &types.CiliumClusterConfig{
+				Capabilities: types.CiliumClusterConfigCapabilities{
+					SyncedCanaries: true,
+					Cached:         true,
+				},
+			},
+			kvs: map[string]string{
+				"cilium/state/nodes/v1/foo/bar":    "qux1",
+				"cilium/state/services/v1/foo/bar": "qux2",
+				"cilium/state/identities/v1/bar":   "qux3",
+				"cilium/state/ip/v1/default/bar":   "qux4",
+			},
+		},
+		{
+			name: "remote cluster supports the synced canaries",
+			srccfg: &types.CiliumClusterConfig{
+				Capabilities: types.CiliumClusterConfigCapabilities{
+					SyncedCanaries: true,
+				},
+			},
+			dstcfg: &types.CiliumClusterConfig{
+				Capabilities: types.CiliumClusterConfigCapabilities{
+					SyncedCanaries: true,
+					Cached:         true,
+				},
+			},
+			kvs: map[string]string{
+				"cilium/state/nodes/v1/foo/bar":    "qux1",
+				"cilium/state/services/v1/foo/bar": "qux2",
+				"cilium/state/identities/v1/bar":   "qux3",
+				"cilium/state/ip/v1/default/bar":   "qux4",
+			},
+		},
+		{
+			name: "remote cluster supports the cached prefixes",
+			srccfg: &types.CiliumClusterConfig{
+				ID: 10,
+				Capabilities: types.CiliumClusterConfigCapabilities{
+					Cached: true,
+				},
+			},
+			dstcfg: &types.CiliumClusterConfig{
+				ID: 10,
+				Capabilities: types.CiliumClusterConfigCapabilities{
+					SyncedCanaries: true,
+					Cached:         true,
+				},
+			},
+			kvs: map[string]string{
+				"cilium/cache/nodes/v1/foo/bar":      "qux1",
+				"cilium/cache/services/v1/foo/bar":   "qux2",
+				"cilium/cache/identities/v1/foo/bar": "qux3",
+				"cilium/cache/ip/v1/foo/bar":         "qux4",
+			},
+		},
+		{
+			name: "remote cluster supports both synced canaries and cached prefixes",
+			srccfg: &types.CiliumClusterConfig{
+				ID: 10,
+				Capabilities: types.CiliumClusterConfigCapabilities{
+					SyncedCanaries: true,
+					Cached:         true,
+				},
+			},
+			dstcfg: &types.CiliumClusterConfig{
+				ID: 10,
+				Capabilities: types.CiliumClusterConfigCapabilities{
+					SyncedCanaries: true,
+					Cached:         true,
+				},
+			},
+			kvs: map[string]string{
+				"cilium/cache/nodes/v1/foo/bar":      "qux1",
+				"cilium/cache/services/v1/foo/bar":   "qux2",
+				"cilium/cache/identities/v1/foo/bar": "qux3",
+				"cilium/cache/ip/v1/foo/bar":         "qux4",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wg sync.WaitGroup
+			ctx, cancel := context.WithCancel(context.Background())
+
+			t.Cleanup(func() {
+				cancel()
+				wg.Wait()
+
+				require.NoError(t, kvstore.Client().DeletePrefix(context.Background(), "cilium/"))
+			})
+
+			remoteClient := &remoteEtcdClientWrapper{
+				BackendOperations: kvstore.Client(),
+				name:              "foo",
+				cached:            tt.srccfg != nil && tt.srccfg.Capabilities.Cached,
+				kvs:               tt.kvs,
+			}
+
+			km := KVStoreMesh{backend: kvstore.Client()}
+			rc := km.newRemoteCluster("foo", nil)
+
+			wg.Add(1)
+			go func() {
+				rc.Run(ctx, remoteClient, tt.srccfg)
+				rc.Stop()
+				wg.Done()
+			}()
+
+			// Assert that the cluster config got properly propagated
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				cfg, err := utils.GetClusterConfig(ctx, "foo", kvstore.Client())
+				assert.NoError(c, err)
+				assert.Equal(c, tt.dstcfg, cfg)
+			}, timeout, tick, "Failed to retrieve the cluster config")
+
+			// Assert that the keys have been properly reflected
+			for key, value := range map[string]string{
+				"cilium/cache/nodes/v1/foo/bar":      "qux1",
+				"cilium/cache/services/v1/foo/bar":   "qux2",
+				"cilium/cache/identities/v1/foo/bar": "qux3",
+				"cilium/cache/ip/v1/foo/bar":         "qux4",
+			} {
+				require.EventuallyWithTf(t, func(c *assert.CollectT) {
+					v, err := kvstore.Client().Get(ctx, key)
+					assert.NoError(c, err)
+					assert.Equal(c, value, string(v))
+				}, timeout, tick, "Expected key %q does not seem to have the correct value %q", key, value)
+			}
+
+			// Assert that the sync canaries have been properly set
+			for _, key := range []string{
+				"cilium/synced/foo/cilium/cache/nodes/v1",
+				"cilium/synced/foo/cilium/cache/services/v1",
+				"cilium/synced/foo/cilium/cache/identities/v1",
+				"cilium/synced/foo/cilium/cache/ip/v1",
+			} {
+				require.EventuallyWithTf(t, func(c *assert.CollectT) {
+					v, err := kvstore.Client().Get(ctx, key)
+					assert.NoError(c, err)
+					assert.NotEmpty(c, string(v))
+				}, timeout, tick, "Expected sync canary %q is not correctly present", key)
+			}
+
+			// Assert that synced canaries have been watched if expected
+			require.Equal(t, tt.srccfg != nil && tt.srccfg.Capabilities.SyncedCanaries, remoteClient.syncedCanariesWatched)
+		})
+	}
+}

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package kvstoremesh
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"sync"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
+	identityCache "github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/kvstore/store"
+	nodeStore "github.com/cilium/cilium/pkg/node/store"
+	serviceStore "github.com/cilium/cilium/pkg/service/store"
+)
+
+// remoteCluster represents a remote cluster other than the local one this
+// service is running in
+type remoteCluster struct {
+	name string
+
+	localBackend kvstore.BackendOperations
+
+	nodes      reflector
+	services   reflector
+	identities reflector
+	ipcache    reflector
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperations, srccfg *types.CiliumClusterConfig) error {
+	dstcfg := types.CiliumClusterConfig{
+		Capabilities: types.CiliumClusterConfigCapabilities{
+			SyncedCanaries: true,
+			Cached:         true,
+		},
+	}
+
+	if srccfg != nil {
+		dstcfg.ID = srccfg.ID
+	}
+
+	if err := cmutils.SetClusterConfig(ctx, rc.name, &dstcfg, rc.localBackend); err != nil {
+		return fmt.Errorf("failed to propagate cluster configuration: %w", err)
+	}
+
+	var capabilities types.CiliumClusterConfigCapabilities
+	if srccfg != nil {
+		capabilities = srccfg.Capabilities
+	}
+
+	var mgr store.WatchStoreManager
+	if capabilities.SyncedCanaries {
+		mgr = store.NewWatchStoreManagerSync(backend, rc.name)
+	} else {
+		mgr = store.NewWatchStoreManagerImmediate(rc.name)
+	}
+
+	adapter := func(prefix string) string { return prefix }
+	if capabilities.Cached {
+		adapter = kvstore.StateToCachePrefix
+	}
+
+	mgr.Register(adapter(nodeStore.NodeStorePrefix), func(ctx context.Context) {
+		rc.nodes.watcher.Watch(ctx, backend, path.Join(adapter(nodeStore.NodeStorePrefix), rc.name))
+	})
+
+	mgr.Register(adapter(serviceStore.ServiceStorePrefix), func(ctx context.Context) {
+		rc.services.watcher.Watch(ctx, backend, path.Join(adapter(serviceStore.ServiceStorePrefix), rc.name))
+	})
+
+	mgr.Register(adapter(ipcache.IPIdentitiesPath), func(ctx context.Context) {
+		suffix := ipcache.DefaultAddressSpace
+		if capabilities.Cached {
+			suffix = rc.name
+		}
+
+		rc.ipcache.watcher.Watch(ctx, backend, path.Join(adapter(ipcache.IPIdentitiesPath), suffix))
+	})
+
+	mgr.Register(adapter(identityCache.IdentitiesPath), func(ctx context.Context) {
+		var suffix string
+		if capabilities.Cached {
+			suffix = rc.name
+		}
+
+		rc.identities.watcher.Watch(ctx, backend, path.Join(adapter(identityCache.IdentitiesPath), suffix))
+	})
+
+	mgr.Run(ctx)
+	return nil
+}
+
+func (rc *remoteCluster) Stop() {
+	rc.cancel()
+	rc.wg.Wait()
+}
+
+func (rc *remoteCluster) Remove() {
+	// Cluster specific keys are not explicitly removed, but they will be
+	// disappear once the associated lease expires.
+}
+
+type reflector struct {
+	watcher store.WatchStore
+	syncer  syncer
+}
+
+type syncer struct {
+	store.SyncStore
+}
+
+func (o *syncer) OnUpdate(key store.Key) {
+	o.UpsertKey(context.Background(), key)
+}
+
+func (o *syncer) OnDelete(key store.NamedKey) {
+	o.DeleteKey(context.Background(), key)
+}
+
+func (o *syncer) OnSync(ctx context.Context) {
+	o.Synced(ctx)
+}
+
+func newReflector(local kvstore.BackendOperations, cluster, prefix string) reflector {
+	prefix = kvstore.StateToCachePrefix(prefix)
+	syncer := syncer{
+		SyncStore: store.NewWorkqueueSyncStore(cluster, local, path.Join(prefix, cluster),
+			store.WSSWithSyncedKeyOverride(prefix)),
+	}
+
+	watcher := store.NewRestartableWatchStore(cluster, store.KVPairCreator, &syncer,
+		store.RWSWithOnSyncCallback(syncer.OnSync),
+	)
+
+	return reflector{
+		syncer:  syncer,
+		watcher: watcher,
+	}
+}

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -36,6 +36,11 @@ type CiliumClusterConfig struct {
 type CiliumClusterConfigCapabilities struct {
 	// Supports per-prefix "synced" canaries
 	SyncedCanaries bool `json:"syncedCanaries,omitempty"`
+
+	// The information concerning the given cluster is cached from an external
+	// kvstore (for instance, by kvstoremesh). This implies that keys are stored
+	// under the dedicated "cilium/cache" prefix, and all are cluster-scoped.
+	Cached bool `json:"cached,omitempty"`
 }
 
 func (c0 *CiliumClusterConfig) IsCompatible(c1 *CiliumClusterConfig) error {

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -26,6 +26,9 @@ const (
 	// GopsPortApiserver is the default value for option.GopsPort in the apiserver
 	GopsPortApiserver = 9892
 
+	// GopsPortKVStoreMesh is the default value for option.GopsPort in kvstoremesh
+	GopsPortKVStoreMesh = 9894
+
 	// IPv6ClusterAllocCIDR is the default value for option.IPv6ClusterAllocCIDR
 	IPv6ClusterAllocCIDR = IPv6ClusterAllocCIDRBase + "/64"
 

--- a/pkg/kvstore/dummy.go
+++ b/pkg/kvstore/dummy.go
@@ -7,12 +7,12 @@ import "context"
 
 // SetupDummy sets up kvstore for tests
 func SetupDummy(dummyBackend string) {
-	setupDummyWithConfigOpts(dummyBackend, nil)
+	SetupDummyWithConfigOpts(dummyBackend, nil)
 }
 
-// setupDummyWithConfigOpts sets up the dummy kvstore for tests but also
+// SetupDummyWithConfigOpts sets up the dummy kvstore for tests but also
 // configures the module with the provided opts.
-func setupDummyWithConfigOpts(dummyBackend string, opts map[string]string) {
+func SetupDummyWithConfigOpts(dummyBackend string, opts map[string]string) {
 	module := getBackend(dummyBackend)
 	if module == nil {
 		log.Panicf("Unknown dummy kvstore backend %s", dummyBackend)

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -671,7 +671,12 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 		statusCheckErrors:    make(chan error, 128),
 	}
 
-	ec.leaseManager = newEtcdLeaseManager(c, option.Config.KVstoreLeaseTTL, etcdMaxKeysPerLease, ec.expiredLeaseObserver, ec.getLogger())
+	leaseTTL := option.Config.KVstoreLeaseTTL
+	if option.Config.KVstoreLeaseTTL == 0 {
+		leaseTTL = defaults.KVstoreLeaseTTL
+	}
+
+	ec.leaseManager = newEtcdLeaseManager(c, leaseTTL, etcdMaxKeysPerLease, ec.expiredLeaseObserver, ec.getLogger())
 
 	// create session in parallel as this is a blocking operation
 	go func() {

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -1676,7 +1676,7 @@ var _ = Suite(&EtcdRateLimiterSuite{})
 func (e *EtcdRateLimiterSuite) setupWithRateLimiter() {
 	// The rate limiter is configured with max QPS and burst both
 	// configured to the provided value for rate limit option.
-	setupDummyWithConfigOpts("etcd", map[string]string{
+	SetupDummyWithConfigOpts("etcd", map[string]string{
 		EtcdRateLimitOption: fmt.Sprintf("%d", e.maxQPS),
 	})
 

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -4,6 +4,7 @@
 package kvstore
 
 import (
+	"strings"
 	"time"
 )
 
@@ -59,3 +60,13 @@ const (
 	// HeartbeatPath is updated
 	HeartbeatWriteInterval = time.Minute
 )
+
+// StateToCachePrefix converts a kvstore prefix starting with "cilium/state"
+// (holding the cilium state) to the corresponding one holding cached information
+// from another kvstore (that is, "cilium/cache").
+func StateToCachePrefix(prefix string) string {
+	if strings.HasPrefix(prefix, "cilium/state") {
+		return strings.Replace(prefix, "cilium/state", "cilium/cache", 1)
+	}
+	return prefix
+}

--- a/pkg/kvstore/kvstore_test.go
+++ b/pkg/kvstore/kvstore_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/testutils"
 )
@@ -41,5 +42,35 @@ func (s *independentSuite) TestValidateScopesFromKey(c *C) {
 
 	for key, val := range mockData {
 		c.Assert(GetScopeFromKey(key), Equals, val)
+	}
+}
+
+func TestStateToCachePrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "a prefix starting with cilium/state",
+			input:    "cilium/state/foo/bar",
+			expected: "cilium/cache/foo/bar",
+		},
+		{
+			name:     "a prefix not starting with cilium/state",
+			input:    "cilium/foo/bar",
+			expected: "cilium/foo/bar",
+		},
+		{
+			name:     "a prefix containing but not starting with cilium/state",
+			input:    "cilium/foo/bar/cilium/state/qux",
+			expected: "cilium/foo/bar/cilium/state/qux",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, StateToCachePrefix(tt.input))
+		})
 	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -75,6 +75,10 @@ const (
 	// Cilium Cluster Mesh API Server
 	CiliumClusterMeshAPIServerNamespace = "cilium_clustermesh_apiserver"
 
+	// CiliumClusterMeshAPIServerNamespace is used to scope metrics from
+	// Cilium KVStoreMesh
+	CiliumKVStoreMeshNamespace = "cilium_kvstoremesh"
+
 	// LabelError indicates the type of error (string)
 	LabelError = "error"
 


### PR DESCRIPTION
Please review commit by commit. I'm reporting the description of the main commit here for your convenience:

```
In the current clustermesh implementation, each agent connects to the
kvstore in all remote clusters, pulling information about nodes,
services, identities and IPs. The number of etcd watchers can grow
significantly large (~ 5 * total nodes in the clustermesh), as well
as the number of events to be relayed by etcd to the agents (especially
if the churn rate is high).

kvstoremesh is a new component responsible for synchronizing the
information from the remote kvstores to the local one. In other words,
the local kvstore caches the state of the entire clustermesh, so that
all agents only need to connect to the local kvstore, and not the remote
ones. Overall, this provides better isolation (because the only component
connecting to remote kvstores is now the kvstoremesh operator) and
reduces the number of agents connecting to a single kvstore.

While the number of events to be processed by a single kvstore is
similar to the vanilla clustermesh case, with kvstoremesh the load
is less spiky (because a specific event is propagated to a much lower
number of agents) and it is also easier to rate limit (configuring the
maximum number of keys that can be written by kvstoremesh per second).
This allows to trade latency for reliability in case of high churn in
the clustermesh. Finally, given that the number of watchers is
proportional to the number of nodes in the local cluster only (rather
than the nodes in the entire clustermesh), the dimensioning of the
kvstore is also simplified.

The kvstoremesh concept has been initially proposed by the Cloud-Network
team @Trip.com, led by Arthur Chiao:
http://arthurchiao.art/blog/trip-first-step-towards-cloud-native-security/
```

The Dockerfile and CI modifications required to build the new image, as well as the appropriate extensions to the helm chart, will be introduced in a subsequent PR to limit the size of the current one.

<!-- Description of change -->

```release-note
Introduce kvstoremesh, a clustermesh-apiserver companion component allowing to cache remote cluster information in the local kvstore for increased scalability and separation.
```
