### PR TITLE
AWS CNI v1.12 Cilium install fixed.

### DIFF
--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -179,7 +179,7 @@ jobs:
             --helm-set=eni.enabled=false \
             --helm-set=ipam.mode=cluster-pool \
             --helm-set=tunnel=disabled \
-            --helm-set=bandwidthManager=false \
+            --helm-set=bandwidthManager.enabled=false \
             --wait=false \
             --rollback=false \
             --config monitor-aggregation=none \


### PR DESCRIPTION
Cilium installation for `conformance-aws-cni-v1.12` workflow fixed.
Example of successful Cilium installation: https://github.com/cilium/cilium/actions/runs/5223819581/jobs/9431222838?pr=26084