### PR TITLE
gha: fix conformance-ginkgo base branch retrieval

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -104,7 +104,7 @@ jobs:
             echo "base=$(jq -r '.base.sha' pr.json)" >> $GITHUB_OUTPUT
             echo "head=$(jq -r '.head.sha' pr.json)" >> $GITHUB_OUTPUT
             echo "sha=$(jq -r '.head.sha' pr.json)" >> $GITHUB_OUTPUT
-            echo "base_branch=${{ github.base_ref }}" >> $GITHUB_OUTPUT
+            echo "base_branch=$(jq -r '.base.ref' pr.json)" >> $GITHUB_OUTPUT
           else
             echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
             echo "base_branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -100,7 +100,7 @@ jobs:
         id: sha
         run: |
           if [ ${{ github.event.issue.pull_request || github.event.pull_request }} ]; then
-            curl ${{ github.event.issue.pull_request.url }} > pr.json
+            curl ${{ github.event.issue.pull_request.url || github.event.pull_request.url }} > pr.json
             echo "base=$(jq -r '.base.sha' pr.json)" >> $GITHUB_OUTPUT
             echo "head=$(jq -r '.head.sha' pr.json)" >> $GITHUB_OUTPUT
             echo "sha=$(jq -r '.head.sha' pr.json)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Retrieving the base branch from `github.base_branch` does not work when the action is triggered by a comment, because that field is not populated. Let's retrieve it from the json information about the PR. Additionally, let's make sure that we use the correct URL to retrieve the PR information also when the workflow is triggered by a pull_request event.

Link to running workflow: https://github.com/cilium/cilium/actions/runs/5224161919/jobs/9432015821?pr=26085