### PR TITLE
[v1.12] Backport print-chart-version script for dev Helm chart push

### DIFF
--- a/contrib/scripts/print-chart-version.sh
+++ b/contrib/scripts/print-chart-version.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2001
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+VERSION="$(cat "$SCRIPT_DIR/../../VERSION")"
+GIT_COMMIT_COUNT="$(git rev-list --count "$(git log --follow -1 --pretty=%H VERSION)"..HEAD)"
+GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+GIT_BRANCH_SANITIZED="$(echo "${GIT_BRANCH}" | sed 's/[^[:alnum:]]/-/g' )"
+GIT_HASH="$(git rev-parse --short HEAD)"
+CHART_VERSION_PRERELEASE_PREFIX=dev
+CHART_VERSION_DEV="${VERSION}-${CHART_VERSION_PRERELEASE_PREFIX}.${GIT_COMMIT_COUNT}+${GIT_BRANCH_SANITIZED}-${GIT_HASH}"
+# Using an OCI repository for helm means versions are stored as OCI tags, which cannot contain +.
+# Using _ isn't valid either, because helm chart versions must be semver compatible.
+# No v prefix for the chart version.
+CHART_VERSION=$(echo "${CHART_VERSION_DEV}" | sed 's/+/-/g')
+
+echo "${CHART_VERSION}"


### PR DESCRIPTION
[ upstream commit d90803cec8e7a1508558b183600cde7dcbdd719f ]
[ upstream commit 2c367de92d1825bf2ab80de2fd4e848ee2e28c46 ]
[ Backporter's notes:
  - Removed github workflow. Workflow operates from main branch.
  - Applied /usr/bin/env hunk to the script (was treewide). ]

Related: #25205


```upstream-prs
$ for pr in 25205; do contrib/backporting/set-labels.py $pr done v1.12; done
```