### PR TITLE
Add kvstoremesh Dockerfile and build images through the CI

### DIFF
--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -48,6 +48,9 @@ jobs:
           - name: clustermesh-apiserver
             dockerfile: ./images/clustermesh-apiserver/Dockerfile
 
+          - name: kvstoremesh
+            dockerfile: ./images/kvstoremesh/Dockerfile
+
           - name: docker-plugin
             dockerfile: ./images/cilium-docker-plugin/Dockerfile
 

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -59,6 +59,9 @@ jobs:
           - name: clustermesh-apiserver
             dockerfile: ./images/clustermesh-apiserver/Dockerfile
 
+          - name: kvstoremesh
+            dockerfile: ./images/kvstoremesh/Dockerfile
+
           - name: docker-plugin
             dockerfile: ./images/cilium-docker-plugin/Dockerfile
 

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -42,6 +42,9 @@ jobs:
           - name: clustermesh-apiserver
             dockerfile: ./images/clustermesh-apiserver/Dockerfile
 
+          - name: kvstoremesh
+            dockerfile: ./images/kvstoremesh/Dockerfile
+
           - name: docker-plugin
             dockerfile: ./images/cilium-docker-plugin/Dockerfile
 

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -45,6 +45,9 @@ jobs:
           - name: clustermesh-apiserver
             dockerfile: ./images/clustermesh-apiserver/Dockerfile
 
+          - name: kvstoremesh
+            dockerfile: ./images/kvstoremesh/Dockerfile
+
           - name: docker-plugin
             dockerfile: ./images/cilium-docker-plugin/Dockerfile
 

--- a/.github/workflows/ci-images-cache-cleaner.yaml
+++ b/.github/workflows/ci-images-cache-cleaner.yaml
@@ -33,6 +33,8 @@ jobs:
 
           - name: clustermesh-apiserver
 
+          - name: kvstoremesh
+
           - name: docker-plugin
 
     steps:

--- a/Makefile
+++ b/Makefile
@@ -447,16 +447,19 @@ $(1): export DOCKER_REGISTRY=localhost:5000
 $(1): export LOCAL_AGENT_IMAGE=$$(DOCKER_REGISTRY)/$$(DOCKER_DEV_ACCOUNT)/cilium-dev:$$(LOCAL_IMAGE_TAG)
 $(1): export LOCAL_OPERATOR_IMAGE=$$(DOCKER_REGISTRY)/$$(DOCKER_DEV_ACCOUNT)/operator-generic:$$(LOCAL_IMAGE_TAG)
 $(1): export LOCAL_CLUSTERMESH_IMAGE=$$(DOCKER_REGISTRY)/$$(DOCKER_DEV_ACCOUNT)/clustermesh-apiserver:$$(LOCAL_IMAGE_TAG)
+$(1): export LOCAL_KVSTOREMESH_IMAGE=$$(DOCKER_REGISTRY)/$$(DOCKER_DEV_ACCOUNT)/kvstoremesh:$$(LOCAL_IMAGE_TAG)
 endef
 
 $(eval $(call KIND_ENV,kind-clustermesh-images))
-kind-clustermesh-images: kind-clustermesh-ready kind-build-clustermesh-apiserver kind-build-image-agent kind-build-image-operator ## Builds images and imports them into clustermesh clusters
+kind-clustermesh-images: kind-clustermesh-ready kind-build-clustermesh-apiserver kind-build-kvstoremesh kind-build-image-agent kind-build-image-operator ## Builds images and imports them into clustermesh clusters
 	$(QUIET)kind load docker-image $(LOCAL_CLUSTERMESH_IMAGE) --name clustermesh1
 	$(QUIET)kind load docker-image $(LOCAL_CLUSTERMESH_IMAGE) --name clustermesh2
 	$(QUIET)kind load docker-image $(LOCAL_AGENT_IMAGE) --name clustermesh1
 	$(QUIET)kind load docker-image $(LOCAL_AGENT_IMAGE) --name clustermesh2
 	$(QUIET)kind load docker-image $(LOCAL_OPERATOR_IMAGE) --name clustermesh1
 	$(QUIET)kind load docker-image $(LOCAL_OPERATOR_IMAGE) --name clustermesh2
+	$(QUIET)kind load docker-image $(LOCAL_KVSTOREMESH_IMAGE) --name clustermesh1
+	$(QUIET)kind load docker-image $(LOCAL_KVSTOREMESH_IMAGE) --name clustermesh2
 
 $(eval $(call KIND_ENV,kind-install-cilium-clustermesh))
 kind-install-cilium-clustermesh: kind-clustermesh-ready ## Install a local Cilium version into the clustermesh clusters and enable clustermesh.
@@ -514,6 +517,10 @@ kind-image-operator: kind-ready kind-build-image-operator ## Build cilium-operat
 $(eval $(call KIND_ENV,kind-build-clustermesh-apiserver))
 kind-build-clustermesh-apiserver: ## Build cilium-clustermesh-apiserver docker image
 	$(QUIET)$(MAKE) docker-clustermesh-apiserver-image DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
+
+$(eval $(call KIND_ENV,kind-build-kvstoremesh))
+kind-build-kvstoremesh: ## Build cilium-kvstoremesh docker image
+	$(QUIET)$(MAKE) docker-kvstoremesh-image DOCKER_IMAGE_TAG=$(LOCAL_IMAGE_TAG)
 
 .PHONY: kind-image
 kind-image: ## Build cilium and operator images and import them into kind.

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -136,6 +136,9 @@ $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-hubble-relay-image,images/hubble-rela
 # docker-clustermesh-apiserver-image
 $(eval $(call DOCKER_IMAGE_TEMPLATE,docker-clustermesh-apiserver-image,images/clustermesh-apiserver/Dockerfile,clustermesh-apiserver,$(DOCKER_IMAGE_TAG),release))
 
+# docker-kvstoremesh-image
+$(eval $(call DOCKER_IMAGE_TEMPLATE,docker-kvstoremesh-image,images/kvstoremesh/Dockerfile,kvstoremesh,$(DOCKER_IMAGE_TAG),release))
+
 # docker-operator-images.
 # We eat the ending of "operator" in to the stem ('%') to allow this pattern
 # to build also 'docker-operator-image', where the stem would be empty otherwise.
@@ -146,9 +149,9 @@ $(eval $(call DOCKER_IMAGE_TEMPLATE,dev-docker-opera%-image-debug,images/operato
 #
 # docker-*-all targets are mainly used from the CI
 #
-docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-clustermesh-apiserver-image docker-operator-images-all ## Build all Cilium related docker images.
+docker-images-all: docker-cilium-image docker-plugin-image docker-hubble-relay-image docker-clustermesh-apiserver-image docker-kvstoremesh-image docker-operator-images-all ## Build all Cilium related docker images.
 
-docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-clustermesh-apiserver-image-unstripped docker-operator-images-all-unstripped ## Build all Cilium related unstripped docker images.
+docker-images-all-unstripped: docker-cilium-image-unstripped docker-plugin-image-unstripped docker-hubble-relay-image-unstripped docker-clustermesh-apiserver-image-unstripped docker-kvstoremesh-image-unstripped docker-operator-images-all-unstripped ## Build all Cilium related unstripped docker images.
 
 docker-operator-images-all: docker-operator-image docker-operator-aws-image docker-operator-azure-image docker-operator-alibabacloud-image docker-operator-generic-image ## Build all variants of cilium-operator images.
 

--- a/images/kvstoremesh/.dockerignore
+++ b/images/kvstoremesh/.dockerignore
@@ -1,0 +1,23 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+# since this is image is built with root context, most of the files
+# need to be excluded for faster builds and to avoid spoiling build
+# cache due to unchecked files (like configs or random binaries)
+*
+
+# must-have toplevel files
+!/Makefile*
+!/go.sum
+!/go.mod
+!/VERSION
+
+# directories
+!/.git
+!/api
+!/kvstoremesh
+!/images/runtime/build-gops.sh
+!/operator
+!/pkg
+!/tools
+!/vendor

--- a/images/kvstoremesh/Dockerfile
+++ b/images/kvstoremesh/Dockerfile
@@ -1,0 +1,66 @@
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+ARG BASE_IMAGE=scratch
+ARG GOLANG_IMAGE=docker.io/library/golang:1.20.4@sha256:4dd688d42e7c0af5564b96105b11cfc6c6264fa94224234bf6d9f34edd06c18b
+ARG ALPINE_IMAGE=docker.io/library/alpine:3.17.3@sha256:124c7d2707904eea7431fffe91522a01e5a861a624ee31d03372cc1d138a3126
+
+# BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
+# Represents the plataform where the build is happening, do not mix with
+# TARGETARCH
+FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as builder
+
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+ARG NOSTRIP
+ARG NOOPT
+ARG LOCKDEBUG
+ARG RACE
+
+WORKDIR /go/src/github.com/cilium/cilium/clustermesh-apiserver
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
+    mkdir -p /out/${TARGETOS}/${TARGETARCH} && cp etcd-config.yaml /out/${TARGETOS}/${TARGETARCH}/etcd-config.yaml
+WORKDIR /go/src/github.com/cilium/cilium/kvstoremesh
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
+    make GOARCH=${TARGETARCH} RACE=${RACE} NOSTRIP=${NOSTRIP} NOOPT=${NOOPT} LOCKDEBUG=${LOCKDEBUG} \
+    && mkdir -p /out/${TARGETOS}/${TARGETARCH}/usr/bin && mv kvstoremesh /out/${TARGETOS}/${TARGETARCH}/usr/bin
+
+WORKDIR /go/src/github.com/cilium/cilium
+# licenses-all is a "script" that executes "go run" so its ARCH should be set
+# to the same ARCH specified in the base image of this Docker stage (BUILDARCH)
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
+    make GOARCH=${BUILDARCH} licenses-all && mv LICENSE.all /out/${TARGETOS}/${TARGETARCH}
+
+# BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
+# Represents the plataform where the build is happening, do not mix with
+# TARGETARCH
+FROM --platform=${BUILDPLATFORM} ${ALPINE_IMAGE} as certs
+RUN apk --update add ca-certificates
+
+# BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
+# Represents the plataform where the build is happening, do not mix with
+# TARGETARCH
+FROM --platform=${BUILDPLATFORM} ${GOLANG_IMAGE} as gops
+
+# build-gops.sh will build both archs at the same time
+WORKDIR /go/src/github.com/cilium/cilium/images/runtime
+RUN apt-get update && apt-get install -y binutils-aarch64-linux-gnu binutils-x86-64-linux-gnu
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
+    ./build-gops.sh
+
+FROM ${BASE_IMAGE} as release
+# TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETOS
+# TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
+ARG TARGETARCH
+LABEL maintainer="maintainer@cilium.io"
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=gops /out/${TARGETOS}/${TARGETARCH}/bin/gops /bin/gops
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/etcd-config.yaml /var/lib/cilium/etcd-config.yaml
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/kvstoremesh /usr/bin/kvstoremesh
+COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
+WORKDIR /
+ENV GOPS_CONFIG_DIR=/
+ENTRYPOINT ["/usr/bin/kvstoremesh"]


### PR DESCRIPTION
This PR is a followup of https://github.com/cilium/cilium/pull/26083, which introduces the Dockerfile for kvstoremesh and adds kvstoremesh to the list of images built through the GitHub actions.