### PR TITLE
ipsec: Split removeStaleXFRMOnce to fix deprioritization issue

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -123,7 +123,8 @@ var (
 
 	// To attempt to remove any stale XFRM configs once at startup, after
 	// we've added the catch-all default-drop policy.
-	removeStaleXFRMOnce sync.Once
+	removeStaleIPv4XFRMOnce sync.Once
+	removeStaleIPv6XFRMOnce sync.Once
 )
 
 func getIPSecKeys(ip net.IP) *ipSecKey {
@@ -439,6 +440,10 @@ func IPsecDefaultDropPolicy(ipv6 bool) error {
 	// new priorities to take precedence.
 	// This code can be removed in Cilium v1.15 to instead remove the old XFRM
 	// OUT policy and state.
+	removeStaleXFRMOnce := &removeStaleIPv4XFRMOnce
+	if ipv6 {
+		removeStaleXFRMOnce = &removeStaleIPv6XFRMOnce
+	}
 	removeStaleXFRMOnce.Do(func() {
 		deprioritizeOldOutPolicy(family)
 	})


### PR DESCRIPTION
We expect deprioritizeOldOutPolicy() to be executed for IPv4 and IPv6, but removeStaleXFRMOnce prevents the second call. If both IPv4 and IPv6 are enabled, v6 xfrm policy won't be deprioritized due to this issue.

This commit fixes it by spliting removeStaleXFRMOnce into removeStaleIPv4XFRMOnce and removeStaleIPv6XFRMOnce.

Fixes: https://github.com/cilium/cilium/commit/688dc9ac802b11f6c16a9cbc5d60baaf77bd6ed0
