### PR TITLE
bpf: lxc: fix one missing drop notification in CT lookup tail calls

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -291,7 +291,7 @@ int NAME(struct __ctx_buff *ctx)						\
 										\
 	hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);				\
 	if (hdrlen < 0)								\
-		return hdrlen;							\
+		return drop_for_direction(ctx, DIR, hdrlen);			\
 										\
 	l4_off = ETH_HLEN + hdrlen;						\
 										\


### PR DESCRIPTION
b2de07a73896 ("bpf: Fix missing drop notifications on ct lookup failures") took care of most paths. But we also need to throw a drop notification when `ipv6_hdrlen()` returns an error.