### PR TITLE
policy: Add GetAuthTypes()

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -370,12 +370,9 @@ func (d *policyDistillery) WithLogBuffer(w io.Writer) *policyDistillery {
 // distillPolicy distills the policy repository into a set of bpf map state
 // entries for an endpoint with the specified labels.
 func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.LabelArray, identity *identity.Identity) (MapState, error) {
-	sp, err := d.Repository.resolvePolicyLocked(identity)
-	if err != nil {
-		return nil, err
-	}
-
-	epp := sp.DistillPolicy(DummyOwner{}, false)
+	sp := d.Repository.GetPolicyCache().insert(identity)
+	d.Repository.GetPolicyCache().UpdatePolicy(identity)
+	epp := sp.Consume(DummyOwner{})
 	if epp == nil {
 		return nil, errors.New("policy distillation failure")
 	}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -219,6 +219,9 @@ func (a *PerSelectorPolicy) Equal(b *PerSelectorPolicy) bool {
 // AuthType enumerates the supported authentication types in api.
 type AuthType uint8
 
+// Authmap maps remote selectors to their needed AuthType, if any
+type AuthMap map[CachedSelector]AuthType
+
 const (
 	// AuthTypeDisabled means no authentication required
 	AuthTypeDisabled AuthType = iota
@@ -835,7 +838,7 @@ func (l4 *L4Filter) detach(selectorCache *SelectorCache) {
 }
 
 // attach signifies that the L4Filter is ready and reacheable for updates
-// from SelectorCache. L4Filter is read-only after this is called,
+// from SelectorCache. L4Filter (and L4Policy) is read-only after this is called,
 // multiple goroutines will be reading the fields from that point on.
 func (l4 *L4Filter) attach(ctx PolicyContext, l4Policy *L4Policy) {
 	// All rules have been added to the L4Filter at this point.
@@ -846,9 +849,18 @@ func (l4 *L4Filter) attach(ctx PolicyContext, l4Policy *L4Policy) {
 
 	// Compute Envoy policies when a policy is ready to be used
 	if ctx != nil {
-		for _, l7policy := range l4.PerSelectorPolicies {
-			if l7policy != nil && len(l7policy.L7Rules.HTTP) > 0 {
-				l7policy.EnvoyHTTPRules, l7policy.CanShortCircuit = ctx.GetEnvoyHTTPRules(&l7policy.L7Rules)
+		for cs, l7policy := range l4.PerSelectorPolicies {
+			if l7policy != nil {
+				if len(l7policy.L7Rules.HTTP) > 0 {
+					l7policy.EnvoyHTTPRules, l7policy.CanShortCircuit = ctx.GetEnvoyHTTPRules(&l7policy.L7Rules)
+				}
+
+				if authType := l7policy.GetAuthType(); authType != AuthTypeDisabled {
+					if l4Policy.AuthMap == nil {
+						l4Policy.AuthMap = make(AuthMap, 1)
+					}
+					l4Policy.AuthMap[cs] = authType
+				}
 			}
 		}
 	}
@@ -1096,6 +1108,8 @@ func (l4 L4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.
 type L4Policy struct {
 	Ingress L4PolicyMap
 	Egress  L4PolicyMap
+
+	AuthMap AuthMap
 
 	// Revision is the repository revision used to generate this policy.
 	Revision uint64

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -219,8 +219,11 @@ func (a *PerSelectorPolicy) Equal(b *PerSelectorPolicy) bool {
 // AuthType enumerates the supported authentication types in api.
 type AuthType uint8
 
-// Authmap maps remote selectors to their needed AuthType, if any
-type AuthMap map[CachedSelector]AuthType
+// AuthTypes is a set of AuthTypes, usually nil if empty
+type AuthTypes map[AuthType]struct{}
+
+// Authmap maps remote selectors to their needed AuthTypes, if any
+type AuthMap map[CachedSelector]AuthTypes
 
 const (
 	// AuthTypeDisabled means no authentication required
@@ -859,7 +862,12 @@ func (l4 *L4Filter) attach(ctx PolicyContext, l4Policy *L4Policy) {
 					if l4Policy.AuthMap == nil {
 						l4Policy.AuthMap = make(AuthMap, 1)
 					}
-					l4Policy.AuthMap[cs] = authType
+					authTypes := l4Policy.AuthMap[cs]
+					if authTypes == nil {
+						authTypes = make(AuthTypes, 1)
+					}
+					authTypes[authType] = struct{}{}
+					l4Policy.AuthMap[cs] = authTypes
 				}
 			}
 		}

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -144,6 +144,11 @@ func (p *Repository) GetSelectorCache() *SelectorCache {
 	return p.selectorCache
 }
 
+// GetAuthType returns the AuthTypes required by the policy between the localID and remoteID
+func (p *Repository) GetAuthType(localID, remoteID identity.NumericIdentity) AuthType {
+	return p.policyCache.GetAuthType(localID, remoteID)
+}
+
 func (p *Repository) SetEnvoyRulesFunc(f func(certificatemanager.SecretManager, *api.L7Rules, string) (*cilium.HttpNetworkPolicyRules, bool)) {
 	p.getEnvoyHTTPRules = f
 }
@@ -253,7 +258,7 @@ func (p *Repository) Start() {
 //
 // Caller must release resources by calling Detach() on the returned map!
 //
-// Note: Only used for policy tracing
+// NOTE: This is only called from unit tests, but from multiple packages.
 func (p *Repository) ResolveL4IngressPolicy(ctx *SearchContext) (L4PolicyMap, error) {
 	policyCtx := policyContext{
 		repo: p,
@@ -295,6 +300,8 @@ func (p *Repository) ResolveL4EgressPolicy(ctx *SearchContext) (L4PolicyMap, err
 // context and returns the verdict for ingress. If no matching policy allows for
 // the  connection, the request will be denied. The policy repository mutex must
 // be held.
+//
+// NOTE: This is only called from unit tests, but from multiple packages.
 func (p *Repository) AllowsIngressRLocked(ctx *SearchContext) api.Decision {
 	// Lack of DPorts in the SearchContext means L3-only search
 	if len(ctx.DPorts) == 0 {

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -144,9 +144,9 @@ func (p *Repository) GetSelectorCache() *SelectorCache {
 	return p.selectorCache
 }
 
-// GetAuthType returns the AuthTypes required by the policy between the localID and remoteID
-func (p *Repository) GetAuthType(localID, remoteID identity.NumericIdentity) AuthType {
-	return p.policyCache.GetAuthType(localID, remoteID)
+// GetAuthTypes returns the AuthTypes required by the policy between the localID and remoteID
+func (p *Repository) GetAuthTypes(localID, remoteID identity.NumericIdentity) AuthTypes {
+	return p.policyCache.GetAuthTypes(localID, remoteID)
 }
 
 func (p *Repository) SetEnvoyRulesFunc(f func(certificatemanager.SecretManager, *api.L7Rules, string) (*cilium.HttpNetworkPolicyRules, bool)) {


### PR DESCRIPTION
Track the required authentication mode for all selected remote identities
in a selector policy, and add GetAuthTypes() that can be used to find out
the required authentication modes between a local and remote security
identity.

We recently added authentication requirement support to Cilium Network Policy. This is currently plumbed to bpf datapath policymap values so that the datapath may enforce authentication status of traffic by consulting the new bpf authmap. Authmap is updated by Cilium Agent's auth manager (`pkg/auth`), currently based on the "authentication required" signals delivered from the datapath to the agent via signalmap. Once authentication is done, auth manager updates authmap and datapath starts accepting traffic.

The new functionality provided in this PR is needed for the auth manager to be able to decide if an expiring authentication needs to be renewed (re-authenticated). Without this functionality re-authentication between given Cilium security IDs (local/remote) will be done perpetually, or until either the security ID is removed, or the node with which the authentication was done, is removed. The new `GetAuthTypes()` function is intended to be called by the auth manager to potentially end re-authentication for the given local/remote security ID pair, when no AuthTypes are returned, indicating that the policy has changed to not require authentication between the given local/remote security ID any more. 

https://github.com/cilium/cilium/pull/26068 uses this new functionality and is currently blocked for this functionality to be added.