### PR TITLE
clustermesh: Introduce ClusterID reservation mechanism

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -5,12 +5,12 @@ package clustermesh
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/clustermesh/internal"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
-	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -88,12 +88,45 @@ type ClusterMesh struct {
 	// internal implements the common logic to connect to remote clusters.
 	internal internal.ClusterMesh
 
+	usedIDs *ClusterMeshUsedIDs
 	// globalServices is a list of all global services. The datastructure
 	// is protected by its own mutex inside the structure.
 	globalServices *globalServiceCache
 
 	// nodeName is the name of the local node. This is used for logging and metrics
 	nodeName string
+}
+
+type ClusterMeshUsedIDs struct {
+	usedClusterIDs      map[uint32]struct{}
+	usedClusterIDsMutex lock.Mutex
+}
+
+func newClusterMeshUsedIDs() *ClusterMeshUsedIDs {
+	return &ClusterMeshUsedIDs{
+		usedClusterIDs: make(map[uint32]struct{}),
+	}
+}
+
+func (cm *ClusterMeshUsedIDs) reserveClusterID(clusterID uint32) error {
+	cm.usedClusterIDsMutex.Lock()
+	defer cm.usedClusterIDsMutex.Unlock()
+
+	if _, ok := cm.usedClusterIDs[clusterID]; ok {
+		// ClusterID already used
+		return fmt.Errorf("clusterID %d is already used", clusterID)
+	}
+
+	cm.usedClusterIDs[clusterID] = struct{}{}
+
+	return nil
+}
+
+func (cm *ClusterMeshUsedIDs) releaseClusterID(clusterID uint32) {
+	cm.usedClusterIDsMutex.Lock()
+	defer cm.usedClusterIDsMutex.Unlock()
+
+	delete(cm.usedClusterIDs, clusterID)
 }
 
 // NewClusterMesh creates a new remote cluster cache based on the
@@ -106,6 +139,7 @@ func NewClusterMesh(lifecycle hive.Lifecycle, c Configuration) *ClusterMesh {
 	nodeName := nodeTypes.GetName()
 	cm := &ClusterMesh{
 		conf:     c,
+		usedIDs:  newClusterMeshUsedIDs(),
 		nodeName: nodeName,
 		globalServices: newGlobalServiceCache(
 			c.Metrics.TotalGlobalServices.WithLabelValues(c.ClusterName, nodeName),
@@ -130,10 +164,11 @@ func NewClusterMesh(lifecycle hive.Lifecycle, c Configuration) *ClusterMesh {
 
 func (cm *ClusterMesh) newRemoteCluster(name string, status internal.StatusFunc) internal.RemoteCluster {
 	rc := &remoteCluster{
-		name:   name,
-		mesh:   cm,
-		status: status,
-		swg:    lock.NewStoppableWaitGroup(),
+		name:    name,
+		mesh:    cm,
+		usedIDs: cm.usedIDs,
+		status:  status,
+		swg:     lock.NewStoppableWaitGroup(),
 	}
 
 	rc.remoteNodes = store.NewRestartableWatchStore(
@@ -153,25 +188,6 @@ func (cm *ClusterMesh) newRemoteCluster(name string, status internal.StatusFunc)
 	rc.ipCacheWatcher = ipcache.NewIPIdentityWatcher(name, cm.conf.IPCache)
 
 	return rc
-}
-
-func (cm *ClusterMesh) canConnect(name string, config *cmtypes.CiliumClusterConfig) error {
-	return cm.internal.ForEachRemoteCluster(func(rci internal.RemoteCluster) error {
-		rc := rci.(*remoteCluster)
-
-		rc.mutex.RLock()
-		defer rc.mutex.RUnlock()
-
-		if rc.name == name || rc.config == nil {
-			return nil
-		}
-
-		if err := rc.config.IsCompatible(config); err != nil {
-			return err
-		}
-
-		return nil
-	})
 }
 
 // NumReadyClusters returns the number of remote clusters to which a connection

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -154,6 +154,7 @@ func TestRemoteClusterRun(t *testing.T) {
 					Metrics:               newMetrics(),
 				},
 				globalServices: newGlobalServiceCache(metrics.NoOpGauge),
+				usedIDs:        newClusterMeshUsedIDs(),
 			}
 			rc := cm.newRemoteCluster("foo", nil).(*remoteCluster)
 			ready := make(chan error)

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -81,7 +81,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 
 	for i, cluster := range []string{clusterName1, clusterName2} {
 		config := cmtypes.CiliumClusterConfig{
-			ID: uint32(i),
+			ID: uint32(i + 1),
 		}
 		err := cmutils.SetClusterConfig(ctx, cluster, &config, kvstore.Client())
 		c.Assert(err, IsNil)

--- a/pkg/clustermesh/types/addressing.go
+++ b/pkg/clustermesh/types/addressing.go
@@ -328,6 +328,10 @@ func (pc PrefixCluster) AddrCluster() AddrCluster {
 	return AddrClusterFrom(pc.prefix.Addr(), pc.clusterID)
 }
 
+func (pc PrefixCluster) ClusterID() uint32 {
+	return pc.clusterID
+}
+
 func (pc PrefixCluster) String() string {
 	if pc.clusterID == 0 {
 		return pc.prefix.String()

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -43,8 +43,8 @@ type CiliumClusterConfigCapabilities struct {
 	Cached bool `json:"cached,omitempty"`
 }
 
-func (c0 *CiliumClusterConfig) IsCompatible(c1 *CiliumClusterConfig) error {
-	if c1 == nil {
+func (c *CiliumClusterConfig) Validate() error {
+	if c == nil || c.ID == 0 {
 		// When remote cluster doesn't have cluster config, we
 		// currently just bypass the validation for compatibility.
 		// Otherwise, we cannot connect with older cluster which
@@ -54,14 +54,12 @@ func (c0 *CiliumClusterConfig) IsCompatible(c1 *CiliumClusterConfig) error {
 		// we should properly check it here and return error. Now
 		// we only have ClusterID which used to be ignored.
 		return nil
-	} else {
-		// Remote cluster has cluster config. Do validations.
-
-		// ID shouldn't be duplicated
-		if c0.ID == c1.ID {
-			return fmt.Errorf("duplicated cluster id")
-		}
 	}
+
+	if err := ValidateClusterID(c.ID); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Improve the lifecycle of cluster config by introducing the ClusterID reservation mechanism. More details in commit message