### PR TITLE
Add cilium bpf nodeid list to bugtool and print nodeid in hex in ipcache dump

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -417,6 +417,7 @@ func copyCiliumInfoCommands(cmdDir string, k8sPods []string) []string {
 		"cilium policy selectors -o json",
 		"cilium node list",
 		"cilium node list -o json",
+		"cilium bpf nodeid list",
 		"cilium lrp list",
 		"cilium cgroups list -o json",
 	}

--- a/cilium/cmd/bpf_nodeid_list.go
+++ b/cilium/cmd/bpf_nodeid_list.go
@@ -81,7 +81,7 @@ func printNodeIDList(nodeIDList []nodeID) {
 
 	fmt.Fprintln(w, "NODE ID\tIP ADDRESSES")
 	for _, nodeID := range nodeIDList {
-		fmt.Fprintf(w, "%d\t%s\n", nodeID.ID, nodeID.Address)
+		fmt.Fprintf(w, "0x%x\t%s\n", nodeID.ID, nodeID.Address)
 	}
 
 	w.Flush()

--- a/cilium/cmd/node_id_list.go
+++ b/cilium/cmd/node_id_list.go
@@ -60,7 +60,7 @@ func printNodeID(w *tabwriter.Writer, nodeID *models.NodeID) {
 	first := true
 	for _, ip := range nodeID.Ips {
 		if first {
-			fmt.Fprintf(w, "%d\t%s\n", *nodeID.ID, ip)
+			fmt.Fprintf(w, "0x%x\t%s\n", *nodeID.ID, ip)
 			first = false
 		} else {
 			fmt.Fprintf(w, "\t%s\n", ip)

--- a/pkg/maps/ipcache/ipcache.go
+++ b/pkg/maps/ipcache/ipcache.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"strconv"
 	"sync"
 	"unsafe"
 
@@ -129,8 +130,8 @@ type RemoteEndpointInfo struct {
 }
 
 func (v *RemoteEndpointInfo) String() string {
-	return fmt.Sprintf("identity=%d encryptkey=%d tunnelendpoint=%s nodeid=%d",
-		v.SecurityIdentity, v.Key, v.TunnelEndpoint, v.NodeID)
+	return fmt.Sprintf("identity=%d encryptkey=%d tunnelendpoint=%s nodeid=0x%s",
+		v.SecurityIdentity, v.Key, v.TunnelEndpoint, strconv.FormatUint(uint64(v.NodeID), 16))
 }
 
 func (v *RemoteEndpointInfo) New() bpf.MapValue { return &RemoteEndpointInfo{} }


### PR DESCRIPTION
To help to detect when IPcache is out of sync with locally stored Node IDs.
