### PR TITLE
operator: Fix default API server addr in metrics subcommand

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_metrics_list.md
@@ -11,9 +11,10 @@ cilium-operator-alibabacloud metrics list [flags]
 ### Options
 
 ```
-  -h, --help                   help for list
-  -p, --match-pattern string   Show only metrics whose names match matchpattern
-  -o, --output string          json| yaml| jsonpath='{}'
+  -h, --help                    help for list
+  -p, --match-pattern string    Show only metrics whose names match matchpattern
+  -o, --output string           json| yaml| jsonpath='{}'
+  -s, --server-address string   Address of the operator API server (default "localhost:9234")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-aws_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator-aws_metrics_list.md
@@ -11,9 +11,10 @@ cilium-operator-aws metrics list [flags]
 ### Options
 
 ```
-  -h, --help                   help for list
-  -p, --match-pattern string   Show only metrics whose names match matchpattern
-  -o, --output string          json| yaml| jsonpath='{}'
+  -h, --help                    help for list
+  -p, --match-pattern string    Show only metrics whose names match matchpattern
+  -o, --output string           json| yaml| jsonpath='{}'
+  -s, --server-address string   Address of the operator API server (default "localhost:9234")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-azure_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator-azure_metrics_list.md
@@ -11,9 +11,10 @@ cilium-operator-azure metrics list [flags]
 ### Options
 
 ```
-  -h, --help                   help for list
-  -p, --match-pattern string   Show only metrics whose names match matchpattern
-  -o, --output string          json| yaml| jsonpath='{}'
+  -h, --help                    help for list
+  -p, --match-pattern string    Show only metrics whose names match matchpattern
+  -o, --output string           json| yaml| jsonpath='{}'
+  -s, --server-address string   Address of the operator API server (default "localhost:9234")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator-generic_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator-generic_metrics_list.md
@@ -11,9 +11,10 @@ cilium-operator-generic metrics list [flags]
 ### Options
 
 ```
-  -h, --help                   help for list
-  -p, --match-pattern string   Show only metrics whose names match matchpattern
-  -o, --output string          json| yaml| jsonpath='{}'
+  -h, --help                    help for list
+  -p, --match-pattern string    Show only metrics whose names match matchpattern
+  -o, --output string           json| yaml| jsonpath='{}'
+  -s, --server-address string   Address of the operator API server (default "localhost:9234")
 ```
 
 ### SEE ALSO

--- a/Documentation/cmdref/cilium-operator_metrics_list.md
+++ b/Documentation/cmdref/cilium-operator_metrics_list.md
@@ -11,9 +11,10 @@ cilium-operator metrics list [flags]
 ### Options
 
 ```
-  -h, --help                   help for list
-  -p, --match-pattern string   Show only metrics whose names match matchpattern
-  -o, --output string          json| yaml| jsonpath='{}'
+  -h, --help                    help for list
+  -p, --match-pattern string    Show only metrics whose names match matchpattern
+  -o, --output string           json| yaml| jsonpath='{}'
+  -s, --server-address string   Address of the operator API server (default "localhost:9234")
 ```
 
 ### SEE ALSO

--- a/operator/cmd/metrics_list.go
+++ b/operator/cmd/metrics_list.go
@@ -15,10 +15,14 @@ import (
 
 	"github.com/cilium/cilium/api/v1/operator/client"
 	"github.com/cilium/cilium/api/v1/operator/models"
+	"github.com/cilium/cilium/operator/api"
 	"github.com/cilium/cilium/pkg/command"
 )
 
-var matchPattern string
+var (
+	matchPattern string
+	operatorAddr string
+)
 
 // MetricsListCmd dumps all metrics into stdout
 var MetricsListCmd = &cobra.Command{
@@ -74,5 +78,6 @@ func init() {
 	MetricsCmd.AddCommand(MetricsListCmd)
 
 	MetricsListCmd.Flags().StringVarP(&matchPattern, "match-pattern", "p", "", "Show only metrics whose names match matchpattern")
+	MetricsListCmd.Flags().StringVarP(&operatorAddr, "server-address", "s", api.OperatorAPIServeAddrDefault, "Address of the operator API server")
 	command.AddOutputOption(MetricsListCmd)
 }

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -74,8 +74,6 @@ var (
 	leaderElectionCtx       context.Context
 	leaderElectionCtxCancel context.CancelFunc
 
-	operatorAddr string
-
 	// isLeader is an atomic boolean value that is true when the Operator is
 	// elected leader. Otherwise, it is false.
 	isLeader atomic.Bool


### PR DESCRIPTION
The operator API server has been modularized into its independent cell in a previous commit.

Doing that, the flag to specify a custom address for the server has been moved from the global operator config to the new cell config.

The `metrics list` subcommand needs to know the operator API server address to query the "/metrics" endpoint.  Before the modularization, the subcommand was at least able to query the server if that was started at the default address.

This commit adds a new flag to specify the address of the operator API server. Also, the default value for this flag is set to the same default used in the operator/api server cell.  Doing that fixes the bug introduced in the modularization and also allows to specify another address if the operator API server is listening on a non-default one.

Fixes: 11d5856e17 ("operator/api: Modularize api server")
