### PR TITLE
CIDRGroup reference metric will not count nonexistent CIDRGroups

### DIFF
--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -252,9 +252,11 @@ func (k *K8sWatcher) onUpsert(
 		return nil
 	}
 
-	// check if this cnp was referencing or is now referencing a
+	// check if this cnp was referencing or is now referencing at least one non-empty
 	// CiliumCIDRGroup and update the relevant metric accordingly.
-	if len(getCIDRGroupRefs(cnp)) > 0 {
+	cidrGroupRefs := getCIDRGroupRefs(cnp)
+	cidrsSets, _ := cidrGroupRefsToCIDRsSets(cidrGroupRefs, cidrGroupCache)
+	if len(cidrsSets) > 0 {
 		cidrGroupPolicies[key] = struct{}{}
 	} else {
 		delete(cidrGroupPolicies, key)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -314,6 +314,7 @@ var (
 	CIDRGroupTranslationTimeStats = NoOpHistogram
 
 	// CIDRGroupPolicies is the number of CNPs and CCNPs referencing at least one CiliumCIDRGroup.
+	// CNPs with empty or non-existing CIDRGroupRefs are not considered
 	CIDRGroupPolicies = NoOpGauge
 
 	// Identity


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #25022

Added a check on CIDRGroupRef to make sure that the reference is valid. 

```release note
CIDRGroup reference metric will not count nonexistent CIDRGroups
```

Signed-off-by: Alok Kumar Singh alokaks601@gmail.com