### PR TITLE
doc: Documented pitfall with NS labels in CNPs

### DIFF
--- a/Documentation/security/policy/kubernetes.rst
+++ b/Documentation/security/policy/kubernetes.rst
@@ -16,25 +16,39 @@ Namespaces
 
 `Namespaces <https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/>`_
 are used to create virtual clusters within a Kubernetes cluster. All Kubernetes objects
-including NetworkPolicy and CiliumNetworkPolicy belong to a particular
-namespace. Depending on how a policy is being defined and created, Kubernetes
-namespaces are automatically being taken into account:
+including `NetworkPolicy` and `CiliumNetworkPolicy` belong to a particular
+namespace.
 
-* Network policies created and imported as `CiliumNetworkPolicy` CRD and
-  `NetworkPolicy` apply within the namespace, i.e. the policy only applies
-  to pods within that namespace. It is however possible to grant access to and
-  from pods in other namespaces as described below.
+Known Pitfalls
+~~~~~~~~~~~~~~
 
-* Network policies imported directly via the :ref:`api_ref` apply to all
-  namespaces unless a namespace selector is specified as described below.
+Depending on how a policy is defined and created, Kubernetes namespaces are automatically taken into account.
 
-.. note:: While specification of the namespace via the label
-	  ``k8s:io.kubernetes.pod.namespace`` in the ``fromEndpoints`` and
-	  ``toEndpoints`` fields is deliberately supported. Specification of the
-	  namespace in the ``endpointSelector`` is prohibited as it would
-	  violate the namespace isolation principle of Kubernetes. The
-	  ``endpointSelector`` always applies to pods of the namespace which is
-	  associated with the CiliumNetworkPolicy resource itself.
+Network policies imported directly with the :ref:`api_ref` apply to all
+namespaces unless a namespace selector is specified as described in
+:ref:`example_cnp_ns_boundaries`.
+
+Network policies created and imported as `CiliumNetworkPolicy` CRD and
+`NetworkPolicy` apply within the namespace. In other words, the policy **only** applies
+to pods within that namespace. It's possible, however, to grant access to and
+from pods in other namespaces as described in :ref:`example_cnp_across_ns`.
+
+Specifying the namespace by way of the label
+``k8s:io.kubernetes.pod.namespace`` in the ``fromEndpoints`` and
+``toEndpoints`` fields is supported as described in 
+:ref:`example_cnp_egress_to_kube_system`.
+However, Kubernetes prohibits specifying the namespace in the ``endpointSelector``,
+as it would violate the namespace isolation principle of Kubernetes. The
+``endpointSelector`` always applies to pods in the namespace 
+associated with the `CiliumNetworkPolicy` resource itself.
+
+Using namespace-specific information like
+``io.cilium.k8s.namespace.labels`` within a ``fromEndpoints`` or
+``toEndpoints`` is supported only for a `CiliumClusterwideNetworkPolicy`
+and not a `CiliumNetworkPolicy`. Hence, ``io.cilium.k8s.namespace.labels``
+will be ignored in `CiliumNetworkPolicy` resources.
+
+.. _example_cnp_ns_boundaries:
 
 Example: Enforce namespace boundaries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -65,6 +79,8 @@ namespace.
 
         .. literalinclude:: ../../../examples/policies/kubernetes/namespace/isolate-namespaces.json
 
+.. _example_cnp_across_ns:
+
 Example: Expose pods across namespaces
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -88,6 +104,8 @@ for a fully functional example including pods deployed to different namespaces.
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/kubernetes/namespace/namespace-policy.json
+
+.. _example_cnp_egress_to_kube_system:
 
 Example: Allow egress to kube-dns in kube-system namespace
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I wanted to document a potential pitfall for users who are trying to do advanced things using CNPs.

For example, this doesn't work:
```yaml
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "default-egress"
  namespace: internal
spec:
  endpointSelector: {}
  ingress:
  - {}
  egress:
  - toEndpoints:
    - matchLabels:
        k8s:io.cilium.k8s.namespace.labels.exposed-public: "true"
```

Traffic will be denied:
```bash
k exec -it -n kube-system cilium-h6qdb -c cilium-agent -- hubble observe -n internal -f
Jun  9 21:02:24.314: internal/tshoot:41832 (ID:1836) <> public/nginx:80 (ID:2277) policy-verdict:none EGRESS DENIED (TCP Flags: SYN)
Jun  9 21:02:24.314: internal/tshoot:41832 (ID:1836) <> public/nginx:80 (ID:2277) Policy denied DROPPED (TCP Flags: SYN)
Jun  9 21:02:25.364: internal/tshoot:41832 (ID:1836) <> public/nginx:80 (ID:2277) policy-verdict:none EGRESS DENIED (TCP Flags: SYN)
Jun  9 21:02:25.364: internal/tshoot:41832 (ID:1836) <> public/nginx:80 (ID:2277) Policy denied DROPPED (TCP Flags: SYN)
```

<details>
<summary>Testing setup details</summary>

Namespaces:
```bash
k get ns --show-labels
NAME              STATUS   AGE    LABELS
default           Active   120d   kubernetes.io/metadata.name=default
kube-system       Active   120d   kubernetes.io/metadata.name=kube-system
kube-public       Active   120d   kubernetes.io/metadata.name=kube-public
kube-node-lease   Active   120d   kubernetes.io/metadata.name=kube-node-lease
public            Active   21m    exposed-public=true,kubernetes.io/metadata.name=public
internal          Active   20m    kubernetes.io/metadata.name=internal
```

The pods:
```bash
$ kgp -o wide -n internal                                                      
NAME     READY   STATUS    RESTARTS   AGE   IP           NODE                   NOMINATED NODE   READINESS GATES
tshoot   1/1     Running   0          20m   10.0.0.176   lima-rancher-desktop   <none>           <none>
$ kgp -o wide -n public
NAME    READY   STATUS    RESTARTS   AGE   IP           NODE                   NOMINATED NODE   READINESS GATES
nginx   1/1     Running   0          21m   10.0.0.119   lima-rancher-desktop   <none>           <none>
```

My testing command from inside internal/tshoot:
```bash
tshoot:~# curl 10.0.0.119
```
… and finally the cilium endpoint list:
```bash
root@lima-rancher-desktop:/home/cilium# cilium endpoint list
ENDPOINT   POLICY (ingress)   POLICY (egress)   IDENTITY   LABELS (source:key[=value])                                                      IPv6   IPv4         STATUS
           ENFORCEMENT        ENFORCEMENT
426        Enabled            Enabled           1836       k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=internal                 10.0.0.176   ready
                                                           k8s:io.cilium.k8s.policy.cluster=default
                                                           k8s:io.cilium.k8s.policy.serviceaccount=default
                                                           k8s:io.kubernetes.pod.namespace=internal
                                                           k8s:run=tshoot
508        Disabled           Disabled          2277       k8s:io.cilium.k8s.namespace.labels.exposed-public=true                                  10.0.0.119   ready
                                                           k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=public
                                                           k8s:io.cilium.k8s.policy.cluster=default
                                                           k8s:io.cilium.k8s.policy.serviceaccount=default
                                                           k8s:io.kubernetes.pod.namespace=public
                                                           k8s:run=nginx
```

</details>

Turns out, the following CCNP works:
```yaml
apiVersion: "cilium.io/v2"
kind: CiliumClusterwideNetworkPolicy
metadata:
  name: "default-egress"
spec:
  endpointSelector:
    matchExpressions:
    - key: k8s:io.kubernetes.pod.namespace
      operator: NotIn
      values:
      - kube-system
  egress:
  - toEndpoints:
    - matchLabels:
        k8s:io.cilium.k8s.namespace.labels.exposed-public: "true"
```

This is how it looks:
![image](https://github.com/cilium/cilium/assets/5549063/3698fcab-e0ec-4215-85f6-ae2dac455e5a)


Please ensure your pull request adheres to the following guidelines:

- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.

<!-- Description of change -->

```release-note
doc: Documented pitfall with NS labels in CNPs
```
