### PR TITLE
bpf: SRv6 fib on encap

### DIFF
--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -4,6 +4,7 @@
 #ifndef __LIB_EGRESS_POLICIES_H_
 #define __LIB_EGRESS_POLICIES_H_
 
+#include "lib/fib.h"
 #include "lib/identity.h"
 
 #include "maps.h"
@@ -579,25 +580,91 @@ srv6_store_meta_sid(struct __ctx_buff *ctx, const union v6addr *sid)
 	ctx_store_meta(ctx, CB_SRV6_SID_4, sid->p4);
 }
 
+#ifdef ENABLE_IPV6
+/* SRv6 encapsulation occurs at the native-dev currently.
+ * Its possible that after encapsulation a fib entry exists which would actually
+ * route the IPv6 destination somewhere else.
+ *
+ * Therefore, this function performs an additional fib lookup on the encap'd
+ * packet to ensure we transmit it via the correct link and with the correct
+ * l2 addresses.
+ */
+static __always_inline int
+srv6_refib(struct __ctx_buff *ctx, int *ext_err)
+{
+	struct bpf_fib_lookup_padded params = {0};
+	__u32 old_oif = ctx_get_ifindex(ctx);
+	void *data, *data_end;
+	struct ipv6hdr *ip6;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+		return DROP_INVALID;
+
+	*ext_err = (__s8)fib_lookup_v6(ctx,
+				       &params,
+				       &ip6->saddr,
+				       &ip6->daddr,
+				       BPF_FIB_LOOKUP_OUTPUT);
+
+	switch (*ext_err) {
+	case BPF_FIB_LKUP_RET_SUCCESS:
+		/* We found an oif and ARP was successful.
+		 * We may need to redirect to the appropriate oif, if not
+		 * rewrite the layer 2 and continue processing.
+		 */
+		if (old_oif != params.l.ifindex)
+			return fib_do_redirect(ctx, true, &params,
+					      (__s8 *)ext_err, (int *)&old_oif);
+
+		if (eth_store_daddr(ctx, params.l.dmac, 0) < 0)
+			return DROP_WRITE_ERROR;
+
+		break;
+	case BPF_FIB_LKUP_RET_NO_NEIGH:
+		/* In this case, we found an oif, but ARP failed.
+		 * We can't rule out that oif is a veth, in which ARP is not
+		 * strictly necessary to deliver the packet, since the kernel
+		 * can fill in the veth pair's dmac without it, we lets deliver
+		 * or redirect.
+		 */
+		if (old_oif != params.l.ifindex)
+			return fib_do_redirect(ctx, true, &params,
+					      (__s8 *)ext_err, (int *)&old_oif);
+		break;
+	default:
+		return DROP_NO_FIB;
+	};
+	return CTX_ACT_OK;
+}
+#endif /* ENABLE_IPV6 */
+
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SRV6_ENCAP)
 int tail_srv6_encap(struct __ctx_buff *ctx)
 {
 	struct in6_addr dst_sid;
 	__u32 vrf_id;
 	int ret = 0;
+	int __maybe_unused ext_err = 0;
 
 	srv6_load_meta_sid(ctx, &dst_sid);
 	vrf_id = ctx_load_meta(ctx, CB_SRV6_VRF_ID);
 
 	ret = srv6_handling(ctx, vrf_id, &dst_sid);
-
 	if (ret < 0)
 		return send_drop_notify_error(ctx, SECLABEL, ret, CTX_ACT_DROP,
 					      METRIC_EGRESS);
 
+#ifdef ENABLE_IPV6
+	ret = srv6_refib(ctx, &ext_err);
+	if (ret < 0)
+		return send_drop_notify_ext(ctx, SECLABEL, 0, 0, ret, ext_err,
+					   CTX_ACT_DROP, METRIC_EGRESS);
+#endif
+
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL, 0, 0, 0,
 			  TRACE_REASON_UNKNOWN, 0);
-	return CTX_ACT_OK;
+
+	return ret;
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_SRV6_DECAP)

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -40,14 +40,134 @@ static __always_inline bool fib_ok(int ret)
 	return likely(ret == CTX_ACT_TX || ret == CTX_ACT_REDIRECT);
 }
 
-/* fib_redirect() is common helper code which performs fib lookup, populates
- * the corresponding hardware addresses and pushes the packet to a target
- * device for the next hop. Calling fib_redirect_v{4,6} is preferred unless
- * due to NAT46x64 struct bpf_fib_lookup_padded needs to be prepared at the
- * callsite. oif must be 0 if otherwise not passed in from the BPF CT. The
- * needs_l2_check must be true if the packet could transition between L2->L3
- * or L3->L2 device.
- */
+ /* fib_do_redirect will redirect the ctx to a particular output interface.
+  *
+  * the redirect can occur with or without a previous call to fib_lookup.
+  *
+  * if a previous fib_lookup was performed, this function will attempt to redirect
+  * to the output interface in the provided 'fib_params', as long as 'fib_ret'
+  * is set to 'BPF_FIB_LKUP_RET_SUCCESS'
+  *
+  * if a previous fib_lookup was performed and the return was 'BPF_FIB_LKUP_NO_NEIGH'
+  * this function will then attempt to copy the af_family and destination address
+  * out of 'fib_params' and into 'redir_neigh' struct then perform a
+  * 'redirect_neigh'.
+  *
+  * if no previous fib_lookup was performed, and the desire is to simply use
+  * 'redirect_neigh' then set 'fib_params' to nil and 'fib_ret' to
+  * 'BPF_FIB_LKUP_RET_NO_NEIGH'.
+  * in this case, the 'oif' value will be used for the 'redirect_neigh' call.
+  *
+  * in a special case, if a previous fib_lookup was performed, and the return
+  * was 'BPF_FIB_LKUP_RET_NO_NEIGH', and we are on a kernel version where
+  * the target interface for the fib lookup is not returned
+  * (due to ARP failing, see Kernel commit d1c362e1dd68) the provided 'oif'
+  * will be used as output interface for redirect.
+  */
+static __always_inline int
+fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
+		const struct bpf_fib_lookup_padded *fib_params, __s8 *fib_ret,
+		int *oif)
+{
+	struct bpf_redir_neigh nh_params;
+	struct bpf_redir_neigh *nh = NULL;
+	union macaddr smac = NATIVE_DEV_MAC_BY_IFINDEX(*oif);
+	union macaddr *dmac = 0;
+	int ret;
+
+	/* sanity check, we only enter this function with these two fib lookup
+	 * return codes.
+	 */
+	if (*fib_ret && (*fib_ret != BPF_FIB_LKUP_RET_NO_NEIGH))
+		return DROP_NO_FIB;
+
+	/* determine which oif to use before needs_l2_check determines if layer 2
+	 * header needs to be pushed.
+	 */
+	if (fib_params) {
+		if (*fib_ret == BPF_FIB_LKUP_RET_NO_NEIGH &&
+		    !is_defined(HAVE_FIB_IFINDEX) && *oif) {
+			/* For kernels without d1c362e1dd68 ("bpf: Always
+			 * return target ifindex in bpf_fib_lookup") we
+			 * fall back to use the caller-provided oif when
+			 * necessary.
+			 * no-op
+			 */
+		} else {
+			*oif = fib_params->l.ifindex;
+		}
+	}
+
+	/* determine if we need to append layer 2 header */
+	if (needs_l2_check) {
+		bool l2_hdr_required = true;
+
+		ret = maybe_add_l2_hdr(ctx, *oif, &l2_hdr_required);
+		if (ret != 0)
+			return ret;
+		if (!l2_hdr_required)
+			goto out_send;
+	}
+
+	/* determine if we are performing redirect or redirect_neigh*/
+	switch (*fib_ret) {
+	case BPF_FIB_LKUP_RET_SUCCESS:
+		if (eth_store_daddr(ctx, fib_params->l.dmac, 0) < 0)
+			return DROP_WRITE_ERROR;
+		if (eth_store_saddr(ctx, fib_params->l.smac, 0) < 0)
+			return DROP_WRITE_ERROR;
+		break;
+	case BPF_FIB_LKUP_RET_NO_NEIGH:
+		/* previous fib lookup was performed, we can fillout both
+		 * a bpf_redir_neigh and a dmac.
+		 *
+		 * the former is used if we have access to redirect_neigh
+		 * the latter is used if we don't and have to use the eBPF
+		 * neighbor map.
+		 */
+		if (fib_params) {
+			nh_params.nh_family = fib_params->l.family;
+			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
+					     &fib_params->l.ipv6_dst,
+					     sizeof(nh_params.ipv6_nh));
+			nh = &nh_params;
+
+			if (!neigh_resolver_available()) {
+				/* The neigh_record_ip{4,6} locations are mainly from
+				 * inbound client traffic on the load-balancer where we
+				 * know that replies need to go back to them.
+				 */
+				dmac = fib_params->l.family == AF_INET ?
+				neigh_lookup_ip4(&fib_params->l.ipv4_dst) :
+				neigh_lookup_ip6((void *)&fib_params->l.ipv6_dst);
+			}
+		}
+
+		/* If we are able to resolve neighbors on demand, always
+		 * prefer that over the BPF neighbor map since the latter
+		 * might be less accurate in some asymmetric corner cases.
+		 */
+		if (neigh_resolver_available()) {
+			if (nh)
+				return redirect_neigh(*oif, &nh_params,
+						sizeof(nh_params), 0);
+			else
+				return redirect_neigh(*oif, NULL, 0, 0);
+		} else {
+			if (!dmac) {
+				*fib_ret = BPF_FIB_MAP_NO_NEIGH;
+				return DROP_NO_FIB;
+			}
+			if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0)
+				return DROP_WRITE_ERROR;
+			if (eth_store_saddr_aligned(ctx, smac.addr, 0) < 0)
+				return DROP_WRITE_ERROR;
+		}
+	};
+out_send:
+	return ctx_redirect(ctx, *oif, 0);
+}
+
 static __always_inline int
 fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 	     struct bpf_fib_lookup_padded *fib_params, __s8 *fib_err, int *oif)

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -254,6 +254,28 @@ out_send:
 }
 
 #ifdef ENABLE_IPV6
+/* fib_lookup_v6 will perform a fib lookup with the src and dest addresses
+ * provided.
+ *
+ * after the function returns 'fib_params' will have the results of the fib lookup
+ * if successful.
+ */
+static __always_inline int
+fib_lookup_v6(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
+	      const struct in6_addr *ipv6_src, const struct in6_addr *ipv6_dst,
+	      int flags)
+{
+	fib_params->l.family	= AF_INET6;
+	fib_params->l.ifindex	= ctx_get_ifindex(ctx);
+
+	ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_src,
+		       (union v6addr *)ipv6_src);
+	ipv6_addr_copy((union v6addr *)&fib_params->l.ipv6_dst,
+		       (union v6addr *)ipv6_dst);
+
+	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
+};
+
 static __always_inline int
 fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 		struct ipv6hdr *ip6, const bool needs_l2_check,
@@ -281,6 +303,23 @@ fib_redirect_v6(struct __ctx_buff *ctx, int l3_off,
 #endif /* ENABLE_IPV6 */
 
 #ifdef ENABLE_IPV4
+/* fib_lookup_v4 will perform a fib lookup with the src and dest addresses
+ * provided.
+ *
+ * after the function returns 'fib_params' will have the results of the fib lookup
+ * if successful.
+ */
+static __always_inline int
+fib_lookup_v4(struct __ctx_buff *ctx, struct bpf_fib_lookup_padded *fib_params,
+	      __be32 ipv4_src, __be32 ipv4_dst, int flags) {
+	fib_params->l.family	= AF_INET;
+	fib_params->l.ifindex	= ctx_get_ifindex(ctx);
+	fib_params->l.ipv4_src	= ipv4_src;
+	fib_params->l.ipv4_dst	= ipv4_dst;
+
+	return fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), flags);
+}
+
 static __always_inline int
 fib_redirect_v4(struct __ctx_buff *ctx, int l3_off,
 		struct iphdr *ip4, const bool needs_l2_check,

--- a/bpf/tests/fib_tests.c
+++ b/bpf/tests/fib_tests.c
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+/* make neigh_resolver_available() return true */
+#define HAVE_FIB_NEIGH 1
+/* assume fib_lookup always returns target oif if available */
+#define HAVE_FIB_IFINDEX 1
+
+#include "common.h"
+#include "bpf/ctx/skb.h"
+#include "linux/bpf.h"
+
+#define CTX_REDIRECT_ENTERED 1001
+
+struct ctx_redirect_recorder {
+	const struct __sk_buff *ctx;
+	__u32 ifindex;
+	__u64 flags;
+} redir_recorder = {0};
+
+void reset_redir_recorder(struct ctx_redirect_recorder *r)
+{
+	r->ctx = 0;
+	r->ifindex = 0;
+	r->flags = 0XFFFFFFFFFFFFFFFF;
+}
+
+#define ctx_redirect mock_ctx_redirect
+
+long mock_ctx_redirect(__maybe_unused const struct __sk_buff *ctx,
+		       __maybe_unused __u32 ifindex,
+		       __maybe_unused __u64 flags)
+{
+	redir_recorder.flags = flags;
+	redir_recorder.ifindex = ifindex;
+	redir_recorder.ctx = ctx;
+	return CTX_REDIRECT_ENTERED;
+}
+
+#define REDIR_NEIGH_ENTERED 1002
+
+struct redir_neigh_recorder {
+	__u32 ifindex;
+	struct bpf_redir_neigh *params;
+	int plen;
+	__u32 flags;
+} redir_neigh_recorder = {0};
+
+void reset_redir_neigh_recorder(struct redir_neigh_recorder *r)
+{
+	r->ifindex = 0;
+	r->params = 0;
+	r->plen = 0;
+	r->flags = 0XFFFFFFFF;
+}
+
+#define redirect_neigh mock_redirect_neigh
+
+long mock_redirect_neigh(__maybe_unused int ifindex,
+			 __maybe_unused struct bpf_redir_neigh *params,
+			 __maybe_unused int plen,
+			 __maybe_unused __u32 flags)
+{
+	redir_neigh_recorder.ifindex = ifindex;
+	redir_neigh_recorder.params = params;
+	redir_neigh_recorder.plen = plen;
+	redir_neigh_recorder.flags = flags;
+	return REDIR_NEIGH_ENTERED;
+}
+
+#include "lib/dbg.h"
+#include "node_config.h"
+#include "lib/fib.h"
+
+CHECK("tc", "fib_do_redirect_happy_path")
+int test1_check(struct __ctx_buff *ctx)
+{
+	test_init();
+
+	/* Simulate a successful fib lookup with an output interface.
+	 * We expect to enter ctx_redirect with the ifindex provided in the
+	 * fib params.
+	 */
+	TEST("lookup_success", {
+		__u32 ifindex_bad  = 0xDEADBEEF;
+		__u32 ifindex_good = 0xAAAAAAAA;
+		int ret = -1;
+		__s8 flags = BPF_FIB_LKUP_RET_SUCCESS;
+		struct bpf_fib_lookup_padded params = {0};
+
+		params.l.ifindex = ifindex_good;
+
+		ret = fib_do_redirect(ctx, false, &params, &flags,
+				      (int *)&ifindex_bad);
+		if (ret != CTX_REDIRECT_ENTERED)
+			test_fatal("did not enter ctx_redirect");
+
+		if (redir_recorder.ifindex != ifindex_good)
+			test_fatal("expected %x, got %d", ifindex_good,
+				   redir_recorder.ifindex);
+
+		if (redir_recorder.ctx != ctx)
+			test_fatal("ctx pointer mismatch");
+
+		if (redir_recorder.flags != 0)
+			test_fatal("unexpected flags: ");
+
+		reset_redir_recorder(&redir_recorder);
+	});
+
+	/* Simulate fib lookup with no neighbor return.
+	 * We expect to enter redirect_neigh with the ifindex provided in
+	 * fib params and a non-nil bpf_redir_neigh
+	 */
+	TEST("lookup_no_neigh", {
+		__u32 ifindex_bad  = 0xDEADBEEF;
+		__u32 ifindex_good = 0xAAAAAAAA;
+		int ret = -1;
+		__s8 flags = BPF_FIB_LKUP_RET_NO_NEIGH;
+		struct bpf_fib_lookup_padded params = {0};
+
+		params.l.ifindex = ifindex_good;
+
+		if (!neigh_resolver_available())
+			test_fatal("expected neigh_resolver_available true");
+
+		ret = fib_do_redirect(ctx, false, &params, &flags, (int *)&ifindex_bad);
+		if (ret != REDIR_NEIGH_ENTERED)
+			test_fatal("did not enter redirect_neigh");
+
+		if (redir_neigh_recorder.ifindex != ifindex_good)
+			test_fatal("expected ifindex %x, got %d", ifindex_good,
+				   redir_neigh_recorder.ifindex);
+
+		if (!redir_neigh_recorder.params)
+			test_fatal("redirect_neigh called with nil params");
+
+		if (redir_neigh_recorder.plen != sizeof(struct bpf_redir_neigh))
+			test_fatal("expected plen %d, got %d",
+				   sizeof(struct bpf_redir_neigh),
+				   redir_neigh_recorder.plen);
+
+		if (redir_neigh_recorder.flags != 0)
+			test_fatal("expected flags 0, got %d", flags);
+
+		reset_redir_neigh_recorder(&redir_neigh_recorder);
+	});
+
+	/* Simulate no fib lookup.
+	 * We expect to enter redirect_neigh with the oif provided in the
+	 * argument to fib_do_redirect and a nil bpf_redir_neigh structure.
+	 */
+	TEST("lookup_no_neigh_no_fib", {
+		__u32 ifindex_good = 0xBEEFDEAD;
+		int ret = -1;
+		__s8 flags = BPF_FIB_LKUP_RET_NO_NEIGH;
+
+		if (!neigh_resolver_available())
+			test_fatal("expected neigh_resolver_available true");
+
+		ret = fib_do_redirect(ctx, false, NULL, &flags, (int *)&ifindex_good);
+		if (ret != REDIR_NEIGH_ENTERED)
+			test_fatal("did not enter redirect_neigh");
+
+		if (redir_neigh_recorder.ifindex != ifindex_good)
+			test_fatal("expected ifindex %x, got %d", ifindex_good,
+				   redir_neigh_recorder.ifindex);
+
+		if (redir_neigh_recorder.params)
+			test_fatal("expected nil bpf_redir_neigh");
+
+		if (redir_neigh_recorder.plen != 0)
+			test_fatal("expected plen to be 0");
+
+		if (redir_neigh_recorder.flags != 0)
+			test_fatal("expected flags 0, got %d", flags);
+
+		reset_redir_neigh_recorder(&redir_neigh_recorder);
+	});
+	test_finish();
+}
+
+CHECK("tc", "fib_do_redirect_sad_path")
+int test2_check(__maybe_unused struct __ctx_buff *ctx)
+{
+	test_init();
+
+	/* Confirm we return a DROP_NO_FIB for all unsupported flags. */
+	TEST("bad_flags", {
+		__s8 flag = BPF_FIB_LKUP_RET_BLACKHOLE;
+
+		for (; flag <= BPF_FIB_LKUP_RET_FRAG_NEEDED; flag++) {
+			if (flag == BPF_FIB_LKUP_RET_NO_NEIGH)
+				continue;
+
+			if (fib_do_redirect(NULL, false, NULL, &flag, NULL) != DROP_NO_FIB)
+				test_fatal("expected DROP_NO_FIB with flag %d", flag);
+		}
+	});
+
+	test_finish();
+}


### PR DESCRIPTION
This is the first PR in a set of two.

In this PR we introduce new functions in lib/fib.h to fix the issue described below

A follow up PR will be opened once this is merged which carries the non-backported refactor of fib/lib.h, removing the duplicate code introduced in this PR. 

see https://github.com/cilium/cilium/pull/26048#issuecomment-1587382600 for an explanation of why this occurs in two PRs.

Original SRv6 encapsulation flow:

``` mermaid
 flowchart LR
p["pod"] 
v1["veth1"]
v2["veth2"]
hs["host stack"]
e["eth0"]
tx["tx"]

p-->|egress pkt|v1-->v2-->hs-->|fib lookup|e-->|SRv6 encap|tx
```
This results in the egress packet always choosing the output interface, source, and destination mac from the FIB lookup that occurred on the inner packet. 

SRv6 encapsulation flow corrected:

``` mermaid
 flowchart LR
p["pod"] 
v1["veth1"]
v2["veth2"]
hs["host stack"]
e["eth0"]
tx["tx"]

p-->|egress pkt|v1-->v2-->hs-->|fib lookup|e-->|SRv6 encap\n+\nfib lookup|tx
```

Now, we perform an additional fib lookup once the egress packet has been encapsulated, ensuring the encapsulated packet is forwarded correctly based on the host namespace's FIB.

Performing these actions independently is currently necessary for this SRv6 datapath fix. 
This is because we perform the `fib_lookup` already at a egress interface and we **may or may not** need to redirect to a new interface for tx. 

It is obvious to see that two fib lookups are occurring here. 
It does seem to me that this can be reduced to one, however this involves changing where encapsulation occurs and will be a larger refactor, however I will also look into this. 

```release-note
Fixes an issue where SRv6 encapsulated packets are forwarded to the wrong layer 2 next hop.
```
