### PR TITLE
.github: add cilium sysdump to test artifacts

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -325,6 +325,7 @@ jobs:
           cmd: |
             git config --global --add safe.directory /host
             mv /host/helm /usr/bin
+            mv /host/cilium-cli /usr/bin
 
       - name: Provision kind
         timeout-minutes: 5
@@ -428,10 +429,7 @@ jobs:
           cmd: |
             cd /host
             kubectl get pods --all-namespaces -o wide
-            ./cilium-cli status
-            mkdir -p cilium-sysdumps
             tar -zcf "test_results-${{ env.job_name }}.tar.gz" /host/test/test_results
-            ./cilium-cli sysdump --output-filename "cilium-sysdump-${{ env.job_name }}-final" || true
 
       - name: Upload artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
With e93fdd87b963, cilium sysdumps were being collected by relying on the cilium-cli to be available on the host where the tests ran. This commit fixes the sysdump capture on conformance-ginkgo by adding cilium-cli to host where the tests are running.

Fixes: ce55298e0bbd ("test: Don't collect bugtool reports in artifacts")