### PR TITLE
bpf: test: fix pktgen for IPv6 NEXTHDR_DEST option

### DIFF
--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -778,6 +778,7 @@ void pktgen__finish(const struct pktgen *builder)
 				break;
 			case PKT_LAYER_IPV6_DEST:
 				ipv6_opt_layer->nexthdr = NEXTHDR_DEST;
+				break;
 			case PKT_LAYER_TCP:
 				ipv6_opt_layer->nexthdr = IPPROTO_TCP;
 				break;


### PR DESCRIPTION
When building packets with multiple IPv6 options, a missing `break` for the NEXTHDR_DEST option would cause us to set up the preceding option's `nexthdr` field incorrectly.