### PR TITLE
Aspsk/re enable smoke und kind

### DIFF
--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -117,31 +117,22 @@ jobs:
           pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
-      # The recent [stable] linux kernels contain a commit which increases
-      # complexity a lot. In particular, this breaks the connectivity test when
-      # ipsec is enabled. Temporarily disable this test until a better solution
-      # is found.
-
       - name: Install Cilium with encryption
-        if: ${{ false }} # temporary, see the comment above
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} \
             --encryption=ipsec
 
       - name: Enable Relay
-        if: ${{ false }} # temporary, see the comment above
         run: |
           cilium hubble enable ${{ steps.vars.outputs.hubble_enable_defaults }}
 
       - name: Port forward Relay
-        if: ${{ false }} # temporary, see the comment above
         run: |
           cilium hubble port-forward&
           sleep 10s
           [[ $(pgrep -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" | wc -l) == 2 ]]
 
       - name: Run connectivity test
-        if: ${{ false }} # temporary, see the comment above
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} --force-deploy
 

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -118,15 +118,12 @@ jobs:
 
       - name: Install cilium chart
         run: |
-          # The recent [stable] linux kernels contain a commit which increases
-          # complexity a lot. In particular, this breaks the connectivity test when
-          # hostServices.enabled=false. Temporarily set hostServices.enabled=true
           helm install cilium ./install/kubernetes/cilium \
              --wait \
              --namespace kube-system \
              --set nodeinit.enabled=true \
              --set kubeProxyReplacement=partial \
-             --set hostServices.enabled=true \
+             --set hostServices.enabled=false \
              --set externalIPs.enabled=true \
              --set nodePort.enabled=true \
              --set hostPort.enabled=true \


### PR DESCRIPTION
Re-enable the smoke test and the confirmance-kind test, as https://github.com/cilium/cilium/pull/25993 was merged and should have fixed those tests.

<!-- Description of change -->

```release-note
Re-enable the smoke test and the conformance-kind test for the CI.
```
