### PR TITLE
Agent: add support for watching kvstoremesh prefixes

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -113,7 +113,7 @@ func (f *FakeRefcountingIdentityAllocator) Close() {
 func (f *FakeRefcountingIdentityAllocator) InitIdentityAllocator(versioned.Interface) <-chan struct{} {
 	return nil
 }
-func (f *FakeRefcountingIdentityAllocator) WatchRemoteIdentities(string, kvstore.BackendOperations) (*allocator.RemoteCache, error) {
+func (f *FakeRefcountingIdentityAllocator) WatchRemoteIdentities(string, kvstore.BackendOperations, bool) (*allocator.RemoteCache, error) {
 	return nil, nil
 }
 

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -23,7 +23,7 @@ var Cell = cell.Module(
 	cell.Provide(NewClusterMesh),
 
 	// Convert concrete objects into more restricted interfaces used by clustermesh.
-	cell.ProvidePrivate(func(sc *k8s.ServiceCache) ServiceMerger { return sc }),
+	cell.ProvidePrivate(func(sc *k8s.ServiceCache) (ServiceMerger, k8s.ServiceIPGetter) { return sc, sc }),
 	cell.ProvidePrivate(func(ipcache *ipcache.IPCache) ipcache.IPCacher { return ipcache }),
 	cell.ProvidePrivate(func(mgr nodemanager.NodeManager) (store.Observer, kvstore.ClusterSizeDependantIntervalFunc) {
 		return nodeStore.NewNodeObserver(mgr), mgr.ClusterSizeDependantInterval

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
@@ -56,6 +57,9 @@ type Configuration struct {
 
 	// ClusterSizeDependantInterval allows to calculate intervals based on cluster size.
 	ClusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc
+
+	// ServiceIPGetter, if not nil, is used to create a custom dialer for service resolution.
+	ServiceIPGetter k8s.ServiceIPGetter
 
 	Metrics         Metrics
 	InternalMetrics internal.Metrics
@@ -110,6 +114,7 @@ func NewClusterMesh(lifecycle hive.Lifecycle, c Configuration) *ClusterMesh {
 		Config:                       c.Config,
 		ClusterIDName:                c.ClusterIDName,
 		ClusterSizeDependantInterval: c.ClusterSizeDependantInterval,
+		ServiceIPGetter:              c.ServiceIPGetter,
 
 		NewRemoteCluster: cm.newRemoteCluster,
 

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -67,8 +67,9 @@ type RemoteIdentityWatcher interface {
 	// WatchRemoteIdentities returns a RemoteCache instance which can be later
 	// started to watch identities in another kvstore and sync them to the local
 	// identity cache. remoteName should be unique unless replacing an existing
-	// remote's backend.
-	WatchRemoteIdentities(remoteName string, backend kvstore.BackendOperations) (*allocator.RemoteCache, error)
+	// remote's backend. When cachedPrefix is set, identities are assumed to be
+	// stored under the "cilium/cache" prefix, and the watcher is adapted accordingly.
+	WatchRemoteIdentities(remoteName string, backend kvstore.BackendOperations, cachedPrefix bool) (*allocator.RemoteCache, error)
 
 	// RemoveRemoteIdentities removes any reference to a remote identity source,
 	// emitting a deletion event for all previously known identities.

--- a/pkg/clustermesh/internal/clustermesh.go
+++ b/pkg/clustermesh/internal/clustermesh.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -50,6 +51,9 @@ type Configuration struct {
 
 	// ClusterSizeDependantInterval allows to calculate intervals based on cluster size.
 	ClusterSizeDependantInterval kvstore.ClusterSizeDependantIntervalFunc
+
+	// ServiceIPGetter, if not nil, is used to create a custom dialer for service resolution.
+	ServiceIPGetter k8s.ServiceIPGetter
 
 	// Metrics holds the different clustermesh metrics.
 	Metrics Metrics
@@ -112,6 +116,7 @@ func (cm *ClusterMesh) newRemoteCluster(name, path string) *remoteCluster {
 		name:                         name,
 		configPath:                   path,
 		clusterSizeDependantInterval: cm.conf.ClusterSizeDependantInterval,
+		serviceIPGetter:              cm.conf.ServiceIPGetter,
 
 		changed:     make(chan bool, configNotificationsChannelSize),
 		controllers: controller.NewManager(),

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -70,7 +70,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		capabilities = config.Capabilities
 	}
 
-	remoteIdentityCache, err := rc.mesh.conf.RemoteIdentityWatcher.WatchRemoteIdentities(rc.name, backend)
+	remoteIdentityCache, err := rc.mesh.conf.RemoteIdentityWatcher.WatchRemoteIdentities(rc.name, backend, capabilities.Cached)
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		rc.ipCacheWatcher.Watch(ctx, backend, ipcache.WithCachedPrefix(capabilities.Cached))
 	})
 
-	mgr.Register(identityCache.IdentitiesPath, func(ctx context.Context) {
+	mgr.Register(adapter(identityCache.IdentitiesPath), func(ctx context.Context) {
 		rc.remoteIdentityCache.Watch(ctx)
 	})
 

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -100,8 +100,8 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 		rc.remoteServices.Watch(ctx, backend, path.Join(adapter(serviceStore.ServiceStorePrefix), rc.name))
 	})
 
-	mgr.Register(ipcache.IPIdentitiesPath, func(ctx context.Context) {
-		rc.ipCacheWatcher.Watch(ctx, backend)
+	mgr.Register(adapter(ipcache.IPIdentitiesPath), func(ctx context.Context) {
+		rc.ipCacheWatcher.Watch(ctx, backend, ipcache.WithCachedPrefix(capabilities.Cached))
 	})
 
 	mgr.Register(identityCache.IdentitiesPath, func(ctx context.Context) {

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/testutils"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+// Configure a generous timeout to prevent flakes when running in a noisy CI environment.
+var (
+	tick    = 10 * time.Millisecond
+	timeout = 5 * time.Second
+)
+
+type remoteEtcdClientWrapper struct {
+	kvstore.BackendOperations
+	name                  string
+	syncedCanariesWatched bool
+}
+
+// Override the ListAndWatch method so that we can track whether the synced canaries prefix has been watched.
+func (w *remoteEtcdClientWrapper) ListAndWatch(ctx context.Context, name, prefix string, chanSize int) *kvstore.Watcher {
+	if prefix == fmt.Sprintf("cilium/synced/%s/", w.name) {
+		w.syncedCanariesWatched = true
+	}
+
+	return w.BackendOperations.ListAndWatch(ctx, name, prefix, chanSize)
+}
+
+type fakeIPCache struct{ updates atomic.Int32 }
+
+func (f *fakeIPCache) ForEachListener(func(listener ipcache.IPIdentityMappingListener)) {}
+func (f *fakeIPCache) Delete(string, source.Source) bool                                { return false }
+func (f *fakeIPCache) Upsert(string, net.IP, uint8, *ipcache.K8sMetadata, ipcache.Identity) (bool, error) {
+	f.updates.Add(1)
+	return false, nil
+}
+
+func TestRemoteClusterRun(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	kvstore.SetupDummyWithConfigOpts("etcd",
+		// Explicitly set higher QPS than the default to speedup the test
+		map[string]string{kvstore.EtcdRateLimitOption: "100"},
+	)
+	t.Cleanup(func() {
+		kvstore.Client().Close(context.Background())
+	})
+
+	tests := []struct {
+		name   string
+		srccfg *types.CiliumClusterConfig
+		kvs    map[string]string
+	}{
+		{
+			name:   "remote cluster has no cluster config",
+			srccfg: nil,
+			kvs: map[string]string{
+				"cilium/state/nodes/v1/foo/bar":      `{"name": "bar"}`,
+				"cilium/state/services/v1/foo/bar":   `{"name": "bar"}`,
+				"cilium/state/identities/v1/id/9999": `key1=value1;key2=value2`,
+				"cilium/state/ip/v1/default/1.1.1.1": `{"IP": "1.1.1.1"}`,
+			},
+		},
+		{
+			name: "remote cluster supports sync canaries",
+			srccfg: &types.CiliumClusterConfig{
+				Capabilities: types.CiliumClusterConfigCapabilities{
+					SyncedCanaries: true,
+				},
+			},
+			kvs: map[string]string{
+				"cilium/state/nodes/v1/foo/bar":      `{"name": "bar"}`,
+				"cilium/state/services/v1/foo/bar":   `{"name": "bar"}`,
+				"cilium/state/identities/v1/id/9999": `key1=value1;key2=value2`,
+				"cilium/state/ip/v1/default/1.1.1.1": `{"IP": "1.1.1.1"}`,
+
+				"cilium/synced/foo/cilium/state/nodes/v1":      "true",
+				"cilium/synced/foo/cilium/state/services/v1":   "true",
+				"cilium/synced/foo/cilium/state/identities/v1": "true",
+				"cilium/synced/foo/cilium/state/ip/v1":         "true",
+			},
+		},
+		{
+			name: "remote cluster supports both sync canaries and cached prefixes",
+			srccfg: &types.CiliumClusterConfig{
+				Capabilities: types.CiliumClusterConfigCapabilities{
+					SyncedCanaries: true,
+					Cached:         true,
+				},
+			},
+			kvs: map[string]string{
+				"cilium/cache/nodes/v1/foo/bar":          `{"name": "bar"}`,
+				"cilium/cache/services/v1/foo/bar":       `{"name": "bar"}`,
+				"cilium/cache/identities/v1/foo/id/9999": `key1=value1;key2=value2`,
+				"cilium/cache/ip/v1/foo/1.1.1.1":         `{"IP": "1.1.1.1"}`,
+
+				"cilium/synced/foo/cilium/cache/nodes/v1":      "true",
+				"cilium/synced/foo/cilium/cache/services/v1":   "true",
+				"cilium/synced/foo/cilium/cache/identities/v1": "true",
+				"cilium/synced/foo/cilium/cache/ip/v1":         "true",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var wg sync.WaitGroup
+			ctx, cancel := context.WithCancel(context.Background())
+
+			// The nils are only used by k8s CRD identities. We default to kvstore.
+			allocator := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
+			<-allocator.InitIdentityAllocator(nil)
+
+			defer t.Cleanup(func() {
+				cancel()
+				wg.Wait()
+
+				allocator.Close()
+				require.NoError(t, kvstore.Client().DeletePrefix(context.Background(), "cilium/"))
+			})
+
+			// Populate the kvstore with the appropriate KV pairs
+			for key, value := range tt.kvs {
+				require.NoErrorf(t, kvstore.Client().Set(ctx, key, []byte(value)), "Failed to set %s=%s", key, value)
+			}
+
+			var ipc fakeIPCache
+			cm := ClusterMesh{
+				conf: Configuration{
+					NodeKeyCreator:        testNodeCreator,
+					NodeObserver:          &testObserver{},
+					IPCache:               &ipc,
+					RemoteIdentityWatcher: allocator,
+					Metrics:               newMetrics(),
+				},
+				globalServices: newGlobalServiceCache("cluster", "node"),
+			}
+			rc := cm.newRemoteCluster("foo", nil).(*remoteCluster)
+
+			remoteClient := &remoteEtcdClientWrapper{
+				BackendOperations: kvstore.Client(),
+				name:              "foo",
+			}
+
+			wg.Add(1)
+			go func() {
+				rc.Run(ctx, remoteClient, tt.srccfg)
+				wg.Done()
+			}()
+
+			// Assert that we correctly watch nodes
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.EqualValues(c, 1, rc.remoteNodes.NumEntries())
+			}, timeout, tick, "Nodes are not watched correctly")
+
+			// Assert that we correctly watch services
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.EqualValues(c, 1, rc.remoteServices.NumEntries())
+			}, timeout, tick, "Services are not watched correctly")
+
+			// Assert that we correctly watch ipcache entries
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.EqualValues(c, 1, ipc.updates.Load())
+			}, timeout, tick, "IPCache entries are not watched correctly")
+
+			// Assert that we correctly watch identities
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				rc.mutex.RLock()
+				defer rc.mutex.RUnlock()
+				assert.EqualValues(c, 1, rc.remoteIdentityCache.NumEntries())
+			}, timeout, tick, "Identities are not watched correctly")
+
+			// Assert that synced canaries have been watched if expected
+			require.Equal(t, tt.srccfg != nil && tt.srccfg.Capabilities.SyncedCanaries, remoteClient.syncedCanariesWatched)
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces a set of minor modifications to enable Cilium agents watching the kvstore prefixes used by [kvstoremesh](https://github.com/cilium/cilium/pull/26083). Please refer to the individual commit descriptions for additional details. 

