### PR TITLE
node_ids: introduce GetNodeID

### DIFF
--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -151,6 +151,11 @@ func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params a
 		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumIdentity]]("auth identities gc", mapGC.handleCiliumIdentityEvent, params.CiliumIdentities))
 	}
 
+	// Add node based auth gc if k8s client is enabled
+	if params.CiliumNodes != nil {
+		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumNode]]("auth nodes gc", mapGC.handleCiliumNodeEvent, params.CiliumNodes))
+	}
+
 	jobGroup.Add(job.Timer("auth expiration gc", mapGC.CleanupExpiredEntries, params.Config.MeshAuthExpiredGCInterval))
 }
 

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -40,7 +40,7 @@ type authManager struct {
 // ipCache is the set of interactions the auth manager performs with the IPCache
 type ipCache interface {
 	GetNodeIP(uint16) string
-	AllocateNodeID(net.IP) uint16
+	GetNodeID(nodeIP net.IP) (nodeID uint16, exists bool)
 }
 
 // authHandler is responsible to handle authentication for a specific auth type

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -184,14 +184,14 @@ func (r *fakeIPCache) GetNodeIP(id uint16) string {
 	return r.nodeIdMappings[id]
 }
 
-func (r *fakeIPCache) AllocateNodeID(hostIP net.IP) uint16 {
+func (r *fakeIPCache) GetNodeID(nodeIP net.IP) (uint16, bool) {
 	for id, ip := range r.nodeIdMappings {
-		if ip == hostIP.String() {
-			return id
+		if ip == nodeIP.String() {
+			return id, true
 		}
 	}
 
-	return 9999
+	return 0, false
 }
 
 // Fake AuthHandler

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -18,6 +18,10 @@ type FakeNodeHandler struct {
 	Nodes map[string]nodeTypes.Node
 }
 
+func (n *FakeNodeHandler) GetNodeID(_ net.IP) (uint16, bool) {
+	return 0, true
+}
+
 // NewNodeHandler returns a fake NodeHandler that stores the nodes,
 // but performs no other actions.
 func NewNodeHandler() *FakeNodeHandler {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -53,7 +53,7 @@ type NeighLink struct {
 }
 
 type linuxNodeHandler struct {
-	mutex                lock.Mutex
+	mutex                lock.RWMutex
 	isInitialized        bool
 	nodeConfig           datapath.LocalNodeConfiguration
 	nodeAddressing       datapath.NodeAddressing

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -61,8 +61,8 @@ func (n *linuxNodeHandler) AllocateNodeID(nodeIP net.IP) uint16 {
 }
 
 func (n *linuxNodeHandler) GetNodeIP(nodeID uint16) string {
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
 
 	// Check for local node ID explicitly as local node IPs are not in our maps!
 	if nodeID == 0 {
@@ -73,8 +73,8 @@ func (n *linuxNodeHandler) GetNodeIP(nodeID uint16) string {
 }
 
 func (n *linuxNodeHandler) GetNodeID(nodeIP net.IP) (uint16, bool) {
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
+	n.mutex.RLock()
+	defer n.mutex.RUnlock()
 
 	return n.getNodeIDForIP(nodeIP)
 }

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -80,8 +80,9 @@ func (n *linuxNodeHandler) GetNodeID(nodeIP net.IP) (uint16, bool) {
 }
 
 func (n *linuxNodeHandler) getNodeIDForIP(nodeIP net.IP) (uint16, bool) {
-	localNode := node.GetIPv4()
-	if localNode.Equal(nodeIP) {
+	localNodeV4 := node.GetIPv4()
+	localNodeV6 := node.GetIPv6()
+	if localNodeV4.Equal(nodeIP) || localNodeV6.Equal(nodeIP) {
 		return 0, true
 	}
 

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -33,16 +33,11 @@ func (n *linuxNodeHandler) AllocateNodeID(nodeIP net.IP) uint16 {
 		return 0
 	}
 
-	// Don't allocate a node ID for the local node.
-	localNode := node.GetIPv4()
-	if localNode.Equal(nodeIP) {
-		return 0
-	}
-
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
-	if nodeID, exists := n.nodeIDsByIPs[nodeIP.String()]; exists {
+	if nodeID, exists := n.getNodeIDForIP(nodeIP); exists {
+		// Don't allocate a node ID if one already exists.
 		return nodeID
 	}
 
@@ -77,8 +72,28 @@ func (n *linuxNodeHandler) GetNodeIP(nodeID uint16) string {
 	return n.nodeIPsByIDs[nodeID]
 }
 
+func (n *linuxNodeHandler) GetNodeID(nodeIP net.IP) (uint16, bool) {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	return n.getNodeIDForIP(nodeIP)
+}
+
+func (n *linuxNodeHandler) getNodeIDForIP(nodeIP net.IP) (uint16, bool) {
+	localNode := node.GetIPv4()
+	if localNode.Equal(nodeIP) {
+		return 0, true
+	}
+
+	if nodeID, exists := n.nodeIDsByIPs[nodeIP.String()]; exists {
+		return nodeID, true
+	}
+
+	return 0, false
+}
+
 // getNodeIDForNode gets the node ID for the given node if one was allocated
-// for any of the node IP addresses. If none if found, 0 is returned.
+// for any of the node IP addresses. If none is found, 0 is returned.
 func (n *linuxNodeHandler) getNodeIDForNode(node *nodeTypes.Node) uint16 {
 	nodeID := uint16(0)
 	for _, addr := range node.IPAddresses {

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -147,6 +147,9 @@ type NodeIDHandler interface {
 	// GetNodeIP returns the string node IP that was previously registered as the given node ID.
 	GetNodeIP(uint16) string
 
+	// GetNodeID gets the node ID for the given node IP. If none is found, exists is false.
+	GetNodeID(nodeIP net.IP) (nodeID uint16, exists bool)
+
 	// DumpNodeIDs returns all node IDs and their associated IP addresses.
 	DumpNodeIDs() []*models.NodeID
 

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -662,6 +662,10 @@ func (s *IPCacheTestSuite) TestIPCacheShadowing(c *C) {
 
 type mockNodeIDHandler struct{}
 
+func (m *mockNodeIDHandler) GetNodeID(_ net.IP) (nodeID uint16, exists bool) {
+	return 0, true
+}
+
 func (m *mockNodeIDHandler) AllocateNodeID(_ net.IP) uint16 {
 	return 0
 }

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/ipcache/types/fake"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/types"
@@ -47,7 +48,7 @@ func (s *IPCacheTestSuite) SetUpTest(c *C) {
 		IdentityAllocator: allocator,
 		PolicyHandler:     &mockUpdater{},
 		DatapathHandler:   &mockTriggerer{},
-		NodeIDHandler:     &mockNodeIDHandler{},
+		NodeIDHandler:     &fake.FakeNodeIDHandler{},
 	})
 
 	s.cleanup = func() {
@@ -553,7 +554,7 @@ func benchmarkIPCacheUpsert(b *testing.B, num int) {
 			IdentityAllocator: allocator,
 			PolicyHandler:     &mockUpdater{},
 			DatapathHandler:   &mockTriggerer{},
-			NodeIDHandler:     &mockNodeIDHandler{},
+			NodeIDHandler:     &fake.FakeNodeIDHandler{},
 		})
 
 		// We only want to measure the calls to upsert.
@@ -658,18 +659,4 @@ func (s *IPCacheTestSuite) TestIPCacheShadowing(c *C) {
 	ipc.Delete(endpointIP, source.KVStore)
 	_, exists := ipc.LookupByPrefix(cidrOverlap)
 	c.Assert(exists, Equals, false)
-}
-
-type mockNodeIDHandler struct{}
-
-func (m *mockNodeIDHandler) GetNodeID(_ net.IP) (nodeID uint16, exists bool) {
-	return 0, true
-}
-
-func (m *mockNodeIDHandler) AllocateNodeID(_ net.IP) uint16 {
-	return 0
-}
-
-func (m *mockNodeIDHandler) GetNodeIP(_ uint16) string {
-	return ""
 }

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/ipcache/types/fake"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -413,7 +414,7 @@ func setupTest(t *testing.T) (cleanup func()) {
 		IdentityAllocator: allocator,
 		PolicyHandler:     &mockUpdater{},
 		DatapathHandler:   &mockTriggerer{},
-		NodeIDHandler:     &mockNodeIDHandler{},
+		NodeIDHandler:     &fake.FakeNodeIDHandler{},
 	})
 
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "kube-uid", labels.LabelKubeAPIServer)

--- a/pkg/ipcache/types/fake/nodeidhandler.go
+++ b/pkg/ipcache/types/fake/nodeidhandler.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fake
+
+import "net"
+
+type FakeNodeIDHandler struct{}
+
+func (m *FakeNodeIDHandler) GetNodeID(_ net.IP) (nodeID uint16, exists bool) {
+	return 0, true
+}
+
+func (m *FakeNodeIDHandler) AllocateNodeID(_ net.IP) uint16 {
+	return 0
+}
+
+func (m *FakeNodeIDHandler) GetNodeIP(_ uint16) string {
+	return ""
+}

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -65,6 +65,7 @@ func NewResourceID(kind ResourceKind, namespace, name string) ResourceID {
 type NodeIDHandler interface {
 	AllocateNodeID(net.IP) uint16
 	GetNodeIP(uint16) string
+	GetNodeID(nodeIP net.IP) (nodeID uint16, exists bool)
 }
 
 // TunnelPeer is the IP address of the host associated with this prefix. This is

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/cidr"
 	iputil "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipcache"
+	"github.com/cilium/cilium/pkg/ipcache/types/fake"
 	"github.com/cilium/cilium/pkg/source"
 )
 
@@ -82,7 +83,7 @@ func containsIP(allowedIPs []net.IPNet, ipnet *net.IPNet) bool {
 func newTestAgent(ctx context.Context) (*Agent, *ipcache.IPCache) {
 	ipCache := ipcache.NewIPCache(&ipcache.Configuration{
 		Context:       ctx,
-		NodeIDHandler: &mockNodeHandler{},
+		NodeIDHandler: &fake.FakeNodeIDHandler{},
 	})
 	wgAgent := &Agent{
 		wgClient:         &fakeWgClient{},
@@ -230,18 +231,4 @@ func (a *AgentSuite) TestAgent_PeerConfig_WithEncryptNode(c *C) {
 	c.Assert(containsIP(k8s1.allowedIPs, pod2IPv4), Equals, true)
 	c.Assert(containsIP(k8s1.allowedIPs, iputil.IPToPrefix(k8s1NodeIPv4)), Equals, true)
 	c.Assert(containsIP(k8s1.allowedIPs, iputil.IPToPrefix(k8s1NodeIPv6)), Equals, true)
-}
-
-type mockNodeHandler struct{}
-
-func (m *mockNodeHandler) GetNodeID(_ net.IP) (uint16, bool) {
-	return 0, true
-}
-
-func (m *mockNodeHandler) AllocateNodeID(_ net.IP) uint16 {
-	return 0
-}
-
-func (m *mockNodeHandler) GetNodeIP(_ uint16) string {
-	return ""
 }

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -234,6 +234,10 @@ func (a *AgentSuite) TestAgent_PeerConfig_WithEncryptNode(c *C) {
 
 type mockNodeHandler struct{}
 
+func (m *mockNodeHandler) GetNodeID(_ net.IP) (uint16, bool) {
+	return 0, true
+}
+
 func (m *mockNodeHandler) AllocateNodeID(_ net.IP) uint16 {
 	return 0
 }


### PR DESCRIPTION
This PR introduces the possibility to retrieve the node id for a given node IP without having to use `AllocateNodeID` which comes with the drawback of actually allocating a new node id if one doesn't exist yet for the given IP.

Example: Using `ipcache.AllocateNodeID` to lookup the node ID for a node IP during auth gc initialisation results in unintended node ID allocations if the nodeids doesn't exist yet for the cilium nodes.

By using the new method `GetNodeID` we remove this unintended side-effect.

Therefore, the temporarily disabled auth map GC functionality has been re-enabled!

Related to: https://github.com/cilium/cilium/pull/26073 & https://github.com/cilium/cilium/issues/25964