### PR TITLE
metrics: provide the global services metric through the hive

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -100,9 +100,11 @@ func NewClusterMesh(lifecycle hive.Lifecycle, c Configuration) *ClusterMesh {
 
 	nodeName := nodeTypes.GetName()
 	cm := &ClusterMesh{
-		conf:           c,
-		nodeName:       nodeName,
-		globalServices: newGlobalServiceCache(c.ClusterName, nodeName),
+		conf:     c,
+		nodeName: nodeName,
+		globalServices: newGlobalServiceCache(
+			c.Metrics.TotalGlobalServices.WithLabelValues(c.ClusterName, nodeName),
+		),
 	}
 
 	cm.internal = internal.NewClusterMesh(internal.Configuration{

--- a/pkg/clustermesh/metrics.go
+++ b/pkg/clustermesh/metrics.go
@@ -11,6 +11,9 @@ import (
 type Metrics struct {
 	// TotalNodes tracks the number of total nodes in a remote cluster.
 	TotalNodes metric.Vec[metric.Gauge]
+
+	// TotalGlobalServices tracks the total number of global services.
+	TotalGlobalServices metric.Vec[metric.Gauge]
 }
 
 func newMetrics() Metrics {
@@ -22,5 +25,13 @@ func newMetrics() Metrics {
 			Name:       "remote_cluster_nodes",
 			Help:       "The total number of nodes in the remote cluster",
 		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
+
+		TotalGlobalServices: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_" + subsystem + "_global_services",
+			Namespace:  metrics.Namespace,
+			Subsystem:  subsystem,
+			Name:       "global_services",
+			Help:       "The total number of global services in the cluster mesh",
+		}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName}),
 	}
 }

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/metrics"
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/rand"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
@@ -352,7 +353,7 @@ func (f *fakeServiceMerger) MergeExternalServiceDelete(service *serviceStore.Clu
 func (s *ClusterMeshServicesTestSuite) TestRemoteServiceObserver(c *C) {
 	svc1 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name", IncludeExternal: false, Shared: true}
 	svc2 := serviceStore.ClusterService{Cluster: "remote", Namespace: "namespace", Name: "name"}
-	cache := newGlobalServiceCache("cluster", "node")
+	cache := newGlobalServiceCache(metrics.NoOpGauge)
 	merger := fakeServiceMerger{}
 
 	observer := remoteServiceObserver{


### PR DESCRIPTION
This PR extracts the initialization of the global services metric from the global service cache constructor, providing it through `cell.Metric` and propagating it as appropriate.