### PR TITLE
bpf: xdp: use CT tuple hash for tunnel encap's source port

### DIFF
--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -212,21 +212,25 @@ encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 }
 #endif /* TUNNEL_MODE || ENABLE_HIGH_SCALE_IPCACHE */
 
-static __always_inline __be16 tunnel_gen_src_port_v4(void)
+static __always_inline __be16
+tunnel_gen_src_port_v4(struct ipv4_ct_tuple *tuple __maybe_unused)
 {
 #if __ctx_is == __ctx_xdp
-	/* TODO hash, based on CT tuple */
-	return bpf_htons(TUNNEL_PORT);
+	__be32 hash = hash_from_tuple_v4(tuple);
+
+	return (hash >> 16)  ^ (__be16)hash;
 #else
 	return 0;
 #endif
 }
 
-static __always_inline __be16 tunnel_gen_src_port_v6(void)
+static __always_inline __be16
+tunnel_gen_src_port_v6(struct ipv6_ct_tuple *tuple __maybe_unused)
 {
 #if __ctx_is == __ctx_xdp
-	/* TODO hash, based on CT tuple */
-	return bpf_htons(TUNNEL_PORT);
+	__be32 hash = hash_from_tuple_v6(tuple);
+
+	return (hash >> 16)  ^ (__be16)hash;
 #else
 	return 0;
 #endif


### PR DESCRIPTION
(follow-on to https://github.com/cilium/cilium/pull/24422)

`hash_from_tuple_v*()` isn't perfect (as it ignores the .daddr), but much better than what we currently have.

The one path where we might notice the reduced entropy is in a config with EgressGW and native-routing, when processing EgressGW reply traffic with non-service protocol (ICMP or other exotic types). As here we currently don't extract any L4 ports either.