### PR TITLE
daemon: Do not require native routing CIDR if ipmasq-agent is enabled

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3638,26 +3638,36 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 }
 
 func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
-	if c.GetIPv4NativeRoutingCIDR() == nil && c.EnableIPv4Masquerade && !c.TunnelingEnabled() &&
-		c.IPAMMode() != ipamOption.IPAMENI && c.EnableIPv4 && c.IPAMMode() != ipamOption.IPAMAlibabaCloud {
+	if c.GetIPv4NativeRoutingCIDR() == nil &&
+		c.EnableIPv4 && c.EnableIPv4Masquerade &&
+		!c.EnableIPMasqAgent &&
+		!c.TunnelingEnabled() &&
+		c.IPAMMode() != ipamOption.IPAMENI && c.IPAMMode() != ipamOption.IPAMAlibabaCloud {
 		return fmt.Errorf(
 			"native routing cidr must be configured with option --%s "+
-				"in combination with --%s --%s=%s --%s=%s --%s=true",
-			IPv4NativeRoutingCIDR, EnableIPv4Masquerade, RoutingMode, RoutingModeNative,
-			IPAM, c.IPAMMode(), EnableIPv4Name)
+				"in combination with --%s=true --%s=true --%s=false --%s=%s --%s=%s",
+			IPv4NativeRoutingCIDR,
+			EnableIPv4Name, EnableIPv4Masquerade,
+			EnableIPMasqAgent,
+			RoutingMode, RoutingModeNative,
+			IPAM, c.IPAMMode())
 	}
 
 	return nil
 }
 
 func (c *DaemonConfig) checkIPv6NativeRoutingCIDR() error {
-	if c.GetIPv6NativeRoutingCIDR() == nil && c.EnableIPv6Masquerade && !c.TunnelingEnabled() &&
-		c.EnableIPv6 {
+	if c.GetIPv6NativeRoutingCIDR() == nil &&
+		c.EnableIPv6 && c.EnableIPv6Masquerade &&
+		!c.EnableIPMasqAgent &&
+		!c.TunnelingEnabled() {
 		return fmt.Errorf(
 			"native routing cidr must be configured with option --%s "+
-				"in combination with --%s --%s=%s --%s=true",
-			IPv6NativeRoutingCIDR, EnableIPv6Masquerade, RoutingMode, RoutingModeNative,
-			EnableIPv6Name)
+				"in combination with --%s=true --%s=true --%s=false --%s=%s",
+			IPv6NativeRoutingCIDR,
+			EnableIPv6Name, EnableIPv6Masquerade,
+			EnableIPMasqAgent,
+			RoutingMode, RoutingModeNative)
 	}
 
 	return nil

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -571,6 +571,18 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "without native routing cidr and tunnel disabled, but ipmasq-agent",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade: true,
+				EnableIPv6Masquerade: true,
+				RoutingMode:          RoutingModeNative,
+				IPAM:                 ipamOption.IPAMKubernetes,
+				EnableIPv4:           true,
+				EnableIPMasqAgent:    true,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -632,6 +644,17 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 				EnableIPv6:           true,
 			},
 			wantErr: true,
+		},
+		{
+			name: "without native routing cidr and tunnel disabled, but ipmasq-agent",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade: true,
+				EnableIPv6Masquerade: true,
+				RoutingMode:          RoutingModeNative,
+				EnableIPv6:           true,
+				EnableIPMasqAgent:    true,
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
Cilium's built-in [ipmasq-agent replacement](https://docs.cilium.io/en/v1.13/network/concepts/masquerading/#ebpf-based) acts as a replacement for the native routing CIDR. Therefore, it does not make sense to require the native routing CIDR if the ipmasq-agent is enabled, since the two flags are basically mutually exclusive.

In addition, this commit also slightly restructures and aligns the if condition with the error message, to make it a bit easier to read.

Fixes: e7d4f5c6af7d ("daemon: validate IPv4NativeRoutingCIDR value in DaemonConfig")
