### PR TITLE
docs: clarify that L3 DNS policies require L7 proxy enabled

### DIFF
--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -518,13 +518,18 @@ provided in DNS responses are allowed by Cilium in a similar manner to IPs in
 or are not know a priori, or when DNS is more convenient. To enforce policy on
 DNS requests themselves, see `Layer 7 Examples`_.
 
-IP information is captured from DNS responses per-Endpoint via a `DNS Proxy`_.
+.. note::
+
+	In order to associate domain names with IP addresses, Cilium intercepts
+	DNS responses per-Endpoint using a `DNS Proxy`_. This requires Cilium
+	to be configured with ``--enable-l7-proxy=true`` and an L7 policy allowing
+	DNS requests. For more details, see :ref:`DNS Obtaining Data`.
+
 An L3 `CIDR based`_ rule is generated for every ``toFQDNs``
 rule and applies to the same endpoints. The IP information is selected for
 insertion by ``matchName`` or ``matchPattern`` rules, and is collected from all
 DNS responses seen by Cilium on the node. Multiple selectors may be included in
-a single egress rule. See :ref:`DNS Obtaining Data` for information on
-collecting this IP data.
+a single egress rule.
 
 .. note:: The DNS Proxy is provided in each Cilium agent.
    As a result, DNS requests targeted by policies depend on the availability


### PR DESCRIPTION
Add a note to the L3 policy documentation clarifying that L3 DNS policies require the L7 proxy enabled and an L7 policy for DNS traffic so Cilium can intercept DNS responses.

Previously, the documentation linked to other sections describing the DNS Proxy, but I know at least a few people who were surprised that a policy under "L3 Examples" would require an L7 proxy. Hopefully adding a note near the beginning of the section will make this requirement more obvious.