### PR TITLE
gha: enable debug logs in conformance-clustermesh workflows

### DIFF
--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -273,6 +273,7 @@ jobs:
 
         # bpf.masquerade is disabled due to #23283
         CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=debug.enabled=true \
           --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
           --helm-set=image.useDigest=false \
           --helm-set=image.tag=${SHA} \

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -268,6 +268,7 @@ jobs:
 
         # bpf.masquerade is disabled due to #23283
         CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=debug.enabled=true \
           --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
           --helm-set=image.useDigest=false \
           --helm-set=image.tag=${SHA} \

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -268,6 +268,7 @@ jobs:
 
         # bpf.masquerade is disabled due to #23283
         CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=debug.enabled=true \
           --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
           --helm-set=image.useDigest=false \
           --helm-set=image.tag=${SHA} \

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -266,6 +266,7 @@ jobs:
 
         # bpf.masquerade is disabled due to #23283
         CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
+          --helm-set=debug.enabled=true \
           --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
           --helm-set=image.useDigest=false \
           --helm-set=image.tag=${SHA} \


### PR DESCRIPTION
Let's enable debug-level logs in conformance-clustermesh workflows, as they might be useful when investigating possible flakes to gather more information.

Link to successful run: https://github.com/cilium/cilium/actions/runs/5256914992/jobs/9498930808?pr=26186