### PR TITLE
daemon: don't allow egress gateway with KV store identity allocation

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1514,6 +1514,12 @@ func initEnv() {
 			)
 		}
 	}
+
+	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeKVstore {
+		if option.Config.EnableIPv4EgressGateway {
+			log.Fatal("The egress gateway is not supported in KV store identity allocation mode.")
+		}
+	}
 }
 
 func (d *Daemon) initKVStore() {


### PR DESCRIPTION
as the egress gateway feature would not be supported