### PR TITLE
bgpv1: pass router state to gobgp

### DIFF
--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	apb "google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
@@ -53,7 +54,7 @@ type GoBGPServer struct {
 }
 
 // NewGoBGPServerWithConfig returns instance of go bgp router wrapper.
-func NewGoBGPServerWithConfig(ctx context.Context, log *logrus.Entry, params types.ServerParameters) (types.Router, error) {
+func NewGoBGPServerWithConfig(ctx context.Context, log *logrus.Entry, params types.ServerParameters, _ *agent.ControlPlaneState) (types.Router, error) {
 	logger := NewServerLogger(log.Logger, LogParams{
 		AS:        params.Global.ASN,
 		Component: "gobgp.BgpServerInstance",

--- a/pkg/bgpv1/manager/instance.go
+++ b/pkg/bgpv1/manager/instance.go
@@ -6,6 +6,7 @@ package manager
 import (
 	"context"
 
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -45,8 +46,8 @@ type ServerWithConfig struct {
 //
 // Canceling the provided context will kill the BgpServer along with calling the
 // underlying BgpServer's Stop() method.
-func NewServerWithConfig(ctx context.Context, params types.ServerParameters) (*ServerWithConfig, error) {
-	s, err := gobgp.NewGoBGPServerWithConfig(ctx, log, params)
+func NewServerWithConfig(ctx context.Context, params types.ServerParameters, cstate *agent.ControlPlaneState) (*ServerWithConfig, error) {
+	s, err := gobgp.NewGoBGPServerWithConfig(ctx, log, params, cstate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -226,7 +226,7 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context, c *v2alpha1api
 		},
 	}
 
-	if s, err = NewServerWithConfig(ctx, globalConfig); err != nil {
+	if s, err = NewServerWithConfig(ctx, globalConfig, cstate); err != nil {
 		return fmt.Errorf("failed to start BGP server for config with local ASN %v: %w", c.LocalASN, err)
 	}
 

--- a/pkg/bgpv1/manager/reconcile.go
+++ b/pkg/bgpv1/manager/reconcile.go
@@ -155,7 +155,7 @@ func preflightReconciler(
 	sc.Server.Stop()
 
 	// create a new one via ServerWithConfig constructor
-	s, err := NewServerWithConfig(ctx, globalConfig)
+	s, err := NewServerWithConfig(ctx, globalConfig, cstate)
 	if err != nil {
 		l.WithError(err).Errorf("Failed to start BGP server for virtual router with local ASN %v", newc.LocalASN)
 		return fmt.Errorf("failed to start BGP server for virtual router with local ASN %v: %w", newc.LocalASN, err)
@@ -300,7 +300,7 @@ func neighborReconciler(
 	// create new neighbors
 	for _, n := range toCreate {
 		l.Infof("Adding peer %v %v to local ASN %v", n.PeerAddress, n.PeerASN, newc.LocalASN)
-		if err := sc.Server.AddNeighbor(ctx, types.NeighborRequest{Neighbor: n}); err != nil {
+		if err := sc.Server.AddNeighbor(ctx, types.NeighborRequest{Neighbor: n, VR: newc}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
 		}
 	}
@@ -308,7 +308,7 @@ func neighborReconciler(
 	// update neighbors
 	for _, n := range toUpdate {
 		l.Infof("Updating peer %v %v in local ASN %v", n.PeerAddress, n.PeerASN, newc.LocalASN)
-		if err := sc.Server.UpdateNeighbor(ctx, types.NeighborRequest{Neighbor: n}); err != nil {
+		if err := sc.Server.UpdateNeighbor(ctx, types.NeighborRequest{Neighbor: n, VR: newc}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
 		}
 	}
@@ -316,7 +316,7 @@ func neighborReconciler(
 	// remove neighbors
 	for _, n := range toRemove {
 		l.Infof("Removing peer %v %v from local ASN %v", n.PeerAddress, n.PeerASN, newc.LocalASN)
-		if err := sc.Server.RemoveNeighbor(ctx, types.NeighborRequest{Neighbor: n}); err != nil {
+		if err := sc.Server.RemoveNeighbor(ctx, types.NeighborRequest{Neighbor: n, VR: newc}); err != nil {
 			return fmt.Errorf("failed while reconciling neighbor %v %v: %w", n.PeerAddress, n.PeerASN, err)
 		}
 	}

--- a/pkg/bgpv1/manager/reconcile_test.go
+++ b/pkg/bgpv1/manager/reconcile_test.go
@@ -105,7 +105,7 @@ func TestPreflightReconciler(t *testing.T) {
 					ListenPort: tt.localPort,
 				},
 			}
-			testSC, err := NewServerWithConfig(context.Background(), srvParams)
+			testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
 			if err != nil {
 				t.Fatalf("failed to create test BgpServer: %v", err)
 			}
@@ -313,7 +313,7 @@ func TestNeighborReconciler(t *testing.T) {
 					ListenPort: -1,
 				},
 			}
-			testSC, err := NewServerWithConfig(context.Background(), srvParams)
+			testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
 			if err != nil {
 				t.Fatalf("failed to create test BgpServer: %v", err)
 			}
@@ -330,6 +330,7 @@ func TestNeighborReconciler(t *testing.T) {
 				oldc.Neighbors = append(oldc.Neighbors, n)
 				testSC.Server.AddNeighbor(context.Background(), types.NeighborRequest{
 					Neighbor: &n,
+					VR:       oldc,
 				})
 			}
 			testSC.Config = oldc
@@ -468,7 +469,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				ExportPodCIDR: pointer.Bool(tt.enabled),
 				Neighbors:     []v2alpha1api.CiliumBGPNeighbor{},
 			}
-			testSC, err := NewServerWithConfig(context.Background(), srvParams)
+			testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
 			if err != nil {
 				t.Fatalf("failed to create test bgp server: %v", err)
 			}
@@ -1055,7 +1056,7 @@ func TestLBServiceReconciler(t *testing.T) {
 				Neighbors:       []v2alpha1api.CiliumBGPNeighbor{},
 				ServiceSelector: tt.oldServiceSelector,
 			}
-			testSC, err := NewServerWithConfig(context.Background(), srvParams)
+			testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
 			if err != nil {
 				t.Fatalf("failed to create test bgp server: %v", err)
 			}
@@ -1198,7 +1199,7 @@ func TestReconcileAfterServerReinit(t *testing.T) {
 		},
 	}
 
-	testSC, err := NewServerWithConfig(context.Background(), srvParams)
+	testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
 	require.NoError(t, err)
 
 	originalServer := testSC.Server

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -40,6 +40,7 @@ type Advertisement struct {
 // NeighborRequest contains neighbor parameters used when enabling or disabling peer
 type NeighborRequest struct {
 	Neighbor *v2alpha1api.CiliumBGPNeighbor
+	VR       *v2alpha1api.CiliumBGPVirtualRouter
 }
 
 // PathRequest contains parameters for advertising or withdrawing routes


### PR DESCRIPTION
This change passes additional context regarding the control plane state to GoBGP.