### PR TITLE
BGP CP: Adds Intro to Docs

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -9,6 +9,14 @@
 Cilium BGP Control Plane
 ========================
 
+BGP Control Plane provides a way for Cilium to advertise routes to connected routers by using the
+`Border Gateway Protocol`_ (BGP). BGP Control Plane makes Pod networks and/or Services of type
+``LoadBalancer`` reachable from outside the cluster for environments that support BGP. Because BGP
+Control Plane does not program the :ref:`datapath <ebpf_datapath>`, do not use it to establish
+reachability within the cluster.
+
+.. _Border Gateway Protocol: https://datatracker.ietf.org/doc/html/rfc4271
+
 Usage
 -----
 

--- a/pkg/bgpv1/README.md
+++ b/pkg/bgpv1/README.md
@@ -1,5 +1,14 @@
 # Cilium BGP Control Plane
 
+BGP Control Plane provides a way for Cilium to advertise routes to connected routers by using the
+[Border Gateway Protocol][] (BGP). BGP Control Plane makes Pod networks and/or Services of type
+`LoadBalancer` reachable from outside the cluster for environments that support BGP. Because BGP
+Control Plane does not program the [datapath][], do not use it to establish reachability within
+the cluster.
+
+[Border Gateway Protocol]: https://datatracker.ietf.org/doc/html/rfc4271
+[datapath]: https://docs.cilium.io/en/latest/network/ebpf/
+
 ## Usage
 
 Currently a single flag in the `Cilium Agent` exists to turn on the `BGP Control Plane` feature set.


### PR DESCRIPTION
Updates BGP CP docs with an introduction section that provides an explanation of the feature.

Relates to: #26146
