### PR TITLE
cilium: enable bpf host routing with per endpoint routes for IPv6 as well

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -415,9 +415,6 @@ func finishKubeProxyReplacementInit() error {
 		// KPR=strict is needed or we might rely on netfilter.
 		case option.Config.KubeProxyReplacement != option.KubeProxyReplacementStrict:
 			msg = fmt.Sprintf("BPF host routing requires %s=%s.", option.KubeProxyReplacement, option.KubeProxyReplacementStrict)
-		// All cases below still need to be implemented ...
-		case option.Config.EnableEndpointRoutes && option.Config.EnableIPv6:
-			msg = fmt.Sprintf("BPF host routing is currently not supported with %s when IPv6 is enabled.", option.EnableEndpointRoutes)
 		default:
 			if probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnRedirectNeigh) != nil ||
 				probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnRedirectPeer) != nil {


### PR DESCRIPTION
See commit descriptions.