### PR TITLE
bpf: nat: improve tracing in to-netdev program

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1499,7 +1499,7 @@ out:
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.
 		 */
-		ret = handle_nat_fwd(ctx, 0);
+		ret = handle_nat_fwd(ctx, 0, &trace);
 		if (IS_ERR(ret))
 			return send_drop_notify_error(ctx, 0, ret,
 						      CTX_ACT_DROP,

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -671,6 +671,7 @@ out:
 __section("to-overlay")
 int cil_to_overlay(struct __ctx_buff *ctx)
 {
+	struct trace_ctx trace __maybe_unused;
 	int ret = TC_ACT_OK;
 	__u32 cluster_id __maybe_unused = 0;
 
@@ -703,7 +704,7 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
 	cluster_id = ctx_get_cluster_id_mark(ctx);
 #endif
-	ret = handle_nat_fwd(ctx, cluster_id);
+	ret = handle_nat_fwd(ctx, cluster_id, &trace);
 out:
 #endif
 	if (IS_ERR(ret))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1358,11 +1358,10 @@ __handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 	return ret;
 }
 
-static __always_inline int handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
+static __always_inline int
+handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 {
-	struct trace_ctx trace;
-
-	return __handle_nat_fwd_ipv6(ctx, &trace);
+	return __handle_nat_fwd_ipv6(ctx, trace);
 }
 
 declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
@@ -2703,14 +2702,14 @@ __handle_nat_fwd_ipv4(struct __ctx_buff *ctx, __u32 cluster_id __maybe_unused,
 	return ret;
 }
 
-static __always_inline int handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
+static __always_inline int
+handle_nat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 {
-	struct trace_ctx trace;
 	__u32 cluster_id = ctx_load_meta(ctx, CB_CLUSTER_ID_EGRESS);
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, 0);
 
-	return __handle_nat_fwd_ipv4(ctx, cluster_id, &trace);
+	return __handle_nat_fwd_ipv4(ctx, cluster_id, trace);
 }
 
 declare_tailcall_if(__or4(__and(is_defined(ENABLE_IPV4),
@@ -2840,7 +2839,9 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused)
 }
 #endif /* ENABLE_HEALTH_CHECK */
 
-static __always_inline int handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_id)
+static __always_inline int
+handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_id,
+	       struct trace_ctx *trace __maybe_unused)
 {
 	int ret = CTX_ACT_OK;
 	__u16 proto;
@@ -2852,25 +2853,25 @@ static __always_inline int handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		ret = invoke_tailcall_if(__or4(__and(is_defined(ENABLE_IPV4),
-						     is_defined(ENABLE_IPV6)),
-					       __and(is_defined(ENABLE_HOST_FIREWALL),
-						     is_defined(IS_BPF_HOST)),
-					       __and(is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING),
-						     is_defined(ENABLE_INTER_CLUSTER_SNAT)),
-					       is_defined(ENABLE_EGRESS_GATEWAY)),
-					 CILIUM_CALL_IPV4_NODEPORT_NAT_FWD,
-					 handle_nat_fwd_ipv4);
+		ret = invoke_tailcall_if_trace(__or4(__and(is_defined(ENABLE_IPV4),
+							   is_defined(ENABLE_IPV6)),
+						     __and(is_defined(ENABLE_HOST_FIREWALL),
+							   is_defined(IS_BPF_HOST)),
+						     __and(is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING),
+							   is_defined(ENABLE_INTER_CLUSTER_SNAT)),
+						     is_defined(ENABLE_EGRESS_GATEWAY)),
+					       CILIUM_CALL_IPV4_NODEPORT_NAT_FWD,
+					       handle_nat_fwd_ipv4, trace);
 		break;
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		ret = invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
-						    is_defined(ENABLE_IPV6)),
-					      __and(is_defined(ENABLE_HOST_FIREWALL),
-						    is_defined(IS_BPF_HOST))),
-					 CILIUM_CALL_IPV6_NODEPORT_NAT_FWD,
-					 handle_nat_fwd_ipv6);
+		ret = invoke_tailcall_if_trace(__or(__and(is_defined(ENABLE_IPV4),
+							  is_defined(ENABLE_IPV6)),
+						    __and(is_defined(ENABLE_HOST_FIREWALL),
+							  is_defined(IS_BPF_HOST))),
+					       CILIUM_CALL_IPV6_NODEPORT_NAT_FWD,
+					       handle_nat_fwd_ipv6, trace);
 		break;
 #endif /* ENABLE_IPV6 */
 	default:

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -98,6 +98,7 @@ static __always_inline bool nodeport_uses_dsr6(const struct ipv6_ct_tuple *tuple
 }
 
 static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
+						  struct trace_ctx *trace,
 						  __s8 *ext_err)
 {
 	struct ipv6_nat_target target = {
@@ -107,7 +108,7 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 	int ret;
 
 	ret = snat_v6_needed(ctx, &target.addr) ?
-	      snat_v6_nat(ctx, &target, ext_err) : CTX_ACT_OK;
+	      snat_v6_nat(ctx, &target, trace, ext_err) : CTX_ACT_OK;
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
 
@@ -847,6 +848,10 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 		.src_from_world = true,
 		.addr = IPV6_DIRECT_ROUTING,
 	};
+	struct trace_ctx trace = {
+		.reason = (enum trace_reason)CT_NEW,
+		.monitor = TRACE_PAYLOAD_LEN,
+	};
 	int ret, oif = 0;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
@@ -876,7 +881,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 		BPF_V6(target.addr, ROUTER_IP);
 	}
 #endif
-	ret = snat_v6_nat(ctx, &target, &ext_err);
+	ret = snat_v6_nat(ctx, &target, &trace, &ext_err);
 	if (IS_ERR(ret) && ret != NAT_PUNT_TO_STACK)
 		goto drop_err;
 
@@ -892,8 +897,9 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 					  WORLD_ID,
 					  dst_sec_identity,
 					  NOT_VTEP_DST,
-					  (enum trace_reason)CT_NEW,
-					  TRACE_PAYLOAD_LEN, &oif);
+					  trace.reason,
+					  trace.monitor,
+					  &oif);
 		if (IS_ERR(ret))
 			goto drop_err;
 
@@ -1322,16 +1328,21 @@ drop:
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_NODEPORT_SNAT_FWD)
 int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 {
+	struct trace_ctx trace = {
+		.reason = TRACE_REASON_UNKNOWN,
+		.monitor = 0,
+	};
 	int ret;
 	__s8 ext_err = 0;
 
-	ret = nodeport_snat_fwd_ipv6(ctx, &ext_err);
+	ret = nodeport_snat_fwd_ipv6(ctx, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
 						  CTX_ACT_DROP, METRIC_EGRESS);
 
 #ifdef IS_BPF_HOST
-	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0, 0, TRACE_REASON_UNKNOWN, 0);
+	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0, 0, trace.reason,
+			  trace.monitor);
 #endif
 
 	return ret;
@@ -1398,6 +1409,7 @@ static __always_inline bool nodeport_uses_dsr4(const struct ipv4_ct_tuple *tuple
 
 static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 						  __u32 cluster_id __maybe_unused,
+						  struct trace_ctx *trace,
 						  __s8 *ext_err)
 {
 	struct ipv4_nat_target target = {
@@ -1414,7 +1426,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 
 	snat_needed = snat_v4_prepare_state(ctx, &target);
 	if (snat_needed)
-		ret = snat_v4_nat(ctx, &target, ext_err);
+		ret = snat_v4_nat(ctx, &target, trace, ext_err);
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
 
@@ -2151,6 +2163,10 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		 */
 		.addr = IPV4_DIRECT_ROUTING,
 	};
+	struct trace_ctx trace = {
+		.reason = (enum trace_reason)CT_NEW,
+		.monitor = TRACE_PAYLOAD_LEN,
+	};
 	int ret, oif = 0;
 	void *data, *data_end;
 	struct iphdr *ip4;
@@ -2173,7 +2189,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		target.addr = IPV4_GATEWAY;
 	}
 #endif
-	ret = snat_v4_nat(ctx, &target, &ext_err);
+	ret = snat_v4_nat(ctx, &target, &trace, &ext_err);
 	if (IS_ERR(ret) && ret != NAT_PUNT_TO_STACK)
 		goto drop_err;
 
@@ -2196,8 +2212,9 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 					  WORLD_ID,
 					  dst_sec_identity,
 					  NOT_VTEP_DST,
-					  (enum trace_reason)CT_NEW,
-					  TRACE_PAYLOAD_LEN, &oif);
+					  trace.reason,
+					  trace.monitor,
+					  &oif);
 		if (IS_ERR(ret))
 			goto drop_err;
 
@@ -2658,12 +2675,16 @@ __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_NODEPORT_SNAT_FWD)
 int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 {
 	__u32 cluster_id = ctx_load_meta(ctx, CB_CLUSTER_ID_EGRESS);
+	struct trace_ctx trace = {
+		.reason = TRACE_REASON_UNKNOWN,
+		.monitor = 0,
+	};
 	int ret;
 	__s8 ext_err = 0;
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, 0);
 
-	ret = nodeport_snat_fwd_ipv4(ctx, cluster_id, &ext_err);
+	ret = nodeport_snat_fwd_ipv4(ctx, cluster_id, &trace, &ext_err);
 	if (IS_ERR(ret))
 		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
 						  CTX_ACT_DROP, METRIC_EGRESS);
@@ -2672,7 +2693,8 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 	/* encap helpers already send a TRACE_TO_OVERLAY, so don't
 	 * send another one here when called from to-overlay.
 	 */
-	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0, 0, TRACE_REASON_UNKNOWN, 0);
+	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0, 0, trace.reason,
+			  trace.monitor);
 #endif
 
 	return ret;

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -111,4 +111,14 @@
 #define invoke_tailcall_if(COND, NAME, FUNC)  \
 	__eval(__invoke_tailcall_if_, COND)(NAME, FUNC)
 
+#define __invoke_tailcall_if_trace_0(NAME, FUNC, TRACE)			\
+	FUNC(ctx, TRACE)
+#define __invoke_tailcall_if_trace_1(NAME, FUNC, TRACE)			\
+	({								\
+		ep_tail_call(ctx, NAME);				\
+		DROP_MISSED_TAIL_CALL;					\
+	})
+#define invoke_tailcall_if_trace(COND, NAME, FUNC, TRACE)		\
+	__eval(__invoke_tailcall_if_trace_, COND)(NAME, FUNC, TRACE)
+
 #endif /* TAILCALL_H */

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -570,7 +570,9 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	struct trace_ctx trace;
+
+	ret = snat_v4_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -679,7 +681,9 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	struct trace_ctx trace;
+
+	ret = snat_v4_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -787,7 +791,9 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	struct trace_ctx trace;
+
+	ret = snat_v4_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -884,7 +890,9 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	struct trace_ctx trace;
+
+	ret = snat_v4_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;


### PR DESCRIPTION
When invoke_tailcall_if() expands into an inline function, we currently can't pass through the trace_ctx from the to-netdev program. This prevents us from using the trace information that the CT lookups inside handle_nat_fwd() would provide.

Add a variant of invoke_tailcall_if() that also takes a TRACE parameter, and wire this up from the to-netdev program.