### PR TITLE
bpf: Use "fallthrough;", compile with -Wimplicit-fallthrough

### DIFF
--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -12,6 +12,7 @@ CLANG_FLAGS += -Wno-unknown-warning-option
 CLANG_FLAGS += -Wno-gnu-variable-sized-type-not-at-end
 CLANG_FLAGS += -Wdeclaration-after-statement
 CLANG_FLAGS += -Wimplicit-int-conversion -Wenum-conversion
+CLANG_FLAGS += -Wimplicit-fallthrough
 LLC_FLAGS := -march=bpf
 # Mimics the mcpu values set by cilium-agent. See GetBPFCPU().
 ifeq ("$(KERNEL)","netnext")

--- a/bpf/include/bpf/builtins.h
+++ b/bpf/include/bpf/builtins.h
@@ -51,17 +51,17 @@ static __always_inline void __bpf_memzero(void *d, __u64 len)
 	d += len;
 
 	switch (len) {
-	case 96:         __it_set(d, 64);
-	case 88: jmp_88: __it_set(d, 64);
-	case 80: jmp_80: __it_set(d, 64);
-	case 72: jmp_72: __it_set(d, 64);
-	case 64: jmp_64: __it_set(d, 64);
-	case 56: jmp_56: __it_set(d, 64);
-	case 48: jmp_48: __it_set(d, 64);
-	case 40: jmp_40: __it_set(d, 64);
-	case 32: jmp_32: __it_set(d, 64);
-	case 24: jmp_24: __it_set(d, 64);
-	case 16: jmp_16: __it_set(d, 64);
+	case 96:         __it_set(d, 64); fallthrough;
+	case 88: jmp_88: __it_set(d, 64); fallthrough;
+	case 80: jmp_80: __it_set(d, 64); fallthrough;
+	case 72: jmp_72: __it_set(d, 64); fallthrough;
+	case 64: jmp_64: __it_set(d, 64); fallthrough;
+	case 56: jmp_56: __it_set(d, 64); fallthrough;
+	case 48: jmp_48: __it_set(d, 64); fallthrough;
+	case 40: jmp_40: __it_set(d, 64); fallthrough;
+	case 32: jmp_32: __it_set(d, 64); fallthrough;
+	case 24: jmp_24: __it_set(d, 64); fallthrough;
+	case 16: jmp_16: __it_set(d, 64); fallthrough;
 	case  8: jmp_8:  __it_set(d, 64);
 		break;
 
@@ -164,17 +164,17 @@ static __always_inline void __bpf_memcpy(void *d, const void *s, __u64 len)
 	}
 
 	switch (len) {
-	case 96:         __it_mob(d, s, 64);
-	case 88: jmp_88: __it_mob(d, s, 64);
-	case 80: jmp_80: __it_mob(d, s, 64);
-	case 72: jmp_72: __it_mob(d, s, 64);
-	case 64: jmp_64: __it_mob(d, s, 64);
-	case 56: jmp_56: __it_mob(d, s, 64);
-	case 48: jmp_48: __it_mob(d, s, 64);
-	case 40: jmp_40: __it_mob(d, s, 64);
-	case 32: jmp_32: __it_mob(d, s, 64);
-	case 24: jmp_24: __it_mob(d, s, 64);
-	case 16: jmp_16: __it_mob(d, s, 64);
+	case 96:         __it_mob(d, s, 64); fallthrough;
+	case 88: jmp_88: __it_mob(d, s, 64); fallthrough;
+	case 80: jmp_80: __it_mob(d, s, 64); fallthrough;
+	case 72: jmp_72: __it_mob(d, s, 64); fallthrough;
+	case 64: jmp_64: __it_mob(d, s, 64); fallthrough;
+	case 56: jmp_56: __it_mob(d, s, 64); fallthrough;
+	case 48: jmp_48: __it_mob(d, s, 64); fallthrough;
+	case 40: jmp_40: __it_mob(d, s, 64); fallthrough;
+	case 32: jmp_32: __it_mob(d, s, 64); fallthrough;
+	case 24: jmp_24: __it_mob(d, s, 64); fallthrough;
+	case 16: jmp_16: __it_mob(d, s, 64); fallthrough;
 	case  8: jmp_8:  __it_mob(d, s, 64);
 		break;
 
@@ -285,14 +285,14 @@ static __always_inline __u64 __bpf_memcmp(const void *x, const void *y,
 	}
 
 	switch (len) {
-	case 72:         __it_xor(x, y, r, 64);
-	case 64: jmp_64: __it_xor(x, y, r, 64);
-	case 56: jmp_56: __it_xor(x, y, r, 64);
-	case 48: jmp_48: __it_xor(x, y, r, 64);
-	case 40: jmp_40: __it_xor(x, y, r, 64);
-	case 32: jmp_32: __it_xor(x, y, r, 64);
-	case 24: jmp_24: __it_xor(x, y, r, 64);
-	case 16: jmp_16: __it_xor(x, y, r, 64);
+	case 72:         __it_xor(x, y, r, 64); fallthrough;
+	case 64: jmp_64: __it_xor(x, y, r, 64); fallthrough;
+	case 56: jmp_56: __it_xor(x, y, r, 64); fallthrough;
+	case 48: jmp_48: __it_xor(x, y, r, 64); fallthrough;
+	case 40: jmp_40: __it_xor(x, y, r, 64); fallthrough;
+	case 32: jmp_32: __it_xor(x, y, r, 64); fallthrough;
+	case 24: jmp_24: __it_xor(x, y, r, 64); fallthrough;
+	case 16: jmp_16: __it_xor(x, y, r, 64); fallthrough;
 	case  8: jmp_8:  __it_xor(x, y, r, 64);
 		break;
 
@@ -383,17 +383,17 @@ static __always_inline void __bpf_memmove_fwd(void *d, const void *s, __u64 len)
 		__throw_build_bug();
 
 	switch (len) {
-	case 96:         __it_mof(d, s, 64);
-	case 88: jmp_88: __it_mof(d, s, 64);
-	case 80: jmp_80: __it_mof(d, s, 64);
-	case 72: jmp_72: __it_mof(d, s, 64);
-	case 64: jmp_64: __it_mof(d, s, 64);
-	case 56: jmp_56: __it_mof(d, s, 64);
-	case 48: jmp_48: __it_mof(d, s, 64);
-	case 40: jmp_40: __it_mof(d, s, 64);
-	case 32: jmp_32: __it_mof(d, s, 64);
-	case 24: jmp_24: __it_mof(d, s, 64);
-	case 16: jmp_16: __it_mof(d, s, 64);
+	case 96:         __it_mof(d, s, 64); fallthrough;
+	case 88: jmp_88: __it_mof(d, s, 64); fallthrough;
+	case 80: jmp_80: __it_mof(d, s, 64); fallthrough;
+	case 72: jmp_72: __it_mof(d, s, 64); fallthrough;
+	case 64: jmp_64: __it_mof(d, s, 64); fallthrough;
+	case 56: jmp_56: __it_mof(d, s, 64); fallthrough;
+	case 48: jmp_48: __it_mof(d, s, 64); fallthrough;
+	case 40: jmp_40: __it_mof(d, s, 64); fallthrough;
+	case 32: jmp_32: __it_mof(d, s, 64); fallthrough;
+	case 24: jmp_24: __it_mof(d, s, 64); fallthrough;
+	case 16: jmp_16: __it_mof(d, s, 64); fallthrough;
 	case  8: jmp_8:  __it_mof(d, s, 64);
 		break;
 

--- a/bpf/include/bpf/compiler.h
+++ b/bpf/include/bpf/compiler.h
@@ -119,4 +119,8 @@ static __always_inline void bpf_barrier(void)
 				   __val; })
 #endif
 
+#ifndef fallthrough
+# define fallthrough		__attribute__((fallthrough))
+#endif
+
 #endif /* __BPF_COMPILER_H_ */

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -430,7 +430,7 @@ ct_extract_ports6(struct __ctx_buff *ctx, int off,
 
 			case ICMPV6_ECHO_REQUEST:
 				tuple->dport = identifier;
-				/* fall through */
+				fallthrough;
 			default:
 				return ACTION_CREATE;
 			}
@@ -502,6 +502,7 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ct
 			goto out;
 
 		/* now lookup in forward direction: */
+		fallthrough;
 	case SCOPE_FORWARD:
 		ipv6_ct_tuple_reverse(tuple);
 		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
@@ -706,7 +707,7 @@ ct_extract_ports4(struct __ctx_buff *ctx, int off, enum ct_dir dir,
 				break;
 			case ICMP_ECHO:
 				tuple->dport = identifier;
-				/* fall through */
+				fallthrough;
 			default:
 				return ACTION_CREATE;
 			}
@@ -780,6 +781,7 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ct
 			goto out;
 
 		/* now lookup in forward direction: */
+		fallthrough;
 	case SCOPE_FORWARD:
 		ipv4_ct_tuple_reverse(tuple);
 		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,

--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -372,6 +372,7 @@ srv6_create_state_entry(struct __ctx_buff *ctx)
 
 		if (map_update_elem(&SRV6_STATE_MAP6, inner_ips, outer_ips, 0) < 0)
 			return DROP_INVALID;
+		break;
 	}
 #  ifdef ENABLE_IPV4
 	case IPPROTO_IPIP: {
@@ -384,6 +385,7 @@ srv6_create_state_entry(struct __ctx_buff *ctx)
 
 		if (map_update_elem(&SRV6_STATE_MAP4, inner_ips, outer_ips, 0) < 0)
 			return DROP_INVALID;
+		break;
 	}
 #  endif /* ENABLE_IPV4 */
 	}

--- a/bpf/lib/jhash.h
+++ b/bpf/lib/jhash.h
@@ -59,20 +59,21 @@ static __always_inline __u32 jhash(const void *key, __u32 length,
 	}
 
 	switch (length) {
-	case 12: c += (__u32)k[11] << 24;
-	case 11: c += (__u32)k[10] << 16;
-	case 10: c +=  (__u32)k[9] <<  8;
-	case 9:  c +=  (__u32)k[8];
-	case 8:  b +=  (__u32)k[7] << 24;
-	case 7:  b +=  (__u32)k[6] << 16;
-	case 6:  b +=  (__u32)k[5] <<  8;
-	case 5:  b +=  (__u32)k[4];
-	case 4:  a +=  (__u32)k[3] << 24;
-	case 3:  a +=  (__u32)k[2] << 16;
-	case 2:  a +=  (__u32)k[1] <<  8;
+	case 12: c += (__u32)k[11] << 24; fallthrough;
+	case 11: c += (__u32)k[10] << 16; fallthrough;
+	case 10: c +=  (__u32)k[9] <<  8; fallthrough;
+	case 9:  c +=  (__u32)k[8];       fallthrough;
+	case 8:  b +=  (__u32)k[7] << 24; fallthrough;
+	case 7:  b +=  (__u32)k[6] << 16; fallthrough;
+	case 6:  b +=  (__u32)k[5] <<  8; fallthrough;
+	case 5:  b +=  (__u32)k[4];       fallthrough;
+	case 4:  a +=  (__u32)k[3] << 24; fallthrough;
+	case 3:  a +=  (__u32)k[2] << 16; fallthrough;
+	case 2:  a +=  (__u32)k[1] <<  8; fallthrough;
 	case 1:  a +=  (__u32)k[0];
 
 		__jhash_final(a, b, c);
+		break;
 	case 0: /* Nothing left to add */
 		break;
 	}

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -18,6 +18,7 @@ CLANG_FLAGS += -Wno-address-of-packed-member
 CLANG_FLAGS += -Wno-unknown-warning-option
 CLANG_FLAGS += -Wno-gnu-variable-sized-type-not-at-end
 CLANG_FLAGS += -Wimplicit-int-conversion -Wenum-conversion
+CLANG_FLAGS += -Wimplicit-fallthrough
 LLC_FLAGS := -march=bpf
 # Mimics the mcpu values set by cilium-agent. See GetBPFCPU().
 ifeq ("$(KERNEL)","netnext")


### PR DESCRIPTION
> **Warning** to backporters:
>
> Only the first commit should be backported.

We can label intentional fall-throughs and tell clang to report unannotated ones, to catch bugs that would be caused by involuntarily falling through between switch labels.

The result is not super aesthetic in builtins.h or jhash.h, but at the same time it's just one keyword so not too much boilerplate either. And it catches bugs. The one fixed in commit 9a641116021a (`"bpf: test: fix pktgen for IPv6 NEXTHDR_DEST option"`), or the first commit in this PR, were found this way.

I wasn't able to pin down the exact version that got support for the relevant attribute, but clang 10 has it for sure and it seems to be much older than that, so we don't have to worry and test for its availability.

Inspired by checkpatch complaining about the `/* fall through */` comments.