### PR TITLE
docs: Remove IPv6 BPF masquerading restriction with BIG TCP

### DIFF
--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -80,7 +80,6 @@ To enable IPv6 BIG TCP:
              --set routingMode=native \\
              --set bpf.masquerade=true \\
              --set ipv6.enabled=true \\
-             --set enableIPv6Masquerade=false \\
              --set enableIPv6BIGTCP=true \\
              --set kubeProxyReplacement=strict
 


### PR DESCRIPTION
Now that we have support for IPv6 BPF masquerading, we no longer need to tell users to turn off IPv6 masquerading for using BIG TCP.
