### PR TITLE
Removed unnecessary 'revert' parameter from Newk8sTranslator

### DIFF
--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -210,7 +210,7 @@ func TestTranslate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			lator := tt.translator()
 			args := tt.args()
-			tr := NewK8sTranslator(lator.sid, lator.oldEPs, lator.newEPs, lator.revert, lator.labels)
+			tr := NewK8sTranslator(lator.sid, lator.oldEPs, lator.newEPs, lator.labels)
 			err := tr.Translate(args.rule, args.result)
 			assert.Equal(t, tt.expected, err)
 			assert.Equal(t, tt.expectedResult, args.result)
@@ -262,7 +262,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, map[string]string{})
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, map[string]string{})
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -276,7 +276,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epAddrCluster.Addr().String()+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, endpointInfo, true, map[string]string{})
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, Endpoints{}, map[string]string{})
 	result, err = repo.TranslateRules(translator)
 	c.Assert(result.NumToServicesRules, Equals, 1)
 
@@ -318,7 +318,7 @@ func (s *K8sSuite) TestServiceMatches(c *C) {
 		},
 	}
 
-	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, svcLabels)
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, svcLabels)
 	c.Assert(translator.serviceMatches(service), Equals, true)
 }
 
@@ -368,7 +368,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 		Labels: tag1,
 	}
 
-	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, svcLabels)
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, svcLabels)
 
 	_, _, err := repo.Add(rule1, []policy.Endpoint{})
 	c.Assert(err, IsNil)
@@ -382,7 +382,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 	c.Assert(len(rule.ToCIDRSet), Equals, 1)
 	c.Assert(string(rule.ToCIDRSet[0].Cidr), Equals, epAddrCluster.Addr().String()+"/32")
 
-	translator = NewK8sTranslator(serviceInfo, endpointInfo, endpointInfo, true, svcLabels)
+	translator = NewK8sTranslator(serviceInfo, endpointInfo, Endpoints{}, svcLabels)
 	result, err = repo.TranslateRules(translator)
 
 	rule = repo.SearchRLocked(tag1)[0].Egress[0]
@@ -423,7 +423,7 @@ func (s *K8sSuite) TestGenerateToCIDRFromEndpoint(c *C) {
 		Namespace: "default",
 	}
 
-	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, map[string]string{})
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, map[string]string{})
 	_, err := translator.generateToCidrFromEndpoint(rule, endpointInfo)
 	c.Assert(err, IsNil)
 	cidrs := rule.ToCIDRSet.StringSlice()
@@ -575,7 +575,7 @@ func (s *K8sSuite) TestDontDeleteUserRules(c *C) {
 		Namespace: "default",
 	}
 
-	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, false, map[string]string{})
+	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, map[string]string{})
 	_, err := translator.generateToCidrFromEndpoint(rule, endpointInfo)
 	c.Assert(err, IsNil)
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -632,7 +632,7 @@ func (k *K8sWatcher) k8sServiceHandler() {
 			if event.OldEndpoints != nil {
 				oldEP = *event.OldEndpoints
 			}
-			translator := k8s.NewK8sTranslator(event.ID, oldEP, *event.Endpoints, false, svc.Labels)
+			translator := k8s.NewK8sTranslator(event.ID, oldEP, *event.Endpoints, svc.Labels)
 			result, err := k.policyRepository.TranslateRules(translator)
 			if err != nil {
 				log.WithError(err).Error("Unable to repopulate egress policies from ToService rules")
@@ -658,9 +658,9 @@ func (k *K8sWatcher) k8sServiceHandler() {
 				return
 			}
 
-			// Use the current Endpoints object as the "old" object and "new"
-			// object due to deletion.
-			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, *event.Endpoints, true, svc.Labels)
+			// Use the current Endpoints object as the "old" object and an empty
+			// Endpoints as "new" object.
+			translator := k8s.NewK8sTranslator(event.ID, *event.Endpoints, k8s.Endpoints{}, svc.Labels)
 			result, err := k.policyRepository.TranslateRules(translator)
 			if err != nil {
 				log.WithError(err).Error("Unable to depopulate egress policies from ToService rules")


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

---

- Removed the revert parameter from Newk8sTranslator definition
- Updated api calls and comments accordingly.
- Updated unit tests.

Fixes: #26094 

```release-note
removed unnecessary 'revert' parameter from Newk8sTranslator and updated api calls accordingly.
```
