### PR TITLE
endpoint: fix policy map sync warning due to policymap authtype diffs

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1337,6 +1337,7 @@ func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 		policyEntry := policy.MapStateEntry{
 			ProxyPort: policymapEntry.GetProxyPort(),
 			IsDeny:    policymapEntry.IsDeny(),
+			AuthType:  policy.AuthType(policymapEntry.AuthType),
 		}
 		currentMap[policyKey] = policyEntry
 	}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -274,7 +274,7 @@ func (e *MapStateEntry) DatapathEqual(o *MapStateEntry) bool {
 
 // String returns a string representation of the MapStateEntry
 func (e MapStateEntry) String() string {
-	return fmt.Sprintf("ProxyPort=%d", e.ProxyPort)
+	return fmt.Sprintf("ProxyPort=%d,IsDeny=%t,AuthType=%s", e.ProxyPort, e.IsDeny, e.AuthType.String())
 }
 
 // DenyPreferredInsert inserts a key and entry into the map by given preference


### PR DESCRIPTION
PolicyMap sync warns about diffs in mapstate entries where authentication is enabled - even though the policy map is in sync.

```
level=debug msg="map[dumpedPolicyMap:map[Identity=0,DestPort=0,Nexthdr=0,TrafficDirection=1:ProxyPort=0 Identity=1,DestPort=0,Nexthdr=0,TrafficDirection=0:ProxyPort=0 Identity=8689,DestPort=80,Nexthdr=6,TrafficDirection=0:ProxyPort=14197]]syncPolicyMapWithDump" containerID=662cba3891 datapathPolicyRevision=4 desiredPolicyRevision=4 endpointID=98 identity=52226 ipv4=10.244.2.131 ipv6="fd00:10:244:2::b2ee" k8sPodName=mtls-test/test2-fff868488-xrb47 subsys=endpoint
level=debug msg="map[dumpedDiffs:[{true Identity=8689,DestPort=80,Nexthdr=6,TrafficDirection=0 ProxyPort=14197}]]syncPolicyMapWithDump" containerID=662cba3891 datapathPolicyRevision=4 desiredPolicyRevision=4 endpointID=98 identity=52226 ipv4=10.244.2.131 ipv6="fd00:10:244:2::b2ee" k8sPodName=mtls-test/test2-fff868488-xrb47 subsys=endpoint
```

with

```
Identity=8689,DestPort=80,Nexthdr=6,TrafficDirection=0 => ProxyPort=12894,IsDeny=false,AuthType=disabled
!=
Identity=8689,DestPort=80,Nexthdr=6,TrafficDirection=0 => ProxyPort=12894,IsDeny=false,AuthType=spire
```

The problem is that dumping the map state doesn't map the property auth type, which results in an unwanted diff.

This PR adds the auth type property to the mapping.

In addition, the fields `IsDeny` & `AuthType` have been added to `MapStateEntry.String`

@meyskens: thanks for reporting the issue!