### PR TITLE
gha: Increase Ingress status wait time

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -211,7 +211,7 @@ jobs:
         timeout-minutes: 30
         run: |
           cd ingress-controller-conformance
-          ./ingress-controller-conformance -ingress-class cilium -wait-time-for-ingress-status 10s -wait-time-for-ready 60s
+          ./ingress-controller-conformance -ingress-class cilium -wait-time-for-ingress-status 60s -wait-time-for-ready 60s
 
       - name: Post-test information gathering
         if: ${{ !success() }}


### PR DESCRIPTION
### Description

The current value is set as 10s, which might not be enough for a small kind cluster in CI environment, hence timeout happened as per below. This commit is to increase the max wait time to 60s to mitigate the issue.

```
  Scenario: An Ingress with a trailing slashes in a prefix path rule should ignore the trailing slash and send traffic to the matching backend service # features/path_rules.feature:181
    Then The Ingress status shows the IP address or FQDN where it is exposed # features/path_rules.feature:93
      Error: waiting for ingress status update: timed out waiting for the condition
```

Fixes: #25040

### Testing

Testing was done by re-running ingress conformance tests for 4x9 times.

https://github.com/cilium/cilium/actions/runs/5265957417

```
#!/bin/bash
for i in {1..8}
do
  now=$(date +"%T")
  echo "$now: Re-run the job $i times"
  gh run rerun 5265957417
  sleep 25m
done
```