### PR TITLE
clustermesh-apiserver: don't wait for the presence of unused CRDs

### DIFF
--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -526,7 +526,7 @@ func startServer(startCtx hive.HookContext, clientset k8sClient.Clientset, backe
 	}).Info("Starting clustermesh-apiserver...")
 
 	if mockFile == "" {
-		synced.SyncCRDs(startCtx, clientset, synced.AllCiliumCRDResourceNames(), &synced.Resources{}, &synced.APIGroups{})
+		synced.SyncCRDs(startCtx, clientset, synced.ClusterMeshAPIServerResourceNames(), &synced.Resources{}, &synced.APIGroups{})
 	}
 
 	var err error

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -83,8 +83,20 @@ func AgentCRDResourceNames() []string {
 	return agentCRDResourceNames()
 }
 
+// ClusterMeshAPIServerResourceNames returns a list of all CRD resource names the
+// clustermesh-apiserver needs to wait to be registered before initializing any
+// k8s watchers.
+func ClusterMeshAPIServerResourceNames() []string {
+	return []string{
+		CRDResourceName(v2.CNName),
+		CRDResourceName(v2.CIDName),
+		CRDResourceName(v2.CEPName),
+		CRDResourceName(v2.CEWName),
+	}
+}
+
 // AllCiliumCRDResourceNames returns a list of all Cilium CRD resource names
-// that the clustermesh-apiserver or testsuite may register.
+// that the cilium operator or testsuite may register.
 func AllCiliumCRDResourceNames() []string {
 	return append(
 		AgentCRDResourceNames(),


### PR DESCRIPTION
Currently, the clustermesh-apiserver waits for the presence of all the CRDs before starting the main logic, way more than the resource types actually used afterwards. This ends up preventing the possibility of running a newer version of the clustermesh-apiserver alongside older versions of cilium/cilium-operator due to newly introduced CRDs.

This PR modifies the logic to only wait for the CRDs which are actually used (the new list matches the entries listed in the clustermesh-apiserver cluster role).

<!-- Description of change -->

```release-note
clustermesh-apiserver: don't wait for the presence of unused CRDs
```
