### PR TITLE
gateway-api: Enable HTTPRouteListenerHostnameMatching test

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -170,8 +170,7 @@ jobs:
             --gateway-class cilium \
             --supported-features ReferenceGrant,HTTPRoute,TLSRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,RouteDestinationPortMatching,GatewayClassObservedGenerationBump,HTTPResponseHeaderModification \
             -test.run "TestConformance" \
-            -test.skip "TestConformance/HTTPRouteListenerHostnameMatching|TestConformance/HTTPRouteRedirectHostAndStatus" 
-            # Enable once HTTPRouteListenerHostnameMatchings #24217 is fixed
+            -test.skip "TestConformance/HTTPRouteRedirectHostAndStatus" 
             # Enable HTTPRouteRedirectHostAndStatus once https://github.com/kubernetes-sigs/gateway-api/issues/1805 is fixed upstream
 
       - name: Post-test information gathering


### PR DESCRIPTION
### Description

This was fixed as part of a recent refactor and v0.7.0 upgrade.

Fixes: #24217

### Testing

Testing was done with the [temp commit](https://github.com/cilium/cilium/pull/26226/commits/c4d1765f4d5804541b0fa6d08dc6efe6e04fd76a) triggering conformance test 20 times in the same workflow run.

https://github.com/cilium/cilium/actions/runs/5267708914/jobs/9523337823?pr=26226