### PR TITLE
docs: remove clustermesh-apiserver gops port from system requirements

### DIFF
--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -140,7 +140,7 @@ to ``/etc/systemd/network/01-no-dhcp.network`` and then
         systemctl daemon-reload
         systemctl restart systemd-networkd
 
-Ubuntu 22.04 on Raspberry Pi 
+Ubuntu 22.04 on Raspberry Pi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Before running Cilium on Ubuntu 22.04 on a Raspberry Pi, please make sure to install the following package:
@@ -427,7 +427,6 @@ Port Range / Protocol    Description
 9879/tcp                 cilium-agent health status API (listening on 127.0.0.1 and/or ::1)
 9890/tcp                 cilium-agent gops server (listening on 127.0.0.1)
 9891/tcp                 operator gops server (listening on 127.0.0.1)
-9892/tcp                 clustermesh-apiserver gops server (listening on 127.0.0.1)
 9893/tcp                 Hubble Relay gops server (listening on 127.0.0.1)
 9962/tcp                 cilium-agent Prometheus metrics
 9963/tcp                 cilium-operator Prometheus metrics


### PR DESCRIPTION
clustermesh-apiserver runs in pod network, hence there is no risk of port conflicts with services running on the underlying nodes. Hence, let's remove its gops port from the system requirements table.
