### PR TITLE
ci: add Ariane configuration file

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -1,0 +1,65 @@
+triggers:
+  /ariane-test:
+    workflows:
+    - conformance-aks.yaml
+    - conformance-aws-cni.yaml
+    - conformance-clustermesh.yaml
+    - conformance-e2e.yaml
+    - conformance-eks.yaml
+    - conformance-externalworkloads.yaml
+    - conformance-ginkgo.yaml
+    - conformance-gke.yaml
+    - tests-datapath-verifier.yaml
+    - tests-l4lb.yaml
+  /ariane-ci-aks:
+    workflows:
+    - conformance-aks.yaml
+  /ariane-ci-awscni:
+    workflows:
+    - conformance-aws-cni.yaml
+  /ariane-ci-multicluster:
+    workflows:
+    - conformance-clustermesh.yaml
+  /ariane-ci-e2e:
+    workflows:
+    - conformance-e2e.yaml
+  /ariane-ci-eks:
+    workflows:
+    - conformance-eks.yaml
+  /ariane-ci-external-workloads:
+    workflows:
+    - conformance-externalworkloads.yaml
+  /ariane-ci-ginkgo:
+    workflows:
+    - conformance-ginkgo.yaml
+  /ariane-ci-gke:
+    workflows:
+    - conformance-gke.yaml
+  /ariane-ci-verifier:
+    workflows:
+    - tests-datapath-verifier.yaml
+  /ariane-ci-l4lb:
+    workflows:
+    - tests-l4lb.yaml
+
+workflows:
+  conformance-aks.yaml:
+    paths-ignore-regex: (test|Documentation)/
+  conformance-aws-cni.yaml:
+    paths-ignore-regex: (test|Documentation)/
+  conformance-clustermesh.yaml:
+    paths-ignore-regex: (test|Documentation)/
+  conformance-e2e.yaml:
+    paths-ignore-regex: (test|Documentation)/
+  conformance-eks.yaml:
+    paths-ignore-regex: (test|Documentation)/
+  conformance-externalworkloads.yaml:
+    paths-ignore-regex: (test|Documentation)/
+  conformance-ginkgo.yaml:
+    paths-ignore-regex: Documentation/
+  conformance-gke.yaml:
+    paths-ignore-regex: (test|Documentation)/
+  tests-datapath-verifier.yaml:
+    paths-regex: (bpf|test/verifier)/
+  tests-l4lb.yaml:
+    paths-regex: (pkg|daemon|bpf|test/l4lb|images)/


### PR DESCRIPTION
Ariane is a new GitHub App intended to trigger Cilium CI workflows based on trigger phrases commented in pull requests, in order to replace the existing `issue_comment`-based workflows and simplify our CI stack.

This commit adds a temporary configuration setting up triggers such that existing workflows can be triggered with the same trigger phrases, and based on the same PR changelist match / ignore.

The only difference to the final configuration is that all triggers are prefixed with `ariane`, so that we can iterate on the workflows in the PR without interfering with the regular CI until we are ready to merge.