### PR TITLE
bpf: nat: Make snat_v6_needed() get on par with snat_v4_prepare_state()

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1686,8 +1686,8 @@ static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 	tuple->flags = dir;
 }
 
-static __always_inline bool snat_v6_needed(struct __ctx_buff *ctx,
-					   struct ipv6_nat_target *target)
+static __always_inline bool
+snat_v6_prepare_state(struct __ctx_buff *ctx, struct ipv6_nat_target *target)
 {
 	union v6addr masq_addr __maybe_unused;
 	const union v6addr dr_addr = IPV6_DIRECT_ROUTING;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1684,7 +1684,7 @@ static __always_inline void snat_v6_init_tuple(const struct ipv6hdr *ip6,
 }
 
 static __always_inline bool snat_v6_needed(struct __ctx_buff *ctx,
-					   union v6addr *addr)
+					   struct ipv6_nat_target *target)
 {
 	union v6addr masq_addr __maybe_unused;
 	const union v6addr dr_addr = IPV6_DIRECT_ROUTING;
@@ -1700,13 +1700,13 @@ static __always_inline bool snat_v6_needed(struct __ctx_buff *ctx,
 	/* See comment in snat_v4_prepare_state(). */
 	if (DIRECT_ROUTING_DEV_IFINDEX == NATIVE_DEV_IFINDEX &&
 	    ipv6_addr_equals((union v6addr *)&ip6->saddr, &dr_addr)) {
-		ipv6_addr_copy(addr, &dr_addr);
+		ipv6_addr_copy(&target->addr, &dr_addr);
 		return true;
 	}
 #ifdef ENABLE_MASQUERADE_IPV6 /* SNAT local pod to world packets */
 	BPF_V6(masq_addr, IPV6_MASQUERADE);
 	if (ipv6_addr_equals((union v6addr *)&ip6->saddr, &masq_addr)) {
-		ipv6_addr_copy(addr, &masq_addr);
+		ipv6_addr_copy(&target->addr, &masq_addr);
 		return true;
 	}
 
@@ -1784,7 +1784,7 @@ static __always_inline bool snat_v6_needed(struct __ctx_buff *ctx,
 
 		/* See comment in snat_v4_prepare_state(). */
 		if (!is_reply && local_ep) {
-			ipv6_addr_copy(addr, &masq_addr);
+			ipv6_addr_copy(&target->addr, &masq_addr);
 			return true;
 		}
 	}

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -106,7 +106,7 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 	};
 	int ret;
 
-	ret = snat_v6_needed(ctx, &target.addr) ?
+	ret = snat_v6_needed(ctx, &target) ?
 	      snat_v6_nat(ctx, &target, ext_err) : CTX_ACT_OK;
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -104,10 +104,12 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 	};
-	int ret;
+	int ret = CTX_ACT_OK;
+	bool snat_needed;
 
-	ret = snat_v6_needed(ctx, &target) ?
-	      snat_v6_nat(ctx, &target, ext_err) : CTX_ACT_OK;
+	snat_needed = snat_v6_prepare_state(ctx, &target);
+	if (snat_needed)
+		ret = snat_v6_nat(ctx, &target, ext_err);
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
 


### PR DESCRIPTION
We recently implemented snat_v6_needed() in the datapath to determine whether we need SNAT for IPv6 masquerading; but the function was written long before it was merged and was based on snat_v4_needed(), which has since been consolidated and renamed as snat_v4_prepare_state(), and changed again to prepare for Egress Gateway.

This PR aims at bringing snat_v6_needed() as close to snat_v4_prepare_state() as possible. In the process, we also fix a condition for SNAT-ing packets from local endpoints, and the IP address to use for masquerading packets leaving through a tunnel.

Commits:

- bpf: nat: Move check on dest being outside cluster in snat_v6_needed()
- bpf: nat: Pass target directly to snat_v6_needed()
- bpf: nat: Do not skip IPv6 SNAT for packets from local endpoints
- bpf: nat: Rename snat_v6_needed() into snat_v6_prepare_state()
- bpf: nat: Use gateway IP for SNAT in the case of BPF overlay

```release-note
bpf: Update IPv6 BPF masquerading code to bring it closer to IPv4's, fix SNAT for packets from local endpoints, for overlay
```
