### PR TITLE
add controller group runs metric

### DIFF
--- a/clustermesh-apiserver/users_mgmt.go
+++ b/clustermesh-apiserver/users_mgmt.go
@@ -97,6 +97,7 @@ func (us *usersManager) Start(hive.HookContext) error {
 	}
 
 	us.manager.UpdateController(usersMgmtCtrl, controller.ControllerParams{
+		Group:   usersMgmtCtrl,
 		Context: context.Background(),
 		DoFunc:  us.sync,
 	})

--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -179,6 +179,7 @@ func (c *cniConfigManager) Start(hive.HookContext) error {
 	// Install the CNI file controller
 	c.controller.UpdateController(cniControllerName,
 		controller.ControllerParams{
+			Group: cniControllerName,
 			DoFunc: func(ctx context.Context) error {
 				err := c.setupCNIConfFile()
 				if err != nil {

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1213,6 +1213,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	d.controllers.UpdateController(
 		syncHostIPsController,
 		controller.ControllerParams{
+			Group: syncHostIPsController,
 			DoFunc: func(ctx context.Context) error {
 				err := d.syncHostIPs()
 				select {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1523,6 +1523,7 @@ func (d *Daemon) initKVStore() {
 
 	controller.NewManager().UpdateController("kvstore-locks-gc",
 		controller.ControllerParams{
+			Group: "kvstore-locks-gc",
 			DoFunc: func(ctx context.Context) error {
 				kvstore.RunLockGC()
 				return nil

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -424,6 +424,7 @@ func (d *Daemon) initMaps() error {
 	// the prometheus server.
 	controller.NewManager().UpdateController("metricsmap-bpf-prom-sync",
 		controller.ControllerParams{
+			Group:       "metricsmap-bpf-prom-sync",
 			DoFunc:      metricsmap.SyncMetricsMap,
 			RunInterval: 5 * time.Second,
 			Context:     d.ctx,

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -193,6 +193,7 @@ func (d *Daemon) bootstrapFQDN(possibleEndpoints map[uint16]*endpoint.Endpoint, 
 	dnsGCJobName := "dns-garbage-collector-job"
 	dnsGCJobInterval := 1 * time.Minute
 	controller.NewManager().UpdateController(dnsGCJobName, controller.ControllerParams{
+		Group:       dnsGCJobName,
 		RunInterval: dnsGCJobInterval,
 		DoFunc: func(ctx context.Context) error {
 			var (

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -53,6 +53,7 @@ func (d *Daemon) initHealth(spec *healthApi.Spec, cleaner *daemonCleanup) {
 
 	controller.NewManager().UpdateController(defaults.HealthEPName,
 		controller.ControllerParams{
+			Group: defaults.HealthEPName,
 			DoFunc: func(ctx context.Context) error {
 				var err error
 

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -471,6 +471,7 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 				// not be cleaned up by the daemon until it restarts.
 				controller.NewManager().UpdateController("sync-lb-maps-with-k8s-services",
 					controller.ControllerParams{
+						Group: "sync-lb-maps-with-k8s-services",
 						DoFunc: func(ctx context.Context) error {
 							return d.svc.SyncWithK8sFinished()
 						},

--- a/operator/cmd/ccnp_event.go
+++ b/operator/cmd/ccnp_event.go
@@ -128,6 +128,7 @@ func enableCCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sCli
 
 	mgr.UpdateController("ccnp-to-groups",
 		controller.ControllerParams{
+			Group: "ccnp-to-groups",
 			DoFunc: func(ctx context.Context) error {
 				groups.UpdateCNPInformation(clientset)
 				return nil

--- a/operator/cmd/cilium_node.go
+++ b/operator/cmd/cilium_node.go
@@ -410,6 +410,7 @@ func runCNPNodeStatusGC(name string, clusterwide bool, ctx context.Context, wg *
 
 	mgr.UpdateController(name,
 		controller.ControllerParams{
+			Group:       name,
 			RunInterval: operatorOption.Config.CNPNodeStatusGCInterval,
 			StopFunc: func(context.Context) error {
 				close(removeNodeFromCNP)

--- a/operator/cmd/cnp_event.go
+++ b/operator/cmd/cnp_event.go
@@ -134,6 +134,7 @@ func enableCNPWatcher(ctx context.Context, wg *sync.WaitGroup, clientset k8sClie
 
 	mgr.UpdateController("cnp-to-groups",
 		controller.ControllerParams{
+			Group: "cnp-to-groups",
 			DoFunc: func(ctx context.Context) error {
 				groups.UpdateCNPInformation(clientset)
 				return nil

--- a/operator/cmd/k8s_cep_gc.go
+++ b/operator/cmd/k8s_cep_gc.go
@@ -71,6 +71,7 @@ func enableCiliumEndpointSyncGC(ctx context.Context, wg *sync.WaitGroup, clients
 
 	mgr.UpdateController(controllerName,
 		controller.ControllerParams{
+			Group:       controllerName,
 			RunInterval: gcInterval,
 			DoFunc: func(ctx context.Context) error {
 				return doCiliumEndpointSyncGC(ctx, clientset, cns, once, cancel, scopedLog)

--- a/operator/cmd/k8s_pod_controller.go
+++ b/operator/cmd/k8s_pod_controller.go
@@ -45,6 +45,7 @@ func enableUnmanagedController(ctx context.Context, wg *sync.WaitGroup, clientse
 
 	mgr.UpdateController("restart-unmanaged-pods",
 		controller.ControllerParams{
+			Group:       "restart-unmanaged-pods",
 			RunInterval: time.Duration(operatorOption.Config.UnmanagedPodWatcherInterval) * time.Second,
 			DoFunc: func(ctx context.Context) error {
 				for podName, lastRestart := range lastPodRestart {

--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -32,6 +32,7 @@ func (igc *GC) startCRDModeGC(ctx context.Context) error {
 	igc.mgr = controller.NewManager()
 	igc.mgr.UpdateController("crd-identity-gc",
 		controller.ControllerParams{
+			Group:        "crd-identity-gc",
 			RunInterval:  igc.gcInterval,
 			DoFunc:       igc.gc,
 			NoErrorRetry: true,

--- a/operator/watchers/cilium_node_gc.go
+++ b/operator/watchers/cilium_node_gc.go
@@ -69,6 +69,7 @@ func RunCiliumNodeGC(ctx context.Context, wg *sync.WaitGroup, clientset k8sClien
 	// create the controller to perform mark and sweep operation for cilium nodes
 	ctrlMgr.UpdateController("cilium-node-gc",
 		controller.ControllerParams{
+			Group:   "cilium-node-gc",
 			Context: ctx,
 			DoFunc: func(ctx context.Context) error {
 				return performCiliumNodeGC(ctx, clientset.CiliumV2().CiliumNodes(), ciliumNodeStore,

--- a/operator/watchers/node_taint.go
+++ b/operator/watchers/node_taint.go
@@ -470,6 +470,7 @@ func markNode(c kubernetes.Interface, nodeGetter slimNodeGetter, nodeName string
 
 	ctrlMgr.UpdateController(ctrlName,
 		controller.ControllerParams{
+			Group: "mark-k8s-node-taints-conditions",
 			DoFunc: func(ctx context.Context) error {
 				if running && options.RemoveNodeTaint {
 					err := removeNodeTaint(ctx, c, nodeGetter, nodeName)

--- a/pkg/aws/eni/eni_gc.go
+++ b/pkg/aws/eni/eni_gc.go
@@ -32,6 +32,7 @@ func StartENIGarbageCollector(ctx context.Context, api EC2API, params GarbageCol
 
 	var enisMarkedForDeletion []string
 	controllerManager.UpdateController(gcENIControllerName, controller.ControllerParams{
+		Group: gcENIControllerName,
 		DoFunc: func(ctx context.Context) error {
 			// Unfortunately, the EC2 API does not allow us to determine the age of
 			// a network interface. To mitigate a race where Cilium just created a new

--- a/pkg/bpf/events.go
+++ b/pkg/bpf/events.go
@@ -92,6 +92,7 @@ func (m *Map) initEventsBuffer(maxSize int, eventsTTL time.Duration) {
 		mapControllers.UpdateController(
 			fmt.Sprintf("bpf-event-buffer-gc-%s", m.name),
 			controller.ControllerParams{
+				Group: "bpf-event-buffer-gc",
 				DoFunc: func(_ context.Context) error {
 					m.scopedLogger().Debugf("clearing bpf map events older than %s", b.eventTTL)
 					b.buffer.Compact(func(e interface{}) bool {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -317,7 +317,9 @@ func (c *controller) recordError(err error) {
 	c.lastErrorStamp = time.Now()
 	c.failureCount++
 	c.consecutiveErrors++
+
 	metrics.ControllerRuns.WithLabelValues(failure).Inc()
+	metrics.ControllerGroupRuns.WithLabelValues(c.name, failure).Inc()
 	metrics.ControllerRunsDuration.WithLabelValues(failure).Observe(c.lastDuration.Seconds())
 }
 
@@ -330,5 +332,6 @@ func (c *controller) recordSuccess() {
 	c.consecutiveErrors = 0
 
 	metrics.ControllerRuns.WithLabelValues(success).Inc()
+	metrics.ControllerGroupRuns.WithLabelValues(c.name, success).Inc()
 	metrics.ControllerRunsDuration.WithLabelValues(success).Observe(c.lastDuration.Seconds())
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -326,7 +326,9 @@ func (c *controller) recordError(err error) {
 	c.consecutiveErrors++
 
 	metrics.ControllerRuns.WithLabelValues(failure).Inc()
-	metrics.ControllerGroupRuns.WithLabelValues(c.group, failure).Inc()
+	if c.group != "" {
+		metrics.ControllerGroupRuns.WithLabelValues(c.group, failure).Inc()
+	}
 	metrics.ControllerRunsDuration.WithLabelValues(failure).Observe(c.lastDuration.Seconds())
 }
 
@@ -339,6 +341,8 @@ func (c *controller) recordSuccess() {
 	c.consecutiveErrors = 0
 
 	metrics.ControllerRuns.WithLabelValues(success).Inc()
-	metrics.ControllerGroupRuns.WithLabelValues(c.group, success).Inc()
+	if c.group != "" {
+		metrics.ControllerGroupRuns.WithLabelValues(c.group, success).Inc()
+	}
 	metrics.ControllerRunsDuration.WithLabelValues(success).Observe(c.lastDuration.Seconds())
 }

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -77,6 +77,7 @@ func (m *Manager) updateController(name string, params ControllerParams) *manage
 		ctrl = &managedController{
 			controller: controller{
 				name:       name,
+				group:      params.Group,
 				uuid:       uuid.New().String(),
 				stop:       make(chan struct{}),
 				update:     make(chan ControllerParams, 1),

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -252,6 +252,7 @@ func (l *BPFListener) OnIPIdentityCacheGC() {
 	// consistent state.
 	l.ipcache.UpdateController("ipcache-bpf-garbage-collection",
 		controller.ControllerParams{
+			Group: "ipcache-bpf-garbage-collection",
 			DoFunc: func(ctx context.Context) error {
 				wg, err := l.garbageCollect(ctx)
 				if err != nil {

--- a/pkg/datapath/link/link.go
+++ b/pkg/datapath/link/link.go
@@ -77,6 +77,7 @@ func NewLinkCache() *LinkCache {
 		linkCache = LinkCache{}
 		controller.NewManager().UpdateController("link-cache",
 			controller.ControllerParams{
+				Group:       "link-cache",
 				RunInterval: 15 * time.Second,
 				DoFunc: func(ctx context.Context) error {
 					return linkCache.syncCache()

--- a/pkg/datapath/linux/utime/cell.go
+++ b/pkg/datapath/linux/utime/cell.go
@@ -38,6 +38,7 @@ func initUtimeSync(lifecycle hive.Lifecycle, configMap configmap.Map) {
 			// between monotonic and boottime clocks.
 			controllerManager.UpdateController(syncControllerName,
 				controller.ControllerParams{
+					Group: syncControllerName,
 					DoFunc: func(ctx context.Context) error {
 						return ctrl.sync()
 					},

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -140,6 +140,7 @@ func newObjectCache(c datapath.ConfigWriter, nodeCfg *datapath.LocalNodeConfigur
 	oc.Update(nodeCfg)
 	controller.NewManager().UpdateController("template-dir-watcher",
 		controller.ControllerParams{
+			Group:  "template-dir-watcher",
 			DoFunc: oc.watchTemplatesDirectory,
 			// No run interval but needs to re-run on errors.
 		})

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1411,6 +1411,7 @@ func (e *Endpoint) syncPolicyMapController() {
 	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
 	e.controllers.UpdateController(ctrlName,
 		controller.ControllerParams{
+			Group: "sync-policymap",
 			DoFunc: func(ctx context.Context) (reterr error) {
 				// Failure to lock is not an error, it means
 				// that the endpoint was disconnected and we

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -1597,6 +1597,7 @@ func (e *Endpoint) RunMetadataResolver(resolveMetadata MetadataResolverCB) {
 
 	e.controllers.UpdateController(controllerName,
 		controller.ControllerParams{
+			Group: controllerPrefix,
 			DoFunc: func(ctx context.Context) error {
 				ns, podName := e.GetK8sNamespace(), e.GetK8sPodName()
 				pod, cp, identityLabels, info, _, err := resolveMetadata(ns, podName)
@@ -1817,6 +1818,7 @@ func (e *Endpoint) runIdentityResolver(ctx context.Context, myChangeRev int, blo
 	ctrlName := fmt.Sprintf("resolve-identity-%d", e.ID)
 	e.controllers.UpdateController(ctrlName,
 		controller.ControllerParams{
+			Group: "resolve-identity",
 			DoFunc: func(ctx context.Context) error {
 				_, err := e.identityLabelsChanged(ctx, myChangeRev)
 				switch err {

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -119,6 +119,7 @@ func (s *EndpointSuite) TestGetCiliumEndpointStatusSuccessfulControllers(c *chec
 	for i := 0; i < 50; i++ {
 		e.controllers.UpdateController(fmt.Sprintf("controller-%d", i),
 			controller.ControllerParams{
+				Group: "controller",
 				DoFunc: func(ctx context.Context) error {
 					return nil
 				},

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -649,6 +649,7 @@ var reasonRegenRetry = "retrying regeneration"
 // fails inside of the controller,
 func (e *Endpoint) startRegenerationFailureHandler() {
 	e.controllers.UpdateController(fmt.Sprintf("endpoint-%s-regeneration-recovery", e.StringID()), controller.ControllerParams{
+		Group: "endpoint-regeneration-recovery",
 		DoFunc: func(ctx context.Context) error {
 			select {
 			case <-e.regenFailedChan:
@@ -714,6 +715,7 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 
 	e.controllers.UpdateController(fmt.Sprintf("sync-%s-identity-mapping (%d)", addressFamily, e.ID),
 		controller.ControllerParams{
+			Group: "sync-address-identity-mapping",
 			DoFunc: func(ctx context.Context) error {
 				if err := e.rlockAlive(); err != nil {
 					return controller.NewExitReason("Endpoint disappeared")

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -231,6 +231,7 @@ func (e *Endpoint) restoreIdentity() error {
 	)
 	e.UpdateController(controllerName,
 		controller.ControllerParams{
+			Group: "restoring-ep-identity",
 			DoFunc: func(ctx context.Context) (err error) {
 				allocateCtx, cancel := context.WithTimeout(ctx, option.Config.KVstoreConnectivityTimeout)
 				defer cancel()
@@ -264,6 +265,7 @@ func (e *Endpoint) restoreIdentity() error {
 		var gotInitialGlobalIdentities = make(chan struct{})
 		e.UpdateController(controllerName,
 			controller.ControllerParams{
+				Group: "waiting-initial-global-identities-ep",
 				DoFunc: func(ctx context.Context) (err error) {
 					identityCtx, cancel := context.WithTimeout(ctx, option.Config.KVstoreConnectivityTimeout)
 					defer cancel()

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -116,6 +116,7 @@ func (mgr *endpointManager) WithPeriodicEndpointGC(ctx context.Context, checkHea
 	mgr.checkHealth = checkHealth
 	mgr.controllers.UpdateController("endpoint-gc",
 		controller.ControllerParams{
+			Group:       "endpoint-gc",
 			DoFunc:      mgr.markAndSweep,
 			RunInterval: interval,
 			Context:     ctx,

--- a/pkg/ipam/allocator/multipool/node_handler.go
+++ b/pkg/ipam/allocator/multipool/node_handler.go
@@ -97,6 +97,7 @@ func (n *NodeHandler) createUpsertController(resource *v2.CiliumNode) {
 	// 1. It will retry allocations upon failure, e.g. if a pool does not exist yet.
 	// 2. Will try to synchronize the allocator's state with the CiliumNode CRD in k8s.
 	n.controllerManager.UpdateController(controllerName(resource.Name), controller.ControllerParams{
+		Group: "ipam-multi-pool-sync",
 		DoFunc: func(ctx context.Context) error {
 			// errorMessage is written to the resource status
 			errorMessage := ""

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -206,6 +206,7 @@ func NewNodesPodCIDRManager(
 			// keep retrying the sync against k8s in case of failure.
 			n.k8sReSyncController.UpdateController("update-cilium-nodes-pod-cidr",
 				controller.ControllerParams{
+					Group: "update-cilium-nodes-pod-cidr",
 					DoFunc: func(context.Context) error {
 						n.Mutex.Lock()
 						defer n.Mutex.Unlock()

--- a/pkg/ipam/clusterpool.go
+++ b/pkg/ipam/clusterpool.go
@@ -306,6 +306,7 @@ func (c *crdWatcher) restoreFinished() {
 
 	// creating a new controller will execute DoFunc immediately
 	c.controller.UpdateController(clusterPoolStatusControllerName, controller.ControllerParams{
+		Group:  clusterPoolStatusControllerName,
 		DoFunc: c.updateCiliumNodeStatus,
 	})
 	c.finishedRestore = true

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -314,6 +314,7 @@ func (m *multiPoolManager) ciliumNodeUpdated(newNode *ciliumv2.CiliumNode) {
 		// This enables the upstream sync controller. It requires m.node to be populated.
 		// Note: The controller will only run after m.mutex is unlocked
 		m.controller.UpdateController(multiPoolControllerName, controller.ControllerParams{
+			Group:  multiPoolControllerName,
 			DoFunc: m.updateCiliumNode,
 		})
 	}

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -240,6 +240,7 @@ func (n *NodeManager) Start(ctx context.Context) error {
 		mngr := controller.NewManager()
 		mngr.UpdateController("ipam-node-interval-refresh",
 			controller.ControllerParams{
+				Group:       "ipam-node-interval-refresh",
 				RunInterval: time.Minute,
 				DoFunc: func(ctx context.Context) error {
 					if syncTime, ok := n.instancesAPIResync(ctx); ok {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -561,6 +561,7 @@ func (ipc *IPCache) TriggerLabelInjection() {
 	ipc.UpdateController(
 		LabelInjectorName,
 		controller.ControllerParams{
+			Group:   LabelInjectorName,
 			Context: ipc.Configuration.Context,
 			DoFunc: func(ctx context.Context) error {
 				var err error

--- a/pkg/k8s/annotate.go
+++ b/pkg/k8s/annotate.go
@@ -85,6 +85,7 @@ func AnnotateNode(cs kubernetes.Interface, nodeName string, nd nodeTypes.Node, e
 	annotation := prepareNodeAnnotation(nd, encryptKey)
 	controller.NewManager().UpdateController("update-k8s-node-annotations",
 		controller.ControllerParams{
+			Group: "update-k8s-node-annotations",
 			DoFunc: func(_ context.Context) error {
 				err := updateNodeAnnotation(cs, nodeName, annotation)
 				if err != nil {

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -263,6 +263,7 @@ func (c *compositeClientset) startHeartbeat() {
 
 	c.controller.UpdateController("k8s-heartbeat",
 		controller.ControllerParams{
+			Group: "k8d-heartbeat",
 			DoFunc: func(context.Context) error {
 				runHeartbeat(
 					c.log,

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -356,6 +356,7 @@ func (k *K8sWatcher) addCiliumNetworkPolicyV2(ciliumNPClient clientset.Interface
 		ctrlName := cnp.GetControllerName()
 		k8sCM.UpdateController(ctrlName,
 			controller.ControllerParams{
+				Group: "sync-cnp-policy-status",
 				DoFunc: func(ctx context.Context) error {
 					return updateContext.UpdateStatus(ctx, cnp, rev, policyImportErr)
 				},
@@ -491,6 +492,7 @@ func (k *K8sWatcher) updateCiliumNetworkPolicyV2AnnotationsOnly(ciliumNPClient c
 
 	k8sCM.UpdateController(ctrlName,
 		controller.ControllerParams{
+			Group: "sync-cnp-policy-status",
 			DoFunc: func(ctx context.Context) error {
 				return updateContext.UpdateStatus(ctx, cnp, meta.revision, meta.policyImportError)
 			},

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -85,6 +85,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 	// NOTE: The controller functions do NOT hold the endpoint locks
 	e.UpdateController(controllerName,
 		controller.ControllerParams{
+			Group:       "sync-to-k8s-ciliumendpoint",
 			RunInterval: 10 * time.Second,
 			DoFunc: func(ctx context.Context) (err error) {
 				// Update logger as scopeLog might not have the podName when it
@@ -401,6 +402,7 @@ func (epSync *EndpointSynchronizer) DeleteK8sCiliumEndpointSync(e *endpoint.Endp
 	// NOTE: The controller functions do NOT hold the endpoint locks
 	e.UpdateController(controllerName,
 		controller.ControllerParams{
+			Group: "sync-to-k8s-ciliumendpoint",
 			StopFunc: func(ctx context.Context) error {
 				return deleteCEP(ctx, scopedLog, ciliumClient, e)
 			},

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -419,6 +419,7 @@ func updateCiliumEndpointLabels(clientset client.Clientset, ep *endpoint.Endpoin
 	// This is to make sure that the controller is also deleted once the endpoint is gone.
 	ep.UpdateController(controllerName,
 		controller.ControllerParams{
+			Group: "sync-pod-labels-with-cilium-endpoint",
 			DoFunc: func(ctx context.Context) (err error) {
 				pod := ep.GetPod()
 				if pod == nil {

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -241,6 +241,7 @@ func newConsulClient(ctx context.Context, config *consulAPI.Config, opts *ExtraO
 
 	client.controllers.UpdateController(fmt.Sprintf("consul-lease-keepalive-%p", c),
 		controller.ControllerParams{
+			Group: "consul-lease-keepalive",
 			DoFunc: func(ctx context.Context) error {
 				wo := &consulAPI.WriteOptions{}
 				_, _, err := c.Session().Renew(lease, wo.WithContext(ctx))

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -752,6 +752,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 
 	ec.controllers.UpdateController(makeSessionName(etcdLockSessionRenewNamePrefix, opts),
 		controller.ControllerParams{
+			Group: etcdLockSessionRenewNamePrefix,
 			// Stop controller function when etcd client is terminating
 			Context: ec.client.Ctx(),
 			DoFunc: func(ctx context.Context) error {

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -226,6 +226,7 @@ func JoinSharedStore(c Configuration) (*SharedStore, error) {
 
 	controllers.UpdateController(s.controllerName,
 		controller.ControllerParams{
+			Group: "kvstore-sync",
 			DoFunc: func(ctx context.Context) error {
 				return s.syncLocalKeys(ctx, true)
 			},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -154,6 +154,9 @@ const (
 	// started by cilium (Envoy, monitor, etc..)
 	LabelSubsystem = "subsystem"
 
+	// LabelControllerGroupName is the label used to identify controller-specific metrics
+	LabelControllerGroupName = "group_name"
+
 	// LabelKind is the kind of a label
 	LabelKind = "kind"
 
@@ -418,6 +421,9 @@ var (
 	// ControllerRuns is the number of times that a controller process runs.
 	ControllerRuns = NoOpCounterVec
 
+	// ControllerGroupRuns is the number of times that a process in a controller group runs.
+	ControllerGroupRuns = NoOpCounterVec
+
 	// ControllerRunsDuration the duration of the controller process in seconds
 	ControllerRunsDuration = NoOpObserverVec
 
@@ -604,6 +610,7 @@ type LegacyMetrics struct {
 	ServicesCount                    metric.Vec[metric.Counter]
 	ErrorsWarnings                   metric.Vec[metric.Counter]
 	ControllerRuns                   metric.Vec[metric.Counter]
+	ControllerGroupRuns              metric.Vec[metric.Counter]
 	ControllerRunsDuration           metric.Vec[metric.Observer]
 	SubprocessStart                  metric.Vec[metric.Counter]
 	KubernetesEventProcessed         metric.Vec[metric.Counter]
@@ -960,6 +967,13 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Name:       "controllers_runs_total",
 			Help:       "Number of times that a controller process was run labeled by completion status",
 		}, []string{LabelStatus}),
+
+		ControllerGroupRuns: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: Namespace + "_controllers_group_runs_total",
+			Namespace:  Namespace,
+			Name:       "controllers_group_runs_total",
+			Help:       "Number of times that a controller group was run labeled by completion status and controller name",
+		}, []string{LabelControllerGroupName, LabelStatus}),
 
 		ControllerRunsDuration: metric.NewHistogramVec(metric.HistogramOpts{
 			ConfigName: Namespace + "_controllers_runs_duration_seconds",
@@ -1322,6 +1336,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	ServicesCount = lm.ServicesCount
 	ErrorsWarnings = lm.ErrorsWarnings
 	ControllerRuns = lm.ControllerRuns
+	ControllerGroupRuns = lm.ControllerGroupRuns
 	ControllerRunsDuration = lm.ControllerRunsDuration
 	SubprocessStart = lm.SubprocessStart
 	KubernetesEventProcessed = lm.KubernetesEventProcessed

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -678,6 +678,7 @@ func (m *manager) StartNeighborRefresh(nh datapath.NodeNeighbors) {
 	ctx, cancel := context.WithCancel(context.Background())
 	controller.NewManager().UpdateController("neighbor-table-refresh",
 		controller.ControllerParams{
+			Group: "neighbor-table-refresh",
 			DoFunc: func(controllerCtx context.Context) error {
 				// Cancel previous goroutines from previous controller run
 				cancel()

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -293,6 +293,7 @@ func (n *NodeDiscovery) updateLocalNode() {
 			<-n.Registered
 			controller.NewManager().UpdateController("propagating local node change to kv-store",
 				controller.ControllerParams{
+					Group: "local-node-to-kv-store",
 					DoFunc: func(ctx context.Context) error {
 						n.localNodeLock.Lock()
 						localNode := n.localNode.DeepCopy()

--- a/pkg/policy/groups/actions.go
+++ b/pkg/policy/groups/actions.go
@@ -35,6 +35,7 @@ func AddDerivativeCNPIfNeeded(clientset client.Clientset, cnp *cilium_v2.CiliumN
 	}
 	controllerManager.UpdateController(fmt.Sprintf("add-derivative-cnp-%s", cnp.ObjectMeta.Name),
 		controller.ControllerParams{
+			Group: "add-derivative-cnp",
 			DoFunc: func(ctx context.Context) error {
 				return addDerivativePolicy(ctx, clientset, cnp, false)
 			},
@@ -55,6 +56,7 @@ func AddDerivativeCCNPIfNeeded(clientset client.Clientset, cnp *cilium_v2.Cilium
 	}
 	controllerManager.UpdateController(fmt.Sprintf("add-derivative-ccnp-%s", cnp.ObjectMeta.Name),
 		controller.ControllerParams{
+			Group: "add-derivative-ccnp",
 			DoFunc: func(ctx context.Context) error {
 				return addDerivativePolicy(ctx, clientset, cnp, true)
 			},
@@ -77,6 +79,7 @@ func UpdateDerivativeCNPIfNeeded(clientset client.Clientset, newCNP *cilium_v2.C
 
 		controllerManager.UpdateController(fmt.Sprintf("delete-derivative-cnp-%s", oldCNP.ObjectMeta.Name),
 			controller.ControllerParams{
+				Group: "delete-derivative-cnp",
 				DoFunc: func(ctx context.Context) error {
 					return DeleteDerivativeCNP(ctx, clientset, oldCNP)
 				},
@@ -90,6 +93,7 @@ func UpdateDerivativeCNPIfNeeded(clientset client.Clientset, newCNP *cilium_v2.C
 
 	controllerManager.UpdateController(fmt.Sprintf("update-derivative-cnp-%s", newCNP.ObjectMeta.Name),
 		controller.ControllerParams{
+			Group: "update-derivative-cnp",
 			DoFunc: func(ctx context.Context) error {
 				return addDerivativePolicy(ctx, clientset, newCNP, false)
 			},
@@ -111,6 +115,7 @@ func UpdateDerivativeCCNPIfNeeded(clientset client.Clientset, newCCNP *cilium_v2
 
 		controllerManager.UpdateController(fmt.Sprintf("delete-derivative-ccnp-%s", oldCCNP.ObjectMeta.Name),
 			controller.ControllerParams{
+				Group: "delete-derivative-ccnp",
 				DoFunc: func(ctx context.Context) error {
 					return DeleteDerivativeCCNP(ctx, clientset, oldCCNP)
 				},
@@ -124,6 +129,7 @@ func UpdateDerivativeCCNPIfNeeded(clientset client.Clientset, newCCNP *cilium_v2
 
 	controllerManager.UpdateController(fmt.Sprintf("update-derivative-ccnp-%s", newCCNP.ObjectMeta.Name),
 		controller.ControllerParams{
+			Group: "update-derivative-ccnp",
 			DoFunc: func(ctx context.Context) error {
 				return addDerivativePolicy(ctx, clientset, newCCNP, true)
 			},


### PR DESCRIPTION
Adds a metric which counts controller runs by "group" (currently the controller name).

Currently produces the following type of output:

```
cilium_controllers_group_runs_total{group_name="bpf-map-sync-cilium_lxc",status="success"} 25
cilium_controllers_group_runs_total{group_name="cilium-health-ep",status="success"} 3
cilium_controllers_group_runs_total{group_name="dns-garbage-collector-job",status="success"} 3
cilium_controllers_group_runs_total{group_name="endpoint-gc",status="success"} 1
cilium_controllers_group_runs_total{group_name="ipcache-inject-labels",status="success"} 10
cilium_controllers_group_runs_total{group_name="k8s-heartbeat",status="success"} 5
cilium_controllers_group_runs_total{group_name="link-cache",status="success"} 9
cilium_controllers_group_runs_total{group_name="metricsmap-bpf-prom-sync",status="success"} 26
cilium_controllers_group_runs_total{group_name="resolve-identity-2088",status="success"} 1
cilium_controllers_group_runs_total{group_name="restoring-ep-identity (1153)",status="success"} 1
cilium_controllers_group_runs_total{group_name="sync-host-ips",status="success"} 3
cilium_controllers_group_runs_total{group_name="sync-lb-maps-with-k8s-services",status="success"} 1
cilium_controllers_group_runs_total{group_name="sync-policymap-1153",status="success"} 5
cilium_controllers_group_runs_total{group_name="sync-policymap-2088",status="success"} 4
cilium_controllers_group_runs_total{group_name="sync-to-k8s-ciliumendpoint (1153)",status="success"} 13
cilium_controllers_group_runs_total{group_name="sync-to-k8s-ciliumendpoint (2088)",status="success"} 14
cilium_controllers_group_runs_total{group_name="sync-utime",status="success"} 3
cilium_controllers_group_runs_total{group_name="write-cni-file",status="success"} 1
```

Clearly, some of these controller names are dynamic based on the Cilium endpoint ID, which should be handled somehow.

At least three approaches to this:

1. One idea is to require the `controller` struct to have a new field `groupName`, set in order to recieve this metric.
(**likely best idea and going to try this**)

2. Another idea is to dynamically strip anything that looks like an ID in the group name.

3. Yet another idea is to prescriptively strip IDs based on known dynamically-named controllers, although this runs the risk of new such controllers being added without the corresponding aggregation.

Next steps here:

* Find a good way to logically group controllers
* Put this behind a flag.
* Address concerns about cardinality and memory usage with runtime data.





