### PR TITLE
Updates TransformXXX Functions in k8s pkg

### DIFF
--- a/pkg/k8s/factory_functions.go
+++ b/pkg/k8s/factory_functions.go
@@ -472,11 +472,13 @@ func ConvertToSlimIngressLoadBalancerStatus(slimLBStatus *slim_corev1.LoadBalanc
 	}
 }
 
-// TransformToK8sService transforms a *v1.Service into a
-// *slim_corev1.Service or a cache.DeletedFinalStateUnknown into
-// a cache.DeletedFinalStateUnknown with a *slim_corev1.Service in its Obj.
-// If the given obj can't be cast into either *slim_corev1.Service
-// nor cache.DeletedFinalStateUnknown, an error is returned.
+// TransformToK8sService transforms a *v1.Service into a *slim_corev1.Service
+// or a cache.DeletedFinalStateUnknown into a cache.DeletedFinalStateUnknown
+// with a *slim_corev1.Service in its Obj. If obj is a *slim_corev1.Service
+// or a cache.DeletedFinalStateUnknown with a *slim_corev1.Service in its Obj,
+// obj is returned without any transformations. If the given obj can't be cast
+// into either *slim_corev1.Service nor cache.DeletedFinalStateUnknown, an error
+// is returned.
 func TransformToK8sService(obj interface{}) (interface{}, error) {
 	switch concreteObj := obj.(type) {
 	case *v1.Service:
@@ -511,7 +513,12 @@ func TransformToK8sService(obj interface{}) (interface{}, error) {
 				},
 			},
 		}, nil
+	case *slim_corev1.Service:
+		return obj, nil
 	case cache.DeletedFinalStateUnknown:
+		if _, ok := concreteObj.Obj.(*slim_corev1.Service); ok {
+			return obj, nil
+		}
 		svc, ok := concreteObj.Obj.(*v1.Service)
 		if !ok {
 			return nil, fmt.Errorf("unknown object type %T", concreteObj.Obj)
@@ -559,8 +566,10 @@ func TransformToK8sService(obj interface{}) (interface{}, error) {
 // *types.SlimCNP without the Status field of the given CNP, or a
 // cache.DeletedFinalStateUnknown into a cache.DeletedFinalStateUnknown with a
 // *types.SlimCNP, also without the Status field of the given CNP, in its Obj.
-// If the given obj can't be cast into either *cilium_v2.CiliumClusterwideNetworkPolicy
-// nor cache.DeletedFinalStateUnknown, an error is returned.
+// If obj is a *types.SlimCNP or a cache.DeletedFinalStateUnknown with a *types.SlimCNP
+// in its Obj, obj is returned without any transformations. If the given obj can't be
+// cast into either *cilium_v2.CiliumClusterwideNetworkPolicy nor
+// cache.DeletedFinalStateUnknown, an error is returned.
 func TransformToCCNP(obj interface{}) (interface{}, error) {
 	switch concreteObj := obj.(type) {
 	case *cilium_v2.CiliumClusterwideNetworkPolicy:
@@ -572,7 +581,12 @@ func TransformToCCNP(obj interface{}) (interface{}, error) {
 				Specs:      concreteObj.Specs,
 			},
 		}, nil
+	case *types.SlimCNP:
+		return obj, nil
 	case cache.DeletedFinalStateUnknown:
+		if _, ok := concreteObj.Obj.(*types.SlimCNP); ok {
+			return obj, nil
+		}
 		ccnp, ok := concreteObj.Obj.(*cilium_v2.CiliumClusterwideNetworkPolicy)
 		if !ok {
 			return nil, fmt.Errorf("unknown object type %T", concreteObj.Obj)
@@ -600,6 +614,8 @@ func TransformToCCNP(obj interface{}) (interface{}, error) {
 // *types.SlimCNP without the Status field of the given CNP, or a
 // cache.DeletedFinalStateUnknown into a cache.DeletedFinalStateUnknown with a
 // *types.SlimCNP, also without the Status field of the given CNP, in its Obj.
+// If obj is a *types.SlimCNP or a cache.DeletedFinalStateUnknown with a
+// *types.SlimCNP in its Obj, obj is returned without any transformations.
 // If the given obj can't be cast into either *cilium_v2.CiliumNetworkPolicy
 // nor cache.DeletedFinalStateUnknown, an error is returned.
 func TransformToCNP(obj interface{}) (interface{}, error) {
@@ -613,7 +629,12 @@ func TransformToCNP(obj interface{}) (interface{}, error) {
 				Specs:      concreteObj.Specs,
 			},
 		}, nil
+	case *types.SlimCNP:
+		return obj, nil
 	case cache.DeletedFinalStateUnknown:
+		if _, ok := concreteObj.Obj.(*types.SlimCNP); ok {
+			return obj, nil
+		}
 		cnp, ok := concreteObj.Obj.(*cilium_v2.CiliumNetworkPolicy)
 		if !ok {
 			return nil, fmt.Errorf("unknown object type %T", concreteObj.Obj)
@@ -679,7 +700,9 @@ func convertToTaints(v1Taints []v1.Taint) []slim_corev1.Taint {
 
 // TransformToNode transforms a *v1.Node into a *types.Node or a
 // cache.DeletedFinalStateUnknown into a cache.DeletedFinalStateUnknown
-// with a *types.Node in its Obj. If the given obj can't be cast into
+// with a *types.Node in its Obj. If obj is a *slim_corev1.Node or a
+// cache.DeletedFinalStateUnknown with a *slim_corev1.Node in its Obj, obj
+// is returned without any transformations. If the given obj can't be cast into
 // either *v1.Node nor cache.DeletedFinalStateUnknown, an error is returned.
 func TransformToNode(obj interface{}) (interface{}, error) {
 	switch concreteObj := obj.(type) {
@@ -706,7 +729,12 @@ func TransformToNode(obj interface{}) (interface{}, error) {
 				Addresses: convertToAddress(concreteObj.Status.Addresses),
 			},
 		}, nil
+	case *slim_corev1.Node:
+		return obj, nil
 	case cache.DeletedFinalStateUnknown:
+		if _, ok := concreteObj.Obj.(*slim_corev1.Node); ok {
+			return obj, nil
+		}
 		node, ok := concreteObj.Obj.(*v1.Node)
 		if !ok {
 			return nil, fmt.Errorf("unknown object type %T", concreteObj.Obj)
@@ -908,6 +936,8 @@ func ObjToCiliumNode(obj interface{}) *cilium_v2.CiliumNode {
 // TransformToCiliumEndpoint transforms a *cilium_v2.CiliumEndpoint into a
 // *types.CiliumEndpoint or a cache.DeletedFinalStateUnknown into a
 // cache.DeletedFinalStateUnknown with a *types.CiliumEndpoint in its Obj.
+// If obj is a *types.CiliumEndpoint or a cache.DeletedFinalStateUnknown with
+// a *types.CiliumEndpoint in its Obj, obj is returned without any transformations.
 // If the given obj can't be cast into either *cilium_v2.CiliumEndpoint nor
 // cache.DeletedFinalStateUnknown, an error is returned.
 func TransformToCiliumEndpoint(obj interface{}) (interface{}, error) {
@@ -936,7 +966,12 @@ func TransformToCiliumEndpoint(obj interface{}) (interface{}, error) {
 			Networking: concreteObj.Status.Networking,
 			NamedPorts: concreteObj.Status.NamedPorts,
 		}, nil
+	case *types.CiliumEndpoint:
+		return obj, nil
 	case cache.DeletedFinalStateUnknown:
+		if _, ok := concreteObj.Obj.(*types.CiliumEndpoint); ok {
+			return obj, nil
+		}
 		ciliumEndpoint, ok := concreteObj.Obj.(*cilium_v2.CiliumEndpoint)
 		if !ok {
 			return nil, fmt.Errorf("unknown object type %T", concreteObj.Obj)

--- a/pkg/k8s/factory_functions_test.go
+++ b/pkg/k8s/factory_functions_test.go
@@ -927,11 +927,33 @@ func (s *K8sSuite) Test_TransformToK8sService(c *C) {
 			expected: true,
 		},
 		{
+			name: "transformation unneeded",
+			args: args{
+				obj: &slim_corev1.Service{},
+			},
+			want:     &slim_corev1.Service{},
+			expected: true,
+		},
+		{
 			name: "delete final state unknown transformation",
 			args: args{
 				obj: cache.DeletedFinalStateUnknown{
 					Key: "foo",
 					Obj: &core_v1.Service{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &slim_corev1.Service{},
+			},
+			expected: true,
+		},
+		{
+			name: "delete final state unknown transformation with slim Service",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &slim_corev1.Service{},
 				},
 			},
 			want: cache.DeletedFinalStateUnknown{
@@ -1195,6 +1217,14 @@ func (s *K8sSuite) Test_TransformToCNP(c *C) {
 			expected: true,
 		},
 		{
+			name: "transformation unneeded",
+			args: args{
+				obj: &types.SlimCNP{},
+			},
+			want:     &types.SlimCNP{},
+			expected: true,
+		},
+		{
 			name: "delete final state unknown transformation",
 			args: args{
 				obj: cache.DeletedFinalStateUnknown{
@@ -1207,6 +1237,20 @@ func (s *K8sSuite) Test_TransformToCNP(c *C) {
 				Obj: &types.SlimCNP{
 					CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
 				},
+			},
+			expected: true,
+		},
+		{
+			name: "delete final state unknown transformation with SlimCNP",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &types.SlimCNP{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.SlimCNP{},
 			},
 			expected: true,
 		},
@@ -1262,6 +1306,14 @@ func (s *K8sSuite) Test_TransformToCCNP(c *C) {
 			expected: true,
 		},
 		{
+			name: "transformation unneeded",
+			args: args{
+				obj: &types.SlimCNP{},
+			},
+			want:     &types.SlimCNP{},
+			expected: true,
+		},
+		{
 			name: "A CCNP where it doesn't contain neither a spec nor specs",
 			args: args{
 				obj: &v2.CiliumClusterwideNetworkPolicy{},
@@ -1284,6 +1336,20 @@ func (s *K8sSuite) Test_TransformToCCNP(c *C) {
 				Obj: &types.SlimCNP{
 					CiliumNetworkPolicy: &v2.CiliumNetworkPolicy{},
 				},
+			},
+			expected: true,
+		},
+		{
+			name: "delete final state unknown transformation with SlimCNP",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &types.SlimCNP{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.SlimCNP{},
 			},
 			expected: true,
 		},
@@ -1337,11 +1403,33 @@ func (s *K8sSuite) Test_TransformToNode(c *C) {
 			expected: true,
 		},
 		{
+			name: "transformation unneeded",
+			args: args{
+				obj: &slim_corev1.Node{},
+			},
+			want:     &slim_corev1.Node{},
+			expected: true,
+		},
+		{
 			name: "delete final state unknown transformation",
 			args: args{
 				obj: cache.DeletedFinalStateUnknown{
 					Key: "foo",
 					Obj: &core_v1.Node{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &slim_corev1.Node{},
+			},
+			expected: true,
+		},
+		{
+			name: "delete final state unknown transformation with slim Node",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &slim_corev1.Node{},
 				},
 			},
 			want: cache.DeletedFinalStateUnknown{
@@ -1654,6 +1742,14 @@ func (s *K8sSuite) Test_TransformToCiliumEndpoint(c *C) {
 			expected: true,
 		},
 		{
+			name: "transformation unneeded",
+			args: args{
+				obj: &types.CiliumEndpoint{},
+			},
+			want:     &types.CiliumEndpoint{},
+			expected: true,
+		},
+		{
 			name: "delete final state unknown transformation",
 			args: args{
 				obj: cache.DeletedFinalStateUnknown{
@@ -1799,6 +1895,20 @@ func (s *K8sSuite) Test_TransformToCiliumEndpoint(c *C) {
 			},
 			want:     unknownObjErr,
 			expected: false,
+		},
+		{
+			name: "delete final state unknown transformation with a types.CiliumEndpoint",
+			args: args{
+				obj: cache.DeletedFinalStateUnknown{
+					Key: "foo",
+					Obj: &types.CiliumEndpoint{},
+				},
+			},
+			want: cache.DeletedFinalStateUnknown{
+				Key: "foo",
+				Obj: &types.CiliumEndpoint{},
+			},
+			expected: true,
 		},
 		{
 			name: "unknown object type in transformation",


### PR DESCRIPTION
Updates TransformXXX functions to not return an error if the provided and returned objects are the same type. Instead, the provided object is returned without any transformations.

Fixes: #26240
