### PR TITLE
 pkg/datapath: Prefer v4 Node IP addr for NodeID allocation

### DIFF
--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -93,14 +93,13 @@ func (n *linuxNodeHandler) getNodeIDForIP(nodeIP net.IP) (uint16, bool) {
 	return 0, false
 }
 
-// getNodeIDForNode gets the node ID for the given node if one was allocated
-// for any of the node IP addresses. If none is found, 0 is returned.
+// getNodeIDForNode gets the node ID for the given node if one was allocated.
+// If none if found, 0 is returned.
 func (n *linuxNodeHandler) getNodeIDForNode(node *nodeTypes.Node) uint16 {
 	nodeID := uint16(0)
-	for _, addr := range node.IPAddresses {
-		if id, exists := n.nodeIDsByIPs[addr.IP.String()]; exists {
-			nodeID = id
-		}
+	nodeIP := n.getNodeIPForIDAllocation(node)
+	if id, exists := n.nodeIDsByIPs[nodeIP]; exists {
+		nodeID = id
 	}
 	return nodeID
 }
@@ -112,6 +111,7 @@ func (n *linuxNodeHandler) getNodeIDForNode(node *nodeTypes.Node) uint16 {
 func (n *linuxNodeHandler) allocateIDForNode(node *nodeTypes.Node) uint16 {
 	// Did we already allocate a node ID for any IP of that node?
 	nodeID := n.getNodeIDForNode(node)
+	nodeIP := n.getNodeIPForIDAllocation(node)
 
 	if nodeID == 0 {
 		nodeID = uint16(n.nodeIDs.AllocateID())
@@ -121,21 +121,16 @@ func (n *linuxNodeHandler) allocateIDForNode(node *nodeTypes.Node) uint16 {
 			log.WithFields(logrus.Fields{
 				logfields.NodeID:   nodeID,
 				logfields.NodeName: node.Name,
+				logfields.IPAddr:   nodeIP,
 			}).Debug("Allocated new node ID for node")
 		}
 	}
 
-	for _, addr := range node.IPAddresses {
-		ip := addr.IP.String()
-		if _, exists := n.nodeIDsByIPs[ip]; exists {
-			continue
-		}
-		if err := n.mapNodeID(ip, nodeID); err != nil {
-			log.WithError(err).WithFields(logrus.Fields{
-				logfields.NodeID: nodeID,
-				logfields.IPAddr: ip,
-			}).Error("Failed to map node IP address to allocated ID")
-		}
+	if err := n.mapNodeID(nodeIP, nodeID); err != nil {
+		log.WithError(err).WithFields(logrus.Fields{
+			logfields.NodeID: nodeID,
+			logfields.IPAddr: nodeIP,
+		}).Error("Failed to map node IP address to allocated ID")
 	}
 	return nodeID
 }
@@ -143,16 +138,6 @@ func (n *linuxNodeHandler) allocateIDForNode(node *nodeTypes.Node) uint16 {
 // deallocateIDForNode deallocates the node ID for the given node, if it was allocated.
 func (n *linuxNodeHandler) deallocateIDForNode(oldNode *nodeTypes.Node) {
 	nodeID := n.getNodeIDForNode(oldNode)
-
-	for _, addr := range oldNode.IPAddresses {
-		id := n.nodeIDsByIPs[addr.IP.String()]
-		if nodeID != id {
-			log.WithFields(logrus.Fields{
-				logfields.NodeName: oldNode.Name,
-				logfields.IPAddr:   addr.IP,
-			}).Errorf("Found two node IDs (%d and %d) for the same node", id, nodeID)
-		}
-	}
 
 	n.deallocateNodeIDLocked(nodeID)
 }
@@ -308,4 +293,24 @@ func (n *linuxNodeHandler) registerNodeIDAllocations(allocatedNodeIDs map[string
 			}
 		}
 	}
+}
+
+// getNodeIPForIDAllocation is a helper function which tries to retrieve a node IP used
+// for node ID allocations from a given Node object.
+//
+// If the IPv4 is enabled, then IPv4 addr is preferred. This is because we use
+// node IPv4 addr in CiliumEndpoint objects. The node IP addr from CiliumEndpoint
+// is used to create IPcache entries. The latter's creation might invoke the
+// node ID allocation. So, we want to ensure that we always use the same IP addr
+// for the same node when allocating IDs.
+func (n *linuxNodeHandler) getNodeIPForIDAllocation(node *nodeTypes.Node) string {
+	if ip := node.GetNodeIP(false); ip != nil { // ipv4
+		return ip.String()
+	}
+
+	if ip := node.GetNodeIP(true); ip != nil { // ipv6
+		return ip.String()
+	}
+
+	return ""
 }


### PR DESCRIPTION
Previously, node IDs were meant to be allocated per node regardless of node IP addr families. However, this became problematic when running Cilium with both v4 and v6 enabled. Sometimes Cilium could have allocated two different IDs for the same node. This confused XFRM states or IPcache \[1\].

A proper solution is to use node name or other than node IP addr as a reference for node ID allocations. Unfortunately, it's not possible, as the node ID allocation can happen in the pkg/ipcache (see AllocateNodeID), which is not aware of node object. Because of this limitation, we could allocate node IDs per each IP familiy for a given node. However, CiliumEndpoint prefers IPv4 address for host IP, so IPv6 of a node is not always accessible to the pkg/ipcache.

To fix the issue, let's prefer v4 node IP addr. This is the same as we do in CiliumEndpoint creation.

\[1\]: https://github.com/cilium/cilium/issues/26114#issuecomment-1587906785

Fixes: https://github.com/cilium/cilium/pull/23202

