### PR TITLE
gha: test the different auth modes in conformance-clustermesh

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -190,6 +190,8 @@ jobs:
             encryption: 'disabled'
             kube-proxy: 'iptables'
             kvstoremesh: true
+            cm-auth-mode-1: 'legacy'
+            cm-auth-mode-2: 'legacy'
 
           - name: '2'
             tunnel: 'disabled'
@@ -197,6 +199,8 @@ jobs:
             encryption: 'wireguard'
             kube-proxy: 'none'
             kvstoremesh: false
+            cm-auth-mode-1: 'migration'
+            cm-auth-mode-2: 'migration'
 
           # IPsec encryption cannot be used with BPF NodePort.
           - name: '3'
@@ -205,6 +209,8 @@ jobs:
             encryption: 'ipsec'
             kube-proxy: 'iptables'
             kvstoremesh: true
+            cm-auth-mode-1: 'cluster'
+            cm-auth-mode-2: 'cluster'
 
           # IPsec encryption is currently not supported in case of ipv6-only clusters (#23553)
           # Wireguard encryption is currently affected by a bug in case of ipv6-only clusters (#23917)
@@ -214,6 +220,8 @@ jobs:
             encryption: 'disabled'
             kube-proxy: 'none'
             kvstoremesh: false
+            cm-auth-mode-1: 'legacy'
+            cm-auth-mode-2: 'migration'
 
           # IPsec encryption cannot be used with BPF NodePort.
           - name: '5'
@@ -222,6 +230,8 @@ jobs:
             encryption: 'ipsec'
             kube-proxy: 'iptables'
             kvstoremesh: true
+            cm-auth-mode-1: 'migration'
+            cm-auth-mode-2: 'cluster'
 
           - name: '6'
             tunnel: 'vxlan'
@@ -229,6 +239,8 @@ jobs:
             encryption: 'disabled'
             kube-proxy: 'none'
             kvstoremesh: false
+            cm-auth-mode-1: 'cluster'
+            cm-auth-mode-2: 'cluster'
 
           - name: '7'
             tunnel: 'vxlan'
@@ -236,6 +248,8 @@ jobs:
             encryption: 'wireguard'
             kube-proxy: 'iptables'
             kvstoremesh: true
+            cm-auth-mode-1: 'cluster'
+            cm-auth-mode-2: 'cluster'
 
           # IPsec encryption cannot be used with BPF NodePort.
           - name: '8'
@@ -244,6 +258,8 @@ jobs:
             encryption: 'ipsec'
             kube-proxy: 'iptables'
             kvstoremesh: false
+            cm-auth-mode-1: 'cluster'
+            cm-auth-mode-2: 'cluster'
 
         # Tunneling is currently not supported in case of ipv6-only clusters (#17240)
         #  - name: '9'
@@ -252,6 +268,8 @@ jobs:
         #    encryption: 'disabled'
         #    kube-proxy: 'none'
         #    kvstoremesh: true
+        #    cm-auth-mode-1: 'cluster'
+        #    cm-auth-mode-2: 'cluster'
 
           - name: '10'
             tunnel: 'vxlan'
@@ -259,6 +277,8 @@ jobs:
             encryption: 'wireguard'
             kube-proxy: 'iptables'
             kvstoremesh: false
+            cm-auth-mode-1: 'cluster'
+            cm-auth-mode-2: 'cluster'
 
     steps:
     - name: Checkout GitHub main
@@ -457,7 +477,8 @@ jobs:
           ${{ steps.vars.outputs.cilium_install_defaults }} \
           --helm-set cluster.name=${{ env.clusterName1 }} \
           --helm-set cluster.id=1 \
-          --helm-set clustermesh.apiserver.service.nodePort=32379
+          --helm-set clustermesh.apiserver.service.nodePort=32379 \
+          --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-1 }}
 
     - name: Copy the Cilium CA secret to cluster2, as they must match
       run: |
@@ -472,7 +493,8 @@ jobs:
           ${{ steps.vars.outputs.cilium_install_defaults }} \
           --helm-set cluster.name=${{ env.clusterName2 }} \
           --helm-set cluster.id=255 \
-          --helm-set clustermesh.apiserver.service.nodePort=32380
+          --helm-set clustermesh.apiserver.service.nodePort=32380 \
+          --helm-set clustermesh.apiserver.tls.authMode=${{ matrix.cm-auth-mode-2 }}
 
     - name: Wait for cluster mesh status to be ready
       run: |


### PR DESCRIPTION
Now that conformance-clustermesh leverages the CLI Helm mode to configure clustermesh, let's additionally test the different auth modes to ensure that they all work properly.

Link to successful run: https://github.com/cilium/cilium/actions/runs/5288850571/jobs/9574180241?pr=26252 (during the first attempt one of the matrix entries failed due to the known issue affecting to-world checks).