### PR TITLE
CI: Stabilize ConformanceKindEnvoyDaemonSet

### DIFF
--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -76,8 +76,7 @@ jobs:
             --helm-set=bpf.monitorAggregation="none" \
             --wait=false \
             --version="
-          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \
-            --external-target bing.com --external-cidr 8.0.0.0/8 --external-ip 8.8.8.8 --external-other-ip 8.8.4.4"
+          CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure"
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo connectivity_test_defaults=${CONNECTIVITY_TEST_DEFAULTS} >> $GITHUB_OUTPUT
           echo sha=${SHA} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -21,7 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  kind_version: v0.17.0
+  kind_version: v0.19.0
   kind_config: .github/kind-config.yaml
   # renovate: datasource=github-releases depName=cilium/cilium-cli
   cilium_cli_version: v0.14.7

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -65,14 +65,14 @@ jobs:
             --helm-set=clustermesh.apiserver.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
             --helm-set=clustermesh.apiserver.image.tag=${SHA} \
             --helm-set=clustermesh.apiserver.image.useDigest=false \
-            --helm-set hubble.relay.enabled=true \
+            --helm-set=hubble.relay.enabled=true \
             --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${SHA} \
-            --helm-set cni.chainingMode=portmap \
-            --helm-set loadBalancer.l7.backend=envoy \
-            --helm-set tls.secretsBackend=k8s \
-            --helm-set envoy.enabled=true \
-            --helm-set bpf.monitorAggregation="none" \
+            --helm-set=cni.chainingMode=portmap \
+            --helm-set=loadBalancer.l7.backend=envoy \
+            --helm-set=tls.secretsBackend=k8s \
+            --helm-set=envoy.enabled=true \
+            --helm-set=bpf.monitorAggregation="none" \
             --wait=false \
             --version="
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -69,6 +69,7 @@ jobs:
             --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${SHA} \
             --helm-set=cni.chainingMode=portmap \
+            --helm-set-string=kubeProxyReplacement=strict \
             --helm-set=loadBalancer.l7.backend=envoy \
             --helm-set=tls.secretsBackend=k8s \
             --helm-set=envoy.enabled=true \


### PR DESCRIPTION
This PR tries to stabilize and de-flake the check `ConformanceKKindEnvoyDaemonSet` - mainly by removing the explicit connectivity-check flags `external-*` and using the default ones.

Currently it's failing on main and branches with failures when calling the external services: e.g. https://github.com/cilium/cilium/actions/runs/5278470155/jobs/9547854043

```
📋 Test Report
❌ 6/45 tests failed (10/292 actions), 10 tests skipped, 0 scenarios skipped:
Test [no-policies]:
  ❌ no-policies/pod-to-cidr/external-8888-1: cilium-test/client-6965d549d5-7gpbl (10.244.1.96) -> external-8888 (8.8.8.8:443)
connectivity test failed: 6 tests failed
Test [all-ingress-deny]:
  ❌ all-ingress-deny/pod-to-cidr/external-8888-0: cilium-test/client2-76f4d7c5bc-s5245 (10.244.1.212) -> external-8888 (8.8.8.8:443)
  ❌ all-ingress-deny/pod-to-cidr/external-8888-1: cilium-test/client-6965d549d5-7gpbl (10.244.1.96) -> external-8888 (8.8.8.8:443)
Test [all-ingress-deny-knp]:
  ❌ all-ingress-deny-knp/pod-to-cidr/external-8888-0: cilium-test/client-6965d549d5-7gpbl (10.244.1.96) -> external-8888 (8.8.8.8:443)
  ❌ all-ingress-deny-knp/pod-to-cidr/external-8888-1: cilium-test/client2-76f4d7c5bc-s5245 (10.244.1.212) -> external-8888 (8.8.8.8:443)
Test [to-cidr-external]:
  ❌ to-cidr-external/pod-to-cidr/external-8888-1: cilium-test/client2-76f4d7c5bc-s5245 (10.244.1.212) -> external-8888 (8.8.8.8:443)
Test [to-cidr-external-knp]:
  ❌ to-cidr-external-knp/pod-to-cidr/external-8888-0: cilium-test/client-6965d549d5-7gpbl (10.244.1.96) -> external-8888 (8.8.8.8:443)
  ❌ to-cidr-external-knp/pod-to-cidr/external-8888-1: cilium-test/client2-76f4d7c5bc-s5245 (10.244.1.212) -> external-8888 (8.8.8.8:443)
Test [client-egress-to-cidr-deny]:
  ❌ client-egress-to-cidr-deny/pod-to-cidr/external-8888-0: cilium-test/client-6965d549d5-7gpbl (10.244.1.96) -> external-8888 (8.8.8.8:443)
  ❌ client-egress-to-cidr-deny/pod-to-cidr/external-8888-1: cilium-test/client2-76f4d7c5bc-s5245 (10.244.1.212) -> external-8888 (8.8.8.8:443)
```

Additional changes in the check:
* kind version update
* KPR=strict