### PR TITLE
clustermesh: ensure that the status of the remote clusters controller is correcty reported

### DIFF
--- a/pkg/clustermesh/internal/config_test.go
+++ b/pkg/clustermesh/internal/config_test.go
@@ -34,8 +34,8 @@ var _ = Suite(&ClusterMeshTestSuite{})
 
 type fakeRemoteCluster struct{}
 
-func (*fakeRemoteCluster) Run(context.Context, kvstore.BackendOperations, *types.CiliumClusterConfig) error {
-	return nil
+func (*fakeRemoteCluster) Run(_ context.Context, _ kvstore.BackendOperations, _ *types.CiliumClusterConfig, ready chan<- error) {
+	close(ready)
 }
 func (*fakeRemoteCluster) Stop()   {}
 func (*fakeRemoteCluster) Remove() {}

--- a/pkg/clustermesh/internal/remote_cluster.go
+++ b/pkg/clustermesh/internal/remote_cluster.go
@@ -28,7 +28,9 @@ import (
 )
 
 type RemoteCluster interface {
-	Run(ctx context.Context, backend kvstore.BackendOperations, config *types.CiliumClusterConfig) error
+	// Run implements the actual business logic once the connection to the remote cluster has been established.
+	// The ready channel shall be closed when the initialization tasks completed, possibly returning an error.
+	Run(ctx context.Context, backend kvstore.BackendOperations, config *types.CiliumClusterConfig, ready chan<- error)
 
 	Stop()
 	Remove()
@@ -57,6 +59,10 @@ type remoteCluster struct {
 	changed chan bool
 
 	controllers *controller.Manager
+
+	// wg is used to wait for the termination of the goroutines spawned by the
+	// controller upon reconnection for long running background tasks.
+	wg sync.WaitGroup
 
 	// remoteConnectionControllerName is the name of the backing controller
 	// that maintains the remote connection
@@ -107,6 +113,11 @@ func (rc *remoteCluster) getLogger() *logrus.Entry {
 
 // releaseOldConnection releases the etcd connection to a remote cluster
 func (rc *remoteCluster) releaseOldConnection() {
+	rc.metricReadinessStatus.Set(metrics.BoolToFloat64(false))
+
+	// Make sure that all child goroutines terminated before performing cleanup.
+	rc.wg.Wait()
+
 	rc.mutex.Lock()
 	backend := rc.backend
 	rc.backend = nil
@@ -163,28 +174,32 @@ func (rc *remoteCluster) restartRemoteConnection() {
 				rc.backend = backend
 				rc.mutex.Unlock()
 
-				rc.metricReadinessStatus.Set(metrics.BoolToFloat64(true))
-				defer rc.metricReadinessStatus.Set(metrics.BoolToFloat64(false))
-
 				ctx, cancel := context.WithCancel(ctx)
-				var wg sync.WaitGroup
-				wg.Add(1)
-
+				rc.wg.Add(1)
 				go func() {
 					rc.watchdog(ctx, backend)
-					wg.Done()
+					rc.wg.Done()
 				}()
 
-				defer func() {
+				ready := make(chan error)
+
+				// Let's execute the long running logic in background. This allows
+				// to return early from the controller body, so that the statistics
+				// are updated correctly. Instead, blocking until rc.Run terminates
+				// would prevent a previous failure from being cleared out.
+				rc.wg.Add(1)
+				go func() {
+					rc.Run(ctx, backend, config, ready)
 					cancel()
-					wg.Wait()
+					rc.wg.Done()
 				}()
 
-				if err := rc.Run(ctx, backend, config); err != nil {
-					rc.getLogger().WithError(err).Error("Connection to remote cluster failed")
+				if <-ready != nil {
+					rc.getLogger().WithError(err).Warning("Connection to remote cluster failed")
 					return err
 				}
 
+				rc.metricReadinessStatus.Set(metrics.BoolToFloat64(true))
 				return nil
 			},
 			StopFunc: func(ctx context.Context) error {

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -201,13 +201,16 @@ func TestRemoteClusterRun(t *testing.T) {
 
 			km := KVStoreMesh{backend: kvstore.Client()}
 			rc := km.newRemoteCluster("foo", nil)
+			ready := make(chan error)
 
 			wg.Add(1)
 			go func() {
-				rc.Run(ctx, remoteClient, tt.srccfg)
+				rc.Run(ctx, remoteClient, tt.srccfg, ready)
 				rc.Stop()
 				wg.Done()
 			}()
+
+			require.NoError(t, <-ready, "rc.Run() failed")
 
 			// Assert that the cluster config got properly propagated
 			require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -155,6 +155,7 @@ func TestRemoteClusterRun(t *testing.T) {
 				globalServices: newGlobalServiceCache("cluster", "node"),
 			}
 			rc := cm.newRemoteCluster("foo", nil).(*remoteCluster)
+			ready := make(chan error)
 
 			remoteClient := &remoteEtcdClientWrapper{
 				BackendOperations: kvstore.Client(),
@@ -163,9 +164,11 @@ func TestRemoteClusterRun(t *testing.T) {
 
 			wg.Add(1)
 			go func() {
-				rc.Run(ctx, remoteClient, tt.srccfg)
+				rc.Run(ctx, remoteClient, tt.srccfg, ready)
 				wg.Done()
 			}()
+
+			require.NoError(t, <-ready, "rc.Run() failed")
 
 			// Assert that we correctly watch nodes
 			require.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
150de13bd6c6 ("clustermesh: delete stale node/service entries on reconnect/disconnect") and follow-ups changed the behavior of the controller which wraps the logic used to connect to the kvstore in a remote cluster. More specifically, we previously used to return from the controller DoFunc after completing the setup process (while executing in background the actual synchronization tasks). With that commit, instead, we don't return until the context is closed (which means that the connection needed to be restarted/stopped).

While this simplifies the implementation of the cleanup logic, the change turned out to cause issues in the controller health reporting logic. In particular, given that we don't return on success, a previous failure is never cleared out. Which means incorrect metrics and status reporting through the `cilium status` commands.

This PR fixes this issue reworking the logic so that we return from the controller DoFunc as soon as the initialization tasks completed, while executing the long running logic in background.