### PR TITLE
cilium: nodeId, add debug statements and warning

### DIFF
--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -112,7 +112,7 @@ func (n *linuxNodeHandler) allocateIDForNode(node *nodeTypes.Node) uint16 {
 	for _, addr := range node.IPAddresses {
 		ip := addr.IP.String()
 		if _, exists := n.nodeIDsByIPs[ip]; exists {
-			continue
+			log.WithField("nodeId", nodeID).WithField("IP", ip).Warning("Overwriting existing nodeId->IP mapping")
 		}
 		if err := n.mapNodeID(ip, nodeID); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
@@ -128,6 +128,7 @@ func (n *linuxNodeHandler) allocateIDForNode(node *nodeTypes.Node) uint16 {
 func (n *linuxNodeHandler) deallocateIDForNode(oldNode *nodeTypes.Node) {
 	nodeID := n.nodeIDsByIPs[oldNode.IPAddresses[0].IP.String()]
 	for _, addr := range oldNode.IPAddresses {
+		log.Infof("At %s Remove nodeIdsByIPs %s", oldNode.Name, addr.IP.String())
 		id := n.nodeIDsByIPs[addr.IP.String()]
 		if nodeID != id {
 			log.WithFields(logrus.Fields{


### PR DESCRIPTION
Trying to find root cause of why we have some old nodeIds lingering around with single IPs. Add some info to give us the IPs we are removing and then a Warn when we would previously have aborted adding an ID because the IP already exists.

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
