### PR TITLE
cilium: nodeId, node update may remove IPAddresses so sync nodeMap also

### DIFF
--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -55,6 +55,13 @@ func (n *FakeNodeHandler) AllocateNodeID(_ net.IP) uint16 {
 	return 0
 }
 
+func (n *FakeNodeHandler) DeallocateNodeID(_ net.IP) {
+}
+
+func (n *FakeNodeHandler) GetNodeID(_ net.IP) uint16 {
+	return 0
+}
+
 func (n *FakeNodeHandler) DumpNodeIDs() []*models.NodeID {
 	return nil
 }

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -116,6 +116,8 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 	oldHostIP, newHostIP net.IP, oldID *ipcache.Identity, newID ipcache.Identity,
 	encryptKey uint8, nodeID uint16, k8sMeta *ipcache.K8sMetadata) {
 
+	log.WithField("ModType", modType).WithField("cidr", cidr).WithField("oldHostIP", oldHostIP).WithField("newHostIP", newHostIP).WithField("nodeID", nodeID).Warning("OnIPIdentityCacheChange")
+
 	scopedLog := log
 	if option.Config.Debug {
 		scopedLog = log.WithFields(logrus.Fields{

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1126,6 +1126,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		oldNodeIPAddrs         []string
 		newNodeIPAddrs         []string
 	)
+	oldName := ""
 
 	if oldNode != nil {
 		oldIP4Cidr = oldNode.IPv4AllocCIDR
@@ -1133,6 +1134,7 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		oldIP4 = oldNode.GetNodeIP(false)
 		oldIP6 = oldNode.GetNodeIP(true)
 		oldKey = oldNode.EncryptionKey
+		oldName = oldNode.Name
 
 		// Delete the old node IP addresses from nodeID map if they are dropped by the update.
 		for _, address := range oldNode.IPAddresses {
@@ -1143,6 +1145,8 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 	for _, address := range newNode.IPAddresses {
 		newNodeIPAddrs = append(newNodeIPAddrs, address.IP.String())
 	}
+
+	log.WithField("newName", newNode.Name).WithField("newIPs", newNodeIPAddrs).WithField("oldName", oldName).WithField("oldIPs", oldNodeIPAddrs).Warning("Node Update in progress")
 
 	if n.nodeConfig.EnableIPSec && !n.nodeConfig.EncryptNode {
 		n.enableIPsec(newNode)
@@ -1237,6 +1241,13 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 		return nil
 	}
 
+	var oldIPs []string
+
+	for _, address := range oldNode.IPAddresses {
+		oldIPs = append(oldIPs, address.IP.String())
+	}
+
+	log.WithField("oldName", oldNode.Name).WithField("oldIPs", oldIPs).Warning("Node Delete in progress")
 	oldIP4 := oldNode.GetNodeIP(false)
 	oldIP6 := oldNode.GetNodeIP(true)
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -49,6 +49,20 @@ type NeighLink struct {
 	Name string `json:"link-name"`
 }
 
+type nodeIDSource uint16
+
+const (
+	NewNodeCreatedID = iota
+	DatapathRestoreCreatedID
+	IPCacheCreatedID
+)
+
+type nodeID struct {
+	id     uint16
+	refcnt uint32
+	source nodeIDSource
+}
+
 type linuxNodeHandler struct {
 	mutex                lock.Mutex
 	isInitialized        bool
@@ -69,7 +83,7 @@ type linuxNodeHandler struct {
 	// Pool of available IDs for nodes.
 	nodeIDs idpool.IDPool
 	// Node-scoped unique IDs for the nodes.
-	nodeIDsByIPs map[string]uint16
+	nodeIDsByIPs map[string]nodeID
 
 	ipsecMetricCollector prometheus.Collector
 }
@@ -93,7 +107,7 @@ func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapat
 		neighByNextHop:         map[string]*netlink.Neigh{},
 		neighLastPingByNextHop: map[string]time.Time{},
 		nodeIDs:                idpool.NewIDPool(minNodeID, maxNodeID),
-		nodeIDsByIPs:           map[string]uint16{},
+		nodeIDsByIPs:           map[string]nodeID{},
 		ipsecMetricCollector:   ipsec.NewXFRMCollector(),
 	}
 }
@@ -458,6 +472,8 @@ func (n *linuxNodeHandler) NodeAdd(newNode nodeTypes.Node) error {
 
 	if n.isInitialized {
 		return n.nodeUpdate(nil, &newNode, true)
+	} else {
+		log.WithField("newNode", newNode).Warning("skipped nodeUpdate note initialized")
 	}
 
 	return nil
@@ -471,6 +487,8 @@ func (n *linuxNodeHandler) NodeUpdate(oldNode, newNode nodeTypes.Node) error {
 
 	if n.isInitialized {
 		return n.nodeUpdate(&oldNode, &newNode, false)
+	} else {
+		log.WithField("newNode", newNode).WithField("oldNode", oldNode).Warning("skipped nodeUpdate !initialized")
 	}
 
 	return nil
@@ -1226,6 +1244,8 @@ func (n *linuxNodeHandler) NodeDelete(oldNode nodeTypes.Node) error {
 
 		if n.isInitialized {
 			return n.nodeDelete(oldCachedNode)
+		} else {
+			log.WithField("oldNode", oldNode).Warning("skipped nodeDelete note initialized")
 		}
 	}
 

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -47,6 +47,7 @@ func (n *linuxNodeHandler) AllocateNodeID(nodeIP net.IP) uint16 {
 	}
 
 	nodeID := uint16(n.nodeIDs.AllocateID())
+	log.WithField("newIP", nodeIP).WithField("nodeId", nodeID).Warning("AllocateNodeId")
 	if nodeID == uint16(idpool.NoID) {
 		log.Error("No more IDs available for nodes")
 		return nodeID

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -77,6 +77,25 @@ func (n *linuxNodeHandler) getNodeIDForNode(node *nodeTypes.Node) uint16 {
 	return nodeID
 }
 
+func (n *linuxNodeHandler) deleteNodeIPs(oldIPs, newIPs []string) {
+	for _, oldAddr := range oldIPs {
+		found := false
+		for _, newAddr := range newIPs {
+			if newAddr == oldAddr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			if err := n.unmapNodeID(oldAddr); err != nil {
+				log.WithError(err).WithFields(logrus.Fields{
+					logfields.IPAddr: oldAddr,
+				}).Warn("DeleteNodeIPS failed to remove a node IP to node ID mapping")
+			}
+		}
+	}
+}
+
 // allocateIDForNode allocates a new ID for the given node if one hasn't already
 // been assigned. If any of the node IPs have an ID associated, then all other
 // node IPs receive the same. This might happen if we allocated a node ID from

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -250,9 +250,9 @@ func (n *linuxNodeHandler) mapNodeID(ip string, id uint16, source nodeIDSource) 
 		refcnt: 1,
 		source: source,
 	}
-	if err := nodemap.NodeMap().Update(nodeIP, id); err != nil {
-		return err
-	}
+	//if err := nodemap.NodeMap().Update(nodeIP, id); err != nil {
+	//	return err
+	//}
 
 	// We only add the IP <> ID mapping in memory once we are sure it was
 	// successfully added to the BPF map.
@@ -273,9 +273,9 @@ func (n *linuxNodeHandler) unmapNodeID(ip string) error {
 		return fmt.Errorf("invalid node IP %s", ip)
 	}
 
-	if err := nodemap.NodeMap().Delete(nodeIP); err != nil {
-		return err
-	}
+//	if err := nodemap.NodeMap().Delete(nodeIP); err != nil {
+//		return err
+//	}
 
 	delete(n.nodeIDsByIPs, ip)
 

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -43,7 +43,9 @@ func (n *linuxNodeHandler) AllocateNodeID(nodeIP net.IP) uint16 {
 	defer n.mutex.Unlock()
 
 	if nodeID, exists := n.nodeIDsByIPs[nodeIP.String()]; exists {
-		return nodeID
+		nodeID.refcnt++
+		n.nodeIDsByIPs[nodeIP.String()] = nodeID
+		return nodeID.id
 	}
 
 	nodeID := uint16(n.nodeIDs.AllocateID())
@@ -57,7 +59,7 @@ func (n *linuxNodeHandler) AllocateNodeID(nodeIP net.IP) uint16 {
 			logfields.IPAddr: nodeIP,
 		}).Debug("Allocated new node ID for node IP address")
 	}
-	if err := n.mapNodeID(nodeIP.String(), nodeID); err != nil {
+	if err := n.mapNodeID(nodeIP.String(), nodeID, IPCacheCreatedID); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
 			logfields.NodeID: nodeID,
 			logfields.IPAddr: nodeIP.String(),
@@ -66,13 +68,72 @@ func (n *linuxNodeHandler) AllocateNodeID(nodeIP net.IP) uint16 {
 	return nodeID
 }
 
+func (n *linuxNodeHandler) GetNodeID(nodeIP net.IP) uint16 {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	nodeID, exists := n.nodeIDsByIPs[nodeIP.String()]
+	if !exists {
+		return 0
+	}
+	return nodeID.id
+}
+
+func (n *linuxNodeHandler) DeallocateNodeID(nodeIP net.IP) {
+	if len(nodeIP) == 0 || nodeIP.IsUnspecified() {
+		// This should never happen. If it ever does, we may have an unexpected
+		// call to AllocateNodeID.
+		log.Warning("Attempt to dellocate a node ID for an empty node IP address")
+		return
+	}
+
+	// We shouldn't have an ID for local node.
+	localNode := node.GetIPv4()
+	if localNode.Equal(nodeIP) {
+		log.Warning("Attempt to dellocate local node IP")
+		return
+	}
+
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+
+	nodeID, exists := n.nodeIDsByIPs[nodeIP.String()]
+	if !exists {
+		log.Warning("Attempt to dellocate unknown node IP")
+		return
+	}
+
+	// IPCache can allocate/deallocate nodeIDs but if this node was allocated
+	// through a node event lets wait for the paired update to remove it.
+	if nodeID.source != IPCacheCreatedID {
+		return
+	}
+
+	if nodeID.refcnt < 1 {
+		log.Warning("Attempt to dellocate node IP with refcnt < 1")
+		return
+	}
+
+	nodeID.refcnt--
+	if nodeID.refcnt == 0 {
+		if err := n.unmapNodeID(nodeIP.String()); err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.IPAddr: nodeIP.String(),
+			}).Warn("DeallocateNodeID failed to remove a node IP to node ID mapping")
+		}
+	} else {
+		n.nodeIDsByIPs[nodeIP.String()] = nodeID
+	}
+	return
+}
+
 // getNodeIDForNode gets the node ID for the given node if one was allocated
 // for any of the node IP addresses. If none if found, 0 is returned.
 func (n *linuxNodeHandler) getNodeIDForNode(node *nodeTypes.Node) uint16 {
 	nodeID := uint16(0)
 	for _, addr := range node.IPAddresses {
 		if id, exists := n.nodeIDsByIPs[addr.IP.String()]; exists {
-			nodeID = id
+			nodeID = id.id
 		}
 	}
 	return nodeID
@@ -119,10 +180,15 @@ func (n *linuxNodeHandler) allocateIDForNode(node *nodeTypes.Node) uint16 {
 
 	for _, addr := range node.IPAddresses {
 		ip := addr.IP.String()
-		if _, exists := n.nodeIDsByIPs[ip]; exists {
+		// If the entry exists from a previous ipcache and we get an
+		// event from the node manager about this node promote it to
+		// node source so we hold the reference for the paired delete.
+		if e, exists := n.nodeIDsByIPs[ip]; exists {
+			e.source = NewNodeCreatedID
+			n.nodeIDsByIPs[ip] = e
 			continue
 		}
-		if err := n.mapNodeID(ip, nodeID); err != nil {
+		if err := n.mapNodeID(ip, nodeID, NewNodeCreatedID); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				logfields.NodeID: nodeID,
 				logfields.IPAddr: ip,
@@ -137,27 +203,20 @@ func (n *linuxNodeHandler) deallocateIDForNode(oldNode *nodeTypes.Node) {
 	nodeID := n.nodeIDsByIPs[oldNode.IPAddresses[0].IP.String()]
 	for _, addr := range oldNode.IPAddresses {
 		id := n.nodeIDsByIPs[addr.IP.String()]
-		if nodeID != id {
+		if nodeID.id != id.id {
 			log.WithFields(logrus.Fields{
 				logfields.NodeName: oldNode.Name,
 				logfields.IPAddr:   addr.IP,
-			}).Errorf("Found two node IDs (%d and %d) for the same node", id, nodeID)
+			}).Errorf("Found two node IDs (%d and %d) for the same node", id.id, nodeID.id)
 		}
 	}
 
 	n.deallocateNodeIDLocked(nodeID)
 }
 
-// DeallocateNodeID deallocates the given node ID, if it was allocated.
-func (n *linuxNodeHandler) DeallocateNodeID(nodeID uint16) {
-	n.mutex.Lock()
-	defer n.mutex.Unlock()
-	n.deallocateNodeIDLocked(nodeID)
-}
-
-func (n *linuxNodeHandler) deallocateNodeIDLocked(nodeID uint16) {
+func (n *linuxNodeHandler) deallocateNodeIDLocked(nodeID nodeID) {
 	for ip, id := range n.nodeIDsByIPs {
-		if nodeID == id {
+		if nodeID.id == id.id {
 			if err := n.unmapNodeID(ip); err != nil {
 				log.WithError(err).WithFields(logrus.Fields{
 					logfields.NodeID: nodeID,
@@ -167,16 +226,16 @@ func (n *linuxNodeHandler) deallocateNodeIDLocked(nodeID uint16) {
 		}
 	}
 
-	if !n.nodeIDs.Insert(idpool.ID(nodeID)) {
-		log.WithField(logfields.NodeID, nodeID).Warn("Attempted to deallocate a node ID that wasn't allocated")
+	if !n.nodeIDs.Insert(idpool.ID(nodeID.id)) {
+		log.WithField(logfields.NodeID, nodeID.id).Warn("Attempted to deallocate a node ID that wasn't allocated")
 	}
-	log.WithField(logfields.NodeID, nodeID).Debug("Deallocate node ID")
+	log.WithField(logfields.NodeID, nodeID.id).Debug("Deallocate node ID")
 }
 
 // mapNodeID adds a node ID <> IP mapping into the local in-memory map of the
 // Node Manager and in the corresponding BPF map. If any of those map updates
 // fail, both are cancelled and the function returns an error.
-func (n *linuxNodeHandler) mapNodeID(ip string, id uint16) error {
+func (n *linuxNodeHandler) mapNodeID(ip string, id uint16, source nodeIDSource) error {
 	if _, exists := n.nodeIDsByIPs[ip]; exists {
 		return fmt.Errorf("a mapping for node IP %s already exists", ip)
 	}
@@ -186,13 +245,18 @@ func (n *linuxNodeHandler) mapNodeID(ip string, id uint16) error {
 		return fmt.Errorf("invalid node IP %s", ip)
 	}
 
+	nodeID := nodeID{
+		id:     id,
+		refcnt: 1,
+		source: source,
+	}
 	if err := nodemap.NodeMap().Update(nodeIP, id); err != nil {
 		return err
 	}
 
 	// We only add the IP <> ID mapping in memory once we are sure it was
 	// successfully added to the BPF map.
-	n.nodeIDsByIPs[ip] = id
+	n.nodeIDsByIPs[ip] = nodeID
 	return nil
 }
 
@@ -225,12 +289,12 @@ func (n *linuxNodeHandler) DumpNodeIDs() []*models.NodeID {
 
 	nodeIDs := map[uint16]*models.NodeID{}
 	for ip, id := range n.nodeIDsByIPs {
-		if nodeID, exists := nodeIDs[id]; exists {
+		if nodeID, exists := nodeIDs[id.id]; exists {
 			nodeID.Ips = append(nodeID.Ips, ip)
-			nodeIDs[id] = nodeID
+			nodeIDs[id.id] = nodeID
 		} else {
-			i := int64(id)
-			nodeIDs[id] = &models.NodeID{
+			i := int64(id.id)
+			nodeIDs[id.id] = &models.NodeID{
 				ID:  &i,
 				Ips: []string{ip},
 			}
@@ -248,13 +312,17 @@ func (n *linuxNodeHandler) DumpNodeIDs() []*models.NodeID {
 // BPF map and into the node handler in-memory copy.
 func (n *linuxNodeHandler) RestoreNodeIDs() {
 	// Retrieve node IDs from the BPF map to be able to restore them.
-	nodeIDs := make(map[string]uint16)
+	nodeIDs := make(map[string]nodeID)
 	parse := func(key *nodemap.NodeKey, val *nodemap.NodeValue) {
 		address := key.IP.String()
 		if key.Family == bpf.EndpointKeyIPv4 {
 			address = net.IP(key.IP[:net.IPv4len]).String()
 		}
-		nodeIDs[address] = val.NodeID
+		nodeIDs[address] = nodeID{
+			id:     val.NodeID,
+			refcnt: 1,
+			source: DatapathRestoreCreatedID,
+		}
 	}
 	if err := nodemap.NodeMap().IterateWithCallback(parse); err != nil {
 		log.WithError(err).Error("Failed to dump content of node map")
@@ -265,7 +333,7 @@ func (n *linuxNodeHandler) RestoreNodeIDs() {
 	log.Infof("Restored %d node IDs from the BPF map", len(nodeIDs))
 }
 
-func (n *linuxNodeHandler) registerNodeIDAllocations(allocatedNodeIDs map[string]uint16) {
+func (n *linuxNodeHandler) registerNodeIDAllocations(allocatedNodeIDs map[string]nodeID) {
 	n.mutex.Lock()
 	defer n.mutex.Unlock()
 
@@ -283,14 +351,14 @@ func (n *linuxNodeHandler) registerNodeIDAllocations(allocatedNodeIDs map[string
 	// available for allocation.
 	nodeIDs := make(map[uint16]struct{})
 	for _, id := range allocatedNodeIDs {
-		if _, exists := nodeIDs[id]; !exists {
-			nodeIDs[id] = struct{}{}
-			if !n.nodeIDs.Remove(idpool.ID(id)) {
+		if _, exists := nodeIDs[id.id]; !exists {
+			nodeIDs[id.id] = struct{}{}
+			if !n.nodeIDs.Remove(idpool.ID(id.id)) {
 				// This is just a sanity check. It should never happen as we
 				// have checked that we start with a full idpool (0 allocated
 				// node IDs) and then only remove them from the idpool if they
 				// were already removed.
-				log.WithField(logfields.NodeID, id).Error("Node ID was already allocated")
+				log.WithField(logfields.NodeID, id.id).Error("Node ID was already allocated")
 			}
 		}
 	}

--- a/pkg/datapath/linux/node_ids_test.go
+++ b/pkg/datapath/linux/node_ids_test.go
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2018-2021 Authors of Cilium
+
+package linux
+
+import (
+	"net"
+
+	"github.com/cilium/cilium/pkg/datapath"
+	"github.com/cilium/cilium/pkg/datapath/fake"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"gopkg.in/check.v1"
+)
+
+const (
+	dummyHostDeviceName = "dummy_host"
+)
+
+var (
+	testIP1 = net.ParseIP("192.88.99.1")
+	testIP2 = net.ParseIP("192.88.99.2")
+
+	testNode            = &nodeTypes.Node{
+		Name:    "newTestNode",
+		Cluster: "testCluster",
+		IPAddresses: []nodeTypes.Address{
+			nodeTypes.Address{
+				Type: addressing.NodeInternalIP,
+				IP:   testIP1,
+			},
+			nodeTypes.Address{
+				Type: addressing.NodeCiliumInternalIP,
+				IP:   testIP2,
+			},
+		},
+	}
+)
+
+type linuxNodeIDTestSuite struct {
+	nodeAddressing datapath.NodeAddressing
+	enableIPv4     bool
+	enableIPv6     bool
+}
+
+func (n *linuxNodeHandler) checkNodeIdsExist(c *check.C, node *nodeTypes.Node) {
+	for _, addr := range node.IPAddresses {
+		_, exists := n.nodeIDsByIPs[addr.IP.String()]
+		c.Assert(exists, check.Equals, true)
+	}
+}
+
+func (n *linuxNodeHandler) checkNodeIdsRemoved(c *check.C, node *nodeTypes.Node) {
+	for _, addr := range node.IPAddresses {
+		_, exists := n.nodeIDsByIPs[addr.IP.String()]
+		c.Assert(exists, check.Equals, false)
+	}
+}
+
+func (n *linuxNodeHandler) checkIPExists(c *check.C, ip net.IP) {
+	_, exists := n.nodeIDsByIPs[ip.String()]
+	c.Assert(exists, check.Equals, true)
+}
+
+func (n *linuxNodeHandler) checkIPRemoved(c *check.C, ip net.IP) {
+	_, exists := n.nodeIDsByIPs[ip.String()]
+	c.Assert(exists, check.Equals, false)
+}
+
+
+func (s *linuxTestSuite) TestNodeIDAddDelete(c *check.C) {
+	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
+	fakeNodeAddressing := fake.NewNodeAddressing()
+	lnh := NewNodeHandler(dpConfig, fakeNodeAddressing)
+	c.Assert(lnh, check.Not(check.IsNil))
+
+	id := lnh.allocateIDForNode(testNode)
+	c.Assert(id, check.Not(check.Equals), 0)
+	lnh.checkNodeIdsExist(c, testNode)
+	lnh.deallocateIDForNode(testNode)
+	lnh.checkNodeIdsRemoved(c, testNode)
+}
+
+func (s *linuxTestSuite) TestIPCacheAddDelete(c *check.C) {
+	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
+	fakeNodeAddressing := fake.NewNodeAddressing()
+	lnh := NewNodeHandler(dpConfig, fakeNodeAddressing)
+	c.Assert(lnh, check.Not(check.IsNil))
+
+	id := lnh.AllocateNodeID(testIP1)
+	c.Assert(id, check.Not(check.Equals), 0)
+	lnh.checkIPExists(c, testIP1)
+	lnh.DeallocateNodeID(testIP1)
+	lnh.checkIPRemoved(c, testIP1)
+}
+
+// IPCache entries get promoted to Node source if the Node Add events
+// duplicates the entry. The reason for this is so that instead of
+// using the IPCache delete logic we can hook the node delete logic
+// to remove it. I guess we trust the node delete more?
+func (s *linuxTestSuite) TestIPCachePromote1(c *check.C) {
+	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
+	fakeNodeAddressing := fake.NewNodeAddressing()
+	lnh := NewNodeHandler(dpConfig, fakeNodeAddressing)
+	c.Assert(lnh, check.Not(check.IsNil))
+
+	id1 := lnh.AllocateNodeID(testIP1)
+	c.Assert(id1, check.Not(check.Equals), 0)
+	lnh.checkIPExists(c, testIP1)
+	id2 := lnh.allocateIDForNode(testNode)
+	c.Assert(id1, check.Equals, id2)
+	lnh.checkIPExists(c, testIP1)
+
+	// Now id1<->TestIP1 should be promoted to node source
+	lnh.DeallocateNodeID(testIP1)
+	lnh.checkIPExists(c, testIP1)
+	lnh.deallocateIDForNode(testNode)
+	lnh.checkNodeIdsRemoved(c, testNode)
+}
+
+// Same test as above, but lets promote an entry with refcnt gt 1
+func (s *linuxTestSuite) TestIPCachePromote2(c *check.C) {
+	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
+	fakeNodeAddressing := fake.NewNodeAddressing()
+	lnh := NewNodeHandler(dpConfig, fakeNodeAddressing)
+	c.Assert(lnh, check.Not(check.IsNil))
+
+	id1 := lnh.AllocateNodeID(testIP1)
+	c.Assert(id1, check.Not(check.Equals), 0)
+	id2 := lnh.AllocateNodeID(testIP1)
+	c.Assert(id1, check.Equals, id2)
+	lnh.checkIPExists(c, testIP1)
+	id3 := lnh.allocateIDForNode(testNode)
+	c.Assert(id1, check.Equals, id3)
+	lnh.checkIPExists(c, testIP1)
+
+	// Now id1<->TestIP1 should be promoted to node source
+	lnh.DeallocateNodeID(testIP1)
+	lnh.checkIPExists(c, testIP1)
+	lnh.DeallocateNodeID(testIP1)
+	lnh.checkIPExists(c, testIP1)
+	lnh.deallocateIDForNode(testNode)
+	lnh.checkNodeIdsRemoved(c, testNode)
+}
+
+func (s *linuxTestSuite) TestIPCacheRef(c *check.C) {
+	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
+	fakeNodeAddressing := fake.NewNodeAddressing()
+	lnh := NewNodeHandler(dpConfig, fakeNodeAddressing)
+	c.Assert(lnh, check.Not(check.IsNil))
+
+	id1 := lnh.AllocateNodeID(testIP1)
+	c.Assert(id1, check.Not(check.Equals), 0)
+	lnh.checkIPExists(c, testIP1)
+	id2 := lnh.AllocateNodeID(testIP1)
+	c.Assert(id1, check.Equals, id2)
+	lnh.checkIPExists(c, testIP1)
+
+	// Now id1==id2 and refcnt=2 so do two Deallocates
+	lnh.DeallocateNodeID(testIP1)
+	lnh.checkIPExists(c, testIP1)
+	lnh.DeallocateNodeID(testIP1)
+	lnh.checkIPRemoved(c, testIP1)
+}
+
+// Ensure if we get an IPcache allocate after a node Allocate that we
+// continue to correctly manage that IP<->ID mapping. Ensure delete
+// order Node than IPcache correctly removes mapping.
+func (s *linuxTestSuite) TestNodeIPCacheDelete1(c *check.C) {
+	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
+	fakeNodeAddressing := fake.NewNodeAddressing()
+	lnh := NewNodeHandler(dpConfig, fakeNodeAddressing)
+	c.Assert(lnh, check.Not(check.IsNil))
+
+	id1 := lnh.AllocateNodeID(testIP1)
+	c.Assert(id1, check.Not(check.Equals), 0)
+	id2 := lnh.AllocateNodeID(testIP1)
+	c.Assert(id1, check.Equals, id2)
+	lnh.checkIPExists(c, testIP1)
+
+	// Now id1<->IP1 is still owned by Node so node delete
+	// shoudl remove it
+	lnh.deallocateIDForNode(testNode)
+	lnh.checkIPRemoved(c, testIP1)
+	lnh.DeallocateNodeID(testIP1)
+	lnh.checkIPRemoved(c, testIP1)
+}
+
+// Ensure if we get an IPcache allocate after a node Allocate that we
+// continue to correctly manage that IP<->ID mapping. Ensure delete
+// order IPCache than Node correctly removes mapping.
+func (s *linuxTestSuite) TestNodeIPCacheDelete2(c *check.C) {
+	dpConfig := DatapathConfiguration{HostDevice: dummyHostDeviceName}
+	fakeNodeAddressing := fake.NewNodeAddressing()
+	lnh := NewNodeHandler(dpConfig, fakeNodeAddressing)
+	c.Assert(lnh, check.Not(check.IsNil))
+
+	id1 := lnh.AllocateNodeID(testIP1)
+	c.Assert(id1, check.Not(check.Equals), 0)
+	id2 := lnh.AllocateNodeID(testIP1)
+	c.Assert(id1, check.Equals, id2)
+	lnh.checkIPExists(c, testIP1)
+
+	// Now id1<->IP1 is still owned by Node so node delete
+	// shoudl remove it
+	lnh.DeallocateNodeID(testIP1)
+	lnh.checkIPExists(c, testIP1)
+	lnh.deallocateIDForNode(testNode)
+	lnh.checkIPRemoved(c, testIP1)
+}

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -141,8 +141,15 @@ type NodeNeighbors interface {
 
 type NodeIDHandler interface {
 	// AllocateNodeID allocates a new ID for the given node (by IP) if one wasn't
-	// already assigned.
+	// already assigned or increments the refcnt if it exists.
 	AllocateNodeID(net.IP) uint16
+
+	// DeallocateNodeID decrements the refcnt of a node ID and releases the ID
+	// if the refcnt is zero.
+	DeallocateNodeID(net.IP)
+
+	// Get NodeID returns the node ID or zero if it does not exist.
+	GetNodeID(nodeIP net.IP) uint16
 
 	// DumpNodeIDs returns all node IDs and their associated IP addresses.
 	DumpNodeIDs() []*models.NodeID

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -312,6 +312,7 @@ restart:
 				// and the endpoint-runIPIdentitySync where it bounded to a
 				// lease and a controller which is stopped/removed when the
 				// endpoint is gone.
+				log.WithField("hostIP", ipIDPair.HostIP).WithField("ip", ip).Warning("kvstore Upsert")
 				IPIdentityCache.Upsert(ip, ipIDPair.HostIP, ipIDPair.Key, k8sMeta, Identity{
 					ID:     peerIdentity,
 					Source: source.KVStore,
@@ -347,6 +348,7 @@ restart:
 					// The key no longer exists in the
 					// local cache, it is safe to remove
 					// from the datapath ipcache.
+					log.WithField("IP", ip).Warning("kvstore Delete")
 					IPIdentityCache.Delete(ip, source.KVStore)
 				}
 			}

--- a/pkg/k8s/watchers/cilium_endpoint.go
+++ b/pkg/k8s/watchers/cilium_endpoint.go
@@ -189,6 +189,7 @@ func (k *K8sWatcher) endpointUpdated(oldEndpoint, endpoint *types.CiliumEndpoint
 	for _, pair := range endpoint.Networking.Addressing {
 		if pair.IPV4 != "" {
 			ipsAdded = append(ipsAdded, pair.IPV4)
+			log.WithField("hostIP", nodeIP).WithField("ip", pair.IPV4).Warning("cilium endpoint upsert ipv4")
 			portsChanged, _ := ipcache.IPIdentityCache.Upsert(pair.IPV4, nodeIP, encryptionKey, k8sMeta,
 				ipcache.Identity{ID: id, Source: source.CustomResource})
 			if portsChanged {

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -705,6 +705,7 @@ func (k *K8sWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIP
 					}
 				}
 				if !found {
+					log.WithField("oldPodIP", oldPodIP).Warning("k8s pod watch delete")
 					npc := ipcache.IPIdentityCache.Delete(oldPodIP, source.Kubernetes)
 					if npc {
 						namedPortsChanged = true
@@ -776,6 +777,7 @@ func (k *K8sWatcher) updatePodHostData(oldPod, newPod *slim_corev1.Pod, oldPodIP
 		// Initial mapping of podIP <-> hostIP <-> identity. The mapping is
 		// later updated once the allocator has determined the real identity.
 		// If the endpoint remains unmanaged, the identity remains untouched.
+		log.WithField("hostIP", hostIP).WithField("podIp", podIP).Warning("k8s pod watch upsert")
 		npc, err := ipcache.IPIdentityCache.Upsert(podIP, hostIP, hostKey, k8sMeta, ipcache.Identity{
 			ID:     identity.ReservedIdentityUnmanaged,
 			Source: source.Kubernetes,

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -463,6 +463,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			continue
 		}
 		addrStr := address.String()
+		log.WithField("hostIP", nodeIP).WithField("cidr", addrStr).Warning("manager node update upsert")
 		_, err := m.ipcache.Upsert(addrStr, nodeIP, n.EncryptionKey, nil, ipcache.Identity{
 			ID:     identity.ReservedIdentityHealth,
 			Source: n.Source,
@@ -496,6 +497,8 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			m.Iter(func(nh datapath.NodeHandler) {
 				nh.NodeUpdate(oldNode, entry.node)
 			})
+		} else {
+			log.WithField("oldNode", oldNode).Warning("manager oldNodeExists dpUpdate skiped")
 		}
 		// Delete the old node IP addresses if they have changed in this node.
 		var oldNodeIPAddrs []net.IP
@@ -523,7 +526,10 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			m.Iter(func(nh datapath.NodeHandler) {
 				nh.NodeAdd(entry.node)
 			})
+		} else {
+			log.WithField("Node", entry.node).Warning("manager new Node dpUpdate skiped")
 		}
+
 		entry.mutex.Unlock()
 	}
 


### PR DESCRIPTION
NodeID list can get out of sync with reality when nodeUpdates  remove old addresses. The result is we can hit the default drop policy in the xfrm policy handling. See patch for details.