### PR TITLE
bpf: fib: delay smac selection until fib_do_redirect() has picked the oif

### DIFF
--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -71,7 +71,6 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 {
 	struct bpf_redir_neigh nh_params;
 	struct bpf_redir_neigh *nh = NULL;
-	union macaddr smac = NATIVE_DEV_MAC_BY_IFINDEX(*oif);
 	union macaddr *dmac = 0;
 	int ret;
 
@@ -154,6 +153,8 @@ fib_do_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
 			else
 				return redirect_neigh(*oif, NULL, 0, 0);
 		} else {
+			union macaddr smac = NATIVE_DEV_MAC_BY_IFINDEX(*oif);
+
 			if (!dmac) {
 				*fib_ret = BPF_FIB_MAP_NO_NEIGH;
 				return DROP_NO_FIB;


### PR DESCRIPTION
fib_do_redirect() potentially takes the `oif` from the fib_params. But we currently don't consider this when selecting the smac.

Fix this by delaying the smac selection until we actually need it.

Fixes: 5fff05daf9f0 ("bpf,fib: introduce fib_do_redirect function")