### PR TITLE
clustermesh: unbreak test

### DIFF
--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -152,7 +153,7 @@ func TestRemoteClusterRun(t *testing.T) {
 					RemoteIdentityWatcher: allocator,
 					Metrics:               newMetrics(),
 				},
-				globalServices: newGlobalServiceCache("cluster", "node"),
+				globalServices: newGlobalServiceCache(metrics.NoOpGauge),
 			}
 			rc := cm.newRemoteCluster("foo", nil).(*remoteCluster)
 


### PR DESCRIPTION
Error: pkg/clustermesh/remote_cluster_test.go:155:54: too many arguments in call to newGlobalServiceCache
	have (string, string)
	want ("github.com/cilium/cilium/pkg/metrics/metric".Gauge)
