### PR TITLE
treewide: fix some shebangs

### DIFF
--- a/bpf/tests/builtin_gen
+++ b/bpf/tests/builtin_gen
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
 # Copyright Authors of Cilium
 

--- a/pkg/datapath/loader/check-sources.sh
+++ b/pkg/datapath/loader/check-sources.sh
@@ -1,4 +1,6 @@
-#! /bin/bash -efu
+#!/usr/bin/env bash
+
+set -efu
 
 #
 # This simple awk command extracts file names from the definition of the

--- a/test/provision/docker-run-cilium-docker-plugin.sh
+++ b/test/provision/docker-run-cilium-docker-plugin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 CILIUM_DOCKER_PLUGIN_IMAGE=${CILIUM_DOCKER_PLUGIN_IMAGE:-cilium/docker-plugin:latest}
 


### PR DESCRIPTION
Some bash scripts have shebangs that point directly to the bash interpreter, rather than going through `/usr/bin/env`. Replace these in in bash scripts that are invoked in tests.