### PR TITLE
bpf: tests: pktgen infra for tunneling + GENEVE-DSR test

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -162,7 +162,7 @@ jobs:
         env:
           # Disable coverage report for these test cases since they are hitting
           # https://github.com/cilium/coverbee/issues/7
-          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|tc_nodeport_lb6_dsr_backend.o|tc_nodeport_lb6_dsr_lb.o|xdp_egressgw_reply.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o|xdp_nodeport_lb6_dsr_lb.o|bpf_nat_tests.o"
+          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|nodeport_geneve_dsr_*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|tc_nodeport_lb6_dsr_backend.o|tc_nodeport_lb6_dsr_lb.o|xdp_egressgw_reply.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o|xdp_nodeport_lb6_dsr_lb.o|bpf_nat_tests.o"
         run: |
           make -C test run_bpf_tests COVER=1 NOCOVER="$NOCOVER_PATTERN" || (echo "Run 'make -C test run_bpf_tests COVER=1 NOCOVER=\"$NOCOVER_PATTERN\"' locally to investigate failures"; exit 1)
       - name: Archive code coverage results

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -288,7 +288,7 @@ set_geneve_dsr_opt6(__be16 port, const union v6addr *addr,
 	gopt->hdr.opt_class = bpf_htons(DSR_GENEVE_OPT_CLASS);
 	gopt->hdr.type = DSR_GENEVE_OPT_TYPE;
 	gopt->hdr.length = DSR_IPV6_GENEVE_OPT_LEN;
-	ipv6_addr_copy(&gopt->addr, addr);
+	ipv6_addr_copy((union v6addr *)&gopt->addr, addr);
 	gopt->port = port;
 }
 #endif

--- a/bpf/lib/high_scale_ipcache.h
+++ b/bpf/lib/high_scale_ipcache.h
@@ -124,7 +124,7 @@ decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 		__throw_build_bug();
 	}
 
-	*src_id = bpf_ntohl(*src_id) >> 8;
+	*src_id = tunnel_vni_to_sec_identity(*src_id);
 	ctx_store_meta(ctx, CB_SRC_LABEL, *src_id);
 
 	if (ctx_adjust_hroom(ctx, -shrink, BPF_ADJ_ROOM_MAC, ctx_adjust_hroom_flags()))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -409,7 +409,7 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 			    gopt.hdr.type == DSR_GENEVE_OPT_TYPE) {
 				*dsr = true;
 				*port = gopt.port;
-				ipv6_addr_copy(addr, &gopt.addr);
+				ipv6_addr_copy(addr, (union v6addr *)&gopt.addr);
 				return 0;
 			}
 		}

--- a/bpf/lib/tunnel.h
+++ b/bpf/lib/tunnel.h
@@ -77,4 +77,10 @@ struct vxlanhdr {
 	__be32 vx_vni;
 };
 
+static __always_inline __u32
+tunnel_vni_to_sec_identity(__be32 vni)
+{
+	return bpf_ntohl(vni) >> 8;
+}
+
 #endif /* __LIB_TUNNEL_H_ */

--- a/bpf/lib/tunnel.h
+++ b/bpf/lib/tunnel.h
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+#ifndef __LIB_TUNNEL_H_
+#define __LIB_TUNNEL_H_
+
+#include <linux/ipv6.h>
+
+/* The high-order bit of the Geneve option type indicates that
+ * this is a critical option.
+ *
+ * https://www.rfc-editor.org/rfc/rfc8926.html#name-tunnel-options
+ */
+#define GENEVE_OPT_TYPE_CRIT	0x80
+
+/* Geneve option used to carry service addr and port for DSR.
+ *
+ * Class = 0x014B (Cilium according to [1])
+ * Type  = 0x1   (vendor-specific)
+ *
+ * [1]: https://www.iana.org/assignments/nvo3/nvo3.xhtml#geneve-option-class
+ */
+#define DSR_GENEVE_OPT_CLASS	0x014B
+#define DSR_GENEVE_OPT_TYPE	(GENEVE_OPT_TYPE_CRIT | 0x01)
+#define DSR_IPV4_GENEVE_OPT_LEN	\
+	((sizeof(struct geneve_dsr_opt4) - sizeof(struct geneve_opt_hdr)) / 4)
+#define DSR_IPV6_GENEVE_OPT_LEN	\
+	((sizeof(struct geneve_dsr_opt6) - sizeof(struct geneve_opt_hdr)) / 4)
+
+struct geneve_opt_hdr {
+	__be16 opt_class;
+	__u8 type;
+#ifdef __LITTLE_ENDIAN_BITFIELD
+	__u8 length:5,
+	     rsvd:3;
+#else
+	__u8 rsvd:3,
+	     length:5;
+#endif
+};
+
+struct geneve_dsr_opt4 {
+	struct geneve_opt_hdr hdr;
+	__be32	addr;
+	__be16	port;
+	__u16	pad;
+};
+
+struct geneve_dsr_opt6 {
+	struct geneve_opt_hdr hdr;
+	struct in6_addr addr;
+	__be16	port;
+	__u16	pad;
+};
+
+struct genevehdr {
+#ifdef __LITTLE_ENDIAN_BITFIELD
+	__u8 opt_len:6,
+	     ver:2;
+	__u8 rsvd:6,
+	     critical:1,
+	     control:1;
+#else
+	__u8 ver:2,
+	     opt_len:6;
+	__u8 control:1,
+	     critical:1,
+	     rsvd:6;
+#endif
+	__be16 protocol_type;
+	__u8 vni[3];
+	__u8 reserved;
+};
+
+struct vxlanhdr {
+	__be32 vx_flags;
+	__be32 vx_vni;
+};
+
+#endif /* __LIB_TUNNEL_H_ */

--- a/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
+++ b/bpf/tests/nodeport_geneve_dsr_lb_xdp.c
@@ -1,0 +1,518 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/xdp.h>
+#include "pktgen.h"
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4
+#define ENABLE_NODEPORT
+#define ENABLE_NODEPORT_ACCELERATION
+#define ENABLE_DSR		1
+
+#define DSR_ENCAP_IPIP		2
+#define DSR_ENCAP_GENEVE	3
+#define DSR_ENCAP_MODE		DSR_ENCAP_GENEVE
+
+#define TUNNEL_PROTOCOL		TUNNEL_PROTOCOL_GENEVE
+#define ENCAP_IFINDEX		42
+#define TUNNEL_MODE
+
+#define DISABLE_LOOPBACK_LB
+
+/* Skip ingress policy checks, not needed to validate hairpin flow */
+#define USE_BPF_PROG_FOR_INGRESS_POLICY
+#undef FORCE_LOCAL_POLICY_EVAL_AT_SOURCE
+
+#define CLIENT_IP		v4_ext_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define FRONTEND_IP_LOCAL	v4_svc_one
+#define FRONTEND_IP_REMOTE	v4_svc_two
+#define FRONTEND_PORT		tcp_svc_one
+
+#define LB_IP			v4_node_one
+#define IPV4_DIRECT_ROUTING	LB_IP
+#define BACKEND_NODE_IP		v4_node_two
+
+#define DIRECT_ROUTING_IFINDEX	25
+
+#define BACKEND_IP_LOCAL	v4_pod_one
+#define BACKEND_IP_REMOTE	v4_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define fib_lookup mock_fib_lookup
+
+static volatile const __u8 *client_mac = mac_one;
+/* this matches the default node_config.h: */
+static volatile const __u8 lb_mac[ETH_ALEN]	= { 0xce, 0x72, 0xa7, 0x03, 0x88, 0x56 };
+static volatile const __u8 *node_mac = mac_three;
+static volatile const __u8 *local_backend_mac = mac_four;
+static volatile const __u8 *backend_node_mac = mac_six;
+
+static bool fail_fib;
+
+#define ctx_redirect mock_ctx_redirect
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __ctx_buff *ctx __maybe_unused, int ifindex __maybe_unused,
+		  __u32 flags __maybe_unused)
+{
+	if (ifindex != DIRECT_ROUTING_IFINDEX)
+		return CTX_ACT_DROP;
+
+	return CTX_ACT_REDIRECT;
+}
+
+long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	if (fail_fib)
+		return BPF_FIB_LKUP_RET_NO_NEIGH;
+
+	params->ifindex = DIRECT_ROUTING_IFINDEX;
+
+	if (params->ipv4_dst == BACKEND_NODE_IP) {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)backend_node_mac, ETH_ALEN);
+	} else {
+		return CTX_ACT_DROP;
+	}
+
+	return 0;
+}
+
+#include <bpf_xdp.c>
+
+#define FROM_NETDEV	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[FROM_NETDEV] = &cil_xdp_entry,
+	},
+};
+
+/* Test that a SVC request to a local backend
+ * - gets DNATed (but not SNATed)
+ * - gets passed up from XDP to TC
+ */
+PKTGEN("xdp", "nodeport_geneve_dsr_lb_xdp1_local_backend")
+int nodeport_geneve_dsr_lb_xdp1_local_backend_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = FRONTEND_IP_LOCAL;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = FRONTEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("xdp", "nodeport_geneve_dsr_lb_xdp1_local_backend")
+int nodeport_geneve_dsr_lb_xdp1_local_backend_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 1;
+
+	/* Register a fake LB backend matching our packet. */
+	struct lb4_key lb_svc_key = {
+		.address = FRONTEND_IP_LOCAL,
+		.dport = FRONTEND_PORT,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	/* Create a service with only one backend */
+	struct lb4_service lb_svc_value = {
+		.count = 1,
+		.flags = SVC_FLAG_ROUTABLE,
+		.rev_nat_index = revnat_id,
+	};
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+	/* We need to register both in the external and internal scopes for the
+	 * packet to be redirected to a neighboring node
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_INT;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* A backend between 1 and .count is chosen, since we have only one backend
+	 * it is always backend_slot 1. Point it to backend_id 124.
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_EXT;
+	lb_svc_key.backend_slot = 1;
+	lb_svc_value.backend_id = 124;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* Insert a reverse NAT entry for the above service */
+	struct lb4_reverse_nat revnat_value = {
+		.address = FRONTEND_IP_LOCAL,
+		.port = FRONTEND_PORT,
+	};
+	map_update_elem(&LB4_REVERSE_NAT_MAP, &revnat_id, &revnat_value, BPF_ANY);
+
+	struct lb4_backend backend = {
+		.address = BACKEND_IP_LOCAL,
+		.port = BACKEND_PORT,
+		.proto = IPPROTO_TCP,
+		.flags = BE_STATE_ACTIVE,
+	};
+	map_update_elem(&LB4_BACKEND_MAP, &lb_svc_value.backend_id, &backend, BPF_ANY);
+
+	/* add local backend */
+	struct endpoint_info ep_value = {};
+
+	memcpy(&ep_value.mac, (__u8 *)local_backend_mac, ETH_ALEN);
+	memcpy(&ep_value.node_mac, (__u8 *)node_mac, ETH_ALEN);
+
+	struct endpoint_key ep_key = {
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = BACKEND_IP_LOCAL,
+	};
+	map_update_elem(&ENDPOINTS_MAP, &ep_key, &ep_value, BPF_ANY);
+
+	struct ipcache_key cache_key = {
+		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(32),
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = BACKEND_IP_LOCAL,
+	};
+	struct remote_endpoint_info cache_value = {
+		.sec_identity = 112233,
+	};
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("xdp", "nodeport_geneve_dsr_lb_xdp1_local_backend")
+int nodeport_geneve_dsr_lb_xdp1_local_backend_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	__u32 *meta;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	status_code = data;
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	meta = (void *)status_code + sizeof(__u32);
+	if ((void *)meta + sizeof(__u32) > data_end)
+		test_fatal("meta out of bounds");
+
+	l2 = (void *)meta + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	assert(*status_code == CTX_ACT_OK);
+
+	assert((*meta & XFER_PKT_NO_SVC) == XFER_PKT_NO_SVC);
+
+	if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the client MAC");
+	if (memcmp(l2->h_dest, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the LB MAC");
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP_LOCAL)
+		test_fatal("dst IP hasn't been NATed to local backend IP");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst TCP port hasn't been NATed to backend port");
+
+	test_finish();
+}
+
+/* Test that a SVC request that is LBed to a DSR remote backend
+ * - gets DNATed,
+ * - has tunnel encapsulation header added,
+ * - has DSR option inserted
+ */
+PKTGEN("xdp", "nodeport_geneve_dsr_lb_xdp2_fwd")
+int nodeport_geneve_dsr_lb_xdp2_fwd_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = FRONTEND_IP_REMOTE;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = FRONTEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("xdp", "nodeport_geneve_dsr_lb_xdp2_fwd")
+int nodeport_geneve_dsr_lb_xdp2_fwd_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	/* Register a fake LB backend matching our packet. */
+	struct lb4_key lb_svc_key = {
+		.address = FRONTEND_IP_REMOTE,
+		.dport = FRONTEND_PORT,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	/* Create a service with only one backend */
+	struct lb4_service lb_svc_value = {
+		.count = 1,
+		.flags = SVC_FLAG_ROUTABLE,
+		.rev_nat_index = revnat_id,
+	};
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+	/* We need to register both in the external and internal scopes for the
+	 * packet to be redirected to a neighboring node
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_INT;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* A backend between 1 and .count is chosen, since we have only one backend
+	 * it is always backend_slot 1.
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_EXT;
+	lb_svc_key.backend_slot = 1;
+	lb_svc_value.backend_id = 125;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* Insert a reverse NAT entry for the above service */
+	struct lb4_reverse_nat revnat_value = {
+		.address = FRONTEND_IP_REMOTE,
+		.port = FRONTEND_PORT,
+	};
+	map_update_elem(&LB4_REVERSE_NAT_MAP, &revnat_id, &revnat_value, BPF_ANY);
+
+	struct lb4_backend backend = {
+		.address = BACKEND_IP_REMOTE,
+		.port = BACKEND_PORT,
+		.proto = IPPROTO_TCP,
+		.flags = BE_STATE_ACTIVE,
+	};
+	map_update_elem(&LB4_BACKEND_MAP, &lb_svc_value.backend_id, &backend, BPF_ANY);
+
+	struct ipcache_key cache_key = {
+		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(32),
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = BACKEND_IP_REMOTE,
+	};
+	struct remote_endpoint_info cache_value = {
+		.sec_identity = 112233,
+		.tunnel_endpoint = BACKEND_NODE_IP,
+	};
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("xdp", "nodeport_geneve_dsr_lb_xdp2_fwd")
+int nodeport_geneve_dsr_lb_xdp_fwd_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	struct geneve_dsr_opt4 *dsr_opt;
+	struct ethhdr *l2, *inner_l2;
+	struct iphdr *l3, *inner_l3;
+	struct tcphdr *tcp_inner;
+	struct genevehdr *geneve;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct udphdr *udp;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(*l2) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(*l2);
+	if ((void *)l3 + sizeof(*l3) > data_end)
+		test_fatal("l3 out of bounds");
+
+	udp = (void *)l3 + sizeof(*l3);
+	if ((void *)udp + sizeof(*udp) > data_end)
+		test_fatal("udp out of bounds");
+
+	geneve = (void *)udp + sizeof(*udp);
+	if ((void *)geneve + sizeof(*geneve) > data_end)
+		test_fatal("geneve out of bounds");
+
+	dsr_opt = (void *)geneve + sizeof(*geneve);
+	if ((void *)dsr_opt + sizeof(*dsr_opt) > data_end)
+		test_fatal("dsr opt out of bounds");
+	if ((void *)dsr_opt + geneve->opt_len * 4 > data_end)
+		test_fatal("geneve opts out of bounds");
+
+	inner_l2 = (void *)dsr_opt + geneve->opt_len * 4;
+	if ((void *)inner_l2 + sizeof(*inner_l2) > data_end)
+		test_fatal("l2 out of bounds");
+
+	inner_l3 = (void *)inner_l2 + sizeof(*inner_l2);
+	if ((void *)inner_l3 + sizeof(*inner_l3) > data_end)
+		test_fatal("l3 out of bounds");
+
+	tcp_inner = (void *)inner_l3 + sizeof(*inner_l3);
+	if ((void *)tcp_inner + sizeof(*tcp_inner) > data_end)
+		test_fatal("tcp out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the LB MAC");
+	if (memcmp(l2->h_dest, (__u8 *)backend_node_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the backend node MAC");
+
+	if (l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("l2 doesn't have correct proto type");
+
+	if (l3->protocol != IPPROTO_UDP)
+		test_fatal("outer IP doesn't have correct L4 protocol");
+
+	if (l3->saddr != IPV4_DIRECT_ROUTING)
+		test_fatal("outerSrcIP is not correct");
+
+	if (l3->daddr != BACKEND_NODE_IP)
+		test_fatal("outerDstIP is not correct");
+
+	if (udp->dest != bpf_htons(TUNNEL_PORT))
+		test_fatal("outerDstPort is not tunnel port");
+
+	__be32 sec_id;
+
+	memcpy(&sec_id, &geneve->vni, 4);
+	if (tunnel_vni_to_sec_identity(sec_id) != WORLD_ID)
+		test_fatal("geneve has unexpected SrcSecID");
+
+	if (geneve->opt_len * 4 != sizeof(*dsr_opt))
+		test_fatal("geneve has unexpected opt length");
+
+	if (dsr_opt->hdr.opt_class != bpf_htons(DSR_GENEVE_OPT_CLASS))
+		test_fatal("geneve opt has unexpected class");
+	if (dsr_opt->hdr.type != DSR_GENEVE_OPT_TYPE)
+		test_fatal("geneve opt has unexpected type");
+	if (dsr_opt->hdr.length != DSR_IPV4_GENEVE_OPT_LEN)
+		test_fatal("geneve opt has unexpected length");
+	if (dsr_opt->addr != FRONTEND_IP_REMOTE)
+		test_fatal("geneve opt has unexpected svc IP");
+	if (dsr_opt->port != FRONTEND_PORT)
+		test_fatal("geneve opt has unexpected svc port");
+
+	if (inner_l2->h_proto != bpf_htons(ETH_P_IP))
+		test_fatal("inner l2 doesn't have correct proto type");
+
+	if (inner_l3->protocol != IPPROTO_TCP)
+		test_fatal("inner IP doesn't have correct L4 protocol");
+
+	if (inner_l3->saddr != CLIENT_IP)
+		test_fatal("innerSrcIP has changed");
+
+	if (inner_l3->daddr != BACKEND_IP_REMOTE)
+		test_fatal("innerDstIP hasn't been NATed to remote backend IP");
+
+	if (tcp_inner->source != CLIENT_PORT)
+		test_fatal("innerSrcPort has changed");
+
+	if (tcp_inner->dest != BACKEND_PORT)
+		test_fatal("innerDstPort hasn't been NATed to backend port");
+
+	test_finish();
+}

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -17,6 +17,7 @@
 #include <linux/if_arp.h>
 #include <linux/if_ether.h>
 #include <linux/tcp.h>
+#include <linux/udp.h>
 
 /* A collection of pre-defined Ethernet MAC addresses, so tests can reuse them
  * without having to come up with custom addresses.
@@ -610,6 +611,56 @@ struct sctphdr *pktgen__push_sctphdr(struct pktgen *builder)
 	return layer;
 }
 
+/* Push an empty UDP header onto the packet */
+static __always_inline
+__attribute__((warn_unused_result))
+struct udphdr *pktgen__push_udphdr(struct pktgen *builder)
+{
+	struct __ctx_buff *ctx = builder->ctx;
+	struct udphdr *layer;
+	int layer_idx;
+
+	/* Request additional tailroom, and check that we got it. */
+	ctx_adjust_troom(ctx, builder->cur_off + sizeof(struct udphdr) - ctx_full_len(ctx));
+	if (ctx_data(ctx) + builder->cur_off + sizeof(struct udphdr) > ctx_data_end(ctx))
+		return 0;
+
+	/* Check that any value within the struct will not exceed a u16 which
+	 * is the max allowed offset within a packet from ctx->data.
+	 */
+	if (builder->cur_off >= MAX_PACKET_OFF - sizeof(struct udphdr))
+		return 0;
+
+	layer = ctx_data(ctx) + builder->cur_off;
+	layer_idx = pktgen__free_layer(builder);
+
+	if (layer_idx < 0)
+		return 0;
+
+	builder->layers[layer_idx] = PKT_LAYER_UDP;
+	builder->layer_offsets[layer_idx] = builder->cur_off;
+	builder->cur_off += sizeof(struct udphdr);
+
+	return layer;
+}
+
+static __always_inline
+__attribute__((warn_unused_result))
+struct udphdr *pktgen__push_default_udphdr(struct pktgen *builder)
+{
+	struct udphdr *hdr = pktgen__push_udphdr(builder);
+
+	if (!hdr)
+		return NULL;
+
+	if ((void *)hdr + sizeof(*hdr) > ctx_data_end(builder->ctx))
+		return NULL;
+
+	memset(hdr, 0, sizeof(*hdr));
+
+	return hdr;
+}
+
 /* Push room for x bytes of data onto the packet */
 static __always_inline
 __attribute__((warn_unused_result))
@@ -671,6 +722,7 @@ void pktgen__finish(const struct pktgen *builder)
 	struct ipv6hdr *ipv6_layer;
 	struct ipv6_opt_hdr *ipv6_opt_layer;
 	struct tcphdr *tcp_layer;
+	struct udphdr *udp_layer;
 	__u64 layer_off;
 	__u16 v4len;
 	__be16 v6len;
@@ -896,7 +948,17 @@ void pktgen__finish(const struct pktgen *builder)
 			break;
 
 		case PKT_LAYER_UDP:
-			/* No sizes or checksums for UDP, so nothing to do */
+			layer_off = builder->layer_offsets[i];
+			/* Check that any value within the struct will not exceed a u16 which
+			 * is the max allowed offset within a packet from ctx->data.
+			 */
+			if (layer_off >= MAX_PACKET_OFF - sizeof(struct udphdr))
+				return;
+
+			udp_layer = ctx_data(builder->ctx) + layer_off;
+			if ((void *)udp_layer + sizeof(struct udphdr) >
+			    ctx_data_end(builder->ctx))
+				return;
 			break;
 
 		case PKT_LAYER_ICMP:

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -162,7 +162,8 @@ enum pkt_layer {
 
 #define IPV6_DEFAULT_HOPLIMIT 64
 
-#define PKT_BUILDER_LAYERS 6
+/* 3 outer headers + {VXLAN, GENEVE} + 3 inner headers. */
+#define PKT_BUILDER_LAYERS 7
 
 #define MAX_PACKET_OFF 0xffff
 

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -370,6 +370,186 @@ int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
+/* Test that a SVC request (UDP) to a local backend
+ * - gets DNATed (but not SNATed)
+ * - gets redirected by TC (as ENABLE_HOST_ROUTING is set)
+ */
+PKTGEN("tc", "tc_nodeport_udp_local_backend")
+int nodeport_udp_local_backend_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct udphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = FRONTEND_IP_LOCAL;
+
+	/* Push UDP header */
+	l4 = pktgen__push_default_udphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = FRONTEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_udp_local_backend")
+int nodeport_udp_local_backend_setup(struct __ctx_buff *ctx)
+{
+	__u16 revnat_id = 2;
+
+	/* Register a fake LB backend matching our packet. */
+	struct lb4_key lb_svc_key = {
+		.address = FRONTEND_IP_LOCAL,
+		.dport = FRONTEND_PORT,
+		.scope = LB_LOOKUP_SCOPE_EXT,
+	};
+	/* Create a service with only one backend */
+	struct lb4_service lb_svc_value = {
+		.count = 1,
+		.flags = SVC_FLAG_ROUTABLE,
+		.rev_nat_index = revnat_id,
+	};
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+	/* We need to register both in the external and internal scopes for the
+	 * packet to be redirected to a neighboring node
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_INT;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* A backend between 1 and .count is chosen, since we have only one backend
+	 * it is always backend_slot 1. Point it to backend_id 125.
+	 */
+	lb_svc_key.scope = LB_LOOKUP_SCOPE_EXT;
+	lb_svc_key.backend_slot = 1;
+	lb_svc_value.backend_id = 125;
+	map_update_elem(&LB4_SERVICES_MAP_V2, &lb_svc_key, &lb_svc_value, BPF_ANY);
+
+	/* Insert a reverse NAT entry for the above service */
+	struct lb4_reverse_nat revnat_value = {
+		.address = FRONTEND_IP_LOCAL,
+		.port = FRONTEND_PORT,
+	};
+	map_update_elem(&LB4_REVERSE_NAT_MAP, &revnat_id, &revnat_value, BPF_ANY);
+
+	/* Create backend id 124 which contains the IP and port to send the
+	 * packet to.
+	 */
+	struct lb4_backend backend = {
+		.address = BACKEND_IP_LOCAL,
+		.port = BACKEND_PORT,
+		.proto = IPPROTO_UDP,
+		.flags = BE_STATE_ACTIVE,
+	};
+	map_update_elem(&LB4_BACKEND_MAP, &lb_svc_value.backend_id, &backend, BPF_ANY);
+
+	/* add local backend */
+	struct endpoint_info ep_value = {};
+
+	memcpy(&ep_value.mac, (__u8 *)local_backend_mac, ETH_ALEN);
+	memcpy(&ep_value.node_mac, (__u8 *)node_mac, ETH_ALEN);
+
+	struct endpoint_key ep_key = {
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = BACKEND_IP_LOCAL,
+	};
+	map_update_elem(&ENDPOINTS_MAP, &ep_key, &ep_value, BPF_ANY);
+
+	struct ipcache_key cache_key = {
+		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(32),
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = BACKEND_IP_LOCAL,
+	};
+	struct remote_endpoint_info cache_value = {
+		.sec_identity = 112233,
+	};
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_udp_local_backend")
+int nodeport_udp_local_backend_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct udphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(*l4) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the node MAC")
+	if (memcmp(l2->h_dest, (__u8 *)local_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the endpoint MAC")
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP_LOCAL)
+		test_fatal("dst IP hasn't been NATed to local backend IP");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been NATed to backend port");
+
+	test_finish();
+}
+
 /* Test that a SVC request that is LBed to a NAT remote backend
  * - gets DNATed and SNATed,
  * - gets redirected back out by TC


### PR DESCRIPTION
Add the necessary bits so that pktgen can build tunnel encapsulation headers (UDP, VXLAN, GENEVE). Exercise it with some initial tests - more to come.