### PR TITLE
Ingnore updating client-go fork in renovate dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -131,6 +131,7 @@
         "github.com/cilium/dns",
         "sigs.k8s.io/controller-tools",
         "github.com/cilium/controller-tools",
+        "github.com/cilium/client-go",
         // We update this dependency manually together with envoy proxy updates
         "github.com/cilium/proxy",
       ],


### PR DESCRIPTION
Fixes renovate dependencies update for client-go introduced in https://github.com/cilium/cilium/pull/26250
