### PR TITLE
bump kind k8s to 1.27.3

### DIFF
--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -29,7 +29,7 @@ env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
   # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.28.0-rc.0
+  k8s_version: v1.27.3
 
 jobs:
   kubernetes-e2e-net-conformance:

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -29,7 +29,7 @@ env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
   # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.28.0-rc.0
+  k8s_version: v1.27.3
 
 jobs:
   kubernetes-e2e:


### PR DESCRIPTION
Kubernetes 1.27.3 has several fixes on the e2e framework that were causing flakes on the cilium CI


Fixes:
- https://github.com/cilium/cilium/issues/25271
- https://github.com/cilium/cilium/issues/24622
- https://github.com/cilium/cilium/issues/25655

