### PR TITLE
renovate: exclude github.com/{cilium,vishvananda}/netlink

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -125,6 +125,8 @@
         // want to update them automatically.
         "go.universe.tf/metallb",
         "github.com/cilium/metallb",
+        "github.com/vishvananda/netlink",
+        "github.com/cilium/netlink",
         // metallb is still using an old version of "github.com/mdlayher/arp"
         "github.com/mdlayher/arp",
         "github.com/miekg/dns",


### PR DESCRIPTION
The netlink library was switch to a custom fork in commit 142c7c817baa ("vendor: Update vishvananda/netlink/") and updated in commit eb6bf8671f98 ("vendor: Update vishvananda/netlink/"). Avoid accidentially updating this dependencies, so exclude the module from being updated until we switch back to the upstream version.