### PR TITLE
.github/workflows: let renovate update kind

### DIFF
--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -64,6 +64,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.17.0
   k8s_version: v1.23.17
   # renovate: datasource=github-releases depName=cilium/cilium-cli

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -64,6 +64,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.17.0
   k8s_version: v1.24.12
   # renovate: datasource=github-releases depName=cilium/cilium-cli

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -64,6 +64,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.17.0
   k8s_version: v1.24.12
   # renovate: datasource=github-releases depName=cilium/cilium-cli

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -64,6 +64,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.17.0
   k8s_version: v1.27.1
   # renovate: datasource=github-releases depName=cilium/cilium-cli

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -24,6 +24,7 @@ env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
   cilium_cli_version: v0.14.7
   cilium_cli_ci_version:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.17.0
   kind_config: .github/kind-config.yaml
   gateway_api_version: v0.6.1

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -21,6 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.19.0
   cluster_name: cilium-testing
   # renovate: datasource=github-releases depName=cilium/cilium-cli

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -21,6 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.19.0
   cluster_name: cilium-testing
   # renovate: datasource=github-releases depName=cilium/cilium-cli

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -21,6 +21,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.19.0
   kind_config: .github/kind-config.yaml
   # renovate: datasource=github-releases depName=cilium/cilium-cli


### PR DESCRIPTION
Add required renovate annotations such that `kind_version` will be updated automatically in GH action workflows.