### PR TITLE
l2announcer: Fix panic when service labels are nil

### DIFF
--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -1022,6 +1022,10 @@ const (
 
 func svcAndMetaLabels(svc *slim_corev1.Service) labels.Set {
 	labels := maps.Clone(svc.GetLabels())
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
 	labels[serviceNamespaceLabel] = svc.Namespace
 	labels[serviceNameLabel] = svc.Name
 	return labels


### PR DESCRIPTION
There are scenarios in which the labels fields of a service object returns `nil` instead of an empty map. When this happens a panic is triggered, so we have to check for that and init the map if it is `nil`

Fixes: #26163

```release-note
Fix panic due to nil-map assignment in l2announcer
```
