### PR TITLE
kvstoremesh: mark the cilium-kvstoremesh secret as optional in the clustermesh-apiserver volume definition

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -342,6 +342,7 @@ spec:
           sources:
           - secret:
               name: cilium-kvstoremesh
+              optional: true
               # note: items are not explicitly listed here, since the entries of this secret
               # depend on the peers configured, and that would cause a restart of this pod
               # at every addition/removal. Leaving the field empty makes each secret entry


### PR DESCRIPTION
Currently, the cilium-kvstoremesh secret is not marked as optional, causing the clustermesh-apiserver to not start in case it is not present. Yet, that secret is created only when `.Values.clustermesh.config.enabled` is set, and it might not be enabled when clustermesh/kvstoremesh is initially enabled (e.g., through the CLI). Hence, let's mark it as optional so that the pod can start correctly even if it is not present. It will be loaded automatically when it is created afterwards.