### PR TITLE
bgpv1: set N-bit in graceful restart

### DIFF
--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -244,6 +244,7 @@ func (g *GoBGPServer) getPeerConfig(ctx context.Context, n *v2alpha1api.CiliumBG
 	if n.GracefulRestart != nil && n.GracefulRestart.Enabled {
 		peer.GracefulRestart.Enabled = true
 		peer.GracefulRestart.RestartTime = uint32(*n.GracefulRestart.RestartTimeSeconds)
+		peer.GracefulRestart.NotificationEnabled = true
 	}
 	for _, afiConf := range peer.AfiSafis {
 		if afiConf.MpGracefulRestart == nil {


### PR DESCRIPTION
Set N-bit in graceful restart negotiation, so the peer can start graceful restart helper mode if HoldTime expires or there is a session reset because of configuration change. Further details in [RFC-8538](https://www.rfc-editor.org/rfc/rfc8538.html).

Open Message from Cilium : 

<img width="534" alt="image" src="https://github.com/cilium/cilium/assets/128612031/03c38479-eb38-46b4-bdd7-d870d15a5e63">

```release-note
BGPv1: Set N-bit in graceful restart capability negotiation.
```
