### PR TITLE
Add checks to avoid use of logrus WithFields function in hot paths

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -132,8 +132,9 @@ func NoopFunc(ctx context.Context) error {
 //     check for the destruction throughout the run.
 type controller struct {
 	// Constant after creation, safe to access without locking
-	name string
-	uuid string
+	name   string
+	uuid   string
+	logger *logrus.Entry
 
 	// Channels written to and/or closed by the manager
 	stop    chan struct{}
@@ -304,10 +305,14 @@ shutdown:
 
 // logger returns a logrus object with controllerName and UUID fields.
 func (c *controller) getLogger() *logrus.Entry {
-	return log.WithFields(logrus.Fields{
-		fieldControllerName: c.name,
-		fieldUUID:           c.uuid,
-	})
+	if c.logger == nil {
+		c.logger = log.WithFields(logrus.Fields{
+			fieldControllerName: c.name,
+			fieldUUID:           c.uuid,
+		})
+	}
+
+	return c.logger
 }
 
 // recordError updates all statistic collection variables on error

--- a/pkg/endpoint/directory.go
+++ b/pkg/endpoint/directory.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -80,6 +81,8 @@ func moveNewFilesTo(oldDir, newDir string) error {
 // Must be called with endpoint.mutex Lock()ed.
 func (e *Endpoint) synchronizeDirectories(origDir string, stateDirComplete bool) error {
 	scopedLog := e.getLogger()
+	debugLogEnabled := logging.CanLogAt(scopedLog.Logger, logrus.DebugLevel)
+
 	scopedLog.Debug("synchronizing directories")
 
 	tmpDir := e.NextDirectoryPath()
@@ -101,10 +104,13 @@ func (e *Endpoint) synchronizeDirectories(origDir string, stateDirComplete bool)
 		e.removeDirectory(backupDir)
 
 		// Move the current endpoint directory to a backup location
-		scopedLog.WithFields(logrus.Fields{
-			"originalDirectory": origDir,
-			"backupDirectory":   backupDir,
-		}).Debug("moving current directory to backup location")
+		if debugLogEnabled {
+			scopedLog.WithFields(logrus.Fields{
+				"originalDirectory": origDir,
+				"backupDirectory":   backupDir,
+			}).Debug("moving current directory to backup location")
+		}
+
 		if err := os.Rename(origDir, backupDir); err != nil {
 			return fmt.Errorf("unable to rename current endpoint directory: %s", err)
 		}
@@ -142,10 +148,13 @@ func (e *Endpoint) synchronizeDirectories(origDir string, stateDirComplete bool)
 	// simple move
 	default:
 		// Make temporary directory the new endpoint directory
-		scopedLog.WithFields(logrus.Fields{
-			"temporaryDirectory": tmpDir,
-			"originalDirectory":  origDir,
-		}).Debug("attempting to make temporary directory new directory for endpoint programs")
+		if debugLogEnabled {
+			scopedLog.WithFields(logrus.Fields{
+				"temporaryDirectory": tmpDir,
+				"originalDirectory":  origDir,
+			}).Debug("attempting to make temporary directory new directory for endpoint programs")
+		}
+
 		if err := os.Rename(tmpDir, origDir); err != nil {
 			return fmt.Errorf("atomic endpoint directory move failed: %s", err)
 		}
@@ -159,7 +168,9 @@ func (e *Endpoint) synchronizeDirectories(origDir string, stateDirComplete bool)
 }
 
 func (e *Endpoint) removeDirectory(path string) error {
-	e.getLogger().WithField("directory", path).Debug("removing directory")
+	if logger := e.getLogger(); logging.CanLogAt(logger.Logger, logrus.DebugLevel) {
+		logger.WithField("directory", path).Debug("removing directory")
+	}
 	return os.RemoveAll(path)
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -944,12 +944,15 @@ func (e *Endpoint) logStatusLocked(typ StatusType, code StatusCode, msg string) 
 		Timestamp: time.Now().UTC(),
 	}
 	e.status.addStatusLog(sts)
-	e.getLogger().WithFields(logrus.Fields{
-		"code":                   sts.Status.Code,
-		"type":                   sts.Status.Type,
-		logfields.EndpointState:  sts.Status.State,
-		logfields.PolicyRevision: e.policyRevision,
-	}).Debug(msg)
+
+	if logger := e.getLogger(); logging.CanLogAt(logger.Logger, logrus.DebugLevel) {
+		logger.WithFields(logrus.Fields{
+			"code":                   sts.Status.Code,
+			"type":                   sts.Status.Type,
+			logfields.EndpointState:  sts.Status.State,
+			logfields.PolicyRevision: e.policyRevision,
+		}).Debug(msg)
+	}
 }
 
 type UpdateValidationError struct {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -603,13 +603,15 @@ func (k *K8sWatcher) k8sServiceHandler() {
 			logfields.K8sNamespace: event.ID.Namespace,
 		})
 
-		scopedLog.WithFields(logrus.Fields{
-			"action":        event.Action.String(),
-			"service":       event.Service.String(),
-			"old-service":   event.OldService.String(),
-			"endpoints":     event.Endpoints.String(),
-			"old-endpoints": event.OldEndpoints.String(),
-		}).Debug("Kubernetes service definition changed")
+		if logging.CanLogAt(scopedLog.Logger, logrus.DebugLevel) {
+			scopedLog.WithFields(logrus.Fields{
+				"action":        event.Action.String(),
+				"service":       event.Service.String(),
+				"old-service":   event.OldService.String(),
+				"endpoints":     event.Endpoints.String(),
+				"old-endpoints": event.OldEndpoints.String(),
+			}).Debug("Kubernetes service definition changed")
+		}
 
 		switch event.Action {
 		case k8s.UpdateService:

--- a/pkg/policy/trigger.go
+++ b/pkg/policy/trigger.go
@@ -38,7 +38,7 @@ func NewUpdater(r *Repository, regen regenerator) (*Updater, error) {
 		// changes in agent configuration, changes in endpoint labels, and
 		// change of security identities.
 		TriggerFunc: func(reasons []string) {
-			log.Debugf("Regenerating all endpoints")
+			log.Debug("Regenerating all endpoints")
 			reason := strings.Join(reasons, ", ")
 
 			regenerationMetadata := &regeneration.ExternalRegenerationMetadata{

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -290,12 +291,14 @@ func (s *Service) RegisterL7LBService(serviceName, resourceName lb.ServiceName, 
 		return err
 	}
 
-	log.WithFields(logrus.Fields{
-		logfields.ServiceName:       serviceName.Name,
-		logfields.ServiceNamespace:  serviceName.Namespace,
-		logfields.L7LBFrontendPorts: ports,
-		logfields.L7LBProxyPort:     proxyPort,
-	}).Debug("Registering service for L7 load balancing")
+	if logging.CanLogAt(log.Logger, logrus.DebugLevel) {
+		log.WithFields(logrus.Fields{
+			logfields.ServiceName:       serviceName.Name,
+			logfields.ServiceNamespace:  serviceName.Namespace,
+			logfields.L7LBFrontendPorts: ports,
+			logfields.L7LBProxyPort:     proxyPort,
+		}).Debug("Registering service for L7 load balancing")
+	}
 
 	svcs := s.GetDeepCopyServicesByName(serviceName.Name, serviceName.Namespace)
 	for _, svc := range svcs {
@@ -581,30 +584,45 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 		params.SessionAffinityTimeoutSec = 0
 	}
 
-	scopedLog := log.WithFields(logrus.Fields{
-		logfields.ServiceIP: params.Frontend.L3n4Addr,
-		logfields.Backends:  params.Backends,
+	// Implement a "lazy load" function for the scoped logger, so the expensive
+	// call to 'WithFields' is only done if needed.
+	debugLogsEnabled := logging.CanLogAt(log.Logger, logrus.DebugLevel)
+	scopedLog := log
+	scopedLogPopulated := false
+	getScopedLog := func() *logrus.Entry {
+		if !scopedLogPopulated {
+			scopedLog = scopedLog.WithFields(logrus.Fields{
+				logfields.ServiceIP: params.Frontend.L3n4Addr,
+				logfields.Backends:  params.Backends,
 
-		logfields.ServiceType:                params.Type,
-		logfields.ServiceExtTrafficPolicy:    params.ExtTrafficPolicy,
-		logfields.ServiceIntTrafficPolicy:    params.IntTrafficPolicy,
-		logfields.ServiceHealthCheckNodePort: params.HealthCheckNodePort,
-		logfields.ServiceName:                params.Name.Name,
-		logfields.ServiceNamespace:           params.Name.Namespace,
+				logfields.ServiceType:                params.Type,
+				logfields.ServiceExtTrafficPolicy:    params.ExtTrafficPolicy,
+				logfields.ServiceIntTrafficPolicy:    params.IntTrafficPolicy,
+				logfields.ServiceHealthCheckNodePort: params.HealthCheckNodePort,
+				logfields.ServiceName:                params.Name.Name,
+				logfields.ServiceNamespace:           params.Name.Namespace,
 
-		logfields.SessionAffinity:        params.SessionAffinity,
-		logfields.SessionAffinityTimeout: params.SessionAffinityTimeoutSec,
+				logfields.SessionAffinity:        params.SessionAffinity,
+				logfields.SessionAffinityTimeout: params.SessionAffinityTimeoutSec,
 
-		logfields.LoadBalancerSourceRanges: params.LoadBalancerSourceRanges,
+				logfields.LoadBalancerSourceRanges: params.LoadBalancerSourceRanges,
 
-		logfields.L7LBProxyPort:     params.L7LBProxyPort,
-		logfields.L7LBFrontendPorts: params.L7LBFrontendPorts,
-	})
-	scopedLog.Debug("Upserting service")
+				logfields.L7LBProxyPort:     params.L7LBProxyPort,
+				logfields.L7LBFrontendPorts: params.L7LBFrontendPorts,
+			})
+
+			scopedLogPopulated = true
+		}
+		return scopedLog
+	}
+
+	if debugLogsEnabled {
+		getScopedLog().Debug("Upserting service")
+	}
 
 	if !option.Config.EnableSVCSourceRangeCheck &&
 		len(params.LoadBalancerSourceRanges) != 0 {
-		scopedLog.Warnf("--%s is disabled, ignoring loadBalancerSourceRanges",
+		getScopedLog().Warnf("--%s is disabled, ignoring loadBalancerSourceRanges",
 			option.EnableSVCSourceRangeCheck)
 	}
 
@@ -650,9 +668,14 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 	if err != nil {
 		return false, lb.ID(0), err
 	}
+
 	// TODO(brb) defer ServiceID release after we have a lbmap "rollback"
+	// If getScopedLog() has not been called, this field will still be included
+	// from this point on in the function.
 	scopedLog = scopedLog.WithField(logfields.ServiceID, svc.frontend.ID)
-	scopedLog.Debug("Acquired service ID")
+	if debugLogsEnabled {
+		getScopedLog().Debug("Acquired service ID")
+	}
 
 	filterBackends := svc.filterBackends(params.Frontend)
 	prevBackendCount := len(svc.backends)
@@ -683,7 +706,9 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 		// Filter backend based on list of port numbers, then upsert backends
 		// as Envoy endpoints
 		be := filterServiceBackends(svc, l7lbInfo.frontendPorts)
-		scopedLog.WithField("filteredBackends", be).Debugf("Upsert envoy endpoints")
+		if debugLogsEnabled {
+			getScopedLog().WithField("filteredBackends", be).Debug("Upsert envoy endpoints")
+		}
 		if err = s.envoyCache.UpsertEnvoyEndpoints(params.Name, be); err != nil {
 			return false, lb.ID(0), err
 		}
@@ -692,7 +717,7 @@ func (s *Service) upsertService(params *lb.SVC) (bool, lb.ID, error) {
 	// Update lbmaps (BPF service maps)
 	if err = s.upsertServiceIntoLBMaps(svc, svc.isExtLocal(), svc.isIntLocal(), prevBackendCount,
 		newBackends, obsoleteBackendIDs, prevSessionAffinity, prevLoadBalancerSourceRanges,
-		obsoleteSVCBackendIDs, scopedLog); err != nil {
+		obsoleteSVCBackendIDs, getScopedLog, debugLogsEnabled); err != nil {
 
 		return false, lb.ID(0), err
 	}
@@ -896,12 +921,15 @@ func (s *Service) UpdateBackendsState(backends []*lb.Backend) error {
 	if len(backends) == 0 {
 		return nil
 	}
-	for _, b := range backends {
-		log.WithFields(logrus.Fields{
-			logfields.L3n4Addr:         b.L3n4Addr.String(),
-			logfields.BackendState:     b.State,
-			logfields.BackendPreferred: b.Preferred,
-		}).Debug("Update backend states")
+
+	if logging.CanLogAt(log.Logger, logrus.DebugLevel) {
+		for _, b := range backends {
+			log.WithFields(logrus.Fields{
+				logfields.L3n4Addr:         b.L3n4Addr.String(),
+				logfields.BackendState:     b.State,
+				logfields.BackendPreferred: b.Preferred,
+			}).Debug("Update backend states")
+		}
 	}
 
 	var (
@@ -1376,7 +1404,9 @@ func (s *Service) addBackendsToAffinityMatchMap(svcID lb.ID, backendIDs []lb.Bac
 func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal bool,
 	prevBackendCount int, newBackends []*lb.Backend, obsoleteBackendIDs []lb.BackendID,
 	prevSessionAffinity bool, prevLoadBalancerSourceRanges []*cidr.CIDR,
-	obsoleteSVCBackendIDs []lb.BackendID, scopedLog *logrus.Entry) error {
+	obsoleteSVCBackendIDs []lb.BackendID, getScopedLog func() *logrus.Entry,
+	debugLogsEnabled bool,
+) error {
 
 	v6FE := svc.frontend.IsIPv6()
 
@@ -1427,11 +1457,13 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 
 	// Add new backends into BPF maps
 	for _, b := range newBackends {
-		scopedLog.WithFields(logrus.Fields{
-			logfields.BackendID:     b.ID,
-			logfields.BackendWeight: b.Weight,
-			logfields.L3n4Addr:      b.L3n4Addr,
-		}).Debug("Adding new backend")
+		if debugLogsEnabled {
+			getScopedLog().WithFields(logrus.Fields{
+				logfields.BackendID:     b.ID,
+				logfields.BackendWeight: b.Weight,
+				logfields.L3n4Addr:      b.L3n4Addr,
+			}).Debug("Adding new backend")
+		}
 
 		if err := s.lbmap.AddBackend(b, b.L3n4Addr.IsIPv6()); err != nil {
 			return err
@@ -1503,8 +1535,10 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 
 	// Remove backends not used by any service from BPF maps
 	for _, id := range obsoleteBackendIDs {
-		scopedLog.WithField(logfields.BackendID, id).
-			Debug("Removing obsolete backend")
+		if debugLogsEnabled {
+			getScopedLog().WithField(logfields.BackendID, id).
+				Debug("Removing obsolete backend")
+		}
 		s.lbmap.DeleteBackendByID(id)
 	}
 
@@ -1518,14 +1552,19 @@ func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{
 		return fmt.Errorf("Unable to dump backend maps: %s", err)
 	}
 
+	debugLogsEnabled := logging.CanLogAt(log.Logger, logrus.DebugLevel)
+
 	svcBackendsCount := len(svcBackendsById)
 	for _, b := range backends {
-		log.WithFields(logrus.Fields{
-			logfields.BackendID:        b.ID,
-			logfields.L3n4Addr:         b.L3n4Addr.String(),
-			logfields.BackendState:     b.State,
-			logfields.BackendPreferred: b.Preferred,
-		}).Debug("Restoring backend")
+		if debugLogsEnabled {
+			log.WithFields(logrus.Fields{
+				logfields.BackendID:        b.ID,
+				logfields.L3n4Addr:         b.L3n4Addr.String(),
+				logfields.BackendState:     b.State,
+				logfields.BackendPreferred: b.Preferred,
+			}).Debug("Restoring backend")
+		}
+
 		if _, ok := svcBackendsById[b.ID]; !ok && (svcBackendsCount != 0) {
 			// If a backend by ID isn't referenced by any of the services, it's
 			// likely a leaked backend. In case of duplicate leaked backends,
@@ -1568,12 +1607,14 @@ func (s *Service) restoreBackendsLocked(svcBackendsById map[lb.BackendID]struct{
 				// in case...
 				log.Errorf("unable to delete leaked backend: %v", id)
 			}
-			log.WithFields(logrus.Fields{
-				logfields.BackendID:        b.ID,
-				logfields.L3n4Addr:         b.L3n4Addr,
-				logfields.BackendState:     b.State,
-				logfields.BackendPreferred: b.Preferred,
-			}).Debug("Leaked backend entry not restored")
+			if debugLogsEnabled {
+				log.WithFields(logrus.Fields{
+					logfields.BackendID:        b.ID,
+					logfields.L3n4Addr:         b.L3n4Addr,
+					logfields.BackendState:     b.State,
+					logfields.BackendPreferred: b.Preferred,
+				}).Debug("Leaked backend entry not restored")
+			}
 			skipped++
 			continue
 		}


### PR DESCRIPTION
This commit modifies identified hot paths that contain the use of logrus' WithFields function, to add extra conditions to only call this expensive function as necessary. The most common case was a scoped logger created using WithFields that is only used to emit debug messages.

These hot paths were identified using profiles taken from cilium agents in a 100 node ClusterLoader2 scale test. For example, the function `pkg/endpoint.(*Endpoint).removeDirectory` had a wasted call to WithFields which accounted for 1.5% of overall memory allocations and 0.13% of overall CPU time, as it is called during endpoint regeneration.

I believe this needs the following labels:

* `release-note/misc`
* `kind/bug`
