### PR TITLE
Add secondary iface to KIND network

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -368,7 +368,7 @@ jobs:
             if [ "${{ matrix.ipv6 }}" == "false" ]; then
               IP_FAM="ipv4"
             fi
-            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
+            ./contrib/scripts/kind.sh --xdp --secondary-network "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
 
             kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
             if [ "${{ matrix.encryption }}" == "ipsec" ]; then

--- a/contrib/scripts/kind-down.sh
+++ b/contrib/scripts/kind-down.sh
@@ -11,9 +11,13 @@ fi
 
 default_cluster_name="kind"
 default_network="kind-cilium"
+secondary_network="${default_network}-secondary"
 
 for cluster in "${@:-${default_cluster_name}}"; do
     kind delete cluster --name "$cluster"
 done
 
 docker network rm ${default_network}
+if docker network inspect "${secondary_network}" >/dev/null 2>&1; then
+  docker network rm ${secondary_network}
+fi


### PR DESCRIPTION
Add secondary iface to KIND network, so that we can test the NodePort via secondary iface.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!


Part of #18846
