### PR TITLE
cilium: nodeId tracking fixes for ipcache and upsert

### DIFF
--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -55,6 +55,13 @@ func (n *FakeNodeHandler) AllocateNodeID(_ net.IP) uint16 {
 	return 0
 }
 
+func (n *FakeNodeHandler) DeallocateNodeID(_ net.IP) {
+}
+
+func (n *FakeNodeHandler) GetNodeID(_ net.IP) uint16 {
+	return 0
+}
+
 func (n *FakeNodeHandler) DumpNodeIDs() []*models.NodeID {
 	return nil
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -49,6 +49,20 @@ type NeighLink struct {
 	Name string `json:"link-name"`
 }
 
+type nodeIDSource uint16
+
+const (
+	NewNodeCreatedID = iota
+	DatapathRestoreCreatedID
+	IPCacheCreatedID
+)
+
+type nodeID struct {
+	id     uint16
+	refcnt uint32
+	source nodeIDSource
+}
+
 type linuxNodeHandler struct {
 	mutex                lock.Mutex
 	isInitialized        bool
@@ -69,7 +83,7 @@ type linuxNodeHandler struct {
 	// Pool of available IDs for nodes.
 	nodeIDs idpool.IDPool
 	// Node-scoped unique IDs for the nodes.
-	nodeIDsByIPs map[string]uint16
+	nodeIDsByIPs map[string]nodeID
 
 	ipsecMetricCollector prometheus.Collector
 }
@@ -93,7 +107,7 @@ func NewNodeHandler(datapathConfig DatapathConfiguration, nodeAddressing datapat
 		neighByNextHop:         map[string]*netlink.Neigh{},
 		neighLastPingByNextHop: map[string]time.Time{},
 		nodeIDs:                idpool.NewIDPool(minNodeID, maxNodeID),
-		nodeIDsByIPs:           map[string]uint16{},
+		nodeIDsByIPs:           map[string]nodeID{},
 		ipsecMetricCollector:   ipsec.NewXFRMCollector(),
 	}
 }

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -77,6 +77,25 @@ func (n *linuxNodeHandler) getNodeIDForNode(node *nodeTypes.Node) uint16 {
 	return nodeID
 }
 
+func (n *linuxNodeHandler) deleteNodeIPs(oldIPs, newIPs []string) {
+	for _, oldAddr := range oldIPs {
+		found := false
+		for _, newAddr := range newIPs {
+			if newAddr == oldAddr {
+				found = true
+				break
+			}
+		}
+		if !found {
+			if err := n.unmapNodeID(oldAddr); err != nil {
+				log.WithError(err).WithFields(logrus.Fields{
+					logfields.IPAddr: oldAddr,
+				}).Warn("DeleteNodeIPS failed to remove a node IP to node ID mapping")
+			}
+		}
+	}
+}
+
 // allocateIDForNode allocates a new ID for the given node if one hasn't already
 // been assigned. If any of the node IPs have an ID associated, then all other
 // node IPs receive the same. This might happen if we allocated a node ID from

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -141,8 +141,15 @@ type NodeNeighbors interface {
 
 type NodeIDHandler interface {
 	// AllocateNodeID allocates a new ID for the given node (by IP) if one wasn't
-	// already assigned.
+	// already assigned or increments the refcnt if it exists.
 	AllocateNodeID(net.IP) uint16
+
+	// DeallocateNodeID decrements the refcnt of a node ID and releases the ID
+	// if the refcnt is zero.
+	DeallocateNodeID(net.IP)
+
+	// Get NodeID returns the node ID or zero if it does not exist.
+	GetNodeID(nodeIP net.IP) uint16
 
 	// DumpNodeIDs returns all node IDs and their associated IP addresses.
 	DumpNodeIDs() []*models.NodeID


### PR DESCRIPTION
This adds fixes for nodeID tracking to correctly trace Node updates where newNode and oldNode have different IP lists. This can happen when a IP is removed from the oldNode or otherwise changed.

The other fix is to correctly handle IP addresses being sent to the IPCache through kvstore and k8s watchers. In this case we were leaking idnodes because we never removed allocated ids through this path. At first this might simply sound like a small memory leak, but then those IPs may get reused by the IPAM and we have incorrect nodeID<->IP mappings that can result in incorrectly setting the skb->mark in the datapath, finally resulting in Policy Block policy dropping the traffic.

So too fix we refcnt the nodeIDs and add code to track IP deletes through ipcache so that we correctly release the nodeID<->IP mapping but also ensure we only release it when no more IPs are mapped to it.

TBD: Still need a fix for cilum agent restart the DumpListener code in the ipcache needs to be smart enough to correctly sync and refcnt the nodeID map on init. But, also this dump callback can be called through other non-init paths so in those cases needs to ensure we don't increment the refcnt which would pin the node id mapping in the map. I can either add that fix here or in another PR.