### PR TITLE
policy: Optimize getNets()

### DIFF
--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -40,6 +40,10 @@ var (
 	ep2 = testutils.NewTestEndpoint()
 )
 
+func localIdentity(n uint32) identity.NumericIdentity {
+	return identity.NumericIdentity(n) | identity.LocalIdentityFlag
+
+}
 func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
 	cache := repo.policyCache
@@ -1205,7 +1209,7 @@ var (
 		owners:           map[MapStateOwner]struct{}{},
 	}
 
-	worldIPIdentity    = identity.NumericIdentity(16324)
+	worldIPIdentity    = localIdentity(16324)
 	worldCIDR          = api.CIDR("192.0.2.3/32")
 	lblWorldIP         = labels.ParseSelectLabelArray(fmt.Sprintf("%s:%s", labels.LabelSourceCIDR, worldCIDR))
 	ruleL3AllowWorldIP = api.NewRule().WithIngressRules([]api.IngressRule{{
@@ -1218,7 +1222,7 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	worldSubnetIdentity = identity.NumericIdentity(16325)
+	worldSubnetIdentity = localIdentity(16325)
 	worldSubnet         = api.CIDR("192.0.2.0/24")
 	worldSubnetRule     = api.CIDRRule{
 		Cidr: worldSubnet,

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -198,11 +198,11 @@ func (e *MapStateEntry) getNets(identities Identities, ident uint32) []*net.IPNe
 		}
 		return e.cachedNets
 	}
-	if identities == nil {
+	// CIDR identities have a local scope, so we can skip the rest if id is not of local scope.
+	if !id.HasLocalScope() || identities == nil {
 		return nil
 	}
 	lbls := identities.GetLabels(id)
-	nets := make([]*net.IPNet, 0, 1)
 	var (
 		maskSize         int
 		mostSpecificCidr *net.IPNet
@@ -219,10 +219,10 @@ func (e *MapStateEntry) getNets(identities Identities, ident uint32) []*net.IPNe
 		}
 	}
 	if mostSpecificCidr != nil {
-		nets = append(nets, mostSpecificCidr)
+		e.cachedNets = []*net.IPNet{mostSpecificCidr}
+		return e.cachedNets
 	}
-	e.cachedNets = nets
-	return nets
+	return nil
 }
 
 // AddDependent adds 'key' to the set of dependent keys.


### PR DESCRIPTION
getNets is used in DenyPreferredInsert for MapState. It is somewhat costly, and uses a cache to compute the result at most once for each MapStateEntry. Speed up the computation with two strategies:

- skip looking for CIDR labels when the identity is not a local identity. This works due to CIDR identities always being locally allocated
- skip allocating a slice when not needed, returning a nil map instead if the locally allocated identity has no CIDR labels
