### PR TITLE
Improve reliability of kvstore-related tests

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -57,8 +57,6 @@ type DaemonSuite struct {
 	// as returned by policy.GetPolicyEnabled().
 	oldPolicyEnabled string
 
-	kvstoreInit bool
-
 	// Owners interface mock
 	OnGetPolicyRepository  func() *policy.Repository
 	OnGetNamedPorts        func() (npm types.NamedPortMultiMap)
@@ -208,11 +206,6 @@ func (ds *DaemonSuite) TearDownTest(c *C) {
 		os.RemoveAll(option.Config.RunDir)
 	}
 
-	if ds.kvstoreInit {
-		kvstore.Client().DeletePrefix(ctx, kvstore.OperationalPath)
-		kvstore.Client().DeletePrefix(ctx, kvstore.BaseKeyPrefix)
-	}
-
 	// Restore the policy enforcement mode.
 	policy.SetPolicyEnabled(ds.oldPolicyEnabled)
 
@@ -230,12 +223,10 @@ var _ = Suite(&DaemonEtcdSuite{})
 
 func (e *DaemonEtcdSuite) SetUpSuite(c *C) {
 	testutils.IntegrationTest(c)
-
-	kvstore.SetupDummy("etcd")
-	e.DaemonSuite.kvstoreInit = true
 }
 
 func (e *DaemonEtcdSuite) SetUpTest(c *C) {
+	kvstore.SetupDummy(c, "etcd")
 	e.DaemonSuite.SetUpTest(c)
 }
 
@@ -251,12 +242,10 @@ var _ = Suite(&DaemonConsulSuite{})
 
 func (e *DaemonConsulSuite) SetUpSuite(c *C) {
 	testutils.IntegrationTest(c)
-
-	kvstore.SetupDummy("consul")
-	e.DaemonSuite.kvstoreInit = true
 }
 
 func (e *DaemonConsulSuite) SetUpTest(c *C) {
+	kvstore.SetupDummy(c, "consul")
 	e.DaemonSuite.SetUpTest(c)
 }
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -100,11 +100,7 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvstore.SetupDummy("etcd")
-	defer func() {
-		kvstore.Client().DeletePrefix(context.TODO(), kvstore.BaseKeyPrefix)
-		kvstore.Client().Close(ctx)
-	}()
+	kvstore.SetupDummy(c, "etcd")
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -81,7 +81,6 @@ func (w *remoteEtcdClientWrapper) ListAndWatch(ctx context.Context, name, prefix
 }
 
 func TestRemoteClusterRun(t *testing.T) {
-	t.Skip("Skip: it appears to badly interact with the other clustermesh tests")
 	testutils.IntegrationTest(t)
 
 	kvstore.SetupDummyWithConfigOpts(t, "etcd",

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh_test.go
@@ -84,13 +84,10 @@ func TestRemoteClusterRun(t *testing.T) {
 	t.Skip("Skip: it appears to badly interact with the other clustermesh tests")
 	testutils.IntegrationTest(t)
 
-	kvstore.SetupDummyWithConfigOpts("etcd",
+	kvstore.SetupDummyWithConfigOpts(t, "etcd",
 		// Explicitly set higher QPS than the default to speedup the test
 		map[string]string{kvstore.EtcdRateLimitOption: "100"},
 	)
-	t.Cleanup(func() {
-		kvstore.Client().Close(context.Background())
-	})
 
 	tests := []struct {
 		name   string

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -58,13 +58,10 @@ func (f *fakeIPCache) Upsert(string, net.IP, uint8, *ipcache.K8sMetadata, ipcach
 func TestRemoteClusterRun(t *testing.T) {
 	testutils.IntegrationTest(t)
 
-	kvstore.SetupDummyWithConfigOpts("etcd",
+	kvstore.SetupDummyWithConfigOpts(t, "etcd",
 		// Explicitly set higher QPS than the default to speedup the test
 		map[string]string{kvstore.EtcdRateLimitOption: "100"},
 	)
-	t.Cleanup(func() {
-		kvstore.Client().Close(context.Background())
-	})
 
 	tests := []struct {
 		name   string

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -62,7 +62,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	kvstore.SetupDummy("etcd")
+	kvstore.SetupDummy(c, "etcd")
 
 	s.randomName = rand.RandomString()
 	clusterName1 := s.randomName + "1"
@@ -121,8 +121,6 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 
 func (s *ClusterMeshServicesTestSuite) TearDownTest(c *C) {
 	os.RemoveAll(s.testDir)
-	kvstore.Client().DeletePrefix(context.TODO(), kvstore.BaseKeyPrefix)
-	kvstore.Client().Close(context.TODO())
 }
 
 func (s *ClusterMeshServicesTestSuite) expectEvent(c *C, action k8s.CacheAction, id k8s.ServiceID, fn func(event k8s.ServiceEvent) bool) {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -142,7 +142,7 @@ func NewCachingIdentityAllocator(owner cache.IdentityAllocatorOwner) fakeIdentit
 
 func (s *EndpointSuite) SetUpTest(c *C) {
 	/* Required to test endpoint CEP policy model */
-	kvstore.SetupDummy("etcd")
+	kvstore.SetupDummy(c, "etcd")
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
@@ -153,7 +153,6 @@ func (s *EndpointSuite) SetUpTest(c *C) {
 
 func (s *EndpointSuite) TearDownTest(c *C) {
 	s.mgr.Close()
-	kvstore.Client().Close(context.TODO())
 	node.UnsetTestLocalNodeStore()
 }
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -131,8 +131,7 @@ func (d *DummyOwner) UpdateIdentities(added, deleted cache.IdentityCache) {}
 
 func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	// Setup dependencies for endpoint.
-	kvstore.SetupDummy("etcd")
-	defer kvstore.Client().Close(context.TODO())
+	kvstore.SetupDummy(c, "etcd")
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -94,11 +94,7 @@ func (e *IdentityAllocatorEtcdSuite) SetUpSuite(c *C) {
 }
 
 func (e *IdentityAllocatorEtcdSuite) SetUpTest(c *C) {
-	kvstore.SetupDummy("etcd")
-}
-
-func (e *IdentityAllocatorEtcdSuite) TearDownTest(c *C) {
-	kvstore.Client().Close(context.TODO())
+	kvstore.SetupDummy(c, "etcd")
 }
 
 type IdentityAllocatorConsulSuite struct {
@@ -112,11 +108,7 @@ func (e *IdentityAllocatorConsulSuite) SetUpSuite(c *C) {
 }
 
 func (e *IdentityAllocatorConsulSuite) SetUpTest(c *C) {
-	kvstore.SetupDummy("consul")
-}
-
-func (e *IdentityAllocatorConsulSuite) TearDownTest(c *C) {
-	kvstore.Client().Close(context.TODO())
+	kvstore.SetupDummy(c, "consul")
 }
 
 type dummyOwner struct {

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -50,12 +50,7 @@ func (e *AllocatorEtcdSuite) SetUpSuite(c *C) {
 
 func (e *AllocatorEtcdSuite) SetUpTest(c *C) {
 	e.backend = "etcd"
-	kvstore.SetupDummy("etcd")
-}
-
-func (e *AllocatorEtcdSuite) TearDownTest(c *C) {
-	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close(context.TODO())
+	kvstore.SetupDummy(c, "etcd")
 }
 
 type AllocatorConsulSuite struct {
@@ -70,12 +65,7 @@ func (e *AllocatorConsulSuite) SetUpSuite(c *C) {
 
 func (e *AllocatorConsulSuite) SetUpTest(c *C) {
 	e.backend = "consul"
-	kvstore.SetupDummy("consul")
-}
-
-func (e *AllocatorConsulSuite) TearDownTest(c *C) {
-	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close(context.TODO())
+	kvstore.SetupDummy(c, "consul")
 }
 
 // FIXME: this should be named better, it implements pkg/allocator.Backend

--- a/pkg/kvstore/base_test.go
+++ b/pkg/kvstore/base_test.go
@@ -42,7 +42,7 @@ func testValue(i int) string {
 
 func (s *BaseTests) TestGetSet(c *C) {
 	prefix := "unit-test/"
-	maxID := 256
+	maxID := 8
 
 	Client().DeletePrefix(context.TODO(), prefix)
 	defer Client().DeletePrefix(context.TODO(), prefix)
@@ -68,8 +68,9 @@ func (s *BaseTests) TestGetSet(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(string(val), checker.DeepEquals, testValue(i))
 
-		val, err = Client().Get(context.TODO(), testKey(prefix, i))
+		key, val, err = Client().GetPrefix(context.TODO(), testKey(prefix, i))
 		c.Assert(err, IsNil)
+		c.Assert(key, checker.DeepEquals, testKey(prefix, i))
 		c.Assert(string(val), checker.DeepEquals, testValue(i))
 	}
 

--- a/pkg/kvstore/consul_test.go
+++ b/pkg/kvstore/consul_test.go
@@ -28,11 +28,7 @@ func (e *ConsulSuite) SetUpSuite(c *C) {
 }
 
 func (e *ConsulSuite) SetUpTest(c *C) {
-	SetupDummy("consul")
-}
-
-func (e *ConsulSuite) TearDownTest(c *C) {
-	Client().Close(context.TODO())
+	SetupDummy(c, "consul")
 }
 
 var handler http.HandlerFunc

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -33,11 +33,7 @@ func (e *EtcdSuite) SetUpSuite(c *C) {
 }
 
 func (e *EtcdSuite) SetUpTest(c *C) {
-	SetupDummy("etcd")
-}
-
-func (e *EtcdSuite) TearDownTest(c *C) {
-	Client().Close(context.TODO())
+	SetupDummy(c, "etcd")
 }
 
 type MaintenanceMocker struct {
@@ -344,7 +340,7 @@ var _ = Suite(&EtcdLockedSuite{})
 func (e *EtcdLockedSuite) SetUpSuite(c *C) {
 	testutils.IntegrationTest(c)
 
-	SetupDummy("etcd")
+	SetupDummy(c, "etcd")
 
 	// setup client
 	cfg := etcdAPI.Config{}
@@ -353,14 +349,6 @@ func (e *EtcdLockedSuite) SetUpSuite(c *C) {
 	cli, err := etcdAPI.New(cfg)
 	c.Assert(err, IsNil)
 	e.etcdClient = cli
-}
-
-func (e *EtcdLockedSuite) TearDownSuite(c *C) {
-	testutils.IntegrationTest(c)
-
-	err := e.etcdClient.Close()
-	c.Assert(err, IsNil)
-	Client().Close(context.TODO())
 }
 
 func (e *EtcdLockedSuite) TestGetIfLocked(c *C) {
@@ -1875,12 +1863,8 @@ func testEtcdRateLimiter(t *testing.T, qps, count int, cmp func(require.TestingT
 				err      error
 			)
 
-			SetupDummyWithConfigOpts("etcd", map[string]string{
+			SetupDummyWithConfigOpts(t, "etcd", map[string]string{
 				EtcdRateLimitOption: fmt.Sprintf("%d", qps),
-			})
-			t.Cleanup(func() {
-				client.Delete(ctx, "", etcdAPI.WithPrefix())
-				Client().Close(ctx)
 			})
 
 			if tt.populateKVPairs {

--- a/pkg/kvstore/etcd_test.go
+++ b/pkg/kvstore/etcd_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 	etcdAPI "go.etcd.io/etcd/client/v3"
 
 	"github.com/cilium/cilium/pkg/checker"
@@ -1662,268 +1663,204 @@ func TestShuffleEndpoints(t *testing.T) {
 	}
 }
 
-type EtcdRateLimiterSuite struct {
-	etcdClient *etcdAPI.Client
-	maxQPS     int
-	txnCount   int
+func TestEtcdRateLimiter(t *testing.T) {
+	testutils.IntegrationTest(t)
 
-	// minTime should be calculated as floor(txnCount / rateLimit) - 1
-	minTime time.Duration
-}
-
-var _ = Suite(&EtcdRateLimiterSuite{})
-
-func (e *EtcdRateLimiterSuite) setupWithRateLimiter() {
-	// The rate limiter is configured with max QPS and burst both
-	// configured to the provided value for rate limit option.
-	SetupDummyWithConfigOpts("etcd", map[string]string{
-		EtcdRateLimitOption: fmt.Sprintf("%d", e.maxQPS),
+	t.Run("with QPS=100", func(t *testing.T) {
+		testEtcdRateLimiter(t, 100, 10, require.Less)
 	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancel()
-	<-Client().Connected(ctx)
+	t.Run("with QPS=4", func(t *testing.T) {
+		testEtcdRateLimiter(t, 4, 10, require.Greater)
+	})
 }
 
-func (e *EtcdRateLimiterSuite) setupWithoutRateLimiter() {
-	SetupDummy("etcd")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-	defer cancel()
-	<-Client().Connected(ctx)
-}
+func testEtcdRateLimiter(t *testing.T, qps, count int, cmp func(require.TestingT, interface{}, interface{}, ...interface{})) {
+	const (
+		prefix  = "foo"
+		condKey = prefix + "-cond-key"
+		value   = "bar"
 
-func (e *EtcdRateLimiterSuite) SetUpSuite(c *C) {
-	testutils.IntegrationTest(c)
+		threshold = time.Second
+	)
 
-	e.maxQPS = 3
-	e.txnCount = e.maxQPS*2 + 2
-	e.minTime = time.Second
-
-	// setup client
-	cfg := etcdAPI.Config{}
-	cfg.Endpoints = []string{etcdDummyAddress}
-	cfg.DialTimeout = 0
-	cli, err := etcdAPI.New(cfg)
-	c.Assert(err, IsNil)
-	e.etcdClient = cli
-}
-
-func (e *EtcdRateLimiterSuite) TearDownSuite(c *C) {
-	testutils.IntegrationTest(c)
-
-	err := e.etcdClient.Close()
-	c.Assert(err, IsNil)
-}
-
-func (e *EtcdRateLimiterSuite) getKey(prefix string, c int) string {
-	if prefix != "" {
-		return fmt.Sprintf("%s-%d", prefix, c)
+	ctx := context.Background()
+	getKey := func(id int) string {
+		return fmt.Sprintf("%s-%d", prefix, id)
 	}
 
-	return fmt.Sprintf("foobar-%d", c)
-}
-
-func (e *EtcdRateLimiterSuite) populateKVPairs(c *C, prefix string, count int) {
-	for i := 0; i < count; i++ {
-		key := e.getKey(prefix, i)
-
-		_, err := e.etcdClient.Put(context.Background(), key, "bar")
-		c.Assert(err, IsNil)
+	// Initialize a separate etcd client which is not subject to any rate limiting
+	cfg := etcdAPI.Config{
+		Endpoints:   []string{etcdDummyAddress},
+		DialTimeout: 5 * time.Second,
 	}
-}
+	client, err := etcdAPI.New(cfg)
+	require.NoError(t, err)
 
-func (e *EtcdRateLimiterSuite) cleanKVPairs(c *C, prefix string, count int) {
-	for i := 0; i < count; i++ {
-		key := e.getKey(prefix, i)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
 
-		_, err := e.etcdClient.Delete(context.Background(), key)
-		c.Assert(err, IsNil)
-	}
-}
-
-func (e *EtcdRateLimiterSuite) TestRateLimiter(c *C) {
-	randomPath := c.MkDir()
-	kvstoreVal := []byte("bar")
-	key := randomPath + "foo"
-	condKey := key + "-cond-key"
-
-	opsFuncList := []struct {
-		fn              func(*C, string, int, KVLocker)
+	tests := []struct {
+		fn              func(*testing.T, string, int, KVLocker)
 		name            string
 		useKVLocker     bool
 		needCondKey     bool
 		populateKVPairs bool
-		cleanKVPairs    bool
 	}{
 		{
-			fn: func(c *C, key string, k int, locker KVLocker) {
-				value, err := Client().GetIfLocked(context.TODO(), e.getKey(key, k), locker)
-				c.Assert(err, IsNil)
-				c.Assert(value, checker.DeepEquals, kvstoreVal)
+			fn: func(t *testing.T, key string, k int, locker KVLocker) {
+				val, err := Client().GetIfLocked(ctx, getKey(k), locker)
+				require.NoError(t, err)
+				require.Equal(t, []byte(value), val)
 			},
 			name:            "GetIfLocked",
 			useKVLocker:     true,
 			populateKVPairs: true,
-			cleanKVPairs:    true,
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				value, err := Client().Get(context.TODO(), e.getKey(key, k))
-				c.Assert(err, IsNil)
-				c.Assert(value, checker.DeepEquals, kvstoreVal)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				val, err := Client().Get(ctx, getKey(k))
+				require.NoError(t, err)
+				require.Equal(t, []byte(value), val)
 			},
 			name:            "Get",
 			populateKVPairs: true,
-			cleanKVPairs:    true,
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				retKey, value, err := Client().GetPrefix(context.TODO(), e.getKey(key, k))
-				c.Assert(err, IsNil)
-				c.Assert(retKey, Equals, e.getKey(key, k))
-				c.Assert(value, checker.DeepEquals, kvstoreVal)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				retKey, val, err := Client().GetPrefix(ctx, getKey(k))
+				require.NoError(t, err)
+				require.Equal(t, getKey(k), retKey)
+				require.Equal(t, []byte(value), val)
 			},
 			name:            "GetPrefix",
 			populateKVPairs: true,
-			cleanKVPairs:    true,
 		},
 		{
-			fn: func(c *C, key string, k int, locker KVLocker) {
-				retKey, value, err := Client().GetPrefixIfLocked(context.TODO(), e.getKey(key, k), locker)
-				c.Assert(err, IsNil)
-				c.Assert(retKey, Equals, e.getKey(key, k))
-				c.Assert(value, checker.DeepEquals, kvstoreVal)
+			fn: func(t *testing.T, key string, k int, locker KVLocker) {
+				retKey, val, err := Client().GetPrefixIfLocked(ctx, getKey(k), locker)
+				require.NoError(t, err)
+				require.Equal(t, getKey(k), retKey)
+				require.Equal(t, []byte(value), val)
 			},
 			name:            "GetPrefixIfLocked",
 			useKVLocker:     true,
 			populateKVPairs: true,
-			cleanKVPairs:    true,
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				kvPairs, err := Client().ListPrefix(context.TODO(), e.getKey(key, k))
-				c.Assert(err, IsNil)
-				c.Assert(len(kvPairs), Equals, 1)
-				value, ok := kvPairs[e.getKey(key, k)]
-				c.Assert(ok, Equals, true)
-				c.Assert(value.Data, checker.DeepEquals, kvstoreVal)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				kvPairs, err := Client().ListPrefix(ctx, getKey(k))
+				require.NoError(t, err)
+				require.Len(t, kvPairs, 1)
+				val, ok := kvPairs[getKey(k)]
+				require.True(t, ok)
+				require.Equal(t, []byte(value), val.Data)
 			},
 			name:            "ListPrefix",
 			populateKVPairs: true,
-			cleanKVPairs:    true,
 		},
 		{
-			fn: func(c *C, key string, k int, locker KVLocker) {
-				kvPairs, err := Client().ListPrefixIfLocked(context.TODO(), e.getKey(key, k), locker)
-				c.Assert(err, IsNil)
-				c.Assert(len(kvPairs), Equals, 1)
-				value, ok := kvPairs[e.getKey(key, k)]
-				c.Assert(ok, Equals, true)
-				c.Assert(value.Data, checker.DeepEquals, kvstoreVal)
+			fn: func(t *testing.T, key string, k int, locker KVLocker) {
+				kvPairs, err := Client().ListPrefixIfLocked(ctx, getKey(k), locker)
+				require.NoError(t, err)
+				require.Len(t, kvPairs, 1)
+				val, ok := kvPairs[getKey(k)]
+				require.True(t, ok)
+				require.Equal(t, []byte(value), val.Data)
 			},
 			name:            "ListPrefixIfLocked",
 			useKVLocker:     true,
 			populateKVPairs: true,
-			cleanKVPairs:    true,
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				newVal := []byte("bar-new")
-				updated, err := Client().UpdateIfDifferent(context.TODO(), e.getKey(key, k), newVal, true)
-				c.Assert(err, IsNil)
-				c.Assert(updated, Equals, true)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				updated, err := Client().UpdateIfDifferent(ctx, getKey(k), []byte("bar-new"), true)
+				require.NoError(t, err)
+				require.True(t, updated)
 			},
 			name:            "UpdateIfDifferent",
 			populateKVPairs: true,
-			cleanKVPairs:    true,
 		},
 		{
-			fn: func(c *C, key string, k int, locker KVLocker) {
-				newVal := []byte("bar-new")
-				updated, err := Client().UpdateIfDifferentIfLocked(context.TODO(), e.getKey(key, k), newVal, true, locker)
-				c.Assert(err, IsNil)
-				c.Assert(updated, Equals, true)
+			fn: func(t *testing.T, key string, k int, locker KVLocker) {
+				updated, err := Client().UpdateIfDifferentIfLocked(ctx, getKey(k), []byte("bar-new"), true, locker)
+				require.NoError(t, err)
+				require.True(t, updated)
 			},
 			name:            "UpdateIfDifferentIfLocked",
 			useKVLocker:     true,
 			populateKVPairs: true,
-			cleanKVPairs:    true,
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				err := Client().Set(context.TODO(), e.getKey(key, k), kvstoreVal)
-				c.Assert(err, IsNil)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				err := Client().Set(ctx, getKey(k), []byte(value))
+				require.NoError(t, err)
 			},
-			name:         "Set",
-			cleanKVPairs: true,
+			name: "Set",
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				err := Client().Update(context.TODO(), e.getKey(key, k), []byte(kvstoreVal), true)
-				c.Assert(err, IsNil)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				err := Client().Update(ctx, getKey(k), []byte(value), true)
+				require.NoError(t, err)
 			},
-			name:         "Update",
-			cleanKVPairs: true,
+			name: "Update",
 		},
 		{
-			fn: func(c *C, key string, k int, locker KVLocker) {
-				err := Client().UpdateIfLocked(context.TODO(), e.getKey(key, k), []byte(kvstoreVal), true, locker)
-				c.Assert(err, IsNil)
+			fn: func(t *testing.T, key string, k int, locker KVLocker) {
+				err := Client().UpdateIfLocked(ctx, getKey(k), []byte(value), true, locker)
+				require.NoError(t, err)
 			},
-			name:         "UpdateIfLocked",
-			useKVLocker:  true,
-			cleanKVPairs: true,
+			name:        "UpdateIfLocked",
+			useKVLocker: true,
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				created, err := Client().CreateOnly(context.TODO(), e.getKey(key, k), []byte(kvstoreVal), true)
-				c.Assert(err, IsNil)
-				c.Assert(created, Equals, true)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				created, err := Client().CreateOnly(ctx, getKey(k), []byte(value), true)
+				require.NoError(t, err)
+				require.True(t, created)
 			},
-			name:         "CreateOnly",
-			cleanKVPairs: true,
+			name: "CreateOnly",
 		},
 		{
-			fn: func(c *C, key string, k int, locker KVLocker) {
-				created, err := Client().CreateOnlyIfLocked(context.TODO(), e.getKey(key, k), []byte(kvstoreVal), true, locker)
-				c.Assert(err, IsNil)
-				c.Assert(created, Equals, true)
+			fn: func(t *testing.T, key string, k int, locker KVLocker) {
+				created, err := Client().CreateOnlyIfLocked(ctx, getKey(k), []byte(value), true, locker)
+				require.NoError(t, err)
+				require.True(t, created)
 			},
-			name:         "CreateOnlyIfLocked",
-			useKVLocker:  true,
-			cleanKVPairs: true,
+			name:        "CreateOnlyIfLocked",
+			useKVLocker: true,
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				err := Client().CreateIfExists(context.TODO(), condKey, e.getKey(key, k), []byte(kvstoreVal), true)
-				c.Assert(err, IsNil)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				err := Client().CreateIfExists(ctx, condKey, getKey(k), []byte(value), true)
+				require.NoError(t, err)
 			},
-			name:         "CreateIfExists",
-			useKVLocker:  true,
-			needCondKey:  true,
-			cleanKVPairs: true,
+			name:        "CreateIfExists",
+			useKVLocker: true,
+			needCondKey: true,
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				err := Client().Delete(context.TODO(), e.getKey(key, k))
-				c.Assert(err, IsNil)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				err := Client().Delete(ctx, getKey(k))
+				require.NoError(t, err)
 			},
 			name:            "Delete",
 			populateKVPairs: true,
 		},
 		{
-			fn: func(c *C, key string, k int, locker KVLocker) {
-				err := Client().DeleteIfLocked(context.TODO(), e.getKey(key, k), locker)
-				c.Assert(err, IsNil)
+			fn: func(t *testing.T, key string, k int, locker KVLocker) {
+				err := Client().DeleteIfLocked(ctx, getKey(k), locker)
+				require.NoError(t, err)
 			},
 			name:            "DeleteIfLocked",
 			useKVLocker:     true,
 			populateKVPairs: true,
 		},
 		{
-			fn: func(c *C, key string, k int, _ KVLocker) {
-				err := Client().DeletePrefix(context.TODO(), e.getKey(key, k))
-				c.Assert(err, IsNil)
+			fn: func(t *testing.T, key string, k int, _ KVLocker) {
+				err := Client().DeletePrefix(ctx, getKey(k))
+				require.NoError(t, err)
 			},
 			name:            "DeletePrefix",
 			useKVLocker:     true,
@@ -1931,89 +1868,55 @@ func (e *EtcdRateLimiterSuite) TestRateLimiter(c *C) {
 		},
 	}
 
-	for _, op := range opsFuncList {
-		c.Logf("Validating operation: %s\n", op.name)
-		var (
-			kvlocker KVLocker
-			err      error
-		)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				kvlocker KVLocker
+				err      error
+			)
 
-		if op.populateKVPairs {
-			e.populateKVPairs(c, key, e.txnCount)
-		}
-		if op.needCondKey {
-			_, err = e.etcdClient.Put(context.Background(), condKey, string(kvstoreVal))
-			c.Assert(err, IsNil)
-		}
+			SetupDummyWithConfigOpts("etcd", map[string]string{
+				EtcdRateLimitOption: fmt.Sprintf("%d", qps),
+			})
+			t.Cleanup(func() {
+				client.Delete(ctx, "", etcdAPI.WithPrefix())
+				Client().Close(ctx)
+			})
 
-		// Run test without rate limiter configured for etcd client.
-		e.setupWithoutRateLimiter()
+			if tt.populateKVPairs {
+				for i := 0; i < count; i++ {
+					_, err := client.Put(ctx, getKey(i), value)
+					require.NoError(t, err)
+				}
+			}
 
-		if op.useKVLocker {
-			kvlocker, err = Client().LockPath(context.Background(), "locks/"+key+"/.lock")
-			c.Assert(err, IsNil)
-		}
+			if tt.needCondKey {
+				_, err = client.Put(ctx, condKey, value)
+				require.NoError(t, err)
+			}
 
-		start := time.Now()
-		wg := sync.WaitGroup{}
-		for i := 0; i < e.txnCount; i++ {
-			wg.Add(1)
-			go func(wg *sync.WaitGroup, i int) {
-				defer wg.Done()
-				op.fn(c, key, i, kvlocker)
-			}(&wg, i)
-		}
-		wg.Wait()
-		c.Assert(time.Since(start) < e.minTime, Equals, true)
+			if tt.useKVLocker {
+				kvlocker, err = Client().LockPath(ctx, "locks/"+prefix+"/.lock")
+				require.NoError(t, err)
 
-		if op.useKVLocker {
-			err = kvlocker.Unlock(context.TODO())
-			c.Assert(err, IsNil)
-		}
-		Client().Close(context.TODO())
+				t.Cleanup(func() {
+					require.NoError(t, kvlocker.Unlock(ctx))
+				})
+			}
 
-		// Clean created KV Pairs if populateKVPairs is disabled and cleanKVPairs is enabled.
-		if !op.populateKVPairs && op.cleanKVPairs {
-			e.cleanKVPairs(c, key, e.txnCount)
-		}
+			start := time.Now()
+			wg := sync.WaitGroup{}
+			for i := 0; i < count; i++ {
+				wg.Add(1)
+				go func(wg *sync.WaitGroup, i int) {
+					defer wg.Done()
+					tt.fn(t, prefix, i, kvlocker)
+				}(&wg, i)
+			}
+			wg.Wait()
 
-		// Populate KV Pairs again if populateKVPairs is enabled and cleanKVPairs is disabled.
-		if op.populateKVPairs && !op.cleanKVPairs {
-			e.populateKVPairs(c, key, e.txnCount)
-		}
-
-		// Run tests with rate limiter configured for etcd client.
-		e.setupWithRateLimiter()
-		if op.useKVLocker {
-			kvlocker, err = Client().LockPath(context.Background(), "locks/"+key+"/.lock")
-			c.Assert(err, IsNil)
-		}
-
-		start = time.Now()
-		wg = sync.WaitGroup{}
-		for i := 0; i < e.txnCount; i++ {
-			wg.Add(1)
-			go func(wg *sync.WaitGroup, i int) {
-				defer wg.Done()
-				op.fn(c, key, i, kvlocker)
-			}(&wg, i)
-		}
-		wg.Wait()
-		c.Assert(time.Since(start) > e.minTime, Equals, true)
-
-		if op.useKVLocker {
-			err = kvlocker.Unlock(context.TODO())
-			c.Assert(err, IsNil)
-		}
-		Client().Close(context.TODO())
-
-		if op.needCondKey {
-			_, err = e.etcdClient.Delete(context.Background(), condKey)
-			c.Assert(err, IsNil)
-		}
-		if op.cleanKVPairs {
-			e.cleanKVPairs(c, key, e.txnCount)
-		}
+			cmp(t, time.Since(start), threshold)
+		})
 	}
 }
 

--- a/pkg/kvstore/store/store_test.go
+++ b/pkg/kvstore/store/store_test.go
@@ -46,12 +46,7 @@ func (e *StoreEtcdSuite) SetUpSuite(c *C) {
 }
 
 func (e *StoreEtcdSuite) SetUpTest(c *C) {
-	kvstore.SetupDummy("etcd")
-}
-
-func (e *StoreEtcdSuite) TearDownTest(c *C) {
-	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close(context.TODO())
+	kvstore.SetupDummy(c, "etcd")
 }
 
 type StoreConsulSuite struct {
@@ -65,13 +60,7 @@ func (e *StoreConsulSuite) SetUpSuite(c *C) {
 }
 
 func (e *StoreConsulSuite) SetUpTest(c *C) {
-	kvstore.SetupDummy("consul")
-}
-
-func (e *StoreConsulSuite) TearDownTest(c *C) {
-	kvstore.Client().DeletePrefix(context.TODO(), testPrefix)
-	kvstore.Client().Close(context.TODO())
-	time.Sleep(sharedKeyDeleteDelay + 5*time.Second)
+	kvstore.SetupDummy(c, "consul")
 }
 
 type TestType struct {


### PR DESCRIPTION
This PR introduces a set of changes to improve the reliability of the kvstore-related tests, in particular preventing that multiple tests can operate on the same kvstore in parallel. Please refer to the individual commit messages for additional details.

* kvstore: TestGetSet misc improvements
* kvstore: refactor the EtcdRateLimiter test
* kvstore: prevent multiple test clients from being created in parallel
* kvstoremesh: re-enable the integration tests