### PR TITLE
k8s,metrics: Remove double k8s event accounting

### DIFF
--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -227,23 +227,13 @@ func (k *K8sWatcher) onUpsert(
 ) error {
 	initialRecvTime := time.Now()
 
-	var (
-		equal  bool
-		action string
-	)
-
-	// wrap k.K8sEventReceived call into a naked func() to capture equal in the closure
 	defer func() {
-		k.K8sEventReceived(apiGroup, metricLabel, action, true, equal)
+		k.k8sResourceSynced.SetEventTimestamp(apiGroup)
 	}()
 
 	oldCNP, ok := cnpCache[key]
-	if !ok {
-		action = resources.MetricCreate
-	} else {
-		action = resources.MetricUpdate
+	if ok {
 		if oldCNP.DeepEqual(cnp) {
-			equal = true
 			return nil
 		}
 	}
@@ -282,8 +272,6 @@ func (k *K8sWatcher) onUpsert(
 		cnpCache[key] = cnpCpy
 	}
 
-	k.K8sEventProcessed(metricLabel, action, err == nil)
-
 	return err
 }
 
@@ -302,8 +290,7 @@ func (k *K8sWatcher) onDelete(
 	delete(cidrGroupPolicies, key)
 	metrics.CIDRGroupPolicies.Set(float64(len(cidrGroupPolicies)))
 
-	k.K8sEventProcessed(metricLabel, resources.MetricDelete, err == nil)
-	k.K8sEventReceived(apiGroup, metricLabel, resources.MetricDelete, true, true)
+	k.k8sResourceSynced.SetEventTimestamp(apiGroup)
 
 	return err
 }

--- a/pkg/k8s/watchers/endpoints.go
+++ b/pkg/k8s/watchers/endpoints.go
@@ -25,11 +25,6 @@ func (k *K8sWatcher) endpointsInit() {
 	// real resource kind since the codepath is the same for all.
 	apiGroup := resources.K8sAPIGroupEndpointSliceOrEndpoint
 
-	metric := resources.MetricEndpoint
-	if k8s.SupportsEndpointSlice() {
-		metric = resources.MetricEndpointSlice
-	}
-
 	var synced atomic.Bool
 	synced.Store(false)
 
@@ -56,13 +51,11 @@ func (k *K8sWatcher) endpointsInit() {
 				case resource.Sync:
 					synced.Store(true)
 				case resource.Upsert:
-					k.K8sEventReceived(apiGroup, metric, resources.MetricUpdate, true, false)
+					k.k8sResourceSynced.SetEventTimestamp(apiGroup)
 					k.updateEndpoint(event.Object, swg)
-					k.K8sEventProcessed(metric, resources.MetricUpdate, true)
 				case resource.Delete:
-					k.K8sEventReceived(apiGroup, metric, resources.MetricDelete, true, false)
+					k.k8sResourceSynced.SetEventTimestamp(apiGroup)
 					k.K8sSvcCache.DeleteEndpoints(event.Object.EndpointSliceID, swg)
-					k.K8sEventProcessed(metric, resources.MetricDelete, true)
 				}
 				event.Done(nil)
 			}

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -59,7 +58,6 @@ func (k *K8sWatcher) namespacesInit() {
 					synced.Store(true)
 				case resource.Upsert:
 					err = nsUpdater.update(event.Object)
-					k.K8sEventProcessed(metricNS, resources.MetricUpdate, err == nil)
 				}
 				event.Done(err)
 			}

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
-	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
 	"github.com/cilium/cilium/pkg/lock"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -79,15 +78,13 @@ func (k *K8sWatcher) nodeEventLoop(synced *atomic.Bool, swg *lock.StoppableWaitG
 			case resource.Upsert:
 				newNode := event.Object
 				if oldNode == nil {
-					k.K8sEventReceived(apiGroup, metricNode, resources.MetricCreate, true, false)
+					k.k8sResourceSynced.SetEventTimestamp(apiGroup)
 					errs = k.NodeChain.OnAddNode(newNode, swg)
-					k.K8sEventProcessed(metricNode, resources.MetricCreate, errs == nil)
 				} else {
 					equal := nodeEventsAreEqual(oldNode, newNode)
-					k.K8sEventReceived(apiGroup, metricNode, resources.MetricUpdate, true, equal)
+					k.k8sResourceSynced.SetEventTimestamp(apiGroup)
 					if !equal {
 						errs = k.NodeChain.OnUpdateNode(oldNode, newNode, swg)
-						k.K8sEventProcessed(metricNode, resources.MetricUpdate, errs == nil)
 					}
 				}
 				oldNode = newNode

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -51,14 +51,12 @@ func (k *K8sWatcher) serviceEventLoop(synced *atomic.Bool, swg *lock.StoppableWa
 				synced.Store(true)
 			case resource.Upsert:
 				svc := event.Object
-				k.K8sEventReceived(apiGroup, resources.MetricService, resources.MetricUpdate, true, false)
+				k.k8sResourceSynced.SetEventTimestamp(apiGroup)
 				err = k.upsertK8sServiceV1(svc, swg)
-				k.K8sEventProcessed(resources.MetricService, resources.MetricUpdate, err == nil)
 			case resource.Delete:
 				svc := event.Object
-				k.K8sEventReceived(apiGroup, resources.MetricService, resources.MetricUpdate, true, false)
+				k.k8sResourceSynced.SetEventTimestamp(apiGroup)
 				err = k.deleteK8sServiceV1(svc, swg)
-				k.K8sEventProcessed(resources.MetricService, resources.MetricDelete, err == nil)
 			}
 			event.Done(err)
 		}


### PR DESCRIPTION
Resources increment the k8s event metrics themselves now. This causes duplicate metric accounting for k8s watchers that have been implemented in terms of resources and also do metrics tracking.

This PR removes the metrics tracking done by k8s watchers that are implemented with resources.

```release-note
Fixed double metric accounting for k8s events 
```
