### PR TITLE
.github/workflows: don't error out if pkill finds no processes

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -19,7 +19,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
 
@@ -353,7 +353,7 @@ jobs:
 
       - name: Clean up Cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Create custom IPsec secret

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -19,7 +19,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
 
@@ -355,7 +355,7 @@ jobs:
 
       - name: Clean up Cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Create custom IPsec secret

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -19,7 +19,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
 
@@ -355,7 +355,7 @@ jobs:
 
       - name: Clean up Cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Create custom IPsec secret

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -19,7 +19,7 @@ on:
   # - Don't forget to remove the `DO NOT MERGE` commit once satisfied. The run
   #   will disappear from the PR checks: please provide a direct link to the
   #   successful workflow run (can be found from Actions tab) in a comment.
-  # 
+  #
   # pull_request: {}
   ###
 
@@ -347,7 +347,7 @@ jobs:
 
       - name: Clean up Cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall
 
       - name: Create custom IPsec secret

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Clean up Cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Create custom IPsec secret

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Clean up Cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Create custom IPsec secret

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -346,7 +346,7 @@ jobs:
 
       - name: Clean up Cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall --chart-directory=install/kubernetes/cilium --wait
 
       - name: Create custom IPsec secret

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -340,7 +340,7 @@ jobs:
 
       - name: Clean up Cilium
         run: |
-          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay"
+          pkill -f "cilium.*hubble.*port-forward|kubectl.*port-forward.*hubble-relay" || test $? -eq 1
           cilium uninstall --wait
 
       - name: Create custom IPsec secret


### PR DESCRIPTION
The pkill invocation in GH workflows is meant to kill background tasks started earlier in the workflow. It seems like some of them exit of their own accord, with tests still passing.

Ignore the pkill error code 1 which indicates that no processes were matched / signalled:

       1      No processes matched or none of them could be signalled.

Fixes #26075