### PR TITLE
test: Fix the attempted fix for the hostfw flake

### DIFF
--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -450,7 +450,7 @@ var _ = Describe("K8sDatapathConfig", func() {
 			}
 			deploymentManager.DeployCilium(options, DeployCiliumOptionsAndDNS)
 
-			prepareHostPolicyEnforcement(kubectl)
+			prepareHostPolicyEnforcement(kubectl, "host-policies.yaml")
 		})
 
 		AfterAll(func() {
@@ -666,8 +666,8 @@ var _ = Describe("K8sDatapathConfig", func() {
 // case, we remove the policies to allow everything through and enable proper
 // termination of those connections.
 // This function implements that process.
-func prepareHostPolicyEnforcement(kubectl *helpers.Kubectl) {
-	demoHostPolicies := helpers.ManifestGet(kubectl.BasePath(), "host-policies.yaml")
+func prepareHostPolicyEnforcement(kubectl *helpers.Kubectl, hostPolicy string) {
+	demoHostPolicies := helpers.ManifestGet(kubectl.BasePath(), hostPolicy)
 	By(fmt.Sprintf("Applying policies %s for 1min", demoHostPolicies))
 	_, err := kubectl.CiliumClusterwidePolicyAction(demoHostPolicies, helpers.KubectlApply, helpers.HelperTimeout)
 	ExpectWithOffset(1, err).Should(BeNil(), fmt.Sprintf("Error creating resource %s: %s", demoHostPolicies, err))

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -643,6 +643,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 		})
 
 		SkipContextIf(func() bool { return helpers.RunsOnGKE() || helpers.SkipQuarantined() }, "With host policy", func() {
+			hostPolicyFilename := "ccnp-host-policy-nodeport-tests.yaml"
 			var ccnpHostPolicy string
 
 			BeforeAll(func() {
@@ -655,9 +656,9 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				}
 				DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
 
-				prepareHostPolicyEnforcement(kubectl)
+				prepareHostPolicyEnforcement(kubectl, hostPolicyFilename)
 
-				originalCCNPHostPolicy := helpers.ManifestGet(kubectl.BasePath(), "ccnp-host-policy-nodeport-tests.yaml")
+				originalCCNPHostPolicy := helpers.ManifestGet(kubectl.BasePath(), hostPolicyFilename)
 				res := kubectl.ExecMiddle("mktemp")
 				res.ExpectSuccess()
 				ccnpHostPolicy = strings.Trim(res.Stdout(), "\n")


### PR DESCRIPTION
Commit 0cfce97f31 ("test/k8s: add host firewall workaround for svc host policy test.") ported the fix from 439a0a059 ("test: Fix ACK and FIN+ACK policy drops in hostfw tests") to a new set of host firewall tests.

It is however not enough to call the same function. We also need to ensure that the same policy as in the tests themselves is loaded during the preparation.

This pull request makes that small change.

Related: https://github.com/cilium/cilium/pull/25461.