### PR TITLE
clustermesh: improve reliability of TestClusterMesh

### DIFF
--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 	"testing"
-	"time"
 
-	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/pkg/clustermesh/internal"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
@@ -30,18 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
-
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type ClusterMeshTestSuite struct{}
-
-var _ = Suite(&ClusterMeshTestSuite{})
-
-func (s *ClusterMeshTestSuite) SetUpSuite(c *C) {
-	testutils.IntegrationTest(c)
-}
 
 var (
 	nodes      = map[string]*testNode{}
@@ -96,9 +85,15 @@ func (o *testObserver) OnDelete(k store.NamedKey) {
 	nodesMutex.Unlock()
 }
 
-func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
+func TestClusterMesh(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	var wg sync.WaitGroup
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	defer func() {
+		cancel()
+		wg.Wait()
+	}()
 
 	kvstore.SetupDummy("etcd")
 	defer func() {
@@ -110,12 +105,9 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	<-mgr.InitIdentityAllocator(nil)
-	defer mgr.Close()
+	t.Cleanup(mgr.Close)
 
-	dir, err := os.MkdirTemp("", "multicluster")
-	c.Assert(err, IsNil)
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	etcdConfig := []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
 
 	// cluster3 doesn't have cluster configuration on kvstore. This emulates
@@ -132,28 +124,25 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 			config.Capabilities.SyncedCanaries = true
 		}
 
-		err = cmutils.SetClusterConfig(ctx, name, &config, kvstore.Client())
-		c.Assert(err, IsNil)
+		err := cmutils.SetClusterConfig(ctx, name, &config, kvstore.Client())
+		require.NoErrorf(t, err, "Failed to set cluster config for %s", name)
 	}
 
 	config1 := path.Join(dir, "cluster1")
-	err = os.WriteFile(config1, etcdConfig, 0644)
-	c.Assert(err, IsNil)
+	require.NoError(t, os.WriteFile(config1, etcdConfig, 0644), "Failed to write config file for cluster1")
 
 	config2 := path.Join(dir, "cluster2")
-	err = os.WriteFile(config2, etcdConfig, 0644)
-	c.Assert(err, IsNil)
+	require.NoError(t, os.WriteFile(config2, etcdConfig, 0644), "Failed to write config file for cluster2")
 
 	config3 := path.Join(dir, "cluster3")
-	err = os.WriteFile(config3, etcdConfig, 0644)
-	c.Assert(err, IsNil)
+	require.NoError(t, os.WriteFile(config3, etcdConfig, 0644), "Failed to write config file for cluster3")
 
 	ipc := ipcache.NewIPCache(&ipcache.Configuration{
 		Context: ctx,
 	})
-	defer ipc.Shutdown()
+	t.Cleanup(func() { ipc.Shutdown() })
 
-	cm := NewClusterMesh(hivetest.Lifecycle(c), Configuration{
+	cm := NewClusterMesh(hivetest.Lifecycle(t), Configuration{
 		Config:                internal.Config{ClusterMeshConfig: dir},
 		ClusterIDName:         types.ClusterIDName{ClusterID: 255, ClusterName: "test2"},
 		NodeKeyCreator:        testNodeCreator,
@@ -163,105 +152,111 @@ func (s *ClusterMeshTestSuite) TestClusterMesh(c *C) {
 		Metrics:               newMetrics(),
 		InternalMetrics:       internal.MetricsProvider(subsystem)(),
 	})
-	c.Assert(cm, Not(IsNil))
+	require.NotNil(t, cm, "Failed to initialize clustermesh")
 
 	// cluster2 is the cluster which is tested with sync canaries
 	nodesWSS := store.NewWorkqueueSyncStore("cluster2", kvstore.Client(), nodeStore.NodeStorePrefix)
-	go nodesWSS.Run(ctx)
+	wg.Add(1)
+	go func() {
+		nodesWSS.Run(ctx)
+		wg.Done()
+	}()
 	nodeNames := []string{"foo", "bar", "baz"}
 
 	// wait for all clusters to appear in the list of cm clusters
-	c.Assert(testutils.WaitUntil(func() bool {
-		return cm.NumReadyClusters() == 3
-	}, 10*time.Second), IsNil)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 3, cm.NumReadyClusters())
+	}, timeout, tick, "Clusters did not become ready in time")
 
 	// Ensure that ClusterIDs are reserved correctly after connect
-	cm.usedIDs.usedClusterIDsMutex.Lock()
-	_, ok := cm.usedIDs.usedClusterIDs[2]
-	c.Assert(ok, Equals, true)
-	_, ok = cm.usedIDs.usedClusterIDs[3]
-	c.Assert(ok, Equals, true)
-	// cluster3 doesn't have config, so only 2 IDs should be reserved
-	c.Assert(cm.usedIDs.usedClusterIDs, HasLen, 2)
-	cm.usedIDs.usedClusterIDsMutex.Unlock()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		cm.usedIDs.usedClusterIDsMutex.Lock()
+		defer cm.usedIDs.usedClusterIDsMutex.Unlock()
+
+		assert.Contains(c, cm.usedIDs.usedClusterIDs, uint32(2))
+		assert.Contains(c, cm.usedIDs.usedClusterIDs, uint32(3))
+		// cluster3 doesn't have config, so only 2 IDs should be reserved
+		assert.Len(c, cm.usedIDs.usedClusterIDs, 2)
+	}, timeout, tick, "Cluster IDs were not reserved correctly")
 
 	// Reconnect cluster with changed ClusterID
 	config := cmtypes.CiliumClusterConfig{
 		ID: 255,
 	}
-	err = cmutils.SetClusterConfig(ctx, "cluster1", &config, kvstore.Client())
-	c.Assert(err, IsNil)
+	err := cmutils.SetClusterConfig(ctx, "cluster1", &config, kvstore.Client())
+	require.NoErrorf(t, err, "Failed to set cluster config for cluster1")
 	// Ugly hack to trigger config update
 	etcdConfigNew := append(etcdConfig, []byte("\n")...)
-	config1New := path.Join(dir, "cluster1")
-	err = os.WriteFile(config1New, etcdConfigNew, 0644)
-	c.Assert(err, IsNil)
+	require.NoError(t, os.WriteFile(config1, etcdConfigNew, 0644), "Failed to write config file for cluster1")
 
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		cm.usedIDs.usedClusterIDsMutex.Lock()
+		defer cm.usedIDs.usedClusterIDsMutex.Unlock()
+
 		// Ensure if old ClusterID for cluster1 is released
 		// and new ClusterID is reserved.
-		cm.usedIDs.usedClusterIDsMutex.Lock()
-		_, ok1 := cm.usedIDs.usedClusterIDs[2]
-		_, ok2 := cm.usedIDs.usedClusterIDs[255]
-		cm.usedIDs.usedClusterIDsMutex.Unlock()
-		return ok1 == false && ok2 == true
-	}, 10*time.Second), IsNil)
+		assert.NotContains(c, cm.usedIDs.usedClusterIDs, uint32(2))
+		assert.Contains(c, cm.usedIDs.usedClusterIDs, uint32(255))
+	}, timeout, tick, "Reserved cluster IDs not updated correctly")
 
 	for _, cluster := range []string{"cluster1", "cluster2", "cluster3"} {
 		for _, name := range nodeNames {
-			nodesWSS.UpsertKey(ctx, &testNode{Name: name, Cluster: cluster})
-			c.Assert(err, IsNil)
+			require.NoErrorf(t, nodesWSS.UpsertKey(ctx, &testNode{Name: name, Cluster: cluster}),
+				"Failed upserting node %s/%s into kvstore", cluster, name)
 		}
 	}
 
 	// Write the sync canary for cluster2
-	nodesWSS.Synced(ctx)
+	require.NoError(t, nodesWSS.Synced(ctx), "Failed writing the synched key into kvstore")
 
 	// wait for all cm nodes in both clusters to appear in the node list
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		nodesMutex.RLock()
 		defer nodesMutex.RUnlock()
-		return len(nodes) == 3*len(nodeNames)
-	}, 10*time.Second), IsNil)
+		assert.Len(c, nodes, 3*len(nodeNames))
+	}, timeout, tick, "Nodes not watched correctly")
 
-	os.RemoveAll(config2)
+	require.NoError(t, os.Remove(config2), "Failed to remove config file for cluster2")
 
 	// wait for the removed cluster to disappear
-	c.Assert(testutils.WaitUntil(func() bool {
-		return cm.NumReadyClusters() == 2
-	}, 5*time.Second), IsNil)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 2, cm.NumReadyClusters())
+	}, timeout, tick, "Cluster2 was not correctly removed")
 
 	// Make sure that ID is freed
-	cm.usedIDs.usedClusterIDsMutex.Lock()
-	_, ok = cm.usedIDs.usedClusterIDs[2]
-	c.Assert(ok, Equals, false)
-	c.Assert(cm.usedIDs.usedClusterIDs, HasLen, 1)
-	cm.usedIDs.usedClusterIDsMutex.Unlock()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		cm.usedIDs.usedClusterIDsMutex.Lock()
+		defer cm.usedIDs.usedClusterIDsMutex.Unlock()
+		assert.NotContains(c, cm.usedIDs.usedClusterIDs, uint32(2))
+		assert.Len(c, cm.usedIDs.usedClusterIDs, 1)
+	}, timeout, tick, "Cluster IDs were not freed correctly")
 
 	// wait for the nodes of the removed cluster to disappear
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		nodesMutex.RLock()
 		defer nodesMutex.RUnlock()
-		return len(nodes) == 2*len(nodeNames)
-	}, 10*time.Second), IsNil)
+		assert.Len(c, nodes, 2*len(nodeNames))
+	}, timeout, tick, "Nodes were not drained correctly")
 
-	os.RemoveAll(config1)
-	os.RemoveAll(config3)
+	require.NoError(t, os.Remove(config1), "Failed to remove config file for cluster1")
+	require.NoError(t, os.Remove(config3), "Failed to remove config file for cluster3")
 
 	// wait for the removed cluster to disappear
-	c.Assert(testutils.WaitUntil(func() bool {
-		return cm.NumReadyClusters() == 0
-	}, 5*time.Second), IsNil)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 0, cm.NumReadyClusters())
+	}, timeout, tick, "Clusters were not correctly removed")
 
 	// wait for the nodes of the removed cluster to disappear
-	c.Assert(testutils.WaitUntil(func() bool {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		nodesMutex.RLock()
 		defer nodesMutex.RUnlock()
-		return len(nodes) == 0
-	}, 10*time.Second), IsNil)
+		assert.Len(c, nodes, 0)
+	}, timeout, tick, "Nodes were not drained correctly")
 
 	// Make sure that IDs are freed
-	cm.usedIDs.usedClusterIDsMutex.Lock()
-	c.Assert(cm.usedIDs.usedClusterIDs, HasLen, 0)
-	cm.usedIDs.usedClusterIDsMutex.Unlock()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		cm.usedIDs.usedClusterIDsMutex.Lock()
+		defer cm.usedIDs.usedClusterIDsMutex.Unlock()
+		assert.Len(c, cm.usedIDs.usedClusterIDs, 0)
+	}, timeout, tick, "Cluster IDs were not freed correctly")
 }

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"testing"
 	"time"
 
 	. "github.com/cilium/checkmate"
@@ -36,6 +37,10 @@ import (
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
+
+func Test(t *testing.T) {
+	TestingT(t)
+}
 
 var etcdConfig = []byte(fmt.Sprintf("endpoints:\n- %s\n", kvstore.EtcdDummyAddress()))
 


### PR DESCRIPTION
Currently, TestClusterMesh is subject to possible race conditions caused by the conjoint usage of defer (i.e., to stop the identity allocator) and Cleanup (i.e., to execute the stop hook of the clustermesh subsystem). Additionally, some cluster ID reservation assertions may fail due race conditions as they are not "eventually" tested.

Let's fix this possible issues to improve the reliability of the test. While at it, let's also convert it to leverage the testing framework.