### PR TITLE
identity: Make identity allocations observable

### DIFF
--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -42,6 +42,7 @@ import (
 	policyAPI "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/safetime"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/stream"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 
@@ -81,9 +82,11 @@ type policyOut struct {
 	IdentityAllocator      CachingIdentityAllocator
 	CacheIdentityAllocator cache.IdentityAllocator
 	RemoteIdentityWatcher  clustermesh.RemoteIdentityWatcher
-	Repository             *policy.Repository
-	Updater                *policy.Updater
-	IPCache                *ipcache.IPCache
+	IdentityObservable     stream.Observable[cache.IdentityChange]
+
+	Repository *policy.Repository
+	Updater    *policy.Updater
+	IPCache    *ipcache.IPCache
 }
 
 // newPolicyTrifecta instantiates CachingIdentityAllocator, Repository and IPCache.
@@ -145,6 +148,7 @@ func newPolicyTrifecta(params policyParams) (policyOut, error) {
 		IdentityAllocator:      idAlloc,
 		CacheIdentityAllocator: idAlloc,
 		RemoteIdentityWatcher:  idAlloc,
+		IdentityObservable:     idAlloc,
 		Repository:             iao.policy,
 		Updater:                policyUpdater,
 		IPCache:                ipc,

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -1020,3 +1020,9 @@ func (rc *RemoteCache) NumEntries() int {
 func (rc *RemoteCache) close() {
 	rc.cache.allocator.Delete()
 }
+
+// Observe the identity changes. Conforms to stream.Observable.
+// Replays the current state of the cache when subscribing.
+func (a *Allocator) Observe(ctx context.Context, next func(AllocatorChange), complete func(error)) {
+	a.mainCache.Observe(ctx, next, complete)
+}

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -186,3 +186,7 @@ func (f *MockIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context.Context, i
 func (f *MockIdentityAllocator) GetIdentityCache() cache.IdentityCache {
 	return f.IdentityCache
 }
+
+func (f *MockIdentityAllocator) Observe(ctx context.Context, next func(cache.IdentityChange), complete func(error)) {
+	go complete(nil)
+}


### PR DESCRIPTION
This makes the identity allocator changes observable in order to provide cells backend-agnostic access to identity allocations.

The identity allocation changes are now provided in the hive as stream.Observable[cache.IdentityChange]. When observing the initial listing is first waited for, then the current state is replayed followed by sync event and updates to state:

`[ (wait for OnListDone()), Upsert, Upsert, Sync, Upsert, Delete, ... ]`

Related to https://github.com/cilium/cilium/issues/25898 as this lays the foundation to replace the use of `Resource[CiliumIdentity]` with the observable identity allocator. This comes with the advantage of getting rid of the duplicated K8s Watcher for CiliumIdentities and the additional support for KVStore identity backend. A [follow up PR](https://github.com/cilium/cilium/pull/26375) will refactor the authentication related part (garbage collection).

Original PR by @joamaki: https://github.com/cilium/cilium/pull/26229