### PR TITLE
auth: Switch to observing identity changes

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -248,7 +248,7 @@ cilium-agent [flags]
       --log-opt map                                             Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
       --log-system-load                                         Enable periodic logging of system load
       --mesh-auth-enabled                                       Enable authentication processing & garbage collection (default true)
-      --mesh-auth-gc-interval duration                          Interval in which auth entries are attempted to be garbage collected (default 15m0s)
+      --mesh-auth-gc-interval duration                          Interval in which auth entries are attempted to be garbage collected (default 5m0s)
       --mesh-auth-mutual-listener-port int                      Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                                Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int             The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -248,7 +248,7 @@ cilium-agent [flags]
       --log-opt map                                             Log driver options for cilium-agent, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local5","syslog.tag":"cilium-agent"}
       --log-system-load                                         Enable periodic logging of system load
       --mesh-auth-enabled                                       Enable authentication processing & garbage collection (default true)
-      --mesh-auth-expired-gc-interval duration                  Interval in which expired auth entries are attempted to be garbage collected (default 15m0s)
+      --mesh-auth-gc-interval duration                          Interval in which auth entries are attempted to be garbage collected (default 15m0s)
       --mesh-auth-mutual-listener-port int                      Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                                Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int             The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -35,7 +35,7 @@ cilium-agent hive [flags]
       --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
       --l2-pod-announcements-interface string            Interface used for sending gratuitous arp messages
       --mesh-auth-enabled                                Enable authentication processing & garbage collection (default true)
-      --mesh-auth-expired-gc-interval duration           Interval in which expired auth entries are attempted to be garbage collected (default 15m0s)
+      --mesh-auth-gc-interval duration                   Interval in which auth entries are attempted to be garbage collected (default 15m0s)
       --mesh-auth-mutual-listener-port int               Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                         Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int      The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -35,7 +35,7 @@ cilium-agent hive [flags]
       --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
       --l2-pod-announcements-interface string            Interface used for sending gratuitous arp messages
       --mesh-auth-enabled                                Enable authentication processing & garbage collection (default true)
-      --mesh-auth-gc-interval duration                   Interval in which auth entries are attempted to be garbage collected (default 15m0s)
+      --mesh-auth-gc-interval duration                   Interval in which auth entries are attempted to be garbage collected (default 5m0s)
       --mesh-auth-mutual-listener-port int               Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                         Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int      The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -40,7 +40,7 @@ cilium-agent hive dot-graph [flags]
       --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
       --l2-pod-announcements-interface string            Interface used for sending gratuitous arp messages
       --mesh-auth-enabled                                Enable authentication processing & garbage collection (default true)
-      --mesh-auth-gc-interval duration                   Interval in which auth entries are attempted to be garbage collected (default 15m0s)
+      --mesh-auth-gc-interval duration                   Interval in which auth entries are attempted to be garbage collected (default 5m0s)
       --mesh-auth-mutual-listener-port int               Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                         Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int      The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -40,7 +40,7 @@ cilium-agent hive dot-graph [flags]
       --k8s-kubeconfig-path string                       Absolute path of the kubernetes kubeconfig file
       --l2-pod-announcements-interface string            Interface used for sending gratuitous arp messages
       --mesh-auth-enabled                                Enable authentication processing & garbage collection (default true)
-      --mesh-auth-expired-gc-interval duration           Interval in which expired auth entries are attempted to be garbage collected (default 15m0s)
+      --mesh-auth-gc-interval duration                   Interval in which auth entries are attempted to be garbage collected (default 15m0s)
       --mesh-auth-mutual-listener-port int               Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                         Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int      The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -44,8 +44,8 @@
      - Enable authentication processing and garbage collection. Note that if disabled, policy enforcement will still block requests that require authentication. But the resulting authentication requests for these requests will not be processed, therefore the requests not be allowed.
      - bool
      - ``true``
-   * - authentication.expiredGCInterval
-     - Interval for garbage collection of expired auth map entries.
+   * - authentication.gcInterval
+     - Interval for garbage collection of auth map entries.
      - string
      - ``"15m0s"``
    * - authentication.mutual.port

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -47,7 +47,7 @@
    * - authentication.gcInterval
      - Interval for garbage collection of auth map entries.
      - string
-     - ``"15m0s"``
+     - ``"5m0s"``
    * - authentication.mutual.port
      - Port on the agent where mutual authentication handshakes between agents will be performed
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -61,7 +61,7 @@ contributors across the globe, there is almost always someone available to help.
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
 | authentication.enabled | bool | `true` | Enable authentication processing and garbage collection. Note that if disabled, policy enforcement will still block requests that require authentication. But the resulting authentication requests for these requests will not be processed, therefore the requests not be allowed. |
-| authentication.gcInterval | string | `"15m0s"` | Interval for garbage collection of auth map entries. |
+| authentication.gcInterval | string | `"5m0s"` | Interval for garbage collection of auth map entries. |
 | authentication.mutual.port | int | `4250` | Port on the agent where mutual authentication handshakes between agents will be performed |
 | authentication.mutual.spire.adminSocketPath | string | `"/run/spire/sockets/admin.sock"` | SPIRE socket path where the SPIRE delegated api agent is listening |
 | authentication.mutual.spire.agentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE socket path where the SPIRE workload agent is listening. Applies to both the Cilium Agent and Operator |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -61,7 +61,7 @@ contributors across the globe, there is almost always someone available to help.
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
 | authentication.enabled | bool | `true` | Enable authentication processing and garbage collection. Note that if disabled, policy enforcement will still block requests that require authentication. But the resulting authentication requests for these requests will not be processed, therefore the requests not be allowed. |
-| authentication.expiredGCInterval | string | `"15m0s"` | Interval for garbage collection of expired auth map entries. |
+| authentication.gcInterval | string | `"15m0s"` | Interval for garbage collection of auth map entries. |
 | authentication.mutual.port | int | `4250` | Port on the agent where mutual authentication handshakes between agents will be performed |
 | authentication.mutual.spire.adminSocketPath | string | `"/run/spire/sockets/admin.sock"` | SPIRE socket path where the SPIRE delegated api agent is listening |
 | authentication.mutual.spire.agentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE socket path where the SPIRE workload agent is listening. Applies to both the Cilium Agent and Operator |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1108,7 +1108,7 @@ data:
   mesh-auth-enabled: {{ .Values.authentication.enabled | quote }}
   mesh-auth-queue-size: {{ .Values.authentication.queueSize | quote }}
   mesh-auth-rotated-identities-queue-size: {{ .Values.authentication.rotatedIdentitiesQueueSize | quote }}
-  mesh-auth-expired-gc-interval: {{ include "validateDuration" .Values.authentication.expiredGCInterval | quote }}
+  mesh-auth-gc-interval: {{ include "validateDuration" .Values.authentication.gcInterval | quote }}
 
 {{- if .Values.authentication.mutual.spire.enabled }}
   mesh-auth-mutual-enabled: "true"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3074,8 +3074,8 @@ authentication:
   queueSize: 1024
   # -- Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers.
   rotatedIdentitiesQueueSize: 1024
-    # -- Interval for garbage collection of expired auth map entries.
-  expiredGCInterval: "15m0s"
+    # -- Interval for garbage collection of auth map entries.
+  gcInterval: "15m0s"
   # Configuration for Cilium's service-to-service mutual authentication using TLS handshakes.
   # Note that this is not full mTLS support without also enabling encryption of some form.
   # Current encryption options are Wireguard or IPSec, configured in encryption block above.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3075,7 +3075,7 @@ authentication:
   # -- Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers.
   rotatedIdentitiesQueueSize: 1024
     # -- Interval for garbage collection of auth map entries.
-  gcInterval: "15m0s"
+  gcInterval: "5m0s"
   # Configuration for Cilium's service-to-service mutual authentication using TLS handshakes.
   # Note that this is not full mTLS support without also enabling encryption of some form.
   # Current encryption options are Wireguard or IPSec, configured in encryption block above.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3072,7 +3072,7 @@ authentication:
   # -- Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers.
   rotatedIdentitiesQueueSize: 1024
     # -- Interval for garbage collection of auth map entries.
-  gcInterval: "15m0s"
+  gcInterval: "5m0s"
   # Configuration for Cilium's service-to-service mutual authentication using TLS handshakes.
   # Note that this is not full mTLS support without also enabling encryption of some form.
   # Current encryption options are Wireguard or IPSec, configured in encryption block above.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3071,8 +3071,8 @@ authentication:
   queueSize: 1024
   # -- Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers.
   rotatedIdentitiesQueueSize: 1024
-    # -- Interval for garbage collection of expired auth map entries.
-  expiredGCInterval: "15m0s"
+    # -- Interval for garbage collection of auth map entries.
+  gcInterval: "15m0s"
   # Configuration for Cilium's service-to-service mutual authentication using TLS handshakes.
   # Note that this is not full mTLS support without also enabling encryption of some form.
   # Current encryption options are Wireguard or IPSec, configured in encryption block above.

--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -315,7 +315,7 @@ func (r *authMapGarbageCollector) cleanupDeletedIdentity(id identity.NumericIden
 // Policies
 
 func (r *authMapGarbageCollector) cleanupEntriesWithoutAuthPolicy(_ context.Context) error {
-	r.logger.Debug("Cleaning up expired entries")
+	r.logger.Debug("Cleaning up entries which no longer require authentication by a policy")
 
 	err := r.authmap.DeleteIf(func(key authKey, info authInfo) bool {
 		authTypes := r.policyRepo.GetAuthTypes(key.localIdentity, key.remoteIdentity)
@@ -339,11 +339,14 @@ func (r *authMapGarbageCollector) cleanupEntriesWithoutAuthPolicy(_ context.Cont
 // Expired
 
 func (r *authMapGarbageCollector) cleanupExpiredEntries(_ context.Context) error {
-	r.logger.Debug("auth: cleaning up expired entries")
 	now := time.Now()
+	r.logger.
+		WithField("gc_time", now).
+		Debug("Cleaning up expired entries")
 	err := r.authmap.DeleteIf(func(key authKey, info authInfo) bool {
 		if info.expiration.Before(now) {
 			r.logger.
+				WithField("gc_time", now).
 				WithField("expiration", info.expiration).
 				Debug("Deleting entry due to expiration")
 			return true

--- a/pkg/auth/authmap_gc_test.go
+++ b/pkg/auth/authmap_gc_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/identity"
@@ -20,158 +21,276 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 )
 
-func Test_authMapGarbageCollector_initialSync(t *testing.T) {
+func Test_authMapGarbageCollector_cleanupIdentities(t *testing.T) {
 	ctx := context.TODO()
 
 	authMap := &fakeAuthMap{
 		entries: map[authKey]authInfo{
-			{localIdentity: identity.NumericIdentity(1), remoteIdentity: identity.NumericIdentity(2), remoteNodeID: 10, authType: policy.AuthTypeDisabled}:  {expiration: time.Now().Add(5 * time.Minute)},
-			{localIdentity: identity.NumericIdentity(2), remoteIdentity: identity.NumericIdentity(4), remoteNodeID: 0, authType: policy.AuthTypeDisabled}:   {expiration: time.Now().Add(5 * time.Minute)},
-			{localIdentity: identity.NumericIdentity(10), remoteIdentity: identity.NumericIdentity(11), remoteNodeID: 0, authType: policy.AuthTypeDisabled}: {expiration: time.Now().Add(5 * time.Minute)},
-			{localIdentity: identity.NumericIdentity(2), remoteIdentity: identity.NumericIdentity(3), remoteNodeID: 11, authType: policy.AuthTypeDisabled}:  {expiration: time.Now().Add(-5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire}:        {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 3, remoteNodeID: 0, authType: policy.AuthTypeSpire}:        {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 11, remoteNodeID: 0, authType: policy.AuthTypeSpire}:       {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 12, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire}:       {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 11, remoteIdentity: 12, remoteNodeID: 0, authType: policy.AuthTypeAlwaysFail}: {expiration: time.Now().Add(5 * time.Minute)},
 		},
 	}
-	am := newAuthMapGC(logrus.New(), authMap, newFakeIPCache(map[uint16]string{
-		9:  "172.18.0.2",
-		10: "172.18.0.3",
-		11: "172.18.0.4",
-	}), nil)
+	gc := newAuthMapGC(logrus.New(), authMap, nil, nil)
 
-	assert.Len(t, am.ciliumNodesDiscovered, 1) // local node 0
-	assert.Empty(t, am.ciliumIdentitiesDiscovered)
-	assert.False(t, am.ciliumIdentitiesSynced)
+	assert.Len(t, authMap.entries, 5)
+	assert.Empty(t, gc.ciliumIdentitiesDiscovered)
+	assert.Empty(t, gc.ciliumIdentitiesDeleted)
+	assert.False(t, gc.ciliumIdentitiesSynced)
 
-	err := am.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Upsert, "172.18.0.3"))
+	err := gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, 1))
+	assert.NoError(t, err, "Handling an identity change event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Identity changes should never modify the map directly")
+	assert.Len(t, gc.ciliumIdentitiesDiscovered, 1, "Discovered identities should be kept in the internal state")
+
+	err = gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, 2))
+	assert.NoError(t, err, "Handling an identity change event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Identity changes should never modify the map directly")
+	assert.Len(t, gc.ciliumIdentitiesDiscovered, 2, "Discovered identities should be kept in the internal state")
+
+	err = gc.cleanupIdentities(ctx)
 	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 4)
-	assert.Len(t, am.ciliumNodesDiscovered, 2)
+	assert.Len(t, authMap.entries, 5, "GC run before the initial sync should not delete any entries from the auth map")
+	assert.Len(t, gc.ciliumIdentitiesDiscovered, 2, "GC run before the initial sync should not delete the discovered identities")
 
-	err = am.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Sync, ""))
+	err = gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeSync, 0))
+	assert.NoError(t, err, "Handling an identity change event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Identity changes should never modify the map directly")
+	assert.True(t, gc.ciliumIdentitiesSynced, "Identity changed sync event will mark the identities as synced")
+
+	err = gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeDelete, 3))
+	assert.NoError(t, err, "Handling an identity change event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Identity changes should never modify the map directly")
+	assert.Len(t, gc.ciliumIdentitiesDeleted, 1, "Deleted identities after the sync and before the initial GC run should already be kept")
+
+	err = gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, 3))
+	assert.NoError(t, err, "Handling an identity change event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Identity changes should never modify the map directly")
+	assert.Len(t, gc.ciliumIdentitiesDiscovered, 3, "Discovered identities after the sync event should be kept until the first GC run")
+
+	err = gc.cleanupIdentities(ctx)
 	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 4)
-	assert.Len(t, am.ciliumNodesDiscovered, 2)
-	assert.True(t, am.ciliumNodesSynced)
+	assert.Len(t, authMap.entries, 1, "GC run after the initial sync should delete all entries which belong to deleted or non-discovered identities")
+	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire},
+		"Auth map entry between ids 1->2 should be the only remaining entry, because the others are no longer existent or already deleted")
+	assert.Nil(t, gc.ciliumIdentitiesDiscovered, "First GC run after the initial sync should reset the option to discover identities")
+	assert.Empty(t, gc.ciliumIdentitiesDeleted, "GC runs should delete the successfully garbage collected entries from the list of deleted identities")
 
-	err = am.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Upsert, "172.18.0.2"))
+	err = gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, 13))
+	assert.NoError(t, err, "Handling an identity change should never result in an error")
+	assert.Len(t, authMap.entries, 1, "Identity changes should never modify the map directly")
+	assert.Nil(t, gc.ciliumIdentitiesDiscovered, "Discovered identities after the first GC run should no longer be of any interest")
+
+	err = gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeDelete, 2))
+	assert.NoError(t, err, "Handling an identity change event should never result in an error")
+	assert.Len(t, authMap.entries, 1, "Identity changes should never modify the map directly")
+	assert.Len(t, gc.ciliumIdentitiesDeleted, 1, "Deleted identities should be kept for the next GC run")
+
+	err = gc.cleanupIdentities(ctx)
 	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 4)
-	assert.Len(t, am.ciliumNodesDiscovered, 3) // Keep collecting upserts until reset
-
-	am.ciliumNodesDiscovered = nil // Reset
-
-	err = am.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Upsert, "172.18.0.4"))
-	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 4)
-	assert.Nil(t, am.ciliumNodesDiscovered)
-
-	err = am.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, 11))
-	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 4)
-	assert.Len(t, am.ciliumIdentitiesDiscovered, 1)
-
-	err = am.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, 10))
-	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 4)
-	assert.Len(t, am.ciliumIdentitiesDiscovered, 2)
-
-	err = am.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeSync, 0))
-	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 4)
-	assert.True(t, am.ciliumIdentitiesSynced)
-
-	err = am.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, 12))
-	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 4)
-	assert.Len(t, am.ciliumIdentitiesDiscovered, 3) // Keep collecting upserts until reset
-
-	am.ciliumIdentitiesDiscovered = nil // Reset
-
-	err = am.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, 13))
-	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 4)
-	assert.Nil(t, am.ciliumIdentitiesDiscovered)
+	assert.Empty(t, authMap.entries, "GC runs should delete all entries which belong to deleted identities")
+	assert.Nil(t, gc.ciliumIdentitiesDiscovered)
+	assert.Empty(t, gc.ciliumIdentitiesDeleted, "GC runs should delete the successfully garbage collected entries from the list of deleted identities")
 }
 
-func Test_authMapGarbageCollector_gc(t *testing.T) {
+func Test_authMapGarbageCollector_cleanupNodes(t *testing.T) {
+	ctx := context.TODO()
+
 	authMap := &fakeAuthMap{
 		entries: map[authKey]authInfo{
-			{localIdentity: identity.NumericIdentity(100), remoteIdentity: identity.NumericIdentity(111), remoteNodeID: 10, authType: policy.AuthTypeSpire}:  {expiration: time.Now().Add(5 * time.Minute)},  // deleted remote node
-			{localIdentity: identity.NumericIdentity(2), remoteIdentity: identity.NumericIdentity(4), remoteNodeID: 0, authType: policy.AuthTypeSpire}:       {expiration: time.Now().Add(5 * time.Minute)},  // deleted remote id
-			{localIdentity: identity.NumericIdentity(10), remoteIdentity: identity.NumericIdentity(11), remoteNodeID: 0, authType: policy.AuthTypeSpire}:     {expiration: time.Now().Add(5 * time.Minute)},  // deleted local id
-			{localIdentity: identity.NumericIdentity(5), remoteIdentity: identity.NumericIdentity(6), remoteNodeID: 12, authType: policy.AuthTypeSpire}:      {expiration: time.Now().Add(5 * time.Minute)},  // no policy present which enforces auth between identities
-			{localIdentity: identity.NumericIdentity(2), remoteIdentity: identity.NumericIdentity(3), remoteNodeID: 12, authType: policy.AuthTypeAlwaysFail}: {expiration: time.Now().Add(5 * time.Minute)},  // no policy present which enforces specific auth type
-			{localIdentity: identity.NumericIdentity(2), remoteIdentity: identity.NumericIdentity(3), remoteNodeID: 11, authType: policy.AuthTypeSpire}:      {expiration: time.Now().Add(-5 * time.Minute)}, // expired
+			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 1, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 2, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 3, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 4, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
 		},
 	}
+	gc := newAuthMapGC(logrus.New(), authMap, newFakeIPCache(map[uint16]string{
+		1: "172.18.0.1",
+		2: "172.18.0.2",
+		3: "172.18.0.3",
+		4: "172.18.0.4",
+		5: "172.18.0.5",
+	}), nil)
 
-	gc := newAuthMapGC(logrus.New(), authMap,
-		newFakeIPCache(map[uint16]string{
-			10: "172.18.0.3",
-		}),
+	assert.Len(t, authMap.entries, 5)
+	assert.Len(t, gc.ciliumNodesDiscovered, 1, "Local node 0 is always present")
+	assert.Empty(t, gc.ciliumNodesDeleted)
+	assert.False(t, gc.ciliumNodesSynced)
+
+	err := gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Upsert, "172.18.0.1"))
+	assert.NoError(t, err, "Handling a node event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Node events should never modify the map directly")
+	assert.Len(t, gc.ciliumNodesDiscovered, 2, "Discovered nodes should be kept in the internal state")
+
+	err = gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Upsert, "172.18.0.2"))
+	assert.NoError(t, err, "Handling a node event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Node events should never modify the map directly")
+	assert.Len(t, gc.ciliumNodesDiscovered, 3, "Discovered nodes should be kept in the internal state")
+
+	err = gc.cleanupIdentities(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 5, "GC run before the initial sync should not delete any entries from the auth map")
+	assert.Len(t, gc.ciliumNodesDiscovered, 3, "GC run before the initial sync should not delete the discovered nodes")
+
+	err = gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Sync, ""))
+	assert.NoError(t, err, "Handling a node event event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Node events should never modify the map directly")
+	assert.True(t, gc.ciliumNodesSynced, "Node sync event will mark the nodes as synced")
+
+	err = gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Delete, "172.18.0.2"))
+	assert.NoError(t, err, "Handling a node event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Node events should never modify the map directly")
+	assert.Len(t, gc.ciliumNodesDeleted, 1, "Deleted nodes after the sync and before the initial GC run should already be kept")
+
+	err = gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Upsert, "172.18.0.3"))
+	assert.NoError(t, err, "Handling a node event should never result in an error")
+	assert.Len(t, authMap.entries, 5, "Node events should never modify the map directly")
+	assert.Len(t, gc.ciliumNodesDiscovered, 4, "Discovered nodes after the sync event should be kept until the first GC run")
+
+	err = gc.cleanupNodes(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 3, "GC run after the initial sync should delete all entries which belong to deleted or non-discovered nodes")
+	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire})
+	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 1, authType: policy.AuthTypeSpire})
+	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 3, authType: policy.AuthTypeSpire})
+	assert.Nil(t, gc.ciliumNodesDiscovered, "First GC run after the initial sync should reset the option to discover nodes")
+	assert.Empty(t, gc.ciliumNodesDeleted, "GC runs should delete the successfully garbage collected entries from the list of deleted nodes")
+
+	err = gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Upsert, "172.18.0.5"))
+	assert.NoError(t, err, "Handling a node should never result in an error")
+	assert.Len(t, authMap.entries, 3, "Node should never modify the map directly")
+	assert.Nil(t, gc.ciliumNodesDiscovered, "Discovered nodes after the first GC run should no longer be of any interest")
+
+	err = gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Delete, "172.18.0.3"))
+	assert.NoError(t, err, "Handling a node event should never result in an error")
+	assert.Len(t, authMap.entries, 3, "Node events should never modify the map directly")
+	assert.Len(t, gc.ciliumNodesDeleted, 1, "Deleted nodes should be kept for the next GC run")
+
+	err = gc.cleanupNodes(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 2, "GC runs should delete all entries which belong to deleted nodes")
+	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire})
+	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 1, authType: policy.AuthTypeSpire})
+	assert.Nil(t, gc.ciliumNodesDiscovered)
+	assert.Empty(t, gc.ciliumNodesDeleted, "GC runs should delete the successfully garbage collected entries from the list of deleted nodes")
+}
+
+func Test_authMapGarbageCollector_cleanupPolicies(t *testing.T) {
+	ctx := context.TODO()
+
+	authMap := &fakeAuthMap{
+		entries: map[authKey]authInfo{
+			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 3, remoteNodeID: 0, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 4, remoteNodeID: 0, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
+		},
+	}
+	gc := newAuthMapGC(logrus.New(), authMap, nil,
 		&fakePolicyRepository{
 			needsAuth: map[identity.NumericIdentity]map[identity.NumericIdentity]policy.AuthTypes{
-				identity.NumericIdentity(1): {
-					identity.NumericIdentity(2): map[policy.AuthType]struct{}{
+				1: {
+					2: map[policy.AuthType]struct{}{
 						policy.AuthTypeSpire: {},
 					},
-				},
-				identity.NumericIdentity(2): {
-					identity.NumericIdentity(3): map[policy.AuthType]struct{}{
-						policy.AuthTypeSpire: {},
-					},
-					identity.NumericIdentity(4): map[policy.AuthType]struct{}{
-						policy.AuthTypeSpire: {},
-					},
-				},
-				identity.NumericIdentity(10): {
-					identity.NumericIdentity(11): map[policy.AuthType]struct{}{
-						policy.AuthTypeSpire: {},
-					},
-				},
-				identity.NumericIdentity(100): {
-					identity.NumericIdentity(111): map[policy.AuthType]struct{}{
-						policy.AuthTypeSpire: {},
+					3: map[policy.AuthType]struct{}{
+						policy.AuthTypeAlwaysFail: {},
 					},
 				},
 			},
 		},
 	)
 
-	assert.Len(t, authMap.entries, 6)
-
-	err := gc.cleanupExpiredEntries(context.Background())
-	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 5)
-
-	err = gc.cleanupEntriesWithoutAuthPolicy(context.Background())
-	assert.NoError(t, err)
 	assert.Len(t, authMap.entries, 3)
 
-	err = gc.handleCiliumNodeEvent(context.Background(), ciliumNodeEvent(resource.Delete, "172.18.0.3"))
+	err := gc.cleanupEntriesWithoutAuthPolicy(ctx)
 	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 3)
+	assert.Len(t, authMap.entries, 1, "GC runs should delete all entries where (the type of) auth is no longer enforced by a policy")
+	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire})
+}
 
-	err = gc.handleIdentityChange(context.Background(), ciliumIdentityEvent(cache.IdentityChangeDelete, 4))
-	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 3)
-	assert.Len(t, gc.ciliumIdentitiesDeleted, 1)
+func Test_authMapGarbageCollector_cleanupExpired(t *testing.T) {
+	ctx := context.TODO()
 
-	err = gc.handleIdentityChange(context.Background(), ciliumIdentityEvent(cache.IdentityChangeDelete, 10))
-	assert.NoError(t, err)
-	assert.Len(t, authMap.entries, 3)
-	assert.Len(t, gc.ciliumIdentitiesDeleted, 2)
+	authMap := &fakeAuthMap{
+		entries: map[authKey]authInfo{
+			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 1, remoteIdentity: 3, remoteNodeID: 0, authType: policy.AuthTypeSpire}: {expiration: time.Now().Add(-5 * time.Minute)},
+		},
+	}
+	gc := newAuthMapGC(logrus.New(), authMap, nil, nil)
 
-	gc.ciliumIdentitiesSynced = true
-	err = gc.cleanupIdentities(context.Background())
-	assert.NoError(t, err)
-	assert.Empty(t, authMap.entries)
-	assert.Empty(t, gc.ciliumIdentitiesDeleted)
+	assert.Len(t, authMap.entries, 2)
 
-	gc.ciliumNodesSynced = true
-	err = gc.cleanupNodes(context.Background())
+	err := gc.cleanupExpiredEntries(ctx)
 	assert.NoError(t, err)
-	assert.Empty(t, authMap.entries)
-	assert.Empty(t, gc.ciliumNodesDeleted)
+	assert.Len(t, authMap.entries, 1, "GC runs should delete all expired entries from the map")
+	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire})
+}
+
+func Test_authMapGarbageCollector_cleanup(t *testing.T) {
+	ctx := context.TODO()
+
+	authMap := &fakeAuthMap{
+		entries: map[authKey]authInfo{
+			{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire}:        {expiration: time.Now().Add(5 * time.Minute)},
+			{localIdentity: 3, remoteIdentity: 4, remoteNodeID: 1, authType: policy.AuthTypeSpire}:        {expiration: time.Now().Add(5 * time.Minute)},  // deleted remote node
+			{localIdentity: 5, remoteIdentity: 6, remoteNodeID: 0, authType: policy.AuthTypeSpire}:        {expiration: time.Now().Add(5 * time.Minute)},  // deleted remote id
+			{localIdentity: 7, remoteIdentity: 8, remoteNodeID: 0, authType: policy.AuthTypeSpire}:        {expiration: time.Now().Add(5 * time.Minute)},  // deleted local id
+			{localIdentity: 9, remoteIdentity: 10, remoteNodeID: 2, authType: policy.AuthTypeSpire}:       {expiration: time.Now().Add(5 * time.Minute)},  // no policy present which enforces auth between identities
+			{localIdentity: 11, remoteIdentity: 12, remoteNodeID: 0, authType: policy.AuthTypeAlwaysFail}: {expiration: time.Now().Add(5 * time.Minute)},  // no policy present which enforces specific auth type
+			{localIdentity: 13, remoteIdentity: 14, remoteNodeID: 0, authType: policy.AuthTypeSpire}:      {expiration: time.Now().Add(-5 * time.Minute)}, // expired
+		},
+	}
+
+	gc := newAuthMapGC(logrus.New(), authMap,
+		newFakeIPCache(map[uint16]string{
+			1: "172.18.0.1",
+			2: "172.18.0.2",
+		}),
+		&fakePolicyRepository{
+			needsAuth: map[identity.NumericIdentity]map[identity.NumericIdentity]policy.AuthTypes{
+				1: {
+					2: map[policy.AuthType]struct{}{policy.AuthTypeSpire: {}},
+				},
+				3: {
+					4: map[policy.AuthType]struct{}{policy.AuthTypeSpire: {}},
+				},
+				5: {
+					6: map[policy.AuthType]struct{}{policy.AuthTypeSpire: {}},
+				},
+				7: {
+					8: map[policy.AuthType]struct{}{policy.AuthTypeSpire: {}},
+				},
+				11: {
+					12: map[policy.AuthType]struct{}{policy.AuthTypeSpire: {}},
+				},
+				13: {
+					14: map[policy.AuthType]struct{}{policy.AuthTypeSpire: {}},
+				},
+			},
+		},
+	)
+
+	assert.Len(t, authMap.entries, 7)
+
+	require.NoError(t, gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Upsert, "172.18.0.1")))
+	require.NoError(t, gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Upsert, "172.18.0.2")))
+	require.NoError(t, gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Sync, "")))
+	require.NoError(t, gc.handleCiliumNodeEvent(ctx, ciliumNodeEvent(resource.Delete, "172.18.0.1")))
+	for i := 1; i < 15; i++ {
+		require.NoError(t, gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeUpsert, identity.NumericIdentity(i))))
+	}
+	require.NoError(t, gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeSync, 0)))
+	require.NoError(t, gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeDelete, 6)))
+	require.NoError(t, gc.handleIdentityChange(ctx, ciliumIdentityEvent(cache.IdentityChangeDelete, 7)))
+
+	err := gc.cleanup(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, authMap.entries, 1)
+	assert.Contains(t, authMap.entries, authKey{localIdentity: 1, remoteIdentity: 2, remoteNodeID: 0, authType: policy.AuthTypeSpire})
 }
 
 func Test_authMapGarbageCollector_HandleNodeEventError(t *testing.T) {

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -52,23 +52,23 @@ var Cell = cell.Module(
 		k8s.CiliumNodeResource,
 	),
 	cell.Config(config{
-		MeshAuthEnabled:           true,
-		MeshAuthQueueSize:         1024,
-		MeshAuthExpiredGCInterval: 15 * time.Minute,
+		MeshAuthEnabled:    true,
+		MeshAuthQueueSize:  1024,
+		MeshAuthGCInterval: 15 * time.Minute,
 	}),
 	cell.Config(MutualAuthConfig{}),
 )
 
 type config struct {
-	MeshAuthEnabled           bool
-	MeshAuthQueueSize         int
-	MeshAuthExpiredGCInterval time.Duration
+	MeshAuthEnabled    bool
+	MeshAuthQueueSize  int
+	MeshAuthGCInterval time.Duration
 }
 
 func (r config) Flags(flags *pflag.FlagSet) {
 	flags.Bool("mesh-auth-enabled", r.MeshAuthEnabled, "Enable authentication processing & garbage collection")
 	flags.Int("mesh-auth-queue-size", r.MeshAuthQueueSize, "Queue size for the auth manager")
-	flags.Duration("mesh-auth-expired-gc-interval", r.MeshAuthExpiredGCInterval, "Interval in which expired auth entries are attempted to be garbage collected")
+	flags.Duration("mesh-auth-gc-interval", r.MeshAuthGCInterval, "Interval in which auth entries are attempted to be garbage collected")
 }
 
 type authManagerParams struct {
@@ -162,9 +162,9 @@ func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params a
 		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumNode]]("auth nodes gc", mapGC.handleCiliumNodeEvent, params.CiliumNodes))
 	}
 
-	jobGroup.Add(job.Timer("auth policies gc", mapGC.cleanupEntriesWithoutAuthPolicy, params.Config.MeshAuthExpiredGCInterval))
+	jobGroup.Add(job.Timer("auth policies gc", mapGC.cleanupEntriesWithoutAuthPolicy, params.Config.MeshAuthGCInterval))
 
-	jobGroup.Add(job.Timer("auth expiration gc", mapGC.cleanupExpiredEntries, params.Config.MeshAuthExpiredGCInterval))
+	jobGroup.Add(job.Timer("auth expiration gc", mapGC.cleanupExpiredEntries, params.Config.MeshAuthGCInterval))
 }
 
 type authHandlerResult struct {

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -161,13 +161,7 @@ func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params a
 		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumNode]]("auth nodes gc events", mapGC.handleCiliumNodeEvent, params.CiliumNodes))
 	}
 
-	jobGroup.Add(job.Timer("auth policies gc", mapGC.cleanupEntriesWithoutAuthPolicy, params.Config.MeshAuthGCInterval))
-
-	jobGroup.Add(job.Timer("auth expiration gc", mapGC.cleanupExpiredEntries, params.Config.MeshAuthGCInterval))
-
-	jobGroup.Add(job.Timer("auth identities gc", mapGC.cleanupIdentities, params.Config.MeshAuthGCInterval))
-
-	jobGroup.Add(job.Timer("auth nodes gc", mapGC.cleanupNodes, params.Config.MeshAuthGCInterval))
+	jobGroup.Add(job.Timer("auth gc", mapGC.cleanup, params.Config.MeshAuthGCInterval))
 }
 
 type authHandlerResult struct {

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -154,8 +154,7 @@ func registerSignalAuthenticationJob(jobGroup job.Group, mgr *authManager, sm si
 }
 
 func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params authManagerParams) {
-	// FIXME: errors from handleIdentityChange not retried!
-	jobGroup.Add(job.Observer("auth identities gc", mapGC.handleIdentityChange, params.IdentityChanges))
+	jobGroup.Add(job.Observer("auth identities gc events", mapGC.handleIdentityChange, params.IdentityChanges))
 
 	// Add node based auth gc if k8s client is enabled
 	if params.CiliumNodes != nil {
@@ -165,6 +164,8 @@ func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params a
 	jobGroup.Add(job.Timer("auth policies gc", mapGC.cleanupEntriesWithoutAuthPolicy, params.Config.MeshAuthGCInterval))
 
 	jobGroup.Add(job.Timer("auth expiration gc", mapGC.cleanupExpiredEntries, params.Config.MeshAuthGCInterval))
+
+	jobGroup.Add(job.Timer("auth identities gc", mapGC.cleanupIdentities, params.Config.MeshAuthGCInterval))
 }
 
 type authHandlerResult struct {

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -54,7 +54,7 @@ var Cell = cell.Module(
 	cell.Config(config{
 		MeshAuthEnabled:    true,
 		MeshAuthQueueSize:  1024,
-		MeshAuthGCInterval: 15 * time.Minute,
+		MeshAuthGCInterval: 5 * time.Minute,
 	}),
 	cell.Config(MutualAuthConfig{}),
 )

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -158,7 +158,7 @@ func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params a
 
 	// Add node based auth gc if k8s client is enabled
 	if params.CiliumNodes != nil {
-		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumNode]]("auth nodes gc", mapGC.handleCiliumNodeEvent, params.CiliumNodes))
+		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumNode]]("auth nodes gc events", mapGC.handleCiliumNodeEvent, params.CiliumNodes))
 	}
 
 	jobGroup.Add(job.Timer("auth policies gc", mapGC.cleanupEntriesWithoutAuthPolicy, params.Config.MeshAuthGCInterval))
@@ -166,6 +166,8 @@ func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params a
 	jobGroup.Add(job.Timer("auth expiration gc", mapGC.cleanupExpiredEntries, params.Config.MeshAuthGCInterval))
 
 	jobGroup.Add(job.Timer("auth identities gc", mapGC.cleanupIdentities, params.Config.MeshAuthGCInterval))
+
+	jobGroup.Add(job.Timer("auth nodes gc", mapGC.cleanupNodes, params.Config.MeshAuthGCInterval))
 }
 
 type authHandlerResult struct {

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -49,9 +50,6 @@ var Cell = cell.Module(
 		// TODO: use node manager to get events of all nodes, including the ones of other clusters (ClusterMesh)
 		// https://github.com/cilium/cilium/issues/25899
 		k8s.CiliumNodeResource,
-		// TODO: add support for KVStore. K8s identity events are only provided for CRD based identity backend.
-		// https://github.com/cilium/cilium/issues/25898
-		k8s.CiliumIdentityResource,
 	),
 	cell.Config(config{
 		MeshAuthEnabled:           true,
@@ -76,17 +74,17 @@ func (r config) Flags(flags *pflag.FlagSet) {
 type authManagerParams struct {
 	cell.In
 
-	Logger           logrus.FieldLogger
-	Lifecycle        hive.Lifecycle
-	JobRegistry      job.Registry
-	Config           config
-	IPCache          *ipcache.IPCache
-	AuthHandlers     []authHandler `group:"authHandlers"`
-	AuthMap          authmap.Map
-	SignalManager    signal.SignalManager
-	CiliumIdentities resource.Resource[*ciliumv2.CiliumIdentity]
-	CiliumNodes      resource.Resource[*ciliumv2.CiliumNode]
-	PolicyRepo       *policy.Repository
+	Logger          logrus.FieldLogger
+	Lifecycle       hive.Lifecycle
+	JobRegistry     job.Registry
+	Config          config
+	IPCache         *ipcache.IPCache
+	AuthHandlers    []authHandler `group:"authHandlers"`
+	AuthMap         authmap.Map
+	SignalManager   signal.SignalManager
+	IdentityChanges stream.Observable[cache.IdentityChange]
+	CiliumNodes     resource.Resource[*ciliumv2.CiliumNode]
+	PolicyRepo      *policy.Repository
 }
 
 func newManager(params authManagerParams) error {
@@ -156,10 +154,8 @@ func registerSignalAuthenticationJob(jobGroup job.Group, mgr *authManager, sm si
 }
 
 func registerGCJobs(jobGroup job.Group, mapGC *authMapGarbageCollector, params authManagerParams) {
-	// Add identities based auth gc if k8s client is enabled
-	if params.CiliumIdentities != nil {
-		jobGroup.Add(job.Observer[resource.Event[*ciliumv2.CiliumIdentity]]("auth identities gc", mapGC.handleCiliumIdentityEvent, params.CiliumIdentities))
-	}
+	// FIXME: errors from handleIdentityChange not retried!
+	jobGroup.Add(job.Observer("auth identities gc", mapGC.handleIdentityChange, params.IdentityChanges))
 
 	// Add node based auth gc if k8s client is enabled
 	if params.CiliumNodes != nil {


### PR DESCRIPTION
Observe the identity changes via the CachingIdentityAllocator instead of using CiliumIdentity CRD directly. This both fixes the issue of having two informers (and thus double the bandwidth), but it also allows auth to work with the kvstore identity allocation
backend.

In addition, the the auth map garbage collection has been refactored to use the events (deleted nodes, deleted 
identities) only to update the internal state - whereas the actual GC is combined to a timer based job. This way we prevent events resulting in errors - that wouldn't be retried in case of the observable identity allocator (therefore this refactoring has become mandatory).

It's recommended to review the individual commits for more clarity & more context.

Depends on: https://github.com/cilium/cilium/pull/26373
Fixes: https://github.com/cilium/cilium/issues/25898