### PR TITLE
bpf: egressgw: refactor unit tests

### DIFF
--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -15,7 +15,7 @@ enum egressgw_test {
 
 struct egressgw_test_ctx {
 	enum egressgw_test test;
-	bool reply;
+	enum ct_dir dir;
 	__u64 tx_packets;
 	__u64 rx_packets;
 	__u32 status_code;

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -45,3 +45,26 @@ static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr
 
 	map_delete_elem(&EGRESS_POLICY_MAP, &in_key);
 }
+
+#ifndef SKIP_POLICY_MAP
+static __always_inline void add_allow_all_egress_policy(void)
+{
+	struct policy_key policy_key = {
+		.egress = 1,
+	};
+	struct policy_entry policy_value = {
+		.deny = 0,
+	};
+
+	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+}
+
+static __always_inline void del_allow_all_egress_policy(void)
+{
+	struct policy_key policy_key = {
+		.egress = 1,
+	};
+
+	map_delete_elem(&POLICY_MAP, &policy_key);
+}
+#endif

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -17,3 +17,31 @@ static __always_inline __be16 client_port(enum egressgw_test t)
 {
 	return CLIENT_PORT + (__be16)t;
 }
+
+static __always_inline void add_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr,
+						      __be32 gateway_ip, __be32 egress_ip)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
+		.saddr   = saddr,
+		.daddr   = daddr,
+	};
+
+	struct egress_gw_policy_entry in_val = {
+		.egress_ip  = egress_ip,
+		.gateway_ip = gateway_ip,
+	};
+
+	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+}
+
+static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
+		.saddr   = saddr,
+		.daddr   = daddr,
+	};
+
+	map_delete_elem(&EGRESS_POLICY_MAP, &in_key);
+}

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+enum egressgw_test {
+	TEST_SNAT1                    = 0,
+	TEST_SNAT2                    = 1,
+	TEST_SNAT_EXCL_CIDR           = 2,
+	TEST_REDIRECT                 = 3,
+	TEST_REDIRECT_EXCL_CIDR       = 4,
+	TEST_REDIRECT_SKIP_NO_GATEWAY = 5,
+	TEST_XDP_REPLY                = 6,
+};
+

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#define CLIENT_PORT __bpf_htons(111)
+
 enum egressgw_test {
 	TEST_SNAT1                    = 0,
 	TEST_SNAT2                    = 1,
@@ -11,3 +13,7 @@ enum egressgw_test {
 	TEST_XDP_REPLY                = 6,
 };
 
+static __always_inline __be16 client_port(enum egressgw_test t)
+{
+	return CLIENT_PORT + (__be16)t;
+}

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -1,7 +1,21 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-#define CLIENT_PORT __bpf_htons(111)
+#define CLIENT_IP		v4_pod_one
+#define CLIENT_PORT		__bpf_htons(111)
+#define CLIENT_NODE_IP		v4_node_one
+
+#define GATEWAY_NODE_IP		v4_node_two
+
+#define EXTERNAL_SVC_IP		v4_ext_one
+#define EXTERNAL_SVC_PORT	__bpf_htons(1234)
+
+#define EGRESS_IP		IPV4(1, 2, 3, 4)
+#define EGRESS_IP2		IPV4(2, 3, 4, 5)
+
+static volatile const __u8 *client_mac  = mac_one;
+static volatile const __u8 *gateway_mac = mac_two;
+static volatile const __u8 *ext_svc_mac = mac_three;
 
 enum egressgw_test {
 	TEST_SNAT1                    = 0,
@@ -76,3 +90,175 @@ static __always_inline void del_allow_all_egress_policy(void)
 	map_delete_elem(&POLICY_MAP, &policy_key);
 }
 #endif
+
+static __always_inline int egressgw_pktgen(struct __ctx_buff *ctx,
+					   struct egressgw_test_ctx test_ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	if (test_ctx.dir == CT_INGRESS)
+		ethhdr__set_macs(l2, (__u8 *)ext_svc_mac, (__u8 *)client_mac);
+	else /* CT_EGRESS */
+		ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	if (test_ctx.dir == CT_INGRESS) {
+		l3->saddr = EXTERNAL_SVC_IP;
+		l3->daddr = EGRESS_IP;
+	} else { /* CT_EGRESS */
+		l3->saddr = CLIENT_IP;
+		l3->daddr = EXTERNAL_SVC_IP;
+	}
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	if (test_ctx.dir == CT_INGRESS) {
+		/* Get the destination port from the NAT entry. */
+		struct ipv4_ct_tuple tuple = {
+			.saddr   = CLIENT_IP,
+			.daddr   = EXTERNAL_SVC_IP,
+			.dport   = EXTERNAL_SVC_PORT,
+			.sport   = client_port(test_ctx.test),
+			.nexthdr = IPPROTO_TCP,
+		};
+		struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
+
+		if (!nat_entry)
+			return TEST_ERROR;
+		l4->source = EXTERNAL_SVC_PORT;
+		l4->dest = nat_entry->to_sport;
+	} else { /* CT_EGRESS */
+		l4->source = client_port(test_ctx.test);
+		l4->dest = EXTERNAL_SVC_PORT;
+	}
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
+					       struct egressgw_test_ctx test_ctx)
+{
+	void *data, *data_end;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	assert(*(__u32 *)data == test_ctx.status_code);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (test_ctx.dir == CT_INGRESS) {
+		if (memcmp(l2->h_source, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
+			test_fatal("src MAC is not the external svc MAC")
+
+		if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
+			test_fatal("dst MAC is not the client MAC")
+
+		if (l3->saddr != EXTERNAL_SVC_IP)
+			test_fatal("src IP has changed");
+
+		if (l3->daddr != CLIENT_IP)
+			test_fatal("dst IP hasn't been revSNATed to client IP");
+	} else { /* CT_EGRESS */
+		if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+			test_fatal("src MAC is not the client MAC")
+
+		if (memcmp(l2->h_dest, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
+			test_fatal("dst MAC is not the external svc MAC")
+
+		if (l3->saddr != EGRESS_IP)
+			test_fatal("src IP hasn't been NATed to egress gateway IP");
+
+		if (l3->daddr != EXTERNAL_SVC_IP)
+			test_fatal("dst IP has changed");
+	}
+
+	/* Lookup the SNAT mapping for the original packet to determine the new source port */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = CLIENT_IP,
+		.saddr   = EXTERNAL_SVC_IP,
+		.dport   = EXTERNAL_SVC_PORT,
+		.sport   = client_port(test_ctx.test),
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	if (ct_entry->tx_packets != test_ctx.tx_packets)
+		test_fatal("bad TX packet count (expected %u, actual %u)",
+			   test_ctx.tx_packets, ct_entry->tx_packets)
+	if (ct_entry->rx_packets != test_ctx.rx_packets)
+		test_fatal("bad RX packet count (expected %u, actual %u)",
+			   test_ctx.rx_packets, ct_entry->rx_packets)
+
+	tuple.saddr = CLIENT_IP;
+	tuple.daddr = EXTERNAL_SVC_IP;
+
+	struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
+
+	if (!nat_entry)
+		test_fatal("could not find a NAT entry for the packet");
+
+	if (test_ctx.dir == CT_INGRESS) {
+		if (l4->source != EXTERNAL_SVC_PORT)
+			test_fatal("src port has changed");
+
+		if (l4->dest != client_port(test_ctx.test))
+			test_fatal("dst TCP port hasn't been revSNATed to client port");
+	} else { /* CT_EGRESS */
+		if (l4->source != nat_entry->to_sport)
+			test_fatal("src TCP port hasn't been NATed to egress gateway port");
+
+		if (l4->dest != EXTERNAL_SVC_PORT)
+			test_fatal("dst port has changed");
+	}
+
+	test_finish();
+}

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -13,6 +13,14 @@ enum egressgw_test {
 	TEST_XDP_REPLY                = 6,
 };
 
+struct egressgw_test_ctx {
+	enum egressgw_test test;
+	bool reply;
+	__u64 tx_packets;
+	__u64 rx_packets;
+	__u32 status_code;
+};
+
 static __always_inline __be16 client_port(enum egressgw_test t)
 {
 	return CLIENT_PORT + (__be16)t;

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -262,3 +262,21 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
 
 	test_finish();
 }
+
+static __always_inline int egressgw_status_check(const struct __ctx_buff *ctx,
+						 struct egressgw_test_ctx test_ctx)
+{
+	void *data, *data_end;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	assert(*(__u32 *)data == test_ctx.status_code);
+
+	test_finish();
+}

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -20,7 +20,6 @@
 #define ENCAP_IFINDEX 0
 
 #define CLIENT_IP		v4_pod_one
-#define CLIENT_PORT		__bpf_htons(111)
 
 #define EXTERNAL_SVC_IP		v4_ext_one
 #define EXTERNAL_SVC_PORT	__bpf_htons(1234)
@@ -33,6 +32,8 @@ static volatile const __u8 *client_mac = mac_one;
 static volatile const __u8 *ext_svc_mac = mac_two;
 
 #include "bpf_lxc.c"
+
+#include "lib/egressgw.h"
 
 #define FROM_CONTAINER 0
 
@@ -82,7 +83,7 @@ int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 	if (!l4)
 		return TEST_ERROR;
 
-	l4->source = CLIENT_PORT;
+	l4->source = client_port(TEST_REDIRECT);
 	l4->dest = EXTERNAL_SVC_PORT;
 
 	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
@@ -182,7 +183,7 @@ int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
 	if (!l4)
 		return TEST_ERROR;
 
-	l4->source = CLIENT_PORT;
+	l4->source = client_port(TEST_REDIRECT_EXCL_CIDR);
 	l4->dest = EXTERNAL_SVC_PORT;
 
 	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
@@ -306,7 +307,7 @@ int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 	if (!l4)
 		return TEST_ERROR;
 
-	l4->source = CLIENT_PORT;
+	l4->source = client_port(TEST_REDIRECT_SKIP_NO_GATEWAY);
 	l4->dest = EXTERNAL_SVC_PORT;
 
 	data = pktgen__push_data(&builder, default_data, sizeof(default_data));

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -101,15 +101,8 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, 0);
 
-	struct policy_key policy_key = {
-		.egress = 1,
-	};
-	struct policy_entry policy_value = {
-		.deny = 0,
-	};
-
 	/* Avoid policy drop */
-	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+	add_allow_all_egress_policy();
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
@@ -134,6 +127,7 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 	status_code = data;
 	assert(*status_code == CTX_ACT_REDIRECT);
 
+	del_allow_all_egress_policy();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
 
 	test_finish();
@@ -193,15 +187,8 @@ int egressgw_skip_excluded_cidr_redirect_setup(struct __ctx_buff *ctx)
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, 0);
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_EXCLUDED_CIDR, 0);
 
-	struct policy_key policy_key = {
-		.egress = 1,
-	};
-	struct policy_entry policy_value = {
-		.deny = 0,
-	};
-
 	/* Avoid policy drop */
-	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+	add_allow_all_egress_policy();
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
@@ -226,6 +213,7 @@ int egressgw_skip_excluded_cidr_redirect_check(const struct __ctx_buff *ctx)
 	status_code = data;
 	assert(*status_code == CTX_ACT_OK);
 
+	del_allow_all_egress_policy();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 
@@ -285,15 +273,8 @@ int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY, 0);
 
-	struct policy_key policy_key = {
-		.egress = 1,
-	};
-	struct policy_entry policy_value = {
-		.deny = 0,
-	};
-
 	/* Avoid policy drop */
-	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+	add_allow_all_egress_policy();
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
@@ -328,6 +309,7 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 		test_fatal("metrics entry not found");
 	assert(entry->count == 1);
 
+	del_allow_all_egress_policy();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 
 	test_finish();

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -252,18 +252,7 @@ int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_snat1")
 int egressgw_snat1_setup(struct __ctx_buff *ctx)
 {
-	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
-	};
-
-	struct egress_gw_policy_entry in_val = {
-		.egress_ip  = EGRESS_IP,
-		.gateway_ip = NODE_IP,
-	};
-
-	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, EGRESS_IP);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
@@ -332,14 +321,7 @@ int egressgw_snat2_check(struct __ctx_buff *ctx)
 {
 	int ret = egressgw_snat_check(ctx, TEST_SNAT2, false, 1, 0, CTX_ACT_OK);
 
-	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
-	};
-
-	/* Remove the policy to eliminate interference with other tests. */
-	map_delete_elem(&EGRESS_POLICY_MAP, &in_key);
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0Xffffff, 24);
 
 	return ret;
 }
@@ -356,31 +338,9 @@ int egressgw_skip_excluded_cidr_snat_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_setup(struct __ctx_buff *ctx)
 {
-	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
-	};
 
-	struct egress_gw_policy_entry in_val = {
-		.egress_ip  = 0,
-		.gateway_ip = NODE_IP,
-	};
-
-	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
-
-	struct egress_gw_policy_key in_key_excluded_cidr = {
-		.lpm_key = { EGRESS_PREFIX_LEN(32), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP,
-	};
-
-	struct egress_gw_policy_entry in_val_excluded_cidr = {
-		.egress_ip  = 0,
-		.gateway_ip = EGRESS_GATEWAY_EXCLUDED_CIDR,
-	};
-
-	map_update_elem(&EGRESS_POLICY_MAP, &in_key_excluded_cidr, &in_val_excluded_cidr, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_EXCLUDED_CIDR, 0);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
@@ -438,16 +398,7 @@ int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
 	if (l4->dest != EXTERNAL_SVC_PORT)
 		test_fatal("dst port has changed");
 
-	/* Delete the excluded CIDR entry otherwise other tests may fail as this
-	 * entry will persist across the different tests.
-	 */
-	struct egress_gw_policy_key in_key_excluded_cidr = {
-		.lpm_key = { EGRESS_PREFIX_LEN(32), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP,
-	};
-
-	map_delete_elem(&EGRESS_POLICY_MAP, &in_key_excluded_cidr);
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 
 	test_finish();
 }

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -275,14 +275,14 @@ int egressgw_snat1_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the from-netdev program
  * gets correctly revSNATed and connection tracked.
  */
-PKTGEN("tc", "tc_egressgw_snat2_reply")
-int egressgw_snat2_reply_pktgen(struct __ctx_buff *ctx)
+PKTGEN("tc", "tc_egressgw_snat1_2_reply")
+int egressgw_snat1_2_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_snat_pktgen(ctx, true);
 }
 
-SETUP("tc", "tc_egressgw_snat2_reply")
-int egressgw_snat2_reply_setup(struct __ctx_buff *ctx)
+SETUP("tc", "tc_egressgw_snat1_2_reply")
+int egressgw_snat1_2_reply_setup(struct __ctx_buff *ctx)
 {
 	/* install ipcache entry for the CLIENT_IP: */
 	struct ipcache_key cache_key = {
@@ -301,20 +301,20 @@ int egressgw_snat2_reply_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "tc_egressgw_snat2_reply")
-int egressgw_snat2_reply_check(const struct __ctx_buff *ctx)
+CHECK("tc", "tc_egressgw_snat1_2_reply")
+int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 {
 	return egressgw_snat_check(ctx, true, 1, 1);
 }
 
-PKTGEN("tc", "tc_egressgw_snat3")
-int egressgw_snat3_pktgen(struct __ctx_buff *ctx)
+PKTGEN("tc", "tc_egressgw_snat2")
+int egressgw_snat2_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_snat_pktgen(ctx, false);
 }
 
-SETUP("tc", "tc_egressgw_snat3")
-int egressgw_snat3_setup(struct __ctx_buff *ctx)
+SETUP("tc", "tc_egressgw_snat2")
+int egressgw_snat2_setup(struct __ctx_buff *ctx)
 {
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
@@ -322,8 +322,8 @@ int egressgw_snat3_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "tc_egressgw_snat3")
-int egressgw_snat3_check(struct __ctx_buff *ctx)
+CHECK("tc", "tc_egressgw_snat2")
+int egressgw_snat2_check(struct __ctx_buff *ctx)
 {
 	int ret = egressgw_snat_check(ctx, false, 2, 1);
 

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -83,9 +83,9 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx,
 	if (!l2)
 		return TEST_ERROR;
 
-	if (test_ctx.reply)
+	if (test_ctx.dir == CT_INGRESS)
 		ethhdr__set_macs(l2, (__u8 *)ext_svc_mac, (__u8 *)client_mac);
-	else
+	else /* CT_EGRESS */
 		ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
 
 	/* Push IPv4 header */
@@ -93,10 +93,10 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx,
 	if (!l3)
 		return TEST_ERROR;
 
-	if (test_ctx.reply) {
+	if (test_ctx.dir == CT_INGRESS) {
 		l3->saddr = EXTERNAL_SVC_IP;
 		l3->daddr = EGRESS_IP;
-	} else {
+	} else { /* CT_EGRESS */
 		l3->saddr = CLIENT_IP;
 		l3->daddr = EXTERNAL_SVC_IP;
 	}
@@ -106,7 +106,7 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx,
 	if (!l4)
 		return TEST_ERROR;
 
-	if (test_ctx.reply) {
+	if (test_ctx.dir == CT_INGRESS) {
 		/* Get the destination port from the NAT entry. */
 		struct ipv4_ct_tuple tuple = {
 			.saddr   = CLIENT_IP,
@@ -121,7 +121,7 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx,
 			return TEST_ERROR;
 		l4->source = EXTERNAL_SVC_PORT;
 		l4->dest = nat_entry->to_sport;
-	} else {
+	} else { /* CT_EGRESS */
 		l4->source = client_port(test_ctx.test);
 		l4->dest = EXTERNAL_SVC_PORT;
 	}
@@ -166,7 +166,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
 	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
 		test_fatal("l4 out of bounds");
 
-	if (test_ctx.reply) {
+	if (test_ctx.dir == CT_INGRESS) {
 		if (memcmp(l2->h_source, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
 			test_fatal("src MAC is not the external svc MAC")
 
@@ -178,7 +178,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
 
 		if (l3->daddr != CLIENT_IP)
 			test_fatal("dst IP hasn't been revSNATed to client IP");
-	} else {
+	} else { /* CT_EGRESS */
 		if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
 			test_fatal("src MAC is not the client MAC")
 
@@ -221,13 +221,13 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
 	if (!nat_entry)
 		test_fatal("could not find a NAT entry for the packet");
 
-	if (test_ctx.reply) {
+	if (test_ctx.dir == CT_INGRESS) {
 		if (l4->source != EXTERNAL_SVC_PORT)
 			test_fatal("src port has changed");
 
 		if (l4->dest != client_port(test_ctx.test))
 			test_fatal("dst TCP port hasn't been revSNATed to client port");
-	} else {
+	} else { /* CT_EGRESS */
 		if (l4->source != nat_entry->to_sport)
 			test_fatal("src TCP port hasn't been NATed to egress gateway port");
 
@@ -279,7 +279,7 @@ int egressgw_snat1_2_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT1,
-			.reply = true,
+			.dir = CT_INGRESS,
 		});
 }
 
@@ -308,7 +308,7 @@ int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 {
 	return egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT1,
-			.reply = true,
+			.dir = CT_INGRESS,
 			.tx_packets = 1,
 			.rx_packets = 1,
 			.status_code = CTX_ACT_REDIRECT,

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -17,20 +17,7 @@
 #define ENABLE_MASQUERADE_IPV4
 #define ENCAP_IFINDEX		42
 
-#define CLIENT_IP		v4_pod_one
-#define CLIENT_NODE_IP		v4_node_two
-
-#define EXTERNAL_SVC_IP		v4_ext_one
-#define EXTERNAL_SVC_PORT	__bpf_htons(1234)
-
-#define NODE_IP			v4_node_one
-
-#define EGRESS_IP		IPV4(1, 2, 3, 4)
-
 #define SECCTX_FROM_IPCACHE 1
-
-static volatile const __u8 *client_mac = mac_one;
-static volatile const __u8 *ext_svc_mac = mac_two;
 
 #define ctx_redirect mock_ctx_redirect
 static __always_inline __maybe_unused int
@@ -66,185 +53,13 @@ struct {
 	},
 };
 
-static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx,
-						struct egressgw_test_ctx test_ctx)
-{
-	struct pktgen builder;
-	struct tcphdr *l4;
-	struct ethhdr *l2;
-	struct iphdr *l3;
-	void *data;
-
-	/* Init packet builder */
-	pktgen__init(&builder, ctx);
-
-	/* Push ethernet header */
-	l2 = pktgen__push_ethhdr(&builder);
-	if (!l2)
-		return TEST_ERROR;
-
-	if (test_ctx.dir == CT_INGRESS)
-		ethhdr__set_macs(l2, (__u8 *)ext_svc_mac, (__u8 *)client_mac);
-	else /* CT_EGRESS */
-		ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
-
-	/* Push IPv4 header */
-	l3 = pktgen__push_default_iphdr(&builder);
-	if (!l3)
-		return TEST_ERROR;
-
-	if (test_ctx.dir == CT_INGRESS) {
-		l3->saddr = EXTERNAL_SVC_IP;
-		l3->daddr = EGRESS_IP;
-	} else { /* CT_EGRESS */
-		l3->saddr = CLIENT_IP;
-		l3->daddr = EXTERNAL_SVC_IP;
-	}
-
-	/* Push TCP header */
-	l4 = pktgen__push_default_tcphdr(&builder);
-	if (!l4)
-		return TEST_ERROR;
-
-	if (test_ctx.dir == CT_INGRESS) {
-		/* Get the destination port from the NAT entry. */
-		struct ipv4_ct_tuple tuple = {
-			.saddr   = CLIENT_IP,
-			.daddr   = EXTERNAL_SVC_IP,
-			.dport   = EXTERNAL_SVC_PORT,
-			.sport   = client_port(test_ctx.test),
-			.nexthdr = IPPROTO_TCP,
-		};
-		struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
-
-		if (!nat_entry)
-			return TEST_ERROR;
-		l4->source = EXTERNAL_SVC_PORT;
-		l4->dest = nat_entry->to_sport;
-	} else { /* CT_EGRESS */
-		l4->source = client_port(test_ctx.test);
-		l4->dest = EXTERNAL_SVC_PORT;
-	}
-
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
-	pktgen__finish(&builder);
-
-	return 0;
-}
-
-static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
-					       struct egressgw_test_ctx test_ctx)
-{
-	void *data, *data_end;
-	struct tcphdr *l4;
-	struct ethhdr *l2;
-	struct iphdr *l3;
-
-	test_init();
-
-	data = (void *)(long)ctx_data(ctx);
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(__u32) > data_end)
-		test_fatal("status code out of bounds");
-
-	assert(*(__u32 *)data == test_ctx.status_code);
-
-	l2 = data + sizeof(__u32);
-	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
-		test_fatal("l2 out of bounds");
-
-	l3 = (void *)l2 + sizeof(struct ethhdr);
-	if ((void *)l3 + sizeof(struct iphdr) > data_end)
-		test_fatal("l3 out of bounds");
-
-	l4 = (void *)l3 + sizeof(struct iphdr);
-	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
-		test_fatal("l4 out of bounds");
-
-	if (test_ctx.dir == CT_INGRESS) {
-		if (memcmp(l2->h_source, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
-			test_fatal("src MAC is not the external svc MAC")
-
-		if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
-			test_fatal("dst MAC is not the client MAC")
-
-		if (l3->saddr != EXTERNAL_SVC_IP)
-			test_fatal("src IP has changed");
-
-		if (l3->daddr != CLIENT_IP)
-			test_fatal("dst IP hasn't been revSNATed to client IP");
-	} else { /* CT_EGRESS */
-		if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
-			test_fatal("src MAC is not the client MAC")
-
-		if (memcmp(l2->h_dest, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
-			test_fatal("dst MAC is not the external svc MAC")
-
-		if (l3->saddr != EGRESS_IP)
-			test_fatal("src IP hasn't been NATed to egress gateway IP");
-
-		if (l3->daddr != EXTERNAL_SVC_IP)
-			test_fatal("dst IP has changed");
-	}
-
-	/* Lookup the SNAT mapping for the original packet to determine the new source port */
-	struct ipv4_ct_tuple tuple = {
-		.daddr   = CLIENT_IP,
-		.saddr   = EXTERNAL_SVC_IP,
-		.dport   = EXTERNAL_SVC_PORT,
-		.sport   = client_port(test_ctx.test),
-		.nexthdr = IPPROTO_TCP,
-		.flags = TUPLE_F_OUT,
-	};
-	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
-
-	if (!ct_entry)
-		test_fatal("no CT entry found");
-
-	if (ct_entry->tx_packets != test_ctx.tx_packets)
-		test_fatal("bad TX packet count (expected %u, actual %u)",
-			   test_ctx.tx_packets, ct_entry->tx_packets)
-	if (ct_entry->rx_packets != test_ctx.rx_packets)
-		test_fatal("bad RX packet count (expected %u, actual %u)",
-			   test_ctx.rx_packets, ct_entry->rx_packets)
-
-	tuple.saddr = CLIENT_IP;
-	tuple.daddr = EXTERNAL_SVC_IP;
-
-	struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
-
-	if (!nat_entry)
-		test_fatal("could not find a NAT entry for the packet");
-
-	if (test_ctx.dir == CT_INGRESS) {
-		if (l4->source != EXTERNAL_SVC_PORT)
-			test_fatal("src port has changed");
-
-		if (l4->dest != client_port(test_ctx.test))
-			test_fatal("dst TCP port hasn't been revSNATed to client port");
-	} else { /* CT_EGRESS */
-		if (l4->source != nat_entry->to_sport)
-			test_fatal("src TCP port hasn't been NATed to egress gateway port");
-
-		if (l4->dest != EXTERNAL_SVC_PORT)
-			test_fatal("dst port has changed");
-	}
-
-	test_finish();
-}
-
 /* Test that a packet matching an egress gateway policy on the to-netdev program
  * gets correctly SNATed with the egress IP of the policy.
  */
 PKTGEN("tc", "tc_egressgw_snat1")
 int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT1,
 		});
 }
@@ -252,7 +67,8 @@ int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_snat1")
 int egressgw_snat1_setup(struct __ctx_buff *ctx)
 {
-	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, EGRESS_IP);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
+				  GATEWAY_NODE_IP, EGRESS_IP);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
@@ -277,7 +93,7 @@ int egressgw_snat1_check(const struct __ctx_buff *ctx)
 PKTGEN("tc", "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT1,
 			.dir = CT_INGRESS,
 		});
@@ -318,7 +134,7 @@ int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 PKTGEN("tc", "tc_egressgw_snat2")
 int egressgw_snat2_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT2,
 		});
 }
@@ -353,7 +169,7 @@ int egressgw_snat2_check(struct __ctx_buff *ctx)
 PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT_EXCL_CIDR,
 		});
 }
@@ -362,7 +178,7 @@ SETUP("tc", "tc_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_setup(struct __ctx_buff *ctx)
 {
 
-	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP, 0);
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_EXCLUDED_CIDR, 0);
 
 	/* Jump into the entrypoint */

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -18,7 +18,6 @@
 #define ENCAP_IFINDEX		42
 
 #define CLIENT_IP		v4_pod_one
-#define CLIENT_PORT		__bpf_htons(111)
 #define CLIENT_NODE_IP		v4_node_two
 
 #define EXTERNAL_SVC_IP		v4_ext_one
@@ -36,6 +35,14 @@ static volatile const __u8 *ext_svc_mac = mac_two;
 #define ctx_redirect mock_ctx_redirect
 static __always_inline __maybe_unused int
 mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused);
+
+#include "bpf_host.c"
+
+#include "lib/egressgw.h"
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
 {
 	if (ifindex == ENCAP_IFINDEX)
@@ -43,8 +50,6 @@ mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
 
 	return CTX_ACT_DROP;
 }
-
-#include "bpf_host.c"
 
 #define TO_NETDEV 0
 #define FROM_NETDEV 1
@@ -61,7 +66,8 @@ struct {
 	},
 };
 
-static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, bool reply)
+static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, enum egressgw_test t,
+						bool reply)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -106,7 +112,7 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, bool rep
 			.saddr   = CLIENT_IP,
 			.daddr   = EXTERNAL_SVC_IP,
 			.dport   = EXTERNAL_SVC_PORT,
-			.sport   = CLIENT_PORT,
+			.sport   = client_port(t),
 			.nexthdr = IPPROTO_TCP,
 		};
 		struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
@@ -116,7 +122,7 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, bool rep
 		l4->source = EXTERNAL_SVC_PORT;
 		l4->dest = nat_entry->to_sport;
 	} else {
-		l4->source = CLIENT_PORT;
+		l4->source = client_port(t);
 		l4->dest = EXTERNAL_SVC_PORT;
 	}
 
@@ -130,7 +136,8 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, bool rep
 	return 0;
 }
 
-static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, bool reply,
+static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, enum egressgw_test t,
+					       bool reply,
 					       __u64 tx_packets, __u64 rx_packets,
 					       __u32 status_code)
 {
@@ -192,7 +199,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, boo
 		.daddr   = CLIENT_IP,
 		.saddr   = EXTERNAL_SVC_IP,
 		.dport   = EXTERNAL_SVC_PORT,
-		.sport   = CLIENT_PORT,
+		.sport   = client_port(t),
 		.nexthdr = IPPROTO_TCP,
 		.flags = TUPLE_F_OUT,
 	};
@@ -220,7 +227,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, boo
 		if (l4->source != EXTERNAL_SVC_PORT)
 			test_fatal("src port has changed");
 
-		if (l4->dest != CLIENT_PORT)
+		if (l4->dest != client_port(t))
 			test_fatal("dst TCP port hasn't been revSNATed to client port");
 	} else {
 		if (l4->source != nat_entry->to_sport)
@@ -239,7 +246,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, boo
 PKTGEN("tc", "tc_egressgw_snat1")
 int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, false);
+	return egressgw_snat_pktgen(ctx, TEST_SNAT1, false);
 }
 
 SETUP("tc", "tc_egressgw_snat1")
@@ -267,7 +274,7 @@ int egressgw_snat1_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_snat1")
 int egressgw_snat1_check(const struct __ctx_buff *ctx)
 {
-	return egressgw_snat_check(ctx, false, 1, 0, CTX_ACT_OK);
+	return egressgw_snat_check(ctx, TEST_SNAT1, false, 1, 0, CTX_ACT_OK);
 }
 
 /* Test that a packet matching an egress gateway policy on the from-netdev program
@@ -276,7 +283,7 @@ int egressgw_snat1_check(const struct __ctx_buff *ctx)
 PKTGEN("tc", "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, true);
+	return egressgw_snat_pktgen(ctx, TEST_SNAT1, true);
 }
 
 SETUP("tc", "tc_egressgw_snat1_2_reply")
@@ -302,13 +309,13 @@ int egressgw_snat1_2_reply_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 {
-	return egressgw_snat_check(ctx, true, 1, 1, CTX_ACT_REDIRECT);
+	return egressgw_snat_check(ctx, TEST_SNAT1, true, 1, 1, CTX_ACT_REDIRECT);
 }
 
 PKTGEN("tc", "tc_egressgw_snat2")
 int egressgw_snat2_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, false);
+	return egressgw_snat_pktgen(ctx, TEST_SNAT2, false);
 }
 
 SETUP("tc", "tc_egressgw_snat2")
@@ -323,7 +330,7 @@ int egressgw_snat2_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_snat2")
 int egressgw_snat2_check(struct __ctx_buff *ctx)
 {
-	int ret = egressgw_snat_check(ctx, false, 2, 1, CTX_ACT_OK);
+	int ret = egressgw_snat_check(ctx, TEST_SNAT2, false, 1, 0, CTX_ACT_OK);
 
 	struct egress_gw_policy_key in_key = {
 		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
@@ -343,7 +350,7 @@ int egressgw_snat2_check(struct __ctx_buff *ctx)
 PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_snat")
 int egressgw_skip_excluded_cidr_snat_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, false);
+	return egressgw_snat_pktgen(ctx, TEST_SNAT_EXCL_CIDR, false);
 }
 
 SETUP("tc", "tc_egressgw_skip_excluded_cidr_snat")
@@ -425,7 +432,7 @@ int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
 	if (l3->daddr != EXTERNAL_SVC_IP)
 		test_fatal("dst IP has changed");
 
-	if (l4->source != CLIENT_PORT)
+	if (l4->source != client_port(TEST_SNAT_EXCL_CIDR))
 		test_fatal("src TCP port has changed");
 
 	if (l4->dest != EXTERNAL_SVC_PORT)

--- a/bpf/tests/xdp_egressgw_reply.c
+++ b/bpf/tests/xdp_egressgw_reply.c
@@ -138,18 +138,7 @@ SETUP("xdp", "xdp_egressgw_reply")
 int egressgw_reply_setup(struct __ctx_buff *ctx)
 {
 	/* install EgressGW policy for the connection: */
-	struct egress_gw_policy_key egressgw_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
-	};
-
-	struct egress_gw_policy_entry egressgw_value = {
-		.egress_ip  = 0, /* not needed */
-		.gateway_ip = GATEWAY_NODE_IP,
-	};
-
-	map_update_elem(&EGRESS_POLICY_MAP, &egressgw_key, &egressgw_value, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP, 0);
 
 	/* install RevSNAT entry */
 	struct ipv4_ct_tuple snat_tuple = {
@@ -273,6 +262,8 @@ int egressgw_reply_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	if (inner_l4->dest != client_port(TEST_XDP_REPLY))
 		test_fatal("innerDstPort hasn't been revNATed to client port");
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
 
 	test_finish();
 }


### PR DESCRIPTION
These changes were originally part of https://github.com/cilium/cilium/pull/26215 (to make it easier to add a new test) but I'm splitting them into a separate PR so that they can get backported without the fib_lookup changes, as it's always good to keep CI as much in sync as possible across all branches.

See individual commits for more context.