### PR TITLE
Use generic Set instead of specified Set

### DIFF
--- a/pkg/k8s/slim/k8s/apis/labels/selector.go
+++ b/pkg/k8s/slim/k8s/apis/labels/selector.go
@@ -267,8 +267,8 @@ func (r *Requirement) Operator() selection.Operator {
 }
 
 // Values returns requirement values
-func (r *Requirement) Values() sets.String {
-	ret := sets.String{}
+func (r *Requirement) Values() sets.Set[string] {
+	ret := sets.New[string]()
 	for i := range r.strValues {
 		ret.Insert(r.strValues[i])
 	}
@@ -686,7 +686,7 @@ func (p *Parser) parseRequirement() (*Requirement, error) {
 	if err != nil {
 		return nil, err
 	}
-	var values sets.String
+	var values sets.Set[string]
 	switch operator {
 	case selection.In, selection.NotIn:
 		values, err = p.parseValues()
@@ -696,7 +696,7 @@ func (p *Parser) parseRequirement() (*Requirement, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewRequirement(key, operator, values.List())
+	return NewRequirement(key, operator, sets.List(values))
 
 }
 
@@ -752,7 +752,7 @@ func (p *Parser) parseOperator() (op selection.Operator, err error) {
 }
 
 // parseValues parses the values for set based matching (x,y,z)
-func (p *Parser) parseValues() (sets.String, error) {
+func (p *Parser) parseValues() (sets.Set[string], error) {
 	tok, lit := p.consume(Values)
 	if tok != OpenParToken {
 		return nil, fmt.Errorf("found '%s' expected: '('", lit)
@@ -770,7 +770,7 @@ func (p *Parser) parseValues() (sets.String, error) {
 		return s, nil
 	case ClosedParToken: // handles "()"
 		p.consume(Values)
-		return sets.NewString(""), nil
+		return sets.New[string](""), nil
 	default:
 		return nil, fmt.Errorf("found '%s', expected: ',', ')' or identifier", lit)
 	}
@@ -778,8 +778,8 @@ func (p *Parser) parseValues() (sets.String, error) {
 
 // parseIdentifiersList parses a (possibly empty) list of
 // of comma separated (possibly empty) identifiers
-func (p *Parser) parseIdentifiersList() (sets.String, error) {
-	s := sets.NewString()
+func (p *Parser) parseIdentifiersList() (sets.Set[string], error) {
+	s := sets.New[string]()
 	for {
 		tok, lit := p.consume(Values)
 		switch tok {
@@ -814,8 +814,8 @@ func (p *Parser) parseIdentifiersList() (sets.String, error) {
 }
 
 // parseExactValue parses the only value for exact match style
-func (p *Parser) parseExactValue() (sets.String, error) {
-	s := sets.NewString()
+func (p *Parser) parseExactValue() (sets.Set[string], error) {
+	s := sets.New[string]()
 	tok, _ := p.lookahead(Values)
 	if tok == EndOfStringToken || tok == CommaToken {
 		s.Insert("")


### PR DESCRIPTION
Use generic Set instead of specified Set
sets.String has been deprecated and the generic Set should be used instead