### PR TITLE
Expand Hubble-exporter with filters and field mask

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -176,6 +176,9 @@ cilium-agent [flags]
       --hubble-disable-tls                                        Allow Hubble server to run on the given listen address without TLS.
       --hubble-event-buffer-capacity int                          Capacity of Hubble events buffer. The provided value must be one less than an integer power of two and no larger than 65535 (ie: 1, 3, ..., 2047, 4095, ..., 65535) (default 4095)
       --hubble-event-queue-size int                               Buffer size of the channel to receive monitor events.
+      --hubble-export-allowlist strings                           Specify allowlist as JSON encoded FlowFilters to Hubble exporter.
+      --hubble-export-denylist strings                            Specify denylist as JSON encoded FlowFilters to Hubble exporter.
+      --hubble-export-fieldmask strings                           Specify list of fields to use for field mask in Hubble exporter.
       --hubble-export-file-compress                               Compress rotated Hubble export files.
       --hubble-export-file-max-backups int                        Number of rotated Hubble export files to keep. (default 5)
       --hubble-export-file-max-size-mb int                        Size in MB at which to rotate Hubble export file. (default 10)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -957,6 +957,15 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.HubbleExportFileCompress, exporteroption.Default.Compress, "Compress rotated Hubble export files.")
 	option.BindEnv(vp, option.HubbleExportFileCompress)
 
+	flags.StringSlice(option.HubbleExportAllowlist, []string{}, "Specify allowlist as JSON encoded FlowFilters to Hubble exporter.")
+	option.BindEnv(vp, option.HubbleExportAllowlist)
+
+	flags.StringSlice(option.HubbleExportDenylist, []string{}, "Specify denylist as JSON encoded FlowFilters to Hubble exporter.")
+	option.BindEnv(vp, option.HubbleExportDenylist)
+
+	flags.StringSlice(option.HubbleExportFieldmask, []string{}, "Specify list of fields to use for field mask in Hubble exporter.")
+	option.BindEnv(vp, option.HubbleExportFieldmask)
+
 	flags.Bool(option.EnableHubbleRecorderAPI, true, "Enable the Hubble recorder API")
 	option.BindEnv(vp, option.EnableHubbleRecorderAPI)
 

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -165,6 +165,9 @@ func (d *Daemon) launchHubble() {
 			exporteroption.WithPath(option.Config.HubbleExportFilePath),
 			exporteroption.WithMaxSizeMB(option.Config.HubbleExportFileMaxSizeMB),
 			exporteroption.WithMaxBackups(option.Config.HubbleExportFileMaxBackups),
+			exporteroption.WithAllowList(option.Config.HubbleExportAllowlist),
+			exporteroption.WithDenyList(option.Config.HubbleExportDenylist),
+			exporteroption.WithFieldMask(option.Config.HubbleExportFieldmask),
 		}
 		if option.Config.HubbleExportFileCompress {
 			exporterOpts = append(exporterOpts, exporteroption.WithCompress())

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -169,7 +169,7 @@ func (d *Daemon) launchHubble() {
 		if option.Config.HubbleExportFileCompress {
 			exporterOpts = append(exporterOpts, exporteroption.WithCompress())
 		}
-		hubbleExporter, err := exporter.NewExporter(logger, exporterOpts...)
+		hubbleExporter, err := exporter.NewExporter(d.ctx, logger, exporterOpts...)
 		if err != nil {
 			logger.WithError(err).Error("Failed to configure Hubble export")
 		} else {

--- a/pkg/hubble/exporter/exporter_test.go
+++ b/pkg/hubble/exporter/exporter_test.go
@@ -6,7 +6,6 @@ package exporter
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"io"
 	"testing"
 
@@ -17,8 +16,13 @@ import (
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
+
+type bytesWriteCloser struct{ bytes.Buffer }
+
+func (bwc *bytesWriteCloser) Close() error { return nil }
 
 func TestExporter(t *testing.T) {
 	// override node name for unit test.
@@ -39,11 +43,12 @@ func TestExporter(t *testing.T) {
 		{Timestamp: &timestamp.Timestamp{Seconds: 3}, Event: &observerpb.DebugEvent{}},
 		{Timestamp: &timestamp.Timestamp{Seconds: 4}, Event: &observerpb.LostEvent{}},
 	}
-	var buf bytes.Buffer
-	encoder := json.NewEncoder(&buf)
+	buf := &bytesWriteCloser{bytes.Buffer{}}
 	log := logrus.New()
 	log.SetOutput(io.Discard)
-	exporter := newExporter(log, encoder)
+	exporter, err := newExporter(context.Background(), log, buf, exporteroption.Default)
+	assert.NoError(t, err)
+
 	ctx := context.Background()
 	for _, ev := range events {
 		stop, err := exporter.OnDecodedEvent(ctx, ev)
@@ -55,6 +60,85 @@ func TestExporter(t *testing.T) {
 {"agent_event":{},"node_name":"my-node","time":"1970-01-01T00:00:02Z"}
 {"debug_event":{},"node_name":"my-node","time":"1970-01-01T00:00:03Z"}
 {"lost_events":{},"node_name":"my-node","time":"1970-01-01T00:00:04Z"}
+`, buf.String())
+}
+
+func TestExporterWithFilters(t *testing.T) {
+	allowNodeName := "allow/node"
+	events := []*v1.Event{
+		// Non-flow events will not be processed when filters are set
+		{Timestamp: &timestamp.Timestamp{Seconds: 2}, Event: &observerpb.AgentEvent{}},
+		{Timestamp: &timestamp.Timestamp{Seconds: 3}, Event: &observerpb.DebugEvent{}},
+		{Timestamp: &timestamp.Timestamp{Seconds: 4}, Event: &observerpb.LostEvent{}},
+		{
+			Event: &observerpb.Flow{
+				NodeName: allowNodeName,
+				Time:     &timestamp.Timestamp{Seconds: 12},
+			},
+		},
+		{
+			Event: &observerpb.Flow{
+				SourceNames: []string{"deny-pod/a"},
+				NodeName:    allowNodeName,
+				Time:        &timestamp.Timestamp{Seconds: 13},
+			},
+		},
+		{
+			Event: &observerpb.Flow{
+				SourceNames: []string{"allow-pod/a"},
+				NodeName:    allowNodeName,
+				Time:        &timestamp.Timestamp{Seconds: 14},
+			},
+		},
+		{
+			Event: &observerpb.Flow{
+				SourceNames: []string{"allow-pod/a"},
+				NodeName:    "another-node",
+				Time:        &timestamp.Timestamp{Seconds: 15},
+			},
+		},
+		{
+			Event: &observerpb.Flow{
+				SourceNames: []string{"allow-pod/a"},
+				NodeName:    allowNodeName,
+				Time:        &timestamp.Timestamp{Seconds: 16},
+			},
+		},
+	}
+	buf := &bytesWriteCloser{bytes.Buffer{}}
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+
+	allowFilter := &flowpb.FlowFilter{NodeName: []string{"allow/"}}
+	denyFilter := &flowpb.FlowFilter{SourcePod: []string{"deny-pod/"}}
+
+	opts := exporteroption.Default
+	for _, opt := range []exporteroption.Option{
+		exporteroption.WithAllowList([]*flowpb.FlowFilter{allowFilter}),
+		exporteroption.WithDenyList([]*flowpb.FlowFilter{denyFilter}),
+	} {
+		err := opt(&opts)
+		assert.NoError(t, err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	exporter, err := newExporter(ctx, log, buf, opts)
+	assert.NoError(t, err)
+
+	for i, ev := range events {
+		// Check if processing stops (shouldn't write the last event)
+		if i == len(events)-1 {
+			cancel()
+		}
+		stop, err := exporter.OnDecodedEvent(ctx, ev)
+		assert.False(t, stop)
+		assert.NoError(t, err)
+
+	}
+	assert.Equal(t, `{"flow":{"time":"1970-01-01T00:00:12Z","node_name":"allow/node"},"node_name":"allow/node","time":"1970-01-01T00:00:12Z"}
+{"flow":{"time":"1970-01-01T00:00:13Z","node_name":"allow/node","source_names":["deny-pod/a"]},"node_name":"allow/node","time":"1970-01-01T00:00:13Z"}
+{"flow":{"time":"1970-01-01T00:00:14Z","node_name":"allow/node","source_names":["allow-pod/a"]},"node_name":"allow/node","time":"1970-01-01T00:00:14Z"}
 `, buf.String())
 }
 

--- a/pkg/hubble/exporter/exporteroption/option.go
+++ b/pkg/hubble/exporter/exporteroption/option.go
@@ -8,6 +8,9 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/filters"
+	"github.com/cilium/cilium/pkg/hubble/parser/fieldmask"
+
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // Options stores all the configurations values for Hubble exporter.
@@ -18,6 +21,7 @@ type Options struct {
 	Compress   bool
 
 	AllowList, DenyList filters.FilterFuncs
+	FieldMask           fieldmask.FieldMask
 }
 
 // Option customizes the configuration of the hubble server.
@@ -76,6 +80,22 @@ func WithDenyList(f []*flowpb.FlowFilter) Option {
 			return err
 		}
 		o.DenyList = filterList
+		return nil
+	}
+}
+
+// WithFieldMask sets fieldmask for the exporter.
+func WithFieldMask(paths []string) Option {
+	return func(o *Options) error {
+		fm, err := fieldmaskpb.New(&flowpb.Flow{}, paths...)
+		if err != nil {
+			return err
+		}
+		fieldMask, err := fieldmask.New(fm)
+		if err != nil {
+			return err
+		}
+		o.FieldMask = fieldMask
 		return nil
 	}
 }

--- a/pkg/hubble/exporter/exporteroption/option.go
+++ b/pkg/hubble/exporter/exporteroption/option.go
@@ -3,12 +3,21 @@
 
 package exporteroption
 
+import (
+	"context"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	"github.com/cilium/cilium/pkg/hubble/filters"
+)
+
 // Options stores all the configurations values for Hubble exporter.
 type Options struct {
 	Path       string
 	MaxSizeMB  int
 	MaxBackups int
 	Compress   bool
+
+	AllowList, DenyList filters.FilterFuncs
 }
 
 // Option customizes the configuration of the hubble server.
@@ -43,6 +52,30 @@ func WithMaxBackups(backups int) Option {
 func WithCompress() Option {
 	return func(o *Options) error {
 		o.Compress = true
+		return nil
+	}
+}
+
+// WithAllowListFilter sets allowlist filter for the exporter.
+func WithAllowList(f []*flowpb.FlowFilter) Option {
+	return func(o *Options) error {
+		filterList, err := filters.BuildFilterList(context.Background(), f, filters.DefaultFilters)
+		if err != nil {
+			return err
+		}
+		o.AllowList = filterList
+		return nil
+	}
+}
+
+// WithDenyListFilter sets denylist filter for the exporter.
+func WithDenyList(f []*flowpb.FlowFilter) Option {
+	return func(o *Options) error {
+		filterList, err := filters.BuildFilterList(context.Background(), f, filters.DefaultFilters)
+		if err != nil {
+			return err
+		}
+		o.DenyList = filterList
 		return nil
 	}
 }

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -27,6 +27,7 @@ import (
 	observerTypes "github.com/cilium/cilium/pkg/hubble/observer/types"
 	"github.com/cilium/cilium/pkg/hubble/parser"
 	parserErrors "github.com/cilium/cilium/pkg/hubble/parser/errors"
+	"github.com/cilium/cilium/pkg/hubble/parser/fieldmask"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
 
@@ -287,15 +288,15 @@ func (s *LocalObserverServer) GetFlows(
 		return err
 	}
 
-	mask, err := createFilter(req.Experimental.GetFieldMask())
+	mask, err := fieldmask.New(req.Experimental.GetFieldMask())
 	if err != nil {
 		return err
 	}
 
 	var flow *flowpb.Flow
-	if mask.active() {
+	if mask.Active() {
 		flow = new(flowpb.Flow)
-		mask.alloc(flow.ProtoReflect())
+		mask.Alloc(flow.ProtoReflect())
 	}
 
 nextEvent:
@@ -322,9 +323,9 @@ nextEvent:
 					continue nextEvent
 				}
 			}
-			if mask.active() {
+			if mask.Active() {
 				// Copy only fields in the mask
-				mask.copy(flow.ProtoReflect(), ev.ProtoReflect())
+				mask.Copy(flow.ProtoReflect(), ev.ProtoReflect())
 				ev = flow
 			}
 			resp = &observerpb.GetFlowsResponse{

--- a/pkg/hubble/parser/fieldmask/fieldmask.go
+++ b/pkg/hubble/parser/fieldmask/fieldmask.go
@@ -61,7 +61,11 @@ func (f FieldMask) Copy(dst, src protoreflect.Message) {
 				dst.Clear(fd)
 			}
 		} else {
-			next.Copy(dst.Get(fd).Message(), src.Get(fd).Message())
+			if sub := dst.Get(fd); sub.Message().IsValid() {
+				next.Copy(sub.Message(), src.Get(fd).Message())
+			} else {
+				next.Copy(dst.Mutable(fd).Message(), src.Get(fd).Message())
+			}
 		}
 	}
 }

--- a/pkg/hubble/parser/fieldmask/fieldmask_test.go
+++ b/pkg/hubble/parser/fieldmask/fieldmask_test.go
@@ -91,5 +91,10 @@ func TestFieldMask_copy_without_alloc(t *testing.T) {
 		Destination: &flowpb.Endpoint{ID: 5678, PodName: "podB", Namespace: "nsB", Identity: 9123},
 	}
 
-	assert.Panics(t, func() { fm.Copy(flow.ProtoReflect(), srcA.ProtoReflect()) })
+	// Allocate field when not pre-allocated
+	assert.NotPanics(t, func() { fm.Copy(flow.ProtoReflect(), srcA.ProtoReflect()) })
+	assert.EqualExportedValues(t, flowpb.Flow{
+		Source:      &flowpb.Endpoint{PodName: "podA"},
+		Destination: &flowpb.Endpoint{ID: 5678, PodName: "podB", Namespace: "nsB", Identity: 9123},
+	}, *flow)
 }

--- a/pkg/hubble/parser/fieldmask/fieldmask_test.go
+++ b/pkg/hubble/parser/fieldmask/fieldmask_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+//nolint:govet
+package fieldmask
+
+import (
+	"testing"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+)
+
+func TestFieldMask_invalid(t *testing.T) {
+	fm, err := New(&fieldmaskpb.FieldMask{Paths: []string{"invalid-path"}})
+	assert.ErrorContains(t, err, "invalid fieldmask")
+	assert.False(t, fm.Active())
+}
+
+func TestFieldMask_inactive(t *testing.T) {
+	fm, err := New(&fieldmaskpb.FieldMask{Paths: []string{}})
+	assert.NoError(t, err)
+	assert.False(t, fm.Active())
+}
+
+func TestFieldMask_normalized_parent(t *testing.T) {
+	fm, err := New(&fieldmaskpb.FieldMask{Paths: []string{"source", "source.identity", "source", "source.pod_name"}})
+	assert.NoError(t, err)
+	assert.Len(t, fm, 1)
+	assert.Len(t, fm["source"], 0)
+	assert.True(t, fm.Active())
+}
+
+func TestFieldMask_normalized_child(t *testing.T) {
+	fm, err := New(&fieldmaskpb.FieldMask{Paths: []string{"source.identity", "source.identity", "source.pod_name"}})
+	assert.NoError(t, err)
+	assert.Len(t, fm, 1)
+	assert.Len(t, fm["source"], 2)
+	assert.True(t, fm.Active())
+}
+
+func TestFieldMask_copy_with_alloc(t *testing.T) {
+	fm, err := New(&fieldmaskpb.FieldMask{Paths: []string{"source.identity", "source.pod_name", "destination"}})
+	assert.NoError(t, err)
+	assert.True(t, fm.Active())
+
+	flow := new(flowpb.Flow)
+	fm.Alloc(flow.ProtoReflect())
+
+	srcA := &flowpb.Flow{
+		NodeName:    "srcA",
+		Source:      &flowpb.Endpoint{ID: 1234, PodName: "podA", Namespace: "nsA"},
+		Destination: &flowpb.Endpoint{ID: 5678, PodName: "podB", Namespace: "nsB", Identity: 9123},
+	}
+	srcACopy := *srcA
+
+	fm.Copy(flow.ProtoReflect(), srcA.ProtoReflect())
+	// Confirm that source flow wasn't modified
+	assert.EqualExportedValues(t, srcACopy, *srcA)
+
+	assert.EqualExportedValues(t, flowpb.Flow{
+		Source:      &flowpb.Endpoint{PodName: "podA"},
+		Destination: &flowpb.Endpoint{ID: 5678, PodName: "podB", Namespace: "nsB", Identity: 9123},
+	}, *flow)
+
+	// Set a new field and confirm that previous values were cleared.
+	srcB := &flowpb.Flow{
+		NodeName:    "srcB",
+		Source:      &flowpb.Endpoint{Identity: 1234},
+		Destination: &flowpb.Endpoint{Namespace: "nsA", Identity: 0234},
+	}
+	fm.Copy(flow.ProtoReflect(), srcB.ProtoReflect())
+	assert.EqualExportedValues(t, flowpb.Flow{
+		Source:      &flowpb.Endpoint{Identity: 1234},
+		Destination: &flowpb.Endpoint{Namespace: "nsA", Identity: 0234},
+	}, *flow)
+}
+
+func TestFieldMask_copy_without_alloc(t *testing.T) {
+	fm, err := New(&fieldmaskpb.FieldMask{Paths: []string{"source.identity", "source.pod_name", "destination"}})
+	assert.NoError(t, err)
+	assert.True(t, fm.Active())
+
+	flow := new(flowpb.Flow)
+
+	srcA := &flowpb.Flow{
+		NodeName:    "srcA",
+		Source:      &flowpb.Endpoint{ID: 1234, PodName: "podA", Namespace: "nsA"},
+		Destination: &flowpb.Endpoint{ID: 5678, PodName: "podB", Namespace: "nsB", Identity: 9123},
+	}
+
+	assert.Panics(t, func() { fm.Copy(flow.ProtoReflect(), srcA.ProtoReflect()) })
+}


### PR DESCRIPTION
Add support for filters and field mask to Hubble-exporter

This is prerequisite for implementation of #25508

```release-note
Add an option to specify a filters and field mask for hubble-exporter
```
