### PR TITLE
bpf: refactor lib/fib.h to use new funcs

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -629,8 +629,7 @@ ct_recreate6:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 
-		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, ext_err,
-				      ctx_get_ifindex(ctx), &oif);
+		ret = fib_redirect_v6(ctx, ETH_HLEN, ip6, false, ext_err, &oif);
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV6,
 					  *dst_sec_identity, 0, oif,
@@ -1172,8 +1171,7 @@ skip_vtep:
 	if (is_defined(ENABLE_HOST_ROUTING)) {
 		int oif = 0;
 
-		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, ext_err,
-				      ctx_get_ifindex(ctx), &oif);
+		ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, false, ext_err, &oif);
 		if (fib_ok(ret))
 			send_trace_notify(ctx, TRACE_TO_NETWORK, SECLABEL_IPV4,
 					  *dst_sec_identity, 0, oif,

--- a/bpf/lib/fib.h
+++ b/bpf/lib/fib.h
@@ -171,87 +171,20 @@ out_send:
 
 static __always_inline int
 fib_redirect(struct __ctx_buff *ctx, const bool needs_l2_check,
-	     struct bpf_fib_lookup_padded *fib_params, __s8 *fib_err, int *oif)
+	     struct bpf_fib_lookup_padded *fib_params __maybe_unused,
+	     __s8 *fib_err __maybe_unused, int *oif)
 {
-	struct bpf_redir_neigh nh_params;
-	struct bpf_redir_neigh *nh = NULL;
-	bool no_neigh = is_defined(ENABLE_SKIP_FIB);
-	int ret;
-
 #ifndef ENABLE_SKIP_FIB
+	int ret;
 	ret = fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), 0);
-	if (ret != BPF_FIB_LKUP_RET_SUCCESS) {
-		*fib_err = (__s8)ret;
-		if (likely(ret == BPF_FIB_LKUP_RET_NO_NEIGH)) {
-			nh_params.nh_family = fib_params->l.family;
-			__bpf_memcpy_builtin(&nh_params.ipv6_nh,
-					     &fib_params->l.ipv6_dst,
-					     sizeof(nh_params.ipv6_nh));
-			nh = &nh_params;
-			no_neigh = true;
-			/* For kernels without d1c362e1dd68 ("bpf: Always
-			 * return target ifindex in bpf_fib_lookup") we
-			 * fall back to use the caller-provided oif when
-			 * necessary.
-			 */
-			if (!is_defined(HAVE_FIB_IFINDEX) && *oif > 0)
-				goto skip_oif;
-		} else {
-			return DROP_NO_FIB;
-		}
-	}
-	*oif = fib_params->l.ifindex;
-skip_oif:
+	*fib_err = (__s8)ret;
+	return fib_do_redirect(ctx, needs_l2_check, fib_params, fib_err, oif);
 #else
+	__s8 skip_fib = BPF_FIB_LKUP_RET_NO_NEIGH;
+	*fib_err = skip_fib;
 	*oif = DIRECT_ROUTING_DEV_IFINDEX;
-#endif /* ENABLE_SKIP_FIB */
-	if (needs_l2_check) {
-		bool l2_hdr_required = true;
-
-		ret = maybe_add_l2_hdr(ctx, *oif, &l2_hdr_required);
-		if (ret != 0)
-			return ret;
-		if (!l2_hdr_required)
-			goto out_send;
-	}
-	if (no_neigh) {
-		/* If we are able to resolve neighbors on demand, always
-		 * prefer that over the BPF neighbor map since the latter
-		 * might be less accurate in some asymmetric corner cases.
-		 */
-		if (neigh_resolver_available()) {
-			if (nh)
-				return redirect_neigh(*oif, &nh_params,
-						      sizeof(nh_params), 0);
-			else
-				return redirect_neigh(*oif, NULL, 0, 0);
-		} else {
-			union macaddr *dmac, smac = NATIVE_DEV_MAC_BY_IFINDEX(*oif);
-
-			/* The neigh_record_ip{4,6} locations are mainly from
-			 * inbound client traffic on the load-balancer where we
-			 * know that replies need to go back to them.
-			 */
-			dmac = fib_params->l.family == AF_INET ?
-			       neigh_lookup_ip4(&fib_params->l.ipv4_dst) :
-			       neigh_lookup_ip6((void *)&fib_params->l.ipv6_dst);
-			if (!dmac) {
-				*fib_err = BPF_FIB_MAP_NO_NEIGH;
-				return DROP_NO_FIB;
-			}
-			if (eth_store_daddr_aligned(ctx, dmac->addr, 0) < 0)
-				return DROP_WRITE_ERROR;
-			if (eth_store_saddr_aligned(ctx, smac.addr, 0) < 0)
-				return DROP_WRITE_ERROR;
-		}
-	} else {
-		if (eth_store_daddr(ctx, fib_params->l.dmac, 0) < 0)
-			return DROP_WRITE_ERROR;
-		if (eth_store_saddr(ctx, fib_params->l.smac, 0) < 0)
-			return DROP_WRITE_ERROR;
-	}
-out_send:
-	return ctx_redirect(ctx, *oif, 0);
+	return fib_do_redirect(ctx, needs_l2_check, NULL, fib_err, oif);
+#endif
 }
 
 #ifdef ENABLE_IPV6

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -866,8 +866,7 @@ int tail_nat_ipv46(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v6(ctx, l3_off, ip6, false, &ext_err,
-			      ctx_get_ifindex(ctx), &oif);
+	ret = fib_redirect_v6(ctx, l3_off, ip6, false, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -898,8 +897,7 @@ int tail_nat_ipv64(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v4(ctx, l3_off, ip4, false, &ext_err,
-			      ctx_get_ifindex(ctx), &oif);
+	ret = fib_redirect_v4(ctx, l3_off, ip4, false, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;
@@ -2254,8 +2252,7 @@ int tail_nodeport_ipv4_dsr(struct __ctx_buff *ctx)
 		ret = DROP_INVALID;
 		goto drop_err;
 	}
-	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, &ext_err,
-			      ctx_get_ifindex(ctx), &oif);
+	ret = fib_redirect_v4(ctx, ETH_HLEN, ip4, true, &ext_err, &oif);
 	if (fib_ok(ret)) {
 		cilium_capture_out(ctx);
 		return ret;

--- a/bpf/tests/session_affinity_test.c
+++ b/bpf/tests/session_affinity_test.c
@@ -21,8 +21,8 @@ static const char fib_dmac[6] = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37};
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)
 {
-	memcpy(params->smac, fib_smac, sizeof(fib_smac));
-	memcpy(params->dmac, fib_dmac, sizeof(fib_dmac));
+	__bpf_memcpy_builtin(params->smac, fib_smac, ETH_ALEN);
+	__bpf_memcpy_builtin(params->dmac, fib_dmac, ETH_ALEN);
 	return 0;
 }
 
@@ -187,7 +187,7 @@ int test1_check(__maybe_unused const struct __ctx_buff *ctx)
 
 	__u32 *status_code = data;
 
-	if (*status_code != XDP_TX) test_fatal("status code != XDP_TX");
+	if (*status_code != XDP_TX) test_fatal("status code != XDP_TX %u", *status_code);
 
 	data += sizeof(__u32);
 

--- a/bpf/tests/xdp_nodeport_lb4_test.c
+++ b/bpf/tests/xdp_nodeport_lb4_test.c
@@ -17,8 +17,8 @@ static const char fib_dmac[6] = {0x13, 0x37, 0x13, 0x37, 0x13, 0x37};
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)
 {
-	memcpy(params->smac, fib_smac, sizeof(fib_smac));
-	memcpy(params->dmac, fib_dmac, sizeof(fib_dmac));
+	__bpf_memcpy_builtin(params->smac, fib_smac, ETH_ALEN);
+	__bpf_memcpy_builtin(params->dmac, fib_dmac, ETH_ALEN);
 	return 0;
 }
 


### PR DESCRIPTION
- bpf,fib: use fib_do_redirect in fib_redirect
- bpf: refactor fib_redirect_v4/6 to use decoupled functions

This pull request is a follow up on #26136. 

In this pull request we refactor the existing lib/fib.h to use the modularized 
fib functions.

These changes should result in no functional differences in the datapath, instead it
removes the redundant code that is present prior to this commit.

```release-note
bpf,fib: refactor lib/fib.h to remove the now redundant code
```
