### PR TITLE
doc: Improved Cilium ingress annotations table

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -58,39 +58,52 @@ Supported Ingress Annotations
 #############################
 
 .. list-table::
-   :widths: 25 25 50
    :header-rows: 1
 
    * - Name
      - Description
      - Default Value
    * - ``ingress.cilium.io/loadbalancer-mode``
-     - The loadbalancer mode for the ingress. Applicable values are ``dedicated`` and ``shared``.
-     - Defaults to Helm option ``ingressController.loadbalancerMode`` value.
+     - | The loadbalancer mode for the ingress.
+       | Allows a per ingress override
+       | of the default set in the Helm value
+       | ``ingressController.loadbalancerMode``.
+       | Applicable values are ``dedicated`` and
+       | ``shared``.
+     - | ``dedicated``
+       | (from Helm chart)
    * - ``ingress.cilium.io/service-type``
-     - The Service type for dedicated Ingress. Applicable values are ``LoadBalancer`` and ``NodePort``.
-     - Defaults to ``LoadBalancer`` if unspecified.
+     - | The Service type for dedicated Ingress.
+       | Applicable values are ``LoadBalancer``
+       | and ``NodePort``.
+     - ``LoadBalancer``
    * - ``ingress.cilium.io/insecure-node-port``
-     - The NodePort to use for the HTTP Ingress. Applicable only if ``ingress.cilium.io/service-type`` is ``NodePort``.
-     - If unspecified, a random NodePort will be allocated by kubernetes.
+     - | The NodePort to use for the HTTP Ingress.
+       | Applicable only if ``ingress.cilium.io/service-type`` is ``NodePort``. If unspecified, a random
+       | NodePort will be allocated by kubernetes.
+     - unspecified
    * - ``ingress.cilium.io/secure-node-port``
-     - The NodePort to use for the HTTPS Ingress. Applicable only if ``ingress.cilium.io/service-type`` is ``NodePort``.
-     - If unspecified, a random NodePort will be allocated by kubernetes.
+     - | The NodePort to use for the HTTPS Ingress.
+       | Applicable only if ``ingress.cilium.io/service-type`` is ``NodePort``. If unspecified, a random
+       | NodePort will be allocated by kubernetes.
+     - unspecified
    * - ``ingress.cilium.io/tcp-keep-alive``
-     - Enable TCP keep-alive
-     - 1 (enabled)
+     - | Enable TCP keep-alive. Applicable values
+       | are ``enabled`` and ``disabled``.
+     - ``enabled``
    * - ``ingress.cilium.io/tcp-keep-alive-idle``
      - TCP keep-alive idle time (in seconds)
-     - 10s
+     - ``10``
    * - ``ingress.cilium.io/tcp-keep-alive-probe-interval``
      - TCP keep-alive probe intervals (in seconds)
-     - 5s
+     - ``5``
    * - ``ingress.cilium.io/tcp-keep-alive-probe-max-failures``
      - TCP keep-alive probe max failures
-     - 10
+     - ``10``
    * - ``ingress.cilium.io/websocket``
-     - Enable websocket
-     - disabled
+     - | Enable websocket passthrough support.
+       | Applicable values are ``enabled`` and ``disabled``.
+     - ``disabled``
 
 Additionally, cloud-provider specific annotations for the LoadBalancer service
 are supported. Please refer to the `Kubernetes documentation <https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer>`_


### PR DESCRIPTION
* Improved statements about Cilium ingress annotation default values
* Fixed Cilium ingress annotation table formatting so vertical scrolling is not needed anymore.
* Removed `:widths: 25 25 50` because it didn't have an impact at all.

Please ensure your pull request adheres to the following guidelines:

- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.

```release-note
doc: Improved Cilium ingress annotations table
```

Rendered table:
![image](https://github.com/cilium/cilium/assets/5549063/1001502a-6ab4-4e19-ad43-6098ad75884d)

