### PR TITLE
test/controlplane: Disable endpoint GC

### DIFF
--- a/test/controlplane/suite/agent.go
+++ b/test/controlplane/suite/agent.go
@@ -97,6 +97,11 @@ func startCiliumAgent(t *testing.T, clientset k8sClient.Clientset, extraCell cel
 		}),
 	)
 
+	// Unlike global configuration options, cell-specific configuration options
+	// (i.e. the ones defined through cell.Config(...)) must be set to the *viper.Viper
+	// object bound to the test hive.
+	handle.hive.Viper().Set(option.EndpointGCInterval, 0)
+
 	if err := handle.hive.Start(context.TODO()); err != nil {
 		return nil, agentHandle{}, err
 	}


### PR DESCRIPTION
The Endpoint GC is currently not needed in controlplane testing.

Since that GC needs to lock the endpoints map in the endpoint manager, it can possibly delay the execution of the endpoint manager "node subscriber" callback, that needs to hold the same lock.  This in turn might lead to the slow down of the CiliumNodeUpdater callback that needs to wait for the previous callback before running.  The inability of the CiliumNodeUpdater callback to run in time seems to be the possible culprit of the controlplane CiliumNodes test flake.

To mitigate the flake, the endpoint GC is then disabled in controlplane testing.

Related: #26082
