### PR TITLE
clustermesh: fix broken test due to merge race

### DIFF
--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -95,7 +95,7 @@ func TestClusterMesh(t *testing.T) {
 		wg.Wait()
 	}()
 
-	kvstore.SetupDummy(c, "etcd")
+	kvstore.SetupDummy(t, "etcd")
 
 	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.


### PR DESCRIPTION
Due to a merge race, one of the clustermesh tests is currently broken. Let's fix it, removing a leftover reference to checkmate.

Fixes: 081c4d2e1a50 ("kvstore: prevent multiple test clients from being created in parallel")
Fixes: 5409bc51b398 ("clustermesh: improve reliability of TestClusterMesh")