### PR TITLE
.github/workflows: let renovate update kind in ingress workflow

### DIFF
--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -24,6 +24,7 @@ env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
   cilium_cli_version: v0.14.7
   cilium_cli_ci_version:
+  # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.17.0
   kind_config: .github/kind-config.yaml
   metallb_version: 0.12.1


### PR DESCRIPTION
This was missed in commit d722d513dc8d (".github/workflows: let renovate update kind").