### PR TITLE
metrics: fix missing k8s rest client metrics

### DIFF
--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -93,13 +93,8 @@ func init() {
 		k8s.K8sErrorHandler,
 	}
 
-	k8s_metrics.Register(k8s_metrics.RegisterOpts{
-		ClientCertExpiry:      nil,
-		ClientCertRotationAge: nil,
-		RequestLatency:        &k8sMetrics{},
-		RateLimiterLatency:    nil,
-		RequestResult:         &k8sMetrics{},
-	})
+	k8s_metrics.RequestLatency = &k8sMetrics{}
+	k8s_metrics.RequestResult = &k8sMetrics{}
 }
 
 var (


### PR DESCRIPTION
K8s rest client metrics, `cilium_k8s_client_api_latency_time_seconds` and `cilium_k8s_client_api_calls_total`, are missing because of a conflict with controller-runtime on the metrics registration.

controller-runtime(sigs.k8s.io/controller-runtime/pkg/metrics) also registers the client-go rest client metrics on its registry using metrics.Register method in its init function. The metrics.Register can be called only once, and subsequent calls will be ignored.

cilium-agent doesn't use controller-runtime, but there's an indirect dependency from github.com/cilium/cilium/daemon to github.com/cilium/cilium/operator/metrics package. (operator uses controller-runtime in its Gateway API implementation)
For example,

github.com/cilium/cilium/daemon/cmd
-> github.com/cilium/cilium/pkg/ipam
-> github.com/cilium/cilium/pkg/ipam/metrics
-> github.com/cilium/cilium/operator/metrics

The init function of sigs.k8s.io/controller-runtime/pkg/metrics will be called because of this indirect dependency.

This commit fixes this conflict by registering the metrics without using metrics.Register.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #25610

