### PR TITLE
CI Workflows: Fix sysdump file creation

### DIFF
--- a/.github/workflows/conformance-aks-v1.11.yaml
+++ b/.github/workflows/conformance-aks-v1.11.yaml
@@ -390,7 +390,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/conformance-aks-v1.12.yaml
+++ b/.github/workflows/conformance-aks-v1.12.yaml
@@ -392,7 +392,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/conformance-aks-v1.13.yaml
+++ b/.github/workflows/conformance-aks-v1.13.yaml
@@ -392,7 +392,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -390,7 +390,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up AKS

--- a/.github/workflows/conformance-aws-cni-v1.11.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.11.yaml
@@ -361,7 +361,7 @@ jobs:
           echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-aws-cni-v1.12.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.12.yaml
@@ -361,7 +361,7 @@ jobs:
           echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-aws-cni-v1.13.yaml
+++ b/.github/workflows/conformance-aws-cni-v1.13.yaml
@@ -361,7 +361,7 @@ jobs:
           echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -350,7 +350,7 @@ jobs:
           echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-clustermesh-v1.11.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.11.yaml
@@ -519,18 +519,18 @@ jobs:
 
         kubectl config use-context ${{ env.contextName1 }}
         kubectl get pods --all-namespaces -o wide
-        cilium sysdump --output-filename cilium-sysdump-context1-final
+        cilium sysdump --output-filename cilium-sysdump-context1-final-${{ join(matrix.*, '-') }}
 
         kubectl config use-context ${{ env.contextName2 }}
         kubectl get pods --all-namespaces -o wide
-        cilium sysdump --output-filename cilium-sysdump-context2-final
+        cilium sysdump --output-filename cilium-sysdump-context2-final-${{ join(matrix.*, '-') }}
       shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
     - name: Upload artifacts
       if: ${{ !success() }}
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
-        name: cilium-sysdumps-${{ matrix.name }}
+        name: cilium-sysdumps
         path: cilium-sysdump-*.zip
         retention-days: 5
 

--- a/.github/workflows/conformance-clustermesh-v1.12.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.12.yaml
@@ -514,18 +514,18 @@ jobs:
 
         kubectl config use-context ${{ env.contextName1 }}
         kubectl get pods --all-namespaces -o wide
-        cilium sysdump --output-filename cilium-sysdump-context1-final
+        cilium sysdump --output-filename cilium-sysdump-context1-final-${{ join(matrix.*, '-') }}
 
         kubectl config use-context ${{ env.contextName2 }}
         kubectl get pods --all-namespaces -o wide
-        cilium sysdump --output-filename cilium-sysdump-context2-final
+        cilium sysdump --output-filename cilium-sysdump-context2-final-${{ join(matrix.*, '-') }}
       shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
     - name: Upload artifacts
       if: ${{ !success() }}
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
-        name: cilium-sysdumps-${{ matrix.name }}
+        name: cilium-sysdumps
         path: cilium-sysdump-*.zip
         retention-days: 5
 

--- a/.github/workflows/conformance-clustermesh-v1.13.yaml
+++ b/.github/workflows/conformance-clustermesh-v1.13.yaml
@@ -514,18 +514,18 @@ jobs:
 
         kubectl config use-context ${{ env.contextName1 }}
         kubectl get pods --all-namespaces -o wide
-        cilium sysdump --output-filename cilium-sysdump-context1-final
+        cilium sysdump --output-filename cilium-sysdump-context1-${{ join(matrix.*, '-') }}
 
         kubectl config use-context ${{ env.contextName2 }}
         kubectl get pods --all-namespaces -o wide
-        cilium sysdump --output-filename cilium-sysdump-context2-final
+        cilium sysdump --output-filename cilium-sysdump-context2-final-${{ join(matrix.*, '-') }}
       shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
     - name: Upload artifacts
       if: ${{ !success() }}
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
-        name: cilium-sysdumps-${{ matrix.name }}
+        name: cilium-sysdumps
         path: cilium-sysdump-*.zip
         retention-days: 5
 

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -504,18 +504,18 @@ jobs:
 
         kubectl config use-context ${{ env.contextName1 }}
         kubectl get pods --all-namespaces -o wide
-        cilium sysdump --output-filename cilium-sysdump-context1-final
+        cilium sysdump --output-filename cilium-sysdump-context1-final-${{ join(matrix.*, '-') }}
 
         kubectl config use-context ${{ env.contextName2 }}
         kubectl get pods --all-namespaces -o wide
-        cilium sysdump --output-filename cilium-sysdump-context2-final
+        cilium sysdump --output-filename cilium-sysdump-context2-final-${{ join(matrix.*, '-') }}
       shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
     - name: Upload artifacts
       if: ${{ !success() }}
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
-        name: cilium-sysdumps-${{ matrix.name }}
+        name: cilium-sysdumps
         path: cilium-sysdump-*.zip
         retention-days: 5
 

--- a/.github/workflows/conformance-eks-v1.11.yaml
+++ b/.github/workflows/conformance-eks-v1.11.yaml
@@ -381,7 +381,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, "-") }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-eks-v1.12.yaml
+++ b/.github/workflows/conformance-eks-v1.12.yaml
@@ -381,7 +381,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, "-") }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-eks-v1.13.yaml
+++ b/.github/workflows/conformance-eks-v1.13.yaml
@@ -381,7 +381,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, "-") }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -373,7 +373,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, "-") }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up EKS

--- a/.github/workflows/conformance-externalworkloads-v1.11.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.11.yaml
@@ -408,7 +408,7 @@ jobs:
           cilium clustermesh vm status
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} --command "sudo cilium status"
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} --command "sudo docker logs cilium --timestamps"
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE cluster and VM

--- a/.github/workflows/conformance-externalworkloads-v1.12.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.12.yaml
@@ -408,7 +408,7 @@ jobs:
           cilium clustermesh vm status
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} --command "sudo cilium status"
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} --command "sudo docker logs cilium --timestamps"
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE cluster and VM

--- a/.github/workflows/conformance-externalworkloads-v1.13.yaml
+++ b/.github/workflows/conformance-externalworkloads-v1.13.yaml
@@ -408,7 +408,7 @@ jobs:
           cilium clustermesh vm status
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} --command "sudo cilium status"
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} --command "sudo docker logs cilium --timestamps"
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE cluster and VM

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -404,7 +404,7 @@ jobs:
           cilium clustermesh vm status
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} --command "sudo cilium status"
           gcloud compute ssh ${{ env.vmName }}-${{ matrix.vmIndex }} --zone ${{ matrix.zone }} --command "sudo docker logs cilium --timestamps"
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ join(matrix.*, '-') }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE cluster and VM

--- a/.github/workflows/conformance-gke-v1.11.yaml
+++ b/.github/workflows/conformance-gke-v1.11.yaml
@@ -370,7 +370,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ matrix.k8s.version }}-${{ matrix.config.index }}-${{ matrix.config.type }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/conformance-gke-v1.12.yaml
+++ b/.github/workflows/conformance-gke-v1.12.yaml
@@ -370,7 +370,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ matrix.k8s.version }}-${{ matrix.config.index }}-${{ matrix.config.type }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/conformance-gke-v1.13.yaml
+++ b/.github/workflows/conformance-gke-v1.13.yaml
@@ -371,7 +371,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ matrix.k8s.version }}-${{ matrix.config.index }}-${{ matrix.config.type }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -367,7 +367,7 @@ jobs:
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status
-          cilium sysdump --output-filename cilium-sysdump-final
+          cilium sysdump --output-filename cilium-sysdump-final-${{ matrix.k8s.version }}-${{ matrix.config.index }}-${{ matrix.config.type }}
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Clean up GKE


### PR DESCRIPTION
Currently, conformance tests that run in matrix strategy do not create sysdump files with a unique name.
Only one report is uploaded in GitHub artifacts. This changes sysdump files names uniq per matrix run.

Test run, it generates sysdump per matrix run.
https://github.com/cilium/cilium/actions/runs/5336461842?pr=26402
