### PR TITLE
CI: run integration-tests on test changes in PRs

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -5,7 +5,6 @@ on:
   pull_request:
     paths-ignore:
     - 'Documentation/**'
-    - 'test/**'
   push:
     branches:
     - main


### PR DESCRIPTION
Currently, integration-tests were not run on test changes.

Followup from https://github.com/cilium/cilium/pull/26383