### PR TITLE
renovate: ignore ginkgo updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -140,6 +140,7 @@
       "matchPackagePatterns": [
         // Once we decide to spend cycles on ginkgo v2 we should update the
         // dependency manually.
+        "github.com/onsi/ginkgo",
         "github.com/onsi/gomega/*",
         // k8s dependencies will be updated manually along with tests
         "k8s.io/*",


### PR DESCRIPTION
Ignore the github.com/onsi/ginkgo module in addition to github.com/onsi/gomega/* to avoid ginkgo v2 updates as indicated by the existing comment.