### PR TITLE
Fixes for ip-masq-agent

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -108,6 +108,7 @@ include:
 
   ###
   # K8sDatapathConfig Check BPF masquerading with ip-masq-agent DirectRouting
+  # K8sDatapathConfig Check BPF masquerading with ip-masq-agent DirectRouting, IPv4 only
   # K8sDatapathConfig Check BPF masquerading with ip-masq-agent VXLAN
   # K8sDatapathConfig High-scale IPcache Test ingress policy enforcement with GENEVE and endpoint routes
   # K8sDatapathConfig High-scale IPcache Test ingress policy enforcement with VXLAN and no endpoint routes

--- a/cilium/cmd/bpf_ipmasq_list.go
+++ b/cilium/cmd/bpf_ipmasq_list.go
@@ -26,7 +26,15 @@ var bpfIPMasqListCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		common.RequireRootPrivilege("cilium bpf ipmasq list")
 
-		cidrs, err := (&ipmasq.IPMasqBPFMap{}).Dump()
+		// Depending on whether BPF masquerading is enabled for IPv4
+		// and IPv6, we may have zero, one, or two maps to dump, and we
+		// need to tell which ones to DumpForProtocols().
+		// Here we try to open the maps as a hack to avoid going
+		// through a full API request to check the config options from
+		// the agent.
+		ipv4Needed := ipmasq.IPMasq4Map().Open() == nil
+		ipv6Needed := ipmasq.IPMasq6Map().Open() == nil
+		cidrs, err := (&ipmasq.IPMasqBPFMap{}).DumpForProtocols(ipv4Needed, ipv6Needed)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error dumping contents of map: %s\n", err)
 			os.Exit(1)

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -414,14 +414,16 @@ func (d *Daemon) initMaps() error {
 		datapathIpcache.NewListener(d, d, d.ipcache),
 	})
 
-	if option.Config.EnableIPv4 && option.Config.EnableIPMasqAgent {
-		if err := ipmasq.IPMasq4Map().OpenOrCreate(); err != nil {
-			return fmt.Errorf("initializing IPv4 masquerading map: %w", err)
+	if option.Config.EnableIPMasqAgent {
+		if option.Config.EnableIPv4Masquerade {
+			if err := ipmasq.IPMasq4Map().OpenOrCreate(); err != nil {
+				return fmt.Errorf("initializing IPv4 masquerading map: %w", err)
+			}
 		}
-	}
-	if option.Config.EnableIPv6 && option.Config.EnableIPMasqAgent {
-		if err := ipmasq.IPMasq6Map().OpenOrCreate(); err != nil {
-			return fmt.Errorf("initializing IPv6 masquerading map: %w", err)
+		if option.Config.EnableIPv6Masquerade {
+			if err := ipmasq.IPMasq6Map().OpenOrCreate(); err != nil {
+				return fmt.Errorf("initializing IPv6 masquerading map: %w", err)
+			}
 		}
 	}
 

--- a/examples/kubernetes-ip-masq-agent/rfc1918.yaml
+++ b/examples/kubernetes-ip-masq-agent/rfc1918.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
-  kind: ConfigMap
-  metadata:
-    name: ip-masq-agent
-  data:
-    config: |
-      nonMasqueradeCIDRs:
-      - 10.0.0.0/8
-      - 172.16.0.0/12
-      - 192.168.0.0/16
-      masqLinkLocal: true
+kind: ConfigMap
+metadata:
+  name: ip-masq-agent
+data:
+  config: |
+    nonMasqueradeCIDRs:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+    masqLinkLocal: true

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -608,14 +608,8 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 
 				// ip-masq-agent depends on bpf-masq
 				if option.Config.EnableIPMasqAgent {
-					if option.Config.EnableIPv4 {
-						cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV4"] = "1"
-						cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapNameIPv4
-					}
-					if option.Config.EnableIPv6 {
-						cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV6"] = "1"
-						cDefinesMap["IP_MASQ_AGENT_IPV6"] = ipmasq.MapNameIPv6
-					}
+					cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV4"] = "1"
+					cDefinesMap["IP_MASQ_AGENT_IPV4"] = ipmasq.MapNameIPv4
 				}
 			}
 			if option.Config.EnableIPv6Masquerade {
@@ -625,6 +619,11 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 				fw.WriteString(FmtDefineAddress("IPV6_SNAT_EXCLUSION_DST_CIDR", cidr.IP))
 				extraMacrosMap["IPV6_SNAT_EXCLUSION_DST_CIDR_MASK"] = cidr.Mask.String()
 				fw.WriteString(FmtDefineAddress("IPV6_SNAT_EXCLUSION_DST_CIDR_MASK", cidr.Mask))
+
+				if option.Config.EnableIPMasqAgent {
+					cDefinesMap["ENABLE_IP_MASQ_AGENT_IPV6"] = "1"
+					cDefinesMap["IP_MASQ_AGENT_IPV6"] = ipmasq.MapNameIPv6
+				}
 			}
 		}
 

--- a/pkg/datapath/maps/map.go
+++ b/pkg/datapath/maps/map.go
@@ -204,13 +204,12 @@ func (ms *MapSweeper) RemoveDisabledMaps() {
 		maps = append(maps, lbmap.SourceRange6MapName, lbmap.SourceRange4MapName)
 	}
 
-	if !option.Config.EnableIPMasqAgent {
-		if option.Config.EnableIPv4 {
-			maps = append(maps, ipmasq.MapNameIPv4)
-		}
-		if option.Config.EnableIPv6 {
-			maps = append(maps, ipmasq.MapNameIPv6)
-		}
+	if !(option.Config.EnableIPMasqAgent && option.Config.EnableIPv4Masquerade) {
+		maps = append(maps, ipmasq.MapNameIPv4)
+	}
+
+	if !(option.Config.EnableIPMasqAgent && option.Config.EnableIPv6Masquerade) {
+		maps = append(maps, ipmasq.MapNameIPv6)
 	}
 
 	if !option.Config.EnableXDPPrefilter {

--- a/pkg/maps/ipmasq/ipmasq.go
+++ b/pkg/maps/ipmasq/ipmasq.go
@@ -86,18 +86,28 @@ type IPMasqBPFMap struct{}
 
 func (*IPMasqBPFMap) Update(cidr net.IPNet) error {
 	if ip.IsIPv4(cidr.IP) {
-		return IPMasq4Map().Update(keyIPv4(cidr), &Value{})
+		if option.Config.EnableIPv4Masquerade {
+			return IPMasq4Map().Update(keyIPv4(cidr), &Value{})
+		}
 	} else {
-		return IPMasq6Map().Update(keyIPv6(cidr), &Value{})
+		if option.Config.EnableIPv6Masquerade {
+			return IPMasq6Map().Update(keyIPv6(cidr), &Value{})
+		}
 	}
+	return nil
 }
 
 func (*IPMasqBPFMap) Delete(cidr net.IPNet) error {
 	if ip.IsIPv4(cidr.IP) {
-		return IPMasq4Map().Delete(keyIPv4(cidr))
+		if option.Config.EnableIPv4Masquerade {
+			return IPMasq4Map().Delete(keyIPv4(cidr))
+		}
 	} else {
-		return IPMasq6Map().Delete(keyIPv6(cidr))
+		if option.Config.EnableIPv6Masquerade {
+			return IPMasq6Map().Delete(keyIPv6(cidr))
+		}
 	}
+	return nil
 }
 
 func (*IPMasqBPFMap) Dump() ([]net.IPNet, error) {

--- a/pkg/maps/ipmasq/ipmasq.go
+++ b/pkg/maps/ipmasq/ipmasq.go
@@ -110,18 +110,24 @@ func (*IPMasqBPFMap) Delete(cidr net.IPNet) error {
 	return nil
 }
 
-func (*IPMasqBPFMap) Dump() ([]net.IPNet, error) {
+// DumpForProtocols dumps the contents of the ip-masq-agent maps for IPv4
+// and/or IPv6, as requested by the caller.
+// Given that the package does not expose the maps directly, it's necessary to
+// specify which protocol we need when ipMasq4Map/ipMasq6Map, or config
+// options, have not been set, as is the case when calling from the CLI, for
+// example.
+func (*IPMasqBPFMap) DumpForProtocols(ipv4Needed, ipv6Needed bool) ([]net.IPNet, error) {
 	cidrs := []net.IPNet{}
-	if ipMasq4Map != nil {
-		if err := ipMasq4Map.DumpWithCallback(
+	if ipv4Needed {
+		if err := IPMasq4Map().DumpWithCallback(
 			func(keyIPv4 bpf.MapKey, _ bpf.MapValue) {
 				cidrs = append(cidrs, keyToIPNetIPv4(keyIPv4.(*Key4)))
 			}); err != nil {
 			return nil, err
 		}
 	}
-	if ipMasq6Map != nil {
-		if err := ipMasq6Map.DumpWithCallback(
+	if ipv6Needed {
+		if err := IPMasq6Map().DumpWithCallback(
 			func(keyIPv6 bpf.MapKey, _ bpf.MapValue) {
 				cidrs = append(cidrs, keyToIPNetIPv6(keyIPv6.(*Key6)))
 			}); err != nil {
@@ -129,6 +135,12 @@ func (*IPMasqBPFMap) Dump() ([]net.IPNet, error) {
 		}
 	}
 	return cidrs, nil
+}
+
+// Dump dumps the contents of the ip-masq-agent maps for IPv4 and/or IPv6, as
+// required based on configuration options.
+func (*IPMasqBPFMap) Dump() ([]net.IPNet, error) {
+	return (&IPMasqBPFMap{}).DumpForProtocols(option.Config.EnableIPv4Masquerade, option.Config.EnableIPv6Masquerade)
 }
 
 func keyIPv4(cidr net.IPNet) *Key4 {

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -361,6 +361,18 @@ var _ = Describe("K8sDatapathConfig", func() {
 			testIPMasqAgent()
 		})
 
+		It("DirectRouting, IPv4 only", func() {
+			deploymentManager.DeployCilium(map[string]string{
+				"ipMasqAgent.enabled":                   "true",
+				"routingMode":                           "native",
+				"autoDirectNodeRoutes":                  "true",
+				"ipMasqAgent.config.nonMasqueradeCIDRs": fmt.Sprintf("{%s/32}", nodeIP),
+				"ipv6.enabled":                          "false",
+			}, DeployCiliumOptionsAndDNS)
+
+			testIPMasqAgent()
+		})
+
 		It("VXLAN", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"ipMasqAgent.enabled":                   "true",


### PR DESCRIPTION
It looks like I didn't test the ip-masq-agent quite enough when adding support for IPv6 - in particular, I didn't test with IPv4 only. Sebastian reported that when IPv6 is off, ip-masq-agent is broken. This PR contains a number of fixes to address that.

Fixes: #26262

```release-note
Fix some map handling logic as well as some issues with CLI commands related to ip-masq-agent, introduced with IPv6 support
```
