### PR TITLE
egressgw: retry getIdentityLabels on failure

### DIFF
--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -38,6 +38,10 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels label
 		return nil, fmt.Errorf("endpoint has no networking metadata")
 	}
 
+	if len(endpoint.Networking.Addressing) == 0 {
+		return nil, fmt.Errorf("failed to get valid endpoint IPs")
+	}
+
 	for _, pair := range endpoint.Networking.Addressing {
 		if pair.IPV4 != "" {
 			ipv4s = append(ipv4s, net.ParseIP(pair.IPV4).To4())

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -345,13 +345,6 @@ func (manager *Manager) addEndpoint(id types.NamespacedName) {
 	// encounter a failure it cannot be retried
 	delete(manager.pendingEndpointEvents, id)
 
-	if len(endpoint.Networking.Addressing) == 0 {
-		logger.WithError(err).
-			Error("Failed to get valid endpoint IPs, skipping update to egress policy.")
-
-		return
-	}
-
 	if epData, err = getEndpointMetadata(endpoint, identityLabels); err != nil {
 		logger.WithError(err).
 			Error("Failed to get valid endpoint metadata, skipping update to egress policy.")


### PR DESCRIPTION
when the manager fails to resolve the identity of an endpoint to a set of labels, instead of discarding the endpoint update, enqueue the event and retry identity labels resolution following the same exponential backoff logic used by the identity allocator

### testing 
I tested this locally by forcing the identity resolution to randomly fail:

```diff
diff --git a/pkg/egressgateway/manager.go b/pkg/egressgateway/manager.go
index ed7f19399c..0b867b2d12 100644
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -7,6 +7,7 @@ import (
        "container/heap"
        "context"
        "fmt"
+       "math/rand"
        "net"
        "sort"
        "time"
@@ -171,6 +172,10 @@ func NewEgressGatewayManager(p Params) *Manager {
 // getIdentityLabels waits for the global identities to be populated to the cache,
 // then looks up identity by ID from the cached identity allocator and return its labels.
 func (manager *Manager) getIdentityLabels(securityIdentity uint32) (labels.Labels, error) {
+       if rand.Intn(16) > 0 {
+               return nil, fmt.Errorf("fake error")
+       }
+
```

```sh
➜  cilium git:(pr/jibi/egressgw-retry-identity) ks logs cilium-2dc5v --timestamps | grep subsys=egress | grep coredns-5d78c9869d-44vlf
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), clean-cilium-state (init), install-cni-binaries (init)
2023-06-23T10:22:36.698593375Z level=warning msg="Failed to get identity labels for endpoint, will retry." error="fake error" k8sEndpointName=coredns-5d78c9869d-44vlf k8sNamespace=kube-system subsys=egressgateway
2023-06-23T10:22:37.590584472Z level=warning msg="Failed to get identity labels for endpoint, will retry." error="fake error" k8sEndpointName=coredns-5d78c9869d-44vlf k8sNamespace=kube-system subsys=egressgateway
2023-06-23T10:22:42.630015783Z level=warning msg="Failed to get identity labels for endpoint, will retry." error="fake error" k8sEndpointName=coredns-5d78c9869d-44vlf k8sNamespace=kube-system subsys=egressgateway
2023-06-23T10:22:44.710650728Z level=warning msg="Failed to get identity labels for endpoint, will retry." error="fake error" k8sEndpointName=coredns-5d78c9869d-44vlf k8sNamespace=kube-system subsys=egressgateway
2023-06-23T10:22:46.871488814Z level=warning msg="Failed to get identity labels for endpoint, will retry." error="fake error" k8sEndpointName=coredns-5d78c9869d-44vlf k8sNamespace=kube-system subsys=egressgateway
2023-06-23T10:22:52.190670670Z level=warning msg="Failed to get identity labels for endpoint, will retry." error="fake error" k8sEndpointName=coredns-5d78c9869d-44vlf k8sNamespace=kube-system subsys=egressgateway
2023-06-23T10:22:55.113841789Z level=warning msg="Failed to get identity labels for endpoint, will retry." error="fake error" k8sEndpointName=coredns-5d78c9869d-44vlf k8sNamespace=kube-system subsys=egressgateway
2023-06-23T10:22:58.952487945Z level=debug msg="Added CiliumEndpoint" k8sEndpointName=coredns-5d78c9869d-44vlf k8sNamespace=kube-system subsys=egressgateway
```

Fixes: #26158 (hopefully :crossed_fingers:)