### PR TITLE
Fix content headers in Health Check Node Port response

### DIFF
--- a/pkg/service/healthserver/healthserver.go
+++ b/pkg/service/healthserver/healthserver.go
@@ -213,13 +213,14 @@ func (h *httpHealthServer) shutdown() {
 func (h *httpHealthServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Use headers and JSON output compatible with kube-proxy
 	svc := h.loadService()
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
 	if svc.LocalEndpoints == 0 {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	} else {
 		w.WriteHeader(http.StatusOK)
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-Content-Type-Options", "nosniff")
 	if err := json.NewEncoder(w).Encode(&svc); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}

--- a/pkg/service/healthserver/healthserver_test.go
+++ b/pkg/service/healthserver/healthserver_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	. "github.com/cilium/checkmate"
+	"github.com/google/go-cmp/cmp"
 )
 
 type ServiceHealthServerSuite struct{}
@@ -94,7 +94,7 @@ func (s *ServiceHealthServerSuite) Test_httpHealthServer_ServeHTTP(c *C) {
 	assertRespHeader(c, resp, "Content-Type", "application/json")
 	assertRespHeader(c, resp, "X-Content-Type-Options", "nosniff")
 	resp.Body.Close()
-	
+
 	// Remove local endpoints, server must respond with HTTP 503
 	h.updateService(NewService("default", "svc", 0))
 	resp, err = http.Get(ts.URL)


### PR DESCRIPTION
Fix content headers in Health Check Node Port response. 

Before the fix 2 content headers are not returned, because `w.WriteHeader(http.StatusOK)` must be called after setting the headers map

```release-note
Fix: Return "Content-Type" and "X-Content-Type-Options" headers from  Health Check Node Port
```

