### PR TITLE
docs: Fix the cilium-cli default branch name

### DIFF
--- a/Documentation/installation/cli-download.rst
+++ b/Documentation/installation/cli-download.rst
@@ -7,7 +7,7 @@ various features (e.g. clustermesh, Hubble).
 
     .. code-block:: shell-session
 
-      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
       CLI_ARCH=amd64
       if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
       curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
@@ -19,7 +19,7 @@ various features (e.g. clustermesh, Hubble).
 
     .. code-block:: shell-session
 
-      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable.txt)
       CLI_ARCH=amd64
       if [ "$(uname -m)" = "arm64" ]; then CLI_ARCH=arm64; fi
       curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-${CLI_ARCH}.tar.gz{,.sha256sum}


### PR DESCRIPTION
The default branch name for cilium/cilium-cli repo changed from master to main. The current instructions still work because the master branch gets synched with the main branch, but let's update the docs to use the new default branch name to avoid any confusion in the future.

Ref: #26430
Ref: https://github.com/cilium/cilium-cli/blob/main/.github/workflows/mirror.yaml