### PR TITLE
docs: Fix the cilium/proxy default branch name

### DIFF
--- a/Documentation/network/servicemesh/l7-traffic-management.rst
+++ b/Documentation/network/servicemesh/l7-traffic-management.rst
@@ -44,7 +44,7 @@ Envoy extensions available in the Envoy code base.
 
 To see which Envoy extensions are available, please have a look at
 the `Envoy extensions configuration
-file <https://github.com/cilium/proxy/blob/master/envoy_build_config/extensions_build_config.bzl>`_.
+file <https://github.com/cilium/proxy/blob/main/envoy_build_config/extensions_build_config.bzl>`_.
 Only the extensions that have not been commented out with ``#`` are
 built in to the Cilium Envoy image. Currently this contains the
 following extensions:


### PR DESCRIPTION
This is a follow-up PR to #26461 to change the branch name used for cilium/proxy from master to main.