### PR TITLE
v1.12 docs: Use stable-v0.14.txt for cilium-cli version

### DIFF
--- a/Documentation/gettingstarted/cli-download.rst
+++ b/Documentation/gettingstarted/cli-download.rst
@@ -7,7 +7,7 @@ various features (e.g. clustermesh, Hubble).
 
     .. code-block:: shell-session
 
-      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
       CLI_ARCH=amd64
       if [ "$(uname -m)" = "aarch64" ]; then CLI_ARCH=arm64; fi
       curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-linux-${CLI_ARCH}.tar.gz{,.sha256sum}
@@ -19,7 +19,7 @@ various features (e.g. clustermesh, Hubble).
 
     .. code-block:: shell-session
 
-      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/master/stable.txt)
+      CILIUM_CLI_VERSION=$(curl -s https://raw.githubusercontent.com/cilium/cilium-cli/main/stable-v0.14.txt)
       CLI_ARCH=amd64
       if [ "$(uname -m)" = "arm64" ]; then CLI_ARCH=arm64; fi
       curl -L --fail --remote-name-all https://github.com/cilium/cilium-cli/releases/download/${CILIUM_CLI_VERSION}/cilium-darwin-${CLI_ARCH}.tar.gz{,.sha256sum}


### PR DESCRIPTION
The next cilium-cli release is v0.15.0 with Helm mode as the default installation mode. Continue to use v0.14 cilium-cli for v1.12 docs since we haven't validated v1.12 docs using Helm mode.

Also change the branch name from master to main. The default branch name recently changed from master to main in cilium-cli repo.

Ref: https://github.com/cilium/cilium-cli/pull/1759
Ref: #26430