### PR TITLE
Computed and propagated the value of OldEndpoints field when merging …

### DIFF
--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -550,6 +550,8 @@ func (s *ServiceCache) mergeServiceUpdateLocked(service *serviceStore.ClusterSer
 		s.externalEndpoints[id] = externalEndpoints
 	}
 
+	oldEPs, _ := s.correlateEndpoints(id)
+
 	// The cluster the service belongs to will match the current one when dealing with external
 	// workloads (and in that case all endpoints shall be always present), and not match in the
 	// cluster-mesh case (where remote endpoints shall be used only if it is shared).
@@ -579,7 +581,7 @@ func (s *ServiceCache) mergeServiceUpdateLocked(service *serviceStore.ClusterSer
 			Service:      svc,
 			OldService:   oldService,
 			Endpoints:    endpoints,
-			OldEndpoints: endpoints,
+			OldEndpoints: oldEPs,
 			SWG:          swg,
 		}
 	}
@@ -619,6 +621,8 @@ func (s *ServiceCache) mergeExternalServiceDeleteLocked(service *serviceStore.Cl
 	if ok {
 		scopedLog.Debug("Deleting external endpoints")
 
+		oldEPs, _ := s.correlateEndpoints(id)
+
 		delete(externalEndpoints.endpoints, service.Cluster)
 		if len(externalEndpoints.endpoints) == 0 {
 			delete(s.externalEndpoints, id)
@@ -636,7 +640,7 @@ func (s *ServiceCache) mergeExternalServiceDeleteLocked(service *serviceStore.Cl
 				ID:           id,
 				Service:      svc,
 				Endpoints:    endpoints,
-				OldEndpoints: endpoints,
+				OldEndpoints: oldEPs,
 				SWG:          swg,
 			}
 


### PR DESCRIPTION
…information from remote clusters.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

- Updated `mergeServiceUpdateLocked` and `mergeExternalServiceDeleteLocked` to calculate and propagate oldEndpoints.

Fixes: #26176 

```release-note
Computed and propagated the value of OldEndpoints field when merging remote cluster information.
```
Signed-off-by: Alok Kumar Singh <alokaks601@gmail.com>
