### PR TITLE
ci-e2e: Bump CLI version to v0.14.8

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -65,7 +65,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.14.7
+  cilium_cli_version: v0.14.8
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 


### PR DESCRIPTION
The most notable changes - the upgrade test and the error log check. The whole changelog -
https://github.com/cilium/cilium-cli/releases/tag/v0.14.8.

Successful run - https://github.com/cilium/cilium/actions/runs/5374737837/jobs/9750440769?pr=26475.
