### PR TITLE
bpf: ct: fix CT-based packet tracing for IPv6

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -570,7 +570,7 @@ static __always_inline int ct_lookup6(const void *map,
 	if (action < 0)
 		return action;
 
-	return __ct_lookup6(map, tuple, ctx, action, l4_off, dir, SCOPE_BIDIR,
+	return __ct_lookup6(map, tuple, ctx, l4_off, action, dir, SCOPE_BIDIR,
 			    ct_state, monitor);
 }
 


### PR DESCRIPTION
While refactoring the CT lookup helpers, I fat-fingered the order of parameters in the ct_lookup6() helper (which is used by eg. bpf_lxc). But as both parameters are primarily used for tracing policy, this didn't completely break things - we just don't get the expected trace output for packets, and have problems detecting closed / reopened connections.

Fix the parameters up to make things work again.

Fixes: eee902f44979 ("bpf: conntrack: introduce an optimized CT lookup for LB")
Fixes: https://github.com/cilium/cilium/issues/26418
Reported-by: Marco Iorio <marco.iorio@isovalent.com>