### PR TITLE
v1.13 Backports 2023-06-26

### DIFF
--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -14,3 +14,31 @@ static __always_inline __be16 client_port(enum egressgw_test t)
 {
 	return CLIENT_PORT + (__be16)t;
 }
+
+static __always_inline void add_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr,
+						      __be32 gateway_ip, __be32 egress_ip)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
+		.saddr   = saddr,
+		.daddr   = daddr,
+	};
+
+	struct egress_gw_policy_entry in_val = {
+		.egress_ip  = egress_ip,
+		.gateway_ip = gateway_ip,
+	};
+
+	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+}
+
+static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr)
+{
+	struct egress_gw_policy_key in_key = {
+		.lpm_key = { EGRESS_PREFIX_LEN(cidr), {} },
+		.saddr   = saddr,
+		.daddr   = daddr,
+	};
+
+	map_delete_elem(&EGRESS_POLICY_MAP, &in_key);
+}

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
+#define CLIENT_PORT __bpf_htons(111)
+
 enum egressgw_test {
 	TEST_SNAT1                    = 0,
 	TEST_SNAT2                    = 1,
@@ -8,3 +10,7 @@ enum egressgw_test {
 	TEST_REDIRECT_SKIP_NO_GATEWAY = 3,
 };
 
+static __always_inline __be16 client_port(enum egressgw_test t)
+{
+	return CLIENT_PORT + (__be16)t;
+}

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -259,3 +259,21 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
 
 	test_finish();
 }
+
+static __always_inline int egressgw_status_check(const struct __ctx_buff *ctx,
+						 struct egressgw_test_ctx test_ctx)
+{
+	void *data, *data_end;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	assert(*(__u32 *)data == test_ctx.status_code);
+
+	test_finish();
+}

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -12,7 +12,7 @@ enum egressgw_test {
 
 struct egressgw_test_ctx {
 	enum egressgw_test test;
-	bool reply;
+	enum ct_dir dir;
 	__u64 tx_packets;
 	__u64 rx_packets;
 	__u32 status_code;

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -1,7 +1,21 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-#define CLIENT_PORT __bpf_htons(111)
+#define CLIENT_IP		v4_pod_one
+#define CLIENT_PORT		__bpf_htons(111)
+#define CLIENT_NODE_IP		v4_node_one
+
+#define GATEWAY_NODE_IP		v4_node_two
+
+#define EXTERNAL_SVC_IP		v4_ext_one
+#define EXTERNAL_SVC_PORT	__bpf_htons(1234)
+
+#define EGRESS_IP		IPV4(1, 2, 3, 4)
+#define EGRESS_IP2		IPV4(2, 3, 4, 5)
+
+static volatile const __u8 *client_mac  = mac_one;
+static volatile const __u8 *gateway_mac = mac_two;
+static volatile const __u8 *ext_svc_mac = mac_three;
 
 enum egressgw_test {
 	TEST_SNAT1                    = 0,
@@ -73,3 +87,175 @@ static __always_inline void del_allow_all_egress_policy(void)
 	map_delete_elem(&POLICY_MAP, &policy_key);
 }
 #endif
+
+static __always_inline int egressgw_pktgen(struct __ctx_buff *ctx,
+					   struct egressgw_test_ctx test_ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	if (test_ctx.dir == CT_INGRESS)
+		ethhdr__set_macs(l2, (__u8 *)ext_svc_mac, (__u8 *)client_mac);
+	else /* CT_EGRESS */
+		ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	if (test_ctx.dir == CT_INGRESS) {
+		l3->saddr = EXTERNAL_SVC_IP;
+		l3->daddr = EGRESS_IP;
+	} else { /* CT_EGRESS */
+		l3->saddr = CLIENT_IP;
+		l3->daddr = EXTERNAL_SVC_IP;
+	}
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	if (test_ctx.dir == CT_INGRESS) {
+		/* Get the destination port from the NAT entry. */
+		struct ipv4_ct_tuple tuple = {
+			.saddr   = CLIENT_IP,
+			.daddr   = EXTERNAL_SVC_IP,
+			.dport   = EXTERNAL_SVC_PORT,
+			.sport   = client_port(test_ctx.test),
+			.nexthdr = IPPROTO_TCP,
+		};
+		struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
+
+		if (!nat_entry)
+			return TEST_ERROR;
+		l4->source = EXTERNAL_SVC_PORT;
+		l4->dest = nat_entry->to_sport;
+	} else { /* CT_EGRESS */
+		l4->source = client_port(test_ctx.test);
+		l4->dest = EXTERNAL_SVC_PORT;
+	}
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
+					       struct egressgw_test_ctx test_ctx)
+{
+	void *data, *data_end;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	assert(*(__u32 *)data == test_ctx.status_code);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (test_ctx.dir == CT_INGRESS) {
+		if (memcmp(l2->h_source, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
+			test_fatal("src MAC is not the external svc MAC")
+
+		if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
+			test_fatal("dst MAC is not the client MAC")
+
+		if (l3->saddr != EXTERNAL_SVC_IP)
+			test_fatal("src IP has changed");
+
+		if (l3->daddr != CLIENT_IP)
+			test_fatal("dst IP hasn't been revSNATed to client IP");
+	} else { /* CT_EGRESS */
+		if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+			test_fatal("src MAC is not the client MAC")
+
+		if (memcmp(l2->h_dest, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
+			test_fatal("dst MAC is not the external svc MAC")
+
+		if (l3->saddr != EGRESS_IP)
+			test_fatal("src IP hasn't been NATed to egress gateway IP");
+
+		if (l3->daddr != EXTERNAL_SVC_IP)
+			test_fatal("dst IP has changed");
+	}
+
+	/* Lookup the SNAT mapping for the original packet to determine the new source port */
+	struct ipv4_ct_tuple tuple = {
+		.daddr   = CLIENT_IP,
+		.saddr   = EXTERNAL_SVC_IP,
+		.dport   = EXTERNAL_SVC_PORT,
+		.sport   = client_port(test_ctx.test),
+		.nexthdr = IPPROTO_TCP,
+		.flags = TUPLE_F_OUT,
+	};
+	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+	if (!ct_entry)
+		test_fatal("no CT entry found");
+
+	if (ct_entry->tx_packets != test_ctx.tx_packets)
+		test_fatal("bad TX packet count (expected %u, actual %u)",
+			   test_ctx.tx_packets, ct_entry->tx_packets)
+	if (ct_entry->rx_packets != test_ctx.rx_packets)
+		test_fatal("bad RX packet count (expected %u, actual %u)",
+			   test_ctx.rx_packets, ct_entry->rx_packets)
+
+	tuple.saddr = CLIENT_IP;
+	tuple.daddr = EXTERNAL_SVC_IP;
+
+	struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
+
+	if (!nat_entry)
+		test_fatal("could not find a NAT entry for the packet");
+
+	if (test_ctx.dir == CT_INGRESS) {
+		if (l4->source != EXTERNAL_SVC_PORT)
+			test_fatal("src port has changed");
+
+		if (l4->dest != client_port(test_ctx.test))
+			test_fatal("dst TCP port hasn't been revSNATed to client port");
+	} else { /* CT_EGRESS */
+		if (l4->source != nat_entry->to_sport)
+			test_fatal("src TCP port hasn't been NATed to egress gateway port");
+
+		if (l4->dest != EXTERNAL_SVC_PORT)
+			test_fatal("dst port has changed");
+	}
+
+	test_finish();
+}

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -10,6 +10,14 @@ enum egressgw_test {
 	TEST_REDIRECT_SKIP_NO_GATEWAY = 3,
 };
 
+struct egressgw_test_ctx {
+	enum egressgw_test test;
+	bool reply;
+	__u64 tx_packets;
+	__u64 rx_packets;
+	__u32 status_code;
+};
+
 static __always_inline __be16 client_port(enum egressgw_test t)
 {
 	return CLIENT_PORT + (__be16)t;

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -42,3 +42,26 @@ static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr
 
 	map_delete_elem(&EGRESS_POLICY_MAP, &in_key);
 }
+
+#ifndef SKIP_POLICY_MAP
+static __always_inline void add_allow_all_egress_policy(void)
+{
+	struct policy_key policy_key = {
+		.egress = 1,
+	};
+	struct policy_entry policy_value = {
+		.deny = 0,
+	};
+
+	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+}
+
+static __always_inline void del_allow_all_egress_policy(void)
+{
+	struct policy_key policy_key = {
+		.egress = 1,
+	};
+
+	map_delete_elem(&POLICY_MAP, &policy_key);
+}
+#endif

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Cilium */
+
+enum egressgw_test {
+	TEST_SNAT1                    = 0,
+	TEST_SNAT2                    = 1,
+	TEST_REDIRECT                 = 2,
+	TEST_REDIRECT_SKIP_NO_GATEWAY = 3,
+};
+

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -21,7 +21,6 @@
 #define ENCAP_IFINDEX 0
 
 #define CLIENT_IP		v4_pod_one
-#define CLIENT_PORT		__bpf_htons(111)
 
 #define EXTERNAL_SVC_IP		v4_ext_one
 #define EXTERNAL_SVC_PORT	__bpf_htons(1234)
@@ -34,6 +33,8 @@ static volatile const __u8 *client_mac = mac_one;
 static volatile const __u8 *ext_svc_mac = mac_two;
 
 #include "bpf_lxc.c"
+
+#include "lib/egressgw.h"
 
 #define FROM_CONTAINER 0
 
@@ -83,7 +84,7 @@ int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 	if (!l4)
 		return TEST_ERROR;
 
-	l4->source = CLIENT_PORT;
+	l4->source = client_port(TEST_REDIRECT);
 	l4->dest = EXTERNAL_SVC_PORT;
 
 	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
@@ -183,7 +184,7 @@ int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 	if (!l4)
 		return TEST_ERROR;
 
-	l4->source = CLIENT_PORT;
+	l4->source = client_port(TEST_REDIRECT_SKIP_NO_GATEWAY);
 	l4->dest = EXTERNAL_SVC_PORT;
 
 	data = pktgen__push_data(&builder, default_data, sizeof(default_data));

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -102,15 +102,8 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, 0);
 
-	struct policy_key policy_key = {
-		.egress = 1,
-	};
-	struct policy_entry policy_value = {
-		.deny = 0,
-	};
-
 	/* Avoid policy drop */
-	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+	add_allow_all_egress_policy();
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
@@ -135,6 +128,7 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 	status_code = data;
 	assert(*status_code == CTX_ACT_REDIRECT);
 
+	del_allow_all_egress_policy();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
 
 	test_finish();
@@ -193,15 +187,8 @@ int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 {
 	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY, 0);
 
-	struct policy_key policy_key = {
-		.egress = 1,
-	};
-	struct policy_entry policy_value = {
-		.deny = 0,
-	};
-
 	/* Avoid policy drop */
-	map_update_elem(&POLICY_MAP, &policy_key, &policy_value, BPF_ANY);
+	add_allow_all_egress_policy();
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, FROM_CONTAINER);
@@ -236,6 +223,7 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 		test_fatal("metrics entry not found");
 	assert(entry->count == 1);
 
+	del_allow_all_egress_policy();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 
 	test_finish();

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -100,18 +100,7 @@ int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_redirect")
 int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
-	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
-	};
-
-	struct egress_gw_policy_entry in_val = {
-		.egress_ip  = 0,
-		.gateway_ip = NODE_IP,
-	};
-
-	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, 0);
 
 	struct policy_key policy_key = {
 		.egress = 1,
@@ -145,6 +134,8 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 
 	status_code = data;
 	assert(*status_code == CTX_ACT_REDIRECT);
+
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
 
 	test_finish();
 }
@@ -200,18 +191,7 @@ int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_skip_no_gateway_redirect")
 int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 {
-	struct egress_gw_policy_key in_key_no_gateway = {
-		.lpm_key = { EGRESS_PREFIX_LEN(32), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP,
-	};
-
-	struct egress_gw_policy_entry in_val_no_gateway = {
-		.egress_ip  = 0,
-		.gateway_ip = EGRESS_GATEWAY_NO_GATEWAY,
-	};
-
-	map_update_elem(&EGRESS_POLICY_MAP, &in_key_no_gateway, &in_val_no_gateway, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32, EGRESS_GATEWAY_NO_GATEWAY, 0);
 
 	struct policy_key policy_key = {
 		.egress = 1,
@@ -256,16 +236,7 @@ int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 		test_fatal("metrics entry not found");
 	assert(entry->count == 1);
 
-	/* Delete the no gateway entry otherwise other tests may fail as this
-	 * entry will persist across the different tests.
-	 */
-	struct egress_gw_policy_key in_key_no_gateway = {
-		.lpm_key = { EGRESS_PREFIX_LEN(32), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP,
-	};
-
-	map_delete_elem(&EGRESS_POLICY_MAP, &in_key_no_gateway);
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 
 	test_finish();
 }

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -67,24 +67,14 @@ int egressgw_redirect_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_redirect")
 int egressgw_redirect_check(const struct __ctx_buff *ctx)
 {
-	void *data, *data_end;
-	__u32 *status_code;
-
-	test_init();
-
-	data = (void *)(long)ctx_data(ctx);
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(__u32) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_REDIRECT);
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = TC_ACT_REDIRECT,
+	});
 
 	del_allow_all_egress_policy();
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24);
 
-	test_finish();
+	return ret;
 }
 
 /* Test that a packet matching an egress gateway policy without a gateway on the
@@ -116,22 +106,16 @@ int egressgw_skip_no_gateway_redirect_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_skip_no_gateway_redirect")
 int egressgw_skip_no_gateway_redirect_check(const struct __ctx_buff *ctx)
 {
-	void *data, *data_end;
-	__u32 *status_code;
-
 	struct metrics_value *entry = NULL;
 	struct metrics_key key = {};
 
+	int ret = egressgw_status_check(ctx, (struct egressgw_test_ctx) {
+			.status_code = CTX_ACT_DROP,
+	});
+	if (ret != TEST_PASS)
+		return ret;
+
 	test_init();
-
-	data = (void *)(long)ctx_data(ctx);
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(__u32) > data_end)
-		test_fatal("status code out of bounds");
-
-	status_code = data;
-	assert(*status_code == CTX_ACT_DROP);
 
 	key.reason = (__u8)-DROP_NO_EGRESS_GATEWAY;
 	key.dir = METRIC_EGRESS;

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -20,17 +20,7 @@
 #define ENABLE_MASQUERADE
 #define ENCAP_IFINDEX 0
 
-#define CLIENT_IP		v4_pod_one
-
-#define EXTERNAL_SVC_IP		v4_ext_one
-#define EXTERNAL_SVC_PORT	__bpf_htons(1234)
-
-#define NODE_IP			v4_node_one
-
 #define SECCTX_FROM_IPCACHE 1
-
-static volatile const __u8 *client_mac = mac_one;
-static volatile const __u8 *ext_svc_mac = mac_two;
 
 #include "bpf_lxc.c"
 
@@ -55,52 +45,15 @@ struct {
 PKTGEN("tc", "tc_egressgw_redirect")
 int egressgw_redirect_pktgen(struct __ctx_buff *ctx)
 {
-	struct pktgen builder;
-	struct tcphdr *l4;
-	struct ethhdr *l2;
-	struct iphdr *l3;
-	void *data;
-
-	/* Init packet builder */
-	pktgen__init(&builder, ctx);
-
-	/* Push ethernet header */
-	l2 = pktgen__push_ethhdr(&builder);
-	if (!l2)
-		return TEST_ERROR;
-
-	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
-
-	/* Push IPv4 header */
-	l3 = pktgen__push_default_iphdr(&builder);
-	if (!l3)
-		return TEST_ERROR;
-
-	l3->saddr = CLIENT_IP;
-	l3->daddr = EXTERNAL_SVC_IP;
-
-	/* Push TCP header */
-	l4 = pktgen__push_default_tcphdr(&builder);
-	if (!l4)
-		return TEST_ERROR;
-
-	l4->source = client_port(TEST_REDIRECT);
-	l4->dest = EXTERNAL_SVC_PORT;
-
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
-	pktgen__finish(&builder);
-
-	return 0;
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT,
+		});
 }
 
 SETUP("tc", "tc_egressgw_redirect")
 int egressgw_redirect_setup(struct __ctx_buff *ctx)
 {
-	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, GATEWAY_NODE_IP, 0);
 
 	/* Avoid policy drop */
 	add_allow_all_egress_policy();
@@ -140,46 +93,10 @@ int egressgw_redirect_check(const struct __ctx_buff *ctx)
 PKTGEN("tc", "tc_egressgw_skip_no_gateway_redirect")
 int egressgw_skip_no_gateway_redirect_pktgen(struct __ctx_buff *ctx)
 {
-	struct pktgen builder;
-	struct tcphdr *l4;
-	struct ethhdr *l2;
-	struct iphdr *l3;
-	void *data;
 
-	/* Init packet builder */
-	pktgen__init(&builder, ctx);
-
-	/* Push ethernet header */
-	l2 = pktgen__push_ethhdr(&builder);
-	if (!l2)
-		return TEST_ERROR;
-
-	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
-
-	/* Push IPv4 header */
-	l3 = pktgen__push_default_iphdr(&builder);
-	if (!l3)
-		return TEST_ERROR;
-
-	l3->saddr = CLIENT_IP;
-	l3->daddr = EXTERNAL_SVC_IP;
-
-	/* Push TCP header */
-	l4 = pktgen__push_default_tcphdr(&builder);
-	if (!l4)
-		return TEST_ERROR;
-
-	l4->source = client_port(TEST_REDIRECT_SKIP_NO_GATEWAY);
-	l4->dest = EXTERNAL_SVC_PORT;
-
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
-	pktgen__finish(&builder);
-
-	return 0;
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_REDIRECT_SKIP_NO_GATEWAY,
+		});
 }
 
 SETUP("tc", "tc_egressgw_skip_no_gateway_redirect")

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -18,21 +18,7 @@
 #define ENABLE_MASQUERADE
 #define ENCAP_IFINDEX		42
 
-#define CLIENT_IP		v4_pod_one
-#define CLIENT_PORT		__bpf_htons(111)
-#define CLIENT_NODE_IP		v4_node_two
-
-#define EXTERNAL_SVC_IP		v4_ext_one
-#define EXTERNAL_SVC_PORT	__bpf_htons(1234)
-
-#define NODE_IP			v4_node_one
-
-#define EGRESS_IP		IPV4(1, 2, 3, 4)
-
 #define SECCTX_FROM_IPCACHE 1
-
-static volatile const __u8 *client_mac = mac_one;
-static volatile const __u8 *ext_svc_mac = mac_two;
 
 #define ctx_redirect mock_ctx_redirect
 static __always_inline __maybe_unused int
@@ -68,185 +54,13 @@ struct {
 	},
 };
 
-static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx,
-						struct egressgw_test_ctx test_ctx)
-{
-	struct pktgen builder;
-	struct tcphdr *l4;
-	struct ethhdr *l2;
-	struct iphdr *l3;
-	void *data;
-
-	/* Init packet builder */
-	pktgen__init(&builder, ctx);
-
-	/* Push ethernet header */
-	l2 = pktgen__push_ethhdr(&builder);
-	if (!l2)
-		return TEST_ERROR;
-
-	if (test_ctx.dir == CT_INGRESS)
-		ethhdr__set_macs(l2, (__u8 *)ext_svc_mac, (__u8 *)client_mac);
-	else /* CT_EGRESS */
-		ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
-
-	/* Push IPv4 header */
-	l3 = pktgen__push_default_iphdr(&builder);
-	if (!l3)
-		return TEST_ERROR;
-
-	if (test_ctx.dir == CT_INGRESS) {
-		l3->saddr = EXTERNAL_SVC_IP;
-		l3->daddr = EGRESS_IP;
-	} else { /* CT_EGRESS */
-		l3->saddr = CLIENT_IP;
-		l3->daddr = EXTERNAL_SVC_IP;
-	}
-
-	/* Push TCP header */
-	l4 = pktgen__push_default_tcphdr(&builder);
-	if (!l4)
-		return TEST_ERROR;
-
-	if (test_ctx.dir == CT_INGRESS) {
-		/* Get the destination port from the NAT entry. */
-		struct ipv4_ct_tuple tuple = {
-			.saddr   = CLIENT_IP,
-			.daddr   = EXTERNAL_SVC_IP,
-			.dport   = EXTERNAL_SVC_PORT,
-			.sport   = client_port(test_ctx.test),
-			.nexthdr = IPPROTO_TCP,
-		};
-		struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
-
-		if (!nat_entry)
-			return TEST_ERROR;
-		l4->source = EXTERNAL_SVC_PORT;
-		l4->dest = nat_entry->to_sport;
-	} else { /* CT_EGRESS */
-		l4->source = client_port(test_ctx.test);
-		l4->dest = EXTERNAL_SVC_PORT;
-	}
-
-	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
-	if (!data)
-		return TEST_ERROR;
-
-	/* Calc lengths, set protocol fields and calc checksums */
-	pktgen__finish(&builder);
-
-	return 0;
-}
-
-static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
-					       struct egressgw_test_ctx test_ctx)
-{
-	void *data, *data_end;
-	struct tcphdr *l4;
-	struct ethhdr *l2;
-	struct iphdr *l3;
-
-	test_init();
-
-	data = (void *)(long)ctx_data(ctx);
-	data_end = (void *)(long)ctx->data_end;
-
-	if (data + sizeof(__u32) > data_end)
-		test_fatal("status code out of bounds");
-
-	assert(*(__u32 *)data == test_ctx.status_code);
-
-	l2 = data + sizeof(__u32);
-	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
-		test_fatal("l2 out of bounds");
-
-	l3 = (void *)l2 + sizeof(struct ethhdr);
-	if ((void *)l3 + sizeof(struct iphdr) > data_end)
-		test_fatal("l3 out of bounds");
-
-	l4 = (void *)l3 + sizeof(struct iphdr);
-	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
-		test_fatal("l4 out of bounds");
-
-	if (test_ctx.dir == CT_INGRESS) {
-		if (memcmp(l2->h_source, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
-			test_fatal("src MAC is not the external svc MAC")
-
-		if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
-			test_fatal("dst MAC is not the client MAC")
-
-		if (l3->saddr != EXTERNAL_SVC_IP)
-			test_fatal("src IP has changed");
-
-		if (l3->daddr != CLIENT_IP)
-			test_fatal("dst IP hasn't been revSNATed to client IP");
-	} else { /* CT_EGRESS */
-		if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
-			test_fatal("src MAC is not the client MAC")
-
-		if (memcmp(l2->h_dest, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
-			test_fatal("dst MAC is not the external svc MAC")
-
-		if (l3->saddr != EGRESS_IP)
-			test_fatal("src IP hasn't been NATed to egress gateway IP");
-
-		if (l3->daddr != EXTERNAL_SVC_IP)
-			test_fatal("dst IP has changed");
-	}
-
-	/* Lookup the SNAT mapping for the original packet to determine the new source port */
-	struct ipv4_ct_tuple tuple = {
-		.daddr   = CLIENT_IP,
-		.saddr   = EXTERNAL_SVC_IP,
-		.dport   = EXTERNAL_SVC_PORT,
-		.sport   = client_port(test_ctx.test),
-		.nexthdr = IPPROTO_TCP,
-		.flags = TUPLE_F_OUT,
-	};
-	struct ct_entry *ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
-
-	if (!ct_entry)
-		test_fatal("no CT entry found");
-
-	if (ct_entry->tx_packets != test_ctx.tx_packets)
-		test_fatal("bad TX packet count (expected %u, actual %u)",
-			   test_ctx.tx_packets, ct_entry->tx_packets)
-	if (ct_entry->rx_packets != test_ctx.rx_packets)
-		test_fatal("bad RX packet count (expected %u, actual %u)",
-			   test_ctx.rx_packets, ct_entry->rx_packets)
-
-	tuple.saddr = CLIENT_IP;
-	tuple.daddr = EXTERNAL_SVC_IP;
-
-	struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
-
-	if (!nat_entry)
-		test_fatal("could not find a NAT entry for the packet");
-
-	if (test_ctx.dir == CT_INGRESS) {
-		if (l4->source != EXTERNAL_SVC_PORT)
-			test_fatal("src port has changed");
-
-		if (l4->dest != client_port(test_ctx.test))
-			test_fatal("dst TCP port hasn't been revSNATed to client port");
-	} else { /* CT_EGRESS */
-		if (l4->source != nat_entry->to_sport)
-			test_fatal("src TCP port hasn't been NATed to egress gateway port");
-
-		if (l4->dest != EXTERNAL_SVC_PORT)
-			test_fatal("dst port has changed");
-	}
-
-	test_finish();
-}
-
 /* Test that a packet matching an egress gateway policy on the to-netdev program
  * gets correctly SNATed with the egress IP of the policy.
  */
 PKTGEN("tc", "tc_egressgw_snat1")
 int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT1,
 		});
 }
@@ -254,7 +68,8 @@ int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_snat1")
 int egressgw_snat1_setup(struct __ctx_buff *ctx)
 {
-	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, EGRESS_IP);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24,
+				  GATEWAY_NODE_IP, EGRESS_IP);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
@@ -279,7 +94,7 @@ int egressgw_snat1_check(const struct __ctx_buff *ctx)
 PKTGEN("tc", "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT1,
 			.dir = CT_INGRESS,
 		});
@@ -320,7 +135,7 @@ int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 PKTGEN("tc", "tc_egressgw_snat2")
 int egressgw_snat2_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
 			.test = TEST_SNAT2,
 		});
 }

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -254,18 +254,7 @@ int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_snat1")
 int egressgw_snat1_setup(struct __ctx_buff *ctx)
 {
-	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
-	};
-
-	struct egress_gw_policy_entry in_val = {
-		.egress_ip  = EGRESS_IP,
-		.gateway_ip = NODE_IP,
-	};
-
-	map_update_elem(&EGRESS_POLICY_MAP, &in_key, &in_val, 0);
+	add_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0xffffff, 24, NODE_IP, EGRESS_IP);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
@@ -334,14 +323,7 @@ int egressgw_snat2_check(struct __ctx_buff *ctx)
 {
 	int ret = egressgw_snat_check(ctx, TEST_SNAT2, false, 1, 0, CTX_ACT_OK);
 
-	struct egress_gw_policy_key in_key = {
-		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },
-		.saddr   = CLIENT_IP,
-		.daddr   = EXTERNAL_SVC_IP & 0Xffffff,
-	};
-
-	/* Remove the policy to eliminate interference with other tests. */
-	map_delete_elem(&EGRESS_POLICY_MAP, &in_key);
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0Xffffff, 24);
 
 	return ret;
 }

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -132,11 +132,10 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, bool rep
 }
 
 static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, bool reply,
-					       __u64 tx_packets, __u64 rx_packets)
+					       __u64 tx_packets, __u64 rx_packets,
+					       __u32 status_code)
 {
-	__u32 status_result = reply ? CTX_ACT_REDIRECT : CTX_ACT_OK;
 	void *data, *data_end;
-	__u32 *status_code;
 	struct tcphdr *l4;
 	struct ethhdr *l2;
 	struct iphdr *l3;
@@ -149,8 +148,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, boo
 	if (data + sizeof(__u32) > data_end)
 		test_fatal("status code out of bounds");
 
-	status_code = data;
-	assert(*status_code == status_result);
+	assert(*(__u32 *)data == status_code);
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
@@ -270,7 +268,7 @@ int egressgw_snat1_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_snat1")
 int egressgw_snat1_check(const struct __ctx_buff *ctx)
 {
-	return egressgw_snat_check(ctx, false, 1, 0);
+	return egressgw_snat_check(ctx, false, 1, 0, CTX_ACT_OK);
 }
 
 /* Test that a packet matching an egress gateway policy on the from-netdev program
@@ -305,7 +303,7 @@ int egressgw_snat1_2_reply_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 {
-	return egressgw_snat_check(ctx, true, 1, 1);
+	return egressgw_snat_check(ctx, true, 1, 1, CTX_ACT_REDIRECT);
 }
 
 PKTGEN("tc", "tc_egressgw_snat2")
@@ -326,7 +324,7 @@ int egressgw_snat2_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_snat2")
 int egressgw_snat2_check(struct __ctx_buff *ctx)
 {
-	int ret = egressgw_snat_check(ctx, false, 2, 1);
+	int ret = egressgw_snat_check(ctx, false, 2, 1, CTX_ACT_OK);
 
 	struct egress_gw_policy_key in_key = {
 		.lpm_key = { EGRESS_PREFIX_LEN(24), {} },

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -276,14 +276,14 @@ int egressgw_snat1_check(const struct __ctx_buff *ctx)
 /* Test that a packet matching an egress gateway policy on the from-netdev program
  * gets correctly revSNATed and connection tracked.
  */
-PKTGEN("tc", "tc_egressgw_snat2_reply")
-int egressgw_snat2_reply_pktgen(struct __ctx_buff *ctx)
+PKTGEN("tc", "tc_egressgw_snat1_2_reply")
+int egressgw_snat1_2_reply_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_snat_pktgen(ctx, true);
 }
 
-SETUP("tc", "tc_egressgw_snat2_reply")
-int egressgw_snat2_reply_setup(struct __ctx_buff *ctx)
+SETUP("tc", "tc_egressgw_snat1_2_reply")
+int egressgw_snat1_2_reply_setup(struct __ctx_buff *ctx)
 {
 	/* install ipcache entry for the CLIENT_IP: */
 	struct ipcache_key cache_key = {
@@ -302,20 +302,20 @@ int egressgw_snat2_reply_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "tc_egressgw_snat2_reply")
-int egressgw_snat2_reply_check(const struct __ctx_buff *ctx)
+CHECK("tc", "tc_egressgw_snat1_2_reply")
+int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 {
 	return egressgw_snat_check(ctx, true, 1, 1);
 }
 
-PKTGEN("tc", "tc_egressgw_snat3")
-int egressgw_snat3_pktgen(struct __ctx_buff *ctx)
+PKTGEN("tc", "tc_egressgw_snat2")
+int egressgw_snat2_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_snat_pktgen(ctx, false);
 }
 
-SETUP("tc", "tc_egressgw_snat3")
-int egressgw_snat3_setup(struct __ctx_buff *ctx)
+SETUP("tc", "tc_egressgw_snat2")
+int egressgw_snat2_setup(struct __ctx_buff *ctx)
 {
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
@@ -323,8 +323,8 @@ int egressgw_snat3_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "tc_egressgw_snat3")
-int egressgw_snat3_check(struct __ctx_buff *ctx)
+CHECK("tc", "tc_egressgw_snat2")
+int egressgw_snat2_check(struct __ctx_buff *ctx)
 {
 	int ret = egressgw_snat_check(ctx, false, 2, 1);
 

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -68,8 +68,8 @@ struct {
 	},
 };
 
-static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, enum egressgw_test t,
-						bool reply)
+static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx,
+						struct egressgw_test_ctx test_ctx)
 {
 	struct pktgen builder;
 	struct tcphdr *l4;
@@ -85,7 +85,7 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, enum egr
 	if (!l2)
 		return TEST_ERROR;
 
-	if (reply)
+	if (test_ctx.reply)
 		ethhdr__set_macs(l2, (__u8 *)ext_svc_mac, (__u8 *)client_mac);
 	else
 		ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)ext_svc_mac);
@@ -95,7 +95,7 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, enum egr
 	if (!l3)
 		return TEST_ERROR;
 
-	if (reply) {
+	if (test_ctx.reply) {
 		l3->saddr = EXTERNAL_SVC_IP;
 		l3->daddr = EGRESS_IP;
 	} else {
@@ -108,13 +108,13 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, enum egr
 	if (!l4)
 		return TEST_ERROR;
 
-	if (reply) {
+	if (test_ctx.reply) {
 		/* Get the destination port from the NAT entry. */
 		struct ipv4_ct_tuple tuple = {
 			.saddr   = CLIENT_IP,
 			.daddr   = EXTERNAL_SVC_IP,
 			.dport   = EXTERNAL_SVC_PORT,
-			.sport   = client_port(t),
+			.sport   = client_port(test_ctx.test),
 			.nexthdr = IPPROTO_TCP,
 		};
 		struct ipv4_nat_entry *nat_entry = __snat_lookup(&SNAT_MAPPING_IPV4, &tuple);
@@ -124,7 +124,7 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, enum egr
 		l4->source = EXTERNAL_SVC_PORT;
 		l4->dest = nat_entry->to_sport;
 	} else {
-		l4->source = client_port(t);
+		l4->source = client_port(test_ctx.test);
 		l4->dest = EXTERNAL_SVC_PORT;
 	}
 
@@ -138,10 +138,8 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, enum egr
 	return 0;
 }
 
-static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, enum egressgw_test t,
-					       bool reply,
-					       __u64 tx_packets, __u64 rx_packets,
-					       __u32 status_code)
+static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx,
+					       struct egressgw_test_ctx test_ctx)
 {
 	void *data, *data_end;
 	struct tcphdr *l4;
@@ -156,7 +154,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, enu
 	if (data + sizeof(__u32) > data_end)
 		test_fatal("status code out of bounds");
 
-	assert(*(__u32 *)data == status_code);
+	assert(*(__u32 *)data == test_ctx.status_code);
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
@@ -170,7 +168,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, enu
 	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
 		test_fatal("l4 out of bounds");
 
-	if (reply) {
+	if (test_ctx.reply) {
 		if (memcmp(l2->h_source, (__u8 *)ext_svc_mac, ETH_ALEN) != 0)
 			test_fatal("src MAC is not the external svc MAC")
 
@@ -201,7 +199,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, enu
 		.daddr   = CLIENT_IP,
 		.saddr   = EXTERNAL_SVC_IP,
 		.dport   = EXTERNAL_SVC_PORT,
-		.sport   = client_port(t),
+		.sport   = client_port(test_ctx.test),
 		.nexthdr = IPPROTO_TCP,
 		.flags = TUPLE_F_OUT,
 	};
@@ -210,12 +208,12 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, enu
 	if (!ct_entry)
 		test_fatal("no CT entry found");
 
-	if (ct_entry->tx_packets != tx_packets)
+	if (ct_entry->tx_packets != test_ctx.tx_packets)
 		test_fatal("bad TX packet count (expected %u, actual %u)",
-			   tx_packets, ct_entry->tx_packets)
-	if (ct_entry->rx_packets != rx_packets)
+			   test_ctx.tx_packets, ct_entry->tx_packets)
+	if (ct_entry->rx_packets != test_ctx.rx_packets)
 		test_fatal("bad RX packet count (expected %u, actual %u)",
-			   rx_packets, ct_entry->rx_packets)
+			   test_ctx.rx_packets, ct_entry->rx_packets)
 
 	tuple.saddr = CLIENT_IP;
 	tuple.daddr = EXTERNAL_SVC_IP;
@@ -225,11 +223,11 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, enu
 	if (!nat_entry)
 		test_fatal("could not find a NAT entry for the packet");
 
-	if (reply) {
+	if (test_ctx.reply) {
 		if (l4->source != EXTERNAL_SVC_PORT)
 			test_fatal("src port has changed");
 
-		if (l4->dest != client_port(t))
+		if (l4->dest != client_port(test_ctx.test))
 			test_fatal("dst TCP port hasn't been revSNATed to client port");
 	} else {
 		if (l4->source != nat_entry->to_sport)
@@ -248,7 +246,9 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, enu
 PKTGEN("tc", "tc_egressgw_snat1")
 int egressgw_snat1_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, TEST_SNAT1, false);
+	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+		});
 }
 
 SETUP("tc", "tc_egressgw_snat1")
@@ -265,7 +265,12 @@ int egressgw_snat1_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_snat1")
 int egressgw_snat1_check(const struct __ctx_buff *ctx)
 {
-	return egressgw_snat_check(ctx, TEST_SNAT1, false, 1, 0, CTX_ACT_OK);
+	return egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+			.tx_packets = 1,
+			.rx_packets = 0,
+			.status_code = CTX_ACT_OK
+		});
 }
 
 /* Test that a packet matching an egress gateway policy on the from-netdev program
@@ -274,7 +279,10 @@ int egressgw_snat1_check(const struct __ctx_buff *ctx)
 PKTGEN("tc", "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, TEST_SNAT1, true);
+	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+			.reply = true,
+		});
 }
 
 SETUP("tc", "tc_egressgw_snat1_2_reply")
@@ -300,13 +308,21 @@ int egressgw_snat1_2_reply_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_snat1_2_reply")
 int egressgw_snat1_2_reply_check(const struct __ctx_buff *ctx)
 {
-	return egressgw_snat_check(ctx, TEST_SNAT1, true, 1, 1, CTX_ACT_REDIRECT);
+	return egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT1,
+			.reply = true,
+			.tx_packets = 1,
+			.rx_packets = 1,
+			.status_code = CTX_ACT_REDIRECT,
+		});
 }
 
 PKTGEN("tc", "tc_egressgw_snat2")
 int egressgw_snat2_pktgen(struct __ctx_buff *ctx)
 {
-	return egressgw_snat_pktgen(ctx, TEST_SNAT2, false);
+	return egressgw_snat_pktgen(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT2,
+		});
 }
 
 SETUP("tc", "tc_egressgw_snat2")
@@ -321,7 +337,12 @@ int egressgw_snat2_setup(struct __ctx_buff *ctx)
 CHECK("tc", "tc_egressgw_snat2")
 int egressgw_snat2_check(struct __ctx_buff *ctx)
 {
-	int ret = egressgw_snat_check(ctx, TEST_SNAT2, false, 1, 0, CTX_ACT_OK);
+	int ret = egressgw_snat_check(ctx, (struct egressgw_test_ctx) {
+			.test = TEST_SNAT2,
+			.tx_packets = 1,
+			.rx_packets = 0,
+			.status_code = CTX_ACT_OK
+		});
 
 	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP & 0Xffffff, 24);
 

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -16,10 +16,11 @@
 #define ENABLE_NODEPORT
 #define ENABLE_EGRESS_GATEWAY
 #define ENABLE_MASQUERADE
-#define ENCAP_IFINDEX 0
+#define ENCAP_IFINDEX		42
 
 #define CLIENT_IP		v4_pod_one
 #define CLIENT_PORT		__bpf_htons(111)
+#define CLIENT_NODE_IP		v4_node_two
 
 #define EXTERNAL_SVC_IP		v4_ext_one
 #define EXTERNAL_SVC_PORT	__bpf_htons(1234)
@@ -32,6 +33,17 @@
 
 static volatile const __u8 *client_mac = mac_one;
 static volatile const __u8 *ext_svc_mac = mac_two;
+
+#define ctx_redirect mock_ctx_redirect
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if (ifindex == ENCAP_IFINDEX)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_DROP;
+}
 
 #include "bpf_host.c"
 
@@ -122,6 +134,7 @@ static __always_inline int egressgw_snat_pktgen(struct __ctx_buff *ctx, bool rep
 static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, bool reply,
 					       __u64 tx_packets, __u64 rx_packets)
 {
+	__u32 status_result = reply ? CTX_ACT_REDIRECT : CTX_ACT_OK;
 	void *data, *data_end;
 	__u32 *status_code;
 	struct tcphdr *l4;
@@ -137,7 +150,7 @@ static __always_inline int egressgw_snat_check(const struct __ctx_buff *ctx, boo
 		test_fatal("status code out of bounds");
 
 	status_code = data;
-	assert(*status_code == CTX_ACT_OK);
+	assert(*status_code == status_result);
 
 	l2 = data + sizeof(__u32);
 	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
@@ -272,6 +285,17 @@ int egressgw_snat2_reply_pktgen(struct __ctx_buff *ctx)
 SETUP("tc", "tc_egressgw_snat2_reply")
 int egressgw_snat2_reply_setup(struct __ctx_buff *ctx)
 {
+	/* install ipcache entry for the CLIENT_IP: */
+	struct ipcache_key cache_key = {
+		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(32),
+		.family = ENDPOINT_KEY_IPV4,
+		.ip4 = CLIENT_IP,
+	};
+	struct remote_endpoint_info cache_value = {
+		.tunnel_endpoint = CLIENT_NODE_IP,
+	};
+	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
+
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
 	/* Fail if we didn't jump */


### PR DESCRIPTION
 * [x] #25932  (@julianwiedmann)
   * skipped the XDP test changes
 * [ ] #26376 (@jibi)
   * skipped the excluded CIDRs and XDP test changes

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 25932,26376; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=25932,26376
```
