### PR TITLE
metrics: Add map pressure metric for auth map

### DIFF
--- a/pkg/auth/authmap.go
+++ b/pkg/auth/authmap.go
@@ -18,6 +18,7 @@ type authMap interface {
 	DeleteIf(predicate func(key authKey, info authInfo) bool) error
 	Get(key authKey) (authInfo, error)
 	All() (map[authKey]authInfo, error)
+	MaxEntries() uint32
 }
 
 type authKey struct {

--- a/pkg/auth/authmap_writer.go
+++ b/pkg/auth/authmap_writer.go
@@ -105,3 +105,7 @@ func (r *authMapWriter) DeleteIf(predicate func(key authKey, info authInfo) bool
 
 	return nil
 }
+
+func (r *authMapWriter) MaxEntries() uint32 {
+	return r.authMap.MaxEntries()
+}

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -273,6 +273,10 @@ func (r *fakeAuthMap) Update(key authKey, info authInfo) error {
 	return nil
 }
 
+func (r *fakeAuthMap) MaxEntries() uint32 {
+	return 1 << 8
+}
+
 func assertErrorString(errString string) assert.ErrorAssertionFunc {
 	return func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
 		return assert.EqualError(t, err, errString, msgAndArgs)

--- a/pkg/maps/authmap/auth_map.go
+++ b/pkg/maps/authmap/auth_map.go
@@ -35,6 +35,9 @@ type Map interface {
 	// IterateWithCallback iterates through all the keys/values of an auth map,
 	// passing each key/value pair to the cb callback.
 	IterateWithCallback(cb IterateCallback) error
+
+	// MaxEntries returns the maximum number of entries the auth map can hold.
+	MaxEntries() uint32
 }
 
 type authMap struct {
@@ -111,6 +114,10 @@ func (m *authMap) IterateWithCallback(cb IterateCallback) error {
 			cb(key, value)
 		},
 	)
+}
+
+func (m *authMap) MaxEntries() uint32 {
+	return m.bpfMap.MaxEntries()
 }
 
 // AuthKey implements the bpf.MapKey interface.

--- a/pkg/maps/authmap/fake/auth_map.go
+++ b/pkg/maps/authmap/fake/auth_map.go
@@ -47,3 +47,7 @@ func (f fakeAuthMap) IterateWithCallback(cb authmap.IterateCallback) error {
 	}
 	return nil
 }
+
+func (f fakeAuthMap) MaxEntries() uint32 {
+	return 1 << 8
+}


### PR DESCRIPTION
### Description

This commit is to make sure that we are having map pressure metric for auth map to improve observability, which can be useful for adjusting map size if required.

Relates: https://github.com/cilium/cilium/issues/24617

### Testing

Testing was done locally with some auth policies, and then check the metrics as per below

```
$ ksysex ds/cilium -- cilium metrics list | grep pressure
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), wait-for-node-init (init), clean-cilium-state (init), install-cni-binaries (init)
cilium_bpf_map_pressure                               map_name="cilium_auth_map"                                                                                                                                                                                                    0.000004
cilium_bpf_map_pressure                               map_name="ipcache"                                                                                                                                                                                                            0.000021
cilium_bpf_map_pressure                               map_name="lb4_backends_v3"                                                                                                                                                                                                    0.000046
cilium_bpf_map_pressure                               map_name="lb4_reverse_nat"                                                                                                                                                                                                    0.000397
cilium_bpf_map_pressure                               map_name="lb4_services_v2"                                                                                                                                                                                                    0.000397
cilium_bpf_map_pressure                               map_name="lxc"                                                                                                                                                                                                                0.000107
```