### PR TITLE
kvstore: share etcd client logger to reduce memory usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,6 +94,7 @@ require (
 	go.uber.org/dig v1.17.0
 	go.uber.org/goleak v1.2.1
 	go.uber.org/multierr v1.11.0
+	go.uber.org/zap v1.24.0
 	go.universe.tf/metallb v0.11.0
 	go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35
 	golang.org/x/crypto v0.10.0
@@ -240,7 +241,6 @@ require (
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/text v0.10.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -20,10 +20,13 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	v3rpcErrors "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	"go.etcd.io/etcd/client/pkg/v3/logutil"
 	"go.etcd.io/etcd/client/pkg/v3/tlsutil"
 	client "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	clientyaml "go.etcd.io/etcd/client/v3/yaml"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/time/rate"
 	"sigs.k8s.io/yaml"
 
@@ -102,6 +105,11 @@ var (
 	etcdDummyAddress = "http://127.0.0.1:4002"
 
 	etcdInstance = newEtcdModule()
+
+	// etcd3ClientLogger is the logger used for the underlying etcd clients. We
+	// explicitly initialize a logger and propagate it to prevent each client from
+	// automatically creating a new one, which comes with a significant memory cost.
+	etcd3ClientLogger *zap.Logger
 )
 
 func EtcdDummyAddress() string {
@@ -301,6 +309,30 @@ func init() {
 			statusCheckTimeout = timeout
 		}
 	}
+
+	// Initialize the etcd client logger.
+	l, err := logutil.CreateDefaultZapLogger(etcdClientDebugLevel())
+	if err != nil {
+		log.WithError(err).Warning("Failed to initialize etcd client logger")
+		l = zap.NewNop()
+	}
+	etcd3ClientLogger = l.Named("etcd-client")
+}
+
+// etcdClientDebugLevel translates ETCD_CLIENT_DEBUG into zap log level.
+// This is a copy of a private etcd client function:
+// https://github.com/etcd-io/etcd/blob/v3.5.9/client/v3/logger.go#L47-L59
+func etcdClientDebugLevel() zapcore.Level {
+	envLevel := os.Getenv("ETCD_CLIENT_DEBUG")
+	if envLevel == "" || envLevel == "true" {
+		return zapcore.InfoLevel
+	}
+	var l zapcore.Level
+	if err := l.Set(envLevel); err != nil {
+		log.Warning("Invalid value for environment variable 'ETCD_CLIENT_DEBUG'. Using default level: 'info'")
+		return zapcore.InfoLevel
+	}
+	return l
 }
 
 // Hint tries to improve the error message displayed to te user.
@@ -637,6 +669,10 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 	// Timeout if the server does not reply within 15 seconds and close the
 	// connection. Ideally it should be lower than staleLockTimeout
 	config.DialKeepAliveTimeout = clientOptions.KeepAliveTimeout
+
+	// Use the shared etcd client logger to prevent unnecessary allocations.
+	config.Logger = etcd3ClientLogger
+
 	c, err := client.New(*config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently, the etcd client logger is not explicitly configured when a new etcd client is initialized, which means that a new one gets created for every client. Yet, this comes with a significant memory cost, which can be avoided explicitly initializing and configuring a shared logger. This change mimics a similar one implemented for the kubernetes apiserver: https://github.com/kubernetes/kubernetes/pull/111477

The following reports the top 3 nodes from the heap pprof profile of an idle process after initializing 1K etcd clients through `kvstore.NewClient`.

### Without the patch:

Showing nodes accounting for 268.62MB, 88.75% of 302.68MB total Dropped 124 nodes (cum <= 1.51MB)
Showing top 3 nodes out of 60
      flat  flat%   sum%        cum   cum%
  224.33MB 74.11% 74.11%   224.33MB 74.11%  go.uber.org/zap/zapcore.newCounters
   32.45MB 10.72% 84.83%    32.45MB 10.72%  google.golang.org/grpc/internal/transport.newBufWriter
   11.85MB  3.91% 88.75%    11.85MB  3.91%  bufio.NewReaderSize

### With the patch:

Showing nodes accounting for 65.20MB, 69.19% of 94.23MB total Showing top 3 nodes out of 137
      flat  flat%   sum%        cum   cum%
   43.62MB 46.29% 46.29%    43.62MB 46.29%  google.golang.org/grpc/internal/transport.newBufWriter
   19.08MB 20.25% 66.54%    19.08MB 20.25%  bufio.NewReaderSize
    2.50MB  2.65% 69.19%        3MB  3.19%  time.NewTimer

This change was initially proposed by @WingkaiHo as part of https://github.com/cilium/cilium/pull/22263