### PR TITLE
routing: remove ip shellout from setUpRoutingTable()

### DIFF
--- a/pkg/datapath/linux/routing/migrate_test.go
+++ b/pkg/datapath/linux/routing/migrate_test.go
@@ -430,24 +430,11 @@ func setUpRoutingTable(c *C, ifindex, tableID, priority int) (map[string]int, ma
 			Table:     newTableID,
 		}), IsNil)
 
-		// _, cidr, err := net.ParseCIDR("172.16.0.2/24")
-		// c.Assert(err, IsNil)
-		// c.Assert(netlink.RuleAdd(&netlink.Rule{
-		// 	// Src:      &net.IPNet{IP: net.ParseIP("172.16.0.2"), Mask: net.CIDRMask(24, 32)},
-		// 	Src: cidr,
-		// 	// Dst:      &net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)},
-		// 	Priority: linux_defaults.RulePriorityEgress,
-		// 	Table:    dummyTmpl.Index,
-		// }), IsNil)
-
-		// TODO(christarazi): Must shell out here due to netlink request (above)
-		// resulting in EINVAL. See https://github.com/cilium/cilium/issues/14383.
-		err = exec.Command("ip", "rule", "add",
-			"from", linkCIDR.String(),
-			"to", "all",
-			"table", fmt.Sprintf("%d", newTableID),
-			"priority", fmt.Sprintf("%d", priority)).Run()
-		c.Assert(err, IsNil)
+		rule := netlink.NewRule()
+		rule.Src = linkCIDR
+		rule.Priority = priority
+		rule.Table = newTableID
+		c.Assert(netlink.RuleAdd(rule), IsNil)
 
 		// Return the MAC address of the dummy device, which acts as the ENI.
 		link, err := netlink.LinkByName(devName)


### PR DESCRIPTION
The default value of a netlink.Rule does not seem to be useful. netlink.NewRule must be used instead.

Fixes: #14383

```release-note
Remove 'ip' shellout from setUpRoutingTable()
```
