### PR TITLE
Add container scanning workflow with Grype

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -1,0 +1,48 @@
+name: Container vulnerability scan
+on:
+  schedule:
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  container-scan:
+    if: github.repository_owner == 'cilium'
+    name: scan-container
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        image: [
+          {name: cilium, dockerfile: ./images/cilium/Dockerfile},
+          {name: clustermesh-apiserver, dockerfile: ./images/clustermesh-apiserver/Dockerfile},
+          {name: docker-plugin, dockerfile: ./images/cilium-docker-plugin/Dockerfile},
+          {name: hubble-relay, dockerfile: ./images/hubble-relay/Dockerfile},
+          {name: kvstoremesh, dockerfile: ./images/kvstoremesh/Dockerfile},
+          {name: operator-generic, dockerfile: ./images/operator/Dockerfile},
+        ]
+        branch: [v1.11, v1.12, v1.13] 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        ref: ${{ matrix.branch }}
+      - name: Set environment variables
+        uses: ./.github/actions/set-env-variables
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
+      - name: Build local container
+        uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
+        with:
+          context: . 
+          tags: ${{ matrix.image.name }}:${{ matrix.branch }}
+          push: false
+          load: true
+          file: ${{ matrix.image.dockerfile }}
+          build-args: |
+            OPERATOR_VARIANT=${{ matrix.image.name }}
+      - name: Scan image
+        uses: anchore/scan-action@24fd7c9060f3c96848dd1929fac8d796fb5ae4b4 # v3.3.6
+        with:
+          image: ${{ matrix.image.name }}:${{ matrix.branch }}
+          output-format: table
+          severity-cutoff: critical


### PR DESCRIPTION
- Scans the same list of images as used in the Image CI build
- Runs daily + on demand
- Fails if any Critical issues are discovered

```release-note
Add container image scanning to Cilium images.
```
