### PR TITLE
Update documentation to use Helm mode Cilium CLI

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -316,23 +316,6 @@ If the installation fails for some reason, run ``cilium status`` to retrieve
 the overall status of the Cilium deployment and inspect the logs of whatever
 pods are failing to be deployed.
 
-.. tip::
-
-   You may be seeing ``cilium install`` print something like this:
-
-   .. code-block:: shell-session
-
-       ♻️  Restarted unmanaged pod kube-system/event-exporter-gke-564fb97f9-rv8hg
-       ♻️  Restarted unmanaged pod kube-system/kube-dns-6465f78586-hlcrz
-       ♻️  Restarted unmanaged pod kube-system/kube-dns-autoscaler-7f89fb6b79-fsmsg
-       ♻️  Restarted unmanaged pod kube-system/l7-default-backend-7fd66b8b88-qqhh5
-       ♻️  Restarted unmanaged pod kube-system/metrics-server-v0.3.6-7b5cdbcbb8-kjl65
-       ♻️  Restarted unmanaged pod kube-system/stackdriver-metadata-agent-cluster-level-6cc964cddf-8n2rt
-
-   This indicates that your cluster was already running some pods before Cilium
-   was deployed and the installer has automatically restarted them to ensure
-   all pods get networking provided by Cilium.
-
 Validate the Installation
 =========================
 

--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -235,7 +235,7 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        .. code-block:: shell-session
 
-           cilium install --azure-resource-group "${AZURE_RESOURCE_GROUP}"
+           cilium install --helm-set "azure.resourceGroup=${AZURE_RESOURCE_GROUP}"
 
        The Cilium CLI will automatically install Cilium using one of the
        following installation modes based on the ``--network-plugin``


### PR DESCRIPTION
Review all uses of the following commands in the Cilium Docs, and ensure that they are not using deprecated or removed flags that have been replaced by Helm-based equivalents.

In some cases here we must identify the set of flag(s) that implement the same functionality in Helm. There is not a 1 to 1 mapping with removed flags for the `clientgo` based implementation.

```
cilium install
cilium uninstall
cilium upgrade
cilium clustermesh connect
cilium clustermesh disconnect
cilium clustermesh enable
cilium clustermesh disable
cilium hubble enable
cilium hubble disable
```

Required changes:

- [x] Instances of `cilium install --azure-resource-group` flag was removed, replaced with `--helm-set "azure.resourceGroup"
    - [x] Validation: Spun up an Azure BYOCNI cluster to test that the install worked with this new flag
    - [x] Related issues identified during validation: https://github.com/cilium/cilium-cli/pull/1771
- [ ] (Work in Progress...) 

Fixes: https://github.com/cilium/cilium-cli/issues/1624

```release-note
All Cilium CLI commands now operate directly on Helm releases using the Helm charts. Update documentation accordingly.
```