### PR TITLE
Set RouteMTU for generic veth

### DIFF
--- a/plugins/cilium-cni/chaining/api/api.go
+++ b/plugins/cilium-cni/chaining/api/api.go
@@ -11,6 +11,7 @@ import (
 	cniTypesVer "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/client"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/plugins/cilium-cni/lib"
@@ -30,10 +31,11 @@ const (
 
 // PluginContext is the context given to chaining plugins
 type PluginContext struct {
-	Logger  *logrus.Entry
-	Args    *skel.CmdArgs
-	CniArgs types.ArgsSpec
-	NetConf *types.NetConf
+	Logger     *logrus.Entry
+	Args       *skel.CmdArgs
+	CniArgs    types.ArgsSpec
+	NetConf    *types.NetConf
+	CiliumConf *models.DaemonConfigurationStatus
 	//Client  *client.Client
 }
 

--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -67,6 +67,7 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 			return err
 		}
 
+		linkFound := false
 		for _, link := range links {
 			pluginCtx.Logger.Debugf("Found interface in container %+v", link.Attrs())
 
@@ -102,10 +103,49 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 					logfields.Interface: link.Attrs().Name}).Warn("No valid IPv6 address found")
 			}
 
-			return nil
+			linkFound = true
+			break
 		}
 
-		return fmt.Errorf("no link found inside container")
+		if !linkFound {
+			return fmt.Errorf("no link found inside container")
+		}
+
+		if pluginCtx.NetConf.EnableRouteMTU {
+			routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
+			if err != nil {
+				err = fmt.Errorf("unable to list the IPv4 routes: %s", err.Error())
+				return err
+			}
+			for _, rt := range routes {
+				if rt.MTU != int(pluginCtx.CiliumConf.RouteMTU) {
+					rt.MTU = int(pluginCtx.CiliumConf.RouteMTU)
+					err = netlink.RouteReplace(&rt)
+					if err != nil {
+						err = fmt.Errorf("unable to replace the mtu %d for the route %s: %s", rt.MTU, rt.String(), err.Error())
+						return err
+					}
+				}
+			}
+
+			routes, err = netlink.RouteList(nil, netlink.FAMILY_V6)
+			if err != nil {
+				err = fmt.Errorf("unable to list the IPv6 routes: %s", err.Error())
+				return err
+			}
+			for _, rt := range routes {
+				if rt.MTU != int(pluginCtx.CiliumConf.RouteMTU) {
+					rt.MTU = int(pluginCtx.CiliumConf.RouteMTU)
+					err = netlink.RouteReplace(&rt)
+					if err != nil {
+						err = fmt.Errorf("unable to replace the mtu %d for the route %s: %s", rt.MTU, rt.String(), err.Error())
+						return err
+					}
+				}
+			}
+		}
+
+		return nil
 	}); err != nil {
 		return
 	}

--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -397,6 +397,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		return fmt.Errorf("unable to connect to Cilium daemon: %s", client.Hint(err))
 	}
 
+	conf, err := getConfigFromCiliumAgent(c)
+	if err != nil {
+		return err
+	}
+
 	// If CNI ADD gives us a PrevResult, we're a chained plugin and *must* detect a
 	// valid chained mode. If no chained mode we understand is specified, error out.
 	// Otherwise, continue with normal plugin execution.
@@ -405,10 +410,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 			var (
 				res *cniTypesV1.Result
 				ctx = chainingapi.PluginContext{
-					Logger:  logger,
-					Args:    args,
-					CniArgs: cniArgs,
-					NetConf: n,
+					Logger:     logger,
+					Args:       args,
+					CniArgs:    cniArgs,
+					NetConf:    n,
+					CiliumConf: conf,
 				}
 			)
 
@@ -438,11 +444,6 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 	if err = netns.RemoveIfFromNetNSIfExists(netNs, args.IfName); err != nil {
 		return fmt.Errorf("failed removing interface %q from namespace %q: %s",
 			args.IfName, args.Netns, err)
-	}
-
-	conf, err := getConfigFromCiliumAgent(c)
-	if err != nil {
-		return err
 	}
 
 	var ipam *models.IPAMResponse

--- a/plugins/cilium-cni/types/types.go
+++ b/plugins/cilium-cni/types/types.go
@@ -22,16 +22,17 @@ import (
 // NetConf is the Cilium specific CNI network configuration
 type NetConf struct {
 	cniTypes.NetConf
-	MTU          int                    `json:"mtu"`
-	Args         Args                   `json:"args"`
-	ENI          eniTypes.ENISpec       `json:"eni,omitempty"`
-	Azure        azureTypes.AzureSpec   `json:"azure,omitempty"`
-	IPAM         IPAM                   `json:"ipam,omitempty"` // Shadows the JSON field "ipam" in cniTypes.NetConf.
-	AlibabaCloud alibabaCloudTypes.Spec `json:"alibaba-cloud,omitempty"`
-	EnableDebug  bool                   `json:"enable-debug"`
-	LogFormat    string                 `json:"log-format"`
-	LogFile      string                 `json:"log-file"`
-	ChainingMode string                 `json:"chaining-mode"`
+	MTU            int                    `json:"mtu"`
+	Args           Args                   `json:"args"`
+	EnableRouteMTU bool                   `json:"enable-route-mtu"`
+	ENI            eniTypes.ENISpec       `json:"eni,omitempty"`
+	Azure          azureTypes.AzureSpec   `json:"azure,omitempty"`
+	IPAM           IPAM                   `json:"ipam,omitempty"` // Shadows the JSON field "ipam" in cniTypes.NetConf.
+	AlibabaCloud   alibabaCloudTypes.Spec `json:"alibaba-cloud,omitempty"`
+	EnableDebug    bool                   `json:"enable-debug"`
+	LogFormat      string                 `json:"log-format"`
+	LogFile        string                 `json:"log-file"`
+	ChainingMode   string                 `json:"chaining-mode"`
 }
 
 // IPAM is the Cilium specific CNI IPAM configuration


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
The PR inherits from https://github.com/cilium/cilium/pull/21994.  Once `enable-route-mtu` is true, route MTU will be applied to every route inside the pod. Also resolved some minor conflict in the second commit.

