### PR TITLE
[v1.13] bpf: fix error handling for invoke_tailcall_if()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1398,20 +1398,20 @@ to_host_from_lxc(struct __ctx_buff *ctx __maybe_unused)
 # endif
 # ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
-					      is_defined(ENABLE_IPV6)),
-					is_defined(DEBUG)),
-				   CILIUM_CALL_IPV6_TO_HOST_POLICY_ONLY,
-				   tail_ipv6_host_policy_ingress);
+		ret = invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+						    is_defined(ENABLE_IPV6)),
+					      is_defined(DEBUG)),
+					 CILIUM_CALL_IPV6_TO_HOST_POLICY_ONLY,
+					 tail_ipv6_host_policy_ingress);
 		break;
 # endif
 # ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
-					      is_defined(ENABLE_IPV6)),
-					is_defined(DEBUG)),
-				   CILIUM_CALL_IPV4_TO_HOST_POLICY_ONLY,
-				   tail_ipv4_host_policy_ingress);
+		ret = invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+						    is_defined(ENABLE_IPV6)),
+					      is_defined(DEBUG)),
+					 CILIUM_CALL_IPV4_TO_HOST_POLICY_ONLY,
+					 tail_ipv4_host_policy_ingress);
 		break;
 # endif
 	default:

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -136,7 +136,7 @@ int NAME(struct __ctx_buff *ctx)						\
 	if (map_update_elem(&CT_TAIL_CALL_BUFFER4, &zero, &ct_buffer, 0) < 0)	\
 		return drop_for_direction(ctx, DIR, DROP_INVALID_TC_BUFFER);	\
 										\
-	invoke_tailcall_if(CONDITION, TARGET_ID, TARGET_NAME);			\
+	ret = invoke_tailcall_if(CONDITION, TARGET_ID, TARGET_NAME);		\
 	return ret;								\
 }
 
@@ -177,7 +177,7 @@ int NAME(struct __ctx_buff *ctx)						\
 		return drop_for_direction(ctx, DIR,				\
 			DROP_INVALID_TC_BUFFER);				\
 										\
-	invoke_tailcall_if(CONDITION, TARGET_ID, TARGET_NAME);			\
+	ret = invoke_tailcall_if(CONDITION, TARGET_ID, TARGET_NAME);		\
 	return ret;								\
 }
 
@@ -713,8 +713,8 @@ skip_service_lookup:
 	}
 #endif /* ENABLE_PER_PACKET_LB */
 
-	invoke_tailcall_if(is_defined(ENABLE_PER_PACKET_LB),
-			   CILIUM_CALL_IPV6_CT_EGRESS, tail_ipv6_ct_egress);
+	ret = invoke_tailcall_if(is_defined(ENABLE_PER_PACKET_LB),
+				 CILIUM_CALL_IPV6_CT_EGRESS, tail_ipv6_ct_egress);
 	return ret;
 }
 
@@ -1282,8 +1282,8 @@ skip_service_lookup:
 	}
 #endif /* ENABLE_PER_PACKET_LB */
 
-	invoke_tailcall_if(is_defined(ENABLE_PER_PACKET_LB),
-			   CILIUM_CALL_IPV4_CT_EGRESS, tail_ipv4_ct_egress);
+	ret = invoke_tailcall_if(is_defined(ENABLE_PER_PACKET_LB),
+				 CILIUM_CALL_IPV4_CT_EGRESS, tail_ipv4_ct_egress);
 	return ret;
 }
 
@@ -2053,16 +2053,16 @@ int handle_policy(struct __ctx_buff *ctx)
 	switch (proto) {
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
-				   CILIUM_CALL_IPV6_CT_INGRESS_POLICY_ONLY,
-				   tail_ipv6_ct_ingress_policy_only);
+		ret = invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+					 CILIUM_CALL_IPV6_CT_INGRESS_POLICY_ONLY,
+					 tail_ipv6_ct_ingress_policy_only);
 		break;
 #endif /* ENABLE_IPV6 */
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
-				   CILIUM_CALL_IPV4_CT_INGRESS_POLICY_ONLY,
-				   tail_ipv4_ct_ingress_policy_only);
+		ret = invoke_tailcall_if(__and(is_defined(ENABLE_IPV4), is_defined(ENABLE_IPV6)),
+					 CILIUM_CALL_IPV4_CT_INGRESS_POLICY_ONLY,
+					 tail_ipv4_ct_ingress_policy_only);
 		break;
 #endif /* ENABLE_IPV4 */
 	default:

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -137,6 +137,9 @@ int NAME(struct __ctx_buff *ctx)						\
 		return drop_for_direction(ctx, DIR, DROP_INVALID_TC_BUFFER);	\
 										\
 	ret = invoke_tailcall_if(CONDITION, TARGET_ID, TARGET_NAME);		\
+	if (IS_ERR(ret))							\
+		return drop_for_direction(ctx, DIR, ret);			\
+										\
 	return ret;								\
 }
 
@@ -178,6 +181,9 @@ int NAME(struct __ctx_buff *ctx)						\
 			DROP_INVALID_TC_BUFFER);				\
 										\
 	ret = invoke_tailcall_if(CONDITION, TARGET_ID, TARGET_NAME);		\
+	if (IS_ERR(ret))							\
+		return drop_for_direction(ctx, DIR, ret);			\
+										\
 	return ret;								\
 }
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2785,23 +2785,23 @@ static __always_inline int handle_nat_fwd(struct __ctx_buff *ctx)
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):
-		invoke_tailcall_if(__or3(__and(is_defined(ENABLE_IPV4),
-					       is_defined(ENABLE_IPV6)),
-					 __and(is_defined(ENABLE_HOST_FIREWALL),
-					       is_defined(IS_BPF_HOST)),
-					 is_defined(ENABLE_EGRESS_GATEWAY)),
-				   CILIUM_CALL_IPV4_NODEPORT_NAT_FWD,
-				   handle_nat_fwd_ipv4);
+		ret = invoke_tailcall_if(__or3(__and(is_defined(ENABLE_IPV4),
+						     is_defined(ENABLE_IPV6)),
+					       __and(is_defined(ENABLE_HOST_FIREWALL),
+						     is_defined(IS_BPF_HOST)),
+					       is_defined(ENABLE_EGRESS_GATEWAY)),
+					 CILIUM_CALL_IPV4_NODEPORT_NAT_FWD,
+					 handle_nat_fwd_ipv4);
 		break;
 #endif /* ENABLE_IPV4 */
 #ifdef ENABLE_IPV6
 	case bpf_htons(ETH_P_IPV6):
-		invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
-					      is_defined(ENABLE_IPV6)),
-					__and(is_defined(ENABLE_HOST_FIREWALL),
-					      is_defined(IS_BPF_HOST))),
-				   CILIUM_CALL_IPV6_NODEPORT_NAT_FWD,
-				   handle_nat_fwd_ipv6);
+		ret = invoke_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
+						    is_defined(ENABLE_IPV6)),
+					      __and(is_defined(ENABLE_HOST_FIREWALL),
+						    is_defined(IS_BPF_HOST))),
+					 CILIUM_CALL_IPV6_NODEPORT_NAT_FWD,
+					 handle_nat_fwd_ipv6);
 		break;
 #endif /* ENABLE_IPV6 */
 	default:

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -98,12 +98,12 @@
 	__eval(__declare_tailcall_if_, COND)(NAME)
 
 #define __invoke_tailcall_if_0(NAME, FUNC)    \
-	return FUNC(ctx)
+	FUNC(ctx)
 #define __invoke_tailcall_if_1(NAME, FUNC)    \
-	do {                                  \
+	({				      \
 		ep_tail_call(ctx, NAME);      \
-		ret = DROP_MISSED_TAIL_CALL;  \
-	} while (0)
+		DROP_MISSED_TAIL_CALL;        \
+	})
 #define invoke_tailcall_if(COND, NAME, FUNC)  \
 	__eval(__invoke_tailcall_if_, COND)(NAME, FUNC)
 


### PR DESCRIPTION
Manual backport for

* [x] https://github.com/cilium/cilium/pull/26118. Adjusted for additional / missing usage of `invoke_tailcall_if()` in `v1.13` branch.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 26118; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=26118
```
