### PR TITLE
test: Enable IPv6 datapath_configuration tests with BPF masquerading

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -114,6 +114,7 @@ include:
   # K8sDatapathConfig Iptables Skip conntrack for pod traffic
   # K8sDatapathConfig IPv4Only Check connectivity with IPv6 disabled
   # K8sDatapathConfig IPv6 masquerading across K8s nodes, skipped due to native routing CIDR
+  # K8sDatapathConfig IPv6 masquerading for external traffic
   - focus: "f20-datapath-misc-3"
     cliFocus: "K8sDatapathConfig WireGuard encryption strict mode|K8sDatapathConfig Iptables|K8sDatapathConfig IPv4Only|K8sDatapathConfig IPv6"
 


### PR DESCRIPTION
Following the introduction of IPv6 BPF masquerading, we can enable the related tests in datapath_configuration.go.

Logically, these tests should have been enabled when we added IPv6 BPF masquerading, but I missed them.