### PR TITLE
bpf: nat: Handle errors from snat_v(4|6)_prepare_state()

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -612,6 +612,7 @@ enum {
 #define DROP_NO_EGRESS_GATEWAY	-194
 
 #define NAT_PUNT_TO_STACK	DROP_NAT_NOT_NEEDED
+#define NAT_NEEDED		CTX_ACT_OK
 #define NAT_46X64_RECIRC	100
 
 /* Cilium metrics reasons for forwarding packets and other stats.

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -104,11 +104,10 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 	};
-	int ret = CTX_ACT_OK;
-	bool snat_needed;
+	int ret;
 
-	snat_needed = snat_v6_prepare_state(ctx, &target);
-	if (snat_needed)
+	ret = snat_v6_prepare_state(ctx, &target);
+	if (ret == NAT_NEEDED)
 		ret = snat_v6_nat(ctx, &target, ext_err);
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
@@ -1437,11 +1436,10 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 		.cluster_id = cluster_id,
 #endif
 	};
-	int ret = CTX_ACT_OK;
-	bool snat_needed;
+	int ret;
 
-	snat_needed = snat_v4_prepare_state(ctx, &target);
-	if (snat_needed)
+	ret = snat_v4_prepare_state(ctx, &target);
+	if (ret == NAT_NEEDED)
 		ret = snat_v4_nat(ctx, &target, ext_err);
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;


### PR DESCRIPTION
Functions `snat_v4_prepare_state()` and `snat_v6_prepare_state()` woule return a boolean, indicating whether SNAT should happen. They would not report errors that might occur when trying to determine that.

In this commit, we change they return type to an int, in order to report any error to the caller. The SNAT decision is reported via a pointer to a boolean, passed as a new argument.

We report errors if any of `revalidate_data()`, `ct_is_reply4()`, `ct_is_reply6()`, or `ipv6_hdrlen()` fails.
