### PR TITLE
[aws][eni] Ensure security-groups are sorted

### DIFF
--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -319,6 +319,7 @@ func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.ENISpec
 			for _, secGroup := range securityGroups {
 				groups = append(groups, secGroup.ID)
 			}
+			sort.Strings(groups)
 			return groups, nil
 		}
 	}
@@ -338,6 +339,8 @@ func (n *Node) getSecurityGroupIDs(ctx context.Context, eniSpec eniTypes.ENISpec
 	if securityGroups == nil {
 		return nil, fmt.Errorf("failed to get security group ids")
 	}
+
+	sort.Strings(securityGroups)
 
 	return securityGroups, nil
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Under certain circumstances, AWS may return the security-group information in a different order than previously. That causes the operator in AWS ENI mode to update all CiliumNode objects causing further downstream impacts. This change ensures that the security groups are sorted to prevent the unnecessary updates. 

Fixes: N/A

```release-note
In AWS ENI mode, ensure that `securityGroup` information is always sorted. 
```
