### PR TITLE
bpf: nat: fix build error in snat_v6_prepare_state()

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1691,7 +1691,7 @@ snat_v6_prepare_state(struct __ctx_buff *ctx, struct ipv6_nat_target *target)
 {
 	union v6addr masq_addr __maybe_unused, router_ip __maybe_unused;
 	const union v6addr dr_addr __maybe_unused = IPV6_DIRECT_ROUTING;
-	struct remote_endpoint_info *remote_ep;
+	struct remote_endpoint_info *remote_ep __maybe_unused;
 	struct endpoint_info *local_ep;
 	bool is_reply = false;
 	void *data, *data_end;


### PR DESCRIPTION
Without ENABLE_MASQUERADE_IPV6, the `remote_ep` variable isn't used. Fix up the build.

```
In file included from bpf_lxc.c:56:
./cilium/bpf/lib/nat.h:1694:31: error: variable 'remote_ep' set but not used [-Werror,-Wunused-but-set-variable]
        struct remote_endpoint_info *remote_ep;
                                     ^
1 error generated.
```