### PR TITLE
CNI: add host-side interface info to cni.Result

### DIFF
--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -479,6 +479,8 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		ep.DatapathConfiguration.ExternalIpam = true
 	}
 
+	res := &cniTypesV1.Result{}
+
 	switch conf.DatapathMode {
 	case datapathOption.DatapathModeVeth:
 		var (
@@ -500,6 +502,11 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 			}
 		}()
 
+		res.Interfaces = append(res.Interfaces, &cniTypesV1.Interface{
+			Name: veth.Attrs().Name,
+			Mac:  veth.Attrs().HardwareAddr.String(),
+		})
+
 		if err = netlink.LinkSetNsFd(peer, int(netNs.Fd())); err != nil {
 			return fmt.Errorf("unable to move veth pair '%v' to netns: %s", peer, err)
 		}
@@ -514,8 +521,6 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		Client:   c,
 		HostAddr: ipam.HostAddressing,
 	}
-
-	res := &cniTypesV1.Result{}
 
 	if !ipv6IsEnabled(ipam) && !ipv4IsEnabled(ipam) {
 		return fmt.Errorf("IPAM did not provide IPv4 or IPv6 address")
@@ -534,6 +539,8 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		if err != nil {
 			return fmt.Errorf("unable to prepare IP addressing for '%s': %s", ep.Addressing.IPV6, err)
 		}
+		// set the addresses interface index to that of the container-side veth
+		ipConfig.Interface = cniTypesV1.Int(len(res.Interfaces))
 		res.IPs = append(res.IPs, ipConfig)
 		res.Routes = append(res.Routes, routes...)
 	}
@@ -547,6 +554,8 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		if err != nil {
 			return fmt.Errorf("unable to prepare IP addressing for '%s': %s", ep.Addressing.IPV4, err)
 		}
+		// set the addresses interface index to that of the container-side veth
+		ipConfig.Interface = cniTypesV1.Int(len(res.Interfaces))
 		res.IPs = append(res.IPs, ipConfig)
 		res.Routes = append(res.Routes, routes...)
 	}
@@ -577,11 +586,6 @@ func cmdAdd(args *skel.CmdArgs) (err error) {
 		Mac:     macAddrStr,
 		Sandbox: args.Netns,
 	})
-
-	// Add to the result the Interface as index of Interfaces
-	for i := range res.Interfaces {
-		res.IPs[i].Interface = cniTypesV1.Int(i)
-	}
 
 	// Specify that endpoint must be regenerated synchronously. See GH-4409.
 	ep.SyncBuildEndpoint = true


### PR DESCRIPTION
Fixes: https://github.com/cilium/cilium/issues/24899

<!-- Description of change -->

```release-note
Add host-side interface info to cni.Result, which allows bandwidth CNI to work with Cilium
```
