### PR TITLE
bpf: nat: minor improvements

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -97,7 +97,6 @@ struct ipv4_nat_target {
 	__be32 addr;
 	const __u16 min_port; /* host endianness */
 	const __u16 max_port; /* host endianness */
-	bool src_from_world;
 	bool from_local_endpoint;
 	bool egress_gateway; /* NAT is needed because of an egress gateway policy */
 	__u32 cluster_id;
@@ -646,8 +645,7 @@ snat_v4_nat_can_skip(const struct ipv4_nat_target *target, const struct ipv4_ct_
 		return false;
 #endif
 
-	return (!target->from_local_endpoint && !target->src_from_world &&
-		sport < NAT_MIN_EGRESS) ||
+	return (!target->from_local_endpoint && sport < NAT_MIN_EGRESS) ||
 		icmp_echoreply;
 }
 
@@ -1231,7 +1229,6 @@ struct ipv6_nat_target {
 	union v6addr addr;
 	const __u16 min_port; /* host endianness */
 	const __u16 max_port; /* host endianness */
-	bool src_from_world;
 	bool from_local_endpoint;
 };
 
@@ -1644,8 +1641,7 @@ snat_v6_nat_can_skip(const struct ipv6_nat_target *target, const struct ipv6_ct_
 {
 	__u16 sport = bpf_ntohs(tuple->sport);
 
-	return (!target->from_local_endpoint && !target->src_from_world &&
-		sport < NAT_MIN_EGRESS) ||
+	return (!target->from_local_endpoint && sport < NAT_MIN_EGRESS) ||
 		icmp_echoreply;
 }
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -821,9 +821,6 @@ skip_egress_gateway:
 #ifdef IPV4_SNAT_EXCLUSION_DST_CIDR
 	/* Do not MASQ if a dst IP belongs to a pods CIDR
 	 * (ipv4-native-routing-cidr if specified, otherwise local pod CIDR).
-	 * The check is performed before we determine that a packet is
-	 * sent from a local pod, as this check is cheaper than
-	 * the map lookup done in the latter check.
 	 */
 	if (ipv4_is_in_subnet(ip4->daddr, IPV4_SNAT_EXCLUSION_DST_CIDR,
 			      IPV4_SNAT_EXCLUSION_DST_CIDR_LEN))

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -752,15 +752,14 @@ snat_v4_prepare_state(struct __ctx_buff *ctx, struct ipv4_nat_target *target)
 		target->addr = IPV4_DIRECT_ROUTING;
 		return NAT_NEEDED;
 	}
-# ifdef ENABLE_MASQUERADE_IPV4
+#endif /* defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY) */
+
+#if defined(ENABLE_MASQUERADE_IPV4) && defined(IS_BPF_HOST)
 	if (ip4->saddr == IPV4_MASQUERADE) {
 		target->addr = IPV4_MASQUERADE;
 		return NAT_NEEDED;
 	}
-# endif /* ENABLE_MASQUERADE_IPV4 */
-#endif /* defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY) */
 
-#if defined(ENABLE_MASQUERADE_IPV4) && defined(IS_BPF_HOST)
 	local_ep = __lookup_ip4_endpoint(ip4->saddr);
 	remote_ep = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 
@@ -1716,16 +1715,15 @@ snat_v6_prepare_state(struct __ctx_buff *ctx, struct ipv6_nat_target *target)
 		ipv6_addr_copy(&target->addr, &dr_addr);
 		return NAT_NEEDED;
 	}
-# ifdef ENABLE_MASQUERADE_IPV6 /* SNAT local pod to world packets */
+#endif /* defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY) */
+
+#if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
 	BPF_V6(masq_addr, IPV6_MASQUERADE);
 	if (ipv6_addr_equals((union v6addr *)&ip6->saddr, &masq_addr)) {
 		ipv6_addr_copy(&target->addr, &masq_addr);
 		return NAT_NEEDED;
 	}
-# endif /* ENABLE_MASQUERADE_IPV6 */
-#endif /* defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY) */
 
-#if defined(ENABLE_MASQUERADE_IPV6) && defined(IS_BPF_HOST)
 	local_ep = __lookup_ip6_endpoint((union v6addr *)&ip6->saddr);
 	remote_ep = lookup_ip6_remote_endpoint((union v6addr *)&ip6->daddr, 0);
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1744,14 +1744,6 @@ snat_v6_prepare_state(struct __ctx_buff *ctx, struct ipv6_nat_target *target)
 
 		target->from_local_endpoint = true;
 
-		/* ipv6_hdrlen() can return an error. If it does, it makes no
-		 * sense marking this packet as a reply based on a wrong offset.
-		 *
-		 * We should probably improve this code in the future to
-		 * report the error to the caller. Same thing for errors
-		 * from ct_is_reply6() below, and ct_is_reply4() in
-		 * snat_v4_prepare_state().
-		 */
 		l4_off = ipv6_hdrlen(ctx, &tuple.nexthdr);
 		if (IS_ERR(l4_off))
 			return l4_off;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -791,7 +791,6 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 	struct ipv6_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
-		.src_from_world = true,
 	};
 	__s8 ext_err = 0;
 	int ret;
@@ -847,7 +846,6 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	struct ipv6_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
-		.src_from_world = true,
 		.addr = IPV6_DIRECT_ROUTING,
 	};
 	struct ipv6_ct_tuple tuple = {};
@@ -2120,7 +2118,6 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	struct ipv4_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
-		.src_from_world = true,
 	};
 	__s8 ext_err = 0;
 	int ret;
@@ -2181,7 +2178,6 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	struct ipv4_nat_target target = {
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
-		.src_from_world = true,
 		/* Unfortunately, the bpf_fib_lookup() is not able to set src IP addr.
 		 * So we need to assume that the direct routing device is going to be
 		 * used to fwd the NodePort request, thus SNAT-ing to its IP addr.


### PR DESCRIPTION
Some small housekeeping patches for our NAT code
- remove dead code  / comments
- avoid accidental inclusion of some NAT code into bpf_overlay