### PR TITLE
docs: Multi-Pool IPAM now partially supports iptables-based NAT

### DIFF
--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -150,11 +150,12 @@ Multi-Pool IPAM mode:
      of endpoints by way of the IPCache.
    - Multi-Pool IPAM does not support local node routes (``enable-local-node-route``) and
      requires the use of per-endpoint routes (see :ref:`native_routing`) instead.
-   - iptables-based masquerading (see masquerading :ref:`masq_modes` for details) is not supported,
-     due to an implementation bug which assumes a single PodCIDR per node (:gh-issue:`22273`).
-     Use eBPF-based masquerading instead. Also note that if the used IPAM pools do not share a single
-     native-routing CIDR, you may want to use ``ip-masq-agent`` instead.
-     See :ref:`concepts_masquerading` for details on how to exclude more than one CIDR from
-     masquerading.
+   - iptables-based masquerading requires ``egressMasqueradeInterfaces`` to be set
+     (see masquerading :ref:`masq_modes` and :gh-issue:`22273` for details).
+     Alternatively, eBPF-based masquerading is fully supported and may be used instead.
+     Note that if the used IPAM pools do not belong to a common native-routing CIDR,
+     you may want to use ``ip-masq-agent``, which allows multiple disjunct non-masquerading
+     CIDRs to be defined. See :ref:`concepts_masquerading` for details on how to use the
+     ``ip-masq-agent`` feature.
    - Announcing PodCIDRs by way of the built-in :ref:`bgp` mode is not yet
      supported.  Use ``auto-direct-node-routes`` instead.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -390,6 +390,7 @@ disableEnvoyVersionCheck
 disableIptablesFeederRules
 disassembly
 discoverable
+disjunct
 distro
 distros
 dmesg


### PR DESCRIPTION
With #26397 merged, iptables-based masquerading can now be used together with Multi-Pool IPAM, as long as `egressMasqueradeInterfaces` is set too. I have locally verified that  #26397 fixed the issues with Multi-Pool IPAM.

This commit adjusts the documentation to reflect that, and improves the wording a bit.
