### PR TITLE
treewide: wrap multiple errors using the standard library

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -71,6 +71,10 @@ linters-settings:
               - testing
               - github.com/stretchr/testify/assert
             reason: "gocheck has been deprecated, see https://docs.cilium.io/en/latest/contributing/testing/unit/#migrating-tests-off-of-gopkg-in-check-v1"
+        - go.uber.org/multierr:
+            recommendations:
+              - errors
+            reason: "Go 1.20+ has support for combining multiple errors, see https://go.dev/doc/go1.20#errors"
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/go.mod
+++ b/go.mod
@@ -93,7 +93,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.16.0
 	go.uber.org/dig v1.17.0
 	go.uber.org/goleak v1.2.1
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
 	go.universe.tf/metallb v0.11.0
 	go4.org/netipx v0.0.0-20230303233057-f1b76eb4bb35
@@ -241,6 +240,7 @@ require (
 	go.mongodb.org/mongo-driver v1.11.3 // indirect
 	go.opentelemetry.io/otel/metric v1.16.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/oauth2 v0.7.0 // indirect
 	golang.org/x/text v0.10.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -5,6 +5,7 @@ package hive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -17,7 +18,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 	"go.uber.org/dig"
-	"go.uber.org/multierr"
 
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/logging"
@@ -187,27 +187,23 @@ func (h *Hive) Run() error {
 	startCtx, cancel := context.WithTimeout(context.Background(), h.startTimeout)
 	defer cancel()
 
-	var errors []error
-
+	var errs error
 	if err := h.Start(startCtx); err != nil {
-		errors = append(errors, fmt.Errorf("failed to start: %w", err))
+		errs = errors.Join(errs, fmt.Errorf("failed to start: %w", err))
 	}
 
 	// If start was successful, wait for Shutdown() or interrupt.
-	if len(errors) == 0 {
-		shutdownErr := h.waitForSignalOrShutdown()
-		if shutdownErr != nil {
-			errors = append(errors, shutdownErr)
-		}
+	if errs == nil {
+		errs = errors.Join(errs, h.waitForSignalOrShutdown())
 	}
 
 	stopCtx, cancel := context.WithTimeout(context.Background(), h.stopTimeout)
 	defer cancel()
 
 	if err := h.Stop(stopCtx); err != nil {
-		errors = append(errors, fmt.Errorf("failed to stop: %w", err))
+		errs = errors.Join(errs, fmt.Errorf("failed to stop: %w", err))
 	}
-	return multierr.Combine(errors...)
+	return errs
 }
 
 func (h *Hive) waitForSignalOrShutdown() error {

--- a/pkg/ipam/allocator/podcidr/podcidr_v2_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_v2_test.go
@@ -384,7 +384,7 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_allocateNodeV2(c *C) {
 							},
 						},
 						OperatorStatus: ipamTypes.OperatorStatus{
-							Error: "allocator clusterCIDR: 10.0.0.0/24, nodeMask: 24 full; allocator full",
+							Error: "allocator clusterCIDR: 10.0.0.0/24, nodeMask: 24 full\nallocator full",
 						},
 					},
 				},

--- a/test/controlplane/node/localnode.go
+++ b/test/controlplane/node/localnode.go
@@ -5,10 +5,10 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
-	"go.uber.org/multierr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -59,7 +59,7 @@ type errorer struct {
 }
 
 func (e *errorer) Errorf(format string, args ...interface{}) {
-	e.err = multierr.Append(e.err, fmt.Errorf(format, args...))
+	e.err = errors.Join(e.err, fmt.Errorf(format, args...))
 }
 
 func validateLocalNodeInit(lns *node.LocalNodeStore) error {


### PR DESCRIPTION
 Go 1.20 expands support for error wrapping to permit an error to wrap multiple other errors. Therefore, `go.uber.org/multierr` is no longer required. See https://go.dev/doc/go1.20#errors for more details.
 
 EDIT: I should have called this out: there's one difference in the error string when multiple errors are wrapped together: with `multierr`, the error strings are joined with `; ` while with the standard library `errors.Join()`, they are [joined with a newline](https://cs.opensource.google/go/go/+/refs/tags/go1.20.5:src/errors/join.go;l=42) `\n`. I think this _may_ be a problem when logging systems expect one line per log.
