### PR TITLE
auth: display textual representation of auth type in authKey.String()

### DIFF
--- a/pkg/auth/authmap.go
+++ b/pkg/auth/authmap.go
@@ -28,7 +28,7 @@ type authKey struct {
 }
 
 func (r authKey) String() string {
-	return fmt.Sprintf("localIdentity=%d, remoteIdentity=%d, remoteNodeID=%d, authType=%d", r.localIdentity, r.remoteIdentity, r.remoteNodeID, r.authType)
+	return fmt.Sprintf("localIdentity=%d, remoteIdentity=%d, remoteNodeID=%d, authType=%s", r.localIdentity, r.remoteIdentity, r.remoteNodeID, r.authType)
 }
 
 type authInfo struct {


### PR DESCRIPTION
Currently, the numeric representation of the auth type is displayed when displaying textual representation of the authKey. This isn't ideal when logging the authkey as field within a log message.

To facilitate log message analysis, this commit changes this to use the textual representation of the auth type when displaying the auth key.

```
level=debug msg="Handle authentication request" key="<...>, authType=1" subsys=auth
```

->

```
level=debug msg="Handle authentication request" key="<...>, authType=spire" subsys=auth
```