### PR TITLE
bpf: ct: simplify ct_action parameter for CT lookup

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -47,6 +47,17 @@ struct ct_buffer6 {
 };
 #endif
 
+static __always_inline enum ct_action ct_tcp_select_action(union tcp_flags flags)
+{
+	if (unlikely(flags.value & (TCP_FLAG_RST | TCP_FLAG_FIN)))
+		return ACTION_CLOSE;
+
+	if (unlikely(flags.value & TCP_FLAG_SYN))
+		return ACTION_CREATE;
+
+	return ACTION_UNSPEC;
+}
+
 static __always_inline bool ct_entry_seen_both_syns(const struct ct_entry *entry)
 {
 	bool rx_syn = entry->rx_flags_seen & TCP_FLAG_SYN;
@@ -247,7 +258,7 @@ __ct_lookup(const void *map, struct __ctx_buff *ctx, const void *tuple,
 #endif
 		switch (action) {
 		case ACTION_CREATE:
-			if (unlikely(syn && ct_entry_closing(entry))) {
+			if (unlikely(ct_entry_closing(entry))) {
 				ct_reset_closing(entry);
 				*monitor = ct_update_timeout(entry, is_tcp, dir, seen_flags);
 				return CT_REOPENED;
@@ -491,8 +502,9 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ct
 		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
-		if (unlikely(tcp_flags.value & (TCP_FLAG_RST | TCP_FLAG_FIN)))
-			action = ACTION_CLOSE;
+		action = ct_tcp_select_action(tcp_flags);
+	} else {
+		action = ACTION_UNSPEC;
 	}
 
 	cilium_dbg3(ctx, DBG_CT_LOOKUP6_1, (__u32)tuple->saddr.p4, (__u32)tuple->daddr.p4,
@@ -742,8 +754,9 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ct
 		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
 			return DROP_CT_INVALID_HDR;
 
-		if (unlikely(tcp_flags.value & (TCP_FLAG_RST | TCP_FLAG_FIN)))
-			action = ACTION_CLOSE;
+		action = ct_tcp_select_action(tcp_flags);
+	} else {
+		action = ACTION_UNSPEC;
 	}
 
 #ifndef QUIET_CT

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -869,7 +869,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 		return DROP_NO_SERVICE;
 
 	/* See lb4_local comments re svc endpoint lookup process */
-	ret = ct_lazy_lookup6(map, tuple, ctx, l4_off, ACTION_CREATE, CT_SERVICE,
+	ret = ct_lazy_lookup6(map, tuple, ctx, l4_off, CT_SERVICE,
 			      SCOPE_REVERSE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
@@ -1553,7 +1553,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 	if (unlikely(svc->count == 0))
 		return DROP_NO_SERVICE;
 
-	ret = ct_lazy_lookup4(map, tuple, ctx, l4_off, has_l4_header, ACTION_CREATE,
+	ret = ct_lazy_lookup4(map, tuple, ctx, l4_off, has_l4_header,
 			      CT_SERVICE, SCOPE_REVERSE, state, &monitor);
 	switch (ret) {
 	case CT_NEW:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -261,7 +261,6 @@ static __always_inline int
 snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 			   struct ipv4_ct_tuple *tuple,
 			   bool has_l4_header,
-			   enum ct_action ct_action,
 			   struct ipv4_nat_entry **state,
 			   struct ipv4_nat_entry *tmp,
 			   __u32 off,
@@ -288,7 +287,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 		ipv4_ct_tuple_swap_addrs(&tuple_snat);
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_snat), &tuple_snat,
-				      ctx, off, has_l4_header, ct_action, CT_EGRESS,
+				      ctx, off, has_l4_header, CT_EGRESS,
 				      SCOPE_FORWARD, &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
@@ -314,7 +313,6 @@ static __always_inline int
 snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       struct ipv4_ct_tuple *tuple,
 			       bool has_l4_header,
-			       enum ct_action ct_action,
 			       struct ipv4_nat_entry **state,
 			       __u32 off,
 			       const struct ipv4_nat_target *target)
@@ -343,7 +341,7 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 		ipv4_ct_tuple_swap_ports(&tuple_revsnat);
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_revsnat), &tuple_revsnat,
-				      ctx, off, has_l4_header, ct_action, CT_INGRESS,
+				      ctx, off, has_l4_header, CT_INGRESS,
 				      SCOPE_REVERSE, &ct_state, &monitor);
 		if (ret < 0)
 			return ret;
@@ -906,16 +904,15 @@ snat_v4_nat_handle_icmp_frag_needed(struct __ctx_buff *ctx, __u64 off,
 
 static __always_inline int
 __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
-	      bool has_l4_header, int l4_off, enum ct_action action,
-	      bool update_tuple, const struct ipv4_nat_target *target,
+	      bool has_l4_header, int l4_off, bool update_tuple,
+	      const struct ipv4_nat_target *target,
 	      struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ipv4_nat_entry *state, tmp;
 	int ret;
 
-	ret = snat_v4_nat_handle_mapping(ctx, tuple, has_l4_header, action,
-					 &state, &tmp, l4_off, target,
-					 trace, ext_err);
+	ret = snat_v4_nat_handle_mapping(ctx, tuple, has_l4_header, &state,
+					 &tmp, l4_off, target, trace, ext_err);
 	if (ret < 0)
 		return ret;
 
@@ -934,7 +931,6 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
 	    bool has_l4_header, const struct ipv4_nat_target *target,
 	    struct trace_ctx *trace, __s8 *ext_err)
 {
-	enum ct_action ct_action = ACTION_UNSPEC;
 	struct icmphdr icmphdr __align_stack_8;
 	struct {
 		__be16 sport;
@@ -952,9 +948,9 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
 #endif  /* ENABLE_SCTP */
 		if (ctx_load_bytes(ctx, off, &l4hdr, sizeof(l4hdr)) < 0)
 			return DROP_INVALID;
+
 		tuple->dport = l4hdr.dport;
 		tuple->sport = l4hdr.sport;
-		ct_action = ACTION_CREATE;
 		break;
 	case IPPROTO_ICMP:
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
@@ -964,7 +960,6 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
 		case ICMP_ECHO:
 			tuple->dport = 0;
 			tuple->sport = icmphdr.un.echo.id;
-			ct_action = ACTION_CREATE;
 			break;
 		case ICMP_ECHOREPLY:
 			tuple->dport = icmphdr.un.echo.id;
@@ -986,8 +981,8 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
 	if (snat_v4_nat_can_skip(target, tuple, icmp_echoreply))
 		return NAT_PUNT_TO_STACK;
 
-	return __snat_v4_nat(ctx, tuple, has_l4_header, off, ct_action,
-			     false, target, trace, ext_err);
+	return __snat_v4_nat(ctx, tuple, has_l4_header, off, false, target,
+			     trace, ext_err);
 }
 
 static __always_inline __maybe_unused int
@@ -1070,7 +1065,6 @@ static __always_inline __maybe_unused int
 snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		__s8 *ext_err __maybe_unused)
 {
-	enum ct_action ct_action = ACTION_UNSPEC;
 	struct icmphdr icmphdr __align_stack_8;
 	struct ipv4_nat_entry *state;
 	struct ipv4_ct_tuple tuple = {};
@@ -1102,7 +1096,6 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 			return DROP_INVALID;
 		tuple.dport = l4hdr.dport;
 		tuple.sport = l4hdr.sport;
-		ct_action = ACTION_CREATE;
 		break;
 	case IPPROTO_ICMP:
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
@@ -1126,7 +1119,7 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 
 	if (snat_v4_rev_nat_can_skip(target, &tuple))
 		return NAT_PUNT_TO_STACK;
-	ret = snat_v4_rev_nat_handle_mapping(ctx, &tuple, has_l4_header, ct_action, &state,
+	ret = snat_v4_rev_nat_handle_mapping(ctx, &tuple, has_l4_header, &state,
 					     off, target);
 	if (ret < 0)
 		return ret;
@@ -1305,7 +1298,6 @@ out:
 static __always_inline int
 snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			   struct ipv6_ct_tuple *tuple,
-			   enum ct_action ct_action,
 			   struct ipv6_nat_entry **state,
 			   struct ipv6_nat_entry *tmp,
 			   __u32 off,
@@ -1327,8 +1319,8 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 		ipv6_ct_tuple_swap_addrs(&tuple_snat);
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple_snat), &tuple_snat,
-				      ctx, off, ct_action, CT_EGRESS,
-				      SCOPE_FORWARD, &ct_state, &trace->monitor);
+				      ctx, off, CT_EGRESS, SCOPE_FORWARD,
+				      &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
 
@@ -1352,7 +1344,6 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 static __always_inline int
 snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       struct ipv6_ct_tuple *tuple,
-			       enum ct_action ct_action,
 			       struct ipv6_nat_entry **state,
 			       __u32 off)
 {
@@ -1374,8 +1365,8 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 		ipv6_ct_tuple_swap_ports(&tuple_revsnat);
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple_revsnat), &tuple_revsnat,
-				      ctx, off, ct_action, CT_INGRESS,
-				      SCOPE_REVERSE, &ct_state, &monitor);
+				      ctx, off, CT_INGRESS, SCOPE_REVERSE,
+				      &ct_state, &monitor);
 		if (ret < 0)
 			return ret;
 	}
@@ -1700,15 +1691,15 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 
 static __always_inline int
 __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
-	      int l4_off, enum ct_action action, bool update_tuple,
+	      int l4_off, bool update_tuple,
 	      const struct ipv6_nat_target *target,
 	      struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ipv6_nat_entry *state, tmp;
 	int ret;
 
-	ret = snat_v6_nat_handle_mapping(ctx, tuple, action, &state, &tmp,
-					 l4_off, target, trace, ext_err);
+	ret = snat_v6_nat_handle_mapping(ctx, tuple, &state, &tmp, l4_off,
+					 target, trace, ext_err);
 	if (ret < 0)
 		return ret;
 
@@ -1727,7 +1718,6 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 	    const struct ipv6_nat_target *target, struct trace_ctx *trace,
 	    __s8 *ext_err)
 {
-	enum ct_action ct_action = ACTION_UNSPEC;
 	struct icmp6hdr icmp6hdr __align_stack_8;
 	struct {
 		__be16 sport;
@@ -1744,9 +1734,9 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 #endif  /* ENABLE_SCTP */
 		if (ctx_load_bytes(ctx, off, &l4hdr, sizeof(l4hdr)) < 0)
 			return DROP_INVALID;
+
 		tuple->dport = l4hdr.dport;
 		tuple->sport = l4hdr.sport;
-		ct_action = ACTION_CREATE;
 		break;
 	case IPPROTO_ICMPV6:
 		if (ctx_load_bytes(ctx, off, &icmp6hdr, sizeof(icmp6hdr)) < 0)
@@ -1760,7 +1750,6 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 		case ICMPV6_ECHO_REQUEST:
 			tuple->dport = 0;
 			tuple->sport = icmp6hdr.icmp6_dataun.u_echo.identifier;
-			ct_action = ACTION_CREATE;
 			break;
 		default:
 			return DROP_NAT_UNSUPP_PROTO;
@@ -1773,8 +1762,7 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 	if (snat_v6_nat_can_skip(target, tuple))
 		return NAT_PUNT_TO_STACK;
 
-	return __snat_v6_nat(ctx, tuple, off, ct_action, false, target,
-			     trace, ext_err);
+	return __snat_v6_nat(ctx, tuple, off, false, target, trace, ext_err);
 }
 
 static __always_inline __maybe_unused int
@@ -1873,7 +1861,6 @@ static __always_inline __maybe_unused int
 snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		__s8 *ext_err __maybe_unused)
 {
-	enum ct_action ct_action = ACTION_UNSPEC;
 	struct icmp6hdr icmp6hdr __align_stack_8;
 	struct ipv6_nat_entry *state;
 	struct ipv6_ct_tuple tuple = {};
@@ -1909,7 +1896,6 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 			return DROP_INVALID;
 		tuple.dport = l4hdr.dport;
 		tuple.sport = l4hdr.sport;
-		ct_action = ACTION_CREATE;
 		break;
 	case IPPROTO_ICMPV6:
 		if (ctx_load_bytes(ctx, off, &icmp6hdr, sizeof(icmp6hdr)) < 0)
@@ -1931,7 +1917,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 
 	if (snat_v6_rev_nat_can_skip(target, &tuple))
 		return NAT_PUNT_TO_STACK;
-	ret = snat_v6_rev_nat_handle_mapping(ctx, &tuple, ct_action, &state, off);
+	ret = snat_v6_rev_nat_handle_mapping(ctx, &tuple, &state, off);
 	if (ret < 0)
 		return ret;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -802,7 +802,7 @@ int tail_nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx)
 	/* look up with SCOPE_FORWARD: */
 	__ipv6_ct_tuple_reverse(&tuple);
 
-	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
 			      CT_EGRESS, SCOPE_FORWARD, &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
@@ -1043,8 +1043,8 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	ipv6_ct_tuple_swap_ports(&tuple);
 	tuple.flags = TUPLE_F_OUT;
 
-	ret = __snat_v6_nat(ctx, &tuple, l4_off, ACTION_CREATE, true,
-			    &target, &trace, &ext_err);
+	ret = __snat_v6_nat(ctx, &tuple, l4_off, true, &target, &trace,
+			    &ext_err);
 	if (IS_ERR(ret))
 		goto drop_err;
 
@@ -1230,7 +1230,7 @@ skip_service_lookup:
 		/* lookup with SCOPE_FORWARD: */
 		__ipv6_ct_tuple_reverse(&tuple);
 
-		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
 				      CT_EGRESS, SCOPE_FORWARD, &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
@@ -1336,8 +1336,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		return ret;
 #endif
 
-	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
-			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &trace->monitor);
+	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
+			      SCOPE_REVERSE, &ct_state, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -1391,7 +1391,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __s8 *ext_er
 	if (!ct_has_nodeport_egress_entry6(get_ct_map6(&tuple), &tuple, NULL, false))
 		goto out;
 
-	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
+	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
 			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index,
@@ -2297,8 +2297,8 @@ int tail_nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx)
 	__ipv4_ct_tuple_reverse(&tuple);
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
-			      has_l4_header, ACTION_CREATE, CT_EGRESS,
-			      SCOPE_FORWARD, &ct_state, &monitor);
+			      has_l4_header, CT_EGRESS, SCOPE_FORWARD,
+			      &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	/* Maybe we can be a bit more selective about CT_REOPENED?
@@ -2495,7 +2495,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	tuple.flags = TUPLE_F_OUT;
 
 	ret = __snat_v4_nat(ctx, &tuple, ipv4_has_l4_header(ip4), l4_off,
-			    ACTION_CREATE, true, &target, &trace, &ext_err);
+			    true, &target, &trace, &ext_err);
 	if (IS_ERR(ret))
 		goto drop_err;
 
@@ -2710,8 +2710,7 @@ skip_service_lookup:
 		__ipv4_ct_tuple_reverse(&tuple);
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-				      ACTION_CREATE, CT_EGRESS, SCOPE_FORWARD,
-				      &ct_state, &monitor);
+				      CT_EGRESS, SCOPE_FORWARD, &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
 redo:
@@ -2811,8 +2810,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 #endif
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      ACTION_CREATE, CT_INGRESS, SCOPE_REVERSE, &ct_state,
-			      &trace->monitor);
+			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &trace->monitor);
 
 	/* nodeport_rev_dnat_get_info_ipv4() just checked that such a
 	 * CT entry exists:
@@ -2909,7 +2907,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 		goto out;
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      ACTION_CREATE, CT_INGRESS, SCOPE_REVERSE, &ct_state, &monitor);
+			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		reason = TRACE_REASON_CT_REPLY;
 		ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index, false,

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -119,7 +119,8 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value |= TCP_FLAG_SYN;
 
 		/* First packet is monitored */
-		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple, ACTION_CREATE, CT_INGRESS,
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_INGRESS,
 				  &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
@@ -129,7 +130,8 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		 * lifetime back to CT_SYN_TIMEOUT.
 		 */
 		advance_time();
-		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple, ACTION_CREATE, CT_INGRESS,
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_INGRESS,
 				  &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
@@ -138,7 +140,8 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		/* Subsequent non-SYN packets result in a default TCP lifetime */
 		advance_time();
 		seen_flags.value &= ~TCP_FLAG_SYN;
-		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple, ACTION_CREATE, CT_INGRESS,
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_INGRESS,
 				  &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
@@ -147,7 +150,8 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		/* Monitor if the connection is closing on one side */
 		advance_time();
 		seen_flags.value |= TCP_FLAG_FIN;
-		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple, ACTION_CLOSE, CT_INGRESS,
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_INGRESS,
 				  &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
@@ -156,7 +160,8 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		/* This doesn't automatically trigger monitor for subsequent packets */
 		advance_time();
 		seen_flags.value &= ~TCP_FLAG_FIN;
-		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple, ACTION_CREATE, CT_INGRESS,
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_INGRESS,
 				  &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
@@ -168,7 +173,8 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		 */
 		advance_time();
 		seen_flags.value |= TCP_FLAG_FIN;
-		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple, ACTION_CLOSE, CT_EGRESS,
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_EGRESS,
 				  &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
@@ -178,7 +184,8 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		advance_time();
 		monitor = 0;
 		seen_flags.value &= ~TCP_FLAG_FIN;
-		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple, ACTION_CREATE, CT_EGRESS,
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_EGRESS,
 				  &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
@@ -188,7 +195,8 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		advance_time();
 		monitor = 0;
 		seen_flags.value = TCP_FLAG_SYN;
-		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple, ACTION_CREATE, CT_EGRESS,
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_EGRESS,
 				  &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_REOPENED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
@@ -197,7 +205,8 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		/* Label connection as new if the tuple wasn't previously tracked */
 		tuple.saddr = 123;
 		seen_flags.value = TCP_FLAG_SYN;
-		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple, ACTION_CREATE, CT_INGRESS,
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_INGRESS,
 				  &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_NEW);
 		assert(monitor == TRACE_PAYLOAD_LEN);


### PR DESCRIPTION
For a CT lookup, the calling paths currently need to determine a
`ct_action` parameter. This is typically ACTION_CREATE (for TCP/UDP/SCTP),
or ACTION_UNSPEC for most types of ICMP traffic.

But ever since https://github.com/cilium/cilium/commit/fd5ea2a3d2132c1f130be2ccf2b465e0e9754041 ("bpf: Don't reset TCP timer on final ACK"),
__ct_lookup() will only apply ACTION_CREATE handling to TCP packets with
the SYN flag set. Otherwise it has the same effect as ACTION_UNSPEC.

Simplify the logic by ignoring the passed-in value, and manually selecting
ACTION_CREATE for applicable traffic in the CT lookup helpers (same as we
already do for ACTION_CLOSE).