### PR TITLE
bgpv1: set correct upper limits to BPG timers and GR restart time

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -133,7 +133,7 @@ spec:
                               value for the BGP ConnectRetryTimer (RFC 4271, Section
                               8).
                             format: int32
-                            maximum: 2147483647
+                            maximum: 65535
                             minimum: 1
                             type: integer
                           eBGPMultihopTTL:
@@ -165,7 +165,7 @@ spec:
                                   will remove stale routes. This is described RFC
                                   4724 section 4.2.
                                 format: int32
-                                maximum: 2147483647
+                                maximum: 4095
                                 minimum: 1
                                 type: integer
                             required:
@@ -177,7 +177,7 @@ spec:
                               for the BGP HoldTimer (RFC 4271, Section 4.2). Updating
                               this value will cause a session reset.
                             format: int32
-                            maximum: 2147483647
+                            maximum: 65535
                             minimum: 3
                             type: integer
                           keepAliveTimeSeconds:
@@ -187,7 +187,7 @@ spec:
                               8). It can not be larger than HoldTimeSeconds. Updating
                               this value will cause a session reset.
                             format: int32
-                            maximum: 2147483647
+                            maximum: 65535
                             minimum: 1
                             type: integer
                           peerASN:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -133,7 +133,7 @@ spec:
                               value for the BGP ConnectRetryTimer (RFC 4271, Section
                               8).
                             format: int32
-                            maximum: 65535
+                            maximum: 2147483647
                             minimum: 1
                             type: integer
                           eBGPMultihopTTL:

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -94,7 +94,7 @@ type CiliumBGPNeighborGracefulRestart struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=2147483647
+	// +kubebuilder:validation:Maximum=4095
 	// +kubebuilder:default=120
 	RestartTimeSeconds *int32 `json:"restartTimeSeconds,omitempty"`
 }
@@ -138,7 +138,7 @@ type CiliumBGPNeighbor struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=2147483647
+	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:default=120
 	ConnectRetryTimeSeconds *int32 `json:"connectRetryTimeSeconds,omitempty"`
 	// HoldTimeSeconds defines the initial value for the BGP HoldTimer (RFC 4271, Section 4.2).
@@ -146,7 +146,7 @@ type CiliumBGPNeighbor struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=3
-	// +kubebuilder:validation:Maximum=2147483647
+	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:default=90
 	HoldTimeSeconds *int32 `json:"holdTimeSeconds,omitempty"`
 	// KeepaliveTimeSeconds defines the initial value for the BGP KeepaliveTimer (RFC 4271, Section 8).
@@ -154,7 +154,7 @@ type CiliumBGPNeighbor struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=2147483647
+	// +kubebuilder:validation:Maximum=65535
 	// +kubebuilder:default=30
 	KeepAliveTimeSeconds *int32 `json:"keepAliveTimeSeconds,omitempty"`
 	// GracefulRestart defines graceful restart parameters which are negotiated

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -138,7 +138,7 @@ type CiliumBGPNeighbor struct {
 	//
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=65535
+	// +kubebuilder:validation:Maximum=2147483647
 	// +kubebuilder:default=120
 	ConnectRetryTimeSeconds *int32 `json:"connectRetryTimeSeconds,omitempty"`
 	// HoldTimeSeconds defines the initial value for the BGP HoldTimer (RFC 4271, Section 4.2).


### PR DESCRIPTION
BGP holdtime is 16 bits unsigned int and GR restart time is 12 bits.
This limit is set in cilium BGP CRDs to validate configuration at the API layer.

