### PR TITLE
Add client secret if clustermesh apiserver is enabled

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/client-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-provided/client-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.externalWorkloads.enabled (not .Values.clustermesh.apiserver.tls.auto.enabled) }}
+{{- if and (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer) (not .Values.clustermesh.apiserver.tls.auto.enabled) }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes: #[issue-number](https://github.com/cilium/cilium-cli/issues/1730)

```release-note
Fix issue with missing client secret when deploying clustermesh through helm.
```
