### PR TITLE
ci-multi-pool: Use ip-masq-agent for masquerading

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -68,9 +68,6 @@ jobs:
           #  - iptables-based masquerading does not support multiple non-masquerade
           #    CIDRs. Thus, we enable BPF masquerading where we can add multiple
           #    non-masquerade CIDRs.
-          #  - TODO: We currently cannot use ip-masq-agent, because it is broken
-          #    on main (#26262). For now, we use a single native-routing-cidr in
-          #    10.0.0.0/8 subnet and have all pools be part of that subnet.
           CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
             --helm-set=debug.enabled=true \
             --helm-set=debug.verbose=envoy \
@@ -93,14 +90,16 @@ jobs:
             --helm-set=bpf.masquerade=true \
             --helm-set=bpf.hostLegacyRouting=true\
             --helm-set=ipv4NativeRoutingCIDR=10.0.0.0/8 \
+            --helm-set=ipMasqAgent.enabled=true \
+            --helm-set=ipMasqAgent.config.nonMasqueradeCIDRs='{192.168.0.0/16}' \
             --helm-set=ipam.mode=multi-pool \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.cidrs='{10.10.0.0/16}' \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.maskSize=24 \
-            --helm-set=ipam.operator.autoCreateCiliumPodIPPools.cilium-test-pool.ipv4.cidrs='{10.30.0.0/16}' \
+            --helm-set=ipam.operator.autoCreateCiliumPodIPPools.cilium-test-pool.ipv4.cidrs='{10.20.0.0/16}' \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.cilium-test-pool.ipv4.maskSize=24 \
-            --helm-set=ipam.operator.autoCreateCiliumPodIPPools.client-pool.ipv4.cidrs='{10.20.0.0/20}' \
+            --helm-set=ipam.operator.autoCreateCiliumPodIPPools.client-pool.ipv4.cidrs='{192.168.0.0/20}' \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.client-pool.ipv4.maskSize=27 \
-            --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.cidrs='{10.20.16.0/20}' \
+            --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.cidrs='{192.168.16.0/20}' \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.echo-other-node-pool.ipv4.maskSize=27"
 
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled --hubble=false --collect-sysdump-on-failure \


### PR DESCRIPTION
Now that #26262 has been fixed, we can use disjunct CIDRs for the IP pools. This will make the testing a bit more realistic, as we expect users to define IP pools from different CIDR ranges.

CI run with these changes is green: 
 - :heavy_check_mark:  https://github.com/cilium/cilium/actions/runs/5403357970/jobs/9816045998?pr=26538