### PR TITLE
init.sh: move obsolete bpf_host removal to Go

### DIFF
--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -319,6 +319,3 @@ for iface in $(ip -o -a l | awk '{print $2}' | cut -d: -f1 | cut -d@ -f1 | grep 
 	done
 done
 
-if [ "$HOST_DEV1" != "$HOST_DEV2" ]; then
-	tc filter del dev $HOST_DEV2 "egress" 2> /dev/null || true
-fi

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -13,7 +13,7 @@ TUNNEL_PROTOCOL=${8}
 # Only set if TUNNEL_PROTOCOL = "vxlan", "geneve"
 TUNNEL_PORT=${9}
 # Only set if MODE = "direct"
-NATIVE_DEVS=${10}
+# NATIVE_DEVS=${10}
 HOST_DEV1=${11}
 HOST_DEV2=${12}
 MTU=${13}
@@ -21,7 +21,7 @@ MTU=${13}
 # SOCKETLB_PEER=${15}
 # CGROUP_ROOT=${16}
 # BPFFS_ROOT=${17}
-NODE_PORT=${18}
+# NODE_PORT=${18}
 # NODE_PORT_BIND=${19}
 # MCPU=${20}
 # NR_CPUS=${21}
@@ -274,25 +274,4 @@ if [ "${TUNNEL_PROTOCOL}" != "<nil>" ]; then
 	ENCAP_IDX=$(cat "${SYSCLASSNETDIR}/${ENCAP_DEV}/ifindex")
 	sed -i '/^#.*ENCAP_IFINDEX.*$/d' $RUNDIR/globals/node_config.h
 	echo "#define ENCAP_IFINDEX $ENCAP_IDX" >> $RUNDIR/globals/node_config.h
-fi
-
-if [ "$MODE" = "direct" ] || [ "$NODE_PORT" = "true" ] ; then
-	if [ "$NATIVE_DEVS" == "<nil>" ]; then
-		echo "No device specified for $MODE mode, ignoring..."
-	else
-		if [ "$IP6_HOST" != "<nil>" ]; then
-			echo 1 > "${PROCSYSNETDIR}/ipv6/conf/all/forwarding"
-		fi
-		echo "$NATIVE_DEVS" > $RUNDIR/device.state
-	fi
-else
-	FILE=$RUNDIR/device.state
-	if [ -f $FILE ]; then
-		DEVS=$(cat $FILE)
-		for DEV in ${DEVS//,/ }; do
-			echo "Removed BPF program from device $DEV"
-			tc qdisc del dev $DEV clsact 2> /dev/null || true
-		done
-		rm $FILE
-	fi
 fi

--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -29,14 +29,6 @@ import (
 )
 
 var (
-	excludedDevicePrefixes = []string{
-		"cilium_",
-		"lo",
-		"lxc",
-		"cni",
-		"docker",
-	}
-
 	// Route filter to look at all routing tables.
 	routeFilter = netlink.Route{
 		Table: unix.RT_TABLE_UNSPEC,
@@ -190,7 +182,7 @@ func (dm *DeviceManager) isViableDevice(l3DevOK, hasDefaultRoute bool, link netl
 	name := link.Attrs().Name
 
 	// Do not consider any of the excluded devices.
-	for _, p := range excludedDevicePrefixes {
+	for _, p := range defaults.ExcludedDevicePrefixes {
 		if strings.HasPrefix(name, p) {
 			log.WithField(logfields.Device, name).
 				Debugf("Skipping device as it has excluded prefix '%s'", p)

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -405,12 +405,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initArgSocketLBPeer] = "<nil>"
 	args[initArgCgroupRoot] = "<nil>"
 	args[initArgBpffsRoot] = "<nil>"
-
-	if len(option.Config.GetDevices()) != 0 {
-		args[initArgDevices] = strings.Join(option.Config.GetDevices(), ";")
-	} else {
-		args[initArgDevices] = "<nil>"
-	}
+	args[initArgDevices] = "<nil>"
 
 	if !option.Config.TunnelingEnabled() {
 		if option.Config.EnableIPv4EgressGateway || option.Config.EnableHighScaleIPcache {
@@ -434,14 +429,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 		args[initArgTunnelPort] = fmt.Sprintf("%d", option.Config.TunnelPort)
 	}
 
-	if option.Config.EnableNodePort {
-		args[initArgNodePort] = "true"
-	} else {
-		args[initArgNodePort] = "false"
-	}
-
+	args[initArgNodePort] = "<nil>"
 	args[initArgNodePortBind] = "<nil>"
-
 	args[initBPFCPU] = "<nil>"
 	args[initArgNrCPUs] = "<nil>"
 

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -196,6 +197,90 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 	return hostObj.Write(dstPath, opts, strings)
 }
 
+func isObsoleteDev(dev string) bool {
+	// exclude devices we never attach to/from_netdev to.
+	for _, prefix := range defaults.ExcludedDevicePrefixes {
+		if strings.HasPrefix(dev, prefix) {
+			return false
+		}
+	}
+
+	// exclude devices that will still be managed going forward.
+	for _, d := range option.Config.GetDevices() {
+		if dev == d {
+			return false
+		}
+	}
+
+	return true
+}
+
+// removeObsoleteNetdevPrograms removes cil_to_netdev and cil_from_netdev from devices
+// that cilium potentially doesn't manage anymore after a restart, e.g. if the set of
+// devices in option.Config.GetDevices() changes between restarts.
+//
+// This code assumes that the agent was upgraded from a prior version while maintaining
+// the same list of managed physical devices. This ensures that all tc bpf filters get
+// replaced using the naming convention of the 'current' agent build. For example,
+// before 1.13, most filters were named e.g. bpf_host.o:[to-host], to be changed to
+// cilium-<device> in 1.13, then to cil_to_host-<device> in 1.14. As a result, this
+// function only cleans up filters following the current naming scheme.
+func removeObsoleteNetdevPrograms() error {
+	links, err := netlink.LinkList()
+	if err != nil {
+		return fmt.Errorf("retrieving all netlink devices: %w", err)
+	}
+
+	// collect all devices that have netdev programs attached on either ingress or egress.
+	ingressDevs := []netlink.Link{}
+	egressDevs := []netlink.Link{}
+	for _, l := range links {
+		if !isObsoleteDev(l.Attrs().Name) {
+			continue
+		}
+
+		ingressFilters, err := netlink.FilterList(l, directionToParent(dirIngress))
+		if err != nil {
+			return fmt.Errorf("listing ingress filters: %w", err)
+		}
+		for _, filter := range ingressFilters {
+			if bpfFilter, ok := filter.(*netlink.BpfFilter); ok {
+				if strings.HasPrefix(bpfFilter.Name, symbolFromHostNetdevEp) {
+					ingressDevs = append(ingressDevs, l)
+				}
+			}
+		}
+
+		egressFilters, err := netlink.FilterList(l, directionToParent(dirEgress))
+		if err != nil {
+			return fmt.Errorf("listing egress filters: %w", err)
+		}
+		for _, filter := range egressFilters {
+			if bpfFilter, ok := filter.(*netlink.BpfFilter); ok {
+				if strings.HasPrefix(bpfFilter.Name, symbolToHostNetdevEp) {
+					egressDevs = append(egressDevs, l)
+				}
+			}
+		}
+	}
+
+	for _, dev := range ingressDevs {
+		err = RemoveTCFilters(dev.Attrs().Name, directionToParent(dirIngress))
+		if err != nil {
+			log.WithError(err).Errorf("couldn't remove ingress tc filters from %s", dev.Attrs().Name)
+		}
+	}
+
+	for _, dev := range egressDevs {
+		err = RemoveTCFilters(dev.Attrs().Name, directionToParent(dirEgress))
+		if err != nil {
+			log.WithError(err).Errorf("couldn't remove egress tc filters from %s", dev.Attrs().Name)
+		}
+	}
+
+	return nil
+}
+
 // reloadHostDatapath loads bpf_host programs attached to the host device
 // (usually cilium_host) and the native devices if any. To that end, it
 // uses a single object file, pointed to by objPath, compiled for the host
@@ -290,6 +375,12 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		}
 		// Defer map removal until all interfaces' progs have been replaced.
 		defer finalize()
+	}
+
+	// call at the end of the function so that we can easily detect if this removes necessary
+	// programs that have just been attached.
+	if err := removeObsoleteNetdevPrograms(); err != nil {
+		log.WithError(err).Error("Failed to remove obsolete netdev programs")
 	}
 
 	return nil

--- a/pkg/defaults/node.go
+++ b/pkg/defaults/node.go
@@ -52,4 +52,13 @@ var (
 
 	// IPv4DefaultRoute is the default IPv4 route.
 	IPv4DefaultRoute = net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 32)}
+
+	// ExcludedDevicePrefixes are prefixes that we don't consider during automatic device detection.
+	ExcludedDevicePrefixes = []string{
+		"cilium_",
+		"lo",
+		"lxc",
+		"cni",
+		"docker",
+	}
 )


### PR DESCRIPTION
This PR removes more code from `init.sh` that is related to cleaning up bpf resources. As a drive by it adds some test to netlink wrappers in `pkg` `loader`:

NB: The first and last commit just remove code without explicitly replacing it, the respective commit messages explain why.

Fixes: #26251 