### PR TITLE
[v1.13] bgpv1: skip invalid node selector config in policy selection

### DIFF
--- a/pkg/bgpv1/agent/controller.go
+++ b/pkg/bgpv1/agent/controller.go
@@ -295,6 +295,7 @@ func PolicySelection(ctx context.Context, labels map[string]string, policies []*
 		nodeSelector, err := slimmetav1.LabelSelectorAsSelector(policy.Spec.NodeSelector)
 		if err != nil {
 			l.WithError(err).Error("Failed to convert CiliumBGPPeeringPolicy's NodeSelector to a label.Selector interface")
+			continue
 		}
 		l.WithFields(logrus.Fields{
 			"policyNodeSelector": nodeSelector.String(),

--- a/pkg/bgpv1/agent/controller_test.go
+++ b/pkg/bgpv1/agent/controller_test.go
@@ -238,6 +238,73 @@ func TestPolicySelection(t *testing.T) {
 			err: nil,
 		},
 		{
+			name: "nil MatchExpression for node label selector",
+			nodeLabels: map[string]string{
+				"bgp-peering-policy": "a",
+			},
+			policies: []struct {
+				want     bool
+				selector *v1.LabelSelector
+			}{
+				{
+					want: false,
+					selector: &v1.LabelSelector{
+						MatchLabels:      map[string]string{},
+						MatchExpressions: nil,
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "nil values in MatchExpressions for node label selector",
+			nodeLabels: map[string]string{
+				"bgp-peering-policy": "a",
+			},
+			policies: []struct {
+				want     bool
+				selector *v1.LabelSelector
+			}{
+				{
+					want: false,
+					selector: &v1.LabelSelector{
+						MatchExpressions: []v1.LabelSelectorRequirement{
+							{
+								Key:      "bgp-peering-policy",
+								Operator: "In",
+								Values:   nil,
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "valid value in MatchExpressions for node label selector",
+			nodeLabels: map[string]string{
+				"bgp-peering-policy": "a",
+			},
+			policies: []struct {
+				want     bool
+				selector *v1.LabelSelector
+			}{
+				{
+					want: true,
+					selector: &v1.LabelSelector{
+						MatchExpressions: []v1.LabelSelectorRequirement{
+							{
+								Key:      "bgp-peering-policy",
+								Operator: "In",
+								Values:   []string{"a"},
+							},
+						},
+					},
+				},
+			},
+			err: nil,
+		},
+		{
 			// expect first policy returned, error nil
 			name: "policy match",
 			nodeLabels: map[string]string{
@@ -370,7 +437,12 @@ func TestPolicySelection(t *testing.T) {
 			if (tt.err == nil) != (err == nil) {
 				t.Fatalf("expected err: %v", (tt.err == nil))
 			}
+
 			if want != nil {
+				if policy == nil {
+					t.Fatalf("got: <nil>, want: %+v", *want)
+				}
+
 				// pointer comparison, not a deep equal.
 				if policy != want {
 					t.Fatalf("got: %+v, want: %+v", *policy, *want)


### PR DESCRIPTION
Manual backport for
- https://github.com/cilium/cilium/pull/26365 


