### PR TITLE
hubble: Optimize namespace tracking

### DIFF
--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -623,20 +623,18 @@ func (r *eventsReader) Next(ctx context.Context) (*v1.Event, error) {
 
 func (s *LocalObserverServer) trackNamespaces(flow *flowpb.Flow) {
 	// track namespaces seen.
-	var namespaces []*observerpb.Namespace
 	if srcNs := flow.GetSource().GetNamespace(); srcNs != "" {
-		namespaces = append(namespaces, &observerpb.Namespace{
+		s.namespaceManager.AddNamespace(&observerpb.Namespace{
 			Namespace: srcNs,
 			Cluster:   nodeTypes.GetClusterName(),
 		})
 	}
 	if dstNs := flow.GetDestination().GetNamespace(); dstNs != "" {
-		namespaces = append(namespaces, &observerpb.Namespace{
+		s.namespaceManager.AddNamespace(&observerpb.Namespace{
 			Namespace: dstNs,
 			Cluster:   nodeTypes.GetClusterName(),
 		})
 	}
-	s.namespaceManager.AddNamespace(namespaces...)
 }
 
 func validateRequest(req genericRequest) error {

--- a/pkg/hubble/observer/namespace_manager.go
+++ b/pkg/hubble/observer/namespace_manager.go
@@ -22,7 +22,7 @@ const (
 
 type NamespaceManager interface {
 	GetNamespaces() []*observerpb.Namespace
-	AddNamespace(...*observerpb.Namespace)
+	AddNamespace(*observerpb.Namespace)
 }
 
 type namespaceRecord struct {
@@ -85,11 +85,10 @@ func (m *namespaceManager) GetNamespaces() []*observerpb.Namespace {
 	return namespaces
 }
 
-func (m *namespaceManager) AddNamespace(namespaces ...*observerpb.Namespace) {
+func (m *namespaceManager) AddNamespace(ns *observerpb.Namespace) {
 	m.mu.Lock()
-	for _, ns := range namespaces {
-		key := ns.GetCluster() + "/" + ns.GetNamespace()
-		m.namespaces[key] = namespaceRecord{namespace: ns, added: m.nowFunc()}
-	}
-	m.mu.Unlock()
+	defer m.mu.Unlock()
+
+	key := ns.GetCluster() + "/" + ns.GetNamespace()
+	m.namespaces[key] = namespaceRecord{namespace: ns, added: m.nowFunc()}
 }

--- a/pkg/hubble/observer/namespace_manager_test.go
+++ b/pkg/hubble/observer/namespace_manager_test.go
@@ -32,11 +32,10 @@ func TestNamespaceManager(t *testing.T) {
 	assert.Equal(t, expected, mgr.GetNamespaces())
 
 	// add a few namespaces
-	nses1 := []*observerpb.Namespace{
-		{Namespace: "ns-2"},
-		{Namespace: "ns-1"}, // out of order, we'll verify it's sorted when we call GetNamespaces later
-	}
-	mgr.AddNamespace(nses1...)
+
+	// out of order, we'll verify it's sorted when we call GetNamespaces later
+	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-2"})
+	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-1"})
 
 	// namespaces that we added should be returned, sorted
 	expected = []*observerpb.Namespace{
@@ -50,13 +49,9 @@ func TestNamespaceManager(t *testing.T) {
 	assert.Equal(t, expected, mgr.GetNamespaces())
 
 	// add more namespaces now that the clock has been advanced
-	nses2 := []*observerpb.Namespace{
-		// ns-1 was in the original set, adding it again here to verify it's TTL gets renewed
-		{Namespace: "ns-1"},
-		{Namespace: "ns-3"},
-		{Namespace: "ns-4"},
-	}
-	mgr.AddNamespace(nses2...)
+	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-1"})
+	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-3"})
+	mgr.AddNamespace(&observerpb.Namespace{Namespace: "ns-4"})
 
 	// we expect all namespaces to exist, the first 2 are 30 minutes old, and the
 	// next two are 0 minutes old

--- a/pkg/hubble/relay/observer/server.go
+++ b/pkg/hubble/relay/observer/server.go
@@ -263,7 +263,9 @@ func (s *Server) GetNamespaces(ctx context.Context, req *observerpb.GetNamespace
 				}).Warning("Failed to retrieve namespaces")
 				return nil
 			}
-			namespaceManager.AddNamespace(nsResp.GetNamespaces()...)
+			for _, ns := range nsResp.GetNamespaces() {
+				namespaceManager.AddNamespace(ns)
+			}
 			return nil
 		})
 	}


### PR DESCRIPTION
Avoiding the use of varargs saves some allocations

Before
```
Benchmark_TrackNamespaces-12    	 5122684	       231.8 ns/op	     192 B/op	       6 allocs/op
```

After
```
Benchmark_TrackNamespaces-12    	 6114062	       187.9 ns/op	     168 B/op	       4 allocs/op
```
