### PR TITLE
add links to support and slack in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+contact_links:
+  - name: Get Enterprise Support
+    url: https://cilium.io/enterprise/
+    about: See Cilium Enterprise Distributions and Trainings
+  - name: Join Slack
+    url: https://cilium.io/slack
+    about: Join the Cilium & eBPF Slack for conversation and quick questions


### PR DESCRIPTION
```release-note
add links to enterprise support and slack to the issues page for easier discoverability
```
