### PR TITLE
bpf: Replace deprecated "-target bpf" with "--target=bpf" for clang

### DIFF
--- a/Documentation/bpf/debug_and_test.rst
+++ b/Documentation/bpf/debug_and_test.rst
@@ -360,7 +360,7 @@ by ``pahole``:
 
 .. code-block:: shell-session
 
-     # clang [...] -O2 -target bpf -g -emit-llvm -c test_xdp_noinline.c -o - |
+     # clang [...] -O2 --target=bpf -g -emit-llvm -c test_xdp_noinline.c -o - |
        llc -march=bpf -mcpu=probe -mattr=dwarfris -filetype=obj -o test_xdp_noinline.o
      # pahole -J test_xdp_noinline.o
 

--- a/Documentation/bpf/toolchain.rst
+++ b/Documentation/bpf/toolchain.rst
@@ -319,7 +319,7 @@ It can then be compiled and loaded into the kernel as follows:
 
 .. code-block:: shell-session
 
-    $ clang -O2 -Wall -target bpf -c xdp-example.c -o xdp-example.o
+    $ clang -O2 -Wall --target=bpf -c xdp-example.c -o xdp-example.o
     # ip link set dev em1 xdp obj xdp-example.o
 
 .. note:: Attaching an XDP BPF program to a network device as above requires
@@ -374,7 +374,7 @@ For debugging, clang can generate the assembler output as follows:
 
 .. code-block:: shell-session
 
-    $ clang -O2 -S -Wall -target bpf -c xdp-example.c -o xdp-example.S
+    $ clang -O2 -S -Wall --target=bpf -c xdp-example.c -o xdp-example.S
     $ cat xdp-example.S
         .text
         .section    prog,"ax",@progbits
@@ -405,7 +405,7 @@ the usual workflow by adding ``-g`` for compilation.
 
 .. code-block:: shell-session
 
-    $ clang -O2 -g -Wall -target bpf -c xdp-example.c -o xdp-example.o
+    $ clang -O2 -g -Wall --target=bpf -c xdp-example.c -o xdp-example.o
     $ llvm-objdump -S --no-show-raw-insn xdp-example.o
 
     xdp-example.o:        file format ELF64-BPF
@@ -466,7 +466,7 @@ can later on be passed to llc:
 
 .. code-block:: shell-session
 
-    $ clang -O2 -Wall -target bpf -emit-llvm -c xdp-example.c -o xdp-example.bc
+    $ clang -O2 -Wall --target=bpf -emit-llvm -c xdp-example.c -o xdp-example.bc
     $ llc xdp-example.bc -march=bpf -filetype=obj -o xdp-example.o
 
 The generated LLVM IR can also be dumped in human readable format through:
@@ -539,7 +539,7 @@ line. Note that ``-g`` is needed independently of whether ``llc``'s
 
 .. code-block:: shell-session
 
-    $ clang -O2 -g -Wall -target bpf -emit-llvm -c xdp-example.c -o xdp-example.bc
+    $ clang -O2 -g -Wall --target=bpf -emit-llvm -c xdp-example.c -o xdp-example.bc
     $ llc xdp-example.bc -march=bpf -mattr=dwarfris -filetype=obj -o xdp-example.o
 
 Alternatively, by using clang only to build a BPF program with debugging
@@ -548,7 +548,7 @@ elfutils version):
 
 .. code-block:: shell-session
 
-    $ clang -target bpf -O2 -g -c -Xclang -target-feature -Xclang +dwarfris -c xdp-example.c -o xdp-example.o
+    $ clang --target=bpf -O2 -g -c -Xclang -target-feature -Xclang +dwarfris -c xdp-example.c -o xdp-example.o
 
 After successful compilation ``pahole`` can be used to properly dump structures
 of the BPF program based on the DWARF information:
@@ -571,7 +571,7 @@ newly added BTF data. Full ``clang`` and ``pahole`` example combined:
 
 .. code-block:: shell-session
 
-    $ clang -target bpf -O2 -Wall -g -c -Xclang -target-feature -Xclang +dwarfris -c xdp-example.c -o xdp-example.o
+    $ clang --target=bpf -O2 -Wall -g -c -Xclang -target-feature -Xclang +dwarfris -c xdp-example.c -o xdp-example.o
     $ pahole -J xdp-example.o
 
 The presence of a ``.BTF`` section can be seen through ``readelf`` tool:
@@ -624,12 +624,12 @@ A full command line example with llc's ``-mcpu=probe``:
 
 .. code-block:: shell-session
 
-    $ clang -O2 -Wall -target bpf -emit-llvm -c xdp-example.c -o xdp-example.bc
+    $ clang -O2 -Wall --target=bpf -emit-llvm -c xdp-example.c -o xdp-example.bc
     $ llc xdp-example.bc -march=bpf -mcpu=probe -filetype=obj -o xdp-example.o
 
 Generally, LLVM IR generation is architecture independent. There are
-however a few differences when using ``clang -target bpf`` versus
-leaving ``-target bpf`` out and thus using clang's default target which,
+however a few differences when using ``clang --target=bpf`` versus
+leaving ``--target=bpf`` out and thus using clang's default target which,
 depending on the underlying architecture, might be ``x86_64``, ``arm64``
 or others.
 
@@ -651,7 +651,7 @@ Quoting from the kernel's ``Documentation/bpf/bpf_devel_QA.txt``:
   option ``-fno-jump-tables`` can be used to disable switch table
   generation.
 
-* For clang ``-target bpf``, it is guaranteed that pointer or long /
+* For clang ``--target=bpf``, it is guaranteed that pointer or long /
   unsigned long types will always have a width of 64 bit, no matter
   whether underlying clang binary or default target (or kernel) is
   32 bit. However, when native clang target is used, then it will
@@ -663,7 +663,7 @@ Quoting from the kernel's ``Documentation/bpf/bpf_devel_QA.txt``:
 The native target is mostly needed in tracing for the case of walking
 the kernel's ``struct pt_regs`` that maps CPU registers, or other kernel
 structures where CPU's register width matters. In all other cases such
-as networking, the use of ``clang -target bpf`` is the preferred choice.
+as networking, the use of ``clang --target=bpf`` is the preferred choice.
 
 Also, LLVM started to support 32-bit subregisters and BPF ALU32 instructions since
 LLVM's release 7.0. A new code generation attribute ``alu32`` is added. When it is
@@ -685,7 +685,7 @@ At default code generation, the assembler will looks like:
 
 .. code-block:: shell-session
 
-    $ clang -target bpf -emit-llvm -S 32-bit-example.c
+    $ clang --target=bpf -emit-llvm -S 32-bit-example.c
     $ llc -march=bpf 32-bit-example.ll
     $ cat 32-bit-example.s
         cal:
@@ -932,7 +932,7 @@ describe some of the differences for the BPF model:
 
   .. code-block:: shell-session
 
-    $ clang -O2 -Wall -target bpf -c tc-example.c -o tc-example.o
+    $ clang -O2 -Wall --target=bpf -c tc-example.c -o tc-example.o
 
     # tc qdisc add dev em1 clsact
     # tc filter add dev em1 ingress bpf da obj tc-example.o sec ingress

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -25,7 +25,7 @@ build_all: force
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) bpf_all BUILD_PERMUTATIONS=1
 
 testdata:
-	${CLANG} ${FLAGS} -target bpf -Wall -Werror \
+	${CLANG} ${FLAGS} --target=bpf -Wall -Werror \
 	-c ../pkg/alignchecker/testdata/bpf_foo.c \
 	-o ../pkg/alignchecker/testdata/bpf_foo.o
 

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -3,7 +3,7 @@
 
 FLAGS := -I$(ROOT_DIR)/bpf/include -I$(ROOT_DIR)/bpf -D__NR_CPUS__=$(shell nproc --all) -O2 -g
 
-CLANG_FLAGS := ${FLAGS} -target bpf -std=gnu89 -nostdinc -emit-llvm
+CLANG_FLAGS := ${FLAGS} --target=bpf -std=gnu89 -nostdinc -emit-llvm
 # eBPF verifier enforces unaligned access checks where necessary, so don't
 # let clang complain too early.
 CLANG_FLAGS += -Wall -Wextra -Werror -Wshadow
@@ -97,7 +97,7 @@ check: coccicheck checkpatch
 preprocess: $(LIB)
 	$(QUIET) $(foreach TARGET,$(shell find $(ROOT_DIR)/$(RELATIVE_DIR)/ -name 'bpf_*.c'), \
 		echo "  GEN   $(patsubst %.c,%.i,${TARGET})"; \
-		${CLANG} $(FLAGS) -E -target bpf -c ${TARGET} -o $(patsubst %.c,%.i,${TARGET}); )
+		${CLANG} $(FLAGS) -E --target=bpf -c ${TARGET} -o $(patsubst %.c,%.i,${TARGET}); )
 	$(QUIET) $(foreach SUBDIR,$(SUBDIRS), \
 		$(MAKE) $(SUBMAKEOPTS) -C $(SUBDIR) $@ &&) true
 

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -10,7 +10,7 @@ LLC   ?= llc
 
 FLAGS := -I$(ROOT_DIR)/bpf/include -I$(ROOT_DIR)/bpf -D__NR_CPUS__=$(shell nproc --all) -O2 -g
 
-CLANG_FLAGS := ${FLAGS} -target bpf -std=gnu99 -nostdinc -emit-llvm
+CLANG_FLAGS := ${FLAGS} --target=bpf -std=gnu99 -nostdinc -emit-llvm
 # eBPF verifier enforces unaligned access checks where necessary, so don't
 # let clang complain too early.
 CLANG_FLAGS += -Wall -Wextra -Werror -Wshadow

--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -153,7 +153,7 @@ EOF
 if [ "${xdp}" = true ]; then
   if ! [ -f "${CILIUM_ROOT}/test/l4lb/bpf_xdp_veth_host.o" ]; then
     pushd "${CILIUM_ROOT}/test/l4lb/" > /dev/null
-    clang -O2 -Wall -target bpf -c bpf_xdp_veth_host.c -o bpf_xdp_veth_host.o
+    clang -O2 -Wall --target=bpf -c bpf_xdp_veth_host.c -o bpf_xdp_veth_host.o
     popd > /dev/null
   fi
 

--- a/pkg/datapath/loader/compile.go
+++ b/pkg/datapath/loader/compile.go
@@ -95,7 +95,7 @@ type directoryInfo struct {
 }
 
 var (
-	standardCFlags = []string{"-O2", "-target", "bpf", "-std=gnu89",
+	standardCFlags = []string{"-O2", "--target=bpf", "-std=gnu89",
 		"-nostdinc", fmt.Sprintf("-D__NR_CPUS__=%d", common.GetNumPossibleCPUs(log)),
 		"-Wall", "-Wextra", "-Werror", "-Wshadow",
 		"-Wno-address-of-packed-member",

--- a/test/bpf/Makefile
+++ b/test/bpf/Makefile
@@ -12,7 +12,7 @@ FLAGS_CLANG += -Wno-gnu-variable-sized-type-not-at-end
 FLAGS_CLANG += -Wdeclaration-after-statement
 FLAGS_CLANG += -g
 
-BPF_CC_FLAGS := ${FLAGS} -target bpf -std=gnu89 -nostdinc -emit-llvm
+BPF_CC_FLAGS := ${FLAGS} --target=bpf -std=gnu89 -nostdinc -emit-llvm
 BPF_LLC_FLAGS := -march=bpf -mcpu=probe -filetype=obj
 
 LIB := $(shell find ../../bpf/ -name '*.h')

--- a/test/l4lb/test.sh
+++ b/test/l4lb/test.sh
@@ -19,14 +19,14 @@ IMG_TAG=${2:-latest}
 # attach the dummy program.
 apt-get update
 apt-get install -y gcc-multilib libbpf-dev
-clang -O2 -Wall -target bpf -c bpf_xdp_veth_host.c -o bpf_xdp_veth_host.o
+clang -O2 -Wall --target=bpf -c bpf_xdp_veth_host.c -o bpf_xdp_veth_host.o
 
 # The worker (aka backend node) will receive IPIP packets from the LB node.
 # To decapsulate the packets instead of creating an ipip dev which would
 # complicate network setup, we will attach the following program which
 # terminates the tunnel.
 # The program is taken from the Linux kernel selftests.
-clang -O2 -Wall -target bpf -c test_tc_tunnel.c -o test_tc_tunnel.o
+clang -O2 -Wall --target=bpf -c test_tc_tunnel.c -o test_tc_tunnel.o
 
 # With Docker-in-Docker we create two nodes:
 #


### PR DESCRIPTION
Passing the target to clang with `-target <name>` has been [considered deprecated since clang 3.4][0], released in 2013, in favour of the more recent syntax `--target=<name>`. Let's update our code and documentation to use the recommended syntax.

This replicates [a similar patch submitted to the Linux kernel][1].

[0]: https://github.com/llvm/llvm-project/commit/274b6f0c87a6a1798de0a68135afc7f95def6277
[1]: https://lore.kernel.org/all/20230624001856.1903733-1-maskray@google.com/
