### PR TITLE
helm: Updated description for Helm 'devices' flag

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -629,7 +629,8 @@ daemon:
 # -- Specify which network interfaces can run the eBPF datapath. This means
 # that a packet sent from a pod to a destination outside the cluster will be
 # masqueraded (to an output device IPv4 address), if the output device runs the
-# program. When not specified, probing will automatically detect devices.
+# program. When not specified, probing will automatically detect devices that have
+# a non-local route. This should be used only when autodetection is not suitable.
 # devices: ""
 
 # -- Enables experimental support for the detection of new and removed datapath

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -626,7 +626,8 @@ daemon:
 # -- Specify which network interfaces can run the eBPF datapath. This means
 # that a packet sent from a pod to a destination outside the cluster will be
 # masqueraded (to an output device IPv4 address), if the output device runs the
-# program. When not specified, probing will automatically detect devices.
+# program. When not specified, probing will automatically detect devices that have
+# a non-local route. This should be used only when autodetection is not suitable.
 # devices: ""
 
 # -- Enables experimental support for the detection of new and removed datapath


### PR DESCRIPTION
* Added hint regarding Cilium's autodetection of interfaces with non-local route
* Added recommendation to not use `devices` unless autodetection really doesn't work.

FYI: The `devices` flag isn't listed in `Documentation/helm-values.rst` and `install/kubernetes/cilium/README.md`. Should that be like this? I therefore also didn't update these two files.

Setting this flag to an interface that doesn't actually do the node's routing can cause severe connectivity issues up to full unreachability of the whole node as long as Cilium runs.

```release-note
helm: Updated description for Helm 'devices' flag
```
