### PR TITLE
monitor: update DBG_CT_LOOKUP4_2 / DBG_CT_LOOKUP6_2 output

### DIFF
--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -167,8 +167,8 @@ func ctLookup4Info1(n *DebugMsg) string {
 }
 
 func ctLookup4Info2(n *DebugMsg) string {
-	return fmt.Sprintf("nexthdr=%d flags=%d",
-		n.Arg1>>8, n.Arg1&0xFF)
+	return fmt.Sprintf("nexthdr=%d flags=%d dir=%d scope=%d",
+		n.Arg1>>8, n.Arg1&0xFF, n.Arg2, n.Arg3)
 }
 
 func ctCreate4Info(n *DebugMsg) string {


### PR DESCRIPTION
bde55cdeb3b7 ("bpf: ct: introduce scope parameter for CT lookup") added additional `dir` and `scope` fields to the debug message.

Format these in the monitor output.