### PR TITLE
ci: Run documentation workflow on README.rst updates

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -44,6 +44,7 @@ jobs:
               - 'hubble-relay/cmd/**'
               - 'install/kubernetes/**'
               - 'operator/cmd/**'
+              - README.rst
 
   # Runs only if code under Documentation or */cmd/ is changed as the docs
   # should be unaffected otherwise.


### PR DESCRIPTION
In commit 5951d1ddef15 ("docs: Run rstcheck on README.rst, too."), we added README.rst to the list of files on which we run rstcheck, be it manually or as part of the CI workflow for documentation. However, the workflow does not trigger for updates to README.rst. Let's address this.

Building the full documentation for README.rst-only updates is not necessary, but we're interested in rstcheck (run from check-build.sh) to catch RST formatting issue, which seems an acceptable trade-off given the low volume of changes on README.rst.
