### PR TITLE
bpf: minor ICMPv6 improvements

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -159,7 +159,7 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 
 #ifdef ENABLE_HOST_FIREWALL
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
 		if (ret == SKIP_HOST_FIREWALL)
 			goto skip_host_firewall;
 		if (IS_ERR(ret))
@@ -455,7 +455,7 @@ handle_to_netdev_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace, __s8 *ext
 		return hdrlen;
 
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
-		ret = icmp6_host_handle(ctx);
+		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
 		if (ret == SKIP_HOST_FIREWALL)
 			return CTX_ACT_OK;
 		if (IS_ERR(ret))

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1610,7 +1610,7 @@ static __always_inline int snat_v6_rewrite_ingress(struct __ctx_buff *ctx,
 			__u8 type = 0;
 			__be32 from, to;
 
-			if (ctx_load_bytes(ctx, off, &type, 1) < 0)
+			if (icmp6_load_type(ctx, off, &type) < 0)
 				return DROP_INVALID;
 			if (type == ICMPV6_ECHO_REQUEST || type == ICMPV6_ECHO_REPLY) {
 				if (ctx_store_bytes(ctx, off +
@@ -1953,7 +1953,7 @@ snat_v6_rev_nat_handle_icmp_pkt_toobig(struct __ctx_buff *ctx, __u32 off)
 		/* No reasons to see a packet different than
 		 * ICMPV6_ECHO_REQUEST.
 		 */
-		if (ctx_load_bytes(ctx, icmpoff, &type, sizeof(type)) < 0 ||
+		if (icmp6_load_type(ctx, icmpoff, &type) < 0 ||
 		    type != ICMPV6_ECHO_REQUEST)
 			return DROP_INVALID;
 		if (ctx_load_bytes(ctx, icmpoff +

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -44,7 +44,8 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 			    sizeof(struct icmp6hdr) > data_end)
 				return DROP_INVALID;
 
-			if (icmp6_load_type(ctx, ETH_HLEN, &icmp_type) < 0)
+			if (icmp6_load_type(ctx, ETH_HLEN + sizeof(struct ipv6hdr),
+					    &icmp_type) < 0)
 				return DROP_INVALID;
 
 			if (icmp_type == ICMP6_NA_MSG_TYPE)


### PR DESCRIPTION
Add error handling for the helper to load a packet's ICMPv6 type, and use the helper in more places.