### PR TITLE
make: drop redundant `go vet ./...` from integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,6 @@ BENCH_EVAL := "."
 BENCH ?= $(BENCH_EVAL)
 BENCHFLAGS_EVAL := -bench=$(BENCH) -run=^$ -benchtime=10s
 BENCHFLAGS ?= $(BENCHFLAGS_EVAL)
-SKIP_VET ?= "false"
 SKIP_KVSTORES ?= "false"
 SKIP_K8S_CODE_GEN_CHECK ?= "true"
 SKIP_CUSTOMVET_CHECK ?= "false"
@@ -130,9 +129,6 @@ generate-cov: ## Generate HTML coverage report at coverage-all.html.
 
 integration-tests: start-kvstores ## Run Go tests including ones that are marked as integration tests.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C test/bpf/
-ifeq ($(SKIP_VET),"false")
-	$(MAKE) govet
-endif
 	@$(ECHO_CHECK) running integration tests...
 	INTEGRATION_TESTS=true $(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(TESTPKGS) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) | $(GOTEST_FORMATTER)
 	$(MAKE) generate-cov


### PR DESCRIPTION
The Go toolchain will already run vet during `go test` since Go 1.10, see https://go.dev/doc/go1.10#test and
https://github.com/golang/go/issues/18084 for details.

This reduces total run time of `make integration-tests` on my machine from ~16min to ~18min.