### PR TITLE
Documentation/community: add multi-pool IPAM to list of beta features

### DIFF
--- a/Documentation/community/roadmap.rst
+++ b/Documentation/community/roadmap.rst
@@ -123,6 +123,7 @@ following features to graduate to stable:
 * :ref:`bandwidth-manager`
 * :ref:`Local Redirect Policy<local-redirect-policy>`
 * :ref:`CiliumEndpointSlice<gsg_ces>`
+* :ref:`Multi-Pool IPAM<ipam_crd_multi_pool>`
 
 .. _rm-hubble-observability:
 


### PR DESCRIPTION
Multi-pool IPAM was added during the 1.14 release cycle and is currently considered a beta feature.