### PR TITLE
pkg/bpf: fix bug where second value can be skipped.

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -672,6 +672,11 @@ func (m *Map) DumpReliablyWithCallback(cb DumpCallback, stats *DumpStats) error 
 				// map, nextKey may be the actual key element after the deleted
 				// one, or the first element in the map.
 				currentKey = nextKey
+				// To avoid having nextKey and currentKey pointing at the same memory
+				// we allocate a new key for nextKey. Without this currentKey and nextKey
+				// would be the same pointer value and would get double iterated on the next
+				// iterations m.NextKey(...) call.
+				nextKey = m.key.New()
 				stats.Interrupted++
 			}
 			continue


### PR DESCRIPTION
DumpReliablyWithCallback will skip a value callback in some situations.

In cases where the initial key is deleted just after being retrieved, there is no previous key to fallback on. The reliable dump will attempt to use the current nextKey (that was based on the deleted current key).

The local currentKey and nextKey Key types are being passed to NextKey which eventually writes the nextKey output to the nextKeys pointer location (via the bpf syscall).

The currentValue was simply being assinged by the equals operator, which was copying the underlying interface pointer.

Thus in this situation, the next iteration attempt was passing the same pointer twice to NextKey causing the currentKey to be set to the next key a second time - skipping a map element.

Fixes #26491

## Validating the fix

Because the test has [256 possible keys](https://github.com/cilium/cilium/blob/bd9c7cdcc8fe10ee6eb225992dee985b213a9367/pkg/bpf/map_linux_test.go#L505) the particular start condition for this failure seems to be quite rare in CI, by reducing this to 5 it happens much more often (presumably 20% of the time?) - making this much easier to reproduce.

I tested this change by continuously running the DumpReliablyWithCallback (modified with maxSize=5) test to reproduce, and after the fix to validate (ran it 1000 times post fix without failure).

```release-note
Fix bug where bpf map entries may not be reliably dumped or garbage collected when the map is actively being updated.
```