### PR TITLE
bgpv1: Unconditionally select node when empty nodeSelector is given

### DIFF
--- a/pkg/bgpv1/agent/controller_test.go
+++ b/pkg/bgpv1/agent/controller_test.go
@@ -330,7 +330,7 @@ func TestPolicySelection(t *testing.T) {
 			err: nil,
 		},
 		{
-			name: "nil MatchExpression for node label selector",
+			name: "nil node label selector",
 			nodeLabels: map[string]string{
 				"bgp-peering-policy": "a",
 			},
@@ -339,10 +339,26 @@ func TestPolicySelection(t *testing.T) {
 				selector *v1.LabelSelector
 			}{
 				{
-					want: false,
+					want:     true,
+					selector: nil,
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "empty node label selector",
+			nodeLabels: map[string]string{
+				"bgp-peering-policy": "a",
+			},
+			policies: []struct {
+				want     bool
+				selector *v1.LabelSelector
+			}{
+				{
+					want: true,
 					selector: &v1.LabelSelector{
 						MatchLabels:      map[string]string{},
-						MatchExpressions: nil,
+						MatchExpressions: []v1.LabelSelectorRequirement{},
 					},
 				},
 			},


### PR DESCRIPTION
The CRD spec of CiliumBGPPeeringPolicy states

```
NodeSelector selects a group of nodes where this BGP Peering Policy
applies. If empty / nil this policy applies to all nodes.
```

However, our current implementation treats empty / nil selector as an error. This commit fixes it.

This issue was reported by an OSS community user on Slack.

![スクリーンショット 2023-07-03 15 57 33](https://github.com/cilium/cilium/assets/9045765/bb4666d2-01a7-402b-8665-dba8f610c2d7)

```release-note
bgpv1: Unconditionally select node when empty nodeSelector is given
```
