### PR TITLE
bpf: nat: improve logic that creates the NAT entries

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -45,13 +45,13 @@ struct nat_entry {
 # define SNAT_SIGNAL_THRES		16
 #endif
 
-static __always_inline __be16 __snat_clamp_port_range(__u16 start, __u16 end,
-						      __u16 val)
+static __always_inline __u16 __snat_clamp_port_range(__u16 start, __u16 end,
+						     __u16 val)
 {
 	return (val % (__u16)(end - start)) + start;
 }
 
-static __always_inline __maybe_unused __be16
+static __always_inline __maybe_unused __u16
 __snat_try_keep_port(__u16 start, __u16 end, __u16 val)
 {
 	return val >= start && val <= end ? val :

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -171,15 +171,6 @@ struct ipv4_nat_entry *snat_v4_lookup(const struct ipv4_ct_tuple *tuple)
 	return __snat_lookup(&SNAT_MAPPING_IPV4, tuple);
 }
 
-static __always_inline int snat_v4_update(const struct ipv4_ct_tuple *otuple,
-					  const struct ipv4_nat_entry *ostate,
-					  const struct ipv4_ct_tuple *rtuple,
-					  const struct ipv4_nat_entry *rstate)
-{
-	return __snat_update(&SNAT_MAPPING_IPV4, otuple, ostate,
-			     rtuple, rstate);
-}
-
 static __always_inline void snat_v4_swap_tuple(const struct ipv4_ct_tuple *otuple,
 					       struct ipv4_ct_tuple *rtuple)
 {


### PR DESCRIPTION
The logic in `snat_v*_new_mapping()` is super tricky, and I start afresh every time I need to look at it. Re-organize the code, and add comments to the crucial pieces.