### PR TITLE
datapath: remove fill-up notification for CT maps

### DIFF
--- a/bpf/lib/signal.h
+++ b/bpf/lib/signal.h
@@ -17,7 +17,7 @@ struct {
 
 enum {
 	SIGNAL_NAT_FILL_UP = 0,
-	SIGNAL_CT_FILL_UP,
+	SIGNAL_CT_FILL_UP /* unused */,
 	SIGNAL_AUTH_REQUIRED,
 };
 
@@ -55,12 +55,6 @@ static __always_inline void send_signal_nat_fill_up(struct __ctx_buff *ctx,
 						    __u32 proto)
 {
 	SEND_SIGNAL(ctx, SIGNAL_NAT_FILL_UP, proto, proto);
-}
-
-static __always_inline void send_signal_ct_fill_up(struct __ctx_buff *ctx,
-						   __u32 proto)
-{
-	SEND_SIGNAL(ctx, SIGNAL_CT_FILL_UP, proto, proto);
 }
 
 static __always_inline void send_signal_auth_required(struct __ctx_buff *ctx,

--- a/pkg/maps/ctmap/gc/cell.go
+++ b/pkg/maps/ctmap/gc/cell.go
@@ -10,11 +10,11 @@ import (
 	"github.com/cilium/cilium/pkg/signal"
 )
 
-// Cell registers a signal handler for CT and NAT fill-up signals.
+// Cell registers a signal handler for NAT fill-up signals.
 var Cell = cell.Invoke(registerSignalHandler)
 
 // SignalData holds the IP address family type BPF program sent along with
-// the SignalNatFillUp and SignalCTFillUp signals.
+// the SignalNatFillUp signal.
 type SignalData uint32
 
 const (
@@ -45,15 +45,15 @@ var muteSignals = func() error { return errors.New("muteSignals not implemented"
 var unmuteSignals = func() error { return errors.New("unmuteSignals not implemented") }
 
 func registerSignalHandler(sm signal.SignalManager) {
-	err := sm.RegisterHandler(signal.ChannelHandler(wakeup), signal.SignalCTFillUp, signal.SignalNatFillUp)
+	err := sm.RegisterHandler(signal.ChannelHandler(wakeup), signal.SignalNatFillUp)
 	if err != nil {
-		log.WithError(err).Warningf("Failed to set up signal channel for CT & NAT fill-up events!")
+		log.WithError(err).Warningf("Failed to set up signal channel for NAT fill-up events!")
 		return
 	}
 	muteSignals = func() error {
-		return sm.MuteSignals(signal.SignalCTFillUp, signal.SignalNatFillUp)
+		return sm.MuteSignals(signal.SignalNatFillUp)
 	}
 	unmuteSignals = func() error {
-		return sm.UnmuteSignals(signal.SignalCTFillUp, signal.SignalNatFillUp)
+		return sm.UnmuteSignals(signal.SignalNatFillUp)
 	}
 }

--- a/pkg/signal/signal.go
+++ b/pkg/signal/signal.go
@@ -30,7 +30,7 @@ type SignalType uint32
 const (
 	// SignalNatFillUp denotes potential congestion on the NAT table
 	SignalNatFillUp SignalType = iota
-	// SignalCTFillUp denotes potential congestion on the CT table
+	// SignalCTFillUp denotes potential congestion on the CT table. Unused.
 	SignalCTFillUp
 	// SignalAuthRequired denotes a connection dropped due to missing authentication
 	SignalAuthRequired


### PR DESCRIPTION
With https://github.com/cilium/cilium/pull/24378 merged, CT always uses LRU maps. So we no longer have to deal with fill-up of the CT maps.