### PR TITLE
.github: dump buddyinfo and pagetypeinfo when ci-e2e fails

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -491,6 +491,8 @@ jobs:
             ./cilium-cli status
             mkdir -p cilium-sysdumps
             ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+            # To debug https://github.com/cilium/cilium/issues/26062
+            head -n -0 /proc/buddyinfo /proc/pagetypeinfo
 
       - name: Upload artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
There is a persistent CI flake where the kernel returns ENOMEM from BPF map
updates. Grab buddyinfo and pagetypeinfo from /proc to see whether the
allocation failures are related to memory fragmentation.

Updates #26062
