### PR TITLE
docs: Update the docs for Helm mode Cilium CLI

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -235,7 +235,7 @@ You can install Cilium on any Kubernetes cluster. Pick one of the options below:
 
        .. code-block:: shell-session
 
-           cilium install --azure-resource-group "${AZURE_RESOURCE_GROUP}"
+           cilium install --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}"
 
        The Cilium CLI will automatically install Cilium using one of the
        following installation modes based on the ``--network-plugin``

--- a/Documentation/installation/cli-download.rst
+++ b/Documentation/installation/cli-download.rst
@@ -1,3 +1,15 @@
+.. warning::
+  Make sure you install `cilium-cli v0.15.0 <https://github.com/cilium/cilium-cli/releases/tag/v0.15.0>`_
+  or later. The rest of instructions do not work with older versions of
+  cilium-cli. To confirm the cilium-cli version that's installed in your system,
+  run:
+
+  .. code-block:: shell-session
+
+    cilium version --client
+
+  See :ref:`Cilium CLI upgrade notes <upgrade_cilium_cli_helm_mode>` for more details.
+
 Install the latest version of the Cilium CLI. The Cilium CLI can be used to
 install Cilium, inspect the state of a Cilium installation, and enable/disable
 various features (e.g. clustermesh, Hubble).

--- a/Documentation/installation/k3s.rst
+++ b/Documentation/installation/k3s.rst
@@ -70,13 +70,13 @@ Install Cilium
 
 .. note::
 
-   Install Cilium with ``--helm-set=ipam.operator.clusterPoolIPv4PodCIDR="10.42.0.0/16"`` to match k3s default podCIDR 10.42.0.0/16.
+   Install Cilium with ``--set=ipam.operator.clusterPoolIPv4PodCIDR="10.42.0.0/16"`` to match k3s default podCIDR 10.42.0.0/16.
 
 Install Cilium by running:
 
 .. code-block:: shell-session
 
-    cilium install --helm-set=ipam.operator.clusterPoolIPv4PodCIDR="10.42.0.0/16"
+    cilium install --set=ipam.operator.clusterPoolIPv4PodCIDR="10.42.0.0/16"
 
 Validate the Installation
 =========================

--- a/Documentation/installation/k8s-install-migration.rst
+++ b/Documentation/installation/k8s-install-migration.rst
@@ -190,7 +190,7 @@ Preparation
 
     .. code-block:: shell-session
 
-        $ cilium install --helm-values values-migration.yaml --helm-auto-gen-values values-initial.yaml
+        $ cilium install --values values-migration.yaml --dry-run-helm-values > values-initial.yaml
         $ cat values-initial.yaml
 
 
@@ -323,10 +323,10 @@ Perform these steps once the cluster is fully migrated.
 
     .. code-block:: shell-session
 
-      $ cilium install --helm-values values-initial.yaml --helm-auto-gen-values values-final.yaml \
-        --helm-set operator.unmanagedPodWatcher.restart=true --helm-set cni.customConf=false \
-        --helm-set policyEnforcementMode=default \
-        --helm-set bpf.hostLegacyRouting=false # optional, can cause brief interruptions
+      $ cilium install --values values-initial.yaml --dry-run-helm-values \
+        --set operator.unmanagedPodWatcher.restart=true --set cni.customConf=false \
+        --set policyEnforcementMode=default \
+        --set bpf.hostLegacyRouting=false > values-final.yaml # optional, can cause brief interruptions
       $ diff values-initial.yaml values-final.yaml
 
     Then, apply the changes to the cluster:

--- a/Documentation/network/clustermesh/aks-clustermesh-prep.rst
+++ b/Documentation/network/clustermesh/aks-clustermesh-prep.rst
@@ -90,9 +90,9 @@ Install cluster one
     .. code-block:: bash
 
         cilium install \
-            --azure-resource-group "${AZURE_RESOURCE_GROUP}" \
-            --cluster-id 1 \
-            --config "cluster-pool-ipv4-cidr=10.10.0.0/16"
+            --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}" \
+            --set cluster.id=1 \
+            --set ipam.operator.clusterPoolIPv4PodCIDRList='{10.10.0.0/16}'
 
 5.  Check the status of Cilium.
 
@@ -178,9 +178,9 @@ arguments.
     .. code-block:: bash
         
         cilium install \
-            --azure-resource-group "${AZURE_RESOURCE_GROUP}" \
-            --cluster-id 2 \
-            --config "cluster-pool-ipv4-cidr=10.20.0.0/16"
+            --set azure.resourceGroup="${AZURE_RESOURCE_GROUP}" \
+            --set cluster.id=2 \
+            --set ipam.operator.clusterPoolIPv4PodCIDRList='{10.20.0.0/16}'
 
 5.  Check the status of Cilium.
 

--- a/Documentation/network/servicemesh/gateway-api/installation.rst
+++ b/Documentation/network/servicemesh/gateway-api/installation.rst
@@ -62,9 +62,9 @@ Installation
 
         .. code-block:: shell-session
 
-            $ cilium install \\
-                --kube-proxy-replacement=strict \\
-                --helm-set gatewayAPI.enabled=true
+            $ cilium install \
+                --set kubeProxyReplacement=true \
+                --set gatewayAPI.enabled=true
 
         Next you can check the status of the Cilium agent and operator:
 

--- a/Documentation/network/servicemesh/installation.rst
+++ b/Documentation/network/servicemesh/installation.rst
@@ -60,13 +60,13 @@ Installation
 
         .. code-block:: shell-session
 
-            $ cilium install \\
-                --kube-proxy-replacement=strict \\
-                --helm-set ingressController.enabled=true \\
-                --helm-set ingressController.loadbalancerMode=dedicated
+            $ cilium install \
+                --set kubeProxyReplacement=true \
+                --set ingressController.enabled=true \
+                --set ingressController.loadbalancerMode=dedicated
 
         Cilium can become the default ingress controller by setting the
-        ``--helm-set ingressController.default=true`` flag. This will create ingress entries even when the ``ingressClass`` 
+        ``--set ingressController.default=true`` flag. This will create ingress entries even when the ``ingressClass`` 
         is not set.
 
         If you only want to use envoy traffic management feature without Ingress support, you should only
@@ -74,18 +74,18 @@ Installation
 
         .. code-block:: shell-session
 
-            $ cilium install \\
-                --kube-proxy-replacement=strict \\
-                --helm-set-string extraConfig.enable-envoy-config=true
+            $ cilium install \
+                --set kubeProxyReplacement=true \
+                --set-string extraConfig.enable-envoy-config=true
 
         Additionally, the proxy load-balancing feature can be configured with the ``loadBalancer.l7.backend=envoy`` flag.
 
         .. code-block:: shell-session
 
-            $ cilium install \\
-                --kube-proxy-replacement=strict \\
-                --helm-set-string extraConfig.enable-envoy-config=true \\
-                --helm-set loadBalancer.l7.backend=envoy
+            $ cilium install \
+                --set kubeProxyReplacement=true \
+                --set-string extraConfig.enable-envoy-config=true \
+                --set loadBalancer.l7.backend=envoy
 
         Next you can check the status of the Cilium agent and operator:
 

--- a/Documentation/network/servicemesh/tls-default-certificate.rst
+++ b/Documentation/network/servicemesh/tls-default-certificate.rst
@@ -49,5 +49,5 @@ Installation
         .. code-block:: shell-session
 
             $ cilium install \
-                --helm-set ingressController.defaultSecretNamespace=kube-system \
-                --helm-set ingressController.defaultSecretName=default-cert
+                --set ingressController.defaultSecretNamespace=kube-system \
+                --set ingressController.defaultSecretName=default-cert

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -178,7 +178,9 @@ To enable the iptables connection-tracking bypass:
 
        .. code-block:: shell-session
 
-          cilium install --config install-no-conntrack-iptables-rules=true
+          cilium install \
+            --set installNoConntrackIptablesRules=true \
+            --set kubeProxyReplacement=true
 
     .. group-tab:: Helm
 
@@ -187,7 +189,7 @@ To enable the iptables connection-tracking bypass:
            helm install cilium |CHART_RELEASE| \\
              --namespace kube-system \\
              --set installNoConntrackIptablesRules=true \\
-             --set kubeProxyReplacement=strict
+             --set kubeProxyReplacement=true
 
 Hubble
 ======

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -513,6 +513,23 @@ Helm Options
   or "false" as values, you should remove the quotes. For example in helm command, instead of
   ``--set-string disableEndpointCRD="true"``, it should be replaced by ``--set disableEndpointCRD=true``.
 
+.. _upgrade_cilium_cli_helm_mode:
+
+Cilium CLI
+~~~~~~~~~~
+
+Upgrade Cilium CLI to `v0.15.0 <https://github.com/cilium/cilium-cli/releases/tag/v0.15.0>`_
+or later to switch to `Helm installation mode <https://github.com/cilium/cilium-cli#helm-installation-mode>`_
+to install and manage Cilium v1.14. Classic installation mode is **not**
+supported with Cilium v1.14.
+
+Helm and classic mode installations are not compatible with each other. Do not
+use Cilium CLI in Helm mode to manage classic mode installations, and vice versa.
+
+To migrate a classic mode Cilium installation to Helm mode, you need to
+uninstall Cilium using classic mode Cilium CLI, and then re-install Cilium
+using Helm mode Cilium CLI.
+
 .. _earlier_upgrade_notes:
 
 Earlier Upgrade Notes

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -68,7 +68,9 @@ Enable Encryption in Cilium
 
        .. code-block:: shell-session
 
-          cilium install --encryption ipsec
+          cilium install \
+             --set encryption.enabled=true \
+             --set encryption.type=ipsec
 
     .. group-tab:: Helm
 
@@ -111,7 +113,10 @@ interface as follows:
 
        .. code-block:: shell-session
 
-          cilium install --encryption ipsec --config encrypt-interface=ethX
+          cilium install \
+             --set encryption.enabled=true \
+             --set encryption.type=ipsec \
+             --set encryption.ipsec.interface=ethX
 
     .. group-tab:: Helm
 

--- a/Documentation/security/network/encryption-wireguard.rst
+++ b/Documentation/security/network/encryption-wireguard.rst
@@ -74,7 +74,9 @@ production workloads that require high availability.
 
        .. code-block:: shell-session
 
-          cilium install --encryption wireguard
+          cilium install \
+             --set encryption.enabled=true \
+             --set encryption.type=wireguard
 
     .. group-tab:: Helm
 
@@ -232,7 +234,10 @@ options:
 
        .. code-block:: shell-session
 
-          cilium install --encryption wireguard --node-encryption
+          cilium install \
+             --set encryption.enabled=true \
+             --set encryption.type=wireguard \
+             --set encryption.nodeEncryption=true
 
     .. group-tab:: Helm
 


### PR DESCRIPTION
- Consistently use the --set flag.
- Replace --helm-auto-gen-values with --dry-run-helm-values.
- Set kubeProxyReplacement to "true" instead of "strict".

Ref: #26430
Fixes: https://github.com/cilium/cilium-cli/issues/1624