### PR TITLE
bpf: dsr: fix IPIP health-encap on older kernels

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2820,6 +2820,7 @@ static __always_inline int
 health_encap_v4(struct __ctx_buff *ctx, __u32 tunnel_ep,
 		__u32 seclabel)
 {
+	__u32 key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
 	struct bpf_tunnel_key key;
 
 	/* When encapsulating, a packet originating from the local
@@ -2831,7 +2832,7 @@ health_encap_v4(struct __ctx_buff *ctx, __u32 tunnel_ep,
 	key.remote_ipv4 = bpf_htonl(tunnel_ep);
 	key.tunnel_ttl = IPDEFTTL;
 
-	if (unlikely(ctx_set_tunnel_key(ctx, &key, sizeof(key),
+	if (unlikely(ctx_set_tunnel_key(ctx, &key, key_size,
 					BPF_F_ZERO_CSUM_TX) < 0))
 		return DROP_WRITE_ERROR;
 	return 0;
@@ -2841,6 +2842,7 @@ static __always_inline int
 health_encap_v6(struct __ctx_buff *ctx, const union v6addr *tunnel_ep,
 		__u32 seclabel)
 {
+	__u32 key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
 	struct bpf_tunnel_key key;
 
 	memset(&key, 0, sizeof(key));
@@ -2851,7 +2853,7 @@ health_encap_v6(struct __ctx_buff *ctx, const union v6addr *tunnel_ep,
 	key.remote_ipv6[3] = tunnel_ep->p4;
 	key.tunnel_ttl = IPDEFTTL;
 
-	if (unlikely(ctx_set_tunnel_key(ctx, &key, sizeof(key),
+	if (unlikely(ctx_set_tunnel_key(ctx, &key, key_size,
 					BPF_F_ZERO_CSUM_TX |
 					BPF_F_TUNINFO_IPV6) < 0))
 		return DROP_WRITE_ERROR;


### PR DESCRIPTION
87855a957541 ("bpf: Set outer source IP to pod IP") added a field for the source IP to the `bpf_tunnel_key` struct. But as this isn't supported on older kernels, we need to reduce the key length for the IPIP health path's usage of ctx_set_tunnel_key().