### PR TITLE
bpf: exclude EgressGW logic in bpf_overlay

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -266,7 +266,7 @@ snat_v4_needs_ct(const struct ipv4_ct_tuple *tuple,
 		return true;
 	}
 
-#if defined(ENABLE_EGRESS_GATEWAY)
+#if defined(ENABLE_EGRESS_GATEWAY) && defined(IS_BPF_HOST)
 	/* Track egress gateway connections, but only if they are related to a
 	 * remote endpoint (if the endpoint is local then the connection is
 	 * already tracked).
@@ -641,7 +641,7 @@ snat_v4_nat_can_skip(const struct ipv4_nat_target *target, const struct ipv4_ct_
 {
 	__u16 sport = bpf_ntohs(tuple->sport);
 
-#if defined(ENABLE_EGRESS_GATEWAY)
+#if defined(ENABLE_EGRESS_GATEWAY) && defined(IS_BPF_HOST)
 	if (target->egress_gateway)
 		return false;
 #endif

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2155,7 +2155,7 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	 * CALL_IPV4_FROM_NETDEV in the code above.
 	 */
 #if !defined(ENABLE_DSR) || (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) ||	\
-    (defined(ENABLE_EGRESS_GATEWAY) && !defined(TUNNEL_MODE))
+    (defined(ENABLE_EGRESS_GATEWAY) && !defined(IS_BPF_OVERLAY) && !defined(TUNNEL_MODE))
 	/* If we're not in full DSR mode, reply traffic from remote backends
 	 * might pass back through the LB node and requires revDNAT.
 	 *
@@ -2611,7 +2611,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 			return ret;
 	}
 
-#if defined(ENABLE_EGRESS_GATEWAY) && !defined(TUNNEL_MODE)
+#if defined(ENABLE_EGRESS_GATEWAY) && !defined(IS_BPF_OVERLAY) && !defined(TUNNEL_MODE)
 	/* If we are not using TUNNEL_MODE, the gateway node needs to manually steer
 	 * any reply traffic for a remote pod into the tunnel (to avoid iptables
 	 * potentially dropping the packets).
@@ -2660,7 +2660,7 @@ out:
 	ctx_skip_nodeport_set(ctx);
 	ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
 	return DROP_MISSED_TAIL_CALL;
-#if defined(ENABLE_EGRESS_GATEWAY) || defined(TUNNEL_MODE)
+#if (defined(ENABLE_EGRESS_GATEWAY) && !defined(IS_BPF_OVERLAY)) || defined(TUNNEL_MODE)
 encap_redirect:
 	src_port = tunnel_gen_src_port_v4(&tuple);
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2784,7 +2784,8 @@ declare_tailcall_if(__or4(__and(is_defined(ENABLE_IPV4),
 				is_defined(IS_BPF_HOST)),
 			  __and(is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING),
 				is_defined(ENABLE_INTER_CLUSTER_SNAT)),
-			  is_defined(ENABLE_EGRESS_GATEWAY)),
+			  __and(is_defined(ENABLE_EGRESS_GATEWAY),
+				is_defined(IS_BPF_HOST))),
 		    CILIUM_CALL_IPV4_NODEPORT_NAT_FWD)
 int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 {
@@ -2925,7 +2926,8 @@ static __always_inline int handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_
 						     is_defined(IS_BPF_HOST)),
 					       __and(is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING),
 						     is_defined(ENABLE_INTER_CLUSTER_SNAT)),
-					       is_defined(ENABLE_EGRESS_GATEWAY)),
+					       __and(is_defined(ENABLE_EGRESS_GATEWAY),
+						     is_defined(IS_BPF_HOST))),
 					 CILIUM_CALL_IPV4_NODEPORT_NAT_FWD,
 					 handle_nat_fwd_ipv4);
 		break;


### PR DESCRIPTION
Explicitly exclude the EgressGW-specific paths when the `nodeport.h` and `nat.h` code is pulled into bpf_overlay. They are not needed, all relevant EgressGW functionality lives in bpf_host (and bpf_xdp).

Motivation is mostly about better self-documentation ("where does this code run"), there's no pressing BPF complexity concerns for bpf_overlay.