### PR TITLE
clustermesh: fix error propagation issue which prevented retrying on certain validation errors

### DIFF
--- a/pkg/clustermesh/internal/remote_cluster.go
+++ b/pkg/clustermesh/internal/remote_cluster.go
@@ -194,7 +194,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 					rc.wg.Done()
 				}()
 
-				if <-ready != nil {
+				if err := <-ready; err != nil {
 					rc.getLogger().WithError(err).Warning("Connection to remote cluster failed")
 					return err
 				}


### PR DESCRIPTION
This PR fixes the propagation of the possible error which can be returned by `rc.Run()` (e.g., if the validation of the cluster ID failed). This ensures that the controller registers the failure and performs another attempt.

<!-- Description of change -->

```release-note
Fix error propagation issue in clustermesh which prevented retrying on certain validation errors
```
