### PR TITLE
clustermesh: silence misleading logs about service resolution 

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1571,7 +1571,7 @@ func (d *Daemon) initKVStore() {
 		)
 		log := log.WithField(logfields.LogSubsys, "etcd")
 		goopts.DialOption = []grpc.DialOption{
-			grpc.WithContextDialer(k8s.CreateCustomDialer(d.k8sWatcher.K8sSvcCache, log)),
+			grpc.WithContextDialer(k8s.CreateCustomDialer(d.k8sWatcher.K8sSvcCache, log, true)),
 		}
 	}
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -553,7 +553,7 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 					log := log.WithField(logfields.LogSubsys, "etcd")
 					goopts = &kvstore.ExtraOptions{
 						DialOption: []grpc.DialOption{
-							grpc.WithContextDialer(k8s.CreateCustomDialer(svcGetter, log)),
+							grpc.WithContextDialer(k8s.CreateCustomDialer(svcGetter, log, true)),
 						},
 					}
 				}

--- a/pkg/clustermesh/internal/remote_cluster.go
+++ b/pkg/clustermesh/internal/remote_cluster.go
@@ -311,7 +311,8 @@ func (rc *remoteCluster) makeExtraOpts() kvstore.ExtraOptions {
 	if rc.serviceIPGetter != nil {
 		// Allow to resolve service names without depending on the DNS. This prevents the need
 		// for setting the DNSPolicy to ClusterFirstWithHostNet when running in host network.
-		dialOpts = append(dialOpts, grpc.WithContextDialer(k8s.CreateCustomDialer(rc.serviceIPGetter, rc.getLogger())))
+		logger := log.WithField(fieldClusterName, rc.name)
+		dialOpts = append(dialOpts, grpc.WithContextDialer(k8s.CreateCustomDialer(rc.serviceIPGetter, logger, false)))
 	}
 
 	return kvstore.ExtraOptions{

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -728,6 +728,6 @@ func CreateCustomDialer(b ServiceIPGetter, log *logrus.Entry, verboseLogs bool) 
 		}
 
 		log.Debugf("Custom dialer based on k8s service backend is dialing to %q", s)
-		return net.Dial("tcp", s)
+		return (&net.Dialer{}).DialContext(ctx, "tcp", s)
 	}
 }


### PR DESCRIPTION
9f5a82aba625 ("clustermesh: use custom dialer for service resolution") configured a custom dialer to perform service resolution when the etcd address refers to a local service (mainly in the kvstoremesh case).

Yet, the custom dialer function outputs quite verbose log messages, which can be misleading when the address does not point to a local service (as it is correct that the address cannot be parsed). One example being:

```
level=error msg="Unable to parse etcd service URL" error="parse \"172.19.0.2:2379\": first path segment in URL cannot contain colon"
```

Hence, let's silence them, as they do more harm than good in this specific situation. We still print (at debug level) the outcome of the translation, so that we know to whom we are actually connecting.

<!-- Description of change -->

```release-note
Silence misleading log messages about service resolution in clustermesh 
```
