### PR TITLE
loader: check enabled L7 proxy via config property

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -541,7 +541,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	// Reinstall proxy rules for any running proxies if needed
-	if p != nil {
+	if option.Config.EnableL7Proxy {
 		if err := p.ReinstallRules(ctx); err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently, the check whether l7 proxy functionality is enabled is based on whether the passed proxy reference is `nil` or not.

Due to Go's nil-handling on Interfaces, this result in calls to `proxy.ReinstallRules` even though l7 proxy functionality isn't enabled. It doesn't result in nil panics, because the method doesn't access the proxy itself. (I detected the actual issue in a [separate PR](https://github.com/cilium/cilium/pull/26619) which accesses fields of the proxy struct in this method)

Therefore, this commit changes the check towards checking the config property.

As an alternative, it would be possible to add a nil check based on `reflect.ValueOf(p).IsNil()` - but i thought it's better to check the config property.