### PR TITLE
cocci: Re-license Coccinelle scripts as Apache 2.0

### DIFF
--- a/contrib/coccinelle/aligned.cocci
+++ b/contrib/coccinelle/aligned.cocci
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium.
 /// Find cases of missing __align_stack_8. On-the-stack objects of size > 8
 /// bytes must be force-aligned when 8 bytes isn't their natural object
 /// alignment (e.g., __u8 foo[12]).
@@ -6,7 +7,6 @@
 /// Coccinelle v1.0.7 is needed to handle the presence of #pragma unrolls in
 /// our code.
 // Confidence: Medium
-// Copyright Authors of Cilium.
 // Comments:
 // Options: --include-headers
 

--- a/contrib/coccinelle/const.cocci
+++ b/contrib/coccinelle/const.cocci
@@ -1,9 +1,9 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium.
 /// Find function arguments that can be declared const. Confidence in the
 /// results in low for now, but the compiler should catch any incorrect const
 /// qualifier.
 // Confidence: Low
-// Copyright Authors of Cilium.
 // Comments:
 // Options: --include-headers
 

--- a/contrib/coccinelle/identity_is_node.cocci
+++ b/contrib/coccinelle/identity_is_node.cocci
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium.
 /// Find missing calls to identity_is_remote_node and identity_is_node.
 /// We want to use those functions whenever possible, to make sure
 /// KUBE_APISERVER_NODE_ID is properly accounted for and to prepare for

--- a/contrib/coccinelle/null.cocci
+++ b/contrib/coccinelle/null.cocci
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium.
+//
 // spatch --sp-file null.cocci lib/*.h *.c *.h
 //
 // This script finds undefined behavior in BPF C code which LLVM

--- a/contrib/coccinelle/tail_calls.cocci
+++ b/contrib/coccinelle/tail_calls.cocci
@@ -1,9 +1,9 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium.
 /// Find tail calls not followed by a call to send_drop_notify_error with
 /// DROP_MISSED_TAIL_CALL. Such code patterns may lead to missed tail calls not
 /// being logged.
 // Confidence: Medium
-// Copyright Authors of Cilium.
 // Comments:
 // Options: --include-headers
 

--- a/contrib/coccinelle/zero_trace_reason.cocci
+++ b/contrib/coccinelle/zero_trace_reason.cocci
@@ -1,9 +1,9 @@
-// SPDX-License-Identifier: GPL-2.0
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium.
 /// Prevent passing 0 as a reason to send_trace_notify(), because 0 is a valid
 /// value corresponding to new conntrack connections, and passing it instead of
 /// TRACE_REASON_UNKNOWN may confuse Hubble.
 // Confidence: Medium
-// Copyright Authors of Cilium.
 // Comments:
 // Options: --include-headers
 


### PR DESCRIPTION
We want to change the license under which we distribute the Coccinelle scripts, in order make it consistent with the rest of the repository, and to help with Cilium's Graduation process.

These scripts were written from scratch by Cilium contributors. Looking at the Git history:

    $ git log --reverse --format='%an' -- contrib/coccinelle/*.cocci | sort -u
    Alexandre Perrin
    André Martins
    Anton Protopopov
    Daniel Borkmann
    Dylan Reimerink
    Paul Chaignon
    Quentin Monnet

... we note that all contributors are currently affiliated with Isovalent. Liz Rice, currently Chief Open Source Officer at Isovalent, gave her consent for the change.

Fixes: https://github.com/cilium/cilium/issues/26599

Cc: @kaworu @aanm @aspsk @borkmann @dylandreimerink @pchaigno 