### PR TITLE
docs: Add docs structure recommendations, update style guide

### DIFF
--- a/Documentation/contributing/docs/docsstructure.rst
+++ b/Documentation/contributing/docs/docsstructure.rst
@@ -1,0 +1,99 @@
+.. only:: not (epub or latex or html)
+
+    WARNING: You are looking at unreleased Cilium documentation.
+    Please use the official rendered version released here:
+    https://docs.cilium.io
+
+******************************************
+Recommendations on Documentation Structure
+******************************************
+
+This page contains recommendations to help contributors write better
+documentation. The goal of better documentation is a better user experience. If
+you take only one thing away from this guide, let it be this: don't document
+your feature. Instead, **document how your feature guides users on their
+journey.**
+
+Maintaining Good Information Architecture
+-----------------------------------------
+
+When you add, update, or remove documentation, consider how the change affects
+the site's `information architecture`_. Information architecture is what shapes
+a user's experience and their ability to accomplish their goals with Cilium. If
+an addition, change, or removal would significantly alter a user's journey or
+prevent their success, make sure to flag the change clearly in :ref:`upgrade
+notes <current_release_required_changes>`.
+
+.. _information architecture: https://www.usability.gov/what-and-why/information-architecture.html
+
+Adding a New Page
+-----------------
+
+When you need to write completely new content, create one or more new pages as
+one of the three following types:
+
+- Concept (no steps, just knowledge)
+- Task (how to do one discrete thing)
+- Tutorial (how to combine multiple features to accomplish specific goals)
+
+A *concept* explains some aspect of Cilium. Typically, concept pages don't
+include sequences of steps. Instead, they link to tasks or tutorials.
+
+For an example of a concept page, see :ref:`Routing <Routing>`.
+
+A *task* shows how to do one discrete thing with Cilium. Task pages give
+readers a sequence of steps to perform. A task page can be short or long, but
+must remain focused on the task's singular goal. Task pages can blend brief
+explanations with the steps to perform, but if you need to provide a lengthy
+explanation, write a separate concept and link to it. Link related task and
+concept pages to each other.
+
+For an example of a task page, see :ref:`Migrating a Cluster to Cilium
+<cni_migration>`.
+
+A *tutorial* shows how to accomplish a goal using multiple Cilium features.
+Tutorials are flexible: for example, a tutorial page could provide several
+discrete sequences of steps to perform, or show how related pieces of code
+could interact. Tutorials can blend brief explanations with the steps to
+perform, but lengthy explanations should link to related concept topics.
+
+For an example of a tutorial page, see :ref:`Inspecting Network Flows with the
+CLI <hubble_cli>`.
+
+.. note::
+
+  You may need to add multiple pages to support a new feature. For example, if
+  a new feature requires an explanation of its underlying ideas, add a concept
+  page as well as a task page.
+
+Updating an Existing Page
+-------------------------
+
+Consider whether you can update an existing page or whether to add a new one.
+
+If adding or updating content to a page keeps it centered on a single concept
+or task, then you can update an existing page. If adding or updating content to
+a page expands it to include multiple concepts or tasks, then add new pages for
+individual concepts and tasks.
+
+If you're moving a page and changing its URL, make sure you update every link
+to that page in the documentation. Ask on Slack (``#sig-docs``) for someone to
+set up a HTTP redirection from the old URL to the new one, if necessary.
+
+Removing Content and Entire Pages
+---------------------------------
+
+Removing stale content is a part of maintaining healthy docs.
+
+Whether you're removing stale content on a page or removing a page altogether,
+make sure to consider the impact of removal on a user's journey. Specific
+considerations include:
+
+- Updating any links to removed content
+- Ensuring users have clear guidance on what to do next
+
+.. note::
+
+  Without a clearly defined user journey, evaluation is largely qualitative.
+  Practice empathy: would someone succeed if they had your skills but not your
+  context?

--- a/Documentation/contributing/docs/docsstyle.rst
+++ b/Documentation/contributing/docs/docsstyle.rst
@@ -20,8 +20,24 @@ documentation. They have several objectives:
 
 - Help keep a consistent style throughout the documentation.
 
+- In the end, provide a better experience to users, and help them find the
+  information they need.
+
 See also :ref:`the documentation for testing <testing-documentation>` for
 instructions on how to preview documentation changes.
+
+General Considerations
+----------------------
+
+Write in US English.
+For example, use "prioritize" instead of ":spelling:ignore:`prioritise`" and
+"color" instead of ":spelling:ignore:`colour`".
+
+Maintain a consistent style with the rest of the documentation when possible,
+or at least with the rest of the updated page.
+
+Omit hyphens when possible. For example, use "load balancing" instead of
+"load-balancing".
 
 Header
 ------
@@ -253,6 +269,57 @@ Lists
     1. First item
     2. Second item
 
+- Be consistent with periods at the end of list items. In general, omit periods
+  from bulleted list items unless the items are complete sentences. But if one
+  list item requires a period, use periods for all items.
+
+  Prefer:
+
+  .. code-block:: rst
+
+    - This is one list item
+    - This is another list item
+
+  Avoid:
+
+  .. code-block:: rst
+
+    - This is one list item, period. We use punctuation.
+    - This list item should have a period too, but doesn't
+
+Callouts
+--------
+
+Use callouts effectively. For example, use the ``.. note::`` directive to
+highlight information that helps users in a specific context. Do not use it to
+avoid refactoring a section or paragraph.
+
+For example, when adding information about a new configuration flag that
+completes a feature, there is no need to append it as a note, given that it
+does not require particular attention from the reader. Avoid the following:
+
+.. parsed-literal::
+
+    Blinking pods are easier to spot in the dark. Use feature flag
+    \`\`--blinking-pods\`\` to make new pods blink twice when they launch. If
+    you create blinking pods often, sunglasses may help protect your eyes.
+
+    **\.. note::
+
+        Use the flag \`\`--blinking-pods-blink-number\`\` to change the number
+        of times pods blink on start-up.**
+
+Instead, merge the new content with the existing paragraph:
+
+.. parsed-literal::
+
+    Blinking pods are easier to spot in the dark. Use feature flag
+    \`\`--blinking-pods\`\` to make new pods blink when they launch. **By
+    default, blinking pods blink twice, but you can use the flag
+    \`\`--blinking-pods-blink-number\`\` to specify how many times they blink
+    on start-up.** If you create blinking pods often, sunglasses may help
+    protect your eyes.
+
 Roles
 -----
 
@@ -270,3 +337,170 @@ Roles
   .. code-block:: rst
 
     See `this GitHub issue <https://github.com/cilium/cilium/issues/1234>`__.
+
+Common Pitfalls
+---------------
+
+There are best practices for writing documentation; follow them. In general,
+default to the `Kubernetes style guide`_, especially for `content best
+practices`_. The following subsections cover the most common feedback given for
+Cilium documentation Pull Requests.
+
+Use active voice
+~~~~~~~~~~~~~~~~
+
+Prefer::
+
+    Enable the flag.
+
+Avoid::
+
+    Ensure the flag is enabled.
+
+Use present tense
+~~~~~~~~~~~~~~~~~
+
+Prefer::
+
+    The service returns a response code.
+
+Avoid::
+
+    The service will return a response code.
+
+Address the user as "you", not "we"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prefer::
+
+    You can specify values to filter tags.
+
+Avoid::
+
+    We'll specify this value to filter tags.
+
+Use plain, direct language
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prefer::
+
+    Always configure the bundle explicitly in production environments.
+
+Avoid::
+
+    It is recommended to always configure the bundle explicitly in production environments.
+
+Write for good localization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Assume that what you write will be localized with machine translation. Figures
+of speech often localize poorly, as do idioms like "above" and "below".
+
+Prefer::
+
+    The following example
+    To assist this process,
+
+Avoid::
+
+    The example below
+    To give this process a boost,
+
+Define abbreviations
+~~~~~~~~~~~~~~~~~~~~
+
+Define abbreviations when you first use them on a page.
+
+Prefer::
+
+    Certificate authority (CA)
+
+Avoid::
+
+    CA
+
+Don't use Latin abbreviations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prefer::
+
+    - For example,
+    - In other words,
+    - by following the ...
+    - and others
+
+Avoid::
+
+    - e.g.
+    - i.e.
+    - via
+    - etc.
+
+Spell words fully
+~~~~~~~~~~~~~~~~~
+
+Prefer::
+
+    and
+
+Avoid::
+
+    &
+
+.. _Kubernetes style guide: https://kubernetes.io/docs/contribute/style/style-guide/
+.. _content best practices: https://kubernetes.io/docs/contribute/style/style-guide/#content-best-practices
+
+Specific Language
+-----------------
+
+Use specific language. Avoid words like "this" (as a pronoun) and "it" when
+referring to concepts, actions, or process states. Be as specific as possible,
+even if specificity seems overly repetitive. This requirement exists for two
+reasons:
+
+1. Indirect language assumes too much clarity on the part of the writer and too
+   much understanding on the part of the reader.
+
+2. Specific language is easier to review and easier to localize.
+
+Words like "this" and "it" are indirect references. For example:
+
+.. code-block:: rst
+
+  Feature A requires all pods to be painted blue. This means that the Agent
+  must apply its "paint" action to all pods. To achieve this, use the dedicated
+  CLI invocation.
+
+In the preceding paragraph, the word "this" indirectly references both an
+inferred consequence ("this means") and a desired goal state ("to achieve
+this"). Instead, be as specific as possible:
+
+.. code-block:: rst
+
+  Feature A requires all pods to be painted blue. Consequently, the Agent must
+  apply its "paint" action to all pods. To make the Agent paint all pods blue,
+  use the dedicated CLI invocation.
+
+The following subsections contain more examples.
+
+Use specific wording rather than vague wording
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prefer::
+
+    For each core, the Ingester attempts to spawn a worker pool.
+
+Avoid::
+
+    For each core, it attempts to spawn a worker pool.
+
+Use specific instructions rather than vague instructions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Prefer::
+
+    Set the annotation value to remote.
+
+Avoid::
+
+    Set it to remote.

--- a/Documentation/contributing/docs/docsstyle.rst
+++ b/Documentation/contributing/docs/docsstyle.rst
@@ -69,6 +69,40 @@ Wrap the lines for long sentences or paragraphs. There is no fixed convention
 on the length of lines, but targeting a width of about 80 characters should be
 safe in most circumstances.
 
+Capitalization
+--------------
+
+Follow `the section on capitalization for API objects`_ from the Kubernetes
+style guide for when to (not) capitalize API objects. In particular:
+
+    When you refer specifically to interacting with an API object, use
+    `UpperCamelCase`_, also known as Pascal case.
+
+And:
+
+    When you are generally discussing an API object, use `sentence-style
+    capitalization`_
+
+For example, write "Gateway API", capitalized. Use "Gateway" when writing about
+an API object as an entity, and "gateway" for a specific instance.
+
+The following examples are correct::
+
+    - Gateway API is a subproject of Kubernetes SIG Network.
+    - Cilium is conformant to the Gateway API spec at version X.Y.Z.
+    - In order to expose this service, create a Gateway to hold the listener configuration.
+    - Traffic from the Internet passes through the gateway to get to the backend service.
+    - Now that you have created the "foo" gateway, you need to create some Routes.
+
+But the following examples are incorrect::
+
+    - The implemention of gateway API
+    - To create a gateway object, ...
+
+.. _the section on capitalization for API objects: https://kubernetes.io/docs/contribute/style/style-guide/#use-upper-camel-case-for-api-objects
+.. _UpperCamelCase: https://en.wikipedia.org/wiki/Camel_case
+.. _sentence-style capitalization: https://docs.microsoft.com/en-us/style-guide/text-formatting/using-type/use-sentence-style-capitalization
+
 Code Blocks
 -----------
 

--- a/Documentation/contributing/docs/index.rst
+++ b/Documentation/contributing/docs/index.rst
@@ -9,13 +9,18 @@
 Documentation
 -------------
 
-This section describes the style and testing methods of Cilium documentation. Before contributing, please review the documentation style guide below.
-See the :ref:`clone and provision environment section <provision_environment>` to learn how to fork and clone the repository.
+This section provides guidance on the structure of Cilium documentation,
+describes its style, and explains how to test it. Before contributing, please
+review the structure recommendations and style guide.
+
+See the :ref:`clone and provision environment section <provision_environment>`
+to learn how to fork and clone the repository.
 
 .. toctree::
    :maxdepth: 2
    :glob:
 
+   docsstructure
    docsstyle
    docstest
 

--- a/Documentation/network/concepts/routing.rst
+++ b/Documentation/network/concepts/routing.rst
@@ -4,6 +4,8 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
+.. _routing:
+
 #######
 Routing
 #######

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -172,6 +172,7 @@ buildx
 bytecode
 cBPF
 callee
+callouts
 cancelled
 cardinality
 cass


### PR DESCRIPTION
Expand the docs for contributing to Cilium's documentation, by adding new items to the style guide (including common pitfalls to avoid), and by adding a new section with recommendations on the structure of the docs.

Most of the new additions were written by Sarah, I mostly took care of porting them to Cilium's documentation.
