### PR TITLE
bpf: nodeport: add RevDNAT-based FIB lookup for reply traffic 

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1521,6 +1521,9 @@ out:
 			return send_drop_notify_error(ctx, 0, ret,
 						      CTX_ACT_DROP,
 						      METRIC_EGRESS);
+
+		if (ret == CTX_ACT_REDIRECT)
+			return ret;
 	}
 #endif
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -124,6 +124,29 @@ static __always_inline bool dsr_is_too_big(struct __ctx_buff *ctx __maybe_unused
 	return false;
 }
 
+static __always_inline int
+nodeport_fib_lookup_and_redirect(struct __ctx_buff *ctx,
+				 struct bpf_fib_lookup_padded *fib_params,
+				 __s8 *ext_err)
+{
+	int oif = NATIVE_DEV_IFINDEX;
+	int ret;
+
+	ret = fib_lookup(ctx, &fib_params->l, sizeof(fib_params->l), 0);
+	*ext_err = (__s8)ret;
+
+	switch (ret) {
+	case BPF_FIB_LKUP_RET_SUCCESS:
+	case BPF_FIB_LKUP_RET_NO_NEIGH:
+		if ((__u32)oif == fib_params->l.ifindex)
+			return CTX_ACT_OK;
+
+		return fib_do_redirect(ctx, true, fib_params, ext_err, &oif);
+	default:
+		return DROP_NO_FIB;
+	}
+}
+
 #ifdef ENABLE_IPV6
 static __always_inline bool nodeport_uses_dsr6(const struct ipv6_ct_tuple *tuple)
 {
@@ -1269,8 +1292,10 @@ redo:
 }
 
 static __always_inline int
-nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
+nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
+			   __s8 *ext_err __maybe_unused)
 {
+	struct bpf_fib_lookup_padded fib_params __maybe_unused = {};
 	struct lb6_reverse_nat *nat_info;
 	struct ipv6_ct_tuple tuple = {};
 	struct ct_state ct_state = {};
@@ -1291,6 +1316,19 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 	nat_info = nodeport_rev_dnat_get_info_ipv6(ctx, &tuple);
 	if (!nat_info)
 		return CTX_ACT_OK;
+
+#if defined(IS_BPF_HOST) && !defined(ENABLE_SKIP_FIB)
+	fib_params.l.family = AF_INET6;
+	fib_params.l.ifindex = ctx_get_ifindex(ctx);
+	ipv6_addr_copy((union v6addr *)fib_params.l.ipv6_src,
+		       &nat_info->address);
+	ipv6_addr_copy((union v6addr *)fib_params.l.ipv6_dst,
+		       &tuple.daddr);
+
+	ret = nodeport_fib_lookup_and_redirect(ctx, &fib_params, ext_err);
+	if (ret != CTX_ACT_OK)
+		return ret;
+#endif
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
 			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &trace->monitor);
@@ -1484,12 +1522,13 @@ int tail_handle_snat_fwd_ipv6(struct __ctx_buff *ctx)
 }
 
 static __always_inline int
-__handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
+__handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
+		      __s8 *ext_err)
 {
 	int ret;
 
-	ret = nodeport_rev_dnat_fwd_ipv6(ctx, trace);
-	if (IS_ERR(ret))
+	ret = nodeport_rev_dnat_fwd_ipv6(ctx, trace, ext_err);
+	if (ret != CTX_ACT_OK)
 		return ret;
 
 #if !defined(ENABLE_DSR) ||						\
@@ -1507,8 +1546,9 @@ __handle_nat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 static __always_inline int handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 {
 	struct trace_ctx trace;
+	__s8 ext_err = 0;
 
-	return __handle_nat_fwd_ipv6(ctx, &trace);
+	return __handle_nat_fwd_ipv6(ctx, &trace, &ext_err);
 }
 
 declare_tailcall_if(__or(__and(is_defined(ENABLE_IPV4),
@@ -1524,6 +1564,7 @@ int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 	};
 	int ret;
 	enum trace_point obs_point;
+	__s8 ext_err = 0;
 
 #ifdef IS_BPF_OVERLAY
 	obs_point = TRACE_TO_OVERLAY;
@@ -1531,12 +1572,14 @@ int tail_handle_nat_fwd_ipv6(struct __ctx_buff *ctx)
 	obs_point = TRACE_TO_NETWORK;
 #endif
 
-	ret = __handle_nat_fwd_ipv6(ctx, &trace);
+	ret = __handle_nat_fwd_ipv6(ctx, &trace, &ext_err);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_EGRESS);
 
-	send_trace_notify(ctx, obs_point, 0, 0, 0, 0, trace.reason,
-			  trace.monitor);
+	if (ret == CTX_ACT_OK)
+		send_trace_notify(ctx, obs_point, 0, 0, 0, 0, trace.reason,
+				  trace.monitor);
 
 	return ret;
 }
@@ -2708,8 +2751,10 @@ redo:
 }
 
 static __always_inline int
-nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
+nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
+			   __s8 *ext_err __maybe_unused)
 {
+	struct bpf_fib_lookup_padded fib_params __maybe_unused = {};
 	int ret, l3_off = ETH_HLEN, l4_off;
 	struct lb4_reverse_nat *nat_info;
 	struct ipv4_ct_tuple tuple = {};
@@ -2734,6 +2779,20 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 	nat_info = nodeport_rev_dnat_get_info_ipv4(ctx, &tuple);
 	if (!nat_info)
 		return CTX_ACT_OK;
+
+#if defined(IS_BPF_HOST) && !defined(ENABLE_SKIP_FIB)
+	/* Perform FIB lookup with post-RevDNAT src IP, and redirect
+	 * packet to the correct egress interface:
+	 */
+	fib_params.l.family = AF_INET;
+	fib_params.l.ifindex = ctx_get_ifindex(ctx);
+	fib_params.l.ipv4_src = nat_info->address;
+	fib_params.l.ipv4_dst = tuple.daddr;
+
+	ret = nodeport_fib_lookup_and_redirect(ctx, &fib_params, ext_err);
+	if (ret != CTX_ACT_OK)
+		return ret;
+#endif
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
 			      ACTION_CREATE, CT_INGRESS, SCOPE_REVERSE, &ct_state,
@@ -2953,12 +3012,12 @@ int tail_handle_snat_fwd_ipv4(struct __ctx_buff *ctx)
 
 static __always_inline int
 __handle_nat_fwd_ipv4(struct __ctx_buff *ctx, __u32 cluster_id __maybe_unused,
-		      struct trace_ctx *trace)
+		      struct trace_ctx *trace, __s8 *ext_err)
 {
 	int ret;
 
-	ret = nodeport_rev_dnat_fwd_ipv4(ctx, trace);
-	if (IS_ERR(ret))
+	ret = nodeport_rev_dnat_fwd_ipv4(ctx, trace, ext_err);
+	if (ret != CTX_ACT_OK)
 		return ret;
 
 #if !defined(ENABLE_DSR) ||						\
@@ -2979,10 +3038,11 @@ static __always_inline int handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 {
 	struct trace_ctx trace;
 	__u32 cluster_id = ctx_load_meta(ctx, CB_CLUSTER_ID_EGRESS);
+	__s8 ext_err = 0;
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, 0);
 
-	return __handle_nat_fwd_ipv4(ctx, cluster_id, &trace);
+	return __handle_nat_fwd_ipv4(ctx, cluster_id, &trace, &ext_err);
 }
 
 declare_tailcall_if(__or4(__and(is_defined(ENABLE_IPV4),
@@ -3003,6 +3063,7 @@ int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 	int ret;
 	enum trace_point obs_point;
 	__u32 cluster_id = ctx_load_meta(ctx, CB_CLUSTER_ID_EGRESS);
+	__s8 ext_err = 0;
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, 0);
 
@@ -3012,12 +3073,14 @@ int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
 	obs_point = TRACE_TO_NETWORK;
 #endif
 
-	ret = __handle_nat_fwd_ipv4(ctx, cluster_id, &trace);
+	ret = __handle_nat_fwd_ipv4(ctx, cluster_id, &trace, &ext_err);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_EGRESS);
 
-	send_trace_notify(ctx, obs_point, 0, 0, 0, 0, trace.reason,
-			  trace.monitor);
+	if (ret == CTX_ACT_OK)
+		send_trace_notify(ctx, obs_point, 0, 0, 0, 0, trace.reason,
+				  trace.monitor);
 
 	return ret;
 }

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -24,6 +24,7 @@
 
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_PORT		__bpf_htons(111)
+#define CLIENT_IP_2		v4_ext_two
 
 #define FRONTEND_IP		v4_svc_one
 #define FRONTEND_PORT		tcp_svc_one
@@ -31,9 +32,57 @@
 #define BACKEND_IP		v4_pod_one
 #define BACKEND_PORT		__bpf_htons(8080)
 
+#define NATIVE_DEV_IFINDEX	24
+#define DEFAULT_IFACE		NATIVE_DEV_IFINDEX
+#define BACKEND_IFACE		25
+#define SVC_EGRESS_IFACE	26
+
 static volatile const __u8 *client_mac = mac_one;
 static volatile const __u8 *node_mac = mac_three;
 static volatile const __u8 *backend_mac = mac_four;
+
+#define fib_lookup mock_fib_lookup
+
+long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	params->ifindex = DEFAULT_IFACE;
+
+	if (params->ipv4_src == FRONTEND_IP && params->ipv4_dst == CLIENT_IP_2) {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)node_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)client_mac, ETH_ALEN);
+		params->ifindex = SVC_EGRESS_IFACE;
+	}
+
+	return BPF_FIB_LKUP_RET_SUCCESS;
+}
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	void *data = (void *)(long)ctx_data(ctx);
+	void *data_end = (void *)(long)ctx->data_end;
+	struct iphdr *ip4;
+
+	ip4 = data + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		return CTX_ACT_DROP;
+
+	/* Forward to backend: */
+	if (ip4->saddr == CLIENT_IP && ifindex == BACKEND_IFACE)
+		return CTX_ACT_REDIRECT;
+	if (ip4->saddr == CLIENT_IP_2 && ifindex == BACKEND_IFACE)
+		return CTX_ACT_REDIRECT;
+
+	/* Redirected reply: */
+	if (ip4->daddr == CLIENT_IP_2 && ifindex == SVC_EGRESS_IFACE)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_DROP;
+}
 
 #define SECCTX_FROM_IPCACHE 1
 
@@ -118,7 +167,7 @@ SETUP("tc", "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 {
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP, 0, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP, BACKEND_IFACE, 0, 0,
 			      (__u8 *)backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP, 0, 112233, 0, 0);
@@ -344,4 +393,275 @@ CHECK("tc", "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
+}
+
+/* Same scenario as above, but for a different CLIENT_IP_2. Here replies
+ * should leave via a non-default interface.
+ */
+PKTGEN("tc", "tc_nodeport_dsr_backend_redirect")
+int nodeport_dsr_backend_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	struct dsr_opt_v4 *opt;
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)node_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr_with_options(&builder, 2);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP_2;
+	l3->daddr = BACKEND_IP;
+
+	opt = (void *)l3 + sizeof(*l3);
+	opt->type = DSR_IPV4_OPT_TYPE;
+	opt->len = sizeof(*opt);
+	opt->port = bpf_ntohs(FRONTEND_PORT);
+	opt->addr = bpf_ntohl(FRONTEND_IP);
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = BACKEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_dsr_backend_redirect")
+int nodeport_dsr_backend_redirect_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_dsr_backend_redirect")
+int nodeport_dsr_backend_redirect_check(struct __ctx_buff *ctx)
+{
+	struct dsr_opt_v4 *opt;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	opt = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)opt + 2 * sizeof(__u32) > data_end)
+		test_fatal("l3 DSR option out of bounds");
+
+	l4 = (void *)opt + sizeof(*opt);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the node MAC")
+	if (memcmp(l2->h_dest, (__u8 *)backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the endpoint MAC")
+
+	if (l3->saddr != CLIENT_IP_2)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP)
+		test_fatal("dst IP has changed");
+
+	if (opt->type != DSR_IPV4_OPT_TYPE)
+		test_fatal("type in DSR IP option has changed")
+	if (opt->len != 8)
+		test_fatal("length in DSR IP option has changed")
+	if (opt->port != __bpf_ntohs(FRONTEND_PORT))
+		test_fatal("port in DSR IP option has changed")
+	if (opt->addr != __bpf_ntohl(FRONTEND_IP))
+		test_fatal("addr in DSR IP option has changed")
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port has changed");
+
+	struct ipv4_ct_tuple tuple;
+	struct ct_entry *ct_entry;
+	int l4_off, ret;
+
+	ret = lb4_extract_tuple(ctx, l3, sizeof(*status_code) + ETH_HLEN,
+				&l4_off, &tuple);
+	assert(!IS_ERR(ret));
+
+	tuple.flags = TUPLE_F_IN;
+	ipv4_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr)
+		test_fatal("CT entry doesn't have the .dsr flag set");
+
+	struct ipv4_nat_entry *nat_entry;
+
+	tuple.sport = BACKEND_PORT;
+	tuple.dport = CLIENT_PORT;
+
+	nat_entry = snat_v4_lookup(&tuple);
+	if (!nat_entry)
+		test_fatal("no SNAT entry for DSR found");
+	if (nat_entry->to_saddr != FRONTEND_IP)
+		test_fatal("SNAT entry has wrong address");
+	if (nat_entry->to_sport != FRONTEND_PORT)
+		test_fatal("SNAT entry has wrong port");
+
+	test_finish();
+}
+
+PKTGEN("tc", "tc_nodeport_dsr_backend_redirect_reply")
+int nodeport_dsr_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)node_mac, (__u8 *)client_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = BACKEND_IP;
+	l3->daddr = CLIENT_IP_2;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = BACKEND_PORT;
+	l4->dest = CLIENT_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_dsr_backend_redirect_reply")
+int nodeport_dsr_backend_redirect_reply_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+/* Test that to-netdev respects the routing needed for CLIENT_IP_2,
+ * and redirects the packet to the correct egress interface.
+ */
+CHECK("tc", "tc_nodeport_dsr_backend_redirect_reply")
+int nodeport_dsr_backend_redirect_reply_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the node MAC")
+	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the client MAC")
+
+	if (l3->saddr != BACKEND_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != CLIENT_IP_2)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != BACKEND_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != CLIENT_PORT)
+		test_fatal("dst port has changed");
+
+	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -22,6 +22,7 @@
 
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_PORT		__bpf_htons(111)
+#define CLIENT_IP_2		v4_ext_two
 
 #define FRONTEND_IP_LOCAL	v4_svc_one
 #define FRONTEND_IP_REMOTE	v4_svc_two
@@ -33,6 +34,11 @@
 #define BACKEND_IP_LOCAL	v4_pod_one
 #define BACKEND_IP_REMOTE	v4_pod_two
 #define BACKEND_PORT		__bpf_htons(8080)
+
+#define NATIVE_DEV_IFINDEX	24
+#define DEFAULT_IFACE		NATIVE_DEV_IFINDEX
+#define BACKEND_IFACE		25
+#define SVC_EGRESS_IFACE	26
 
 #define fib_lookup mock_fib_lookup
 
@@ -46,21 +52,61 @@ static volatile const __u8 *remote_backend_mac = mac_five;
 static __be16 nat_source_port;
 static bool fail_fib;
 
+#define fib_lookup mock_fib_lookup
+
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)
 {
 	if (fail_fib)
 		return BPF_FIB_LKUP_RET_NO_NEIGH;
 
+	params->ifindex = DEFAULT_IFACE;
+
 	if (params->ipv4_dst == BACKEND_IP_REMOTE) {
 		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
 		__bpf_memcpy_builtin(params->dmac, (__u8 *)remote_backend_mac, ETH_ALEN);
+	} else if (params->ipv4_src == FRONTEND_IP_LOCAL &&
+		   params->ipv4_dst == CLIENT_IP_2) {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)client_mac, ETH_ALEN);
+		params->ifindex = SVC_EGRESS_IFACE;
 	} else {
 		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
 		__bpf_memcpy_builtin(params->dmac, (__u8 *)client_mac, ETH_ALEN);
 	}
 
 	return 0;
+}
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	void *data = (void *)(long)ctx_data(ctx);
+	void *data_end = (void *)(long)ctx->data_end;
+	struct iphdr *ip4;
+
+	ip4 = data + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		return CTX_ACT_DROP;
+
+	/* Forward to backend: */
+	if (ip4->saddr == CLIENT_IP && ifindex == BACKEND_IFACE)
+		return CTX_ACT_REDIRECT;
+	if (ip4->saddr == CLIENT_IP_2 && ifindex == BACKEND_IFACE)
+		return CTX_ACT_REDIRECT;
+	if (ip4->saddr == LB_IP && ifindex == DEFAULT_IFACE)
+		return CTX_ACT_REDIRECT;
+
+	/* Redirected reply: */
+	if (ip4->daddr == CLIENT_IP_2 && ifindex == SVC_EGRESS_IFACE)
+		return CTX_ACT_REDIRECT;
+	if (ip4->saddr == FRONTEND_IP_REMOTE && ifindex == DEFAULT_IFACE)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_DROP;
 }
 
 #define SECCTX_FROM_IPCACHE 1
@@ -145,7 +191,7 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_TCP, 0);
 
 	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0,
+	endpoint_v4_add_entry(BACKEND_IP_LOCAL, BACKEND_IFACE, 0, 0,
 			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
 
 	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);
@@ -317,6 +363,226 @@ int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
+/* Same scenario as above, but for a different CLIENT_IP_2. Here replies
+ * should leave via a non-default interface.
+ */
+PKTGEN("tc", "tc_nodeport_local_backend_redirect")
+int nodeport_local_backend_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP_2;
+	l3->daddr = FRONTEND_IP_LOCAL;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = FRONTEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_local_backend_redirect")
+int nodeport_local_backend_redirect_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_local_backend_redirect")
+int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the node MAC")
+	if (memcmp(l2->h_dest, (__u8 *)local_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the endpoint MAC")
+
+	if (l3->saddr != CLIENT_IP_2)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP_LOCAL)
+		test_fatal("dst IP hasn't been NATed to local backend IP");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst TCP port hasn't been NATed to backend port");
+
+	test_finish();
+}
+
+/* Test that to-netdev respects the routing needed for CLIENT_IP_2,
+ * and redirects the packet to the correct egress interface.
+ */
+PKTGEN("tc", "tc_nodeport_local_backend_redirect_reply")
+int nodeport_local_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)lb_mac, (__u8 *)client_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = BACKEND_IP_LOCAL;
+	l3->daddr = CLIENT_IP_2;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = BACKEND_PORT;
+	l4->dest = CLIENT_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_local_backend_redirect_reply")
+int nodeport_local_backend_redirect_reply_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_local_backend_redirect_reply")
+int nodeport_local_backend_redirect_reply_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the LB MAC")
+	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the client MAC")
+
+	if (l3->saddr != BACKEND_IP_LOCAL)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != CLIENT_IP_2)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != BACKEND_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != CLIENT_PORT)
+		test_fatal("dst port has changed");
+
+	test_finish();
+}
+
 /* Test that a SVC request (UDP) to a local backend
  * - gets DNATed (but not SNATed)
  * - gets redirected by TC (as ENABLE_HOST_ROUTING is set)
@@ -374,12 +640,6 @@ int nodeport_udp_local_backend_setup(struct __ctx_buff *ctx)
 	lb_v4_add_service(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, revnat_id);
 	lb_v4_add_backend(FRONTEND_IP_LOCAL, FRONTEND_PORT, 1, 125,
 			  BACKEND_IP_LOCAL, BACKEND_PORT, IPPROTO_UDP, 0);
-
-	/* add local backend */
-	endpoint_v4_add_entry(BACKEND_IP_LOCAL, 0, 0, 0,
-			      (__u8 *)local_backend_mac, (__u8 *)node_mac);
-
-	ipcache_v4_add_entry(BACKEND_IP_LOCAL, 0, 112233, 0, 0);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);

--- a/bpf/tests/tc_nodeport_lb6_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_backend.c
@@ -17,6 +17,7 @@
 #define ENABLE_HOST_ROUTING
 
 #define DISABLE_LOOPBACK_LB
+#define ENABLE_SKIP_FIB		1
 
 /* Skip ingress policy checks, not needed to validate hairpin flow */
 #define USE_BPF_PROG_FOR_INGRESS_POLICY


### PR DESCRIPTION
When moving the RevDNAT for backend replies from `bpf_lxc` into `bpf_host`, we lost the routing based on the post-RevDNAT layout of the packet. Depending on the installed routing rules, we then end up sending the (RevDNATed) packet from the wrong egress interface.

So as part of the RevDNAT processing in `to-netdev`, do a FIB lookup that considers the desired source IP.  And redirect the packet if it's currently on the wrong interface. We intentionally delay the actual RevDNAT rewrite until the packet has reached the correct interface, so that the packet looks as expected to components in `to-netdev` (in particular HostFW).

Long-term we would want
- a `FIB_DONE` mark on the packet (similar to `SNAT_DONE`),  to skip additional lookups.
- improve the FIB lookup  in `from-container` (for BPF Host Routing) to already consider service RevDNAT.

The initial idea was to have this check at the very top of the to-netdev program (see https://github.com/cilium/cilium/pull/26635). But we're hitting program size limits in 4.19 there, and improving that is too much of a refactor for a fix PR.

Fixes: https://github.com/cilium/cilium/issues/26166