### PR TITLE
.clang-format: Re-write and re-license .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,23 +1,19 @@
-# SPDX-License-Identifier: GPL-2.0
+# Configuration file for clang-format.
+# Intended for clang-format >= 15.
 #
-# clang-format configuration file. Intended for clang-format >= 15.
+# The list and meaning of the options is available at:
 #
-# For more information, see:
-#
-#   Documentation/process/clang-format.rst
-#   https://clang.llvm.org/docs/ClangFormat.html
 #   https://clang.llvm.org/docs/ClangFormatStyleOptions.html
-#
-# Originally obtained from: https://github.com/torvalds/linux/blob/7acc1372113083fa281ba426021801e2402caca1/.clang-format
-# Settings here should be compatible with (current-release-major - 2) of clang-format
 ---
-AccessModifierOffset: -4
+# BasedOnStyle                              # No base style in use
+# AccessModifierOffset                      # We don't use access modifiers
 AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments: false
 AlignConsecutiveBitFields:
   Enabled: true
   AcrossEmptyLines: true
   AcrossComments: true
-AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros:
   Enabled: true
@@ -26,112 +22,159 @@ AlignConsecutiveMacros:
 AlignEscapedNewlines: Left
 AlignOperands: true
 AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+# AllowAllConstructorInitializersOnNextLine # Deprecated
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
-AllowShortIfStatementsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: Never
+# AllowShortLambdasOnASingleLine            # We don't use lambdas
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
+# AlwaysBreakAfterDefinitionReturnType      # Deprecated
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
+# AlwaysBreakTemplateDeclarations           # We don't use templates
+# AttributeMacros                           # Unused at this time
 BinPackArguments: true
 BinPackParameters: true
+BitFieldColonSpacing: None
 BraceWrapping:
-  AfterClass: false
-  AfterControlStatement: false
+  AfterCaseLabel: true
+  # AfterClass                              # We don't use classes
+  AfterControlStatement: Never
   AfterEnum: false
   AfterFunction: true
-  AfterNamespace: true
-  AfterObjCDeclaration: false
+  # AfterNamespace                          # We don't use namespaces
+  # AfterObjCDeclaration                    # We don't use ObjC
   AfterStruct: false
   AfterUnion: false
   AfterExternBlock: false
-  BeforeCatch: false
+  # BeforeCatch                             # We don't use try/catch
   BeforeElse: false
+  # BeforeLambdaBody                        # We don't use lambdas
+  BeforeWhile: false
   IndentBraces: false
   SplitEmptyFunction: true
   SplitEmptyRecord: true
-  SplitEmptyNamespace: true
+  # SplitEmptyNamespace                     # We don't use namespaces
+# BreakAfterJavaFieldAnnotations            # We don't use Java
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
-BreakBeforeInheritanceComma: false
+# BreakBeforeConceptDeclarations            # We don't use concepts
 BreakBeforeTernaryOperators: false
-BreakConstructorInitializersBeforeComma: false
-BreakConstructorInitializers: BeforeComma
-BreakAfterJavaFieldAnnotations: false
+# BreakConstructorInitializers              # We don't use constructors
+# BreakInheritanceList                      # We don't use inheritance
 BreakStringLiterals: false
 ColumnLimit: 80
-CommentPragmas: '^ IWYU pragma:'
-CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-ConstructorInitializerIndentWidth: 8
+# CommentPragmas                            # Unused at this time
+# CompactNamespaces                         # We don't use namespaces
+# ConstructorInitializerAllOnOneLineOrOnePerLine # Deprecated
+# ConstructorInitializerIndentWidth         # We don't use constructors
 ContinuationIndentWidth: 8
 Cpp11BracedListStyle: false
+# DeriveLineEnding                          # Deprecated
 DerivePointerAlignment: false
 DisableFormat: false
-ExperimentalAutoDetectBinPacking: false
-FixNamespaceComments: false
-
+# EmptyLineAfterAccessModifier              # We don't use access modifiers
+# EmptyLineBeforeAccessModifier             # We don't use access modifiers
+# ExperimentalAutoDetectBinPacking          # Experimental, "Use at your own risk"
+# FixNamespaceComments                      # We don't use namespaces
+# ForEachMacros                             # Unused at this time
+# IfMacros                                  # Unused at this time
 IncludeBlocks: Preserve
-IncludeCategories:
-  - Regex: '.*'
-    Priority: 1
-IncludeIsMainRegex: '(Test)?$'
+# IncludeCategories                         # Unused at this time
+# IncludeIsMainRegex                        # Unused at this time
+# IncludeIsMainSourceRegex                  # Unused at this time
+# IndentAccessModifiers                     # We don't use access modifiers
+IndentCaseBlocks: false
 IndentCaseLabels: false
+# IndentExternBlock                         # We don't use extern blocks
 IndentGotoLabels: false
-IndentPPDirectives: None
+IndentPPDirectives: AfterHash
+# IndentRequiresClause                      # We don't use equire clauses
 IndentWidth: 8
 IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
+InsertBraces: false
+# InsertTrailingCommas                      # We don't use JavaScript
+# JavaImportGroups                          # We don't use Java
+# JavaScriptQuotes                          # We don't use JavaScript
+# JavaScriptWrapImports                     # We don't use JavaScript
 KeepEmptyLinesAtTheStartOfBlocks: false
-MacroBlockBegin: ''
-MacroBlockEnd: ''
+# LambdaBodyIndentation                     # We don't use lambdas
+Language: Cpp
+# MacroBlockBegin                           # Unused at this time
+# MacroBlockEnd                             # Unused at this time
 MaxEmptyLinesToKeep: 1
-NamespaceIndentation: None
-ObjCBinPackProtocolList: Auto
-ObjCBlockIndentWidth: 8
-ObjCSpaceAfterProperty: true
-ObjCSpaceBeforeProtocolList: true
+# NamespaceIndentation                      # We don't use namespaces
+# NamespaceMacros                           # We don't use namespaces
+# ObjCBinPackProtocolList                   # We don't use ObjC
+# ObjCBlockIndentWidth                      # We don't use ObjC
+# ObjCBreakBeforeNestedBlockParam           # We don't use ObjC
+# ObjCSpaceAfterProperty                    # We don't use ObjC
+# ObjCSpaceBeforeProtocolList               # We don't use ObjC
+PPIndentWidth: 1
+# PackConstructorInitializers               # We don't use constructors
 
-# Taken from git's rules
-# This decides in what order (weighting) things
-# should be done if a line is too long
-# 100 = try everything else before this.
+# Penalties decide in what order (weighting) things should be done if a line is
+# too long: 100 = try everything else before this.
 # See https://stackoverflow.com/a/46749925
 PenaltyBreakAssignment: 10
 PenaltyBreakBeforeFirstCallParameter: 0
 PenaltyBreakComment: 0
 PenaltyBreakFirstLessLess: 0
-PenaltyBreakString: 10
 PenaltyBreakOpenParenthesis: 100
+PenaltyBreakString: 10
+# PenaltyBreakTemplateDeclaration           # We don't use templates
 PenaltyExcessCharacter: 100
+PenaltyIndentedWhitespace: 100
 PenaltyReturnTypeOnItsOwnLine: 100
 
 PointerAlignment: Right
+QualifierAlignment: Leave
+# QualifierOrder                            # Unused at this time
+# RawStringFormats                          # Unused at this time
+# ReferenceAlignment                        # We don't use references
 ReflowComments: false
-SortIncludes: false
-SortUsingDeclarations: false
+RemoveBracesLLVM: false
+# RequiresClausePosition                    # We don't use require clauses
+SeparateDefinitionBlocks: Leave
+# ShortNamespaceLines                       # We don't use namespaces
+SortIncludes: Never
+# SortJavaStaticImport                      # We don't use Java
+# SortUsingDeclarations                     # We don't use using declarations
 SpaceAfterCStyleCast: false
-SpaceAfterTemplateKeyword: true
+SpaceAfterLogicalNot: false
+# SpaceAfterTemplateKeyword                 # We don't use templates
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCtorInitializerColon: true
-# kernel.org sets this to true,
-# however this also seems to affect labels,
-# which seems like a bug.
-SpaceBeforeInheritanceColon: false
+SpaceBeforeCaseColon: false
+# SpaceBeforeCpp11BracedList                # We don't use C++11 braced lists to initialize objects
+# SpaceBeforeCtorInitializerColon           # We don't use constructors
+# SpaceBeforeInheritanceColon               # We don't use inheritance
 SpaceBeforeParens: ControlStatements
-SpaceBeforeRangeBasedForLoopColon: true
+# SpaceBeforeParensOptions                  # No need for custom SpaceBeforeParens options
+# SpaceBeforeRangeBasedForLoopColon         # We don't use range-based for loops
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
-SpacesInContainerLiterals: false
+# SpacesInAngles                            # We don't use templates
 SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: 1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: Cpp03
+Standard: C++03
+# StatementAttributeLikeMacros              # Unused at this time
+# StatementMacros                           # Unused at this time
 TabWidth: 8
+# TypenameMacros                            # Unused at this time
+# UseCRLF # Deprecated
 UseTab: Always
+# WhitespaceSensitiveMacros                 # Unused at this time
 ...


### PR DESCRIPTION
As part of the effort to harmonise licensing for the different files in the project, rewrite the .clang-format from scratch, and remove the attached GPL v2 license.

I went through all options for clang-format <= 15 currently described on https://clang.llvm.org/docs/ClangFormatStyleOptions.html, set them to the value we desire, and commented out the ones that are not relevant to Cilium's BPF code.

Tweaks for penalties were kept from commit b482af0f2de9 ("Apply initial cilium-specific tweaks").

Obviously, there are some similarities with the previous version, given that it's a config file and that we still want more or less the same config as before.

I didn't use any particular license marker, because I don't see it relevant for a config file; if one is necessary, the file now falls under the license global to the repository (Apache v2.0).

Cc: @bleggett, could you please ACK if you agree with the change?