### PR TITLE
test: print logical instruction count per program

### DIFF
--- a/test/verifier/verifier_test.go
+++ b/test/verifier/verifier_test.go
@@ -188,12 +188,24 @@ func TestVerifier(t *testing.T) {
 				})
 				var ve *ebpf.VerifierError
 				if errors.As(err, &ve) {
+					// Write full verifier log to a path on disk for offline analysis.
 					var buf bytes.Buffer
 					fmt.Fprintf(&buf, "%+v", ve)
 					fullLogFile := name + "_verifier.log"
 					_ = os.WriteFile(fullLogFile, buf.Bytes(), 0444)
 					t.Log("Full verifier log at", fullLogFile)
-					t.Fatalf("Verifier error: %-10v\nDatapath build config: %s", ve, datapathConfig)
+
+					// Print unverified instruction count.
+					t.Log("BPF unverified instruction count per program:")
+					for n, p := range spec.Programs {
+						t.Logf("\t%s: %d insns", n, len(p.Instructions))
+					}
+
+					// Include the original err in the output since it contains the name
+					// of the program that triggered the verifier error.
+					// ebpf.VerifierError only contains the return code and verifier log
+					// buffer.
+					t.Fatalf("Error: %v\nVerifier error tail: %-10v\nDatapath build config: %s", err, ve, datapathConfig)
 				}
 				if err != nil {
 					t.Fatal(err)
@@ -207,7 +219,7 @@ func TestVerifier(t *testing.T) {
 					// Offset points at the last newline, increment by 1 to skip it.
 					// Turn a -1 into a 0 if there are no newlines in the log.
 					lastOff := strings.LastIndex(p.VerifierLog, "\n") + 1
-					t.Logf("%s: %v", n, p.VerifierLog[lastOff:])
+					t.Logf("%s: %v (%d unverified insns)", n, p.VerifierLog[lastOff:], len(spec.Programs[n].Instructions))
 				}
 			})
 


### PR DESCRIPTION
As it says on the tin, echo instruction count for all programs, both if the Collection fails to load, as well as at the end of the last line of the verifier log on a successful load.

Example output of successful load:
```
=== RUN   TestVerifier/bpf_host_1
    verifier_test.go:216: tail_srv6_reply: processed 277 insns (limit 1000000) ... mark_read 8 (201 unverified insns)
...
```

Example output of unsuccessful load:

```
=== RUN   TestVerifier/bpf_lxc_1
    verifier_test.go:201: Full verifier log at bpf_lxc_1_verifier.log
    verifier_test.go:203: BPF unverified instruction count per program:
    verifier_test.go:205: tail_handle_ipv4: 1048 insns
```
