### PR TITLE
[highscale] fqdn/policy: expand service frontends IPs to backend IPs 

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -655,6 +655,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		d.cgroupManager,
 		params.Resources,
 		params.ServiceCache,
+		d.dnsNameManager,
 	)
 	nd.RegisterK8sGetters(d.k8sWatcher)
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -636,6 +636,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		egressGatewayWatcher = d.egressGatewayManager
 	}
 
+	d.newFQDNManager()
+
 	d.k8sWatcher = watchers.NewK8sWatcher(
 		params.Clientset,
 		d.endpointManager,

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -3,6 +3,8 @@
 
 package fqdn
 
+// foo
+
 import (
 	"encoding/json"
 	"net"
@@ -71,15 +73,15 @@ type nameEntries map[string]*cacheEntry
 
 // getIPs returns a sorted list of non-expired unique IPs.
 // This needs a read-lock
-func (s ipEntries) getIPs(now time.Time) []net.IP {
-	ips := make([]net.IP, 0, len(s)) // worst case size
+func (s ipEntries) getIPs(now time.Time) []netip.Addr {
+	ips := make([]netip.Addr, 0, len(s)) // worst case size
 	for ip, entry := range s {
 		if entry != nil && !entry.isExpiredBy(now) {
-			ips = append(ips, ip.Unmap().AsSlice())
+			ips = append(ips, ip)
 		}
 	}
 
-	return ippkg.KeepUniqueIPs(ips) // sorts IPs
+	return ippkg.KeepUniqueAddrs(ips) // sorts IPs
 }
 
 // DNSCache manages DNS data that will expire after a certain TTL. Information
@@ -397,7 +399,7 @@ func (c *DNSCache) ReplaceFromCacheByNames(namesToUpdate []string, updates ...*D
 // Lookup returns a set of unique IPs that are currently unexpired for name, if
 // any exist. An empty list indicates no valid records exist. The IPs are
 // returned sorted.
-func (c *DNSCache) Lookup(name string) (ips []net.IP) {
+func (c *DNSCache) Lookup(name string) (ips []netip.Addr) {
 	c.RLock()
 	defer c.RUnlock()
 
@@ -406,7 +408,7 @@ func (c *DNSCache) Lookup(name string) (ips []net.IP) {
 
 // lookupByTime takes a timestamp for expiration comparisons, and is only
 // intended for testing.
-func (c *DNSCache) lookupByTime(now time.Time, name string) (ips []net.IP) {
+func (c *DNSCache) lookupByTime(now time.Time, name string) (ips []netip.Addr) {
 	entries, found := c.forward[name]
 	if !found {
 		return nil
@@ -417,14 +419,14 @@ func (c *DNSCache) lookupByTime(now time.Time, name string) (ips []net.IP) {
 
 // LookupByRegexp returns all non-expired cache entries that match re as a map
 // of name -> IPs
-func (c *DNSCache) LookupByRegexp(re *regexp.Regexp) (matches map[string][]net.IP) {
+func (c *DNSCache) LookupByRegexp(re *regexp.Regexp) (matches map[string][]netip.Addr) {
 	return c.lookupByRegexpByTime(c.lastCleanup, re)
 }
 
 // lookupByRegexpByTime takes a timestamp for expiration comparisons, and is
 // only intended for testing.
-func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (matches map[string][]net.IP) {
-	matches = make(map[string][]net.IP)
+func (c *DNSCache) lookupByRegexpByTime(now time.Time, re *regexp.Regexp) (matches map[string][]netip.Addr) {
+	matches = make(map[string][]netip.Addr)
 
 	c.RLock()
 	defer c.RUnlock()

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/fqdn/re"
-	ippkg "github.com/cilium/cilium/pkg/ip"
 )
 
 type DNSCacheTestSuite struct{}
@@ -106,7 +105,7 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 		c.Assert(len(ips), Equals, 2, Commentf("Wrong count of IPs returned (%v) for non-deleted name '%s'", ips, name))
 		c.Assert(cache.forward, checker.HasKey, name, Commentf("Expired name '%s' not deleted from forward", name))
 		for _, ip := range ips {
-			c.Assert(cache.reverse, checker.HasKey, ippkg.MustAddrFromIP(ip), Commentf("Expired IP '%s' not deleted from reverse", ip))
+			c.Assert(cache.reverse, checker.HasKey, ip, Commentf("Expired IP '%s' not deleted from reverse", ip))
 		}
 	}
 
@@ -129,7 +128,7 @@ func (ds *DNSCacheTestSuite) TestDelete(c *C) {
 		c.Assert(len(ips), Equals, 2, Commentf("Wrong count of IPs returned (%v) for non-deleted name '%s'", ips, name))
 		c.Assert(cache.forward, checker.HasKey, name, Commentf("Expired name '%s' not deleted from forward", name))
 		for _, ip := range ips {
-			c.Assert(cache.reverse, checker.HasKey, ippkg.MustAddrFromIP(ip), Commentf("Expired IP '%s' not deleted from reverse", ip))
+			c.Assert(cache.reverse, checker.HasKey, ip, Commentf("Expired IP '%s' not deleted from reverse", ip))
 		}
 	}
 

--- a/pkg/fqdn/helpers.go
+++ b/pkg/fqdn/helpers.go
@@ -5,6 +5,7 @@ package fqdn
 
 import (
 	"net"
+	"net/netip"
 	"regexp"
 
 	"github.com/sirupsen/logrus"
@@ -30,7 +31,7 @@ func (n *NameManager) MapSelectorsToIPsLocked(fqdnSelectors map[api.FQDNSelector
 
 	// Map each FQDNSelector to set of CIDRs
 	for ToFQDN := range fqdnSelectors {
-		ipsSelected := make([]net.IP, 0)
+		ipsSelected := make([]netip.Addr, 0)
 		// lookup matching DNS names
 		if len(ToFQDN.MatchName) > 0 {
 			dnsName := prepareMatchName(ToFQDN.MatchName)
@@ -82,9 +83,9 @@ func (n *NameManager) MapSelectorsToIPsLocked(fqdnSelectors map[api.FQDNSelector
 			}
 		}
 
-		ips := ip.KeepUniqueIPs(ipsSelected)
+		ips := ip.KeepUniqueAddrs(ipsSelected)
 		if len(ips) > 0 {
-			selectorIPMapping[ToFQDN] = ips
+			selectorIPMapping[ToFQDN] = ip.IPsFromAddrs(ips)
 		}
 	}
 

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -255,5 +255,5 @@ func (n *NameManager) updateIPsForName(lookupTime time.Time, dnsName string, new
 	// The 0 checks below account for an unlike race condition where this
 	// function is called with already expired data and if other cache data
 	// from before also expired.
-	return (len(cacheIPs) == 0 && len(sortedNewIPs) == 0) || !ip.SortedIPListsAreEqual(sortedNewIPs, cacheIPs)
+	return (len(cacheIPs) == 0 && len(sortedNewIPs) == 0) || !ip.SortedAddrListsAreEqual(sortedNewIPs, cacheIPs)
 }

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -137,6 +137,15 @@ func (e *Endpoints) Prefixes() []netip.Prefix {
 	return prefixes
 }
 
+// Addrs returns the endpoint's backends as a slice of netip.Addr
+func (e *Endpoints) Addrs() []netip.Addr {
+	addrs := make([]netip.Addr, 0, len(e.Backends))
+	for addrCluster := range e.Backends {
+		addrs = append(addrs, addrCluster.Addr())
+	}
+	return addrs
+}
+
 // ParseEndpointsID parses a Kubernetes endpoints and returns the EndpointSliceID
 func ParseEndpointsID(ep *slim_corev1.Endpoints) EndpointSliceID {
 	return EndpointSliceID{

--- a/pkg/k8s/utils/utils.go
+++ b/pkg/k8s/utils/utils.go
@@ -84,6 +84,10 @@ type PolicyConfiguration interface {
 	K8sNetworkPolicyEnabled() bool
 }
 
+type HighScaleConfiguration interface {
+	HighScaleIPcacheEnabled() bool
+}
+
 // GetEndpointSliceListOptionsModifier returns the options modifier for endpointSlice object list.
 // This methods returns a ListOptions modifier which adds a label selector to
 // select all endpointSlice objects that do not contain the k8s headless service label.

--- a/pkg/k8s/watchers/watcher_test.go
+++ b/pkg/k8s/watchers/watcher_test.go
@@ -54,6 +54,10 @@ func (f *fakeWatcherConfiguration) K8sNetworkPolicyEnabled() bool {
 	return true
 }
 
+func (f *fakeWatcherConfiguration) HighScaleIPcacheEnabled() bool {
+	return false
+}
+
 type fakePolicyManager struct {
 	OnTriggerPolicyUpdates func(force bool, reason string)
 	OnPolicyAdd            func(rules api.Rules, opts *policy.AddOptions) (newRev uint64, err error)
@@ -206,6 +210,7 @@ func (s *K8sWatcherSuite) TestUpdateToServiceEndpointsGH9525(c *C) {
 		nil,
 		emptyResources,
 		k8s.NewServiceCache(dp.LocalNodeAddressing()),
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -531,6 +536,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ClusterIP(c *C) {
 		nil,
 		emptyResources,
 		k8s.NewServiceCache(dp.LocalNodeAddressing()),
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -685,6 +691,7 @@ func (s *K8sWatcherSuite) TestChangeSVCPort(c *C) {
 		nil,
 		emptyResources,
 		k8s.NewServiceCache(dp.LocalNodeAddressing()),
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1168,6 +1175,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_NodePort(c *C) {
 		nil,
 		emptyResources,
 		k8s.NewServiceCache(dp.LocalNodeAddressing()),
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1485,6 +1493,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_1(c *C) {
 		nil,
 		emptyResources,
 		k8s.NewServiceCache(dp.LocalNodeAddressing()),
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -1795,6 +1804,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_GH9576_2(c *C) {
 		nil,
 		emptyResources,
 		k8s.NewServiceCache(dp.LocalNodeAddressing()),
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()
@@ -2719,6 +2729,7 @@ func (s *K8sWatcherSuite) Test_addK8sSVCs_ExternalIPs(c *C) {
 		nil,
 		emptyResources,
 		k8s.NewServiceCache(dp.LocalNodeAddressing()),
+		nil,
 	)
 	go w.k8sServiceHandler()
 	swg := lock.NewStoppableWaitGroup()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2733,6 +2733,10 @@ func (c *DaemonConfig) K8sGatewayAPIEnabled() bool {
 	return c.EnableGatewayAPI
 }
 
+func (c *DaemonConfig) HighScaleIPcacheEnabled() bool {
+	return c.EnableHighScaleIPcache
+}
+
 // DirectRoutingDeviceRequired return whether the Direct Routing Device is needed under
 // the current configuration.
 func (c *DaemonConfig) DirectRoutingDeviceRequired() bool {

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -51,6 +51,9 @@ func (m *MockIPCache) DeleteOnMetadataMatch(IP string, source source.Source, nam
 	return false
 }
 
+func (m *MockIPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[netip.Prefix]*identity.Identity, usedIdentities []*identity.Identity) {
+}
+
 func NewMockIPCache() *MockIPCache {
 	return &MockIPCache{}
 }


### PR DESCRIPTION
For more details, see the individual commit messages.

As part of enabling egress policy for high-scale cache, we would like to enable toFQDN policy to reference kubernetes service IPs. However, this presently does not work because policy enforcement always sees the "real" destination IP, not the virtual / service IP.

So, we need to configure the policy engine to expand frontend IPs to their backend IPs without changing the DNS response. Additionally, we need to recompute FQDN policy whenever a service's backend IPs have changed.

```release-note
TODO
```
