### PR TITLE
Add 5 second timeout to Auth dialer

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -253,6 +253,7 @@ cilium-agent [flags]
       --log-system-load                                           Enable periodic logging of system load
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (default true)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)
+      --mesh-auth-mutual-connect-timeout duration                 Timeout for connecting to the remote node TCP socket (default 5s)
       --mesh-auth-mutual-listener-port int                        Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                                  Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int               The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -38,6 +38,7 @@ cilium-agent hive [flags]
       --l2-pod-announcements-interface string                     Interface used for sending gratuitous arp messages
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (default true)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)
+      --mesh-auth-mutual-connect-timeout duration                 Timeout for connecting to the remote node TCP socket (default 5s)
       --mesh-auth-mutual-listener-port int                        Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                                  Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int               The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -43,6 +43,7 @@ cilium-agent hive dot-graph [flags]
       --l2-pod-announcements-interface string                     Interface used for sending gratuitous arp messages
       --mesh-auth-enabled                                         Enable authentication processing & garbage collection (default true)
       --mesh-auth-gc-interval duration                            Interval in which auth entries are attempted to be garbage collected (default 5m0s)
+      --mesh-auth-mutual-connect-timeout duration                 Timeout for connecting to the remote node TCP socket (default 5s)
       --mesh-auth-mutual-listener-port int                        Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents
       --mesh-auth-queue-size int                                  Queue size for the auth manager (default 1024)
       --mesh-auth-rotated-identities-queue-size int               The size of the queue for signaling rotated identities. (default 1024)

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -48,6 +48,10 @@
      - Interval for garbage collection of auth map entries.
      - string
      - ``"5m0s"``
+   * - :spelling:ignore:`authentication.mutual.connectTimeout`
+     - Timeout for connecting to the remote node TCP socket
+     - string
+     - ``"5s"``
    * - :spelling:ignore:`authentication.mutual.port`
      - Port on the agent where mutual authentication handshakes between agents will be performed
      - int

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -62,6 +62,7 @@ contributors across the globe, there is almost always someone available to help.
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
 | authentication.enabled | bool | `true` | Enable authentication processing and garbage collection. Note that if disabled, policy enforcement will still block requests that require authentication. But the resulting authentication requests for these requests will not be processed, therefore the requests not be allowed. |
 | authentication.gcInterval | string | `"5m0s"` | Interval for garbage collection of auth map entries. |
+| authentication.mutual.connectTimeout | string | `"5s"` | Timeout for connecting to the remote node TCP socket |
 | authentication.mutual.port | int | `4250` | Port on the agent where mutual authentication handshakes between agents will be performed |
 | authentication.mutual.spire.adminSocketPath | string | `"/run/spire/sockets/admin.sock"` | SPIRE socket path where the SPIRE delegated api agent is listening |
 | authentication.mutual.spire.agentSocketPath | string | `"/run/spire/sockets/agent/agent.sock"` | SPIRE socket path where the SPIRE workload agent is listening. Applies to both the Cilium Agent and Operator |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1140,6 +1140,7 @@ data:
   mesh-auth-mutual-enabled: "true"
   mesh-auth-mutual-listener-port: {{ .Values.authentication.mutual.port | quote }}
   mesh-auth-spire-agent-socket: {{ .Values.authentication.mutual.spire.agentSocketPath | quote }}
+  mesh-auth-mutual-connect-timeout: {{ include "validateDuration" .Values.authentication.mutual.connectTimeout | quote }}
   {{- if .Values.authentication.mutual.spire.serverAddress }}
   mesh-auth-spire-server-address: {{ .Values.authentication.mutual.spire.serverAddress | quote }}
   {{- else }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3117,6 +3117,8 @@ authentication:
   mutual:
     # -- Port on the agent where mutual authentication handshakes between agents will be performed
     port: 4250
+    # -- Timeout for connecting to the remote node TCP socket
+    connectTimeout: 5s
     # Settings for SPIRE
     spire:
       # -- Enable SPIRE integration

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3114,6 +3114,8 @@ authentication:
   mutual:
     # -- Port on the agent where mutual authentication handshakes between agents will be performed
     port: 4250
+    # -- Timeout for connecting to the remote node TCP socket
+    connectTimeout: 5s
     # Settings for SPIRE
     spire:
       # -- Enable SPIRE integration

--- a/pkg/auth/mutual_authhandler.go
+++ b/pkg/auth/mutual_authhandler.go
@@ -53,12 +53,15 @@ func newMutualAuthHandler(logger logrus.FieldLogger, lc hive.Lifecycle, cfg Mutu
 }
 
 type MutualAuthConfig struct {
-	MutualAuthListenerPort int `mapstructure:"mesh-auth-mutual-listener-port"`
+	MutualAuthListenerPort   int           `mapstructure:"mesh-auth-mutual-listener-port"`
+	MutualAuthConnectTimeout time.Duration `mapstructure:"mesh-auth-mutual-connect-timeout"`
 }
 
 func (cfg MutualAuthConfig) Flags(flags *pflag.FlagSet) {
 	flags.IntVar(&cfg.MutualAuthListenerPort, "mesh-auth-mutual-listener-port", 0,
 		"Port on which the Cilium Agent will perform mutual authentication handshakes between other Agents")
+	flags.DurationVar(&cfg.MutualAuthConnectTimeout, "mesh-auth-mutual-connect-timeout", 5*time.Second,
+		"Timeout for connecting to the remote node TCP socket")
 }
 
 type mutualAuthHandler struct {
@@ -87,7 +90,9 @@ func (m *mutualAuthHandler) authenticate(ar *authRequest) (*authResponse, error)
 	}
 
 	// set up TCP connection
-	conn, err := net.Dial("tcp", net.JoinHostPort(ar.remoteNodeIP, strconv.Itoa(m.cfg.MutualAuthListenerPort)))
+	conn, err := net.DialTimeout("tcp",
+		net.JoinHostPort(ar.remoteNodeIP, strconv.Itoa(m.cfg.MutualAuthListenerPort)),
+		m.cfg.MutualAuthConnectTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to dial %s:%d: %w", ar.remoteNodeIP, m.cfg.MutualAuthListenerPort, err)
 	}


### PR DESCRIPTION
The TCP level dialer had no timeout before. This could cause some issues. This change adds a configurable timeout of default 5 seconds to the TCP dailer.

```release-note
Add a 5 second timeout to the Mutual Auth TCP handshake
```
