### PR TITLE
multi-pool: Document unsupported kvstore mode

### DIFF
--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -159,3 +159,4 @@ Multi-Pool IPAM mode:
      ``ip-masq-agent`` feature.
    - Announcing PodCIDRs by way of the built-in :ref:`bgp` mode is not yet
      supported.  Use ``auto-direct-node-routes`` instead.
+   - KVstore-based identity allocation mode is currently not supported (:gh-issue:`26621`)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1481,6 +1481,9 @@ func initEnv() {
 		if option.Config.EnableIPSec {
 			log.Fatalf("Cannot specify IPAM mode %s with %s.", option.Config.IPAM, option.EnableIPSecName)
 		}
+		if option.Config.IdentityAllocationMode != option.IdentityAllocationModeCRD {
+			log.Fatalf("IPAM mode %s does not support %s=%s", option.Config.IPAM, option.IdentityAllocationMode, option.Config.IdentityAllocationMode)
+		}
 	}
 
 	if option.Config.InstallNoConntrackIptRules {


### PR DESCRIPTION
This commit adds a check and documentation that kvstore-based identity allocation mode is currently not supported. This is due to #26621. We intend to fix that in Cilium v1.15.