### PR TITLE
datapath/linux/probes: remove unused Have{Map,Program}Type wrappers

### DIFF
--- a/pkg/datapath/linux/probes/probes.go
+++ b/pkg/datapath/linux/probes/probes.go
@@ -339,34 +339,6 @@ func (p *ProbeManager) KernelConfigAvailable() bool {
 	return true
 }
 
-// HaveMapType is a wrapper around features.HaveMapType() to check if a certain
-// BPF map type is supported by the kernel.
-// On unexpected probe results this function will terminate with log.Fatal().
-func HaveMapType(mt ebpf.MapType) error {
-	err := features.HaveMapType(mt)
-	if errors.Is(err, ebpf.ErrNotSupported) {
-		return err
-	}
-	if err != nil {
-		log.WithError(err).WithField("maptype", mt).Fatal("failed to probe MapType")
-	}
-	return nil
-}
-
-// HaveProgramType is a wrapper around features.HaveProgramType() to check
-// if a certain BPF program type is supported by the kernel.
-// On unexpected probe results this function will terminate with log.Fatal().
-func HaveProgramType(pt ebpf.ProgramType) error {
-	err := features.HaveProgramType(pt)
-	if errors.Is(err, ebpf.ErrNotSupported) {
-		return err
-	}
-	if err != nil {
-		log.WithError(err).WithField("programtype", pt).Fatal("failed to probe ProgramType")
-	}
-	return nil
-}
-
 // HaveProgramHelper is a wrapper around features.HaveProgramHelper() to
 // check if a certain BPF program/helper copmbination is supported by the kernel.
 // On unexpected probe results this function will terminate with log.Fatal().


### PR DESCRIPTION
These are unused  since commit 87c8746e254d ("Remove sockops-enable and friends"). If needed again, the respective functionality from github.com/cilium/ebpf/features can be used directly.
