### PR TITLE
bugtool: Added map dump for L2 responder map to bugtool

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -190,6 +190,7 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_snat_v4_external", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_snat_v6_external", bpffsMountpoint),
 			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_vtep_map", bpffsMountpoint),
+			fmt.Sprintf("bpftool map dump pinned %s/tc/globals/cilium_l2_responder_v4", bpffsMountpoint),
 		}...)
 	}
 


### PR DESCRIPTION
Currently sysdumps do not contain the L2 responder map dumps. This commit adds these so that we can debug issues with the L2 announcements if they come up in the future.

```release-note
Add L2 responder map dumping to sysdump
```
