### PR TITLE
Update docs for Kubernetes 1.27 

### DIFF
--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -369,9 +369,6 @@ contain any characters after it.
 
 The Kubernetes tests support the following Kubernetes versions:
 
-* 1.16
-* 1.17
-* 1.18
 * 1.19
 * 1.20
 * 1.21

--- a/Documentation/network/kubernetes/compatibility.rst
+++ b/Documentation/network/kubernetes/compatibility.rst
@@ -17,12 +17,12 @@ with Cilium. Older Kubernetes versions not listed in this table do not have
 Cilium support. Newer Kubernetes versions, while not listed, will depend on the
 backward compatibility offered by Kubernetes.
 
-+------------------------------------------------+---------------------------+----------------------------------+
-| k8s Version                                    | k8s NetworkPolicy API     | CiliumNetworkPolicy              |
-+------------------------------------------------+---------------------------+----------------------------------+
-|                                                |                           | ``cilium.io/v2`` has a           |
-| 1.19, 1.20, 1.21, 1.22, 1.23, 1.24, 1.25, 1.26 | * `networking.k8s.io/v1`_ | :term:`CustomResourceDefinition` |
-+------------------------------------------------+---------------------------+----------------------------------+
++------------------------------------------------------+---------------------------+----------------------------------+
+| k8s Version                                          | k8s NetworkPolicy API     | CiliumNetworkPolicy              |
++------------------------------------------------------+---------------------------+----------------------------------+
+|                                                      |                           | ``cilium.io/v2`` has a           |
+| 1.19, 1.20, 1.21, 1.22, 1.23, 1.24, 1.25, 1.26, 1.27 | * `networking.k8s.io/v1`_ | :term:`CustomResourceDefinition` |
++------------------------------------------------------+---------------------------+----------------------------------+
 
 Cilium CRD schema validation
 ============================


### PR DESCRIPTION
- docs: Update Kubernetes compatibility section with K8s 1.27
- docs: Remove old unsupported Kubernetes versions in testing section
