### PR TITLE
bpf: snat: DSR-eligible traffic can skip check for Nodeport NAT conflict

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -190,6 +190,20 @@ struct {
 #define cilium_dbg_lb(a, b, c, d)
 #endif
 
+static __always_inline bool lb_is_svc_proto(__u8 proto)
+{
+	switch (proto) {
+	case IPPROTO_TCP:
+	case IPPROTO_UDP:
+#ifdef ENABLE_SCTP
+	case IPPROTO_SCTP:
+#endif /* ENABLE_SCTP */
+		return true;
+	default:
+		return false;
+	}
+}
+
 static __always_inline
 bool lb4_svc_is_loadbalancer(const struct lb4_service *svc __maybe_unused)
 {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -150,6 +150,7 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 	l4_off = ETH_HLEN + hdrlen;
 
 	if (lb_is_svc_proto(tuple.nexthdr) &&
+	    !nodeport_uses_dsr6(&tuple) &&
 	    nodeport_has_nat_conflict_ipv6(ip6, &target))
 		goto apply_snat;
 
@@ -1529,6 +1530,7 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 
 	if (lb_is_svc_proto(tuple.nexthdr) &&
+	    !nodeport_uses_dsr4(&tuple) &&
 	    nodeport_has_nat_conflict_ipv4(ip4, &target))
 		goto apply_snat;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -149,7 +149,8 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 	snat_v6_init_tuple(ip6, NAT_DIR_EGRESS, &tuple);
 	l4_off = ETH_HLEN + hdrlen;
 
-	if (nodeport_has_nat_conflict_ipv6(ip6, &target))
+	if (lb_is_svc_proto(tuple.nexthdr) &&
+	    nodeport_has_nat_conflict_ipv6(ip6, &target))
 		goto apply_snat;
 
 	ret = snat_v6_needs_masquerade(ctx, ip6, &target);
@@ -1527,7 +1528,8 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &tuple);
 	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 
-	if (nodeport_has_nat_conflict_ipv4(ip4, &target))
+	if (lb_is_svc_proto(tuple.nexthdr) &&
+	    nodeport_has_nat_conflict_ipv4(ip4, &target))
 		goto apply_snat;
 
 	ret = snat_v4_needs_masquerade(ctx, ip4, &target);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -133,12 +133,21 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 	};
+	struct ipv6_ct_tuple tuple = {};
+	int hdrlen, l4_off, ret;
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
-	int ret;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
+
+	tuple.nexthdr = ip6->nexthdr;
+	hdrlen = ipv6_hdrlen(ctx, &tuple.nexthdr);
+	if (hdrlen < 0)
+		return hdrlen;
+
+	snat_v6_init_tuple(ip6, NAT_DIR_EGRESS, &tuple);
+	l4_off = ETH_HLEN + hdrlen;
 
 	if (nodeport_has_nat_conflict_ipv6(ip6, &target))
 		goto apply_snat;
@@ -148,7 +157,7 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 		goto out;
 
 apply_snat:
-	ret = snat_v6_nat(ctx, &target, ext_err);
+	ret = snat_v6_nat(ctx, &tuple, l4_off, &target, ext_err);
 
 out:
 	if (ret == NAT_PUNT_TO_STACK)
@@ -1507,12 +1516,16 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 		.cluster_id = cluster_id,
 #endif
 	};
+	struct ipv4_ct_tuple tuple = {};
 	void *data, *data_end;
 	struct iphdr *ip4;
-	int ret;
+	int l4_off, ret;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
+
+	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &tuple);
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
 
 	if (nodeport_has_nat_conflict_ipv4(ip4, &target))
 		goto apply_snat;
@@ -1522,7 +1535,8 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 		goto out;
 
 apply_snat:
-	ret = snat_v4_nat(ctx, &target, ext_err);
+	ret = snat_v4_nat(ctx, &tuple, l4_off, ipv4_has_l4_header(ip4),
+			  &target, ext_err);
 
 out:
 	if (ret == NAT_PUNT_TO_STACK)

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -97,6 +97,35 @@ static __always_inline bool nodeport_uses_dsr6(const struct ipv6_ct_tuple *tuple
 	return nodeport_uses_dsr(tuple->nexthdr);
 }
 
+static __always_inline bool
+nodeport_has_nat_conflict_ipv6(const struct ipv6hdr *ip6 __maybe_unused,
+			       struct ipv6_nat_target *target __maybe_unused)
+{
+#if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
+	union v6addr router_ip;
+
+	BPF_V6(router_ip, ROUTER_IP);
+	if (ipv6_addr_equals((union v6addr *)&ip6->saddr, &router_ip)) {
+		ipv6_addr_copy(&target->addr, &router_ip);
+		return true;
+	}
+#endif /* TUNNEL_MODE && IS_BPF_OVERLAY */
+
+#if defined(IS_BPF_HOST)
+	const union v6addr dr_addr = IPV6_DIRECT_ROUTING;
+	__u32 dr_ifindex = DIRECT_ROUTING_DEV_IFINDEX;
+
+	/* See comment in nodeport_has_nat_conflict_ipv4(). */
+	if (dr_ifindex == NATIVE_DEV_IFINDEX &&
+	    ipv6_addr_equals((union v6addr *)&ip6->saddr, &dr_addr)) {
+		ipv6_addr_copy(&target->addr, &dr_addr);
+		return true;
+	}
+#endif /* IS_BPF_HOST */
+
+	return false;
+}
+
 static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 						  __s8 *ext_err)
 {
@@ -104,11 +133,24 @@ static __always_inline int nodeport_snat_fwd_ipv6(struct __ctx_buff *ctx,
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 	};
+	void *data, *data_end;
+	struct ipv6hdr *ip6;
 	int ret;
 
-	ret = snat_v6_prepare_state(ctx, &target);
-	if (ret == NAT_NEEDED)
-		ret = snat_v6_nat(ctx, &target, ext_err);
+	if (!revalidate_data(ctx, &data, &data_end, &ip6))
+		return DROP_INVALID;
+
+	if (nodeport_has_nat_conflict_ipv6(ip6, &target))
+		goto apply_snat;
+
+	ret = snat_v6_needs_masquerade(ctx, ip6, &target);
+	if (IS_ERR(ret))
+		goto out;
+
+apply_snat:
+	ret = snat_v6_nat(ctx, &target, ext_err);
+
+out:
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
 
@@ -1424,6 +1466,34 @@ static __always_inline bool nodeport_uses_dsr4(const struct ipv4_ct_tuple *tuple
 	return nodeport_uses_dsr(tuple->nexthdr);
 }
 
+static __always_inline bool
+nodeport_has_nat_conflict_ipv4(const struct iphdr *ip4 __maybe_unused,
+			       struct ipv4_nat_target *target __maybe_unused)
+{
+#if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
+	if (ip4->saddr == IPV4_GATEWAY) {
+		target->addr = IPV4_GATEWAY;
+		return true;
+	}
+#endif /* TUNNEL_MODE && IS_BPF_OVERLAY */
+
+#if defined(IS_BPF_HOST)
+	__u32 dr_ifindex = DIRECT_ROUTING_DEV_IFINDEX;
+
+	/* NATIVE_DEV_IFINDEX == DIRECT_ROUTING_DEV_IFINDEX cannot be moved into
+	 * preprocessor, as the former is known only during load time (templating).
+	 * This checks whether bpf_host is running on the direct routing device.
+	 */
+	if (dr_ifindex == NATIVE_DEV_IFINDEX &&
+	    ip4->saddr == IPV4_DIRECT_ROUTING) {
+		target->addr = IPV4_DIRECT_ROUTING;
+		return true;
+	}
+#endif /* IS_BPF_HOST */
+
+	return false;
+}
+
 static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 						  __u32 cluster_id __maybe_unused,
 						  __s8 *ext_err)
@@ -1437,11 +1507,24 @@ static __always_inline int nodeport_snat_fwd_ipv4(struct __ctx_buff *ctx,
 		.cluster_id = cluster_id,
 #endif
 	};
+	void *data, *data_end;
+	struct iphdr *ip4;
 	int ret;
 
-	ret = snat_v4_prepare_state(ctx, &target);
-	if (ret == NAT_NEEDED)
-		ret = snat_v4_nat(ctx, &target, ext_err);
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	if (nodeport_has_nat_conflict_ipv4(ip4, &target))
+		goto apply_snat;
+
+	ret = snat_v4_needs_masquerade(ctx, ip4, &target);
+	if (IS_ERR(ret))
+		goto out;
+
+apply_snat:
+	ret = snat_v4_nat(ctx, &target, ext_err);
+
+out:
 	if (ret == NAT_PUNT_TO_STACK)
 		ret = CTX_ACT_OK;
 

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -572,19 +572,24 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 				  NULL);
 	assert(ret == 0);
 
+	struct ipv4_ct_tuple icmp_tuple = {};
+	void *data, *data_end;
+	struct iphdr *ip4;
+	int l4_off;
+
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &icmp_tuple);
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
+			  &target, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
-	void *data;
-	void *data_end;
-
 	int l3_off;
-	int l4_off;
-	struct iphdr *ip4;
 	struct icmphdr icmphdr __align_stack_8;
 
 	assert(validate_ethertype(ctx, &proto));
@@ -682,19 +687,24 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 				  NULL);
 	assert(ret == 0);
 
+	struct ipv4_ct_tuple icmp_tuple = {};
+	void *data, *data_end;
+	struct iphdr *ip4;
+	int l4_off;
+
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &icmp_tuple);
+
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
+			  &target, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
-	void *data;
-	void *data_end;
-
 	int l3_off;
-	int l4_off;
-	struct iphdr *ip4;
 	struct icmphdr icmphdr __align_stack_8;
 
 	assert(validate_ethertype(ctx, &proto));
@@ -791,19 +801,24 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 				  NULL);
 	assert(ret == 0);
 
+	struct ipv4_ct_tuple icmp_tuple = {};
+	void *data, *data_end;
+	struct iphdr *ip4;
+	int l4_off;
+
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &icmp_tuple);
+
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
+			  &target, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
-	void *data;
-	void *data_end;
-
 	int l3_off;
-	int l4_off;
-	struct iphdr *ip4;
 	struct icmphdr icmphdr __align_stack_8;
 
 	assert(validate_ethertype(ctx, &proto));
@@ -889,19 +904,24 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 				  NULL);
 	assert(ret == 0);
 
+	struct ipv4_ct_tuple icmp_tuple = {};
+	void *data, *data_end;
+	struct iphdr *ip4;
+	int l4_off;
+
+	assert(revalidate_data(ctx, &data, &data_end, &ip4));
+	l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+	snat_v4_init_tuple(ip4, NAT_DIR_EGRESS, &icmp_tuple);
+
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
+			  &target, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
-	void *data;
-	void *data_end;
-
 	int l3_off;
-	int l4_off;
-	struct iphdr *ip4;
 	struct icmphdr icmphdr __align_stack_8;
 
 	assert(validate_ethertype(ctx, &proto));


### PR DESCRIPTION
Right now the SNAT logic in `to-overlay` / `to-netdev` tracks all (host-originating) connections that potentially conflict with NAT connections by the N/S LB to remote backends (ie. `tail_nodeport_nat_egress_ipv4()`).

If the LB uses DSR for the packet's L4 protocol type, there's no risk of conflicting with a NATed LB connection. So we don't need to track such a connection.