### PR TITLE
docs: Add debugging guide for inspecting gops / pprof profiles

### DIFF
--- a/Documentation/operations/troubleshooting.rst
+++ b/Documentation/operations/troubleshooting.rst
@@ -792,6 +792,8 @@ Reporting a problem
 Before you report a problem, make sure to retrieve the necessary information
 from your cluster before the failure state is lost.
 
+.. _sysdump:
+
 Automatic log & state collection
 --------------------------------
 


### PR DESCRIPTION
Document what is already known in the community for debugging CPU
bottlenecks and memory leaks within Cilium.

Fixes: https://github.com/cilium/cilium/issues/23004
Signed-off-by: Chris Tarazi <chris@isovalent.com>
