### PR TITLE
.github: Remove remaining references to v1.11

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -29,16 +29,6 @@ move-to-projects-for-labels-xored:
     backport-done/1.12:
       project: "https://github.com/cilium/cilium/projects/243"
       column: "Backport done to v1.12"
-  v1.11:
-    needs-backport/1.11:
-      project: "https://github.com/cilium/cilium/projects/242"
-      column: "Needs backport from main"
-    backport-pending/1.11:
-      project: "https://github.com/cilium/cilium/projects/242"
-      column: "Backport pending to v1.11"
-    backport-done/1.11:
-      project: "https://github.com/cilium/cilium/projects/242"
-      column: "Backport done to v1.11"
 require-msgs-in-commit:
   - msg: "Signed-off-by"
     helper: "https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -47,8 +47,7 @@
     "main",
     "v1.14",
     "v1.13",
-    "v1.12",
-    "v1.11"
+    "v1.12"
   ],
   "vulnerabilityAlerts": {
     "enabled": true
@@ -116,8 +115,7 @@
       matchBaseBranches: [
         "v1.14",
         "v1.13",
-        "v1.12",
-        "v1.11"
+        "v1.12"
       ]
     },
     {
@@ -203,8 +201,7 @@
       ],
       "allowedVersions": "20.04",
       "matchBaseBranches": [
-        "v1.12",
-        "v1.11"
+        "v1.12"
       ]
     },
     {
@@ -250,16 +247,6 @@
     },
     {
       "matchPackageNames": [
-        "docker.io/library/golang",
-        "go"
-      ],
-      "allowedVersions": "<1.20",
-      "matchBaseBranches": [
-        "v1.11"
-      ]
-    },
-    {
-      "matchPackageNames": [
         "docker.io/library/alpine"
       ],
       "allowedVersions": "<3.19",
@@ -282,8 +269,7 @@
       ],
       "allowedVersions": "<3.17",
       "matchBaseBranches": [
-        "v1.12",
-        "v1.11"
+        "v1.12"
       ]
     },
     {
@@ -352,8 +338,7 @@
       "matchBaseBranches": [
         "v1.14",
         "v1.13",
-        "v1.12",
-        "v1.11"
+        "v1.12"
       ]
     }
   ],

--- a/.github/workflows/ci-images-garbage-collect.yaml
+++ b/.github/workflows/ci-images-garbage-collect.yaml
@@ -19,6 +19,6 @@ jobs:
       - uses: docker://quay.io/cilium/scruffy:v0.0.3@sha256:ca997451b739cbf03c204cb2523a671c31c61edc606aa5d20dc3560bc7f25bc7
         with:
           entrypoint: scruffy
-          args: --git-repository=./ --stable-branches=origin/main,origin/v1.9,origin/v1.10,origin/v1.11,origin/v1.12,origin/v1.13,origin/v1.14
+          args: --git-repository=./ --stable-branches=origin/main,origin/v1.12,origin/v1.13,origin/v1.14
         env:
           QUAY_TOKEN: ${{ secrets.SCRUFFY_QUAY_TOKEN }}

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -21,10 +21,8 @@ jobs:
           {name: kvstoremesh, dockerfile: ./images/kvstoremesh/Dockerfile},
           {name: operator-generic, dockerfile: ./images/operator/Dockerfile},
         ]
-        branch: [v1.11, v1.12, v1.13, v1.14]
+        branch: [v1.12, v1.13, v1.14]
         exclude:
-          - image: {name: kvstoremesh, dockerfile: ./images/kvstoremesh/Dockerfile}
-            branch: v1.11
           - image: {name: kvstoremesh, dockerfile: ./images/kvstoremesh/Dockerfile}
             branch: v1.12
           - image: {name: kvstoremesh, dockerfile: ./images/kvstoremesh/Dockerfile}

--- a/Documentation/contributing/testing/ci.rst
+++ b/Documentation/contributing/testing/ci.rst
@@ -58,8 +58,6 @@ them all at once:
 +------------------+--------------------------+
 | v1.12            | /test-backport-1.12      |
 +------------------+--------------------------+
-| v1.11            | /test-backport-1.11      |
-+------------------+--------------------------+
 
 Pull requests submitted against older stable branches such as v1.13 may also be
 subject to Jenkins CI jobs. For more information, see


### PR DESCRIPTION
This should be applied to the main branch only once v1.14.0 final is released.