### PR TITLE
docs: Fix unintentional boolean value in YAML

### DIFF
--- a/examples/policies/l3/service/service-labels.yaml
+++ b/examples/policies/l3/service/service-labels.yaml
@@ -11,4 +11,4 @@ spec:
     - k8sServiceSelector:
         selector:
           matchLabels:
-            external: yes
+            external: "yes"


### PR DESCRIPTION
This used an unquoted "yes", which becomes boolean in YAML, it should be a string as it's a label value.

Fixes: 959fb0d74c4

Fixes warning from make:

```
/src/examples/policies/l3/service/service-labels.yaml
  14:23     warning  truthy value should be one of [false, true]  (truthy)
```
