### PR TITLE
docs: optimize ingress default tls secret documentation

### DIFF
--- a/Documentation/network/servicemesh/tls-default-certificate.rst
+++ b/Documentation/network/servicemesh/tls-default-certificate.rst
@@ -49,5 +49,7 @@ Installation
         .. code-block:: shell-session
 
             $ cilium install \
+                --set kubeProxyReplacement=true \
+                --set ingressController.enabled=true \
                 --set ingressController.defaultSecretNamespace=kube-system \
                 --set ingressController.defaultSecretName=default-cert


### PR DESCRIPTION
Currently, the example Cilium CLI command to configure ingress with a default tls secret doesn't contain the flag to enable the ingress functionality. That's why the command actually doesn't configure the default secret too.

Therefore, this commit will add the missing flag to the command.
