### PR TITLE
ipam: remove always-nil NewCIDRRange error return value

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -1073,12 +1073,7 @@ func (ipam *LBIPAM) handleNewPool(ctx context.Context, pool *cilium_api_v2alpha1
 			return fmt.Errorf("Error parsing cidr '%s': %w", cidrBlock.Cidr, err)
 		}
 
-		lbRange, err := NewLBRange(cidr, pool)
-		if err != nil {
-			return fmt.Errorf("Error making LB Range for '%s': %w", cidrBlock.Cidr, err)
-		}
-
-		ipam.rangesStore.Add(lbRange)
+		ipam.rangesStore.Add(newLBRange(cidr, pool))
 	}
 
 	// Unmark new pools so they get a conflict: False condition set, otherwise kubectl will report a blank field.
@@ -1137,12 +1132,7 @@ func (ipam *LBIPAM) handlePoolModified(ctx context.Context, pool *cilium_api_v2a
 			continue
 		}
 
-		newRange, err := NewLBRange(&newCIDR, pool)
-		if err != nil {
-			return fmt.Errorf("Error while making new LB range for CIDR '%s': %w", newCIDR.String(), err)
-		}
-
-		ipam.rangesStore.Add(newRange)
+		ipam.rangesStore.Add(newLBRange(&newCIDR, pool))
 	}
 
 	existingRanges, _ = ipam.rangesStore.GetRangesForPool(pool.GetName())

--- a/operator/pkg/lbipam/range_store.go
+++ b/operator/pkg/lbipam/range_store.go
@@ -69,18 +69,13 @@ type LBRange struct {
 	originPool string
 }
 
-func NewLBRange(cidr *net.IPNet, pool *cilium_api_v2alpha1.CiliumLoadBalancerIPPool) (*LBRange, error) {
-	allocRange, err := ipallocator.NewCIDRRange(cidr)
-	if err != nil {
-		return nil, fmt.Errorf("new cidr range: %w", err)
-	}
-
+func newLBRange(cidr *net.IPNet, pool *cilium_api_v2alpha1.CiliumLoadBalancerIPPool) *LBRange {
 	return &LBRange{
-		allocRange:         allocRange,
+		allocRange:         ipallocator.NewCIDRRange(cidr),
 		internallyDisabled: false,
 		externallyDisabled: pool.Spec.Disabled,
 		originPool:         pool.GetName(),
-	}, nil
+	}
 }
 
 func (lr *LBRange) Disabled() bool {

--- a/pkg/alibabacloud/api/mock/mock.go
+++ b/pkg/alibabacloud/api/mock/mock.go
@@ -33,10 +33,6 @@ type API struct {
 // NewAPI returns a new mocked ECS API
 func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, securityGroups []*types.SecurityGroup) *API {
 	_, cidr, _ := net.ParseCIDR("10.0.0.0/8")
-	cidrRange, err := ipallocator.NewCIDRRange(cidr)
-	if err != nil {
-		panic(err)
-	}
 
 	api := &API{
 		unattached:     map[string]*eniTypes.ENI{},
@@ -44,7 +40,7 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 		subnets:        map[string]*ipamTypes.Subnet{},
 		vpcs:           map[string]*ipamTypes.VirtualNetwork{},
 		securityGroups: map[string]*types.SecurityGroup{},
-		allocator:      cidrRange,
+		allocator:      ipallocator.NewCIDRRange(cidr),
 	}
 
 	api.UpdateSubnets(subnets)

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -67,10 +67,8 @@ func NewAPI(subnets []*ipamTypes.Subnet, vpcs []*ipamTypes.VirtualNetwork, secur
 	// Use 10.10.0.0/17 for IP allocations
 	cidrSet, _ := cidrset.NewCIDRSet(baseCidr, 17)
 	podCidr, _ := cidrSet.AllocateNext()
-	podCidrRange, err := ipallocator.NewCIDRRange(podCidr)
-	if err != nil {
-		panic(err)
-	}
+	podCidrRange := ipallocator.NewCIDRRange(podCidr)
+
 	// Use 10.10.128.0/17 for prefix allocations
 	pdCidr, _ := cidrSet.AllocateNext()
 	pdCidrRange, err := cidrset.NewCIDRSet(pdCidr, 28)

--- a/pkg/azure/api/mock/mock.go
+++ b/pkg/azure/api/mock/mock.go
@@ -67,14 +67,10 @@ func (a *API) UpdateSubnets(subnets []*ipamTypes.Subnet) {
 	a.subnets = map[string]*subnet{}
 	for _, s := range subnets {
 		_, cidr, _ := net.ParseCIDR(s.CIDR.String())
-		cidrRange, err := ipallocator.NewCIDRRange(cidr)
-		if err != nil {
-			panic(err)
-		}
 
 		a.subnets[s.ID] = &subnet{
 			subnet:    s.DeepCopy(),
-			allocator: cidrRange,
+			allocator: ipallocator.NewCIDRRange(cidr),
 		}
 	}
 	a.mutex.Unlock()

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -18,16 +18,10 @@ type hostScopeAllocator struct {
 }
 
 func newHostScopeAllocator(n *net.IPNet) Allocator {
-	cidrRange, err := ipallocator.NewCIDRRange(n)
-	if err != nil {
-		panic(err)
-	}
-	a := &hostScopeAllocator{
+	return &hostScopeAllocator{
 		allocCIDR: n,
-		allocator: cidrRange,
+		allocator: ipallocator.NewCIDRRange(n),
 	}
-
-	return a
 }
 
 func (h *hostScopeAllocator) Allocate(ip net.IP, owner string, pool Pool) (*AllocationResult, error) {

--- a/pkg/ipam/pool.go
+++ b/pkg/ipam/pool.go
@@ -374,11 +374,7 @@ func (p *podCIDRPool) updatePool(podCIDRs []string) {
 		if _, ok := existingAllocators[cidrStr]; ok {
 			continue
 		}
-		ipAllocator, err := ipallocator.NewCIDRRange(cidrNet)
-		if err != nil {
-			log.WithError(err).WithField(logfields.CIDR, cidrStr).Error("cannot create *ipallocator.Range")
-			continue
-		}
+		ipAllocator := ipallocator.NewCIDRRange(cidrNet)
 		if ipAllocator.Free() == 0 {
 			log.WithField(logfields.CIDR, cidrNet.String()).Error("skipping too-small pod CIDR")
 			p.released[cidrNet.String()] = struct{}{}


### PR DESCRIPTION
NewCIDRRange will never return an error, so omit the error return value to simplify some call sites.

Also fold the implementations of NewCIDRRange and NewAllocatorCIDRRange as the latter is only called by the former.