### PR TITLE
helm,docs: Add client rate limit helm values

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1964,6 +1964,30 @@
      - Configure Kubernetes specific configuration
      - object
      - ``{}``
+   * - k8sClientRateLimit
+     - Configure the client side rate limit for the agent and operator  If the amount of requests to the Kubernetes API server exceeds the configured rate limit, the agent and operator will start to throttle requests by delaying them until there is budget or the request times out.
+     - object
+     - ``{"burst":10,"qps":5}``
+   * - k8sClientRateLimit
+     - Configure the client side rate limit for the agent and operator  If the amount of requests to the Kubernetes API server exceeds the configured rate limit, the agent and operator will start to throttle requests by delaying them until there is budget or the request times out.
+     - object
+     - ``{"burst":10,"qps":5}``
+   * - k8sClientRateLimit.burst
+     - The burst request rate in requests per second. The rate limiter will allow short bursts with a higher rate.
+     - int
+     - ``10``
+   * - k8sClientRateLimit.burst
+     - The burst request rate in requests per second. The rate limiter will allow short bursts with a higher rate.
+     - int
+     - ``10``
+   * - k8sClientRateLimit.qps
+     - The sustained request rate in requests per second.
+     - int
+     - ``5``
+   * - k8sClientRateLimit.qps
+     - The sustained request rate in requests per second.
+     - int
+     - ``5``
    * - k8sNetworkPolicy.enabled
      - Enable support for K8s NetworkPolicy
      - bool

--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -39,6 +39,8 @@ The L2 Announcements feature and all the requirements can be enabled as follows:
                --namespace kube-system \\
                --reuse-values \\
                --set l2announcements.enabled=true \\
+               --set k8sClientRateLimit.qps={QPS} \\
+               --set k8sClientRateLimit.burst={BURST} \\
                --set kubeProxyReplacement=strict \\
                --set k8sServiceHost=${API_SERVER_IP} \\
                --set k8sServicePort=${API_SERVER_PORT}
@@ -50,6 +52,12 @@ The L2 Announcements feature and all the requirements can be enabled as follows:
 
             enable-l2-announcements: true
             kube-proxy-replacement: strict
+            k8s-client-qps: {QPS}
+            k8s-client-burst: {BURST}
+
+.. warning::
+  Sizing the client rate limit (``k8sClientRateLimit.qps`` and ``k8sClientRateLimit.burst``) 
+  is important when using this feature due to increased API usage. See :ref:`sizing_client_rate_limit` for sizing guidelines.
 
 Prerequisites
 #############
@@ -292,6 +300,8 @@ There are three Helm options that can be tuned with regards to leases:
                --set kubeProxyReplacement=strict \\
                --set k8sServiceHost=${API_SERVER_IP} \\
                --set k8sServicePort=${API_SERVER_PORT} \\
+               --set k8sClientRateLimit.qps={QPS} \\
+               --set k8sClientRateLimit.burst={BURST} \\
                --set l2announcements.leaseDuration=3s \\
                --set l2announcements.leaseRenewDeadline=1s \\
                --set l2announcements.leaseRetryPeriod=200ms
@@ -305,11 +315,46 @@ There are three Helm options that can be tuned with regards to leases:
             l2-announcements-lease-duration: 3s
             l2-announcements-renew-deadline: 1s
             l2-announcements-retry-period: 200ms
+            k8s-client-qps: {QPS}
+            k8s-client-burst: {BURST}
 
 There is a trade-off between fast failure detection and CPU + network usage. 
 Each service incurs a CPU and network overhead, so clusters with smaller amounts
 of services can more easily afford faster failover times. Larger clusters might
 need to increase parameters if the overhead is too high.
+
+.. _sizing_client_rate_limit:
+
+Sizing client rate limit
+========================
+
+The leader election process continually generates API traffic, the exact amount
+depends on the configured lease duration, configured renew deadline, and amount
+of services using the feature.
+
+The default client rate limit is 5 QPS with allowed bursts up to 10 QPS. this
+default limit is quickly reached when utilizing L2 announcements and thus users
+should size the client rate limit accordingly.
+
+In a worst case scenario, services are distributed unevenly, so we will assume
+a peek load based on the renew deadline. In complex scenarios with multiple 
+policies over disjunct sets of node, max QPS per node will be lower.
+
+.. code-block:: text
+
+  QPS = #services * (1 / leaseRenewDeadline)
+
+  // example
+  #services = 65
+  leaseRenewDeadline = 2s
+  QPS = 65 * (1 / 2s) = 32.5 QPS
+
+Setting the base QPS to around the calculated value should be sufficient, given
+in multi-node scenarios leases are spread around nodes, and non-holders participating
+in the election have a lower QPS.
+
+The burst QPS should be slightly higher to allow for bursts of traffic caused
+by other features which also use the API server.
 
 Failover
 --------

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -899,6 +899,7 @@ qdisc
 qdiscs
 qede
 qemu
+qps
 quantiles
 queryable
 queueSize
@@ -952,6 +953,7 @@ runPath
 runnable
 runtime
 runtimes
+sClientRateLimit
 sEventHandover
 sNetworkPolicy
 sNode

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -541,6 +541,12 @@ contributors across the globe, there is almost always someone available to help.
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |
 | ipv6NativeRoutingCIDR | string | `""` | Allows to explicitly specify the IPv6 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag. |
 | k8s | object | `{}` | Configure Kubernetes specific configuration |
+| k8sClientRateLimit | object | `{"burst":10,"qps":5}` | Configure the client side rate limit for the agent and operator  If the amount of requests to the Kubernetes API server exceeds the configured rate limit, the agent and operator will start to throttle requests by delaying them until there is budget or the request times out. |
+| k8sClientRateLimit | object | `{"burst":10,"qps":5}` | Configure the client side rate limit for the agent and operator  If the amount of requests to the Kubernetes API server exceeds the configured rate limit, the agent and operator will start to throttle requests by delaying them until there is budget or the request times out. |
+| k8sClientRateLimit.burst | int | `10` | The burst request rate in requests per second. The rate limiter will allow short bursts with a higher rate. |
+| k8sClientRateLimit.burst | int | `10` | The burst request rate in requests per second. The rate limiter will allow short bursts with a higher rate. |
+| k8sClientRateLimit.qps | int | `5` | The sustained request rate in requests per second. |
+| k8sClientRateLimit.qps | int | `5` | The sustained request rate in requests per second. |
 | k8sNetworkPolicy.enabled | bool | `true` | Enable support for K8s NetworkPolicy |
 | k8sServiceHost | string | `""` | Kubernetes service host |
 | k8sServicePort | string | `""` | Kubernetes service port |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -1063,6 +1063,11 @@ data:
   annotate-k8s-node: "true"
 {{- end }}
 
+{{- if hasKey .Values "k8sClientRateLimit" }}
+  k8s-client-qps: {{ .Values.k8sClientRateLimit.qps | quote }}
+  k8s-client-burst: {{ .Values.k8sClientRateLimit.burst | quote }}
+{{- end }}
+
 {{- if and .Values.operator.setNodeTaints (not .Values.operator.removeNodeTaints) -}}
   {{ fail "Cannot have operator.setNodeTaintsMaxNodes and not operator.removeNodeTaints = false" }}
 {{- end -}}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -41,6 +41,18 @@ k8sServiceHost: ""
 # -- (string) Kubernetes service port
 k8sServicePort: ""
 
+# -- Configure the client side rate limit for the agent and operator
+#
+# If the amount of requests to the Kubernetes API server exceeds the configured
+# rate limit, the agent and operator will start to throttle requests by delaying
+# them until there is budget or the request times out.
+k8sClientRateLimit:
+  # -- The sustained request rate in requests per second.
+  qps: 5
+  # -- The burst request rate in requests per second.
+  # The rate limiter will allow short bursts with a higher rate.
+  burst: 10
+
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.
   name: default
@@ -3182,3 +3194,15 @@ authentication:
       agentSocketPath: /run/spire/sockets/agent/agent.sock
       # -- SPIRE connection timeout
       connectionTimeout: 30s
+
+# -- Configure the client side rate limit for the agent and operator
+#
+# If the amount of requests to the Kubernetes API server exceeds the configured
+# rate limit, the agent and operator will start to throttle requests by delaying
+# them until there is budget or the request times out.
+k8sClientRateLimit:
+  # -- The sustained request rate in requests per second.
+  qps: 5
+  # -- The burst request rate in requests per second.
+  # The rate limiter will allow short bursts with a higher rate.
+  burst: 10

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -38,6 +38,18 @@ k8sServiceHost: ""
 # -- (string) Kubernetes service port
 k8sServicePort: ""
 
+# -- Configure the client side rate limit for the agent and operator
+#
+# If the amount of requests to the Kubernetes API server exceeds the configured
+# rate limit, the agent and operator will start to throttle requests by delaying
+# them until there is budget or the request times out.
+k8sClientRateLimit:
+  # -- The sustained request rate in requests per second.
+  qps: 5
+  # -- The burst request rate in requests per second.
+  # The rate limiter will allow short bursts with a higher rate.
+  burst: 10
+
 cluster:
   # -- Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE.
   name: default
@@ -3179,3 +3191,15 @@ authentication:
       agentSocketPath: /run/spire/sockets/agent/agent.sock
       # -- SPIRE connection timeout
       connectionTimeout: 30s
+
+# -- Configure the client side rate limit for the agent and operator
+#
+# If the amount of requests to the Kubernetes API server exceeds the configured
+# rate limit, the agent and operator will start to throttle requests by delaying
+# them until there is budget or the request times out.
+k8sClientRateLimit:
+  # -- The sustained request rate in requests per second.
+  qps: 5
+  # -- The burst request rate in requests per second.
+  # The rate limiter will allow short bursts with a higher rate.
+  burst: 10


### PR DESCRIPTION
This PR adds the helm values for the client rate limit feature. This makes it easier for users to tune the client rate limit which is necessary for L2 announcements to work properly.

Added warnings about client rate limits and sizing instructions to the L2 announcements documentation.

This doesn't fully address #26586 since we are putting an additional burden on the user, but should provide a half decent workaround for the v1.14 release which gives us time to come up with a permanent more user friendly fix.

```release-note
Add helm values for K8s API server client rate limits and instructions on how to size them when using L2 announcements.
```
