### PR TITLE
helm: add default tunnel values in configmap

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -442,6 +442,10 @@ data:
 {{- else if eq .Values.tunnel "geneve" }}
   routing-mode: "tunnel"
   tunnel-protocol: "geneve"
+{{- else if not (or .Values.gke.enabled .Values.aksbyocni.enabled) }}
+  # Default case
+  routing-mode: "tunnel"
+  tunnel-protocol: "vxlan"
 {{- end }}
 
 {{- if .Values.routingMode }}


### PR DESCRIPTION
<!-- Description of change -->

This PR fixes the feature discovery for tunneling in `cilium-cli`.

Background:
With the new `routingMode` and `tunnelProtocol` helm values, the default is not filled in as a value in values.yaml anymore (in contrast to the old tunnel value, see: https://github.com/cilium/cilium/pull/24561/files). Therefore, those default values don't show up in the config-map. The cilium-cli tries to get the enabled features by (among other things) reading out the config-map. Since it does not find any value, it sets the feature to `Enabled: false` (see: cilium-cli/check/features.go:209 or https://github.com/cilium/cilium-cli/pull/1655/files)

Of course there are multiple places to fix this behavior. I opted for this solution as I think that the configuration should always be reflected in the configmap for visibility reasons. Especially if the default is tunneling + vxlan not disabled tunneling.

```release-note
Add the tunnel values to the config map even when the default values are used.
```
