### PR TITLE
Bump allowed Golang version for v1.11 and v1.12

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -230,7 +230,7 @@
         "docker.io/library/golang",
         "go"
       ],
-      "allowedVersions": "<1.19",
+      "allowedVersions": "<1.20",
       "matchBaseBranches": [
         "v1.12"
       ]
@@ -240,7 +240,7 @@
         "docker.io/library/golang",
         "go"
       ],
-      "allowedVersions": "<1.18",
+      "allowedVersions": "<1.20",
       "matchBaseBranches": [
         "v1.11"
       ]


### PR DESCRIPTION
Allow v1.11 and v1.12 to use a supported Golang version, which will remove several CVEs
currently being reported by scanners.

Bumping based on the recently added documentation in: https://docs.cilium.io/en/latest/contributing/development/dev_setup/#minor-version

Signed-off-by: Feroz Salam <feroz.salam@isovalent.com>
