### PR TITLE
docs: fix minor TOC issues

### DIFF
--- a/Documentation/index.rst
+++ b/Documentation/index.rst
@@ -84,7 +84,6 @@ get started and experiment with Cilium.
    network/external-toc
    network/servicemesh/index
    network/vtep
-   network/lb-ipam
    network/l2-announcements
 
 .. toctree::

--- a/Documentation/network/kubernetes/compatibility.rst
+++ b/Documentation/network/kubernetes/compatibility.rst
@@ -6,8 +6,9 @@
 
 .. _k8scompatibility:
 
+************************
 Kubernetes Compatibility
-========================
+************************
 
 Cilium is compatible with multiple Kubernetes API Groups. Some are deprecated
 or beta, and may only be available in specific versions of Kubernetes.


### PR DESCRIPTION
* The first issue is that lb-ipam is present in both BGP and Networking TOC. This change removes it from the top-level Networking TOC
* The second issue is the Kubernetes compatibility TOC displayed a subsection (CRD validation) at the same level as its parent.

