### PR TITLE
ariane: don't skip verifier and l4lb tests on vendor/ changes

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -60,6 +60,6 @@ workflows:
   conformance-gke.yaml:
     paths-ignore-regex: (test|Documentation)/
   tests-datapath-verifier.yaml:
-    paths-regex: (bpf|test/verifier)/
+    paths-regex: (bpf|test/verifier|vendor)/
   tests-l4lb.yaml:
-    paths-regex: (pkg|daemon|bpf|test/l4lb|images)/
+    paths-regex: (bpf|daemon|images|pkg|test/l4lb|vendor)/


### PR DESCRIPTION
Both of these workflows use binaries that are built in CI making use of various vendored dependencies, so run them as well on PRs only changing vendor/.