### PR TITLE
renovate: Pin cilium-cli version for <v1.14

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -292,11 +292,29 @@
       ],
       "versioning": "regex:^v0.0.0-(<patch>\\d+)-.*$",
     },
+    // Ref: https://github.com/cilium/cilium-cli#releases
     {
       "groupName": "Cilium CLI",
       "groupSlug": "cilium-cli",
       "matchDepNames": [
         "cilium/cilium-cli"
+      ],
+      "matchBaseBranches": [
+        "main",
+        "v1.14",
+      ]
+    },
+    {
+      "groupName": "Cilium CLI",
+      "groupSlug": "cilium-cli",
+      "matchDepNames": [
+        "cilium/cilium-cli"
+      ],
+      "allowedVersions": "/^v0\\.14\\.[0-9]+$/",
+      "matchBaseBranches": [
+        "v1.13",
+        "v1.12",
+        "v1.11",
       ]
     },
     {


### PR DESCRIPTION
Pin cilium-cli to v0.14 for Cilium <1.14 based on supported versions
defined in https://github.com/cilium/cilium-cli#releases