### PR TITLE
egressgw: improve reconciliation for IP routes

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -630,21 +630,27 @@ nextIpRule:
 		}
 	}
 
-	// Then go through each interface on the node
-	links, err := netlink.LinkList()
+	// Fetch all IP routes, and delete the unused EgressGW-specific routes:
+	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
 	if err != nil {
-		logger.WithError(err).Error("Cannot list interfaces")
+		logger.WithError(err).Error("Cannot list IP routes")
 		return
 	}
 
-	for _, l := range links {
-		// If egress gateway is active for this interface, move to the next interface
-		if _, ok := activeEgressGwIfaceIndexes[l.Attrs().Index]; ok {
+	for _, route := range routes {
+		linkIndex := route.LinkIndex
+
+		// Keep the route if it was not created by EgressGW.
+		if route.Table != egressGatewayRoutingTableIdx(linkIndex) {
 			continue
 		}
 
-		// Otherwise delete the whole routing table for that interface
-		deleteIpRouteTable(egressGatewayRoutingTableIdx(l.Attrs().Index))
+		// Keep the route if EgressGW still uses this interface.
+		if _, ok := activeEgressGwIfaceIndexes[linkIndex]; ok {
+			continue
+		}
+
+		deleteIpRoute(route)
 	}
 }
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -541,11 +541,7 @@ func (manager *Manager) addMissingIpRulesAndRoutes(isRetry bool) (shouldRetry bo
 		return false
 	}
 
-	addIPRulesAndRoutesForConfig := func(endpointIP net.IP, dstCIDR *net.IPNet, gwc *gatewayConfig) {
-		if !gwc.localNodeConfiguredAsGateway {
-			return
-		}
-
+	addIPRulesForConfig := func(endpointIP net.IP, dstCIDR *net.IPNet, gwc *gatewayConfig) {
 		logger := log.WithFields(logrus.Fields{
 			logfields.SourceIP:        endpointIP,
 			logfields.DestinationCIDR: dstCIDR.String(),
@@ -563,16 +559,27 @@ func (manager *Manager) addMissingIpRulesAndRoutes(isRetry bool) (shouldRetry bo
 		} else {
 			logger.Debug("Added IP rule")
 		}
-
-		if err := addEgressIpRoutes(gwc.egressIP, gwc.ifaceIndex); err != nil {
-			logger.WithError(err).Warn("Can't add IP routes")
-			return
-		}
-		logger.Debug("Added IP routes")
 	}
 
 	for _, policyConfig := range manager.policyConfigs {
-		policyConfig.forEachEndpointAndDestination(addIPRulesAndRoutesForConfig)
+		gwc := &policyConfig.gatewayConfig
+
+		if gwc.localNodeConfiguredAsGateway &&
+			len(policyConfig.matchedEndpoints) > 0 {
+
+			policyConfig.forEachEndpointAndDestination(addIPRulesForConfig)
+
+			logger := log.WithFields(logrus.Fields{
+				logfields.EgressIP:  gwc.egressIP.IP,
+				logfields.LinkIndex: gwc.ifaceIndex,
+			})
+
+			if err := addEgressIpRoutes(gwc.egressIP, gwc.ifaceIndex); err != nil {
+				logger.WithError(err).Warn("Can't add IP routes")
+			} else {
+				logger.Debug("Added IP routes")
+			}
+		}
 	}
 
 	return

--- a/pkg/egressgateway/net.go
+++ b/pkg/egressgateway/net.go
@@ -159,19 +159,6 @@ func deleteIpRule(ipRule netlink.Rule) {
 		})
 }
 
-func deleteIpRouteTable(tableIndex int) {
-	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4,
-		&netlink.Route{Table: tableIndex}, uint64(netlink.RT_FILTER_TABLE))
-	if err != nil {
-		log.WithError(err).Error("Cannot list IP routes")
-		return
-	}
-
-	for _, route := range routes {
-		deleteIpRoute(route)
-	}
-}
-
 func deleteIpRoute(ipRoute netlink.Route) {
 	logger := log.WithFields(logrus.Fields{})
 


### PR DESCRIPTION
For configs with `--install-egress-gateway-routes`, optimize the logic that reconciles the IP routes.