### PR TITLE
cilium: Add nodeID object with reference counts for OOO events

### DIFF
--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -73,6 +73,9 @@ func (n *FakeNodeHandler) AllocateNodeID(_ net.IP) uint16 {
 	return 0
 }
 
+func (n *FakeNodeHandler) DeallocateNodeID(_ net.IP) {
+}
+
 func (n *FakeNodeHandler) GetNodeIP(_ uint16) string {
 	return ""
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1184,6 +1184,8 @@ func (n *linuxNodeHandler) nodeUpdate(oldNode, newNode *nodeTypes.Node, firstAdd
 		oldIP4 = oldNode.GetNodeIP(false)
 		oldIP6 = oldNode.GetNodeIP(true)
 		oldKey = oldNode.EncryptionKey
+
+		n.deleteNodeIPs(oldNode.IPAddresses, newNode.IPAddresses)
 	}
 
 	if n.nodeConfig.EnableIPSec && !n.nodeConfig.EncryptNode {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -53,7 +53,8 @@ type NeighLink struct {
 }
 
 type nodeID struct {
-	id uint16
+	id     uint16
+	refcnt uint32
 }
 
 type linuxNodeHandler struct {

--- a/pkg/datapath/linux/node_ids.go
+++ b/pkg/datapath/linux/node_ids.go
@@ -105,6 +105,25 @@ func (n *linuxNodeHandler) getNodeIDForNode(node *nodeTypes.Node) uint16 {
 	return nodeID
 }
 
+func (n *linuxNodeHandler) deleteNodeIPs(oldIPs, newIPs []nodeTypes.Address) {
+	for _, oldAddr := range oldIPs {
+		found := false
+		for _, newAddr := range newIPs {
+			if newAddr.IP.String() == oldAddr.IP.String() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			if err := n.unmapNodeID(oldAddr.IP.String()); err != nil {
+				log.WithError(err).WithFields(logrus.Fields{
+					logfields.IPAddr: oldAddr,
+				}).Warn("DeleteNodeIPS failed to remove a node IP to node ID mapping")
+			}
+		}
+	}
+}
+
 // allocateIDForNode allocates a new ID for the given node if one hasn't already
 // been assigned. If any of the node IPs have an ID associated, then all other
 // node IPs receive the same. This might happen if we allocated a node ID from

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -141,8 +141,12 @@ type NodeNeighbors interface {
 
 type NodeIDHandler interface {
 	// AllocateNodeID allocates a new ID for the given node (by IP) if one wasn't
-	// already assigned.
+	// already assigned or increments the refcnt if it exists.
 	AllocateNodeID(net.IP) uint16
+
+	// DeallocateNodeID decrements the refcnt of a node ID and releases the ID
+	// if the refcnt is zero.
+	DeallocateNodeID(net.IP)
 
 	// GetNodeIP returns the string node IP that was previously registered as the given node ID.
 	GetNodeIP(uint16) string

--- a/pkg/ipcache/types/fake/nodeidhandler.go
+++ b/pkg/ipcache/types/fake/nodeidhandler.go
@@ -15,6 +15,9 @@ func (m *FakeNodeIDHandler) AllocateNodeID(_ net.IP) uint16 {
 	return 0
 }
 
+func (n *FakeNodeIDHandler) DeallocateNodeID(_ net.IP) {
+}
+
 func (m *FakeNodeIDHandler) GetNodeIP(_ uint16) string {
 	return ""
 }

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -64,6 +64,7 @@ func NewResourceID(kind ResourceKind, namespace, name string) ResourceID {
 // NodeIDHandler is responsible for the management of node identities.
 type NodeIDHandler interface {
 	AllocateNodeID(net.IP) uint16
+	DeallocateNodeID(net.IP)
 	GetNodeIP(uint16) string
 	GetNodeID(nodeIP net.IP) (nodeID uint16, exists bool)
 }


### PR DESCRIPTION
Handle OOO pod/kvstore/node events.

### Assumptions and Requirements:

We require same event types for single objects to be ordered. For example:

  NodeAdd(1) -> NodeDelete(1)

is valid. But we would not handle this order currently,

  NodeDelete(1) -> NodeAdd(1)

I'm assuming the API server and watchers can at least maintain this constraint. We don't however require any ordering between Node events and Pod events nor between different objects. So these are valid,

   PodAdd(hostA.IP) -> NodeAdd(hostA) -> NodeDelete(hostA.IP) -> PodDelete(hostA.IP)

   NodeAdd(hostA) -> NodeDelete(hostA) -> PodAdd(hostA.IP) -> PodDelete(hostA.IP)

Also noteworthy we require the Delete events to eventually reach us to be eventually consistent. We also require the delete events to reach us before the system reuses the IP. If the system were to try to reuse the hostIP before we received a delete for the same IP we wouldn't be able to identify if the next delete event was for the old object or the latest object.

### NodeID Issue

The following flow can currently cause an orphaned nodeID, meaning  a nodeID is associated with an IP in the nodeID table but it maps to a stale IP.

   NodeDelete(hostA) -> Pod{Add|Delete}(hostA.IP)

the reason is nodeIDs are removed from the nodeID map on Node Delete. But, in order to handle the case where pod or kvstore events are received before the NodeAdd ipcacheUpdates will also create an id if no id is found. So we get,
```
     Event                                              Mapping
 ---------------------------------------------------------------
     NodeAdd(hostA)                           id:1, hostA.IP
     NodeDelete(hostA)                      --- // empty now
     PodAdd(hostA.IP)                          id:2, hostA.IP
     PodDelete(hostA.IP)                     id.2, hostA.IP                        
```
After the last PodDelete we have a stale entry and no future node delete to clean up the table. Couple things might happen now. We can leak nodeIds until nodeID cache runs out. If the IPAM reuses an IP we can collide and use the old id which would be incorrect.

### Fix

The first naive attempt is to just delete the id on PodDelete() but this trivially breaks the expected case,

 NodeAdd() -> PodAdd() -> PodDelete() /// broken -> NodeDelete()

So we can't simply remove on PodDelete. This series instead adds refcnt and delete from pod flow so that the broken case is resolved as follows,
```
     Event                                              Mapping                     RefCnt:
 ----------------------------------------------------------------------------------------------
     NodeAdd(hostA)                           id:1, hostA.IP                 1
     NodeDelete(hostA)                      --- // empty now            0
     PodAdd(hostA.IP)                          id:2, hostA.IP                1
     PodDelete(hostA.IP)                    --- // empty now             0        
```
And the good case continues to work as expected,
```
     Event                                              Mapping                     RefCnt:
 ----------------------------------------------------------------------------------------------
     NodeAdd(hostA)                           id:1, hostA.IP                 1
     PodAdd(hostA.IP)                          id:2, hostA.IP                2
     PodDelete(hostA.IP)                     id:2, hostA.IP                 1 
     NodeDelete(hostA)                      --- // empty now             0
```

### Nice to do

I didn't do all the nice to have things in this series couple items on the todo list,
* Lift nodeID logic into its own pkg so we can fake the map updates and write unit tests
* Lift nodeID allocation out of ipsec and encap specific logic and use in all cases

### Testing

I wrote a set of unit tests to handle the cases attached here. But, unfortunately it requires commenting out the bpf map updates because there is no way to "fake" those from this layer easily. Also I didn't catch if there was a way to fake the GetLocalIP calls they were panic'ing because I didn't setup those layers correctly from the unit tests.

Then I tested by hand in an EKS ENI setup with 30nodes. Where I jumped down/up between nodes and had a stress test nginx server that ran on all nodes as they came online and would terminate and restart every few minutes. This let me get lots of interesting order on events posted for node add/delete and pod add/delete while having traffic in-flight which would trigger warnings/bugs when hitting nodeid mismatches. Also doing this shows that we get IP reuse so that we get collisions. With this PR I've managed to run this scenario for 24hrs or so without any further issues.

To test if we have "bad" id mappings I check the clusters ipcache for any entries that are not local objects without a nodeID or with a nodeID not in the nodeID list. And then check the other way to ensure the nodeID list only has IP addresses that exist. Before the PR the nodeID list would grow over long running tests as well. Now it correctly stays roughly aligned with number of nodes in the system

Note I didn't test this PR exactly but the backport onto released version.
