### PR TITLE
ci: skip post-test info gathering in case of skipped cilium installation

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -221,6 +221,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -284,7 +285,7 @@ jobs:
           --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -226,6 +226,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -251,7 +252,7 @@ jobs:
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -375,6 +375,7 @@ jobs:
         kubectl --context ${{ env.contextName2 }} create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="${SECRET}"
 
     - name: Install Cilium in cluster1
+      id: install-cilium-cluster1
       run: |
         # Explicitly configure the NodePort to make sure that it is different in
         # each cluster, to workaround #24692
@@ -436,7 +437,7 @@ jobs:
         --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
     - name: Post-test information gathering
-      if: ${{ !success() }}
+      if: ${{ !success() && steps.install-cilium-cluster1.outcome != 'skipped' }}
       run: |
         cilium --context ${{ env.contextName1 }} status
         cilium --context ${{ env.contextName1 }} clustermesh status

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -354,6 +354,7 @@ jobs:
           done
 
       - name: Run tests (${{ join(matrix.*, ', ') }})
+        id: run-tests
         uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
         with:
           provision: 'false'
@@ -387,7 +388,7 @@ jobs:
             ./contrib/scripts/kind-down.sh
 
       - name: Fetch artifacts
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.run-tests.outcome != 'skipped' }}
         uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
         with:
           provision: 'false'

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -219,6 +219,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -276,7 +277,7 @@ jobs:
           --junit-property github_job_step="Run connectivity test with IPSec (${{ join(matrix.*, ', ') }})"
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -250,6 +250,7 @@ jobs:
           done
 
       - name: Install Cilium in cluster
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -298,7 +299,7 @@ jobs:
           --junit-property github_job_step="Run connectivity test (${{ join(matrix.*, ', ') }})"
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           kubectl get cew --all-namespaces -o wide

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -137,6 +137,7 @@ jobs:
           kubectl wait --for condition=Established crd/referencegrants.gateway.networking.k8s.io --timeout=${{ env.timeout }}
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -192,7 +193,7 @@ jobs:
             -test.skip "${{ steps.vars.outputs.skipped_tests }}"
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -240,6 +240,7 @@ jobs:
           kubectl create -n kube-system secret generic cilium-ipsec-keys --from-literal=keys="15 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }} ${{ matrix.config.cilium-install-opts }}
 
@@ -269,7 +270,7 @@ jobs:
           --junit-property github_job_step="Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})"
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -136,6 +136,7 @@ jobs:
           done
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -216,7 +217,7 @@ jobs:
           ./ingress-controller-conformance -ingress-class cilium -wait-time-for-ingress-status 60s -wait-time-for-ready 60s
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -175,6 +175,7 @@ jobs:
           done
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install --wait ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -217,7 +218,7 @@ jobs:
             --disable-log-dump=true
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -174,6 +174,7 @@ jobs:
           done
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install --wait ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -217,7 +218,7 @@ jobs:
             --disable-log-dump=true
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -80,6 +80,7 @@ jobs:
           config: ${{ env.KIND_CONFIG }}
 
       - name: Install cilium chart
+        id: install-cilium
         run: |
           helm install cilium ./install/kubernetes/cilium \
              --wait \
@@ -125,7 +126,7 @@ jobs:
           ci-version: ${{ env.cilium_cli_ci_version }}
 
       - name: Report cluster failure status and capture cilium-sysdump
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           echo "=== Retrieve cluster state ==="
           kubectl get pods --all-namespaces -o wide

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -109,6 +109,7 @@ jobs:
           done
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -133,7 +134,7 @@ jobs:
           --junit-file "cilium-junits/${{ env.job_name }}.xml" --junit-property github_job_step="Run connectivity test"
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -134,6 +134,7 @@ jobs:
           done
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           CILIUM_CLI_MODE=helm cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -179,7 +180,7 @@ jobs:
           assert ip_address("${{ steps.ips.outputs.echo-other-node }}") in ip_network("${{ steps.ips.outputs.echo-other-node-pool }}"), "echo-other-node pool mismatch"
 
       - name: Post-test information gathering
-        if: ${{ !success() }}
+        if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}
         run: |
           kubectl get pods --all-namespaces -o wide
           cilium status

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -148,6 +148,7 @@ jobs:
           cilium version
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -168,7 +169,7 @@ jobs:
           kubectl wait --for=condition=Available --all deployment --timeout=${{ env.TIMEOUT }}
 
       - name: Report cluster failure status and capture cilium-sysdump
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.install-cilium.outcome != 'skipped' }}
         # The following is needed to prevent hubble from receiving an empty
         # file (EOF) on stdin and displaying no flows.
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -157,6 +157,7 @@ jobs:
           cilium version
 
       - name: Install Cilium
+        id: install-cilium
         run: |
           cilium install ${{ steps.vars.outputs.cilium_install_defaults }}
 
@@ -193,7 +194,7 @@ jobs:
           cat metrics.prom | promtool check metrics
 
       - name: Report cluster failure status and capture cilium-sysdump
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.install-cilium.outcome != 'skipped' }}
         # The following is needed to prevent hubble from receiving an empty
         # file (EOF) on stdin and displaying no flows.
         shell: 'script -q -e -c "bash --noprofile --norc -eo pipefail {0}"'


### PR DESCRIPTION
Currently, getting the Cilium status (in steps like "Post-test information gathering" (or similar ones)) always fail if the Cilium installation is skipped due to missing images. As a consequence, these steps are confusingly listed in CI analysis.

IMO we should try to avoid having "post-processing" steps fail due to some missing pre-requisites (like Cilium being installed).

Therefore, this commit skips these steps if Cilium installation has been skipped.