### PR TITLE
daemon: fix issue where IPAM options in custom CNI confs was ignored

### DIFF
--- a/daemon/cmd/cni/cell.go
+++ b/daemon/cmd/cni/cell.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/option"
+	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
 var Cell = cell.Module(
@@ -41,6 +42,8 @@ type CNIConfigManager interface {
 
 	// GetChainingMode returns the configured CNI chaining mode
 	GetChainingMode() string
+
+	GetCustomNetConf() *cnitypes.NetConf
 }
 
 var defaultConfig = Config{

--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -47,24 +47,32 @@ type cniConfigManager struct {
 // GetMTU returns the MTU as written in the CNI configuration file.
 // This is one way to override the node's MTU.
 func (c *cniConfigManager) GetMTU() int {
-	if c.config.ReadCNIConf == "" {
+	conf := c.GetCustomNetConf()
+	if conf == nil {
 		return 0
 	}
-
-	conf, err := cnitypes.ReadNetConf(c.config.ReadCNIConf)
-	if err != nil {
-		c.log.WithField("path", c.config.ReadCNIConf).WithError(err).Warnf("Failed to parse existing CNI configuration file")
-	}
-
-	if conf.MTU > 0 {
-		return conf.MTU
-	}
-	return 0
+	return conf.MTU
 }
 
 // GetChainingMode returns the configured chaining mode.
 func (c *cniConfigManager) GetChainingMode() string {
 	return c.config.CNIChainingMode
+}
+
+// GetCustomNetConf returns the parsed custom CNI configuration, if provided
+// (In other words, the value to --read-cni-conf).
+// Otherwise, returns nil.
+func (c *cniConfigManager) GetCustomNetConf() *cnitypes.NetConf {
+	if c.config.ReadCNIConf == "" {
+		return nil
+	}
+
+	conf, err := cnitypes.ReadNetConf(c.config.ReadCNIConf)
+	if err != nil {
+		c.log.WithField("path", c.config.ReadCNIConf).WithError(err).Warnf("Failed to parse existing CNI configuration file")
+		return nil
+	}
+	return conf
 }
 
 // cniConfigs are the default configurations, per chaining mode

--- a/daemon/cmd/cni/fake/fakecni.go
+++ b/daemon/cmd/cni/fake/fakecni.go
@@ -3,6 +3,10 @@
 
 package fake
 
+import (
+	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
+)
+
 type FakeCNIConfigManager struct{}
 
 func (f *FakeCNIConfigManager) GetMTU() int {
@@ -12,4 +16,8 @@ func (f *FakeCNIConfigManager) GetMTU() int {
 // GetChainingMode returns the configured CNI chaining mode
 func (f *FakeCNIConfigManager) GetChainingMode() string {
 	return "none"
+}
+
+func (f *FakeCNIConfigManager) GetCustomNetConf() *cnitypes.NetConf {
+	return nil
 }

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -92,7 +92,6 @@ import (
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/status"
 	"github.com/cilium/cilium/pkg/trigger"
-	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 
 const (
@@ -160,8 +159,6 @@ type Daemon struct {
 
 	// ipam is the IP address manager of the agent
 	ipam *ipam.IPAM
-
-	netConf *cnitypes.NetConf
 
 	endpointManager endpointmanager.EndpointManager
 
@@ -400,11 +397,7 @@ func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 
 // newDaemon creates and returns a new Daemon with the parameters set in c.
 func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams) (*Daemon, *endpointRestoreState, error) {
-	var (
-		err           error
-		netConf       *cnitypes.NetConf
-		configuredMTU = option.Config.MTU
-	)
+	var err error
 
 	bootstrapStats.daemonInit.Start()
 
@@ -412,11 +405,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeCRD && !params.Clientset.IsEnabled() &&
 		option.Config.DatapathMode != datapathOption.DatapathModeLBOnly {
 		return nil, nil, fmt.Errorf("CRD Identity allocation mode requires k8s to be configured")
-	}
-
-	if mtu := params.CNIConfigManager.GetMTU(); mtu > 0 {
-		configuredMTU = mtu
-		log.WithField("mtu", configuredMTU).Info("Overwriting MTU based on CNI configuration")
 	}
 
 	// Check the kernel if we can make use of managed neighbor entries which
@@ -485,6 +473,11 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	if externalIP == nil {
 		externalIP = node.GetIPv6()
 	}
+	configuredMTU := option.Config.MTU
+	if mtu := params.CNIConfigManager.GetMTU(); mtu > 0 {
+		configuredMTU = mtu
+		log.WithField("mtu", configuredMTU).Info("Overwriting MTU based on CNI configuration")
+	}
 	// ExternalIP could be nil but we are covering that case inside NewConfiguration
 	mtuConfig = mtu.NewConfiguration(
 		authKeySize,
@@ -507,7 +500,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
 	}
 
-	nd := nodediscovery.NewNodeDiscovery(params.NodeManager, params.Clientset, mtuConfig, netConf)
+	nd := nodediscovery.NewNodeDiscovery(params.NodeManager, params.Clientset, mtuConfig, params.CNIConfigManager.GetCustomNetConf())
 
 	devMngr, err := linuxdatapath.NewDeviceManager()
 	if err != nil {
@@ -520,7 +513,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		prefixLengths:     createPrefixLengthCounter(),
 		buildEndpointSem:  semaphore.NewWeighted(int64(numWorkerThreads())),
 		compilationMutex:  new(lock.RWMutex),
-		netConf:           netConf,
 		mtuConfig:         mtuConfig,
 		datapath:          params.Datapath,
 		deviceManager:     devMngr,


### PR DESCRIPTION
As part of a CNI refactor, a bug was introduced where node-specific IPAM overrides were no longer being loaded. Specifically, the parsed network configuration wasn't properly being passed down to the NodeDiscovery manager.

Fixes: #26731
Fixes: 1254bf403f