### PR TITLE
[v1.13] endpoint: don't hold the endpoint lock while generating policy

### DIFF
--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -393,9 +393,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 			ep.Logger("api").WithError(err).Warning("Unable to fetch kubernetes labels")
 		} else {
 			ep.SetPod(pod)
-			if err := ep.SetK8sMetadata(cp); err != nil {
-				return invalidDataError(ep, fmt.Errorf("Invalid ContainerPorts %v: %s", cp, err))
-			}
+			ep.SetK8sMetadata(cp)
 			addLabels.MergeLabels(identityLabels)
 			infoLabels.MergeLabels(info)
 			if _, ok := annotations[bandwidth.IngressBandwidth]; ok {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -369,7 +369,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	var err error
 
 	if option.Config.EnableIPv6 && ep.IPv6.IsValid() {
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanStringLocked()+" [restored]")
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv6.AsSlice(), ep.HumanString()+" [restored]")
 		if err != nil {
 			return fmt.Errorf("unable to reallocate %s IPv6 address: %w", ep.IPv6, err)
 		}
@@ -382,7 +382,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) error {
 	}
 
 	if option.Config.EnableIPv4 && ep.IPv4.IsValid() {
-		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanStringLocked()+"[restored]")
+		_, err = d.ipam.AllocateIPWithoutSyncUpstream(ep.IPv4.AsSlice(), ep.HumanString()+"[restored]")
 		switch {
 		// We only check for BypassIPAllocUponRestore for IPv4 because we
 		// assume that this flag is only turned on for IPv4-only IPAM modes

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -289,10 +290,12 @@ func (e *Endpoint) GetHealthModel() *models.EndpointHealth {
 }
 
 // getNamedPortsModel returns the endpoint's NamedPorts object.
-//
-// Must be called with e.mutex RLock()ed.
 func (e *Endpoint) getNamedPortsModel() (np models.NamedPorts) {
-	k8sPorts := e.k8sPorts
+	var k8sPorts types.NamedPortMap
+	if p := e.k8sPorts.Load(); p != nil {
+		k8sPorts = *p
+	}
+
 	// keep named ports ordered to avoid the unnecessary updates to
 	// kube-apiserver
 	names := make([]string, 0, len(k8sPorts))

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -137,7 +137,7 @@ func (e *Endpoint) getModelEndpointIdentitiersRLocked() *models.EndpointIdentifi
 		ContainerName:    e.containerName,
 		DockerEndpointID: e.dockerEndpointID,
 		DockerNetworkID:  e.dockerNetworkID,
-		PodName:          e.getK8sNamespaceAndPodName(),
+		PodName:          e.GetK8sNamespaceAndPodName(),
 		K8sPodName:       e.K8sPodName,
 		K8sNamespace:     e.K8sNamespace,
 	}
@@ -455,6 +455,9 @@ func (e *Endpoint) policyStatus() models.EndpointPolicyEnabled {
 // purposes should a caller choose to try to regenerate this endpoint, as well
 // as an error if the Endpoint is being deleted, since there is no point in
 // changing an Endpoint if it is going to be deleted.
+//
+// Before adding any new fields here, check to see if they are assumed to be mutable after
+// endpoint creation!
 func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionState bool) (string, error) {
 	var (
 		changed bool

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -742,8 +742,18 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 	stats := &regenContext.Stats
 	datapathRegenCtxt := regenContext.datapathRegenerationContext
 
+	// regenerate policy without holding the lock.
+	// This is because policy generation needs the ipcache to make progress, and the ipcache needs to call
+	// endpoint.ApplyPolicyMapChanges()
+	stats.policyCalculation.Start()
+	policyResult, err := e.regeneratePolicy()
+	stats.policyCalculation.End(err == nil)
+	if err != nil {
+		return false, fmt.Errorf("unable to regenerate policy for '%s': %w", e.StringID(), err)
+	}
+
 	stats.waitingForLock.Start()
-	err := e.lockAlive()
+	err = e.lockAlive()
 	stats.waitingForLock.End(err == nil)
 	if err != nil {
 		return false, err
@@ -776,6 +786,12 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 		close(datapathRegenCtxt.ctCleaned)
 	}
 
+	// Set the computed policy as the "incoming" policy. This can fail if
+	// the endpoint's security identity changed during or after policy calculation.
+	if err := e.setDesiredPolicy(policyResult); err != nil {
+		return false, err
+	}
+
 	// We cannot obtain the rules while e.mutex is held, because obtaining
 	// fresh DNSRules requires the IPCache lock (which must not be taken while
 	// holding e.mutex to avoid deadlocks). Therefore, rules are obtained
@@ -784,12 +800,6 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 
 	// If dry mode is enabled, no further changes to BPF maps are performed
 	if option.Config.DryMode {
-
-		// Compute policy for this endpoint.
-		if err = e.regeneratePolicy(); err != nil {
-			return false, fmt.Errorf("Unable to regenerate policy: %s", err)
-		}
-
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
 		// Dry mode needs Network Policy Updates, but the proxy wait group must
@@ -826,12 +836,6 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 	// Only generate & populate policy map if a security identity is set up for
 	// this endpoint.
 	if e.SecurityIdentity != nil {
-		stats.policyCalculation.Start()
-		err = e.regeneratePolicy()
-		stats.policyCalculation.End(err == nil)
-		if err != nil {
-			return false, fmt.Errorf("unable to regenerate policy for '%s': %s", e.StringID(), err)
-		}
 
 		_ = e.updateAndOverrideEndpointOptions(nil)
 
@@ -862,6 +866,7 @@ func (e *Endpoint) runPreCompilationSteps(regenContext *regenerationContext, rul
 		//
 		// Do this before updating the bpf policy maps below, so that the proxy listeners have a chance to be
 		// ready when new traffic is redirected to them.
+		// note: unlike regeneratePolicy, updateNetworkPolicy requires the endpoint read lock
 		stats.proxyPolicyCalculation.Start()
 		err, networkPolicyRevertFunc := e.updateNetworkPolicy(datapathRegenCtxt.proxyWaitGroup)
 		stats.proxyPolicyCalculation.End(err == nil)

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -244,7 +244,9 @@ type Endpoint struct {
 	logLimiter logging.Limiter
 
 	// policyRevision is the policy revision this endpoint is currently on
-	// to modify this field please use endpoint.setPolicyRevision instead
+	// to modify this field please use endpoint.setPolicyRevision instead.
+	//
+	// To write, both ep.mutex and ep.buildMutex must be held.
 	policyRevision uint64
 
 	// policyRevisionSignals contains a map of PolicyRevision signals that
@@ -267,7 +269,8 @@ type Endpoint struct {
 	proxyStatistics map[string]*models.ProxyStatistics
 
 	// nextPolicyRevision is the policy revision that the endpoint has
-	// updated to and that will become effective with the next regenerate
+	// updated to and that will become effective with the next regenerate.
+	// Must hold the endpoint mutex *and* buildMutex to write, and either to read.
 	nextPolicyRevision uint64
 
 	// forcePolicyCompute full endpoint policy recomputation
@@ -298,7 +301,8 @@ type Endpoint struct {
 	// realizedRedirects maps the ID of each proxy redirect that has been
 	// successfully added into a proxy for this endpoint, to the redirect's
 	// proxy port number.
-	// You must hold Endpoint.mutex to read or write it.
+	// You must hold Endpoint.mutex AND Endpoint.buildMutex to write to it,
+	// and either (or both) of those locks to read from it.
 	realizedRedirects map[string]uint16
 
 	// ctCleaned indicates whether the conntrack table has already been
@@ -311,8 +315,13 @@ type Endpoint struct {
 	// for all endpoints that have the same Identity.
 	selectorPolicy policy.SelectorPolicy
 
+	// desiredPolicy is the policy calculated during regeneration. After
+	// successful regeneration, it is copied to realizedPolicy
+	// To write, both ep.mutex and ep.buildMutex must be held.
 	desiredPolicy *policy.EndpointPolicy
 
+	// realizedPolicy is the policy that has most recently been applied.
+	// ep.mutex must be held.
 	realizedPolicy *policy.EndpointPolicy
 
 	visibilityPolicy *policy.VisibilityPolicy
@@ -1968,6 +1977,10 @@ func (e *Endpoint) identityLabelsChanged(ctx context.Context, myChangeRev int) (
 // SetPolicyRevision sets the endpoint's policy revision with the given
 // revision.
 func (e *Endpoint) SetPolicyRevision(rev uint64) {
+	// Wait for any in-progress regenerations to finish.
+	e.buildMutex.Lock()
+	defer e.buildMutex.Unlock()
+
 	if err := e.lockAlive(); err != nil {
 		return
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -232,13 +233,10 @@ type Endpoint struct {
 
 	// k8sPorts contains container ports associated in the pod.
 	// It is used to enforce k8s network policies with port names.
-	k8sPorts types.NamedPortMap
+	k8sPorts atomic.Pointer[types.NamedPortMap]
 
 	// logLimiter rate limits potentially repeating warning logs
 	logLimiter logging.Limiter
-
-	// k8sPortsSet keep track when k8sPorts was set at least one time.
-	hasK8sMetadata bool
 
 	// policyRevision is the policy revision this endpoint is currently on
 	// to modify this field please use endpoint.setPolicyRevision instead
@@ -1204,9 +1202,8 @@ func (e *Endpoint) SetK8sNamespace(name string) {
 // SetK8sMetadata sets the k8s container ports specified by kubernetes.
 // Note that once put in place, the new k8sPorts is never changed,
 // so that the map can be used concurrently without keeping locks.
-// Reading the 'e.k8sPorts' member (the "map pointer") *itself* requires the endpoint lock!
 // Can't really error out as that might break backwards compatibility.
-func (e *Endpoint) SetK8sMetadata(containerPorts []slim_corev1.ContainerPort) error {
+func (e *Endpoint) SetK8sMetadata(containerPorts []slim_corev1.ContainerPort) {
 	k8sPorts := make(types.NamedPortMap, len(containerPorts))
 	for _, cp := range containerPorts {
 		if cp.Name == "" {
@@ -1218,33 +1215,21 @@ func (e *Endpoint) SetK8sMetadata(containerPorts []slim_corev1.ContainerPort) er
 			continue
 		}
 	}
-	if len(k8sPorts) == 0 {
-		k8sPorts = nil // nil map with no storage
-	}
-	e.mutex.Lock()
-	e.hasK8sMetadata = true
-	e.k8sPorts = k8sPorts
-	e.mutex.Unlock()
-	return nil
+	e.k8sPorts.Store(&k8sPorts)
 }
 
 // GetK8sPorts returns the k8sPorts, which must not be modified by the caller
-func (e *Endpoint) GetK8sPorts() (k8sPorts types.NamedPortMap, err error) {
-	err = e.rlockAlive()
-	if err != nil {
-		return nil, err
+func (e *Endpoint) GetK8sPorts() (k8sPorts types.NamedPortMap) {
+	if p := e.k8sPorts.Load(); p != nil {
+		k8sPorts = *p
 	}
-	k8sPorts = e.k8sPorts
-	e.mutex.RUnlock()
-	return k8sPorts, nil
+	return k8sPorts
 }
 
 // HaveK8sMetadata returns true once hasK8sMetadata was set
 func (e *Endpoint) HaveK8sMetadata() (metadataSet bool) {
-	e.mutex.RLock()
-	metadataSet = e.hasK8sMetadata
-	e.mutex.RUnlock()
-	return
+	p := e.k8sPorts.Load()
+	return p != nil
 }
 
 // K8sNamespaceAndPodNameIsSet returns true if the pod name is set

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -127,10 +127,12 @@ type Endpoint struct {
 	// mutex protects write operations to this endpoint structure
 	mutex lock.RWMutex
 
-	// containerName is the name given to the endpoint by the container runtime
+	// containerName is the name given to the endpoint by the container runtime.
+	// Mutable, must be read with the endpoint lock!
 	containerName string
 
-	// containerID is the container ID that docker has assigned to the endpoint
+	// containerID is the container ID that docker has assigned to the endpoint.
+	// Mutable, must be read with the endpoint lock!
 	containerID string
 
 	// dockerNetworkID is the network ID of the libnetwork network if the
@@ -138,7 +140,8 @@ type Endpoint struct {
 	dockerNetworkID string
 
 	// dockerEndpointID is the Docker network endpoint ID if managed by
-	// libnetwork
+	// libnetwork.
+	// immutable.
 	dockerEndpointID string
 
 	// ifName is the name of the host facing interface (veth pair) which
@@ -222,14 +225,16 @@ type Endpoint struct {
 	// compiled and installed.
 	bpfHeaderfileHash string
 
-	// K8sPodName is the Kubernetes pod name of the endpoint
+	// K8sPodName is the Kubernetes pod name of the endpoint.
+	// Immutable after Endpoint creation.
 	K8sPodName string
 
-	// K8sNamespace is the Kubernetes namespace of the endpoint
+	// K8sNamespace is the Kubernetes namespace of the endpoint.
+	// Immutable after Endpoint creation.
 	K8sNamespace string
 
 	// pod
-	pod *slim_corev1.Pod
+	pod atomic.Pointer[slim_corev1.Pod]
 
 	// k8sPorts contains container ports associated in the pod.
 	// It is used to enforce k8s network policies with port names.
@@ -1168,35 +1173,19 @@ func (e *Endpoint) leaveLocked(proxyWaitGroup *completion.WaitGroup, conf Delete
 // GetK8sNamespace returns the name of the pod if the endpoint represents a
 // Kubernetes pod
 func (e *Endpoint) GetK8sNamespace() string {
-	e.unconditionalRLock()
+	// const after creation
 	ns := e.K8sNamespace
-	e.runlock()
 	return ns
 }
 
 // SetPod sets the pod related to this endpoint.
 func (e *Endpoint) SetPod(pod *slim_corev1.Pod) {
-	e.unconditionalLock()
-	e.pod = pod
-	e.unlock()
+	e.pod.Store(pod)
 }
 
 // GetPod retrieves the pod related to this endpoint
 func (e *Endpoint) GetPod() *slim_corev1.Pod {
-	e.unconditionalRLock()
-	pod := e.pod
-	e.runlock()
-	return pod
-}
-
-// SetK8sNamespace modifies the endpoint's pod name
-func (e *Endpoint) SetK8sNamespace(name string) {
-	e.unconditionalLock()
-	e.K8sNamespace = name
-	e.UpdateLogger(map[string]interface{}{
-		logfields.K8sPodName: e.getK8sNamespaceAndPodName(),
-	})
-	e.unlock()
+	return e.pod.Load()
 }
 
 // SetK8sMetadata sets the k8s container ports specified by kubernetes.
@@ -1235,7 +1224,7 @@ func (e *Endpoint) HaveK8sMetadata() (metadataSet bool) {
 // K8sNamespaceAndPodNameIsSet returns true if the pod name is set
 func (e *Endpoint) K8sNamespaceAndPodNameIsSet() bool {
 	e.unconditionalLock()
-	podName := e.getK8sNamespaceAndPodName()
+	podName := e.GetK8sNamespaceAndPodName()
 	e.unlock()
 	return podName != "" && podName != "/"
 }

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -70,7 +70,7 @@ func (e *Endpoint) Logger(subsystem string) *logrus.Entry {
 //
 // Note: You must hold Endpoint.mutex.Lock() to synchronize logger pointer
 // updates if the endpoint is already exposed. Callers that create new
-// endopoints do not need locks to call this.
+// endpoints do not need locks to call this.
 func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	e.updatePolicyLogger(fields)
 	v := atomic.LoadPointer(&e.logger)
@@ -114,12 +114,12 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	l := baseLogger.WithFields(logrus.Fields{
 		logfields.LogSubsys:              subsystem,
 		logfields.EndpointID:             e.ID,
-		logfields.ContainerID:            e.getShortContainerID(),
+		logfields.ContainerID:            e.getShortContainerIDLocked(),
 		logfields.DatapathPolicyRevision: e.policyRevision,
 		logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 		logfields.IPv4:                   e.GetIPv4Address(),
 		logfields.IPv6:                   e.GetIPv6Address(),
-		logfields.K8sPodName:             e.getK8sNamespaceAndPodName(),
+		logfields.K8sPodName:             e.GetK8sNamespaceAndPodName(),
 	})
 
 	if e.SecurityIdentity != nil {
@@ -173,12 +173,12 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
 		policyLogger = policyLogger.WithFields(logrus.Fields{
 			logfields.LogSubsys:              subsystem,
 			logfields.EndpointID:             e.ID,
-			logfields.ContainerID:            e.getShortContainerID(),
+			logfields.ContainerID:            e.getShortContainerIDLocked(),
 			logfields.DatapathPolicyRevision: e.policyRevision,
 			logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 			logfields.IPv4:                   e.GetIPv4Address(),
 			logfields.IPv6:                   e.GetIPv6Address(),
-			logfields.K8sPodName:             e.getK8sNamespaceAndPodName(),
+			logfields.K8sPodName:             e.GetK8sNamespaceAndPodName(),
 		})
 
 		if e.SecurityIdentity != nil {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -92,7 +92,7 @@ func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
 // lookupRedirectPort returns the redirect L4 proxy port for the given L4
 // policy map key, in host byte order. Returns 0 if not found or the
 // filter doesn't require a redirect.
-// Must be called with Endpoint.mutex held.
+// Must be called with either Endpoint.mutex or Endpoint.buildMutex held for reading.
 func (e *Endpoint) LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16 {
 	return e.realizedRedirects[policy.ProxyID(e.ID, ingress, protocol, port)]
 }
@@ -132,6 +132,13 @@ func (e *Endpoint) setNextPolicyRevision(revision uint64) {
 	})
 }
 
+type policyGenerateResult struct {
+	policyRevision   uint64
+	selectorPolicy   policy.SelectorPolicy
+	endpointPolicy   *policy.EndpointPolicy
+	identityRevision int
+}
+
 // regeneratePolicy computes the policy for the given endpoint based off of the
 // rules in regeneration.Owner's policy repository.
 //
@@ -141,81 +148,166 @@ func (e *Endpoint) setNextPolicyRevision(revision uint64) {
 // however, and it is possible that policy update succeeds for some endpoints,
 // while it fails for other endpoints.
 //
-// Returns:
-//   - err: any error in obtaining information for computing policy, or if
+// Failure may be due to any error in obtaining information for computing policy,
+// or if policy could not be generated given the current set of rules in the repository.
 //
-// policy could not be generated given the current set of rules in the
-// repository.
-// Must be called with endpoint mutex held.
-func (e *Endpoint) regeneratePolicy() (retErr error) {
-	var forceRegeneration bool
+// endpoint lock must NOT be held. This is because the ipcache needs to be able to
+// make progress while generating policy, and *that* needs the endpoint unlocked to call
+// ep.ApplyPolicyMapChanges. Specifically, computing policy may cause identity allocation
+// which requires ipcache progress.
+//
+// buildMutex MUST be held, and not released until setDesiredPolicy and
+// updateRealizedState have been called
+//
+// There are a few fields that depend on this exact configuration of locking:
+//   - ep.desiredPolicy: ep.mutex must be locked between writing this and committing to
+//     the policy maps, or else policy drops may occur
+//   - ep.policyRevision: ep.mutex and ep.buildMutex must be held to write to this
+//   - ep.selectorPolicy: this may be nulled if the endpoints identity changes; we must
+//     check for this when committing. ep.mutex must be held
+//   - ep.realizedRedirects: this is read by external callers as part of policy generation,
+//     so ep.mutex must not be required to read this. Instead, both ep.mutex and ep.buildMutex
+//     must be held to write to this (i.e. we are deep in regeneration)
+//
+// Returns a result that should be passed to setDesiredPolicy after the endpoint's
+// write lock has been acquired, or err if recomputing policy failed.
+func (e *Endpoint) regeneratePolicy() (*policyGenerateResult, error) {
+	var err error
+
+	// lock the endpoint, read our values, then unlock
+	err = e.rlockAlive()
+	if err != nil {
+		return nil, err
+	}
 
 	// No point in calculating policy if endpoint does not have an identity yet.
 	if e.SecurityIdentity == nil {
 		e.getLogger().Warn("Endpoint lacks identity, skipping policy calculation")
-		return nil
+		e.runlock()
+		return nil, nil
 	}
+
+	// Copy out some values we care about, then unlock
+	forcePolicyCompute := e.forcePolicyCompute
+	securityIdentity := e.SecurityIdentity
+
+	// We are computing policy; set this to false.
+	// We do this now, not in setDesiredPolicy(), because if another caller
+	// comes in and forces computation, we should leave that for the *next*
+	// regeneration.
+	e.forcePolicyCompute = false
+
+	result := &policyGenerateResult{
+		selectorPolicy:   e.selectorPolicy,
+		endpointPolicy:   e.desiredPolicy,
+		identityRevision: e.identityRevision,
+	}
+	e.runlock()
 
 	e.getLogger().Debug("Starting policy recalculation...")
 	stats := &policyRegenerationStatistics{}
 	stats.totalTime.Start()
+	defer func() {
+		stats.totalTime.End(err == nil)
+		e.updatePolicyRegenerationStatistics(stats, forcePolicyCompute, err)
+	}()
 
 	stats.waitingForPolicyRepository.Start()
 	repo := e.policyGetter.GetPolicyRepository()
-	repo.Mutex.RLock()
-	revision := repo.GetRevision()
-	defer repo.Mutex.RUnlock()
+	repo.Mutex.RLock() // Be sure to release this lock!
 	stats.waitingForPolicyRepository.End(true)
 
-	// Recompute policy for this endpoint only if not already done for this revision.
-	if !e.forcePolicyCompute && e.nextPolicyRevision >= revision {
-		e.getLogger().WithFields(logrus.Fields{
-			"policyRevision.next": e.nextPolicyRevision,
-			"policyRevision.repo": revision,
-			"policyChanged":       e.nextPolicyRevision > e.policyRevision,
-		}).Debug("Skipping unnecessary endpoint policy recalculation")
+	result.policyRevision = repo.GetRevision()
 
-		return nil
+	// Recompute policy for this endpoint only if not already done for this revision
+	// and identity.
+	if e.nextPolicyRevision >= result.policyRevision &&
+		e.desiredPolicy != nil && result.selectorPolicy != nil {
+
+		if !forcePolicyCompute {
+			e.getLogger().WithFields(logrus.Fields{
+				"policyRevision.next": e.nextPolicyRevision,
+				"policyRevision.repo": result.policyRevision,
+				"policyChanged":       e.nextPolicyRevision > e.policyRevision,
+			}).Debug("Skipping unnecessary endpoint policy recalculation")
+			repo.Mutex.RUnlock()
+			return result, nil
+		} else {
+			e.getLogger().Debug("Forced policy recalculation")
+		}
 	}
 
 	stats.policyCalculation.Start()
-	if e.selectorPolicy == nil {
+	defer func() { stats.policyCalculation.End(err == nil) }()
+	if result.selectorPolicy == nil {
 		// Upon initial insertion or restore, there's currently no good
 		// trigger point to ensure that the security Identity is
 		// assigned after the endpoint is added to the endpointmanager
 		// (and hence also the identitymanager). In that case, detect
 		// that the selectorPolicy is not set and find it.
-		e.selectorPolicy = repo.GetPolicyCache().Lookup(e.SecurityIdentity)
-		if e.selectorPolicy == nil {
+		result.selectorPolicy = repo.GetPolicyCache().Lookup(securityIdentity)
+		if result.selectorPolicy == nil {
 			err := fmt.Errorf("no cached selectorPolicy found")
 			e.getLogger().WithError(err).Warning("Failed to regenerate from cached policy")
-			return err
+			repo.Mutex.RUnlock()
+			return result, err
 		}
 	}
-	// TODO: GH-7515: This should be triggered closer to policy change
-	// handlers, but for now let's just update it here.
-	if err := repo.GetPolicyCache().UpdatePolicy(e.SecurityIdentity); err != nil {
+
+	// UpdatePolicy ensures the SelectorPolicy is fully resolved.
+	// Endpoint lock must not be held!
+	// TODO: GH-7515: Consider ways to compute policy outside of the
+	// endpoint regeneration process, ideally as part of the policy change
+	// handler.
+	err = repo.GetPolicyCache().UpdatePolicy(securityIdentity)
+	if err != nil {
 		e.getLogger().WithError(err).Warning("Failed to update policy")
-		return err
+		repo.Mutex.RUnlock()
+		return nil, err
 	}
-	calculatedPolicy := e.selectorPolicy.Consume(e)
+	repo.Mutex.RUnlock() // Done with policy repository; release this now as Consume() can be slow
 
-	stats.policyCalculation.End(true)
+	// Consume converts a SelectorPolicy in to an EndpointPolicy
+	result.endpointPolicy = result.selectorPolicy.Consume(e)
+	return result, nil
+}
 
-	// This marks the e.desiredPolicy different from the previously realized policy
-	e.desiredPolicy = calculatedPolicy
+// setDesiredPolicy updates the endpoint with the results of a policy calculation.
+//
+// The endpoint write lock must be held and not released until the desired policy has
+// been pushed in to the policymaps via `syncPolicyMap`. This is so that we block
+// ApplyPolicyMapChanges, which has the effect of blocking the ipcache from updating
+// the ipcache bpf map. It is required that any pending changes are pushed in to
+// the policymap before the ipcache map, otherwise endpoints could experience transient
+// policy drops.
+//
+// Specifically, since policy is calculated asynchronously from the ipcacache's apply loop,
+// it is probable that the new policy diverges from the bpf PolicyMap. So, we cannot safely
+// consume incremental changes (and thus allow the ipcache to continue) until we have
+// successfully performed a full sync with the endpoints PolicyMap. Otherwise,
+// the ipcache may remove an identity from the ipcache that the bpf PolicyMap is still
+// relying on.
+func (e *Endpoint) setDesiredPolicy(res *policyGenerateResult) error {
+	// nil result means endpoint had no identity while policy was calculated
+	if res == nil {
+		if e.SecurityIdentity != nil {
+			e.getLogger().Info("Endpoint SecurityIdentity changed during policy regeneration")
+			return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration", e.ID)
+		}
 
-	if e.forcePolicyCompute {
-		forceRegeneration = true     // Options were changed by the caller.
-		e.forcePolicyCompute = false // Policies just computed
-		e.getLogger().Debug("Forced policy recalculation")
+		return nil
+	}
+	// if the security identity changed, reject the policy computation
+	if e.identityRevision != res.identityRevision {
+		e.getLogger().Info("Endpoint SecurityIdentity changed during policy regeneration")
+		return fmt.Errorf("endpoint %d SecurityIdentity changed during policy regeneration", e.ID)
 	}
 
 	// Set the revision of this endpoint to the current revision of the policy
 	// repository.
-	e.setNextPolicyRevision(revision)
-
-	e.updatePolicyRegenerationStatistics(stats, forceRegeneration, retErr)
+	e.setNextPolicyRevision(res.policyRevision)
+	e.selectorPolicy = res.selectorPolicy
+	e.desiredPolicy = res.endpointPolicy
 
 	return nil
 }

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -44,29 +44,7 @@ import (
 func (e *Endpoint) GetNamedPort(ingress bool, name string, proto uint8) uint16 {
 	if ingress {
 		// Ingress only needs the ports of the POD itself
-		k8sPorts, err := e.GetK8sPorts()
-		if err != nil {
-			if e.logLimiter.Allow() {
-				e.getLogger().WithFields(logrus.Fields{
-					logfields.PortName:         name,
-					logfields.Protocol:         u8proto.U8proto(proto).String(),
-					logfields.TrafficDirection: "ingress",
-				}).WithError(err).Warning("Skipping named port")
-			}
-			return 0
-		}
-		return e.getNamedPortIngress(k8sPorts, name, proto)
-	}
-	// egress needs named ports of all the pods
-	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto)
-}
-
-// GetNamedPortLocked returns port for the given name. May return an invalid (0) port
-// Must be called with e.mutex held.
-func (e *Endpoint) GetNamedPortLocked(ingress bool, name string, proto uint8) uint16 {
-	if ingress {
-		// Ingress only needs the ports of the POD itself
-		return e.getNamedPortIngress(e.k8sPorts, name, proto)
+		return e.getNamedPortIngress(e.GetK8sPorts(), name, proto)
 	}
 	// egress needs named ports of all the pods
 	return e.getNamedPortEgress(e.namedPortsGetter.GetNamedPorts(), name, proto)
@@ -103,7 +81,7 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
 	port := uint16(l4.Port)
 	if port == 0 && l4.PortName != "" {
-		port = e.GetNamedPortLocked(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+		port = e.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 		if port == 0 {
 			return ""
 		}
@@ -731,13 +709,12 @@ func (e *Endpoint) runIPIdentitySync(endpointIP netip.Addr) {
 				metadata := e.FormatGlobalEndpointID()
 				k8sNamespace := e.K8sNamespace
 				k8sPodName := e.K8sPodName
-				namedPorts := e.k8sPorts
 
 				// Release lock as we do not want to have long-lasting key-value
 				// store operations resulting in lock being held for a long time.
 				e.runlock()
 
-				if err := ipcache.UpsertIPToKVStore(ctx, IP, hostIP, ID, key, metadata, k8sNamespace, k8sPodName, namedPorts); err != nil {
+				if err := ipcache.UpsertIPToKVStore(ctx, IP, hostIP, ID, key, metadata, k8sNamespace, k8sPodName, e.GetK8sPorts()); err != nil {
 					return fmt.Errorf("unable to add endpoint IP mapping '%s'->'%d': %s", IP.String(), ID, err)
 				}
 				return nil

--- a/pkg/endpoint/policy_generation_test.go
+++ b/pkg/endpoint/policy_generation_test.go
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoint
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/identity/cache"
+	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
+	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
+)
+
+// This test fuzzes the incremental update engine from an end-to-end perspective
+// to ensure we don't ever miss an incremental update.
+//
+// It works by simulating a "churning" IPcache that is constantly allocating new identities.
+// There is a single policy that -- funnily enough -- selects all of the new identities.
+// We then continuously simulate endpoint regeneration and ensure the computed policy contains
+// all the generated identities.
+//
+// By default, we test 1000 identities, which should take less than 10 seconds. If this test fails,
+// please bump the factor to something massive and start debugging :-).
+func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
+	const testfactor = 1000 // bump this to stress-test
+
+	pe := policy.GetPolicyEnabled()
+	policy.SetPolicyEnabled("always")
+	defer policy.SetPolicyEnabled(pe)
+
+	idcache := make(cache.IdentityCache, testfactor)
+	fakeAllocator := testidentity.NewMockIdentityAllocator(idcache)
+	repo := policy.NewPolicyRepository(fakeAllocator, fakeAllocator.GetIdentityCache(), nil)
+
+	defer func() {
+		repo.RepositoryChangeQueue.Stop()
+		repo.RuleReactionQueue.Stop()
+		repo.RepositoryChangeQueue.WaitToBeDrained()
+		repo.RuleReactionQueue.WaitToBeDrained()
+	}()
+
+	addIdentity := func(labelKeys ...string) *identity.Identity {
+		t.Helper()
+		lbls := labels.Labels{}
+		for _, labelKey := range labelKeys {
+			lbls[labelKey] = labels.NewLabel("k8s:"+labelKey, "", "")
+		}
+		id, _, err := fakeAllocator.AllocateIdentity(context.Background(), lbls, false, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		//t.Logf("allocated label %s id %d", labelKeys, id.ID) // commented out for speed
+
+		wg := &sync.WaitGroup{}
+		repo.GetSelectorCache().UpdateIdentities(cache.IdentityCache{
+			id.ID: id.LabelArray,
+		}, nil, wg)
+		wg.Wait()
+		return id
+	}
+
+	podID := addIdentity("pod")
+	repo.GetPolicyCache().LocalEndpointIdentityAdded(podID)
+
+	ep := Endpoint{
+		SecurityIdentity: podID,
+		policyGetter:     &mockPolicyGetter{repo},
+	}
+	ep.UpdateLogger(nil)
+
+	podSelectLabel := labels.ParseSelectLabel("pod")
+	egressSelectLabel := labels.ParseSelectLabel("peer")
+
+	// Create a rule for our pod that selects all peer identities
+	egressDenyRule := &api.Rule{
+		EndpointSelector: api.NewESFromLabels(podSelectLabel),
+		EgressDeny: []api.EgressDenyRule{
+			{
+				EgressCommonRule: api.EgressCommonRule{
+					ToEndpoints: []api.EndpointSelector{
+						api.NewESFromLabels(egressSelectLabel),
+					},
+				},
+				ToPorts: []api.PortDenyRule{
+					{
+						Ports: []api.PortProtocol{
+							{
+								Port:     "80",
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+			},
+		},
+		Labels: labels.LabelArray{
+			labels.NewLabel(k8sConst.PolicyLabelName, "egressDenyRule", labels.LabelSourceAny),
+		},
+	}
+
+	_, _, err := repo.Add(*egressDenyRule, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Track all IDs we allocate so we can validate later that we never miss any
+	checkMutex := lock.Mutex{}
+	allocatedIDs := make(sets.Set[identity.NumericIdentity], testfactor)
+	done := false
+
+	// simulate ipcache churn: continuously allocate IDs and push them to the policy engine.
+	go func() {
+		for i := 0; i < testfactor; i++ {
+			if i%100 == 0 {
+				t.Log(i)
+			}
+			id := addIdentity("peer", fmt.Sprintf("peer%d", i))
+
+			// note: we could stop checking here and the last ID would be missing from allocatedIDs
+			// so we will have to handle the case where we select one more ID than is in allocatedIDs
+			checkMutex.Lock()
+			allocatedIDs.Insert(id.ID)
+			checkMutex.Unlock()
+
+		}
+		done = true
+	}()
+
+	// Continuously compute policy for the pod and ensure we never missed an incremental update.
+	for {
+		t.Log("Calculating policy...")
+		res, err := ep.regeneratePolicy()
+		assert.Nil(t, err)
+
+		// Sleep a random amount, so we accumulate some changes
+		// This does not slow down the test, since we always generate testFactor identities.
+		time.Sleep(time.Duration(rand.Intn(10)) * time.Millisecond)
+
+		// Now, check that all the expected entries are there
+		checkMutex.Lock()
+		t.Log("Checking policy...")
+
+		// Apply any pending incremental changes
+		// This mirrors the existing code, where we consume map changes
+		// while holding the endpoint lock
+		res.endpointPolicy.ConsumeMapChanges()
+		haveIDs := make(sets.Set[identity.NumericIdentity], testfactor)
+		for k := range res.endpointPolicy.PolicyMapState {
+			haveIDs.Insert(identity.NumericIdentity(k.Identity))
+		}
+
+		// It is okay if we have *more* IDs than allocatedIDs, since we may have propagated
+		// an ID change through the policy system but not yet added to the extra list we're
+		// keeping in this test.
+		//
+		// It is confusing, but this assertion checks that allocatedIDs is a subset of haveIDs,
+		// not the other way around.
+		assert.Subset(t, haveIDs, allocatedIDs, "stress-testing the incremental update system failed! DO NOT just retest, there is a race condition!")
+
+		checkMutex.Unlock()
+
+		if done {
+			break
+		}
+	}
+}
+
+type mockPolicyGetter struct {
+	repo *policy.Repository
+}
+
+func (m *mockPolicyGetter) GetPolicyRepository() *policy.Repository {
+	return m.repo
+}

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -174,7 +174,9 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return firstAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	res, err := ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
 	c.Assert(err, check.IsNil)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -197,7 +199,11 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return secondAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	res, err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
+	c.Assert(err, check.IsNil)
+
 	c.Assert(err, check.IsNil)
 	d, err, _, _ := ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
@@ -217,7 +223,11 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return thirdAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	res, err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
+	c.Assert(err, check.IsNil)
+
 	c.Assert(err, check.IsNil)
 	_, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
@@ -264,7 +274,11 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	ep.UpdateVisibilityPolicy(func(_, _ string) (proxyVisibility string, err error) {
 		return noAnno, nil
 	})
-	err = ep.regeneratePolicy()
+	res, err = ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
+	c.Assert(err, check.IsNil)
+
 	c.Assert(err, check.IsNil)
 	d, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
@@ -394,7 +408,9 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	}
 	do.repo.AddList(rules)
 
-	err = ep.regeneratePolicy()
+	res, err := ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
 	c.Assert(err, check.IsNil)
 
 	expected := policy.MapState{

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -12,12 +12,14 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	apiv1 "github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/datapath"
 	"github.com/cilium/cilium/pkg/endpoint"
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
+	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -116,26 +118,22 @@ func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) 
 }
 
 func (s *EndpointManagerSuite) TestLookup(c *C) {
-	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
-	mgr := NewEndpointManager(&dummyEpSyncher{})
 	type args struct {
 		id string
 	}
 	type want struct {
-		ep       *endpoint.Endpoint
+		ep       bool
 		err      error
 		errCheck Checker
 	}
 	tests := []struct {
-		name        string
-		setupArgs   func() args
-		setupWant   func() want
-		preTestRun  func()
-		postTestRun func()
+		name      string
+		setupArgs func() args
+		setupWant func() want
+		cm        apiv1.EndpointChangeRequest
 	}{
 		{
-			name:       "endpoint does not exist",
-			preTestRun: func() {},
+			name: "endpoint does not exist",
 			setupArgs: func() args {
 				return args{
 					"1234",
@@ -143,18 +141,16 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			setupWant: func() want {
 				return want{
-					ep:       nil,
+					ep:       false,
 					err:      nil,
 					errCheck: Equals,
 				}
 			},
-			postTestRun: func() {},
 		},
 		{
 			name: "endpoint by cilium local ID",
-			preTestRun: func() {
-				ep.ID = 1234
-				mgr.expose(ep)
+			cm: apiv1.EndpointChangeRequest{
+				ID: 1234,
 			},
 			setupArgs: func() args {
 				return args{
@@ -163,22 +159,16 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			setupWant: func() want {
 				return want{
-					ep:       ep,
+					ep:       true,
 					err:      nil,
 					errCheck: Equals,
 				}
 			},
-			postTestRun: func() {
-				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
-				ep.ID = 0
-			},
 		},
 		{
 			name: "endpoint by cilium global ID",
-			preTestRun: func() {
-				ep.ID = 1234
-				mgr.expose(ep)
+			cm: apiv1.EndpointChangeRequest{
+				ID: 1234,
 			},
 			setupArgs: func() args {
 				return args{
@@ -191,17 +181,11 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 					errCheck: Equals,
 				}
 			},
-			postTestRun: func() {
-				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
-				ep.ID = 0
-			},
 		},
 		{
 			name: "endpoint by container ID",
-			preTestRun: func() {
-				ep.SetContainerID("1234")
-				mgr.expose(ep)
+			cm: apiv1.EndpointChangeRequest{
+				ContainerID: "1234",
 			},
 			setupArgs: func() args {
 				return args{
@@ -210,22 +194,16 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			setupWant: func() want {
 				return want{
-					ep:       ep,
+					ep:       true,
 					err:      nil,
 					errCheck: Equals,
 				}
 			},
-			postTestRun: func() {
-				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
-				ep.SetContainerID("")
-			},
 		},
 		{
 			name: "endpoint by docker endpoint ID",
-			preTestRun: func() {
-				ep.SetDockerEndpointID("1234")
-				mgr.expose(ep)
+			cm: apiv1.EndpointChangeRequest{
+				DockerEndpointID: "1234",
 			},
 			setupArgs: func() args {
 				return args{
@@ -234,22 +212,16 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			setupWant: func() want {
 				return want{
-					ep:       ep,
+					ep:       true,
 					err:      nil,
 					errCheck: Equals,
 				}
 			},
-			postTestRun: func() {
-				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
-				ep.SetDockerEndpointID("")
-			},
 		},
 		{
 			name: "endpoint by container name",
-			preTestRun: func() {
-				ep.SetContainerName("foo")
-				mgr.expose(ep)
+			cm: apiv1.EndpointChangeRequest{
+				ContainerName: "foo",
 			},
 			setupArgs: func() args {
 				return args{
@@ -258,23 +230,17 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			setupWant: func() want {
 				return want{
-					ep:       ep,
+					ep:       true,
 					err:      nil,
 					errCheck: Equals,
 				}
 			},
-			postTestRun: func() {
-				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
-				ep.SetContainerName("")
-			},
 		},
 		{
 			name: "endpoint by pod name",
-			preTestRun: func() {
-				ep.SetK8sNamespace("default")
-				ep.SetK8sPodName("foo")
-				mgr.expose(ep)
+			cm: apiv1.EndpointChangeRequest{
+				K8sNamespace: "default",
+				K8sPodName:   "foo",
 			},
 			setupArgs: func() args {
 				return args{
@@ -283,22 +249,18 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			setupWant: func() want {
 				return want{
-					ep:       ep,
+					ep:       true,
 					err:      nil,
 					errCheck: Equals,
 				}
 			},
-			postTestRun: func() {
-				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
-				ep.SetK8sPodName("")
-			},
 		},
 		{
 			name: "endpoint by ipv4",
-			preTestRun: func() {
-				ep.IPv4 = netip.MustParseAddr("127.0.0.1")
-				mgr.expose(ep)
+			cm: apiv1.EndpointChangeRequest{
+				Addressing: &apiv1.AddressPair{
+					IPV4: "127.0.0.1",
+				},
 			},
 			setupArgs: func() args {
 				return args{
@@ -307,21 +269,14 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 			},
 			setupWant: func() want {
 				return want{
-					ep:       ep,
+					ep:       true,
 					err:      nil,
 					errCheck: Equals,
 				}
 			},
-			postTestRun: func() {
-				mgr.WaitEndpointRemoved(ep)
-				ep = endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 10, endpoint.StateReady)
-				ep.IPv4 = netip.Addr{}
-			},
 		},
 		{
 			name: "invalid ID",
-			preTestRun: func() {
-			},
 			setupArgs: func() args {
 				return args{
 					endpointid.NewID("foo", "bar"),
@@ -333,13 +288,9 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 					errCheck: Not(Equals),
 				}
 			},
-			postTestRun: func() {
-			},
 		},
 		{
 			name: "invalid cilium ID",
-			preTestRun: func() {
-			},
 			setupArgs: func() args {
 				return args{
 					endpointid.NewID(endpointid.CiliumLocalIdPrefix, "bar"),
@@ -351,18 +302,26 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 					errCheck: Not(Equals),
 				}
 			},
-			postTestRun: func() {
-			},
 		},
 	}
 	for _, tt := range tests {
-		tt.preTestRun()
+		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), &tt.cm)
+		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
+		mgr := NewEndpointManager(&dummyEpSyncher{})
+
+		err = mgr.expose(ep)
+		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
+
 		args := tt.setupArgs()
 		want := tt.setupWant()
 		got, err := mgr.Lookup(args.id)
 		c.Assert(err, want.errCheck, want.err, Commentf("Test Name: %s", tt.name))
-		c.Assert(got, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
-		tt.postTestRun()
+		if want.ep {
+			c.Assert(got, checker.DeepEquals, ep, Commentf("Test Name: %s", tt.name))
+		} else {
+			c.Assert(got, IsNil, Commentf("Test Name: %s", tt.name))
+		}
+		idallocator.ReallocatePool()
 	}
 }
 
@@ -435,67 +394,18 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 
 func (s *EndpointManagerSuite) TestLookupContainerID(c *C) {
 	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 3, endpoint.StateReady)
-	type args struct {
-		id string
-	}
-	type want struct {
-		ep *endpoint.Endpoint
-	}
-	tests := []struct {
-		name        string
-		setupArgs   func() args
-		setupWant   func() want
-		preTestRun  func()
-		postTestRun func()
-	}{
-		{
-			name: "existing container ID",
-			preTestRun: func() {
-				ep.SetContainerID("foo")
-				mgr.expose(ep)
-			},
-			setupArgs: func() args {
-				return args{
-					"foo",
-				}
-			},
-			setupWant: func() want {
-				return want{
-					ep: ep,
-				}
-			},
-			postTestRun: func() {
-				mgr.WaitEndpointRemoved(ep)
-				ep.SetContainerID("")
-			},
-		},
-		{
-			name: "non-existing container ID",
-			preTestRun: func() {
-			},
-			setupArgs: func() args {
-				return args{
-					"foo",
-				}
-			},
-			setupWant: func() want {
-				return want{
-					ep: nil,
-				}
-			},
-			postTestRun: func() {
-			},
-		},
-	}
-	for _, tt := range tests {
-		tt.preTestRun()
-		args := tt.setupArgs()
-		want := tt.setupWant()
-		got := mgr.LookupContainerID(args.id)
-		c.Assert(got, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
-		tt.postTestRun()
-	}
+	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), &apiv1.EndpointChangeRequest{
+		ContainerID: "foo",
+	})
+	c.Assert(err, IsNil)
+	mgr.expose(ep)
+
+	good := mgr.LookupContainerID("foo")
+	c.Assert(good, checker.DeepEquals, ep)
+
+	bad := mgr.LookupContainerID("asdf")
+	c.Assert(bad, IsNil)
+
 }
 
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
@@ -582,8 +492,8 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 		{
 			name: "existing PodName",
 			preTestRun: func() {
-				ep.SetK8sNamespace("default")
-				ep.SetK8sPodName("foo")
+				ep.K8sNamespace = "default"
+				ep.K8sPodName = "foo"
 				mgr.expose(ep)
 			},
 			setupArgs: func() args {
@@ -630,60 +540,44 @@ func (s *EndpointManagerSuite) TestLookupPodName(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
-	mgr := NewEndpointManager(&dummyEpSyncher{})
-	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 6, endpoint.StateReady)
-	type args struct {
-		ep *endpoint.Endpoint
-	}
+	var ep *endpoint.Endpoint
 	type want struct {
 		ep *endpoint.Endpoint
 	}
 	tests := []struct {
-		name        string
-		setupArgs   func() args
-		setupWant   func() want
-		preTestRun  func()
-		postTestRun func()
+		name      string
+		cm        apiv1.EndpointChangeRequest
+		setupWant func() want
 	}{
 		{
 			name: "Updating all references",
-			preTestRun: func() {
-				ep.ID = 1
-				mgr.expose(ep)
-			},
-			setupArgs: func() args {
-				// Update endpoint before running test
-				ep.SetK8sNamespace("default")
-				ep.SetK8sPodName("foo")
-				ep.SetContainerID("container")
-				ep.SetDockerEndpointID("dockerendpointID")
-				ep.IPv4 = netip.MustParseAddr("127.0.0.1")
-				ep.SetContainerName("containername")
-				return args{
-					ep: ep,
-				}
+			cm: apiv1.EndpointChangeRequest{
+				K8sNamespace:     "default",
+				K8sPodName:       "foo",
+				ContainerID:      "container",
+				DockerEndpointID: "dockerendpointID",
+				Addressing: &apiv1.AddressPair{
+					IPV4: "127.0.0.1",
+				},
+				ContainerName: "containername",
 			},
 			setupWant: func() want {
 				return want{
 					ep: ep,
 				}
 			},
-			postTestRun: func() {
-				mgr.WaitEndpointRemoved(ep)
-				ep.SetK8sNamespace("")
-				ep.SetK8sPodName("")
-				ep.SetContainerID("")
-				ep.SetDockerEndpointID("")
-				ep.IPv4 = netip.Addr{}
-				ep.SetContainerName("")
-			},
 		},
 	}
 	for _, tt := range tests {
-		tt.preTestRun()
-		args := tt.setupArgs()
+		var err error
+		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), &tt.cm)
+		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
+		mgr := NewEndpointManager(&dummyEpSyncher{})
+
+		err = mgr.expose(ep)
+		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
 		want := tt.setupWant()
-		mgr.updateReferencesLocked(args.ep, args.ep.IdentifiersLocked())
+		mgr.updateReferencesLocked(ep, ep.IdentifiersLocked())
 
 		ep = mgr.LookupContainerID(want.ep.GetContainerID())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
@@ -699,7 +593,6 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 
 		ep = mgr.LookupPodName(want.ep.GetK8sNamespaceAndPodName())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))
-		tt.postTestRun()
 	}
 }
 

--- a/pkg/envoy/server.go
+++ b/pkg/envoy/server.go
@@ -1546,7 +1546,7 @@ func getDirectionNetworkPolicy(ep logger.EndpointUpdater, l4Policy policy.L4Poli
 
 		port := uint16(l4.Port)
 		if port == 0 && l4.PortName != "" {
-			port = ep.GetNamedPortLocked(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
+			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 			if port == 0 {
 				continue
 			}

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -491,7 +491,7 @@ func (l4Filter *L4Filter) ToMapState(policyOwner PolicyOwner, direction trafficd
 
 	// resolve named port
 	if port == 0 && l4Filter.PortName != "" {
-		port = policyOwner.GetNamedPortLocked(l4Filter.Ingress, l4Filter.PortName, proto)
+		port = policyOwner.GetNamedPort(l4Filter.Ingress, l4Filter.PortName, proto)
 		if port == 0 {
 			return keysToAdd
 		}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -849,7 +849,7 @@ func (keys MapState) DeniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 
 	// resolve named port
 	if port == 0 && l4.PortName != "" {
-		port = policyOwner.GetNamedPortLocked(l4.Ingress, l4.PortName, proto)
+		port = policyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
 		if port == 0 {
 			return true
 		}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -68,7 +68,6 @@ type PolicyOwner interface {
 	GetID() uint64
 	LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
-	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
 	PolicyDebug(fields logrus.Fields, msg string)
 }
 

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -17,15 +17,7 @@ type EndpointInfoSource interface {
 	GetID() uint64
 	GetIPv4Address() string
 	GetIPv6Address() string
-	GetIdentityLocked() identity.NumericIdentity
-	GetLabels() []string
 	HasSidecarProxy() bool
-	// ConntrackName assumes that the caller has *not* acquired any mutexes
-	// that may be associated with this EndpointInfoSource. It is (unfortunately)
-	// up to the caller to know when to use this vs. ConntrackNameLocked, which
-	// assumes that the caller has acquired any needed mutexes of the
-	// implementation.
-	ConntrackName() string
 	ConntrackNameLocked() string
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
 }

--- a/pkg/proxy/logger/epinfo.go
+++ b/pkg/proxy/logger/epinfo.go
@@ -27,7 +27,7 @@ type EndpointInfoSource interface {
 	// implementation.
 	ConntrackName() string
 	ConntrackNameLocked() string
-	GetNamedPortLocked(ingress bool, name string, proto uint8) uint16
+	GetNamedPort(ingress bool, name string, proto uint8) uint16
 }
 
 // EndpointUpdater returns information about an endpoint being proxied and

--- a/pkg/proxy/logger/test/epinfo.go
+++ b/pkg/proxy/logger/test/epinfo.go
@@ -23,17 +23,17 @@ type ProxyUpdaterMock struct {
 func (m *ProxyUpdaterMock) UnconditionalRLock() { m.RWMutex.RLock() }
 func (m *ProxyUpdaterMock) RUnlock()            { m.RWMutex.RUnlock() }
 
-func (m *ProxyUpdaterMock) GetID() uint64                                 { return m.Id }
-func (m *ProxyUpdaterMock) GetIPv4Address() string                        { return m.Ipv4 }
-func (m *ProxyUpdaterMock) GetIPv6Address() string                        { return m.Ipv6 }
-func (m *ProxyUpdaterMock) GetLabels() []string                           { return m.Labels }
-func (m *ProxyUpdaterMock) GetEgressPolicyEnabledLocked() bool            { return true }
-func (m *ProxyUpdaterMock) GetIngressPolicyEnabledLocked() bool           { return true }
-func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity   { return m.Identity }
-func (m *ProxyUpdaterMock) GetNamedPortLocked(bool, string, uint8) uint16 { return 0 }
-func (m *ProxyUpdaterMock) HasSidecarProxy() bool                         { return m.SidecarProxy }
-func (m *ProxyUpdaterMock) ConntrackName() string                         { return m.ConntrackNameLocked() }
-func (m *ProxyUpdaterMock) ConntrackNameLocked() string                   { return "global" }
+func (m *ProxyUpdaterMock) GetID() uint64                               { return m.Id }
+func (m *ProxyUpdaterMock) GetIPv4Address() string                      { return m.Ipv4 }
+func (m *ProxyUpdaterMock) GetIPv6Address() string                      { return m.Ipv6 }
+func (m *ProxyUpdaterMock) GetLabels() []string                         { return m.Labels }
+func (m *ProxyUpdaterMock) GetEgressPolicyEnabledLocked() bool          { return true }
+func (m *ProxyUpdaterMock) GetIngressPolicyEnabledLocked() bool         { return true }
+func (m *ProxyUpdaterMock) GetIdentityLocked() identity.NumericIdentity { return m.Identity }
+func (m *ProxyUpdaterMock) GetNamedPort(bool, string, uint8) uint16     { return 0 }
+func (m *ProxyUpdaterMock) HasSidecarProxy() bool                       { return m.SidecarProxy }
+func (m *ProxyUpdaterMock) ConntrackName() string                       { return m.ConntrackNameLocked() }
+func (m *ProxyUpdaterMock) ConntrackNameLocked() string                 { return "global" }
 
 func (m *ProxyUpdaterMock) OnProxyPolicyUpdate(policyRevision uint64) {}
 func (m *ProxyUpdaterMock) UpdateProxyStatistics(l4Protocol string, port uint16, ingress, request bool,

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -104,6 +104,7 @@ func (f *MockIdentityAllocator) AllocateIdentity(_ context.Context, lbls labels.
 		Labels:         lbls,
 		ReferenceCount: 1,
 	}
+	realID.Sanitize() // copy Labels to LabelArray
 	f.idToIdentity[id] = realID
 
 	return realID, true, nil

--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -243,6 +243,7 @@ const (
 	failedToUpdateLock         = "Failed to update lock:"
 	failedToReleaseLock        = "Failed to release lock:"
 	errorCreatingInitialLeader = "error initially creating leader election record:"
+	secIdentityChanged         = "SecurityIdentity changed during policy regeneration"
 
 	// HelmTemplate is the location of the Helm templates to install Cilium
 	HelmTemplate = "../install/kubernetes/cilium"
@@ -305,7 +306,7 @@ var badLogMessages = map[string][]string{
 	"DATA RACE":         nil,
 	// Exceptions for level=error should only be added as a last resort, if the
 	// error cannot be fixed in Cilium or in the test.
-	"level=error": {opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader},
+	"level=error": {opCantBeFulfilled, initLeaderElection, globalDataSupport, removeInexistentID, failedToListCRDs, retrieveResLock, failedToRelLockEmptyName, failedToUpdateLock, failedToReleaseLock, errorCreatingInitialLeader, secIdentityChanged},
 }
 
 var ciliumCLICommands = map[string]string{


### PR DESCRIPTION
I manually backported this PR to generate the hotfix build, might as well save the backporter some bother and submit it as well.

- [x] #26242 -- endpoint: don't hold the endpoint lock while generating policy (@squeed)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 26242; do contrib/backporting/set-labels.py $pr done 1.13; done
```