### PR TITLE
egressgw: improve reconciliation for IP rules

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -541,44 +541,62 @@ func (manager *Manager) addMissingIpRulesAndRoutes(isRetry bool) (shouldRetry bo
 		return false
 	}
 
-	addIPRulesForConfig := func(endpointIP net.IP, dstCIDR *net.IPNet, gwc *gatewayConfig) {
-		logger := log.WithFields(logrus.Fields{
-			logfields.SourceIP:        endpointIP,
-			logfields.DestinationCIDR: dstCIDR.String(),
-			logfields.EgressIP:        gwc.egressIP.IP,
-			logfields.LinkIndex:       gwc.ifaceIndex,
-		})
-
-		if err := addEgressIpRule(endpointIP, dstCIDR, gwc.egressIP.IP, gwc.ifaceIndex); err != nil {
-			if isRetry {
-				logger.WithError(err).Warn("Can't add IP rule")
-			} else {
-				logger.WithError(err).Debug("Can't add IP rule, will retry")
-				shouldRetry = true
-			}
-		} else {
-			logger.Debug("Added IP rule")
-		}
-	}
-
 	for _, policyConfig := range manager.policyConfigs {
 		gwc := &policyConfig.gatewayConfig
 
-		if gwc.localNodeConfiguredAsGateway &&
-			len(policyConfig.matchedEndpoints) > 0 {
+		if !gwc.localNodeConfiguredAsGateway || len(policyConfig.matchedEndpoints) == 0 {
+			continue
+		}
 
-			policyConfig.forEachEndpointAndDestination(addIPRulesForConfig)
+		logger := log.WithFields(logrus.Fields{
+			logfields.EgressIP:  gwc.egressIP.IP,
+			logfields.LinkIndex: gwc.ifaceIndex,
+		})
 
+		routingTableIdx := egressGatewayRoutingTableIdx(gwc.ifaceIndex)
+
+		ipRules, err := listEgressIpRulesForRoutingTable(routingTableIdx)
+		if err != nil {
+			logger.WithError(err).Warn("Can't fetch IP rules")
+			continue
+		}
+
+		addIPRulesForConfig := func(endpointIP net.IP, dstCIDR *net.IPNet, gwc *gatewayConfig) {
 			logger := log.WithFields(logrus.Fields{
-				logfields.EgressIP:  gwc.egressIP.IP,
-				logfields.LinkIndex: gwc.ifaceIndex,
+				logfields.SourceIP:        endpointIP,
+				logfields.DestinationCIDR: dstCIDR.String(),
+				logfields.EgressIP:        gwc.egressIP.IP,
+				logfields.LinkIndex:       gwc.ifaceIndex,
 			})
 
-			if err := addEgressIpRoutes(gwc.egressIP, gwc.ifaceIndex); err != nil {
-				logger.WithError(err).Warn("Can't add IP routes")
-			} else {
-				logger.Debug("Added IP routes")
+			// check if the corresponding IP rule already exists
+			for _, ipRule := range ipRules {
+				if egressIPRuleMatches(&ipRule, endpointIP, dstCIDR) {
+					return
+				}
 			}
+
+			// insert the missing rule
+			newRule := newEgressIpRule(endpointIP, dstCIDR, routingTableIdx)
+
+			if err := netlink.RuleAdd(newRule); err != nil {
+				if isRetry {
+					logger.WithError(err).Warn("Can't add IP rule")
+				} else {
+					logger.WithError(err).Debug("Can't add IP rule, will retry")
+					shouldRetry = true
+				}
+			} else {
+				logger.Debug("Added IP rule")
+			}
+		}
+
+		policyConfig.forEachEndpointAndDestination(addIPRulesForConfig)
+
+		if err := addEgressIpRoutes(gwc.egressIP, gwc.ifaceIndex); err != nil {
+			logger.WithError(err).Warn("Can't add IP routes")
+		} else {
+			logger.Debug("Added IP routes")
 		}
 	}
 

--- a/pkg/egressgateway/net.go
+++ b/pkg/egressgateway/net.go
@@ -161,7 +161,7 @@ func addEgressIpRoutes(egressIP net.IPNet, ifaceIndex int) error {
 		Gw:        eniGatewayIP,
 		Protocol:  linux_defaults.RTProto,
 	}); err != nil {
-		return fmt.Errorf("unable to add L2 nexthop route: %w", err)
+		return fmt.Errorf("unable to add default route: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Follow-on to https://github.com/cilium/cilium/pull/26721. Also improve the reconciliation for IP rules when EgressGW is used with `--install-egress-gateway-routes`.