### PR TITLE
v1.12 Backports 2023-07-10

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -44,4 +44,4 @@ workflows:
   conformance-gke.yaml:
     paths-ignore-regex: (test|Documentation)/
   tests-l4lb.yaml:
-    paths-regex: (pkg|daemon|bpf|test/l4lb|images)/
+    paths-regex: (bpf|daemon|images|pkg|test/l4lb|vendor)/


### PR DESCRIPTION
 * [x] #26715 (@tklauser)

PRs skipped due to conflicts:

 * #26590 (@YutaroHayakawa)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 26715; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
make add-labels BRANCH=v1.12 ISSUES=26715
```
