### PR TITLE
cni: log format byte array as string

### DIFF
--- a/plugins/cilium-cni/main.go
+++ b/plugins/cilium-cni/main.go
@@ -363,7 +363,7 @@ func setupLogging(n *types.NetConf) error {
 func cmdAdd(args *skel.CmdArgs) (err error) {
 	n, err := types.LoadNetConf(args.StdinData)
 	if err != nil {
-		return fmt.Errorf("unable to parse CNI configuration \"%s\": %s", args.StdinData, err)
+		return fmt.Errorf("unable to parse CNI configuration \"%s\": %v", string(args.StdinData), err)
 	}
 
 	if err = setupLogging(n); err != nil {
@@ -609,7 +609,7 @@ func cmdDel(args *skel.CmdArgs) error {
 	// are guaranteed to be recoverable.
 	n, err := types.LoadNetConf(args.StdinData)
 	if err != nil {
-		return fmt.Errorf("unable to parse CNI configuration \"%s\": %s", args.StdinData, err)
+		return fmt.Errorf("unable to parse CNI configuration \"%s\": %v", string(args.StdinData), err)
 	}
 
 	if err := setupLogging(n); err != nil {
@@ -710,7 +710,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	n, err := types.LoadNetConf(args.StdinData)
 	if err != nil {
 		return cniTypes.NewError(cniTypes.ErrInvalidNetworkConfig, "InvalidNetworkConfig",
-			fmt.Sprintf("unable to parse CNI configuration \"%s\": %s", args.StdinData, err))
+			fmt.Sprintf("unable to parse CNI configuration \"%s\": %v", string(args.StdinData), err))
 	}
 
 	if err := setupLogging(n); err != nil {


### PR DESCRIPTION
Existing cni code logs the StdinData as an array of bytes, that is incomprensible for users checking the logs.

Format cni logs to convert the stdin byte aray to a string.

Example:

> ./cilium-testing-worker2/containerd.log:Jul 06 23:29:42 cilium-testing-worker2 containerd[106]: level=debug msg="Processing CNI ADD request &skel.CmdArgs{ContainerID:\"8e1464e2eba2853979365f7b40ad30826f3e5060e9d3cee93ada262306e9be5b\", Netns:\"/var/run/netns/cni-0e9e8042-fb78-a4fc-c4fa-549f6f44c007\", IfName:\"eth0\", Args:\"K8S_POD_UID=41ae5812-0b9b-4b9f-a9fc-a33db9111522;IgnoreUnknown=1;K8S_POD_NAMESPACE=netpol-x-3947;K8S_POD_NAME=c;K8S_POD_INFRA_CONTAINER_ID=8e1464e2eba2853979365f7b40ad30826f3e5060e9d3cee93ada262306e9be5b\", Path:\"/opt/cni/bin\", StdinData:[]uint8{0x7b, 0x22, 0x63, 0x6e, 0x69, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x22, 0x3a, 0x22, 0x30, 0x2e, 0x33, 0x2e, 0x31, 0x22, 0x2c, 0x22, 0x65, 0x6e, 0x61, 0x62, 0x6c, 0x65, 0x2d, 0x64, 0x65, 0x62, 0x75, 0x67, 0x22, 0x3a, 0x74, 0x72, 0x75, 0x65, 0x2c, 0x22, 0x6c, 0x6f, 0x67, 0x2d, 0x66, 0x69, 0x6c, 0x65, 0x22, 0x3a, 0x22, 0x2f, 0x76, 0x61, 0x72, 0x2f, 0x72, 0x75, 0x6e, 0x2f, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2f, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2d, 0x63, 0x6e, 0x69, 0x2e, 0x6c, 0x6f, 0x67, 0x22, 0x2c, 0x22, 0x6e, 0x61, 0x6d, 0x65, 0x22, 0x3a, 0x22, 0x70, 0x6f, 0x72, 0x74, 0x6d, 0x61, 0x70, 0x22, 0x2c, 0x22, 0x74, 0x79, 0x70, 0x65, 0x22, 0x3a, 0x22, 0x63, 0x69, 0x6c, 0x69, 0x75, 0x6d, 0x2d, 0x63, 0x6e, 0x69, 0x22, 0x7d}}" eventUUID=c15eb614-f63a-44af-9f17-640712ce8b1d subsys=cilium-cni


```release-note
```
