### PR TITLE
map: fix reconciliation failure caused by out of sync errors number

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -84,9 +84,12 @@ type Map struct {
 	// was last scheduled
 	errorResolverLastScheduled time.Time
 
-	// outstandingErrors is the number of outsanding errors syncing with
-	// the kernel
-	outstandingErrors int
+	// outstandingErrors states whether there are outstanding errors, occurred while
+	// syncing an entry with the kernel, that need to be resolved. This variable exists
+	// to avoid iterating over the full cache to check if reconciliation is necessary,
+	// but it is possible that it gets out of sync if an error is automatically
+	// resolved while performing a subsequent Update/Delete operation on the same key.
+	outstandingErrors bool
 
 	// pressureGauge is a metric that tracks the pressure on this map
 	pressureGauge *metrics.GaugeWithThreshold
@@ -213,7 +216,7 @@ func (m *Map) NonPrefixedName() string {
 //
 // m.lock must be held for writing
 func (m *Map) scheduleErrorResolver() {
-	m.outstandingErrors++
+	m.outstandingErrors = true
 
 	if time.Since(m.errorResolverLastScheduled) <= errorResolverSchedulerMinInterval {
 		return
@@ -1037,7 +1040,22 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 		return nil
 	}
 
-	if m.outstandingErrors == 0 {
+	if !m.outstandingErrors {
+		return nil
+	}
+
+	outstanding := 0
+	for _, e := range m.cache {
+		switch e.DesiredAction {
+		case Insert, Delete:
+			outstanding++
+		}
+	}
+
+	// Errors appear to have already been resolved. This can happen if a subsequent
+	// Update/Delete operation acting on the same key succeeded.
+	if outstanding == 0 {
+		m.outstandingErrors = false
 		return nil
 	}
 
@@ -1046,7 +1064,7 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 	}
 
 	scopedLogger := m.scopedLogger()
-	scopedLogger.WithField("remaining", m.outstandingErrors).
+	scopedLogger.WithField("remaining", outstanding).
 		Debug("Starting periodic BPF map error resolver")
 
 	resolved := 0
@@ -1067,7 +1085,7 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 				e.DesiredAction = OK
 				e.LastError = nil
 				resolved++
-				m.outstandingErrors--
+				outstanding--
 			} else {
 				e.LastError = err
 				nerr++
@@ -1083,7 +1101,7 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 			if err == nil || errors.Is(err, ebpf.ErrKeyNotExist) {
 				delete(m.cache, k)
 				resolved++
-				m.outstandingErrors--
+				outstanding--
 			} else {
 				e.LastError = err
 				nerr++
@@ -1102,14 +1120,15 @@ func (m *Map) resolveErrors(ctx context.Context) error {
 	m.updatePressureMetric()
 
 	scopedLogger.WithFields(logrus.Fields{
-		"remaining": m.outstandingErrors,
+		"remaining": outstanding,
 		"resolved":  resolved,
 		"scanned":   scanned,
 		"duration":  time.Since(started),
 	}).Debug("BPF map error resolver completed")
 
-	if m.outstandingErrors > 0 {
-		return fmt.Errorf("%d map sync errors", m.outstandingErrors)
+	m.outstandingErrors = outstanding > 0
+	if m.outstandingErrors {
+		return fmt.Errorf("%d map sync errors", outstanding)
 	}
 
 	return nil


### PR DESCRIPTION
Cached maps come with a controller that retries Update/Delete operations in case an error occurred while synchronizing the given entry with the kernel. Currently, it relies on the `outstandingErrors` counter to determine whether reconciliation is necessary, as well as if any entry still needs to be processed in a subsequent operation.

Yet, it is possible that this counter gets out of sync, in particular in case the given error is resolved automatically when a subsequent operation acting on the same key succeed. If this happens, the reconciliation function will never complete successfully, as there will continue to be an error that cannot be resolved (as it no longer exists). The given controller will this continue failing forever until the agent gets restarted.

Let's fix this inferring the number of outstanding errors from the cache itself. The `outstandingErrors` variable is preserved (although converted to a boolean) to avoid iterating over the full cache in case it is known that no error occurred. Still, if this flag gets out of sync, the only consequence will be that the cache is iterated once to determine that there's actually no failure, ensuring that the reconciliation logic still converges properly.

<!-- Description of change -->

```release-note
Fix issue which caused the map reconciliation process to never complete successfully if the error resolved automatically
```
