### PR TITLE
Add blocking for EnableIngressController in validation

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3785,6 +3785,15 @@ func (c *DaemonConfig) checkIPAMDelegatedPlugin() error {
 		if c.EnableEndpointHealthChecking {
 			return fmt.Errorf("--%s must be disabled with --%s=%s", EnableEndpointHealthChecking, IPAM, ipamOption.IPAMDelegatedPlugin)
 		}
+		// Ingress controller and envoy config require cilium-agent to create an IP address
+		// specifically for differentiating ingress and envoy traffic, which is not possible
+		// with delegated IPAM.
+		if c.EnableIngressController {
+			return fmt.Errorf("--%s must be disabled with --%s=%s", EnableIngressController, IPAM, ipamOption.IPAMDelegatedPlugin)
+		}
+		if c.EnableEnvoyConfig {
+			return fmt.Errorf("--%s must be disabled with --%s=%s", EnableEnvoyConfig, IPAM, ipamOption.IPAMDelegatedPlugin)
+		}
 	}
 	return nil
 }

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -697,6 +697,22 @@ func TestCheckIPAMDelegatedPlugin(t *testing.T) {
 			},
 			expectErr: fmt.Errorf("--local-router-ipv6 must be provided when IPv6 is enabled with --ipam=delegated-plugin"),
 		},
+		{
+			name: "IPAMDelegatedPlugin with ingress controller enabled",
+			d: &DaemonConfig{
+				IPAM:                    ipamOption.IPAMDelegatedPlugin,
+				EnableIngressController: true,
+			},
+			expectErr: fmt.Errorf("--enable-ingress-controller must be disabled with --ipam=delegated-plugin"),
+		},
+		{
+			name: "IPAMDelegatedPlugin with envoy config enabled",
+			d: &DaemonConfig{
+				IPAM:              ipamOption.IPAMDelegatedPlugin,
+				EnableEnvoyConfig: true,
+			},
+			expectErr: fmt.Errorf("--enable-envoy-config must be disabled with --ipam=delegated-plugin"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
We want to block any configurations that enable ingress controllers when using delegated IPAM. Cilium allocates its own IP address for sending and differentiating ingress traffic, which is not possible with delegated IPAM. This change will provide a clearer error message for this. The behavior remains the same with or without these changes as cilium-agent still fails on startup when allocating an IP address.

Here is the current error message:
```
Defaulted container "cilium-agent" out of: cilium-agent, install-cni-binaries (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), clean-cilium-state (init), systemd-networkd-overrides (init), block-wireserver (init)
...
...
...
level=info msg="  Local IPv4 addresses:" subsys=daemon
level=info msg="  - 10.224.0.4" subsys=daemon
level=fatal msg="Error while creating daemon" error="unable to allocate ingress IPs: Operation not supported, see https://cilium.link/ipam-range-full" subsys=daemon
level=warning msg="github.com/cilium/cilium/pkg/k8s/watchers/secret.go:89: failed to list *v1.Secret: secrets is forbidden: User \"system:serviceaccount:kube-system:cilium\" cannot list resource \"secrets\" in API group \"\" at the cluster scope" subsys=klog
level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/watchers/secret.go:89: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User \"system:serviceaccount:kube-system:cilium\" cannot list resource \"secrets\" in API group \"\" at the cluster scope" subsys=k8s
```

We should also add a note that delegated IPAM and ingress controller are incompatible in the **Prerequisites** section of the [ingress controller docs ](https://github.com/cilium/cilium/blob/main/Documentation/network/servicemesh/ingress.rst#prerequisites).

Below is the [background information in Slack](https://cilium.slack.com/archives/C2B917YHE/p1688749487422489) behind this change. 

**Will Daly**
We were doing some testing yesterday with Cilium delegated IPAM and `enable-ingress-controller=true` in Cilium 1.12. Noticed that cilium-agent failed on startup trying to allocate an ingress IP here: https://github.com/cilium/cilium/blob/30c501c11bb4ddd8729354326b4bf669774544a0/daemon/cmd/ipam.go#L349-L352
Delegated IPAM uses the [no-op IP allocator](https://github.com/cilium/cilium/blob/30c501c11bb4ddd8729354326b4bf669774544a0/pkg/ipam/noop_allocator.go#L13-L36), so I'm not too surprised that allocating an IP fails.
However, I'm curious why Cilium's ingress controller needs to allocate an IP in cilium-agent. I see that the IP is used in [pkg/envoy](https://github.com/cilium/cilium/blob/30c501c11bb4ddd8729354326b4bf669774544a0/pkg/envoy/server.go#L707) and [pkg/nodediscovery](https://github.com/cilium/cilium/blob/30c501c11bb4ddd8729354326b4bf669774544a0/pkg/nodediscovery/nodediscovery.go#L237), but I'm not really sure how these interact with the ingress controller.
Could someone help me understand why cilium-agent allocates an ingress IP when the ingress controller is enabled? Thanks!

**Joe Stringer**
Enabling ingress causes Cilium to introduce an L7 proxy in the path for traffic coming into the cluster towards pods inside the cluster. This L7 proxy terminates the TCP connections, so therefore all traffic flowing through the ingress resource between the external peer and the internal peer must have each connection terminated at that proxy.

So we end up with two connections, External Peer to Ingress IP (let's shorten Ext <-> Ing), then from the proxy towards the backend pod (let's shorten Ing <-> Pod)

Broadly there's a couple of ways to handle this TCP termination: Either to attempt transparent proxying, ie the Ing<->Pod connection uses the External IP as the source, or to opaquely proxy, ie the Ing<->Pod connection uses an IP associated with the Ingress node.

For transparent proxying, when the proxy handles the Ing<->Pod connection, the proxy sets the source IP address to the same as the original source IP from the incoming connection. So for the Ing<->Pod connection, the traffic is actually using the IPs of Ext<->Pod. The tricky part here is that for replies back from the Pod, Cilium needs to force that the Pod->Ext 5tuple traffic is actually redirected to the Ingress. Taking this a little further, the Ingress node may be different from the Pod node, so this can get very complicated very quickly. Cilium must track the fact that these specific connections are different from any other connections that go between the Pod and the external IP, in order to force the traffic to be sent back through the proxy (so that the TCP connections / windows / etc line up).

The alternative is to use an IP associated with the node. One option here is that Cilium just uses the Node's IP address in order to initiate the backend connection. While this works from a connectivity perspective, this also makes it difficult to enforce policies differently between traffic that actually originates from the node vs. traffic that is proxied through the node. In both cases, the connection to the Pod backend is actually just initiated from a process on the intermediate node (either local process or the proxy, which is a local process).

So, in order to simplify policy enforcement for traffic coming from an Ingress, Cilium prefers to allocate a brand new IP address specifically for Ingress traffic, and then use this specific IP address when implementing the Ingress proxy logic. When traffic arrives at the backend node for the target Pod, Cilium can then easily differentiate traffic that came into the cluster via the Ingress (because it uses the Ingress IP) vs. traffic that came directly from that particular node.

```release-note
Prevent Cilium from running with Delegated IPAM at the same time as Ingress
```