### PR TITLE
bgpv1: move Signaler to BGPCPSignaler cell

### DIFF
--- a/pkg/bgpv1/agent/nodespecer.go
+++ b/pkg/bgpv1/agent/nodespecer.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/daemon/k8s"
+	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
@@ -35,7 +36,7 @@ type localNodeStoreSpecerParams struct {
 	Config             *option.DaemonConfig
 	NodeResource       k8s.LocalNodeResource
 	CiliumNodeResource k8s.LocalCiliumNodeResource
-	Signaler           Signaler
+	Signaler           *signaler.BGPCPSignaler
 }
 
 // NewNodeSpecer constructs a new nodeSpecer and registers it in the hive lifecycle
@@ -71,7 +72,7 @@ type kubernetesNodeSpecer struct {
 
 	currentNode *slim_corev1.Node
 	workerpool  *workerpool.WorkerPool
-	signaler    Signaler
+	signaler    *signaler.BGPCPSignaler
 }
 
 func (s *kubernetesNodeSpecer) Start(_ hive.HookContext) error {
@@ -153,7 +154,7 @@ type ciliumNodeSpecer struct {
 
 	currentNode *ciliumv2.CiliumNode
 	workerpool  *workerpool.WorkerPool
-	signaler    Signaler
+	signaler    *signaler.BGPCPSignaler
 }
 
 func (s *ciliumNodeSpecer) Start(_ hive.HookContext) error {

--- a/pkg/bgpv1/agent/signaler/signaler.go
+++ b/pkg/bgpv1/agent/signaler/signaler.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+package signaler
+
+// BGPCPSignaler multiplexes multiple event sources into a single level-triggered
+// event instructing the BGP Control Plane Controller to perform reconciliation.
+//
+// BGPCPSignaler should always be constructed with a channel of size 1.
+//
+// Use of a BGPCPSignaler allows for bursts of events to be "rolled-up".
+// This is a suitable approach since the Controller checks the entire state of
+// the world on each iteration of its control loop.
+//
+// Additionally, this precludes any need for ordering between different event
+// sources.
+type BGPCPSignaler struct {
+	Sig chan struct{}
+}
+
+// NewSignaler constructs a Signaler
+func NewBGPCPSignaler() *BGPCPSignaler {
+	return &BGPCPSignaler{
+		Sig: make(chan struct{}, 1),
+	}
+}
+
+// Event adds an edge triggered event to the Signaler.
+//
+// A controller which uses this Signaler will be notified of this event some
+// time after.
+//
+// This signature adheres to the common event handling signatures of
+// cache.ResourceEventHandlerFuncs for convenience.
+func (s BGPCPSignaler) Event(_ interface{}) {
+	select {
+	case s.Sig <- struct{}{}:
+	default:
+	}
+}

--- a/pkg/bgpv1/cell.go
+++ b/pkg/bgpv1/cell.go
@@ -5,6 +5,7 @@ package bgpv1
 
 import (
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/bgpv1/manager"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -22,10 +23,8 @@ var Cell = cell.Module(
 	"BGP Control Plane",
 
 	// The Controller which is the entry point of the module
-	cell.Provide(agent.NewController),
+	cell.Provide(agent.NewController, signaler.NewBGPCPSignaler),
 	cell.ProvidePrivate(
-		// Signaler is used by all cells that observe resources to signal the controller to start reconciliation.
-		agent.NewSignaler,
 		// Local Node Store Specer provides the module with information about the current node.
 		agent.NewNodeSpecer,
 		// BGP Peering Policy resource provides the module with a stream of events for the BGPPeeringPolicy resource.

--- a/pkg/bgpv1/manager/diffstore.go
+++ b/pkg/bgpv1/manager/diffstore.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -33,7 +33,7 @@ type diffStoreParams[T k8sRuntime.Object] struct {
 
 	Lifecycle hive.Lifecycle
 	Resource  resource.Resource[T]
-	Signaler  agent.Signaler
+	Signaler  *signaler.BGPCPSignaler
 }
 
 // diffStore takes a resource.Resource[T] and watches for events, it stores all of the keys that have been changed.
@@ -43,7 +43,7 @@ type diffStore[T k8sRuntime.Object] struct {
 	resource.Store[T]
 
 	resource resource.Resource[T]
-	signaler agent.Signaler
+	signaler *signaler.BGPCPSignaler
 
 	ctx      context.Context
 	cancel   context.CancelFunc

--- a/pkg/bgpv1/manager/diffstore_test.go
+++ b/pkg/bgpv1/manager/diffstore_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -21,7 +21,7 @@ import (
 
 type DiffStoreFixture struct {
 	diffStore DiffStore[*slimv1.Service]
-	signaler  agent.Signaler
+	signaler  *signaler.BGPCPSignaler
 	slimCs    *slim_fake.Clientset
 	hive      *hive.Hive
 }
@@ -49,10 +49,10 @@ func newDiffStoreFixture() *DiffStoreFixture {
 			}
 		}),
 
-		cell.Provide(agent.NewSignaler),
+		cell.Provide(signaler.NewBGPCPSignaler),
 
 		cell.Invoke(func(
-			signaler agent.Signaler,
+			signaler *signaler.BGPCPSignaler,
 			diffFactory DiffStore[*slimv1.Service],
 		) {
 			fixture.signaler = signaler


### PR DESCRIPTION
In order to promote modularity, move BGPCPSignaler to its own cell.

This will allow other subsystems to add this Cell to their dependencies without relying on the BGP-CP-Controller.

Subsystems can then use this event source as a way to notify the BGP-CP it should perform a reconciliation.

```release-note
bpgv1: move the internal BGP signaler to a cell and allow other cells to depend on it.
```
