### PR TITLE
proxy: remove unused xds resource access timeout

### DIFF
--- a/pkg/envoy/grpc.go
+++ b/pkg/envoy/grpc.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"time"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_service_cluster "github.com/cilium/proxy/go/envoy/service/cluster/v3"
@@ -32,10 +31,10 @@ var (
 // startXDSGRPCServer starts a gRPC server to serve xDS APIs using the given
 // resource watcher and network listener.
 // Returns a function that stops the GRPC server when called.
-func startXDSGRPCServer(listener net.Listener, config map[string]*xds.ResourceTypeConfiguration, resourceAccessTimeout time.Duration) context.CancelFunc {
+func startXDSGRPCServer(listener net.Listener, config map[string]*xds.ResourceTypeConfiguration) context.CancelFunc {
 	grpcServer := grpc.NewServer()
 
-	xdsServer := xds.NewServer(config, resourceAccessTimeout)
+	xdsServer := xds.NewServer(config)
 	dsServer := (*xdsGRPCServer)(xdsServer)
 
 	// TODO: https://github.com/cilium/cilium/issues/5051

--- a/pkg/envoy/xds/cache.go
+++ b/pkg/envoy/xds/cache.go
@@ -4,7 +4,6 @@
 package xds
 
 import (
-	"context"
 	"sort"
 
 	"github.com/sirupsen/logrus"
@@ -194,7 +193,7 @@ func (c *Cache) Clear(typeURL string) (version uint64, updated bool) {
 	return c.version, cacheIsUpdated
 }
 
-func (c *Cache) GetResources(ctx context.Context, typeURL string, lastVersion uint64, nodeIP string, resourceNames []string) (*VersionedResources, error) {
+func (c *Cache) GetResources(typeURL string, lastVersion uint64, nodeIP string, resourceNames []string) (*VersionedResources, error) {
 	c.locker.RLock()
 	defer c.locker.RUnlock()
 
@@ -288,7 +287,7 @@ func (c *Cache) EnsureVersion(typeURL string, version uint64) {
 // if available, and returns it. Otherwise, returns nil. If an error occurs while
 // fetching the resource, also returns the error.
 func (c *Cache) Lookup(typeURL string, resourceName string) (proto.Message, error) {
-	res, err := c.GetResources(context.Background(), typeURL, 0, "", []string{resourceName})
+	res, err := c.GetResources(typeURL, 0, "", []string{resourceName})
 	if err != nil || res == nil || len(res.Resources) == 0 {
 		return nil, err
 	}

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	envoy_service_discovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
 	"github.com/sirupsen/logrus"
@@ -92,12 +91,11 @@ type ResourceTypeConfiguration struct {
 // sources.
 // types maps each supported resource type URL to its corresponding resource
 // source and ACK observer.
-func NewServer(resourceTypes map[string]*ResourceTypeConfiguration,
-	resourceAccessTimeout time.Duration) *Server {
+func NewServer(resourceTypes map[string]*ResourceTypeConfiguration) *Server {
 	watchers := make(map[string]*ResourceWatcher, len(resourceTypes))
 	ackObservers := make(map[string]ResourceVersionAckObserver, len(resourceTypes))
 	for typeURL, resType := range resourceTypes {
-		w := NewResourceWatcher(typeURL, resType.Source, resourceAccessTimeout)
+		w := NewResourceWatcher(typeURL, resType.Source)
 		resType.Source.AddResourceVersionObserver(w)
 		watchers[typeURL] = w
 

--- a/pkg/envoy/xds/server_e2e_test.go
+++ b/pkg/envoy/xds/server_e2e_test.go
@@ -144,8 +144,7 @@ func (s *ServerSuite) TestRequestAllResources(c *C) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}},
-		TestTimeout)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
 
 	streamDone := make(chan struct{})
 
@@ -270,8 +269,7 @@ func (s *ServerSuite) TestAck(c *C) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}},
-		TestTimeout)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
 
 	streamDone := make(chan struct{})
 
@@ -396,8 +394,7 @@ func (s *ServerSuite) TestRequestSomeResources(c *C) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}},
-		TestTimeout)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
 
 	streamDone := make(chan struct{})
 
@@ -570,8 +567,7 @@ func (s *ServerSuite) TestUpdateRequestResources(c *C) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}},
-		TestTimeout)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
 
 	streamDone := make(chan struct{})
 
@@ -673,8 +669,7 @@ func (s *ServerSuite) TestRequestStaleNonce(c *C) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}},
-		TestTimeout)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
 
 	streamDone := make(chan struct{})
 
@@ -813,8 +808,7 @@ func (s *ServerSuite) TestNAck(c *C) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}},
-		TestTimeout)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
 
 	streamDone := make(chan struct{})
 
@@ -948,8 +942,7 @@ func (s *ServerSuite) TestNAckFromTheStart(c *C) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}},
-		TestTimeout)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
 
 	streamDone := make(chan struct{})
 
@@ -1082,8 +1075,7 @@ func (s *ServerSuite) TestRequestHighVersionFromTheStart(c *C) {
 	stream := NewMockStream(streamCtx, 1, 1, StreamTimeout, StreamTimeout)
 	defer stream.Close()
 
-	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}},
-		TestTimeout)
+	server := NewServer(map[string]*ResourceTypeConfiguration{typeURL: {Source: cache, AckObserver: mutator}})
 
 	streamDone := make(chan struct{})
 

--- a/pkg/envoy/xds/set.go
+++ b/pkg/envoy/xds/set.go
@@ -4,8 +4,6 @@
 package xds
 
 import (
-	"context"
-
 	"google.golang.org/protobuf/proto"
 
 	"github.com/cilium/cilium/pkg/lock"
@@ -21,8 +19,7 @@ type ResourceSource interface {
 	// changed since lastVersion, nil is returned.
 	// If resourceNames is empty, all resources are returned.
 	// Should not be blocking.
-	GetResources(ctx context.Context, typeURL string, lastVersion uint64,
-		nodeIP string, resourceNames []string) (*VersionedResources, error)
+	GetResources(typeURL string, lastVersion uint64, nodeIP string, resourceNames []string) (*VersionedResources, error)
 
 	// EnsureVersion increases this resource set's version to be at least the
 	// given version. If the current version is already higher than the

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_mysql_proxy "github.com/cilium/proxy/go/contrib/envoy/extensions/filters/network/mysql_proxy/v3"
@@ -224,7 +223,7 @@ func (s *xdsServer) start() error {
 
 	resourceConfig := s.initializeXdsConfigs()
 
-	s.stopFunc = startXDSGRPCServer(socketListener, resourceConfig, 5*time.Second)
+	s.stopFunc = startXDSGRPCServer(socketListener, resourceConfig)
 
 	return nil
 }
@@ -1755,7 +1754,7 @@ func (s *xdsServer) RemoveAllNetworkPolicies() {
 }
 
 func (s *xdsServer) GetNetworkPolicies(resourceNames []string) (map[string]*cilium.NetworkPolicy, error) {
-	resources, err := s.networkPolicyCache.GetResources(context.Background(), NetworkPolicyTypeURL, 0, "", resourceNames)
+	resources, err := s.networkPolicyCache.GetResources(NetworkPolicyTypeURL, 0, "", resourceNames)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
xds cache acepts a resource access timeout which isn't actually used.

It's only used as a timeout on a context.Context that isn't used in the code path.

Therefore, this commit deleted the parameter.