### PR TITLE
hive: Add "hive stats" command

### DIFF
--- a/pkg/hive/cell/cell.go
+++ b/pkg/hive/cell/cell.go
@@ -25,7 +25,7 @@ var (
 //   - Config(): Cell providing a configuration struct.
 type Cell interface {
 	// Info provides a structural summary of the cell for printing purposes.
-	Info(container) Info
+	Info(container, *Stats) Info
 
 	// Apply the cell to the dependency graph container.
 	Apply(container) error

--- a/pkg/hive/cell/config.go
+++ b/pkg/hive/cell/config.go
@@ -136,7 +136,8 @@ func (c *config[Cfg]) Apply(cont container) error {
 	return cont.Provide(c.provideConfig, dig.Export(true))
 }
 
-func (c *config[Cfg]) Info(cont container) (info Info) {
+func (c *config[Cfg]) Info(cont container, s *Stats) (info Info) {
+	s.Configs++
 	cont.Invoke(func(cfg Cfg) {
 		info = &InfoStruct{cfg}
 	})

--- a/pkg/hive/cell/decorator.go
+++ b/pkg/hive/cell/decorator.go
@@ -53,10 +53,10 @@ func (d *decorator) Apply(c container) error {
 	return nil
 }
 
-func (d *decorator) Info(c container) Info {
+func (d *decorator) Info(c container, s *Stats) Info {
 	n := NewInfoNode(fmt.Sprintf("🔀 %s: %s", internal.FuncNameAndLocation(d.decorator), internal.PrettyType(d.decorator)))
 	for _, cell := range d.cells {
-		n.Add(cell.Info(c))
+		n.Add(cell.Info(c, s))
 	}
 	return n
 }

--- a/pkg/hive/cell/group.go
+++ b/pkg/hive/cell/group.go
@@ -20,10 +20,10 @@ func (g group) Apply(c container) error {
 	return nil
 }
 
-func (g group) Info(c container) Info {
+func (g group) Info(c container, s *Stats) Info {
 	n := NewInfoNode("")
 	for _, cell := range g {
-		n.Add(cell.Info(c))
+		n.Add(cell.Info(c, s))
 	}
 	return n
 }

--- a/pkg/hive/cell/info.go
+++ b/pkg/hive/cell/info.go
@@ -43,6 +43,8 @@ type Info interface {
 
 type InfoLeaf string
 
+func (l InfoLeaf) FillStats(*Stats) {}
+
 func (l InfoLeaf) Print(indent int, w *InfoPrinter) {
 	buf := bufio.NewWriter(w)
 	indentString := strings.Repeat(" ", indent)
@@ -77,8 +79,7 @@ type InfoNode struct {
 	// not indented.
 	header    string
 	condensed bool
-
-	children []Info
+	children  []Info
 }
 
 func NewInfoNode(header string) *InfoNode {
@@ -121,4 +122,27 @@ func (n *InfoStruct) Print(indent int, w *InfoPrinter) {
 			fmt.Fprintf(w, "%s%s\n", indentString, line)
 		}
 	}
+}
+
+type Stats struct {
+	Modules   int
+	Providers int
+	Invokes   int
+	Metrics   int
+	Configs   int
+}
+
+func (s *Stats) String() string {
+	return fmt.Sprintf(
+		"Modules: %d\n"+
+			"Providers: %d\n"+
+			"Invokes: %d\n"+
+			"Metrics: %d\n"+
+			"Configs: %d\n",
+		s.Modules,
+		s.Providers,
+		s.Invokes,
+		s.Metrics,
+		s.Configs,
+	)
 }

--- a/pkg/hive/cell/invoke.go
+++ b/pkg/hive/cell/invoke.go
@@ -52,11 +52,12 @@ func (i *invoker) Apply(c container) error {
 	})
 }
 
-func (i *invoker) Info(container) Info {
+func (i *invoker) Info(c container, s *Stats) Info {
 	n := NewInfoNode("")
 	for _, namedFunc := range i.funcs {
 		n.AddLeaf("🛠️ %s: %s", namedFunc.name, internal.PrettyType(namedFunc.fn))
 	}
+	s.Invokes += len(i.funcs)
 	return n
 }
 

--- a/pkg/hive/cell/metric.go
+++ b/pkg/hive/cell/metric.go
@@ -119,10 +119,10 @@ func (m *metric[S]) provideMetrics(metricSet S) metricOut {
 	}
 }
 
-func (m *metric[S]) Info(container) Info {
+func (m *metric[S]) Info(c container, s *Stats) Info {
 	n := NewInfoNode(fmt.Sprintf("📈 %s", internal.FuncNameAndLocation(m.ctor)))
 	n.condensed = true
-
+	s.Metrics++
 	return n
 }
 

--- a/pkg/hive/cell/module.go
+++ b/pkg/hive/cell/module.go
@@ -81,10 +81,11 @@ func (m *module) Apply(c container) error {
 	return nil
 }
 
-func (m *module) Info(c container) Info {
+func (m *module) Info(c container, s *Stats) Info {
 	n := NewInfoNode("Ⓜ️ " + m.id + " (" + m.title + ")")
+	s.Modules++
 	for _, cell := range m.cells {
-		n.Add(cell.Info(c))
+		n.Add(cell.Info(c, s))
 	}
 	return n
 }

--- a/pkg/hive/cell/provide.go
+++ b/pkg/hive/cell/provide.go
@@ -30,7 +30,7 @@ func (p *provider) Apply(c container) error {
 	return nil
 }
 
-func (p *provider) Info(container) Info {
+func (p *provider) Info(c container, s *Stats) Info {
 	n := &InfoNode{}
 	for i, ctor := range p.ctors {
 		info := p.infos[i]
@@ -57,6 +57,7 @@ func (p *provider) Info(container) Info {
 		ctorNode.AddLeaf("⇦ %s", strings.Join(outs, ", "))
 		n.Add(ctorNode)
 	}
+	s.Providers += len(p.ctors)
 	return n
 }
 

--- a/pkg/hive/command.go
+++ b/pkg/hive/command.go
@@ -33,7 +33,15 @@ func (h *Hive) Command() *cobra.Command {
 				h.PrintDotGraph()
 			},
 			TraverseChildren: false,
-		})
+		},
+		&cobra.Command{
+			Use:   "stats",
+			Short: "Output statistics about the hive",
+			Run: func(cmd *cobra.Command, args []string) {
+				h.PrintStats()
+			},
+		},
+	)
 
 	return cmd
 }

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -346,8 +346,9 @@ func (h *Hive) PrintObjects() {
 
 	fmt.Printf("Cells:\n\n")
 	ip := cell.NewInfoPrinter()
+	s := cell.Stats{}
 	for _, c := range h.cells {
-		c.Info(h.container).Print(2, ip)
+		c.Info(h.container, &s).Print(2, ip)
 		fmt.Println()
 	}
 	h.lifecycle.PrintHooks()
@@ -361,6 +362,18 @@ func (h *Hive) PrintDotGraph() {
 	if err := dig.Visualize(h.container, os.Stdout); err != nil {
 		log.WithError(err).Fatal("Failed to Visualize()")
 	}
+}
+
+func (h *Hive) PrintStats() {
+	if err := h.Populate(); err != nil {
+		log.WithError(err).Fatal("Failed to populate object graph")
+	}
+
+	stats := cell.Stats{}
+	for _, c := range h.cells {
+		c.Info(h.container, &stats)
+	}
+	fmt.Print(stats.String())
 }
 
 // getEnvName returns the environment variable to be used for the given option name.


### PR DESCRIPTION
Outputs statistics about the hive. Useful for tracking how we're progressing with the modularization effort.

```
$ go run ./daemon hive stats
Modules: 45
Providers: 74
Invokes: 13
Metrics: 5
Configs: 19
```