### PR TITLE
Endpoint: actually treat identifiers as immutable, remove lock

### DIFF
--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -7,7 +7,6 @@
 package endpoint
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/netip"
@@ -514,28 +513,6 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		if e.setState(StateWaitingForIdentity, "Update endpoint from API PATCH") {
 			changed = true
 		}
-	}
-
-	if len(newEp.mac) != 0 && !bytes.Equal(e.mac, newEp.mac) {
-		e.mac = newEp.mac
-		changed = true
-	}
-
-	if len(newEp.nodeMAC) != 0 && !bytes.Equal(e.GetNodeMAC(), newEp.nodeMAC) {
-		e.nodeMAC = newEp.nodeMAC
-		changed = true
-	}
-
-	if newEp.IPv6.IsValid() && e.IPv6 != newEp.IPv6 {
-		e.IPv6 = newEp.IPv6
-		e.IPv6IPAMPool = newEp.IPv6IPAMPool
-		changed = true
-	}
-
-	if newEp.IPv4.IsValid() && e.IPv4 != newEp.IPv4 {
-		e.IPv4 = newEp.IPv4
-		e.IPv4IPAMPool = newEp.IPv4IPAMPool
-		changed = true
 	}
 
 	if newContainerName := newEp.containerName.Load(); newContainerName != nil && *newContainerName != "" {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -97,11 +97,11 @@ func (e *Endpoint) writeInformationalComments(w io.Writer) error {
 		e.logStatusLocked(BPF, Warning, fmt.Sprintf("Unable to create a base64: %s", err))
 	}
 
-	if e.containerID == "" {
+	if cid := e.GetContainerID(); cid == "" {
 		fmt.Fprintf(fw, " * Docker Network ID: %s\n", e.dockerNetworkID)
 		fmt.Fprintf(fw, " * Docker Endpoint ID: %s\n", e.dockerEndpointID)
 	} else {
-		fmt.Fprintf(fw, " * Container ID: %s\n", e.containerID)
+		fmt.Fprintf(fw, " * Container ID: %s\n", cid)
 		fmt.Fprintf(fw, " * Container Interface: %s\n", e.containerIfName)
 	}
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -140,6 +140,7 @@ type Endpoint struct {
 
 	// dockerNetworkID is the network ID of the libnetwork network if the
 	// endpoint is a docker managed container which uses libnetwork
+	// Constant after endpoint creation / restoration.
 	dockerNetworkID string
 
 	// dockerEndpointID is the Docker network endpoint ID if managed by
@@ -176,22 +177,27 @@ type Endpoint struct {
 	bps uint64
 
 	// mac is the MAC address of the endpoint
-	//
+	// Constant after endpoint creation / restoration.
 	mac mac.MAC // Container MAC address.
 
-	// IPv6 is the IPv6 address of the endpoint
+	// IPv6 is the IPv6 address of the endpoint.
+	// Constant after endpoint creation / restoration.
 	IPv6 netip.Addr
 
-	// IPv6IPAMPool is the IPAM address pool from which the IPv6 address has been allocated from
+	// IPv6IPAMPool is the IPAM address pool from which the IPv6 address has been allocated from.
+	// Constant after endpoint creation / restoration.
 	IPv6IPAMPool string
 
-	// IPv4 is the IPv4 address of the endpoint
+	// IPv4 is the IPv4 address of the endpoint.
+	// Constant after endpoint creation / restoration.
 	IPv4 netip.Addr
 
-	// IPv4IPAMPool is the IPAM address pool from which the IPv4 address has been allocated from
+	// IPv4IPAMPool is the IPAM address pool from which the IPv4 address has been allocated from.
+	// Constant after endpoint creation / restoration.
 	IPv4IPAMPool string
 
 	// nodeMAC is the MAC of the node (agent). The MAC is different for every endpoint.
+	// Constant after endpoint creation / restoration.
 	nodeMAC mac.MAC
 
 	// SecurityIdentity is the security identity of this endpoint. This is computed from
@@ -368,6 +374,7 @@ type Endpoint struct {
 
 	noTrackPort uint16
 
+	// mutable! must hold the endpoint lock to read
 	ciliumEndpointUID k8sTypes.UID
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -127,12 +127,16 @@ type Endpoint struct {
 	mutex lock.RWMutex
 
 	// containerName is the name given to the endpoint by the container runtime.
-	// Mutable, must be read with the endpoint lock!
-	containerName string
+	// It is not mutable once set, but is not set on the initial endpoint creation
+	// when using the docker plugin. CNI-based clusters (read: all clusters) set
+	// this on endpoint creation.
+	containerName atomic.Pointer[string]
 
 	// containerID is the container ID that docker has assigned to the endpoint.
-	// Mutable, must be read with the endpoint lock!
-	containerID string
+	// It is not mutable once set, but is not set on the initial endpoint creation
+	// when using the docker plugin. CNI-based clusters (read: all clusters) set
+	// this on endpoint creation.
+	containerID atomic.Pointer[string]
 
 	// dockerNetworkID is the network ID of the libnetwork network if the
 	// endpoint is a docker managed container which uses libnetwork

--- a/pkg/endpoint/identifiers.go
+++ b/pkg/endpoint/identifiers.go
@@ -104,9 +104,8 @@ func (e *Endpoint) GetDockerEndpointID() string {
 	return e.dockerEndpointID
 }
 
-// IdentifiersLocked fetches the set of attributes that uniquely identify the
-// endpoint. The caller must hold exclusive control over the endpoint.
-func (e *Endpoint) IdentifiersLocked() id.Identifiers {
+// Identifiers fetches the set of attributes that uniquely identify the endpoint.
+func (e *Endpoint) Identifiers() id.Identifiers {
 	refs := make(id.Identifiers, 8)
 	if cniID := e.GetCNIAttachmentID(); cniID != "" {
 		refs[id.CNIAttachmentIdPrefix] = cniID
@@ -141,16 +140,6 @@ func (e *Endpoint) IdentifiersLocked() id.Identifiers {
 	}
 
 	return refs
-}
-
-// Identifiers fetches the set of attributes that uniquely identify the endpoint.
-func (e *Endpoint) Identifiers() (id.Identifiers, error) {
-	if err := e.rlockAlive(); err != nil {
-		return nil, err
-	}
-	defer e.runlock()
-
-	return e.IdentifiersLocked(), nil
 }
 
 // GetCiliumEndpointUID returns the UID of the CiliumEndpoint.

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -110,7 +110,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	f := logrus.Fields{
 		logfields.LogSubsys:              subsystem,
 		logfields.EndpointID:             e.ID,
-		logfields.ContainerID:            e.getShortContainerIDLocked(),
+		logfields.ContainerID:            e.GetShortContainerID(),
 		logfields.ContainerInterface:     e.containerIfName,
 		logfields.DatapathPolicyRevision: e.policyRevision,
 		logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
@@ -170,7 +170,7 @@ func (e *Endpoint) updatePolicyLogger(fields map[string]interface{}) {
 		f := logrus.Fields{
 			logfields.LogSubsys:              subsystem,
 			logfields.EndpointID:             e.ID,
-			logfields.ContainerID:            e.getShortContainerIDLocked(),
+			logfields.ContainerID:            e.GetShortContainerID(),
 			logfields.DatapathPolicyRevision: e.policyRevision,
 			logfields.DesiredPolicyRevision:  e.nextPolicyRevision,
 			logfields.IPv4:                   e.GetIPv4Address(),

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -203,10 +203,7 @@ func (e *Endpoint) RegenerateAfterRestore() error {
 		return fmt.Errorf("failed while regenerating endpoint")
 	}
 
-	// NOTE: unconditionalRLock is used here because it's used only for logging an already restored endpoint
-	e.unconditionalRLock()
 	scopedLog.WithField(logfields.IPAddr, []string{e.GetIPv4Address(), e.GetIPv6Address()}).Info("Restored endpoint")
-	e.runlock()
 	return nil
 }
 

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -364,8 +364,8 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 
 	return &serializableEndpoint{
 		ID:                       e.ID,
-		ContainerName:            e.containerName,
-		ContainerID:              e.containerID,
+		ContainerName:            e.GetContainerName(),
+		ContainerID:              e.GetContainerID(),
 		DockerNetworkID:          e.dockerNetworkID,
 		DockerEndpointID:         e.dockerEndpointID,
 		IfName:                   e.ifName,
@@ -521,8 +521,8 @@ func (ep *Endpoint) MarshalJSON() ([]byte, error) {
 func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.ID = r.ID
 	ep.createdAt = time.Now()
-	ep.containerName = r.ContainerName
-	ep.containerID = r.ContainerID
+	ep.containerName.Store(&r.ContainerName)
+	ep.containerID.Store(&r.ContainerID)
 	ep.dockerNetworkID = r.DockerNetworkID
 	ep.dockerEndpointID = r.DockerEndpointID
 	ep.ifName = r.IfName

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -378,14 +378,7 @@ func (mgr *endpointManager) ReleaseID(ep *endpoint.Endpoint) error {
 // unexpose removes the endpoint from the endpointmanager, so subsequent
 // lookups will no longer find the endpoint.
 func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
-	// Fetch the identifiers; this will only fail if the endpoint is
-	// already disconnected, in which case we don't need to proceed with
-	// the rest of cleaning up the endpoint.
-	identifiers, err := ep.Identifiers()
-	if err != nil {
-		// Already disconnecting
-		return
-	}
+	identifiers := ep.Identifiers()
 	previousState := ep.GetState()
 
 	mgr.mutex.Lock()
@@ -398,7 +391,7 @@ func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
 	// We haven't yet allocated the ID for a restoring endpoint, so no
 	// need to release it.
 	if previousState != endpoint.StateRestoring {
-		if err = mgr.ReleaseID(ep); err != nil {
+		if err := mgr.ReleaseID(ep); err != nil {
 			log.WithError(err).WithFields(logrus.Fields{
 				"state":                   previousState,
 				logfields.CNIAttachmentID: identifiers[endpointid.CNIAttachmentIdPrefix],
@@ -525,10 +518,7 @@ func (mgr *endpointManager) UpdateReferences(ep *endpoint.Endpoint) error {
 	mgr.mutex.Lock()
 	defer mgr.mutex.Unlock()
 
-	identifiers, err := ep.Identifiers()
-	if err != nil {
-		return err
-	}
+	identifiers := ep.Identifiers()
 	mgr.updateReferencesLocked(ep, identifiers)
 
 	return nil
@@ -620,7 +610,7 @@ func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 
 	mgr.mutex.Lock()
 	// Get a copy of the identifiers before exposing the endpoint
-	identifiers := ep.IdentifiersLocked()
+	identifiers := ep.Identifiers()
 	ep.Start(newID)
 	mgr.mcastManager.AddAddress(ep.IPv6)
 	mgr.updateIDReferenceLocked(ep)

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -724,7 +724,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 		err = mgr.expose(ep)
 		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
 		want := tt.setupWant()
-		mgr.updateReferencesLocked(ep, ep.IdentifiersLocked())
+		mgr.updateReferencesLocked(ep, ep.Identifiers())
 
 		ep = mgr.LookupCNIAttachmentID(want.ep.GetCNIAttachmentID())
 		c.Assert(ep, checker.DeepEquals, want.ep, Commentf("Test Name: %s", tt.name))


### PR DESCRIPTION
The EndpointPatch request has been deprecated since 2018. It's still used by the docker network plugin, but that doesn't support changing identifiers, only labels.

So, remove the ability to patch IDs. Then remove an unnecessary lock now that these fields are static.