### PR TITLE
v1.14 backport: Policy deny override redirect

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -219,21 +219,21 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 	}
 	mapState := e.desiredPolicy.PolicyMapState
 
-	insertedDesiredMapState := make(map[policy.Key]struct{})
-	updatedDesiredMapState := make(policy.MapState)
+	adds := make(policy.Keys)
+	old := make(policy.MapState)
 
 	for _, l4 := range m {
 		// Deny policies do not support redirects
 		if l4.IsRedirect() {
 
-			// Check if we are allowing this specific L4 first
-			if !mapState.AllowsL4(e, l4) {
+			// Check if we are denying this specific L4 first regardless the L3
+			if mapState.DeniesL4(e, l4) {
 				continue
 			}
 
 			var redirectPort uint16
 			// Only create a redirect if the proxy is NOT running in a sidecar container
-			// and the parser is HTTP. If running in a sidecar container and the parser
+			// or the parser is not HTTP. If running in a sidecar container and the parser
 			// is HTTP, just allow traffic to the port at L4 by setting the proxy port
 			// to 0.
 			if !e.hasSidecarProxy || l4.L7Parser != policy.ParserTypeHTTP {
@@ -302,22 +302,13 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				direction = trafficdirection.Egress
 			}
 
-			keysFromFilter := l4.ToMapState(e, direction, &policyIdentitiesLabelLookup{e})
-
+			idLookup := &policyIdentitiesLabelLookup{e}
+			keysFromFilter := l4.ToMapState(e, direction, idLookup)
 			for keyFromFilter, entry := range keysFromFilter {
-				if oldEntry, ok := e.desiredPolicy.PolicyMapState[keyFromFilter]; ok {
-					// Keep the original old entry for revert if there are duplicate keys,
-					// which are possible due to named ports resolving to the same number.
-					if _, isDup := updatedDesiredMapState[keyFromFilter]; !isDup {
-						updatedDesiredMapState[keyFromFilter] = oldEntry
-					}
-				} else {
-					insertedDesiredMapState[keyFromFilter] = struct{}{}
-				}
 				if entry.IsRedirectEntry() {
 					entry.ProxyPort = redirectPort
 				}
-				e.desiredPolicy.PolicyMapState[keyFromFilter] = entry
+				e.desiredPolicy.PolicyMapState.DenyPreferredInsertWithChanges(keyFromFilter, entry, adds, nil, old, idLookup)
 			}
 		}
 	}
@@ -330,13 +321,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 		}
 		e.proxyStatisticsMutex.Unlock()
 
-		// Restore the desired policy map state.
-		for key := range insertedDesiredMapState {
-			delete(e.desiredPolicy.PolicyMapState, key)
-		}
-		for key, entry := range updatedDesiredMapState {
-			e.desiredPolicy.PolicyMapState[key] = entry
-		}
+		e.desiredPolicy.PolicyMapState.RevertChanges(adds, old)
 		return nil
 	})
 

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 
 	check "github.com/cilium/checkmate"
+	"github.com/sirupsen/logrus"
 
+	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -18,8 +20,10 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/option"
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/endpoint"
 	"github.com/cilium/cilium/pkg/revert"
@@ -49,7 +53,7 @@ type RedirectSuiteProxy struct {
 // ProxyPolicy parameter.
 func (r *RedirectSuiteProxy) CreateOrUpdateRedirect(ctx context.Context, l4 policy.ProxyPolicy, id string, localEndpoint endpoint.EndpointUpdater, wg *completion.WaitGroup) (proxyPort uint16, err error, finalizeFunc revert.FinalizeFunc, revertFunc revert.RevertFunc) {
 	pp := r.parserProxyPortMap[l4.GetL7Parser()]
-	return pp, nil, nil, nil
+	return pp, nil, func() { log.Infof("FINALIZER CALLED") }, nil
 }
 
 // RemoveRedirect does nothing.
@@ -202,7 +206,6 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	err = ep.setDesiredPolicy(res)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(err, check.IsNil)
 	d, err, _, _ := ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
@@ -226,7 +229,6 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	err = ep.setDesiredPolicy(res)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(err, check.IsNil)
 	_, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
@@ -277,9 +279,211 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	err = ep.setDesiredPolicy(res)
 	c.Assert(err, check.IsNil)
 
-	c.Assert(err, check.IsNil)
 	d, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
 	ep.removeOldRedirects(d, cmp)
 	c.Assert(len(ep.realizedRedirects), check.Equals, 0)
+}
+
+var (
+	// Identity, labels, selectors for an endpoint named "foo"
+	identityFoo = uint32(100)
+	labelsFoo   = labels.ParseSelectLabelArray("foo", "red")
+	selectFoo_  = api.NewESFromLabels(labels.ParseSelectLabel("foo"))
+	denyFooL3__ = selectFoo_
+
+	identityBar = uint32(200)
+
+	labelsBar  = labels.ParseSelectLabelArray("bar", "blue")
+	selectBar_ = api.NewESFromLabels(labels.ParseSelectLabel("bar"))
+
+	denyAllL4_ []api.PortDenyRule
+
+	allowPort80 = []api.PortRule{{
+		Ports: []api.PortProtocol{
+			{Port: "80", Protocol: api.ProtoTCP},
+		},
+	}}
+	allowHTTPRoot = &api.L7Rules{
+		HTTP: []api.PortRuleHTTP{
+			{Method: "GET", Path: "/"},
+		},
+		L7Proto: policy.ParserTypeHTTP.String(),
+	}
+
+	lblsL3DenyFoo = labels.ParseLabelArray("l3-deny")
+	ruleL3DenyFoo = api.NewRule().
+			WithLabels(lblsL3DenyFoo).
+			WithIngressDenyRules([]api.IngressDenyRule{{
+			IngressCommonRule: api.IngressCommonRule{
+				FromEndpoints: []api.EndpointSelector{denyFooL3__},
+			},
+			ToPorts: denyAllL4_,
+		}})
+	lblsL4L7Allow = labels.ParseLabelArray("l4l7-allow")
+	ruleL4L7Allow = api.NewRule().
+			WithLabels(lblsL4L7Allow).
+			WithIngressRules([]api.IngressRule{{
+			IngressCommonRule: api.IngressCommonRule{
+				FromEndpoints: []api.EndpointSelector{},
+			},
+			ToPorts: combineL4L7(allowPort80, allowHTTPRoot),
+		}})
+
+	AllowAnyEgressLabels = labels.LabelArray{labels.NewLabel(policy.LabelKeyPolicyDerivedFrom,
+		policy.LabelAllowAnyEgress,
+		labels.LabelSourceReserved)}
+
+	dirIngress      = trafficdirection.Ingress.Uint8()
+	dirEgress       = trafficdirection.Egress.Uint8()
+	mapKeyAllL7     = policy.Key{Identity: 0, DestPort: 80, Nexthdr: 6, TrafficDirection: dirIngress}
+	mapKeyFoo       = policy.Key{Identity: identityFoo, DestPort: 0, Nexthdr: 0, TrafficDirection: dirIngress}
+	mapKeyFooL7     = policy.Key{Identity: identityFoo, DestPort: 80, Nexthdr: 6, TrafficDirection: dirIngress}
+	mapKeyAllowAllE = policy.Key{Identity: 0, DestPort: 0, Nexthdr: 0, TrafficDirection: dirEgress}
+)
+
+// combineL4L7 returns a new PortRule that refers to the specified l4 ports and
+// l7 rules.
+func combineL4L7(l4 []api.PortRule, l7 *api.L7Rules) []api.PortRule {
+	result := make([]api.PortRule, 0, len(l4))
+	for _, pr := range l4 {
+		result = append(result, api.PortRule{
+			Ports: pr.Ports,
+			Rules: l7,
+		})
+	}
+	return result
+}
+
+func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
+	// Setup dependencies for endpoint.
+	kvstore.SetupDummy(c, "etcd")
+
+	oldPolicyEnable := policy.GetPolicyEnabled()
+	defer policy.SetPolicyEnabled(oldPolicyEnable)
+	policy.SetPolicyEnabled(option.DefaultEnforcement)
+
+	identity.InitWellKnownIdentities(&fakeConfig.Config{})
+	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
+
+	mgr := NewCachingIdentityAllocator(idAllocatorOwner)
+	<-mgr.InitIdentityAllocator(nil)
+	defer mgr.Close()
+
+	identityCache := cache.IdentityCache{
+		identity.NumericIdentity(identityFoo): labelsFoo,
+		identity.NumericIdentity(identityBar): labelsBar,
+	}
+
+	do := &DummyOwner{
+		repo: policy.NewPolicyRepository(mgr, identityCache, nil, nil),
+	}
+	identitymanager.Subscribe(do.repo)
+
+	httpPort := uint16(19001)
+	dnsPort := uint16(19002)
+	kafkaPort := uint16(19003)
+
+	rsp := &RedirectSuiteProxy{
+		parserProxyPortMap: map[policy.L7ParserType]uint16{
+			policy.ParserTypeHTTP:  httpPort,
+			policy.ParserTypeDNS:   dnsPort,
+			policy.ParserTypeKafka: kafkaPort,
+		},
+		redirectPortUserMap: make(map[uint16][]string),
+	}
+
+	ep := NewEndpointWithState(do, do, testipcache.NewMockIPCache(), rsp, mgr, 12345, StateRegenerating)
+
+	epIdentity, _, err := mgr.AllocateIdentity(context.Background(), labelsBar.Labels(),
+		true, identity.NumericIdentity(identityBar))
+	c.Assert(err, check.IsNil)
+	ep.SetIdentity(epIdentity, true)
+
+	// Policy denies anything to "foo"
+	rules := api.Rules{
+		ruleL3DenyFoo.WithEndpointSelector(selectBar_),
+		ruleL4L7Allow.WithEndpointSelector(selectBar_),
+	}
+	do.repo.AddList(rules)
+
+	res, err := ep.regeneratePolicy()
+	c.Assert(err, check.IsNil)
+	err = ep.setDesiredPolicy(res)
+	c.Assert(err, check.IsNil)
+
+	expected := policy.MapState{
+		mapKeyAllowAllE: policy.MapStateEntry{
+			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
+		},
+		mapKeyFoo: policy.MapStateEntry{
+			IsDeny:           true,
+			DerivedFromRules: labels.LabelArrayList{lblsL3DenyFoo},
+		},
+	}
+
+	equal, errStr := checker.ExportedEqual(ep.desiredPolicy.PolicyMapState, expected)
+	c.Assert(errStr, check.Equals, "")
+	c.Assert(equal, check.Equals, true)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmp := completion.NewWaitGroup(ctx)
+
+	logger := ep.getLogger().Logger
+	oldLogLevel := logger.GetLevel()
+	logger.SetLevel(logrus.DebugLevel)
+	defer logger.SetLevel(oldLogLevel)
+
+	desiredRedirects, err, finalizeFunc, revertFunc := ep.addNewRedirects(cmp)
+	c.Assert(err, check.IsNil)
+	finalizeFunc()
+
+	// Redirect is still created, even if all MapState entries may have been overridden by a
+	// deny entry.  A new FQDN redirect may have no MapState entries as the associated CIDR
+	// identities may match no numeric IDs yet, so we can not count the number of added MapState
+	// entries and make any conclusions from it.
+	c.Assert(len(desiredRedirects), check.Equals, 1)
+
+	expected2 := policy.MapState{
+		mapKeyAllowAllE: policy.MapStateEntry{
+			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
+		},
+		mapKeyAllL7: policy.MapStateEntry{
+			IsDeny:           false,
+			ProxyPort:        httpPort,
+			DerivedFromRules: labels.LabelArrayList{lblsL4L7Allow},
+		},
+		mapKeyFoo: policy.MapStateEntry{
+			IsDeny:           true,
+			DerivedFromRules: labels.LabelArrayList{lblsL3DenyFoo},
+		},
+		mapKeyFooL7: policy.MapStateEntry{
+			IsDeny:           true,
+			DerivedFromRules: labels.LabelArrayList{lblsL3DenyFoo},
+		},
+	}
+
+	// Redirect for the HTTP port should have been added, but there should be a deny for Foo on
+	// that port, as it is shadowed by the deny rule
+	equal, errStr = checker.ExportedEqual(ep.desiredPolicy.PolicyMapState, expected2)
+	c.Assert(errStr, check.Equals, "")
+	c.Assert(equal, check.Equals, true)
+
+	// Keep only desired redirects
+	ep.removeOldRedirects(desiredRedirects, cmp)
+
+	// Check that the redirect is still realized
+	c.Assert(len(ep.realizedRedirects), check.Equals, 1)
+	c.Assert(len(ep.desiredPolicy.PolicyMapState), check.Equals, 4)
+
+	// Pretend that something failed and revert the changes
+	revertFunc()
+
+	// Check that the state before addRedirects is restored
+	equal, errStr = checker.ExportedEqual(ep.desiredPolicy.PolicyMapState, expected)
+	c.Assert(errStr, check.Equals, "")
+	c.Assert(equal, check.Equals, true)
+	c.Assert(len(ep.realizedRedirects), check.Equals, 0)
+	c.Assert(len(ep.desiredPolicy.PolicyMapState), check.Equals, 2)
 }

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -567,11 +567,15 @@ func (keys MapState) DenyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 // redirectPreferredInsert inserts a new entry giving priority to L7-redirects by
 // not overwriting a L7-redirect entry with a non-redirect entry.
 func (keys MapState) redirectPreferredInsert(key Key, entry MapStateEntry, adds, deletes Keys, old MapState) {
-	// Do not overwrite the entry, but only merge owners if the old entry is a deny or redirect.
-	// This prevents an existing deny or redirect being overridden by a non-deny or a non-redirect.
+	// Do not overwrite the entry, but only merge owners if the old entry is a deny or if the
+	// old entry is redirect and the new entry is not a redirect.  This prevents an existing
+	// deny entry being overridden, but allows redirect entries to be overridden by other
+	// redirect entries.
 	// Merging owners from the new entry to the existing one has no datapath impact so we skip
 	// adding anything to 'adds' here.
-	if oldEntry, exists := keys[key]; exists && (oldEntry.IsRedirectEntry() || oldEntry.IsDeny) {
+	// Merging owners has the effect of keeping the shared entry alive as long as one of the owners exists.
+	if oldEntry, exists := keys[key]; exists &&
+		(!entry.IsRedirectEntry() && oldEntry.IsRedirectEntry() || oldEntry.IsDeny) {
 		// Save old value before any changes, if desired
 		if old != nil && !entry.DeepEqual(&oldEntry) {
 			old.insertIfNotExists(key, oldEntry)
@@ -839,7 +843,7 @@ func (keys MapState) AllowAllIdentities(ingress, egress bool) {
 	}
 }
 
-func (keys MapState) AllowsL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
+func (keys MapState) DeniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	port := uint16(l4.Port)
 	proto := uint8(l4.U8Proto)
 
@@ -847,7 +851,7 @@ func (keys MapState) AllowsL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	if port == 0 && l4.PortName != "" {
 		port = policyOwner.GetNamedPort(l4.Ingress, l4.PortName, proto)
 		if port == 0 {
-			return false
+			return true
 		}
 	}
 
@@ -863,10 +867,10 @@ func (keys MapState) AllowsL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 		Nexthdr:          0,
 		TrafficDirection: dir,
 	}
-	// Are we explicitly denying any traffic?
+	// Are we explicitly denying all traffic?
 	v, ok := keys[anyKey]
 	if ok && v.IsDeny {
-		return false
+		return true
 	}
 
 	// Are we explicitly denying this L4-only traffic?
@@ -874,10 +878,12 @@ func (keys MapState) AllowsL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	anyKey.Nexthdr = proto
 	v, ok = keys[anyKey]
 	if ok && v.IsDeny {
-		return false
+		return true
 	}
 
-	return true
+	// The given L4 is not categorically denied.
+	// Traffic to/from a specific L3 on any of the selectors can still be denied.
+	return false
 }
 
 func (pms MapState) GetIdentities(log *logrus.Logger) (ingIdentities, egIdentities []int64) {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -235,8 +235,10 @@ func (owner Key) AddDependent(keys MapState, key Key) {
 
 // RemoveDependent removes 'key' from the list of dependent keys.
 // This is called when a dependent entry is being deleted.
-func (keys MapState) RemoveDependent(owner Key, dependent Key) {
+// If 'old' is not nil, then old value is added there before any modifications.
+func (keys MapState) RemoveDependent(owner Key, dependent Key, old MapState) {
 	if e, exists := keys[owner]; exists {
+		old.insertIfNotExists(owner, e)
 		e.RemoveDependent(dependent)
 		keys[owner] = e
 	}
@@ -272,6 +274,43 @@ func (e *MapStateEntry) DatapathEqual(o *MapStateEntry) bool {
 	return e.IsDeny == o.IsDeny && e.ProxyPort == o.ProxyPort && e.AuthType == o.AuthType
 }
 
+// DeepEqual is a manually generated deepequal function, deeply comparing the
+// receiver with other. in must be non-nil.
+// Defined manually due to deepequal-gen not supporting interface types.
+// 'cachedNets' member is ignored in comparison, as it is a cached value and
+// makes no functional difference.
+func (e *MapStateEntry) DeepEqual(o *MapStateEntry) bool {
+	if !e.DatapathEqual(o) {
+		return false
+	}
+
+	if !e.DerivedFromRules.DeepEqual(&o.DerivedFromRules) {
+		return false
+	}
+
+	if len(e.owners) != len(o.owners) {
+		return false
+	}
+	for k := range o.owners {
+		if _, exists := e.owners[k]; !exists {
+			return false
+		}
+	}
+
+	if len(e.dependents) != len(o.dependents) {
+		return false
+	}
+	for k := range o.dependents {
+		if _, exists := e.dependents[k]; !exists {
+			return false
+		}
+	}
+
+	// ignoring cachedNets
+
+	return true
+}
+
 // String returns a string representation of the MapStateEntry
 func (e MapStateEntry) String() string {
 	return fmt.Sprintf("ProxyPort=%d,IsDeny=%t,AuthType=%s", e.ProxyPort, e.IsDeny, e.AuthType.String())
@@ -282,15 +321,20 @@ func (e MapStateEntry) String() string {
 // This form may be used when a full policy is computed and we are not yet interested
 // in accumulating incremental changes.
 func (keys MapState) DenyPreferredInsert(newKey Key, newEntry MapStateEntry, identities Identities) {
-	keys.denyPreferredInsertWithChanges(newKey, newEntry, nil, nil, identities)
+	keys.DenyPreferredInsertWithChanges(newKey, newEntry, nil, nil, nil, identities)
 }
 
-// addKeyWithChanges adds a 'key' with value 'entry' to 'keys' keeping track of incremental changes in 'adds' and 'deletes'
-func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, deletes Keys) {
+// addKeyWithChanges adds a 'key' with value 'entry' to 'keys' keeping track of incremental changes in 'adds' and 'deletes', and any changed or removed old values in 'old', if not nil.
+func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, deletes Keys, old MapState) {
 	// Keep all owners that need this entry so that it is deleted only if all the owners delete their contribution
 	updatedEntry := entry
 	oldEntry, exists := keys[key]
 	if exists {
+		// Save old value before any changes, if desired
+		if old != nil && !entry.DeepEqual(&oldEntry) {
+			old.insertIfNotExists(key, oldEntry)
+		}
+
 		// keep the existing owners of the old entry
 		updatedEntry.owners = oldEntry.owners
 		// keep the existing dependent entries
@@ -318,15 +362,18 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, adds, delet
 
 // deleteKeyWithChanges deletes a 'key' from 'keys' keeping track of incremental changes in 'adds' and 'deletes'.
 // The key is unconditionally deleted if 'cs' is nil, otherwise only the contribution of this 'cs' is removed.
-func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, deletes Keys) {
+func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, deletes Keys, old MapState) {
 	if entry, exists := keys[key]; exists {
+		// Save old value before any changes, if desired
+		oldAdded := old.insertIfNotExists(key, entry)
+
 		if owner != nil {
 			// remove the contribution of the given selector only
 			if _, exists = entry.owners[owner]; exists {
 				// Remove the contribution of this selector from the entry
 				delete(entry.owners, owner)
 				if ownerKey, ok := owner.(Key); ok {
-					keys.RemoveDependent(ownerKey, key)
+					keys.RemoveDependent(ownerKey, key, old)
 				}
 				// key is not deleted if other owners still need it
 				if len(entry.owners) > 0 {
@@ -334,6 +381,9 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, de
 				}
 			} else {
 				// 'owner' was not found, do not change anything
+				if oldAdded {
+					delete(old, key)
+				}
 				return
 			}
 		}
@@ -345,7 +395,7 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, de
 			for owner := range entry.owners {
 				if owner != nil {
 					if ownerKey, ok := owner.(Key); ok {
-						keys.RemoveDependent(ownerKey, key)
+						keys.RemoveDependent(ownerKey, key, old)
 					}
 				}
 			}
@@ -353,7 +403,7 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, de
 
 		// Check if dependent entries need to be deleted as well
 		for k := range entry.dependents {
-			keys.deleteKeyWithChanges(k, key, adds, deletes)
+			keys.deleteKeyWithChanges(k, key, adds, deletes, old)
 		}
 		if deletes != nil {
 			deletes[key] = struct{}{}
@@ -388,11 +438,23 @@ func protocolsMatch(a, b Key) bool {
 	return a.Nexthdr == 0 || b.Nexthdr == 0 || a.Nexthdr == b.Nexthdr
 }
 
-// denyPreferredInsertWithChanges contains the most important business logic for policy insertions. It inserts
+// RevertChanges undoes changes to 'keys' as indicated by 'adds' and 'old' collected via
+// DenyPreferredInsertWithChanges().
+func (keys MapState) RevertChanges(adds Keys, old MapState) {
+	for k := range adds {
+		delete(keys, k)
+	}
+	// 'old' contains all the original values of both modified and deleted entries
+	for k, v := range old {
+		keys[k] = v
+	}
+}
+
+// DenyPreferredInsertWithChanges contains the most important business logic for policy insertions. It inserts
 // a key and entry into the map by giving preference to deny entries, and L3-only deny entries over L3-L4 allows.
 // Incremental changes performed are recorded in 'adds' and 'deletes', if not nil.
 // See https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw#gid=2109052536 for details
-func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, adds, deletes Keys, identities Identities) {
+func (keys MapState) DenyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, adds, deletes Keys, old MapState, identities Identities) {
 	allCpy := allKey
 	allCpy.TrafficDirection = newKey.TrafficDirection
 	// If we have a deny "all" we don't accept any kind of map entry.
@@ -417,7 +479,7 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 						newKeyCpy.DestPort = k.DestPort
 						newKeyCpy.Nexthdr = k.Nexthdr
 						l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, false, true, AuthTypeDisabled)
-						keys.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, adds, deletes)
+						keys.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, adds, deletes, old)
 						// L3-only entries can be deleted incrementally so we need to track their
 						// effects on other entries so that those effects can be reverted when the
 						// identity is removed.
@@ -429,7 +491,7 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 					// If the new-entry is a superset (or equal) of the iterated-allow-entry and
 					// the new-entry has a broader (or equal) port-protocol then we
 					// should delete the iterated-allow-entry
-					keys.deleteKeyWithChanges(k, nil, adds, deletes)
+					keys.deleteKeyWithChanges(k, nil, adds, deletes, old)
 				}
 			} else if (newKey.Identity == k.Identity ||
 				entryIdentityIsSupersetOf(k, v, newKey, newEntry, identities)) &&
@@ -456,10 +518,10 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 				//
 				// NOTE: This condition could be broader to reject more deny entries,
 				// but there *may* be performance tradeoffs.
-				keys.deleteKeyWithChanges(k, nil, adds, deletes)
+				keys.deleteKeyWithChanges(k, nil, adds, deletes, old)
 			}
 		}
-		keys.addKeyWithChanges(newKey, newEntry, adds, deletes)
+		keys.addKeyWithChanges(newKey, newEntry, adds, deletes, old)
 	} else {
 		for k, v := range keys {
 			// Protocols and traffic directions that don't match ensure that the policies
@@ -480,7 +542,7 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 						denyKeyCpy.DestPort = newKey.DestPort
 						denyKeyCpy.Nexthdr = newKey.Nexthdr
 						l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, false, true, AuthTypeDisabled)
-						keys.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, adds, deletes)
+						keys.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, adds, deletes, old)
 						// L3-only entries can be deleted incrementally so we need to track their
 						// effects on other entries so that those effects can be reverted when the
 						// identity is removed.
@@ -498,24 +560,28 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 				}
 			}
 		}
-		keys.redirectPreferredInsert(newKey, newEntry, adds, deletes)
+		keys.redirectPreferredInsert(newKey, newEntry, adds, deletes, old)
 	}
 }
 
 // redirectPreferredInsert inserts a new entry giving priority to L7-redirects by
 // not overwriting a L7-redirect entry with a non-redirect entry.
-func (keys MapState) redirectPreferredInsert(key Key, entry MapStateEntry, adds, deletes Keys) {
+func (keys MapState) redirectPreferredInsert(key Key, entry MapStateEntry, adds, deletes Keys, old MapState) {
 	// Do not overwrite the entry, but only merge owners if the old entry is a deny or redirect.
 	// This prevents an existing deny or redirect being overridden by a non-deny or a non-redirect.
 	// Merging owners from the new entry to the existing one has no datapath impact so we skip
 	// adding anything to 'adds' here.
 	if oldEntry, exists := keys[key]; exists && (oldEntry.IsRedirectEntry() || oldEntry.IsDeny) {
+		// Save old value before any changes, if desired
+		if old != nil && !entry.DeepEqual(&oldEntry) {
+			old.insertIfNotExists(key, oldEntry)
+		}
 		oldEntry.MergeReferences(&entry)
 		keys[key] = oldEntry
 		return
 	}
 	// Otherwise write the entry to the map
-	keys.addKeyWithChanges(key, entry, adds, deletes)
+	keys.addKeyWithChanges(key, entry, adds, deletes, old)
 }
 
 var visibilityDerivedFromLabels = labels.LabelArray{
@@ -524,12 +590,16 @@ var visibilityDerivedFromLabels = labels.LabelArray{
 
 var visibilityDerivedFrom = labels.LabelArrayList{visibilityDerivedFromLabels}
 
-func (keys MapState) insertIfNotExists(key Key, entry MapStateEntry) {
+// insertIfNotExists only inserts `key=value` if `key` does not exist in keys already
+// returns 'true' if 'key=entry' was added to 'keys'
+func (keys MapState) insertIfNotExists(key Key, entry MapStateEntry) bool {
 	if keys != nil {
 		if _, exists := keys[key]; !exists {
 			keys[key] = entry
+			return true
 		}
 	}
+	return false
 }
 
 // AddVisibilityKeys adjusts and expands PolicyMapState keys
@@ -917,11 +987,11 @@ func (mc *MapChanges) consumeMapChanges(policyMapState MapState, identities Iden
 			// insert but do not allow non-redirect entries to overwrite a redirect entry,
 			// nor allow non-deny entries to overwrite deny entries.
 			// Collect the incremental changes to the overall state in 'mc.adds' and 'mc.deletes'.
-			policyMapState.denyPreferredInsertWithChanges(mc.changes[i].Key, mc.changes[i].Value, adds, deletes, identities)
+			policyMapState.DenyPreferredInsertWithChanges(mc.changes[i].Key, mc.changes[i].Value, adds, deletes, nil, identities)
 		} else {
 			// Delete the contribution of this cs to the key and collect incremental changes
 			for cs := range mc.changes[i].Value.owners { // get the sole selector
-				policyMapState.deleteKeyWithChanges(mc.changes[i].Key, cs, adds, deletes)
+				policyMapState.deleteKeyWithChanges(mc.changes[i].Key, cs, adds, deletes, nil)
 			}
 		}
 	}


### PR DESCRIPTION
 * [ ] #26344 (@jrajahalme)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 26344; do contrib/backporting/set-labels.py $pr done 1.14; done
```
or with
```
make add-labels BRANCH=v1.14 ISSUES=26344
```
