### PR TITLE
Fix spelling for "WireGuard"

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -150,8 +150,8 @@ cilium-agent [flags]
       --enable-unreachable-routes                                 Add unreachable routes on pod deletion
       --enable-vtep                                               Enable  VXLAN Tunnel Endpoint (VTEP) Integration (beta)
       --enable-well-known-identities                              Enable well-known identities for known Kubernetes components (default true)
-      --enable-wireguard                                          Enable wireguard
-      --enable-wireguard-userspace-fallback                       Enables the fallback to the wireguard userspace implementation
+      --enable-wireguard                                          Enable WireGuard
+      --enable-wireguard-userspace-fallback                       Enable fallback to the WireGuard userspace implementation
       --enable-xdp-prefilter                                      Enable XDP prefiltering
       --enable-xt-socket-fallback                                 Enable fallback for missing xt_socket module (default true)
       --encrypt-interface string                                  Transparent encryption interface

--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -144,7 +144,7 @@ Multi-Pool IPAM mode:
 
 .. warning::
    - Tunnel mode is not supported. Multi-Pool IPAM may only be used in direct routing mode.
-   - Transparent encryption is only supported with Wireguard and cannot be used with IPSec.
+   - Transparent encryption is only supported with WireGuard and cannot be used with IPSec.
    - IPAM pools with overlapping CIDRs are not supported. Each pod IP must be
      unique in the cluster due the way Cilium determines the security identity
      of endpoints by way of the IPCache.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -694,7 +694,6 @@ webhook
 webhooks
 webservice
 whitespace
-wireguard
 www
 xDS
 xdp

--- a/api/v1/models/debug_info.go
+++ b/api/v1/models/debug_info.go
@@ -336,7 +336,7 @@ func (m *DebugInfo) UnmarshalBinary(b []byte) error {
 // swagger:model DebugInfoEncryption
 type DebugInfoEncryption struct {
 
-	// Status of the Wireguard agent
+	// Status of the WireGuard agent
 	Wireguard *WireguardStatus `json:"wireguard,omitempty"`
 }
 

--- a/api/v1/models/encryption_status.go
+++ b/api/v1/models/encryption_status.go
@@ -32,7 +32,7 @@ type EncryptionStatus struct {
 	// Human readable status/error/warning message
 	Msg string `json:"msg,omitempty"`
 
-	// Status of the Wireguard agent
+	// Status of the WireGuard agent
 	Wireguard *WireguardStatus `json:"wireguard,omitempty"`
 }
 

--- a/api/v1/models/wireguard_interface.go
+++ b/api/v1/models/wireguard_interface.go
@@ -17,14 +17,14 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// WireguardInterface Status of a Wireguard interface
+// WireguardInterface Status of a WireGuard interface
 //
 // +k8s:deepcopy-gen=true
 //
 // swagger:model WireguardInterface
 type WireguardInterface struct {
 
-	// Port on which the Wireguard endpoint is exposed
+	// Port on which the WireGuard endpoint is exposed
 	ListenPort int64 `json:"listen-port,omitempty"`
 
 	// Name of the interface
@@ -33,7 +33,7 @@ type WireguardInterface struct {
 	// Number of peers configured on this interface
 	PeerCount int64 `json:"peer-count,omitempty"`
 
-	// Optional list of wireguard peers
+	// Optional list of WireGuard peers
 	Peers []*WireguardPeer `json:"peers"`
 
 	// Public key of this interface

--- a/api/v1/models/wireguard_peer.go
+++ b/api/v1/models/wireguard_peer.go
@@ -17,7 +17,7 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// WireguardPeer Status of a Wireguard peer
+// WireguardPeer Status of a WireGuard peer
 //
 // +k8s:deepcopy-gen=true
 //

--- a/api/v1/models/wireguard_status.go
+++ b/api/v1/models/wireguard_status.go
@@ -17,14 +17,14 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// WireguardStatus Status of the Wireguard agent
+// WireguardStatus Status of the WireGuard agent
 //
 // +k8s:deepcopy-gen=true
 //
 // swagger:model WireguardStatus
 type WireguardStatus struct {
 
-	// Wireguard interfaces managed by this Cilium instance
+	// WireGuard interfaces managed by this Cilium instance
 	Interfaces []*WireguardInterface `json:"interfaces"`
 
 	// Node Encryption status

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1643,7 +1643,7 @@ definitions:
         type: object
         properties:
           wireguard:
-            description: Status of the Wireguard agent
+            description: Status of the WireGuard agent
             "$ref": "#/definitions/WireguardStatus"
   CgroupDumpMetadata:
     description: cgroup full metadata
@@ -3481,7 +3481,7 @@ definitions:
         type: string
         description: Human readable status/error/warning message
       wireguard:
-        description: Status of the Wireguard agent
+        description: Status of the WireGuard agent
         "$ref": "#/definitions/WireguardStatus"
   CNIChainingStatus:
     description: |-
@@ -3499,7 +3499,7 @@ definitions:
           - portmap
   WireguardStatus:
     description: |-
-      Status of the Wireguard agent
+      Status of the WireGuard agent
 
       +k8s:deepcopy-gen=true
     properties:
@@ -3507,13 +3507,13 @@ definitions:
         description: Node Encryption status
         type: string
       interfaces:
-        description: Wireguard interfaces managed by this Cilium instance
+        description: WireGuard interfaces managed by this Cilium instance
         type: array
         items:
           "$ref": "#/definitions/WireguardInterface"
   WireguardInterface:
     description: |-
-      Status of a Wireguard interface
+      Status of a WireGuard interface
 
       +k8s:deepcopy-gen=true
     properties:
@@ -3524,19 +3524,19 @@ definitions:
         description: Public key of this interface
         type: string
       listen-port:
-        description: Port on which the Wireguard endpoint is exposed
+        description: Port on which the WireGuard endpoint is exposed
         type: integer
       peer-count:
         description: Number of peers configured on this interface
         type: integer
       peers:
-        description: Optional list of wireguard peers
+        description: Optional list of WireGuard peers
         type: array
         items:
           "$ref": "#/definitions/WireguardPeer"
   WireguardPeer:
     description: |-
-      Status of a Wireguard peer
+      Status of a WireGuard peer
 
       +k8s:deepcopy-gen=true
     properties:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2385,7 +2385,7 @@ func init() {
           "type": "object",
           "properties": {
             "wireguard": {
-              "description": "Status of the Wireguard agent",
+              "description": "Status of the WireGuard agent",
               "$ref": "#/definitions/WireguardStatus"
             }
           }
@@ -2438,7 +2438,7 @@ func init() {
           "type": "string"
         },
         "wireguard": {
-          "description": "Status of the Wireguard agent",
+          "description": "Status of the WireGuard agent",
           "$ref": "#/definitions/WireguardStatus"
         }
       }
@@ -4596,10 +4596,10 @@ func init() {
       }
     },
     "WireguardInterface": {
-      "description": "Status of a Wireguard interface\n\n+k8s:deepcopy-gen=true",
+      "description": "Status of a WireGuard interface\n\n+k8s:deepcopy-gen=true",
       "properties": {
         "listen-port": {
-          "description": "Port on which the Wireguard endpoint is exposed",
+          "description": "Port on which the WireGuard endpoint is exposed",
           "type": "integer"
         },
         "name": {
@@ -4611,7 +4611,7 @@ func init() {
           "type": "integer"
         },
         "peers": {
-          "description": "Optional list of wireguard peers",
+          "description": "Optional list of WireGuard peers",
           "type": "array",
           "items": {
             "$ref": "#/definitions/WireguardPeer"
@@ -4624,7 +4624,7 @@ func init() {
       }
     },
     "WireguardPeer": {
-      "description": "Status of a Wireguard peer\n\n+k8s:deepcopy-gen=true",
+      "description": "Status of a WireGuard peer\n\n+k8s:deepcopy-gen=true",
       "properties": {
         "allowed-ips": {
           "description": "List of IPs which may be routed through this peer",
@@ -4657,10 +4657,10 @@ func init() {
       }
     },
     "WireguardStatus": {
-      "description": "Status of the Wireguard agent\n\n+k8s:deepcopy-gen=true",
+      "description": "Status of the WireGuard agent\n\n+k8s:deepcopy-gen=true",
       "properties": {
         "interfaces": {
-          "description": "Wireguard interfaces managed by this Cilium instance",
+          "description": "WireGuard interfaces managed by this Cilium instance",
           "type": "array",
           "items": {
             "$ref": "#/definitions/WireguardInterface"
@@ -7458,7 +7458,7 @@ func init() {
           "type": "object",
           "properties": {
             "wireguard": {
-              "description": "Status of the Wireguard agent",
+              "description": "Status of the WireGuard agent",
               "$ref": "#/definitions/WireguardStatus"
             }
           }
@@ -7499,7 +7499,7 @@ func init() {
       "type": "object",
       "properties": {
         "wireguard": {
-          "description": "Status of the Wireguard agent",
+          "description": "Status of the WireGuard agent",
           "$ref": "#/definitions/WireguardStatus"
         }
       }
@@ -7520,7 +7520,7 @@ func init() {
           "type": "string"
         },
         "wireguard": {
-          "description": "Status of the Wireguard agent",
+          "description": "Status of the WireGuard agent",
           "$ref": "#/definitions/WireguardStatus"
         }
       }
@@ -10122,10 +10122,10 @@ func init() {
       }
     },
     "WireguardInterface": {
-      "description": "Status of a Wireguard interface\n\n+k8s:deepcopy-gen=true",
+      "description": "Status of a WireGuard interface\n\n+k8s:deepcopy-gen=true",
       "properties": {
         "listen-port": {
-          "description": "Port on which the Wireguard endpoint is exposed",
+          "description": "Port on which the WireGuard endpoint is exposed",
           "type": "integer"
         },
         "name": {
@@ -10137,7 +10137,7 @@ func init() {
           "type": "integer"
         },
         "peers": {
-          "description": "Optional list of wireguard peers",
+          "description": "Optional list of WireGuard peers",
           "type": "array",
           "items": {
             "$ref": "#/definitions/WireguardPeer"
@@ -10150,7 +10150,7 @@ func init() {
       }
     },
     "WireguardPeer": {
-      "description": "Status of a Wireguard peer\n\n+k8s:deepcopy-gen=true",
+      "description": "Status of a WireGuard peer\n\n+k8s:deepcopy-gen=true",
       "properties": {
         "allowed-ips": {
           "description": "List of IPs which may be routed through this peer",
@@ -10183,10 +10183,10 @@ func init() {
       }
     },
     "WireguardStatus": {
-      "description": "Status of the Wireguard agent\n\n+k8s:deepcopy-gen=true",
+      "description": "Status of the WireGuard agent\n\n+k8s:deepcopy-gen=true",
       "properties": {
         "interfaces": {
-          "description": "Wireguard interfaces managed by this Cilium instance",
+          "description": "WireGuard interfaces managed by this Cilium instance",
           "type": "array",
           "items": {
             "$ref": "#/definitions/WireguardInterface"

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -323,7 +323,7 @@ func addEncryption(w *tabwriter.Writer, p *models.DebugInfo) {
 	printMD(w, "Cilium encryption\n", "")
 
 	if p.Encryption != nil && p.Encryption.Wireguard != nil {
-		fmt.Fprint(w, "##### Wireguard\n\n")
+		fmt.Fprint(w, "##### WireGuard\n\n")
 		printTicks(w)
 		for _, wg := range p.Encryption.Wireguard.Interfaces {
 			fmt.Fprintf(w, "interface: %s\n", wg.Name)

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -882,8 +882,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 	if params.WGAgent != nil && option.Config.EnableWireguard {
 		if err := params.WGAgent.Init(d.ipcache, d.mtuConfig); err != nil {
-			log.WithError(err).Error("failed to initialize wireguard agent")
-			return nil, nil, fmt.Errorf("failed to initialize wireguard agent: %w", err)
+			log.WithError(err).Error("failed to initialize WireGuard agent")
+			return nil, nil, fmt.Errorf("failed to initialize WireGuard agent: %w", err)
 		}
 
 		params.NodeManager.Subscribe(params.WGAgent)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -360,7 +360,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableIPsecKeyWatcher, defaults.EnableIPsecKeyWatcher, "Enable watcher for IPsec key. If disabled, a restart of the agent will be necessary on key rotations.")
 	option.BindEnv(vp, option.EnableIPsecKeyWatcher)
 
-	flags.Bool(option.EnableWireguard, false, "Enable wireguard")
+	flags.Bool(option.EnableWireguard, false, "Enable WireGuard")
 	option.BindEnv(vp, option.EnableWireguard)
 
 	flags.Bool(option.EnableL2Announcements, false, "Enable L2 announcements")
@@ -375,7 +375,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(option.L2AnnouncerRetryPeriod, 2*time.Second, "Timeout after a renew failure, before the next retry")
 	option.BindEnv(vp, option.L2AnnouncerRetryPeriod)
 
-	flags.Bool(option.EnableWireguardUserspaceFallback, false, "Enables the fallback to the wireguard userspace implementation")
+	flags.Bool(option.EnableWireguardUserspaceFallback, false, "Enable fallback to the WireGuard userspace implementation")
 	option.BindEnv(vp, option.EnableWireguardUserspaceFallback)
 
 	flags.String(option.NodeEncryptionOptOutLabels, defaults.NodeEncryptionOptOutLabels, "Label selector for nodes which will opt-out of node-to-node encryption")
@@ -1704,7 +1704,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 
 	if params.WGAgent != nil {
 		if err := params.WGAgent.RestoreFinished(); err != nil {
-			log.WithError(err).Error("Failed to set up wireguard peers")
+			log.WithError(err).Error("Failed to set up WireGuard peers")
 		}
 	}
 

--- a/daemon/cmd/local_node_init.go
+++ b/daemon/cmd/local_node_init.go
@@ -111,7 +111,7 @@ func (ini *localNodeInitializer) initFromK8s(ctx context.Context, node *node.Loc
 	//   - Cilium internal IPs (restored from cilium_host or allocated by IPAM)
 	//   - Health IPs (allocated by IPAM)
 	//   - Ingress IPs (restored from ipcachemap or allocated)
-	//   - Wireguard key (set by wireguard agent)
+	//   - WireGuard key (set by WireGuard agent)
 	//   - IPsec key (set by IPsec)
 	//   - alloc CIDRs (depends on IPAM mode; restored from Node or CiliumNode)
 	//   - ClusterID (set by NodeDiscovery)

--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -114,7 +114,7 @@ const (
 	NoTrackAlias = Prefix + ".no-track-port"
 
 	// WireguardPubKey / WireguardPubKeyAlias is the annotation name used to store
-	// the Wireguard public key in the CiliumNode CRD that we need to use to encrypt
+	// the WireGuard public key in the CiliumNode CRD that we need to use to encrypt
 	// traffic to that node.
 	WireguardPubKey      = NetworkPrefix + "/wg-pub-key"
 	WireguardPubKeyAlias = Prefix + ".network.wg-pub-key"

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -78,7 +78,7 @@ func newWireguardAgent(lc hive.Lifecycle, localNodeStore *node.LocalNodeStore) *
 	var wgAgent *wg.Agent
 	if option.Config.EnableWireguard {
 		if option.Config.EnableIPSec {
-			log.Fatalf("Wireguard (--%s) cannot be used with IPSec (--%s)",
+			log.Fatalf("WireGuard (--%s) cannot be used with IPsec (--%s)",
 				option.EnableWireguard, option.EnableIPSecName)
 		}
 
@@ -86,7 +86,7 @@ func newWireguardAgent(lc hive.Lifecycle, localNodeStore *node.LocalNodeStore) *
 		privateKeyPath := filepath.Join(option.Config.StateDir, wgTypes.PrivKeyFilename)
 		wgAgent, err = wg.NewAgent(privateKeyPath, localNodeStore)
 		if err != nil {
-			log.Fatalf("failed to initialize wireguard: %s", err)
+			log.Fatalf("failed to initialize WireGuard: %s", err)
 		}
 
 		lc.Append(hive.Hook{
@@ -96,7 +96,7 @@ func newWireguardAgent(lc hive.Lifecycle, localNodeStore *node.LocalNodeStore) *
 			},
 		})
 	} else {
-		// Delete wireguard device from previous run (if such exists)
+		// Delete WireGuard device from previous run (if such exists)
 		link.DeleteByName(wgTypes.IfaceName)
 	}
 	return wgAgent

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -12,7 +12,7 @@ const (
 	// RouteTableIPSec is the default table ID to use for IPSec routing rules
 	RouteTableIPSec = 200
 
-	// RouteTableWireguard is the default table ID to use for Wireguard routing
+	// RouteTableWireguard is the default table ID to use for WireGuard routing
 	// rules
 	RouteTableWireguard = 201
 
@@ -64,7 +64,7 @@ const (
 	// RTProto is the default protocol we install our fib rules and routes with
 	RTProto = unix.RTPROT_KERNEL
 
-	// RulePriorityWireguard is the priority of the rule used for routing packets to Wireguard device for encryption
+	// RulePriorityWireguard is the priority of the rule used for routing packets to WireGuard device for encryption
 	RulePriorityWireguard = 1
 
 	// RulePriorityEgressGateway is the priority used in IP routes added by the manager.

--- a/pkg/datapath/types/datapath.go
+++ b/pkg/datapath/types/datapath.go
@@ -25,7 +25,7 @@ type Datapath interface {
 	// for loading, reloading, and compiling datapath programs.
 	Loader() Loader
 
-	// WireguardAgent returns the Wireguard agent for the local node
+	// WireguardAgent returns the WireGuard agent for the local node
 	WireguardAgent() WireguardAgent
 
 	// LBMap returns the load-balancer map

--- a/pkg/datapath/types/wireguard.go
+++ b/pkg/datapath/types/wireguard.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 )
 
-// WireguardAgent manages the Wireguard peers
+// WireguardAgent manages the WireGuard peers
 type WireguardAgent interface {
 	UpdatePeer(nodeName, pubKeyHex string, nodeIPv4, nodeIPv6 net.IP) error
 	DeletePeer(nodeName string) error

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -502,10 +502,10 @@ const (
 	// InstallNoConntrackRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = false
 
-	// WireguardSubnetV4 is a default wireguard tunnel subnet
+	// WireguardSubnetV4 is a default WireGuard tunnel subnet
 	WireguardSubnetV4 = "172.16.43.0/24"
 
-	// WireguardSubnetV6 is a default wireguard tunnel subnet
+	// WireguardSubnetV6 is a default WireGuard tunnel subnet
 	WireguardSubnetV6 = "fdc9:281f:04d7:9ee9::1/64"
 
 	// ExternalClusterIP enables cluster external access to ClusterIP services.

--- a/pkg/k8s/watchers/cilium_node.go
+++ b/pkg/k8s/watchers/cilium_node.go
@@ -68,7 +68,7 @@ func (k *K8sWatcher) ciliumNodeInit(ciliumNPClient client.Clientset, asyncContro
 						if ciliumNode := k8s.CastInformerEvent[cilium_v2.CiliumNode](newObj); ciliumNode != nil {
 							valid = true
 							isLocal := k8s.IsLocalCiliumNode(ciliumNode)
-							// Comparing Annotations here since wg-pub-key annotation is used to exchange rotated Wireguard keys.
+							// Comparing Annotations here since wg-pub-key annotation is used to exchange rotated WireGuard keys.
 							if oldCN.DeepEqual(ciliumNode) &&
 								comparator.MapStringEquals(oldCN.ObjectMeta.Labels, ciliumNode.ObjectMeta.Labels) &&
 								comparator.MapStringEquals(oldCN.ObjectMeta.Annotations, ciliumNode.ObjectMeta.Annotations) {

--- a/pkg/mtu/mtu.go
+++ b/pkg/mtu/mtu.go
@@ -56,7 +56,7 @@ const (
 	// key secrets.
 	EncryptionDefaultAuthKeyLength = 16
 
-	// WireguardOverhead is an approximation for the overhead of wireguard
+	// WireguardOverhead is an approximation for the overhead of WireGuard
 	// encapsulation.
 	//
 	// https://github.com/torvalds/linux/blob/v5.12/drivers/net/wireguard/device.c#L262:

--- a/pkg/mtu/mtu_test.go
+++ b/pkg/mtu/mtu_test.go
@@ -68,7 +68,7 @@ func (m *MTUSuite) TestNewConfiguration(c *C) {
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-(TunnelOverhead+EncryptionIPsecOverhead+16))
 
-	// Add routes with wireguard enabled
+	// Add routes with WireGuard enabled
 	conf = NewConfiguration(32, false, false, true, false, 1400, nil)
 	c.Assert(conf.GetDeviceMTU(), Equals, 1400)
 	c.Assert(conf.GetRouteMTU(), Equals, conf.GetDeviceMTU()-WireguardOverhead)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -756,7 +756,7 @@ const (
 	// IPSecKeyFileName is the name of the option for ipsec key file
 	IPSecKeyFileName = "ipsec-key-file"
 
-	// EnableWireguard is the name of the option to enable wireguard
+	// EnableWireguard is the name of the option to enable WireGuard
 	EnableWireguard = "enable-wireguard"
 
 	// EnableL2Announcements is the name of the option to enable l2 announcements
@@ -782,7 +782,7 @@ const (
 	// or direct routing is used and the node CIDR and pod CIDR overlap.
 	EncryptionStrictModeAllowRemoteNodeIdentities = "encryption-strict-mode-allow-remote-node-identities"
 
-	// EnableWireguardUserspaceFallback is the name of the option that enables the fallback to wireguard userspace mode
+	// EnableWireguardUserspaceFallback is the name of the option that enables the fallback to WireGuard userspace mode
 	EnableWireguardUserspaceFallback = "enable-wireguard-userspace-fallback"
 
 	// NodeEncryptionOptOutLabels is the name of the option for the node-to-node encryption opt-out labels

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-// This package contains the agent code used to configure the Wireguard tunnel
+// This package contains the agent code used to configure the WireGuard tunnel
 // between nodes. The code supports adding and removing peers at run-time
 // and the peer information is retrieved via the CiliumNode object.
 package agent
@@ -55,7 +55,7 @@ type wireguardClient interface {
 	ConfigureDevice(name string, cfg wgtypes.Config) error
 }
 
-// Agent needs to be initialized with Init(). In Init(), the Wireguard tunnel
+// Agent needs to be initialized with Init(). In Init(), the WireGuard tunnel
 // device will be created and the proper routes set.  During Init(), existing
 // peer keys are placed into `restoredPubKeys`.  Once RestoreFinished() is
 // called obsolete keys and peers are removed.  UpdatePeer() inserts or updates
@@ -78,7 +78,7 @@ type Agent struct {
 	nodeToNodeEncryption bool
 }
 
-// NewAgent creates a new Wireguard Agent
+// NewAgent creates a new WireGuard Agent
 func NewAgent(privKeyPath string, localNodeStore *node.LocalNodeStore) (*Agent, error) {
 	key, err := loadOrGeneratePrivKey(privKeyPath)
 	if err != nil {
@@ -143,7 +143,7 @@ func (a *Agent) initUserspaceDevice(linkMTU int) (netlink.Link, error) {
 
 	uapiServer, err := ipc.UAPIListen(types.IfaceName, uapiSocket)
 	if err != nil {
-		return nil, fmt.Errorf("failed to start wireguard uapi server: %w", err)
+		return nil, fmt.Errorf("failed to start WireGuard UAPI server: %w", err)
 	}
 
 	scopedLog := log.WithField(logfields.LogSubsys, "wireguard-userspace")
@@ -164,7 +164,7 @@ func (a *Agent) initUserspaceDevice(linkMTU int) (netlink.Link, error) {
 			conn, err := uapiServer.Accept()
 			if err != nil {
 				scopedLog.WithError(err).
-					Error("failed to handle wireguard userspace connection")
+					Error("failed to handle WireGuard userspace connection")
 				return
 			}
 			go dev.IpcHandle(conn)
@@ -211,18 +211,18 @@ func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.Configuration) erro
 	err := netlink.LinkAdd(link)
 	if err != nil && !errors.Is(err, unix.EEXIST) {
 		if !errors.Is(err, unix.EOPNOTSUPP) {
-			return fmt.Errorf("failed to add wireguard device: %w", err)
+			return fmt.Errorf("failed to add WireGuard device: %w", err)
 		}
 
 		if !option.Config.EnableWireguardUserspaceFallback {
-			return fmt.Errorf("wireguard not supported by the Linux kernel (netlink: %w). "+
+			return fmt.Errorf("WireGuard not supported by the Linux kernel (netlink: %w). "+
 				"Please upgrade your kernel, manually install the kernel module "+
 				"(https://www.wireguard.com/install/), or set enable-wireguard-userspace-fallback=true", err)
 		}
 
 		link, err = a.initUserspaceDevice(linkMTU)
 		if err != nil {
-			return fmt.Errorf("wireguard userspace: %w", err)
+			return fmt.Errorf("WireGuard userspace: %w", err)
 		}
 	}
 
@@ -240,7 +240,7 @@ func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.Configuration) erro
 		FirewallMark: &fwMark,
 	}
 	if err := a.wgClient.ConfigureDevice(types.IfaceName, cfg); err != nil {
-		return fmt.Errorf("failed to configure wireguard device: %w", err)
+		return fmt.Errorf("failed to configure WireGuard device: %w", err)
 	}
 
 	// set MTU again explicitly in case we are re-using an existing device
@@ -254,7 +254,7 @@ func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.Configuration) erro
 
 	dev, err := a.wgClient.Device(types.IfaceName)
 	if err != nil {
-		return fmt.Errorf("failed to obtain wireguard device: %w", err)
+		return fmt.Errorf("failed to obtain WireGuard device: %w", err)
 	}
 	for _, peer := range dev.Peers {
 		a.restoredPubKeys[peer.PublicKey] = struct{}{}
@@ -453,7 +453,7 @@ func (a *Agent) deletePeerByPubKey(pubKey wgtypes.Key) error {
 	return nil
 }
 
-// updatePeerByConfig updates the Wireguard kernel peer config based on peerConfig p
+// updatePeerByConfig updates the WireGuard kernel peer config based on peerConfig p
 func (a *Agent) updatePeerByConfig(p *peerConfig) error {
 	peer := wgtypes.PeerConfig{
 		PublicKey:         p.pubKey,
@@ -557,7 +557,7 @@ func (a *Agent) OnIPIdentityCacheChange(modType ipcache.CacheModification, cidrC
 				logfields.NewNode:      newHostIP,
 				logfields.PubKey:       updatedPeer.pubKey,
 			}).WithError(err).
-				Error("Failed to update Wireguard peer after ipcache update")
+				Error("Failed to update WireGuard peer after ipcache update")
 		}
 	}
 }
@@ -567,7 +567,7 @@ func (a *Agent) OnIPIdentityCacheGC() {
 	// ignored
 }
 
-// Status returns the state of the Wireguard tunnel managed by this instance.
+// Status returns the state of the WireGuard tunnel managed by this instance.
 // If withPeers is true, then the details about each connected peer are
 // are populated as well.
 func (a *Agent) Status(withPeers bool) (*models.WireguardStatus, error) {
@@ -623,13 +623,13 @@ func (a *Agent) Status(withPeers bool) (*models.WireguardStatus, error) {
 	return status, nil
 }
 
-// peerConfig represents the kernel state of each Wireguard peer.
+// peerConfig represents the kernel state of each WireGuard peer.
 // In order to be able to add and remove individual IPs from the
-// `AllowedIPs` list, we store a `peerConfig` for each known Wireguard peer.
+// `AllowedIPs` list, we store a `peerConfig` for each known WireGuard peer.
 // When a peer is first discovered via node manager, we obtain the remote
 // peers `AllowedIPs` by querying Cilium's user-space copy of the IPCache
 // in the agent. In addition, we also subscribe to IPCache updates in the
-// Wireguard agent and update the `AllowedIPs` list of known peers
+// WireGuard agent and update the `AllowedIPs` list of known peers
 // accordingly.
 type peerConfig struct {
 	pubKey             wgtypes.Key

--- a/pkg/wireguard/agent/node_handler.go
+++ b/pkg/wireguard/agent/node_handler.go
@@ -48,7 +48,7 @@ func (a *Agent) nodeUpsert(node nodeTypes.Node) error {
 	if err := a.UpdatePeer(node.Fullname(), node.WireguardPubKey, newIP4, newIP6); err != nil {
 		log.WithError(err).
 			WithField(logfields.NodeName, node.Fullname()).
-			Warning("Failed to update wireguard configuration for peer")
+			Warning("Failed to update WireGuard configuration for peer")
 	}
 
 	return nil

--- a/pkg/wireguard/types/types.go
+++ b/pkg/wireguard/types/types.go
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-// Common Wireguard types and constants
+// Common WireGuard types and constants
 package types
 
 const (
-	// IfaceName is the name of the Wireguard tunnel device
+	// IfaceName is the name of the WireGuard tunnel device
 	IfaceName = "cilium_wg0"
-	// PrivKeyFilename is the name of the Wireguard private key file
+	// PrivKeyFilename is the name of the WireGuard private key file
 	PrivKeyFilename = "cilium_wg0.key"
 	// StaticEncryptKey is used in the IPCache to mark entries for which we
-	// want to enable Wireguard encryption
+	// want to enable WireGuard encryption
 	StaticEncryptKey = uint8(0xFF)
 )


### PR DESCRIPTION
Late follow-up to https://github.com/cilium/cilium/pull/16293.

We had a custom filter for the spell checker in the docs, to ensure we'd never write "Wireguard" again. It's been broken since we added "wireguard" (considered case-insensitive) to the list of exceptions for the spell checker.

Let's fix this, and let's clean up the occurrences of "Wireguard" or "wireguard" where relevant in docs, comments, output strings that are not API.