### PR TITLE
docs: Add missing spelling exception

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -71,6 +71,7 @@ Mellanox
 Meltwater
 Menlo
 MiB
+Monnet
 Mythbusters
 NDP
 Netronome


### PR DESCRIPTION
In commit e846b71196e4, we removed many entries from the list of exceptions for the spell checker... In fact, I removed one too many. Here's what happened, as far as I
understand:

  - I removed all entries from spelling exceptions, then re-added just the necessary ones, locally.
  - When creating the PR, CI complained about people names.
    - The difference between local/CI is because (I think) Sphinx checks for contributors' names from the Git history.
    - In CI, we `git clone --depth 1` so we don't have names of contributors for Sphinx.
  - So I re-added all names CI workflow was complaining about.
  - But... `git clone --depth 1` still contains one commit, which was enough for Sphinx to find _my_ name, so it didn't complain about it, and I didn't re-add it.
  - On PRs from different contributors though, it can't find my name and breaks.

Fixes: #26759

Really, I don't understand why “Monnet” is not universally known in every dictionary in the world :slightly_smiling_face: 
