### PR TITLE
ci: skip cosign / sbom in case of building images during cache rebuild

### DIFF
--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -208,14 +208,22 @@ jobs:
             OPERATOR_VARIANT=${{ matrix.name }}
 
       - name: Sign Container Images
-        if: ${{ github.event_name != 'pull_request_target' }}
+        # Only sign when the event name was a GitHub push and not workflow_run (re-building cache).
+        # In this case the image wasn't pushed, therefore it's not necessary to execute this step too.
+        # It would even fail because `steps.docker_build_ci_main*.outputs.digest` isn't set in case
+        # neither push nor load are set in the docker/build-push-action action.
+        if: ${{ github.event_name == 'push' }}
         run: |
           cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main.outputs.digest }}
           cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main_detect_race_condition.outputs.digest }}
           cosign sign -y quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main_unstripped.outputs.digest }}
 
       - name: Generate SBOM
-        if: ${{ github.event_name != 'pull_request_target' }}
+        # Only sign when the event name was a GitHub push and not workflow_run (re-building cache).
+        # In this case the image wasn't pushed, therefore it's not necessary to execute this step too.
+        # It would even fail because `steps.docker_build_ci_main*.outputs.digest` isn't set in case
+        # neither push nor load are set in the docker/build-push-action action.
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         # To-Do: generate SBOM from source after https://github.com/kubernetes-sigs/bom/issues/202 is fixed
         # To-Do: format SBOM output to json after cosign v2.0 is released with https://github.com/sigstore/cosign/pull/2479
@@ -228,14 +236,22 @@ jobs:
           --image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${{ steps.tag.outputs.tag }}-unstripped
 
       - name: Attach SBOM to Container Images
-        if: ${{ github.event_name != 'pull_request_target' }}
+        # Only sign when the event name was a GitHub push and not workflow_run (re-building cache).
+        # In this case the image wasn't pushed, therefore it's not necessary to execute this step too.
+        # It would even fail because `steps.docker_build_ci_main*.outputs.digest` isn't set in case
+        # neither push nor load are set in the docker/build-push-action action.
+        if: ${{ github.event_name == 'push' }}
         run: |
           cosign attach sbom --sbom sbom_ci_main_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main.outputs.digest }}
           cosign attach sbom --sbom sbom_ci_main_race_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main_detect_race_condition.outputs.digest }}
           cosign attach sbom --sbom sbom_ci_main_unstripped_${{ matrix.name }}_${{ steps.tag.outputs.tag }}.spdx quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${{ steps.docker_build_ci_main_unstripped.outputs.digest }}
 
       - name: Sign SBOM Images
-        if: ${{ github.event_name != 'pull_request_target' }}
+        # Only sign when the event name was a GitHub push and not workflow_run (re-building cache).
+        # In this case the image wasn't pushed, therefore it's not necessary to execute this step too.
+        # It would even fail because `steps.docker_build_ci_main*.outputs.digest` isn't set in case
+        # neither push nor load are set in the docker/build-push-action action.
+        if: ${{ github.event_name == 'push' }}
         run: |
           docker_build_ci_main_digest="${{ steps.docker_build_ci_main.outputs.digest }}"
           image_name="quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci:${docker_build_ci_main_digest/:/-}.sbom"
@@ -253,7 +269,11 @@ jobs:
           cosign sign -y "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/${{ matrix.name }}-ci@${docker_build_ci_main_unstripped_sbom_digest}"
 
       - name: CI Image Releases digests
-        if: ${{ github.event_name != 'pull_request_target' }}
+        # Only sign when the event name was a GitHub push and not workflow_run (re-building cache).
+        # In this case the image wasn't pushed, therefore it's not necessary to execute this step too.
+        # It would even fail because `steps.docker_build_ci_main*.outputs.digest` isn't set in case
+        # neither push nor load are set in the docker/build-push-action action.
+        if: ${{ github.event_name == 'push' }}
         shell: bash
         run: |
           mkdir -p image-digest/


### PR DESCRIPTION
Docker cache re-build is triggered via event `workflow_run`. In this case, the container image isn't pushed to a docker registry, therefore `outputs.digest` isn't set. This results in cosign and sbom steps to fail because they depend on this.

This commit fixes this by only executing these steps in case of a github event of type `push`.

Cosign & sbom support has been introduced after the [cache](https://github.com/cilium/cilium/pull/17623). It looks like the cache-refresh use-case hasn't been considered.

Failing runs: https://github.com/cilium/cilium/actions/workflows/build-images-ci.yaml?query=event%3Aworkflow_run