### PR TITLE
.github: add 'name' field for the conformance-e2e job

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -67,6 +67,7 @@ jobs:
 
   setup-and-test:
     runs-on: ubuntu-latest-4cores-16gb
+    name: 'Setup & Test'
     env:
       job_name: 'Setup & Test'
     strategy:


### PR DESCRIPTION
jobs.<job>.env.job_name should be the same as the job name. Thus, adding the field 'name' to the job will make sure that connectivity tests junit test results are stored in bigquery for lookerstudio visualization.

Fixes: 12d7643ccd0a ("ci/workflows: add junit reports upload")
