### PR TITLE
v1.13 backports 2023-07-12

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -318,15 +318,6 @@ skip_host_firewall:
 		/* See IPv4 comment. */
 		return DROP_UNROUTABLE;
 	}
-
-#ifdef ENABLE_IPSEC
-	if (info && info->key && info->tunnel_endpoint) {
-		__u8 key = get_min_encrypt_key(info->key);
-
-		set_encrypt_key_meta(ctx, key, info->node_id);
-		set_identity_meta(ctx, secctx);
-	}
-#endif
 	return CTX_ACT_OK;
 }
 
@@ -610,15 +601,6 @@ skip_vtep:
 		 */
 		return DROP_UNROUTABLE;
 	}
-
-#ifdef ENABLE_IPSEC
-	if (info && info->key && info->tunnel_endpoint) {
-		__u8 key = get_min_encrypt_key(info->key);
-
-		set_encrypt_key_meta(ctx, key, info->node_id);
-		set_identity_meta(ctx, secctx);
-	}
-#endif
 	return CTX_ACT_OK;
 }
 

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -12,29 +12,6 @@
 #ifdef HAVE_ENCAP
 #ifdef ENABLE_IPSEC
 static __always_inline int
-encap_and_redirect_nomark_ipsec(struct __ctx_buff *ctx, __u8 key,
-				__u16 node_id, __u32 seclabel)
-{
-	/* Traffic from local host in tunnel mode will be passed to
-	 * cilium_host. In non-IPSec case traffic with non-local dst
-	 * will then be redirected to tunnel device. In IPSec case
-	 * though we need to traverse xfrm path still. The mark +
-	 * cb[4] hints will not survive a veth pair xmit to ingress
-	 * however so below encap_and_redirect_ipsec will not work.
-	 * Instead pass hints via cb[0], cb[4] (cb is not cleared
-	 * by dev_ctx_forward) and catch hints with bpf_host
-	 * prog that will populate mark/cb as expected by xfrm and 2nd
-	 * traversal into bpf_host. Remember we can't use cb[0-3]
-	 * in both cases because xfrm layer would overwrite them. We
-	 * use cb[4] here so it doesn't need to be reset by
-	 * bpf_host.
-	 */
-	set_encrypt_key_meta(ctx, key, node_id);
-	ctx_store_meta(ctx, CB_ENCRYPT_IDENTITY, seclabel);
-	return CTX_ACT_OK;
-}
-
-static __always_inline int
 encap_and_redirect_ipsec(struct __ctx_buff *ctx, __u8 key, __u16 node_id,
 			 __u32 seclabel)
 {
@@ -154,20 +131,15 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 }
 
 /* encap_and_redirect_with_nodeid returns CTX_ACT_OK after ctx meta-data is
- * set (eg. when IPSec is enabled). Caller should pass the ctx to the stack at this
- * point. Otherwise returns CTX_ACT_REDIRECT on successful redirect to tunnel device.
+ * set. Caller should pass the ctx to the stack at this point. Otherwise
+ * returns CTX_ACT_REDIRECT on successful redirect to tunnel device.
  * On error returns CTX_ACT_DROP or DROP_WRITE_ERROR.
  */
 static __always_inline int
 encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
-			       __u8 key __maybe_unused,
 			       __u16 node_id __maybe_unused, __u32 seclabel,
 			       __u32 dstid, const struct trace_ctx *trace)
 {
-#ifdef ENABLE_IPSEC
-	if (key)
-		return encap_and_redirect_nomark_ipsec(ctx, key, node_id, seclabel);
-#endif
 	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, dstid, NOT_VTEP_DST,
 						trace);
 }
@@ -260,15 +232,6 @@ encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 	if (!tunnel)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-#ifdef ENABLE_IPSEC
-	if (tunnel->key) {
-		__u8 key = get_min_encrypt_key(tunnel->key);
-
-		return encap_and_redirect_nomark_ipsec(ctx, key,
-						       tunnel->node_id,
-						       seclabel);
-	}
-#endif
 	return __encap_and_redirect_with_nodeid(ctx, tunnel->ip4, seclabel,
 						0, NOT_VTEP_DST, trace);
 }

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -162,12 +162,12 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 						seclabel);
 #endif
 
-#if !defined(ENABLE_NODEPORT) && (defined(ENABLE_IPSEC) || defined(ENABLE_HOST_FIREWALL))
-	/* For IPSec and the host firewall, traffic from a pod to a remote node
-	 * is sent through the tunnel. In the case of node --> VIP@remote pod,
-	 * packets may be DNATed when they enter the remote node. If kube-proxy
-	 * is used, the response needs to go through the stack on the way to
-	 * the tunnel, to apply the correct reverse DNAT.
+#if !defined(ENABLE_NODEPORT) && defined(ENABLE_HOST_FIREWALL)
+	/* For the host firewall, traffic from a pod to a remote node is sent
+	 * through the tunnel. In the case of node --> VIP@remote pod, packets may
+	 * be DNATed when they enter the remote node. If kube-proxy is used, the
+	 * response needs to go through the stack on the way to the tunnel, to
+	 * apply the correct reverse DNAT.
 	 * See #14674 for details.
 	 */
 	ret = __encap_with_nodeid(ctx, tunnel_endpoint, seclabel, dstid, NOT_VTEP_DST,
@@ -180,7 +180,7 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 #else
 	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint,
 						seclabel, dstid, NOT_VTEP_DST, trace);
-#endif /* !ENABLE_NODEPORT && (ENABLE_IPSEC || ENABLE_HOST_FIREWALL) */
+#endif /* !ENABLE_NODEPORT && ENABLE_HOST_FIREWALL */
 }
 
 #ifdef TUNNEL_MODE

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -114,6 +114,24 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 		*identity = HOST_ID;
 	} else if (magic == MARK_MAGIC_ENCRYPT) {
 		*identity = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+
+		/* Special case needed to handle upgrades. Can be removed in v1.15.
+		 * Before the upgrade, bpf_lxc will write the tunnel endpoint in
+		 * skb->cb[4]. After the upgrade, it will write the security identity.
+		 * For the upgrade to happen without drops, bpf_host thus needs to
+		 * handle both cases.
+		 * We can distinguish between the two cases by looking at the first
+		 * byte. Identities are on 24-bits so the first byte will be zero;
+		 * conversely, tunnel endpoint addresses within the range 0.0.0.0/8
+		 * (first byte is zero) are impossible because special purpose
+		 * (RFC6890).
+		 */
+		if ((*identity & 0xFF000000) != 0) {
+			/* skb->cb[4] was actually carrying the tunnel endpoint and the
+			 * security identity is in the mark.
+			 */
+			*identity = get_identity(ctx);
+		}
 #if defined(ENABLE_L7_LB)
 	} else if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
 		*identity = get_epid(ctx); /* endpoint identity, not security identity! */

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -61,12 +61,6 @@ set_encrypt_key_mark(struct __sk_buff *ctx, __u8 key, __u32 node_id)
 	ctx->mark = or_encrypt_key(key) | node_id << 16;
 }
 
-static __always_inline __maybe_unused void
-set_encrypt_key_meta(struct __sk_buff *ctx, __u8 key, __u32 node_id)
-{
-	ctx->cb[CB_ENCRYPT_MAGIC] = or_encrypt_key(key) | node_id << 16;
-}
-
 /**
  * set_encrypt_mark - sets the encryption mark to make skb to match ip rule
  * used to steer packet into Wireguard tunnel device (cilium_wg0) in order to

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -38,12 +38,6 @@ set_encrypt_key_mark(struct xdp_md *ctx __maybe_unused, __u8 key __maybe_unused,
 {
 }
 
-static __always_inline __maybe_unused void
-set_encrypt_key_meta(struct xdp_md *ctx __maybe_unused, __u8 key __maybe_unused,
-		     __u32 node_id __maybe_unused)
-{
-}
-
 static __always_inline __maybe_unused int
 redirect_self(struct xdp_md *ctx __maybe_unused)
 {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ipam"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -281,8 +280,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		}
 	}
 
-	if option.Config.EnableIPSec &&
-		(option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) {
+	if option.Config.EnableIPSec {
 		// If IPsec is enabled on EKS or AKS, we need to restore the host
 		// endpoint before any other endpoint, to ensure a dropless upgrade.
 		// This code can be removed in v1.15.
@@ -309,8 +307,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 	}
 
 	for _, ep := range state.restored {
-		if ep.IsHost() && option.Config.EnableIPSec &&
-			(option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) {
+		if ep.IsHost() && option.Config.EnableIPSec {
 			// The host endpoint was handled above.
 			continue
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1053,11 +1053,10 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 				upsertIPsecLog(err, "out IPv4", wildcardCIDR, cidr, spi)
 			}
 		} else {
-			localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
 			remoteCIDR := newNode.IPv4AllocCIDR.IPNet
 			n.replaceNodeIPSecOutRoute(new4Net)
-			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
-			upsertIPsecLog(err, "out IPv4", localCIDR, remoteCIDR, spi)
+			spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
+			upsertIPsecLog(err, "out IPv4", wildcardCIDR, remoteCIDR, spi)
 		}
 	}
 }
@@ -1127,11 +1126,10 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, zeroMark boo
 				upsertIPsecLog(err, "out IPv6", wildcardCIDR, cidr, spi)
 			}
 		} else {
-			localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
 			remoteCIDR := newNode.IPv6AllocCIDR.IPNet
 			n.replaceNodeIPSecOutRoute(new6Net)
-			spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
-			upsertIPsecLog(err, "out IPv6", localCIDR, remoteCIDR, spi)
+			spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
+			upsertIPsecLog(err, "out IPv6", wildcardCIDR, remoteCIDR, spi)
 		}
 	}
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -65,7 +65,6 @@ type Configuration interface {
 	TunnelingEnabled() bool
 	RemoteNodeIdentitiesEnabled() bool
 	NodeEncryptionEnabled() bool
-	EncryptionEnabled() bool
 }
 
 // Notifier is the interface the wraps Subscribe and Unsubscribe. An
@@ -367,11 +366,6 @@ func (m *Manager) legacyNodeIpBehavior() bool {
 	if m.conf.NodeEncryptionEnabled() {
 		return false
 	}
-	// Needed to store the tunnel endpoint for pod->remote node in the
-	// ipcache so that this traffic goes through the tunnel.
-	if m.conf.EncryptionEnabled() && m.conf.TunnelingEnabled() {
-		return false
-	}
 	return true
 }
 
@@ -411,7 +405,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// through the tunnel to preserve the source identity as part of the
 		// encapsulation. In encryption case we also want to use vxlan device
 		// to create symmetric traffic when sending nodeIP->pod and pod->nodeIP.
-		if address.Type == addressing.NodeCiliumInternalIP || m.conf.EncryptionEnabled() ||
+		if address.Type == addressing.NodeCiliumInternalIP ||
 			option.Config.EnableHostFirewall || option.Config.JoinCluster {
 			tunnelIP = nodeIP
 		}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -429,8 +429,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// to encrypt something we know does not have an encryption policy installed
 		// in the datapath. By setting key=0 and tunnelIP this will result in traffic
 		// being sent unencrypted over overlay device.
-		if !m.conf.NodeEncryptionEnabled() &&
-			(address.Type == addressing.NodeExternalIP || address.Type == addressing.NodeInternalIP) {
+		if !m.conf.NodeEncryptionEnabled() {
 			key = 0
 		}
 


### PR DESCRIPTION
 - [x] #25440 -- bpf: Don't encrypt on path hostns -> remote pod (@pchaigno)
     - Many small conflicts all around. Usually easy to resolve because we are removing code anyway.
 - [x] #26708 -- Fix upgrade for IPsec with tunneling (@pchaigno)
     - Minor conflicts for code that was removed anyway or code that was moved in the same file.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25440 26708; do contrib/backporting/set-labels.py $pr done 1.13; done
```
