### PR TITLE
Fix LookupReservedIdentityByLabels function to return consistent results

### DIFF
--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -86,6 +86,26 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentityByLabels(c *C) {
 			want: identity.NewIdentity(ni, labels.Labels{"kvstore": labels.NewLabel("kvstore", "", labels.LabelSourceReserved)}),
 		},
 		{
+			name: "fixed-identity+reserved-identity returns fixed",
+			args: args{
+				lbls: labels.Labels{
+					labels.LabelKeyFixedIdentity: labels.ParseLabel(labels.LabelKeyFixedIdentity + "=" + "kvstore"),
+					labels.IDNameHost:            labels.LabelHost[labels.IDNameHost],
+				},
+			},
+			want: identity.NewIdentity(ni, labels.Labels{"kvstore": labels.NewLabel("kvstore", "", labels.LabelSourceReserved)}),
+		},
+		{
+			name: "reserved-identity+fixed-identity returns fixed",
+			args: args{
+				lbls: labels.Labels{
+					labels.IDNameHost:            labels.LabelHost[labels.IDNameHost],
+					labels.LabelKeyFixedIdentity: labels.ParseLabel(labels.LabelKeyFixedIdentity + "=" + "kvstore"),
+				},
+			},
+			want: identity.NewIdentity(ni, labels.Labels{"kvstore": labels.NewLabel("kvstore", "", labels.LabelSourceReserved)}),
+		},
+		{
 			name: "non-existing-fixed-identity",
 			args: args{
 				lbls: labels.Labels{labels.LabelKeyFixedIdentity: labels.ParseLabel(labels.LabelKeyFixedIdentity + "=" + "kube-dns")},
@@ -95,21 +115,21 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentityByLabels(c *C) {
 		{
 			name: "reserved-identity",
 			args: args{
-				lbls: labels.Labels{labels.LabelSourceReserved: labels.NewLabel(labels.LabelSourceReservedKeyPrefix+"host", "", labels.LabelSourceReserved)},
+				lbls: labels.LabelHost,
 			},
-			want: identity.NewIdentity(identity.ReservedIdentityHost, labels.Labels{"host": labels.ParseLabel("reserved:host")}),
+			want: identity.NewIdentity(identity.ReservedIdentityHost, labels.LabelHost),
 		},
 		{
 			name: "reserved-identity+other-labels",
 			args: args{
 				lbls: labels.Labels{
-					labels.LabelSourceReserved: labels.ParseLabel("reserved:host"),
-					"id.foo":                   labels.ParseLabel("id.foo"),
+					labels.IDNameHost: labels.LabelHost[labels.IDNameHost],
+					"id.foo":          labels.ParseLabel("id.foo"),
 				},
 			},
 			want: identity.NewIdentity(identity.ReservedIdentityHost, labels.Labels{
-				labels.LabelSourceReserved: labels.ParseLabel("reserved:host"),
-				"id.foo":                   labels.ParseLabel("id.foo"),
+				labels.IDNameHost: labels.LabelHost[labels.IDNameHost],
+				"id.foo":          labels.ParseLabel("id.foo"),
 			},
 			),
 		},
@@ -119,6 +139,15 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentityByLabels(c *C) {
 				lbls: kvstoreLabels,
 			},
 			want: identity.NewIdentity(identity.ReservedCiliumKVStore, kvstoreLabels),
+		},
+		{
+			name: "no fixed and reserved identities returns nil",
+			args: args{
+				lbls: labels.Labels{
+					"id.foo": labels.ParseLabel("id.foo"),
+				},
+			},
+			want: nil,
 		},
 	}
 

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -96,6 +96,7 @@ func (s *IdentityTestSuite) TestNewIdentityFromLabelArray(c *C) {
 }
 
 func TestLookupReservedIdentityByLabels(t *testing.T) {
+	cidrPrefix := netip.MustParsePrefix("10.0.0.0/24")
 	type want struct {
 		id     NumericIdentity
 		labels labels.Labels
@@ -134,6 +135,14 @@ func TestLookupReservedIdentityByLabels(t *testing.T) {
 			want: &want{
 				id:     ReservedIdentityHealth,
 				labels: labels.LabelHealth,
+			},
+		},
+		{
+			name: "world",
+			args: labels.LabelWorld,
+			want: &want{
+				id:     ReservedIdentityWorld,
+				labels: labels.LabelWorld,
 			},
 		},
 		{
@@ -221,6 +230,14 @@ func TestLookupReservedIdentityByLabels(t *testing.T) {
 				id:     ReservedIdentityIngress,
 				labels: labels.LabelIngress,
 			},
+		},
+		{
+			name: "cidr",
+			args: labels.Map2Labels(map[string]string{
+				labels.LabelWorld.String():              "",
+				cidr.GetCIDRLabels(cidrPrefix).String(): "",
+			}, ""),
+			want: nil,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

The function results inconsistent results if both fixed and reserved identities are present.

For e.g., the following returns `1`
```
- "reserved:host"
- "k8s:io.cilium.fixed-identity=128"
```
whereas the following returns `128`
```
- "k8s:io.cilium.fixed-identity=128"
- "reserved:host"
```

Also, this simplifies the logic to make it more readable.

