### PR TITLE
bpf: untangle tunnel encap and IPsec code

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -338,8 +338,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 #ifdef TUNNEL_MODE
 	if (info != NULL && info->tunnel_endpoint != 0) {
 		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
-						      info->node_id, secctx,
-						      info->sec_identity,
+						      secctx, info->sec_identity,
 						      &trace);
 	} else {
 		struct tunnel_key key = {};
@@ -747,8 +746,7 @@ skip_vtep:
 #ifdef TUNNEL_MODE
 	if (info != NULL && info->tunnel_endpoint != 0) {
 		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
-						      info->node_id, secctx,
-						      info->sec_identity,
+						      secctx, info->sec_identity,
 						      &trace);
 	} else {
 		/* IPv4 lookup key: daddr & IPV4_MASK */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -682,9 +682,7 @@ pass_to_stack:
 # ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {
 		set_encrypt_key_mark(ctx, encrypt_key, node_id);
-#  ifdef ENABLE_IDENTITY_MARK
 		set_identity_meta(ctx, SECLABEL);
-#  endif /* ENABLE_IDENTITY_MARK */
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* TUNNEL_MODE */
@@ -1217,9 +1215,7 @@ pass_to_stack:
 # ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {
 		set_encrypt_key_mark(ctx, encrypt_key, node_id);
-#  ifdef ENABLE_IDENTITY_MARK
 		set_identity_meta(ctx, SECLABEL);
-#  endif
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* TUNNEL_MODE */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1094,13 +1094,8 @@ ct_recreate4:
 				return DROP_NO_EGRESS_GATEWAY;
 			}
 			/* Send the packet to egress gateway node through a tunnel. */
-			ret = __encap_and_redirect_lxc(ctx, tunnel_endpoint, 0,
-						       node_id, SECLABEL,
-						       *dst_sec_identity, &trace);
-			if (ret == CTX_ACT_OK)
-				goto encrypt_to_stack;
-
-			return ret;
+			return __encap_and_redirect_lxc(ctx, tunnel_endpoint,
+							SECLABEL, *dst_sec_identity, &trace);
 		}
 	}
 skip_egress_gateway:
@@ -1231,7 +1226,7 @@ pass_to_stack:
 #endif
 	}
 
-#if defined(TUNNEL_MODE) || defined(ENABLE_EGRESS_GATEWAY) || defined(ENABLE_HIGH_SCALE_IPCACHE)
+#if defined(TUNNEL_MODE) || defined(ENABLE_HIGH_SCALE_IPCACHE)
 encrypt_to_stack:
 #endif
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL, *dst_sec_identity, 0, 0,

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1208,6 +1208,10 @@ encrypt_to_stack:
 #endif
 #ifdef ENABLE_IPSEC
 	if (encrypt_key && tunnel_endpoint) {
+		/* When changing this part, consider that bpf_host needs
+		 * to understand both formats. Otherwise packets will
+		 * not get handled correctly during up-/downgrade.
+		 */
 		set_encrypt_key_mark(ctx, encrypt_key, node_id);
 		set_identity_meta(ctx, SECLABEL);
 	} else

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -100,7 +100,6 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip __maybe_un
  */
 static __always_inline int
 encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
-			       __u16 node_id __maybe_unused,
 			       __u32 seclabel, __u32 dstid,
 			       const struct trace_ctx *trace)
 {


### PR DESCRIPTION
With the recent changes & simplifications in IPsec land, it's possible to lift most of the IPsec logic from `encap.h` into `bpf_lxc` proper.