### PR TITLE
helm: fix indentation of extra env for hubble ui backend

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -102,7 +102,7 @@ spec:
           value: "hubble-relay:80"
         {{- end }}
         {{- with .Values.hubble.ui.backend.extraEnv }}
-        {{- toYaml . | trim | nindent 10 }}
+        {{- toYaml . | trim | nindent 8 }}
         {{- end }}
         ports:
         - name: grpc


### PR DESCRIPTION
This PR fixes a bug caused by incorrect indentation of the extraEnv parameter for Hubble UI backend.

The following command will fail without this fix:

```console
❯ cat <<EOF | helm template cilium install/kubernetes/cilium -f - --debug
agent: false
operator:
  enabled: false

hubble:
  ui:
    enabled: true

    standalone:
      enabled: true

    backend:
      extraEnv:
      - name: FOO
        value: bar
EOF

(...)

      - name: backend
        image: "quay.io/cilium/hubble-ui-backend:v0.11.0@sha256:14c04d11f78da5c363f88592abae8d2ecee3cbe009f443ef11df6ac5f692d839"
        imagePullPolicy: Always
        env:
        - name: EVENTS_SERVER_PORT
          value: "8090"
        - name: FLOWS_API_ADDR
          value: "hubble-relay:80"
          - name: FOO
            value: bar

(...)

Error: YAML parse error on cilium/templates/hubble-ui/deployment.yaml: error converting YAML to JSON: yaml: line 52: did not find expected key

Use --debug flag to render out invalid YAML
```

With this fix, we can generate manifests without errors:

```console
❯ cat <<EOF | helm template cilium install/kubernetes/cilium -f -
agent: false
operator:
  enabled: false

hubble:
  ui:
    enabled: true

    standalone:
      enabled: true

    backend:
      extraEnv:
      - name: FOO
        value: bar
EOF

(...)
      - name: backend
        image: "quay.io/cilium/hubble-ui-backend:v0.11.0@sha256:14c04d11f78da5c363f88592abae8d2ecee3cbe009f443ef11df6ac5f692d839"
        imagePullPolicy: Always
        env:
        - name: EVENTS_SERVER_PORT
          value: "8090"
        - name: FLOWS_API_ADDR
          value: "hubble-relay:80"
        - name: FOO
          value: bar
(...)
```

```release-note
helm: Fix a bug caused by incorrect indentation of the extraEnv parameter for Hubble UI backend
```
