### PR TITLE
bpf: tests: improve CT checks for observed TCP flags

### DIFF
--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -24,6 +24,11 @@ union tcp_flags {
 	__u32 value;
 };
 
+static __always_inline __u8 tcp_flags_to_u8(__be32 value)
+{
+	return ((union tcp_flags)value).lower_bits;
+}
+
 /**
  * Modify L4 port and correct checksum
  * @arg ctx:      packet

--- a/bpf/tests/bpf_ct_tests.c
+++ b/bpf/tests/bpf_ct_tests.c
@@ -141,6 +141,11 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 			test_fail();
 		}
 
+		struct ct_entry *entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+		assert(entry);
+		assert(entry->tx_flags_seen == tcp_flags_to_u8(TCP_FLAG_SYN));
+
 		if (data + pkt_size > data_end)
 			test_fatal("packet shrank");
 
@@ -200,6 +205,7 @@ int test_ct4_rst1_check(__maybe_unused struct __ctx_buff *ctx)
 		struct ct_entry *entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
 
 		assert(entry);
+		assert(entry->rx_flags_seen == tcp_flags_to_u8(TCP_FLAG_SYN | TCP_FLAG_RST));
 
 		__u32 expires = entry->lifetime - bpf_ktime_get_sec();
 

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -74,7 +74,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		monitor = __ct_update_timeout(&entry, 1000, CT_INGRESS, flags, REPORT_ALL_FLAGS);
 		assert(monitor);
 		assert(entry.last_rx_report == __now);
-		assert(entry.rx_flags_seen == bpf_ntohs(TCP_FLAG_SYN));
+		assert(entry.rx_flags_seen == tcp_flags_to_u8(TCP_FLAG_SYN));
 		assert(entry.last_tx_report == 0);
 		assert(entry.tx_flags_seen == 0);
 		/* Same call; no report. */
@@ -85,7 +85,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		flags.value |= TCP_FLAG_FIN;
 		monitor = __ct_update_timeout(&entry, 1000, CT_INGRESS, flags, REPORT_NO_FLAGS);
 		assert(!monitor);
-		assert(entry.rx_flags_seen == bpf_ntohs(TCP_FLAG_SYN));
+		assert(entry.rx_flags_seen == tcp_flags_to_u8(TCP_FLAG_SYN));
 		assert(entry.tx_flags_seen == 0);
 	});
 


### PR DESCRIPTION
The code in conntrack_test.c is very confused. It takes a __be32 value (TCP_FLAG_SYN), and then clamps it to __be16 before byte-swapping to host-order (it should use bpf_ntohl() instead). The u16 then gets compared to .rx_flags_seen, which is actually an __u8.

Amazingly all this magic works out well, because the flag bits are *just* in the right position of the TCP header's flag word. At least on little-endian.

Clean it up by introducing a little helper that accesses the right part of the flag word. Use it to add some checks in the other CT tests.