### PR TITLE
bgpv1: Add GetRoutes method to Router interface and generic Path type

### DIFF
--- a/pkg/bgpv1/gobgp/conversions.go
+++ b/pkg/bgpv1/gobgp/conversions.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gobgp
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	gobgp "github.com/osrg/gobgp/v3/api"
+	"github.com/osrg/gobgp/v3/pkg/apiutil"
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+)
+
+// ToGoBGPPath converts the Agent Path type to the GoBGP Path type
+func ToGoBGPPath(p *types.Path) (*gobgp.Path, error) {
+	nlri, err := apiutil.MarshalNLRI(p.NLRI)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert NLRI: %w", err)
+	}
+
+	pattrs, err := apiutil.MarshalPathAttributes(p.PathAttributes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert PathAttribute: %w", err)
+	}
+
+	// ageTimestamp is Path's creation time stamp.
+	// It is calculated by subtraction of the AgeNanoseconds from the current timestamp.
+	ageTimestamp := timestamppb.New(time.Now().Add(time.Duration(-1 * p.AgeNanoseconds)))
+
+	family := &gobgp.Family{
+		Afi:  gobgp.Family_Afi(p.NLRI.AFI()),
+		Safi: gobgp.Family_Safi(p.NLRI.SAFI()),
+	}
+
+	return &gobgp.Path{
+		Nlri:   nlri,
+		Pattrs: pattrs,
+		Age:    ageTimestamp,
+		Best:   p.Best,
+		Family: family,
+	}, nil
+}
+
+// ToAgentPath converts the GoBGP Path type to the Agent Path type
+func ToAgentPath(p *gobgp.Path) (*types.Path, error) {
+	family := bgp.AfiSafiToRouteFamily(uint16(p.Family.Afi), uint8(p.Family.Safi))
+
+	nlri, err := apiutil.UnmarshalNLRI(family, p.Nlri)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert Nlri: %w", err)
+	}
+
+	pattrs, err := apiutil.UnmarshalPathAttributes(p.Pattrs)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert Pattrs: %w", err)
+	}
+
+	// ageNano is time since the Path was created in nanoseconds.
+	// It is calculated by difference in time from age timestamp till now.
+	ageNano := int64(time.Now().Sub(p.Age.AsTime()))
+
+	return &types.Path{
+		NLRI:           nlri,
+		PathAttributes: pattrs,
+		AgeNanoseconds: ageNano,
+		Best:           p.Best,
+	}, nil
+}
+
+// ToAgentPaths converts slice of the GoBGP Path type to slice of the Agent Path type
+func ToAgentPaths(paths []*gobgp.Path) ([]*types.Path, error) {
+	errs := []error{}
+	ps := []*types.Path{}
+
+	for _, path := range paths {
+		p, err := ToAgentPath(path)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		ps = append(ps, p)
+	}
+
+	if len(errs) != 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return ps, nil
+}

--- a/pkg/bgpv1/gobgp/conversions_test.go
+++ b/pkg/bgpv1/gobgp/conversions_test.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gobgp
+
+import (
+	"context"
+	"testing"
+
+	gobgp "github.com/osrg/gobgp/v3/api"
+	"github.com/osrg/gobgp/v3/pkg/server"
+	"github.com/stretchr/testify/require"
+)
+
+// Test common Path type conversions appearing in the codebase
+func TestPathConversions(t *testing.T) {
+	for _, tt := range commonPaths {
+		t.Run(tt.name, func(t *testing.T) {
+			s := server.NewBgpServer()
+			go s.Serve()
+
+			err := s.StartBgp(context.TODO(), &gobgp.StartBgpRequest{
+				Global: &gobgp.Global{
+					Asn:        65000,
+					RouterId:   "127.0.0.1",
+					ListenPort: -1,
+				},
+			})
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				s.Stop()
+			})
+
+			path, err := ToGoBGPPath(&tt.path)
+			require.NoError(t, err)
+
+			res, err := s.AddPath(context.TODO(), &gobgp.AddPathRequest{
+				Path: path,
+			})
+			require.NoError(t, err)
+			require.NotZero(t, res.Uuid)
+
+			req := &gobgp.ListPathRequest{
+				Family: path.Family,
+			}
+			err = s.ListPath(context.TODO(), req, func(destination *gobgp.Destination) {
+				paths, err := ToAgentPaths(destination.Paths)
+				require.NoError(t, err)
+				require.NotZero(t, paths)
+				require.EqualValues(t, tt.path.NLRI, paths[0].NLRI)
+				require.EqualValues(t, tt.path.PathAttributes, paths[0].PathAttributes)
+			})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/bgpv1/gobgp/test_fixtures.go
+++ b/pkg/bgpv1/gobgp/test_fixtures.go
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gobgp
+
+import (
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
+
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+)
+
+var (
+	prefixV4             = bgp.NewIPAddrPrefix(24, "10.0.0.0")
+	prefixV6             = bgp.NewIPv6AddrPrefix(64, "fd00::")
+	originAttribute      = bgp.NewPathAttributeOrigin(0)
+	nextHopAttribute     = bgp.NewPathAttributeNextHop("0.0.0.0")
+	mpReachNLRIAttribute = bgp.NewPathAttributeMpReachNLRI("::", []bgp.AddrPrefixInterface{prefixV6})
+
+	// common path structure appearing in the agent code
+	commonPaths = []struct {
+		name string
+		path types.Path
+	}{
+		{
+			name: "IPv4 unicast advertisement",
+			path: types.Path{
+				NLRI: prefixV4,
+				PathAttributes: []bgp.PathAttributeInterface{
+					originAttribute,
+					nextHopAttribute,
+				},
+			},
+		},
+		{
+			name: "IPv6 unicast advertisement",
+			path: types.Path{
+				NLRI: prefixV6,
+				PathAttributes: []bgp.PathAttributeInterface{
+					originAttribute,
+					mpReachNLRIAttribute,
+				},
+			},
+		},
+	}
+)

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -83,6 +83,46 @@ type ServerParameters struct {
 	Global BGPGlobal
 }
 
+// Family holds Address Family Indicator (AFI) and Subsequent Address Family Indicator for Multi-Protocol BGP
+type Family struct {
+	Afi  Afi
+	Safi Safi
+}
+
+// Route represents a single route in the RIB of underlying router
+type Route struct {
+	Prefix string
+	Paths  []*Path
+}
+
+// TableType specifies the routing table type of underlying router
+type TableType int
+
+const (
+	TableTypeUnknown TableType = iota
+	TableTypeLocRIB
+	TableTypeAdjRIBIn
+	TableTypeAdjRIBOut
+)
+
+// GetRoutesRequest contains parameters for retrieving routes from the RIB of underlying router
+type GetRoutesRequest struct {
+	// TableType specifies a table type to retrieve
+	TableType TableType
+
+	// Family specifies an address family of the table
+	Family Family
+
+	// Neighbor specifies which neighbor's table to retrieve. Must be
+	// specified when TableTypeAdjRIBIn/Out is specified in TableType.
+	Neighbor netip.Addr
+}
+
+// GetRoutesResponse contains routes retrieved from the RIB of underlying router
+type GetRoutesResponse struct {
+	Routes []*Route
+}
+
 // Router is vendor-agnostic cilium bgp configuration layer. Parameters of this layer
 // are standard BGP RFC complaint and not specific to any underlying implementation.
 type Router interface {
@@ -105,6 +145,9 @@ type Router interface {
 
 	// GetPeerState returns status of BGP peers
 	GetPeerState(ctx context.Context) (GetPeerStateResponse, error)
+
+	// GetRoutes retrieves routes from the RIB of underlying router
+	GetRoutes(ctx context.Context, r *GetRoutesRequest) (*GetRoutesResponse, error)
 
 	// GetBGP returns configured BGP global parameters
 	GetBGP(ctx context.Context) (GetBGPResponse, error)

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"net/netip"
 
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
+
 	"github.com/cilium/cilium/api/v1/models"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
@@ -35,6 +37,19 @@ type RouteSelectionOptions struct {
 type Advertisement struct {
 	Prefix        netip.Prefix
 	GoBGPPathUUID []byte // path identifier in underlying implementation
+}
+
+// Path is an object representing a single routing Path. It is an analogue of GoBGP's Path object,
+// but only contains minimal fields required for Cilium usecases.
+type Path struct {
+	// read/write
+	NLRI           bgp.AddrPrefixInterface
+	PathAttributes []bgp.PathAttributeInterface
+
+	// readonly
+	AgeNanoseconds int64 // time duration in nanoseconds since the Path was created
+	Best           bool
+	GoBGPPathUUID  []byte // path identifier in underlying implementation
 }
 
 // NeighborRequest contains neighbor parameters used when enabling or disabling peer


### PR DESCRIPTION
Adds `GetRoutes` method to the Router interface and generic `Path` and `Route` types, that can be used to retrieve existing routes from the RIB of underlying router.

This is the first step towards exposing the BGP routes via cilium API + CLI.