### PR TITLE
envoy: Bump envoy to v1.24.9

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -9,7 +9,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:a1e4569c4bce113515d15a2f8
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.24-663bfb51e886b10203449217b71e62a2ede0430a@sha256:56375f7306880d378caaa5498646675cf4ddfb5a84631200576524a03595f52c as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.24-26ae46eeea118f61f9decb2f8b99e6bd82fd7de5@sha256:432f71ac017e49677c47744c248a818d5f433fb0bde50f255b6b395903f4c0dc as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
This is to include the fix for the below CVE.

CVE: https://github.com/envoyproxy/envoy/security/advisories/GHSA-jfxv-29pc-x22r
GHA build: https://github.com/cilium/proxy/actions/runs/5544741749/jobs/10122649239
