### PR TITLE
docs/ipsec: Extend troubleshooting section

### DIFF
--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -609,6 +609,7 @@ subclasses
 subcommand
 subcommands
 subdirectories
+subfeatures
 subnet
 subnets
 subregister


### PR DESCRIPTION
Recent bugs with IPsec have highlighted a need to document several caveats of IPsec operations. This commit documents those caveats as well as common XFRM errors.