### PR TITLE
docs/ipsec: Clarify limitation on number of nodes

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -220,4 +220,5 @@ Limitations
       top of other CNI plugins. For more information, see :gh-issue:`15596`.
     * :ref:`HostPolicies` are not currently supported with IPsec encryption.
     * IPsec encryption is not currently supported in combination with IPv6-only clusters.
-    * IPsec encryption is not supported on clusters with more than 65535 nodes.
+    * IPsec encryption is not supported on clusters or clustermeshes with more
+      than 65535 nodes.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -196,6 +196,7 @@ cls
 clusterIP
 clustermesh
 clustermeshcertgen
+clustermeshes
 clusterwide
 cni
 cnp


### PR DESCRIPTION
The limitation on the number of nodes in the cluster when using IPsec applies to clustermeshes as well and is the total number of nodes. This limitation arises from the use of the node IDs, which are encoded on 16-bits.