### PR TITLE
envoy: Bump envoy to v1.25.8

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1031,7 +1031,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:7edab48930186cc988baa6fb2ef6c352325306f0d6a0c89e43bef28941189095","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.25.7-8fddead4e52c704a6b189e3f80a69403c6cdc997","useDigest":true}``
+     - ``{"digest":"sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:483f2dc4ce453d423ca4c05cf
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.25.7-8fddead4e52c704a6b189e3f80a69403c6cdc997@sha256:7edab48930186cc988baa6fb2ef6c352325306f0d6a0c89e43bef28941189095 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80@sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5 as cilium-envoy
 
 #
 # Hubble CLI

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -307,7 +307,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:7edab48930186cc988baa6fb2ef6c352325306f0d6a0c89e43bef28941189095","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.25.7-8fddead4e52c704a6b189e3f80a69403c6cdc997","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/cilium-envoy","tag":"v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1868,9 +1868,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.25.7-8fddead4e52c704a6b189e3f80a69403c6cdc997"
+    tag: "v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80"
     pullPolicy: "Always"
-    digest: "sha256:7edab48930186cc988baa6fb2ef6c352325306f0d6a0c89e43bef28941189095"
+    digest: "sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1865,9 +1865,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.25.7-8fddead4e52c704a6b189e3f80a69403c6cdc997"
+    tag: "v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80"
     pullPolicy: "${PULL_POLICY}"
-    digest: "sha256:7edab48930186cc988baa6fb2ef6c352325306f0d6a0c89e43bef28941189095"
+    digest: "sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.


### PR DESCRIPTION
This is to include the fix for the below CVE.

CVE: GHSA-jfxv-29pc-x22r
GHA build: https://github.com/cilium/proxy/actions/runs/5548261876/jobs/10131017073