### PR TITLE
bpf: ct: clean up tuple swapping for forward lookups

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -398,6 +398,16 @@ ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
 }
 
 static __always_inline void
+ipv6_ct_tuple_swap_addrs(struct ipv6_ct_tuple *tuple)
+{
+	union v6addr tmp_addr = {};
+
+	ipv6_addr_copy(&tmp_addr, &tuple->saddr);
+	ipv6_addr_copy(&tuple->saddr, &tuple->daddr);
+	ipv6_addr_copy(&tuple->daddr, &tmp_addr);
+}
+
+static __always_inline void
 ipv6_ct_tuple_swap_ports(struct ipv6_ct_tuple *tuple)
 {
 	__be16 tmp;
@@ -523,9 +533,6 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ct
 		ipv6_ct_tuple_reverse(tuple);
 		fallthrough;
 	case SCOPE_FORWARD:
-		if (scope == SCOPE_FORWARD)
-			__ipv6_ct_tuple_reverse(tuple);
-
 		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
 				  is_tcp, tcp_flags, monitor);
 	}
@@ -621,6 +628,15 @@ ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 {
 	__ipv4_ct_tuple_reverse(tuple);
 	ct_flip_tuple_dir4(tuple);
+}
+
+static __always_inline void
+ipv4_ct_tuple_swap_addrs(struct ipv4_ct_tuple *tuple)
+{
+	__be32 tmp_addr = tuple->saddr;
+
+	tuple->saddr = tuple->daddr;
+	tuple->daddr = tmp_addr;
 }
 
 static __always_inline void
@@ -777,9 +793,6 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ct
 		ipv4_ct_tuple_reverse(tuple);
 		fallthrough;
 	case SCOPE_FORWARD:
-		if (scope == SCOPE_FORWARD)
-			__ipv4_ct_tuple_reverse(tuple);
-
 		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
 				  is_tcp, tcp_flags, monitor);
 	}
@@ -797,7 +810,8 @@ out:
  * @arg has_l4_header	packet has L4 header
  * @arg action		ACTION_CREATE or ACTION_UNSPEC for __ct_lookup
  * @arg dir		lookup direction
- * @arg scope		CT scope
+ * @arg scope		CT scope. For SCOPE_FORWARD, the tuple also needs to
+ *			be in forward layout.
  * @arg ct_state	returned CT entry
  * @arg monitor		monitor feedback for trace aggregation
  *

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -289,6 +289,24 @@ ct_new: __maybe_unused;
 	return CT_NEW;
 }
 
+static __always_inline __u8
+ct_lookup_select_tuple_type(enum ct_dir dir, enum ct_scope scope)
+{
+	if (dir == CT_SERVICE)
+		return TUPLE_F_SERVICE;
+
+	switch (scope) {
+	case SCOPE_FORWARD:
+		return (dir == CT_EGRESS) ? TUPLE_F_OUT : TUPLE_F_IN;
+	case SCOPE_BIDIR:
+		/* Due to policy requirements, RELATED or REPLY state takes
+		 * precedence over ESTABLISHED. So lookup in reverse direction first:
+		 */
+	case SCOPE_REVERSE:
+		return (dir == CT_EGRESS) ? TUPLE_F_IN : TUPLE_F_OUT;
+	}
+}
+
 /* The function determines whether an egress flow identified by the given
  * tuple is a reply.
  *
@@ -502,9 +520,12 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ct
 			goto out;
 
 		/* now lookup in forward direction: */
+		ipv6_ct_tuple_reverse(tuple);
 		fallthrough;
 	case SCOPE_FORWARD:
-		ipv6_ct_tuple_reverse(tuple);
+		if (scope == SCOPE_FORWARD)
+			__ipv6_ct_tuple_reverse(tuple);
+
 		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
 				  is_tcp, tcp_flags, monitor);
 	}
@@ -521,21 +542,7 @@ ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
 		enum ct_dir dir, enum ct_scope scope, struct ct_state *ct_state,
 		__u32 *monitor)
 {
-	/* The tuple is created in reverse order initially to find a
-	 * potential reverse flow. This is required because the RELATED
-	 * or REPLY state takes precedence over ESTABLISHED due to
-	 * policy requirements.
-	 *
-	 * tuple->flags separates entries that could otherwise be overlapping.
-	 */
-	if (dir == CT_INGRESS)
-		tuple->flags = TUPLE_F_OUT;
-	else if (dir == CT_EGRESS)
-		tuple->flags = TUPLE_F_IN;
-	else if (dir == CT_SERVICE)
-		tuple->flags = TUPLE_F_SERVICE;
-	else
-		return DROP_CT_INVALID_HDR;
+	tuple->flags = ct_lookup_select_tuple_type(dir, scope);
 
 	return __ct_lookup6(map, tuple, ctx, l4_off, action, dir, scope,
 			    ct_state, monitor);
@@ -550,21 +557,7 @@ static __always_inline int ct_lookup6(const void *map,
 {
 	int action;
 
-	/* The tuple is created in reverse order initially to find a
-	 * potential reverse flow. This is required because the RELATED
-	 * or REPLY state takes precedence over ESTABLISHED due to
-	 * policy requirements.
-	 *
-	 * tuple->flags separates entries that could otherwise be overlapping.
-	 */
-	if (dir == CT_INGRESS)
-		tuple->flags = TUPLE_F_OUT;
-	else if (dir == CT_EGRESS)
-		tuple->flags = TUPLE_F_IN;
-	else if (dir == CT_SERVICE)
-		tuple->flags = TUPLE_F_SERVICE;
-	else
-		return DROP_CT_INVALID_HDR;
+	tuple->flags = ct_lookup_select_tuple_type(dir, SCOPE_BIDIR);
 
 	action = ct_extract_ports6(ctx, l4_off, dir, tuple, NULL);
 	if (action < 0)
@@ -781,9 +774,12 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ct
 			goto out;
 
 		/* now lookup in forward direction: */
+		ipv4_ct_tuple_reverse(tuple);
 		fallthrough;
 	case SCOPE_FORWARD:
-		ipv4_ct_tuple_reverse(tuple);
+		if (scope == SCOPE_FORWARD)
+			__ipv4_ct_tuple_reverse(tuple);
+
 		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
 				  is_tcp, tcp_flags, monitor);
 	}
@@ -819,21 +815,7 @@ ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple,
 		enum ct_action action, enum ct_dir dir, enum ct_scope scope,
 		struct ct_state *ct_state, __u32 *monitor)
 {
-	/* The tuple is created in reverse order initially to find a
-	 * potential reverse flow. This is required because the RELATED
-	 * or REPLY state takes precedence over ESTABLISHED due to
-	 * policy requirements.
-	 *
-	 * tuple->flags separates entries that could otherwise be overlapping.
-	 */
-	if (dir == CT_INGRESS)
-		tuple->flags = TUPLE_F_OUT;
-	else if (dir == CT_EGRESS)
-		tuple->flags = TUPLE_F_IN;
-	else if (dir == CT_SERVICE)
-		tuple->flags = TUPLE_F_SERVICE;
-	else
-		return DROP_CT_INVALID_HDR;
+	tuple->flags = ct_lookup_select_tuple_type(dir, scope);
 
 	return __ct_lookup4(map, tuple, ctx, l4_off, has_l4_header,
 			    action, dir, scope, ct_state, monitor);
@@ -848,21 +830,7 @@ static __always_inline int ct_lookup4(const void *map,
 	int action;
 	bool has_l4_header = true;
 
-	/* The tuple is created in reverse order initially to find a
-	 * potential reverse flow. This is required because the RELATED
-	 * or REPLY state takes precedence over ESTABLISHED due to
-	 * policy requirements.
-	 *
-	 * tuple->flags separates entries that could otherwise be overlapping.
-	 */
-	if (dir == CT_INGRESS)
-		tuple->flags = TUPLE_F_OUT;
-	else if (dir == CT_EGRESS)
-		tuple->flags = TUPLE_F_IN;
-	else if (dir == CT_SERVICE)
-		tuple->flags = TUPLE_F_SERVICE;
-	else
-		return DROP_CT_INVALID_HDR;
+	tuple->flags = ct_lookup_select_tuple_type(dir, SCOPE_BIDIR);
 
 	action = ct_extract_ports4(ctx, off, dir, tuple, &has_l4_header);
 	if (action < 0)

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -376,28 +376,6 @@ static __always_inline void ct_flip_tuple_dir6(struct ipv6_ct_tuple *tuple)
 }
 
 static __always_inline void
-__ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
-{
-	union v6addr tmp_addr = {};
-	__be16 tmp;
-
-	ipv6_addr_copy(&tmp_addr, &tuple->saddr);
-	ipv6_addr_copy(&tuple->saddr, &tuple->daddr);
-	ipv6_addr_copy(&tuple->daddr, &tmp_addr);
-
-	tmp = tuple->sport;
-	tuple->sport = tuple->dport;
-	tuple->dport = tmp;
-}
-
-static __always_inline void
-ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
-{
-	__ipv6_ct_tuple_reverse(tuple);
-	ct_flip_tuple_dir6(tuple);
-}
-
-static __always_inline void
 ipv6_ct_tuple_swap_addrs(struct ipv6_ct_tuple *tuple)
 {
 	union v6addr tmp_addr = {};
@@ -420,6 +398,20 @@ ipv6_ct_tuple_swap_ports(struct ipv6_ct_tuple *tuple)
 	tmp = tuple->sport;
 	tuple->sport = tuple->dport;
 	tuple->dport = tmp;
+}
+
+static __always_inline void
+__ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
+{
+	ipv6_ct_tuple_swap_addrs(tuple);
+	ipv6_ct_tuple_swap_ports(tuple);
+}
+
+static __always_inline void
+ipv6_ct_tuple_reverse(struct ipv6_ct_tuple *tuple)
+{
+	__ipv6_ct_tuple_reverse(tuple);
+	ct_flip_tuple_dir6(tuple);
 }
 
 static __always_inline int
@@ -610,27 +602,6 @@ static __always_inline void ct_flip_tuple_dir4(struct ipv4_ct_tuple *tuple)
 }
 
 static __always_inline void
-__ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
-{
-	__be32 tmp_addr = tuple->saddr;
-	__be16 tmp;
-
-	tuple->saddr = tuple->daddr;
-	tuple->daddr = tmp_addr;
-
-	tmp = tuple->sport;
-	tuple->sport = tuple->dport;
-	tuple->dport = tmp;
-}
-
-static __always_inline void
-ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
-{
-	__ipv4_ct_tuple_reverse(tuple);
-	ct_flip_tuple_dir4(tuple);
-}
-
-static __always_inline void
 ipv4_ct_tuple_swap_addrs(struct ipv4_ct_tuple *tuple)
 {
 	__be32 tmp_addr = tuple->saddr;
@@ -652,6 +623,20 @@ ipv4_ct_tuple_swap_ports(struct ipv4_ct_tuple *tuple)
 	tmp = tuple->sport;
 	tuple->sport = tuple->dport;
 	tuple->dport = tmp;
+}
+
+static __always_inline void
+__ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
+{
+	ipv4_ct_tuple_swap_addrs(tuple);
+	ipv4_ct_tuple_swap_ports(tuple);
+}
+
+static __always_inline void
+ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
+{
+	__ipv4_ct_tuple_reverse(tuple);
+	ct_flip_tuple_dir4(tuple);
 }
 
 static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -309,11 +309,8 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 		int ret;
 
 		memcpy(&tuple_snat, tuple, sizeof(tuple_snat));
-
-		/* CT expects a tuple with the source and destination ports reversed,
-		 * while NAT uses normal tuples that match packet headers.
-		 */
-		ipv4_ct_tuple_swap_ports(&tuple_snat);
+		/* Lookup with SCOPE_FORWARD. Ports are already in correct layout: */
+		ipv4_ct_tuple_swap_addrs(&tuple_snat);
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_snat), &tuple_snat,
 				      ctx, off, has_l4_header, ct_action, CT_EGRESS,
@@ -1362,10 +1359,8 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 		int ret;
 
 		memcpy(&tuple_snat, tuple, sizeof(tuple_snat));
-		/* CT expects a tuple with the source and destination ports reversed,
-		 * while NAT uses normal tuples that match packet headers.
-		 */
-		ipv6_ct_tuple_swap_ports(&tuple_snat);
+		/* Lookup with SCOPE_FORWARD. Ports are already in correct layout: */
+		ipv6_ct_tuple_swap_addrs(&tuple_snat);
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple_snat), &tuple_snat,
 				      ctx, off, ct_action, CT_EGRESS,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -765,6 +765,9 @@ int tail_nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
+	/* look up with SCOPE_FORWARD: */
+	__ipv6_ct_tuple_reverse(&tuple);
+
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
 			      CT_EGRESS, SCOPE_FORWARD, &ct_state, &monitor);
 	switch (ret) {
@@ -1154,6 +1157,9 @@ skip_service_lookup:
 		return DROP_INVALID;
 	if (backend_local || !nodeport_uses_dsr6(&tuple)) {
 		struct ct_state ct_state = {};
+
+		/* lookup with SCOPE_FORWARD: */
+		__ipv6_ct_tuple_reverse(&tuple);
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
 				      CT_EGRESS, SCOPE_FORWARD, &ct_state, &monitor);
@@ -2190,6 +2196,9 @@ int tail_nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx)
 		goto drop_err;
 	}
 
+	/* lookup with SCOPE_FORWARD: */
+	__ipv4_ct_tuple_reverse(&tuple);
+
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off,
 			      has_l4_header, ACTION_CREATE, CT_EGRESS,
 			      SCOPE_FORWARD, &ct_state, &monitor);
@@ -2564,6 +2573,9 @@ skip_service_lookup:
 	 */
 	if (backend_local || !nodeport_uses_dsr4(&tuple)) {
 		struct ct_state ct_state = {};
+
+		/* lookup with SCOPE_FORWARD: */
+		__ipv4_ct_tuple_reverse(&tuple);
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
 				      ACTION_CREATE, CT_EGRESS, SCOPE_FORWARD,


### PR DESCRIPTION
While working on https://github.com/cilium/cilium/pull/25826, @gentoo-root suggested that we can also stream-line some of the CT tuple swapping. For SCOPE_FORWARD lookups, it doesn't make sense to first build a tuple in "standard" (== reverse) layout, when it immediately gets swapped again.