### PR TITLE
k8s/apis: refactor CRD registration helpers into a separate package

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -6,28 +6,22 @@ package client
 import (
 	"context"
 	_ "embed"
-	goerrors "errors"
 	"fmt"
-	"time"
 
-	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	v1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/yaml"
 
 	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sconstv2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/apis/crdhelpers"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 const (
@@ -86,12 +80,8 @@ const (
 	CPIPCRDName = k8sconstv2alpha1.CPIPKindDefinition + "/" + k8sconstv2alpha1.CustomResourceDefinitionVersion
 )
 
-var (
-	// log is the k8s package logger object.
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsysK8s)
-
-	comparableCRDSchemaVersion = versioncheck.MustVersion(k8sconst.CustomResourceDefinitionSchemaVersion)
-)
+// log is the k8s package logger object.
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsysK8s)
 
 type CRDList struct {
 	Name     string
@@ -311,56 +301,12 @@ func createCRD(crdVersionedName string, crdMetaName string) func(clientset apiex
 	return func(clientset apiextensionsclient.Interface) error {
 		ciliumCRD := GetPregeneratedCRD(crdVersionedName)
 
-		return createUpdateCRD(
+		return crdhelpers.CreateUpdateCRD(
 			clientset,
 			constructV1CRD(crdMetaName, ciliumCRD),
-			newDefaultPoller(),
+			crdhelpers.NewDefaultPoller(),
 		)
 	}
-}
-
-// createUpdateCRD ensures the CRD object is installed into the K8s cluster. It
-// will create or update the CRD and its validation schema as necessary. This
-// function only accepts v1 CRD objects.
-func createUpdateCRD(
-	clientset apiextensionsclient.Interface,
-	crd *apiextensionsv1.CustomResourceDefinition,
-	poller poller,
-) error {
-	scopedLog := log.WithField("name", crd.Name)
-
-	v1CRDClient := clientset.ApiextensionsV1()
-	clusterCRD, err := v1CRDClient.CustomResourceDefinitions().Get(
-		context.TODO(),
-		crd.ObjectMeta.Name,
-		metav1.GetOptions{})
-	if errors.IsNotFound(err) {
-		scopedLog.Info("Creating CRD (CustomResourceDefinition)...")
-
-		clusterCRD, err = v1CRDClient.CustomResourceDefinitions().Create(
-			context.TODO(),
-			crd,
-			metav1.CreateOptions{})
-		// This occurs when multiple agents race to create the CRD. Since another has
-		// created it, it will also update it, hence the non-error return.
-		if errors.IsAlreadyExists(err) {
-			return nil
-		}
-	}
-	if err != nil {
-		return err
-	}
-
-	if err := updateV1CRD(scopedLog, crd, clusterCRD, v1CRDClient, poller); err != nil {
-		return err
-	}
-	if err := waitForV1CRD(scopedLog, clusterCRD, v1CRDClient, poller); err != nil {
-		return err
-	}
-
-	scopedLog.Info("CRD (CustomResourceDefinition) is installed and up-to-date")
-
-	return nil
 }
 
 func constructV1CRD(
@@ -386,152 +332,6 @@ func constructV1CRD(
 			Versions: template.Spec.Versions,
 		},
 	}
-}
-
-func needsUpdateV1(clusterCRD *apiextensionsv1.CustomResourceDefinition) bool {
-	if clusterCRD.Spec.Versions[0].Schema == nil {
-		// no validation detected
-		return true
-	}
-	v, ok := clusterCRD.Labels[k8sconst.CustomResourceDefinitionSchemaVersionKey]
-	if !ok {
-		// no schema version detected
-		return true
-	}
-
-	clusterVersion, err := versioncheck.Version(v)
-	if err != nil || clusterVersion.LT(comparableCRDSchemaVersion) {
-		// version in cluster is either unparsable or smaller than current version
-		return true
-	}
-
-	return false
-}
-
-func updateV1CRD(
-	scopedLog *logrus.Entry,
-	crd, clusterCRD *apiextensionsv1.CustomResourceDefinition,
-	client v1client.CustomResourceDefinitionsGetter,
-	poller poller,
-) error {
-	scopedLog.Debug("Checking if CRD (CustomResourceDefinition) needs update...")
-
-	if crd.Spec.Versions[0].Schema != nil && needsUpdateV1(clusterCRD) {
-		scopedLog.Info("Updating CRD (CustomResourceDefinition)...")
-
-		// Update the CRD with the validation schema.
-		err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-			var err error
-			clusterCRD, err = client.CustomResourceDefinitions().Get(
-				context.TODO(),
-				crd.ObjectMeta.Name,
-				metav1.GetOptions{})
-			if err != nil {
-				return false, err
-			}
-
-			// This seems too permissive but we only get here if the version is
-			// different per needsUpdate above. If so, we want to update on any
-			// validation change including adding or removing validation.
-			if needsUpdateV1(clusterCRD) {
-				scopedLog.Debug("CRD validation is different, updating it...")
-
-				clusterCRD.ObjectMeta.Labels = crd.ObjectMeta.Labels
-				clusterCRD.Spec = crd.Spec
-
-				// Even though v1 CRDs omit this field by default (which also
-				// means it's false) it is still carried over from the previous
-				// CRD. Therefore, we must set this to false explicitly because
-				// the apiserver will carry over the old value (true).
-				clusterCRD.Spec.PreserveUnknownFields = false
-
-				_, err := client.CustomResourceDefinitions().Update(
-					context.TODO(),
-					clusterCRD,
-					metav1.UpdateOptions{})
-				switch {
-				case errors.IsConflict(err): // Occurs as Operators race to update CRDs.
-					scopedLog.WithError(err).
-						Debug("The CRD update was based on an older version, retrying...")
-					return false, nil
-				case err == nil:
-					return true, nil
-				}
-
-				scopedLog.WithError(err).Debug("Unable to update CRD validation")
-
-				return false, err
-			}
-
-			return true, nil
-		})
-		if err != nil {
-			scopedLog.WithError(err).Error("Unable to update CRD")
-			return err
-		}
-	}
-
-	return nil
-}
-
-func waitForV1CRD(
-	scopedLog *logrus.Entry,
-	crd *apiextensionsv1.CustomResourceDefinition,
-	client v1client.CustomResourceDefinitionsGetter,
-	poller poller,
-) error {
-	scopedLog.Debug("Waiting for CRD (CustomResourceDefinition) to be available...")
-
-	err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
-		for _, cond := range crd.Status.Conditions {
-			switch cond.Type {
-			case apiextensionsv1.Established:
-				if cond.Status == apiextensionsv1.ConditionTrue {
-					return true, nil
-				}
-			case apiextensionsv1.NamesAccepted:
-				if cond.Status == apiextensionsv1.ConditionFalse {
-					err := goerrors.New(cond.Reason)
-					scopedLog.WithError(err).Error("Name conflict for CRD")
-					return false, err
-				}
-			}
-		}
-
-		var err error
-		if crd, err = client.CustomResourceDefinitions().Get(
-			context.TODO(),
-			crd.ObjectMeta.Name,
-			metav1.GetOptions{}); err != nil {
-			return false, err
-		}
-		return false, err
-	})
-	if err != nil {
-		return fmt.Errorf("error occurred waiting for CRD: %w", err)
-	}
-
-	return nil
-}
-
-// poller is an interface that abstracts the polling logic when dealing with
-// CRD changes / updates to the apiserver. The reason this exists is mainly for
-// unit-testing.
-type poller interface {
-	Poll(interval, duration time.Duration, conditionFn func() (bool, error)) error
-}
-
-func newDefaultPoller() defaultPoll {
-	return defaultPoll{}
-}
-
-type defaultPoll struct{}
-
-func (p defaultPoll) Poll(
-	interval, duration time.Duration,
-	conditionFn func() (bool, error),
-) error {
-	return wait.Poll(interval, duration, conditionFn)
 }
 
 // RegisterCRDs registers all CRDs with the K8s apiserver.

--- a/pkg/k8s/apis/cilium.io/client/register.go
+++ b/pkg/k8s/apis/cilium.io/client/register.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 const (
@@ -305,6 +306,8 @@ func createCRD(crdVersionedName string, crdMetaName string) func(clientset apiex
 			clientset,
 			constructV1CRD(crdMetaName, ciliumCRD),
 			crdhelpers.NewDefaultPoller(),
+			k8sconst.CustomResourceDefinitionSchemaVersionKey,
+			versioncheck.MustVersion(k8sconst.CustomResourceDefinitionSchemaVersion),
 		)
 	}
 }

--- a/pkg/k8s/apis/crdhelpers/register.go
+++ b/pkg/k8s/apis/crdhelpers/register.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package crdhelpers
+
+import (
+	"context"
+	goerrors "errors"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	v1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/versioncheck"
+)
+
+// subsysK8s is the value for logfields.LogSubsys
+const subsysK8s = "k8s"
+
+var (
+	// log is the k8s package logger object.
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, subsysK8s)
+
+	comparableCRDSchemaVersion = versioncheck.MustVersion(k8sconst.CustomResourceDefinitionSchemaVersion)
+)
+
+// CreateUpdateCRD ensures the CRD object is installed into the K8s cluster. It
+// will create or update the CRD and its validation schema as necessary. This
+// function only accepts v1 CRD objects.
+func CreateUpdateCRD(
+	clientset apiextensionsclient.Interface,
+	crd *apiextensionsv1.CustomResourceDefinition,
+	poller poller,
+) error {
+	scopedLog := log.WithField("name", crd.Name)
+
+	v1CRDClient := clientset.ApiextensionsV1()
+	clusterCRD, err := v1CRDClient.CustomResourceDefinitions().Get(
+		context.TODO(),
+		crd.ObjectMeta.Name,
+		metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		scopedLog.Info("Creating CRD (CustomResourceDefinition)...")
+
+		clusterCRD, err = v1CRDClient.CustomResourceDefinitions().Create(
+			context.TODO(),
+			crd,
+			metav1.CreateOptions{})
+		// This occurs when multiple agents race to create the CRD. Since another has
+		// created it, it will also update it, hence the non-error return.
+		if errors.IsAlreadyExists(err) {
+			return nil
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := updateV1CRD(scopedLog, crd, clusterCRD, v1CRDClient, poller); err != nil {
+		return err
+	}
+	if err := waitForV1CRD(scopedLog, clusterCRD, v1CRDClient, poller); err != nil {
+		return err
+	}
+
+	scopedLog.Info("CRD (CustomResourceDefinition) is installed and up-to-date")
+
+	return nil
+}
+
+
+func needsUpdateV1(clusterCRD *apiextensionsv1.CustomResourceDefinition) bool {
+	if clusterCRD.Spec.Versions[0].Schema == nil {
+		// no validation detected
+		return true
+	}
+	v, ok := clusterCRD.Labels[k8sconst.CustomResourceDefinitionSchemaVersionKey]
+	if !ok {
+		// no schema version detected
+		return true
+	}
+
+	clusterVersion, err := versioncheck.Version(v)
+	if err != nil || clusterVersion.LT(comparableCRDSchemaVersion) {
+		// version in cluster is either unparsable or smaller than current version
+		return true
+	}
+
+	return false
+}
+
+func updateV1CRD(
+	scopedLog *logrus.Entry,
+	crd, clusterCRD *apiextensionsv1.CustomResourceDefinition,
+	client v1client.CustomResourceDefinitionsGetter,
+	poller poller,
+) error {
+	scopedLog.Debug("Checking if CRD (CustomResourceDefinition) needs update...")
+
+	if crd.Spec.Versions[0].Schema != nil && needsUpdateV1(clusterCRD) {
+		scopedLog.Info("Updating CRD (CustomResourceDefinition)...")
+
+		// Update the CRD with the validation schema.
+		err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+			var err error
+			clusterCRD, err = client.CustomResourceDefinitions().Get(
+				context.TODO(),
+				crd.ObjectMeta.Name,
+				metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+
+			// This seems too permissive but we only get here if the version is
+			// different per needsUpdate above. If so, we want to update on any
+			// validation change including adding or removing validation.
+			if needsUpdateV1(clusterCRD) {
+				scopedLog.Debug("CRD validation is different, updating it...")
+
+				clusterCRD.ObjectMeta.Labels = crd.ObjectMeta.Labels
+				clusterCRD.Spec = crd.Spec
+
+				// Even though v1 CRDs omit this field by default (which also
+				// means it's false) it is still carried over from the previous
+				// CRD. Therefore, we must set this to false explicitly because
+				// the apiserver will carry over the old value (true).
+				clusterCRD.Spec.PreserveUnknownFields = false
+
+				_, err := client.CustomResourceDefinitions().Update(
+					context.TODO(),
+					clusterCRD,
+					metav1.UpdateOptions{})
+				switch {
+				case errors.IsConflict(err): // Occurs as Operators race to update CRDs.
+					scopedLog.WithError(err).
+						Debug("The CRD update was based on an older version, retrying...")
+					return false, nil
+				case err == nil:
+					return true, nil
+				}
+
+				scopedLog.WithError(err).Debug("Unable to update CRD validation")
+
+				return false, err
+			}
+
+			return true, nil
+		})
+		if err != nil {
+			scopedLog.WithError(err).Error("Unable to update CRD")
+			return err
+		}
+	}
+
+	return nil
+}
+
+func waitForV1CRD(
+	scopedLog *logrus.Entry,
+	crd *apiextensionsv1.CustomResourceDefinition,
+	client v1client.CustomResourceDefinitionsGetter,
+	poller poller,
+) error {
+	scopedLog.Debug("Waiting for CRD (CustomResourceDefinition) to be available...")
+
+	err := poller.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+		for _, cond := range crd.Status.Conditions {
+			switch cond.Type {
+			case apiextensionsv1.Established:
+				if cond.Status == apiextensionsv1.ConditionTrue {
+					return true, nil
+				}
+			case apiextensionsv1.NamesAccepted:
+				if cond.Status == apiextensionsv1.ConditionFalse {
+					err := goerrors.New(cond.Reason)
+					scopedLog.WithError(err).Error("Name conflict for CRD")
+					return false, err
+				}
+			}
+		}
+
+		var err error
+		if crd, err = client.CustomResourceDefinitions().Get(
+			context.TODO(),
+			crd.ObjectMeta.Name,
+			metav1.GetOptions{}); err != nil {
+			return false, err
+		}
+		return false, err
+	})
+	if err != nil {
+		return fmt.Errorf("error occurred waiting for CRD: %w", err)
+	}
+
+	return nil
+}
+
+// poller is an interface that abstracts the polling logic when dealing with
+// CRD changes / updates to the apiserver. The reason this exists is mainly for
+// unit-testing.
+type poller interface {
+	Poll(interval, duration time.Duration, conditionFn func() (bool, error)) error
+}
+
+func NewDefaultPoller() defaultPoll {
+	return defaultPoll{}
+}
+
+type defaultPoll struct{}
+
+func (p defaultPoll) Poll(
+	interval, duration time.Duration,
+	conditionFn func() (bool, error),
+) error {
+	return wait.Poll(interval, duration, conditionFn)
+}

--- a/pkg/k8s/apis/crdhelpers/register_test.go
+++ b/pkg/k8s/apis/crdhelpers/register_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package client
+package crdhelpers
 
 import (
 	"context"
@@ -90,7 +90,7 @@ func (s *CiliumV2RegisterSuite) TestCreateUpdateCRD(c *C) {
 				crd := s.getV1TestCRD()
 				client := fake.NewSimpleClientset()
 				c.Assert(k8sversion.Force(v1Support.Major+"."+v1Support.Minor), IsNil)
-				return createUpdateCRD(client, crd, newFakePoller())
+				return CreateUpdateCRD(client, crd, newFakePoller())
 			},
 			wantErr: false,
 		},
@@ -101,7 +101,7 @@ func (s *CiliumV2RegisterSuite) TestCreateUpdateCRD(c *C) {
 				crd := s.getV1TestCRD()
 				client := fake.NewSimpleClientset()
 				c.Assert(k8sversion.Force(v1beta1Support.Major+"."+v1beta1Support.Minor), IsNil)
-				return createUpdateCRD(client, crd, newFakePoller())
+				return CreateUpdateCRD(client, crd, newFakePoller())
 			},
 			wantErr: false,
 		},
@@ -128,7 +128,7 @@ func (s *CiliumV2RegisterSuite) TestCreateUpdateCRD(c *C) {
 				)
 				c.Assert(err, IsNil)
 
-				return createUpdateCRD(client, crd, newFakePoller())
+				return CreateUpdateCRD(client, crd, newFakePoller())
 			},
 			wantErr: false,
 		},
@@ -161,14 +161,14 @@ func (s *CiliumV2RegisterSuite) TestCreateUpdateCRD(c *C) {
 				client.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = v1beta1Support
 				c.Assert(k8sversion.Force(v1beta1Support.Major+"."+v1beta1Support.Minor), IsNil)
 
-				// Retrieve v1 CRD here as that's what createUpdateCRD will be
+				// Retrieve v1 CRD here as that's what CreateUpdateCRD will be
 				// expecting, and change the name to match to-be installed CRD.
-				// This tests that createUpdateCRD will fallback on its v1beta1
+				// This tests that CreateUpdateCRD will fallback on its v1beta1
 				// variant.
 				crd := s.getV1TestCRD()
 				crd.ObjectMeta.Name = crdToInstall.ObjectMeta.Name
 
-				return createUpdateCRD(client, crd, newFakePoller())
+				return CreateUpdateCRD(client, crd, newFakePoller())
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
The first commit factors out the helper functions used to create and install CRD objects with k8s. The second commit changes the factored out helpers to no longer depend on a specific API version but take all values as parameters.
