### PR TITLE
Full CES Reconciliation in the Operator

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -11,6 +11,10 @@ cilium-operator-alibabacloud hive [flags]
 ### Options
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -17,6 +17,10 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -11,6 +11,10 @@ cilium-operator-aws hive [flags]
 ### Options
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -17,6 +17,10 @@ cilium-operator-aws hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -11,6 +11,10 @@ cilium-operator-azure hive [flags]
 ### Options
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -17,6 +17,10 @@ cilium-operator-azure hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -11,6 +11,10 @@ cilium-operator-generic hive [flags]
 ### Options
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -17,6 +17,10 @@ cilium-operator-generic hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -11,6 +11,10 @@ cilium-operator hive [flags]
 ### Options
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -17,6 +17,10 @@ cilium-operator hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --ces-max-ciliumendpoints-per-ces int                  Maximum number of CiliumEndpoints allowed in a CES (default 100)
+      --ces-slice-mode string                                Slicing mode define how ceps are grouped into a CES (default "cesSliceModeIdentity")
+      --ces-write-qps-burst int                              CES work queue burst rate (default 20)
+      --ces-write-qps-limit float                            CES work queue rate limit (default 10)
       --cluster-id uint32                                    Unique identifier of the cluster
       --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -280,32 +280,8 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.BGPConfigPath, "/var/lib/cilium/bgp/config.yaml", "Path to file containing the BGP configuration")
 	option.BindEnv(vp, option.BGPConfigPath)
 
-	enableCES := flags.Bool(option.EnableCiliumEndpointSlice, false, "If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.")
+	flags.Bool(option.EnableCiliumEndpointSlice, false, "If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.")
 	option.BindEnv(vp, option.EnableCiliumEndpointSlice)
-
-	flags.Int(operatorOption.CESMaxCEPsInCES, operatorOption.CESMaxCEPsInCESDefault, "Maximum number of CiliumEndpoints allowed in a CES")
-	if *enableCES {
-		flags.MarkHidden(operatorOption.CESMaxCEPsInCES)
-	}
-	option.BindEnv(vp, operatorOption.CESMaxCEPsInCES)
-
-	flags.String(operatorOption.CESSlicingMode, operatorOption.CESSlicingModeDefault, "Slicing mode define how ceps are grouped into a CES")
-	if *enableCES {
-		flags.MarkHidden(operatorOption.CESSlicingMode)
-	}
-	option.BindEnv(vp, operatorOption.CESSlicingMode)
-
-	flags.Float64(operatorOption.CESWriteQPSLimit, operatorOption.CESWriteQPSLimitDefault, "CES work queue rate limit")
-	if *enableCES {
-		flags.MarkHidden(operatorOption.CESWriteQPSLimit)
-	}
-	option.BindEnv(vp, operatorOption.CESWriteQPSLimit)
-
-	flags.Int(operatorOption.CESWriteQPSBurst, operatorOption.CESWriteQPSBurstDefault, "CES work queue burst rate")
-	if *enableCES {
-		flags.MarkHidden(operatorOption.CESWriteQPSBurst)
-	}
-	option.BindEnv(vp, operatorOption.CESWriteQPSBurst)
 
 	flags.String(operatorOption.CiliumK8sNamespace, "", fmt.Sprintf("Name of the Kubernetes namespace in which Cilium is deployed in. Defaults to the same namespace defined in %s", option.K8sNamespaceName))
 	option.BindEnv(vp, operatorOption.CiliumK8sNamespace)

--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -5,16 +5,17 @@ package identitygc
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	"github.com/cilium/cilium/operator/metrics"
-	"github.com/cilium/cilium/operator/pkg/ciliumendpointslice"
-	"github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/controller"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -68,13 +69,11 @@ func (igc *GC) runHeartbeatUpdater(ctx context.Context) error {
 // since HeartbeatTimeout.
 func (igc *GC) gc(ctx context.Context) error {
 	igc.logger.Debug("Running CRD identity garbage collector")
-
-	select {
-	case <-watchers.CiliumEndpointsSynced:
-	case <-ctx.Done():
-		return nil
+	cepStore, err := igc.ciliumEndpoint.Store(ctx)
+	if err != nil {
+		igc.logger.WithError(err).Error("unable to get CEP store")
+		return err
 	}
-
 	identitiesStore, err := igc.identity.Store(ctx)
 	if err != nil {
 		igc.logger.WithError(err).Error("unable to get Cilium identities from local store")
@@ -84,7 +83,12 @@ func (igc *GC) gc(ctx context.Context) error {
 	var idsInCESs map[string]bool
 	cesEnabled := option.Config.EnableCiliumEndpointSlice
 	if cesEnabled {
-		idsInCESs = ciliumendpointslice.UsedIdentitiesInCESs()
+		cesStore, err := igc.ciliumEndpointSlice.Store(ctx)
+		if err != nil {
+			igc.logger.WithError(err).Warning("unable to get CES  store")
+		} else {
+			idsInCESs = usedIdentitiesInCESs(cesStore)
+		}
 	}
 
 	identities := identitiesStore.List()
@@ -98,7 +102,7 @@ func (igc *GC) gc(ctx context.Context) error {
 			_, foundInCES = idsInCESs[identity.Name]
 		}
 		// The identity is definitely alive if there's a CE or CES using it.
-		alive := foundInCES || watchers.HasCEWithIdentity(identity.Name)
+		alive := foundInCES || hasCEWithIdentity(cepStore, identity.Name)
 
 		if alive {
 			igc.heartbeatStore.markAlive(identity.Name, timeNow)
@@ -211,4 +215,21 @@ func (igc *GC) updateIdentity(ctx context.Context, identity *v2.CiliumIdentity) 
 	log.WithField(logfields.Identity, identity.GetName()).Debug("Updated identity")
 
 	return nil
+}
+
+func hasCEWithIdentity(cepStore resource.Store[*v2.CiliumEndpoint], identity string) bool {
+	ces, _ := cepStore.IndexKeys(operatorK8s.CiliumEndpointIndexIdentity, identity)
+	return len(ces) != 0
+}
+
+func usedIdentitiesInCESs(cesStore resource.Store[*v2alpha1.CiliumEndpointSlice]) map[string]bool {
+	usedIdentities := make(map[string]bool)
+	cesObjList := cesStore.List()
+	for _, ces := range cesObjList {
+		for _, cep := range ces.Endpoints {
+			id := strconv.FormatInt(cep.IdentityID, 10)
+			usedIdentities[id] = true
+		}
+	}
+	return usedIdentities
 }

--- a/operator/identitygc/crd_gc_test.go
+++ b/operator/identitygc/crd_gc_test.go
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package identitygc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestUsedIdentitiesInCESs(t *testing.T) {
+	var fakeClient k8sClient.FakeClientset
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Invoke(func(c *k8sClient.FakeClientset, ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+			fakeClient = *c
+			ciliumEndpointSlice = ces
+			return nil
+		}),
+	)
+	err := hive.Start(context.Background())
+	if err != nil {
+		t.Fatalf("unable to start hive for the test: %s", err)
+	}
+
+	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+
+	// Empty store.
+	gotIdentities := usedIdentitiesInCESs(cesStore)
+	wantIdentities := make(map[string]bool)
+	assertEqualIDs(t, wantIdentities, gotIdentities)
+
+	// 5 IDs in the store.
+	cesA := createCESWithIDs("cesA", []int64{1, 2, 3, 4, 5})
+	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(context.Background(), cesA, meta_v1.CreateOptions{})
+	err = testutils.WaitUntil(isCESPresent("cesA", cesStore), time.Second)
+	if err != nil {
+		t.Fatalf("cesA not present in the store after timeout: %s", err)
+	}
+	wantIdentities["1"] = true
+	wantIdentities["2"] = true
+	wantIdentities["3"] = true
+	wantIdentities["4"] = true
+	wantIdentities["5"] = true
+	gotIdentities = usedIdentitiesInCESs(cesStore)
+	assertEqualIDs(t, wantIdentities, gotIdentities)
+
+	// 10 IDs in the store.
+	cesB := createCESWithIDs("cesB", []int64{10, 20, 30, 40, 50})
+	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(context.Background(), cesB, meta_v1.CreateOptions{})
+	err = testutils.WaitUntil(isCESPresent("cesB", cesStore), time.Second)
+	if err != nil {
+		t.Fatalf("cesB not present in the store after timeout: %s", err)
+	}
+	wantIdentities["10"] = true
+	wantIdentities["20"] = true
+	wantIdentities["30"] = true
+	wantIdentities["40"] = true
+	wantIdentities["50"] = true
+	gotIdentities = usedIdentitiesInCESs(cesStore)
+	assertEqualIDs(t, wantIdentities, gotIdentities)
+
+	err = hive.Stop(context.Background())
+	if err != nil {
+		t.Fatalf("unable to stop hive for the test: %s", err)
+	}
+}
+
+func isCESPresent(cesName string, cesStore resource.Store[*cilium_v2a1.CiliumEndpointSlice]) testutils.ConditionFunc {
+	return func() bool {
+		_, exists, _ := cesStore.GetByKey(resource.Key{Name: cesName})
+		return exists
+	}
+}
+
+func createCESWithIDs(cesName string, ids []int64) *cilium_v2a1.CiliumEndpointSlice {
+	ces := &cilium_v2a1.CiliumEndpointSlice{ObjectMeta: meta_v1.ObjectMeta{Name: cesName}}
+	for _, id := range ids {
+		cep := cilium_v2a1.CoreCiliumEndpoint{IdentityID: id}
+		ces.Endpoints = append(ces.Endpoints, cep)
+	}
+	return ces
+}
+
+func assertEqualIDs(t *testing.T, wantIdentities, gotIdentities map[string]bool) {
+	t.Helper()
+	if diff := cmp.Diff(wantIdentities, gotIdentities); diff != "" {
+		t.Errorf("Unexpected Identites in the CES store (-want +got): \n%s", diff)
+	}
+}

--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	ciliumV2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/resource"
@@ -32,9 +33,11 @@ type params struct {
 	Logger    logrus.FieldLogger
 	Lifecycle hive.Lifecycle
 
-	Clientset          k8sClient.Clientset
-	Identity           resource.Resource[*v2.CiliumIdentity]
-	AuthIdentityClient authIdentity.Provider
+	Clientset           k8sClient.Clientset
+	Identity            resource.Resource[*v2.CiliumIdentity]
+	CiliumEndpoint      resource.Resource[*v2.CiliumEndpoint]
+	CiliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+	AuthIdentityClient  authIdentity.Provider
 
 	Cfg         Config
 	SharedCfg   SharedConfig
@@ -45,9 +48,11 @@ type params struct {
 type GC struct {
 	logger logrus.FieldLogger
 
-	clientset          ciliumV2.CiliumIdentityInterface
-	identity           resource.Resource[*v2.CiliumIdentity]
-	authIdentityClient authIdentity.Provider
+	clientset           ciliumV2.CiliumIdentityInterface
+	identity            resource.Resource[*v2.CiliumIdentity]
+	ciliumEndpoint      resource.Resource[*v2.CiliumEndpoint]
+	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+	authIdentityClient  authIdentity.Provider
 
 	clusterInfo    cmtypes.ClusterInfo
 	allocationMode string
@@ -88,16 +93,18 @@ func registerGC(p params) {
 	}
 
 	gc := &GC{
-		logger:             p.Logger,
-		clientset:          p.Clientset.CiliumV2().CiliumIdentities(),
-		identity:           p.Identity,
-		authIdentityClient: p.AuthIdentityClient,
-		clusterInfo:        p.ClusterInfo,
-		allocationMode:     p.SharedCfg.IdentityAllocationMode,
-		gcInterval:         p.Cfg.Interval,
-		heartbeatTimeout:   p.Cfg.HeartbeatTimeout,
-		gcRateInterval:     p.Cfg.RateInterval,
-		gcRateLimit:        p.Cfg.RateLimit,
+		logger:              p.Logger,
+		clientset:           p.Clientset.CiliumV2().CiliumIdentities(),
+		identity:            p.Identity,
+		ciliumEndpoint:      p.CiliumEndpoint,
+		ciliumEndpointSlice: p.CiliumEndpointSlice,
+		authIdentityClient:  p.AuthIdentityClient,
+		clusterInfo:         p.ClusterInfo,
+		allocationMode:      p.SharedCfg.IdentityAllocationMode,
+		gcInterval:          p.Cfg.Interval,
+		heartbeatTimeout:    p.Cfg.HeartbeatTimeout,
+		gcRateInterval:      p.Cfg.RateInterval,
+		gcRateLimit:         p.Cfg.RateLimit,
 		heartbeatStore: newHeartbeatStore(
 			p.Cfg.HeartbeatTimeout,
 		),

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -5,29 +5,22 @@ package identitygc
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strconv"
-	"sync"
 	"testing"
 	"time"
 
 	"go.uber.org/goleak"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 
 	authIdentity "github.com/cilium/cilium/operator/auth/identity"
 	"github.com/cilium/cilium/operator/auth/spire"
 	"github.com/cilium/cilium/operator/k8s"
-	"github.com/cilium/cilium/operator/watchers"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/informer"
-	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -90,7 +83,6 @@ func TestIdentitiesGC(t *testing.T) {
 			return nil
 		}),
 
-		cell.Invoke(setupCiliumEndpointWatcher),
 		cell.Invoke(registerGC),
 	)
 
@@ -245,78 +237,4 @@ func setupCiliumEndpoint(clientset k8sClient.Clientset) error {
 		return fmt.Errorf("failed to create endpoint %v: %w", endpoint, err)
 	}
 	return nil
-}
-
-func setupCiliumEndpointWatcher(
-	lc hive.Lifecycle,
-	params params,
-) {
-	var wg sync.WaitGroup
-
-	lc.Append(hive.Hook{
-		OnStart: func(ctx hive.HookContext) error {
-			// identity gc internally depends on the global watchers.CiliumEndpointStore,
-			// so we have to create a mock one here (and run an informer) to get the gc
-			// to work properly.
-
-			watchers.CiliumEndpointStore = cache.NewIndexer(
-				cache.DeletionHandlingMetaNamespaceKeyFunc,
-				cache.Indexers{
-					cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-					"identity": func(obj interface{}) ([]string, error) {
-						endpointObj, ok := obj.(*v2.CiliumEndpoint)
-						if !ok {
-							return nil, errors.New("failed to convert cilium endpoint")
-						}
-						identityID := "0"
-						if endpointObj.Status.Identity != nil {
-							identityID = strconv.FormatInt(endpointObj.Status.Identity.ID, 10)
-						}
-						return []string{identityID}, nil
-					},
-				},
-			)
-			ciliumEndpointInformer := informer.NewInformerWithStore(
-				utils.ListerWatcherFromTyped[*v2.CiliumEndpointList](params.Clientset.CiliumV2().CiliumEndpoints("")),
-				&v2.CiliumEndpoint{},
-				0,
-				cache.ResourceEventHandlerFuncs{},
-				func(obj interface{}) (interface{}, error) {
-					endpointObj, ok := obj.(*v2.CiliumEndpoint)
-					if !ok {
-						return nil, errors.New("failed to convert cilium endpoint")
-					}
-					return &v2.CiliumEndpoint{
-						TypeMeta: endpointObj.TypeMeta,
-						ObjectMeta: metav1.ObjectMeta{
-							Name: endpointObj.Name,
-						},
-						Status: v2.EndpointStatus{
-							Identity: endpointObj.Status.Identity,
-						},
-					}, nil
-				},
-				watchers.CiliumEndpointStore,
-			)
-
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				ciliumEndpointInformer.Run(ctx.Done())
-			}()
-			cache.WaitForCacheSync(ctx.Done(), ciliumEndpointInformer.HasSynced)
-			// signal that endpoints are sync-ed, otherwise identities gc won't start
-			close(watchers.CiliumEndpointsSynced)
-
-			return nil
-		},
-		OnStop: func(ctx hive.HookContext) error {
-			// force cleanup of goroutines run from initialization of watchers.nodeQueue
-			watchers.NodeQueueShutDown()
-			// wait for CiliumEndpointInformer goroutine to be cleaned up
-			wg.Wait()
-
-			return nil
-		},
-	})
 }

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CiliumEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumEndpoint], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](cs.CiliumV2().CiliumEndpoints("")),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2.CiliumEndpoint](lc, lw, resource.WithMetric("CiliumEndpoint")), nil
+}

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -4,13 +4,19 @@
 package k8s
 
 import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func CiliumEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumEndpoint], error) {
@@ -21,7 +27,24 @@ func CiliumEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...func
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](cs.CiliumV2().CiliumEndpoints("")),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumEndpoint](lc, lw, resource.WithMetric("CiliumEndpoint")), nil
+	indexers := cache.Indexers{
+		cache.NamespaceIndex:        cache.MetaNamespaceIndexFunc,
+		CiliumEndpointIndexIdentity: identityIndexFunc,
+	}
+	return resource.New[*cilium_api_v2.CiliumEndpoint](
+		lc, lw, resource.WithMetric("CiliumEndpoint"), resource.WithIndexers(indexers)), nil
+}
+
+func identityIndexFunc(obj interface{}) ([]string, error) {
+	switch t := obj.(type) {
+	case *cilium_api_v2.CiliumEndpoint:
+		if t.Status.Identity != nil {
+			id := strconv.FormatInt(t.Status.Identity.ID, 10)
+			return []string{id}, nil
+		}
+		return []string{"0"}, nil
+	}
+	return nil, fmt.Errorf("%w - found %T", errors.New("object is not a *cilium_api_v2.CiliumEndpoint"), obj)
 }
 
 func CiliumEndpointSliceResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/utils"
@@ -21,4 +22,15 @@ func CiliumEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...func
 		opts...,
 	)
 	return resource.New[*cilium_api_v2.CiliumEndpoint](lc, lw, resource.WithMetric("CiliumEndpoint")), nil
+}
+
+func CiliumEndpointSliceResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumEndpointSliceList](cs.CiliumV2alpha1().CiliumEndpointSlices()),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](lc, lw, resource.WithMetric("CiliumEndpointSlice")), nil
 }

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -28,6 +28,7 @@ var (
 			k8s.LBIPPoolsResource,
 			k8s.CiliumIdentityResource,
 			k8s.CiliumPodIPPoolResource,
+			CiliumEndpointResource,
 		),
 	)
 )
@@ -41,4 +42,5 @@ type Resources struct {
 	LBIPPools        resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]
 	Identities       resource.Resource[*cilium_api_v2.CiliumIdentity]
 	CiliumPodIPPools resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool]
+	CiliumEndpoints  resource.Resource[*cilium_api_v2.CiliumEndpoint]
 }

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -29,6 +29,7 @@ var (
 			k8s.CiliumIdentityResource,
 			k8s.CiliumPodIPPoolResource,
 			CiliumEndpointResource,
+			CiliumEndpointSliceResource,
 		),
 	)
 )
@@ -37,10 +38,11 @@ var (
 type Resources struct {
 	cell.In
 
-	Services         resource.Resource[*slim_corev1.Service]
-	Endpoints        resource.Resource[*k8s.Endpoints]
-	LBIPPools        resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]
-	Identities       resource.Resource[*cilium_api_v2.CiliumIdentity]
-	CiliumPodIPPools resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool]
-	CiliumEndpoints  resource.Resource[*cilium_api_v2.CiliumEndpoint]
+	Services             resource.Resource[*slim_corev1.Service]
+	Endpoints            resource.Resource[*k8s.Endpoints]
+	LBIPPools            resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]
+	Identities           resource.Resource[*cilium_api_v2.CiliumIdentity]
+	CiliumPodIPPools     resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool]
+	CiliumEndpoints      resource.Resource[*cilium_api_v2.CiliumEndpoint]
+	CiliumEndpointSlices resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice]
 }

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -12,6 +12,10 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
+const (
+	CiliumEndpointIndexIdentity = "identity"
+)
+
 var (
 	// ResourcesCell provides a set of handles to Kubernetes resources used throughout the
 	// operator. Each of the resources share a client-go informer and backing store so we only

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -26,26 +26,6 @@ const (
 	// PrometheusServeAddr is the default server address for operator metrics
 	PrometheusServeAddr = ":9963"
 
-	// CESMaxCEPsInCESDefault is the maximum number of cilium endpoints allowed in a CES
-	CESMaxCEPsInCESDefault = 100
-
-	// CESSlicingModeDefault is default method for grouping CEP in a CES.
-	CESSlicingModeDefault = "cesSliceModeIdentity"
-
-	// CESWriteQPSLimitDefault is the default rate limit for the CES work queue.
-	CESWriteQPSLimitDefault = 10
-
-	// CESWriteQPSLimitMax is the maximum rate limit for the CES work queue.
-	// CES work queue QPS limit cannot exceed this value, regardless of other config.
-	CESWriteQPSLimitMax = 50
-
-	// CESWriteQPSBurstDefault is the default burst rate for the CES work queue.
-	CESWriteQPSBurstDefault = 20
-
-	// CESWriteQPSBurstMax is the maximum burst rate for the CES work queue.
-	// CES work queue QPS burst cannot exceed this value, regardless of other config.
-	CESWriteQPSBurstMax = 100
-
 	// CNPStatusCleanupQPSDefault is the default rate for the CNP NodeStatus updates GC.
 	CNPStatusCleanupQPSDefault = 10
 
@@ -238,25 +218,6 @@ const (
 	// Enabling this option reduces waste of IP addresses but may increase
 	// the number of API calls to AlibabaCloud ECS service.
 	AlibabaCloudReleaseExcessIPs = "alibaba-cloud-release-excess-ips"
-
-	// CiliumEndpointSlice options
-
-	// CESMaxCEPsInCES is the maximum number of cilium endpoints allowed in single
-	// a CiliumEndpointSlice resource.
-	CESMaxCEPsInCES = "ces-max-ciliumendpoints-per-ces"
-
-	// CESSlicingMode instructs how CEPs are grouped in a CES.
-	CESSlicingMode = "ces-slice-mode"
-
-	// CESWriteQPSLimit is the rate limit per second for the CES work queue to
-	// process  CES events that result in CES write (Create, Update, Delete)
-	// requests to the kube-apiserver.
-	CESWriteQPSLimit = "ces-write-qps-limit"
-
-	// CESWriteQPSBurst is the burst rate per second used with CESWriteQPSLimit
-	// for the CES work queue to process CES events that result in CES write
-	// (Create, Update, Delete) requests to the kube-apiserver.
-	CESWriteQPSBurst = "ces-write-qps-burst"
 
 	// LoadBalancerL7 enables loadbalancer capabilities for services via envoy proxy
 	LoadBalancerL7 = "loadbalancer-l7"
@@ -514,26 +475,6 @@ type OperatorConfig struct {
 	// the number of API calls to AlibabaCloud ECS service.
 	AlibabaCloudReleaseExcessIPs bool
 
-	// CiliumEndpointSlice options
-
-	// CESMaxCEPsInCES is the maximum number of CiliumEndpoints allowed in single
-	// a CiliumEndpointSlice resource.
-	// The default value of maximum CiliumEndpoints allowed in a CiliumEndpointSlice resource is 100.
-	CESMaxCEPsInCES int
-
-	// CESSlicingMode instructs how CEPs are grouped in a CES.
-	CESSlicingMode string
-
-	// CESWriteQPSLimit is the rate limit per second for the CES work queue to
-	// process  CES events that result in CES write (Create, Update, Delete)
-	// requests to the kube-apiserver.
-	CESWriteQPSLimit float64
-
-	// CESWriteQPSBurst is the burst rate per second used with CESWriteQPSLimit
-	// for the CES work queue to process CES events that result in CES write
-	// (Create, Update, Delete) requests to the kube-apiserver.
-	CESWriteQPSBurst int
-
 	// LoadBalancerL7 enables loadbalancer capabilities for services.
 	LoadBalancerL7 string
 
@@ -698,12 +639,6 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 
 	c.AlibabaCloudVPCID = vp.GetString(AlibabaCloudVPCID)
 	c.AlibabaCloudReleaseExcessIPs = vp.GetBool(AlibabaCloudReleaseExcessIPs)
-
-	// CiliumEndpointSlice options
-	c.CESMaxCEPsInCES = vp.GetInt(CESMaxCEPsInCES)
-	c.CESSlicingMode = vp.GetString(CESSlicingMode)
-	c.CESWriteQPSLimit = vp.GetFloat64(CESWriteQPSLimit)
-	c.CESWriteQPSBurst = vp.GetInt(CESWriteQPSBurst)
 
 	// Option maps and slices
 

--- a/operator/pkg/ciliumendpointslice/cell.go
+++ b/operator/pkg/ciliumendpointslice/cell.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+const (
+	// CESMaxCEPsInCES is the maximum number of cilium endpoints allowed in single
+	// a CiliumEndpointSlice resource.
+	CESMaxCEPsInCES = "ces-max-ciliumendpoints-per-ces"
+
+	// CESSlicingMode instructs how CEPs are grouped in a CES.
+	CESSlicingMode = "ces-slice-mode"
+
+	// CESWriteQPSLimit is the rate limit per second for the CES work queue to
+	// process  CES events that result in CES write (Create, Update, Delete)
+	// requests to the kube-apiserver.
+	CESWriteQPSLimit = "ces-write-qps-limit"
+
+	// CESWriteQPSBurst is the burst rate per second used with CESWriteQPSLimit
+	// for the CES work queue to process CES events that result in CES write
+	// (Create, Update, Delete) requests to the kube-apiserver.
+	CESWriteQPSBurst = "ces-write-qps-burst"
+)
+
+// Cell is a cell that implements a Cilium Endpoint Slice Controller.
+// The controller subscribes to cilium endpoint and cilium endpoint slices
+// events and reconciles the state of the cilium endpoint slices in the cluster.
+var Cell = cell.Module(
+	"k8s-ces-controller",
+	"Cilium Endpoint Slice Controller",
+	cell.Config(defaultConfig),
+	cell.Invoke(registerController),
+)
+
+type Config struct {
+	CESMaxCEPsInCES  int     `mapstructure:"ces-max-ciliumendpoints-per-ces"`
+	CESSlicingMode   string  `mapstructure:"ces-slice-mode"`
+	CESWriteQPSLimit float64 `mapstructure:"ces-write-qps-limit"`
+	CESWriteQPSBurst int     `mapstructure:"ces-write-qps-burst"`
+}
+
+var defaultConfig = Config{
+	CESMaxCEPsInCES:  100,
+	CESSlicingMode:   "cesSliceModeIdentity",
+	CESWriteQPSLimit: 10,
+	CESWriteQPSBurst: 20,
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.Int(CESMaxCEPsInCES, def.CESMaxCEPsInCES, "Maximum number of CiliumEndpoints allowed in a CES")
+	flags.String(CESSlicingMode, def.CESSlicingMode, "Slicing mode define how ceps are grouped into a CES")
+	flags.Float64(CESWriteQPSLimit, def.CESWriteQPSLimit, "CES work queue rate limit")
+	flags.Int(CESWriteQPSBurst, def.CESWriteQPSBurst, "CES work queue burst rate")
+}
+
+// SharedConfig contains the configuration that is shared between
+// this module and others.
+// It is a temporary solution meant to avoid polluting this module with a direct
+// dependency on global operator and daemon configurations.
+type SharedConfig struct {
+	// EnableCiliumEndpointSlice enables the cilium endpoint slicing feature and the CES Controller.
+	EnableCiliumEndpointSlice bool
+}

--- a/operator/pkg/ciliumendpointslice/ceptocesmap.go
+++ b/operator/pkg/ciliumendpointslice/ceptocesmap.go
@@ -8,104 +8,137 @@ import "github.com/cilium/cilium/pkg/lock"
 type CEPName string
 type CESName string
 
-// CESToCEPMapping is used to map CiliumEndpointSlice name to cesTracker object
-// which in turn consists of CEPs, a CES name to list of all CEPs.
-// Also, it manages a map CEP name to CES name.
-// These maps are used by the CES manager, primarily used for storing and retrieving
-// the desired CESs by thread-safe.
+// CESToCEPMapping is used to map Cilium Endpoints to CiliumEndpointSlices and
+// retrieving all the Cilium Endpoints mapped to the given CiliumEndpointSlice.
 // This map is protected by lock for consistent and concurrent access.
 type CESToCEPMapping struct {
-	cesMutex lock.RWMutex
-	// cepNametoCESName is used to map CiliumEndpoint name to CiliumEndpointSlice name.
-	cepNametoCESName map[CEPName]CESName
-	// desiredCESs is used to map cesName to cesTracker object.
-	desiredCESs map[CESName]*cesTracker
+	mutex lock.RWMutex
+	// cepNameToCESName is used to map CiliumEndpoint name to CiliumEndpointSlice name.
+	cepNameToCESName map[CEPName]CESName
+	// cesNameToCEPNameSet is used to map CiliumEndpointSlice name to all CiliumEndpoints names it contains.
+	cesNameToCEPNameSet map[CESName]map[CEPName]struct{}
+	cesData             map[CESName]CESData
+}
+
+// CESData contains all CES data except endpoints.
+// CES is reconicled to have endpoints equal to CEPs mapped to it
+// and other fields set from the CESData.
+type CESData struct {
+	ns string
 }
 
 // Creates and intializes the new CESToCEPMapping
-func newDesiredCESMap() *CESToCEPMapping {
+func newCESToCEPMapping() *CESToCEPMapping {
 	return &CESToCEPMapping{
-		desiredCESs:      make(map[CESName]*cesTracker),
-		cepNametoCESName: make(map[CEPName]CESName),
+		cepNameToCESName:    make(map[CEPName]CESName),
+		cesNameToCEPNameSet: make(map[CESName]map[CEPName]struct{}),
+		cesData:             make(map[CESName]CESData),
 	}
 }
 
 // Insert the CEP in cache, map CEP name to CES name
-func (c *CESToCEPMapping) insertCEP(cepName, cesName string) {
-	c.cesMutex.Lock()
-	defer c.cesMutex.Unlock()
-	c.cepNametoCESName[CEPName(cepName)] = CESName(cesName)
+func (c *CESToCEPMapping) insertCEP(cepName CEPName, cesName CESName) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.cepNameToCESName[cepName] = cesName
+	c.cesNameToCEPNameSet[cesName][cepName] = struct{}{}
 }
 
 // Remove the CEP entry from map
-func (c *CESToCEPMapping) deleteCEP(cepName string) {
-	c.cesMutex.Lock()
-	defer c.cesMutex.Unlock()
-	delete(c.cepNametoCESName, CEPName(cepName))
+func (c *CESToCEPMapping) deleteCEP(cepName CEPName) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	delete(c.cesNameToCEPNameSet[c.cepNameToCESName[cepName]], cepName)
+	delete(c.cepNameToCESName, cepName)
 }
 
-func (c *CESToCEPMapping) getCESName(cepName string) (string, bool) {
-	c.cesMutex.RLock()
-	defer c.cesMutex.RUnlock()
-	name, ok := c.cepNametoCESName[CEPName(cepName)]
-	return string(name), ok
+// Return CES to which the given CEP is assigned
+func (c *CESToCEPMapping) getCESName(cepName CEPName) (CESName, bool) {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	name, ok := c.cepNameToCESName[cepName]
+	return name, ok
 }
 
-func (c *CESToCEPMapping) hasCEP(cepName string) bool {
-	c.cesMutex.RLock()
-	defer c.cesMutex.RUnlock()
-	_, ok := c.cepNametoCESName[CEPName(cepName)]
+func (c *CESToCEPMapping) hasCEP(cepName CEPName) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	_, ok := c.cepNameToCESName[cepName]
 	return ok
 }
 
 // Return total number of CEPs stored in cache
 func (c *CESToCEPMapping) countCEPs() int {
-	c.cesMutex.RLock()
-	defer c.cesMutex.RUnlock()
-	return len(c.cepNametoCESName)
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return len(c.cepNameToCESName)
 }
 
-// Insert the CES tracker in map
-func (c *CESToCEPMapping) insertCES(cesName string, ces *cesTracker) {
-	c.cesMutex.Lock()
-	defer c.cesMutex.Unlock()
-	c.desiredCESs[CESName(cesName)] = ces
+// Return total number of CEPs mapped to the given CES
+func (c *CESToCEPMapping) countCEPsInCES(ces CESName) int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return len(c.cesNameToCEPNameSet[ces])
 }
 
-// Remove the CES tracker from map
-func (c *CESToCEPMapping) deleteCES(cesName string) {
-	c.cesMutex.Lock()
-	defer c.cesMutex.Unlock()
-	delete(c.desiredCESs, CESName(cesName))
+// Return CEP Names mapped to the given CES
+func (c *CESToCEPMapping) getCEPsInCES(ces CESName) []CEPName {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	ceps := make([]CEPName, 0, len(c.cesNameToCEPNameSet[ces]))
+	for cep := range c.cesNameToCEPNameSet[ces] {
+		ceps = append(ceps, cep)
+	}
+	return ceps
 }
 
-func (c *CESToCEPMapping) getCESTracker(cesName string) (*cesTracker, bool) {
-	c.cesMutex.RLock()
-	defer c.cesMutex.RUnlock()
-	ces, ok := c.desiredCESs[CESName(cesName)]
-	return ces, ok
+// Initializes mapping structure for CES
+func (c *CESToCEPMapping) insertCES(cesName CESName, ns string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.cesNameToCEPNameSet[cesName] = make(map[CEPName]struct{})
+	c.cesData[cesName] = CESData{
+		ns: ns,
+	}
 }
 
-func (c *CESToCEPMapping) getAllCESs() []*cesTracker {
-	c.cesMutex.RLock()
-	defer c.cesMutex.RUnlock()
-	var cess []*cesTracker
-	for _, ces := range c.desiredCESs {
+// Remove mapping structure for CES
+func (c *CESToCEPMapping) deleteCES(cesName CESName) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	delete(c.cesNameToCEPNameSet, cesName)
+	delete(c.cesData, cesName)
+}
+
+func (c *CESToCEPMapping) hasCESName(cesName CESName) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	_, ok := c.cesNameToCEPNameSet[cesName]
+	return ok
+}
+
+// Return the total number of CESs.
+func (c *CESToCEPMapping) getCESCount() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return len(c.cesNameToCEPNameSet)
+}
+
+// Return names of all CESs.
+func (c *CESToCEPMapping) getAllCESs() []CESName {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	cess := make([]CESName, 0, len(c.cesNameToCEPNameSet))
+	for ces := range c.cesNameToCEPNameSet {
 		cess = append(cess, ces)
 	}
 	return cess
 }
 
-func (c *CESToCEPMapping) hasCESName(cesName string) bool {
-	c.cesMutex.RLock()
-	defer c.cesMutex.RUnlock()
-	_, ok := c.desiredCESs[CESName(cesName)]
-	return ok
-}
-
-// Return the total number of desired CESs.
-func (c *CESToCEPMapping) getCESCount() int {
-	c.cesMutex.RLock()
-	defer c.cesMutex.RUnlock()
-	return len(c.desiredCESs)
+// Return the CES data
+func (c *CESToCEPMapping) getCESData(name CESName) CESData {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	data := c.cesData[name]
+	return data
 }

--- a/operator/pkg/ciliumendpointslice/ceptocesmap.go
+++ b/operator/pkg/ciliumendpointslice/ceptocesmap.go
@@ -3,10 +3,14 @@
 
 package ciliumendpointslice
 
-import "github.com/cilium/cilium/pkg/lock"
+import (
+	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/lock"
+)
 
-type CEPName string
-type CESName string
+type CEPName resource.Key
+type CESName resource.Key
 
 // CESToCEPMapping is used to map Cilium Endpoints to CiliumEndpointSlices and
 // retrieving all the Cilium Endpoints mapped to the given CiliumEndpointSlice.
@@ -141,4 +145,32 @@ func (c *CESToCEPMapping) getCESData(name CESName) CESData {
 	defer c.mutex.RUnlock()
 	data := c.cesData[name]
 	return data
+}
+
+func (ces CESName) key() resource.Key {
+	return resource.Key(ces)
+}
+
+func (cep CEPName) key() resource.Key {
+	return resource.Key(cep)
+}
+
+func (ces CESName) string() string {
+	return ces.key().String()
+}
+
+func (cep CEPName) string() string {
+	return cep.key().String()
+}
+
+func NewCESName(name string) CESName {
+	return CESName(resource.Key{Name: name})
+}
+
+func NewCEPName(name, ns string) CEPName {
+	return CEPName(resource.Key{Name: name, Namespace: ns})
+}
+
+func GetCEPNameFromCCEP(cep *capi_v2a1.CoreCiliumEndpoint, namespace string) CEPName {
+	return NewCEPName(cep.Name, namespace)
 }

--- a/operator/pkg/ciliumendpointslice/ceptocesmap_test.go
+++ b/operator/pkg/ciliumendpointslice/ceptocesmap_test.go
@@ -18,32 +18,32 @@ func TestCepToCESCounts(t *testing.T) {
 	}{
 		{
 			name:    "Insert CEPs - 1",
-			cepName: "cilium-adf8-kube-system",
-			cesName: "ces-dfbkjswert-twis",
+			cepName: NewCEPName("cilium-adf8-kube-system", "ns"),
+			cesName: NewCESName("ces-dfbkjswert-twis"),
 			count:   1,
 		},
 		{
 			name:    "Insert CEPs - 2",
-			cepName: "cilium-dtyr-kube-system",
-			cesName: "ces-dfbkjswert-twis",
+			cepName: NewCEPName("cilium-dtyr-kube-system", "ns"),
+			cesName: NewCESName("ces-dfbkjswert-twis"),
 			count:   2,
 		},
 		{
 			name:    "Insert CEPs - 3",
-			cepName: "cilium-fgh8-kube-system",
-			cesName: "ces-dfbkjswert-twis",
+			cepName: NewCEPName("cilium-fgh8-kube-system", "ns"),
+			cesName: NewCESName("ces-dfbkjswert-twis"),
 			count:   3,
 		},
 		{
 			name:    "Insert CEPs - 4",
-			cepName: "cilium-cspn-kube-system",
-			cesName: "ces-dfbkjswert-twis",
+			cepName: NewCEPName("cilium-cspn-kube-system", "ns"),
+			cesName: NewCESName("ces-dfbkjswert-twis"),
 			count:   4,
 		},
 		{
 			name:    "Check same CEP-name with CES name",
-			cepName: "cilium-cspn-kube-system",
-			cesName: "ces-dfbkjswert-0wis",
+			cepName: NewCEPName("cilium-cspn-kube-system", "ns"),
+			cesName: NewCESName("ces-dfbkjswert-0wis"),
 			count:   4,
 		},
 	}
@@ -56,7 +56,7 @@ func TestCepToCESCounts(t *testing.T) {
 			cmap.insertCEP(CEPName(tc.cepName), CESName(tc.cesName))
 			assert.Equal(t, cmap.countCEPs(), tc.count, "Number of CEP entries in cmap should match with Count")
 			assert.Equal(t, cmap.hasCEP(tc.cepName), true, "CEP name should present in cmap")
-			assert.Equal(t, cmap.hasCEP("not-really-cep"), false, "Random string should NOT present in cmap as Key")
+			assert.Equal(t, cmap.hasCEP(NewCEPName("not-really-cep", "ns")), false, "Random string should NOT present in cmap as Key")
 		})
 	}
 

--- a/operator/pkg/ciliumendpointslice/ceptocesmap_test.go
+++ b/operator/pkg/ciliumendpointslice/ceptocesmap_test.go
@@ -12,8 +12,8 @@ import (
 func TestCepToCESCounts(t *testing.T) {
 	testCases := []struct {
 		name    string
-		cepName string
-		cesName string
+		cepName CEPName
+		cesName CESName
 		count   int
 	}{
 		{
@@ -47,21 +47,23 @@ func TestCepToCESCounts(t *testing.T) {
 			count:   4,
 		},
 	}
-	cmap := newDesiredCESMap()
+	cmap := newCESToCEPMapping()
 
 	// Insert new CEPs in cepCache map and check its total count
 	for _, tc := range testCases {
 		t.Run(tc.name, func(*testing.T) {
-			cmap.insertCEP(tc.cepName, tc.cesName)
+			cmap.insertCES(CESName(tc.cesName), "ns")
+			cmap.insertCEP(CEPName(tc.cepName), CESName(tc.cesName))
 			assert.Equal(t, cmap.countCEPs(), tc.count, "Number of CEP entries in cmap should match with Count")
 			assert.Equal(t, cmap.hasCEP(tc.cepName), true, "CEP name should present in cmap")
-			assert.Equal(t, cmap.hasCEP(tc.cesName), false, "CES name should NOT present in cmap as Key")
+			assert.Equal(t, cmap.hasCEP("not-really-cep"), false, "Random string should NOT present in cmap as Key")
 		})
 	}
 
 	// Insert and remove CEPs in cepCache and check for any stale entries present in cepCache.
 	for _, tc := range testCases {
 		t.Run(tc.name, func(*testing.T) {
+			cmap.insertCES(CESName(tc.cesName), "ns")
 			cmap.insertCEP(tc.cepName, tc.cesName)
 			cesName, ok := cmap.getCESName(tc.cepName)
 			assert.Equal(t, ok, true, "CEP name should be there in map")

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+import (
+	"context"
+	"time"
+
+	"github.com/cilium/workerpool"
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// params contains all the dependencies for the CiliumEndpointSlice controller.
+// They will be provided through dependency injection.
+type params struct {
+	cell.In
+
+	Logger    logrus.FieldLogger
+	Lifecycle hive.Lifecycle
+
+	Clientset           k8sClient.Clientset
+	CiliumEndpoint      resource.Resource[*v2.CiliumEndpoint]
+	CiliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+
+	Cfg       Config
+	SharedCfg SharedConfig
+}
+
+type Controller struct {
+	logger        logrus.FieldLogger
+	context       context.Context
+	contextCancel context.CancelFunc
+
+	// Cilium kubernetes clients to access V2 and V2alpha1 resources
+	clientset           k8sClient.Clientset
+	ciliumEndpoint      resource.Resource[*v2.CiliumEndpoint]
+	ciliumEndpointSlice resource.Resource[*v2alpha1.CiliumEndpointSlice]
+
+	// reconciler is an util used to reconcile CiliumEndpointSlice changes.
+	reconciler *reconciler
+
+	// Manager is used to create and maintain a local datastore. Manager watches for
+	// cilium endpoint changes and enqueues/dequeues the cilium endpoint changes in CES.
+	// It maintains the desired state of the CESs in dataStore
+	manager      operations
+	slicingMode  string
+	maxCEPsInCES int
+
+	// workqueue is used to sync CESs with the api-server. this will rate-limit the
+	// CES requests going to api-server, ensures a single CES will not be proccessed
+	// multiple times concurrently, and if CES is added multiple times before it
+	// can be processed, this will only be processed only once.
+	queue           workqueue.RateLimitingInterface
+	queueTerminated chan struct{}
+	writeQPSLimit   float64
+	writeQPSBurst   int
+
+	enqueuedAt     map[CESName]time.Time
+	enqueuedAtLock lock.Mutex
+
+	wp *workerpool.WorkerPool
+}
+
+// registerController creates and initializes the CES controller
+func registerController(p params) {
+	if !p.Clientset.IsEnabled() || !p.SharedCfg.EnableCiliumEndpointSlice {
+		return
+	}
+
+	cesController := &Controller{
+		logger:              p.Logger,
+		clientset:           p.Clientset,
+		ciliumEndpoint:      p.CiliumEndpoint,
+		ciliumEndpointSlice: p.CiliumEndpointSlice,
+		slicingMode:         p.Cfg.CESSlicingMode,
+		maxCEPsInCES:        p.Cfg.CESMaxCEPsInCES,
+		writeQPSLimit:       p.Cfg.CESWriteQPSLimit,
+		writeQPSBurst:       p.Cfg.CESWriteQPSBurst,
+		enqueuedAt:          make(map[CESName]time.Time),
+	}
+
+	p.Lifecycle.Append(cesController)
+}

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestRegisterController(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
+		// To ignore goroutine started by the workqueue. It reports metrics
+		// on unfinished work with default tick period of 0.5s - it terminates
+		// no longer than 0.5s after the workqueue is stopped.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
+	)
+	var fakeClient k8sClient.FakeClientset
+	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Provide(func() Config {
+			return defaultConfig
+		}),
+		cell.Provide(func() SharedConfig {
+			return SharedConfig{
+				EnableCiliumEndpointSlice: true,
+			}
+		}),
+		cell.Invoke(func(p params) error {
+			registerController(p)
+			return nil
+		}),
+		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+			fakeClient = *c
+			ciliumEndpoint = cep
+			ciliumEndpointSlice = ces
+			return nil
+		}),
+	)
+	if err := hive.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+	cesCreated, err := createCEPandVerifyCESCreated(fakeClient, ciliumEndpoint, ciliumEndpointSlice)
+	if err != nil {
+		t.Fatalf("Couldn't verify if CES is created: %s", err)
+	}
+	// Verify CES is created when CES features is enabled
+	assert.Equal(t, true, cesCreated)
+	if err := hive.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
+	defer goleak.VerifyNone(
+		t,
+		// To ignore goroutine started by the workqueue. It reports metrics
+		// on unfinished work with default tick period of 0.5s - it terminates
+		// no longer than 0.5s after the workqueue is stopped.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*Type).updateUnfinishedWorkLoop"),
+	)
+	var fakeClient k8sClient.FakeClientset
+	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	h := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Provide(func() Config {
+			return defaultConfig
+		}),
+		cell.Provide(func() SharedConfig {
+			return SharedConfig{
+				EnableCiliumEndpointSlice: false,
+			}
+		}),
+		cell.Invoke(func(p params) error {
+			registerController(p)
+			return nil
+		}),
+		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+			fakeClient = *c
+			ciliumEndpoint = cep
+			ciliumEndpointSlice = ces
+			return nil
+		}),
+	)
+	if err := h.Start(context.Background()); err != nil {
+		t.Fatalf("failed to start: %s", err)
+	}
+	cesCreated, err := createCEPandVerifyCESCreated(fakeClient, ciliumEndpoint, ciliumEndpointSlice)
+	if err != nil {
+		t.Fatalf("Couldn't verify if CES is created: %s", err)
+	}
+	// Verify CES is NOT created when CES features is disabled
+	assert.Equal(t, false, cesCreated)
+	if err = h.Stop(context.Background()); err != nil {
+		t.Fatalf("failed to stop: %s", err)
+	}
+}
+
+func createCEPandVerifyCESCreated(fakeClient k8sClient.FakeClientset, ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint], ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) (bool, error) {
+	cep := createStoreEndpoint("cep1", "ns", 1)
+	fakeClient.CiliumV2().CiliumEndpoints("ns").Create(context.Background(), cep, meta_v1.CreateOptions{})
+	cepStore, _ := ciliumEndpoint.Store(context.Background())
+	if err := testutils.WaitUntil(func() bool {
+		return len(cepStore.List()) > 0
+	}, time.Second); err != nil {
+		return false, fmt.Errorf("failed to get CEP: %s", err)
+	}
+	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	err := testutils.WaitUntil(func() bool {
+		return len(cesStore.List()) > 0
+	}, time.Second)
+	// err == nil means CES was created
+	return err == nil, nil
+}

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -5,36 +5,22 @@ package ciliumendpointslice
 
 import (
 	"context"
-	"strconv"
-	"sync"
 	"time"
 
+	"github.com/cilium/workerpool"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	csv2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
-	csv2a1 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/informer"
-	"github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-)
-
-type eventType int
-
-const (
-	updateEvent eventType = iota
-	deleteEvent
 )
 
 const (
@@ -55,226 +41,82 @@ const (
 	CESControllerWorkQueueQPSLimit = 10
 	// default burst limit value for workqueues.
 	CESControllerWorkQueueBurstLimit = 100
-	// Delayed CES Synctime, CES's are synced with k8s-apiserver after certain delay
-	// Some CES's are delayed to sync with k8s-apiserver.
-	DelayedCESSyncTime = 15 * time.Second
 	// Default CES Synctime, multiple consecutive syncs with k8s-apiserver are
 	// batched and synced together after a short delay.
 	DefaultCESSyncTime = 500 * time.Millisecond
+
+	CESWriteQPSLimitMax = 50
+	CESWriteQPSBurstMax = 100
 )
 
-var (
-	ceSliceStore cache.Store
-)
-
-type EndpointEvent struct {
-	event eventType
-	cep   *cilium_api_v2.CiliumEndpoint
-}
-
-type CiliumEndpointSliceController struct {
-	// Cilium kubernetes clients to access V2 and V2alpha1 resources
-	clientV2   csv2.CiliumV2Interface
-	clientV2a1 csv2a1.CiliumV2alpha1Interface
-
-	// reconciler is an util used to reconcile CiliumEndpointSlice changes.
-	reconciler *reconciler
-
-	// Manager is used to create and maintain a local datastore. Manager watches for
-	// cilium endpoint changes and enqueues/dequeues the cilium endpoint changes in CES.
-	// It maintains the desired state of the CESs in dataStore
-	Manager operations
-
-	// workerLoopPeriod is the time between worker runs
-	workerLoopPeriod time.Duration
-
-	// workqueue is used to sync CESs with the api-server. this will rate-limit the
-	// CES requests going to api-server, ensures a single CES will not be proccessed
-	// multiple times concurrently, and if CES is added multiple times before it
-	// can be processed, this will only be processed only once.
-	queue workqueue.RateLimitingInterface
-
-	// slicingMode indicates how CEP are sliceed in a CES
-	slicingMode string
-
-	enqueuedAt map[string]time.Time
-
-	preInitEnqueuedEndpointsEvents []EndpointEvent
-
-	endpointsMappingInitialized bool
-}
-
-var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ces-controller")
-
-// Derives the unique name from CoreCiliumEndpoint object.
-// This unique name is used for mapping CiliumEndpoint to CiliumEndpointSlice.
-// Used widely, to determine if the given CEP is mapped to any CES or not.
-func GetCEPNameFromCCEP(cep *capi_v2a1.CoreCiliumEndpoint, namespace string) string {
-	return namespace + "/" + cep.Name
-}
-
-// NewCESController, creates and initializes the CES controller
-func NewCESController(
-	ctx context.Context,
-	wg *sync.WaitGroup,
-	clientset k8sClient.Clientset,
-	maxCEPsInCES int,
-	slicingMode string,
-	qpsLimit float64,
-	burstLimit int,
-) *CiliumEndpointSliceController {
-	rlQueue := initializeQueue(qpsLimit, burstLimit)
-
-	manager := newCESManagerFcfs(maxCEPsInCES)
-	if slicingMode == cesIdentityBasedSlicing {
-		manager = newCESManagerIdentity(maxCEPsInCES)
+func (c *Controller) initializeQueue() {
+	if c.writeQPSLimit == 0 {
+		c.writeQPSLimit = CESControllerWorkQueueQPSLimit
+	} else if c.writeQPSLimit > CESWriteQPSLimitMax {
+		c.writeQPSLimit = CESWriteQPSLimitMax
 	}
 
-	controller := &CiliumEndpointSliceController{
-		clientV2:                       clientset.CiliumV2(),
-		clientV2a1:                     clientset.CiliumV2alpha1(),
-		reconciler:                     newReconciler(clientset.CiliumV2alpha1(), manager),
-		Manager:                        manager,
-		queue:                          rlQueue,
-		slicingMode:                    slicingMode,
-		workerLoopPeriod:               1 * time.Second,
-		enqueuedAt:                     make(map[string]time.Time),
-		preInitEnqueuedEndpointsEvents: make([]EndpointEvent, 0),
-		endpointsMappingInitialized:    false,
-	}
-	cesStore := ciliumEndpointSliceInit(controller, clientset.CiliumV2alpha1(), ctx, wg)
-	ceSliceStore = cesStore
-	return controller
-}
-
-func ciliumEndpointSliceInit(contorller *CiliumEndpointSliceController, client csv2a1.CiliumV2alpha1Interface, ctx context.Context, wg *sync.WaitGroup) cache.Store {
-	cesStore, cesController := informer.NewInformer(
-		utils.ListerWatcherFromTyped[*capi_v2a1.CiliumEndpointSliceList](
-			client.CiliumEndpointSlices()),
-		&capi_v2a1.CiliumEndpointSlice{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				if ces := objToCES(obj); ces != nil {
-					contorller.onSliceUpdate(ces)
-				}
-			},
-			UpdateFunc: func(oldObj, newObj interface{}) {
-				if oldCES := objToCES(oldObj); oldCES != nil {
-					if newCES := objToCES(newObj); newCES != nil {
-						if oldCES.DeepEqual(newCES) {
-							return
-						}
-						contorller.onSliceUpdate(newCES)
-					}
-				}
-			},
-			DeleteFunc: func(obj interface{}) {
-				if ces := objToCES(obj); ces != nil {
-					contorller.onSliceDelete(ces)
-				}
-			},
-		},
-		nil,
-	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		cesController.Run(ctx.Done())
-	}()
-	cache.WaitForCacheSync(ctx.Done(), cesController.HasSynced)
-	return cesStore
-}
-
-func objToCES(obj interface{}) *capi_v2a1.CiliumEndpointSlice {
-	switch concreteObj := obj.(type) {
-	case *capi_v2a1.CiliumEndpointSlice:
-		return concreteObj
-	case cache.DeletedFinalStateUnknown:
-		ciliumEndpoint, ok := concreteObj.Obj.(*capi_v2a1.CiliumEndpointSlice)
-		if !ok {
-			log.WithField(logfields.Object, logfields.Repr(concreteObj.Obj)).
-				Warn("Ignoring invalid v2alpha1 CiliumEndpointSlice")
-			return nil
-		}
-		return ciliumEndpoint
-	}
-	log.WithField(logfields.Object, logfields.Repr(obj)).
-		Warn("Ignoring invalid v2alpha1 CiliumEndpoint")
-	return nil
-}
-
-func initializeQueue(qpsLimit float64, burstLimit int) workqueue.RateLimitingInterface {
-	if qpsLimit == 0 {
-		qpsLimit = CESControllerWorkQueueQPSLimit
-	} else if qpsLimit > operatorOption.CESWriteQPSLimitMax {
-		qpsLimit = operatorOption.CESWriteQPSLimitMax
+	if c.writeQPSBurst == 0 {
+		c.writeQPSBurst = CESControllerWorkQueueBurstLimit
+	} else if c.writeQPSBurst > CESWriteQPSBurstMax {
+		c.writeQPSBurst = CESWriteQPSBurstMax
 	}
 
-	if burstLimit == 0 {
-		burstLimit = CESControllerWorkQueueBurstLimit
-	} else if burstLimit > operatorOption.CESWriteQPSBurstMax {
-		burstLimit = operatorOption.CESWriteQPSBurstMax
-	}
-
-	log.WithFields(logrus.Fields{
-		logfields.WorkQueueQPSLimit:    qpsLimit,
-		logfields.WorkQueueBurstLimit:  burstLimit,
+	c.logger.WithFields(logrus.Fields{
+		logfields.WorkQueueQPSLimit:    c.writeQPSLimit,
+		logfields.WorkQueueBurstLimit:  c.writeQPSBurst,
 		logfields.WorkQueueSyncBackOff: defaultSyncBackOff,
 	}).Info("CES controller workqueue configuration")
 
-	return workqueue.NewNamedRateLimitingQueue(workqueue.NewMaxOfRateLimiter(
+	c.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewMaxOfRateLimiter(
 		workqueue.NewItemExponentialFailureRateLimiter(defaultSyncBackOff, maxSyncBackOff),
 		// 10 qps, 100 bucket size. This is only for retry speed and its
 		// only the overall factor (not per item).
-		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(qpsLimit), burstLimit)},
+		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(c.writeQPSLimit), c.writeQPSBurst)},
 	), "cilium_endpoint_slice")
+	c.queueTerminated = make(chan struct{})
 }
 
-func (c *CiliumEndpointSliceController) OnEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
 	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
 		return
 	}
-	if c.endpointsMappingInitialized {
-		touchedCESs := c.Manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
-		c.enqueueCESReconciliation(touchedCESs)
-	} else {
-		c.preInitEnqueuedEndpointsEvents = append(c.preInitEnqueuedEndpointsEvents, EndpointEvent{event: updateEvent, cep: cep})
-	}
+	touchedCESs := c.manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
+	c.enqueueCESReconciliation(touchedCESs)
 }
 
-func (c *CiliumEndpointSliceController) OnEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {
-	if c.endpointsMappingInitialized {
-		touchedCES := c.Manager.RemoveCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
-		c.enqueueCESReconciliation([]CESName{touchedCES})
-	} else {
-		c.preInitEnqueuedEndpointsEvents = append(c.preInitEnqueuedEndpointsEvents, EndpointEvent{event: deleteEvent, cep: cep})
-	}
+func (c *Controller) onEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {
+	touchedCES := c.manager.RemoveCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
+	c.enqueueCESReconciliation([]CESName{touchedCES})
 }
 
-func (c *CiliumEndpointSliceController) onSliceUpdate(ces *capi_v2a1.CiliumEndpointSlice) {
-	c.enqueueCESReconciliation([]CESName{CESName(ces.Name)})
+func (c *Controller) onSliceUpdate(ces *capi_v2a1.CiliumEndpointSlice) {
+	c.enqueueCESReconciliation([]CESName{NewCESName(ces.Name)})
 }
 
-func (c *CiliumEndpointSliceController) onSliceDelete(ces *capi_v2a1.CiliumEndpointSlice) {
-	c.enqueueCESReconciliation([]CESName{CESName(ces.Name)})
+func (c *Controller) onSliceDelete(ces *capi_v2a1.CiliumEndpointSlice) {
+	c.enqueueCESReconciliation([]CESName{NewCESName(ces.Name)})
 }
 
-func (c *CiliumEndpointSliceController) enqueueCESReconciliation(cess []CESName) {
+func (c *Controller) enqueueCESReconciliation(cess []CESName) {
 	for _, ces := range cess {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: ces,
-		}).Debug("Enquing CES (if not empty name")
-		if ces != "" {
-			if c.enqueuedAt[string(ces)].IsZero() {
-				c.enqueuedAt[string(ces)] = time.Now()
+		c.logger.WithFields(logrus.Fields{
+			logfields.CESName: ces.string(),
+		}).Debug("Enqueueing CES (if not empty name)")
+		if ces.Name != "" {
+			c.enqueuedAtLock.Lock()
+			if c.enqueuedAt[ces].IsZero() {
+				c.enqueuedAt[ces] = time.Now()
 			}
-			c.queue.AddAfter(string(ces), DefaultCESSyncTime)
+			c.enqueuedAtLock.Unlock()
+			c.queue.AddAfter(ces, DefaultCESSyncTime)
 		}
 	}
 }
 
-func (c *CiliumEndpointSliceController) getAndResetCESProcessingDelay(ces string) float64 {
+func (c *Controller) getAndResetCESProcessingDelay(ces CESName) float64 {
+	c.enqueuedAtLock.Lock()
+	defer c.enqueuedAtLock.Unlock()
 	enqueued, exists := c.enqueuedAt[ces]
 	if !exists {
 		return 0
@@ -288,79 +130,119 @@ func (c *CiliumEndpointSliceController) getAndResetCESProcessingDelay(ces string
 }
 
 // start the worker thread, reconciles the modified CESs with api-server
-func (c *CiliumEndpointSliceController) Run(ciliumEndpointStore cache.Indexer, stopCh <-chan struct{}) {
-	log.Info("Bootstrap ces controller")
+func (c *Controller) Start(ctx hive.HookContext) error {
+	c.logger.Info("Bootstrap ces controller")
+	c.context, c.contextCancel = context.WithCancel(context.Background())
 	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
+	if c.slicingMode == cesIdentityBasedSlicing {
+		c.manager = newCESManagerIdentity(c.maxCEPsInCES, c.logger)
+	} else {
+		c.manager = newCESManagerFcfs(c.maxCEPsInCES, c.logger)
+	}
+	c.reconciler = newReconciler(c.clientset.CiliumV2alpha1(), c.manager, c.logger, c.ciliumEndpoint, c.ciliumEndpointSlice, c.context)
 
-	// List all existing CESs from the api-server and cache it locally.
-	// This sync should happen before starting CEP watcher, because CEP watcher
-	// emits the existing CEPs as newly added CEPs. If we don't have local sync
-	// cesManager would assume those are new CEPs and may create new CESs for those CEPs.
-	// This situation ends up having duplicate CEPs in different CESs. Hence, we need
-	// to sync existing CESs before starting a CEP watcher.
-	c.syncCESsInLocalCache()
-	c.processEnqueuedPreInitEndpoints()
-	c.reconciler.ciliumEndpointStore = ciliumEndpointStore
+	c.initializeQueue()
 
-	log.WithFields(logrus.Fields{
-		logfields.CESSliceMode: c.slicingMode,
-	}).Info("Starting CES controller reconciler.")
+	if err := c.syncCESsInLocalCache(ctx); err != nil {
+		return err
+	}
 
-	// TODO: multiple worker threads can run concurrently to reconcile with api-server
-	go wait.Until(c.worker, c.workerLoopPeriod, stopCh)
+	// Start the work pools processing CEP events only after syncing CES in local cache.
+	c.wp = workerpool.New(2)
+	c.wp.Submit("cilium-endpoints-updater", c.runCiliumEndpointsUpdater)
+	c.wp.Submit("cilium-endpoint-slices-updater", c.runCiliumEndpointSliceUpdater)
 
-	go func() {
-		defer utilruntime.HandleCrash()
-	}()
+	c.logger.Info("Starting CES controller reconciler.")
+	go c.worker()
 
-	<-stopCh
+	return nil
+}
+
+func (c *Controller) Stop(ctx hive.HookContext) error {
+	c.wp.Close()
+	c.stopQueueAndWait()
+	c.contextCancel()
+	return nil
+}
+
+func (c *Controller) stopQueueAndWait() {
+	c.queue.ShutDown()
+	<-c.queueTerminated
+}
+
+func (c *Controller) runCiliumEndpointsUpdater(ctx context.Context) error {
+	for event := range c.ciliumEndpoint.Events(ctx) {
+		switch event.Kind {
+		case resource.Upsert:
+			c.logger.WithFields(logrus.Fields{
+				logfields.CEPName: event.Key.String()}).Debug("Got Upsert Endpoint event")
+			c.onEndpointUpdate(event.Object)
+		case resource.Delete:
+			c.logger.WithFields(logrus.Fields{
+				logfields.CEPName: event.Key.String()}).Debug("Got Upsert Endpoint event")
+			c.onEndpointDelete(event.Object)
+		}
+		event.Done(nil)
+	}
+	return nil
+}
+
+func (c *Controller) runCiliumEndpointSliceUpdater(ctx context.Context) error {
+	for event := range c.ciliumEndpointSlice.Events(ctx) {
+		switch event.Kind {
+		case resource.Upsert:
+			c.logger.WithFields(logrus.Fields{
+				logfields.CESName: event.Key.String()}).Debug("Got Upsert Endpoint event")
+			c.onSliceUpdate(event.Object)
+		case resource.Delete:
+			c.logger.WithFields(logrus.Fields{
+				logfields.CESName: event.Key.String()}).Debug("Got Upsert Endpoint event")
+			c.onSliceDelete(event.Object)
+		}
+		event.Done(nil)
+	}
+	return nil
 }
 
 // Sync all CESs from cesStore to manager cache.
 // Note: CESs are synced locally before CES controller running and this is required.
-func (c *CiliumEndpointSliceController) syncCESsInLocalCache() {
-	for _, obj := range ceSliceStore.List() {
-		ces := obj.(*capi_v2a1.CiliumEndpointSlice)
-		cesName := c.Manager.initializeMappingForCES(ces)
+func (c *Controller) syncCESsInLocalCache(ctx context.Context) error {
+	store, err := c.ciliumEndpointSlice.Store(ctx)
+	if err != nil {
+		c.logger.WithError(err).Warn("Error getting CES Store")
+		return err
+	}
+	for _, ces := range store.List() {
+		cesName := c.manager.initializeMappingForCES(ces)
 		for _, cep := range ces.Endpoints {
-			c.Manager.initializeMappingCEPtoCES(&cep, ces.Namespace, cesName)
+			c.manager.initializeMappingCEPtoCES(&cep, ces.Namespace, cesName)
 		}
 	}
-	c.endpointsMappingInitialized = true
-	log.Debug("Successfully synced all CESs locally")
-}
-
-func (c *CiliumEndpointSliceController) processEnqueuedPreInitEndpoints() {
-	for _, e := range c.preInitEnqueuedEndpointsEvents {
-		if e.event == updateEvent {
-			c.OnEndpointUpdate(e.cep)
-		} else if e.event == deleteEvent {
-			c.OnEndpointDelete(e.cep)
-		} else {
-			log.Warnf("Processing pre init event of unknown type %d", e.event)
-		}
-	}
+	c.logger.Debug("Successfully synced all CESs locally")
+	return nil
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and
-// marks them done. You may run as many of these in parallel as you wish; the
-// workqueue guarantees that they will not end up processing the same ces
-// at the same time
-func (c *CiliumEndpointSliceController) worker() {
+// marks them done.
+func (c *Controller) worker() {
+	defer close(c.queueTerminated)
 	for c.processNextWorkItem() {
 	}
 }
 
-func (c *CiliumEndpointSliceController) processNextWorkItem() bool {
+func (c *Controller) processNextWorkItem() bool {
 	cKey, quit := c.queue.Get()
 	if quit {
 		return false
 	}
-	defer c.queue.Done(cKey)
+	key := cKey.(CESName)
+	c.logger.WithFields(logrus.Fields{
+		logfields.CESName: key.string(),
+	}).Debug("Processing CES")
+	defer c.queue.Done(key)
 
-	queueDelay := c.getAndResetCESProcessingDelay(cKey.(string))
-	err := c.reconciler.reconcileCES(cKey.(string))
+	queueDelay := c.getAndResetCESProcessingDelay(key)
+	err := c.reconciler.reconcileCES(key)
 	if operatorOption.Config.EnableMetrics {
 		metrics.CiliumEndpointSliceQueueDelay.Observe(queueDelay)
 		if err != nil {
@@ -370,12 +252,12 @@ func (c *CiliumEndpointSliceController) processNextWorkItem() bool {
 		}
 	}
 
-	c.handleErr(err, cKey)
+	c.handleErr(err, key)
 
 	return true
 }
 
-func (c *CiliumEndpointSliceController) handleErr(err error, key interface{}) {
+func (c *Controller) handleErr(err error, key CESName) {
 	if err == nil {
 		c.queue.Forget(key)
 		return
@@ -392,37 +274,8 @@ func (c *CiliumEndpointSliceController) handleErr(err error, key interface{}) {
 	}
 
 	// Drop the CES from queue, we maxed out retries.
-	log.WithError(err).WithFields(logrus.Fields{
-		logfields.CESName: key,
+	c.logger.WithError(err).WithFields(logrus.Fields{
+		logfields.CESName: key.string(),
 	}).Error("Dropping the CES from queue, exceeded maxRetries")
 	c.queue.Forget(key)
-}
-
-// UsedIdentitiesInCESs returns all Identities that are used in CESs.
-func UsedIdentitiesInCESs() map[string]bool {
-	return usedIdentitiesInCESs(ceSliceStore)
-}
-
-// usedIdentitiesInCESs returns all Identities that are used in CESs in the
-// specified store.
-func usedIdentitiesInCESs(cesStore cache.Store) map[string]bool {
-	usedIdentities := make(map[string]bool)
-	if cesStore == nil {
-		return usedIdentities
-	}
-
-	cesObjList := cesStore.List()
-	for _, cesObj := range cesObjList {
-		ces, ok := cesObj.(*capi_v2a1.CiliumEndpointSlice)
-		if !ok {
-			continue
-		}
-
-		for _, cep := range ces.Endpoints {
-			id := strconv.FormatInt(cep.IdentityID, 10)
-			usedIdentities[id] = true
-		}
-	}
-
-	return usedIdentities
 }

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
-	"k8s.io/apimachinery/pkg/api/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -28,6 +28,13 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+type eventType int
+
+const (
+	updateEvent eventType = iota
+	deleteEvent
 )
 
 const (
@@ -60,6 +67,11 @@ var (
 	ceSliceStore cache.Store
 )
 
+type EndpointEvent struct {
+	event eventType
+	cep   *cilium_api_v2.CiliumEndpoint
+}
+
 type CiliumEndpointSliceController struct {
 	// Cilium kubernetes clients to access V2 and V2alpha1 resources
 	clientV2   csv2.CiliumV2Interface
@@ -73,9 +85,6 @@ type CiliumEndpointSliceController struct {
 	// It maintains the desired state of the CESs in dataStore
 	Manager operations
 
-	// ciliumEndpointStore is used to get current active CEPs in a cluster.
-	ciliumEndpointStore cache.Indexer
-
 	// workerLoopPeriod is the time between worker runs
 	workerLoopPeriod time.Duration
 
@@ -85,11 +94,14 @@ type CiliumEndpointSliceController struct {
 	// can be processed, this will only be processed only once.
 	queue workqueue.RateLimitingInterface
 
-	// ciliumEndpointSliceStore is used to get current active CESs in a cluster.
-	ciliumEndpointSliceStore cache.Store
-
 	// slicingMode indicates how CEP are sliceed in a CES
 	slicingMode string
+
+	enqueuedAt map[string]time.Time
+
+	preInitEnqueuedEndpointsEvents []EndpointEvent
+
+	endpointsMappingInitialized bool
 }
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ces-controller")
@@ -111,6 +123,88 @@ func NewCESController(
 	qpsLimit float64,
 	burstLimit int,
 ) *CiliumEndpointSliceController {
+	rlQueue := initializeQueue(qpsLimit, burstLimit)
+
+	manager := newCESManagerFcfs(maxCEPsInCES)
+	if slicingMode == cesIdentityBasedSlicing {
+		manager = newCESManagerIdentity(maxCEPsInCES)
+	}
+
+	controller := &CiliumEndpointSliceController{
+		clientV2:                       clientset.CiliumV2(),
+		clientV2a1:                     clientset.CiliumV2alpha1(),
+		reconciler:                     newReconciler(clientset.CiliumV2alpha1(), manager),
+		Manager:                        manager,
+		queue:                          rlQueue,
+		slicingMode:                    slicingMode,
+		workerLoopPeriod:               1 * time.Second,
+		enqueuedAt:                     make(map[string]time.Time),
+		preInitEnqueuedEndpointsEvents: make([]EndpointEvent, 0),
+		endpointsMappingInitialized:    false,
+	}
+	cesStore := ciliumEndpointSliceInit(controller, clientset.CiliumV2alpha1(), ctx, wg)
+	ceSliceStore = cesStore
+	return controller
+}
+
+func ciliumEndpointSliceInit(contorller *CiliumEndpointSliceController, client csv2a1.CiliumV2alpha1Interface, ctx context.Context, wg *sync.WaitGroup) cache.Store {
+	cesStore, cesController := informer.NewInformer(
+		utils.ListerWatcherFromTyped[*capi_v2a1.CiliumEndpointSliceList](
+			client.CiliumEndpointSlices()),
+		&capi_v2a1.CiliumEndpointSlice{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				if ces := objToCES(obj); ces != nil {
+					contorller.onSliceUpdate(ces)
+				}
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				if oldCES := objToCES(oldObj); oldCES != nil {
+					if newCES := objToCES(newObj); newCES != nil {
+						if oldCES.DeepEqual(newCES) {
+							return
+						}
+						contorller.onSliceUpdate(newCES)
+					}
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				if ces := objToCES(obj); ces != nil {
+					contorller.onSliceDelete(ces)
+				}
+			},
+		},
+		nil,
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		cesController.Run(ctx.Done())
+	}()
+	cache.WaitForCacheSync(ctx.Done(), cesController.HasSynced)
+	return cesStore
+}
+
+func objToCES(obj interface{}) *capi_v2a1.CiliumEndpointSlice {
+	switch concreteObj := obj.(type) {
+	case *capi_v2a1.CiliumEndpointSlice:
+		return concreteObj
+	case cache.DeletedFinalStateUnknown:
+		ciliumEndpoint, ok := concreteObj.Obj.(*capi_v2a1.CiliumEndpointSlice)
+		if !ok {
+			log.WithField(logfields.Object, logfields.Repr(concreteObj.Obj)).
+				Warn("Ignoring invalid v2alpha1 CiliumEndpointSlice")
+			return nil
+		}
+		return ciliumEndpoint
+	}
+	log.WithField(logfields.Object, logfields.Repr(obj)).
+		Warn("Ignoring invalid v2alpha1 CiliumEndpoint")
+	return nil
+}
+
+func initializeQueue(qpsLimit float64, burstLimit int) workqueue.RateLimitingInterface {
 	if qpsLimit == 0 {
 		qpsLimit = CESControllerWorkQueueQPSLimit
 	} else if qpsLimit > operatorOption.CESWriteQPSLimitMax {
@@ -129,19 +223,75 @@ func NewCESController(
 		logfields.WorkQueueSyncBackOff: defaultSyncBackOff,
 	}).Info("CES controller workqueue configuration")
 
-	rlQueue := workqueue.NewNamedRateLimitingQueue(workqueue.NewMaxOfRateLimiter(
+	return workqueue.NewNamedRateLimitingQueue(workqueue.NewMaxOfRateLimiter(
 		workqueue.NewItemExponentialFailureRateLimiter(defaultSyncBackOff, maxSyncBackOff),
 		// 10 qps, 100 bucket size. This is only for retry speed and its
 		// only the overall factor (not per item).
 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(qpsLimit), burstLimit)},
 	), "cilium_endpoint_slice")
+}
 
-	manager := newCESManagerFcfs(rlQueue, maxCEPsInCES)
-	if slicingMode == cesIdentityBasedSlicing {
-		manager = newCESManagerIdentity(rlQueue, maxCEPsInCES)
+func (c *CiliumEndpointSliceController) OnEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
+	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
+		return
 	}
-	cesStore := ciliumEndpointSliceInit(clientset.CiliumV2alpha1(), ctx, wg)
-	ceSliceStore = cesStore
+	if c.endpointsMappingInitialized {
+		touchedCESs := c.Manager.UpdateCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
+		c.enqueueCESReconciliation(touchedCESs)
+	} else {
+		c.preInitEnqueuedEndpointsEvents = append(c.preInitEnqueuedEndpointsEvents, EndpointEvent{event: updateEvent, cep: cep})
+	}
+}
+
+func (c *CiliumEndpointSliceController) OnEndpointDelete(cep *cilium_api_v2.CiliumEndpoint) {
+	if c.endpointsMappingInitialized {
+		touchedCES := c.Manager.RemoveCEPMapping(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
+		c.enqueueCESReconciliation([]CESName{touchedCES})
+	} else {
+		c.preInitEnqueuedEndpointsEvents = append(c.preInitEnqueuedEndpointsEvents, EndpointEvent{event: deleteEvent, cep: cep})
+	}
+}
+
+func (c *CiliumEndpointSliceController) onSliceUpdate(ces *capi_v2a1.CiliumEndpointSlice) {
+	c.enqueueCESReconciliation([]CESName{CESName(ces.Name)})
+}
+
+func (c *CiliumEndpointSliceController) onSliceDelete(ces *capi_v2a1.CiliumEndpointSlice) {
+	c.enqueueCESReconciliation([]CESName{CESName(ces.Name)})
+}
+
+func (c *CiliumEndpointSliceController) enqueueCESReconciliation(cess []CESName) {
+	for _, ces := range cess {
+		log.WithFields(logrus.Fields{
+			logfields.CESName: ces,
+		}).Debug("Enquing CES (if not empty name")
+		if ces != "" {
+			if c.enqueuedAt[string(ces)].IsZero() {
+				c.enqueuedAt[string(ces)] = time.Now()
+			}
+			c.queue.AddAfter(string(ces), DefaultCESSyncTime)
+		}
+	}
+}
+
+func (c *CiliumEndpointSliceController) getAndResetCESProcessingDelay(ces string) float64 {
+	enqueued, exists := c.enqueuedAt[ces]
+	if !exists {
+		return 0
+	}
+	if !enqueued.IsZero() {
+		delay := time.Since(enqueued)
+		c.enqueuedAt[ces] = time.Time{}
+		return delay.Seconds()
+	}
+	return 0
+}
+
+// start the worker thread, reconciles the modified CESs with api-server
+func (c *CiliumEndpointSliceController) Run(ciliumEndpointStore cache.Indexer, stopCh <-chan struct{}) {
+	log.Info("Bootstrap ces controller")
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
 
 	// List all existing CESs from the api-server and cache it locally.
 	// This sync should happen before starting CEP watcher, because CEP watcher
@@ -149,30 +299,9 @@ func NewCESController(
 	// cesManager would assume those are new CEPs and may create new CESs for those CEPs.
 	// This situation ends up having duplicate CEPs in different CESs. Hence, we need
 	// to sync existing CESs before starting a CEP watcher.
-	syncCESsInLocalCache(cesStore, manager)
-	return &CiliumEndpointSliceController{
-		clientV2:                 clientset.CiliumV2(),
-		clientV2a1:               clientset.CiliumV2alpha1(),
-		reconciler:               newReconciler(clientset.CiliumV2alpha1(), manager),
-		Manager:                  manager,
-		queue:                    rlQueue,
-		ciliumEndpointSliceStore: cesStore,
-		slicingMode:              slicingMode,
-		workerLoopPeriod:         1 * time.Second,
-	}
-}
-
-// start the worker thread, reconciles the modified CESs with api-server
-func (c *CiliumEndpointSliceController) Run(ces cache.Indexer, stopCh <-chan struct{}) {
-	log.Info("Bootstrap ces controller")
-	defer utilruntime.HandleCrash()
-	defer c.queue.ShutDown()
-
-	// Cache CiliumEndpointStore Interface locally
-	c.ciliumEndpointStore = ces
-
-	// On operator warm boot, remove stale CEP entries present in CES
-	c.removeStaleAndDuplicatedCEPEntries()
+	c.syncCESsInLocalCache()
+	c.processEnqueuedPreInitEndpoints()
+	c.reconciler.ciliumEndpointStore = ciliumEndpointStore
 
 	log.WithFields(logrus.Fields{
 		logfields.CESSliceMode: c.slicingMode,
@@ -188,90 +317,30 @@ func (c *CiliumEndpointSliceController) Run(ces cache.Indexer, stopCh <-chan str
 	<-stopCh
 }
 
-// Upon warm boot[restart], Iterate over all CEPs which we got from the api-server
-// and compare it with CEPs packed inside CES.
-// If there are any stale CEPs present in CESs, remove them from their CES.
-// If there are any duplicated CEPs present in CESs, remove all but one trying
-// to keep the CEP with matching identity if it's present.
-func (c *CiliumEndpointSliceController) removeStaleAndDuplicatedCEPEntries() {
-	log.Info("Remove stale and duplicated CEP entries in CES")
-
-	type cepMapping struct {
-		identity int64
-		cesName  string
-	}
-
-	cepsMapping := make(map[string][]cepMapping)
-
-	// Get all CEPs from local datastore
-	// Map CEP Names to list of whole structure + CES Name
-	for _, ces := range c.Manager.getAllCESs() {
-		for _, cep := range ces.getAllCEPs() {
-			cepName := ces.getCEPNameFromCCEP(&cep)
-			cepsMapping[cepName] = append(cepsMapping[cepName], cepMapping{identity: cep.IdentityID, cesName: ces.getCESName()})
-		}
-	}
-
-	for cepName, mappings := range cepsMapping {
-		storeCep, exists, err := c.ciliumEndpointStore.GetByKey(cepName)
-		// Ignore error from below api, this is added to avoid accidental cep rmeoval from cache
-		if err != nil {
-			continue
-		}
-		if !exists {
-			// Remove stale CEP entries present in CES
-			for _, mapping := range mappings {
-				log.WithFields(logrus.Fields{
-					logfields.CEPName: cepName,
-				}).Debug("Removing stale CEP entry.")
-				c.Manager.removeCEPFromCES(cepName, mapping.cesName, DefaultCESSyncTime, 0, false)
-			}
-		} else if len(mappings) > 1 {
-			// Remove duplicated CEP entries present in CES
-			found := false
-			cep := storeCep.(*cilium_api_v2.CiliumEndpoint)
-			// Skip first element for now
-			for _, mapping := range mappings[1:] {
-				if !found && mapping.identity == cep.Status.Identity.ID {
-					// Don't remove the first element for which identity matches
-					found = true
-					// All others elements will be removed so update mapping to make sure
-					// it points to the element that was kept
-					c.Manager.updateCEPToCESMapping(cepName, mapping.cesName)
-					continue
-				}
-				c.Manager.removeCEPFromCES(cepName, mapping.cesName, DefaultCESSyncTime, mapping.identity, true)
-			}
-			if found {
-				// Remove first element if element with matching identity was found
-				c.Manager.removeCEPFromCES(cepName, mappings[0].cesName, DefaultCESSyncTime, mappings[0].identity, true)
-			} else {
-				// All others elements were removed so update mapping to make sure
-				// it points to the only element left
-				c.Manager.updateCEPToCESMapping(cepName, mappings[0].cesName)
-			}
-		}
-	}
-}
-
 // Sync all CESs from cesStore to manager cache.
 // Note: CESs are synced locally before CES controller running and this is required.
-func syncCESsInLocalCache(cesStore cache.Store, manager operations) {
-	for _, obj := range cesStore.List() {
+func (c *CiliumEndpointSliceController) syncCESsInLocalCache() {
+	for _, obj := range ceSliceStore.List() {
 		ces := obj.(*capi_v2a1.CiliumEndpointSlice)
-		// If CES is already cached locally, do nothing.
-		if _, err := manager.getCESFromCache(ces.GetName()); err == nil {
-			continue
+		cesName := c.Manager.initializeMappingForCES(ces)
+		for _, cep := range ces.Endpoints {
+			c.Manager.initializeMappingCEPtoCES(&cep, ces.Namespace, cesName)
 		}
-
-		// Create new CES locally, with the given cesName
-		manager.createCES(ces.GetName())
-
-		// Deep copy the ces, we got from api-server to local datastore.
-		manager.updateCESInCache(ces, true)
-
 	}
+	c.endpointsMappingInitialized = true
 	log.Debug("Successfully synced all CESs locally")
+}
+
+func (c *CiliumEndpointSliceController) processEnqueuedPreInitEndpoints() {
+	for _, e := range c.preInitEnqueuedEndpointsEvents {
+		if e.event == updateEvent {
+			c.OnEndpointUpdate(e.cep)
+		} else if e.event == deleteEvent {
+			c.OnEndpointDelete(e.cep)
+		} else {
+			log.Warnf("Processing pre init event of unknown type %d", e.event)
+		}
+	}
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and
@@ -290,8 +359,10 @@ func (c *CiliumEndpointSliceController) processNextWorkItem() bool {
 	}
 	defer c.queue.Done(cKey)
 
-	err := c.syncCES(cKey.(string))
+	queueDelay := c.getAndResetCESProcessingDelay(cKey.(string))
+	err := c.reconciler.reconcileCES(cKey.(string))
 	if operatorOption.Config.EnableMetrics {
+		metrics.CiliumEndpointSliceQueueDelay.Observe(queueDelay)
 		if err != nil {
 			metrics.CiliumEndpointSliceSyncTotal.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
 		} else {
@@ -315,14 +386,6 @@ func (c *CiliumEndpointSliceController) handleErr(err error, key interface{}) {
 		metrics.CiliumEndpointSliceSyncErrors.Inc()
 	}
 
-	if errors.IsConflict(err) {
-		// Update metadata of the object from store on conflict
-		obj, exists, err := c.ciliumEndpointSliceStore.GetByKey(key.(string))
-		if err == nil && exists {
-			c.Manager.updateCESInCache(obj.(*capi_v2a1.CiliumEndpointSlice), false)
-		}
-	}
-
 	if c.queue.NumRequeues(key) < maxRetries {
 		c.queue.AddRateLimited(key)
 		return
@@ -333,62 +396,6 @@ func (c *CiliumEndpointSliceController) handleErr(err error, key interface{}) {
 		logfields.CESName: key,
 	}).Error("Dropping the CES from queue, exceeded maxRetries")
 	c.queue.Forget(key)
-}
-
-// syncCES reconciles the queued CES with api-server.
-func (c *CiliumEndpointSliceController) syncCES(key string) error {
-	// Update metrics
-	if operatorOption.Config.EnableMetrics {
-		metrics.CiliumEndpointSliceDensity.Observe(float64(c.Manager.getCEPCountInCES(key)))
-		cepInsert, cepRemove := c.Manager.getCESMetricCountersAndClear(key)
-		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPInsert).Observe(float64(cepInsert))
-		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPRemove).Observe(float64(cepRemove))
-		metrics.CiliumEndpointSliceQueueDelay.Observe(c.Manager.getCESQueueDelayInSeconds(key))
-	}
-	// Check the CES exists is in cesStore i.e. in api-server copy of CESs, if exist update or delete the CES.
-	obj, exists, err := c.ciliumEndpointSliceStore.GetByKey(key)
-	if err == nil && exists {
-		ces := obj.(*capi_v2a1.CiliumEndpointSlice)
-		// Delete the CES, only if CEP count is zero in local copy of CES and api-server copy of CES,
-		// else Update the CES
-		if len(ces.Endpoints) == 0 && c.Manager.getCEPCountInCES(key) == 0 {
-			if err := c.reconciler.reconcileCESDelete(key); err != nil {
-				return err
-			}
-		} else {
-			if err := c.reconciler.reconcileCESUpdate(key); err != nil {
-				return err
-			}
-		}
-	}
-
-	if err == nil && !exists {
-		// Create the CES with api-server
-		if err := c.reconciler.reconcileCESCreate(key); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// Initialize and start CES watcher
-// TODO Watch for CES's, make sure only CES controller Create/Update/Delete the CES not bad actors.
-func ciliumEndpointSliceInit(client csv2a1.CiliumV2alpha1Interface, ctx context.Context, wg *sync.WaitGroup) cache.Store {
-	cesStore, cesController := informer.NewInformer(
-		utils.ListerWatcherFromTyped[*capi_v2a1.CiliumEndpointSliceList](
-			client.CiliumEndpointSlices()),
-		&capi_v2a1.CiliumEndpointSlice{},
-		0,
-		cache.ResourceEventHandlerFuncs{},
-		nil,
-	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		cesController.Run(ctx.Done())
-	}()
-	cache.WaitForCacheSync(ctx.Done(), cesController.HasSynced)
-	return cesStore
 }
 
 // UsedIdentitiesInCESs returns all Identities that are used in CESs.

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -5,17 +5,13 @@ package ciliumendpointslice
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/cache"
 
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -40,6 +36,7 @@ func createStoreEndpoint(name string, namespace string, identity int64) *v2.Cili
 			Identity: &v2.EndpointIdentity{
 				ID: identity,
 			},
+			Networking: &v2.EndpointNetworking{},
 		},
 	}
 }
@@ -54,171 +51,6 @@ func createStoreEndpointSlice(name string, namespace string, endpoints []capi_v2
 	}
 }
 
-func TestRemoveStaleCEPEntries(t *testing.T) {
-	namespace := "ns"
-	testCases := []struct {
-		desc      string
-		storeCESs []*capi_v2a1.CiliumEndpointSlice
-		storeCEPs []*v2.CiliumEndpoint
-		want      map[string]string
-	}{
-		{
-			desc: "No stale CEPs",
-			storeCESs: []*capi_v2a1.CiliumEndpointSlice{
-				createStoreEndpointSlice("slice1", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 1)}),
-			},
-			storeCEPs: []*v2.CiliumEndpoint{createStoreEndpoint("cep1", namespace, 1)},
-			want:      map[string]string{"ns/cep1": "slice1"},
-		},
-		{
-			desc: "Remove stale CEP",
-			storeCESs: []*capi_v2a1.CiliumEndpointSlice{
-				createStoreEndpointSlice("slice1", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 1),
-					createManagerEndpoint("cep2", 2),
-				}),
-			},
-			storeCEPs: []*v2.CiliumEndpoint{createStoreEndpoint("cep1", namespace, 1)},
-			want:      map[string]string{"ns/cep1": "slice1"},
-		},
-		{
-			desc: "Remove duplicated CEP from single slice",
-			storeCESs: []*capi_v2a1.CiliumEndpointSlice{
-				createStoreEndpointSlice("slice1", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 1),
-					createManagerEndpoint("cep1", 1),
-				}),
-			},
-			storeCEPs: []*v2.CiliumEndpoint{createStoreEndpoint("cep1", namespace, 1)},
-			want:      map[string]string{"ns/cep1": "slice1"},
-		},
-		{
-			desc: "Remove duplicated CEP from separate slice",
-			storeCESs: []*capi_v2a1.CiliumEndpointSlice{
-				createStoreEndpointSlice("slice1", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 1),
-				}),
-				createStoreEndpointSlice("slice2", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 1),
-				}),
-			},
-			storeCEPs: []*v2.CiliumEndpoint{createStoreEndpoint("cep1", namespace, 1)},
-			want:      map[string]string{"ns/cep1": ""}, // empty ces name as any ces is ok
-		},
-		{
-			desc: "Remove old CEP from first slice",
-			storeCESs: []*capi_v2a1.CiliumEndpointSlice{
-				createStoreEndpointSlice("slice1", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 2),
-				}),
-				createStoreEndpointSlice("slice2", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 1),
-				}),
-			},
-			storeCEPs: []*v2.CiliumEndpoint{createStoreEndpoint("cep1", namespace, 1)},
-			want:      map[string]string{"ns/cep1": "slice2"},
-		},
-		{
-			desc: "Remove old CEP from second slice",
-			storeCESs: []*capi_v2a1.CiliumEndpointSlice{
-				createStoreEndpointSlice("slice1", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 1),
-				}),
-				createStoreEndpointSlice("slice2", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 2),
-				}),
-			},
-			storeCEPs: []*v2.CiliumEndpoint{createStoreEndpoint("cep1", namespace, 1)},
-			want:      map[string]string{"ns/cep1": "slice1"},
-		},
-		{
-			desc: "Big remove case with multiple stale and duplicated CEPs from multiple slices",
-			storeCESs: []*capi_v2a1.CiliumEndpointSlice{
-				createStoreEndpointSlice("slice1", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 1),
-					createManagerEndpoint("cep2", 1),
-					createManagerEndpoint("cep3", 1),
-				}),
-				createStoreEndpointSlice("slice2", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 2),
-					createManagerEndpoint("cep4", 2),
-					createManagerEndpoint("cep5", 2),
-					createManagerEndpoint("cep6", 2),
-				}),
-				createStoreEndpointSlice("slice3", namespace, []capi_v2a1.CoreCiliumEndpoint{
-					createManagerEndpoint("cep1", 2),
-					createManagerEndpoint("cep4", 2),
-					createManagerEndpoint("cep7", 2),
-					createManagerEndpoint("cep8", 2),
-					createManagerEndpoint("cep9", 2),
-				}),
-			},
-			storeCEPs: []*v2.CiliumEndpoint{
-				createStoreEndpoint("cep1", namespace, 1),
-				createStoreEndpoint("cep2", namespace, 1),
-				createStoreEndpoint("cep3", namespace, 1),
-				createStoreEndpoint("cep4", namespace, 2),
-				createStoreEndpoint("cep5", namespace, 2),
-			},
-			want: map[string]string{
-				"ns/cep1": "slice1",
-				"ns/cep2": "slice1",
-				"ns/cep3": "slice1",
-				"ns/cep4": "",
-				"ns/cep5": "slice2",
-			},
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			_, client := client.NewFakeClientset()
-			ciliumEndpointStore := cache.NewIndexer(
-				cache.DeletionHandlingMetaNamespaceKeyFunc,
-				cache.Indexers{
-					cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-					"identity": func(obj interface{}) ([]string, error) {
-						endpointObj, ok := obj.(*v2.CiliumEndpoint)
-						if !ok {
-							return nil, errors.New("failed to convert cilium endpoint")
-						}
-						identityID := "0"
-						if endpointObj.Status.Identity != nil {
-							identityID = strconv.FormatInt(endpointObj.Status.Identity.ID, 10)
-						}
-						return []string{identityID}, nil
-					},
-				},
-			)
-			cesController := NewCESController(context.Background(), &sync.WaitGroup{}, client, 5, cesIdentityBasedSlicing, 10, 20)
-			cesController.ciliumEndpointStore = ciliumEndpointStore
-			manager := cesController.Manager.(*cesManagerIdentity)
-			for _, cep := range tc.storeCEPs {
-				ciliumEndpointStore.Add(cep)
-			}
-			for _, ces := range tc.storeCESs {
-				cesController.ciliumEndpointSliceStore.Add(ces)
-			}
-			syncCESsInLocalCache(cesController.ciliumEndpointSliceStore, manager)
-			cesController.removeStaleAndDuplicatedCEPEntries()
-			wantedCEPs := make([]string, len(tc.want))
-			i := 0
-			for cep := range tc.want {
-				wantedCEPs[i] = cep
-				i++
-			}
-			assert.ElementsMatch(t, wantedCEPs, manager.getAllCEPNames())
-			for cep := range tc.want {
-				actualCES, exists := manager.desiredCESs.getCESName(cep)
-				assert.True(t, exists)
-				if tc.want[cep] != "" {
-					assert.Equal(t, tc.want[cep], actualCES)
-				}
-			}
-		})
-	}
-}
-
 func createCESWithIDs(cesName string, ids []int64) *capi_v2a1.CiliumEndpointSlice {
 	ces := &capi_v2a1.CiliumEndpointSlice{ObjectMeta: meta_v1.ObjectMeta{Name: cesName}}
 	for _, id := range ids {
@@ -228,11 +60,70 @@ func createCESWithIDs(cesName string, ids []int64) *capi_v2a1.CiliumEndpointSlic
 	return ces
 }
 
-func assertEqualIDs(t *testing.T, wantIdentities, gotIdentities map[string]bool) {
-	t.Helper()
-	if diff := cmp.Diff(wantIdentities, gotIdentities); diff != "" {
-		t.Errorf("Unexpected Identites in the CES store (-want +got): \n%s", diff)
-	}
+func TestSyncCESsInLocalCache(t *testing.T) {
+	_, c := client.NewFakeClientset()
+	cesController := NewCESController(context.Background(), &sync.WaitGroup{}, c, 5, "", 10, 20)
+
+	cep1 := createManagerEndpoint("cep1", 1)
+	cep2 := createManagerEndpoint("cep2", 1)
+	cep3 := createManagerEndpoint("cep3", 2)
+	cep4 := createManagerEndpoint("cep4", 2)
+	ces1 := createStoreEndpointSlice("ces1", "ns", []capi_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
+	ceSliceStore.Add(ces1)
+	cep5 := createManagerEndpoint("cep5", 1)
+	cep6 := createManagerEndpoint("cep6", 1)
+	cep7 := createManagerEndpoint("cep7", 2)
+	ces2 := createStoreEndpointSlice("ces2", "ns", []capi_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
+	ceSliceStore.Add(ces2)
+
+	cesController.syncCESsInLocalCache()
+
+	mapping := cesController.Manager.(*cesManagerFcfs).mapping
+
+	cesN, _ := mapping.getCESName("ns/cep1")
+	assert.Equal(t, cesN, CESName("ces1"))
+	cesN, _ = mapping.getCESName("ns/cep2")
+	assert.Equal(t, cesN, CESName("ces1"))
+	cesN, _ = mapping.getCESName("ns/cep3")
+	assert.Equal(t, cesN, CESName("ces1"))
+	cesN, _ = mapping.getCESName("ns/cep4")
+	assert.Equal(t, cesN, CESName("ces1"))
+	cesN, _ = mapping.getCESName("ns/cep5")
+	assert.Equal(t, cesN, CESName("ces2"))
+	cesN, _ = mapping.getCESName("ns/cep6")
+	assert.Equal(t, cesN, CESName("ces2"))
+	cesN, _ = mapping.getCESName("ns/cep7")
+	assert.Equal(t, cesN, CESName("ces2"))
+}
+
+func TestEnqueueingPreIntitialization(t *testing.T) {
+	_, c := client.NewFakeClientset()
+
+	cesController := NewCESController(context.Background(), &sync.WaitGroup{}, c, 5, "", 10, 20)
+	assert.Equal(t, 0, cesController.queue.Len())
+
+	cep1 := createStoreEndpoint("cep1", "ns", 1)
+	cep2 := createStoreEndpoint("cep2", "ns", 1)
+	cep3 := createStoreEndpoint("cep3", "ns", 2)
+	cesController.OnEndpointUpdate(cep1)
+	cesController.OnEndpointUpdate(cep2)
+	cesController.OnEndpointUpdate(cep3)
+	cesController.OnEndpointDelete(cep2)
+	ces1 := createStoreEndpointSlice("ces1", "ns", []capi_v2a1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
+	ceSliceStore.Add(ces1)
+	ces2 := createStoreEndpointSlice("ces2", "ns", []capi_v2a1.CoreCiliumEndpoint{createManagerEndpoint("cep2", 1)})
+	ceSliceStore.Add(ces2)
+	time.Sleep(DefaultCESSyncTime * 2) // elements are added to the queue with a default delay
+	assert.Equal(t, 0, cesController.queue.Len())
+	assert.Equal(t, 4, len(cesController.preInitEnqueuedEndpointsEvents))
+	assert.Equal(t, false, cesController.endpointsMappingInitialized)
+
+	cesController.syncCESsInLocalCache()
+	assert.Equal(t, true, cesController.endpointsMappingInitialized)
+
+	cesController.processEnqueuedPreInitEndpoints()
+	time.Sleep(DefaultCESSyncTime * 2) // elements are added to the queue with a default delay
+	assert.Equal(t, 2, cesController.queue.Len())
 }
 
 func TestUsedIdentitiesInCESs(t *testing.T) {
@@ -266,28 +157,9 @@ func TestUsedIdentitiesInCESs(t *testing.T) {
 	assertEqualIDs(t, wantIdentities, gotIdentities)
 }
 
-func TestHandleErr(t *testing.T) {
-	t.Run("Cache is updated on conflict", func(t *testing.T) {
-		_, client := client.NewFakeClientset()
-		cesController := NewCESController(context.Background(), &sync.WaitGroup{}, client, 5, cesIdentityBasedSlicing, 10, 20)
-		manager := cesController.Manager
-
-		key := "some-ces"
-		initialCES := createCESWithIDs(key, []int64{1, 2})
-		initialCES.Generation = 1
-		manager.createCES(key)
-		manager.updateCESInCache(initialCES, true)
-		updatedCES := createCESWithIDs(key, []int64{1, 2})
-		updatedCES.Generation = 2
-		cesController.ciliumEndpointSliceStore.Add(updatedCES)
-
-		var err error = k8s_errors.NewConflict(
-			schema.GroupResource{Group: "", Resource: "ciliumendpointslices"},
-			key,
-			fmt.Errorf("conflict"))
-		cesController.handleErr(err, key)
-
-		managerCES, _ := manager.getCESFromCache(key)
-		assert.Equal(t, updatedCES.Generation, managerCES.Generation)
-	})
+func assertEqualIDs(t *testing.T, wantIdentities, gotIdentities map[string]bool) {
+	t.Helper()
+	if diff := cmp.Diff(wantIdentities, gotIdentities); diff != "" {
+		t.Errorf("Unexpected Identites in the CES store (-want +got): \n%s", diff)
+	}
 }

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -5,44 +5,45 @@ package ciliumendpointslice
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
 
-	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 )
 
-func createManagerEndpoint(name string, identity int64) capi_v2a1.CoreCiliumEndpoint {
-	return capi_v2a1.CoreCiliumEndpoint{
+func createManagerEndpoint(name string, identity int64) cilium_v2a1.CoreCiliumEndpoint {
+	return cilium_v2a1.CoreCiliumEndpoint{
 		Name:       name,
 		IdentityID: identity,
 	}
 }
 
-func createStoreEndpoint(name string, namespace string, identity int64) *v2.CiliumEndpoint {
-	return &v2.CiliumEndpoint{
+func createStoreEndpoint(name string, namespace string, identity int64) *cilium_v2.CiliumEndpoint {
+	return &cilium_v2.CiliumEndpoint{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
-		Status: v2.EndpointStatus{
-			Identity: &v2.EndpointIdentity{
+		Status: cilium_v2.EndpointStatus{
+			Identity: &cilium_v2.EndpointIdentity{
 				ID: identity,
 			},
-			Networking: &v2.EndpointNetworking{},
+			Networking: &cilium_v2.EndpointNetworking{},
 		},
 	}
 }
 
-func createStoreEndpointSlice(name string, namespace string, endpoints []capi_v2a1.CoreCiliumEndpoint) *capi_v2a1.CiliumEndpointSlice {
-	return &capi_v2a1.CiliumEndpointSlice{
+func createStoreEndpointSlice(name string, namespace string, endpoints []cilium_v2a1.CoreCiliumEndpoint) *cilium_v2a1.CiliumEndpointSlice {
+	return &cilium_v2a1.CiliumEndpointSlice{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: name,
 		},
@@ -51,115 +52,69 @@ func createStoreEndpointSlice(name string, namespace string, endpoints []capi_v2
 	}
 }
 
-func createCESWithIDs(cesName string, ids []int64) *capi_v2a1.CiliumEndpointSlice {
-	ces := &capi_v2a1.CiliumEndpointSlice{ObjectMeta: meta_v1.ObjectMeta{Name: cesName}}
-	for _, id := range ids {
-		cep := capi_v2a1.CoreCiliumEndpoint{IdentityID: id}
-		ces.Endpoints = append(ces.Endpoints, cep)
-	}
-	return ces
-}
-
 func TestSyncCESsInLocalCache(t *testing.T) {
-	_, c := client.NewFakeClientset()
-	cesController := NewCESController(context.Background(), &sync.WaitGroup{}, c, 5, "", 10, 20)
+	var r *reconciler
+	var fakeClient k8sClient.FakeClientset
+	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
+	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+			fakeClient = *c
+			ciliumEndpoint = cep
+			ciliumEndpointSlice = ces
+			return nil
+		}),
+	)
+	hive.Start(context.Background())
+	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+	cesController := &Controller{
+		logger:              log,
+		clientset:           fakeClient.Clientset,
+		ciliumEndpoint:      ciliumEndpoint,
+		ciliumEndpointSlice: ciliumEndpointSlice,
+		reconciler:          r,
+		manager:             m,
+		writeQPSBurst:       2,
+		writeQPSLimit:       1,
+		enqueuedAt:          make(map[CESName]time.Time),
+	}
+	cesController.initializeQueue()
 
 	cep1 := createManagerEndpoint("cep1", 1)
 	cep2 := createManagerEndpoint("cep2", 1)
 	cep3 := createManagerEndpoint("cep3", 2)
 	cep4 := createManagerEndpoint("cep4", 2)
-	ces1 := createStoreEndpointSlice("ces1", "ns", []capi_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
-	ceSliceStore.Add(ces1)
+	ces1 := createStoreEndpointSlice("ces1", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep1, cep2, cep3, cep4})
+	cesStore.CacheStore().Add(ces1)
 	cep5 := createManagerEndpoint("cep5", 1)
 	cep6 := createManagerEndpoint("cep6", 1)
 	cep7 := createManagerEndpoint("cep7", 2)
-	ces2 := createStoreEndpointSlice("ces2", "ns", []capi_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
-	ceSliceStore.Add(ces2)
+	ces2 := createStoreEndpointSlice("ces2", "ns", []cilium_v2a1.CoreCiliumEndpoint{cep5, cep6, cep7})
+	cesStore.CacheStore().Add(ces2)
 
-	cesController.syncCESsInLocalCache()
+	cesController.syncCESsInLocalCache(context.Background())
 
-	mapping := cesController.Manager.(*cesManagerFcfs).mapping
+	mapping := m.mapping
 
-	cesN, _ := mapping.getCESName("ns/cep1")
-	assert.Equal(t, cesN, CESName("ces1"))
-	cesN, _ = mapping.getCESName("ns/cep2")
-	assert.Equal(t, cesN, CESName("ces1"))
-	cesN, _ = mapping.getCESName("ns/cep3")
-	assert.Equal(t, cesN, CESName("ces1"))
-	cesN, _ = mapping.getCESName("ns/cep4")
-	assert.Equal(t, cesN, CESName("ces1"))
-	cesN, _ = mapping.getCESName("ns/cep5")
-	assert.Equal(t, cesN, CESName("ces2"))
-	cesN, _ = mapping.getCESName("ns/cep6")
-	assert.Equal(t, cesN, CESName("ces2"))
-	cesN, _ = mapping.getCESName("ns/cep7")
-	assert.Equal(t, cesN, CESName("ces2"))
-}
+	cesN, _ := mapping.getCESName(NewCEPName("cep1", "ns"))
+	assert.Equal(t, cesN, NewCESName("ces1"))
+	cesN, _ = mapping.getCESName(NewCEPName("cep2", "ns"))
+	assert.Equal(t, cesN, NewCESName("ces1"))
+	cesN, _ = mapping.getCESName(NewCEPName("cep3", "ns"))
+	assert.Equal(t, cesN, NewCESName("ces1"))
+	cesN, _ = mapping.getCESName(NewCEPName("cep4", "ns"))
+	assert.Equal(t, cesN, NewCESName("ces1"))
+	cesN, _ = mapping.getCESName(NewCEPName("cep5", "ns"))
+	assert.Equal(t, cesN, NewCESName("ces2"))
+	cesN, _ = mapping.getCESName(NewCEPName("cep6", "ns"))
+	assert.Equal(t, cesN, NewCESName("ces2"))
+	cesN, _ = mapping.getCESName(NewCEPName("cep7", "ns"))
+	assert.Equal(t, cesN, NewCESName("ces2"))
 
-func TestEnqueueingPreIntitialization(t *testing.T) {
-	_, c := client.NewFakeClientset()
-
-	cesController := NewCESController(context.Background(), &sync.WaitGroup{}, c, 5, "", 10, 20)
-	assert.Equal(t, 0, cesController.queue.Len())
-
-	cep1 := createStoreEndpoint("cep1", "ns", 1)
-	cep2 := createStoreEndpoint("cep2", "ns", 1)
-	cep3 := createStoreEndpoint("cep3", "ns", 2)
-	cesController.OnEndpointUpdate(cep1)
-	cesController.OnEndpointUpdate(cep2)
-	cesController.OnEndpointUpdate(cep3)
-	cesController.OnEndpointDelete(cep2)
-	ces1 := createStoreEndpointSlice("ces1", "ns", []capi_v2a1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
-	ceSliceStore.Add(ces1)
-	ces2 := createStoreEndpointSlice("ces2", "ns", []capi_v2a1.CoreCiliumEndpoint{createManagerEndpoint("cep2", 1)})
-	ceSliceStore.Add(ces2)
-	time.Sleep(DefaultCESSyncTime * 2) // elements are added to the queue with a default delay
-	assert.Equal(t, 0, cesController.queue.Len())
-	assert.Equal(t, 4, len(cesController.preInitEnqueuedEndpointsEvents))
-	assert.Equal(t, false, cesController.endpointsMappingInitialized)
-
-	cesController.syncCESsInLocalCache()
-	assert.Equal(t, true, cesController.endpointsMappingInitialized)
-
-	cesController.processEnqueuedPreInitEndpoints()
-	time.Sleep(DefaultCESSyncTime * 2) // elements are added to the queue with a default delay
-	assert.Equal(t, 2, cesController.queue.Len())
-}
-
-func TestUsedIdentitiesInCESs(t *testing.T) {
-	cesStore := cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-
-	// Empty store.
-	gotIdentities := usedIdentitiesInCESs(cesStore)
-	wantIdentities := make(map[string]bool)
-	assertEqualIDs(t, wantIdentities, gotIdentities)
-
-	// 5 IDs in the store.
-	cesA := createCESWithIDs("cesA", []int64{1, 2, 3, 4, 5})
-	cesStore.Add(cesA)
-	wantIdentities["1"] = true
-	wantIdentities["2"] = true
-	wantIdentities["3"] = true
-	wantIdentities["4"] = true
-	wantIdentities["5"] = true
-	gotIdentities = usedIdentitiesInCESs(cesStore)
-	assertEqualIDs(t, wantIdentities, gotIdentities)
-
-	// 10 IDs in the store.
-	cesB := createCESWithIDs("cesB", []int64{10, 20, 30, 40, 50})
-	cesStore.Add(cesB)
-	wantIdentities["10"] = true
-	wantIdentities["20"] = true
-	wantIdentities["30"] = true
-	wantIdentities["40"] = true
-	wantIdentities["50"] = true
-	gotIdentities = usedIdentitiesInCESs(cesStore)
-	assertEqualIDs(t, wantIdentities, gotIdentities)
-}
-
-func assertEqualIDs(t *testing.T, wantIdentities, gotIdentities map[string]bool) {
-	t.Helper()
-	if diff := cmp.Diff(wantIdentities, gotIdentities); diff != "" {
-		t.Errorf("Unexpected Identites in the CES store (-want +got): \n%s", diff)
-	}
+	cesController.queue.ShutDown()
+	hive.Stop(context.Background())
 }

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -4,17 +4,10 @@
 package ciliumendpointslice
 
 import (
-	"fmt"
-	"math/rand"
-	"time"
-
-	"github.com/sirupsen/logrus"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/workqueue"
-
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -23,75 +16,30 @@ var (
 	sequentialLetters = []rune("bcdfghjklmnpqrstvwxyz2456789")
 )
 
-// cesTracker holds the desired state of CiliumEndpointSlice and list of ceps to be removed
-// in next sync with k8s-apiserver.
-type cesTracker struct {
-	// Mutex to protect cep insert/removal in ces and removedCEPs
-	// The identityLock and backendMutex locks always need to be acquired in the
-	// same order to avoid deadlocks. First identityLock and then backendMutex,
-	// because identityLock is a higher level lock of cesManagerIdentity which
-	// contains cesTrackers with backendMutex locks within it.
-	backendMutex lock.RWMutex
-	// The desired state of ces object
-	ces *cilium_v2.CiliumEndpointSlice
-	// set of CEPs to be removed in the CES object in next sync.
-	removedCEPs map[string]struct{}
-	// number of CEPs inserted in a CES
-	cepInserted int64
-	// number of CEPs removed from a CES
-	cepRemoved int64
-	// CES insert time at workqueue
-	cesInsertedAt time.Time
-}
-
 // operations is an interface to all operations that a CES manager can perform.
 type operations interface {
 	// External APIs to Insert/Remove CEP in local dataStore
-	InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string) string
-	updateCEPToCESMapping(cepName string, cesName string)
-	RemoveCEPFromCache(cepName string, baseDelay time.Duration)
-	removeCEPFromCES(cepName string, cesName string, baseDelay time.Duration, identity int64, checkIdentity bool)
-	// Supporting APIs to Insert/Remove CEP in local dataStore and effectively
-	// manages CES's.
-	getCESFromCache(cesName string) (*cilium_v2.CiliumEndpointSlice, error)
-	getCESCopyFromCache(cesName string) (*cilium_v2.CiliumEndpointSlice, error)
-	updateCESInCache(ces *cilium_v2.CiliumEndpointSlice, deepCopy bool)
-	deleteCESFromCache(cesName string)
-	getRemovedCEPs(string) map[string]struct{}
-	clearRemovedCEPs(string, map[string]struct{})
-	createCES(cesName string) *cesTracker
-	addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker)
-	insertCESInWorkQueue(ces *cesTracker, baseDelay time.Duration)
-	// APIs to collect metrics of CES and CEP
-	getTotalCEPCount() int
-	getCEPCountInCES(cesName string) int
-	getCESCount() int
-	getAllCESs() []cesOperations
-	getAllCEPNames() []string
-	getCESMetricCountersAndClear(cesName string) (cepInsert int64, cepRemove int64)
-	getCESQueueDelayInSeconds(cesName string) (diff float64)
-}
+	UpdateCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) []CESName
+	RemoveCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) CESName
 
-type cesOperations interface {
-	getAllCEPs() []cilium_v2.CoreCiliumEndpoint
-	getCESName() string
-	getCEPNameFromCCEP(cep *cilium_v2.CoreCiliumEndpoint) string
+	initializeMappingForCES(ces *cilium_v2.CiliumEndpointSlice) CESName
+	initializeMappingCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ns string, ces CESName)
+
+	getCEPCountInCES(ces CESName) int
+	getCEPinCES(ces CESName) []CEPName
+	getCESData(ces CESName) CESData
+	isCEPinCES(cep CEPName, ces CESName) bool
 }
 
 // cesMgr is used to batch CEP into a CES, based on FirstComeFirstServe. If a new CEP
 // is inserted, then the CEP is queued in any one of the available CES. CEPs are
 // inserted into CESs without any preference or any priority.
 type cesMgr struct {
-
-	// desiredCESs is used to map CESName to CESTracker[i.e. list of CEPs],
+	// mapping is used to map CESName to CESTracker[i.e. list of CEPs],
 	// as well as CEPName to CESName.
-	desiredCESs *CESToCEPMapping
+	mapping *CESToCEPMapping
 
-	// workqueue is used to sync CESs with the api-server. this will rate-limit the
-	// CES requests going to api-server, ensures a single CES will not be proccessed
-	// multiple times concurrently, and if CES is added multiple times before it
-	// can be processed, this will only be processed only once.
-	queue workqueue.RateLimitingInterface
+	mutex lock.Mutex
 
 	// maxCEPsInCES is the maximum number of CiliumCoreEndpoint(s) packed in
 	// a CiliumEndpointSlice Resource.
@@ -109,99 +57,32 @@ type cesManagerFcfs struct {
 // cesManagerIdentity is used to batch CEPs in CES based on CEP identity.
 type cesManagerIdentity struct {
 	cesMgr
-	// Mutex to protect cep insert/removal in ces and removedCEPs
-	// The identityLock and backendMutex locks always need to be acquired in the
-	// same order to avoid deadlocks. First identityLock and then backendMutex,
-	// because identityLock is a higher level lock of cesManagerIdentity which
-	// contains cesTrackers with backendMutex locks within it.
-	identityLock lock.RWMutex
 	// CEP identity to cesTracker map
-	identityToCES map[int64][]*cesTracker
+	identityToCES map[int64][]CESName
 	// reverse map of identityToCES i.e. cesName to CEP identity
-	cesToIdentity map[string]int64
+	cesToIdentity map[CESName]int64
 }
 
 // newCESManagerFcfs creates and initializes a new FirstComeFirstServe based CES
 // manager, in this mode CEPs are batched based on FirstComeFirtServe algorithm.
-func newCESManagerFcfs(workQueue workqueue.RateLimitingInterface, maxCEPsInCES int) operations {
+func newCESManagerFcfs(maxCEPsInCES int) operations {
 	return &cesManagerFcfs{
 		cesMgr{
-			desiredCESs:  newDesiredCESMap(),
-			queue:        workQueue,
+			mapping:      newCESToCEPMapping(),
 			maxCEPsInCES: maxCEPsInCES,
 		},
 	}
 }
 
 // newCESManagerIdentity creates and initializes a new Identity based manager.
-func newCESManagerIdentity(workQueue workqueue.RateLimitingInterface, maxCEPsInCES int) operations {
-	c := cesMgr{
-		desiredCESs:  newDesiredCESMap(),
-		queue:        workQueue,
-		maxCEPsInCES: maxCEPsInCES,
-	}
+func newCESManagerIdentity(maxCEPsInCES int) operations {
 	return &cesManagerIdentity{
-		cesMgr:        c,
-		identityToCES: make(map[int64][]*cesTracker),
-		cesToIdentity: make(map[string]int64),
-	}
-}
-
-// addCEPtoCES inserts the CEP in a CES, if the CEP already exists in a CES
-// it replaces with new CEP.
-func (c *cesMgr) addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker) {
-	ces.backendMutex.Lock()
-	defer ces.backendMutex.Unlock()
-	// If cep already exists in ces, compare new cep with cached cep.
-	// Update only if there is any change.
-	log.WithFields(logrus.Fields{
-		logfields.CEPName:  cep.Name,
-		logfields.CESName:  ces.ces.GetName(),
-		logfields.CEPCount: len(ces.ces.Endpoints),
-	}).Debug("Queueing CEP in the CES")
-
-	for i, ep := range ces.ces.Endpoints {
-		if GetCEPNameFromCCEP(&ep, ces.ces.Namespace) == GetCEPNameFromCCEP(cep, ces.ces.Namespace) {
-			if cep.DeepEqual(&ep) {
-				return
-			}
-			// Remove the matched cep from ces endpoints list.
-			ces.ces.Endpoints =
-				append(ces.ces.Endpoints[:i], ces.ces.Endpoints[i+1:]...)
-			break
-		}
-	}
-
-	// Insert the cep in ces endpoints list.
-	ces.ces.Endpoints = append(ces.ces.Endpoints, *cep)
-	// If this CEP is re-generated again before previous CEP-DELETE completed.
-	// remove this from removedCEP list.
-	delete(ces.removedCEPs, GetCEPNameFromCCEP(cep, ces.ces.Namespace))
-	// Increment the cepInsert counter
-	ces.cepInserted += 1
-	c.insertCESInWorkQueue(ces, DefaultCESSyncTime)
-}
-
-// Generate random string for given length of characters.
-func randomName(n int) string {
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = sequentialLetters[rand.Intn(len(sequentialLetters))]
-	}
-	return string(b)
-}
-
-// Generates unique random name for the CiliumEndpointSlice, the format
-// of a CES name is similar to pod k8s naming convention "ces-123456789-abcde".
-// First 3 letters indicates ces resource, followed by random letters.
-func uniqueCESliceName(desiredCESs *CESToCEPMapping) string {
-	rand.Seed(time.Now().UnixNano())
-	var cesName string
-	for {
-		cesName = fmt.Sprintf("%s-%s-%s", cesNamePrefix, randomName(9), randomName(5))
-		if !desiredCESs.hasCESName(cesName) {
-			return cesName
-		}
+		cesMgr: cesMgr{
+			mapping:      newCESToCEPMapping(),
+			maxCEPsInCES: maxCEPsInCES,
+		},
+		identityToCES: make(map[int64][]CESName),
+		cesToIdentity: make(map[CESName]int64),
 	}
 }
 
@@ -211,211 +92,86 @@ func uniqueCESliceName(desiredCESs *CESToCEPMapping) string {
 //     with an empty name, it generates a random unique name and assign it to the CES.
 //  2. During operator warm boot [after crash or software upgrade], slicing manager
 //     creates a CES, by passing unique name.
-func (c *cesMgr) createCES(name string) *cesTracker {
-	var cesName string = name
+func (c *cesMgr) createCES(name, ns string) CESName {
+	var cesName = name
 	if name == "" {
-		cesName = uniqueCESliceName(c.desiredCESs)
+		cesName = uniqueCESliceName(c.mapping)
 	}
-	ces := &cesTracker{
-		ces: &cilium_v2.CiliumEndpointSlice{
-			TypeMeta: meta_v1.TypeMeta{
-				Kind:       "CiliumEndpointSlice",
-				APIVersion: cilium_v2.SchemeGroupVersion.String(),
-			},
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: cesName,
-			},
-			Endpoints: make([]cilium_v2.CoreCiliumEndpoint, 0, c.maxCEPsInCES),
-		},
-		removedCEPs: make(map[string]struct{}),
-	}
-	c.desiredCESs.insertCES(cesName, ces)
+	c.mapping.insertCES(CESName(cesName), ns)
 	log.WithFields(logrus.Fields{
 		logfields.CESName: cesName,
 	}).Debug("Generated CES")
-	return ces
+	return CESName(cesName)
 }
 
-// If exists, remove CES object from cache. deleteCESFromCache is called after successful removal from
-// apiserver.
-func (c *cesMgr) deleteCESFromCache(cesName string) {
-	if !c.desiredCESs.hasCESName(cesName) {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: cesName,
-		}).Debug("Failed to retrieve CES object in local cache.")
-		return
-	}
-	c.desiredCESs.deleteCES(cesName)
-}
-
-// updateCESInCache function copies the ciliumEndpoint object in local cache. if isDeepCopy flag is set,
-// whole CoreCiliumEndpoint object stored in local cache.
-// There are two scenarios updateCESInCache is called.
-// 1) During operator warm boot[after crash or software upgrade], CES controller sync CES states from
-// api-server to cache. In this case, isDeepCopy set to true to copy entire CEP object locally.
-// 2) During runtime, reconciler sync current state with API server and update metadata only.
-// isDeepCopy flag is set to false.
-func (c *cesMgr) updateCESInCache(srcCES *cilium_v2.CiliumEndpointSlice, isDeepCopy bool) {
-	if ces, ok := c.desiredCESs.getCESTracker(srcCES.GetName()); ok {
-		ces.backendMutex.Lock()
-		defer ces.backendMutex.Unlock()
-		if !isDeepCopy {
-			ces.ces.ObjectMeta = srcCES.ObjectMeta
-		} else {
-			ces.ces = srcCES
-			for _, cep := range ces.ces.Endpoints {
-				// Update the desiredCESs, to reflect all CEPs are packed in a CES
-				c.desiredCESs.insertCEP(GetCEPNameFromCCEP(&cep, ces.ces.Namespace), srcCES.GetName())
-			}
-		}
-	} else {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: srcCES.GetName(),
-		}).Debug("Attempted to updateCESInCache non-existent, skipping.")
-	}
-}
-
-// If available, getCESFromCache returns CiliumEndpointSlice object.
-func (c *cesMgr) getCESFromCache(cesName string) (*cilium_v2.CiliumEndpointSlice, error) {
-	if ces, exists := c.desiredCESs.getCESTracker(cesName); exists {
-		return ces.ces, nil
-	}
-	return nil, fmt.Errorf("Failed to get CES from local cache for the CESName: %s", cesName)
-}
-
-// getCESCopyFromCache returns the copy of CiliumEndpointSlice object.
-func (c *cesMgr) getCESCopyFromCache(cesName string) (*cilium_v2.CiliumEndpointSlice, error) {
-	if ces, exists := c.desiredCESs.getCESTracker(cesName); exists {
-		outCES := new(cilium_v2.CiliumEndpointSlice)
-		ces.backendMutex.RLock()
-		ces.ces.DeepCopyInto(outCES)
-		ces.backendMutex.RUnlock()
-		return outCES, nil
-
-	}
-	return nil, fmt.Errorf("Failed to get CES Copy from local cache for the CESName: %s", cesName)
-}
-
-// InsertCEPInCache is used to insert CEP in local cache, this may result in creating a new
+// UpdateCEPMapping is used to insert CEP in local cache, this may result in creating a new
 // CES object or updating an existing CES object.
-func (c *cesMgr) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string) string {
+func (c *cesManagerFcfs) UpdateCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) []CESName {
 	log.WithFields(logrus.Fields{
 		logfields.CEPName: GetCEPNameFromCCEP(cep, ns),
 	}).Debug("Insert CEP in local cache")
-
 	// check the given cep is already exists in any of the CES.
 	// if yes, Update a ces with the given cep object.
-	cepName := GetCEPNameFromCCEP(cep, ns)
-	if cesName, exists := c.desiredCESs.getCESName(cepName); exists {
-		if ces, ok := c.desiredCESs.getCESTracker(cesName); ok {
-			// add a cep into the ces
-			c.addCEPtoCES(cep, ces)
-			return cesName
-		} else {
-			log.WithFields(logrus.Fields{
-				logfields.CESName: cesName,
-				logfields.CEPName: cepName,
-			}).Debug("Could not insert CEP - missing CESName, skipping.")
-		}
+	cepName := CEPName(GetCEPNameFromCCEP(cep, ns))
+	cesName, exists := c.mapping.getCESName(cepName)
+	if exists {
+		log.WithFields(logrus.Fields{
+			logfields.CEPName: cepName,
+			logfields.CESName: cesName,
+		}).Debug("CEP already mapped to CES")
+		return []CESName{cesName}
 	}
 
-	// If given cep object isn't packed in any of the CES. find a new ces
-	// to pack this cep.
-	cb, cesName := func() (*cesTracker, string) {
-		// Get the largest available CES.
-		// This ensures the minimum number of CES updates, as the CESs will be
-		// consistently filled up in order.
-		ces := c.getLargestAvailableCESForNamespace(ns)
-		if ces != nil {
-			ces.backendMutex.RLock()
-			defer ces.backendMutex.RUnlock()
-			return ces, ces.ces.GetName()
-		}
-		// allocate a new cesTracker and return
-		newCES := c.createCES("")
-		// Update the namespace to CES
-		newCES.ces.Namespace = ns
-		return newCES, newCES.ces.GetName()
-	}()
-
-	// Cache CEP name with newly allocated CES.
-	c.updateCEPToCESMapping(GetCEPNameFromCCEP(cep, ns), cesName)
-
-	// Queue the CEP in CES
-	c.addCEPtoCES(cep, cb)
-	return cesName
-}
-
-func (c *cesMgr) updateCEPToCESMapping(cepName string, cesName string) {
-	c.desiredCESs.insertCEP(cepName, cesName)
-}
-
-// RemoveCEPFromCache is used to remove the CEP from local cache, this may result in
-// Updating an existing CES object.
-func (c *cesMgr) RemoveCEPFromCache(cepName string, baseDelay time.Duration) {
+	// Get the largest available CES.
+	// This ensures the minimum number of CES updates, as the CESs will be
+	// consistently filled up in order.
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	cesName = c.getLargestAvailableCESForNamespace(ns)
+	if cesName == "" {
+		cesName = c.createCES("", ns)
+	}
+	c.mapping.insertCEP(cepName, cesName)
 	log.WithFields(logrus.Fields{
 		logfields.CEPName: cepName,
-	}).Debug("Remove CEP from local cache")
-
-	// Check in local cache, if a given cep is already batched in one of the ces.
-	// and if exists, delete cep from ces.
-	if cesName, exists := c.desiredCESs.getCESName(cepName); exists {
-		c.removeCEPFromCES(cepName, cesName, baseDelay, 0, false)
-	} else {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: cesName,
-			logfields.CEPName: cepName,
-		}).Debug("Could not remove CEP from local cache missing CEPName.")
-	}
+		logfields.CESName: cesName,
+	}).Debug("CEP mapped to CES")
+	return []CESName{cesName}
 }
 
-func (c *cesMgr) removeCEPFromCES(cepName string, cesName string, baseDelay time.Duration, identity int64, checkIdentity bool) {
-	var ces *cesTracker
-	var exists bool
-	if ces, exists = c.desiredCESs.getCESTracker(cesName); !exists {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: cesName,
-			logfields.CEPName: cepName,
-		}).Info("Attempted to remove non-existent CES, skipping.")
-		return
-	}
-
-	ces.backendMutex.Lock()
-	defer ces.backendMutex.Unlock()
-	for i, ep := range ces.ces.Endpoints {
-		if GetCEPNameFromCCEP(&ep, ces.ces.Namespace) == cepName && (!checkIdentity || ep.IdentityID == identity) {
-			// Insert deleted CoreCEP in removedCEPs
-			ces.removedCEPs[GetCEPNameFromCCEP(&ep, ces.ces.Namespace)] = struct{}{}
-			ces.ces.Endpoints =
-				append(ces.ces.Endpoints[:i],
-					ces.ces.Endpoints[i+1:]...)
-			break
-		}
-	}
+func (c *cesManagerFcfs) RemoveCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) CESName {
 	log.WithFields(logrus.Fields{
-		logfields.CESName:  cesName,
-		logfields.CEPName:  cepName,
-		logfields.CEPCount: len(ces.ces.Endpoints),
-	}).Debug("Removed CEP from CES")
-
-	// Increment the cepRemove counter
-	ces.cepRemoved += 1
-	c.insertCESInWorkQueue(ces, baseDelay)
+		logfields.CEPName: GetCEPNameFromCCEP(cep, ns),
+	}).Debug("Removing CEP from local cache")
+	cepName := CEPName(GetCEPNameFromCCEP(cep, ns))
+	cesName, exists := c.mapping.getCESName(cepName)
+	if exists {
+		log.WithFields(logrus.Fields{
+			logfields.CEPName: GetCEPNameFromCCEP(cep, ns),
+			logfields.CESName: cesName,
+		}).Debug("Removing CEP from CES")
+		c.mapping.deleteCEP(cepName)
+		if c.mapping.countCEPsInCES(cesName) == 0 {
+			c.mutex.Lock()
+			defer c.mutex.Unlock()
+			if c.mapping.countCEPsInCES(cesName) == 0 {
+				c.mapping.deleteCES(cesName)
+			}
+		}
+		return cesName
+	}
+	return ""
 }
 
 // getLargestAvailableCESForNamespace returns the largest CES from cache for the
 // specified namespace that has at least 1 CEP and 1 available spot (less than
 // maximum CEPs). If it is not found, a nil is returned.
-func (c *cesMgr) getLargestAvailableCESForNamespace(ns string) *cesTracker {
-	var selectedCES *cesTracker
+func (c *cesManagerFcfs) getLargestAvailableCESForNamespace(ns string) CESName {
 	largestCEPCount := 0
-
-	for _, ces := range c.desiredCESs.getAllCESs() {
-		ces.backendMutex.RLock()
-		cepCount := len(ces.ces.Endpoints)
-		ces.backendMutex.RUnlock()
-
-		if cepCount < c.maxCEPsInCES && cepCount > largestCEPCount && ces.ces.Namespace == ns {
+	selectedCES := CESName("")
+	for _, ces := range c.mapping.getAllCESs() {
+		cepCount := c.mapping.countCEPsInCES(ces)
+		if cepCount < c.maxCEPsInCES && cepCount > largestCEPCount && c.mapping.getCESData(ces).ns == ns {
 			selectedCES = ces
 			largestCEPCount = cepCount
 			if largestCEPCount == c.maxCEPsInCES-1 {
@@ -423,182 +179,12 @@ func (c *cesMgr) getLargestAvailableCESForNamespace(ns string) *cesTracker {
 			}
 		}
 	}
-
 	return selectedCES
 }
 
-// Returns the total number of CEPs in the cluster
-func (c *cesMgr) getTotalCEPCount() int {
-	cnt := 0
-	for _, ces := range c.desiredCESs.getAllCESs() {
-		ces.backendMutex.RLock()
-		cnt += len(ces.ces.Endpoints)
-		ces.backendMutex.RUnlock()
-	}
-	return cnt
-}
-
-// Returns the total number of CEPs in the ces
-func (c *cesMgr) getCEPCountInCES(cesName string) (cnt int) {
-	if ces, ok := c.desiredCESs.getCESTracker(cesName); ok {
-		ces.backendMutex.RLock()
-		cnt = len(ces.ces.Endpoints)
-		ces.backendMutex.RUnlock()
-	} else {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: cesName,
-		}).Debug("Attempted to getCEPCountInCES non-existent CES ,skipping.")
-	}
-	return
-}
-
-// Returns the total count of CESs in local cache
-func (c *cesMgr) getCESCount() int {
-	return c.desiredCESs.getCESCount()
-}
-
-func (c *cesMgr) getAllCESs() []cesOperations {
-	allCESs := c.desiredCESs.getAllCESs()
-	cess := make([]cesOperations, len(allCESs))
-	for i, ces := range allCESs {
-		cess[i] = ces
-	}
-	return cess
-}
-
-func (ces *cesTracker) getAllCEPs() []cilium_v2.CoreCiliumEndpoint {
-	return ces.ces.Endpoints
-}
-
-func (ces *cesTracker) getCESName() string {
-	return ces.ces.Name
-}
-
-func (ces *cesTracker) getCEPNameFromCCEP(cep *cilium_v2.CoreCiliumEndpoint) string {
-	return GetCEPNameFromCCEP(cep, ces.ces.Namespace)
-}
-
-// Returns the list of cep names
-func (c *cesMgr) getAllCEPNames() []string {
-	var ceps []string
-	for _, ces := range c.desiredCESs.getAllCESs() {
-		ces.backendMutex.RLock()
-		for _, cep := range ces.ces.Endpoints {
-			ceps = append(ceps, GetCEPNameFromCCEP(&cep, ces.ces.Namespace))
-		}
-		ces.backendMutex.RUnlock()
-	}
-
-	return ceps
-}
-
-// Returns the list of removed Core CEPs
-func (c *cesMgr) getRemovedCEPs(cesName string) map[string]struct{} {
-	cepNames := make(map[string]struct{})
-	if ces, ok := c.desiredCESs.getCESTracker(cesName); ok {
-		ces.backendMutex.RLock()
-		for cepName := range ces.removedCEPs {
-			cepNames[cepName] = struct{}{}
-		}
-		ces.backendMutex.RUnlock()
-	} else {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: cesName,
-		}).Debug("Attempted to getRemovedCEPs non-existent cesName,skipping.")
-	}
-
-	return cepNames
-}
-
-// After successful sync with api-server, delete removed ceps in a CES.
-// If no more CEPs are packed in CES, Delete the CES in next DeleteSYNC.
-func (c *cesMgr) clearRemovedCEPs(cesName string, remCEPs map[string]struct{}) {
-	var ok bool
-	var ces *cesTracker
-	// Check if CES exists in local cache
-	if ces, ok = c.desiredCESs.getCESTracker(cesName); !ok {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: cesName,
-		}).Error("Unable to find the CES in local cache")
-		return
-	}
-
-	ces.backendMutex.Lock()
-	defer ces.backendMutex.Unlock()
-	// Delete removed CEPs from caches.
-	for cn := range remCEPs {
-		if _, ok = ces.removedCEPs[cn]; ok {
-			// Delete the CEP-to-CES entry only if CEP is batched in same CES.
-			// We have a corner case, at runtime if CEP Identity is changed, based on
-			// batching mode, we may remove the CEP from CES, re-inser the CEP in new
-			// CES. In this case, change in CEP Identity translates into
-			// 1. Remove the CEP from a CES
-			// 2. Insert the CEP in a new CES
-			// hence, CEP-to-CES map should be checked to see it has correct CEP-CES mapping
-			if cesNameFromCEPMap, _ := c.desiredCESs.getCESName(cn); cesNameFromCEPMap == cesName {
-				c.desiredCESs.deleteCEP(cn)
-			}
-			delete(ces.removedCEPs, cn)
-		}
-	}
-
-	// If there are no CEPs are packed in CES, mark for delete.
-	if len(ces.ces.Endpoints) == 0 && len(ces.removedCEPs) == 0 {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: cesName,
-		}).Debug("Remove CES from local cache")
-		// On next DeleteSync, Delete this CES with api-server.
-		c.insertCESInWorkQueue(ces, DefaultCESSyncTime)
-	}
-}
-
-func (c *cesMgr) getCESMetricCountersAndClear(cesName string) (cepInsert int64, cepRemove int64) {
-	ces, exists := c.desiredCESs.getCESTracker(cesName)
-	if !exists {
-		return
-	}
-
-	ces.backendMutex.Lock()
-	defer ces.backendMutex.Unlock()
-	cepInsert = ces.cepInserted
-	cepRemove = ces.cepRemoved
-	ces.cepInserted = 0
-	ces.cepRemoved = 0
-
-	return
-}
-
-// If exists, remove CES object from cache. deleteCESFromCache is called after successful removal from
-// apiserver.
-func (c *cesManagerIdentity) deleteCESFromCache(cesName string) {
-	if !c.desiredCESs.hasCESName(cesName) {
-		log.WithFields(logrus.Fields{
-			logfields.CESName: cesName,
-		}).Debug("Failed to retrieve CES object in local cache.")
-		return
-	}
-
-	c.identityLock.Lock()
-	identity := c.cesToIdentity[cesName]
-	for i, ces := range c.identityToCES[identity] {
-		if cesName == ces.ces.GetName() {
-			c.identityToCES[identity] = append(c.identityToCES[identity][:i],
-				c.identityToCES[identity][i+1:]...)
-
-			if len(c.identityToCES[identity]) == 0 {
-				delete(c.identityToCES, identity)
-			}
-			break
-		}
-	}
-	delete(c.cesToIdentity, cesName)
-	c.identityLock.Unlock()
-	c.desiredCESs.deleteCES(cesName)
-}
-
-// InsertCEPInCache is used to insert CEP in local cache, this may result in creating a new
+// UpdateCEPMapping is used to insert CEP in local cache, this may result in creating a new
 // CES object or updating an existing CES object. CEPs are grouped based on CEP identity.
-func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint, ns string) string {
+func (c *cesManagerIdentity) UpdateCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) []CESName {
 	// check the given cep is already exists in any of the CES.
 	// if yes, compare the given CEP Identity with the CEPs stored in CES.
 	// If they are same UPDATE the CEP in the CES. This will trigger CES UPDATE to k8s-apiserver.
@@ -607,133 +193,125 @@ func (c *cesManagerIdentity) InsertCEPInCache(cep *cilium_v2.CoreCiliumEndpoint,
 	// 1) CES UPDATE to k8s-apiserver, removing CEP in old CES
 	// 2) CES CREATE to k8s-apiserver, inserting the given CEP in a new CES or
 	// 3) CES UPDATE to k8s-apiserver, inserting the given CEP in existing CES
-	if cesName, exists := c.desiredCESs.getCESName(GetCEPNameFromCCEP(cep, ns)); exists {
+	log.WithFields(logrus.Fields{
+		logfields.CEPName: GetCEPNameFromCCEP(cep, ns),
+	}).Debug("Insert CEP in local cache")
+	cepName := CEPName(GetCEPNameFromCCEP(cep, ns))
+	var cesName CESName
+	var exists bool
+	removedFromCES := CESName("")
+	if cesName, exists = c.mapping.getCESName(cepName); exists {
 		if c.cesToIdentity[cesName] != cep.IdentityID {
-			c.RemoveCEPFromCache(GetCEPNameFromCCEP(cep, ns), DelayedCESSyncTime)
+			log.WithFields(logrus.Fields{
+				logfields.CEPName: cepName,
+				logfields.CESName: cesName,
+			}).Debug("CEP already mapped to CES but identity has changed")
+			removedFromCES = cesName
+			c.mapping.deleteCEP(cepName)
 		} else {
-			if ces, ok := c.desiredCESs.getCESTracker(cesName); ok {
-				// add a cep into the ces
-				c.addCEPtoCES(cep, ces)
-				return cesName
-			} else {
-				log.WithFields(logrus.Fields{
-					logfields.CESName: cesName,
-				}).Debug("Attempted to InsertCEPInCache non-existent cesName,skipping")
-			}
+			log.WithFields(logrus.Fields{
+				logfields.CEPName: cepName,
+				logfields.CESName: cesName,
+			}).Debug("CEP already mapped to CES")
+			return []CESName{cesName}
 		}
 	}
 
 	// If given cep object isn't packed in any of the CES. find a new ces
 	// to pack this cep.
-	cb, cesName := func() (*cesTracker, string) {
-		// The identityLock and backendMutex locks always need to be acquired in the
-		// same order to avoid deadlocks. First identityLock and then backendMutex,
-		// because identityLock is a higher level lock of cesManagerIdentity which
-		// contains cesTrackers with backendMutex locks within it.
-		c.identityLock.RLock()
-		// get first available CES
-		if cess, exist := c.identityToCES[cep.IdentityID]; exist {
-			for _, ces := range cess {
-				ces.backendMutex.RLock()
-				if len(ces.ces.Endpoints) >= c.maxCEPsInCES || len(ces.ces.Endpoints) == 0 {
-					ces.backendMutex.RUnlock()
-					continue
-				}
-				defer ces.backendMutex.RUnlock()
-				defer c.identityLock.RUnlock()
-				return ces, ces.ces.GetName()
-			}
-		}
-		c.identityLock.RUnlock()
-
-		// allocate a new cesTracker and return
-		ces := c.createCES("")
-		// Update the namespace to CES
-		ces.ces.Namespace = ns
-
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	cesName = c.getLargestAvailableCESForIdentity(cep.IdentityID, ns)
+	if cesName == "" {
+		cesName = c.createCES("", ns)
 		// Update the identityToCES and cesToIdentity maps respectively.
-		c.identityLock.Lock()
-		c.identityToCES[cep.IdentityID] = append(c.identityToCES[cep.IdentityID], ces)
-		c.cesToIdentity[ces.ces.GetName()] = cep.IdentityID
-		c.identityLock.Unlock()
-
-		return ces, ces.ces.GetName()
-	}()
-
-	// Cache CEP name with newly allocated CES.
-	c.desiredCESs.insertCEP(GetCEPNameFromCCEP(cep, ns), cesName)
-
-	// Queue the CEP in CES
-	c.addCEPtoCES(cep, cb)
-	return cesName
+		c.identityToCES[cep.IdentityID] = append(c.identityToCES[cep.IdentityID], cesName)
+		c.cesToIdentity[cesName] = cep.IdentityID
+	}
+	c.mapping.insertCEP(cepName, cesName)
+	log.WithFields(logrus.Fields{
+		logfields.CEPName: cepName,
+		logfields.CESName: cesName,
+	}).Debug("CEP mapped to CES")
+	return []CESName{removedFromCES, cesName}
 }
 
-// updateCESInCache function copies the ciliumEndpoint object in local cache. if isDeepCopy flag is set,
-// whole CoreCiliumEndpoint object stored in local cache.
-// There are two scenarios updateCESInCache is called.
-// 1) During operator warm boot[after crash or software upgrade], CES controller sync CES states from
-// api-server to cache. In this case, isDeepCopy set to true to copy entire CEP object locally.
-// 2) During runtime, reconciler sync current state with API server and update metadata only.
-// isDeepCopy flag is set to false.
-func (c *cesManagerIdentity) updateCESInCache(srcCES *cilium_v2.CiliumEndpointSlice, isDeepCopy bool) {
-	if ces, ok := c.desiredCESs.getCESTracker(srcCES.GetName()); ok {
-		// The identityLock and backendMutex locks always need to be acquired in the
-		// same order to avoid deadlocks. First identityLock and then backendMutex,
-		// because identityLock is a higher level lock of cesManagerIdentity which
-		// contains cesTrackers with backendMutex locks within it.
-		c.identityLock.Lock()
-		defer c.identityLock.Unlock()
-		ces.backendMutex.Lock()
-		defer ces.backendMutex.Unlock()
-		if !isDeepCopy {
-			ces.ces.ObjectMeta = srcCES.ObjectMeta
-		} else {
-			ces.ces = srcCES
-			_, exist := c.cesToIdentity[srcCES.GetName()]
-			for _, cep := range ces.ces.Endpoints {
-				// Update the identityToCES and cesToIdentity maps respectively.
-				if !exist {
-					c.identityToCES[cep.IdentityID] = append(c.identityToCES[cep.IdentityID], ces)
-					c.cesToIdentity[srcCES.GetName()] = cep.IdentityID
-					exist = true
+func (c *cesManagerIdentity) getLargestAvailableCESForIdentity(id int64, ns string) CESName {
+	largestCEPCount := 0
+	selectedCES := CESName("")
+	if cess, exist := c.identityToCES[id]; exist {
+		for _, ces := range cess {
+			cepCount := c.mapping.countCEPsInCES(ces)
+			if cepCount < c.maxCEPsInCES && cepCount > largestCEPCount && c.mapping.getCESData(ces).ns == ns {
+				selectedCES = ces
+				largestCEPCount = cepCount
+				if largestCEPCount == c.maxCEPsInCES-1 {
+					break
 				}
-				// Update the desiredCESs, to reflect all CEPs are packed in a CES
-				c.desiredCESs.insertCEP(GetCEPNameFromCCEP(&cep, ces.ces.Namespace), srcCES.GetName())
 			}
 		}
-	} else {
+	}
+	return selectedCES
+}
+
+func (c *cesManagerIdentity) RemoveCEPMapping(cep *cilium_v2.CoreCiliumEndpoint, ns string) CESName {
+	log.WithFields(logrus.Fields{
+		logfields.CEPName: GetCEPNameFromCCEP(cep, ns),
+	}).Debug("Removing CEP from local cache")
+	cepName := CEPName(GetCEPNameFromCCEP(cep, ns))
+	cesName, exists := c.mapping.getCESName(cepName)
+	if exists {
 		log.WithFields(logrus.Fields{
-			logfields.CESName: srcCES.GetName(),
-		}).Debug("Attempted to updateCESInCache non-existent cesName , skipping")
+			logfields.CEPName: GetCEPNameFromCCEP(cep, ns),
+			logfields.CESName: cesName,
+		}).Debug("Removing CEP from CES")
+		c.mapping.deleteCEP(cepName)
+		if c.mapping.countCEPsInCES(cesName) == 0 {
+			c.mutex.Lock()
+			defer c.mutex.Unlock()
+			if c.mapping.countCEPsInCES(cesName) == 0 {
+				c.removeCESToIdentity(cep.IdentityID, cesName)
+				c.mapping.deleteCES(cesName)
+			}
+		}
+		return cesName
 	}
+	return ""
 }
 
-// Insert the ces in workqueue
-func (c *cesMgr) insertCESInWorkQueue(ces *cesTracker, baseDelay time.Duration) {
-	// If CES insert time is not zero, save current time.
-	if ces.cesInsertedAt.IsZero() {
-		ces.cesInsertedAt = time.Now()
+func (c *cesManagerIdentity) removeCESToIdentity(id int64, cesName CESName) {
+	cesSlice := c.identityToCES[id]
+	for i, ces := range cesSlice {
+		if ces == cesName {
+			cesSlice[i] = cesSlice[len(cesSlice)-1]
+		}
 	}
-
-	c.queue.AddAfter(ces.ces.GetName(), baseDelay)
+	c.identityToCES[id] = cesSlice
+	delete(c.cesToIdentity, cesName)
 }
 
-// Return the CES queue delay in seconds and reset cesInsert time.
-func (c *cesMgr) getCESQueueDelayInSeconds(cesName string) (diff float64) {
-	ces, exists := c.desiredCESs.getCESTracker(cesName)
-	if !exists {
-		return
-	}
+func (c *cesMgr) initializeMappingForCES(ces *cilium_v2.CiliumEndpointSlice) CESName {
+	return c.createCES(ces.Name, ces.Namespace)
+}
 
-	ces.backendMutex.Lock()
-	defer ces.backendMutex.Unlock()
-	timeSinceCESQueued := time.Since(ces.cesInsertedAt)
-	if !ces.cesInsertedAt.IsZero() {
-		var t time.Time
-		// Reset the cesInsertedAt value
-		ces.cesInsertedAt = t
-		diff = timeSinceCESQueued.Seconds()
-	}
+func (c *cesMgr) initializeMappingCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ns string, ces CESName) {
+	cepName := CEPName(GetCEPNameFromCCEP(cep, ns))
+	c.mapping.insertCEP(cepName, ces)
+}
 
-	return
+func (c *cesMgr) getCEPCountInCES(ces CESName) int {
+	return c.mapping.countCEPsInCES(ces)
+}
+
+func (c *cesMgr) getCESData(ces CESName) CESData {
+	return c.mapping.getCESData(ces)
+}
+
+func (c *cesMgr) getCEPinCES(ces CESName) []CEPName {
+	return c.mapping.getCEPsInCES(ces)
+}
+
+func (c *cesMgr) isCEPinCES(cep CEPName, ces CESName) bool {
+	mappedCES, exists := c.mapping.getCESName(cep)
+	return exists && string(mappedCES) == string(ces)
 }

--- a/operator/pkg/ciliumendpointslice/manager_test.go
+++ b/operator/pkg/ciliumendpointslice/manager_test.go
@@ -6,8 +6,9 @@ package ciliumendpointslice
 import (
 	"testing"
 
-	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/stretchr/testify/assert"
+
+	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
 func getCEP(name string, id int64) *capi_v2a1.CoreCiliumEndpoint {
@@ -19,13 +20,13 @@ func getCEP(name string, id int64) *capi_v2a1.CoreCiliumEndpoint {
 
 func TestFCFSManager(t *testing.T) {
 	t.Run("Test adding new CEP to map", func(*testing.T) {
-		m := newCESManagerFcfs(2).(*cesManagerFcfs)
+		m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		assert.Equal(t, 1, m.mapping.getCESCount(), "Total number of CESs allocated is 1")
 		assert.Equal(t, 1, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test creating enough CESs", func(*testing.T) {
-		m := newCESManagerFcfs(2).(*cesManagerFcfs)
+		m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c3", 0), "ns")
@@ -35,7 +36,7 @@ func TestFCFSManager(t *testing.T) {
 		assert.Equal(t, 5, m.mapping.countCEPs(), "Total number of CEPs inserted is 5")
 	})
 	t.Run("Test keeping the CEPs from different namespaces in different CESs", func(*testing.T) {
-		m := newCESManagerFcfs(5).(*cesManagerFcfs)
+		m := newCESManagerFcfs(5, log).(*cesManagerFcfs)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns1")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns2")
 		m.UpdateCEPMapping(getCEP("c3", 0), "ns3")
@@ -45,14 +46,14 @@ func TestFCFSManager(t *testing.T) {
 		assert.Equal(t, 5, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test keeping the same mapping", func(*testing.T) {
-		m := newCESManagerFcfs(2).(*cesManagerFcfs)
+		m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c1", 5), "ns")
 		assert.Equal(t, 1, m.mapping.getCESCount(), "Total number of CESs allocated is 1")
 		assert.Equal(t, 1, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test reusing CES", func(*testing.T) {
-		m := newCESManagerFcfs(2).(*cesManagerFcfs)
+		m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns")
 		m.RemoveCEPMapping(getCEP("c1", 0), "ns")
@@ -68,13 +69,13 @@ func TestFCFSManager(t *testing.T) {
 
 func TestIdentityManager(t *testing.T) {
 	t.Run("Test adding new CEP to map", func(*testing.T) {
-		m := newCESManagerIdentity(2).(*cesManagerIdentity)
+		m := newCESManagerIdentity(2, log).(*cesManagerIdentity)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		assert.Equal(t, 1, m.mapping.getCESCount(), "Total number of CESs allocated is 1")
 		assert.Equal(t, 1, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test creating enough CESs", func(*testing.T) {
-		m := newCESManagerIdentity(2).(*cesManagerIdentity)
+		m := newCESManagerIdentity(2, log).(*cesManagerIdentity)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c3", 0), "ns")
@@ -84,7 +85,7 @@ func TestIdentityManager(t *testing.T) {
 		assert.Equal(t, 5, m.mapping.countCEPs(), "Total number of CEPs inserted is 5")
 	})
 	t.Run("Test keeping the CEPs from different namespaces in different CESs", func(*testing.T) {
-		m := newCESManagerIdentity(5).(*cesManagerIdentity)
+		m := newCESManagerIdentity(5, log).(*cesManagerIdentity)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns1")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns2")
 		m.UpdateCEPMapping(getCEP("c3", 0), "ns3")
@@ -94,7 +95,7 @@ func TestIdentityManager(t *testing.T) {
 		assert.Equal(t, 5, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test grouping by id", func(*testing.T) {
-		m := newCESManagerIdentity(2).(*cesManagerIdentity)
+		m := newCESManagerIdentity(2, log).(*cesManagerIdentity)
 		m.UpdateCEPMapping(getCEP("c1", 1), "ns")
 		m.UpdateCEPMapping(getCEP("c2", 2), "ns")
 		m.UpdateCEPMapping(getCEP("c3", 3), "ns")
@@ -104,21 +105,21 @@ func TestIdentityManager(t *testing.T) {
 		assert.Equal(t, 5, m.mapping.countCEPs(), "Total number of CEPs inserted is 5")
 	})
 	t.Run("Test keeping the same mapping", func(*testing.T) {
-		m := newCESManagerIdentity(2).(*cesManagerIdentity)
+		m := newCESManagerIdentity(2, log).(*cesManagerIdentity)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		assert.Equal(t, 1, m.mapping.getCESCount(), "Total number of CESs allocated is 1")
 		assert.Equal(t, 1, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test moving CEP when ID changed", func(*testing.T) {
-		m := newCESManagerIdentity(2).(*cesManagerIdentity)
+		m := newCESManagerIdentity(2, log).(*cesManagerIdentity)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c1", 1), "ns")
 		assert.Equal(t, 2, m.mapping.getCESCount(), "Total number of CESs allocated is 1")
 		assert.Equal(t, 1, m.mapping.countCEPs(), "Total number of CEPs inserted is 1")
 	})
 	t.Run("Test reusing CES", func(*testing.T) {
-		m := newCESManagerIdentity(2).(*cesManagerIdentity)
+		m := newCESManagerIdentity(2, log).(*cesManagerIdentity)
 		m.UpdateCEPMapping(getCEP("c1", 0), "ns")
 		m.UpdateCEPMapping(getCEP("c2", 0), "ns")
 		m.RemoveCEPMapping(getCEP("c1", 0), "ns")

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -7,9 +7,14 @@ import (
 	"context"
 
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
 
-	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/operator/metrics"
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/k8s"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
@@ -17,8 +22,9 @@ import (
 // reconciler is used to sync the current (i.e. desired) state of the CESs in datastore into current state CESs in the k8s-apiserver.
 // The source of truth is in local datastore.
 type reconciler struct {
-	client     clientset.CiliumV2alpha1Interface
-	cesManager operations
+	client              clientset.CiliumV2alpha1Interface
+	cesManager          operations
+	ciliumEndpointStore cache.Store
 }
 
 // newReconciler creates and initializes a new reconciler.
@@ -29,71 +35,169 @@ func newReconciler(client clientset.CiliumV2alpha1Interface, cesMgr operations) 
 	}
 }
 
-// Create a new CES in api-server.
-func (r *reconciler) reconcileCESCreate(cesToCreate string) (err error) {
-	var retCES, ces *cilium_v2.CiliumEndpointSlice
-	// Get the copy of CES from the cesManager
-	if ces, err = r.cesManager.getCESCopyFromCache(cesToCreate); err != nil {
+func (r *reconciler) reconcileCES(ces string) (err error) {
+	cesName := CESName(ces)
+	desiredCEPsNumber := r.cesManager.getCEPCountInCES(cesName)
+	if operatorOption.Config.EnableMetrics {
+		metrics.CiliumEndpointSliceDensity.Observe(float64(desiredCEPsNumber))
+	}
+	// Check the CES exists is in cesStore i.e. in api-server copy of CESs, if exist update or delete the CES.
+	obj, exists, err := ceSliceStore.GetByKey(ces)
+	if err != nil {
 		return
 	}
+	var cesObj *cilium_v2a1.CiliumEndpointSlice = nil
+	if obj != nil {
+		cesObj = obj.(*cilium_v2a1.CiliumEndpointSlice)
+	}
+	if !exists && desiredCEPsNumber > 0 {
+		return r.reconcileCESCreate(cesName)
+	} else if exists && desiredCEPsNumber > 0 {
+		return r.reconcileCESUpdate(cesName, cesObj)
+	} else if exists && desiredCEPsNumber == 0 {
+		return r.reconcileCESDelete(cesObj)
+	} else { //!exist && desiredCEPsNumber == 0 => no op
+		return nil
+	}
+}
 
-	if len(ces.Endpoints) == 0 {
-		// The CES is empty, delete ces information from cache rather than creating
-		// empty CES.
-		r.cesManager.deleteCESFromCache(cesToCreate)
-		return
+// Create a new CES in api-server.
+func (r *reconciler) reconcileCESCreate(cesName CESName) (err error) {
+	log.WithFields(logrus.Fields{
+		logfields.CESName: cesName,
+	}).Debug("Reconciling CES Create.")
+	ceps := r.cesManager.getCEPinCES(cesName)
+	if operatorOption.Config.EnableMetrics {
+		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPInsert).Observe(float64(len(ceps)))
+	}
+	newCES := &cilium_v2a1.CiliumEndpointSlice{
+		TypeMeta: meta_v1.TypeMeta{
+			Kind:       "CiliumEndpointSlice",
+			APIVersion: cilium_v2.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: string(cesName),
+		},
+		Endpoints: make([]cilium_v2a1.CoreCiliumEndpoint, 0, len(ceps)),
+	}
+
+	cesData := r.cesManager.getCESData(cesName)
+	newCES.Namespace = cesData.ns
+
+	for _, cepName := range ceps {
+		ccep := r.getCoreEndpointFromStore(cepName)
+		if ccep != nil {
+			newCES.Endpoints = append(newCES.Endpoints, *ccep)
+		}
 	}
 
 	// Call the client API, to Create CES
-	if retCES, err = r.client.CiliumEndpointSlices().Create(
-		context.TODO(), ces, metav1.CreateOptions{}); err != nil {
+	if _, err = r.client.CiliumEndpointSlices().Create(
+		context.TODO(), newCES, meta_v1.CreateOptions{}); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
-			logfields.CESName: cesToCreate,
+			logfields.CESName: newCES.Name,
 		}).Info("Unable to create CiliumEndpointSlice in k8s-apiserver")
-		return
 	}
-	// Update local datastore CES with latest object metadata values.
-	r.cesManager.updateCESInCache(retCES, false)
 	return
 }
 
 // Update an existing CES
-func (r *reconciler) reconcileCESUpdate(cesToUpdate string) (err error) {
-	var retCES, ces *cilium_v2.CiliumEndpointSlice
+func (r *reconciler) reconcileCESUpdate(cesName CESName, cesObj *cilium_v2a1.CiliumEndpointSlice) (err error) {
+	log.WithFields(logrus.Fields{
+		logfields.CESName: cesName,
+	}).Debug("Reconciling CES Update.")
+	updatedCES := cesObj.DeepCopy()
+	cesEqual := true
+	cepInserted := 0
+	cepRemoved := 0
+	cepUpdated := 0
 
-	// Before syncing with ApiServer, get list of removed CEPs
-	remCEPs := r.cesManager.getRemovedCEPs(cesToUpdate)
-	// Get the copy of CES from the cesManager
-	if ces, err = r.cesManager.getCESCopyFromCache(cesToUpdate); err != nil {
-		return
+	// Names of all CEPs that should be in the CES
+	cepsAssignedToCES := r.cesManager.getCEPinCES(cesName)
+	// Final endpoints list. CES endpoints will be set to this list.
+	updatedEndpoints := make([]cilium_v2a1.CoreCiliumEndpoint, 0, len(cepsAssignedToCES))
+	cepNameToCEP := make(map[CEPName]*cilium_v2a1.CoreCiliumEndpoint)
+	// Get the CEPs objects from the CEP Store and map the names to them
+	for _, cepName := range cepsAssignedToCES {
+		ccep := r.getCoreEndpointFromStore(cepName)
+		if ccep != nil {
+			updatedEndpoints = append(updatedEndpoints, *ccep)
+			cepNameToCEP[cepName] = ccep
+		}
+		cepInserted = cepInserted + 1
+	}
+	// Grab metrics about number of inserted, updated and deleted CEPs and
+	// determine whether CES needs to be updated at all.
+	for _, ep := range updatedCES.Endpoints {
+		epName := CEPName(GetCEPNameFromCCEP(&ep, updatedCES.Namespace))
+		if r.cesManager.isCEPinCES(epName, cesName) {
+			cepInserted = cepInserted - 1
+			if !ep.DeepEqual(cepNameToCEP[epName]) {
+				cesEqual = false
+				cepUpdated = cepUpdated + 1
+			}
+		} else {
+			cesEqual = false
+			cepRemoved = cepRemoved + 1
+		}
+	}
+	updatedCES.Endpoints = updatedEndpoints
+	log.WithFields(logrus.Fields{
+		logfields.CESName: cesName,
+	}).Debugf("Inserted %d endpoints, updated %d endpoints, removed %d endpoints", cepInserted, cepUpdated, cepRemoved)
+
+	data := r.cesManager.getCESData(cesName)
+	if updatedCES.Namespace != data.ns {
+		updatedCES.Namespace = data.ns
+		cesEqual = false
 	}
 
-	// Call the client API, to Create CESs
-	if retCES, err = r.client.CiliumEndpointSlices().Update(
-		context.TODO(), ces, metav1.UpdateOptions{}); err != nil {
-		log.WithError(err).WithFields(logrus.Fields{
-			logfields.CESName: cesToUpdate,
-		}).Info("Unable to update CiliumEndpointSlice in k8s-apiserver")
-		return
+	if operatorOption.Config.EnableMetrics {
+		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPInsert).Observe(float64(cepInserted + cepUpdated))
+		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPRemove).Observe(float64(cepRemoved))
 	}
-	// Update local datastore CES with latest object metadata values.
-	r.cesManager.updateCESInCache(retCES, false)
-	// Since local copy of CES is synced with api-server, we don't need to track anymore removed
-	// CEPS.
-	r.cesManager.clearRemovedCEPs(cesToUpdate, remCEPs)
+
+	if !cesEqual {
+		log.WithFields(logrus.Fields{
+			logfields.CESName: cesName,
+		}).Debug("CES changed, updating")
+		// Call the client API, to Create CESs
+		if _, err = r.client.CiliumEndpointSlices().Update(
+			context.TODO(), updatedCES, meta_v1.UpdateOptions{}); err != nil {
+			log.WithError(err).WithFields(logrus.Fields{
+				logfields.CESName: updatedCES.Name,
+			}).Info("Unable to update CiliumEndpointSlice in k8s-apiserver")
+		}
+	} else {
+		log.WithFields(logrus.Fields{
+			logfields.CESName: cesName,
+		}).Debug("CES up to date, skipping update")
+	}
 	return
 }
 
 // Delete the CES.
-func (r *reconciler) reconcileCESDelete(cesToDelete string) (err error) {
+func (r *reconciler) reconcileCESDelete(ces *cilium_v2a1.CiliumEndpointSlice) (err error) {
+	log.WithFields(logrus.Fields{
+		logfields.CESName: ces.Name,
+	}).Debug("Reconciling CES Delete.")
+	if operatorOption.Config.EnableMetrics {
+		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPRemove).Observe(float64(len(ces.Endpoints)))
+	}
 	if err = r.client.CiliumEndpointSlices().Delete(
-		context.TODO(), cesToDelete, metav1.DeleteOptions{}); err != nil {
+		context.TODO(), ces.Name, meta_v1.DeleteOptions{}); err != nil {
 		log.WithError(err).WithFields(logrus.Fields{
-			logfields.CESName: cesToDelete,
+			logfields.CESName: ces.Name,
 		}).Info("Unable to delete CiliumEndpointSlice in k8s-apiserver")
 		return
 	}
-	// Delete ces information from cache
-	r.cesManager.deleteCESFromCache(cesToDelete)
 	return
+}
+
+func (r *reconciler) getCoreEndpointFromStore(cepName CEPName) *cilium_v2a1.CoreCiliumEndpoint {
+	cepObj, exists, err := r.ciliumEndpointStore.GetByKey(string(cepName))
+	if err == nil && exists {
+		return k8s.ConvertCEPToCoreCEP(cepObj.(*cilium_v2.CiliumEndpoint))
+	}
+	return nil
 }

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -5,216 +5,149 @@ package ciliumendpointslice
 
 import (
 	"testing"
-
+	
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/time/rate"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8stesting "k8s.io/client-go/testing"
-	"k8s.io/client-go/util/workqueue"
+	k8sTesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
 
-	capi_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	fake "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/fake"
-	clientset "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/client"
 )
 
-const (
-	CESReconcilerUID      = "12345"
-	CESReconcilerGenerate = 9090
-)
+func TestReconcileCreate(t *testing.T) {
+	m := newCESManagerFcfs(2).(*cesManagerFcfs)
+	c, _ := client.NewFakeClientset()
 
-var (
-	// Test CES object, with 2 CEPs packed in it.
-	CES1 = &capi_v2a1.CiliumEndpointSlice{
-		TypeMeta: meta_v1.TypeMeta{
-			Kind:       "CiliumEndpointSlice",
-			APIVersion: capi_v2a1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "CES-apple-one",
-		},
-		Endpoints: []capi_v2a1.CoreCiliumEndpoint{
-			{
-				Name:       "cilium-abcd-123",
-				IdentityID: 364748,
-			},
-			{
-				Name:       "cilium-abcd-456",
-				IdentityID: 364748,
-			},
-		},
-	}
+	var createdSlice *v2alpha1.CiliumEndpointSlice
+	c.CiliumFakeClientset.PrependReactor("create", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		pa := action.(k8sTesting.CreateAction)
+		createdSlice = pa.GetObject().(*v2alpha1.CiliumEndpointSlice)
+		return true, nil, nil
+	})
+	r := newReconciler(c.CiliumFakeClientset.CiliumV2alpha1(), m)
+	r.ciliumEndpointStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+	ceSliceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
-	// Test CES object, with 2 CEPs packed in it.
-	CES2 = &capi_v2a1.CiliumEndpointSlice{
-		TypeMeta: meta_v1.TypeMeta{
-			Kind:       "CiliumEndpointSlice",
-			APIVersion: capi_v2a1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "CES-apple-two",
-		},
-		Endpoints: []capi_v2a1.CoreCiliumEndpoint{
-			{
-				Name:       "cilium-nfgt-123",
-				IdentityID: 364748,
-			},
-			{
-				Name:       "cilium-nfgt-456",
-				IdentityID: 364748,
-			},
-		},
-	}
+	cep1 := createStoreEndpoint("cep1", "ns", 1)
+	r.ciliumEndpointStore.Add(cep1)
+	cep2 := createStoreEndpoint("cep2", "ns", 2)
+	r.ciliumEndpointStore.Add(cep2)
+	cep3 := createStoreEndpoint("cep3", "ns", 2)
+	r.ciliumEndpointStore.Add(cep3)
+	m.mapping.insertCES("ces1", "ns")
+	m.mapping.insertCES("ces2", "ns")
+	m.mapping.insertCEP("ns/cep1", "ces1")
+	m.mapping.insertCEP("ns/cep2", "ces1")
+	m.mapping.insertCEP("ns/cep3", "ces2")
+	r.reconcileCES("ces1")
 
-	// Test CES object, with 2 CEPs packed in it.
-	CES3 = &capi_v2a1.CiliumEndpointSlice{
-		TypeMeta: meta_v1.TypeMeta{
-			Kind:       "CiliumEndpointSlice",
-			APIVersion: capi_v2a1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "CES-apple-three",
-		},
-		Endpoints: []capi_v2a1.CoreCiliumEndpoint{
-			{
-				Name:       "cilium-tkld-123",
-				IdentityID: 364748,
-			},
-			{
-				Name:       "cilium-tkld-456",
-				IdentityID: 364748,
-			},
-		},
-	}
-
-	// Test CES object, with no CEPs packed in it.
-	emptyCES = &capi_v2a1.CiliumEndpointSlice{
-		TypeMeta: meta_v1.TypeMeta{
-			Kind:       "CiliumEndpointSlice",
-			APIVersion: capi_v2a1.SchemeGroupVersion.String(),
-		},
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "CES-empty",
-		},
-		Endpoints: []capi_v2a1.CoreCiliumEndpoint{},
-	}
-)
-
-func newQueue() workqueue.RateLimitingInterface {
-	return workqueue.NewNamedRateLimitingQueue(workqueue.NewMaxOfRateLimiter(
-		workqueue.NewItemExponentialFailureRateLimiter(defaultSyncBackOff, maxSyncBackOff),
-		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(5), 10)}), "fakeQueue")
+	assert.Equal(t, "ces1", createdSlice.Name)
+	assert.Equal(t, 2, len(createdSlice.Endpoints))
+	assert.Equal(t, "ns", createdSlice.Namespace)
+	eps := []string{createdSlice.Endpoints[0].Name, createdSlice.Endpoints[1].Name}
+	assert.Contains(t, eps, "cep1")
+	assert.Contains(t, eps, "cep2")
 }
 
-// Create a fake cilium Client and add prepend reactor for Create/Update/Delete
-func fakeCiliumClient() clientset.CiliumV2alpha1Interface {
-	client := fake.NewSimpleClientset()
-	client.PrependReactor("create", "ciliumendpointslices", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
-		ciliumEndpointSlice := action.(k8stesting.CreateAction).GetObject().(*capi_v2a1.CiliumEndpointSlice)
-		ciliumEndpointSlice.UID = CESReconcilerUID
-		return false, ciliumEndpointSlice, nil
-	}))
-	client.PrependReactor("update", "ciliumendpointslices", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
-		ciliumEndpointSlice := action.(k8stesting.UpdateAction).GetObject().(*capi_v2a1.CiliumEndpointSlice)
-		ciliumEndpointSlice.Generation = CESReconcilerGenerate
-		return false, ciliumEndpointSlice, nil
-	}))
-	client.PrependReactor("delete", "ciliumendpointslices", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
-		return false, nil, nil
-	}))
-	return client.CiliumV2alpha1()
+func TestReconcileUpdate(t *testing.T) {
+	m := newCESManagerFcfs(2).(*cesManagerFcfs)
+	c, _ := client.NewFakeClientset()
+
+	var updatedSlice *v2alpha1.CiliumEndpointSlice
+	c.CiliumFakeClientset.PrependReactor("update", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		pa := action.(k8sTesting.UpdateAction)
+		updatedSlice = pa.GetObject().(*v2alpha1.CiliumEndpointSlice)
+		return true, nil, nil
+	})
+	r := newReconciler(c.CiliumFakeClientset.CiliumV2alpha1(), m)
+	r.ciliumEndpointStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+	ceSliceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+
+	cep1 := createStoreEndpoint("cep1", "ns", 1)
+	r.ciliumEndpointStore.Add(cep1)
+	cep2 := createStoreEndpoint("cep2", "ns", 2)
+	r.ciliumEndpointStore.Add(cep2)
+	cep3 := createStoreEndpoint("cep3", "ns", 2)
+	r.ciliumEndpointStore.Add(cep3)
+	ces1 := createStoreEndpointSlice("ces1", "ns", []v2alpha1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
+	ceSliceStore.Add(ces1)
+	m.mapping.insertCES("ces1", "ns")
+	m.mapping.insertCES("ces2", "ns")
+	m.mapping.insertCEP("ns/cep1", "ces1")
+	m.mapping.insertCEP("ns/cep2", "ces1")
+	m.mapping.insertCEP("ns/cep3", "ces2")
+	// ces1 contains cep1 and cep3, but it's mapped to cep1 and cep2
+	// so it's expected that after update it would contain cep1 and cep2
+	r.reconcileCES("ces1")
+
+	assert.Equal(t, "ces1", updatedSlice.Name)
+	assert.Equal(t, 2, len(updatedSlice.Endpoints))
+	assert.Equal(t, "ns", updatedSlice.Namespace)
+	eps := []string{updatedSlice.Endpoints[0].Name, updatedSlice.Endpoints[1].Name}
+	assert.Contains(t, eps, "cep1")
+	assert.Contains(t, eps, "cep2")
 }
 
-// Test Reconciler by creating CESs, Updating CESs and Deleting CESs
-func TestCiliumReconcile(t *testing.T) {
-	client := fakeCiliumClient()
+func TestReconcileDelete(t *testing.T) {
+	m := newCESManagerFcfs(2).(*cesManagerFcfs)
+	c, _ := client.NewFakeClientset()
 
-	// Store the CESs in local Datastore
-	m := newCESManagerFcfs(newQueue(), 2)
-	// Create a CES and updates the CES in local datastore.
-	// deepcopies the entire CES object in datastore.
-	m.createCES(CES1.Name)
-	m.updateCESInCache(CES1, true)
-	m.createCES(CES2.Name)
-	m.updateCESInCache(CES2, true)
-	m.createCES(CES3.Name)
-	m.updateCESInCache(CES3, true)
-
-	// List of CESs to be created in api-server
-	r := newReconciler(client, m)
-
-	// Create CESs, check errors from api-server and match CESs UID value returned
-	// from api-server with CESs in datastore.
-	t.Run("Create CESs, check for any errors and  compare returned value from api-server with local data", func(*testing.T) {
-		err := r.reconcileCESCreate(CES1.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Create request to api-server")
-		err = r.reconcileCESCreate(CES2.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Create request to api-server")
-		err = r.reconcileCESCreate(CES3.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Create request to api-server")
-		// Get CES from local datastore
-		ces, _ := m.getCESFromCache(CES1.Name)
-		assert.Equal(t, string(ces.GetUID()), CESReconcilerUID, "Returned CES UID from api-server should match with local CES UID")
-		// Get CES from local datastore
-		ces, _ = m.getCESFromCache(CES2.Name)
-		assert.Equal(t, string(ces.GetUID()), CESReconcilerUID, "Returned CES UID from api-server should match with local CES UID")
-		// Get CES from local datastore
-		ces, _ = m.getCESFromCache(CES3.Name)
-		assert.Equal(t, string(ces.GetUID()), CESReconcilerUID, "Returned CES UID from api-server should match with local CES UID")
+	var deletedSlice string
+	c.CiliumFakeClientset.PrependReactor("delete", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		pa := action.(k8sTesting.DeleteAction)
+		deletedSlice = pa.GetName()
+		return true, nil, nil
 	})
+	r := newReconciler(c.CiliumFakeClientset.CiliumV2alpha1(), m)
+	r.ciliumEndpointStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+	ceSliceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
-	t.Run("Attempt to create empty CES and check that it is not created", func(*testing.T) {
-		m.createCES(emptyCES.Name)
-		m.updateCESInCache(emptyCES, true)
-		err := r.reconcileCESCreate(emptyCES.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Create request to api-server")
-		ces, _ := m.getCESFromCache(emptyCES.Name)
-		// CES is empty, so it should be removed from cache instead of created in the api-server
-		assert.Equal(t, (*capi_v2a1.CiliumEndpointSlice)(nil), ces, "Empty CES was removed from cache rather than created in api-server")
+	cep1 := createStoreEndpoint("cep1", "ns", 1)
+	r.ciliumEndpointStore.Add(cep1)
+	cep2 := createStoreEndpoint("cep2", "ns", 2)
+	r.ciliumEndpointStore.Add(cep2)
+	cep3 := createStoreEndpoint("cep3", "ns", 2)
+	r.ciliumEndpointStore.Add(cep3)
+	ces1 := createStoreEndpointSlice("ces1", "ns", []v2alpha1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
+	ceSliceStore.Add(ces1)
+	m.mapping.insertCES("ces1", "ns")
+	m.mapping.insertCES("ces2", "ns")
+	m.mapping.insertCEP("ns/cep1", "ces2")
+	m.mapping.insertCEP("ns/cep2", "ces2")
+	m.mapping.insertCEP("ns/cep3", "ces2")
+	// ces1 contains cep1 and cep3, but it's mapped to nothing so it should be deleted
+	r.reconcileCES("ces1")
+
+	assert.Equal(t, "ces1", deletedSlice)
+}
+
+func TestReconcileNoop(t *testing.T) {
+	m := newCESManagerFcfs(2).(*cesManagerFcfs)
+	c, _ := client.NewFakeClientset()
+
+	noRequest := true
+	c.CiliumFakeClientset.PrependReactor("*", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+		noRequest = false
+		return true, nil, nil
 	})
+	r := newReconciler(c.CiliumFakeClientset.CiliumV2alpha1(), m)
+	r.ciliumEndpointStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
+	ceSliceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
-	// Update CESs, check errors from api-server and match CESs Generate value returned
-	// from api-server with CESs in datastore.
-	t.Run("Update CESs, check for any errors and  compare returned value from api-server with local data", func(*testing.T) {
-		err := r.reconcileCESUpdate(CES1.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Update request to api-server")
-		err = r.reconcileCESUpdate(CES2.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Update request to api-server")
-		err = r.reconcileCESUpdate(CES3.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Update request to api-server")
-		// Get CES from local datastore
-		ces, _ := m.getCESFromCache(CES1.Name)
-		assert.Equal(t, ces.Generation, int64(CESReconcilerGenerate), "Returned CES Generate from api-server should match with constant")
-		// Get CES from local datastore
-		ces, _ = m.getCESFromCache(CES2.Name)
-		assert.Equal(t, ces.Generation, int64(CESReconcilerGenerate), "Returned CES Generate from api-server should match with constant")
-		// Get CES from local datastore
-		ces, _ = m.getCESFromCache(CES3.Name)
-		assert.Equal(t, ces.Generation, int64(CESReconcilerGenerate), "Returned CES Generate from api-server should match with constant")
-	})
+	cep1 := createStoreEndpoint("cep1", "ns", 1)
+	r.ciliumEndpointStore.Add(cep1)
+	cep2 := createStoreEndpoint("cep2", "ns", 2)
+	r.ciliumEndpointStore.Add(cep2)
+	cep3 := createStoreEndpoint("cep3", "ns", 2)
+	r.ciliumEndpointStore.Add(cep3)
+	m.mapping.insertCES("ces1", "ns")
+	m.mapping.insertCES("ces2", "ns")
+	m.mapping.insertCEP("ns/cep1", "ces2")
+	m.mapping.insertCEP("ns/cep2", "ces2")
+	m.mapping.insertCEP("ns/cep3", "ces2")
+	// ces1 contains cep1 and cep3, but it's mapped to nothing so it should be deleted
+	r.reconcileCES("ces1")
 
-	// Delete CESs, check errors from api-server and match CESs and CEPs count
-	t.Run("Delete CESs, check errors from api-server and match CESs and CEPs count ", func(*testing.T) {
-		// Get CESs from local datastore and check it length
-		assert.Equal(t, m.getCESCount(), 3, "Check the total CES, this should match with value 3")
-		assert.Equal(t, m.getTotalCEPCount(), 6, "Check the total CES, this should match with value 6")
-
-		// reconcile with Server
-		err := r.reconcileCESDelete(CES1.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Delete request to api-server")
-		err = r.reconcileCESDelete(CES2.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Delete request to api-server")
-		err = r.reconcileCESDelete(CES3.Name)
-		// There should not be any error from api-server
-		assert.Equal(t, err, nil, "No error in CES Delete request to api-server")
-	})
+	assert.Equal(t, true, noRequest)
 }

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -4,43 +4,66 @@
 package ciliumendpointslice
 
 import (
+	"context"
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sTesting "k8s.io/client-go/testing"
-	"k8s.io/client-go/tools/cache"
 
+	"github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/client"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
+var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ces-controller")
+
 func TestReconcileCreate(t *testing.T) {
-	m := newCESManagerFcfs(2).(*cesManagerFcfs)
-	c, _ := client.NewFakeClientset()
+	var r *reconciler
+	var fakeClient k8sClient.FakeClientset
+	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
+	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+			fakeClient = *c
+			ciliumEndpoint = cep
+			ciliumEndpointSlice = ces
+			return nil
+		}),
+	)
+	hive.Start(context.Background())
+	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	cepStore, _ := ciliumEndpoint.Store(context.Background())
 
 	var createdSlice *v2alpha1.CiliumEndpointSlice
-	c.CiliumFakeClientset.PrependReactor("create", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+	fakeClient.CiliumFakeClientset.PrependReactor("create", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
 		pa := action.(k8sTesting.CreateAction)
 		createdSlice = pa.GetObject().(*v2alpha1.CiliumEndpointSlice)
 		return true, nil, nil
 	})
-	r := newReconciler(c.CiliumFakeClientset.CiliumV2alpha1(), m)
-	r.ciliumEndpointStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-	ceSliceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	cep1 := createStoreEndpoint("cep1", "ns", 1)
-	r.ciliumEndpointStore.Add(cep1)
+	cepStore.CacheStore().Add(cep1)
 	cep2 := createStoreEndpoint("cep2", "ns", 2)
-	r.ciliumEndpointStore.Add(cep2)
+	cepStore.CacheStore().Add(cep2)
 	cep3 := createStoreEndpoint("cep3", "ns", 2)
-	r.ciliumEndpointStore.Add(cep3)
-	m.mapping.insertCES("ces1", "ns")
-	m.mapping.insertCES("ces2", "ns")
-	m.mapping.insertCEP("ns/cep1", "ces1")
-	m.mapping.insertCEP("ns/cep2", "ces1")
-	m.mapping.insertCEP("ns/cep3", "ces2")
-	r.reconcileCES("ces1")
+	cepStore.CacheStore().Add(cep3)
+	m.mapping.insertCES(NewCESName("ces1"), "ns")
+	m.mapping.insertCES(NewCESName("ces2"), "ns")
+	m.mapping.insertCEP(NewCEPName("cep1", "ns"), NewCESName("ces1"))
+	m.mapping.insertCEP(NewCEPName("cep2", "ns"), NewCESName("ces1"))
+	m.mapping.insertCEP(NewCEPName("cep3", "ns"), NewCESName("ces2"))
+	r.reconcileCES(NewCESName("ces1"))
 
 	assert.Equal(t, "ces1", createdSlice.Name)
 	assert.Equal(t, 2, len(createdSlice.Endpoints))
@@ -48,38 +71,54 @@ func TestReconcileCreate(t *testing.T) {
 	eps := []string{createdSlice.Endpoints[0].Name, createdSlice.Endpoints[1].Name}
 	assert.Contains(t, eps, "cep1")
 	assert.Contains(t, eps, "cep2")
+
+	hive.Stop(context.Background())
 }
 
 func TestReconcileUpdate(t *testing.T) {
-	m := newCESManagerFcfs(2).(*cesManagerFcfs)
-	c, _ := client.NewFakeClientset()
+	var r *reconciler
+	var fakeClient k8sClient.FakeClientset
+	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
+	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+			fakeClient = *c
+			ciliumEndpoint = cep
+			ciliumEndpointSlice = ces
+			return nil
+		}),
+	)
+	hive.Start(context.Background())
+	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	cepStore, _ := ciliumEndpoint.Store(context.Background())
+	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
 
 	var updatedSlice *v2alpha1.CiliumEndpointSlice
-	c.CiliumFakeClientset.PrependReactor("update", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+	fakeClient.CiliumFakeClientset.PrependReactor("update", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
 		pa := action.(k8sTesting.UpdateAction)
 		updatedSlice = pa.GetObject().(*v2alpha1.CiliumEndpointSlice)
 		return true, nil, nil
 	})
-	r := newReconciler(c.CiliumFakeClientset.CiliumV2alpha1(), m)
-	r.ciliumEndpointStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-	ceSliceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	cep1 := createStoreEndpoint("cep1", "ns", 1)
-	r.ciliumEndpointStore.Add(cep1)
+	cepStore.CacheStore().Add(cep1)
 	cep2 := createStoreEndpoint("cep2", "ns", 2)
-	r.ciliumEndpointStore.Add(cep2)
+	cepStore.CacheStore().Add(cep2)
 	cep3 := createStoreEndpoint("cep3", "ns", 2)
-	r.ciliumEndpointStore.Add(cep3)
+	cepStore.CacheStore().Add(cep3)
 	ces1 := createStoreEndpointSlice("ces1", "ns", []v2alpha1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
-	ceSliceStore.Add(ces1)
-	m.mapping.insertCES("ces1", "ns")
-	m.mapping.insertCES("ces2", "ns")
-	m.mapping.insertCEP("ns/cep1", "ces1")
-	m.mapping.insertCEP("ns/cep2", "ces1")
-	m.mapping.insertCEP("ns/cep3", "ces2")
+	cesStore.CacheStore().Add(ces1)
+	m.mapping.insertCES(NewCESName("ces1"), "ns")
+	m.mapping.insertCES(NewCESName("ces2"), "ns")
+	m.mapping.insertCEP(NewCEPName("cep1", "ns"), NewCESName("ces1"))
+	m.mapping.insertCEP(NewCEPName("cep2", "ns"), NewCESName("ces1"))
+	m.mapping.insertCEP(NewCEPName("cep3", "ns"), NewCESName("ces2"))
 	// ces1 contains cep1 and cep3, but it's mapped to cep1 and cep2
 	// so it's expected that after update it would contain cep1 and cep2
-	r.reconcileCES("ces1")
+	r.reconcileCES(NewCESName("ces1"))
 
 	assert.Equal(t, "ces1", updatedSlice.Name)
 	assert.Equal(t, 2, len(updatedSlice.Endpoints))
@@ -87,67 +126,100 @@ func TestReconcileUpdate(t *testing.T) {
 	eps := []string{updatedSlice.Endpoints[0].Name, updatedSlice.Endpoints[1].Name}
 	assert.Contains(t, eps, "cep1")
 	assert.Contains(t, eps, "cep2")
+
+	hive.Stop(context.Background())
 }
 
 func TestReconcileDelete(t *testing.T) {
-	m := newCESManagerFcfs(2).(*cesManagerFcfs)
-	c, _ := client.NewFakeClientset()
+	var r *reconciler
+	var fakeClient k8sClient.FakeClientset
+	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
+	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+			fakeClient = *c
+			ciliumEndpoint = cep
+			ciliumEndpointSlice = ces
+			return nil
+		}),
+	)
+	hive.Start(context.Background())
+	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	cepStore, _ := ciliumEndpoint.Store(context.Background())
+	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
 
 	var deletedSlice string
-	c.CiliumFakeClientset.PrependReactor("delete", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+	fakeClient.CiliumFakeClientset.PrependReactor("delete", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
 		pa := action.(k8sTesting.DeleteAction)
 		deletedSlice = pa.GetName()
 		return true, nil, nil
 	})
-	r := newReconciler(c.CiliumFakeClientset.CiliumV2alpha1(), m)
-	r.ciliumEndpointStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-	ceSliceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	cep1 := createStoreEndpoint("cep1", "ns", 1)
-	r.ciliumEndpointStore.Add(cep1)
+	cepStore.CacheStore().Add(cep1)
 	cep2 := createStoreEndpoint("cep2", "ns", 2)
-	r.ciliumEndpointStore.Add(cep2)
+	cepStore.CacheStore().Add(cep2)
 	cep3 := createStoreEndpoint("cep3", "ns", 2)
-	r.ciliumEndpointStore.Add(cep3)
+	cepStore.CacheStore().Add(cep3)
 	ces1 := createStoreEndpointSlice("ces1", "ns", []v2alpha1.CoreCiliumEndpoint{createManagerEndpoint("cep1", 1), createManagerEndpoint("cep3", 2)})
-	ceSliceStore.Add(ces1)
-	m.mapping.insertCES("ces1", "ns")
-	m.mapping.insertCES("ces2", "ns")
-	m.mapping.insertCEP("ns/cep1", "ces2")
-	m.mapping.insertCEP("ns/cep2", "ces2")
-	m.mapping.insertCEP("ns/cep3", "ces2")
+	cesStore.CacheStore().Add(ces1)
+	m.mapping.insertCES(NewCESName("ces1"), "ns")
+	m.mapping.insertCES(NewCESName("ces2"), "ns")
+	m.mapping.insertCEP(NewCEPName("cep1", "ns"), NewCESName("ces2"))
+	m.mapping.insertCEP(NewCEPName("cep2", "ns"), NewCESName("ces2"))
+	m.mapping.insertCEP(NewCEPName("cep3", "ns"), NewCESName("ces2"))
 	// ces1 contains cep1 and cep3, but it's mapped to nothing so it should be deleted
-	r.reconcileCES("ces1")
+	r.reconcileCES(NewCESName("ces1"))
 
 	assert.Equal(t, "ces1", deletedSlice)
+
+	hive.Stop(context.Background())
 }
 
 func TestReconcileNoop(t *testing.T) {
-	m := newCESManagerFcfs(2).(*cesManagerFcfs)
-	c, _ := client.NewFakeClientset()
+	var r *reconciler
+	var fakeClient k8sClient.FakeClientset
+	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
+	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+			fakeClient = *c
+			ciliumEndpoint = cep
+			ciliumEndpointSlice = ces
+			return nil
+		}),
+	)
+	hive.Start(context.Background())
+	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	cepStore, _ := ciliumEndpoint.Store(context.Background())
 
 	noRequest := true
-	c.CiliumFakeClientset.PrependReactor("*", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
+	fakeClient.CiliumFakeClientset.PrependReactor("*", "*", func(action k8sTesting.Action) (handled bool, ret runtime.Object, err error) {
 		noRequest = false
 		return true, nil, nil
 	})
-	r := newReconciler(c.CiliumFakeClientset.CiliumV2alpha1(), m)
-	r.ciliumEndpointStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
-	ceSliceStore = cache.NewStore(cache.DeletionHandlingMetaNamespaceKeyFunc)
 
 	cep1 := createStoreEndpoint("cep1", "ns", 1)
-	r.ciliumEndpointStore.Add(cep1)
+	cepStore.CacheStore().Add(cep1)
 	cep2 := createStoreEndpoint("cep2", "ns", 2)
-	r.ciliumEndpointStore.Add(cep2)
+	cepStore.CacheStore().Add(cep2)
 	cep3 := createStoreEndpoint("cep3", "ns", 2)
-	r.ciliumEndpointStore.Add(cep3)
-	m.mapping.insertCES("ces1", "ns")
-	m.mapping.insertCES("ces2", "ns")
-	m.mapping.insertCEP("ns/cep1", "ces2")
-	m.mapping.insertCEP("ns/cep2", "ces2")
-	m.mapping.insertCEP("ns/cep3", "ces2")
+	cepStore.CacheStore().Add(cep3)
+	m.mapping.insertCES(NewCESName("ces1"), "ns")
+	m.mapping.insertCES(NewCESName("ces2"), "ns")
+	m.mapping.insertCEP(NewCEPName("cep1", "ns"), NewCESName("ces2"))
+	m.mapping.insertCEP(NewCEPName("cep2", "ns"), NewCESName("ces2"))
+	m.mapping.insertCEP(NewCEPName("cep3", "ns"), NewCESName("ces2"))
 	// ces1 contains cep1 and cep3, but it's mapped to nothing so it should be deleted
-	r.reconcileCES("ces1")
+	r.reconcileCES(NewCESName("ces1"))
 
 	assert.Equal(t, true, noRequest)
+
+	hive.Stop(context.Background())
 }

--- a/operator/pkg/ciliumendpointslice/utils.go
+++ b/operator/pkg/ciliumendpointslice/utils.go
@@ -1,0 +1,28 @@
+package ciliumendpointslice
+
+import (
+	"fmt"
+	"math/rand"
+)
+
+// Generate random string for given length of characters.
+func randomName(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = sequentialLetters[rand.Intn(len(sequentialLetters))]
+	}
+	return string(b)
+}
+
+// Generates unique random name for the CiliumEndpointSlice, the format
+// of a CES name is similar to pod k8s naming convention "ces-123456789-abcde".
+// First 3 letters indicates ces resource, followed by random letters.
+func uniqueCESliceName(mapping *CESToCEPMapping) string {
+	var cesName string
+	for {
+		cesName = fmt.Sprintf("%s-%s-%s", cesNamePrefix, randomName(9), randomName(5))
+		if !mapping.hasCESName(CESName(cesName)) {
+			return cesName
+		}
+	}
+}

--- a/operator/pkg/ciliumendpointslice/utils.go
+++ b/operator/pkg/ciliumendpointslice/utils.go
@@ -1,8 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
 package ciliumendpointslice
 
 import (
-	"fmt"
 	"math/rand"
+	"strings"
 )
 
 // Generate random string for given length of characters.
@@ -18,10 +21,18 @@ func randomName(n int) string {
 // of a CES name is similar to pod k8s naming convention "ces-123456789-abcde".
 // First 3 letters indicates ces resource, followed by random letters.
 func uniqueCESliceName(mapping *CESToCEPMapping) string {
-	var cesName string
+	var sb strings.Builder
 	for {
-		cesName = fmt.Sprintf("%s-%s-%s", cesNamePrefix, randomName(9), randomName(5))
-		if !mapping.hasCESName(CESName(cesName)) {
+		rn1, rn2 := randomName(9), randomName(5)
+		sb.Reset()
+		sb.Grow(len(cesNamePrefix) + 1 + len(rn1) + 1 + len(rn2))
+		sb.WriteString(cesNamePrefix)
+		sb.WriteRune('-')
+		sb.WriteString(rn1)
+		sb.WriteRune('-')
+		sb.WriteString(rn2)
+		cesName := sb.String()
+		if !mapping.hasCESName(NewCESName(cesName)) {
 			return cesName
 		}
 	}

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -181,17 +181,6 @@ func transformToCiliumEndpoint(obj interface{}) (interface{}, error) {
 	}
 }
 
-// HasCEWithIdentity returns true or false if the Cilium Endpoint store has
-// the given identity.
-func HasCEWithIdentity(identity string) bool {
-	if CiliumEndpointStore == nil {
-		return false
-	}
-	ces, _ := CiliumEndpointStore.IndexKeys(identityIndex, identity)
-
-	return len(ces) != 0
-}
-
 // HasCE returns true or false if the Cilium Endpoint store has the endpoint
 // with the given name.
 func HasCE(ns, name string) (*cilium_api_v2.CiliumEndpoint, bool, error) {

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -13,13 +13,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	ces "github.com/cilium/cilium/operator/pkg/ciliumendpointslice"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	"github.com/cilium/cilium/pkg/k8s/utils"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 const identityIndex = "identity"
@@ -42,19 +39,7 @@ var (
 	CiliumEndpointsSynced = make(chan struct{})
 	// once is used to make sure CiliumEndpointsInit is only setup once.
 	once sync.Once
-
-	// cesController watches for CiliumEndpoint changes, and accordingly updates CiliumEndpointSlices
-	// CiliumEndpoint watcher notifies the cesController, if any CiliumEndpoint is Added
-	// Updated or Deleted.
-	cesController *ces.CiliumEndpointSliceController
 )
-
-// CiliumEndpointsSliceInit starts a CiliumEndpointWatcher and caches cesController locally.
-func CiliumEndpointsSliceInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sClient.Clientset,
-	cbController *ces.CiliumEndpointSliceController) {
-	cesController = cbController
-	CiliumEndpointsInit(ctx, wg, clientset)
-}
 
 // identityIndexFunc index identities by ID.
 func identityIndexFunc(obj interface{}) ([]string, error) {
@@ -74,39 +59,11 @@ func CiliumEndpointsInit(ctx context.Context, wg *sync.WaitGroup, clientset k8sC
 	once.Do(func() {
 		CiliumEndpointStore = cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, indexers)
 
-		var cacheResourceHandler cache.ResourceEventHandlerFuncs
-
-		// Register notification function only if CES feature is enabled.
-		if option.Config.EnableCiliumEndpointSlice {
-			cacheResourceHandler = cache.ResourceEventHandlerFuncs{
-				AddFunc: func(obj interface{}) {
-					if cep := objToCiliumEndpoint(obj); cep != nil {
-						endpointUpdated(cep)
-					}
-				},
-				UpdateFunc: func(oldObj, newObj interface{}) {
-					if oldCEP := objToCiliumEndpoint(oldObj); oldCEP != nil {
-						if newCEP := objToCiliumEndpoint(newObj); newCEP != nil {
-							if oldCEP.DeepEqual(newCEP) {
-								return
-							}
-							endpointUpdated(newCEP)
-						}
-					}
-				},
-				DeleteFunc: func(obj interface{}) {
-					if cep := objToCiliumEndpoint(obj); cep != nil {
-						endpointDeleted(cep)
-					}
-				},
-			}
-		}
-
 		ciliumEndpointInformer := informer.NewInformerWithStore(
 			utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](clientset.CiliumV2().CiliumEndpoints("")),
 			&cilium_api_v2.CiliumEndpoint{},
 			0,
-			cacheResourceHandler,
+			cache.ResourceEventHandlerFuncs{},
 			transformToCiliumEndpoint,
 			CiliumEndpointStore,
 		)
@@ -196,34 +153,4 @@ func HasCE(ns, name string) (*cilium_api_v2.CiliumEndpoint, bool, error) {
 	}
 	cep := item.(*cilium_api_v2.CiliumEndpoint)
 	return cep, exists, nil
-}
-
-func endpointUpdated(cep *cilium_api_v2.CiliumEndpoint) {
-	cesController.OnEndpointUpdate(cep)
-}
-
-func endpointDeleted(cep *cilium_api_v2.CiliumEndpoint) {
-	cesController.OnEndpointDelete(cep)
-}
-
-// objToCiliumEndpoint attempts to cast object to a CiliumEndpoint object
-// and returns a deep copy if the cast succeeds. Otherwise, nil is returned.
-func objToCiliumEndpoint(obj interface{}) *cilium_api_v2.CiliumEndpoint {
-	cep, ok := obj.(*cilium_api_v2.CiliumEndpoint)
-	if ok {
-		return cep
-	}
-	deletedObj, ok := obj.(cache.DeletedFinalStateUnknown)
-	if ok {
-		// Delete was not observed by the watcher but is
-		// removed from kube-apiserver. This is the last
-		// known state and the object no longer exists.
-		cep, ok := deletedObj.Obj.(*cilium_api_v2.CiliumEndpoint)
-		if ok {
-			return cep
-		}
-	}
-	log.WithField(logfields.Object, logfields.Repr(obj)).
-		Warn("Ignoring invalid v2 CiliumEndpoint")
-	return cep
 }

--- a/operator/watchers/cilium_endpoint.go
+++ b/operator/watchers/cilium_endpoint.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	ces "github.com/cilium/cilium/operator/pkg/ciliumendpointslice"
-	"github.com/cilium/cilium/pkg/k8s"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
@@ -200,14 +199,11 @@ func HasCE(ns, name string) (*cilium_api_v2.CiliumEndpoint, bool, error) {
 }
 
 func endpointUpdated(cep *cilium_api_v2.CiliumEndpoint) {
-	if cep.Status.Networking == nil || cep.Status.Identity == nil || cep.GetName() == "" || cep.Namespace == "" {
-		return
-	}
-	cesController.Manager.InsertCEPInCache(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace)
+	cesController.OnEndpointUpdate(cep)
 }
 
 func endpointDeleted(cep *cilium_api_v2.CiliumEndpoint) {
-	cesController.Manager.RemoveCEPFromCache(ces.GetCEPNameFromCCEP(k8s.ConvertCEPToCoreCEP(cep), cep.Namespace), ces.DefaultCESSyncTime)
+	cesController.OnEndpointDelete(cep)
 }
 
 // objToCiliumEndpoint attempts to cast object to a CiliumEndpoint object

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -653,9 +653,6 @@ const (
 	// WorkQueueSyncBackoff is the backoff time used by workqueues before an attempt to retry sync with k8s-apiserver.
 	WorkQueueSyncBackOff = "workQueueSyncBackOff"
 
-	// CESSliceMode indicates the name of algorithm used to batch CEPs in a CES.
-	CESSliceMode = "ciliumEndpointSliceMode"
-
 	// SourceIP is a source IP
 	SourceIP = "sourceIP"
 


### PR DESCRIPTION
Implement full CES reconciliation logic in the Cilium Operator.

Refactor and unify CEPs and CESs watchers in the operator.
Refactor CES Controller:
- Limit the functionality of the Manager to maintain mapping between CEPs and CESs.
- Implement reconciliation in the Reconcilar based on the mapping from the Manager and CEPs and CESs from the watchers stores.
- React to the CESs events in addition to the CEPs events.

This PR should fix all the problems related to CESs out of sync.
If there is a broken state (stale, duplicated, missing CESs) the operator should always fully reconcile it on startup and maintain good state.
If different client breaks CES operator would fix it back.

Fixes: #24581

```release-note
Implement full CES reconciliation logic in the operator
```
