### PR TITLE
init.sh: move ipip device creation to Go

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -6,7 +6,7 @@ include:
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.27.1@sha256:b7d12ed662b873bd8510879c1846e87c7e676a79fefc93e17b2a52989d3ff42b"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "bpf-next-20230809.013124@sha256:328ba9ef033e07242bfff3ca6ff30848b15f5d6898c0c54d483e598e1c056b62"
+    kernel: "bpf-next-20230808.142051@sha256:4306f62dee78f873a5e42c9fa66ac936e4b7af68a5efbcb922be047506e95dba"
 
   - k8s-version: "1.26"
     ip-family: "dual"

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -256,7 +256,7 @@ jobs:
           test-name: runtime-tests
           install-dependencies: true
           # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          image-version: "bpf-next-20230809.013124@sha256:328ba9ef033e07242bfff3ca6ff30848b15f5d6898c0c54d483e598e1c056b62"
+          image-version: "bpf-next-20230808.142051@sha256:4306f62dee78f873a5e42c9fa66ac936e4b7af68a5efbcb922be047506e95"
           host-mount: ./
           cpu: 4
           mem: 12G

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tidwall/gjson v1.15.0
 	github.com/tidwall/sjson v1.2.5
-	github.com/vishvananda/netlink v1.2.1-beta.2.0.20230621221334-77712cff8739
+	github.com/vishvananda/netlink v1.2.1-beta.2.0.20230714120904-16d31db23588
 	github.com/vishvananda/netns v0.0.4
 	go.etcd.io/etcd/api/v3 v3.5.9
 	go.etcd.io/etcd/client/pkg/v3 v3.5.9

--- a/go.sum
+++ b/go.sum
@@ -774,8 +774,8 @@ github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaO
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
-github.com/vishvananda/netlink v1.2.1-beta.2.0.20230621221334-77712cff8739 h1:mi+RH1U/MmAQvz2Ys7r1/8OWlGJoBvF8iCXRKk2uym4=
-github.com/vishvananda/netlink v1.2.1-beta.2.0.20230621221334-77712cff8739/go.mod h1:0BeLktV/jHb2/Hmw1yLD7+yaIB8PDy11RCty0tCPWZg=
+github.com/vishvananda/netlink v1.2.1-beta.2.0.20230714120904-16d31db23588 h1:+mb9c98jGcGPOKs2iEr1hL50Hn74uxIC1D0mXHqchJo=
+github.com/vishvananda/netlink v1.2.1-beta.2.0.20230714120904-16d31db23588/go.mod h1:whJevzBpTrid75eZy99s3DqCmy05NfibNaF2Ol5Ox5A=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
 github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
@@ -1031,7 +1031,6 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.9.1-0.20230616193735-e0c3b6e6ae3b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.10.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0 h1:eG7RXZHdqOJ1i+0lgLgCpSXAp6M3LYlAo6osgSi0xOM=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -720,6 +720,23 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	}
 	cDefinesMap["EPHEMERAL_MIN"] = fmt.Sprintf("%d", ephemeralMin)
 
+	if option.Config.EnableHealthDatapath {
+		if option.Config.IPv4Enabled() {
+			ipip4, err := netlink.LinkByName(defaults.IPIPv4Device)
+			if err != nil {
+				return err
+			}
+			cDefinesMap["ENCAP4_IFINDEX"] = fmt.Sprintf("%d", ipip4.Attrs().Index)
+		}
+		if option.Config.IPv6Enabled() {
+			ipip6, err := netlink.LinkByName(defaults.IPIPv6Device)
+			if err != nil {
+				return err
+			}
+			cDefinesMap["ENCAP6_IFINDEX"] = fmt.Sprintf("%d", ipip6.Attrs().Index)
+		}
+	}
+
 	// Since golang maps are unordered, we sort the keys in the map
 	// to get a consistent written format to the writer. This maintains
 	// the consistency when we try to calculate hash for a datapath after

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
@@ -83,7 +84,7 @@ func TestSetupDev(t *testing.T) {
 		err := netlink.LinkAdd(dummy)
 		require.NoError(t, err)
 
-		err = setupDev(dummy)
+		err = configureDevice(dummy)
 		require.NoError(t, err)
 
 		enabledSettings := []string{
@@ -269,6 +270,53 @@ func TestRemoveTCPrograms(t *testing.T) {
 
 		err = netlink.LinkDel(dummy)
 		require.NoError(t, err)
+
+		return nil
+	})
+}
+
+func TestSetupIPIPDevices(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	netnsName := "test-setup-ipip-devs"
+	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+	require.NoError(t, err)
+	require.NotNil(t, netns0)
+	t.Cleanup(func() {
+		netns0.Close()
+		netns.RemoveNetNSWithName(netnsName)
+	})
+
+	netns0.Do(func(_ ns.NetNS) error {
+		err := setupIPIPDevices(true, true)
+		require.NoError(t, err)
+
+		_, err = netlink.LinkByName(defaults.IPIPv4Device)
+		require.NoError(t, err)
+
+		_, err = netlink.LinkByName(defaults.IPIPv6Device)
+		require.NoError(t, err)
+
+		_, err = netlink.LinkByName("cilium_tunl")
+		require.NoError(t, err)
+
+		_, err = netlink.LinkByName("cilium_ip6tnl")
+		require.NoError(t, err)
+
+		_, err = netlink.LinkByName("tunl0")
+		require.Error(t, err)
+
+		_, err = netlink.LinkByName("ip6tnl0")
+		require.Error(t, err)
+
+		err = setupIPIPDevices(false, false)
+		require.NoError(t, err)
+
+		_, err = netlink.LinkByName(defaults.IPIPv4Device)
+		require.Error(t, err)
+
+		_, err = netlink.LinkByName(defaults.IPIPv6Device)
+		require.Error(t, err)
 
 		return nil
 	})

--- a/pkg/defaults/node.go
+++ b/pkg/defaults/node.go
@@ -23,6 +23,12 @@ const (
 	// SecondHostDevice is the name of the second interface of the host veth pair.
 	SecondHostDevice = "cilium_net"
 
+	// IPIPv4Device is a device of type 'ipip', created by the agent.
+	IPIPv4Device = "cilium_ipip4"
+
+	// IPIPv6Device is a device of type 'ip6tnl', created by the agent.
+	IPIPv6Device = "cilium_ipip6"
+
 	// CiliumK8sAnnotationPrefix is the prefix key for the annotations used in kubernetes.
 	CiliumK8sAnnotationPrefix = "cilium.io/"
 

--- a/vendor/github.com/vishvananda/netlink/link.go
+++ b/vendor/github.com/vishvananda/netlink/link.go
@@ -1070,6 +1070,7 @@ type Ip6tnl struct {
 	EncapFlags uint16
 	EncapSport uint16
 	EncapDport uint16
+	FlowBased  bool
 }
 
 func (ip6tnl *Ip6tnl) Attrs() *LinkAttrs {

--- a/vendor/github.com/vishvananda/netlink/route_linux.go
+++ b/vendor/github.com/vishvananda/netlink/route_linux.go
@@ -1320,12 +1320,13 @@ func deserializeRoute(m []byte) (Route, error) {
 // RouteGetOptions contains a set of options to use with
 // RouteGetWithOptions
 type RouteGetOptions struct {
-	Iif     string
-	Oif     string
-	VrfName string
-	SrcAddr net.IP
-	UID     *uint32
-	Mark    int
+	Iif      string
+	Oif      string
+	VrfName  string
+	SrcAddr  net.IP
+	UID      *uint32
+	Mark     int
+	FIBMatch bool
 }
 
 // RouteGetWithOptions gets a route to a specific destination from the host system.
@@ -1361,6 +1362,9 @@ func (h *Handle) RouteGetWithOptions(destination net.IP, options *RouteGetOption
 		msg.Src_len = bitlen
 	}
 	msg.Flags = unix.RTM_F_LOOKUP_TABLE
+	if options != nil && options.FIBMatch {
+		msg.Flags |= unix.RTM_F_FIB_MATCH
+	}
 	req.AddData(msg)
 
 	rtaDst := nl.NewRtAttr(unix.RTA_DST, destinationData)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -914,7 +914,7 @@ github.com/tklauser/go-sysconf
 # github.com/tklauser/numcpus v0.6.0
 ## explicit; go 1.13
 github.com/tklauser/numcpus
-# github.com/vishvananda/netlink v1.2.1-beta.2.0.20230621221334-77712cff8739
+# github.com/vishvananda/netlink v1.2.1-beta.2.0.20230714120904-16d31db23588
 ## explicit; go 1.12
 github.com/vishvananda/netlink
 github.com/vishvananda/netlink/nl


### PR DESCRIPTION
vendor: update vishvananda/netlink:
```
This pulls in the following recent changes:

- vishvananda/netlink@88c0de
- vishvananda/netlink@16d31d

These are needed to move ipip device creation from init.sh to Go.

Signed-off-by: Robin Gögge <r.goegge@isovalent.com>
```
init.sh: move ipip device creation to Go:
```
This refactors the creation of the cilium_ipip{4,6} devices to a
Go based implementation and adds a simple device creation test.

One behavioural change was made: no longer try to repurpose
tunl0 by renaming it and enabling collect_md, as that dance is
rather tricky and fragile due to the kernel module needing to be
loaded first.

With this change, we still prefix the fallback devices with cilium_,
meaning cilium_tunl0 for v4 and cilium_ip6tnl0 for v6, but we no
longer try to use or reconfigure these devices. cilium_ipip4/6 are
always created with the correct parameters from the start, reducing
the amount of moving parts.

Signed-off-by: Robin Gögge <r.goegge@isovalent.com>
```
Fixes: #20740

