### PR TITLE
Documentation: Replace netperf images in StarWars demos

### DIFF
--- a/examples/kubernetes-dns/dns-sw-app.yaml
+++ b/examples/kubernetes-dns/dns-sw-app.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   containers:
   - name: mediabot
-    image: docker.io/tgraf/netperf
+    image: docker.io/cilium/json-mock

--- a/examples/minikube/http-sw-app.yaml
+++ b/examples/minikube/http-sw-app.yaml
@@ -47,7 +47,7 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: docker.io/tgraf/netperf
+    image: docker.io/cilium/json-mock
 ---
 apiVersion: v1
 kind: Pod
@@ -60,4 +60,4 @@ metadata:
 spec:
   containers:
   - name: spaceship
-    image: docker.io/tgraf/netperf
+    image: docker.io/cilium/json-mock


### PR DESCRIPTION
The netperf images in the current star wars demos do not support short DNS names like "deathstar" vs
"deathstar.default.svc.cluster.local". This change swaps out @tgraf's image for one controlled by the cilium community that supports DNS short names.

Fixes: #23361
