### PR TITLE
egressgw: consider egress interface when deleting stale IP rules

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -721,6 +721,10 @@ nextIpRule:
 				return false
 			}
 
+			if ipRule.Table != egressGatewayRoutingTableIdx(gwc.ifaceIndex) {
+				return false
+			}
+
 			// no need to check also ipRule.Src.IP.Equal(endpointIP) as we are iterating
 			// over the slice of policies returned by the
 			// policyConfigsBySourceIP[ipRule.Src.IP.String()] map


### PR DESCRIPTION
When an EgressGW policy was updated to select a different egress interface, delete all IP rules that still point to the old interface.

```release-note
Fix a bug in the Egress Gateway feature when using the --install-egress-gateway-routes option. Delete stale IP rules after a CiliumEgressGatewayPolicy is updated and selects a different egress network interface.
```
