### PR TITLE
bpf: nodeport: consolidate packet rewrite in RevDNAT path

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1523,7 +1523,7 @@ skip_policy_enforcement:
 		{
 			bool node_port =
 				ct_has_nodeport_egress_entry6(get_ct_map6(tuple),
-							      tuple, false);
+							      tuple, NULL, false);
 
 			ct_state_new.node_port = node_port;
 			if (ret == CT_REOPENED &&
@@ -1850,7 +1850,7 @@ skip_policy_enforcement:
 		{
 			bool node_port =
 				ct_has_nodeport_egress_entry4(get_ct_map4(tuple),
-							      tuple, false);
+							      tuple, NULL, false);
 
 			ct_state_new.node_port = node_port;
 			if (ret == CT_REOPENED &&

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -990,7 +990,9 @@ ct_recreate4:
 
 		if (ct_state->rev_nat_index) {
 			ret = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
-					  ct_state, tuple, 0, has_l4_header);
+					  ct_state->rev_nat_index,
+					  ct_state->loopback,
+					  tuple, 0, has_l4_header);
 			if (IS_ERR(ret))
 				return ret;
 		}
@@ -1793,8 +1795,9 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, enum ct_status
 			has_l4_header = ipv4_has_l4_header(ip4);
 
 			ret2 = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
-					   ct_state, tuple,
-					   REV_NAT_F_TUPLE_SADDR, has_l4_header);
+					   ct_state->rev_nat_index, false,
+					   tuple, REV_NAT_F_TUPLE_SADDR,
+					   has_l4_header);
 			if (IS_ERR(ret2))
 				return ret2;
 		}

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -1021,6 +1021,19 @@ err_ct_fill_up:
 	return DROP_CT_CREATE_FAILED;
 }
 
+static __always_inline bool
+__ct_has_nodeport_egress_entry(const struct ct_entry *entry,
+			       __u16 *rev_nat_index, bool check_dsr)
+{
+	if (entry->node_port) {
+		if (rev_nat_index)
+			*rev_nat_index = entry->rev_nat_index;
+		return true;
+	}
+
+	return check_dsr && entry->dsr;
+}
+
 /* The function tries to determine whether the flow identified by the given
  * CT_INGRESS tuple belongs to a NodePort traffic (i.e., outside client => N/S
  * LB => local backend).
@@ -1033,7 +1046,7 @@ err_ct_fill_up:
 static __always_inline bool
 ct_has_nodeport_egress_entry4(const void *map,
 			      struct ipv4_ct_tuple *ingress_tuple,
-			      bool check_dsr)
+			      __u16 *rev_nat_index, bool check_dsr)
 {
 	__u8 prev_flags = ingress_tuple->flags;
 	struct ct_entry *entry;
@@ -1042,10 +1055,10 @@ ct_has_nodeport_egress_entry4(const void *map,
 	entry = map_lookup_elem(map, ingress_tuple);
 	ingress_tuple->flags = prev_flags;
 
-	if (entry)
-		return entry->node_port || (check_dsr && entry->dsr);
+	if (!entry)
+		return false;
 
-	return 0;
+	return __ct_has_nodeport_egress_entry(entry, rev_nat_index, check_dsr);
 }
 
 static __always_inline bool
@@ -1067,7 +1080,7 @@ ct_has_dsr_egress_entry4(const void *map, struct ipv4_ct_tuple *ingress_tuple)
 static __always_inline bool
 ct_has_nodeport_egress_entry6(const void *map,
 			      struct ipv6_ct_tuple *ingress_tuple,
-			      bool check_dsr)
+			      __u16 *rev_nat_index, bool check_dsr)
 {
 	__u8 prev_flags = ingress_tuple->flags;
 	struct ct_entry *entry;
@@ -1076,10 +1089,10 @@ ct_has_nodeport_egress_entry6(const void *map,
 	entry = map_lookup_elem(map, ingress_tuple);
 	ingress_tuple->flags = prev_flags;
 
-	if (entry)
-		return entry->node_port || (check_dsr && entry->dsr);
+	if (!entry)
+		return false;
 
-	return 0;
+	return __ct_has_nodeport_egress_entry(entry, rev_nat_index, check_dsr);
 }
 
 static __always_inline bool

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1052,8 +1052,7 @@ lb6_to_lb4_service(const struct lb6_service *svc __maybe_unused)
 static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off,
 					 struct ipv4_ct_tuple *tuple, int flags,
 					 const struct lb4_reverse_nat *nat,
-					 const struct ct_state *ct_state __maybe_unused,
-					 bool has_l4_header)
+					 bool loopback __maybe_unused, bool has_l4_header)
 {
 	__be32 old_sip, sum = 0;
 	int ret;
@@ -1070,7 +1069,7 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 	}
 
 #ifndef DISABLE_LOOPBACK_LB
-	if (ct_state->loopback) {
+	if (loopback) {
 		/* The packet was looped back to the sending endpoint on the
 		 * forward service translation. This implies that the original
 		 * source address of the packet is the source address of the
@@ -1138,20 +1137,21 @@ lb4_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
  * @arg l3_off		offset to L3
  * @arg l4_off		offset to L4
  * @arg index		reverse NAT index
+ * @arg loopback	loopback connection
  * @arg tuple		tuple
  */
 static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l4_off,
-				       struct ct_state *ct_state,
+				       __u16 index, bool loopback,
 				       struct ipv4_ct_tuple *tuple, int flags, bool has_l4_header)
 {
 	struct lb4_reverse_nat *nat;
 
-	nat = lb4_lookup_rev_nat_entry(ctx, ct_state->rev_nat_index);
+	nat = lb4_lookup_rev_nat_entry(ctx, index);
 	if (nat == NULL)
 		return 0;
 
 	return __lb4_rev_nat(ctx, l3_off, l4_off, tuple, flags, nat,
-			     ct_state, has_l4_header);
+			     loopback, has_l4_header);
 }
 
 static __always_inline void

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -475,6 +475,14 @@ static __always_inline int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 	return 0;
 }
 
+static __always_inline struct lb6_reverse_nat *
+lb6_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
+{
+	cilium_dbg_lb(ctx, DBG_LB6_REVERSE_NAT_LOOKUP, index, 0);
+
+	return map_lookup_elem(&LB6_REVERSE_NAT_MAP, &index);
+}
+
 /** Perform IPv6 reverse NAT based on reverse NAT index
  * @arg ctx		packet
  * @arg l4_off		offset to L4
@@ -487,8 +495,7 @@ static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 {
 	struct lb6_reverse_nat *nat;
 
-	cilium_dbg_lb(ctx, DBG_LB6_REVERSE_NAT_LOOKUP, index, 0);
-	nat = map_lookup_elem(&LB6_REVERSE_NAT_MAP, &index);
+	nat = lb6_lookup_rev_nat_entry(ctx, index);
 	if (nat == NULL)
 		return 0;
 
@@ -1118,6 +1125,13 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 	return 0;
 }
 
+static __always_inline struct lb4_reverse_nat *
+lb4_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
+{
+	cilium_dbg_lb(ctx, DBG_LB4_REVERSE_NAT_LOOKUP, index, 0);
+
+	return map_lookup_elem(&LB4_REVERSE_NAT_MAP, &index);
+}
 
 /** Perform IPv4 reverse NAT based on reverse NAT index
  * @arg ctx		packet
@@ -1132,8 +1146,7 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 {
 	struct lb4_reverse_nat *nat;
 
-	cilium_dbg_lb(ctx, DBG_LB4_REVERSE_NAT_LOOKUP, ct_state->rev_nat_index, 0);
-	nat = map_lookup_elem(&LB4_REVERSE_NAT_MAP, &ct_state->rev_nat_index);
+	nat = lb4_lookup_rev_nat_entry(ctx, ct_state->rev_nat_index);
 	if (nat == NULL)
 		return 0;
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -82,6 +82,7 @@ __snat_update(const void *map, const void *otuple, const void *ostate,
 struct ipv4_nat_entry {
 	struct nat_entry common;
 	union {
+		struct lb4_reverse_nat nat_info;
 		struct {
 			__be32 to_saddr;
 			__be16 to_sport;
@@ -1177,6 +1178,7 @@ int snat_v4_rev_nat(struct __ctx_buff *ctx __maybe_unused,
 struct ipv6_nat_entry {
 	struct nat_entry common;
 	union {
+		struct lb6_reverse_nat nat_info;
 		struct {
 			union v6addr to_saddr;
 			__be16       to_sport;
@@ -1242,7 +1244,7 @@ get_cluster_snat_map_v6(__u32 cluster_id __maybe_unused)
 }
 
 static __always_inline
-struct ipv6_nat_entry *snat_v6_lookup(struct ipv6_ct_tuple *tuple)
+struct ipv6_nat_entry *snat_v6_lookup(const struct ipv6_ct_tuple *tuple)
 {
 	return __snat_lookup(&SNAT_MAPPING_IPV6, tuple);
 }

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2756,12 +2756,9 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 			if (ctx_get_tunnel_key(ctx, &key, sizeof(key), 0) < 0)
 				return DROP_NO_TUNNEL_KEY;
 
-			if (!revalidate_data(ctx, &data, &data_end, &ip4))
-				return DROP_INVALID;
-
 			/* kernel returns addresses in flipped locations: */
 			key.remote_ipv4 = key.local_ipv4;
-			key.local_ipv4 = bpf_ntohl(ip4->saddr);
+			key.local_ipv4 = bpf_ntohl(nat_info->address);
 
 			if (ctx_set_tunnel_key(ctx, &key, sizeof(key),
 					       BPF_F_ZERO_CSUM_TX) < 0)

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1267,6 +1267,7 @@ redo:
 static __always_inline int
 nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 {
+	struct lb6_reverse_nat *nat_info;
 	struct ipv6_ct_tuple tuple = {};
 	struct ct_state ct_state = {};
 	void *data, *data_end;
@@ -1283,8 +1284,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 		return ret;
 	}
 
-	if (!ct_has_nodeport_egress_entry6(get_ct_map6(&tuple), &tuple,
-					   NULL, is_defined(ENABLE_DSR)))
+	nat_info = nodeport_rev_dnat_get_info_ipv6(ctx, &tuple);
+	if (!nat_info)
 		return CTX_ACT_OK;
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
@@ -1292,20 +1293,12 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
-		if (ct_state.node_port && ct_state.rev_nat_index) {
-			ret = lb6_rev_nat(ctx, l4_off, ct_state.rev_nat_index,
-					  &tuple, REV_NAT_F_TUPLE_SADDR);
-			if (IS_ERR(ret))
-				return ret;
+		ret = __lb6_rev_nat(ctx, l4_off, &tuple, REV_NAT_F_TUPLE_SADDR,
+				    nat_info);
+		if (IS_ERR(ret))
+			return ret;
 
-			ctx_snat_done_set(ctx);
-#ifdef ENABLE_DSR
-		} else if (ct_state.dsr) {
-			ret = xlate_dsr_v6(ctx, &tuple, l4_off);
-			if (IS_ERR(ret))
-				return ret;
-#endif
-		}
+		ctx_snat_done_set(ctx);
 	}
 
 	return CTX_ACT_OK;
@@ -2710,6 +2703,7 @@ static __always_inline int
 nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 {
 	int ret, l3_off = ETH_HLEN, l4_off;
+	struct lb4_reverse_nat *nat_info;
 	struct ipv4_ct_tuple tuple = {};
 	struct ct_state ct_state = {};
 	void *data, *data_end;
@@ -2729,56 +2723,52 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 		return ret;
 	}
 
-	if (!ct_has_nodeport_egress_entry4(get_ct_map4(&tuple), &tuple,
-					   NULL, is_defined(ENABLE_DSR)))
+	nat_info = nodeport_rev_dnat_get_info_ipv4(ctx, &tuple);
+	if (!nat_info)
 		return CTX_ACT_OK;
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
 			      ACTION_CREATE, CT_INGRESS, SCOPE_REVERSE, &ct_state,
 			      &trace->monitor);
+
+	/* nodeport_rev_dnat_get_info_ipv4() just checked that such a
+	 * CT entry exists:
+	 */
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
-		/* Reply by local backend: */
-		if (ct_state.node_port && ct_state.rev_nat_index) {
-			ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index,
-					  false, &tuple, REV_NAT_F_TUPLE_SADDR,
-					  has_l4_header);
-			if (IS_ERR(ret))
-				return ret;
+		ret = __lb4_rev_nat(ctx, l3_off, l4_off, &tuple,
+				    REV_NAT_F_TUPLE_SADDR, nat_info,
+				    false, has_l4_header);
+		if (IS_ERR(ret))
+			return ret;
 
-			ctx_snat_done_set(ctx);
+		ctx_snat_done_set(ctx);
+
 #ifdef ENABLE_DSR
-		/* Reply by DSR backend: */
-		} else if (ct_state.dsr) {
-			ret = xlate_dsr_v4(ctx, &tuple, l4_off, has_l4_header);
-			if (IS_ERR(ret))
-				return ret;
-
  #if defined(ENABLE_HIGH_SCALE_IPCACHE) &&				\
      defined(IS_BPF_OVERLAY) &&						\
      DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
-			/* For HS IPCache, we also need to revDNAT the OuterSrcIP: */
-			{
-				struct bpf_tunnel_key key;
+		/* For HS IPCache, we also need to revDNAT the OuterSrcIP: */
+		if (ct_state.dsr) {
+			struct bpf_tunnel_key key;
 
-				if (ctx_get_tunnel_key(ctx, &key, sizeof(key), 0) < 0)
-					return DROP_NO_TUNNEL_KEY;
+			if (ctx_get_tunnel_key(ctx, &key, sizeof(key), 0) < 0)
+				return DROP_NO_TUNNEL_KEY;
 
-				if (!revalidate_data(ctx, &data, &data_end, &ip4))
-					return DROP_INVALID;
+			if (!revalidate_data(ctx, &data, &data_end, &ip4))
+				return DROP_INVALID;
 
-				/* kernel returns addresses in flipped locations: */
-				key.remote_ipv4 = key.local_ipv4;
-				key.local_ipv4 = bpf_ntohl(ip4->saddr);
+			/* kernel returns addresses in flipped locations: */
+			key.remote_ipv4 = key.local_ipv4;
+			key.local_ipv4 = bpf_ntohl(ip4->saddr);
 
-				if (ctx_set_tunnel_key(ctx, &key, sizeof(key),
-						       BPF_F_ZERO_CSUM_TX) < 0)
-					return DROP_WRITE_ERROR;
-			}
+			if (ctx_set_tunnel_key(ctx, &key, sizeof(key),
+					       BPF_F_ZERO_CSUM_TX) < 0)
+				return DROP_WRITE_ERROR;
+		}
  #endif
 #endif
-		}
 	}
 
 	return CTX_ACT_OK;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -524,6 +524,12 @@ nodeport_extract_dsr_v6(struct __ctx_buff *ctx,
 	return 0;
 }
 
+static __always_inline struct ipv6_nat_entry *
+nodeport_dsr_lookup_v6_nat_entry(const struct ipv6_ct_tuple *nat_tuple)
+{
+	return snat_v6_lookup(nat_tuple);
+}
+
 static __always_inline int xlate_dsr_v6(struct __ctx_buff *ctx,
 					const struct ipv6_ct_tuple *tuple,
 					int l4_off)
@@ -535,7 +541,7 @@ static __always_inline int xlate_dsr_v6(struct __ctx_buff *ctx,
 	nat_tup.sport = tuple->dport;
 	nat_tup.dport = tuple->sport;
 
-	entry = snat_v6_lookup(&nat_tup);
+	entry = nodeport_dsr_lookup_v6_nat_entry(&nat_tup);
 	if (!entry)
 		return 0;
 
@@ -807,6 +813,36 @@ drop_err:
 	return send_drop_notify_error_ext(ctx, 0, ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
 }
 #endif /* ENABLE_DSR */
+
+static __always_inline struct lb6_reverse_nat *
+nodeport_rev_dnat_get_info_ipv6(struct __ctx_buff *ctx,
+				struct ipv6_ct_tuple *tuple)
+{
+	struct ipv6_nat_entry *dsr_entry __maybe_unused;
+	struct ipv6_ct_tuple dsr_tuple __maybe_unused;
+	__u16 rev_nat_index = 0;
+
+	if (!ct_has_nodeport_egress_entry6(get_ct_map6(tuple), tuple,
+					   &rev_nat_index, is_defined(ENABLE_DSR)))
+		return NULL;
+
+	if (rev_nat_index)
+		return lb6_lookup_rev_nat_entry(ctx, rev_nat_index);
+
+#ifdef ENABLE_DSR
+	dsr_tuple = *tuple;
+
+	dsr_tuple.flags = NAT_DIR_EGRESS;
+	dsr_tuple.sport = tuple->dport;
+	dsr_tuple.dport = tuple->sport;
+
+	dsr_entry = nodeport_dsr_lookup_v6_nat_entry(&dsr_tuple);
+	if (dsr_entry)
+		return &dsr_entry->nat_info;
+#endif
+
+	return NULL;
+}
 
 #ifdef ENABLE_NAT_46X64_GATEWAY
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV46_RFC8215)
@@ -1248,7 +1284,7 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace)
 	}
 
 	if (!ct_has_nodeport_egress_entry6(get_ct_map6(&tuple), &tuple,
-					   is_defined(ENABLE_DSR)))
+					   NULL, is_defined(ENABLE_DSR)))
 		return CTX_ACT_OK;
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
@@ -1311,7 +1347,7 @@ static __always_inline int rev_nodeport_lb6(struct __ctx_buff *ctx, __s8 *ext_er
 		return ret;
 	}
 
-	if (!ct_has_nodeport_egress_entry6(get_ct_map6(&tuple), &tuple, false))
+	if (!ct_has_nodeport_egress_entry6(get_ct_map6(&tuple), &tuple, NULL, false))
 		goto out;
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, ACTION_CREATE,
@@ -1964,6 +2000,12 @@ nodeport_extract_dsr_v4(struct __ctx_buff *ctx,
 	return 0;
 }
 
+static __always_inline struct ipv4_nat_entry *
+nodeport_dsr_lookup_v4_nat_entry(const struct ipv4_ct_tuple *nat_tuple)
+{
+	return snat_v4_lookup(nat_tuple);
+}
+
 static __always_inline int xlate_dsr_v4(struct __ctx_buff *ctx,
 					const struct ipv4_ct_tuple *tuple,
 					int l4_off, bool has_l4_header)
@@ -1975,7 +2017,7 @@ static __always_inline int xlate_dsr_v4(struct __ctx_buff *ctx,
 	nat_tup.sport = tuple->dport;
 	nat_tup.dport = tuple->sport;
 
-	entry = snat_v4_lookup(&nat_tup);
+	entry = nodeport_dsr_lookup_v4_nat_entry(&nat_tup);
 	if (!entry)
 		return 0;
 
@@ -2253,6 +2295,36 @@ drop_err:
 	return send_drop_notify_error_ext(ctx, 0, ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
 }
 #endif /* ENABLE_DSR */
+
+static __always_inline struct lb4_reverse_nat *
+nodeport_rev_dnat_get_info_ipv4(struct __ctx_buff *ctx,
+				struct ipv4_ct_tuple *tuple)
+{
+	struct ipv4_nat_entry *dsr_entry __maybe_unused;
+	struct ipv4_ct_tuple dsr_tuple __maybe_unused;
+	__u16 rev_nat_index = 0;
+
+	if (!ct_has_nodeport_egress_entry4(get_ct_map4(tuple), tuple,
+					   &rev_nat_index, is_defined(ENABLE_DSR)))
+		return NULL;
+
+	if (rev_nat_index)
+		return lb4_lookup_rev_nat_entry(ctx, rev_nat_index);
+
+#ifdef ENABLE_DSR
+	dsr_tuple = *tuple;
+
+	dsr_tuple.flags = NAT_DIR_EGRESS;
+	dsr_tuple.sport = tuple->dport;
+	dsr_tuple.dport = tuple->sport;
+
+	dsr_entry = nodeport_dsr_lookup_v4_nat_entry(&dsr_tuple);
+	if (dsr_entry)
+		return &dsr_entry->nat_info;
+#endif
+
+	return NULL;
+}
 
 declare_tailcall_if(__not(is_defined(IS_BPF_LXC)), CILIUM_CALL_IPV4_NODEPORT_NAT_INGRESS)
 int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
@@ -2658,7 +2730,7 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 	}
 
 	if (!ct_has_nodeport_egress_entry4(get_ct_map4(&tuple), &tuple,
-					   is_defined(ENABLE_DSR)))
+					   NULL, is_defined(ENABLE_DSR)))
 		return CTX_ACT_OK;
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
@@ -2763,7 +2835,7 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 	if (!check_revdnat)
 		goto out;
 
-	if (!ct_has_nodeport_egress_entry4(get_ct_map4(&tuple), &tuple, false))
+	if (!ct_has_nodeport_egress_entry4(get_ct_map4(&tuple), &tuple, NULL, false))
 		goto out;
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2741,8 +2741,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 
 		/* Reply by local backend: */
 		if (ct_state.node_port && ct_state.rev_nat_index) {
-			ret = lb4_rev_nat(ctx, l3_off, l4_off, &ct_state,
-					  &tuple, REV_NAT_F_TUPLE_SADDR,
+			ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index,
+					  false, &tuple, REV_NAT_F_TUPLE_SADDR,
 					  has_l4_header);
 			if (IS_ERR(ret))
 				return ret;
@@ -2842,8 +2842,8 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 			      ACTION_CREATE, CT_INGRESS, SCOPE_REVERSE, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		reason = TRACE_REASON_CT_REPLY;
-		ret = lb4_rev_nat(ctx, l3_off, l4_off, &ct_state, &tuple,
-				  REV_NAT_F_TUPLE_SADDR, has_l4_header);
+		ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index, false,
+				  &tuple, REV_NAT_F_TUPLE_SADDR, has_l4_header);
 		if (IS_ERR(ret))
 			return ret;
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))


### PR DESCRIPTION
This adds some smarts to the nodeport helpers, so that it's possible to split up the RevDNAT lookup (what IP/port to use for the RevDNAT) and the actual packet rewrite. This allows us to use the same helper code for the rewrite, regardless whether the reply comes from a local or a DSR backend.

It's a nice simplification on its own, but will also enable a follow-on fix in the RevDNAT path (https://github.com/cilium/cilium/pull/26638) that would otherwise be rejected by the verifier. So we'll backport this PR accordingly, once that fix is ready to merged.