### PR TITLE
bpf: nat: set .from_local_endpoint for all inter-cluster SNAT traffic

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -724,6 +724,8 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 	if (target->cluster_id != 0 &&
 	    target->cluster_id != CLUSTER_ID) {
 		target->addr = IPV4_INTER_CLUSTER_SNAT;
+		target->from_local_endpoint = true;
+
 		return NAT_NEEDED;
 	}
 # endif


### PR DESCRIPTION
Otherwise snat_v4_nat() bails out in snat_v4_nat_can_skip() for traffic that uses a source port < NAT_MIN_EGRESS.
