### PR TITLE
gh/workflows: Bump CLI to v0.15.3 in ci-e2e

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -51,9 +51,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # renovate is disabled in this workflow until https://github.com/cilium/cilium-cli/issues/1627 is resolved.
-  # renovate_disabled: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.14.5
+  # renovate: datasource=github-releases depName=cilium/cilium-cli
+  cilium_cli_version: v0.15.3
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 


### PR DESCRIPTION
https://github.com/cilium/cilium-cli/pull/1842 fixed the IPv6 failures in v1.13.

Depends on https://github.com/cilium/cilium/pull/26856.
