### PR TITLE
gh/workflows: Optionally enable dual stack in ci-e2e

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -361,7 +361,12 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host/
-            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
+
+            IP_FAM="dual"
+            if [ "${{ matrix.ipv6 }}" == "false" ]; then
+              IP_FAM="ipv4"
+            fi
+            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
 
             kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
             if [ "${{ matrix.encryption }}" == "ipsec" ]; then


### PR DESCRIPTION
Otherwise, when the IPv6 is disabled, the check-log-errors fails with:

    Error while inserting service in LB map" error="Unable to upsert
    service [fd00:10:96::8f2f]:8080 as IPv6 is disabled"
    k8sNamespace=cilium-test k8sSvcName=echo-same-node