### PR TITLE
egressgw: fix up removal for IP routes

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 
@@ -768,7 +769,10 @@ nextIpRule:
 	}
 
 	// Fetch all IP routes, and delete the unused EgressGW-specific routes:
-	routes, err := netlink.RouteList(nil, netlink.FAMILY_V4)
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &netlink.Route{
+		Table: unix.RT_TABLE_UNSPEC,
+	}, netlink.RT_FILTER_TABLE)
+
 	if err != nil {
 		logger.WithError(err).Error("Cannot list IP routes")
 		return


### PR DESCRIPTION
Without specifying a filter, we're only getting the routes from the default table. So explicitly get the routes from all tables for the reconciliation of stale EgressGW IP routes.

Fixes: 9b9e7c2a6259 ("egressgw: improve removal of IP routes")