### PR TITLE
egressgw: ignore endpoint events with .endpoint = nil

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -408,7 +408,7 @@ func (manager *Manager) addEndpoint(id types.NamespacedName) {
 	epEvent, ok := manager.pendingEndpointEvents[id]
 	manager.pendingEndpointEventsLock.RUnlock()
 
-	if !ok {
+	if !ok || epEvent.endpoint == nil {
 		// the endpoint event has been already processed (for example we
 		// received an updated endpoint object or a delete event),
 		// nothing to do


### PR DESCRIPTION
The commit 9fb24de93ebe added a check for pendingEndpointEvents that got
deleted by checking if the `id` was in the map. However, on delete
events, we were also inserting the request into the map but with an
explicit empty endpoint. This commit also checks if the endpoint is not
set for that case which we should skip the 'addEndpoint' events.
    
Fixes: 9fb24de93ebe ("egressgw: retry getIdentityLabels on failure")