### PR TITLE
v1.12 backports 2023-07-17

### DIFF
--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -214,4 +214,5 @@ Limitations
     * Transparent encryption is not currently supported when chaining Cilium on
       top of other CNI plugins. For more information, see :gh-issue:`15596`.
     * :ref:`HostPolicies` are not currently supported with IPsec encryption.
-    * IPsec encryption is not supported on clusters with more than 65535 nodes.
+    * IPsec encryption is not supported on clusters or clustermeshes with more
+      than 65535 nodes.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -264,6 +264,7 @@ clusterPoolIPv
 clusterSize
 clustermesh
 clustermeshcertgen
+clustermeshes
 clusterwide
 cmdref
 cni

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -22,9 +22,6 @@
 /* Pass unknown ICMPv6 NS to stack */
 #define ACTION_UNKNOWN_ICMP6_NS CTX_ACT_OK
 
-/* CB_PROXY_MAGIC overlaps with CB_ENCRYPT_MAGIC */
-#define ENCRYPT_OR_PROXY_MAGIC 0
-
 /* Controls the inclusion of the CILIUM_CALL_SEND_ICMP6_ECHO_REPLY section in
  * the bpf_lxc object file.
  */
@@ -297,17 +294,9 @@ skip_host_firewall:
 	dst = (union v6addr *) &ip6->daddr;
 	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN);
 	if (info != NULL && info->tunnel_endpoint != 0) {
-		ret = encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
-						     info->key, info->node_id, secctx, &trace);
-
-		/* If IPSEC is needed recirc through ingress to use xfrm stack
-		 * and then result will routed back through bpf_netdev on egress
-		 * but with encrypt marks.
-		 */
-		if (ret == IPSEC_ENDPOINT)
-			return CTX_ACT_OK;
-		else
-			return ret;
+		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
+						      info->node_id, secctx,
+						      &trace);
 	} else {
 		struct tunnel_key key = {};
 
@@ -598,14 +587,9 @@ skip_vtep:
 #ifdef TUNNEL_MODE
 	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN);
 	if (info != NULL && info->tunnel_endpoint != 0) {
-		ret = encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
-						     info->key, info->node_id,
-						     secctx, &trace);
-
-		if (ret == IPSEC_ENDPOINT)
-			return CTX_ACT_OK;
-		else
-			return ret;
+		return encap_and_redirect_with_nodeid(ctx, info->tunnel_endpoint,
+						      info->node_id, secctx,
+						      &trace);
 	} else {
 		/* IPv4 lookup key: daddr & IPV4_MASK */
 		struct tunnel_key key = {};
@@ -1126,7 +1110,7 @@ out:
 __section("to-host")
 int to_host(struct __ctx_buff *ctx)
 {
-	__u32 magic = ctx_load_meta(ctx, ENCRYPT_OR_PROXY_MAGIC);
+	__u32 magic = ctx_load_meta(ctx, CB_PROXY_MAGIC);
 	__u16 __maybe_unused proto = 0;
 	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
@@ -1136,10 +1120,7 @@ int to_host(struct __ctx_buff *ctx)
 	bool traced = false;
 	__u32 src_id = 0;
 
-	if ((magic & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_ENCRYPT) {
-		ctx->mark = magic; /* CB_ENCRYPT_MAGIC */
-		src_id = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
-	} else if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
+	if ((magic & 0xFFFF) == MARK_MAGIC_TO_PROXY) {
 		/* Upper 16 bits may carry proxy port number */
 		__be16 port = magic >> 16;
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -333,15 +333,6 @@ skip_host_firewall:
 		/* See IPv4 comment. */
 		return DROP_UNROUTABLE;
 	}
-
-#ifdef ENABLE_IPSEC
-	if (info && info->key && info->tunnel_endpoint) {
-		__u8 key = get_min_encrypt_key(info->key);
-
-		set_encrypt_key_meta(ctx, key, info->node_id);
-		set_identity_meta(ctx, secctx);
-	}
-#endif
 	return CTX_ACT_OK;
 }
 
@@ -644,15 +635,6 @@ skip_vtep:
 		 */
 		return DROP_UNROUTABLE;
 	}
-
-#ifdef ENABLE_IPSEC
-	if (info && info->key && info->tunnel_endpoint) {
-		__u8 key = get_min_encrypt_key(info->key);
-
-		set_encrypt_key_meta(ctx, key, info->node_id);
-		set_identity_meta(ctx, secctx);
-	}
-#endif
 	return CTX_ACT_OK;
 }
 

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -16,29 +16,6 @@
 #define NOT_VTEP_DST 0
 #ifdef ENABLE_IPSEC
 static __always_inline int
-encap_and_redirect_nomark_ipsec(struct __ctx_buff *ctx, __u8 key,
-			        __u16 node_id, __u32 seclabel)
-{
-	/* Traffic from local host in tunnel mode will be passed to
-	 * cilium_host. In non-IPSec case traffic with non-local dst
-	 * will then be redirected to tunnel device. In IPSec case
-	 * though we need to traverse xfrm path still. The mark +
-	 * cb[4] hints will not survive a veth pair xmit to ingress
-	 * however so below encap_and_redirect_ipsec will not work.
-	 * Instead pass hints via cb[0], cb[4] (cb is not cleared
-	 * by dev_ctx_forward) and catch hints with bpf_host
-	 * prog that will populate mark/cb as expected by xfrm and 2nd
-	 * traversal into bpf_host. Remember we can't use cb[0-3]
-	 * in both cases because xfrm layer would overwrite them. We
-	 * use cb[4] here so it doesn't need to be reset by
-	 * bpf_host.
-	 */
-	set_encrypt_key_meta(ctx, key, node_id);
-	ctx_store_meta(ctx, CB_ENCRYPT_IDENTITY, seclabel);
-	return IPSEC_ENDPOINT;
-}
-
-static __always_inline int
 encap_and_redirect_ipsec(struct __ctx_buff *ctx, __u8 key, __u16 node_id,
 			 __u32 seclabel)
 {
@@ -164,21 +141,16 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 	return ctx_redirect(ctx, ENCAP_IFINDEX, 0);
 }
 
-/* encap_and_redirect_with_nodeid returns IPSEC_ENDPOINT after ctx meta-data is
- * set when IPSec is enabled. Caller should pass the ctx to the stack at this
- * point. Otherwise returns CTX_ACT_TX on successful redirect to tunnel device.
- * On error returns CTX_ACT_DROP, DROP_NO_TUNNEL_ENDPOINT or DROP_WRITE_ERROR.
+/* encap_and_redirect_with_nodeid returns CTX_ACT_OK after ctx meta-data is
+ * set. Caller should pass the ctx to the stack at this point. Otherwise
+ * returns CTX_ACT_REDIRECT on successful redirect to tunnel device.
+ * On error returns CTX_ACT_DROP or DROP_WRITE_ERROR.
  */
 static __always_inline int
 encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
-			       __u8 key __maybe_unused,
 			       __u16 node_id __maybe_unused, __u32 seclabel,
 			       const struct trace_ctx *trace)
 {
-#ifdef ENABLE_IPSEC
-	if (key)
-		return encap_and_redirect_nomark_ipsec(ctx, key, node_id, seclabel);
-#endif
 	return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint, seclabel, NOT_VTEP_DST,
 						trace);
 }
@@ -249,15 +221,6 @@ encap_and_redirect_netdev(struct __ctx_buff *ctx, struct tunnel_key *k,
 	if (!tunnel)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
-#ifdef ENABLE_IPSEC
-	if (tunnel->key) {
-		__u8 key = get_min_encrypt_key(tunnel->key);
-
-		return encap_and_redirect_nomark_ipsec(ctx, key,
-						       tunnel->node_id,
-						       seclabel);
-	}
-#endif
 	return __encap_and_redirect_with_nodeid(ctx, tunnel->ip4, seclabel,
 						NOT_VTEP_DST, trace);
 }

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -179,8 +179,8 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 			return encap_and_redirect_ipsec(ctx, encrypt_key,
 						        node_id, seclabel);
 #endif
-#if !defined(ENABLE_NODEPORT) && (defined(ENABLE_IPSEC) || defined(ENABLE_HOST_FIREWALL))
-		/* For IPSec and the host firewall, traffic from a pod to a remote node
+#if !defined(ENABLE_NODEPORT) && defined(ENABLE_HOST_FIREWALL)
+		/* For the host firewall, traffic from a pod to a remote node
 		 * is sent through the tunnel. In the case of node --> VIP@remote pod,
 		 * packets may be DNATed when they enter the remote node. If kube-proxy
 		 * is used, the response needs to go through the stack on the way to
@@ -192,7 +192,7 @@ encap_and_redirect_lxc(struct __ctx_buff *ctx, __u32 tunnel_endpoint,
 #else
 		return __encap_and_redirect_with_nodeid(ctx, tunnel_endpoint,
 							seclabel, NOT_VTEP_DST, trace);
-#endif /* !ENABLE_NODEPORT && (ENABLE_IPSEC || ENABLE_HOST_FIREWALL) */
+#endif /* !ENABLE_NODEPORT && ENABLE_HOST_FIREWALL */
 	}
 
 	tunnel = map_lookup_elem(&TUNNEL_MAP, key);

--- a/bpf/lib/identity.h
+++ b/bpf/lib/identity.h
@@ -114,6 +114,24 @@ static __always_inline __u32 inherit_identity_from_host(struct __ctx_buff *ctx, 
 		*identity = HOST_ID;
 	} else if (magic == MARK_MAGIC_ENCRYPT) {
 		*identity = ctx_load_meta(ctx, CB_ENCRYPT_IDENTITY);
+
+		/* Special case needed to handle upgrades. Can be removed in v1.15.
+		 * Before the upgrade, bpf_lxc will write the tunnel endpoint in
+		 * skb->cb[4]. After the upgrade, it will write the security identity.
+		 * For the upgrade to happen without drops, bpf_host thus needs to
+		 * handle both cases.
+		 * We can distinguish between the two cases by looking at the first
+		 * byte. Identities are on 24-bits so the first byte will be zero;
+		 * conversely, tunnel endpoint addresses within the range 0.0.0.0/8
+		 * (first byte is zero) are impossible because special purpose
+		 * (RFC6890).
+		 */
+		if ((*identity & 0xFF000000) != 0) {
+			/* skb->cb[4] was actually carrying the tunnel endpoint and the
+			 * security identity is in the mark.
+			 */
+			*identity = get_identity(ctx);
+		}
 #if defined(ENABLE_L7_LB)
 	} else if (magic == MARK_MAGIC_PROXY_EGRESS_EPID) {
 		*identity = get_epid(ctx); /* endpoint identity, not security identity! */

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -59,12 +59,6 @@ set_encrypt_key_mark(struct __sk_buff *ctx, __u8 key, __u32 node_id)
 	ctx->mark = or_encrypt_key(key) | node_id << 16;
 }
 
-static __always_inline __maybe_unused void
-set_encrypt_key_meta(struct __sk_buff *ctx, __u8 key, __u32 node_id)
-{
-	ctx->cb[0] = or_encrypt_key(key) | node_id << 16;
-}
-
 /**
  * set_encrypt_mark - sets the encryption mark to make skb to match ip rule
  * used to steer packet into Wireguard tunnel device (cilium_wg0) in order to

--- a/bpf/lib/overloadable_xdp.h
+++ b/bpf/lib/overloadable_xdp.h
@@ -38,12 +38,6 @@ set_encrypt_key_mark(struct xdp_md *ctx __maybe_unused, __u8 key __maybe_unused,
 {
 }
 
-static __always_inline __maybe_unused void
-set_encrypt_key_meta(struct xdp_md *ctx __maybe_unused, __u8 key __maybe_unused,
-		     __u32 node_id __maybe_unused)
-{
-}
-
 static __always_inline __maybe_unused int
 redirect_self(struct xdp_md *ctx __maybe_unused)
 {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ipam"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
@@ -281,8 +280,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		}
 	}
 
-	if option.Config.EnableIPSec &&
-		(option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) {
+	if option.Config.EnableIPSec {
 		// If IPsec is enabled on EKS or AKS, we need to restore the host
 		// endpoint before any other endpoint, to ensure a dropless upgrade.
 		// This code can be removed in v1.15.
@@ -309,8 +307,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 	}
 
 	for _, ep := range state.restored {
-		if ep.IsHost() && option.Config.EnableIPSec &&
-			(option.Config.IPAM == ipamOption.IPAMENI || option.Config.IPAM == ipamOption.IPAMAzure) {
+		if ep.IsHost() && option.Config.EnableIPSec {
 			// The host endpoint was handled above.
 			continue
 		}

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1054,11 +1054,10 @@ func (n *linuxNodeHandler) enableIPsecIPv4(newNode *nodeTypes.Node, zeroMark boo
 				upsertIPsecLog(err, "out IPv4", wildcardCIDR, cidr, spi)
 			}
 		} else {
-			localCIDR := n.nodeAddressing.IPv4().AllocationCIDR().IPNet
 			remoteCIDR := newNode.IPv4AllocCIDR.IPNet
 			n.replaceNodeIPSecOutRoute(new4Net)
-			spi, err = ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
-			upsertIPsecLog(err, "out IPv4", localCIDR, remoteCIDR, spi)
+			spi, err = ipsec.UpsertIPsecEndpoint(wildcardCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
+			upsertIPsecLog(err, "out IPv4", wildcardCIDR, remoteCIDR, spi)
 		}
 	}
 }
@@ -1128,11 +1127,10 @@ func (n *linuxNodeHandler) enableIPsecIPv6(newNode *nodeTypes.Node, zeroMark boo
 				upsertIPsecLog(err, "out IPv6", wildcardCIDR, cidr, spi)
 			}
 		} else {
-			localCIDR := &net.IPNet{IP: localIP, Mask: net.CIDRMask(0, 0)}
 			remoteCIDR := newNode.IPv6AllocCIDR.IPNet
 			n.replaceNodeIPSecOutRoute(new6Net)
-			spi, err := ipsec.UpsertIPsecEndpoint(localCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
-			upsertIPsecLog(err, "out IPv6", localCIDR, remoteCIDR, spi)
+			spi, err := ipsec.UpsertIPsecEndpoint(wildcardCIDR, remoteCIDR, localIP, remoteIP, remoteNodeID, ipsec.IPSecDirOut, false)
+			upsertIPsecLog(err, "out IPv6", wildcardCIDR, remoteCIDR, spi)
 		}
 	}
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -63,7 +63,6 @@ type Configuration interface {
 	TunnelingEnabled() bool
 	RemoteNodeIdentitiesEnabled() bool
 	NodeEncryptionEnabled() bool
-	EncryptionEnabled() bool
 }
 
 // Notifier is the interface the wraps Subscribe and Unsubscribe. An
@@ -373,11 +372,6 @@ func (m *Manager) legacyNodeIpBehavior() bool {
 	if m.conf.NodeEncryptionEnabled() {
 		return false
 	}
-	// Needed to store the SPI for pod->remote node in the ipcache since
-	// that path goes through the tunnel.
-	if m.conf.EncryptionEnabled() && m.conf.TunnelingEnabled() {
-		return false
-	}
 	return true
 }
 
@@ -417,7 +411,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// through the tunnel to preserve the source identity as part of the
 		// encapsulation. In encryption case we also want to use vxlan device
 		// to create symmetric traffic when sending nodeIP->pod and pod->nodeIP.
-		if address.Type == addressing.NodeCiliumInternalIP || m.conf.EncryptionEnabled() ||
+		if address.Type == addressing.NodeCiliumInternalIP || m.conf.NodeEncryptionEnabled() ||
 			option.Config.EnableHostFirewall || option.Config.JoinCluster {
 			tunnelIP = nodeIP
 		}

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -435,8 +435,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// to encrypt something we know does not have an encryption policy installed
 		// in the datapath. By setting key=0 and tunnelIP this will result in traffic
 		// being sent unencrypted over overlay device.
-		if !m.conf.NodeEncryptionEnabled() &&
-			(address.Type == addressing.NodeExternalIP || address.Type == addressing.NodeInternalIP) {
+		if !m.conf.NodeEncryptionEnabled() {
 			key = 0
 		}
 


### PR DESCRIPTION
 - [x] #25440 -- bpf: Don't encrypt on path hostns -> remote pod (@pchaigno)
     - Many small conflicts all around. Usually easy to resolve because we are removing code anyway.
 - [x] #26708 -- Fix upgrade for IPsec with tunneling (@pchaigno)
     - Minor conflicts for code that was removed anyway or code that was moved in the same file.
 - [x] #26810 -- docs/ipsec: Clarify limitation on number of nodes (@pchaigno)
     - Trivial conflict due to one line of docs not being backported to v1.12.

I manually tested:
- [x] Upgrade from v1.12.7 on EKS + overlay
- [x] Upgrade from v1.12.7 on EKS + ENI
- [x] Upgrade from v1.11.14 on EKS + overlay
- [x] Upgrade from v1.11.14 on EKS + ENI

Scale downs & ups as well as key rotations were not tested as we still have known issues on those operations (interruption of connections).

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 25440 26708 26810; do contrib/backporting/set-labels.py $pr done 1.12; done
```
