### PR TITLE
v1.13 Backports 2023-07-17

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -68,6 +68,7 @@ jobs:
 
   setup-and-test:
     runs-on: ubuntu-latest-4cores-16gb
+    name: 'Setup & Test'
     env:
       job_name: "Setup & Test"
     strategy:

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1376,7 +1376,11 @@
    * - ingressController.service
      - Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources.
      - object
-     - ``{"annotations":{},"insecureNodePort":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}``
+     - ``{"allocateLoadBalancerNodePorts":null,"annotations":{},"insecureNodePort":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}``
+   * - ingressController.service.allocateLoadBalancerNodePorts
+     - Configure if node port allocation is required for LB service ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
+     - string
+     - ``nil``
    * - ingressController.service.annotations
      - Annotations to be added for the shared LB service
      - object

--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -115,13 +115,16 @@ Rollout both the agent pods and the operator pods to make the changes effective:
 Compatibility with cloud environments
 -------------------------------------
 
+EKS's ENI mode
+~~~~~~~~~~~~~~
+
 Based on the specific configuration of the cloud provider and network interfaces
 it is possible that traffic leaves a node from the wrong interface. This happens in
 particular on EKS in ENI mode.
 
 To work around this issue, Cilium can be instructed to install the necessary IP
 rules and routes to route traffic through the appropriate network-facing
-interface as follow:
+interface as follows:
 
 .. tabs::
     .. group-tab:: Helm

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -215,4 +215,5 @@ Limitations
       top of other CNI plugins. For more information, see :gh-issue:`15596`.
     * :ref:`HostPolicies` are not currently supported with IPsec encryption.
     * IPsec encryption is not currently supported in combination with IPv6-only clusters.
-    * IPsec encryption is not supported on clusters with more than 65535 nodes.
+    * IPsec encryption is not supported on clusters or clustermeshes with more
+      than 65535 nodes.

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -1286,11 +1286,6 @@ considered external to the cluster.
       - toFQDNs:
           - matchName: "www.google.com"
 
-
-There is currently a known issue (:gh-issue:`24502`) that makes the ``kube-apiserver``
-entity unreliable. Until this is resolved, it is recommended to grant access to the apiserver
-by CIDR or by the special ``world`` entity.
-
 .. _HostPolicies:
 
 Host Policies

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -277,6 +277,7 @@ clusterPoolIPv
 clusterSize
 clustermesh
 clustermeshcertgen
+clustermeshes
 clusterwide
 cmdref
 cni

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -165,6 +165,7 @@ admin
 agentNotReadyTaintKey
 aksbyocni
 alibabacloud
+allocateLoadBalancerNodePorts
 allocator
 allocators
 allowedConfigOverrides

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -394,7 +394,8 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.secretsNamespace.create | bool | `true` | Create secrets namespace for Ingress. |
 | ingressController.secretsNamespace.name | string | `"cilium-secrets"` | Name of Ingress secret namespace. |
 | ingressController.secretsNamespace.sync | bool | `true` | Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally. |
-| ingressController.service | object | `{"annotations":{},"insecureNodePort":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
+| ingressController.service | object | `{"allocateLoadBalancerNodePorts":null,"annotations":{},"insecureNodePort":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
+| ingressController.service.allocateLoadBalancerNodePorts | string | `nil` | Configure if node port allocation is required for LB service ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation |
 | ingressController.service.annotations | object | `{}` | Annotations to be added for the shared LB service |
 | ingressController.service.insecureNodePort | string | `nil` | Configure a specific nodePort for insecure HTTP traffic on the shared LB service |
 | ingressController.service.labels | object | `{}` | Labels to be added for the shared LB service |

--- a/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ingress-service.yaml
@@ -28,6 +28,9 @@ spec:
   {{- if .Values.ingressController.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.ingressController.service.loadBalancerClass }}
   {{- end }}
+  {{- if (not (kindIs "invalid" .Values.ingressController.service.allocateLoadBalancerNodePorts)) }}
+  allocateLoadBalancerNodePorts: {{ .Values.ingressController.service.allocateLoadBalancerNodePorts }}
+  {{- end }}
   {{- end -}}
   {{- if .Values.ingressController.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.ingressController.service.loadBalancerIP }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -665,6 +665,9 @@ ingressController:
     loadBalancerClass: ~
     # -- Configure a specific loadBalancerIP on the shared LB service
     loadBalancerIP : ~
+    # -- Configure if node port allocation is required for LB service
+    # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
+    allocateLoadBalancerNodePorts: ~
 
 gatewayAPI:
   # -- Enable support for Gateway API in cilium

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -662,6 +662,9 @@ ingressController:
     loadBalancerClass: ~
     # -- Configure a specific loadBalancerIP on the shared LB service
     loadBalancerIP : ~
+    # -- Configure if node port allocation is required for LB service
+    # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
+    allocateLoadBalancerNodePorts: ~
 
 gatewayAPI:
   # -- Enable support for Gateway API in cilium


### PR DESCRIPTION
 * [x] #23616 (@deepeshaburse) :information_source: Minor docs conflicts
 * [ ] #26660 (@squeed) :information_source: Minor docs conflicts
 * [x] #26502 (@sayboras) :information_source: Minor docs conflicts
 * [x] #26800 (@tklauser)
 * [x] #26791 (@aanm)
 * [x] #26810 (@pchaigno)

PRs skipped due to conflicts:

 * #26755 (@rolinh)
 * #26759 (@qmonnet)
 * #26846 (@julianwiedmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 23616 26660 26502 26800 26791 26810; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=23616,26660,26502,26800,26791,26810
```
