### PR TITLE
mlh: disable remove PR to project

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -1,5 +1,3 @@
-project: "https://github.com/cilium/cilium/projects/239"
-column: "In progress"
 move-to-projects-for-labels-xored:
   v1.14:
     needs-backport/1.14:


### PR DESCRIPTION
Currently, trying to add new PRs to the 1.15 project dashboard fails because the column `In progress` doesn't exist. It seems as this feature has not been used for quite some time (1.14 timeframe).

To prevent MLH from failing, this feature gets disabled.