### PR TITLE
Default spire.install.enabled to true

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -251,7 +251,6 @@ jobs:
             --helm-set=hubble.eventBufferCapacity=65535 \
             --helm-set=bpf.monitorAggregation=none \
             --helm-set=authentication.mutual.spire.enabled=true \
-            --helm-set=authentication.mutual.spire.install.enabled=true \
             --nodes-without-cilium=kind-worker3 \
             --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
           TUNNEL="--helm-set-string=tunnelProtocol=${{ matrix.tunnel }}"

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -91,7 +91,7 @@
    * - :spelling:ignore:`authentication.mutual.spire.install.enabled`
      - Enable SPIRE installation. This will only take effect only if authentication.mutual.spire.enabled is true
      - bool
-     - ``false``
+     - ``true``
    * - :spelling:ignore:`authentication.mutual.spire.install.namespace`
      - SPIRE namespace to install into
      - string

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -72,7 +72,7 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.install.agent.labels | object | `{}` | SPIRE agent labels |
 | authentication.mutual.spire.install.agent.serviceAccount | object | `{"create":true,"name":"spire-agent"}` | SPIRE agent service account |
 | authentication.mutual.spire.install.agent.skipKubeletVerification | bool | `true` | SPIRE Workload Attestor kubelet verification. |
-| authentication.mutual.spire.install.enabled | bool | `false` | Enable SPIRE installation. This will only take effect only if authentication.mutual.spire.enabled is true |
+| authentication.mutual.spire.install.enabled | bool | `true` | Enable SPIRE installation. This will only take effect only if authentication.mutual.spire.enabled is true |
 | authentication.mutual.spire.install.namespace | string | `"cilium-spire"` | SPIRE namespace to install into |
 | authentication.mutual.spire.install.server.annotations | object | `{}` | SPIRE server annotations |
 | authentication.mutual.spire.install.server.ca.keyType | string | `"rsa-4096"` | SPIRE CA key type AWS requires the use of RSA. EC cryptography is not supported |

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -68,12 +68,6 @@
   {{- end }}
 {{- end }}
 
-{{- if .Values.authentication.mutual.spire.install.enabled }}
-  {{- if not .Values.authentication.mutual.spire.enabled }}
-    {{ fail "SPIRE installation requires .Values.authentication.mutual.enabled=true and .Values.authentication.mutual.spire.enabled=true" }}
-  {{- end }}
-{{- end }}
-
 {{/* validate Cilium operator */}}
 {{- if eq .Values.enableCiliumEndpointSlice true }}
   {{- if eq .Values.disableEndpointCRD true }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -3126,7 +3126,7 @@ authentication:
       install:
         # -- Enable SPIRE installation.
         # This will only take effect only if authentication.mutual.spire.enabled is true
-        enabled: false
+        enabled: true
         # -- SPIRE namespace to install into
         namespace: cilium-spire
         # SPIRE agent configuration

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -3123,7 +3123,7 @@ authentication:
       install:
         # -- Enable SPIRE installation.
         # This will only take effect only if authentication.mutual.spire.enabled is true
-        enabled: false
+        enabled: true
         # -- SPIRE namespace to install into
         namespace: cilium-spire
         # SPIRE agent configuration


### PR DESCRIPTION
This change sets `authentication.mutual.spire.install.enabled` to true. It will only take affect when `authentication.mutual.spire.enabled` is also true. This eliminates the need for 2 flags when installed with built-in spire which is the most common use. 

Fixes: #26771

```release-note
Change default helm value of authentication.mutual.spire.install.enabled to true
```
