### PR TITLE
Documentation: Fix Envoy LB docs incorrect supported annotation values

### DIFF
--- a/Documentation/network/servicemesh/envoy-load-balancing.rst
+++ b/Documentation/network/servicemesh/envoy-load-balancing.rst
@@ -115,8 +115,8 @@ Supported Annotations
      - Default Value
    * - ``service.cilium.io/lb-l7``
      - Enable L7 Load balancing for kubernetes service.
-     - ``envoy``, ``disabled``
-     - Default to ``disabled``
+     - ``enabled``, ``disabled``
+     - Defaults to ``disabled``
    * - ``service.cilium.io/lb-l7-algorithm``
      - The LB algorithm to be used for services.
      - ``round_robin``, ``least_request``, ``random``


### PR DESCRIPTION
There is a one-liner example that advices adding correct `service.cilium.io/lb-l7=enabled` annotation, but the table with supported annotations has a typo with incorrect `envoy` option instead of `enabled`.