### PR TITLE
Removes Deepcopy() Marker From TunnelIP Type

### DIFF
--- a/pkg/maps/tunnel/tunnel.go
+++ b/pkg/maps/tunnel/tunnel.go
@@ -62,7 +62,6 @@ func NewTunnelMap(mapName string) *Map {
 	}
 }
 
-// +k8s:deepcopy-gen=true
 type TunnelIP struct {
 	// represents both IPv6 and IPv4 (in the lowest four bytes)
 	IP     types.IPv6 `align:"$union0"`


### PR DESCRIPTION
Removes the controller-runtime Deepcopy() func marker from the `TunnelIP` API type. No Deepcopy funcs are currently being used for this type and removing the marker is required to prevent the `generate-k8s-api` target from generating the Deepcopy() funcs.

Fixes: #26877
