### PR TITLE
bpf: nat: SNAT cleanups

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1590,13 +1590,12 @@ static __always_inline int snat_v6_rewrite_ingress(struct __ctx_buff *ctx,
 }
 
 static __always_inline bool
-snat_v6_nat_can_skip(const struct ipv6_nat_target *target, const struct ipv6_ct_tuple *tuple,
-		     bool icmp_echoreply)
+snat_v6_nat_can_skip(const struct ipv6_nat_target *target,
+		     const struct ipv6_ct_tuple *tuple)
 {
 	__u16 sport = bpf_ntohs(tuple->sport);
 
-	return (!target->from_local_endpoint && sport < NAT_MIN_EGRESS) ||
-		icmp_echoreply;
+	return (!target->from_local_endpoint && sport < NAT_MIN_EGRESS);
 }
 
 static __always_inline bool
@@ -1763,7 +1762,6 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 		__be16 sport;
 		__be16 dport;
 	} l4hdr;
-	bool icmp_echoreply = false;
 
 	build_bug_on(sizeof(struct ipv6_nat_entry) > 64);
 
@@ -1794,16 +1792,14 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 			tuple->sport = icmp6hdr.icmp6_dataun.u_echo.identifier;
 			ct_action = ACTION_CREATE;
 		} else {
-			tuple->dport = icmp6hdr.icmp6_dataun.u_echo.identifier;
-			tuple->sport = 0;
-			icmp_echoreply = true;
+			return NAT_PUNT_TO_STACK;
 		}
 		break;
 	default:
 		return NAT_PUNT_TO_STACK;
 	};
 
-	if (snat_v6_nat_can_skip(target, tuple, icmp_echoreply))
+	if (snat_v6_nat_can_skip(target, tuple))
 		return NAT_PUNT_TO_STACK;
 
 	return __snat_v6_nat(ctx, tuple, off, ct_action, false, target, ext_err);

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1772,19 +1772,19 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 	case IPPROTO_ICMPV6:
 		if (ctx_load_bytes(ctx, off, &icmp6hdr, sizeof(icmp6hdr)) < 0)
 			return DROP_INVALID;
-		/* Letting neighbor solicitation / advertisement pass through. */
-		if (icmp6hdr.icmp6_type == ICMP6_NS_MSG_TYPE ||
-		    icmp6hdr.icmp6_type == ICMP6_NA_MSG_TYPE)
-			return CTX_ACT_OK;
-		if (icmp6hdr.icmp6_type != ICMPV6_ECHO_REQUEST &&
-		    icmp6hdr.icmp6_type != ICMPV6_ECHO_REPLY)
-			return DROP_NAT_UNSUPP_PROTO;
-		if (icmp6hdr.icmp6_type == ICMPV6_ECHO_REQUEST) {
+
+		switch (icmp6hdr.icmp6_type) {
+		case ICMPV6_ECHO_REPLY:
+		case ICMP6_NS_MSG_TYPE:
+		case ICMP6_NA_MSG_TYPE:
+			return NAT_PUNT_TO_STACK;
+		case ICMPV6_ECHO_REQUEST:
 			tuple->dport = 0;
 			tuple->sport = icmp6hdr.icmp6_dataun.u_echo.identifier;
 			ct_action = ACTION_CREATE;
-		} else {
-			return NAT_PUNT_TO_STACK;
+			break;
+		default:
+			return DROP_NAT_UNSUPP_PROTO;
 		}
 		break;
 	default:

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1935,10 +1935,6 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		if (ctx_load_bytes(ctx, off, &icmp6hdr, sizeof(icmp6hdr)) < 0)
 			return DROP_INVALID;
 		switch (icmp6hdr.icmp6_type) {
-			/* Letting neighbor solicitation / advertisement pass through. */
-		case ICMP6_NS_MSG_TYPE:
-		case ICMP6_NA_MSG_TYPE:
-			return CTX_ACT_OK;
 		case ICMPV6_ECHO_REPLY:
 			tuple.dport = icmp6hdr.icmp6_dataun.u_echo.identifier;
 			tuple.sport = 0;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -604,7 +604,7 @@ static __always_inline int snat_v4_rewrite_ingress(struct __ctx_buff *ctx,
 					   offsetof(struct icmphdr, type),
 					   &type, 1) < 0)
 				return DROP_INVALID;
-			if (type == ICMP_ECHO || type == ICMP_ECHOREPLY) {
+			if (type == ICMP_ECHOREPLY) {
 				if (ctx_store_bytes(ctx, off +
 						    offsetof(struct icmphdr, un.echo.id),
 						    &state->to_dport,
@@ -1126,11 +1126,6 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
 			return DROP_INVALID;
 		switch (icmphdr.type) {
-		case ICMP_ECHO:
-			tuple.dport = 0;
-			tuple.sport = icmphdr.un.echo.id;
-			ct_action = ACTION_CREATE;
-			break;
 		case ICMP_ECHOREPLY:
 			tuple.dport = icmphdr.un.echo.id;
 			tuple.sport = 0;
@@ -1571,7 +1566,7 @@ static __always_inline int snat_v6_rewrite_ingress(struct __ctx_buff *ctx,
 
 			if (icmp6_load_type(ctx, off, &type) < 0)
 				return DROP_INVALID;
-			if (type == ICMPV6_ECHO_REQUEST || type == ICMPV6_ECHO_REPLY) {
+			if (type == ICMPV6_ECHO_REPLY) {
 				if (ctx_store_bytes(ctx, off +
 						    offsetof(struct icmp6hdr,
 							     icmp6_dataun.u_echo.identifier),
@@ -1956,11 +1951,6 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		case ICMP6_NS_MSG_TYPE:
 		case ICMP6_NA_MSG_TYPE:
 			return CTX_ACT_OK;
-		case ICMPV6_ECHO_REQUEST:
-			tuple.dport = 0;
-			tuple.sport = icmp6hdr.icmp6_dataun.u_echo.identifier;
-			ct_action = ACTION_CREATE;
-			break;
 		case ICMPV6_ECHO_REPLY:
 			tuple.dport = icmp6hdr.icmp6_dataun.u_echo.identifier;
 			tuple.sport = 0;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -376,10 +376,8 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 
 	if (*state)
 		return NAT_CONTINUE_XLATE;
-	else
-		return tuple->nexthdr != IPPROTO_ICMP &&
-		       bpf_ntohs(tuple->dport) < target->min_port ?
-		       NAT_PUNT_TO_STACK : DROP_NAT_NO_MAPPING;
+
+	return DROP_NAT_NO_MAPPING;
 }
 
 static __always_inline int
@@ -1392,8 +1390,7 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 			       struct ipv6_ct_tuple *tuple,
 			       enum ct_action ct_action,
 			       struct ipv6_nat_entry **state,
-			       __u32 off,
-			       const struct ipv6_nat_target *target)
+			       __u32 off)
 {
 	*state = snat_v6_lookup(tuple);
 
@@ -1421,10 +1418,8 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 
 	if (*state)
 		return NAT_CONTINUE_XLATE;
-	else
-		return tuple->nexthdr != IPPROTO_ICMPV6 &&
-		       bpf_ntohs(tuple->dport) < target->min_port ?
-		       NAT_PUNT_TO_STACK : DROP_NAT_NO_MAPPING;
+
+	return DROP_NAT_NO_MAPPING;
 }
 
 static __always_inline int snat_v6_icmp_rewrite_embedded(struct __ctx_buff *ctx,
@@ -1982,8 +1977,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 
 	if (snat_v6_rev_nat_can_skip(target, &tuple))
 		return NAT_PUNT_TO_STACK;
-	ret = snat_v6_rev_nat_handle_mapping(ctx, &tuple, ct_action, &state,
-					     off, target);
+	ret = snat_v6_rev_nat_handle_mapping(ctx, &tuple, ct_action, &state, off);
 	if (ret > 0)
 		return CTX_ACT_OK;
 	if (ret < 0)

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -35,8 +35,6 @@ struct nat_entry {
 	__u64 pad2;		/* Future use. */
 };
 
-#define NAT_CONTINUE_XLATE	0
-
 #ifdef HAVE_LARGE_INSN_LIMIT
 # define SNAT_COLLISION_RETRIES		128
 # define SNAT_SIGNAL_THRES		64
@@ -329,7 +327,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 	}
 
 	if (*state)
-		return NAT_CONTINUE_XLATE;
+		return 0;
 	else
 		return snat_v4_new_mapping(ctx, tuple, (*state = tmp), target, needs_ct,
 					   ext_err);
@@ -375,7 +373,7 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 	}
 
 	if (*state)
-		return NAT_CONTINUE_XLATE;
+		return 0;
 
 	return DROP_NAT_NO_MAPPING;
 }
@@ -933,8 +931,6 @@ __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 
 	ret = snat_v4_nat_handle_mapping(ctx, tuple, has_l4_header, action,
 					 &state, &tmp, l4_off, target, ext_err);
-	if (ret > 0)
-		return CTX_ACT_OK;
 	if (ret < 0)
 		return ret;
 
@@ -1146,8 +1142,6 @@ snat_v4_rev_nat(struct __ctx_buff *ctx, const struct ipv4_nat_target *target,
 		return NAT_PUNT_TO_STACK;
 	ret = snat_v4_rev_nat_handle_mapping(ctx, &tuple, has_l4_header, ct_action, &state,
 					     off, target);
-	if (ret > 0)
-		return CTX_ACT_OK;
 	if (ret < 0)
 		return ret;
 
@@ -1374,7 +1368,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 	}
 
 	if (*state)
-		return NAT_CONTINUE_XLATE;
+		return 0;
 	else
 		return snat_v6_new_mapping(ctx, tuple, (*state = tmp), target, needs_ct,
 					   ext_err);
@@ -1412,7 +1406,7 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 	}
 
 	if (*state)
-		return NAT_CONTINUE_XLATE;
+		return 0;
 
 	return DROP_NAT_NO_MAPPING;
 }
@@ -1737,8 +1731,6 @@ __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 
 	ret = snat_v6_nat_handle_mapping(ctx, tuple, action, &state, &tmp,
 					 l4_off, target, ext_err);
-	if (ret > 0)
-		return CTX_ACT_OK;
 	if (ret < 0)
 		return ret;
 
@@ -1964,8 +1956,6 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 	if (snat_v6_rev_nat_can_skip(target, &tuple))
 		return NAT_PUNT_TO_STACK;
 	ret = snat_v6_rev_nat_handle_mapping(ctx, &tuple, ct_action, &state, off);
-	if (ret > 0)
-		return CTX_ACT_OK;
 	if (ret < 0)
 		return ret;
 


### PR DESCRIPTION
Rip out a bunch of small things that on closer look turned out to be unused. I suspect most of this is leftovers from splitting the SNAT code into ingress/egress paths.

Also clean up two small inconsistencies in the ICMPv6 NS / NA handling.