### PR TITLE
ci-gke: Set `useDigest=false` for Hubble Relay

### DIFF
--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -157,6 +157,7 @@ jobs:
             --helm-set=hubble.relay.enabled=true \
             --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
             --helm-set=hubble.relay.image.tag=${SHA} \
+            --helm-set=hubble.relay.image.useDigest=false \
             --helm-set=agentNotReadyTaintKey=ignore-taint.cluster-autoscaler.kubernetes.io/cilium-agent-not-ready \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \


### PR DESCRIPTION
As with all other *-ci images, we should not use check the digest when pulling the image, as it is different for CI builds. On main this has not been an issue, because useDigest already defaults to false, but on release branches (such as v1.14), we do check the digest by default. This caused failing workflows on the v1.14 branch which should be fixed by this commit.

This extends the previous PR which was missing this change for the GKE workflow.

Fixes: 98003d5fef7b ("ci/github: Set `useDigest=false` for Hubble Relay")
