### PR TITLE
docs: Marked L2-Announcements as beta

### DIFF
--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -6,9 +6,11 @@
 
 .. _l2_announcements:
 
-************************************
-L2 Announcements / L2 Aware LB
-************************************
+*************************************
+L2 Announcements / L2 Aware LB (Beta)
+*************************************
+
+.. include:: ../beta.rst
 
 L2 Announcements is a feature which makes services visible and reachable on 
 the local area network. This feature is primarily intended for on-premises


### PR DESCRIPTION
The L2-announcements feature has not yet been used and tested widely and lacks a few features such as metrics. So mark it as beta for now.

```release-note
Marking L2-announcements a beta feature
```
