### PR TITLE
docs: fixed search for every page

### DIFF
--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ sphinx==5.3.0
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@3bd69f33e7b2af2d0173fd997ec7ad21ce19ae3b
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@518ccd93123244a27c36c99e32b53a0db855e574
 # We use semver to parse Cilium's version in the config file
 semver==2.13.0
 # Sphinx extensions


### PR DESCRIPTION
Previously search input didn't work on some pages, updated docs theme should fix this.

Closes #26866

Theme fix PR: https://github.com/cilium/sphinx_rtd_theme/pull/22