### PR TITLE
 option: add LoadBalancerUsesDSR() helper

### DIFF
--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -215,17 +215,17 @@ func initKubeProxyReplacementOptions(tunnelConfig tunnel.Config) error {
 
 	if option.Config.EnableNodePort {
 		if option.Config.TunnelingEnabled() && tunnelConfig.Protocol() == tunnel.VXLAN &&
-			option.Config.NodePortMode != option.NodePortModeSNAT {
+			option.Config.LoadBalancerUsesDSR() {
 			return fmt.Errorf("Node Port %q mode cannot be used with %s tunneling.", option.Config.NodePortMode, tunnel.VXLAN)
 		}
 
-		if option.Config.TunnelingEnabled() && option.Config.NodePortMode != option.NodePortModeSNAT &&
+		if option.Config.TunnelingEnabled() && option.Config.LoadBalancerUsesDSR() &&
 			option.Config.LoadBalancerDSRDispatch != option.DSRDispatchGeneve {
 			return fmt.Errorf("Tunnel routing with Node Port %q mode requires %s dispatch.",
 				option.Config.NodePortMode, option.DSRDispatchGeneve)
 		}
 
-		if option.Config.NodePortMode != option.NodePortModeSNAT &&
+		if option.Config.LoadBalancerUsesDSR() &&
 			option.Config.LoadBalancerDSRDispatch == option.DSRDispatchGeneve &&
 			tunnelConfig.Protocol() != tunnel.Geneve {
 			return fmt.Errorf("Node Port %q mode with %s dispatch requires %s tunnel protocol.",
@@ -474,7 +474,7 @@ func finishKubeProxyReplacementInit() error {
 
 	if option.Config.EnableIPv4 &&
 		!option.Config.TunnelingEnabled() &&
-		option.Config.NodePortMode != option.NodePortModeSNAT &&
+		option.Config.LoadBalancerUsesDSR() &&
 		len(option.Config.GetDevices()) > 1 {
 
 		// In the case of the multi-dev NodePort DSR, if a request from an

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -432,8 +432,7 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 		cDefinesMap["DSR_ENCAP_NONE"] = fmt.Sprintf("%d", dsrEncapNone)
 		cDefinesMap["DSR_XLATE_FRONTEND"] = fmt.Sprintf("%d", dsrL4XlateFrontend)
 		cDefinesMap["DSR_XLATE_BACKEND"] = fmt.Sprintf("%d", dsrL4XlateBackend)
-		if option.Config.NodePortMode == option.NodePortModeDSR ||
-			option.Config.NodePortMode == option.NodePortModeHybrid {
+		if option.Config.LoadBalancerUsesDSR() {
 			cDefinesMap["ENABLE_DSR"] = "1"
 			if option.Config.EnablePMTUDiscovery {
 				cDefinesMap["ENABLE_DSR_ICMP_ERRORS"] = "1"

--- a/pkg/datapath/tunnel/cell.go
+++ b/pkg/datapath/tunnel/cell.go
@@ -35,7 +35,7 @@ var Cell = cell.Module(
 				(dcfg.EnableNodePort ||
 					dcfg.KubeProxyReplacement == option.KubeProxyReplacementStrict ||
 					dcfg.KubeProxyReplacement == option.KubeProxyReplacementTrue) &&
-					dcfg.NodePortMode != option.NodePortModeSNAT &&
+					dcfg.LoadBalancerUsesDSR() &&
 					dcfg.LoadBalancerDSRDispatch == option.DSRDispatchGeneve,
 				// The datapath logic takes care of the MTU overhead. So no need to
 				// take it into account here.

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2769,6 +2769,11 @@ func (c *DaemonConfig) DirectRoutingDeviceRequired() bool {
 	return c.EnableNodePort || BPFHostRoutingEnabled || Config.EnableWireguard
 }
 
+func (c *DaemonConfig) LoadBalancerUsesDSR() bool {
+	return c.NodePortMode == NodePortModeDSR ||
+		c.NodePortMode == NodePortModeHybrid
+}
+
 func (c *DaemonConfig) validateIPv6ClusterAllocCIDR() error {
 	ip, cidr, err := net.ParseCIDR(c.IPv6ClusterAllocCIDR)
 	if err != nil {


### PR DESCRIPTION
Spelling out the different modes that imply DSR is more robust than saying
"if it's not SNAT, it must be DSR".

As discussed in https://github.com/cilium/cilium/pull/25553#pullrequestreview-1454817088.