### PR TITLE
BGP CP: Adds Support for LoadBalancerClass

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -68,7 +68,7 @@ func newLBIPAM(params LBIPAMParams) *LBIPAM {
 
 	var lbClasses []string
 	if params.DaemonConfig.EnableBGPControlPlane {
-		lbClasses = append(lbClasses, "io.cilium/bgp-control-plane")
+		lbClasses = append(lbClasses, cilium_api_v2alpha1.BGPLoadBalancerClass)
 	}
 
 	jobGroup := params.JobRegistry.NewGroup(

--- a/pkg/bgpv1/manager/reconcile.go
+++ b/pkg/bgpv1/manager/reconcile.go
@@ -626,26 +626,33 @@ func (r *LBServiceReconciler) svcDiffReconciliation(ctx context.Context, sc *Ser
 // desired state.
 func (r *LBServiceReconciler) svcDesiredRoutes(newc *v2alpha1api.CiliumBGPVirtualRouter, svc *slim_corev1.Service, ls localServices) ([]netip.Prefix, error) {
 	if newc.ServiceSelector == nil {
-		// If the vRouter has no service selector, there are no desired routes
+		// If the vRouter has no service selector, there are no desired routes.
 		return nil, nil
 	}
 
-	// Ignore non-loadbalancer services
+	// Ignore non-loadbalancer services.
 	if svc.Spec.Type != slim_corev1.ServiceTypeLoadBalancer {
 		return nil, nil
 	}
 
+	// The vRouter has a service selector, so determine the desired routes.
 	svcSelector, err := slim_metav1.LabelSelectorAsSelector(newc.ServiceSelector)
 	if err != nil {
 		return nil, fmt.Errorf("labelSelectorAsSelector: %w", err)
 	}
 
-	// Ignore non matching services
+	// Ignore non matching services.
 	if !svcSelector.Matches(serviceLabelSet(svc)) {
 		return nil, nil
 	}
 
-	// Ignore externalTrafficPolicy == Local && no local endpoints
+	// Ignore service managed by an unsupported LB class.
+	if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass != v2alpha1api.BGPLoadBalancerClass {
+		// The service is managed by a different LB class.
+		return nil, nil
+	}
+
+	// Ignore externalTrafficPolicy == Local && no local endpoints.
 	if svc.Spec.ExternalTrafficPolicy == slim_corev1.ServiceExternalTrafficPolicyLocal &&
 		!hasLocalEndpoints(svc, ls) {
 		return nil, nil

--- a/pkg/bgpv1/manager/reconcile_test.go
+++ b/pkg/bgpv1/manager/reconcile_test.go
@@ -601,6 +601,12 @@ func TestLBServiceReconciler(t *testing.T) {
 	svc1IPv6ETPLocal.Status.LoadBalancer.Ingress[0] = slim_corev1.LoadBalancerIngress{IP: ingressV6}
 	svc1IPv6ETPLocal.Spec.ExternalTrafficPolicy = slim_corev1.ServiceExternalTrafficPolicyLocal
 
+	svc1LbClass := svc1.DeepCopy()
+	svc1LbClass.Spec.LoadBalancerClass = pointer.String(v2alpha1api.BGPLoadBalancerClass)
+
+	svc1UnsupportedClass := svc1LbClass.DeepCopy()
+	svc1UnsupportedClass.Spec.LoadBalancerClass = pointer.String("io.vendor/unsupported-class")
+
 	svc2NonDefault := &slim_corev1.Service{
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name:      svc2NonDefaultName.Name,
@@ -893,6 +899,55 @@ func TestLBServiceReconciler(t *testing.T) {
 				},
 			},
 		},
+		// BGP load balancer class with matching selectors for service.
+		{
+			name:               "lb-class-and-selectors",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1LbClass},
+			updated: map[resource.Key][]string{
+				svc1Name: {
+					ingressV4Prefix,
+				},
+			},
+		},
+		// BGP load balancer class with no selectors for service.
+		{
+			name:               "lb-class-no-selectors",
+			oldServiceSelector: nil,
+			newServiceSelector: nil,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1LbClass},
+			updated:            map[resource.Key][]string{},
+		},
+		// BGP load balancer class with selectors for a different service.
+		{
+			name:               "lb-class-with-diff-selectors",
+			oldServiceSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]string{"io.kubernetes.service.name": "svc-2"}},
+			newServiceSelector: &slim_metav1.LabelSelector{MatchLabels: map[string]string{"io.kubernetes.service.name": "svc-2"}},
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1LbClass},
+			updated:            map[resource.Key][]string{},
+		},
+		// Unsupported load balancer class with matching selectors for service.
+		{
+			name:               "unsupported-lb-class-with-selectors",
+			oldServiceSelector: &blueSelector,
+			newServiceSelector: &blueSelector,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1UnsupportedClass},
+			updated:            map[resource.Key][]string{},
+		},
+		// Unsupported load balancer class with no matching selectors for service.
+		{
+			name:               "unsupported-lb-class-with-no-selectors",
+			oldServiceSelector: nil,
+			newServiceSelector: nil,
+			advertised:         map[resource.Key][]string{},
+			upsertedServices:   []*slim_corev1.Service{svc1UnsupportedClass},
+			updated:            map[resource.Key][]string{},
+		},
 		// No-LB service
 		{
 			name:               "non-lb svc",
@@ -1112,9 +1167,9 @@ func TestLBServiceReconciler(t *testing.T) {
 
 			// if we disable exports of pod cidr ensure no advertisements are
 			// still present.
-			if tt.newServiceSelector == nil {
+			if tt.newServiceSelector == nil && !containsLbClass(tt.upsertedServices) {
 				if len(testSC.ServiceAnnouncements) > 0 {
-					t.Fatal("disabled export but advertisements till present")
+					t.Fatal("disabled export but advertisements still present")
 				}
 			}
 
@@ -1276,4 +1331,13 @@ func toHostPrefix(addr string) string {
 		bits = 128
 	}
 	return netip.PrefixFrom(addrNet, bits).String()
+}
+
+func containsLbClass(svcs []*slim_corev1.Service) bool {
+	for _, svc := range svcs {
+		if svc.Spec.LoadBalancerClass != nil && *svc.Spec.LoadBalancerClass == v2alpha1api.BGPLoadBalancerClass {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -220,8 +220,12 @@ spec:
                       type: array
                     serviceSelector:
                       description: "ServiceSelector selects a group of load balancer
-                        services which this virtual router will announce. \n If empty
-                        / nil no services will be announced."
+                        services which this virtual router will announce. The loadBalancerClass
+                        for a service must be nil or specify a class supported by
+                        Cilium, e.g. \"io.cilium/bgp-control-plane\". Refer to the
+                        following document for additional details regarding load balancer
+                        classes: \n   https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+                        \n If empty / nil no services will be announced."
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -27,6 +27,8 @@ const (
 	DefaultBGPKeepAliveTimeSeconds = 30
 	// DefaultBGPGRRestartTimeSeconds defines default Restart Time for graceful restart (RFC 4724, section 4.2)
 	DefaultBGPGRRestartTimeSeconds = 120
+	// BGPLoadBalancerClass defines the BGP Control Plane load balancer class for Services.
+	BGPLoadBalancerClass = "io.cilium/bgp-control-plane"
 )
 
 // +genclient
@@ -180,7 +182,12 @@ type CiliumBGPVirtualRouter struct {
 	// +kubebuilder:default=false
 	ExportPodCIDR *bool `json:"exportPodCIDR,omitempty"`
 	// ServiceSelector selects a group of load balancer services which this
-	// virtual router will announce.
+	// virtual router will announce. The loadBalancerClass for a service must
+	// be nil or specify a class supported by Cilium, e.g. "io.cilium/bgp-control-plane".
+	// Refer to the following document for additional details regarding load balancer
+	// classes:
+	//
+	//   https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
 	//
 	// If empty / nil no services will be announced.
 	//


### PR DESCRIPTION
Updates BGP CP to support advertising services configured with a [LoadBalancerClass](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class).

Fixes: #26556

```release-note
When BGP control plane is enabled and configured for service announcements, it will only advertise a matching service that has an unspecified loadbalancerClass or set for "io.cilium/bgp-control-plane".
```
