### PR TITLE
clustermesh-apiserver deployment: support lifecycle and terminationGr…

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -121,6 +121,10 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.clustermesh.apiserver.etcd.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       - name: apiserver
         image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
@@ -176,6 +180,10 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.clustermesh.apiserver.lifecycle }}
+        lifecycle:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       volumes:
       - name: etcd-server-secrets
         secret:
@@ -196,6 +204,7 @@ spec:
       priorityClassName: {{ include "cilium.priorityClass" (list $ .Values.clustermesh.apiserver.priorityClassName "system-cluster-critical") }}
       serviceAccount: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.clustermeshApiserver.name | quote }}
+      terminationGracePeriodSeconds: {{ .Values.clustermesh.apiserver.terminationGracePeriodSeconds }}
       automountServiceAccountToken: {{ .Values.serviceAccounts.clustermeshApiserver.automount }}
       {{- with .Values.clustermesh.apiserver.affinity }}
       affinity:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2281,7 +2281,10 @@ clustermesh:
 
       # -- Security context to be added to clustermesh-apiserver etcd containers
       securityContext: {}
-
+      
+      # -- lifecycle setting for the etcd container.
+      lifecycle: {}
+      
       init:
         # -- Specifies the resources for etcd init container in the apiserver
         resources: {}
@@ -2315,6 +2318,12 @@ clustermesh:
 
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
+
+    # -- lifecycle setting for the apiserver container.
+    lifecycle: {}
+
+    # -- terminationGracePeriodSeconds(default 30s) for the clustermesh-apiserver deployment.
+    terminationGracePeriodSeconds: 30
 
     # -- Additional clustermesh-apiserver environment variables.
     extraEnv: []


### PR DESCRIPTION
clustermesh-apiserver deployment: support lifecycle and terminationGracePeriodSeconds

clustermesh-apiserver deployment support lifecycle and terminationGracePeriodSeconds, because we need a while time(by lifecycle.preStop hook) to wait AWS NLB draining target for prevent connection issue when clustermesh-apiserver pod terminating

Please note:  1.14 helm chart also need these settings.

Fixes: #26900

```release-note
clustermesh-apiserver deployment support lifecycle and terminationGracePeriodSeconds.
```
