### PR TITLE
Use the server image from values for SPIRE

### DIFF
--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -39,7 +39,7 @@ spec:
           - |
             {{- tpl (.Files.Get "files/spire/init.bash") . | nindent 12 }}
       - name: spire-server
-        image: ghcr.io/spiffe/spire-server:1.5.1
+        image: {{ .Values.authentication.mutual.spire.install.server.image }}
         args:
         - -config
         - /run/spire/config/server.conf


### PR DESCRIPTION
The SPIRE server wasn't yet set to the ones listed in the values. This fixes that oversight.

```release-note
SPIRE Server image now is the value from the Helm values file
```
