### PR TITLE
services: prevent temporary connectivity loss on agent restart

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -469,7 +469,7 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 				controller.NewManager().UpdateController("sync-lb-maps-with-k8s-services",
 					controller.ControllerParams{
 						DoFunc: func(ctx context.Context) error {
-							return d.svc.SyncWithK8sFinished()
+							return d.svc.SyncWithK8sFinished(d.k8sWatcher.K8sSvcCache.EnsureService)
 						},
 						Context: d.ctx,
 					},

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -20,6 +21,7 @@ import (
 	datapathOpt "github.com/cilium/cilium/pkg/datapath/option"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	datapathTypes "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/k8s"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -104,6 +106,9 @@ type svcInfo struct {
 	LoopbackHostport          bool
 
 	restoredFromDatapath bool
+	// The hashes of the backends restored from the datapath and
+	// not yet heard about from the service cache.
+	restoredBackendHashes sets.Set[string]
 }
 
 func (svc *svcInfo) isL7LBService() bool {
@@ -1072,7 +1077,27 @@ func (s *Service) restoreAndDeleteOrphanSourceRanges() error {
 //
 // The removal is based on an assumption that during the sync period
 // UpsertService() is going to be called for each alive service.
-func (s *Service) SyncWithK8sFinished() error {
+func (s *Service) SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.StoppableWaitGroup) bool) error {
+	servicesWithStaleBackends := sets.New[lb.ServiceName]()
+
+	// We need to trigger the stale services refresh while not holding the
+	// lock, to ensure that the generated events can be processed, and to
+	// prevent a possible deadlock in case the events channel is already full.
+	defer func() {
+		swg := lock.NewStoppableWaitGroup()
+
+		for svc := range servicesWithStaleBackends {
+			ensurer(k8s.ServiceID{
+				Cluster:   svc.Cluster,
+				Namespace: svc.Namespace,
+				Name:      svc.Name,
+			}, swg)
+		}
+
+		swg.Stop()
+		swg.Wait()
+	}()
+
 	s.Lock()
 	defer s.Unlock()
 
@@ -1086,7 +1111,18 @@ func (s *Service) SyncWithK8sFinished() error {
 			if err := s.deleteServiceLocked(svc); err != nil {
 				return fmt.Errorf("Unable to remove service %+v: %s", svc, err)
 			}
+		} else if svc.restoredBackendHashes.Len() > 0 {
+			// The service is still associated with stale backends
+			servicesWithStaleBackends.Insert(svc.svcName)
+			log.WithFields(logrus.Fields{
+				logfields.ServiceID:      svc.frontend.ID,
+				logfields.ServiceName:    svc.svcName.String(),
+				logfields.L3n4Addr:       logfields.Repr(svc.frontend.L3n4Addr),
+				logfields.OrphanBackends: svc.restoredBackendHashes.Len(),
+			}).Info("Service has stale backends: triggering refresh")
 		}
+
+		svc.restoredBackendHashes = nil
 	}
 
 	// Remove no longer existing affinity matches
@@ -1533,6 +1569,14 @@ func (s *Service) restoreServicesLocked(svcBackendsById map[lb.BackendID]struct{
 			svcBackendsById[backend.ID] = struct{}{}
 		}
 
+		if len(newSVC.backendByHash) > 0 {
+			// Indicate that these backends were restored from BPF maps,
+			// so that they are not removed until SyncWithK8sFinished()
+			// is executed (if not observed in the meanwhile) to prevent
+			// disrupting valid connections.
+			newSVC.restoredBackendHashes = sets.KeySet(newSVC.backendByHash)
+		}
+
 		// Recalculate Maglev lookup tables if the maps were removed due to
 		// the changed M param.
 		ipv6 := newSVC.frontend.IsIPv6() || (svc.NatPolicy == lb.SVCNatPolicyNat46)
@@ -1651,6 +1695,10 @@ func (s *Service) updateBackendsCacheLocked(svc *svcInfo, backends []*lb.Backend
 				backends[i].ID = s.backendByHash[hash].ID
 			}
 		} else {
+			// We observed this backend, hence let's remove it from the list
+			// of the restored ones.
+			svc.restoredBackendHashes.Delete(hash)
+
 			backends[i].ID = b.ID
 			// Backend state can either be updated via kubernetes events,
 			// or service API. If the state update is coming via kubernetes events,
@@ -1684,6 +1732,14 @@ func (s *Service) updateBackendsCacheLocked(svc *svcInfo, backends []*lb.Backend
 
 	for hash, backend := range svc.backendByHash {
 		if _, found := backendSet[hash]; !found {
+			if svc.restoredBackendHashes.Has(hash) {
+				// Don't treat backends restored from the datapath and not yet observed as
+				// obsolete, because that would cause connections targeting those backends
+				// to be dropped in case we haven't fully synchronized yet.
+				backends = append(backends, backend)
+				continue
+			}
+
 			obsoleteSVCBackendIDs = append(obsoleteSVCBackendIDs, backend.ID)
 			if s.backendRefCount.Delete(hash) {
 				DeleteBackendID(backend.ID)

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -10,13 +10,17 @@ import (
 
 	. "github.com/cilium/checkmate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/cidr"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	datapathOpt "github.com/cilium/cilium/pkg/datapath/option"
 	datapathTypes "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/k8s"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/service/healthserver"
@@ -611,7 +615,7 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 
 	// cilium-agent finished the initialization, and thus SyncWithK8sFinished
 	// is called
-	err = m.svc.SyncWithK8sFinished()
+	err = m.svc.SyncWithK8sFinished(func(k8s.ServiceID, *lock.StoppableWaitGroup) bool { return true })
 	c.Assert(err, IsNil)
 
 	// svc1 should be removed from cilium while svc2 is synced
@@ -630,6 +634,89 @@ func (m *ManagerTestSuite) TestSyncWithK8sFinished(c *C) {
 	for _, b := range lbmap.ServiceByID[uint16(id2)].Backends {
 		c.Assert(m.lbmap.AffinityMatch[uint16(id2)][b.ID], Equals, struct{}{})
 	}
+}
+
+func TestRestoreServiceWithStaleBackends(t *testing.T) {
+	backendAddrs := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4", "10.0.0.5"}
+
+	service := func(ns, name, frontend string, backends ...string) *lb.SVC {
+		var bes []*lb.Backend
+		for _, backend := range backends {
+			bes = append(bes, lb.NewBackend(0, lb.TCP, cmtypes.MustParseAddrCluster(backend), 8080))
+		}
+
+		return &lb.SVC{
+			Frontend:         *lb.NewL3n4AddrID(lb.TCP, cmtypes.MustParseAddrCluster(frontend), 80, lb.ScopeExternal, 0),
+			Backends:         bes,
+			Type:             lb.SVCTypeClusterIP,
+			ExtTrafficPolicy: lb.SVCTrafficPolicyCluster,
+			IntTrafficPolicy: lb.SVCTrafficPolicyCluster,
+			Name:             lb.ServiceName{Name: name, Namespace: ns},
+		}
+	}
+
+	toBackendAddrs := func(backends []*lb.Backend) (addrs []string) {
+		for _, be := range backends {
+			addrs = append(addrs, be.L3n4Addr.AddrCluster.Addr().String())
+		}
+		return
+	}
+
+	lbmap := mockmaps.NewLBMockMap()
+	svc := NewService(nil, nil, lbmap)
+
+	_, id1, err := svc.upsertService(service("foo", "bar", "172.16.0.1", backendAddrs...))
+	require.NoError(t, err, "Failed to upsert service")
+
+	require.Contains(t, lbmap.ServiceByID, uint16(id1), "lbmap not populated correctly")
+	require.ElementsMatch(t, backendAddrs, toBackendAddrs(lbmap.ServiceByID[uint16(id1)].Backends), "lbmap not populated correctly")
+	require.ElementsMatch(t, backendAddrs, toBackendAddrs(maps.Values(lbmap.BackendByID)), "lbmap not populated correctly")
+
+	// Recreate the Service structure, but keep the lbmap to restore services from
+	svc = NewService(nil, nil, lbmap)
+	require.NoError(t, svc.RestoreServices(), "Failed to restore services")
+
+	// Simulate a set of service updates. Until synchronization completes, a given service
+	// might not yet contain all backends, in case they either belong to different endpointslices
+	// or different clusters.
+	_, id1bis, err := svc.upsertService(service("foo", "bar", "172.16.0.1", "10.0.0.3"))
+	require.NoError(t, err, "Failed to upsert service")
+	require.Equal(t, id1, id1bis, "Service ID changed unexpectedly")
+
+	// No backend should have been removed yet
+	require.Contains(t, lbmap.ServiceByID, uint16(id1), "lbmap incorrectly modified")
+	require.ElementsMatch(t, backendAddrs, toBackendAddrs(lbmap.ServiceByID[uint16(id1)].Backends), "lbmap incorrectly modified")
+	require.ElementsMatch(t, backendAddrs, toBackendAddrs(maps.Values(lbmap.BackendByID)), "lbmap incorrectly modified")
+
+	// Let's do it once more
+	_, id1ter, err := svc.upsertService(service("foo", "bar", "172.16.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.5"))
+	require.NoError(t, err, "Failed to upsert service")
+	require.Equal(t, id1, id1ter, "Service ID changed unexpectedly")
+
+	// No backend should have been removed yet
+	require.Contains(t, lbmap.ServiceByID, uint16(id1), "lbmap incorrectly modified")
+	require.ElementsMatch(t, backendAddrs, toBackendAddrs(lbmap.ServiceByID[uint16(id1)].Backends), "lbmap incorrectly modified")
+	require.ElementsMatch(t, backendAddrs, toBackendAddrs(maps.Values(lbmap.BackendByID)), "lbmap incorrectly modified")
+
+	// Trigger a new upsertion: this mimics what would eventually happen when calling ServiceCache.EnsureService()
+	ensurer := func(id k8s.ServiceID, swg *lock.StoppableWaitGroup) bool {
+		defer swg.Done()
+		if id.Namespace == "foo" && id.Name == "bar" {
+			_, _, err := svc.upsertService(service("foo", "bar", "172.16.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.5"))
+			require.NoError(t, err, "Failed to upsert service")
+			return true
+		}
+		require.Fail(t, "Unexpected service ID", "Service ID: %v", id)
+		return false
+	}
+
+	require.NoError(t, svc.SyncWithK8sFinished(ensurer), "Failed to trigger garbage collection")
+
+	// Stale backends should now have been removed
+	require.Contains(t, lbmap.ServiceByID, uint16(id1), "stale backends not correctly removed from lbmap")
+	finalBackendAddrs := []string{"10.0.0.2", "10.0.0.3", "10.0.0.5"}
+	require.ElementsMatch(t, finalBackendAddrs, toBackendAddrs(lbmap.ServiceByID[uint16(id1)].Backends), "stale backends not correctly removed from lbmap")
+	require.ElementsMatch(t, finalBackendAddrs, toBackendAddrs(maps.Values(lbmap.BackendByID)), "stale backends not correctly removed from lbmap")
 }
 
 func (m *ManagerTestSuite) TestHealthCheckNodePort(c *C) {


### PR DESCRIPTION
Cilium already implements a restore path to prevent dropping existing connections on agent restart. Yet, there's currently an issue which causes the removal of valid backends from a service when receiving incomplete service updates, either because backends are spread across multiple endpointslices or some belong to remote clusters. Indeed, all previously known backends get replaced with the ones we just heard about (and present as part of the service cache event), possibly causing connectivity disruptions.

Let's prevent this behavior keeping a list of restored backends for each service, and continuing merging them with the ones we received an update for, until the bootstrap phase completes. After synchronization, an update is triggered for each service still associated with stale backends, so that they can be removed.

<!-- Description of change -->

Fixes: #23823
Fixes: #26944

```release-note
Fix possible connection drops on agents restart when a service is associated with multiple endpointslices or has backends across multiple clusters
```
