### PR TITLE
v1.12 Backports 2023-07-19

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -20,8 +20,7 @@ RUN apk add --no-cache --virtual --update \
     && true
 
 ADD ./requirements.txt /tmp/requirements.txt
-# Workaround for https://github.com/yaml/pyyaml/issues/601
-RUN pip install "Cython<3.0" pyyaml --no-build-isolation && pip install -r /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
 
 ENV HOME=/tmp
 ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -20,7 +20,8 @@ RUN apk add --no-cache --virtual --update \
     && true
 
 ADD ./requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
+# Workaround for https://github.com/yaml/pyyaml/issues/601
+RUN pip install "Cython<3.0" pyyaml --no-build-isolation && pip install -r /tmp/requirements.txt
 
 ENV HOME=/tmp
 ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -13,7 +13,7 @@ myst-parser==0.17.0
 pyenchant==3.2.2
 Pygments==2.11.2
 pytz==2021.3
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.27.1
 semver==2.13.0
 six==1.16.0

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -115,6 +115,8 @@ func NewClient(host string) (*Client, error) {
 		return nil, fmt.Errorf("invalid host format '%s'", host)
 	}
 
+	hostHeader := tmp[1]
+
 	switch tmp[0] {
 	case "tcp":
 		if _, err := url.Parse("tcp://" + tmp[1]); err != nil {
@@ -123,11 +125,15 @@ func NewClient(host string) (*Client, error) {
 		host = "http://" + tmp[1]
 	case "unix":
 		host = tmp[1]
+		// For local communication (unix domain sockets), the hostname is not used. Leave
+		// Host header empty because otherwise it would be rejected by net/http client-side
+		// sanitization, see https://go.dev/issue/60374.
+		hostHeader = "localhost"
 	}
 
 	transport := configureTransport(nil, tmp[0], host)
 	httpClient := &http.Client{Transport: transport}
-	clientTrans := runtime_client.NewWithClient(tmp[1], clientapi.DefaultBasePath,
+	clientTrans := runtime_client.NewWithClient(hostHeader, clientapi.DefaultBasePath,
 		clientapi.DefaultSchemes, httpClient)
 	return &Client{*clientapi.New(clientTrans, strfmt.Default)}, nil
 }


### PR DESCRIPTION
 * [x] #26800 (@tklauser)
 * [x] #26874 (@michi-covalent)
 * [x] #26883 (@michi-covalent) :warning: Minor conflicts

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 26800 26874 26883; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
make add-labels BRANCH=v1.12 ISSUES=26800,26874,26883
```
