### PR TITLE
v1.11 Backports 2023-07-19

### DIFF
--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -19,8 +19,7 @@ RUN apk add --no-cache --virtual --update \
     && true
 
 ADD ./requirements.txt /tmp/requirements.txt
-# Workaround for https://github.com/yaml/pyyaml/issues/601
-RUN pip install "Cython<3.0" pyyaml --no-build-isolation && pip install -r /tmp/requirements.txt
+RUN pip install -r /tmp/requirements.txt
 
 ENV HOME=/tmp
 ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -19,7 +19,8 @@ RUN apk add --no-cache --virtual --update \
     && true
 
 ADD ./requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
+# Workaround for https://github.com/yaml/pyyaml/issues/601
+RUN pip install "Cython<3.0" pyyaml --no-build-isolation && pip install -r /tmp/requirements.txt
 
 ENV HOME=/tmp
 ENV READTHEDOCS_VERSION=$READTHEDOCS_VERSION

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -11,7 +11,7 @@ MarkupSafe==1.1.1
 pyenchant==2.0.0
 Pygments==2.7.4
 pytz==2018.7
-PyYAML==5.4
+PyYAML==6.0.1
 recommonmark==0.4.0
 requests==2.25.1
 semver==2.9.0

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -115,6 +115,8 @@ func NewClient(host string) (*Client, error) {
 		return nil, fmt.Errorf("invalid host format '%s'", host)
 	}
 
+	hostHeader := tmp[1]
+
 	switch tmp[0] {
 	case "tcp":
 		if _, err := url.Parse("tcp://" + tmp[1]); err != nil {
@@ -123,11 +125,15 @@ func NewClient(host string) (*Client, error) {
 		host = "http://" + tmp[1]
 	case "unix":
 		host = tmp[1]
+		// For local communication (unix domain sockets), the hostname is not used. Leave
+		// Host header empty because otherwise it would be rejected by net/http client-side
+		// sanitization, see https://go.dev/issue/60374.
+		hostHeader = "localhost"
 	}
 
 	transport := configureTransport(nil, tmp[0], host)
 	httpClient := &http.Client{Transport: transport}
-	clientTrans := runtime_client.NewWithClient(tmp[1], clientapi.DefaultBasePath,
+	clientTrans := runtime_client.NewWithClient(hostHeader, clientapi.DefaultBasePath,
 		clientapi.DefaultSchemes, httpClient)
 	return &Client{*clientapi.New(clientTrans, strfmt.Default)}, nil
 }


### PR DESCRIPTION
 * [x] #26800 (@tklauser)
 * [x] #26874 (@michi-covalent)
 * [x] #26883 (@michi-covalent) :rotating_light: This bumped from 5.4 to 6.0.1. Not sure if that's correct

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 26800 26874 26883; do contrib/backporting/set-labels.py $pr done 1.11; done
```
or with
```
make add-labels BRANCH=v1.11 ISSUES=26800,26874,26883
```
