### PR TITLE
Import new version of forked controller-tools

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -267,5 +267,5 @@ replace (
 
 	// Using private fork of controller-tools. See commit msg for more context
 	// as to why we are using a private fork.
-	sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.6.2
+	sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.6.2-1
 )

--- a/go.sum
+++ b/go.sum
@@ -161,8 +161,8 @@ github.com/cilium/checkmate v1.0.3 h1:CQC5eOmlAZeEjPrVZY3ZwEBH64lHlx9mXYdUehEwI5
 github.com/cilium/checkmate v1.0.3/go.mod h1:KiBTasf39/F2hf2yAmHw21YFl3hcEyP4Yk6filxc12A=
 github.com/cilium/client-go v0.27.2-fix h1:dbFQGtP5Y1lFVBhkMCIAwyf/PUWFBn8M1ZTCKA6BUdw=
 github.com/cilium/client-go v0.27.2-fix/go.mod h1:tY0gVmUsHrAmjzHX9zs7eCjxcBsf8IiNe7KQ52biTcQ=
-github.com/cilium/controller-tools v0.6.2 h1:oIkqAzqncKsm+lQFJVP6n+bqHOVs9nUZ06hgZ4PxlMM=
-github.com/cilium/controller-tools v0.6.2/go.mod h1:oaeGpjXn6+ZSEIQkUe/+3I40PNiDYp9aeawbt3xTgJ8=
+github.com/cilium/controller-tools v0.6.2-1 h1:hwWdRnjhk1QasWAetpSTdwV+yuYNNwSCSPRlmknpLPA=
+github.com/cilium/controller-tools v0.6.2-1/go.mod h1:oaeGpjXn6+ZSEIQkUe/+3I40PNiDYp9aeawbt3xTgJ8=
 github.com/cilium/coverbee v0.3.2 h1:RaJN5OaHf/M8tmeLemHmdO0H5bFUhvtTAoYbStDIX14=
 github.com/cilium/coverbee v0.3.2/go.mod h1:p9Q2SRC/sPA0qATNfY19GXBUPdcQP6UVV2LKgOHRIzQ=
 github.com/cilium/deepequal-gen v0.0.0-20230330134849-754271daeec2 h1:/TjcgbZnbhiVkqWdcmFvpOUzk6/dlGBAIipt0qjxzqU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1781,7 +1781,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook
 sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
-# sigs.k8s.io/controller-tools v0.11.4 => github.com/cilium/controller-tools v0.6.2
+# sigs.k8s.io/controller-tools v0.11.4 => github.com/cilium/controller-tools v0.6.2-1
 ## explicit; go 1.16
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
@@ -1828,4 +1828,4 @@ sigs.k8s.io/yaml
 # github.com/miekg/dns => github.com/cilium/dns v1.1.51-0.20220729113855-5b94b11b46fc
 # go.universe.tf/metallb => github.com/cilium/metallb v0.1.1-0.20220829170633-5d7dfb1129f7
 # k8s.io/client-go => github.com/cilium/client-go v0.27.2-fix
-# sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.6.2
+# sigs.k8s.io/controller-tools => github.com/cilium/controller-tools v0.6.2-1

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/gen.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/gen.go
@@ -58,6 +58,11 @@ type Generator struct {
 	// It's required to be false for v1 CRDs.
 	PreserveUnknownFields *bool `marker:",optional"`
 
+	// IgnoreUnexportedFields indicates that we should skip unexported fields.
+	//
+	// Left unspecified, the default is false.
+	IgnoreUnexportedFields *bool `marker:",optional"`
+
 	// AllowDangerousTypes allows types which are usually omitted from CRD generation
 	// because they are not recommended.
 	//
@@ -100,7 +105,8 @@ func (g Generator) Generate(ctx *genall.GenerationContext) error {
 		Collector: ctx.Collector,
 		Checker:   ctx.Checker,
 		// Perform defaulting here to avoid ambiguity later
-		AllowDangerousTypes: g.AllowDangerousTypes != nil && *g.AllowDangerousTypes == true,
+		IgnoreUnexportedFields: g.IgnoreUnexportedFields != nil && *g.IgnoreUnexportedFields == true,
+		AllowDangerousTypes:    g.AllowDangerousTypes != nil && *g.AllowDangerousTypes == true,
 		// Indicates the parser on whether to register the ObjectMeta type or not
 		GenerateEmbeddedObjectMeta: g.GenerateEmbeddedObjectMeta != nil && *g.GenerateEmbeddedObjectMeta == true,
 	}

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/zz_generated.markerhelp.go
@@ -48,7 +48,7 @@ func (DeprecatedVersion) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Warning": markers.DetailedHelp{
+			"Warning": {
 				Summary: "message to be shown on the deprecated version",
 				Details: "",
 			},

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/parser.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/parser.go
@@ -87,6 +87,9 @@ type Parser struct {
 	// TODO: Should we have a more formal mechanism for putting "type patterns" in each of the above categories?
 	AllowDangerousTypes bool
 
+	// IgnoreUnexportedFields specifies if unexported fields on the struct should be skipped
+	IgnoreUnexportedFields bool
+
 	// GenerateEmbeddedObjectMeta specifies if any embedded ObjectMeta should be generated
 	GenerateEmbeddedObjectMeta bool
 }
@@ -178,7 +181,7 @@ func (p *Parser) NeedSchemaFor(typ TypeIdent) {
 	// avoid tripping recursive schemata, like ManagedFields, by adding an empty WIP schema
 	p.Schemata[typ] = apiext.JSONSchemaProps{}
 
-	schemaCtx := newSchemaContext(typ.Package, p, p.AllowDangerousTypes)
+	schemaCtx := newSchemaContext(typ.Package, p, p.AllowDangerousTypes, p.IgnoreUnexportedFields)
 	ctxForInfo := schemaCtx.ForInfo(info)
 
 	pkgMarkers, err := markers.PackageMarkers(p.Collector, typ.Package)

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/zz_generated.markerhelp.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/zz_generated.markerhelp.go
@@ -40,6 +40,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "indicates whether or not we should turn off pruning. ",
 				Details: "Left unspecified, it'll default to true when only a v1beta1 CRD is generated (to preserve compatibility with older versions of this tool), or false otherwise. \n It's required to be false for v1 CRDs.",
 			},
+			"IgnoreUnexportedFields": {
+				Summary: "indicates that we should skip unexported fields. ",
+				Details: "Left unspecified, the default is false.",
+			},
 			"AllowDangerousTypes": {
 				Summary: "allows types which are usually omitted from CRD generation because they are not recommended. ",
 				Details: "Currently the following additional types are allowed when this is true: float32 float64 \n Left unspecified, the default is false",

--- a/vendor/sigs.k8s.io/controller-tools/pkg/schemapatcher/zz_generated.markerhelp.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/schemapatcher/zz_generated.markerhelp.go
@@ -40,6 +40,10 @@ func (Generator) Help() *markers.DefinitionHelp {
 				Summary: "specifies the maximum description length for fields in CRD's OpenAPI schema. ",
 				Details: "0 indicates drop the description for all fields completely. n indicates limit the description to at most n characters and truncate the description to closest sentence boundary if it exceeds n characters.",
 			},
+			"GenerateEmbeddedObjectMeta": {
+				Summary: "specifies if any embedded ObjectMeta in the CRD should be generated",
+				Details: "",
+			},
 		},
 	}
 }


### PR DESCRIPTION
The manually created tag `v0.6.2-1` is used in place of automatically generated `v0.3.1-0.20230718144332-69030211a4bc` (which was not intuitive).

It is required by https://github.com/cilium/cilium/pull/26646
