### PR TITLE
v1.11: ci: increase ginkgo kernel test timeout

### DIFF
--- a/jenkinsfiles/ginkgo-kernel.Jenkinsfile
+++ b/jenkinsfiles/ginkgo-kernel.Jenkinsfile
@@ -11,7 +11,7 @@ pipeline {
         VM_CPUS = "3"
         GOPATH="${WORKSPACE}"
         TESTDIR="${GOPATH}/${PROJ_PATH}/test"
-        GINKGO_TIMEOUT="170m"
+        GINKGO_TIMEOUT="200m"
         RUN_QUARANTINED="""${sh(
                 returnStdout: true,
                 script: 'if [ "${RunQuarantined}" = "" ]; then echo -n "false"; else echo -n "${RunQuarantined}"; fi'


### PR DESCRIPTION
Increase ginkgo kernel test timeout from 170m to 200m to avoid unnecessary timeouts during test execution.

Examples: 
* https://jenkins.cilium.io/job/Cilium-PR-K8s-1.16-kernel-net-next/51/
* https://jenkins.cilium.io/job/Cilium-PR-K8s-1.16-kernel-net-next/54/

So far no occurances on `v1.12` & `v1.13`. `v1.14` and `main` migrated to GitHub actions that don't set the ginkgo timeout explicitly.