### PR TITLE
Fixes: Renamed the OpLabels field to Labels

### DIFF
--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -100,7 +100,7 @@ func (ds *DaemonSuite) TestEndpointAddNoLabels(c *C) {
 	c.Assert(err, IsNil)
 	ep, err := ds.d.endpointManager.Lookup(endpointid.NewIPPrefixID(v4ip))
 	c.Assert(err, IsNil)
-	c.Assert(ep.OpLabels.IdentityLabels(), checker.DeepEquals, expectedLabels)
+	c.Assert(ep.Labels.IdentityLabels(), checker.DeepEquals, expectedLabels)
 
 	secID := ep.WaitForIdentity(3 * time.Second)
 	c.Assert(secID, Not(IsNil))

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -34,16 +34,16 @@ func (e *Endpoint) GetLabelsModel() (*models.LabelConfiguration, error) {
 		return nil, err
 	}
 	spec := &models.LabelConfigurationSpec{
-		User: e.OpLabels.Custom.GetModel(),
+		User: e.Labels.Custom.GetModel(),
 	}
 
 	cfg := models.LabelConfiguration{
 		Spec: spec,
 		Status: &models.LabelConfigurationStatus{
 			Realized:         spec,
-			SecurityRelevant: e.OpLabels.OrchestrationIdentity.GetModel(),
-			Derived:          e.OpLabels.OrchestrationInfo.GetModel(),
-			Disabled:         e.OpLabels.Disabled.GetModel(),
+			SecurityRelevant: e.Labels.OrchestrationIdentity.GetModel(),
+			Derived:          e.Labels.OrchestrationInfo.GetModel(),
+			Disabled:         e.Labels.Disabled.GetModel(),
 		},
 	}
 	e.runlock()
@@ -127,8 +127,8 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 	if base.Labels != nil {
 		lbls := labels.NewLabelsFromModel(base.Labels)
 		identityLabels, infoLabels := labelsfilter.Filter(lbls)
-		ep.OpLabels.OrchestrationIdentity = identityLabels
-		ep.OpLabels.OrchestrationInfo = infoLabels
+		ep.Labels.OrchestrationIdentity = identityLabels
+		ep.Labels.OrchestrationInfo = infoLabels
 	}
 
 	if base.State != nil {
@@ -188,7 +188,7 @@ func (e *Endpoint) GetModelRLocked() *models.Endpoint {
 		statusLog = statusLog[:1]
 	}
 
-	lblMdl := model.NewModel(&e.OpLabels)
+	lblMdl := model.NewModel(&e.Labels)
 
 	// Sort these slices since they come out in random orders. This allows
 	// reflect.DeepEqual to succeed.
@@ -532,8 +532,8 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		e.containerID = newEp.containerID
 	}
 
-	e.replaceInformationLabels(newEp.OpLabels.OrchestrationInfo)
-	rev := e.replaceIdentityLabels(newEp.OpLabels.IdentityLabels())
+	e.replaceInformationLabels(newEp.Labels.OrchestrationInfo)
+	rev := e.replaceIdentityLabels(newEp.Labels.IdentityLabels())
 	if rev != 0 {
 		// Run as a goroutine since the runIdentityResolver needs to get the lock
 		go e.runIdentityResolver(e.aliveCtx, rev, false)
@@ -583,7 +583,7 @@ func (e *Endpoint) GetConfigurationStatus() *models.EndpointConfigurationStatus 
 	return &models.EndpointConfigurationStatus{
 		Realized: &models.EndpointConfigurationSpec{
 			LabelConfiguration: &models.LabelConfigurationSpec{
-				User: e.OpLabels.Custom.GetModel(),
+				User: e.Labels.Custom.GetModel(),
 			},
 			Options: *e.Options.GetMutableModel(),
 		},
@@ -599,7 +599,7 @@ func (e *Endpoint) ApplyUserLabelChanges(lbls labels.Labels) (add, del labels.La
 		return nil, nil, err
 	}
 	defer e.runlock()
-	add, del = e.OpLabels.SplitUserLabelChanges(lbls)
+	add, del = e.Labels.SplitUserLabelChanges(lbls)
 	return
 }
 

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -271,22 +271,22 @@ func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 	// Test that inserting identity labels works
 	rev := e.replaceIdentityLabels(labels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
 	c.Assert(rev, Not(Equals), 0)
-	c.Assert(string(e.OpLabels.OrchestrationIdentity.SortedList()), Equals, "cilium:foo=bar;cilium:zip=zop;")
+	c.Assert(string(e.Labels.OrchestrationIdentity.SortedList()), Equals, "cilium:foo=bar;cilium:zip=zop;")
 	// Test that nothing changes
 	rev = e.replaceIdentityLabels(labels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
 	c.Assert(rev, Equals, 0)
-	c.Assert(string(e.OpLabels.OrchestrationIdentity.SortedList()), Equals, "cilium:foo=bar;cilium:zip=zop;")
+	c.Assert(string(e.Labels.OrchestrationIdentity.SortedList()), Equals, "cilium:foo=bar;cilium:zip=zop;")
 	// Remove one label, change the source and value of the other.
 	rev = e.replaceIdentityLabels(labels.Map2Labels(map[string]string{"foo": "zop"}, "nginx"))
 	c.Assert(rev, Not(Equals), 0)
-	c.Assert(string(e.OpLabels.OrchestrationIdentity.SortedList()), Equals, "nginx:foo=zop;")
+	c.Assert(string(e.Labels.OrchestrationIdentity.SortedList()), Equals, "nginx:foo=zop;")
 
 	// Test that inserting information labels works
 	e.replaceInformationLabels(labels.Map2Labels(map[string]string{"foo": "bar", "zip": "zop"}, "cilium"))
-	c.Assert(string(e.OpLabels.OrchestrationInfo.SortedList()), Equals, "cilium:foo=bar;cilium:zip=zop;")
+	c.Assert(string(e.Labels.OrchestrationInfo.SortedList()), Equals, "cilium:foo=bar;cilium:zip=zop;")
 	// Remove one label, change the source and value of the other.
 	e.replaceInformationLabels(labels.Map2Labels(map[string]string{"foo": "zop"}, "nginx"))
-	c.Assert(string(e.OpLabels.OrchestrationInfo.SortedList()), Equals, "nginx:foo=zop;")
+	c.Assert(string(e.Labels.OrchestrationInfo.SortedList()), Equals, "nginx:foo=zop;")
 }
 
 func (s *EndpointSuite) TestEndpointState(c *C) {
@@ -601,8 +601,8 @@ func TestEndpoint_GetK8sPodLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := &Endpoint{
-				mutex:    lock.RWMutex{},
-				OpLabels: tt.fields.OpLabels,
+				mutex:  lock.RWMutex{},
+				Labels: tt.fields.OpLabels,
 			}
 			if got := e.getK8sPodLabels(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Endpoint.getK8sPodLabels() = %v, want %v", got, tt.want)
@@ -752,7 +752,7 @@ func BenchmarkEndpointGetModel(b *testing.B) {
 func (e *Endpoint) getK8sPodLabels() labels.Labels {
 	e.unconditionalRLock()
 	defer e.runlock()
-	allLabels := e.OpLabels.AllLabels()
+	allLabels := e.Labels.AllLabels()
 	if allLabels == nil {
 		return nil
 	}

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -217,7 +217,7 @@ func (e *Endpoint) restoreIdentity() error {
 	}
 	scopedLog := log.WithField(logfields.EndpointID, e.ID)
 	// Filter the restored labels with the new daemon's filter
-	l, _ := labelsfilter.Filter(e.OpLabels.AllLabels())
+	l, _ := labelsfilter.Filter(e.Labels.AllLabels())
 	e.runlock()
 
 	// Getting the ep's identity while we are restoring should block the
@@ -370,7 +370,7 @@ func (e *Endpoint) toSerializedEndpoint() *serializableEndpoint {
 		DockerEndpointID:      e.dockerEndpointID,
 		IfName:                e.ifName,
 		IfIndex:               e.ifIndex,
-		OpLabels:              e.OpLabels,
+		Labels:                e.Labels,
 		LXCMAC:                e.mac,
 		IPv6:                  e.IPv6,
 		IPv6IPAMPool:          e.IPv6IPAMPool,
@@ -424,10 +424,10 @@ type serializableEndpoint struct {
 	// ifIndex is the interface index of the host face interface (veth pair)
 	IfIndex int
 
-	// OpLabels is the endpoint's label configuration
+	// Labels is the endpoint's label configuration
 	//
 	// FIXME: Rename this field to Labels
-	OpLabels labels.OpLabels
+	Labels labels.OpLabels
 
 	// mac is the MAC address of the endpoint
 	//
@@ -492,7 +492,7 @@ func (ep *Endpoint) UnmarshalJSON(raw []byte) error {
 	// We may have to populate structures in the Endpoint manually to do the
 	// translation from serializableEndpoint --> Endpoint.
 	restoredEp := &serializableEndpoint{
-		OpLabels:   labels.NewOpLabels(),
+		Labels:     labels.NewOpLabels(),
 		DNSHistory: fqdn.NewDNSCacheWithLimit(option.Config.ToFQDNsMinTTL, option.Config.ToFQDNsMaxIPsPerHost),
 		DNSZombies: fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 	}
@@ -518,7 +518,7 @@ func (ep *Endpoint) fromSerializedEndpoint(r *serializableEndpoint) {
 	ep.dockerEndpointID = r.DockerEndpointID
 	ep.ifName = r.IfName
 	ep.ifIndex = r.IfIndex
-	ep.OpLabels = r.OpLabels
+	ep.Labels = r.Labels
 	ep.mac = r.LXCMAC
 	ep.IPv6 = r.IPv6
 	ep.IPv6IPAMPool = r.IPv6IPAMPool

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -70,7 +70,7 @@ func (ds *EndpointSuite) endpointCreator(id uint16, secID identity.NumericIdenti
 	ep.ifIndex = 1
 	ep.nodeMAC = []byte{0x02, 0xff, 0xf2, 0x12, 0x0, 0x0}
 	ep.SecurityIdentity = identity
-	ep.OpLabels = labels.NewOpLabels()
+	ep.Labels = labels.NewOpLabels()
 	return ep
 }
 


### PR DESCRIPTION
…bels

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #26923` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

It basically renames the OpLabels field to Labels in structs having this FIXME comment

Fixes: #26923

```release-note
Fix renamed OpLabel field to Label in structs Endpoint and serializableEndpoint
```
