### PR TITLE
identity: add node-selector-labels

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -144,6 +144,7 @@ cilium-agent [flags]
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --enable-nat46x64-gateway                                   Enable NAT46 and NAT64 gateway
       --enable-node-port                                          Enable NodePort type services by Cilium
+      --enable-node-selector-labels                               Enable use of node label based identity
       --enable-pmtu-discovery                                     Enable path MTU discovery to send ICMP fragmentation-needed replies to the client
       --enable-policy string                                      Enable policy enforcement (default "default")
       --enable-recorder                                           Enable BPF datapath pcap recorder
@@ -286,6 +287,7 @@ cilium-agent [flags]
       --monitor-queue-size int                                    Size of the event queue when reading monitor events
       --mtu int                                                   Overwrite auto-detected MTU of underlying network
       --node-encryption-opt-out-labels string                     Label selector for nodes which will opt-out of node-to-node encryption (default "node-role.kubernetes.io/control-plane")
+      --node-labels strings                                       List of label prefixes used to determine identity of a node (used only when enable-node-selector-labels is enabled)
       --node-port-bind-protection                                 Reject application bind(2) requests to service ports in the NodePort range (default true)
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2364,6 +2364,10 @@
      - Node selector for cilium-agent.
      - object
      - ``{"kubernetes.io/os":"linux"}``
+   * - :spelling:ignore:`nodeSelectorLabels`
+     - Enable/Disable use of node label based identity
+     - bool
+     - ``false``
    * - :spelling:ignore:`nodeinit.affinity`
      - Affinity for cilium-nodeinit
      - object

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1117,6 +1117,12 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.MaxInternalTimerDelay)
 	option.BindEnv(vp, option.MaxInternalTimerDelay)
 
+	flags.Bool(option.EnableNodeSelectorLabels, defaults.EnableNodeSelectorLabels, "Enable use of node label based identity")
+	option.BindEnv(vp, option.EnableNodeSelectorLabels)
+
+	flags.StringSlice(option.NodeLabels, []string{}, "List of label prefixes used to determine identity of a node (used only when enable-node-selector-labels is enabled)")
+	option.BindEnv(vp, option.NodeLabels)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}
@@ -1327,7 +1333,7 @@ func initEnv(vp *viper.Viper) {
 	if !option.Config.EnableIPv4 && !option.Config.EnableIPv6 {
 		log.Fatal("Either IPv4 or IPv6 addressing must be enabled")
 	}
-	if err := labelsfilter.ParseLabelPrefixCfg(option.Config.Labels, option.Config.LabelPrefixFile); err != nil {
+	if err := labelsfilter.ParseLabelPrefixCfg(option.Config.Labels, option.Config.NodeLabels, option.Config.LabelPrefixFile); err != nil {
 		log.WithError(err).Fatal("Unable to parse Label prefix configuration")
 	}
 

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -120,7 +120,7 @@ func (s *DaemonSuite) setupConfigOptions() {
 	option.Config.DryMode = true
 	option.Config.Opts = option.NewIntOptions(&option.DaemonMutableOptionLibrary)
 	// GetConfig the default labels prefix filter
-	err := labelsfilter.ParseLabelPrefixCfg(nil, "")
+	err := labelsfilter.ParseLabelPrefixCfg(nil, nil, "")
 	if err != nil {
 		panic("ParseLabelPrefixCfg() failed")
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -641,6 +641,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodePort.enableHealthCheckLoadBalancerIP | bool | `false` | Enable access of the healthcheck nodePort on the LoadBalancerIP. Needs EnableHealthCheck to be enabled |
 | nodePort.enabled | bool | `false` | Enable the Cilium NodePort service implementation. |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node selector for cilium-agent. |
+| nodeSelectorLabels | bool | `false` | Enable/Disable use of node label based identity |
 | nodeinit.affinity | object | `{}` | Affinity for cilium-nodeinit |
 | nodeinit.annotations | object | `{}` | Annotations to be added to all top-level nodeinit objects (resources under templates/cilium-nodeinit) |
 | nodeinit.bootstrapFile | string | `"/tmp/cilium-bootstrap.d/cilium-bootstrap-time"` | bootstrapFile is the location of the file where the bootstrap timestamp is written by the node-init DaemonSet |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -841,6 +841,7 @@ data:
   enable-well-known-identities: "false"
 {{- end }}
   enable-remote-node-identity: {{ .Values.remoteNodeIdentity | quote }}
+  enable-node-selector-labels: {{ .Values.nodeSelectorLabels | quote }}
 
 {{- if hasKey .Values "synchronizeK8sNodes" }}
   synchronize-k8s-nodes: {{ .Values.synchronizeK8sNodes | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1962,6 +1962,8 @@ envoy:
 # -- Enable use of the remote node identity.
 # ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity
 remoteNodeIdentity: true
+# -- Enable/Disable use of node label based identity
+nodeSelectorLabels: false
 # -- Enable resource quotas for priority classes used in the cluster.
 resourceQuotas:
   enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1959,6 +1959,10 @@ envoy:
 # -- Enable use of the remote node identity.
 # ref: https://docs.cilium.io/en/v1.7/install/upgrade/#configmap-remote-node-identity
 remoteNodeIdentity: true
+
+# -- Enable/Disable use of node label based identity
+nodeSelectorLabels: false
+
 # -- Enable resource quotas for priority classes used in the cluster.
 resourceQuotas:
   enabled: false

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -550,6 +550,9 @@ const (
 	// identity in a numeric identity. Values > 255 will decrease the number of
 	// allocatable identities.
 	MaxConnectedClusters = 255
+
+	// EnableNodeSelectorLabels is the default value for option.EnableNodeSelectorLabels
+	EnableNodeSelectorLabels = false
 )
 
 var (

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -63,7 +63,7 @@ func (s *EndpointSuite) SetUpSuite(c *C) {
 
 	s.repo = policy.NewPolicyRepository(nil, nil, nil, nil)
 	// GetConfig the default labels prefix filter
-	err := labelsfilter.ParseLabelPrefixCfg(nil, "")
+	err := labelsfilter.ParseLabelPrefixCfg(nil, nil, "")
 	if err != nil {
 		panic("ParseLabelPrefixCfg() failed")
 	}

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -193,7 +193,8 @@ func ScopeForLabels(lbls labels.Labels) NumericIdentity {
 	scope := IdentityScopeGlobal
 
 	// If this is a remote node, return the remote node scope.
-	// Note that this is not reachable when policy-cidr-selects-nodes is false, since
+	// Note that this is not reachable when policy-cidr-selects-nodes is false or
+	// when enable-node-selector-labels is false, since
 	// callers will already have gotten a value from LookupReservedIdentityByLabels.
 	if lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) {
 		return IdentityScopeRemoteNode
@@ -266,6 +267,12 @@ func LookupReservedIdentityByLabels(lbls labels.Labels) *Identity {
 		// If selecting remote-nodes via CIDR policies is allowed, then
 		// they no longer have a reserved identity.
 		if option.Config.PolicyCIDRMatchesNodes() {
+			return nil
+		}
+		// If selecting remote-nodes via node labels is allowed, then
+		// they no longer have a reserved identity and are using
+		// IdentityScopeRemoteNode.
+		if option.Config.PerNodeLabelsEnabled() {
 			return nil
 		}
 		nid = ReservedIdentityRemoteNode

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -522,6 +522,10 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 		if !option.Config.PolicyCIDRMatchesNodes() {
 			n = n.Remove(labels.GetCIDRLabels(prefix))
 		}
+		if !option.Config.PerNodeLabelsEnabled() {
+			nodeLabels := n.GetFromSource(labels.LabelSourceNode)
+			n = n.Remove(nodeLabels)
+		}
 		lbls = n
 	}
 

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -351,6 +351,64 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toNodes:
+                      description: ToNodes is a list of nodes identified by an EndpointSelector
+                        to which endpoints subject to the rule is allowed to communicate.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     toPorts:
                       description: "ToPorts is a list of destination ports identified
                         by port number and protocol which the endpoint subject to
@@ -1190,6 +1248,64 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toNodes:
+                      description: ToNodes is a list of nodes identified by an EndpointSelector
+                        to which endpoints subject to the rule is allowed to communicate.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     toPorts:
                       description: "ToPorts is a list of destination ports identified
                         by port number and protocol which the endpoint subject to
@@ -1630,6 +1746,65 @@ spec:
                         - none
                         - kube-apiserver
                         type: string
+                      type: array
+                    fromNodes:
+                      description: FromNodes is a list of nodes identified by an EndpointSelector
+                        which are allowed to communicate with the endpoint subject
+                        to the rule.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       type: array
                     fromRequires:
                       description: "FromRequires is a list of additional constraints
@@ -2353,6 +2528,65 @@ spec:
                         - kube-apiserver
                         type: string
                       type: array
+                    fromNodes:
+                      description: FromNodes is a list of nodes identified by an EndpointSelector
+                        which are allowed to communicate with the endpoint subject
+                        to the rule.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     fromRequires:
                       description: "FromRequires is a list of additional constraints
                         which must be met in order for the selected endpoints to be
@@ -2896,6 +3130,64 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                              type: object
+                          type: object
+                        type: array
+                      toNodes:
+                        description: ToNodes is a list of nodes identified by an EndpointSelector
+                          to which endpoints subject to the rule is allowed to communicate.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         type: array
@@ -3752,6 +4044,64 @@ spec:
                               type: object
                           type: object
                         type: array
+                      toNodes:
+                        description: ToNodes is a list of nodes identified by an EndpointSelector
+                          to which endpoints subject to the rule is allowed to communicate.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        type: array
                       toPorts:
                         description: "ToPorts is a list of destination ports identified
                           by port number and protocol which the endpoint subject to
@@ -4198,6 +4548,65 @@ spec:
                           - none
                           - kube-apiserver
                           type: string
+                        type: array
+                      fromNodes:
+                        description: FromNodes is a list of nodes identified by an
+                          EndpointSelector which are allowed to communicate with the
+                          endpoint subject to the rule.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         type: array
                       fromRequires:
                         description: "FromRequires is a list of additional constraints
@@ -4932,6 +5341,65 @@ spec:
                           - none
                           - kube-apiserver
                           type: string
+                        type: array
+                      fromNodes:
+                        description: FromNodes is a list of nodes identified by an
+                          EndpointSelector which are allowed to communicate with the
+                          endpoint subject to the rule.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         type: array
                       fromRequires:
                         description: "FromRequires is a list of additional constraints

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -355,6 +355,64 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toNodes:
+                      description: ToNodes is a list of nodes identified by an EndpointSelector
+                        to which endpoints subject to the rule is allowed to communicate.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     toPorts:
                       description: "ToPorts is a list of destination ports identified
                         by port number and protocol which the endpoint subject to
@@ -1194,6 +1252,64 @@ spec:
                             type: object
                         type: object
                       type: array
+                    toNodes:
+                      description: ToNodes is a list of nodes identified by an EndpointSelector
+                        to which endpoints subject to the rule is allowed to communicate.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     toPorts:
                       description: "ToPorts is a list of destination ports identified
                         by port number and protocol which the endpoint subject to
@@ -1634,6 +1750,65 @@ spec:
                         - none
                         - kube-apiserver
                         type: string
+                      type: array
+                    fromNodes:
+                      description: FromNodes is a list of nodes identified by an EndpointSelector
+                        which are allowed to communicate with the endpoint subject
+                        to the rule.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       type: array
                     fromRequires:
                       description: "FromRequires is a list of additional constraints
@@ -2357,6 +2532,65 @@ spec:
                         - kube-apiserver
                         type: string
                       type: array
+                    fromNodes:
+                      description: FromNodes is a list of nodes identified by an EndpointSelector
+                        which are allowed to communicate with the endpoint subject
+                        to the rule.
+                      items:
+                        description: EndpointSelector is a wrapper for k8s LabelSelector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  enum:
+                                  - In
+                                  - NotIn
+                                  - Exists
+                                  - DoesNotExist
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty.
+                                    This array is replaced during a strategic merge
+                                    patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              description: MatchLabelsValue represents the value from
+                                the MatchLabels {key,value} pair.
+                              maxLength: 63
+                              pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      type: array
                     fromRequires:
                       description: "FromRequires is a list of additional constraints
                         which must be met in order for the selected endpoints to be
@@ -2900,6 +3134,64 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                              type: object
+                          type: object
+                        type: array
+                      toNodes:
+                        description: ToNodes is a list of nodes identified by an EndpointSelector
+                          to which endpoints subject to the rule is allowed to communicate.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
                               type: object
                           type: object
                         type: array
@@ -3756,6 +4048,64 @@ spec:
                               type: object
                           type: object
                         type: array
+                      toNodes:
+                        description: ToNodes is a list of nodes identified by an EndpointSelector
+                          to which endpoints subject to the rule is allowed to communicate.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                        type: array
                       toPorts:
                         description: "ToPorts is a list of destination ports identified
                           by port number and protocol which the endpoint subject to
@@ -4202,6 +4552,65 @@ spec:
                           - none
                           - kube-apiserver
                           type: string
+                        type: array
+                      fromNodes:
+                        description: FromNodes is a list of nodes identified by an
+                          EndpointSelector which are allowed to communicate with the
+                          endpoint subject to the rule.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         type: array
                       fromRequires:
                         description: "FromRequires is a list of additional constraints
@@ -4936,6 +5345,65 @@ spec:
                           - none
                           - kube-apiserver
                           type: string
+                        type: array
+                      fromNodes:
+                        description: FromNodes is a list of nodes identified by an
+                          EndpointSelector which are allowed to communicate with the
+                          endpoint subject to the rule.
+                        items:
+                          description: EndpointSelector is a wrapper for k8s LabelSelector.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In,
+                                      NotIn, Exists and DoesNotExist.
+                                    enum:
+                                    - In
+                                    - NotIn
+                                    - Exists
+                                    - DoesNotExist
+                                    type: string
+                                  values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists
+                                      or DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                            matchLabels:
+                              additionalProperties:
+                                description: MatchLabelsValue represents the value
+                                  from the MatchLabels {key,value} pair.
+                                maxLength: 63
+                                pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                                type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field
+                                is "key", the operator is "In", and the values array
+                                contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
                         type: array
                       fromRequires:
                         description: "FromRequires is a list of additional constraints

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -111,6 +111,13 @@ func parseToCiliumIngressCommonRule(namespace string, es api.EndpointSelector, i
 		}
 	}
 
+	if ing.FromNodes != nil {
+		retRule.FromNodes = make([]api.EndpointSelector, len(ing.FromNodes))
+		for j, node := range ing.FromNodes {
+			retRule.FromNodes[j] = api.NewESFromK8sLabelSelector("", node.LabelSelector)
+		}
+	}
+
 	if ing.FromCIDR != nil {
 		retRule.FromCIDR = make([]api.CIDR, len(ing.FromCIDR))
 		copy(retRule.FromCIDR, ing.FromCIDR)
@@ -214,6 +221,13 @@ func parseToCiliumEgressCommonRule(namespace string, es api.EndpointSelector, eg
 	if egr.ToEntities != nil {
 		retRule.ToEntities = make([]api.Entity, len(egr.ToEntities))
 		copy(retRule.ToEntities, egr.ToEntities)
+	}
+
+	if egr.ToNodes != nil {
+		retRule.ToNodes = make([]api.EndpointSelector, len(egr.ToNodes))
+		for j, node := range egr.ToNodes {
+			retRule.ToNodes[j] = api.NewESFromK8sLabelSelector("", node.LabelSelector)
+		}
 	}
 
 	if egr.ToGroups != nil {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -124,6 +124,9 @@ const (
 	// LabelSourceCIDR is the label source for generated CIDRs.
 	LabelSourceCIDR = "cidr"
 
+	// LabelSourceNode is the label source for remote-nodes.
+	LabelSourceNode = "node"
+
 	// LabelSourceReservedKeyPrefix is the prefix of a reserved label
 	LabelSourceReservedKeyPrefix = LabelSourceReserved + "."
 

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -31,7 +31,7 @@ func (s *LabelsPrefCfgSuite) TestFilterLabels(c *C) {
 		"foo2.lizards.k8s":            labels.NewLabel("foo2.lizards.k8s", "web", labels.LabelSourceK8s),
 	}
 
-	err := ParseLabelPrefixCfg([]string{":!ignor[eE]", "id.*", "foo"}, "")
+	err := ParseLabelPrefixCfg([]string{":!ignor[eE]", "id.*", "foo"}, []string{}, "")
 	c.Assert(err, IsNil)
 	dlpcfg := validLabelPrefixes
 	allNormalLabels := map[string]string{
@@ -87,7 +87,7 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 		"ioXkubernetes":               labels.NewLabel("ioXkubernetes", "foo", labels.LabelSourceContainer),
 	}
 
-	err := ParseLabelPrefixCfg([]string{}, "")
+	err := ParseLabelPrefixCfg([]string{}, []string{}, "")
 	c.Assert(err, IsNil)
 	dlpcfg := validLabelPrefixes
 	allNormalLabels := map[string]string{
@@ -134,7 +134,7 @@ func (s *LabelsPrefCfgSuite) TestFilterLabelsDocExample(c *C) {
 		"io.kubernetes.pod.namespace":    labels.NewLabel("io.kubernetes.pod.namespace", "docker", labels.LabelSourceAny),
 	}
 
-	err := ParseLabelPrefixCfg([]string{"k8s:io.kubernetes.pod.namespace", "k8s:k8s-app", "k8s:app", "k8s:name"}, "")
+	err := ParseLabelPrefixCfg([]string{"k8s:io.kubernetes.pod.namespace", "k8s:k8s-app", "k8s:app", "k8s:name"}, []string{}, "")
 	c.Assert(err, IsNil)
 	dlpcfg := validLabelPrefixes
 	allNormalLabels := map[string]string{

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -444,6 +445,10 @@ func (m *manager) nodeIdentityLabels(n nodeTypes.Node) (nodeLabels labels.Labels
 			// This needs to match clustermesh-apiserver's VMManager.AllocateNodeIdentity
 			nodeLabels = labels.Map2Labels(n.Labels, labels.LabelSourceK8s)
 			hasOverride = true
+		} else if !n.IsLocal() && option.Config.PerNodeLabelsEnabled() {
+			lbls := labels.Map2Labels(n.Labels, labels.LabelSourceNode)
+			filteredLbls, _ := labelsfilter.FilterNodeLabels(lbls)
+			nodeLabels.MergeLabels(filteredLbls)
 		}
 	} else {
 		nodeLabels = labels.NewFrom(labels.LabelHost)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1180,6 +1180,13 @@ const (
 
 	// PolicyCIDRMatchMode defines the entities that CIDR selectors can reach
 	PolicyCIDRMatchMode = "policy-cidr-match-mode"
+
+	// EnableNodeSelectorLabels enables use of the node label based identity
+	EnableNodeSelectorLabels = "enable-node-selector-labels"
+
+	// NodeLabels is the list of label prefixes used to determine identity of a node (requires enabling of
+	// EnableNodeSelectorLabels)
+	NodeLabels = "node-labels"
 )
 
 // Default string arguments
@@ -2410,6 +2417,13 @@ type DaemonConfig struct {
 
 	// ServiceNoBackendResponse determines how we handle traffic to a service with no backends.
 	ServiceNoBackendResponse string
+
+	// EnableNodeSelectorLabels enables use of the node label based identity
+	EnableNodeSelectorLabels bool
+
+	// NodeLabels is the list of label prefixes used to determine identity of a node (requires enabling of
+	// EnableNodeSelectorLabels)
+	NodeLabels []string
 }
 
 var (
@@ -2703,6 +2717,12 @@ func (c *DaemonConfig) PolicyCIDRMatchesNodes() bool {
 		}
 	}
 	return false
+}
+
+// PerNodeLabelsEnabled returns true if per-node labels feature
+// is enabled
+func (c *DaemonConfig) PerNodeLabelsEnabled() bool {
+	return c.EnableNodeSelectorLabels
 }
 
 func (c *DaemonConfig) validatePolicyCIDRMatchMode() error {
@@ -3517,6 +3537,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	// To support K8s NetworkPolicy
 	c.EnableK8sNetworkPolicy = vp.GetBool(EnableK8sNetworkPolicy)
 	c.PolicyCIDRMatchMode = vp.GetStringSlice(PolicyCIDRMatchMode)
+	c.EnableNodeSelectorLabels = vp.GetBool(EnableNodeSelectorLabels)
+	c.NodeLabels = vp.GetStringSlice(NodeLabels)
 }
 
 func (c *DaemonConfig) populateDevices(vp *viper.Viper) {

--- a/pkg/policy/api/zz_generated.deepcopy.go
+++ b/pkg/policy/api/zz_generated.deepcopy.go
@@ -174,6 +174,13 @@ func (in *EgressCommonRule) DeepCopyInto(out *EgressCommonRule) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.ToNodes != nil {
+		in, out := &in.ToNodes, &out.ToNodes
+		*out = make([]EndpointSelector, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.aggregatedSelectors != nil {
 		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors
 		*out = make(EndpointSelectorSlice, len(*in))
@@ -505,6 +512,13 @@ func (in *IngressCommonRule) DeepCopyInto(out *IngressCommonRule) {
 		in, out := &in.FromEntities, &out.FromEntities
 		*out = make(EntitySlice, len(*in))
 		copy(*out, *in)
+	}
+	if in.FromNodes != nil {
+		in, out := &in.FromNodes, &out.FromNodes
+		*out = make([]EndpointSelector, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	if in.aggregatedSelectors != nil {
 		in, out := &in.aggregatedSelectors, &out.aggregatedSelectors

--- a/pkg/policy/api/zz_generated.deepequal.go
+++ b/pkg/policy/api/zz_generated.deepequal.go
@@ -264,6 +264,23 @@ func (in *EgressCommonRule) DeepEqual(other *EgressCommonRule) bool {
 		}
 	}
 
+	if ((in.ToNodes != nil) && (other.ToNodes != nil)) || ((in.ToNodes == nil) != (other.ToNodes == nil)) {
+		in, other := &in.ToNodes, &other.ToNodes
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if !inElement.DeepEqual(&(*other)[i]) {
+					return false
+				}
+			}
+		}
+	}
+
 	if ((in.aggregatedSelectors != nil) && (other.aggregatedSelectors != nil)) || ((in.aggregatedSelectors == nil) != (other.aggregatedSelectors == nil)) {
 		in, other := &in.aggregatedSelectors, &other.aggregatedSelectors
 		if other == nil || !in.DeepEqual(other) {
@@ -620,6 +637,23 @@ func (in *IngressCommonRule) DeepEqual(other *IngressCommonRule) bool {
 		in, other := &in.FromEntities, &other.FromEntities
 		if other == nil || !in.DeepEqual(other) {
 			return false
+		}
+	}
+
+	if ((in.FromNodes != nil) && (other.FromNodes != nil)) || ((in.FromNodes == nil) != (other.FromNodes == nil)) {
+		in, other := &in.FromNodes, &other.FromNodes
+		if other == nil {
+			return false
+		}
+
+		if len(*in) != len(*other) {
+			return false
+		} else {
+			for i, inElement := range *in {
+				if !inElement.DeepEqual(&(*other)[i]) {
+					return false
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
This is revival of https://github.com/cilium/cilium/pull/22208, based on latest main.

Please take a look at [CFP](https://docs.google.com/document/d/1C4UMzpcd0EDP75dh7b8-RFJgV7hmPt2rT0JrktUF-hM/edit?usp=sharing) for more details.

When one enables `policy-cidr-match-mode=nodes` it allows nodes to be selected by CIDR network policies which is great, but hides the fact that each node in the end has a unique identity from `IdentityScopeRemoteNode`.

```
$ k --context infra8.ng -n cilium exec -it cilium-4r24l -- cilium identity list
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), clean-cilium-state (init), install-cni-binaries (init)
ID         LABELS
1          cidr:2a02:598:245::c8c/128
           reserved:host
2          reserved:world
3          reserved:unmanaged
4          reserved:health
5          reserved:init
6          reserved:remote-node
7          reserved:kube-apiserver
           reserved:remote-node
8          reserved:ingress
9          reserved:world-ipv4
10         reserved:world-ipv6
129        reserved:kube-dns
.
.
.
33563866   cidr:2a02:598:128::4616/128
           reserved:remote-node
33563867   cidr:10.246.52.30/32
           reserved:remote-node
33563868   cidr:2a02:598:128::4630/128
           reserved:remote-node
33563869   cidr:10.246.52.22/32
           reserved:remote-node
33563870   cidr:2a02:598:128::4622/128
           reserved:remote-node
33563871   cidr:10.246.52.34/32
           reserved:remote-node
33563872   cidr:2a02:598:128::4634/128
           reserved:remote-node
33563873   cidr:10.246.3.13/32
           reserved:remote-node
33563874   cidr:2a02:598:128::313/128
           reserved:remote-node
33563875   cidr:10.246.52.20/32
           reserved:remote-node
33563876   cidr:2a02:598:128::4620/128
           reserved:remote-node
33563877   cidr:10.246.52.14/32
           reserved:remote-node
33563878   cidr:2a02:598:128::4614/128
           reserved:remote-node
33563879   cidr:10.246.52.12/32
           reserved:remote-node
33563880   cidr:2a02:598:128::4612/128
           reserved:remote-node
33563881   cidr:10.246.52.24/32
           reserved:remote-node
```

In cases where we have a big clustermesh this results in a lot of identities to be used. Instead we could use this new feature to allow nodes to be selectable by their labels. Which might be filtered out by `--node-labels` list.
The code also adds a new label source `LabelSourceNode="node"` which adds `node:` prefix to node labels.

```
$ k --context infra8.ng -n cilium exec -it cilium-4r24l -- cilium identity list
Defaulted container "cilium-agent" out of: cilium-agent, config (init), mount-cgroup (init), apply-sysctl-overwrites (init), mount-bpf-fs (init), clean-cilium-state (init), install-cni-binaries (init)
ID         LABELS
33554434   node:scif.cz/node=openstack-worker
           reserved:remote-node
33554435   node:scif.cz/node=labrador
           reserved:remote-node
```

With that one could specify this new `fromNodes/toNodes` in their CNPs and allow access only from/to specific nodes:

```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "from-nodes"
spec:
  endpointSelector:
    matchLabels:
      {}
  ingress:
  - fromNodes:
    - matchLabels:
        cilium.io/ci-node: k8s1
```

instead of

```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "from-nodes"
spec:
  endpointSelector:
    matchLabels:
      {}
  ingress:
  - fromEntities:
    - remote-node
```
or
```
apiVersion: "cilium.io/v2"
kind: CiliumNetworkPolicy
metadata:
  name: "from-nodes"
spec:
  endpointSelector:
    matchLabels:
      {}
  ingress:
    - fromCIDR:
      - 10.246.47.36/32
      - 10.249.76.38/32
      - 10.249.189.38/32
      - 10.249.43.31/32
      - 10.249.5.12/32
      - 10.249.81.12/32
      - 10.249.82.12/32
      - 10.249.83.12/32
      - 10.249.95.14/32
      - 10.249.80.54/32
      - 10.249.94.43/32
      - 10.249.96.30/32
      - 10.249.99.38/32
      - 10.249.92.40/32
      - 10.231.3.34/32
      - 10.249.73.21/32
      - 10.249.95.55/32
      - 10.249.97.11/32
      - 10.249.101.36/32
      - 10.249.99.12/32
      - 10.249.102.36/32
      - 10.249.104.36/32
      - 10.249.108.57/32
      - 10.249.38.57/32
      - 10.249.106.48/32
      - 10.249.123.34/32
      - 10.249.72.19/32
      - 10.249.105.36/32
      - 10.249.107.12/32
      - 10.249.110.34/32
      - 10.249.108.12/32
      - 10.249.38.36/32
      - 10.249.106.46/32
      - 10.249.104.38/32
      - 10.249.111.46/32
      - 10.249.121.34/32
```

where one would need to define all node IPs and keep track of them perhaps in a `CiliumCIDRGroup` resource.

Fixes: #21615
Fixes: #19121

```release-note
identity: Allow nodes to be selectable by their labels instead of CIDR and/or remote-node entity.
```
