### PR TITLE
ci: fix Azure cluster names sometimes being too long

### DIFF
--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -3,8 +3,11 @@
 include:
   - version: "1.24"
     location: westeurope
+    index: 1
   - version: "1.25"
     location: westus
+    index: 2
   - version: "1.26"
     location: eastasia
+    index: 3
     default: true

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -125,6 +125,12 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
+      - name: Override cluster name
+        run: |
+          # Extend default name with matrix index to avoid cluster name conflicts
+          NAME=${{ env.name }}-${{ matrix.index }}
+          echo "name=${NAME}" >> "$GITHUB_ENV"
+
       - name: Set up job variables
         id: vars
         run: |
@@ -155,7 +161,7 @@ jobs:
             --helm-set=debug.enabled=true \
             --helm-set loadBalancer.l7.backend=envoy \
             --helm-set tls.secretsBackend=k8s \
-            --helm-set=azure.resourceGroup=${{ env.name }}-${{ matrix.location }} \
+            --helm-set=azure.resourceGroup=${{ env.name }} \
             --helm-set=bpf.monitorAggregation=none"
           CONNECTIVITY_TEST_DEFAULTS="--flow-validation=disabled \
             --hubble=false --collect-sysdump-on-failure --external-target bing.com --external-cidr 8.0.0.0/8 --external-ip 8.8.4.4 --external-other-ip 8.8.8.8"
@@ -185,13 +191,13 @@ jobs:
         run: |
           # Create group
           az group create \
-            --name ${{ env.name }}-${{ matrix.location }} \
+            --name ${{ env.name }} \
             --location ${{ matrix.location }} \
             --tags usage=${{ github.repository_owner }}-${{ github.event.repository.name }} owner=${{ steps.vars.outputs.owner }}
 
           # Create AKS cluster
           az aks create \
-            --resource-group ${{ env.name }}-${{ matrix.location }} \
+            --resource-group ${{ env.name }} \
             --name ${{ env.name }} \
             --location ${{ matrix.location }} \
             --kubernetes-version ${{ matrix.version }} \
@@ -203,7 +209,7 @@ jobs:
       - name: Get cluster credentials
         run: |
           az aks get-credentials \
-            --resource-group ${{ env.name }}-${{ matrix.location }} \
+            --resource-group ${{ env.name }} \
             --name ${{ env.name }}
 
       - name: Wait for images to be available
@@ -296,7 +302,7 @@ jobs:
       - name: Clean up AKS
         if: ${{ always() }}
         run: |
-          az group delete --name ${{ env.name }}-${{ matrix.location }} --yes --no-wait
+          az group delete --name ${{ env.name }} --yes --no-wait
         shell: bash {0} # Disable default fail-fast behaviour so that all commands run independently
 
       - name: Upload artifacts


### PR DESCRIPTION
Azure does not allow having multiple clusters with the same name in the same subscription even if they are hosted on different locations.

In order to avoid name conflicts, we previously added the location name to the cluster name, however in some cases this leads to cluster names exceeding the maximum length.

As a quick fix, we replace the location name with a simple index.