### PR TITLE
endpointslice: fix EndpointSlice import

### DIFF
--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -322,7 +322,7 @@ func (c *CiliumEndpointSliceController) handleErr(err error, key interface{}) {
 		// Update metadata of the object from store on conflict
 		obj, exists, err := c.ciliumEndpointSliceStore.GetByKey(key.(string))
 		if err == nil && exists {
-			c.Manager.updateCESInCache(obj.(*v2alpha1.CiliumEndpointSlice), false)
+			c.Manager.updateCESInCache(obj.(*capi_v2a1.CiliumEndpointSlice), false)
 		}
 	}
 


### PR DESCRIPTION
This commit fixes the import of EndpointSlice.

Merge race between #26455 & #26620

Fixes: #26455