### PR TITLE
cleanup: code cleanup to remove unused parameter from repository add api

### DIFF
--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -142,7 +142,7 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		},
 	}
 
-	_, _, err := repo.Add(*egressDenyRule, nil)
+	_, _, err := repo.Add(*egressDenyRule)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/k8s/rule_translate_test.go
+++ b/pkg/k8s/rule_translate_test.go
@@ -264,7 +264,7 @@ func (s *K8sSuite) TestTranslatorDirect(c *C) {
 
 	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, map[string]string{})
 
-	_, _, err := repo.Add(rule1, []policy.Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	result, err := repo.TranslateRules(translator)
@@ -370,7 +370,7 @@ func (s *K8sSuite) TestTranslatorLabels(c *C) {
 
 	translator := NewK8sTranslator(serviceInfo, Endpoints{}, endpointInfo, svcLabels)
 
-	_, _, err := repo.Add(rule1, []policy.Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	result, err := repo.TranslateRules(translator)

--- a/pkg/policy/repository.go
+++ b/pkg/policy/repository.go
@@ -381,7 +381,7 @@ func (p *Repository) SearchRLocked(lbls labels.LabelArray) api.Rules {
 // TODO: this should be in a test_helpers.go file or something similar
 // so we can clearly delineate what helpers are for testing.
 // NOTE: This is only called from unit tests, but from multiple packages.
-func (p *Repository) Add(r api.Rule, localRuleConsumers []Endpoint) (uint64, map[uint16]struct{}, error) {
+func (p *Repository) Add(r api.Rule) (uint64, map[uint16]struct{}, error) {
 	p.Mutex.Lock()
 	defer p.Mutex.Unlock()
 

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -149,14 +149,14 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 	c.Assert(egr, Equals, false, genCommentf(false, false))
 	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("returned matching rules did not match"))
 
-	_, _, err := repo.Add(fooIngressDenyRule1, []Endpoint{})
+	_, _, err := repo.Add(fooIngressDenyRule1)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, true, genCommentf(true, true))
 	c.Assert(egr, Equals, false, genCommentf(false, false))
 	c.Assert(matchingRules[0].Rule, checker.DeepEquals, fooIngressDenyRule1, Commentf("returned matching rules did not match"))
 
-	_, _, err = repo.Add(fooIngressDenyRule2, []Endpoint{})
+	_, _, err = repo.Add(fooIngressDenyRule2)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, true, genCommentf(true, true))
@@ -179,7 +179,7 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 	c.Assert(egr, Equals, false, genCommentf(false, false))
 	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("returned matching rules did not match"))
 
-	_, _, err = repo.Add(fooEgressDenyRule1, []Endpoint{})
+	_, _, err = repo.Add(fooEgressDenyRule1)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, false, genCommentf(true, false))
@@ -188,7 +188,7 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{fooEgressDenyRule1Label})
 	c.Assert(numDeleted, Equals, 1)
 
-	_, _, err = repo.Add(fooEgressDenyRule2, []Endpoint{})
+	_, _, err = repo.Add(fooEgressDenyRule2)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, false, genCommentf(true, false))
@@ -198,7 +198,7 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{fooEgressDenyRule2Label})
 	c.Assert(numDeleted, Equals, 1)
 
-	_, _, err = repo.Add(combinedRule, []Endpoint{})
+	_, _, err = repo.Add(combinedRule)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, true, genCommentf(true, true))
@@ -215,7 +215,7 @@ func (ds *PolicyTestSuite) TestComputePolicyDenyEnforcementAndRules(c *C) {
 	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("returned matching rules did not match"))
 
 	SetPolicyEnabled(option.NeverEnforce)
-	_, _, err = repo.Add(combinedRule, []Endpoint{})
+	_, _, err = repo.Add(combinedRule)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, false, genCommentf(true, false))
@@ -297,7 +297,7 @@ func (ds *PolicyTestSuite) TestGetRulesMatching(c *C) {
 	c.Assert(egressMatch, Equals, false)
 
 	// When ingress deny policy is applied.
-	_, _, err := repo.Add(ingressDenyRule, []Endpoint{})
+	_, _, err := repo.Add(ingressDenyRule)
 	c.Assert(err, IsNil)
 	ingressMatch, egressMatch = repo.GetRulesMatching(labels.LabelArray{bar, foo})
 	c.Assert(ingressMatch, Equals, true)
@@ -307,7 +307,7 @@ func (ds *PolicyTestSuite) TestGetRulesMatching(c *C) {
 	repo.DeleteByLabels(tag)
 
 	// When egress deny policy is applied.
-	_, _, err = repo.Add(egressDenyRule, []Endpoint{})
+	_, _, err = repo.Add(egressDenyRule)
 	c.Assert(err, IsNil)
 	ingressMatch, egressMatch = repo.GetRulesMatching(labels.LabelArray{bar, foo})
 	c.Assert(ingressMatch, Equals, false)
@@ -372,11 +372,11 @@ func (ds *PolicyTestSuite) TestDeniesIngress(c *C) {
 		Labels: tag1,
 	}
 
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
-	_, _, err = repo.Add(rule2, []Endpoint{})
+	_, _, err = repo.Add(rule2)
 	c.Assert(err, IsNil)
-	_, _, err = repo.Add(rule3, []Endpoint{})
+	_, _, err = repo.Add(rule3)
 	c.Assert(err, IsNil)
 
 	// foo=>bar is not OK
@@ -470,11 +470,11 @@ func (ds *PolicyTestSuite) TestDeniesEgress(c *C) {
 		},
 		Labels: tag1,
 	}
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
-	_, _, err = repo.Add(rule2, []Endpoint{})
+	_, _, err = repo.Add(rule2)
 	c.Assert(err, IsNil)
-	_, _, err = repo.Add(rule3, []Endpoint{})
+	_, _, err = repo.Add(rule3)
 	c.Assert(err, IsNil)
 
 	// foo=>bar is not OK
@@ -539,7 +539,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDeny(c *C) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule, []Endpoint{})
+	_, _, err := repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -595,7 +595,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
 		Labels: labelsL4Kafka,
 	}
 	l49092Rule.Sanitize()
-	_, _, err := repo.Add(l49092Rule, []Endpoint{})
+	_, _, err := repo.Add(l49092Rule)
 	c.Assert(err, IsNil)
 
 	l480Rule := api.Rule{
@@ -615,7 +615,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngressDeny(c *C) {
 		Labels: labelsL4HTTP,
 	}
 	l480Rule.Sanitize()
-	_, _, err = repo.Add(l480Rule, []Endpoint{})
+	_, _, err = repo.Add(l480Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -687,7 +687,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
 		},
 	}
 	l480Rule.Sanitize()
-	_, _, err := repo.Add(l480Rule, []Endpoint{})
+	_, _, err := repo.Add(l480Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -759,7 +759,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
 		},
 	}
 	l480Rule.Sanitize()
-	_, _, err := repo.Add(l480Rule, []Endpoint{})
+	_, _, err := repo.Add(l480Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -839,7 +839,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 		Labels: labelsL4,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule, []Endpoint{})
+	_, _, err := repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	icmpRule := api.Rule{
@@ -861,7 +861,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 	err = icmpRule.Sanitize()
 	c.Assert(err, IsNil)
 
-	_, _, err = repo.Add(icmpRule, nil)
+	_, _, err = repo.Add(icmpRule)
 	c.Assert(err, IsNil)
 
 	icmpV6Rule := api.Rule{
@@ -884,7 +884,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDeny(c *C) {
 	err = icmpV6Rule.Sanitize()
 	c.Assert(err, IsNil)
 
-	_, _, err = repo.Add(icmpV6Rule, nil)
+	_, _, err = repo.Add(icmpV6Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -967,7 +967,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
 		Labels: labelsL3DNS,
 	}
 	l453Rule.Sanitize()
-	_, _, err := repo.Add(l453Rule, []Endpoint{})
+	_, _, err := repo.Add(l453Rule)
 	c.Assert(err, IsNil)
 
 	l480Rule := api.Rule{
@@ -987,7 +987,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgressDeny(c *C) {
 		Labels: labelsL3HTTP,
 	}
 	l480Rule.Sanitize()
-	_, _, err = repo.Add(l480Rule, []Endpoint{})
+	_, _, err = repo.Add(l480Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1071,7 +1071,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
 		Labels: labelsHTTP,
 	}
 	l480Get.Sanitize()
-	_, _, err := repo.Add(l480Get, []Endpoint{})
+	_, _, err := repo.Add(l480Get)
 	c.Assert(err, IsNil)
 
 	l3Rule := api.Rule{
@@ -1086,7 +1086,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err = repo.Add(l3Rule, []Endpoint{})
+	_, _, err = repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1152,7 +1152,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressDenyFromEntities(c *C) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule, []Endpoint{})
+	_, _, err := repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1207,7 +1207,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressDenyToEntities(c *C) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule, []Endpoint{})
+	_, _, err := repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1289,7 +1289,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
 				}},
 			},
 		},
-	}, []Endpoint{})
+	})
 	c.Assert(err, IsNil)
 
 	_, _, err = repo.Add(api.Rule{
@@ -1306,7 +1306,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStartedDeny(c *C) {
 				}},
 			},
 		},
-	}, []Endpoint{})
+	})
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()
@@ -1420,7 +1420,7 @@ Ingress verdict: denied
 
 	// Now, add extra rules to allow specifically baz=>bar on port 80
 	l4rule := buildDenyRule("baz", "bar", "80")
-	_, _, err := repo.Add(l4rule, []Endpoint{})
+	_, _, err := repo.Add(l4rule)
 	c.Assert(err, IsNil)
 
 	// baz=>bar:80 is OK
@@ -1473,7 +1473,7 @@ Ingress verdict: denied
 			},
 		}},
 	}
-	_, _, err = repo.Add(l3rule, []Endpoint{})
+	_, _, err = repo.Add(l3rule)
 	c.Assert(err, IsNil)
 
 	// foo=>bar is now denied due to the FromRequires

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -138,14 +138,14 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 	c.Assert(egr, Equals, false, Commentf("egress policy enforcement should not apply since no rules are in repository"))
 	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("returned matching rules did not match"))
 
-	_, _, err := repo.Add(fooIngressRule1, []Endpoint{})
+	_, _, err := repo.Add(fooIngressRule1)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, true, Commentf("ingress policy enforcement should apply since ingress rule selects"))
 	c.Assert(egr, Equals, false, Commentf("egress policy enforcement should not apply since no egress rules select"))
 	c.Assert(matchingRules[0].Rule, checker.DeepEquals, fooIngressRule1, Commentf("returned matching rules did not match"))
 
-	_, _, err = repo.Add(fooIngressRule2, []Endpoint{})
+	_, _, err = repo.Add(fooIngressRule2)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, true, Commentf("ingress policy enforcement should apply since ingress rule selects"))
@@ -169,7 +169,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 	c.Assert(egr, Equals, false, Commentf("egress policy enforcement should not apply since no rules are in repository"))
 	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("returned matching rules did not match"))
 
-	_, _, err = repo.Add(fooEgressRule1, []Endpoint{})
+	_, _, err = repo.Add(fooEgressRule1)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, false, Commentf("ingress policy enforcement should not apply since no ingress rules select"))
@@ -178,7 +178,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{fooEgressRule1Label})
 	c.Assert(numDeleted, Equals, 1)
 
-	_, _, err = repo.Add(fooEgressRule2, []Endpoint{})
+	_, _, err = repo.Add(fooEgressRule2)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, false, Commentf("ingress policy enforcement should not apply since no ingress rules select"))
@@ -188,7 +188,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 	_, _, numDeleted = repo.DeleteByLabelsLocked(labels.LabelArray{fooEgressRule2Label})
 	c.Assert(numDeleted, Equals, 1)
 
-	_, _, err = repo.Add(combinedRule, []Endpoint{})
+	_, _, err = repo.Add(combinedRule)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, true, Commentf("ingress policy enforcement should apply since ingress rule selects"))
@@ -205,7 +205,7 @@ func (ds *PolicyTestSuite) TestComputePolicyEnforcementAndRules(c *C) {
 	c.Assert(matchingRules, checker.DeepEquals, ruleSlice{}, Commentf("returned matching rules did not match"))
 
 	SetPolicyEnabled(option.NeverEnforce)
-	_, _, err = repo.Add(combinedRule, []Endpoint{})
+	_, _, err = repo.Add(combinedRule)
 	c.Assert(err, IsNil, Commentf("unable to add rule to policy repository"))
 	ing, egr, matchingRules = repo.computePolicyEnforcementAndRules(fooIdentity)
 	c.Assert(ing, Equals, false, Commentf("ingress policy enforcement should not apply since policy enforcement is disabled "))
@@ -241,7 +241,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 	repo.selectorCache = testSelectorCache
 
 	// cannot add empty rule
-	rev, _, err := repo.Add(api.Rule{}, []Endpoint{})
+	rev, _, err := repo.Add(api.Rule{})
 	c.Assert(err, Not(IsNil))
 	c.Assert(rev, Equals, uint64(1))
 
@@ -269,11 +269,11 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 	nextRevision++
 
 	// add rule1,rule2
-	rev, _, err = repo.Add(rule1, []Endpoint{})
+	rev, _, err = repo.Add(rule1)
 	c.Assert(err, IsNil)
 	c.Assert(rev, Equals, nextRevision)
 	nextRevision++
-	rev, _, err = repo.Add(rule2, []Endpoint{})
+	rev, _, err = repo.Add(rule2)
 	c.Assert(err, IsNil)
 	c.Assert(rev, Equals, nextRevision)
 	nextRevision++
@@ -284,7 +284,7 @@ func (ds *PolicyTestSuite) TestAddSearchDelete(c *C) {
 	repo.Mutex.RUnlock()
 
 	// add rule3
-	rev, _, err = repo.Add(rule3, []Endpoint{})
+	rev, _, err = repo.Add(rule3)
 	c.Assert(err, IsNil)
 	c.Assert(rev, Equals, nextRevision)
 	nextRevision++
@@ -345,7 +345,7 @@ func BenchmarkParseLabel(b *testing.B) {
 					labels.NewLabel("namespace", "default", labels.LabelSourceK8s),
 					labels.NewLabel("tag3", J, labels.LabelSourceK8s),
 				},
-			}, []Endpoint{})
+			})
 			if err == nil {
 				cntAdd++
 			}
@@ -419,11 +419,11 @@ func (ds *PolicyTestSuite) TestAllowsIngress(c *C) {
 		Labels: tag1,
 	}
 
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
-	_, _, err = repo.Add(rule2, []Endpoint{})
+	_, _, err = repo.Add(rule2)
 	c.Assert(err, IsNil)
-	_, _, err = repo.Add(rule3, []Endpoint{})
+	_, _, err = repo.Add(rule3)
 	c.Assert(err, IsNil)
 
 	// foo=>bar is OK
@@ -517,11 +517,11 @@ func (ds *PolicyTestSuite) TestAllowsEgress(c *C) {
 		},
 		Labels: tag1,
 	}
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
-	_, _, err = repo.Add(rule2, []Endpoint{})
+	_, _, err = repo.Add(rule2)
 	c.Assert(err, IsNil)
-	_, _, err = repo.Add(rule3, []Endpoint{})
+	_, _, err = repo.Add(rule3)
 	c.Assert(err, IsNil)
 
 	// foo=>bar is OK
@@ -591,7 +591,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule, []Endpoint{})
+	_, _, err := repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	kafkaRule := api.Rule{
@@ -616,7 +616,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 		Labels: labelsKafka,
 	}
 	kafkaRule.Sanitize()
-	_, _, err = repo.Add(kafkaRule, []Endpoint{})
+	_, _, err = repo.Add(kafkaRule)
 	c.Assert(err, IsNil)
 
 	httpRule := api.Rule{
@@ -640,7 +640,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 		},
 		Labels: labelsHTTP,
 	}
-	_, _, err = repo.Add(httpRule, []Endpoint{})
+	_, _, err = repo.Add(httpRule)
 	c.Assert(err, IsNil)
 
 	l7Rule := api.Rule{
@@ -663,7 +663,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 		},
 		Labels: labelsL7,
 	}
-	_, _, err = repo.Add(l7Rule, []Endpoint{})
+	_, _, err = repo.Add(l7Rule)
 	c.Assert(err, IsNil)
 
 	icmpRule := api.Rule{
@@ -682,7 +682,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 		},
 		Labels: labelsICMP,
 	}
-	_, _, err = repo.Add(icmpRule, nil)
+	_, _, err = repo.Add(icmpRule)
 	c.Assert(err, IsNil)
 
 	icmpV6Rule := api.Rule{
@@ -702,7 +702,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngress(c *C) {
 		},
 		Labels: labelsICMPv6,
 	}
-	_, _, err = repo.Add(icmpV6Rule, nil)
+	_, _, err = repo.Add(icmpV6Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -830,7 +830,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 		Labels: labelsL4Kafka,
 	}
 	l49092Rule.Sanitize()
-	_, _, err := repo.Add(l49092Rule, []Endpoint{})
+	_, _, err := repo.Add(l49092Rule)
 	c.Assert(err, IsNil)
 
 	kafkaRule := api.Rule{
@@ -855,7 +855,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 		Labels: labelsL7Kafka,
 	}
 	kafkaRule.Sanitize()
-	_, _, err = repo.Add(kafkaRule, []Endpoint{})
+	_, _, err = repo.Add(kafkaRule)
 	c.Assert(err, IsNil)
 
 	l480Rule := api.Rule{
@@ -875,7 +875,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 		Labels: labelsL4HTTP,
 	}
 	l480Rule.Sanitize()
-	_, _, err = repo.Add(l480Rule, []Endpoint{})
+	_, _, err = repo.Add(l480Rule)
 	c.Assert(err, IsNil)
 
 	httpRule := api.Rule{
@@ -899,7 +899,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesIngress(c *C) {
 		},
 		Labels: labelsL7HTTP,
 	}
-	_, _, err = repo.Add(httpRule, []Endpoint{})
+	_, _, err = repo.Add(httpRule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -989,7 +989,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
 		},
 	}
 	l480Rule.Sanitize()
-	_, _, err := repo.Add(l480Rule, []Endpoint{})
+	_, _, err := repo.Add(l480Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1063,7 +1063,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 		},
 	}
 	l480Rule.Sanitize()
-	_, _, err := repo.Add(l480Rule, []Endpoint{})
+	_, _, err := repo.Add(l480Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1150,7 +1150,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 		Labels: labelsL4,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule, []Endpoint{})
+	_, _, err := repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	dnsRule := api.Rule{
@@ -1175,7 +1175,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 		Labels: labelsDNS,
 	}
 	dnsRule.Sanitize()
-	_, _, err = repo.Add(dnsRule, []Endpoint{})
+	_, _, err = repo.Add(dnsRule)
 	c.Assert(err, IsNil)
 
 	httpRule := api.Rule{
@@ -1199,7 +1199,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 		},
 		Labels: labelsHTTP,
 	}
-	_, _, err = repo.Add(httpRule, []Endpoint{})
+	_, _, err = repo.Add(httpRule)
 	c.Assert(err, IsNil)
 
 	icmpRule := api.Rule{
@@ -1218,7 +1218,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 		},
 		Labels: labelsICMP,
 	}
-	_, _, err = repo.Add(icmpRule, nil)
+	_, _, err = repo.Add(icmpRule)
 	c.Assert(err, IsNil)
 
 	icmpV6Rule := api.Rule{
@@ -1238,7 +1238,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgress(c *C) {
 		},
 		Labels: labelsICMPv6,
 	}
-	_, _, err = repo.Add(icmpV6Rule, nil)
+	_, _, err = repo.Add(icmpV6Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1357,7 +1357,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 		Labels: labelsL3DNS,
 	}
 	l453Rule.Sanitize()
-	_, _, err := repo.Add(l453Rule, []Endpoint{})
+	_, _, err := repo.Add(l453Rule)
 	c.Assert(err, IsNil)
 
 	dnsRule := api.Rule{
@@ -1382,7 +1382,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 		Labels: labelsL7DNS,
 	}
 	dnsRule.Sanitize()
-	_, _, err = repo.Add(dnsRule, []Endpoint{})
+	_, _, err = repo.Add(dnsRule)
 	c.Assert(err, IsNil)
 
 	l480Rule := api.Rule{
@@ -1402,7 +1402,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 		Labels: labelsL3HTTP,
 	}
 	l480Rule.Sanitize()
-	_, _, err = repo.Add(l480Rule, []Endpoint{})
+	_, _, err = repo.Add(l480Rule)
 	c.Assert(err, IsNil)
 
 	httpRule := api.Rule{
@@ -1426,7 +1426,7 @@ func (ds *PolicyTestSuite) TestWildcardL4RulesEgress(c *C) {
 		},
 		Labels: labelsL7HTTP,
 	}
-	_, _, err = repo.Add(httpRule, []Endpoint{})
+	_, _, err = repo.Add(httpRule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1537,7 +1537,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgress(c *C) {
 		Labels: labelsHTTP,
 	}
 	l480Get.Sanitize()
-	_, _, err := repo.Add(l480Get, []Endpoint{})
+	_, _, err := repo.Add(l480Get)
 	c.Assert(err, IsNil)
 
 	l3Rule := api.Rule{
@@ -1552,7 +1552,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgress(c *C) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err = repo.Add(l3Rule, []Endpoint{})
+	_, _, err = repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1631,7 +1631,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule, []Endpoint{})
+	_, _, err := repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	kafkaRule := api.Rule{
@@ -1656,7 +1656,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 		Labels: labelsKafka,
 	}
 	kafkaRule.Sanitize()
-	_, _, err = repo.Add(kafkaRule, []Endpoint{})
+	_, _, err = repo.Add(kafkaRule)
 	c.Assert(err, IsNil)
 
 	httpRule := api.Rule{
@@ -1680,7 +1680,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesIngressFromEntities(c *C) {
 		},
 		Labels: labelsHTTP,
 	}
-	_, _, err = repo.Add(httpRule, []Endpoint{})
+	_, _, err = repo.Add(httpRule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1771,7 +1771,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 		Labels: labelsL3,
 	}
 	l3Rule.Sanitize()
-	_, _, err := repo.Add(l3Rule, []Endpoint{})
+	_, _, err := repo.Add(l3Rule)
 	c.Assert(err, IsNil)
 
 	dnsRule := api.Rule{
@@ -1796,7 +1796,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 		Labels: labelsDNS,
 	}
 	dnsRule.Sanitize()
-	_, _, err = repo.Add(dnsRule, []Endpoint{})
+	_, _, err = repo.Add(dnsRule)
 	c.Assert(err, IsNil)
 
 	httpRule := api.Rule{
@@ -1820,7 +1820,7 @@ func (ds *PolicyTestSuite) TestWildcardL3RulesEgressToEntities(c *C) {
 		},
 		Labels: labelsHTTP,
 	}
-	_, _, err = repo.Add(httpRule, []Endpoint{})
+	_, _, err = repo.Add(httpRule)
 	c.Assert(err, IsNil)
 
 	ctx := &SearchContext{
@@ -1933,7 +1933,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 				}},
 			},
 		},
-	}, []Endpoint{})
+	})
 	c.Assert(err, IsNil)
 
 	_, _, err = repo.Add(api.Rule{
@@ -1955,7 +1955,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 				}},
 			},
 		},
-	}, []Endpoint{})
+	})
 	c.Assert(err, IsNil)
 
 	_, _, err = repo.Add(api.Rule{
@@ -1977,7 +1977,7 @@ func (ds *PolicyTestSuite) TestMinikubeGettingStarted(c *C) {
 				}},
 			},
 		},
-	}, []Endpoint{})
+	})
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()
@@ -2121,7 +2121,7 @@ Ingress verdict: denied
 
 	// Now, add extra rules to allow specifically baz=>bar on port 80
 	l4rule := buildRule("baz", "bar", "80")
-	_, _, err := repo.Add(l4rule, []Endpoint{})
+	_, _, err := repo.Add(l4rule)
 	c.Assert(err, IsNil)
 
 	// baz=>bar:80 is OK
@@ -2174,7 +2174,7 @@ Ingress verdict: denied
 			},
 		}},
 	}
-	_, _, err = repo.Add(l3rule, []Endpoint{})
+	_, _, err = repo.Add(l3rule)
 	c.Assert(err, IsNil)
 
 	// foo=>bar is now denied due to the FromRequires
@@ -2309,7 +2309,7 @@ func (ds *PolicyTestSuite) TestIterate(c *C) {
 					},
 				},
 			},
-		}, []Endpoint{})
+		})
 		c.Assert(err, IsNil)
 	}
 

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -130,7 +130,7 @@ func (ds *PolicyTestSuite) TestL3WithIngressDenyWildcard(c *C) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()
@@ -211,7 +211,7 @@ func (ds *PolicyTestSuite) TestL3WithLocalHostWildcardd(c *C) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()
@@ -296,7 +296,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDenyWildcard(c *C) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()
@@ -409,7 +409,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -282,7 +282,7 @@ func (ds *PolicyTestSuite) TestL7WithIngressWildcard(c *C) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()
@@ -376,7 +376,7 @@ func (ds *PolicyTestSuite) TestL7WithLocalHostWildcardd(c *C) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()
@@ -469,7 +469,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()
@@ -584,7 +584,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	}
 
 	rule1.Sanitize()
-	_, _, err := repo.Add(rule1, []Endpoint{})
+	_, _, err := repo.Add(rule1)
 	c.Assert(err, IsNil)
 
 	repo.Mutex.RLock()


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
Removing unused parameter from add api and also from other references in unit tests which uses this api

