### PR TITLE
[v1.13] egressgw: consider egress interface when deleting stale IP rules

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -322,6 +322,7 @@ nextIpRule:
 		matchFunc := func(endpointIP net.IP, dstCIDR *net.IPNet, gwc *gatewayConfig) bool {
 			return manager.installRoutes &&
 				gwc.localNodeConfiguredAsGateway &&
+				ipRule.Table == egressGatewayRoutingTableIdx(gwc.ifaceIndex) &&
 				ipRule.Src.IP.Equal(endpointIP) && ipRule.Dst.String() == dstCIDR.String()
 		}
 


### PR DESCRIPTION
Manual backport of

- [ ] #26846


Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 26846; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=26846
```