### PR TITLE
config: spell out that --egress-masquerade-interfaces is for iptables

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -84,7 +84,7 @@ cilium-agent [flags]
       --dnsproxy-concurrency-processing-grace-period duration     Grace time to wait when DNS proxy concurrent limit has been reached during DNS message processing
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
-      --egress-masquerade-interfaces string                       Limit egress masquerading to interface selector
+      --egress-masquerade-interfaces string                       Limit iptables-based egress masquerading to interface selector
       --egress-multi-home-ip-rule-compat                          Offset routing table IDs under ENI IPAM mode to avoid collisions with reserved table IDs. If false, the offset is performed (new scheme), otherwise, the old scheme stays in-place.
       --enable-auto-protect-node-port-range                       Append NodePort range to net.ipv4.ip_local_reserved_ports if it overlaps with ephemeral port range (net.ipv4.ip_local_port_range) (default true)
       --enable-bandwidth-manager                                  Enable BPF bandwidth manager

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -300,7 +300,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.DisableCiliumEndpointCRDName, false, "Disable use of CiliumEndpoint CRD")
 	option.BindEnv(vp, option.DisableCiliumEndpointCRDName)
 
-	flags.String(option.EgressMasqueradeInterfaces, "", "Limit egress masquerading to interface selector")
+	flags.String(option.EgressMasqueradeInterfaces, "", "Limit iptables-based egress masquerading to interface selector")
 	option.BindEnv(vp, option.EgressMasqueradeInterfaces)
 
 	flags.Bool(option.BPFSocketLBHostnsOnly, false, "Skip socket LB for services when inside a pod namespace, in favor of service LB at the pod interface. Socket LB is still used when in the host namespace. Required by service mesh (e.g., Istio, Linkerd).")

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -655,7 +655,7 @@ enableRuntimeDeviceDetection: false
 # -- Chains to ignore when installing feeder rules.
 # disableIptablesFeederRules: ""
 
-# -- Limit egress masquerading to interface selector.
+# -- Limit iptables-based egress masquerading to interface selector.
 # egressMasqueradeInterfaces: ""
 
 # -- Whether to enable CNP status updates.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -652,7 +652,7 @@ enableRuntimeDeviceDetection: false
 # -- Chains to ignore when installing feeder rules.
 # disableIptablesFeederRules: ""
 
-# -- Limit egress masquerading to interface selector.
+# -- Limit iptables-based egress masquerading to interface selector.
 # egressMasqueradeInterfaces: ""
 
 # -- Whether to enable CNP status updates.


### PR DESCRIPTION
Make it clear that this option applies to iptables-driven masquerading, not BPF-driven masquerading.
