### PR TITLE
v1.13: node: Fix node encryption condition in incorrect backport

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -405,7 +405,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		// through the tunnel to preserve the source identity as part of the
 		// encapsulation. In encryption case we also want to use vxlan device
 		// to create symmetric traffic when sending nodeIP->pod and pod->nodeIP.
-		if address.Type == addressing.NodeCiliumInternalIP ||
+		if address.Type == addressing.NodeCiliumInternalIP || m.conf.NodeEncryptionEnabled() ||
 			option.Config.EnableHostFirewall || option.Config.JoinCluster {
 			tunnelIP = nodeIP
 		}


### PR DESCRIPTION
Julian noticed that backported commit 7dbd40f280 ("ipsec: Remove workarounds for path asymmetry that was removed") didn't match the upstream commit due to a wrong conflict resolution. This commit fixes it.

We don't expect much impact here as node encryption was never stable, barely used, and eventually removed, but best to fix it, if only for consistency with v1.11 and v1.12.

Fixes: https://github.com/cilium/cilium/pull/26792.