### PR TITLE
[v1.12] Delete IP Label metadata on delete from ipcache

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -502,6 +502,10 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	delete(ipc.ipToHostIPCache, ip)
 	delete(ipc.ipToK8sMetadata, ip)
 
+	// this removes the IP from the metadata map
+	// this prevents old assigned labels from being re-used
+	ipc.metadata.delete(ip)
+
 	// Update named ports
 	namedPortsChanged = false
 	if oldK8sMeta != nil && len(oldK8sMeta.NamedPorts) > 0 {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -79,6 +79,12 @@ func (m *metadata) upsert(prefix string, lbls labels.Labels) {
 	m.Unlock()
 }
 
+func (m *metadata) delete(prefix string) {
+	m.Lock()
+	delete(m.m, prefix)
+	m.Unlock()
+}
+
 // GetIDMetadataByIP returns the associated labels with an IP. The caller must
 // not modifying the returned object as it's a live reference to the underlying
 // map.


### PR DESCRIPTION
This adds a delete call to the metadata map of the ipcache. On a delete from ipcache this info was left bhind. In case a node gets deleted the IP would keep receiving the remote-host label from this cache incorrectly.

This issue came out of an issue where we saw EKS nodes being recycled and the IPs getting re-used and receiving an incorrect remote-host label in identity cache and ip cache.

```release-note
Delete IP Label metadata on delete from ipcache
```

- v1.12: this PR
- v1.13: https://github.com/cilium/cilium/pull/27010
- v1.14: not affected thanks to a refactor :) 
