### PR TITLE
chore: fixing blank k8sPodName in endpoint logger

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -606,6 +606,18 @@ func (mgr *endpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.E
 	if ep.ID != 0 {
 		return fmt.Errorf("Endpoint ID is already set to %d", ep.ID)
 	}
+
+	// Updating logger to re-populate pod fields
+	// when endpoint and its logger are created pod details are not populated
+	// and all subsequent logs have empty pod details like ip addresses, k8sPodName
+	// this update will populate pod details in logger
+	ep.UpdateLogger(map[string]interface{}{
+		logfields.ContainerID: ep.GetShortContainerID(),
+		logfields.IPv4:        ep.GetIPv4Address(),
+		logfields.IPv6:        ep.GetIPv6Address(),
+		logfields.K8sPodName:  ep.GetK8sNamespaceAndPodName(),
+	})
+
 	err = mgr.expose(ep)
 	if err != nil {
 		return err


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

When a new endpoint is created, a logger is created with it. This logger is populated with pod detail fields. Initially the endpoint is not populated with pod name or ip addr details, so, the logger fields are populated with empty fields. These fields are never updated. 

This PR calls update logger to re-populate pod fields. 

Fixes: #22242 

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
