### PR TITLE
chore(lint): Enable linting with gosimple

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -110,6 +110,7 @@ linters:
     - goheader
     - gosec
     - gomodguard
+    - gosimple
 
 # To enable later if makes sense
 #    - deadcode

--- a/bugtool/cmd/root.go
+++ b/bugtool/cmd/root.go
@@ -452,7 +452,7 @@ func writeCmdToFile(cmdDir, prompt string, k8sPods []string, enableMarkdown bool
 			fmt.Fprint(f, string(output))
 		} else if enableMarkdown && len(output) > 0 {
 			// Write prompt as header and the output as body, and/or error but delete empty output.
-			fmt.Fprint(f, fmt.Sprintf("# %s\n\n```\n%s\n```\n", prompt, output))
+			fmt.Fprintf(f, "# %s\n\n```\n%s\n```\n", prompt, output)
 		}
 	}
 

--- a/cilium/cmd/bpf_sha_get.go
+++ b/cilium/cmd/bpf_sha_get.go
@@ -49,7 +49,7 @@ func dumpSha(sha string) {
 			Fatalf("Error preparing regex for parsing JSON: %s\n", err)
 		}
 
-		jsonEncStr := regex.FindString(fmt.Sprintf("%s", text))
+		jsonEncStr := regex.FindString(string(text))
 		if jsonEncStr == "" {
 			Fatalf("No JSON embedded in the file.")
 		}

--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -280,7 +280,7 @@ func runCleanup() {
 	cleanBPF = vp.GetBool(bpfFlagName) || vp.GetBool(cleanBpfEnvVar)
 
 	// if no flags are specified then clean all
-	if (cleanAll || cleanBPF) == false {
+	if !(cleanAll || cleanBPF) {
 		cleanAll = true
 	}
 

--- a/cilium/cmd/debuginfo.go
+++ b/cilium/cmd/debuginfo.go
@@ -364,7 +364,6 @@ func writeJSONPathToOutput(buf bytes.Buffer, path string, suffix string, jsonPat
 	writeFile([]byte(jsonStr), fileName)
 
 	fmt.Printf("%s output at %s\n", jsonpathOutput, fileName)
-	return
 }
 
 func writeToOutput(buf bytes.Buffer, output outputType, path string, suffix string) {

--- a/cilium/cmd/lrp_list.go
+++ b/cilium/cmd/lrp_list.go
@@ -61,7 +61,7 @@ func printLRPList(w *tabwriter.Writer, list []*models.LRPSpec) {
 		entry := fmt.Sprintf("%s\t%s\t%s\t%s", lrp.Namespace, lrp.Name, lrp.FrontendType, lrp.ServiceID)
 		fmt.Fprintln(w, entry)
 		for _, feM := range lrp.FrontendMappings {
-			fmt.Fprintln(w, fmt.Sprintf("\t|\t%s", getPrintableMapping(feM)))
+			fmt.Fprintf(w, "\t|\t%s\n", getPrintableMapping(feM))
 		}
 	}
 	w.Flush()

--- a/cilium/cmd/prefilter_list.go
+++ b/cilium/cmd/prefilter_list.go
@@ -28,7 +28,6 @@ func init() {
 }
 
 func listFilters(cmd *cobra.Command, args []string) {
-	var str string
 	spec, err := client.GetPrefilter()
 	if err != nil {
 		Fatalf("Cannot get CIDR list: %s", err)
@@ -45,11 +44,9 @@ func listFilters(cmd *cobra.Command, args []string) {
 		Fatalf("Cannot get CIDR list: empty response")
 	}
 	w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
-	str = fmt.Sprintf("Revision: %d", spec.Status.Realized.Revision)
-	fmt.Fprintln(w, str)
+	fmt.Fprintf(w, "Revision: %d\n", spec.Status.Realized.Revision)
 	for _, pfx := range spec.Status.Realized.Deny {
-		str = fmt.Sprintf("%s", pfx)
-		fmt.Fprintln(w, str)
+		fmt.Fprintln(w, pfx)
 	}
 	w.Flush()
 }

--- a/daemon/cmd/config.go
+++ b/daemon/cmd/config.go
@@ -109,7 +109,6 @@ func (c *ConfigModifyEvent) configModify(params PatchConfigParams, resChan chan 
 	}
 
 	resChan <- NewPatchConfigOK()
-	return
 }
 
 func patchConfigHandler(d *Daemon, params PatchConfigParams) middleware.Responder {

--- a/daemon/cmd/debuginfo.go
+++ b/daemon/cmd/debuginfo.go
@@ -26,7 +26,7 @@ func getDebugInfoHandler(d *Daemon, params restapi.GetDebuginfoParams) middlewar
 	if kver, err := version.GetKernelVersion(); err != nil {
 		dr.KernelVersion = fmt.Sprintf("Error: %s\n", err)
 	} else {
-		dr.KernelVersion = fmt.Sprintf("%s", kver)
+		dr.KernelVersion = kver.String()
 	}
 
 	status := d.getStatus(false)

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -438,7 +438,7 @@ func finishKubeProxyReplacementInit() error {
 		default:
 			if probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnRedirectNeigh) != nil ||
 				probes.HaveProgramHelper(ebpf.SchedCLS, asm.FnRedirectPeer) != nil {
-				msg = fmt.Sprintf("BPF host routing requires kernel 5.10 or newer.")
+				msg = "BPF host routing requires kernel 5.10 or newer."
 			}
 		}
 		if msg != "" {

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -393,8 +393,6 @@ func (d *Daemon) policyAdd(sourceRules policyAPI.Rules, opts *policy.AddOptions,
 	if err != nil {
 		log.WithError(err).WithField(logfields.PolicyRevision, newRev).Error("enqueue of RuleReactionEvent failed")
 	}
-
-	return
 }
 
 // PolicyReactionEvent is an event which needs to be serialized after changes
@@ -616,8 +614,6 @@ func (d *Daemon) policyDelete(labels labels.LabelArray, opts *policy.DeleteOptio
 	if err := d.SendNotification(monitorAPI.PolicyDeleteMessage(deleted, labels.GetModel(), rev)); err != nil {
 		log.WithError(err).WithField(logfields.PolicyRevision, rev).Warn("Failed to send policy update as monitor notification")
 	}
-
-	return
 }
 
 func deletePolicyHandler(d *Daemon, params DeletePolicyParams) middleware.Responder {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -249,14 +249,12 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) er
 		"failed":   failed,
 	}).Info("Endpoints restored")
 
-	if existingEndpoints != nil {
-		for epIP, info := range existingEndpoints {
-			if ip := net.ParseIP(epIP); !info.IsHost() && ip != nil {
-				if err := lxcmap.DeleteEntry(ip); err != nil {
-					log.WithError(err).Warn("Unable to delete obsolete endpoint from BPF map")
-				} else {
-					log.Debugf("Removed outdated endpoint %d from endpoint map", info.LxcID)
-				}
+	for epIP, info := range existingEndpoints {
+		if ip := net.ParseIP(epIP); !info.IsHost() && ip != nil {
+			if err := lxcmap.DeleteEntry(ip); err != nil {
+				log.WithError(err).Warn("Unable to delete obsolete endpoint from BPF map")
+			} else {
+				log.Debugf("Removed outdated endpoint %d from endpoint map", info.LxcID)
 			}
 		}
 	}
@@ -265,7 +263,7 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) er
 }
 
 func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (restoreComplete chan struct{}) {
-	restoreComplete = make(chan struct{}, 0)
+	restoreComplete = make(chan struct{})
 
 	log.WithField("numRestored", len(state.restored)).Info("Regenerating restored endpoints")
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -527,12 +527,10 @@ func (c *clusterNodesClient) NodeNeighDiscoveryEnabled() bool {
 
 func (c *clusterNodesClient) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
 	// no-op
-	return
 }
 
 func (c *clusterNodesClient) NodeCleanNeighbors(migrateOnly bool) {
 	// no-op
-	return
 }
 
 func (c *clusterNodesClient) AllocateNodeID(_ net.IP) uint16 {
@@ -552,7 +550,6 @@ func (c *clusterNodesClient) DumpNodeIDs() []*models.NodeID {
 
 func (c *clusterNodesClient) RestoreNodeIDs() {
 	// no-op
-	return
 }
 
 func (h *getNodes) cleanupClients(d *Daemon) {
@@ -772,7 +769,7 @@ func (d *Daemon) startStatusCollector(cleaner *daemonCleanup) {
 					state = models.StatusStateFailure
 					msg = fmt.Sprintf("Err: %s", status.Err)
 				case ok:
-					msg = fmt.Sprintf("%s", info)
+					msg = info
 				}
 
 				d.statusCollectMutex.Lock()
@@ -1080,5 +1077,4 @@ func (d *Daemon) startStatusCollector(cleaner *daemonCleanup) {
 
 		}
 	})
-	return
 }

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -186,8 +186,6 @@ func (c *CiliumEndpointSliceController) Run(ces cache.Indexer, stopCh <-chan str
 	}()
 
 	<-stopCh
-
-	return
 }
 
 // Upon warm boot[restart], Iterate over all CEPs which we got from the api-server
@@ -274,7 +272,6 @@ func syncCESsInLocalCache(cesStore cache.Store, manager operations) {
 
 	}
 	log.Debug("Successfully synced all CESs locally")
-	return
 }
 
 // worker runs a worker thread that just dequeues items, processes them, and

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -281,8 +281,7 @@ func TestHandleErr(t *testing.T) {
 		updatedCES.Generation = 2
 		cesController.ciliumEndpointSliceStore.Add(updatedCES)
 
-		var err error
-		err = k8s_errors.NewConflict(
+		var err error = k8s_errors.NewConflict(
 			schema.GroupResource{Group: "", Resource: "ciliumendpointslices"},
 			key,
 			fmt.Errorf("conflict"))

--- a/operator/pkg/ciliumendpointslice/manager.go
+++ b/operator/pkg/ciliumendpointslice/manager.go
@@ -176,13 +176,10 @@ func (c *cesMgr) addCEPtoCES(cep *cilium_v2.CoreCiliumEndpoint, ces *cesTracker)
 	ces.ces.Endpoints = append(ces.ces.Endpoints, *cep)
 	// If this CEP is re-generated again before previous CEP-DELETE completed.
 	// remove this from removedCEP list.
-	if _, ok := ces.removedCEPs[GetCEPNameFromCCEP(cep, ces.ces.Namespace)]; ok {
-		delete(ces.removedCEPs, GetCEPNameFromCCEP(cep, ces.ces.Namespace))
-	}
+	delete(ces.removedCEPs, GetCEPNameFromCCEP(cep, ces.ces.Namespace))
 	// Increment the cepInsert counter
 	ces.cepInserted += 1
 	c.insertCESInWorkQueue(ces, DefaultCESSyncTime)
-	return
 }
 
 // Generate random string for given length of characters.
@@ -370,8 +367,6 @@ func (c *cesMgr) RemoveCEPFromCache(cepName string, baseDelay time.Duration) {
 			logfields.CEPName: cepName,
 		}).Debug("Could not remove CEP from local cache missing CEPName.")
 	}
-
-	return
 }
 
 func (c *cesMgr) removeCEPFromCES(cepName string, cesName string, baseDelay time.Duration, identity int64, checkIdentity bool) {
@@ -584,7 +579,7 @@ func (c *cesManagerIdentity) deleteCESFromCache(cesName string) {
 	}
 
 	c.identityLock.Lock()
-	identity, _ := c.cesToIdentity[cesName]
+	identity := c.cesToIdentity[cesName]
 	for i, ces := range c.identityToCES[identity] {
 		if cesName == ces.ces.GetName() {
 			c.identityToCES[identity] = append(c.identityToCES[identity][:i],

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -216,8 +216,7 @@ func (m *Manager) getListenerResource(svc *slim_corev1.Service) (ciliumv2.XDSRes
 		return ciliumv2.XDSResource{}, nil
 	}
 
-	var filterChains []*envoy_config_listener.FilterChain
-	filterChains = []*envoy_config_listener.FilterChain{
+	var filterChains []*envoy_config_listener.FilterChain = []*envoy_config_listener.FilterChain{
 		{
 			FilterChainMatch: &envoy_config_listener.FilterChainMatch{
 				TransportProtocol: "raw_buffer",

--- a/operator/pkg/gateway-api/controller_test.go
+++ b/operator/pkg/gateway-api/controller_test.go
@@ -333,7 +333,7 @@ func Test_success(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := success()
-			if !tt.wantErr(t, err, fmt.Sprintf("success()")) {
+			if !tt.wantErr(t, err, "success()") {
 				return
 			}
 			assert.Equalf(t, tt.want, got, "success()")

--- a/operator/pkg/ingress/ingress_class.go
+++ b/operator/pkg/ingress/ingress_class.go
@@ -162,7 +162,7 @@ func (i *ingressClassManager) handleIngressClassDeletedEvent(event ingressClassD
 	log.WithField(logfields.IngressClass, event.ingressClass).Debug("Handling ingress class delete")
 
 	if event.ingressClass.GetName() == ciliumIngressClassName {
-		i.ingressQueue.Add(ciliumIngressClassDeletedEvent{ingressClass: event.ingressClass})
+		i.ingressQueue.Add(ciliumIngressClassDeletedEvent(event))
 	}
 	return nil
 }

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -130,11 +130,7 @@ func TestPoolInternalConflict(t *testing.T) {
 
 		pool := fixture.PatchedPool(action)
 
-		if !isPoolConflicting(pool) {
-			return false
-		}
-
-		return true
+		return !isPoolConflicting(pool)
 	}, time.Second)
 
 	go fixture.hive.Start(context.Background())
@@ -151,11 +147,7 @@ func TestPoolInternalConflict(t *testing.T) {
 
 		pool := fixture.PatchedPool(action)
 
-		if isPoolConflicting(pool) {
-			return false
-		}
-
-		return true
+		return !isPoolConflicting(pool)
 	}, 2*time.Second)
 
 	pool, err := fixture.poolClient.Get(context.Background(), "pool-a", meta_v1.GetOptions{})

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -96,10 +96,8 @@ func (s SortableRoute) Less(i, j int) bool {
 	// Make sure the longest header match always comes first
 	headerMatch1 := len(s[i].Match.GetHeaders())
 	headerMatch2 := len(s[j].Match.GetHeaders())
-	if headerMatch1 > headerMatch2 {
-		return true
-	}
-	return false
+
+	return headerMatch1 > headerMatch2
 }
 
 func (s SortableRoute) Swap(i, j int) {

--- a/operator/watchers/k8s_service_sync.go
+++ b/operator/watchers/k8s_service_sync.go
@@ -108,7 +108,7 @@ type ServiceSyncParameters struct {
 // will be synchronized. For clustermesh we only need to synchronize shared services, while for
 // VM support we need to sync all the services.
 func StartSynchronizingServices(ctx context.Context, wg *sync.WaitGroup, cfg ServiceSyncParameters) {
-	kvstoreReady := make(chan struct{}, 0)
+	kvstoreReady := make(chan struct{})
 
 	wg.Add(1)
 	go func() {

--- a/pkg/alibabacloud/api/api.go
+++ b/pkg/alibabacloud/api/api.go
@@ -219,9 +219,7 @@ func (c *Client) GetInstanceTypes(ctx context.Context) ([]ecs.InstanceType, erro
 			return nil, err
 		}
 
-		for _, v := range resp.InstanceTypes.InstanceType {
-			result = append(result, v)
-		}
+		result = append(result, resp.InstanceTypes.InstanceType...)
 
 		if resp.NextToken == "" {
 			break
@@ -412,9 +410,8 @@ func (c *Client) describeNetworkInterfaces(ctx context.Context) ([]ecs.NetworkIn
 			return nil, err
 		}
 
-		for _, v := range resp.NetworkInterfaceSets.NetworkInterfaceSet {
-			result = append(result, v)
-		}
+		result = append(result, resp.NetworkInterfaceSets.NetworkInterfaceSet...)
+
 		if resp.NextToken == "" {
 			break
 		} else {
@@ -442,9 +439,8 @@ func (c *Client) describeNetworkInterfacesByInstance(ctx context.Context, instan
 			break
 		}
 
-		for _, v := range resp.NetworkInterfaceSets.NetworkInterfaceSet {
-			result = append(result, v)
-		}
+		result = append(result, resp.NetworkInterfaceSets.NetworkInterfaceSet...)
+
 		if resp.TotalCount < resp.PageNumber*resp.PageSize {
 			break
 		}

--- a/pkg/alibabacloud/eni/node.go
+++ b/pkg/alibabacloud/eni/node.go
@@ -87,8 +87,6 @@ func (n *Node) PopulateStatusFields(resource *v2.CiliumNode) {
 			}
 			return nil
 		})
-
-	return
 }
 
 // CreateInterface creates an additional interface with the instance and

--- a/pkg/aws/eni/node.go
+++ b/pkg/aws/eni/node.go
@@ -110,8 +110,6 @@ func (n *Node) PopulateStatusFields(k8sObj *v2.CiliumNode) {
 			}
 			return nil
 		})
-
-	return
 }
 
 // getLimits returns the interface and IP limits of this node

--- a/pkg/bgpv1/gobgp/conversions.go
+++ b/pkg/bgpv1/gobgp/conversions.go
@@ -62,7 +62,7 @@ func ToAgentPath(p *gobgp.Path) (*types.Path, error) {
 
 	// ageNano is time since the Path was created in nanoseconds.
 	// It is calculated by difference in time from age timestamp till now.
-	ageNano := int64(time.Now().Sub(p.Age.AsTime()))
+	ageNano := int64(time.Since(p.Age.AsTime()))
 
 	return &types.Path{
 		NLRI:           nlri,

--- a/pkg/bgpv1/gobgp/state.go
+++ b/pkg/bgpv1/gobgp/state.go
@@ -68,7 +68,7 @@ func (g *GoBGPServer) GetPeerState(ctx context.Context) (types.GetPeerStateRespo
 			// Uptime is time since session got established.
 			// It is calculated by difference in time from uptime timestamp till now.
 			if peer.State.SessionState == gobgp.PeerState_ESTABLISHED && peer.Timers != nil && peer.Timers.State != nil {
-				peerState.UptimeNanoseconds = int64(time.Now().Sub(peer.Timers.State.Uptime.AsTime()))
+				peerState.UptimeNanoseconds = int64(time.Since(peer.Timers.State.Uptime.AsTime()))
 			}
 		}
 

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -155,7 +155,7 @@ func Test_NeighborAddDel(t *testing.T) {
 			}
 
 			deadline, _ := testCtx.Deadline()
-			outstanding := deadline.Sub(time.Now())
+			outstanding := time.Until(deadline)
 			require.Greater(t, outstanding, 0*time.Second, "test context deadline exceeded")
 
 			peerStatesMatch := func() bool {
@@ -298,7 +298,7 @@ func Test_NeighborGracefulRestart(t *testing.T) {
 			require.NoError(t, err)
 
 			deadline, _ := testCtx.Deadline()
-			outstanding := deadline.Sub(time.Now())
+			outstanding := time.Until(deadline)
 			require.Greater(t, outstanding, 0*time.Second, "test context deadline exceeded")
 
 			peerStatesMatch := func() bool {

--- a/pkg/cgroups/manager/manager.go
+++ b/pkg/cgroups/manager/manager.go
@@ -132,11 +132,8 @@ func (m *CgroupManager) GetPodMetadataForContainer(cgroupId uint64) *PodMetadata
 		eventType:      podGetMetadataEvent,
 		podMetadataOut: podMetaOut,
 	}
-	select {
 	// We either receive pod metadata, or zero value when the channel is closed.
-	case pm := <-podMetaOut:
-		return pm
-	}
+	return <-podMetaOut
 }
 
 func (m *CgroupManager) DumpPodMetadata() []*FullPodMetadata {
@@ -149,10 +146,7 @@ func (m *CgroupManager) DumpPodMetadata() []*FullPodMetadata {
 		eventType:      podDumpMetadataEvent,
 		allMetadataOut: allMetaOut,
 	}
-	select {
-	case cm := <-allMetaOut:
-		return cm
-	}
+	return <-allMetaOut
 }
 
 // Close should only be called once from daemon close.

--- a/pkg/cidr/cidr.go
+++ b/pkg/cidr/cidr.go
@@ -72,7 +72,6 @@ func (in *CIDR) DeepCopyInto(out *CIDR) {
 		*out = make(net.IPMask, len(*in))
 		copy(*out, *in)
 	}
-	return
 }
 
 // AvailableIPs returns the number of IPs available in a CIDR

--- a/pkg/comparator/comparator.go
+++ b/pkg/comparator/comparator.go
@@ -102,8 +102,5 @@ func MapStringEqualsIgnoreKeys(m1, m2 map[string]string, ignoreKeys []string) bo
 			ignoredM2++
 		}
 	}
-	if len(m1)-ignoredM1 != len(m2)-ignoredM2 {
-		return false
-	}
-	return true
+	return len(m1)-ignoredM1 == len(m2)-ignoredM2
 }

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -62,11 +62,9 @@ func (n *FakeNodeHandler) NodeNeighDiscoveryEnabled() bool {
 }
 
 func (n *FakeNodeHandler) NodeNeighborRefresh(ctx context.Context, node nodeTypes.Node) {
-	return
 }
 
 func (n *FakeNodeHandler) NodeCleanNeighbors(migrateOnly bool) {
-	return
 }
 
 func (n *FakeNodeHandler) AllocateNodeID(_ net.IP) uint16 {
@@ -82,5 +80,4 @@ func (n *FakeNodeHandler) DumpNodeIDs() []*models.NodeID {
 }
 
 func (n *FakeNodeHandler) RestoreNodeIDs() {
-	return
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -123,7 +123,7 @@ func (ipt *ipt) getVersion() (semver.Version, error) {
 	if err != nil {
 		return semver.Version{}, err
 	}
-	v := regexp.MustCompile("v([0-9]+(\\.[0-9]+)+)")
+	v := regexp.MustCompile(`v([0-9]+(\.[0-9]+)+)`)
 	vString := v.FindStringSubmatch(string(b))
 	if vString == nil {
 		return semver.Version{}, fmt.Errorf("no iptables version found in string: %s", string(b))
@@ -1620,7 +1620,7 @@ func (m *IptablesManager) ciliumNoTrackXfrmRules(prog iptablesInterface, input s
 // and 0x*e00 for encryption, colliding with existing rules. Needed
 // for kube-proxy for example.
 func (m *IptablesManager) addCiliumAcceptXfrmRules() error {
-	if option.Config.EnableIPSec == false {
+	if !option.Config.EnableIPSec {
 		return nil
 	}
 

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -132,8 +132,8 @@ func getIPSecKeys(ip net.IP) *ipSecKey {
 	defer ipSecLock.RUnlock()
 
 	key, scoped := ipSecKeysGlobal[ip.String()]
-	if scoped == false {
-		key, _ = ipSecKeysGlobal[""]
+	if !scoped {
+		key = ipSecKeysGlobal[""]
 	}
 	return key
 }

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -645,7 +645,7 @@ type NextHop struct {
 func (n *linuxNodeHandler) insertNeighborCommon(scopedLog *logrus.Entry, ctx context.Context, nextHop NextHop, link netlink.Link, refresh bool) {
 	if refresh {
 		if lastPing, found := n.neighLastPingByNextHop[nextHop.Name]; found &&
-			time.Now().Sub(lastPing) < option.Config.ARPPingRefreshPeriod {
+			time.Since(lastPing) < option.Config.ARPPingRefreshPeriod {
 			// Last ping was issued less than option.Config.ARPPingRefreshPeriod
 			// ago, so skip it (e.g. to avoid ddos'ing the same GW if nodes are
 			// L3 connected)
@@ -2036,7 +2036,7 @@ func deleteOldLocalRule(family int, rule route.Rule) error {
 		}
 	}
 
-	if found == true {
+	if found {
 		err := route.DeleteRule(family, rule)
 		if err != nil {
 			return fmt.Errorf("could not delete old %s local rule: %w", familyStr, err)

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -363,7 +363,7 @@ func (o *objectCache) watchTemplatesDirectory(ctx context.Context) error {
 			} else {
 				log.WithField("event", event).Debug("Ignoring template FS event")
 			}
-		case err, _ = <-templateWatcher.Errors:
+		case err = <-templateWatcher.Errors:
 			return err
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/datapath/prefilter/prefilter.go
+++ b/pkg/datapath/prefilter/prefilter.go
@@ -146,7 +146,7 @@ func (p *PreFilter) Delete(revision int64, cidrs []net.IPNet) error {
 			return fmt.Errorf("No map enabled for CIDR string %s", cidr.String())
 		}
 		// Lets check obvious cases first, so we don't need to painfully unroll
-		if p.maps[which].CIDRExists(cidr) == false {
+		if !p.maps[which].CIDRExists(cidr) {
 			return fmt.Errorf("No map entry for CIDR string %s", cidr.String())
 		}
 	}

--- a/pkg/datapath/tables/l2_announce.go
+++ b/pkg/datapath/tables/l2_announce.go
@@ -26,9 +26,8 @@ type L2AnnounceEntry struct {
 }
 
 func (pne *L2AnnounceEntry) DeepCopy() *L2AnnounceEntry {
-	var n L2AnnounceEntry
 	// Shallow copy
-	n = *pne
+	var n L2AnnounceEntry = *pne
 	// Explicit clone for slices
 	n.IP = slices.Clone(pne.IP)
 	n.Origins = slices.Clone(pne.Origins)

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -298,10 +298,8 @@ func (manager *Manager) processCiliumEndpoints(ctx context.Context, wg *sync.Wai
 
 		retryQueue := manager.endpointEventsQueue
 		go func() {
-			select {
-			case <-ctx.Done():
-				retryQueue.ShutDown()
-			}
+			<-ctx.Done()
+			retryQueue.ShutDown()
 		}()
 
 		for {

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -704,7 +704,6 @@ func tryAssertEgressRules(policyMap egressmap.PolicyMap, rules []egressRule) err
 			}
 
 			untrackedRule = true
-			return
 		})
 
 	if untrackedRule {

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -502,12 +502,12 @@ func (e *Endpoint) ProcessChangeRequest(newEp *Endpoint, validPatchTransitionSta
 		}
 	}
 
-	if len(newEp.mac) != 0 && bytes.Compare(e.mac, newEp.mac) != 0 {
+	if len(newEp.mac) != 0 && !bytes.Equal(e.mac, newEp.mac) {
 		e.mac = newEp.mac
 		changed = true
 	}
 
-	if len(newEp.nodeMAC) != 0 && bytes.Compare(e.GetNodeMAC(), newEp.nodeMAC) != 0 {
+	if len(newEp.nodeMAC) != 0 && !bytes.Equal(e.GetNodeMAC(), newEp.nodeMAC) {
 		e.nodeMAC = newEp.nodeMAC
 		changed = true
 	}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -474,7 +474,7 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 		DNSZombies:       fqdn.NewDNSZombieMappings(option.Config.ToFQDNsMaxDeferredConnectionDeletes, option.Config.ToFQDNsMaxIPsPerHost),
 		state:            "",
 		status:           NewEndpointStatus(),
-		hasBPFProgram:    make(chan struct{}, 0),
+		hasBPFProgram:    make(chan struct{}),
 		desiredPolicy:    policy.NewEndpointPolicy(policyGetter.GetPolicyRepository()),
 		controllers:      controller.NewManager(),
 		regenFailedChan:  make(chan struct{}, 1),
@@ -840,7 +840,7 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter p
 	ep.SetDefaultOpts(ep.Options)
 
 	// Initialize fields to values which are non-nil that are not serialized.
-	ep.hasBPFProgram = make(chan struct{}, 0)
+	ep.hasBPFProgram = make(chan struct{})
 	ep.desiredPolicy = policy.NewEndpointPolicy(policyGetter.GetPolicyRepository())
 	ep.realizedPolicy = ep.desiredPolicy
 	ep.controllers = controller.NewManager()
@@ -1752,11 +1752,7 @@ func (e *Endpoint) UpdateLabelsFrom(oldLbls, newLbls map[string]string, source s
 func (e *Endpoint) identityResolutionIsObsolete(myChangeRev int) bool {
 	// Check if the endpoint has since received a new identity revision, if
 	// so, abort as a new resolution routine will have been started.
-	if myChangeRev != e.identityRevision {
-		return true
-	}
-
-	return false
+	return myChangeRev != e.identityRevision
 }
 
 // runIdentityResolver resolves the numeric identity for the set of labels that

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -65,7 +65,6 @@ func (ev *EndpointRegenerationEvent) Handle(res chan interface{}) {
 	res <- &EndpointRegenerationResult{
 		err: err,
 	}
-	return
 }
 
 // EndpointRegenerationResult contains the results of an endpoint regeneration.
@@ -182,7 +181,6 @@ func (ev *EndpointNoTrackEvent) Handle(res chan interface{}) {
 	res <- &EndpointRegenerationResult{
 		err: nil,
 	}
-	return
 }
 
 // EndpointPolicyVisibilityEvent contains all fields necessary to update the
@@ -248,7 +246,6 @@ func (ev *EndpointPolicyVisibilityEvent) Handle(res chan interface{}) {
 	res <- &EndpointRegenerationResult{
 		err: nil,
 	}
-	return
 }
 
 // EndpointPolicyBandwidthEvent contains all fields necessary to update

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -673,22 +673,20 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 			canceled     bool
 		)
 
-		select {
-		case result, ok := <-resChan:
-			if ok {
-				regenResult := result.(*EndpointRegenerationResult)
-				regenError = regenResult.err
-				buildSuccess = regenError == nil
+		result, ok := <-resChan
+		if ok {
+			regenResult := result.(*EndpointRegenerationResult)
+			regenError = regenResult.err
+			buildSuccess = regenError == nil
 
-				if regenError != nil && !errors.Is(regenError, context.Canceled) {
-					e.getLogger().WithError(regenError).Error("endpoint regeneration failed")
-				}
-			} else {
-				// This may be unnecessary(?) since 'closing' of the results
-				// channel means that event has been cancelled?
-				e.getLogger().Debug("regeneration was cancelled")
-				canceled = true
+			if regenError != nil && !errors.Is(regenError, context.Canceled) {
+				e.getLogger().WithError(regenError).Error("endpoint regeneration failed")
 			}
+		} else {
+			// This may be unnecessary(?) since 'closing' of the results
+			// channel means that event has been cancelled?
+			e.getLogger().Debug("regeneration was cancelled")
+			canceled = true
 		}
 
 		// If a build is canceled, that means that the Endpoint is being deleted

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -75,7 +75,6 @@ type DummyIdentityAllocatorOwner struct{}
 
 // UpdateIdentities does nothing.
 func (d *DummyIdentityAllocatorOwner) UpdateIdentities(added, deleted cache.IdentityCache) {
-	return
 }
 
 // GetNodeSuffix does nothing.

--- a/pkg/endpoint/status.go
+++ b/pkg/endpoint/status.go
@@ -55,7 +55,7 @@ func (sc StatusCode) String() string {
 
 func (s Status) String() string {
 	if s.Msg == "" {
-		return fmt.Sprintf("%s", s.Code)
+		return s.Code.String()
 	}
 	return fmt.Sprintf("%s - %s", s.Code, s.Msg)
 }

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -942,9 +942,7 @@ func (zombies *DNSZombieMappings) GC() (alive, dead []*DNSZombieMapping) {
 		}
 
 		for _, dead := range dead[deadIdx:] {
-			if _, ok := possibleAlive[dead]; ok {
-				delete(possibleAlive, dead)
-			}
+			delete(possibleAlive, dead)
 		}
 
 		for zombie := range possibleAlive {

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -52,7 +52,7 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 	c.Assert(len(selIPMap), Equals, 1, Commentf("Incorrect length for testCase with single ToFQDNs entry"))
 
 	expectedIPs := []net.IP{net.ParseIP("1.1.1.1")}
-	ips, _ := selIPMap[ciliumIOSel]
+	ips := selIPMap[ciliumIOSel]
 	c.Assert(ips[0].Equal(expectedIPs[0]), Equals, true)
 
 	// poll DNS once, check that we only generate 1 rule (for 2 IPs that we

--- a/pkg/fqdn/proxy/proxy.go
+++ b/pkg/fqdn/proxy/proxy.go
@@ -26,7 +26,6 @@ func (m MockFQDNProxy) GetRules(u uint16) (restore.DNSRules, error) {
 }
 
 func (m MockFQDNProxy) RemoveRestoredRules(u uint16) {
-	return
 }
 
 func (m MockFQDNProxy) UpdateAllowed(endpointID uint64, destPort uint16, newRules policy.L7DataMap) error {
@@ -38,13 +37,10 @@ func (m MockFQDNProxy) GetBindPort() uint16 {
 }
 
 func (m MockFQDNProxy) SetRejectReply(s string) {
-	return
 }
 
 func (m MockFQDNProxy) RestoreRules(op *endpoint.Endpoint) {
-	return
 }
 
 func (m MockFQDNProxy) Cleanup() {
-	return
 }

--- a/pkg/hive/job/job.go
+++ b/pkg/hive/job/job.go
@@ -314,8 +314,6 @@ func (jos *jobOneShot) start(ctx context.Context, wg *sync.WaitGroup, options op
 	if options.shutdowner != nil && jos.shutdownOnError {
 		options.shutdowner.Shutdown(hive.ShutdownWithError(err))
 	}
-
-	return
 }
 
 // Timer creates a timer job which can be added to a Group. Timer jobs invoke the given function at the specified
@@ -539,6 +537,4 @@ func (jo *jobObserver[T]) start(ctx context.Context, wg *sync.WaitGroup, options
 	} else {
 		l.WithError(err).Debug("Observer job stopped")
 	}
-
-	return
 }

--- a/pkg/hubble/container/ring.go
+++ b/pkg/hubble/container/ring.go
@@ -124,7 +124,7 @@ func NewRing(n Capacity) *Ring {
 		cycleMask: ^uint64(0) >> cycleExp,
 		halfCycle: halfCycle,
 		dataLen:   dataLen,
-		data:      make([]*v1.Event, dataLen, dataLen),
+		data:      make([]*v1.Event, dataLen),
 		notifyMu:  lock.Mutex{},
 		notifyCh:  nil,
 	}

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -38,7 +38,7 @@ func BenchmarkRingWrite(b *testing.B) {
 func BenchmarkRingRead(b *testing.B) {
 	entry := &v1.Event{}
 	s := NewRing(capacity(b.N))
-	a := make([]*v1.Event, b.N, b.N)
+	a := make([]*v1.Event, b.N)
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		s.Write(entry)
@@ -54,7 +54,7 @@ func BenchmarkRingRead(b *testing.B) {
 func BenchmarkTimeLibListRead(b *testing.B) {
 	entry := &v1.Event{}
 	s := list.New()
-	a := make([]*v1.Event, b.N, b.N)
+	a := make([]*v1.Event, b.N)
 	i := 0
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -69,7 +69,7 @@ func BenchmarkTimeLibListRead(b *testing.B) {
 func BenchmarkTimeLibRingRead(b *testing.B) {
 	entry := &v1.Event{}
 	s := ring.New(b.N)
-	a := make([]*v1.Event, b.N, b.N)
+	a := make([]*v1.Event, b.N)
 	i := 0
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -96,15 +96,16 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 		return errors.ErrEmptyData
 	}
 
+	eventType := data[0]
+
 	var packetOffset int
-	var eventType uint8
-	eventType = data[0]
 	var dn *monitor.DropNotify
 	var tn *monitor.TraceNotify
 	var pvn *monitor.PolicyVerdictNotify
 	var dbg *monitor.DebugCapture
 	var eventSubType uint8
 	var authType flow.AuthType
+
 	switch eventType {
 	case monitorAPI.MessageTypeDrop:
 		packetOffset = monitor.DropNotifyLen

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -142,23 +142,21 @@ func (w *identityWatcher) watch(events allocator.AllocatorEventRecvChan) {
 			deleted := IdentityCache{}
 		First:
 			for {
+				event, ok := <-events
 				// Wait for one identity add or delete or stop
-				select {
-				case event, ok := <-events:
-					if !ok {
-						// 'events' was closed
-						return
+				if !ok {
+					// 'events' was closed
+					return
+				}
+				// Collect first added and deleted labels
+				switch event.Typ {
+				case kvstore.EventTypeCreate, kvstore.EventTypeDelete:
+					if collectEvent(event, added, deleted) {
+						// First event collected
+						break First
 					}
-					// Collect first added and deleted labels
-					switch event.Typ {
-					case kvstore.EventTypeCreate, kvstore.EventTypeDelete:
-						if collectEvent(event, added, deleted) {
-							// First event collected
-							break First
-						}
-					default:
-						// Ignore modify events
-					}
+				default:
+					// Ignore modify events
 				}
 			}
 

--- a/pkg/ip/ip.go
+++ b/pkg/ip/ip.go
@@ -862,11 +862,9 @@ func SortIPList(ipList []net.IP) {
 // getSortedIPList returns a new net.IP slice in which the IPs are sorted.
 func getSortedIPList(ipList []net.IP) []net.IP {
 	sortedIPList := make([]net.IP, len(ipList))
-	for i := 0; i < len(ipList); i++ {
-		sortedIPList[i] = ipList[i]
-	}
-
+	copy(sortedIPList, ipList)
 	SortIPList(sortedIPList)
+
 	return sortedIPList
 }
 

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -410,7 +410,6 @@ func (n *NodesPodCIDRManager) Delete(node *v2.CiliumNode) {
 		op: k8sOpDelete,
 	}
 	n.k8sReSync.Trigger()
-	return
 }
 
 // Resync resyncs the nodes with k8s.

--- a/pkg/ipam/allocator/podcidr/podcidr_test.go
+++ b/pkg/ipam/allocator/podcidr/podcidr_test.go
@@ -222,7 +222,6 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Delete(c *C) {
 					ciliumNodesToK8s: map[string]*ciliumNodeK8sOp{},
 					k8sReSync: mustNewTrigger(func() {
 						atomic.AddInt32(&reSyncCalls, 1)
-						return
 					}, time.Millisecond),
 				}
 			},
@@ -306,7 +305,6 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Resync(c *C) {
 				return &fields{
 					k8sReSync: mustNewTrigger(func() {
 						atomic.AddInt32(&reSyncCalls, 1)
-						return
 					}, time.Millisecond),
 				}
 			},
@@ -368,7 +366,6 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Upsert(c *C) {
 					nodes:            map[string]*nodeCIDRs{},
 					ciliumNodesToK8s: map[string]*ciliumNodeK8sOp{},
 					k8sReSync: mustNewTrigger(func() {
-						return
 					}, time.Second),
 				}
 			},
@@ -424,7 +421,6 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Upsert(c *C) {
 					nodes:            map[string]*nodeCIDRs{},
 					ciliumNodesToK8s: map[string]*ciliumNodeK8sOp{},
 					k8sReSync: mustNewTrigger(func() {
-						return
 					}, time.Second),
 				}
 			},
@@ -515,7 +511,6 @@ func (s *PodCIDRSuite) TestNodesPodCIDRManager_Upsert(c *C) {
 					},
 					ciliumNodesToK8s: map[string]*ciliumNodeK8sOp{},
 					k8sReSync: mustNewTrigger(func() {
-						return
 					}, time.Second),
 				}
 			},

--- a/pkg/k8s/cnpstatus.go
+++ b/pkg/k8s/cnpstatus.go
@@ -114,7 +114,6 @@ func (c *CNPStatusEventHandler) UpdateCNPStore(cnpStore *store.SharedStore) {
 // OnDelete is called when a delete event is called on the CNP status key.
 // It is a NoOp
 func (c *CNPStatusEventHandler) OnDelete(_ store.NamedKey) {
-	return
 }
 
 // OnUpdate is called when a CNPStatus object is modified in the KVStore.

--- a/pkg/k8s/endpoints.go
+++ b/pkg/k8s/endpoints.go
@@ -77,7 +77,6 @@ func (in *Endpoints) DeepCopyInto(out *Endpoints) {
 			(*out)[key] = outVal
 		}
 	}
-	return
 }
 
 func (in *Endpoints) DeepCopy() *Endpoints {

--- a/pkg/k8s/labels.go
+++ b/pkg/k8s/labels.go
@@ -121,9 +121,7 @@ func GetPodMetadata(k8sNs *slim_corev1.Namespace, pod *slim_corev1.Pod) (contain
 	k8sLabels[k8sConst.PolicyLabelCluster] = option.Config.ClusterName
 
 	for _, containers := range pod.Spec.Containers {
-		for _, cp := range containers.Ports {
-			containerPorts = append(containerPorts, cp)
-		}
+		containerPorts = append(containerPorts, containers.Ports...)
 	}
 
 	return containerPorts, k8sLabels, annotations, nil

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -207,7 +207,7 @@ func (r *resource[T]) metricEventProcessed(eventKind EventKind, status bool) {
 	}
 
 	result := "success"
-	if status == false {
+	if !status {
 		result = "failed"
 	}
 

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -111,15 +111,12 @@ func ParseService(svc *slim_corev1.Service, nodeAddressing types.NodeAddressing)
 	switch svc.Spec.Type {
 	case slim_corev1.ServiceTypeClusterIP:
 		svcType = loadbalancer.SVCTypeClusterIP
-		break
 
 	case slim_corev1.ServiceTypeNodePort:
 		svcType = loadbalancer.SVCTypeNodePort
-		break
 
 	case slim_corev1.ServiceTypeLoadBalancer:
 		svcType = loadbalancer.SVCTypeLoadBalancer
-		break
 
 	case slim_corev1.ServiceTypeExternalName:
 		// External-name services must be ignored
@@ -662,7 +659,7 @@ func (s *Service) EqualsClusterService(svc *serviceStore.ClusterService) bool {
 		len(s.LoadBalancerSourceRanges) == 0 &&
 		comparator.MapStringEquals(s.Labels, svc.Labels) &&
 		comparator.MapStringEquals(s.Selector, svc.Selector) &&
-		s.SessionAffinity == false &&
+		!s.SessionAffinity &&
 		s.SessionAffinityTimeoutSec == 0 &&
 		s.Type == loadbalancer.SVCTypeClusterIP {
 

--- a/pkg/k8s/slim/k8s/apis/labels/selector.go
+++ b/pkg/k8s/slim/k8s/apis/labels/selector.go
@@ -908,7 +908,7 @@ func SelectorFromSet(ls Set) Selector {
 // nil and empty Sets are considered equivalent to Everything().
 // The Set is validated client-side, which allows to catch errors early.
 func ValidatedSelectorFromSet(ls Set) (Selector, error) {
-	if ls == nil || len(ls) == 0 {
+	if len(ls) == 0 {
 		return internalSelector{}, nil
 	}
 	requirements := make([]Requirement, 0, len(ls))
@@ -930,7 +930,7 @@ func ValidatedSelectorFromSet(ls Set) (Selector, error) {
 // Note: this method copies the Set; if the Set is immutable, consider wrapping it with ValidatedSetSelector
 // instead, which does not copy.
 func SelectorFromValidatedSet(ls Set) Selector {
-	if ls == nil || len(ls) == 0 {
+	if len(ls) == 0 {
 		return internalSelector{}
 	}
 	requirements := make([]Requirement, 0, len(ls))

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -34,11 +34,7 @@ type NodeUpdate interface {
 }
 
 func nodeEventsAreEqual(oldNode, newNode *slim_corev1.Node) bool {
-	if !comparator.MapStringEquals(oldNode.GetLabels(), newNode.GetLabels()) {
-		return false
-	}
-
-	return true
+	return comparator.MapStringEquals(oldNode.GetLabels(), newNode.GetLabels())
 }
 
 func (k *K8sWatcher) NodesInit(k8sClient client.Clientset) {

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -984,7 +984,7 @@ func (k *K8sWatcher) addK8sSVCs(svcID k8s.ServiceID, oldSvc, svc *k8s.Service, e
 // Kubernetes event
 func (k *K8sWatcher) K8sEventProcessed(scope, action string, status bool) {
 	result := "success"
-	if status == false {
+	if !status {
 		result = "failed"
 	}
 

--- a/pkg/kvstore/etcd_lease_test.go
+++ b/pkg/kvstore/etcd_lease_test.go
@@ -125,7 +125,7 @@ func TestLeaseManagerParallel(t *testing.T) {
 		mgr.Wait()
 	})
 
-	ch := make(chan client.LeaseID, 0)
+	ch := make(chan client.LeaseID)
 
 	// Perform multiple requests in parallel, simulating a slow client, and
 	// assert that they all return the same lease ID

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -166,16 +166,14 @@ func (l2a *L2Announcer) run(ctx context.Context) error {
 
 	// We have to first have a local node before we can start processing other events.
 	for {
-		select {
-		case event, more := <-localNodeChan:
-			// resource closed, shutting down
-			if !more {
-				return nil
-			}
+		event, more := <-localNodeChan
+		// resource closed, shutting down
+		if !more {
+			return nil
+		}
 
-			if err := l2a.processLocalNodeEvent(ctx, event); err != nil {
-				l2a.params.Logger.WithError(err).Warn("Error processing local node event")
-			}
+		if err := l2a.processLocalNodeEvent(ctx, event); err != nil {
+			l2a.params.Logger.WithError(err).Warn("Error processing local node event")
 		}
 
 		if l2a.localNode != nil {

--- a/pkg/maps/ctmap/per_cluster_ctmap.go
+++ b/pkg/maps/ctmap/per_cluster_ctmap.go
@@ -471,8 +471,6 @@ func (gm *dummyPerClusterCTMaps) Cleanup() {
 		gm.tcp6 = nil
 		gm.any6 = nil
 	}
-
-	return
 }
 
 func newPerClusterCTMap(name string, m mapType) (*PerClusterCTMap, error) {

--- a/pkg/maps/ipmasq/ipmasq.go
+++ b/pkg/maps/ipmasq/ipmasq.go
@@ -4,7 +4,6 @@
 package ipmasq
 
 import (
-	"fmt"
 	"net"
 	"sync"
 
@@ -27,7 +26,7 @@ type Key4 struct {
 	Address   types.IPv4
 }
 
-func (k *Key4) String() string  { return fmt.Sprintf("%s", k.Address) }
+func (k *Key4) String() string  { return k.Address.String() }
 func (k *Key4) New() bpf.MapKey { return &Key4{} }
 
 type Key6 struct {
@@ -35,7 +34,7 @@ type Key6 struct {
 	Address   types.IPv6
 }
 
-func (k *Key6) String() string  { return fmt.Sprintf("%s", k.Address) }
+func (k *Key6) String() string  { return k.Address.String() }
 func (k *Key6) New() bpf.MapKey { return &Key6{} }
 
 type Value struct {

--- a/pkg/maps/srv6map/policy.go
+++ b/pkg/maps/srv6map/policy.go
@@ -51,7 +51,7 @@ type PolicyValue struct {
 
 // String pretty print the SID.
 func (v *PolicyValue) String() string {
-	return fmt.Sprintf("%s", v.SID)
+	return v.SID.String()
 }
 
 func initPolicyMaps(create bool) error {

--- a/pkg/maps/srv6map/sid.go
+++ b/pkg/maps/srv6map/sid.go
@@ -4,7 +4,6 @@
 package srv6map
 
 import (
-	"fmt"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -27,7 +26,7 @@ type SIDKey struct {
 }
 
 func (k *SIDKey) String() string {
-	return fmt.Sprintf("%s", k.SID)
+	return k.SID.String()
 }
 
 func NewSIDKey(sid types.IPv6) SIDKey {

--- a/pkg/monitor/datapath_debug.go
+++ b/pkg/monitor/datapath_debug.go
@@ -540,7 +540,7 @@ func (n *DebugCapture) getJSON(data []byte, cpuPrefix string, linkMonitor getter
 func (n *DebugCapture) DumpJSON(data []byte, cpuPrefix string, linkMonitor getters.LinkGetter) {
 	resp, err := n.getJSON(data, cpuPrefix, linkMonitor)
 	if err != nil {
-		fmt.Println(fmt.Sprintf(`{"type":"debug_capture_error","message":%q}`, err.Error()))
+		fmt.Printf(`{"type":"debug_capture_error","message":%q}`+"\n", err.Error())
 		return
 	}
 	fmt.Println(resp)

--- a/pkg/monitor/format/fuzz_test.go
+++ b/pkg/monitor/format/fuzz_test.go
@@ -41,6 +41,5 @@ func FuzzFormatEvent(f *testing.F) {
 		mf := NewMonitorFormatter(0, nil)
 
 		mf.FormatEvent(pl)
-		return
 	})
 }

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -704,5 +704,4 @@ func (m *manager) StartNeighborRefresh(nh datapath.NodeNeighbors) {
 			RunInterval: option.Config.ARPPingRefreshPeriod,
 		},
 	)
-	return
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -389,7 +389,7 @@ func (p *Proxy) AllocateProxyPort(name string, ingress, localOnly bool) (uint16,
 	if pp.proxyPort == 0 {
 		var err error
 		// Try to allocate the same port that was previously used on the datapath
-		if pp.rulesPort != 0 && p.allocatedPorts[pp.rulesPort] == false {
+		if pp.rulesPort != 0 && !p.allocatedPorts[pp.rulesPort] {
 			pp.proxyPort = pp.rulesPort
 		} else {
 			pp.proxyPort, err = p.allocatePort(pp.rulesPort, p.rangeMin, p.rangeMax)

--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -53,7 +53,7 @@ func (ps *fakePodStore) List() []interface{} {
 	if ps.OnList != nil {
 		return ps.OnList()
 	}
-	pods := make([]interface{}, 2, 2)
+	pods := make([]interface{}, 2)
 	pods = append(pods, pod1, pod2)
 	return pods
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1291,9 +1291,7 @@ func (s *Service) upsertServiceIntoLBMaps(svc *svcInfo, isExtLocal, isIntLocal b
 			if prevSessionAffinity {
 				// Remove obsolete svc backends if previously the svc had the affinity enabled
 				toDeleteAffinity = make([]lb.BackendID, 0, len(obsoleteSVCBackendIDs))
-				for _, bID := range obsoleteSVCBackendIDs {
-					toDeleteAffinity = append(toDeleteAffinity, bID)
-				}
+				toDeleteAffinity = append(toDeleteAffinity, obsoleteSVCBackendIDs...)
 			}
 		}
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -996,7 +996,7 @@ func (m *ManagerTestSuite) TestLocalRedirectServiceOverride(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(created, Equals, false)
 	c.Assert(id, Not(Equals), lb.ID(0))
-	svc, _ = m.svc.svcByID[id]
+	svc = m.svc.svcByID[id]
 	// Only node-local backends are selected.
 	c.Assert(len(svc.backends), Equals, len(localBackends))
 

--- a/pkg/stream/operators_test.go
+++ b/pkg/stream/operators_test.go
@@ -172,7 +172,7 @@ func TestRetryFuncs(t *testing.T) {
 			}
 		}
 	}
-	tdiff := time.Now().Sub(t0)
+	tdiff := time.Since(t0)
 	expectedDiff := time.Duration(1+2+4+8+10+10) * time.Millisecond
 
 	if tdiff < expectedDiff || tdiff > 2*expectedDiff {

--- a/pkg/testutils/privileged.go
+++ b/pkg/testutils/privileged.go
@@ -4,7 +4,6 @@
 package testutils
 
 import (
-	"fmt"
 	"os"
 	"testing"
 )
@@ -19,16 +18,13 @@ func PrivilegedTest(tb testing.TB) {
 	tb.Helper()
 
 	if os.Getenv(privilegedEnv) == "" {
-		tb.Skip(fmt.Sprintf("Set %s to run this test", privilegedEnv))
+		tb.Skipf("Set %s to run this test", privilegedEnv)
 	}
 }
 
 // IntegrationTests returns true if integration tests are requested.
 func IntegrationTests() bool {
-	if os.Getenv(integrationEnv) != "" {
-		return true
-	}
-	return false
+	return os.Getenv(integrationEnv) != ""
 }
 
 // IntegrationTest only executes tb if integration tests are requested.
@@ -36,7 +32,7 @@ func IntegrationTest(tb testing.TB) {
 	tb.Helper()
 
 	if os.Getenv(integrationEnv) == "" {
-		tb.Skip(fmt.Sprintf("Set %s to run this test", integrationEnv))
+		tb.Skipf("Set %s to run this test", integrationEnv)
 	}
 }
 
@@ -44,6 +40,6 @@ func GatewayAPIConformanceTest(tb testing.TB) {
 	tb.Helper()
 
 	if os.Getenv(gatewayAPIConformanceEnv) == "" {
-		tb.Skip(fmt.Sprintf("Set %s to run this test", gatewayAPIConformanceEnv))
+		tb.Skipf("Set %s to run this test", gatewayAPIConformanceEnv)
 	}
 }

--- a/pkg/types/ipv4.go
+++ b/pkg/types/ipv4.go
@@ -30,5 +30,4 @@ func (v4 IPv4) String() string {
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
 func (v4 *IPv4) DeepCopyInto(out *IPv4) {
 	copy(out[:], v4[:])
-	return
 }

--- a/pkg/types/ipv4_test.go
+++ b/pkg/types/ipv4_test.go
@@ -25,8 +25,7 @@ type IPv4Suite struct{}
 var _ = check.Suite(&IPv4Suite{})
 
 func (s *IPv4Suite) TestIP(c *check.C) {
-	var expectedAddress net.IP
-	expectedAddress = []byte{10, 0, 0, 2}
+	var expectedAddress net.IP = []byte{10, 0, 0, 2}
 	result := testIPv4Address.IP()
 
 	c.Assert(result, checker.DeepEquals, expectedAddress)

--- a/pkg/types/ipv6.go
+++ b/pkg/types/ipv6.go
@@ -26,5 +26,4 @@ func (v6 IPv6) String() string {
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
 func (v6 *IPv6) DeepCopyInto(out *IPv6) {
 	copy(out[:], v6[:])
-	return
 }

--- a/pkg/types/ipv6_test.go
+++ b/pkg/types/ipv6_test.go
@@ -19,8 +19,7 @@ type IPv6Suite struct{}
 var _ = check.Suite(&IPv6Suite{})
 
 func (s *IPv6Suite) TestIP(c *check.C) {
-	var expectedAddress net.IP
-	expectedAddress = []byte{240, 13, 0, 0, 0, 0, 0, 0, 172, 16, 0, 20, 0, 0, 0, 1}
+	var expectedAddress net.IP = []byte{240, 13, 0, 0, 0, 0, 0, 0, 172, 16, 0, 20, 0, 0, 0, 1}
 	result := testIPv6Address.IP()
 
 	c.Assert(result, checker.DeepEquals, expectedAddress)

--- a/pkg/types/macaddr.go
+++ b/pkg/types/macaddr.go
@@ -21,5 +21,4 @@ func (addr MACAddr) String() string {
 // DeepCopyInto is a deepcopy function, copying the receiver, writing into out. in must be non-nil.
 func (addr *MACAddr) DeepCopyInto(out *MACAddr) {
 	copy(out[:], addr[:])
-	return
 }

--- a/pkg/types/macaddr_test.go
+++ b/pkg/types/macaddr_test.go
@@ -18,8 +18,7 @@ type MACAddrSuite struct{}
 var _ = check.Suite(&MACAddrSuite{})
 
 func (s *MACAddrSuite) TestHardwareAddr(c *check.C) {
-	var expectedAddress net.HardwareAddr
-	expectedAddress = []byte{1, 2, 3, 4, 5, 6}
+	var expectedAddress net.HardwareAddr = []byte{1, 2, 3, 4, 5, 6}
 	result := testMACAddress.hardwareAddr()
 
 	c.Assert(result, checker.DeepEquals, expectedAddress)

--- a/plugins/cilium-docker/driver/ipam.go
+++ b/plugins/cilium-docker/driver/ipam.go
@@ -43,7 +43,7 @@ func (driver *driver) getDefaultAddressSpaces(w http.ResponseWriter, r *http.Req
 
 func (driver *driver) getPoolResponse(req *api.RequestPoolRequest) *api.RequestPoolResponse {
 	addr := driver.conf.Addressing
-	if req.V6 == false {
+	if !req.V6 {
 		return &api.RequestPoolResponse{
 			PoolID: PoolIPv4,
 			Pool:   "0.0.0.0/0",

--- a/test/ginkgo-ext/scopes.go
+++ b/test/ginkgo-ext/scopes.go
@@ -301,7 +301,7 @@ func runAllAfterEach(cs *scope, testName string) {
 var afterFailedStatus map[string]bool = map[string]bool{}
 
 func testFailed(testName string) bool {
-	hasFailed, _ := afterEachFailed[testName]
+	hasFailed := afterEachFailed[testName]
 	return ginkgo.CurrentGinkgoTestDescription().Failed || hasFailed
 }
 
@@ -368,7 +368,7 @@ func RunAfterEach(cs *scope) {
 	afterEachStatus[testName] = true
 
 	// Run the afterFailed in case that something fails on afterEach
-	if hasFailed == false && afterEachFailed[testName] {
+	if !hasFailed && afterEachFailed[testName] {
 		GinkgoPrint("Something has failed on AfterEach, running AfterFailed functions")
 		afterFailedStatus[testName] = false
 		runAllAfterFail(cs, testName)

--- a/test/helpers/ssh_command.go
+++ b/test/helpers/ssh_command.go
@@ -216,22 +216,20 @@ func (client *SSHClient) RunCommandInBackground(ctx context.Context, cmd *SSHCom
 	}
 
 	go func() {
-		select {
-		case <-ctx.Done():
-			_, err := stdin.Write([]byte{3})
-			if err != nil {
-				log.Errorf("write ^C error: %s", err)
-			}
-			err = session.Wait()
-			if err != nil {
-				log.Errorf("wait error: %s", err)
-			}
-			if err = session.Signal(ssh.SIGHUP); err != nil {
-				log.Errorf("failed to kill command: %s", err)
-			}
-			if err = session.Close(); err != nil {
-				log.Errorf("failed to close session: %s", err)
-			}
+		<-ctx.Done()
+		_, err := stdin.Write([]byte{3})
+		if err != nil {
+			log.Errorf("write ^C error: %s", err)
+		}
+		err = session.Wait()
+		if err != nil {
+			log.Errorf("wait error: %s", err)
+		}
+		if err = session.Signal(ssh.SIGHUP); err != nil {
+			log.Errorf("failed to kill command: %s", err)
+		}
+		if err = session.Close(); err != nil {
+			log.Errorf("failed to close session: %s", err)
 		}
 	}()
 	_, err = runCommand(session, cmd)

--- a/test/helpers/utils.go
+++ b/test/helpers/utils.go
@@ -154,10 +154,8 @@ func RepeatUntilTrue(body func() bool, config *TimeoutConfig) error {
 			}
 			// Provide some form of rate-limiting here before running next
 			// execution in case body() returns at a fast rate.
-			select {
-			case <-ticker.C:
-				go asyncBody(bodyChan)
-			}
+			<-ticker.C
+			go asyncBody(bodyChan)
 		case <-done:
 			return fmt.Errorf("%s timeout expired", config.Timeout)
 		}
@@ -465,7 +463,7 @@ func failIfContainsBadLogMsg(logs, label string, blacklist map[string][]string) 
 					}
 				}
 				if !ok {
-					count, _ := uniqueFailures[msg]
+					count := uniqueFailures[msg]
 					uniqueFailures[msg] = count + 1
 				}
 			}
@@ -817,8 +815,5 @@ func SupportIPv6Connectivity() bool {
 // SupportIPv6ToOutside returns true if the CI environment supports IPv6
 // connectivity to the outside world.
 func SupportIPv6ToOutside() bool {
-	if os.Getenv("CILIUM_NO_IPV6_OUTSIDE") != "" {
-		return false
-	}
-	return true
+	return os.Getenv("CILIUM_NO_IPV6_OUTSIDE") == ""
 }

--- a/test/k8s/kafka_policies.go
+++ b/test/k8s/kafka_policies.go
@@ -69,10 +69,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 		waitForKafkaBroker := func(pod string, cmd string) error {
 			body := func() bool {
 				err := kubectl.ExecKafkaPodCmd(helpers.DefaultNamespace, pod, cmd)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}
 			err := helpers.WithTimeout(body, "Kafka Broker not ready", &helpers.TimeoutConfig{Timeout: helpers.HelperTimeout})
 			return err
@@ -83,10 +80,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 				dnsLookupCmd := fmt.Sprintf("nslookup %s", service)
 				res := kubectl.ExecPodCmd(helpers.DefaultNamespace, pod, dnsLookupCmd)
 
-				if !res.WasSuccessful() {
-					return false
-				}
-				return true
+				return res.WasSuccessful()
 			}
 			err := helpers.WithTimeout(body, fmt.Sprintf("unable to resolve DNS for service %s in pod %s", service, pod), &helpers.TimeoutConfig{Timeout: 240 * time.Second})
 			return err
@@ -153,10 +147,7 @@ var _ = SkipDescribeIf(helpers.RunsOn54Kernel, "K8sKafkaPolicyTest", func() {
 				var errBody error
 				body := func() bool {
 					errBody = kubectl.ExecKafkaPodCmd(helpers.DefaultNamespace, pod, arg)
-					if errBody != nil {
-						return false
-					}
-					return true
+					return errBody == nil
 				}
 				err = helpers.WithTimeout(body, description, &helpers.TimeoutConfig{Timeout: 60 * time.Second})
 

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -571,7 +571,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"loadBalancer.algorithm":    "random",
 				"routingMode":               "native",
 				"autoDirectNodeRoutes":      "true",
-				"devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
+				"devices":                   "'{}'", // Revert back to auto-detection after XDP.
 			})
 			testNodePortExternal(kubectl, ni, false, true, false)
 		})
@@ -585,7 +585,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"routingMode":               "native",
 				"autoDirectNodeRoutes":      "true",
 				"loadBalancer.dsrDispatch":  "geneve",
-				"devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
+				"devices":                   "'{}'", // Revert back to auto-detection after XDP.
 			})
 			testNodePortExternal(kubectl, ni, false, true, true)
 		})
@@ -598,7 +598,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"routingMode":               "native",
 				"autoDirectNodeRoutes":      "true",
 				"loadBalancer.dsrDispatch":  "geneve",
-				"devices":                   fmt.Sprintf(`'{}'`),
+				"devices":                   "'{}'",
 			})
 			testNodePortExternal(kubectl, ni, false, true, false)
 		})
@@ -611,7 +611,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"maglev.tableSize":          "251",
 				"tunnelProtocol":            "geneve",
 				"loadBalancer.dsrDispatch":  "geneve",
-				"devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
+				"devices":                   "'{}'", // Revert back to auto-detection after XDP.
 			})
 			testNodePortExternal(kubectl, ni, false, true, true)
 		})
@@ -623,7 +623,7 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				"loadBalancer.algorithm":    "random",
 				"tunnelProtocol":            "geneve",
 				"loadBalancer.dsrDispatch":  "geneve",
-				"devices":                   fmt.Sprintf(`'{}'`),
+				"devices":                   "'{}'",
 			})
 			testNodePortExternal(kubectl, ni, false, true, false)
 		})

--- a/tools/crdcheck/main.go
+++ b/tools/crdcheck/main.go
@@ -23,7 +23,7 @@ var allChecks = []checkCRDFunc{
 
 func main() {
 	if len(os.Args) != 2 {
-		log.Fatal(fmt.Sprintf("usage: %s <path>", os.Args[0]))
+		log.Fatalf("usage: %s <path>", os.Args[0])
 	}
 
 	_ = crdv1.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
This fixes issues found by the [gosimple](https://github.com/dominikh/go-tools/tree/master/simple) linter and enables it in the golangci config. gosimple is enabled by [default](https://golangci-lint.run/usage/linters/) in golang-ci.
Unfortunately it touches a lot of different code, please let me know if you want to have the PR broken down per file path.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```
bugtool/cmd/root.go:455:4: S1038: should use fmt.Fprintf instead of fmt.Fprint(fmt.Sprintf(...)) (gosimple)
                        fmt.Fprint(f, fmt.Sprintf("# %s\n\n```\n%s\n```\n", prompt, output))
                        ^
pkg/hive/job/job.go:318:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/hive/job/job.go:543:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/k8s/resource/resource.go:210:5: S1002: should omit comparison to bool constant, can be simplified to `!status` (gosimple)
        if status == false {
           ^
operator/pkg/model/translation/envoy_virtual_host.go:99:2: S1008: should use 'return headerMatch1 > headerMatch2' instead of 'if headerMatch1 > headerMatch2 { return true }; return false' (gosimple)
        if headerMatch1 > headerMatch2 {
        ^
pkg/maps/ipmasq/ipmasq.go:30:42: S1025: should use String() instead of fmt.Sprintf (gosimple)
func (k *Key4) String() string  { return fmt.Sprintf("%s", k.Address) }
                                         ^
pkg/maps/ipmasq/ipmasq.go:38:42: S1025: should use String() instead of fmt.Sprintf (gosimple)
func (k *Key6) String() string  { return fmt.Sprintf("%s", k.Address) }
                                         ^
test/helpers/kubectl.go:4391:10: S1039: unnecessary use of fmt.Sprintf (gosimple)
                cmd := fmt.Sprintf(`cilium bpf egress list | tail -n +2 | wc -l`)
                       ^
test/helpers/utils.go:468:6: S1005: unnecessary assignment to the blank identifier (gosimple)
                                        count, _ := uniqueFailures[msg]
                                        ^
test/helpers/kubectl.go:939:55: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
        podsNodes, err := kub.GetPodsNodes(DefaultNamespace, fmt.Sprintf("%s", podFilter))
                                                             ^
test/helpers/cilium.go:420:5: S1002: should omit comparison to bool constant, can be simplified to `!data.WasSuccessful()` (gosimple)
        if data.WasSuccessful() == false {
           ^
test/helpers/cilium.go:594:5: S1002: should omit comparison to bool constant, can be simplified to `!res.WasSuccessful()` (gosimple)
        if res.WasSuccessful() == false {
           ^
test/helpers/cilium.go:602:5: S1002: should omit comparison to bool constant, can be simplified to `!res.WasSuccessful()` (gosimple)
        if res.WasSuccessful() == false {
           ^
test/helpers/cilium.go:884:5: S1002: should omit comparison to bool constant, can be simplified to `!ok` (gosimple)
        if ok == false {
           ^
test/helpers/cilium.go:902:6: S1002: should omit comparison to bool constant, can be simplified to `!result` (gosimple)
                if result == false {
                   ^
test/helpers/kubectl.go:277:5: S1002: should omit comparison to bool constant, can be simplified to `!config.CiliumTestConfig.ProvisionK8s` (gosimple)
        if config.CiliumTestConfig.ProvisionK8s == false {
           ^
test/helpers/kubectl.go:2826:7: S1002: should omit comparison to bool constant, can be simplified to `!status` (gosimple)
                        if status == false {
                           ^
test/helpers/cilium.go:763:2: S1000: should use for range instead of for { select {} } (gosimple)
        for {
        ^
test/helpers/kubectl.go:1319:2: S1000: should use for range instead of for { select {} } (gosimple)
        for {
        ^
test/helpers/ssh_command.go:219:3: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)
                select {
                ^
test/helpers/utils.go:157:4: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)
                        select {
                        ^
test/helpers/kubectl.go:2922:4: S1023: redundant break statement (gosimple)
                        break
                        ^
test/helpers/cilium.go:248:3: S1008: should use 'return res.WasSuccessful()' instead of 'if !res.WasSuccessful() { return false }; return true' (gosimple)
                if !res.WasSuccessful() {
                ^
test/helpers/cilium.go:315:3: S1008: should use 'return result[desiredState] == total' instead of 'if result[desiredState] == total { return true }; return false' (gosimple)
                if result[desiredState] == total {
                ^
test/helpers/utils.go:820:2: S1008: should use 'return os.Getenv("CILIUM_NO_IPV6_OUTSIDE") == ""' instead of 'if os.Getenv("CILIUM_NO_IPV6_OUTSIDE") != "" { return false }; return true' (gosimple)
        if os.Getenv("CILIUM_NO_IPV6_OUTSIDE") != "" {
        ^
tools/crdcheck/main.go:26:3: S1038: should use log.Fatalf(...) instead of log.Fatal(fmt.Sprintf(...)) (gosimple)
                log.Fatal(fmt.Sprintf("usage: %s <path>", os.Args[0]))
                ^
operator/pkg/lbipam/lbipam_test.go:133:3: S1008: should use 'return isPoolConflicting(pool)' instead of 'if !isPoolConflicting(pool) { return false }; return true' (gosimple)
                if !isPoolConflicting(pool) {
                ^
operator/pkg/lbipam/lbipam_test.go:154:3: S1008: should use 'return !isPoolConflicting(pool)' instead of 'if isPoolConflicting(pool) { return false }; return true' (gosimple)
                if isPoolConflicting(pool) {
                ^
pkg/ip/ip.go:865:2: S1001: should use copy(to, from) instead of a loop (gosimple)
        for i := 0; i < len(ipList); i++ {
        ^
test/k8s/services.go:574:34: S1039: unnecessary use of fmt.Sprintf (gosimple)
                                "devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
                                                             ^
test/k8s/services.go:588:34: S1039: unnecessary use of fmt.Sprintf (gosimple)
                                "devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
                                                             ^
test/k8s/services.go:601:34: S1039: unnecessary use of fmt.Sprintf (gosimple)
                                "devices":                   fmt.Sprintf(`'{}'`),
                                                             ^
test/k8s/services.go:614:34: S1039: unnecessary use of fmt.Sprintf (gosimple)
                                "devices":                   fmt.Sprintf(`'{}'`), // Revert back to auto-detection after XDP.
                                                             ^
test/k8s/services.go:626:34: S1039: unnecessary use of fmt.Sprintf (gosimple)
                                "devices":                   fmt.Sprintf(`'{}'`),
                                                             ^
test/k8s/kafka_policies.go:72:5: S1008: should use 'return err == nil' instead of 'if err != nil { return false }; return true' (gosimple)
                                if err != nil {
                                ^
test/k8s/kafka_policies.go:86:5: S1008: should use 'return res.WasSuccessful()' instead of 'if !res.WasSuccessful() { return false }; return true' (gosimple)
                                if !res.WasSuccessful() {
                                ^
test/k8s/kafka_policies.go:156:6: S1008: should use 'return errBody == nil' instead of 'if errBody != nil { return false }; return true' (gosimple)
                                        if errBody != nil {
                                        ^
pkg/stream/operators_test.go:175:11: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
        tdiff := time.Now().Sub(t0)
                 ^
pkg/monitor/datapath_debug.go:543:3: S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
                fmt.Println(fmt.Sprintf(`{"type":"debug_capture_error","message":%q}`, err.Error()))
                ^
pkg/node/manager/manager.go:702:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/l2announcer/l2announcer.go:169:3: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)
                select {
                ^
pkg/k8s/slim/k8s/apis/labels/selector.go:911:5: S1009: should omit nil check; len() for github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels.Set is defined as zero (gosimple)
        if ls == nil || len(ls) == 0 {
           ^
pkg/k8s/slim/k8s/apis/labels/selector.go:933:5: S1009: should omit nil check; len() for github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/labels.Set is defined as zero (gosimple)
        if ls == nil || len(ls) == 0 {
           ^
pkg/bgpv1/gobgp/conversions.go:65:19: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
        ageNano := int64(time.Now().Sub(p.Age.AsTime()))
                         ^
pkg/bgpv1/gobgp/state.go:71:41: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
                                peerState.UptimeNanoseconds = int64(time.Now().Sub(peer.Timers.State.Uptime.AsTime()))
                                                                    ^
pkg/egressgateway/manager.go:306:4: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)
                        select {
                        ^
pkg/egressgateway/manager_privileged_test.go:707:4: S1023: redundant `return` statement (gosimple)
                        return
                        ^
pkg/proxy/proxy.go:392:27: S1002: should omit comparison to bool constant, can be simplified to `!p.allocatedPorts[pp.rulesPort]` (gosimple)
                if pp.rulesPort != 0 && p.allocatedPorts[pp.rulesPort] == false {
                                        ^
pkg/fqdn/proxy/proxy.go:29:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/fqdn/proxy/proxy.go:41:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/fqdn/proxy/proxy.go:45:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/fqdn/proxy/proxy.go:49:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/datapath/loader/cache.go:366:8: S1005: unnecessary assignment to the blank identifier (gosimple)
                case err, _ = <-templateWatcher.Errors:
                     ^
operator/pkg/ciliumenvoyconfig/envoy_config.go:219:2: S1021: should merge variable declaration with assignment on next line (gosimple)
        var filterChains []*envoy_config_listener.FilterChain
        ^
pkg/datapath/linux/node.go:648:4: S1012: should use `time.Since` instead of `time.Now().Sub` (gosimple)
                        time.Now().Sub(lastPing) < option.Config.ARPPingRefreshPeriod {
                        ^
pkg/datapath/linux/node.go:2039:5: S1002: should omit comparison to bool constant, can be simplified to `found` (gosimple)
        if found == true {
           ^
pkg/fqdn/name_manager_test.go:55:2: S1005: unnecessary assignment to the blank identifier (gosimple)
        ips, _ := selIPMap[ciliumIOSel]
        ^
pkg/fqdn/cache.go:945:4: S1033: unnecessary guard around call to delete (gosimple)
                        if _, ok := possibleAlive[dead]; ok {
                        ^
pkg/datapath/fake/node.go:65:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/datapath/fake/node.go:69:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/datapath/fake/node.go:85:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/monitor/format/fuzz_test.go:44:3: S1023: redundant `return` statement (gosimple)
                return
                ^
pkg/service/service_test.go:912:2: S1005: unnecessary assignment to the blank identifier (gosimple)
        svc, _ = m.svc.svcByID[id]
        ^
pkg/service/service.go:1264:5: S1011: should replace loop with `toDeleteAffinity = append(toDeleteAffinity, obsoleteSVCBackendIDs...)` (gosimple)
                                for _, bID := range obsoleteSVCBackendIDs {
                                ^
pkg/ipam/allocator/podcidr/podcidr.go:413:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/ipam/allocator/podcidr/podcidr_test.go:225:7: S1023: redundant `return` statement (gosimple)
                                                return
                                                ^
pkg/ipam/allocator/podcidr/podcidr_test.go:309:7: S1023: redundant `return` statement (gosimple)
                                                return
                                                ^
pkg/ipam/allocator/podcidr/podcidr_test.go:371:7: S1023: redundant `return` statement (gosimple)
                                                return
                                                ^
pkg/ipam/allocator/podcidr/podcidr_test.go:427:7: S1023: redundant `return` statement (gosimple)
                                                return
                                                ^
pkg/ipam/allocator/podcidr/podcidr_test.go:518:7: S1023: redundant `return` statement (gosimple)
                                                return
                                                ^
operator/pkg/ciliumendpointslice/manager.go:587:2: S1005: unnecessary assignment to the blank identifier (gosimple)
        identity, _ := c.cesToIdentity[cesName]
        ^
operator/pkg/ciliumendpointslice/manager.go:179:2: S1033: unnecessary guard around call to delete (gosimple)
        if _, ok := ces.removedCEPs[GetCEPNameFromCCEP(cep, ces.ces.Namespace)]; ok {
        ^
operator/pkg/ciliumendpointslice/endpointslice.go:190:2: S1023: redundant `return` statement (gosimple)
        return
        ^
operator/pkg/ciliumendpointslice/endpointslice.go:277:2: S1023: redundant `return` statement (gosimple)
        return
        ^
operator/pkg/ciliumendpointslice/manager.go:185:2: S1023: redundant `return` statement (gosimple)
        return
        ^
operator/pkg/ciliumendpointslice/manager.go:374:2: S1023: redundant `return` statement (gosimple)
        return
        ^
operator/pkg/ciliumendpointslice/endpointslice_test.go:284:3: S1021: should merge variable declaration with assignment on next line (gosimple)
                var err error
                ^
pkg/datapath/iptables/iptables.go:1623:5: S1002: should omit comparison to bool constant, can be simplified to `!option.Config.EnableIPSec` (gosimple)
        if option.Config.EnableIPSec == false {
           ^
pkg/datapath/iptables/iptables.go:126:7: S1007: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (gosimple)
        v := regexp.MustCompile("v([0-9]+(\\.[0-9]+)+)")
             ^
pkg/identity/cache/cache.go:144:4: S1000: should use for range instead of for { select {} } (gosimple)
                        for {
                        ^
test/ginkgo-ext/scopes.go:304:2: S1005: unnecessary assignment to the blank identifier (gosimple)
        hasFailed, _ := afterEachFailed[testName]
        ^
test/ginkgo-ext/scopes.go:371:5: S1002: should omit comparison to bool constant, can be simplified to `!hasFailed` (gosimple)
        if hasFailed == false && afterEachFailed[testName] {
           ^
pkg/maps/ctmap/per_cluster_ctmap.go:475:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/k8s/service.go:665:3: S1002: should omit comparison to bool constant, can be simplified to `!s.SessionAffinity` (gosimple)
                s.SessionAffinity == false &&
                ^
pkg/k8s/labels.go:124:3: S1011: should replace loop with `containerPorts = append(containerPorts, containers.Ports...)` (gosimple)
                for _, cp := range containers.Ports {
                ^
pkg/k8s/service.go:114:3: S1023: redundant break statement (gosimple)
                break
                ^
pkg/k8s/service.go:118:3: S1023: redundant break statement (gosimple)
                break
                ^
pkg/k8s/service.go:122:3: S1023: redundant break statement (gosimple)
                break
                ^
pkg/k8s/cnpstatus.go:117:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/k8s/endpoints.go:80:2: S1023: redundant `return` statement (gosimple)
        return
        ^
cilium/cmd/bpf_sha_get.go:52:34: S1025: the argument's underlying type is a slice of bytes, should use a simple conversion instead of fmt.Sprintf (gosimple)
                jsonEncStr := regex.FindString(fmt.Sprintf("%s", text))
                                               ^
cilium/cmd/prefilter_list.go:51:9: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
                str = fmt.Sprintf("%s", pfx)
                      ^
cilium/cmd/cleanup.go:283:5: S1002: should omit comparison to bool constant, can be simplified to `!(cleanAll || cleanBPF)` (gosimple)
        if (cleanAll || cleanBPF) == false {
           ^
cilium/cmd/debuginfo.go:367:2: S1023: redundant `return` statement (gosimple)
        return
        ^
cilium/cmd/lrp_list.go:64:4: S1038: should use fmt.Fprintf instead of fmt.Fprintln(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
                        fmt.Fprintln(w, fmt.Sprintf("\t|\t%s", getPrintableMapping(feM)))
                        ^
pkg/alibabacloud/api/api.go:222:3: S1011: should replace loop with `result = append(result, resp.InstanceTypes.InstanceType...)` (gosimple)
                for _, v := range resp.InstanceTypes.InstanceType {
                ^
pkg/alibabacloud/api/api.go:415:3: S1011: should replace loop with `result = append(result, resp.NetworkInterfaceSets.NetworkInterfaceSet...)` (gosimple)
                for _, v := range resp.NetworkInterfaceSets.NetworkInterfaceSet {
                ^
pkg/alibabacloud/api/api.go:445:3: S1011: should replace loop with `result = append(result, resp.NetworkInterfaceSets.NetworkInterfaceSet...)` (gosimple)
                for _, v := range resp.NetworkInterfaceSets.NetworkInterfaceSet {
                ^
pkg/datapath/prefilter/prefilter.go:149:6: S1002: should omit comparison to bool constant, can be simplified to `!p.maps[which].CIDRExists(cidr)` (gosimple)
                if p.maps[which].CIDRExists(cidr) == false {
                   ^
operator/watchers/k8s_service_sync.go:111:38: S1019: should use make(chan struct{}) instead (gosimple)
        kvstoreReady := make(chan struct{}, 0)
                                            ^
pkg/hubble/container/ring.go:127:32: S1019: should use make([]*v1.Event, dataLen) instead (gosimple)
                data:      make([]*v1.Event, dataLen, dataLen),
                                             ^
pkg/hubble/container/ring_test.go:41:25: S1019: should use make([]*v1.Event, b.N) instead (gosimple)
        a := make([]*v1.Event, b.N, b.N)
                               ^
pkg/hubble/container/ring_test.go:57:25: S1019: should use make([]*v1.Event, b.N) instead (gosimple)
        a := make([]*v1.Event, b.N, b.N)
                               ^
pkg/hubble/container/ring_test.go:72:25: S1019: should use make([]*v1.Event, b.N) instead (gosimple)
        a := make([]*v1.Event, b.N, b.N)
                               ^
pkg/hubble/parser/threefour/parser.go:100:2: S1021: should merge variable declaration with assignment on next line (gosimple)
        var eventType uint8
        ^
pkg/alibabacloud/eni/node.go:91:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/datapath/tables/l2_announce.go:29:2: S1021: should merge variable declaration with assignment on next line (gosimple)
        var n L2AnnounceEntry
        ^
pkg/k8s/watchers/watcher.go:987:5: S1002: should omit comparison to bool constant, can be simplified to `!status` (gosimple)
        if status == false {
           ^
pkg/k8s/watchers/node.go:37:2: S1008: should use 'return comparator.MapStringEquals(oldNode.GetLabels(), newNode.GetLabels())' instead of 'if !comparator.MapStringEquals(oldNode.GetLabels(), newNode.GetLabels()) { return false }; return true' (gosimple)
        if !comparator.MapStringEquals(oldNode.GetLabels(), newNode.GetLabels()) {
        ^
pkg/kvstore/etcd_lease_test.go:128:34: S1019: should use make(chan client.LeaseID) instead (gosimple)
        ch := make(chan client.LeaseID, 0)
                                        ^
pkg/cidr/cidr.go:75:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/comparator/comparator.go:105:2: S1008: should use 'return len(m1)-ignoredM1 == len(m2)-ignoredM2' instead of 'if len(m1)-ignoredM1 != len(m2)-ignoredM2 { return false }; return true' (gosimple)
        if len(m1)-ignoredM1 != len(m2)-ignoredM2 {
        ^
plugins/cilium-docker/driver/ipam.go:46:5: S1002: should omit comparison to bool constant, can be simplified to `!req.V6` (gosimple)
        if req.V6 == false {
           ^
pkg/cgroups/manager/manager.go:135:2: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)
        select {
        ^
pkg/cgroups/manager/manager.go:152:2: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)
        select {
        ^
daemon/cmd/kube_proxy_replacement.go:441:11: S1039: unnecessary use of fmt.Sprintf (gosimple)
                                msg = fmt.Sprintf("BPF host routing requires kernel 5.10 or newer.")
                                      ^
daemon/cmd/debuginfo.go:29:22: S1025: should use String() instead of fmt.Sprintf (gosimple)
                dr.KernelVersion = fmt.Sprintf("%s", kver)
                                   ^
daemon/cmd/status.go:770:12: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
                                        msg = fmt.Sprintf("%s", info)
                                              ^
daemon/cmd/state.go:252:2: S1031: unnecessary nil check around range (gosimple)
        if existingEndpoints != nil {
        ^
daemon/cmd/config.go:112:2: S1023: redundant `return` statement (gosimple)
        return
        ^
daemon/cmd/policy.go:397:2: S1023: redundant `return` statement (gosimple)
        return
        ^
daemon/cmd/policy.go:620:2: S1023: redundant `return` statement (gosimple)
        return
        ^
daemon/cmd/status.go:525:2: S1023: redundant `return` statement (gosimple)
        return
        ^
daemon/cmd/status.go:530:2: S1023: redundant `return` statement (gosimple)
        return
        ^
daemon/cmd/status.go:550:2: S1023: redundant `return` statement (gosimple)
        return
        ^
daemon/cmd/status.go:1078:2: S1023: redundant `return` statement (gosimple)
        return
        ^
daemon/cmd/state.go:268:40: S1019: should use make(chan struct{}) instead (gosimple)
        restoreComplete = make(chan struct{}, 0)
                                              ^
pkg/testutils/privileged.go:22:3: S1038: should use tb.Skipf(...) instead of tb.Skip(fmt.Sprintf(...)) (gosimple)
                tb.Skip(fmt.Sprintf("Set %s to run this test", privilegedEnv))
                ^
pkg/testutils/privileged.go:39:3: S1038: should use tb.Skipf(...) instead of tb.Skip(fmt.Sprintf(...)) (gosimple)
                tb.Skip(fmt.Sprintf("Set %s to run this test", integrationEnv))
                ^
pkg/testutils/privileged.go:47:3: S1038: should use tb.Skipf(...) instead of tb.Skip(fmt.Sprintf(...)) (gosimple)
                tb.Skip(fmt.Sprintf("Set %s to run this test", gatewayAPIConformanceEnv))
                ^
pkg/testutils/privileged.go:28:2: S1008: should use 'return os.Getenv(integrationEnv) != ""' instead of 'if os.Getenv(integrationEnv) != "" { return true }; return false' (gosimple)
        if os.Getenv(integrationEnv) != "" {
        ^
pkg/bgpv1/test/neighbor_test.go:158:19: S1024: should use time.Until instead of t.Sub(time.Now()) (gosimple)
                        outstanding := deadline.Sub(time.Now())
                                       ^
pkg/bgpv1/test/neighbor_test.go:301:19: S1024: should use time.Until instead of t.Sub(time.Now()) (gosimple)
                        outstanding := deadline.Sub(time.Now())
                                       ^
operator/pkg/ingress/ingress_class.go:165:22: S1016: should convert event (type ingressClassDeletedEvent) to ciliumIngressClassDeletedEvent instead of using struct literal (gosimple)
                i.ingressQueue.Add(ciliumIngressClassDeletedEvent{ingressClass: event.ingressClass})
                                   ^
pkg/redirectpolicy/manager_test.go:56:30: S1019: should use make([]interface{}, 2) instead (gosimple)
        pods := make([]interface{}, 2, 2)
                                    ^
pkg/endpoint/status.go:58:10: S1025: should use String() instead of fmt.Sprintf (gosimple)
                return fmt.Sprintf("%s", s.Code)
                       ^
pkg/endpoint/api.go:505:28: S1004: should use !bytes.Equal(e.mac, newEp.mac) instead (gosimple)
        if len(newEp.mac) != 0 && bytes.Compare(e.mac, newEp.mac) != 0 {
                                  ^
pkg/endpoint/api.go:510:32: S1004: should use !bytes.Equal(e.GetNodeMAC(), newEp.nodeMAC) instead (gosimple)
        if len(newEp.nodeMAC) != 0 && bytes.Compare(e.GetNodeMAC(), newEp.nodeMAC) != 0 {
                                      ^
pkg/endpoint/policy.go:676:3: S1000: should use a simple channel send/receive instead of `select` with a single case (gosimple)
                select {
                ^
pkg/endpoint/events.go:68:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/endpoint/events.go:185:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/endpoint/events.go:251:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/endpoint/redirect_test.go:78:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/endpoint/endpoint.go:1755:2: S1008: should use 'return myChangeRev != e.identityRevision' instead of 'if myChangeRev != e.identityRevision { return true }; return false' (gosimple)
        if myChangeRev != e.identityRevision {
        ^
pkg/endpoint/endpoint.go:477:41: S1019: should use make(chan struct{}) instead (gosimple)
                hasBPFProgram:    make(chan struct{}, 0),
                                                      ^
pkg/endpoint/endpoint.go:843:41: S1019: should use make(chan struct{}) instead (gosimple)
        ep.hasBPFProgram = make(chan struct{}, 0)
                                               ^
pkg/aws/eni/node.go:114:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/maps/srv6map/policy.go:54:9: S1025: should use String() instead of fmt.Sprintf (gosimple)
        return fmt.Sprintf("%s", v.SID)
               ^
pkg/maps/srv6map/sid.go:30:9: S1025: should use String() instead of fmt.Sprintf (gosimple)
        return fmt.Sprintf("%s", k.SID)
               ^
pkg/types/ipv4.go:33:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/types/ipv6.go:29:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/types/macaddr.go:24:2: S1023: redundant `return` statement (gosimple)
        return
        ^
pkg/types/ipv4_test.go:28:2: S1021: should merge variable declaration with assignment on next line (gosimple)
        var expectedAddress net.IP
        ^
pkg/types/ipv6_test.go:22:2: S1021: should merge variable declaration with assignment on next line (gosimple)
        var expectedAddress net.IP
        ^
pkg/types/macaddr_test.go:21:2: S1021: should merge variable declaration with assignment on next line (gosimple)
        var expectedAddress net.HardwareAddr
        ^
operator/pkg/gateway-api/controller_test.go:336:27: S1039: unnecessary use of fmt.Sprintf (gosimple)
                        if !tt.wantErr(t, err, fmt.Sprintf("success()")) {
                                               ^
pkg/datapath/linux/ipsec/ipsec_linux.go:136:3: S1005: unnecessary assignment to the blank identifier (gosimple)
                key, _ = ipSecKeysGlobal[""]
                ^
pkg/datapath/linux/ipsec/ipsec_linux.go:135:5: S1002: should omit comparison to bool constant, can be simplified to `!scoped` (gosimple)
        if scoped == false {
           ^
```

```release-note
chore(lint): Enable linting with gosimple
```
