### PR TITLE
ci: increase connectivity test timeout in GHA external workload

### DIFF
--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -108,7 +108,7 @@ jobs:
     name: "Installation and Connectivity Test"
     needs: generate-matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       job_name: "Installation and Connectivity Test"
     strategy:


### PR DESCRIPTION
This commit increases the timeout of the job `Installation and Connectivity Test` within the worklfow `External Workload` from 30m to 45m.

The current timeout is too low:

> Installation and Connectivity Test (1.26, europe-north1-b, 5) 
> The job running on runner GitHub Actions 52 has exceeded the maximum execution time of 30 minutes.`

https://github.com/cilium/cilium/actions/runs/5604532568
