### PR TITLE
ci: replace GHA action Sibz/github-status-action

### DIFF
--- a/.github/workflows/push-chart-ci.yaml
+++ b/.github/workflows/push-chart-ci.yaml
@@ -27,7 +27,7 @@ permissions:
   contents: read
   # To allow retrieving information from the PR API
   pull-requests: read
-  # So that Sibz/github-status-action can write into the status API
+  # To be able to set commit status
   statuses: write
 
 concurrency:
@@ -37,9 +37,6 @@ concurrency:
       (github.event_name == 'workflow_run' && github.event.workflow_run.head_sha)
     }}
   cancel-in-progress: true
-
-env:
-  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   push-charts:
@@ -79,14 +76,11 @@ jobs:
         fi
 
     - name: Set commit status to pending
-      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
       with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
         sha: ${{ steps.get-ref.outputs.sha }}
-        context: ${{ github.workflow }}
+        status: pending
         description: Helm push in progress
-        state: pending
-        target_url: ${{ env.check_url }}
 
     - name: Checkout Source Code
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -141,33 +135,24 @@ jobs:
 
     - name: Set commit status to success
       if: ${{ success() }}
-      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
       with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
         sha: ${{ steps.get-ref.outputs.sha }}
-        context: ${{ github.workflow }}
+        status: success
         description: Helm push successful
-        state: success
-        target_url: ${{ env.check_url }}
 
     - name: Set commit status to failure
       if: ${{ failure() }}
-      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
       with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
         sha: ${{ steps.get-ref.outputs.sha }}
-        context: ${{ github.workflow }}
+        status: failure
         description: Helm push failed
-        state: failure
-        target_url: ${{ env.check_url }}
 
     - name: Set commit status to cancelled
       if: ${{ cancelled() }}
-      uses: Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f # v1.1.6
+      uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
       with:
-        authToken: ${{ secrets.GITHUB_TOKEN }}
         sha: ${{ steps.get-ref.outputs.sha }}
-        context: ${{ github.workflow }}
+        status: error
         description: Helm push cancelled
-        state: error
-        target_url: ${{ env.check_url }}


### PR DESCRIPTION
This commit replaces the GitHub Action `Sibz/github-status-action` to set the commit status with `myrotvorets/set-commit-status-action`.

Sibz/github-status-action is only used in the Helm Chart Push and builds on top of node12 which is deprecated in GHA.

> The following actions uses node12 which is deprecated and will be forced to run on node16:
Sibz/github-status-action@650dd1a882a76dbbbc4576fb5974b8d22f29847f. For more info:
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Example workflow run with deprecation warning: https://github.com/cilium/cilium/actions/runs/5619983977