### PR TITLE
docs/ipsec: Document RSS limitation

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -272,3 +272,6 @@ Limitations
     * IPsec encryption is not currently supported in combination with IPv6-only clusters.
     * IPsec encryption is not supported on clusters or clustermeshes with more
       than 65535 nodes.
+    * Decryption with Cilium IPsec is limited to a single CPU core per IPsec
+      tunnel. This may affect performance in case of high throughput between
+      two nodes.


### PR DESCRIPTION
All IPsec traffic between two nodes is always send on a single IPsec flow (defined by outer source and destination IP addresses). As a consequence, RSS on such traffic is ineffective and throughput will be limited to the decryption performance of a single core.