### PR TITLE
ci-ipsec-upgrade: Add IPsec upgrade tests

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -27,6 +27,9 @@ triggers:
   /ci-e2e:
     workflows:
     - conformance-e2e.yaml
+  /ci-ipsec-upgrade:
+    workflows:
+    - tests-ipsec-upgrade.yaml
   /ci-eks:
     workflows:
     - conformance-eks.yaml

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -1,0 +1,445 @@
+name: Cilium IPsec upgrade (ci-ipsec-upgrade)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+  # Run every 6 hours
+  schedule:
+    - cron:  '0 5/6 * * *'
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+env:
+  # renovate: datasource=github-releases depName=cilium/cilium-cli
+  cilium_cli_version:
+  # until https://github.com/cilium/cilium-cli/pull/1854 has been released
+  cilium_cli_ci_version: 8c624e141844a19a6b2e21d5255f3ca6195c996d
+  check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  upgrade_cilium_from_vsn: 1.13.4
+  upgrade_cilium_to_vsn: 1.14.0-rc.1 # empty means upgrade to CI build
+
+jobs:
+  commit-status-start:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  setup-and-test:
+    runs-on: ubuntu-latest-4cores-16gb
+    name: 'Setup & Test'
+    env:
+      job_name: 'Setup & Test'
+    strategy:
+      fail-fast: false
+      max-parallel: 16
+      matrix:
+        include:
+          - name: '1'
+            kernel: '5.4-20230420.212204'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            debug: 'true'
+            test-flow-interrupts: 'true'
+            ipv6: 'false' # until https://github.com/cilium/cilium/issues/26944 resolved
+
+          - name: '2'
+            kernel: '5.10-20230420.212204'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            endpoint-routes: 'true'
+            test-flow-interrupts: 'true'
+            ipv6: 'false' # until https://github.com/cilium/cilium/issues/26944 resolved
+
+          - name: '3'
+            kernel: 'bpf-next-20230420.212204'
+            kube-proxy: 'iptables'
+            kpr: 'disabled'
+            tunnel: 'vxlan'
+            encryption: 'ipsec'
+            encryption-node: 'false'
+            endpoint-routes: 'true'
+            test-flow-interrupts: 'true'
+            ipv6: 'false' # until https://github.com/cilium/cilium/issues/26944 resolved
+
+    timeout-minutes: 60
+    steps:
+      - name: Checkout context ref
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Set up job variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SHA="${{ inputs.SHA }}"
+          else
+            SHA="${{ github.sha }}"
+          fi
+
+          # TODO(brb) move the settings derivation into a reusable GH workflow
+          CILIUM_MAIN_IMAGE_SETTINGS="--chart-directory=./install/kubernetes/cilium \
+            --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+            --helm-set=image.useDigest=false \
+            --helm-set=image.tag=${SHA} \
+            --helm-set=debug.enabled=true \
+            --helm-set=debug.verbose=envoy \
+            --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+            --helm-set=operator.image.suffix=-ci \
+            --helm-set=operator.image.tag=${SHA} \
+            --helm-set=operator.image.useDigest=false \
+            --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
+            --helm-set=hubble.relay.image.tag=${SHA}"
+          echo "cilium_main_image_settings=${CILIUM_MAIN_IMAGE_SETTINGS}" >> $GITHUB_OUTPUT
+
+          CILIUM_INSTALL_DEFAULTS="--wait \
+            --helm-set=debug.enabled=true \
+            --helm-set=cni.uninstall=false \
+            --helm-set=cluster.name=default \
+            --helm-set=hubble.eventBufferCapacity=65535 \
+            --helm-set=bpf.monitorAggregation=none \
+            --nodes-without-cilium=kind-worker3 \
+            --helm-set=bpfClockSource=false \
+            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
+
+          TUNNEL="--helm-set-string=tunnelProtocol=${{ matrix.tunnel }}"
+          if [ "${{ matrix.tunnel }}" == "disabled" ]; then
+            TUNNEL="--helm-set-string=routingMode=native --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16 --helm-set-string=tunnel=disabled"
+            TUNNEL="${TUNNEL} --helm-set-string=ipv6NativeRoutingCIDR=fd00:10:244::/56"
+          fi
+          LB_MODE=""
+          if [ "${{ matrix.lb-mode }}" != "" ]; then
+            LB_MODE="--helm-set-string=loadBalancer.mode=${{ matrix.lb-mode }}"
+          fi
+          ENDPOINT_ROUTES=""
+          if [ "${{ matrix.endpoint-routes }}" == "true" ]; then
+            ENDPOINT_ROUTES="--helm-set-string=endpointRoutes.enabled=true"
+          fi
+          IPV6=""
+          if [ "${{ matrix.ipv6 }}" != "false" ]; then
+            IPV6="--helm-set=ipv6.enabled=true"
+          fi
+          MASQ=""
+          if [ "${{ matrix.kpr }}" == "true" ] || [ "${{ matrix.kpr }}" == "strict" ]; then
+            # BPF-masq requires KPR=true.
+            MASQ="--helm-set=bpf.masquerade=true"
+            if [ "${{ matrix.host-fw }}" == "true" ]; then
+              # BPF IPv6 masquerade not currently supported with host firewall - GH-26074
+              MASQ="${MASQ} --helm-set=enableIPv6Masquerade=false"
+            fi
+          fi
+          EGRESS_GATEWAY=""
+          if [ "${{ matrix.egress-gateway }}" == "true" ]; then
+            EGRESS_GATEWAY="--helm-set=egressGateway.enabled=true"
+          fi
+          LB_ACCELERATION=""
+          if [ "${{ matrix.lb-acceleration }}" != "" ]; then
+            LB_ACCELERATION="--helm-set=loadBalancer.acceleration=${{ matrix.lb-acceleration }}"
+          fi
+
+          ENCRYPT=""
+          if [ "${{ matrix.encryption }}" != "" ]; then
+            ENCRYPT="--helm-set=encryption.enabled=true --helm-set=encryption.type=${{ matrix.encryption }}"
+            if [ "${{ matrix.encryption-node }}" != "" ]; then
+              ENCRYPT+=" --helm-set=encryption.nodeEncryption=${{ matrix.encryption-node }}"
+            fi
+          fi
+
+          HOST_FW=""
+          if [ "${{ matrix.host-fw }}" == "true" ]; then
+            HOST_FW="--helm-set=hostFirewall.enabled=true"
+          fi
+
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
+          echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
+          
+          # TODO(brb) Create function to derive EXTRAS_V1{3,2,1}
+          EXTRAS_V13=""
+          if [ "${{ matrix.encryption }}" == "wireguard" ]; then
+            EXTRAS_V13=" --helm-set=l7Proxy=false"
+          fi
+          if [ "${{ matrix.kpr }}" == "strict" ] || [ "${{ matrix.kpr }}" == "true" ]; then
+            # BPF IPv6 masquerade is not supported in < v1.14
+            EXTRAS_V13+=" --helm-set=enableIPv6Masquerade=false"
+          fi
+          echo "cilium_extras_v13=${EXTRAS_V13}" >> $GITHUB_OUTPUT
+
+          JUNIT=""
+          for NAME in ${{ matrix.kube-proxy }} ${{ matrix.tunnel }} ${{ matrix.lb-mode }} ${{ matrix.encryption }} ${{ matrix.endpoint-routes }}; do
+            if [[ "${NAME}" != "" ]] && [[ "${NAME}" != "disabled" ]] && [[ "${NAME}" != "none" ]]; then
+              if [[ "${JUNIT}" != "" ]]; then
+                JUNIT+="-"
+              fi
+              if [[ "${NAME}" == "true" ]];then
+                NAME="endpoint-routes"
+              fi
+              JUNIT+="${NAME}"
+            fi
+          done
+          echo junit_type="${JUNIT}" >> $GITHUB_OUTPUT
+          echo sha=${SHA} >> $GITHUB_OUTPUT
+
+      - name: Checkout pull request for Helm chart
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: ${{ steps.vars.outputs.sha }}
+          persist-credentials: false
+
+      - name: Install Cilium CLI-cli
+        uses: cilium/cilium-cli@829ae9b4d2c65104343051ad77b618b92a2c2b75 # v0.15.3
+        with:
+          release-version: ${{ env.cilium_cli_version }}
+          ci-version: ${{ env.cilium_cli_ci_version }}
+          binary-name: cilium-cli
+          binary-dir: ./
+
+      - name: Provision LVH VMs
+        uses: cilium/little-vm-helper@6a3d1797af8fab1a49f1c3d09afe3230aea559b6 # v0.0.11
+        with:
+          test-name: ipsec-upgrade
+          image-version: ${{ matrix.kernel }}
+          host-mount: ./
+          cpu: 4
+          mem: '12G'
+          dns-resolver: '1.1.1.1'
+          install-dependencies: 'true'
+          cmd: |
+            git config --global --add safe.directory /host
+
+      - name: Wait for images to be available
+        if:  ${{ env.upgrade_cilium_to_vsn == '' }}
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+          done
+
+      - name: Setup K8s cluster (${{ matrix.name }})
+        uses: cilium/little-vm-helper@6a3d1797af8fab1a49f1c3d09afe3230aea559b6 # v0.0.11
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/
+
+            IP_FAM="dual"
+            if [ "${{ matrix.ipv6 }}" == "false" ]; then
+              IP_FAM="ipv4"
+            fi
+            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
+
+            kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
+            kubectl create -n kube-system secret generic cilium-ipsec-keys \
+                --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
+
+            mkdir -p cilium-junits
+
+      - name: Install Cilium ${{ env.upgrade_cilium_from_vsn }} (${{ matrix.name }})
+        uses: cilium/little-vm-helper@6a3d1797af8fab1a49f1c3d09afe3230aea559b6 # v0.0.11
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/
+
+            CILIUM_CLI_MODE=helm ./cilium-cli install \
+              --version ${{ env.upgrade_cilium_from_vsn }} \
+              ${{ steps.vars.outputs.cilium_install_defaults }} \
+              ${{ steps.vars.outputs.cilium_extras_v13 }}
+
+            ./cilium-cli status --wait
+            kubectl get pods --all-namespaces -o wide
+            kubectl -n kube-system exec daemonset/cilium -- cilium status
+
+      - name: Test Cilium ${{ env.upgrade_cilium_from_vsn }} (${{ matrix.name }})
+        uses: cilium/little-vm-helper@6a3d1797af8fab1a49f1c3d09afe3230aea559b6 # v0.0.11
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/
+
+            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+              --flush-ct \
+              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+              --junit-property github_job_step="Run tests upgrade 1 (${{ join(matrix.*, ', ') }})"
+
+            # Create pods which establish long lived connections. It will be used by
+            # subsequent connectivity tests with --include-conn-disrupt-test to catch any
+            # interruption in such flows.
+            ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
+
+      - name: Upgrade Cilium ${{ env.upgrade_cilium_to_vsn }} (${{ matrix.name }})
+        uses: cilium/little-vm-helper@6a3d1797af8fab1a49f1c3d09afe3230aea559b6 # v0.0.11
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/
+
+            if [ -z "${{ env.upgrade_cilium_to_vsn }}" ]; then
+              CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
+                ${{ steps.vars.outputs.cilium_main_image_settings }} \
+                ${{ steps.vars.outputs.cilium_install_defaults }}
+            else
+              CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
+                --version ${{ env.upgrade_cilium_to_vsn }} \
+                ${{ steps.vars.outputs.cilium_install_defaults }}
+            fi
+
+            ./cilium-cli status --wait
+            kubectl get pods --all-namespaces -o wide
+            kubectl -n kube-system exec daemonset/cilium -- cilium status
+
+      - name: Test Cilium after upgrade to ${{ env.upgrade_cilium_to_vsn }} (${{ matrix.name }})
+        uses: cilium/little-vm-helper@6a3d1797af8fab1a49f1c3d09afe3230aea559b6 # v0.0.11
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/
+
+            # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
+            # Disable check-log-errors due to https://github.com/cilium/cilium-cli/issues/1858
+            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+              --include-conn-disrupt-test \
+              --test '!no-missed-tail-calls,!check-log-errors' \
+              --flush-ct \
+              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+              --junit-property github_job_step="Run tests upgrade 2 (${{ join(matrix.*, ', ') }})"
+
+            # --flush-ct interrupts the flows, so we need to set up again.
+            ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
+
+      - name: Downgrade Cilium ${{ env.upgrade_cilium_from_vsn }} (${{ matrix.name }})
+        uses: cilium/little-vm-helper@6a3d1797af8fab1a49f1c3d09afe3230aea559b6 # v0.0.11
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/
+
+            CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
+              --version ${{ env.upgrade_cilium_from_vsn }} \
+              ${{ steps.vars.outputs.cilium_install_defaults }} \
+              ${{ steps.vars.outputs.cilium_extras_v13 }}
+
+            ./cilium-cli status --wait
+            kubectl get pods --all-namespaces -o wide
+            kubectl -n kube-system exec daemonset/cilium -- cilium status
+
+      - name: Test Cilium after downgrade to ${{ env.upgrade_cilium_from_vsn }} (${{ matrix.name }})
+        uses: cilium/little-vm-helper@6a3d1797af8fab1a49f1c3d09afe3230aea559b6 # v0.0.11
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/
+
+            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+              --include-conn-disrupt-test \
+              --test '!no-missed-tail-calls,!check-log-errors' \
+              --flush-ct \
+              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
+              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
+              --junit-property github_job_step="Run tests upgrade 3 (${{ join(matrix.*, ', ') }})"
+
+      - name: Fetch artifacts
+        if: ${{ !success() }}
+        uses: cilium/little-vm-helper@6a3d1797af8fab1a49f1c3d09afe3230aea559b6 # v0.0.11
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host
+            kubectl get pods --all-namespaces -o wide
+            ./cilium-cli status
+            mkdir -p cilium-sysdumps
+            ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+            # To debug https://github.com/cilium/cilium/issues/26062
+            head -n -0 /proc/buddyinfo /proc/pagetypeinfo
+
+      - name: Upload artifacts
+        if: ${{ !success() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-sysdumps
+          path: cilium-sysdump-*.zip
+          retention-days: 5
+
+      - name: Upload JUnits [junit]
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: cilium-junits
+          path: cilium-junits/*.xml
+          retention-days: 2
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
+
+  commit-status-final:
+    if: ${{ always() }}
+    needs: setup-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+          status: ${{ needs.setup-and-test.result }}


### PR DESCRIPTION
This commit adds an option IPsec e2e upgrade test. The test does the following:

* Install the latest stable release version of Cilium.
* Run the CLI's connectivity tests.
* Upgrade Cilium to a PR version.
* Run the CLI's connectivity tests.
* Downgrade to the previous version.
* Run the CLI's connectivity tests.

After each connectivity test case we flush CT to avoid the interference \[1\]\[2\] after running L7 proxy tests.

The test runs pods which established long-lived connections.
The test checks whether they are not interupted during upgrade /
downgrade.

\[1\]: https://github.com/cilium/cilium-cli/issues/367
\[2\]: https://github.com/cilium/cilium/issues/17459