### PR TITLE
ipsec: reject validation of empty keys

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -803,9 +803,7 @@ func LoadIPSecKeys(r io.Reader) (int, uint8, error) {
 		if err != nil {
 			// If no version info is provided assume using key format without
 			// versioning and assign SPI.
-			log.Warning("IPsec secrets without an SPI as the first argument are deprecated and will be unsupported in v1.13.")
-			spiI = 1
-			offsetBase = -1
+			return 0, 0, fmt.Errorf("ipsec secrets must have an SPI as first argument")
 		}
 		if spiI > linux_defaults.IPsecMaxKeyVersion {
 			return 0, 0, fmt.Errorf("encryption key space exhausted. ID must be nonzero and less than %d. Attempted %q", linux_defaults.IPsecMaxKeyVersion+1, s[offsetSPI])

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -34,6 +34,7 @@ var (
 	keysDat        = []byte("1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef\n1 hmac(sha256) 0123456789abcdef0123456789abcdef cbc(aes) 0123456789abcdef0123456789abcdef foobar\n1 digest_null \"\" cipher_null \"\"\n")
 	keysAeadDat    = []byte("6 rfc4106(gcm(aes)) 44434241343332312423222114131211f4f3f2f1 128\n")
 	invalidKeysDat = []byte("1 test abcdefghijklmnopqrstuvwzyzABCDEF test abcdefghijklmnopqrstuvwzyzABCDEF\n")
+	noKey          = []byte("6 rfc4106(gcm(aes)) 128\n")
 )
 
 func (p *IPSecSuitePrivileged) SetUpTest(c *C) {
@@ -48,6 +49,12 @@ func (p *IPSecSuitePrivileged) TearDownTest(c *C) {
 func (p *IPSecSuitePrivileged) TestLoadKeysNoFile(c *C) {
 	_, _, err := LoadIPSecKeysFile(path)
 	c.Assert(os.IsNotExist(err), Equals, true)
+}
+
+func (p *IPSecSuitePrivileged) TestEmptyKey(c *C) {
+	keys := bytes.NewReader(noKey)
+	_, _, err := loadIPSecKeys(keys)
+	c.Assert(err, NotNil)
 }
 
 func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {


### PR DESCRIPTION
Previously, a ipsec xfrm config missing a key would pass validation and be inserted into node configuration.

This would go on to silently fail down the line with EINVAL when node managers: linux datapath handler attempted to create xfrm state with this key.  

This checks if the key is empty upon validation, and causes Cilium to terminate if the key is not valid.

As well, this removes the deprecated functionality of allowing keys without the spi as the first parameter validation.

Finally, when watching for key changes if that functionality is enabled, keys being rejected due to validation errors will be logged.