### PR TITLE
ingress: Delay secret sync if not available

### DIFF
--- a/operator/pkg/ingress/secret.go
+++ b/operator/pkg/ingress/secret.go
@@ -248,14 +248,16 @@ func (sm *syncSecretManager) handleIngressUpsertedEvent(ingress *slim_networking
 		if err != nil {
 			return err
 		}
-		if !exists {
-			return fmt.Errorf("secret does not exist: %s", key)
-		}
 
 		sm.lock.Lock()
-		sm.watchedSecretMap[key] = getSyncedSecretKey(sm.namespace, secret.GetNamespace(), secret.GetName())
+		sm.watchedSecretMap[key] = getSyncedSecretKey(sm.namespace, ingress.GetNamespace(), tls.SecretName)
 		sm.lock.Unlock()
 
+		// the secret might be created after Ingress object, just skip it for now.
+		// The sync will be handled as part of Secret creation later.
+		if !exists {
+			return nil
+		}
 		// proceed to sync secret
 		err = sm.syncSecret(secret)
 		if err != nil {


### PR DESCRIPTION
Currently, if the TLS secret is not available by the time the Ingress object is created, the creation event will be filtered out based on in-memory list of watched secrets. This commit is to make sure that we still add secret name to watch list, so that creation event will trigger the sync accordingly.

Testing is done as per below:

```
$ curl -k -v https://bookinfo.cilium.rocks/details/1
*   Trying 10.104.207.106:443...
* Connected to bookinfo.cilium.rocks (10.104.207.106) port 443 (#0)
* ALPN: offers h2,http/1.1
* TLSv1.3 (OUT), TLS handshake, Client hello (1):
* Recv failure: Connection reset by peer
* OpenSSL SSL_connect: Connection reset by peer in connection to bookinfo.cilium.rocks:443
* Closing connection 0
curl: (35) Recv failure: Connection reset by peer
$ kubectl create secret tls demo-cert --key=_.cilium.rocks/key.pem --cert=_.cilium.rocks/cert.pem
secret/demo-cert created
$ curl -k https://bookinfo.cilium.rocks/details/1
{"id":1,"author":"William Shakespeare","year":1595,"type":"paperback","pages":200,"publisher":"PublisherA","language":"English","ISBN-10":"1234567890","ISBN-13":"123-1234567890"}
```
