### PR TITLE
Refactor hubble redact settings schema

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -187,7 +187,9 @@ cilium-agent [flags]
       --hubble-prefer-ipv6                                        Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-recorder-sink-queue-size int                       Queue size of each Hubble recorder sink (default 1024)
       --hubble-recorder-storage-path string                       Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")
-      --hubble-redact strings                                     List of Hubble redact options
+      --hubble-redact                                             Hubble redact sensitive information from flows
+      --hubble-redact-http-urlquery                               Hubble redact http URL query from flows
+      --hubble-redact-kafka-apikey                                Hubble redact Kafka API key from flows
       --hubble-skip-unknown-cgroup-ids                            Skip Hubble events with unknown cgroup ids (default true)
       --hubble-socket-path string                                 Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
       --hubble-tls-cert-file string                               Path to the public key file for the Hubble server. The file must contain PEM encoded data.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1425,9 +1425,9 @@
      - bool
      - ``false``
    * - :spelling:ignore:`hubble.redact`
-     - Configures the list of redact options for Hubble. Example:    redact:   - http-url-query   - kafka-api-key  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query,kafka-api-key}"
-     - string
-     - ``nil``
+     - Configures the redact options for Hubble. Example:    redact:     enabled: true     http:       urlQuery: true     kafka:       apiKey: false  You can specify the options from the helm CLI:    --set hubble.redact="true"   --set hubble.redact.http.urlQuery="true"   --set hubble.redact.kafka.apiKey="false"
+     - object
+     - ``{"enabled":false,"http":{"urlQuery":false},"kafka":{"apiKey":false}}``
    * - :spelling:ignore:`hubble.relay.affinity`
      - Affinity for hubble-replay
      - object

--- a/Documentation/observability/visibility.rst
+++ b/Documentation/observability/visibility.rst
@@ -79,12 +79,11 @@ parameters, API keys, and others.
    present in `Layer 7 Hubble Flows <https://github.com/cilium/cilium/tree/master/api/v1/flow#flow-Layer7>`_.
 
 To harden security, Cilium provides the ``--hubble-redact`` option which
-accepts a comma-separated list of values that control how Hubble handles
-sensitive information present in Layer 7 flows. More specifically, it offers
-the following features and values for supported Layer 7 protocols:
+enables Hubble to handle sensitive information present in Layer 7 flows.
+More specifically, it offers the following features for supported Layer 7 protocols:
 
-* For HTTP: redacting URL query (GET) parameters (``--hubble-redact=http-url-query``)
-* For Kafka: redacting API key (``--hubble-redact=kafka-api-key``)
+* For HTTP: redacting URL query (GET) parameters (``--hubble-redact-http-urlquery``)
+* For Kafka: redacting API key (``--hubble-redact-kafka-apikey``)
 
 For more information on configuring Cilium, see :ref:`Cilium Configuration <configuration>`.
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -128,6 +128,7 @@ allowedConfigOverrides
 amd
 ansible
 api
+apiKey
 apiKeys
 apiserver
 arithmetics
@@ -674,6 +675,7 @@ uprobes
 uptime
 uretprobes
 url
+urlQuery
 userspace
 uuid
 vCPU

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -977,8 +977,14 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	)
 	option.BindEnv(vp, option.HubbleMonitorEvents)
 
-	flags.StringSlice(option.HubbleRedact, []string{}, "List of Hubble redact options")
+	flags.Bool(option.HubbleRedact, defaults.HubbleRedact, "Hubble redact sensitive information from flows")
 	option.BindEnv(vp, option.HubbleRedact)
+
+	flags.Bool(option.HubbleRedactHttpURLQuery, defaults.HubbleRedactHttpURLQuery, "Hubble redact http URL query from flows")
+	option.BindEnv(vp, option.HubbleRedactHttpURLQuery)
+
+	flags.Bool(option.HubbleRedactKafkaApiKey, defaults.HubbleRedactKafkaApiKey, "Hubble redact Kafka API key from flows")
+	option.BindEnv(vp, option.HubbleRedactKafkaApiKey)
 
 	flags.StringSlice(option.DisableIptablesFeederRules, []string{}, "Chains to ignore when installing feeder rules.")
 	option.BindEnv(vp, option.DisableIptablesFeederRules)

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -139,8 +139,15 @@ func (d *Daemon) launchHubble() {
 		)
 	}
 
-	if len(option.Config.HubbleRedact) > 0 {
-		parserOpts = append(parserOpts, parserOptions.Redact(logger, option.Config.HubbleRedact))
+	if option.Config.HubbleRedact {
+		parserOpts = append(
+			parserOpts,
+			parserOptions.Redact(
+				logger,
+				option.Config.HubbleRedactHttpURLQuery,
+				option.Config.HubbleRedactKafkaApiKey,
+			),
+		)
 	}
 
 	d.linkCache = link.NewLinkCache()

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -406,7 +406,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service, must match the hubble.listenAddress' port. |
 | hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. |
-| hubble.redact | string | `nil` | Configures the list of redact options for Hubble. Example:    redact:   - http-url-query   - kafka-api-key  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query,kafka-api-key}"  |
+| hubble.redact | object | `{"enabled":false,"http":{"urlQuery":false},"kafka":{"apiKey":false}}` | Configures the redact options for Hubble. Example:    redact:     enabled: true     http:       urlQuery: true     kafka:       apiKey: false  You can specify the options from the helm CLI:    --set hubble.redact="true"   --set hubble.redact.http.urlQuery="true"   --set hubble.redact.kafka.apiKey="false"  |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -853,9 +853,17 @@ data:
   enable-hubble-open-metrics: {{ .Values.hubble.metrics.enableOpenMetrics | quote }}
 {{- end }}
 {{- if .Values.hubble.redact }}
-  # A space separated list of redact options for Hubble.
-  hubble-redact: {{- range .Values.hubble.redact }}
-    {{.}}
+{{- if eq .Values.hubble.redact.enabled true }}
+  # Enables hubble redact capabilities
+  hubble-redact: "true"
+{{- if .Values.hubble.redact.http }}
+  # Enables redaction of the http URL query part in flows
+  hubble-redact-http-urlquery: {{ .Values.hubble.redact.http.urlQuery | quote }}
+{{- end }}
+{{- if .Values.hubble.redact.kafka }}
+  # Enables redaction of the Kafka API key part in flows
+  hubble-redact-kafka-apikey: {{ .Values.hubble.redact.kafka.apiKey | quote }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if hasKey .Values.hubble "listenAddress" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1037,18 +1037,28 @@ hubble:
   # -- Unix domain socket path to listen to when Hubble is enabled.
   socketPath: /var/run/cilium/hubble.sock
 
-  # -- Configures the list of redact options for Hubble.
+  # -- Configures the redact options for Hubble.
   # Example:
   #
   #   redact:
-  #   - http-url-query
-  #   - kafka-api-key
+  #     enabled: true
+  #     http:
+  #       urlQuery: true
+  #     kafka:
+  #       apiKey: false
   #
-  # You can specify the list of options from the helm CLI:
+  # You can specify the options from the helm CLI:
   #
-  #   --set hubble.redact="{http-url-query,kafka-api-key}"
+  #   --set hubble.redact="true"
+  #   --set hubble.redact.http.urlQuery="true"
+  #   --set hubble.redact.kafka.apiKey="false"
   #
-  redact: ~
+  redact:
+    enabled: false
+    http:
+        urlQuery: false
+    kafka:
+        apiKey: false
 
   # -- An additional address for Hubble to listen to.
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1034,18 +1034,28 @@ hubble:
   # -- Unix domain socket path to listen to when Hubble is enabled.
   socketPath: /var/run/cilium/hubble.sock
 
-  # -- Configures the list of redact options for Hubble.
+  # -- Configures the redact options for Hubble.
   # Example:
   #
   #   redact:
-  #   - http-url-query
-  #   - kafka-api-key
+  #     enabled: true
+  #     http:
+  #       urlQuery: true
+  #     kafka:
+  #       apiKey: false
   #
-  # You can specify the list of options from the helm CLI:
+  # You can specify the options from the helm CLI:
   #
-  #   --set hubble.redact="{http-url-query,kafka-api-key}"
+  #   --set hubble.redact="true"
+  #   --set hubble.redact.http.urlQuery="true"
+  #   --set hubble.redact.kafka.apiKey="false"
   #
-  redact: ~
+  redact:
+    enabled: false
+    http:
+        urlQuery: false
+    kafka:
+        apiKey: false
 
   # -- An additional address for Hubble to listen to.
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -86,6 +86,15 @@ const (
 	// HubbleRecorderSinkQueueSize is the queue size for each recorder sink
 	HubbleRecorderSinkQueueSize = 1024
 
+	// HubbleRedact controls if sensitive information will be redacted from L7 flows
+	HubbleRedact = false
+
+	// HubbleRedactHttpURLQuery controls if the URL query will be redacted from flows
+	HubbleRedactHttpURLQuery = false
+
+	// HubbleRedactKafkaApiKey controls if the Kafka API key will be redacted from flows
+	HubbleRedactKafkaApiKey = false
+
 	// MonitorSockPath1_2 is the path to the UNIX domain socket used to
 	// distribute BPF and agent events to listeners.
 	// This is the 1.2 protocol version.

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -4,12 +4,9 @@
 package options
 
 import (
-	"github.com/sirupsen/logrus"
-)
+	"fmt"
 
-const (
-	HttpUrlQuery = "http-url-query"
-	KafkaApiKey  = "kafka-api-key"
+	"github.com/sirupsen/logrus"
 )
 
 // Option is used to configure parsers
@@ -30,25 +27,14 @@ func CacheSize(size int) Option {
 }
 
 // Redact configures which data Hubble will redact.
-func Redact(logger logrus.FieldLogger, hubbleRedactOptions []string) Option {
+func Redact(logger logrus.FieldLogger, httpQuery bool, kafkaApiKey bool) Option {
 	return func(opt *Options) {
-		validOpts := []string{}
-		for _, option := range hubbleRedactOptions {
-			switch option {
-			case HttpUrlQuery:
-				opt.RedactHTTPQuery = true
-			case KafkaApiKey:
-				opt.RedactKafkaAPIKey = true
-			default:
-				if logger != nil {
-					logger.WithField("option", option).Warn("ignoring unknown Hubble redact option")
-				}
-				continue
-			}
-			validOpts = append(validOpts, option)
-		}
+		opt.RedactHTTPQuery = httpQuery
+		opt.RedactKafkaAPIKey = kafkaApiKey
 		if logger != nil {
-			logger.WithField("options", validOpts).Info("configured Hubble with redact options")
+			logger.WithField(
+				"options",
+				fmt.Sprintf("%+v", opt)).Info("configured Hubble with redact options")
 		}
 	}
 }

--- a/pkg/hubble/parser/seven/http_test.go
+++ b/pkg/hubble/parser/seven/http_test.go
@@ -170,7 +170,7 @@ func TestDecodeL7HTTPRequestRemoveUrlQuery(t *testing.T) {
 	lr.SourceEndpoint.Port = 56789
 	lr.DestinationEndpoint.Port = 80
 
-	opts := []options.Option{options.Redact(nil, []string{"http-url-query"})}
+	opts := []options.Option{options.Redact(nil, true, false)}
 	parser, err := New(log, nil, nil, nil, nil, opts...)
 	require.NoError(t, err)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1017,9 +1017,14 @@ const (
 	// By default, Hubble observes all monitor events.
 	HubbleMonitorEvents = "hubble-monitor-events"
 
-	// HubbleRedact controls which values Hubble will redact in network flows.
-	// By default, Hubble does not redact any values.
+	// HubbleRedact controls if sensitive information will be redacted from L7 flows
 	HubbleRedact = "hubble-redact"
+
+	// HubbleRedactHttpURLQuery controls if the URL query will be redacted from flows
+	HubbleRedactHttpURLQuery = "hubble-redact-http-urlquery"
+
+	// HubbleRedactKafkaApiKey controls if the Kafka API key will be redacted from flows
+	HubbleRedactKafkaApiKey = "hubble-redact-kafka-apikey"
 
 	// DisableIptablesFeederRules specifies which chains will be excluded
 	// when installing the feeder rules
@@ -2239,9 +2244,14 @@ type DaemonConfig struct {
 	// By default, Hubble observes all monitor events.
 	HubbleMonitorEvents []string
 
-	// HubbleRedact controls which values Hubble will redact in network flows.
-	// By default, Hubble does not redact any values.
-	HubbleRedact []string
+	// HubbleRedact controls if Hubble will be redacting sensitive information from L7 flows
+	HubbleRedact bool
+
+	// HubbleRedactURLQuery controls if the URL query will be redacted from flows
+	HubbleRedactHttpURLQuery bool
+
+	// HubbleRedactKafkaApiKey controls if Kafka API key will be redacted from flows
+	HubbleRedactKafkaApiKey bool
 
 	// EndpointStatus enables population of information in the
 	// CiliumEndpoint.Status resource
@@ -3477,7 +3487,9 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.HubbleRecorderSinkQueueSize = vp.GetInt(HubbleRecorderSinkQueueSize)
 	c.HubbleSkipUnknownCGroupIDs = vp.GetBool(HubbleSkipUnknownCGroupIDs)
 	c.HubbleMonitorEvents = vp.GetStringSlice(HubbleMonitorEvents)
-	c.HubbleRedact = vp.GetStringSlice(HubbleRedact)
+	c.HubbleRedact = vp.GetBool(HubbleRedact)
+	c.HubbleRedactHttpURLQuery = vp.GetBool(HubbleRedactHttpURLQuery)
+	c.HubbleRedactKafkaApiKey = vp.GetBool(HubbleRedactKafkaApiKey)
 
 	c.DisableIptablesFeederRules = vp.GetStringSlice(DisableIptablesFeederRules)
 


### PR DESCRIPTION
This PR implements the refactoring of the `--hubble-redact` option in order to provide more flexibility as per https://github.com/cilium/cilium/issues/23887#issuecomment-1633015416.

Specifically we change 

```yml
hubble:
 redact:
  - http-url-query
  - kafka-api-key
```

to 

```yml
hubble:
  redact:
    enabled: true
    http:
      urlQuery: true
    kafka:
      apiKey: true
```

and 

```console
--hubble-redact=http-url-query,kafka-api-key
```

to

```console
--hubble-redact=true
--hubble-redact-http-url-query=true
--hubble-redact-kafka-api-key=true
```

With this change we aim to support the option for user provided http-headers list.

This will look like the following (as per https://github.com/cilium/cilium/issues/23887#issuecomment-1632167762):

```yml
hubble:
  redact:
    enabled: false
    http:
      userInfo: true
      urlQuery: true
      headers:
        allow:
          - traceparent
          - tracestate
          - Cache-Control
          - ...
    kafka:
      apiKey: true
```

cc: @ioandr 