### PR TITLE
egressgw: use route.Upsert() for inserting nexthop / prefix IP route

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -668,7 +668,7 @@ func (manager *Manager) addMissingIpRulesAndRoutes(isRetry bool) (shouldRetry bo
 
 		policyConfig.forEachEndpointAndDestination(addIPRulesForConfig)
 
-		if err := addEgressIpRoutes(gwc.egressIP, gwc.ifaceIndex); err != nil {
+		if err := addEgressIpRoutes(gwc); err != nil {
 			logger.WithError(err).Warn("Can't add IP routes")
 		} else {
 			logger.Debug("Added IP routes")

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -628,6 +628,12 @@ func (manager *Manager) addMissingIpRulesAndRoutes(isRetry bool) (shouldRetry bo
 			logfields.LinkIndex: gwc.ifaceIndex,
 		})
 
+		if err := addEgressIpRoutes(gwc); err != nil {
+			logger.WithError(err).Warn("Can't add IP routes")
+		} else {
+			logger.Debug("Added IP routes")
+		}
+
 		routingTableIdx := egressGatewayRoutingTableIdx(gwc.ifaceIndex)
 
 		ipRules, err := listEgressIpRulesForRoutingTable(routingTableIdx)
@@ -667,12 +673,6 @@ func (manager *Manager) addMissingIpRulesAndRoutes(isRetry bool) (shouldRetry bo
 		}
 
 		policyConfig.forEachEndpointAndDestination(addIPRulesForConfig)
-
-		if err := addEgressIpRoutes(gwc); err != nil {
-			logger.WithError(err).Warn("Can't add IP routes")
-		} else {
-			logger.Debug("Added IP routes")
-		}
 	}
 
 	return


### PR DESCRIPTION
Upsert() handles the installation of the relevant nexthop route internally, and rolls it back if the prefix route fails.

It also contains a workaround for an issue in the kernel, when the nexthop route is not available immediately.