### PR TITLE
bgpv1: pass agent.ControlPlaneState within types.ServerParameters

### DIFF
--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 	apb "google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 )
 
@@ -53,7 +52,7 @@ type GoBGPServer struct {
 }
 
 // NewGoBGPServerWithConfig returns instance of go bgp router wrapper.
-func NewGoBGPServerWithConfig(ctx context.Context, log *logrus.Entry, params types.ServerParameters, _ *agent.ControlPlaneState) (types.Router, error) {
+func NewGoBGPServerWithConfig(ctx context.Context, log *logrus.Entry, params types.ServerParameters) (types.Router, error) {
 	logger := NewServerLogger(log.Logger, LogParams{
 		AS:        params.Global.ASN,
 		Component: "gobgp.BgpServerInstance",

--- a/pkg/bgpv1/gobgp/state_test.go
+++ b/pkg/bgpv1/gobgp/state_test.go
@@ -257,7 +257,7 @@ func TestGetPeerState(t *testing.T) {
 			},
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			testSC, err := NewGoBGPServerWithConfig(context.Background(), log, srvParams, &agent.ControlPlaneState{})
+			testSC, err := NewGoBGPServerWithConfig(context.Background(), log, srvParams)
 			require.NoError(t, err)
 
 			t.Cleanup(func() {
@@ -377,7 +377,8 @@ func TestGetRoutes(t *testing.T) {
 			RouterID:   "127.0.0.1",
 			ListenPort: -1,
 		},
-	}, &agent.ControlPlaneState{})
+		CState: &agent.ControlPlaneState{},
+	})
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/bgpv1/manager/instance.go
+++ b/pkg/bgpv1/manager/instance.go
@@ -6,7 +6,6 @@ package manager
 import (
 	"context"
 
-	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -46,8 +45,8 @@ type ServerWithConfig struct {
 //
 // Canceling the provided context will kill the BgpServer along with calling the
 // underlying BgpServer's Stop() method.
-func NewServerWithConfig(ctx context.Context, params types.ServerParameters, cstate *agent.ControlPlaneState) (*ServerWithConfig, error) {
-	s, err := gobgp.NewGoBGPServerWithConfig(ctx, log, params, cstate)
+func NewServerWithConfig(ctx context.Context, params types.ServerParameters) (*ServerWithConfig, error) {
+	s, err := gobgp.NewGoBGPServerWithConfig(ctx, log, params)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -224,9 +224,10 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context, c *v2alpha1api
 				AdvertiseInactiveRoutes: true,
 			},
 		},
+		CState: &agent.ControlPlaneState{},
 	}
 
-	if s, err = NewServerWithConfig(ctx, globalConfig, cstate); err != nil {
+	if s, err = NewServerWithConfig(ctx, globalConfig); err != nil {
 		return fmt.Errorf("failed to start BGP server for config with local ASN %v: %w", c.LocalASN, err)
 	}
 

--- a/pkg/bgpv1/manager/reconcile.go
+++ b/pkg/bgpv1/manager/reconcile.go
@@ -149,13 +149,14 @@ func preflightReconciler(
 				AdvertiseInactiveRoutes: true,
 			},
 		},
+		CState: cstate,
 	}
 
 	// stop the old BgpServer
 	sc.Server.Stop()
 
 	// create a new one via ServerWithConfig constructor
-	s, err := NewServerWithConfig(ctx, globalConfig, cstate)
+	s, err := NewServerWithConfig(ctx, globalConfig)
 	if err != nil {
 		l.WithError(err).Errorf("Failed to start BGP server for virtual router with local ASN %v", newc.LocalASN)
 		return fmt.Errorf("failed to start BGP server for virtual router with local ASN %v: %w", newc.LocalASN, err)

--- a/pkg/bgpv1/manager/reconcile_test.go
+++ b/pkg/bgpv1/manager/reconcile_test.go
@@ -104,8 +104,9 @@ func TestPreflightReconciler(t *testing.T) {
 					RouterID:   tt.routerID,
 					ListenPort: tt.localPort,
 				},
+				CState: &agent.ControlPlaneState{},
 			}
-			testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
+			testSC, err := NewServerWithConfig(context.Background(), srvParams)
 			if err != nil {
 				t.Fatalf("failed to create test BgpServer: %v", err)
 			}
@@ -312,8 +313,9 @@ func TestNeighborReconciler(t *testing.T) {
 					RouterID:   "127.0.0.1",
 					ListenPort: -1,
 				},
+				CState: &agent.ControlPlaneState{},
 			}
-			testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
+			testSC, err := NewServerWithConfig(context.Background(), srvParams)
 			if err != nil {
 				t.Fatalf("failed to create test BgpServer: %v", err)
 			}
@@ -463,13 +465,14 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 					RouterID:   "127.0.0.1",
 					ListenPort: -1,
 				},
+				CState: &agent.ControlPlaneState{},
 			}
 			oldc := &v2alpha1api.CiliumBGPVirtualRouter{
 				LocalASN:      64125,
 				ExportPodCIDR: pointer.Bool(tt.enabled),
 				Neighbors:     []v2alpha1api.CiliumBGPNeighbor{},
 			}
-			testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
+			testSC, err := NewServerWithConfig(context.Background(), srvParams)
 			if err != nil {
 				t.Fatalf("failed to create test bgp server: %v", err)
 			}
@@ -1050,13 +1053,14 @@ func TestLBServiceReconciler(t *testing.T) {
 					RouterID:   "127.0.0.1",
 					ListenPort: -1,
 				},
+				CState: &agent.ControlPlaneState{},
 			}
 			oldc := &v2alpha1api.CiliumBGPVirtualRouter{
 				LocalASN:        64125,
 				Neighbors:       []v2alpha1api.CiliumBGPNeighbor{},
 				ServiceSelector: tt.oldServiceSelector,
 			}
-			testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
+			testSC, err := NewServerWithConfig(context.Background(), srvParams)
 			if err != nil {
 				t.Fatalf("failed to create test bgp server: %v", err)
 			}
@@ -1197,9 +1201,10 @@ func TestReconcileAfterServerReinit(t *testing.T) {
 			RouterID:   "127.0.0.1",
 			ListenPort: -1,
 		},
+		CState: &agent.ControlPlaneState{},
 	}
 
-	testSC, err := NewServerWithConfig(context.Background(), srvParams, &agent.ControlPlaneState{})
+	testSC, err := NewServerWithConfig(context.Background(), srvParams)
 	require.NoError(t, err)
 
 	originalServer := testSC.Server

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -10,6 +10,7 @@ import (
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 )
 
@@ -81,6 +82,7 @@ type GetBGPResponse struct {
 // ServerParameters contains information for underlying bgp implementation layer to initializing BGP process.
 type ServerParameters struct {
 	Global BGPGlobal
+	CState *agent.ControlPlaneState
 }
 
 // Family holds Address Family Indicator (AFI) and Subsequent Address Family Indicator for Multi-Protocol BGP


### PR DESCRIPTION
This commit removes the unused ControlPlaneState argument from
`NewGoBGPServerWithConfig` and instead places it in the
`types.ServerParameters`.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>

```release-note
Refactors the use of ControlPlaneState in the BGP-CP
```
