### PR TITLE
v1.14 backports 2023-07-22

### DIFF
--- a/operator/pkg/ingress/secret.go
+++ b/operator/pkg/ingress/secret.go
@@ -248,14 +248,16 @@ func (sm *syncSecretManager) handleIngressUpsertedEvent(ingress *slim_networking
 		if err != nil {
 			return err
 		}
-		if !exists {
-			return fmt.Errorf("secret does not exist: %s", key)
-		}
 
 		sm.lock.Lock()
-		sm.watchedSecretMap[key] = getSyncedSecretKey(sm.namespace, secret.GetNamespace(), secret.GetName())
+		sm.watchedSecretMap[key] = getSyncedSecretKey(sm.namespace, ingress.GetNamespace(), tls.SecretName)
 		sm.lock.Unlock()
 
+		// the secret might be created after Ingress object, just skip it for now.
+		// The sync will be handled as part of Secret creation later.
+		if !exists {
+			return nil
+		}
 		// proceed to sync secret
 		err = sm.syncSecret(secret)
 		if err != nil {


### PR DESCRIPTION
- [x] #26988 -- ingress: Delay secret sync if not available (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 26988; do contrib/backporting/set-labels.py $pr done 1.14; done
```