### PR TITLE
[v1.14] Revert "Add support for --hubble-redact=http-url-query" 

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -184,7 +184,6 @@ cilium-agent [flags]
       --hubble-prefer-ipv6                                        Prefer IPv6 addresses for announcing nodes when both address types are available.
       --hubble-recorder-sink-queue-size int                       Queue size of each Hubble recorder sink (default 1024)
       --hubble-recorder-storage-path string                       Directory in which pcap files created via the Hubble Recorder API are stored (default "/var/run/cilium/pcaps")
-      --hubble-redact strings                                     List of Hubble redact options
       --hubble-skip-unknown-cgroup-ids                            Skip Hubble events with unknown cgroup ids (default true)
       --hubble-socket-path string                                 Set hubble's socket path to listen for connections (default "/var/run/cilium/hubble.sock")
       --hubble-tls-cert-file string                               Path to the public key file for the Hubble server. The file must contain PEM encoded data.

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1357,7 +1357,7 @@
      - bool
      - ``false``
    * - :spelling:ignore:`hubble.metrics.enabled`
-     - Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
+     - Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
      - string
      - ``nil``
    * - :spelling:ignore:`hubble.metrics.port`
@@ -1404,10 +1404,6 @@
      - Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available.
      - bool
      - ``false``
-   * - :spelling:ignore:`hubble.redact`
-     - Configures the list of redact options for Hubble. Example:    redact:   - http-url-query  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query}"
-     - string
-     - ``nil``
    * - :spelling:ignore:`hubble.relay.affinity`
      - Affinity for hubble-replay
      - object

--- a/Documentation/observability/visibility.rst
+++ b/Documentation/observability/visibility.rst
@@ -66,26 +66,6 @@ In order for Cilium to populate the ``INGRESS ENFORCEMENT``, ``EGRESS ENFORCEMEN
 and ``VISIBILITY POLICY`` fields, it must run with ``--endpoint-status=policy``
 to make field values visible.
 
-Security Implications
----------------------
-
-Monitoring Layer 7 traffic involves security considerations for handling
-potentially sensitive information, such as usernames, passwords, query
-parameters, API keys, and others.
-
-.. warning::
-
-   By default, Hubble does not redact potentially sensitive information
-   present in `Layer 7 Hubble Flows <https://github.com/cilium/cilium/tree/master/api/v1/flow#flow-Layer7>`_.
-
-To harden security, Cilium provides the ``--hubble-redact`` option to control
-how Hubble handles sensitive information present in Layer 7 flows. More
-specifically, it offers the following features for supported Layer 7 protocols:
-
-* For HTTP: redacting URL query (GET) parameters
-
-For more information on configuring Cilium, see :ref:`Cilium Configuration <configuration>`.
-
 Troubleshooting
 ---------------
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -557,7 +557,6 @@ hostonlyifs
 hostport
 hostscope
 hq
-http
 httpd
 https
 hubble

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -970,9 +970,6 @@ func initializeFlags() {
 	)
 	option.BindEnv(Vp, option.HubbleMonitorEvents)
 
-	flags.StringSlice(option.HubbleRedact, []string{}, "List of Hubble redact options")
-	option.BindEnv(Vp, option.HubbleRedact)
-
 	flags.StringSlice(option.DisableIptablesFeederRules, []string{}, "Chains to ignore when installing feeder rules.")
 	option.BindEnv(Vp, option.DisableIptablesFeederRules)
 

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/observer"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/hubble/parser"
-	parserOptions "github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/hubble/peer"
 	"github.com/cilium/cilium/pkg/hubble/peer/serviceoption"
 	"github.com/cilium/cilium/pkg/hubble/recorder"
@@ -98,7 +97,6 @@ func (d *Daemon) launchHubble() {
 	var (
 		observerOpts []observeroption.Option
 		localSrvOpts []serveroption.Option
-		parserOpts   []parserOptions.Option
 	)
 
 	if len(option.Config.HubbleMonitorEvents) > 0 {
@@ -139,12 +137,8 @@ func (d *Daemon) launchHubble() {
 		)
 	}
 
-	if len(option.Config.HubbleRedact) > 0 {
-		parserOpts = append(parserOpts, parserOptions.Redact(logger, option.Config.HubbleRedact))
-	}
-
 	d.linkCache = link.NewLinkCache()
-	payloadParser, err := parser.New(logger, d, d, d, d, d, d.linkCache, d.cgroupManager, parserOpts...)
+	payloadParser, err := parser.New(logger, d, d, d, d, d, d.linkCache, d.cgroupManager)
 	if err != nil {
 		logger.WithError(err).Error("Failed to initialize Hubble")
 		return

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -389,7 +389,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.metrics | object | `{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
 | hubble.metrics.dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null}` | Grafana dashboards for hubble grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | hubble.metrics.enableOpenMetrics | bool | `false` | Enables exporting hubble metrics in OpenMetrics format. |
-| hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"  |
+| hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"  |
 | hubble.metrics.port | int | `9965` | Configure the port the hubble metric server listens on. |
 | hubble.metrics.serviceAnnotations | object | `{}` | Annotations to be added to hubble-metrics service. |
 | hubble.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble |
@@ -401,7 +401,6 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service, must match the hubble.listenAddress' port. |
 | hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. |
-| hubble.redact | string | `nil` | Configures the list of redact options for Hubble. Example:    redact:   - http-url-query  You can specify the list of options from the helm CLI:    --set hubble.redact="{http-url-query}"  |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
 | hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
 | hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -844,12 +844,6 @@ data:
 {{- end }}
   enable-hubble-open-metrics: {{ .Values.hubble.metrics.enableOpenMetrics | quote }}
 {{- end }}
-{{- if .Values.hubble.redact }}
-  # A space separated list of redact options for Hubble.
-  hubble-redact: {{- range .Values.hubble.redact }}
-    {{.}}
-{{- end }}
-{{- end }}
 {{- if hasKey .Values.hubble "listenAddress" }}
   # An additional address for Hubble server to listen to (e.g. ":4244").
   hubble-listen-address: {{ .Values.hubble.listenAddress | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -982,7 +982,7 @@ hubble:
     #
     # You can specify the list of metrics from the helm CLI:
     #
-    #   --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
+    #   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
     #
     enabled: ~
     # -- Enables exporting hubble metrics in OpenMetrics format.
@@ -1022,18 +1022,6 @@ hubble:
 
   # -- Unix domain socket path to listen to when Hubble is enabled.
   socketPath: /var/run/cilium/hubble.sock
-
-  # -- Configures the list of redact options for Hubble.
-  # Example:
-  #
-  #   redact:
-  #   - http-url-query
-  #
-  # You can specify the list of options from the helm CLI:
-  #
-  #   --set hubble.redact="{http-url-query}"
-  #
-  redact: ~
 
   # -- An additional address for Hubble to listen to.
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -979,7 +979,7 @@ hubble:
     #
     # You can specify the list of metrics from the helm CLI:
     #
-    #   --set hubble.metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
+    #   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
     #
     enabled: ~
     # -- Enables exporting hubble metrics in OpenMetrics format.
@@ -1019,18 +1019,6 @@ hubble:
 
   # -- Unix domain socket path to listen to when Hubble is enabled.
   socketPath: /var/run/cilium/hubble.sock
-
-  # -- Configures the list of redact options for Hubble.
-  # Example:
-  #
-  #   redact:
-  #   - http-url-query
-  #
-  # You can specify the list of options from the helm CLI:
-  #
-  #   --set hubble.redact="{http-url-query}"
-  #
-  redact: ~
 
   # -- An additional address for Hubble to listen to.
   # Set this field ":4244" if you are enabling Hubble Relay, as it assumes that

--- a/pkg/hubble/parser/options/options.go
+++ b/pkg/hubble/parser/options/options.go
@@ -3,48 +3,17 @@
 
 package options
 
-import (
-	"github.com/sirupsen/logrus"
-)
-
-const (
-	HttpUrlQuery = "http-url-query"
-)
-
 // Option is used to configure parsers
 type Option func(*Options)
 
 // Options contains all parser options
 type Options struct {
-	CacheSize       int
-	RedactHTTPQuery bool
+	CacheSize int
 }
 
 // CacheSize configures the amount of L7 requests cached for latency calculation
 func CacheSize(size int) Option {
 	return func(opt *Options) {
 		opt.CacheSize = size
-	}
-}
-
-// Redact configures which data Hubble will redact.
-func Redact(logger logrus.FieldLogger, hubbleRedactOptions []string) Option {
-	return func(opt *Options) {
-		validOpts := []string{}
-		for _, option := range hubbleRedactOptions {
-			switch option {
-			case HttpUrlQuery:
-				opt.RedactHTTPQuery = true
-			default:
-				if logger != nil {
-					logger.WithField("option", option).Warn("ignoring unknown Hubble redact option")
-				}
-				continue
-			}
-			validOpts = append(validOpts, option)
-		}
-		if logger != nil {
-			logger.WithField("options", validOpts).Info("configured Hubble with redact options")
-		}
 	}
 }

--- a/pkg/hubble/parser/seven/http.go
+++ b/pkg/hubble/parser/seven/http.go
@@ -10,11 +10,10 @@ import (
 	"time"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
-	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 )
 
-func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts *options.Options) *flowpb.Layer7_Http {
+func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP) *flowpb.Layer7_Http {
 	var headers []*flowpb.HTTPHeader
 	keys := make([]string, 0, len(http.Headers))
 	for key := range http.Headers {
@@ -34,10 +33,6 @@ func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts
 			if _, ok := uri.User.Password(); ok {
 				uri.User = url.UserPassword(uri.User.Username(), "HUBBLE_REDACTED")
 			}
-		}
-		if opts.RedactHTTPQuery {
-			uri.RawQuery = ""
-			uri.Fragment = ""
 		}
 		urlString = uri.String()
 	}

--- a/pkg/hubble/parser/seven/http_test.go
+++ b/pkg/hubble/parser/seven/http_test.go
@@ -15,7 +15,6 @@ import (
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
-	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/hubble/testutils"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
@@ -139,54 +138,6 @@ func TestDecodeL7HTTPRequest(t *testing.T) {
 		},
 	}, f.GetL7().GetHttp())
 	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", f.GetTraceContext().GetParent().GetTraceId())
-}
-
-func TestDecodeL7HTTPRequestRemoveUrlQuery(t *testing.T) {
-	requestPath, err := url.Parse("http://myhost/some/path?foo=bar")
-	require.NoError(t, err)
-	lr := &accesslog.LogRecord{
-		Type:                accesslog.TypeRequest,
-		Timestamp:           fakeTimestamp,
-		NodeAddressInfo:     fakeNodeInfo,
-		ObservationPoint:    accesslog.Ingress,
-		SourceEndpoint:      fakeSourceEndpoint,
-		DestinationEndpoint: fakeDestinationEndpoint,
-		IPVersion:           accesslog.VersionIPv4,
-		Verdict:             accesslog.VerdictForwarded,
-		TransportProtocol:   accesslog.TransportProtocol(u8proto.TCP),
-		ServiceInfo:         nil,
-		DropReason:          nil,
-		HTTP: &accesslog.LogRecordHTTP{
-			Code:     0,
-			Method:   "POST",
-			URL:      requestPath,
-			Protocol: "HTTP/1.1",
-			Headers: http.Header{
-				"Host":        {"myhost"},
-				"Traceparent": {"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
-			},
-		},
-	}
-	lr.SourceEndpoint.Port = 56789
-	lr.DestinationEndpoint.Port = 80
-
-	opts := []options.Option{options.Redact(nil, []string{"http-url-query"})}
-	parser, err := New(log, nil, nil, nil, nil, opts...)
-	require.NoError(t, err)
-
-	f := &flowpb.Flow{}
-	err = parser.Decode(lr, f)
-	require.NoError(t, err)
-	assert.Equal(t, &flowpb.HTTP{
-		Code:     0,
-		Method:   "POST",
-		Url:      "http://myhost/some/path",
-		Protocol: "HTTP/1.1",
-		Headers: []*flowpb.HTTPHeader{
-			{Key: "Host", Value: "myhost"},
-			{Key: "Traceparent", Value: "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"},
-		},
-	}, f.GetL7().GetHttp())
 }
 
 func TestDecodeL7HTTPRecordResponse(t *testing.T) {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1006,10 +1006,6 @@ const (
 	// By default, Hubble observes all monitor events.
 	HubbleMonitorEvents = "hubble-monitor-events"
 
-	// HubbleRedact controls which values Hubble will redact in network flows.
-	// By default, Hubble does not redact any values.
-	HubbleRedact = "hubble-redact"
-
 	// DisableIptablesFeederRules specifies which chains will be excluded
 	// when installing the feeder rules
 	DisableIptablesFeederRules = "disable-iptables-feeder-rules"
@@ -2219,10 +2215,6 @@ type DaemonConfig struct {
 	// HubbleMonitorEvents specifies Cilium monitor events for Hubble to observe.
 	// By default, Hubble observes all monitor events.
 	HubbleMonitorEvents []string
-
-	// HubbleRedact controls which values Hubble will redact in network flows.
-	// By default, Hubble does not redact any values.
-	HubbleRedact []string
 
 	// EndpointStatus enables population of information in the
 	// CiliumEndpoint.Status resource
@@ -3448,7 +3440,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.HubbleRecorderSinkQueueSize = vp.GetInt(HubbleRecorderSinkQueueSize)
 	c.HubbleSkipUnknownCGroupIDs = vp.GetBool(HubbleSkipUnknownCGroupIDs)
 	c.HubbleMonitorEvents = vp.GetStringSlice(HubbleMonitorEvents)
-	c.HubbleRedact = vp.GetStringSlice(HubbleRedact)
 
 	c.DisableIptablesFeederRules = vp.GetStringSlice(DisableIptablesFeederRules)
 


### PR DESCRIPTION
See https://github.com/cilium/cilium/issues/23887#issuecomment-1645784815 for motivation. We've determined we should create a a more flexible configuration scheme for redaction of http headers, so instead of shipping the current solution which isn't very flexible, revert it, and we'll ship in the next release with the more flexible configuration scheme.

This PR reverts 2/3 of the commits in https://github.com/cilium/cilium/pull/25746. I left the 1 commit which fixed an issue where a URL object was being mutated in some existing redaction code.