### PR TITLE
ipam: deepcopy interface resource correctly.

### DIFF
--- a/pkg/alibabacloud/eni/types/types.go
+++ b/pkg/alibabacloud/eni/types/types.go
@@ -126,6 +126,10 @@ type ENI struct {
 	Tags map[string]string `json:"tags,omitempty"`
 }
 
+func (e *ENI) DeepCopyInterface() types.Interface {
+	return e.DeepCopy()
+}
+
 // InterfaceID returns the identifier of the interface
 func (e *ENI) InterfaceID() string {
 	return e.NetworkInterfaceID

--- a/pkg/aws/eni/types/types.go
+++ b/pkg/aws/eni/types/types.go
@@ -208,6 +208,10 @@ type ENI struct {
 	Tags map[string]string `json:"tags,omitempty"`
 }
 
+func (e *ENI) DeepCopyInterface() types.Interface {
+	return e.DeepCopy()
+}
+
 // InterfaceID returns the identifier of the interface
 func (e *ENI) InterfaceID() string {
 	return e.ID

--- a/pkg/azure/types/types.go
+++ b/pkg/azure/types/types.go
@@ -126,6 +126,10 @@ type AzureInterface struct {
 	resourceGroup string `json:"-"`
 }
 
+func (a *AzureInterface) DeepCopyInterface() types.Interface {
+	return a.DeepCopy()
+}
+
 // SetID sets the Azure interface ID, as well as extracting other fields from
 // the ID itself.
 func (a *AzureInterface) SetID(id string) {

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -361,6 +361,9 @@ type Interface interface {
 	// ForeachAddress must iterate over all addresses of the interface and
 	// call fn for each address
 	ForeachAddress(instanceID string, fn AddressIterator) error
+
+	// DeepCopyInterface returns a deep copy of the underlying interface type.
+	DeepCopyInterface() Interface
 }
 
 // InterfaceRevision is the configurationr revision of a network interface. It
@@ -542,6 +545,7 @@ func (m *InstanceMap) DeepCopy() *InstanceMap {
 	c := NewInstanceMap()
 	m.ForeachInterface("", func(instanceID, interfaceID string, rev InterfaceRevision) error {
 		// c is not exposed yet, we can access it without locking it
+		rev.Resource = rev.Resource.DeepCopyInterface()
 		c.updateLocked(instanceID, rev)
 		return nil
 	})

--- a/pkg/ipam/types/types_test.go
+++ b/pkg/ipam/types/types_test.go
@@ -31,6 +31,23 @@ type mockInterface struct {
 	pools map[string][]net.IP
 }
 
+func (m *mockInterface) DeepCopyInterface() Interface {
+	mc := &mockInterface{
+		id:    m.id,
+		pools: map[string][]net.IP{},
+	}
+	for id, pool := range m.pools {
+		pc := make([]net.IP, 0, len(pool))
+		for _, ip := range pool {
+			ipc := net.IP{}
+			copy(ipc, ip)
+			pc = append(pc, ipc)
+		}
+		mc.pools[id] = pc
+	}
+	return mc
+}
+
 func (m *mockInterface) InterfaceID() string {
 	return m.id
 }


### PR DESCRIPTION
ipam: deepcopy interface resource correctly.

Currently only used by azure ipam test mocks, was resulting in race
condition prone code where underlying interface addresses where being
shared across resources.

This ensures that the revision interface is correctly deepcopied such
that the underlying resource is also safely copied.

This seems at least partially related to flake https://github.com/cilium/cilium/issues/26617.

Addresses: https://github.com/cilium/cilium/issues/26617

Signed-off-by: Tom Hadlaw <tom.hadlaw@isovalent.com>