### PR TITLE
Add support for tracking map pressure for NAT map

### DIFF
--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -97,7 +97,9 @@ func NewMap(name string, v4 bool, entries int) *Map {
 			mapValue,
 			entries,
 			0,
-		).WithCache().WithEvents(option.Config.GetEventBufferConfig(name)),
+		).WithCache().
+			WithEvents(option.Config.GetEventBufferConfig(name)).
+			WithPressureMetric(),
 		v4: v4,
 	}
 }
@@ -188,6 +190,7 @@ func (m *Map) Flush() int {
 	if m.v4 {
 		return int(doFlush4(m).deleted)
 	}
+
 	return int(doFlush6(m).deleted)
 }
 


### PR DESCRIPTION
Taps into LRU maps GC cycle to surface map pressure metric based on the resulting computed map size.

Add initial map pressure metrics support for the following LRU maps:
- NAT

> Note: This is a temporary solution until LRU map counts are surfaced
in the kernel.

Related: [#20069](https://github.com/cilium/cilium/issues/20069), https://github.com/cilium/cilium/issues/21508

```release-note
Add Prometheus map pressure metrics for NAT maps
```

Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>