### PR TITLE
bgp,docs: clarify MetalLB deprecation vs BGP-CP beta

### DIFF
--- a/Documentation/network/bgp.rst
+++ b/Documentation/network/bgp.rst
@@ -6,9 +6,9 @@
 
 .. _bgp:
 
-****************
-BGP (deprecated)
-****************
+*************************************
+MetalLB BGP ControlPlane (deprecated)
+*************************************
 
 .. warning::
   This feature will only receive security updates and bug fixes. It is recommended


### PR DESCRIPTION
As a suggested follow up, further clarify that the MetalLB based BGP
control plane is being deprecated.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>

```release-note
Further clarify the deprecation of MetalLB BGP ControlPlane in user facing docs. 
```
