### PR TITLE
metrics: fix potential conflict on metrics registration

### DIFF
--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -93,13 +93,29 @@ func init() {
 		k8s.K8sErrorHandler,
 	}
 
-	k8s_metrics.Register(k8s_metrics.RegisterOpts{
+	// The client-go Register function can be called only once,
+	// but there's a possibility that another package calls it and
+	// registers the client-go metrics on its own registry.
+	// The metrics of one who called the init first will take effect,
+	// and which one wins depends on the order of package initialization.
+	// Currently, controller-runtime also calls it in its init function
+	// because there's an indirect dependency on controller-runtime.
+	// Given the possibility that controller-runtime wins, we should set
+	// the adapters directly to override the metrics registration of
+	// controller-runtime as well as calling Register function.
+	// Without calling Register function here, controller-runtime will have
+	// a chance to override our metrics registration.
+	registerOps := k8s_metrics.RegisterOpts{
 		ClientCertExpiry:      nil,
 		ClientCertRotationAge: nil,
 		RequestLatency:        &requestLatencyAdapter{},
 		RateLimiterLatency:    &rateLimiterLatencyAdapter{},
 		RequestResult:         &resultAdapter{},
-	})
+	}
+	k8s_metrics.Register(registerOps)
+	k8s_metrics.RequestLatency = registerOps.RequestLatency
+	k8s_metrics.RateLimiterLatency = registerOps.RateLimiterLatency
+	k8s_metrics.RequestResult = registerOps.RequestResult
 }
 
 var (


### PR DESCRIPTION
In Cilium v1.13, K8s rest client metrics, such as cilium_k8s_client_api_latency_time_seconds and cilium_k8s_client_api_calls_total, are missing because of a conflict with controller-runtime on the metrics registration.

controller-runtime(sigs.k8s.io/controller-runtime/pkg/metrics) also registers the client-go rest client metrics on its registry using metrics.Register method in its init function. The metrics.Register can be called only once, and subsequent calls will be ignored.

cilium-agent doesn't use controller-runtime, but there's an indirect dependency from github.com/cilium/cilium/daemon to github.com/cilium/cilium/operator/metrics package. (operator uses controller-runtime in its Gateway API implementation) For example,
github.com/cilium/cilium/daemon/cmd
-> github.com/cilium/cilium/pkg/ipam
-> github.com/cilium/cilium/pkg/ipam/metrics
-> github.com/cilium/cilium/operator/metrics

The init function of sigs.k8s.io/controller-runtime/pkg/metrics will be called because of this indirect dependency.

The issue(missing client-go metrics) doesn't happen with v1.14 and later, but it can happen if the order of imports changes again. This commit is to prevent the issue from happning.

This commit is a forward port of　https://github.com/cilium/cilium/pull/26412/commits/e4ff641fb30fa0e711dc9a7e2fcce92dd6d510b6

fixes: #25610

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

