### PR TITLE
[v1.13] Delete IP Label metadata on delete from ipcache

### DIFF
--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -107,6 +107,9 @@ func (i *ipcacheMock) Delete(ip string, source source.Source) bool {
 func (i *ipcacheMock) UpsertLabels(netip.Prefix, labels.Labels, source.Source, ipcacheTypes.ResourceID) {
 }
 
+func (i *ipcacheMock) RemoveLabels(prefix netip.Prefix, lbls labels.Labels, resource ipcacheTypes.ResourceID) {
+}
+
 type signalNodeHandler struct {
 	EnableNodeAddEvent                    bool
 	NodeAddEvent                          chan nodeTypes.Node


### PR DESCRIPTION
v1.13 backport of https://github.com/cilium/cilium/pull/26958 

```release-note
Delete IP Label metadata on delete from ipcache
```
