### PR TITLE
Test GatewapAPI conformance with IPv6

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -227,8 +227,8 @@ jobs:
         timeout-minutes: 10
         run: |
           if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
-            IPV6_KIND_SUBNET="$(docker network inspect kind --format='{{(index .IPAM.Config 1).Gateway }}')""
-            METALLB_IP_RANGE="$(IPV6_KIND_SUBNET)00-$(IPV6_KIND_SUBNET)55"
+            IPV6_KIND_SUBNET="$(docker network inspect kind --format='{{(index .IPAM.Config 1).Gateway }}')"
+            METALLB_IP_RANGE="${IPV6_KIND_SUBNET}00-${IPV6_KIND_SUBNET}55"
           else 
             KIND_NET_CIDR=$(docker network inspect kind -f '{{(index .IPAM.Config 0).Subnet}}')
             METALLB_IP_START=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.200@")

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -65,7 +65,7 @@ env:
   kind_config_ipv4: .github/kind-config.yaml
   kind_config_ipv6: .github/kind-config-ipv6.yaml
   gateway_api_version: v0.7.0
-  metallb_version: 0.12.1
+  metallb_version: 0.13.10
   timeout: 5m
 
 jobs:
@@ -193,14 +193,6 @@ jobs:
           # renovate: datasource=golang-version depName=go
           go-version: 1.20.6
 
-      - name: Wait for images to be available
-        timeout-minutes: 30
-        shell: bash
-        run: |
-          for image in cilium-ci operator-generic-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
-          done
-
       - name: Install Gateway API CRDs
         run: |
           # Install Gateway CRDs
@@ -217,6 +209,14 @@ jobs:
           kubectl wait --for condition=Established crd/httproutes.gateway.networking.k8s.io --timeout=${{ env.timeout }}
           kubectl wait --for condition=Established crd/tlsroutes.gateway.networking.k8s.io --timeout=${{ env.timeout }}
           kubectl wait --for condition=Established crd/referencegrants.gateway.networking.k8s.io --timeout=${{ env.timeout }}
+
+      - name: Wait for images to be available
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          for image in cilium-ci operator-generic-ci ; do
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+          done
 
       - name: Install Cilium
         id: install-cilium
@@ -241,24 +241,29 @@ jobs:
             METALLB_IP_RANGE="${METALLB_IP_START}-${METALLB_IP_END}"
           fi
           
-          cat << EOF > metallb_values.yaml
-          configInline:
-            address-pools:
-            - name: default
-              protocol: layer2
-              addresses:
-              - ${METALLB_IP_RANGE}
-          psp:
-            create: false
-          EOF
-          
           helm install --namespace metallb-system \
             --create-namespace \
             --repo https://metallb.github.io/metallb metallb metallb \
             --version ${{ env.metallb_version }} \
-            --values metallb_values.yaml \
             --wait
 
+          kubectl apply -f - <<EOF
+          apiVersion: metallb.io/v1beta1
+          kind: IPAddressPool
+          metadata:
+            name: pool
+            namespace: metallb-system
+          spec:
+            addresses:
+            - ${METALLB_IP_RANGE}
+          ---
+          apiVersion: metallb.io/v1beta1
+          kind: L2Advertisement
+          metadata:
+            name: example
+            namespace: metallb-system
+          EOF
+  
       - name: Run Gateway API conformance test
         timeout-minutes: 30
         run: |

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -101,6 +101,18 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
       
+      - name: Enable IPv6 in docker
+        run: |
+          sudo cat /etc/docker/daemon.json || true
+          # Keep existing config like cgroup-parent in github action
+          sudo sh -c "echo '{ \"exec-opts\": [\"native.cgroupdriver=cgroupfs\"], \"cgroup-parent\": \"/actions_job\", \"ipv6\": true, \"fixed-cidr-v6\": \"2001:db8:1::/64\" }' > /etc/docker/daemon.json"
+          sudo cat /etc/docker/daemon.json
+          sudo ip -6 route add 2001:db8:1::/64 dev docker0
+          sudo sysctl net.ipv6.conf.default.forwarding=1
+          sudo sysctl net.ipv6.conf.all.forwarding=1
+          sudo systemctl restart docker
+
+
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@829ae9b4d2c65104343051ad77b618b92a2c2b75 # v0.15.3
         with:

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -18,13 +18,13 @@ on:
         required: false
         default: '{}'
 
-  push:
-    branches:
-      - main
-      - ft/main/**
-    paths-ignore:
-      - 'Documentation/**'
-      - 'test/**'
+  push: {}
+    # branches:
+    #   - main
+    #   - ft/main/**
+    # paths-ignore:
+    #   - 'Documentation/**'
+    #   - 'test/**'
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -84,7 +84,13 @@ jobs:
       matrix:
         include:
         - crd-channel: experimental
+          ipFamily: ipv4
+        - crd-channel: experimental
+          ipFamily: ipv6
         - crd-channel: standard
+          ipFamily: ipv4
+        - crd-channel: standard
+          ipFamily: ipv6
     steps:
       - name: Checkout main branch to access local actions
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -148,6 +154,34 @@ jobs:
           version: ${{ env.kind_version }}
           config: ${{ env.kind_config }}
 
+      - name: Workaround CoreDNS for IPv6 airgapped
+        if: ${{ matrix.ipFamily == 'ipv6' }}
+        run: |
+          # Patch CoreDNS to work in Github CI
+          # 1. Github CI doesn´t offer IPv6 connectivity, so CoreDNS should be configured
+          # to work in an offline environment:
+          # https://github.com/coredns/coredns/issues/2494#issuecomment-457215452
+          # 2. Github CI adds following domains to resolv.conf search field:
+          # .net.
+          # CoreDNS should handle those domains and answer with NXDOMAIN instead of SERVFAIL
+          # otherwise pods stops trying to resolve the domain.
+          # Get the current config
+          original_coredns=$(/usr/local/bin/kubectl get -oyaml -n=kube-system configmap/coredns)
+          echo "Original CoreDNS config:"
+          echo "${original_coredns}"
+          # Patch it
+          fixed_coredns=$(
+            printf '%s' "${original_coredns}" | sed \
+              -e 's/^.*kubernetes cluster\.local/& net/' \
+              -e '/^.*upstream$/d' \
+              -e '/^.*fallthrough.*$/d' \
+              -e '/^.*forward . \/etc\/resolv.conf$/d' \
+              -e '/^.*loop$/d' \
+          )
+          echo "Patched CoreDNS config:"
+          echo "${fixed_coredns}"
+          printf '%s' "${fixed_coredns}" | /usr/local/bin/kubectl apply -f -
+
       - name: Install Go
         uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
@@ -192,10 +226,15 @@ jobs:
       - name: Install metallb for LB service
         timeout-minutes: 10
         run: |
-          KIND_NET_CIDR=$(docker network inspect kind -f '{{(index .IPAM.Config 0).Subnet}}')
-          METALLB_IP_START=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.200@")
-          METALLB_IP_END=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.250@")
-          METALLB_IP_RANGE="${METALLB_IP_START}-${METALLB_IP_END}"
+          if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
+            IPV6_KIND_SUBNET="$(docker network inspect kind --format='{{(index .IPAM.Config 1).Gateway }}')""
+            METALLB_IP_RANGE="$(IPV6_KIND_SUBNET)00-$(IPV6_KIND_SUBNET)55"
+          else 
+            KIND_NET_CIDR=$(docker network inspect kind -f '{{(index .IPAM.Config 0).Subnet}}')
+            METALLB_IP_START=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.200@")
+            METALLB_IP_END=$(echo ${KIND_NET_CIDR} | sed "s@0.0/16@255.250@")
+            METALLB_IP_RANGE="${METALLB_IP_START}-${METALLB_IP_END}"
+          fi
           
           cat << EOF > metallb_values.yaml
           configInline:

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -247,6 +247,8 @@ jobs:
             --version ${{ env.metallb_version }} \
             --wait
 
+          kubectl delete ValidatingWebhookConfiguration metallb-webhook-configuration
+
           kubectl apply -f - <<EOF
           apiVersion: metallb.io/v1beta1
           kind: IPAddressPool

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -62,7 +62,8 @@ env:
   CILIUM_CLI_MODE: helm
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.20.0
-  kind_config: .github/kind-config.yaml
+  kind_config_ipv4: .github/kind-config.yaml
+  kind_config_ipv6: .github/kind-config-ipv6.yaml
   gateway_api_version: v0.7.0
   metallb_version: 0.12.1
   timeout: 5m
@@ -99,7 +100,7 @@ jobs:
           persist-credentials: false
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
-
+      
       - name: Install Cilium CLI
         uses: cilium/cilium-cli@829ae9b4d2c65104343051ad77b618b92a2c2b75 # v0.15.3
         with:
@@ -138,6 +139,10 @@ jobs:
             --helm-set=securityContext.privileged=true \
             --helm-set=gatewayAPI.enabled=true"
 
+          if [ ${{ matrix.ipFamily }} == "ipv6" ]; then
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set=ipv6.enabled=true"
+          fi
+
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT
           echo skipped_tests=${SKIPPED_TESTS} >> $GITHUB_OUTPUT
           echo supported_features=${SUPPORTED_FEATURES} >> $GITHUB_OUTPUT
@@ -152,7 +157,7 @@ jobs:
         uses: helm/kind-action@dda0770415bac9fc20092cacbc54aa298604d140 # v1.8.0
         with:
           version: ${{ env.kind_version }}
-          config: ${{ env.kind_config }}
+          config: ${{ matrix.ipFamily == 'ipv6' && env.kind_config_ipv6 || env.kind_config_ipv4 }}
 
       - name: Workaround CoreDNS for IPv6 airgapped
         if: ${{ matrix.ipFamily == 'ipv6' }}
@@ -227,7 +232,7 @@ jobs:
         timeout-minutes: 10
         run: |
           if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
-            IPV6_KIND_SUBNET="$(docker network inspect kind --format='{{(index .IPAM.Config 1).Gateway }}')"
+            IPV6_KIND_SUBNET="$(docker network inspect kind --format='{{(index .IPAM.Config 0).Gateway }}')"
             METALLB_IP_RANGE="${IPV6_KIND_SUBNET}00-${IPV6_KIND_SUBNET}55"
           else 
             KIND_NET_CIDR=$(docker network inspect kind -f '{{(index .IPAM.Config 0).Subnet}}')

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -262,9 +262,11 @@ jobs:
           apiVersion: metallb.io/v1beta1
           kind: L2Advertisement
           metadata:
-            name: example
+            name: l2
             namespace: metallb-system
           EOF
+        
+          kubectl get IPAddressPool --all-namespaces -o yaml
   
       - name: Run Gateway API conformance test
         timeout-minutes: 30

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -140,7 +140,7 @@ jobs:
             --helm-set=gatewayAPI.enabled=true"
 
           if [ ${{ matrix.ipFamily }} == "ipv6" ]; then
-            CILIUM_INSTALL_DEFAULTS+=" --helm-set=ipv6.enabled=true"
+            CILIUM_INSTALL_DEFAULTS+=" --helm-set=ipv6.enabled=true --helm-set=ipv4.enabled=false"
           fi
 
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -232,7 +232,7 @@ jobs:
         timeout-minutes: 10
         run: |
           if [[ "${{ matrix.ipFamily }}" == "ipv6" ]]; then
-            IPV6_KIND_SUBNET="$(docker network inspect kind --format='{{(index .IPAM.Config 0).Gateway }}')"
+            IPV6_KIND_SUBNET="$(docker network inspect kind --format='{{(index .IPAM.Config 1).Gateway }}')"
             METALLB_IP_RANGE="${IPV6_KIND_SUBNET}00-${IPV6_KIND_SUBNET}55"
           else 
             KIND_NET_CIDR=$(docker network inspect kind -f '{{(index .IPAM.Config 0).Subnet}}')

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -103,8 +103,9 @@ func getService(resource *model.FullyQualifiedResource, allPorts []uint32) *core
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Type:  corev1.ServiceTypeLoadBalancer,
-			Ports: ports,
+			Type:           corev1.ServiceTypeLoadBalancer,
+			Ports:          ports,
+			IPFamilyPolicy: ipFamilyPolicyPtr(corev1.IPFamilyPolicyPreferDualStack),
 		},
 	}
 }
@@ -134,4 +135,8 @@ func getEndpoints(resource model.FullyQualifiedResource) *corev1.Endpoints {
 			},
 		},
 	}
+}
+
+func ipFamilyPolicyPtr(p corev1.IPFamilyPolicyType) *corev1.IPFamilyPolicyType {
+	return &p
 }

--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -540,9 +540,9 @@ const mismatchRouterIPsMsg = "Mismatch of router IPs found during restoration. T
 // ValidatePostInit validates the entire addressing setup and completes it as
 // required
 func ValidatePostInit() error {
-	if option.Config.EnableIPv4 || option.Config.TunnelingEnabled() {
-		if GetIPv4() == nil {
-			return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
+	if option.Config.TunnelingEnabled() {
+		if (!option.Config.EnableIPv4 || GetIPv4() == nil) && (!option.Config.EnableIPv6 || GetIPv6() == nil) {
+			return fmt.Errorf("external IP address of node could not be derived, please configure via --ipv4-node or --ipv6-node")
 		}
 	}
 


### PR DESCRIPTION
This enables tests of GatewayAPI to run with an IPv6 service 

```release-note
Runs GatewayAPI conformance tests on IPv6 as well
```
