### PR TITLE
New header "X-Load-Balancing-Endpoint-Weight" returned by service health

### DIFF
--- a/pkg/service/healthserver/healthserver.go
+++ b/pkg/service/healthserver/healthserver.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
@@ -215,6 +216,7 @@ func (h *httpHealthServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	svc := h.loadService()
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Load-Balancing-Endpoint-Weight", strconv.Itoa(svc.LocalEndpoints))
 
 	if svc.LocalEndpoints == 0 {
 		w.WriteHeader(http.StatusServiceUnavailable)

--- a/pkg/service/healthserver/healthserver_test.go
+++ b/pkg/service/healthserver/healthserver_test.go
@@ -87,12 +87,13 @@ func (s *ServiceHealthServerSuite) Test_httpHealthServer_ServeHTTP(c *C) {
 	defer ts.Close()
 
 	// Set local endpoints, server must respond with HTTP 200
-	h.updateService(NewService("default", "svc", 1))
+	h.updateService(NewService("default", "svc", 2))
 	resp, err := http.Get(ts.URL)
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
 	assertRespHeader(c, resp, "Content-Type", "application/json")
 	assertRespHeader(c, resp, "X-Content-Type-Options", "nosniff")
+	assertRespHeader(c, resp, "X-Load-Balancing-Endpoint-Weight", "2")
 	resp.Body.Close()
 
 	// Remove local endpoints, server must respond with HTTP 503


### PR DESCRIPTION
add new header "X-Load-Balancing-Endpoint-Weight" returned from service health. Value of the header is number of local endpoints. Header can be used in weighted load balancing. Parsing header for number of endpoints is faster than unmarshalling json from the content body, and it can be returned via HTTP HEAD method.

The header has been already added to kube-proxy service health code in https://github.com/kubernetes/kubernetes/pull/118999 (will be released in kubernetes v1.28)


```release-note
For services with `External Traffic Policy: Local` Service health returns http header "X-Load-Balancing-Endpoint-Weight" with number of local endpoints. The same information is still available in response body JSON payload.LocalEndpoints.
```
