### PR TITLE
ci: increase junit artifact retention from 2 to 5 days

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -319,7 +319,7 @@ jobs:
         with:
           name: cilium-junits
           path: cilium-junits/*.xml
-          retention-days: 2
+          retention-days: 5
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -280,7 +280,7 @@ jobs:
         with:
           name: cilium-junits
           path: cilium-junits/*.xml
-          retention-days: 2
+          retention-days: 5
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -467,7 +467,7 @@ jobs:
       with:
         name: cilium-junits
         path: cilium-junits/*.xml
-        retention-days: 2
+        retention-days: 5
 
     - name: Publish Test Results As GitHub Summary
       if: ${{ always() }}

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -423,7 +423,7 @@ jobs:
         with:
           name: cilium-junits
           path: cilium-junits/*.xml
-          retention-days: 2
+          retention-days: 5
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -305,7 +305,7 @@ jobs:
         with:
           name: cilium-junits
           path: cilium-junits/*.xml
-          retention-days: 2
+          retention-days: 5
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -337,7 +337,7 @@ jobs:
         with:
           name: cilium-junits
           path: cilium-junits/*.xml
-          retention-days: 2
+          retention-days: 5
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -442,9 +442,8 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: cilium-junits
-          path: |
-            cilium-junits/*.xml
-          retention-days: 2
+          path: cilium-junits/*.xml
+          retention-days: 5
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -301,7 +301,7 @@ jobs:
         with:
           name: cilium-junits
           path: cilium-junits/*.xml
-          retention-days: 2
+          retention-days: 5
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-kind-proxy-daemonset.yaml
+++ b/.github/workflows/conformance-kind-proxy-daemonset.yaml
@@ -156,7 +156,7 @@ jobs:
         with:
           name: cilium-junits
           path: cilium-junits/*.xml
-          retention-days: 2
+          retention-days: 5
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -325,9 +325,8 @@ jobs:
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: cilium-junits
-          path: |
-            cilium-junits/*.xml
-          retention-days: 2
+          path: cilium-junits/*.xml
+          retention-days: 5
 
       - name: Publish Test Results As GitHub Summary
         if: ${{ always() }}


### PR DESCRIPTION
Currently JUnit artifacts of test-results (e.g. connectivity tests) are kept for 2 days as GitHub artifact.

For better analysis (by external tooling), the JUnit artifacts should be available as long as the sysdump artifacts.

Therefore, this commit increases the retention of junit artifacts to 5 days.
