### PR TITLE
feat(hubble-ui): Add probes for Hubble-ui

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1684,6 +1684,14 @@
      - Hubble-ui backend image.
      - object
      - ``{"digest":"sha256:8a79a1aad4fc9c2aa2b3e4379af0af872a89fcec9d99e117188190671c66fc2e","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"v0.12.0","useDigest":true}``
+   * - :spelling:ignore:`hubble.ui.backend.livenessProbe.enabled`
+     - Enable liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+     - bool
+     - ``false``
+   * - :spelling:ignore:`hubble.ui.backend.readinessProbe.enabled`
+     - Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+     - bool
+     - ``false``
    * - :spelling:ignore:`hubble.ui.backend.resources`
      - Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -471,6 +471,8 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.backend.extraVolumeMounts | list | `[]` | Additional hubble-ui backend volumeMounts. |
 | hubble.ui.backend.extraVolumes | list | `[]` | Additional hubble-ui backend volumes. |
 | hubble.ui.backend.image | object | `{"digest":"sha256:8a79a1aad4fc9c2aa2b3e4379af0af872a89fcec9d99e117188190671c66fc2e","override":null,"pullPolicy":"Always","repository":"quay.io/cilium/hubble-ui-backend","tag":"v0.12.0","useDigest":true}` | Hubble-ui backend image. |
+| hubble.ui.backend.livenessProbe.enabled | bool | `false` | Enable liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+) |
+| hubble.ui.backend.readinessProbe.enabled | bool | `false` | Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+) |
 | hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.backend.securityContext | object | `{}` | Hubble-ui backend security context. |
 | hubble.ui.baseUrl | string | `"/"` | Defines base url prefix for all hubble-ui http requests. It needs to be changed in case if ingress for hubble-ui is configured under some sub-path. Trailing `/` is required for custom path, ex. `/service-map/` |

--- a/install/kubernetes/cilium/templates/hubble-ui/_nginx.tpl
+++ b/install/kubernetes/cilium/templates/hubble-ui/_nginx.tpl
@@ -49,6 +49,13 @@ server {
             # double `/index.html` is required here 
             try_files $uri $uri/ /index.html /index.html;
         }
+
+        # Liveness probe
+        location /healthz {
+            access_log off;
+            add_header Content-Type text/plain;
+            return 200 'ok';
+        }
     }
 }
 {{- end }}

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -60,6 +60,14 @@ spec:
         env:
           {{- toYaml . | trim | nindent 12 }}
         {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
         {{- with .Values.hubble.ui.frontend.resources }}
         resources:
           {{- toYaml . | trim | nindent 10 }}
@@ -103,6 +111,18 @@ spec:
         {{- end }}
         {{- with .Values.hubble.ui.backend.extraEnv }}
         {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
+        {{- if .Values.hubble.ui.backend.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8090
+        {{- end }}
+        {{- if .Values.hubble.ui.backend.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8090
         {{- end }}
         ports:
         - name: grpc

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1370,6 +1370,14 @@ hubble:
       # -- Additional hubble-ui backend volumeMounts.
       extraVolumeMounts: []
 
+      livenessProbe:
+        # -- Enable liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+        enabled: false
+
+      readinessProbe:
+        # -- Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+        enabled: false
+
       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
       resources: {}
       #   limits:

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1367,6 +1367,14 @@ hubble:
       # -- Additional hubble-ui backend volumeMounts.
       extraVolumeMounts: []
 
+      livenessProbe:
+        # -- Enable liveness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+        enabled: false
+
+      readinessProbe:
+        # -- Enable readiness probe for Hubble-ui backend (requires Hubble-ui 0.12+)
+        enabled: false
+
       # -- Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment.
       resources: {}
       #   limits:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [na ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

As this is a common pattern for all Kubernetes pods, I think it doesn't require additional use cases.
But: I contributed the `/healthz` endpoint only a few days ago. The feature for the backend requires hubble-ui >=0.12:
- https://github.com/cilium/cilium/pull/27011
- https://github.com/cilium/hubble-ui/releases/tag/v0.12.0

Resolves: https://github.com/cilium/hubble-ui/issues/586

```release-note
Hubble-ui now supports liveness and readiness probes
```

/cc: @geakstr