### PR TITLE
resource: Add support for custom Indexers

### DIFF
--- a/pkg/bgpv1/manager/diffstore_fake.go
+++ b/pkg/bgpv1/manager/diffstore_fake.go
@@ -86,6 +86,14 @@ func (mds *fakeDiffStore[T]) Delete(key resource.Key) {
 	mds.changed[key] = true
 }
 
+func (mds *fakeDiffStore[T]) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	return nil, nil
+}
+
+func (mds *fakeDiffStore[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
+	return nil, nil
+}
+
 func (mds *fakeDiffStore[T]) CacheStore() cache.Store {
 	return nil
 }

--- a/pkg/ipam/metadata/manager_test.go
+++ b/pkg/ipam/metadata/manager_test.go
@@ -35,6 +35,14 @@ func (m mockStore[T]) IterKeys() resource.KeyIter {
 	panic("not implemented")
 }
 
+func (m mockStore[T]) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	panic("not implemented")
+}
+
+func (m mockStore[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
+	panic("not implemented")
+}
+
 func (m mockStore[T]) CacheStore() cache.Store {
 	panic("not implemented")
 }

--- a/pkg/k8s/resource/resource.go
+++ b/pkg/k8s/resource/resource.go
@@ -123,6 +123,7 @@ func New[T k8sRuntime.Object](lc hive.Lifecycle, lw cache.ListerWatcher, opts ..
 type options struct {
 	transform   cache.TransformFunc      // if non-nil, the object is transformed with this function before storing
 	sourceObj   func() k8sRuntime.Object // prototype for the object before it is transformed
+	indexers    cache.Indexers           // map of the optional custom indexers to be added to the underlying resource informer
 	metricScope string                   // the scope label used when recording metrics for the resource
 }
 
@@ -160,6 +161,13 @@ func WithLazyTransform(sourceObj func() k8sRuntime.Object, transform cache.Trans
 func WithMetric(scope string) ResourceOption {
 	return func(o *options) {
 		o.metricScope = scope
+	}
+}
+
+// WithIndexers sets additional custom indexers on the resource store.
+func WithIndexers(indexers cache.Indexers) ResourceOption {
+	return func(o *options) {
+		o.indexers = indexers
 	}
 }
 
@@ -295,7 +303,10 @@ func (r *resource[T]) startWhenNeeded() {
 			DeleteFunc: func(obj any) { r.pushDelete(obj) },
 		}
 
-	store, informer := cache.NewTransformingInformer(r.lw, r.opts.sourceObj(), 0, handlerFuncs, r.opts.transform)
+	store, informer := cache.NewTransformingIndexerInformer(
+		r.lw, r.opts.sourceObj(), 0, handlerFuncs,
+		r.opts.indexers, r.opts.transform,
+	)
 	r.storeResolver.Resolve(&typedStore[T]{store})
 
 	r.wg.Add(1)

--- a/pkg/k8s/resource/store.go
+++ b/pkg/k8s/resource/store.go
@@ -23,14 +23,22 @@ type Store[T k8sRuntime.Object] interface {
 	// GetByKey returns the latest version of the object with given key.
 	GetByKey(key Key) (item T, exists bool, err error)
 
+	// IndexKeys returns the keys of the stored objects whose set of indexed values
+	// for the index includes the given indexed value.
+	IndexKeys(indexName, indexedValue string) ([]string, error)
+
+	// ByIndex returns the stored objects whose set of indexed values for the index
+	// includes the given indexed value.
+	ByIndex(indexName, indexedValue string) ([]T, error)
+
 	// CacheStore returns the underlying cache.Store instance. Use for temporary
 	// compatibility purposes only!
 	CacheStore() cache.Store
 }
 
-// typedStore implements Store on top of an untyped cache.Store.
+// typedStore implements Store on top of an untyped cache.Indexer.
 type typedStore[T k8sRuntime.Object] struct {
-	store cache.Store
+	store cache.Indexer
 }
 
 var _ Store[*corev1.Node] = &typedStore[*corev1.Node]{}
@@ -59,6 +67,22 @@ func (s *typedStore[T]) GetByKey(key Key) (item T, exists bool, err error) {
 		item = itemAny.(T)
 	}
 	return
+}
+
+func (s *typedStore[T]) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	return s.store.IndexKeys(indexName, indexedValue)
+}
+
+func (s *typedStore[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
+	itemsAny, err := s.store.ByIndex(indexName, indexedValue)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]T, 0, len(itemsAny))
+	for _, item := range itemsAny {
+		items = append(items, item.(T))
+	}
+	return items, nil
 }
 
 func (s *typedStore[T]) CacheStore() cache.Store {

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -115,6 +115,12 @@ func (fs *fakeStore[T]) GetByKey(key resource.Key) (item T, exists bool, err err
 	var def T
 	return def, false, nil
 }
+func (fs *fakeStore[T]) IndexKeys(indexName, indexedValue string) ([]string, error) {
+	return nil, nil
+}
+func (fs *fakeStore[T]) ByIndex(indexName, indexedValue string) ([]T, error) {
+	return nil, nil
+}
 func (fs *fakeStore[T]) CacheStore() cache.Store { return nil }
 
 var _ resource.Resource[runtime.Object] = (*fakeResource[runtime.Object])(nil)


### PR DESCRIPTION
Add support for custom Indexers to the Resource[T] package.  This enables to add user-defined indexes to the k8s objects in the resource[T] underlying store.