### PR TITLE
[v1.13] Rename bpfClockProbe Helm variable

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -81,10 +81,6 @@
      - Enables the BGP control plane.
      - bool
      - ``false``
-   * - bpf.clockProbe
-     - Enable BPF clock source probing for more efficient tick retrieval.
-     - bool
-     - ``false``
    * - bpf.ctAnyMax
      - Configure the maximum number of entries for the non-TCP connection tracking table.
      - int
@@ -153,6 +149,10 @@
      - Configure explicitly allowed VLAN id's for bpf logic bypass. [0] will allow all VLAN id's without any filtering.
      - list
      - ``[]``
+   * - bpfClockProbe
+     - Enable BPF clock source probing for more efficient tick retrieval.
+     - bool
+     - ``false``
    * - certgen
      - Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually.
      - object

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -71,7 +71,6 @@ contributors across the globe, there is almost always someone available to help.
 | bgp.enabled | bool | `false` | Enable BGP support inside Cilium; embeds a new ConfigMap for BGP inside cilium-agent and cilium-operator |
 | bgpControlPlane | object | `{"enabled":false}` | This feature set enables virtual BGP routers to be created via CiliumBGPPeeringPolicy CRDs. |
 | bgpControlPlane.enabled | bool | `false` | Enables the BGP control plane. |
-| bpf.clockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
 | bpf.ctAnyMax | int | `262144` | Configure the maximum number of entries for the non-TCP connection tracking table. |
 | bpf.ctTcpMax | int | `524288` | Configure the maximum number of entries in the TCP connection tracking table. |
 | bpf.hostLegacyRouting | bool | `false` | Configure whether direct routing mode should route traffic via host stack (true) or directly and more efficiently out of BPF (false) if the kernel supports it. The latter has the implication that it will also bypass netfilter in the host namespace. |
@@ -89,6 +88,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |
 | bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY to reduce reliance on iptables rules for implementing Layer 7 policy. |
 | bpf.vlanBypass | list | `[]` | Configure explicitly allowed VLAN id's for bpf logic bypass. [0] will allow all VLAN id's without any filtering. |
+| bpfClockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
 | certgen | object | `{"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.extraVolumeMounts | list | `[]` | Additional certgen volumeMounts. |
 | certgen.extraVolumes | list | `[]` | Additional certgen volumes. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -361,9 +361,6 @@ bpf:
   # -- Configure the mount point for the BPF filesystem
   root: /sys/fs/bpf
 
-  # -- Enable BPF clock source probing for more efficient tick retrieval.
-  clockProbe: false
-
   # -- Enables pre-allocation of eBPF map values. This increases
   # memory usage but can reduce latency.
   preallocateMaps: false
@@ -433,6 +430,9 @@ bpf:
   # [0] will allow all VLAN id's without any filtering.
   # @default -- `[]`
   vlanBypass: ~
+
+# -- Enable BPF clock source probing for more efficient tick retrieval.
+bpfClockProbe: false
 
 # -- Clean all eBPF datapath state from the initContainer of the cilium-agent
 # DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -358,9 +358,6 @@ bpf:
   # -- Configure the mount point for the BPF filesystem
   root: /sys/fs/bpf
 
-  # -- Enable BPF clock source probing for more efficient tick retrieval.
-  clockProbe: false
-
   # -- Enables pre-allocation of eBPF map values. This increases
   # memory usage but can reduce latency.
   preallocateMaps: false
@@ -430,6 +427,9 @@ bpf:
   # [0] will allow all VLAN id's without any filtering.
   # @default -- `[]`
   vlanBypass: ~
+
+# -- Enable BPF clock source probing for more efficient tick retrieval.
+bpfClockProbe: false
 
 # -- Clean all eBPF datapath state from the initContainer of the cilium-agent
 # DaemonSet.


### PR DESCRIPTION
Author backport of https://github.com/cilium/cilium/pull/26981

[ upstream commit e2d5ae9400796e0f4e8151fc1ad24bf06909c5c2 ]

Rename the Helm variable in values.yaml.tmpl as it was incorrectly named bpf.clockProbe instead of bpfClockProbe.

This will cause the bpf clock probe to be disabled everywhere. Which is currently necessary as it can otherwise cause interrupted connections after an upgrade, due to the garbage collector removing valid entries.

```upstream-prs
$ for pr in 26981; do contrib/backporting/set-labels.py $pr done 1.13; done
```