### PR TITLE
docs: Update l2-announcements policy example to be more realistic

### DIFF
--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -100,8 +100,9 @@ where, and how. This is an example policy using all optional fields:
         matchLabels:
           color: blue
       nodeSelector:
-        matchLabels:
-          role: worker
+        matchExpressions:
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
       interfaces:
       - ^eth[0-9]+
       externalIPs: true


### PR DESCRIPTION
In the example policy for l2-announcements, the example was using a label selector that said: `role: worker`. While it is possible to add such a label, most people will not do that and want to rely on the existing `node-role.kubernetes.io/<role>` labels added by kubeadm and similar tools.

If an inexperienced user copies and pastes our example without modifying the node label selector, it will likely not work. This commit updates the example to be more realistic.

Fixes: #26996

```release-note
Update l2-announcements policy example in docs to be more realistic
```
