### PR TITLE
metrics: Add workqueue metrics

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -480,6 +480,21 @@ Name                                          Labels                            
 ``k8s_client_api_calls_total``                ``host``, ``method``, ``return_code``         Enabled    Number of API calls made to kube-apiserver labeled by host, method and return code
 ============================================= ============================================= ========== ===========================================================
 
+Kubernetes workqueue
+~~~~~~~~~~~~~~~~~~~~
+
+==================================================== ============================================= ========== ===========================================================
+Name                                                 Labels                                        Default    Description
+==================================================== ============================================= ========== ===========================================================
+``k8s_workqueue_depth``                              ``name``                                      Enabled    Current depth of workqueue
+``k8s_workqueue_adds_total``                         ``name``                                      Enabled    Total number of adds handled by workqueue
+``k8s_workqueue_queue_duration_seconds``             ``name``                                      Enabled    Duration in seconds an item stays in workqueue prior to request
+``k8s_workqueue_work_duration_seconds``              ``name``                                      Enabled    Duration in seconds to process an item from workqueue
+``k8s_workqueue_unfinished_work_seconds``            ``name``                                      Enabled    Duration in seconds of work in progress that hasn't been observed by work_duration. Large values indicate stuck threads. You can deduce the number of stuck threads by observing the rate at which this value increases.
+``k8s_workqueue_longest_running_processor_seconds``  ``name``                                      Enabled    Duration in seconds of the longest running processor for workqueue
+``k8s_workqueue_retries_total``                      ``name``                                      Enabled    Total number of retries handled by workqueue
+==================================================== ============================================= ========== ===========================================================
+
 IPAM
 ~~~~
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -716,6 +716,7 @@ webhook
 webhooks
 webservice
 whitespace
+workqueue
 www
 xDS
 xdp

--- a/pkg/k8s/resource/scheme.go
+++ b/pkg/k8s/resource/scheme.go
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resource
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	discoveryv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1"
+	discoveryv1beta1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/discovery/v1beta1"
+	networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
+)
+
+var scheme = runtime.NewScheme()
+
+var localSchemeBuilder = runtime.SchemeBuilder{
+	corev1.AddToScheme,
+	discoveryv1beta1.AddToScheme,
+	discoveryv1.AddToScheme,
+	networkingv1.AddToScheme,
+	cilium_api_v2.AddToScheme,
+	cilium_api_v2alpha1.AddToScheme,
+}
+
+var AddToScheme = localSchemeBuilder.AddToScheme
+
+func init() {
+	utilruntime.Must(AddToScheme(scheme))
+}

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -182,6 +182,7 @@ func EndpointsResource(lc hive.Lifecycle, cs client.Clientset) (resource.Resourc
 		lw,
 		resource.WithLazyTransform(lw.getSourceObj, transformEndpoint),
 		resource.WithMetric("Endpoint"),
+		resource.WithName("endpoints"),
 	), nil
 }
 

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/cache"
 	k8s_metrics "k8s.io/client-go/tools/metrics"
+	"k8s.io/client-go/util/workqueue"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/cidr"
@@ -113,6 +114,8 @@ func init() {
 	k8s_metrics.RequestLatency = registerOps.RequestLatency
 	k8s_metrics.RateLimiterLatency = registerOps.RateLimiterLatency
 	k8s_metrics.RequestResult = registerOps.RequestResult
+
+	workqueue.SetProvider(workqueueMetricsProvider{})
 }
 
 var (
@@ -368,6 +371,36 @@ func (r *resultAdapter) Increment(_ context.Context, code, method, host string) 
 		}
 	}
 	k8smetrics.LastInteraction.Reset()
+}
+
+type workqueueMetricsProvider struct{}
+
+func (workqueueMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {
+	return metrics.WorkQueueDepth.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewAddsMetric(name string) workqueue.CounterMetric {
+	return metrics.WorkQueueAddsTotal.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewLatencyMetric(name string) workqueue.HistogramMetric {
+	return metrics.WorkQueueLatency.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewWorkDurationMetric(name string) workqueue.HistogramMetric {
+	return metrics.WorkQueueDuration.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewUnfinishedWorkSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return metrics.WorkQueueUnfinishedWork.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewLongestRunningProcessorSecondsMetric(name string) workqueue.SettableGaugeMetric {
+	return metrics.WorkQueueLongestRunningProcessor.WithLabelValues(name)
+}
+
+func (workqueueMetricsProvider) NewRetriesMetric(name string) workqueue.CounterMetric {
+	return metrics.WorkQueueRetries.WithLabelValues(name)
 }
 
 // WaitForCacheSync blocks until the given resources have been synchronized from k8s.  Note that if


### PR DESCRIPTION
This PR adds client-go workqueue metrics for cilium-agent

- workqueue_depth
- workqueue_adds_total
- workqueue_queue_duration_seconds
- workqueue_work_duration_seconds
- workqueue_unfinished_work_seconds
- workqueue_longest_running_processor_seconds
- workqueue_retries_total

The name label of the workqueue metrics is set GroupVersionKind.Kind resolved from a reconciled object, which is the same approach as the controller-runtime.
https://github.com/kubernetes-sigs/controller-runtime/blob/7f0c6dc440f334849b25866dd9990ac1a5a777c2/pkg/builder/controller.go#L332-L340

Without setting a name to the workqueue, client-go doesn't export the workqueue metrics.
https://github.com/kubernetes/client-go/blob/c5b1c13ccbedeb03c00ba162ef27566b0dfb512d/util/workqueue/metrics.go#L247-L260

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #26122
