### PR TITLE
maps: maglev_test: remove toleration for 4.9 kernel

### DIFF
--- a/pkg/maps/lbmap/maglev_test.go
+++ b/pkg/maps/lbmap/maglev_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
-	"github.com/cilium/cilium/pkg/version"
-	"github.com/cilium/cilium/pkg/versioncheck"
 )
 
 func Test(t *testing.T) {
@@ -32,22 +30,11 @@ var _ = Suite(&MaglevSuite{})
 func (s *MaglevSuite) SetUpSuite(c *C) {
 	testutils.PrivilegedTest(c)
 
-	vsn, err := version.GetKernelVersion()
-	c.Assert(err, IsNil)
-	constraint, err := versioncheck.Compile(">=4.11.0")
-	c.Assert(err, IsNil)
-
-	if !constraint(vsn) {
-		// Currently, we run privileged tests on the 4.9 kernel in CI. That
-		// kernel does not have the support for map-in-map. Thus, this skip.
-		c.Skip("Skipping as >= 4.11 kernel is required for map-in-map support")
-	}
-
 	s.prevMaglevTableSize = option.Config.MaglevTableSize
 	s.prevNodePortAlg = option.Config.NodePortAlg
 
 	// Otherwise opening the map might fail with EPERM
-	err = rlimit.RemoveMemlock()
+	err := rlimit.RemoveMemlock()
 	c.Assert(err, IsNil)
 
 	option.Config.LBMapEntries = DefaultMaxEntries


### PR DESCRIPTION
There's no more 4.9 kernel in CI, rip out the special handling for it.