### PR TITLE
proxy: refactor redirect integration

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -122,7 +122,7 @@ endif
 ifneq ($(wildcard $(dir $(lastword $(MAKEFILE_LIST)))/images/cilium/Dockerfile),)
     CILIUM_ENVOY_REF=$(shell sed -E -e 's/^FROM (--[^ ]* )*([^ ]*) as cilium-envoy/\2/p;d' < $(ROOT_DIR)/images/cilium/Dockerfile)
     CILIUM_ENVOY_SHA=$(shell echo $(CILIUM_ENVOY_REF) | sed -E -e 's/[^/]*\/[^:]*:(.*-)?([^:@]*).*/\2/p;d')
-    GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/proxy.requiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
+    GO_BUILD_LDFLAGS += -X "github.com/cilium/cilium/pkg/envoy.requiredEnvoyVersionSHA=$(CILIUM_ENVOY_SHA)"
 endif
 
 # Use git only if in a Git repo, otherwise find the files from the file system

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1332,7 +1332,10 @@ func changedOption(key string, value option.OptionSetting, data interface{}) {
 			logging.SetLogLevelToDebug()
 		}
 		// Reflect log level change to proxies
-		proxy.ChangeLogLevel(logging.GetLevel(logging.DefaultLogger))
+		// Might not be initialized yet
+		if option.Config.EnableL7Proxy {
+			d.l7Proxy.ChangeLogLevel(logging.GetLevel(logging.DefaultLogger))
+		}
 	}
 	d.policy.BumpRevision() // force policy recalculation
 }

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -460,3 +460,19 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 		log.WithError(err).Fatal("Envoy: Error writing Envoy bootstrap file")
 	}
 }
+
+// getEmbeddedEnvoyVersion returns the envoy binary version string
+func getEmbeddedEnvoyVersion() (string, error) {
+	out, err := exec.Command(ciliumEnvoy, "--version").Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to execute '%s --version': %w", ciliumEnvoy, err)
+	}
+	envoyVersionString := strings.TrimSpace(string(out))
+
+	envoyVersionArray := strings.Fields(envoyVersionString)
+	if len(envoyVersionArray) < 3 {
+		return "", fmt.Errorf("failed to extract version from truncated Envoy version string")
+	}
+
+	return envoyVersionArray[2], nil
+}

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -5,6 +5,7 @@ package envoy
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -81,9 +82,9 @@ type EmbeddedEnvoy struct {
 	admin  *EnvoyAdminClient
 }
 
-// StartEmbeddedEnvoy starts an Envoy proxy instance.
-func StartEmbeddedEnvoy(runDir, logPath string, baseID uint64) *EmbeddedEnvoy {
-	e := &EmbeddedEnvoy{
+// startEmbeddedEnvoy starts an Envoy proxy instance.
+func startEmbeddedEnvoy(runDir, logPath string, baseID uint64) (*EmbeddedEnvoy, error) {
+	envoy := &EmbeddedEnvoy{
 		stopCh: make(chan struct{}),
 		errCh:  make(chan error, 1),
 		admin:  NewEnvoyAdminClientForSocket(GetSocketDir(runDir)),
@@ -99,7 +100,7 @@ func StartEmbeddedEnvoy(runDir, logPath string, baseID uint64) *EmbeddedEnvoy {
 	createBootstrap(bootstrapPath, nodeId, ingressClusterName,
 		xdsSocketPath, egressClusterName, ingressClusterName, getAdminSocketPath(GetSocketDir(runDir)))
 
-	log.Debugf("Envoy: Starting: %v", *e)
+	log.Debugf("Envoy: Starting: %v", *envoy)
 
 	// make it a buffered channel, so we can not only
 	// read the written value but also skip it in
@@ -176,27 +177,27 @@ func StartEmbeddedEnvoy(runDir, logPath string, baseID uint64) *EmbeddedEnvoy {
 			case <-crashCh:
 				// Start Envoy again
 				continue
-			case <-e.stopCh:
+			case <-envoy.stopCh:
 				log.Infof("Envoy: Stopping proxy with pid %d", cmd.Process.Pid)
-				if err := e.admin.quit(); err != nil {
+				if err := envoy.admin.quit(); err != nil {
 					log.WithError(err).Fatalf("Envoy: Envoy admin quit failed, killing process with pid %d", cmd.Process.Pid)
 
 					if err := cmd.Process.Kill(); err != nil {
 						log.WithError(err).Fatal("Envoy: Stopping Envoy failed")
-						e.errCh <- err
+						envoy.errCh <- err
 					}
 				}
-				close(e.errCh)
+				close(envoy.errCh)
 				return
 			}
 		}
 	}()
 
 	if <-started {
-		return e
+		return envoy, nil
 	}
 
-	return nil
+	return nil, errors.New("failed to start embedded Envoy server")
 }
 
 // newEnvoyLogPiper creates a writer that parses and logs log messages written by Envoy.
@@ -267,7 +268,7 @@ func newEnvoyLogPiper() io.WriteCloser {
 	return writer
 }
 
-// Stop kills the Envoy process started with StartEmbeddedEnvoy. The gRPC API streams are terminated
+// Stop kills the Envoy process started with startEmbeddedEnvoy. The gRPC API streams are terminated
 // first.
 func (e *EmbeddedEnvoy) Stop() error {
 	close(e.stopCh)

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -77,8 +77,9 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 	defer accessLogServer.stop()
 
 	// launch debug variant of the Envoy proxy
-	envoyProxy := StartEmbeddedEnvoy(testRunDir, filepath.Join(testRunDir, "cilium-envoy.log"), 0)
+	envoyProxy, err := startEmbeddedEnvoy(testRunDir, filepath.Join(testRunDir, "cilium-envoy.log"), 0)
 	c.Assert(envoyProxy, NotNil)
+	c.Assert(err, IsNil)
 	log.Debug("started Envoy")
 
 	log.Debug("adding metrics listener")
@@ -166,8 +167,9 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 	defer accessLogServer.stop()
 
 	// launch debug variant of the Envoy proxy
-	envoyProxy := StartEmbeddedEnvoy(testRunDir, filepath.Join(testRunDir, "cilium-envoy.log"), 42)
+	envoyProxy, err := startEmbeddedEnvoy(testRunDir, filepath.Join(testRunDir, "cilium-envoy.log"), 42)
 	c.Assert(envoyProxy, NotNil)
+	c.Assert(err, IsNil)
 	log.Debug("started Envoy")
 
 	rName := "listener:22"

--- a/pkg/envoy/versioncheck.go
+++ b/pkg/envoy/versioncheck.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package envoy
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// requiredEnvoyVersionSHA is set during build
+// Running Envoy version will be checked against `requiredEnvoyVersionSHA`.
+// By default, cilium-agent will fail to start if there is a version mismatch.
+var requiredEnvoyVersionSHA string
+
+func checkEnvoyVersion(envoyVersionFunc func() (string, error)) error {
+	envoyVersion, err := envoyVersionFunc()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve Envoy version: %w", err)
+	}
+
+	log.Infof("Envoy: Version %s", envoyVersion)
+
+	// Make sure Envoy version matches the required one
+	if !strings.HasPrefix(envoyVersion, requiredEnvoyVersionSHA) {
+		return fmt.Errorf("envoy version %s does not match with required version %s", envoyVersion, requiredEnvoyVersionSHA)
+	}
+
+	log.Debugf("Envoy: Envoy version %s is matching required version %s", envoyVersion, requiredEnvoyVersionSHA)
+
+	return nil
+}
+
+func getRemoteEnvoyVersion(envoyAdminClient *EnvoyAdminClient) (string, error) {
+	const versionRetryAttempts = 20
+	const versionRetryWait = 500 * time.Millisecond
+
+	// Retry is necessary because Envoy might not be ready yet
+	for i := 0; i <= versionRetryAttempts; i++ {
+		envoyVersion, err := envoyAdminClient.GetEnvoyVersion()
+		if err != nil {
+			if i < versionRetryAttempts {
+				log.Info("Envoy: Unable to retrieve Envoy version - retry")
+				time.Sleep(versionRetryWait)
+				continue
+			}
+			return "", fmt.Errorf("failed to retrieve Envoy version: %w", err)
+		}
+
+		return envoyVersion, nil
+	}
+
+	return "", errors.New("failed to retrieve Envoy version")
+}

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -5,10 +5,7 @@ package envoy
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/cilium/cilium/pkg/completion"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -19,9 +16,8 @@ import (
 type onDemandXdsStarter struct {
 	XDSServer
 
-	runDir      string
-	adminClient *EnvoyAdminClient
-	envoyOnce   sync.Once
+	runDir    string
+	envoyOnce sync.Once
 }
 
 var _ XDSServer = &onDemandXdsStarter{}
@@ -50,11 +46,6 @@ func (o *onDemandXdsStarter) UpdateEnvoyResources(ctx context.Context, old, new 
 	return o.XDSServer.UpdateEnvoyResources(ctx, old, new, portAllocator)
 }
 
-// requiredEnvoyVersionSHA is set during build
-// Running Envoy version will be checked against `requiredEnvoyVersionSHA`.
-// By default, cilium-agent will fail to start if there is a version mismatch.
-var requiredEnvoyVersionSHA string
-
 func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error {
 	var startErr error
 
@@ -70,44 +61,7 @@ func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error 
 			// but then a failure to bind to the configured port would fail starting Envoy.
 			o.XDSServer.AddMetricsListener(uint16(option.Config.ProxyPrometheusPort), wg)
 		}
-
-		if !option.Config.DisableEnvoyVersionCheck {
-			if err := o.checkEnvoyVersion(); err != nil {
-				log.WithError(err).Error("Envoy: Version check failed")
-			}
-		}
 	})
 
 	return startErr
-}
-
-func (o *onDemandXdsStarter) checkEnvoyVersion() error {
-	const versionRetryAttempts = 20
-	const versionRetryWait = 500 * time.Millisecond
-
-	// Retry is necessary because Envoy might not be ready yet
-	for i := 0; i <= versionRetryAttempts; i++ {
-		envoyVersion, err := o.adminClient.GetEnvoyVersion()
-		if err != nil {
-			if i < versionRetryAttempts {
-				log.Info("Envoy: Unable to retrieve Envoy version - retry")
-				time.Sleep(versionRetryWait)
-				continue
-			}
-			return fmt.Errorf("failed to retrieve Envoy version: %w", err)
-		}
-
-		log.Infof("Envoy: Version %s", envoyVersion)
-
-		// Make sure Envoy version matches ours
-		if !strings.HasPrefix(envoyVersion, requiredEnvoyVersionSHA) {
-			log.Errorf("Envoy: Envoy version %s does not match with required version %s, aborting.",
-				envoyVersion, requiredEnvoyVersionSHA)
-		}
-
-		log.Debugf("Envoy: Envoy version %s is matching required version %s", envoyVersion, requiredEnvoyVersionSHA)
-		return nil
-	}
-
-	return nil
 }

--- a/pkg/envoy/xds_server_ondemand.go
+++ b/pkg/envoy/xds_server_ondemand.go
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package envoy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy"
+)
+
+type onDemandXdsStarter struct {
+	XDSServer
+
+	runDir      string
+	adminClient *EnvoyAdminClient
+	envoyOnce   sync.Once
+}
+
+var _ XDSServer = &onDemandXdsStarter{}
+
+func (o *onDemandXdsStarter) AddListener(name string, kind policy.L7ParserType, port uint16, isIngress bool, mayUseOriginalSourceAddr bool, wg *completion.WaitGroup) {
+	if err := o.startEmbeddedEnvoy(nil); err != nil {
+		log.WithError(err).Error("Envoy: Failed to start embedded Envoy proxy on demand")
+	}
+
+	o.XDSServer.AddListener(name, kind, port, isIngress, mayUseOriginalSourceAddr, wg)
+}
+
+func (o *onDemandXdsStarter) UpsertEnvoyResources(ctx context.Context, resources Resources, portAllocator PortAllocator) error {
+	if err := o.startEmbeddedEnvoy(nil); err != nil {
+		log.WithError(err).Error("Envoy: Failed to start embedded Envoy proxy on demand")
+	}
+
+	return o.XDSServer.UpsertEnvoyResources(ctx, resources, portAllocator)
+}
+
+func (o *onDemandXdsStarter) UpdateEnvoyResources(ctx context.Context, old, new Resources, portAllocator PortAllocator) error {
+	if err := o.startEmbeddedEnvoy(nil); err != nil {
+		log.WithError(err).Error("Envoy: Failed to start embedded Envoy proxy on demand")
+	}
+
+	return o.XDSServer.UpdateEnvoyResources(ctx, old, new, portAllocator)
+}
+
+// requiredEnvoyVersionSHA is set during build
+// Running Envoy version will be checked against `requiredEnvoyVersionSHA`.
+// By default, cilium-agent will fail to start if there is a version mismatch.
+var requiredEnvoyVersionSHA string
+
+func (o *onDemandXdsStarter) startEmbeddedEnvoy(wg *completion.WaitGroup) error {
+	var startErr error
+
+	o.envoyOnce.Do(func() {
+		// Start embedded Envoy on first invocation
+		_, startErr = startEmbeddedEnvoy(o.runDir, option.Config.EnvoyLogPath, 0)
+
+		// Add Prometheus listener if the port is (properly) configured
+		if option.Config.ProxyPrometheusPort < 0 || option.Config.ProxyPrometheusPort > 65535 {
+			log.WithField(logfields.Port, option.Config.ProxyPrometheusPort).Error("Envoy: Invalid configured proxy-prometheus-port")
+		} else if option.Config.ProxyPrometheusPort != 0 {
+			// We could do this in the bootstrap config as with the Envoy DaemonSet,
+			// but then a failure to bind to the configured port would fail starting Envoy.
+			o.XDSServer.AddMetricsListener(uint16(option.Config.ProxyPrometheusPort), wg)
+		}
+
+		if !option.Config.DisableEnvoyVersionCheck {
+			if err := o.checkEnvoyVersion(); err != nil {
+				log.WithError(err).Error("Envoy: Version check failed")
+			}
+		}
+	})
+
+	return startErr
+}
+
+func (o *onDemandXdsStarter) checkEnvoyVersion() error {
+	const versionRetryAttempts = 20
+	const versionRetryWait = 500 * time.Millisecond
+
+	// Retry is necessary because Envoy might not be ready yet
+	for i := 0; i <= versionRetryAttempts; i++ {
+		envoyVersion, err := o.adminClient.GetEnvoyVersion()
+		if err != nil {
+			if i < versionRetryAttempts {
+				log.Info("Envoy: Unable to retrieve Envoy version - retry")
+				time.Sleep(versionRetryWait)
+				continue
+			}
+			return fmt.Errorf("failed to retrieve Envoy version: %w", err)
+		}
+
+		log.Infof("Envoy: Version %s", envoyVersion)
+
+		// Make sure Envoy version matches ours
+		if !strings.HasPrefix(envoyVersion, requiredEnvoyVersionSHA) {
+			log.Errorf("Envoy: Envoy version %s does not match with required version %s, aborting.",
+				envoyVersion, requiredEnvoyVersionSHA)
+		}
+
+		log.Debugf("Envoy: Envoy version %s is matching required version %s", envoyVersion, requiredEnvoyVersionSHA)
+		return nil
+	}
+
+	return nil
+}

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -49,14 +49,15 @@ func newProxy(params proxyParams) *Proxy {
 	configureProxyLogger(params.EndpointInfoRegistry, params.MonitorAgent, option.Config.AgentLabels)
 
 	// FIXME: Make the port range configurable.
-	return createProxy(10000, 20000, option.Config.RunDir, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration, params.XdsServer)
+	return createProxy(10000, 20000, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration, params.XdsServer)
 }
 
 type envoyProxyIntegrationParams struct {
 	cell.In
 
-	Datapath  datapath.Datapath
-	XdsServer envoy.XDSServer
+	Datapath    datapath.Datapath
+	XdsServer   envoy.XDSServer
+	AdminClient *envoy.EnvoyAdminClient
 }
 
 func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyIntegration {
@@ -65,9 +66,9 @@ func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyInt
 	}
 
 	return &envoyProxyIntegration{
-		runDir:    option.Config.RunDir,
-		xdsServer: params.XdsServer,
-		datapath:  params.Datapath,
+		xdsServer:   params.XdsServer,
+		datapath:    params.Datapath,
+		adminClient: params.AdminClient,
 	}
 }
 

--- a/pkg/proxy/cell.go
+++ b/pkg/proxy/cell.go
@@ -7,7 +7,6 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/hive/cell"
-	"github.com/cilium/cilium/pkg/ipcache"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy/logger"
@@ -22,17 +21,20 @@ var Cell = cell.Module(
 	"L7 Proxy provides support for L7 network policies",
 
 	cell.Provide(newProxy),
+	cell.Provide(newEnvoyProxyIntegration),
+	cell.Provide(newDNSProxyIntegration),
 	cell.ProvidePrivate(endpoint.NewEndpointInfoRegistry),
 )
 
 type proxyParams struct {
 	cell.In
 
-	IPCache              *ipcache.IPCache
-	Datapath             datapath.Datapath
-	EndpointInfoRegistry logger.EndpointInfoRegistry
-	MonitorAgent         monitoragent.Agent
-	XdsServer            envoy.XDSServer
+	Datapath              datapath.Datapath
+	EndpointInfoRegistry  logger.EndpointInfoRegistry
+	MonitorAgent          monitoragent.Agent
+	EnvoyProxyIntegration *envoyProxyIntegration
+	DNSProxyIntegration   *dnsProxyIntegration
+	XdsServer             envoy.XDSServer
 }
 
 func newProxy(params proxyParams) *Proxy {
@@ -47,7 +49,34 @@ func newProxy(params proxyParams) *Proxy {
 	configureProxyLogger(params.EndpointInfoRegistry, params.MonitorAgent, option.Config.AgentLabels)
 
 	// FIXME: Make the port range configurable.
-	return createProxy(10000, 20000, option.Config.RunDir, params.Datapath, params.EndpointInfoRegistry, params.XdsServer)
+	return createProxy(10000, 20000, option.Config.RunDir, params.Datapath, params.EnvoyProxyIntegration, params.DNSProxyIntegration, params.XdsServer)
+}
+
+type envoyProxyIntegrationParams struct {
+	cell.In
+
+	Datapath  datapath.Datapath
+	XdsServer envoy.XDSServer
+}
+
+func newEnvoyProxyIntegration(params envoyProxyIntegrationParams) *envoyProxyIntegration {
+	if !option.Config.EnableL7Proxy {
+		return nil
+	}
+
+	return &envoyProxyIntegration{
+		runDir:    option.Config.RunDir,
+		xdsServer: params.XdsServer,
+		datapath:  params.Datapath,
+	}
+}
+
+func newDNSProxyIntegration() *dnsProxyIntegration {
+	if !option.Config.EnableL7Proxy {
+		return nil
+	}
+
+	return &dnsProxyIntegration{}
 }
 
 func configureProxyLogger(eir logger.EndpointInfoRegistry, monitorAgent monitoragent.Agent, agentLabels []string) {

--- a/pkg/proxy/crd.go
+++ b/pkg/proxy/crd.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package proxy
+
+import (
+	"github.com/cilium/cilium/pkg/completion"
+	"github.com/cilium/cilium/pkg/revert"
+)
+
+// Redirect type for custom Listeners, which are managed externally.
+type CRDRedirect struct{}
+
+func (r *CRDRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error) {
+	return func() error { return nil }, nil
+}
+
+func (r *CRDRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
+	return nil, func() error { return nil }
+}

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/proxy"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/proxy/logger"
 	"github.com/cilium/cilium/pkg/revert"
 )
 
@@ -21,10 +20,9 @@ var (
 
 // dnsRedirect implements the Redirect interface for an l7 proxy
 type dnsRedirect struct {
-	redirect             *Redirect
-	endpointInfoRegistry logger.EndpointInfoRegistry
-	currentRules         policy.L7DataMap
-	proxyRuleUpdater     proxyRuleUpdater
+	redirect         *Redirect
+	currentRules     policy.L7DataMap
+	proxyRuleUpdater proxyRuleUpdater
 }
 
 // proxyRuleUpdater updates L7 proxy rules per endpoint.
@@ -73,13 +71,15 @@ func (dr *dnsRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, rev
 	}, nil
 }
 
-// creatednsRedirect creates a redirect to the dns proxy. The redirect structure passed
+type dnsProxyIntegration struct {
+}
+
+// createRedirect creates a redirect to the dns proxy. The redirect structure passed
 // in is safe to access for reading and writing.
-func createDNSRedirect(r *Redirect, endpointInfoRegistry logger.EndpointInfoRegistry) (RedirectImplementation, error) {
+func (p *dnsProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitGroup) (RedirectImplementation, error) {
 	dr := &dnsRedirect{
-		redirect:             r,
-		endpointInfoRegistry: endpointInfoRegistry,
-		proxyRuleUpdater:     DefaultDNSProxy,
+		redirect:         r,
+		proxyRuleUpdater: DefaultDNSProxy,
 	}
 
 	log.WithFields(logrus.Fields{

--- a/pkg/proxy/dns.go
+++ b/pkg/proxy/dns.go
@@ -89,6 +89,10 @@ func (p *dnsProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitGro
 	return dr, dr.setRules(nil, r.rules)
 }
 
+func (p *dnsProxyIntegration) changeLogLevel(level logrus.Level) error {
+	return nil
+}
+
 func copyRules(rules policy.L7DataMap) policy.L7DataMap {
 	currentRules := policy.L7DataMap{}
 	for key, val := range rules {

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -6,101 +6,27 @@ package proxy
 import (
 	"fmt"
 	"net"
-	"strings"
-	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/completion"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/envoy"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
 )
-
-// the global EnvoyAdminClient instance
-var envoyAdminClient *envoy.EnvoyAdminClient
-
-// requiredEnvoyVersionSHA is set during build
-// Running Envoy version will be checked against `requiredEnvoyVersionSHA`.
-// By default, cilium-agent will fail to start if there is a version mismatch.
-var requiredEnvoyVersionSHA string
 
 // envoyRedirect implements the RedirectImplementation interface for an l7 proxy.
 type envoyRedirect struct {
 	listenerName string
 	xdsServer    envoy.XDSServer
-}
-
-var envoyOnce sync.Once
-
-func initEnvoy(runDir string, xdsServer envoy.XDSServer, wg *completion.WaitGroup) {
-	envoyOnce.Do(func() {
-		if option.Config.ExternalEnvoyProxy {
-			envoyAdminClient = envoy.NewEnvoyAdminClientForSocket(envoy.GetSocketDir(runDir))
-		} else {
-			// Start embedded Envoy on first invocation
-			embeddedEnvoy := envoy.StartEmbeddedEnvoy(runDir, option.Config.EnvoyLogPath, 0)
-			if embeddedEnvoy != nil {
-				envoyAdminClient = embeddedEnvoy.GetAdminClient()
-			}
-
-			// Add Prometheus listener if the port is (properly) configured
-			if option.Config.ProxyPrometheusPort < 0 || option.Config.ProxyPrometheusPort > 65535 {
-				log.WithField(logfields.Port, option.Config.ProxyPrometheusPort).Error("Envoy: Invalid configured proxy-prometheus-port")
-			} else if option.Config.ProxyPrometheusPort != 0 {
-				// We could do this in the bootstrap config as with the Envoy DaemonSet,
-				// but then a failure to bind to the configured port would fail starting Envoy.
-				xdsServer.AddMetricsListener(uint16(option.Config.ProxyPrometheusPort), wg)
-			}
-		}
-
-		if envoyAdminClient != nil && !option.Config.DisableEnvoyVersionCheck {
-			if err := checkEnvoyVersion(); err != nil {
-				log.WithError(err).Error("Envoy: Version check failed")
-			}
-		}
-	})
-}
-
-func checkEnvoyVersion() error {
-	const versionRetryAttempts = 20
-	const versionRetryWait = 500 * time.Millisecond
-
-	// Retry is necessary because Envoy might not be ready yet
-	for i := 0; i <= versionRetryAttempts; i++ {
-		envoyVersion, err := envoyAdminClient.GetEnvoyVersion()
-		if err != nil {
-			if i < versionRetryAttempts {
-				log.Info("Envoy: Unable to retrieve Envoy version - retry")
-				time.Sleep(versionRetryWait)
-				continue
-			}
-			return fmt.Errorf("failed to retrieve Envoy version: %w", err)
-		}
-
-		log.Infof("Envoy: Version %s", envoyVersion)
-
-		// Make sure Envoy version matches ours
-		if !strings.HasPrefix(envoyVersion, requiredEnvoyVersionSHA) {
-			log.Errorf("Envoy: Envoy version %s does not match with required version %s, aborting.",
-				envoyVersion, requiredEnvoyVersionSHA)
-		}
-
-		log.Debugf("Envoy: Envoy version %s is matching required version %s", envoyVersion, requiredEnvoyVersionSHA)
-		return nil
-	}
-
-	return nil
+	adminClient  *envoy.EnvoyAdminClient
 }
 
 type envoyProxyIntegration struct {
-	runDir    string
-	xdsServer envoy.XDSServer
-	datapath  datapath.Datapath
+	adminClient *envoy.EnvoyAdminClient
+	xdsServer   envoy.XDSServer
+	datapath    datapath.Datapath
 }
 
 // createRedirect creates a redirect with corresponding proxy configuration. This will launch a proxy instance.
@@ -115,49 +41,34 @@ func (p *envoyProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitG
 }
 
 func (p *envoyProxyIntegration) changeLogLevel(level logrus.Level) error {
-	if envoyAdminClient != nil {
-		return envoyAdminClient.ChangeLogLevel(level)
-	}
-
-	return nil
+	return p.adminClient.ChangeLogLevel(level)
 }
 
 func (p *envoyProxyIntegration) handleEnvoyRedirect(r *Redirect, wg *completion.WaitGroup) (RedirectImplementation, error) {
-	initEnvoy(p.runDir, p.xdsServer, wg)
-
 	l := r.listener
-	if envoyAdminClient != nil {
-		redirect := &envoyRedirect{
-			listenerName: net.JoinHostPort(r.name, fmt.Sprintf("%d", l.proxyPort)),
-			xdsServer:    p.xdsServer,
-		}
-
-		mayUseOriginalSourceAddr := p.datapath.SupportsOriginalSourceAddr()
-		// Only use original source address for egress
-		if l.ingress {
-			mayUseOriginalSourceAddr = false
-		}
-		p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.proxyType), l.proxyPort, l.ingress,
-			mayUseOriginalSourceAddr, wg)
-
-		return redirect, nil
+	redirect := &envoyRedirect{
+		listenerName: net.JoinHostPort(r.name, fmt.Sprintf("%d", l.proxyPort)),
+		xdsServer:    p.xdsServer,
+		adminClient:  p.adminClient,
 	}
 
-	return nil, fmt.Errorf("%s: Envoy proxy process failed to start, cannot add redirect", r.name)
+	mayUseOriginalSourceAddr := p.datapath.SupportsOriginalSourceAddr()
+	// Only use original source address for egress
+	if l.ingress {
+		mayUseOriginalSourceAddr = false
+	}
+	p.xdsServer.AddListener(redirect.listenerName, policy.L7ParserType(l.proxyType), l.proxyPort, l.ingress, mayUseOriginalSourceAddr, wg)
+
+	return redirect, nil
 }
 
-// UpdateRules is a no-op for envoy, as redirect data is synchronized via the
-// xDS cache.
+// UpdateRules is a no-op for envoy, as redirect data is synchronized via the xDS cache.
 func (k *envoyRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error) {
 	return func() error { return nil }, nil
 }
 
 // Close the redirect.
 func (r *envoyRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
-	if envoyAdminClient == nil {
-		return nil, nil
-	}
-
 	revertFunc := r.xdsServer.RemoveListener(r.listenerName, wg)
 
 	return nil, func() error {

--- a/pkg/proxy/envoyproxy.go
+++ b/pkg/proxy/envoyproxy.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/cilium/cilium/pkg/completion"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -110,6 +112,14 @@ func (p *envoyProxyIntegration) createRedirect(r *Redirect, wg *completion.WaitG
 
 	// create an Envoy Listener for Cilium policy enforcement
 	return p.handleEnvoyRedirect(r, wg)
+}
+
+func (p *envoyProxyIntegration) changeLogLevel(level logrus.Level) error {
+	if envoyAdminClient != nil {
+		return envoyAdminClient.ChangeLogLevel(level)
+	}
+
+	return nil
 }
 
 func (p *envoyProxyIntegration) handleEnvoyRedirect(r *Redirect, wg *completion.WaitGroup) (RedirectImplementation, error) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -720,10 +720,13 @@ func (p *Proxy) removeRedirect(id string, wg *completion.WaitGroup) (error, reve
 }
 
 // ChangeLogLevel changes proxy log level to correspond to the logrus log level 'level'.
-func ChangeLogLevel(level logrus.Level) {
-	if envoyAdminClient != nil {
-		err := envoyAdminClient.ChangeLogLevel(level)
-		log.WithError(err).Debug("failed to change log level in Envoy")
+func (p *Proxy) ChangeLogLevel(level logrus.Level) {
+	if err := p.envoyIntegration.changeLogLevel(level); err != nil {
+		log.WithError(err).Debug("failed to change log level in Envoy proxy")
+	}
+
+	if err := p.dnsIntegration.changeLogLevel(level); err != nil {
+		log.WithError(err).Debug("failed to change log level in DNS proxy")
 	}
 }
 

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -41,7 +41,7 @@ func (s *ProxySuite) TestPortAllocator(c *C) {
 	err := os.MkdirAll(socketDir, 0700)
 	c.Assert(err, IsNil)
 
-	p := createProxy(10000, 20000, testRunDir, mockDatapathUpdater, nil, nil, nil)
+	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil, nil)
 
 	port, err := p.AllocateProxyPort("listener1", false, true)
 	c.Assert(err, IsNil)
@@ -209,7 +209,7 @@ func (s *ProxySuite) TestCreateOrUpdateRedirectMissingListener(c *C) {
 	err := os.MkdirAll(socketDir, 0700)
 	c.Assert(err, IsNil)
 
-	p := createProxy(10000, 20000, testRunDir, mockDatapathUpdater, nil, nil, nil)
+	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil, nil)
 
 	ep := &endpointtest.ProxyUpdaterMock{
 		Id:       1000,

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -41,7 +41,7 @@ func (s *ProxySuite) TestPortAllocator(c *C) {
 	err := os.MkdirAll(socketDir, 0700)
 	c.Assert(err, IsNil)
 
-	p := createProxy(10000, 20000, testRunDir, mockDatapathUpdater, nil, nil)
+	p := createProxy(10000, 20000, testRunDir, mockDatapathUpdater, nil, nil, nil)
 
 	port, err := p.AllocateProxyPort("listener1", false, true)
 	c.Assert(err, IsNil)
@@ -209,7 +209,7 @@ func (s *ProxySuite) TestCreateOrUpdateRedirectMissingListener(c *C) {
 	err := os.MkdirAll(socketDir, 0700)
 	c.Assert(err, IsNil)
 
-	p := createProxy(10000, 20000, testRunDir, mockDatapathUpdater, nil, nil)
+	p := createProxy(10000, 20000, testRunDir, mockDatapathUpdater, nil, nil, nil)
 
 	ep := &endpointtest.ProxyUpdaterMock{
 		Id:       1000,

--- a/pkg/proxy/redirect.go
+++ b/pkg/proxy/redirect.go
@@ -28,17 +28,6 @@ type RedirectImplementation interface {
 	Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc)
 }
 
-// Redirect type for custom Listeners, which are managed externally.
-type CRDRedirect struct{}
-
-func (r *CRDRedirect) UpdateRules(wg *completion.WaitGroup) (revert.RevertFunc, error) {
-	return func() error { return nil }, nil
-}
-
-func (r *CRDRedirect) Close(wg *completion.WaitGroup) (revert.FinalizeFunc, revert.RevertFunc) {
-	return nil, func() error { return nil }
-}
-
 type Redirect struct {
 	// The following fields are only written to during initialization, it
 	// is safe to read these fields without locking the mutex


### PR DESCRIPTION
This PR separates the `Proxy`(PortAllocator) from the actual proxy implementations (Envoy & DNS/FQDN) by introducing separate hive sub-cells for them.

This way, the Proxy doesn't need to know about the details of how to create a concrete redirection and keeping the relevant data as fields. Most importantly how to start the embedded Envoy server on demand.

See the individual commits for more information.