### PR TITLE
cilium: use absolute path to include Makefile.defs

### DIFF
--- a/cilium/Makefile
+++ b/cilium/Makefile
@@ -1,7 +1,9 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-include ../Makefile.defs
+ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
+
+include ${ROOT_DIR}/../Makefile.defs
 
 TARGET := cilium
 

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,7 +1,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include ${ROOT_DIR}/../Makefile.defs
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,7 +1,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
 
 include ${ROOT_DIR}/../Makefile.defs
 


### PR DESCRIPTION
cilium/Makefile currently can't be included from elsewhere, since it uses a relative path to Makefile.defs. Copy the approach used for daemon and operator.

At the same time, avoid a possible shell splitting issue by quoting the arguments to dirname.