### PR TITLE
envoy: Bump envoy version to v1.24.10

### DIFF
--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -7,7 +7,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:e78aa4c3914b7583cd00d7d94
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.24-26ae46eeea118f61f9decb2f8b99e6bd82fd7de5@sha256:432f71ac017e49677c47744c248a818d5f433fb0bde50f255b6b395903f4c0dc as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.24-ad831bdec4c93feeb2378aa9e1847c936ada6ef7@sha256:7e9dd951f251f5aa43c0ec8d62d13bb95cb93776860426e28a9a90d988050868 as cilium-envoy
 
 #
 # Hubble CLI


### PR DESCRIPTION
This is for the below CVEs from the upstream.

CVEs:
https://github.com/envoyproxy/envoy/security/advisories/GHSA-pvgm-7jpg-pw5g https://github.com/envoyproxy/envoy/security/advisories/GHSA-69vr-g55c-v2v4 https://github.com/envoyproxy/envoy/security/advisories/GHSA-mc6h-6j9x-v3gq https://github.com/envoyproxy/envoy/security/advisories/GHSA-7mhv-gr67-hq55

Build: The build is coming from https://github.com/cilium/proxy/actions/runs/5661705068/job/15340176601

Release: https://github.com/envoyproxy/envoy/releases/tag/v1.24.10
