### PR TITLE
enhancement(policy, aws): Construct CIDR rules for referenced AWS security groups by querying associated network interfaces

### DIFF
--- a/Documentation/security/aws.rst
+++ b/Documentation/security/aws.rst
@@ -11,9 +11,9 @@ Locking Down External Access Using AWS Metadata
 ***********************************************
 
 This document serves as an introduction to using Cilium to enforce policies
-based on AWS instances metadata. It is a detailed walk-through of getting a
-single-node Cilium environment running on your machine. It is designed to take
-15-30 minutes with some experience running Kubernetes.
+based on AWS metadata. It provides a detailed walk-through of running a single-node
+Cilium environment on your machine. It is designed to take 15-30 minutes
+for users with some experience running Kubernetes.
 
 
 Setup Cilium
@@ -155,12 +155,12 @@ Configure AWS Security Groups
 
 Cilium's AWS Metadata filtering capability enables explicit whitelisting
 of communication between a subset of pods (identified by Kubernetes labels)
-with a set of destination EC2 VMs (identified by membership in an AWS security group).
+with a set of destination EC2 ENIs (identified by membership in an AWS security group).
 
-In this example, the destination EC2 VMs are a member of a single AWS security
-group ('sg-0f2146100a88d03c3') and pods with label class=xwing should
-only be able to make connections outside the cluster to the destination
-VMs in that security group.
+In this example, the destination EC2 elastic network interfaces are attached to
+EC2 instances that are members of a single AWS security group ('sg-0f2146100a88d03c3').
+Pods with label ``class=xwing`` should only be able to make connections outside the
+cluster to the destination network interfaces in that security group.
 
 To enable this, the VMs acting as Kubernetes worker nodes must be able to
 send traffic to the destination VMs that are being accessed by pods.  One approach
@@ -236,8 +236,8 @@ Policy Language:
             securityGroupsIds:
             - 'sg-0f2146100a88d03c3'
 
-This policy allows traffic from pod *xwing* to any AWS instance that is in
-the security group with ID ``sg-0f2146100a88d03c3``.
+This policy allows traffic from pod *xwing* to any AWS elastic network interface
+in the security group with ID ``sg-0f2146100a88d03c3``.
 
 Validate that derived policy is in place
 ----------------------------------------
@@ -245,8 +245,8 @@ Validate that derived policy is in place
 Every time that a new policy with ToGroups rules is added, an equivalent policy
 (also called "derivative policy"), will be created. This policy will contain the
 set of CIDRs that correspond to the specification in ToGroups, e.g., the IPs of
-all instances that are part of a specified security group. The list of IPs will
-be updated periodically.
+all network interfaces that are part of a specified security group. The list of
+IPs is updated periodically.
 
 .. code-block:: shell-session
 


### PR DESCRIPTION
👋 Hello!

In the current implementation, Cilium can enforce policies based on AWS metadata by cross-walking referenced security group IDs or names to the IP addresses of EC2 instances associated with matching security groups. This PR extends this functionality to any VPC-enabled service, e.g. RDS, ElastiCache, VPC endpoints, etc. by querying the underlying network interfaces directly.

```release-note
Extend AWS metadata-based policy enforcement to work with any VPC-enabled service.
```

First time contributor. Please let me know if this need anything else. Thanks!