### PR TITLE
ci-gke: adjust junit file names to matrix properties

### DIFF
--- a/.github/actions/gke/test-config-classic.yaml
+++ b/.github/actions/gke/test-config-classic.yaml
@@ -3,7 +3,6 @@
 config:
   - type: "no-tunnel"
     index: 1
-    cilium-install-opts: ""
   - type: "tunnel"
     index: 2
     cilium-install-opts: "--datapath-mode=tunnel"

--- a/.github/actions/gke/test-config-helm.yaml
+++ b/.github/actions/gke/test-config-helm.yaml
@@ -3,7 +3,6 @@
 config:
   - type: "no-tunnel"
     index: 1
-    cilium-install-opts: ""
   - type: "tunnel"
     index: 2
     cilium-install-opts: "--datapath-mode=tunnel"

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -267,7 +267,7 @@ jobs:
       - name: Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})
         run: |
           cilium connectivity test ${{ steps.vars.outputs.connectivity_test_defaults }} \
-          --junit-file "cilium-junits/${{ env.job_name }} (${{matrix.k8s.version}}, ${{matrix.config.index}}, ${{matrix.config.type}}).xml" \
+          --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.k8s.*, ', ') }}, ${{ join(matrix.config.*, ', ') }}).xml" \
           --junit-property github_job_step="Run connectivity test (${{ matrix.k8s.version }}, ${{ matrix.config.index }}, ${{ matrix.config.type }})"
 
       - name: Post-test information gathering


### PR DESCRIPTION
Currently, the name of the junit files no longer matches the name of the job including the values of the matrix properties.

This is kind of a requirement for external tooling to match them against a specific job.

This commit fixes this and uses `(${{ join(matrix.*, ', ') }})` to keep the names in sync.
