### PR TITLE
remove stable tag from image build

### DIFF
--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -94,8 +94,6 @@ jobs:
           tags: |
             ${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
             quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}
-            ${{ github.repository_owner }}/${{ matrix.name }}:stable
-            quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:stable
           target: release
           build-args: |
             OPERATOR_VARIANT=${{ matrix.name }}
@@ -153,8 +151,6 @@ jobs:
           echo "" >> image-digest/${{ matrix.name }}.txt
           echo "\`docker.io/${{ github.repository_owner }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "\`quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:${{ steps.tag.outputs.tag }}@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
-          echo "\`docker.io/${{ github.repository_owner }}/${{ matrix.name }}:stable@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
-          echo "\`quay.io/${{ env.QUAY_ORGANIZATION }}/${{ matrix.name }}:stable@${{ steps.docker_build_release.outputs.digest }}\`" >> image-digest/${{ matrix.name }}.txt
           echo "" >> image-digest/${{ matrix.name }}.txt
 
       # Upload artifact digests


### PR DESCRIPTION
Once we release v1.14.0, this will be the stable version.