### PR TITLE
envoy: Bump envoy version to v1.25.9

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1015,7 +1015,7 @@
    * - :spelling:ignore:`envoy.image`
      - Envoy container image.
      - object
-     - ``{"digest":"sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80","useDigest":true}``
+     - ``{"digest":"sha256:023d09eeb8a44ae99b489f4af7ffed8b8b54f19a532e0bc6ab4c1e4b31acaab1","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699","useDigest":true}``
    * - :spelling:ignore:`envoy.livenessProbe.failureThreshold`
      - failure threshold of liveness probe
      - int

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -6,7 +6,7 @@ ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:7d0e6a849d973bc5c81089967
 
 # cilium-envoy from github.com/cilium/proxy
 #
-FROM quay.io/cilium/cilium-envoy:v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80@sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5 as cilium-envoy
+FROM quay.io/cilium/cilium-envoy:v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699@sha256:023d09eeb8a44ae99b489f4af7ffed8b8b54f19a532e0bc6ab4c1e4b31acaab1 as cilium-envoy
 
 #
 # Hubble CLI

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -303,7 +303,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:023d09eeb8a44ae99b489f4af7ffed8b8b54f19a532e0bc6ab4c1e4b31acaab1","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1842,9 +1842,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80"
+    tag: "v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699"
     pullPolicy: "IfNotPresent"
-    digest: "sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5"
+    digest: "sha256:023d09eeb8a44ae99b489f4af7ffed8b8b54f19a532e0bc6ab4c1e4b31acaab1"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1839,9 +1839,9 @@ envoy:
   image:
     override: ~
     repository: "quay.io/cilium/cilium-envoy"
-    tag: "v1.25.8-f7f3427d20c150bc812e76e8820cdec60125dc80"
+    tag: "v1.25.9-f039e2bd380b7eef2f2feea5750676bb36133699"
     pullPolicy: "${PULL_POLICY}"
-    digest: "sha256:632bed08c13f546892fe08c90d2d90aee8ee225350c091462c30332a059863e5"
+    digest: "sha256:023d09eeb8a44ae99b489f4af7ffed8b8b54f19a532e0bc6ab4c1e4b31acaab1"
     useDigest: true
 
   # -- Additional containers added to the cilium Envoy DaemonSet.


### PR DESCRIPTION
This is for the below CVEs from the upstream.

CVEs:
https://github.com/envoyproxy/envoy/security/advisories/GHSA-pvgm-7jpg-pw5g https://github.com/envoyproxy/envoy/security/advisories/GHSA-69vr-g55c-v2v4 https://github.com/envoyproxy/envoy/security/advisories/GHSA-mc6h-6j9x-v3gq https://github.com/envoyproxy/envoy/security/advisories/GHSA-7mhv-gr67-hq55

Build: https://github.com/cilium/proxy/actions/runs/5666538565/job/15353476426

Release: https://github.com/envoyproxy/envoy/releases/tag/v1.25.9
