### PR TITLE
bpf: nat: let caller determine whether SNATed connection needs CT

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -140,6 +140,8 @@ nodeport_has_nat_conflict_ipv6(const struct ipv6hdr *ip6 __maybe_unused,
 	BPF_V6(router_ip, ROUTER_IP);
 	if (ipv6_addr_equals((union v6addr *)&ip6->saddr, &router_ip)) {
 		ipv6_addr_copy(&target->addr, &router_ip);
+		target->needs_ct = true;
+
 		return true;
 	}
 #endif /* TUNNEL_MODE && IS_BPF_OVERLAY */
@@ -152,6 +154,8 @@ nodeport_has_nat_conflict_ipv6(const struct ipv6hdr *ip6 __maybe_unused,
 	if (dr_ifindex == NATIVE_DEV_IFINDEX &&
 	    ipv6_addr_equals((union v6addr *)&ip6->saddr, &dr_addr)) {
 		ipv6_addr_copy(&target->addr, &dr_addr);
+		target->needs_ct = true;
+
 		return true;
 	}
 #endif /* IS_BPF_HOST */
@@ -1551,6 +1555,8 @@ nodeport_has_nat_conflict_ipv4(const struct iphdr *ip4 __maybe_unused,
 #if defined(TUNNEL_MODE) && defined(IS_BPF_OVERLAY)
 	if (ip4->saddr == IPV4_GATEWAY) {
 		target->addr = IPV4_GATEWAY;
+		target->needs_ct = true;
+
 		return true;
 	}
 #endif /* TUNNEL_MODE && IS_BPF_OVERLAY */
@@ -1565,6 +1571,8 @@ nodeport_has_nat_conflict_ipv4(const struct iphdr *ip4 __maybe_unused,
 	if (dr_ifindex == NATIVE_DEV_IFINDEX &&
 	    ip4->saddr == IPV4_DIRECT_ROUTING) {
 		target->addr = IPV4_DIRECT_ROUTING;
+		target->needs_ct = true;
+
 		return true;
 	}
 #endif /* IS_BPF_HOST */

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -189,8 +189,7 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -299,8 +298,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -408,8 +406,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -506,8 +503,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -568,8 +564,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	struct ipv4_ct_tuple icmp_tuple = {};
@@ -683,8 +678,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	struct ipv4_ct_tuple icmp_tuple = {};
@@ -797,8 +791,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	struct ipv4_ct_tuple icmp_tuple = {};
@@ -900,8 +893,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	struct ipv4_ct_tuple icmp_tuple = {};


### PR DESCRIPTION
Right now this is decided at the lowest level of the SNAT path. But actually the callers know much better. In particular this avoids one case where we bake EgressGW knowledge deep into the SNAT code.