### PR TITLE
CODEOWNERS: assign bpf/lib/auth.h to sig-servicemesh

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -246,6 +246,7 @@ Makefile* @cilium/build
 /bpf/Makefile* @cilium/loader
 /bpf/init.sh @cilium/loader
 /bpf/custom/Makefile* @cilium/build @cilium/loader
+/bpf/lib/auth.h @cilium/sig-datapath @cilium/sig-servicemesh
 /bpf/lib/encrypt.h @cilium/ipsec
 /bugtool/ @cilium/tophat
 /bugtool/cmd/ @cilium/cli


### PR DESCRIPTION
sig-servicemesh is responsible mutual authentication and therefore should review `bpf/lib/auth.h`.
