### PR TITLE
docs: kpr: remove caveat about XDP + tunnel performance

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -678,9 +678,6 @@ each underlying device's driver must have native XDP support on all Cilium manag
 nodes. In addition, for performance reasons we recommend kernel >= 5.5 for
 the multi-device XDP acceleration.
 
-NodePort acceleration can be used with either direct routing (``routingMode=native``)
-or tunnel mode. Direct routing is recommended to achieve optimal performance.
-
 A list of drivers supporting XDP can be found in :ref:`the XDP documentation<xdp_drivers>`.
 
 The current Cilium kube-proxy XDP acceleration mode can also be introspected through


### PR DESCRIPTION
We recently added support for in-XDP tunnel encapsulation with https://github.com/cilium/cilium/pull/24422. Thus the performance concerns (packets needing to bounce through TC for encapsulation) no longer apply.