### PR TITLE
Fix ValidatePostInit for IPv6-only + tunnel

### DIFF
--- a/pkg/node/address.go
+++ b/pkg/node/address.go
@@ -540,9 +540,9 @@ const mismatchRouterIPsMsg = "Mismatch of router IPs found during restoration. T
 // ValidatePostInit validates the entire addressing setup and completes it as
 // required
 func ValidatePostInit() error {
-	if option.Config.EnableIPv4 || option.Config.TunnelingEnabled() {
-		if GetIPv4() == nil {
-			return fmt.Errorf("external IPv4 node address could not be derived, please configure via --ipv4-node")
+	if option.Config.TunnelingEnabled() {
+		if (!option.Config.EnableIPv4 || GetIPv4() == nil) && (!option.Config.EnableIPv6 || GetIPv6() == nil) {
+			return fmt.Errorf("external IP address of node could not be derived, please configure via --ipv4-node or --ipv6-node")
 		}
 	}
 


### PR DESCRIPTION
This fixes a check in ValidatePostInit in tunnel mode where it would error on not having a v4 host address. This adds a check if a v6 host address was found. 

```release-note
Fix Cilium startup for IPv6 only and routingMode=tunnel
```
