### PR TITLE
BGP CP: Adds Support for Multi-Pool IPAM

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -856,7 +856,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		// in large clusters.
 		d.k8sWatcher.NodesInit(d.clientset)
 
-		if option.Config.IPAM == ipamOption.IPAMClusterPool {
+		if option.Config.IPAM == ipamOption.IPAMClusterPool ||
+			option.Config.IPAM == ipamOption.IPAMMultiPool {
 			// Create the CiliumNode custom resource. This call will block until
 			// the custom resource has been created
 			d.nodeDiscovery.UpdateCiliumNodeResource()

--- a/pkg/bgpv1/agent/controller_test.go
+++ b/pkg/bgpv1/agent/controller_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/mock"
+	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/node"
@@ -39,7 +40,7 @@ func TestControllerSanity(t *testing.T) {
 		// a mock List method for the controller's PolicyLister
 		plist func() ([]*v2alpha1api.CiliumBGPPeeringPolicy, error)
 		// a mock ConfigurePeers method for the controller's BGPRouterManager
-		configurePeers func(context.Context, *v2alpha1api.CiliumBGPPeeringPolicy, *node.LocalNode) error
+		configurePeers func(context.Context, *v2alpha1api.CiliumBGPPeeringPolicy, *node.LocalNode, *v2api.CiliumNode) error
 		// error nil or not
 		err error
 	}{
@@ -53,7 +54,7 @@ func TestControllerSanity(t *testing.T) {
 			plist: func() ([]*v2alpha1api.CiliumBGPPeeringPolicy, error) {
 				return []*v2alpha1api.CiliumBGPPeeringPolicy{wantPolicy}, nil
 			},
-			configurePeers: func(_ context.Context, p *v2alpha1api.CiliumBGPPeeringPolicy, node *node.LocalNode) error {
+			configurePeers: func(_ context.Context, p *v2alpha1api.CiliumBGPPeeringPolicy, node *node.LocalNode, ciliumNode *v2api.CiliumNode) error {
 				if !p.DeepEqual(wantPolicy) {
 					t.Fatalf("got: %+v, want: %+v", p, wantPolicy)
 				}
@@ -86,7 +87,7 @@ func TestControllerSanity(t *testing.T) {
 				}
 				return []*v2alpha1api.CiliumBGPPeeringPolicy{p}, nil
 			},
-			configurePeers: func(_ context.Context, p *v2alpha1api.CiliumBGPPeeringPolicy, _ *node.LocalNode) error {
+			configurePeers: func(_ context.Context, p *v2alpha1api.CiliumBGPPeeringPolicy, _ *node.LocalNode, _ *v2api.CiliumNode) error {
 				for _, r := range p.Spec.VirtualRouters {
 					for _, n := range r.Neighbors {
 						if n.PeerPort == nil ||
@@ -112,7 +113,7 @@ func TestControllerSanity(t *testing.T) {
 				"bgp-policy": "a",
 			},
 			annotations: map[string]string{},
-			configurePeers: func(_ context.Context, p *v2alpha1api.CiliumBGPPeeringPolicy, _ *node.LocalNode) error {
+			configurePeers: func(_ context.Context, p *v2alpha1api.CiliumBGPPeeringPolicy, _ *node.LocalNode, _ *v2api.CiliumNode) error {
 				return errors.New("")
 			},
 			err: errors.New(""),
@@ -141,7 +142,7 @@ func TestControllerSanity(t *testing.T) {
 				"bgp-policy": "a",
 			},
 			annotations: map[string]string{},
-			configurePeers: func(_ context.Context, p *v2alpha1api.CiliumBGPPeeringPolicy, _ *node.LocalNode) error {
+			configurePeers: func(_ context.Context, p *v2alpha1api.CiliumBGPPeeringPolicy, _ *node.LocalNode, _ *v2api.CiliumNode) error {
 				return nil
 			},
 			err: errors.New(""),

--- a/pkg/bgpv1/agent/routermgr.go
+++ b/pkg/bgpv1/agent/routermgr.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
+	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/node"
 )
@@ -33,7 +34,7 @@ type BGPRouterManager interface {
 	//
 	// Providing a nil policy to ConfigurePeers will withdrawal all routes
 	// and disconnect from the peers.
-	ConfigurePeers(ctx context.Context, policy *v2alpha1api.CiliumBGPPeeringPolicy, node *node.LocalNode) error
+	ConfigurePeers(ctx context.Context, policy *v2alpha1api.CiliumBGPPeeringPolicy, node *node.LocalNode, ciliumNode *v2api.CiliumNode) error
 
 	// GetPeers fetches BGP peering state from underlying routing daemon.
 	//

--- a/pkg/bgpv1/manager/instance.go
+++ b/pkg/bgpv1/manager/instance.go
@@ -33,6 +33,9 @@ type ServerWithConfig struct {
 	// Holds any announced PodCIDR routes.
 	PodCIDRAnnouncements []*types.Path
 
+	// Holds any announced pod ip pool CIDRs keyed by pool name of the backing CiliumPodIPPool.
+	PodIPPoolAnnouncements map[resource.Key][]*types.Path
+
 	// Holds any announced Service routes.
 	ServiceAnnouncements map[resource.Key][]*types.Path
 
@@ -55,10 +58,11 @@ func NewServerWithConfig(ctx context.Context, params types.ServerParameters) (*S
 	}
 
 	return &ServerWithConfig{
-		Server:               s,
-		Config:               nil,
-		PodCIDRAnnouncements: []*types.Path{},
-		ServiceAnnouncements: make(map[resource.Key][]*types.Path),
-		RoutePolicies:        make(map[string]*types.RoutePolicy),
+		Server:                 s,
+		Config:                 nil,
+		PodCIDRAnnouncements:   []*types.Path{},
+		ServiceAnnouncements:   make(map[resource.Key][]*types.Path),
+		RoutePolicies:          make(map[string]*types.RoutePolicy),
+		PodIPPoolAnnouncements: make(map[resource.Key][]*types.Path),
 	}, nil
 }

--- a/pkg/bgpv1/manager/pod_ip_pool_reconciler.go
+++ b/pkg/bgpv1/manager/pod_ip_pool_reconciler.go
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
+)
+
+type PodIPPoolReconcilerOut struct {
+	cell.Out
+
+	Reconciler ConfigReconciler `group:"bgp-config-reconciler"`
+}
+
+type PodIPPoolReconciler struct {
+	poolStore BGPCPResourceStore[*v2alpha1api.CiliumPodIPPool]
+}
+
+func NewPodIPPoolReconciler(poolStore BGPCPResourceStore[*v2alpha1api.CiliumPodIPPool]) PodIPPoolReconcilerOut {
+	if poolStore == nil {
+		return PodIPPoolReconcilerOut{}
+	}
+
+	return PodIPPoolReconcilerOut{
+		Reconciler: &PodIPPoolReconciler{
+			poolStore: poolStore,
+		},
+	}
+}
+
+func (r *PodIPPoolReconciler) Priority() int {
+	return 50
+}
+
+func (r *PodIPPoolReconciler) Reconcile(ctx context.Context, p ReconcileParams) error {
+	lp := r.populateLocalPools(p.CiliumNode)
+
+	if err := r.fullReconciliation(ctx, p.CurrentServer, p.DesiredConfig, lp); err != nil {
+		return fmt.Errorf("full reconciliation failed: %w", err)
+	}
+
+	return nil
+}
+
+// populateLocalPools returns a map of allocated multi-pool IPAM CIDRs of the local CiliumNode,
+// keyed by the pool name.
+func (r *PodIPPoolReconciler) populateLocalPools(localNode *v2api.CiliumNode) map[string][]netip.Prefix {
+	var (
+		l = log.WithFields(
+			logrus.Fields{
+				"component": "manager.podIPPoolReconciler",
+			},
+		)
+	)
+
+	if localNode == nil {
+		return nil
+	}
+
+	lp := make(map[string][]netip.Prefix)
+	for _, pool := range localNode.Spec.IPAM.Pools.Allocated {
+		var prefixes []netip.Prefix
+		for _, cidr := range pool.CIDRs {
+			if p, err := cidr.ToPrefix(); err == nil {
+				prefixes = append(prefixes, *p)
+			} else {
+				l.Errorf("invalid ipam pool cidr %v: %v", cidr, err)
+			}
+		}
+		lp[pool.Pool] = prefixes
+	}
+
+	return lp
+}
+
+// fullReconciliation reconciles all pod ip pools.
+func (r *PodIPPoolReconciler) fullReconciliation(ctx context.Context,
+	sc *ServerWithConfig,
+	newc *v2alpha1api.CiliumBGPVirtualRouter,
+	localPools map[string][]netip.Prefix) error {
+	// Loop over all existing announcements, delete announcements for pod ip pools that no longer exist.
+	for poolKey := range sc.PodIPPoolAnnouncements {
+		_, found, err := r.poolStore.GetByKey(poolKey)
+		if err != nil {
+			return fmt.Errorf("failed to get pod ip pool from resource store: %w", err)
+		}
+		// If the pod ip pool no longer exists, withdraw all associated routes.
+		if !found {
+			if err := r.withdrawPool(ctx, sc, poolKey); err != nil {
+				return fmt.Errorf("failed to withdraw pod ip pool: %w", err)
+			}
+			continue
+		}
+	}
+
+	// Loop over all pod ip pools, reconcile any updates to the pool.
+	pools := r.poolStore.List()
+	for _, pool := range pools {
+		if err := r.reconcilePodIPPool(ctx, sc, newc, pool, localPools); err != nil {
+			return fmt.Errorf("failed to reconcile pod ip pool: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// withdrawPool removes all announcements for the given pod ip pool.
+func (r *PodIPPoolReconciler) withdrawPool(ctx context.Context, sc *ServerWithConfig, key resource.Key) error {
+	advertisements := sc.PodIPPoolAnnouncements[key]
+	// Loop in reverse order so we can delete without effect to the iteration.
+	for i := len(advertisements) - 1; i >= 0; i-- {
+		advertisement := advertisements[i]
+		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: advertisement}); err != nil {
+			// Persist remaining advertisements
+			sc.PodIPPoolAnnouncements[key] = advertisements
+			return fmt.Errorf("failed to withdraw deleted pod ip pool route: %v: %w", advertisement.NLRI, err)
+		}
+
+		// Delete the advertisement after each withdraw in case we error half way through
+		advertisements = slices.Delete(advertisements, i, i+1)
+	}
+
+	// If all were withdrawn without error, we can delete the whole pod ip pool from the map
+	delete(sc.PodIPPoolAnnouncements, key)
+
+	return nil
+}
+
+// reconcilePodIPPool ensures the CIDRs of the given pool are announced if they are present
+// on the local node, adding missing announcements or withdrawing unwanted ones.
+func (r *PodIPPoolReconciler) reconcilePodIPPool(ctx context.Context,
+	sc *ServerWithConfig,
+	newc *v2alpha1api.CiliumBGPVirtualRouter,
+	pool *v2alpha1api.CiliumPodIPPool,
+	localPools map[string][]netip.Prefix) error {
+	poolKey := resource.NewKey(pool)
+
+	desiredRoutes, err := r.poolDesiredRoutes(newc, pool, localPools)
+	if err != nil {
+		return fmt.Errorf("poolDesiredRoutes(): %w", err)
+	}
+
+	for _, desiredRoute := range desiredRoutes {
+		// If this route has already been announced, don't add it again
+		if slices.ContainsFunc(sc.PodIPPoolAnnouncements[poolKey], func(existing *types.Path) bool {
+			return desiredRoute.String() == existing.NLRI.String()
+		}) {
+			continue
+		}
+
+		// Advertise the new cidr
+		advertPathResp, err := sc.Server.AdvertisePath(ctx, types.PathRequest{
+			Path: types.NewPathForPrefix(desiredRoute),
+		})
+		if err != nil {
+			return fmt.Errorf("failed to advertise service route %v: %w", desiredRoute, err)
+		}
+		sc.PodIPPoolAnnouncements[poolKey] = append(sc.PodIPPoolAnnouncements[poolKey], advertPathResp.Path)
+	}
+
+	// Loop over announcements in reverse order so we can delete entries without effecting iteration.
+	for i := len(sc.PodIPPoolAnnouncements[poolKey]) - 1; i >= 0; i-- {
+		announcement := sc.PodIPPoolAnnouncements[poolKey][i]
+		// If the announcement is within the list of desired routes, don't remove it
+		if slices.ContainsFunc(desiredRoutes, func(existing netip.Prefix) bool {
+			return existing.String() == announcement.NLRI.String()
+		}) {
+			continue
+		}
+
+		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: announcement}); err != nil {
+			return fmt.Errorf("failed to withdraw service route %s: %w", announcement.NLRI, err)
+		}
+
+		// Delete announcement from slice
+		sc.PodIPPoolAnnouncements[poolKey] = slices.Delete(sc.PodIPPoolAnnouncements[poolKey], i, i+1)
+	}
+
+	return nil
+}
+
+// poolDesiredRoutes returns routes that should be announced for the given pool.
+func (r *PodIPPoolReconciler) poolDesiredRoutes(
+	newc *v2alpha1api.CiliumBGPVirtualRouter,
+	pool *v2alpha1api.CiliumPodIPPool,
+	localPools map[string][]netip.Prefix) ([]netip.Prefix, error) {
+	if newc.PodIPPoolSelector == nil {
+		// If the vRouter has no pool selector, there are no desired routes.
+		return nil, nil
+	}
+
+	// The vRouter has a pool selector, so determine the desired routes.
+	poolSelector, err := slim_metav1.LabelSelectorAsSelector(newc.PodIPPoolSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert label selector: %w", err)
+	}
+
+	// Ignore non matching pools.
+	if !poolSelector.Matches(podIPPoolLabelSet(pool)) {
+		return nil, nil
+	}
+
+	var desiredRoutes []netip.Prefix
+	if localCIDRs, ok := localPools[pool.Name]; ok {
+		desiredRoutes = append(desiredRoutes, localCIDRs...)
+	}
+
+	return desiredRoutes, nil
+}

--- a/pkg/bgpv1/manager/pod_ip_pool_reconciler_test.go
+++ b/pkg/bgpv1/manager/pod_ip_pool_reconciler_test.go
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package manager
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/pkg/bgpv1/types"
+	ipamtypes "github.com/cilium/cilium/pkg/ipam/types"
+	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/node/addressing"
+	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+)
+
+func TestPodIPPoolReconciler(t *testing.T) {
+	blueSelector := slim_metav1.LabelSelector{MatchLabels: map[string]string{"color": "blue"}}
+
+	pool1Key := resource.Key{Name: "pool-1", Namespace: "default"}
+	pool1 := &v2alpha1api.CiliumPodIPPool{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      pool1Key.Name,
+			Namespace: pool1Key.Namespace,
+			Labels:    blueSelector.MatchLabels,
+		},
+		Spec: v2alpha1api.IPPoolSpec{
+			IPv4: &v2alpha1api.IPv4PoolSpec{
+				CIDRs:    []v2alpha1api.PoolCIDR{"10.0.0.0/16"},
+				MaskSize: 24,
+			},
+			IPv6: &v2alpha1api.IPv6PoolSpec{
+				CIDRs:    []v2alpha1api.PoolCIDR{"2001:0:0:1234::/64"},
+				MaskSize: 96,
+			},
+		},
+	}
+
+	pool2Key := resource.Key{Name: "pool-2", Namespace: "default"}
+	pool2 := &v2alpha1api.CiliumPodIPPool{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      pool2Key.Name,
+			Namespace: pool2Key.Namespace,
+			Labels:    blueSelector.MatchLabels,
+		},
+		Spec: v2alpha1api.IPPoolSpec{
+			IPv4: &v2alpha1api.IPv4PoolSpec{
+				CIDRs: []v2alpha1api.PoolCIDR{
+					"20.0.0.0/16",
+					"30.0.0.0/16",
+					"40.0.0.0/16",
+				},
+				MaskSize: 24,
+			},
+			IPv6: &v2alpha1api.IPv6PoolSpec{
+				CIDRs: []v2alpha1api.PoolCIDR{
+					"2002:0:0:1234::/64",
+					"2003:0:0:1234::/64",
+					"2004:0:0:1234::/64",
+				},
+				MaskSize: 96,
+			},
+		},
+	}
+
+	var table = []struct {
+		// name of the test case
+		name string
+		// The pod IP pools allocated to the local node
+		nodeAllocs []ipamtypes.IPAMPoolAllocation
+		// The pool selector of the vRouter
+		poolSelector *slim_metav1.LabelSelector
+		// the pools which will be "upserted" in the diffstore
+		upsertedPools []*v2alpha1api.CiliumPodIPPool
+		// the updated pool CIDR blocks to reconcile
+		updated map[resource.Key][]string
+		// error nil or not
+		err error
+	}{
+		{
+			name:          "no matching node cidrs from pool",
+			nodeAllocs:    nil,
+			poolSelector:  &blueSelector,
+			upsertedPools: []*v2alpha1api.CiliumPodIPPool{pool1},
+			updated:       map[resource.Key][]string{},
+		},
+		{
+			name: "match one ipv4 cidr from one pool",
+			nodeAllocs: []ipamtypes.IPAMPoolAllocation{
+				{
+					Pool:  pool1.Name,
+					CIDRs: []ipamtypes.IPAMPodCIDR{"10.0.1.0/24"},
+				},
+			},
+			poolSelector:  &blueSelector,
+			upsertedPools: []*v2alpha1api.CiliumPodIPPool{pool1},
+			updated:       map[resource.Key][]string{pool1Key: {"10.0.1.0/24"}},
+		},
+		{
+			name: "match one ipv6 cidr from one pool",
+			nodeAllocs: []ipamtypes.IPAMPoolAllocation{
+				{
+					Pool: pool1.Name,
+					CIDRs: []ipamtypes.IPAMPodCIDR{
+						"2001:0:0:1234:5678::/96",
+					},
+				},
+			},
+			poolSelector:  &blueSelector,
+			upsertedPools: []*v2alpha1api.CiliumPodIPPool{pool1},
+			updated:       map[resource.Key][]string{pool1Key: {"2001:0:0:1234:5678::/96"}},
+		},
+		{
+			name: "match multiple ipv4 and ipv6 cidrs from one pool",
+			nodeAllocs: []ipamtypes.IPAMPoolAllocation{
+				{
+					Pool: pool1.Name,
+					CIDRs: []ipamtypes.IPAMPodCIDR{
+						"10.0.1.0/24",
+						"10.0.2.0/24",
+						"10.0.3.0/24",
+						"2001:0:0:1234:5678::/96",
+						"2001:0:0:1234:5679::/96",
+						"2001:0:0:1234:5680::/96",
+					},
+				},
+			},
+			poolSelector:  &blueSelector,
+			upsertedPools: []*v2alpha1api.CiliumPodIPPool{pool1},
+			updated: map[resource.Key][]string{
+				pool1Key: {
+					"10.0.1.0/24",
+					"10.0.2.0/24",
+					"10.0.3.0/24",
+					"2001:0:0:1234:5678::/96",
+					"2001:0:0:1234:5679::/96",
+					"2001:0:0:1234:5680::/96",
+				},
+			},
+		},
+		{
+			name: "match multiple ipv4 and ipv6 cidrs from two pools",
+			nodeAllocs: []ipamtypes.IPAMPoolAllocation{
+				{
+					Pool: pool1.Name,
+					CIDRs: []ipamtypes.IPAMPodCIDR{
+						"10.0.1.0/24",
+						"10.0.2.0/24",
+						"2001:0:0:1234:5678::/96",
+						"2001:0:0:1234:5679::/96",
+					},
+				},
+				{
+					Pool: pool2.Name,
+					CIDRs: []ipamtypes.IPAMPodCIDR{
+						"20.0.1.0/24",
+						"30.0.1.0/24",
+						"2002:0:0:1234:5678::/96",
+						"2003:0:0:1234:5678::/96",
+					},
+				},
+			},
+			poolSelector:  &blueSelector,
+			upsertedPools: []*v2alpha1api.CiliumPodIPPool{pool1, pool2},
+			updated: map[resource.Key][]string{
+				pool1Key: {
+					"10.0.1.0/24",
+					"10.0.2.0/24",
+					"2001:0:0:1234:5678::/96",
+					"2001:0:0:1234:5679::/96",
+				},
+				pool2Key: {
+					"20.0.1.0/24",
+					"30.0.1.0/24",
+					"2002:0:0:1234:5678::/96",
+					"2003:0:0:1234:5678::/96",
+				},
+			},
+		},
+	}
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup the test server, create a bgp virtual router, and upsert the test pools
+			// into the diff store.
+			srvParams := types.ServerParameters{
+				Global: types.BGPGlobal{
+					ASN:        64125,
+					RouterID:   "127.0.0.1",
+					ListenPort: -1,
+				},
+			}
+			testSC, err := NewServerWithConfig(context.Background(), srvParams)
+			if err != nil {
+				t.Fatalf("failed to create test bgp server: %v", err)
+			}
+			testSC.Config = &v2alpha1api.CiliumBGPVirtualRouter{
+				LocalASN:          64125,
+				Neighbors:         []v2alpha1api.CiliumBGPNeighbor{},
+				PodIPPoolSelector: tt.poolSelector,
+			}
+
+			// Setup the pool reconciler, local node, CiliumNode, and assign test
+			// pools to CiliumNode.
+			store := newMockBGPCPResourceStore[*v2alpha1api.CiliumPodIPPool]()
+			for _, obj := range tt.upsertedPools {
+				store.Upsert(obj)
+			}
+			reconciler := NewPodIPPoolReconciler(store).Reconciler
+
+			node := &node.LocalNode{
+				Node: nodeTypes.Node{
+					Name: "node1",
+					IPAddresses: []nodeTypes.Address{
+						{
+							Type: addressing.NodeExternalIP,
+							IP:   net.ParseIP("127.0.0.1"),
+						},
+					},
+				},
+			}
+
+			ciliumNode := &v2api.CiliumNode{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name:      node.Name,
+					Namespace: "default",
+				},
+			}
+
+			if tt.nodeAllocs != nil {
+				ciliumNode.Spec.IPAM.Pools.Allocated = append(ciliumNode.Spec.IPAM.Pools.Allocated, tt.nodeAllocs...)
+			}
+			err = reconciler.Reconcile(context.Background(), ReconcileParams{
+				CurrentServer: testSC,
+				DesiredConfig: testSC.Config,
+				Node:          node,
+				CiliumNode:    ciliumNode,
+			})
+			if err != nil {
+				t.Fatalf("failed to reconcile pool cidr advertisements: %v", err)
+			}
+
+			// If the pool selector is disabled, ensure no advertisements are still present.
+			if tt.poolSelector == nil && tt.upsertedPools != nil {
+				if len(testSC.PodIPPoolAnnouncements) > 0 {
+					t.Fatal("disabled pool selector but pool cidr advertisements still present")
+				}
+			}
+
+			log.Printf("%+v %+v", testSC.PodIPPoolAnnouncements, tt.updated)
+
+			// Ensure we see tt.updated in testSC.PodIPPoolAnnouncements
+			for poolKey, cidrs := range tt.updated {
+				for _, cidr := range cidrs {
+					prefix := netip.MustParsePrefix(cidr)
+					var seen bool
+					for _, advrt := range testSC.PodIPPoolAnnouncements[poolKey] {
+						if advrt.NLRI.String() == prefix.String() {
+							seen = true
+						}
+					}
+					if !seen {
+						t.Fatalf("failed to advertise %v", cidr)
+					}
+				}
+			}
+
+			// ensure testSC.PodIPPoolAnnouncements does not contain advertisements
+			// not in tt.updated
+			for poolKey, advrts := range testSC.PodIPPoolAnnouncements {
+				for _, advrt := range advrts {
+					var seen bool
+					for _, cidr := range tt.updated[poolKey] {
+						if advrt.NLRI.String() == cidr {
+							seen = true
+						}
+					}
+					if !seen {
+						t.Fatalf("unwanted advert %+v", advrt)
+					}
+				}
+			}
+
+		})
+	}
+}

--- a/pkg/bgpv1/manager/workdiff.go
+++ b/pkg/bgpv1/manager/workdiff.go
@@ -6,6 +6,7 @@ package manager
 import (
 	"fmt"
 
+	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/node"
 )
@@ -19,6 +20,8 @@ type reconcileDiff struct {
 	seen map[int64]*v2alpha1api.CiliumBGPVirtualRouter
 	// the Cilium node information at the time which reconciliation was triggered.
 	node *node.LocalNode
+	// The local CiliumNode node information at the time which reconciliation was triggered.
+	ciliumNode *v2api.CiliumNode
 	// Local ASNs which BgpServers must be instantiated, configured,
 	// and added to the manager. Intended key for `seen` map.
 	register []int64
@@ -33,13 +36,14 @@ type reconcileDiff struct {
 
 // newReconcileDiff constructs a new *reconcileDiff with all internal instructures
 // initialized.
-func newReconcileDiff(node *node.LocalNode) *reconcileDiff {
+func newReconcileDiff(node *node.LocalNode, ciliumNode *v2api.CiliumNode) *reconcileDiff {
 	return &reconcileDiff{
-		seen:      make(map[int64]*v2alpha1api.CiliumBGPVirtualRouter),
-		node:      node,
-		register:  []int64{},
-		withdraw:  []int64{},
-		reconcile: []int64{},
+		seen:       make(map[int64]*v2alpha1api.CiliumBGPVirtualRouter),
+		node:       node,
+		ciliumNode: ciliumNode,
+		register:   []int64{},
+		withdraw:   []int64{},
+		reconcile:  []int64{},
 	}
 }
 

--- a/pkg/bgpv1/mock/mocks.go
+++ b/pkg/bgpv1/mock/mocks.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/node"
 
@@ -36,14 +37,14 @@ func (m *MockNodeLister) Get(name string) (*v1.Node, error) {
 var _ agent.BGPRouterManager = (*MockBGPRouterManager)(nil)
 
 type MockBGPRouterManager struct {
-	ConfigurePeers_ func(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, node *node.LocalNode) error
+	ConfigurePeers_ func(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, node *node.LocalNode, ciliumNode *v2.CiliumNode) error
 	GetPeers_       func(ctx context.Context) ([]*models.BgpPeer, error)
 	GetRoutes_      func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
 	Stop_           func()
 }
 
-func (m *MockBGPRouterManager) ConfigurePeers(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, node *node.LocalNode) error {
-	return m.ConfigurePeers_(ctx, policy, node)
+func (m *MockBGPRouterManager) ConfigurePeers(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, node *node.LocalNode, ciliumNode *v2.CiliumNode) error {
+	return m.ConfigurePeers_(ctx, policy, node, ciliumNode)
 }
 
 func (m *MockBGPRouterManager) GetPeers(ctx context.Context) ([]*models.BgpPeer, error) {

--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -9,8 +9,11 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/pkg/cidr"
+	ipam_option "github.com/cilium/cilium/pkg/ipam/option"
+	ipam_types "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/testutils"
 
@@ -170,6 +173,255 @@ func Test_PodCIDRAdvert(t *testing.T) {
 
 			// match events in any order
 			require.ElementsMatch(t, step.expectedRouteEvents, receivedEvents, step.description)
+		})
+	}
+}
+
+// Test_PodIPPoolAdvert validates pod ip pools are advertised to BGP peers.
+func Test_PodIPPoolAdvert(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	node.SetTestLocalNodeStore()
+	defer node.UnsetTestLocalNodeStore()
+
+	// Steps define the order that tests are run. Note, this is different from table tests,
+	// in which each unit is independent. In this case, tests are run sequentially and there
+	// is dependency on previous test step.
+	var steps = []struct {
+		name         string
+		ipPools      []ipam_types.IPAMPoolAllocation
+		poolLabels   map[string]string
+		nodePools    map[string][]string
+		poolSelector *slim_metav1.LabelSelector
+		expected     []routeEvent
+	}{
+		{
+			name: "nil pool labels",
+			ipPools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"10.1.0.0/16"},
+				},
+			},
+			poolLabels: nil,
+			nodePools: map[string][]string{
+				"pool1": {"10.1.1.0/24", "10.1.2.0/24"},
+			},
+			poolSelector: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{"no": "pool-labels"},
+			},
+			expected: []routeEvent{},
+		},
+		{
+			name: "nil node pools",
+			ipPools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"10.1.0.0/16"},
+				},
+			},
+			poolLabels: map[string]string{"no": "node-cidrs"},
+			nodePools:  nil,
+			poolSelector: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{"no": "node-cidrs"},
+			},
+			expected: []routeEvent{},
+		},
+		{
+			name: "matching ipv4 pool",
+			ipPools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"11.1.0.0/16"},
+				},
+			},
+			poolLabels: map[string]string{"label": "matched"},
+			nodePools: map[string][]string{
+				"pool1": {"11.1.1.0/24"},
+			},
+			poolSelector: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{"label": "matched"},
+			},
+			expected: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "11.1.1.0",
+					prefixLen:   24,
+					isWithdrawn: false,
+				},
+			},
+		},
+		{
+			name: "update matching ipv4 pool",
+			ipPools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"11.2.0.0/16"},
+				},
+			},
+			poolLabels: map[string]string{"label": "matched"},
+			nodePools: map[string][]string{
+				"pool1": {"11.2.1.0/24"},
+			},
+			poolSelector: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{"label": "matched"},
+			},
+			expected: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "11.1.1.0",
+					prefixLen:   24,
+					isWithdrawn: true,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "11.2.1.0",
+					prefixLen:   24,
+					isWithdrawn: false,
+				},
+			},
+		},
+		{
+			name: "matching ipv6 pool",
+			ipPools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"2001:0:0:1234::/64"},
+				},
+			},
+			poolLabels: map[string]string{"label": "matched"},
+			nodePools: map[string][]string{
+				"pool1": {"2001:0:0:1234:5678::/96"},
+			},
+			poolSelector: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{"label": "matched"},
+			},
+			expected: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "2001:0:0:1234:5678::",
+					prefixLen:   96,
+					isWithdrawn: false,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "11.2.1.0",
+					prefixLen:   24,
+					isWithdrawn: true,
+				},
+			},
+		},
+		{
+			name: "update matching ipv6 pool",
+			ipPools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"2002:0:0:1234::/64"},
+				},
+			},
+			poolLabels: map[string]string{"label": "matched"},
+			nodePools: map[string][]string{
+				"pool1": {"2002:0:0:1234:5678::/96"},
+			},
+			poolSelector: &slim_metav1.LabelSelector{
+				MatchLabels: map[string]string{"label": "matched"},
+			},
+			expected: []routeEvent{
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "2001:0:0:1234:5678::",
+					prefixLen:   96,
+					isWithdrawn: true,
+				},
+				{
+					sourceASN:   ciliumASN,
+					prefix:      "2002:0:0:1234:5678::",
+					prefixLen:   96,
+					isWithdrawn: false,
+				},
+			},
+		},
+	}
+
+	testCtx, testDone := context.WithTimeout(context.Background(), maxTestDuration)
+	defer testDone()
+
+	// setup topology
+	cfg := fixtureConf
+	cfg.ipam = ipam_option.IPAMMultiPool
+	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, cfg)
+	require.NoError(t, err)
+	require.Len(t, gobgpPeers, 1)
+	defer cleanup()
+
+	// setup neighbor
+	err = setupSingleNeighbor(testCtx, fixture)
+	require.NoError(t, err)
+
+	// wait for peering to establish
+	err = gobgpPeers[0].waitForSessionState(testCtx, []string{"ESTABLISHED"})
+	require.NoError(t, err)
+
+	tracker := fixture.fakeClientSet.CiliumFakeClientset.Tracker()
+
+	for i, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			// Setup pod ip pool objects with test case pool cidrs.
+			var poolObjs []*v2alpha1.CiliumPodIPPool
+			for _, pool := range step.ipPools {
+				var confCIDRs []ipam_types.IPAMPodCIDR
+				confCIDRs = append(confCIDRs, pool.CIDRs...)
+				poolObj := newIPPoolObj(ipPoolConfig{
+					name:   pool.Pool,
+					labels: step.poolLabels,
+					cidrs:  confCIDRs,
+				})
+				poolObjs = append(poolObjs, poolObj)
+			}
+
+			// Add or update the pod ip pool object in the object tracker.
+			if i == 0 {
+				for _, obj := range poolObjs {
+					err = tracker.Add(obj)
+				}
+			} else {
+				for _, obj := range poolObjs {
+					err = tracker.Update(v2alpha1.SchemeGroupVersion.WithResource("ciliumpodippools"), obj, "")
+				}
+			}
+			require.NoError(t, err)
+
+			// Setup the cilium node object with test case node cidrs.
+			allocs := make(map[string][]string)
+			for pool, cidrs := range step.nodePools {
+				allocs[pool] = cidrs
+			}
+			nodeObj := newCiliumNode(&ciliumNodeConfig{
+				name:   "test",
+				allocs: allocs,
+			})
+
+			// Add or update the cilium node object in the object tracker.
+			if i == 0 {
+				err = tracker.Add(nodeObj)
+			} else {
+				err = tracker.Update(v2.SchemeGroupVersion.WithResource("ciliumnodes"), nodeObj, "")
+			}
+			require.NoError(t, err)
+
+			// Setup the bgp policy object with the test case pool selector.
+			fixture.config.policy.Spec.VirtualRouters[0].PodIPPoolSelector = step.poolSelector
+			_, err = fixture.policyClient.Update(testCtx, &fixture.config.policy, meta_v1.UpdateOptions{})
+			require.NoError(t, err)
+
+			// Validate the expected result.
+			receivedEvents, err := gobgpPeers[0].getRouteEvents(testCtx, len(step.expected))
+			require.NoError(t, err, step.name)
+
+			// Match events in any order.
+			t.Logf("expected events: %v", step.expected)
+			t.Logf("received events: %v", receivedEvents)
+			require.ElementsMatch(t, step.expected, receivedEvents, step.name)
 		})
 	}
 }
@@ -357,7 +609,7 @@ func Test_LBEgressAdvertisement(t *testing.T) {
 			if step.op == "add" {
 				err = tracker.Add(&srvObj)
 			} else {
-				err = tracker.Update(slimv1.Unversioned.WithResource("services"), &srvObj, "")
+				err = tracker.Update(slim_metav1.Unversioned.WithResource("services"), &srvObj, "")
 			}
 			require.NoError(t, err, step.description)
 

--- a/pkg/bgpv1/test/objects.go
+++ b/pkg/bgpv1/test/objects.go
@@ -4,6 +4,10 @@
 package test
 
 import (
+	"net/netip"
+
+	ipam_types "github.com/cilium/cilium/pkg/ipam/types"
+	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -70,4 +74,83 @@ func newLBServiceObj(conf lbSrvConfig) slim_core_v1.Service {
 	}
 
 	return srvObj
+}
+
+// ipPoolConfig data used to create a CiliumPodIPPool resource.
+type ipPoolConfig struct {
+	name   string
+	cidrs  []ipam_types.IPAMPodCIDR
+	labels map[string]string
+}
+
+// newIPPoolObj creates a CiliumPodIPPool resource based on the provided conf.
+func newIPPoolObj(conf ipPoolConfig) *v2alpha1.CiliumPodIPPool {
+	obj := &v2alpha1.CiliumPodIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              conf.name,
+			UID:               uid,
+			CreationTimestamp: metav1.Now(),
+			Labels:            make(map[string]string),
+		},
+		Spec: v2alpha1.IPPoolSpec{
+			IPv4: &v2alpha1.IPv4PoolSpec{
+				CIDRs:    []v2alpha1.PoolCIDR{},
+				MaskSize: 24,
+			},
+			IPv6: &v2alpha1.IPv6PoolSpec{
+				CIDRs:    []v2alpha1.PoolCIDR{},
+				MaskSize: 64,
+			},
+		},
+	}
+
+	if conf.labels != nil {
+		obj.Labels = conf.labels
+	}
+
+	for _, cidr := range conf.cidrs {
+		if p := netip.MustParsePrefix(string(cidr)); p.Addr().Is4() {
+			obj.Spec.IPv4.CIDRs = append(obj.Spec.IPv4.CIDRs, v2alpha1.PoolCIDR(cidr))
+		}
+		if p := netip.MustParsePrefix(string(cidr)); p.Addr().Is6() {
+			obj.Spec.IPv6.CIDRs = append(obj.Spec.IPv6.CIDRs, v2alpha1.PoolCIDR(cidr))
+		}
+	}
+
+	return obj
+}
+
+// ciliumNodeConfig data used to create a CiliumNode resource.
+type ciliumNodeConfig struct {
+	name   string
+	allocs map[string][]string
+}
+
+// newCiliumNode creates a CiliumNode resource based on the provided conf.
+func newCiliumNode(conf *ciliumNodeConfig) *v2.CiliumNode {
+	obj := &v2.CiliumNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              conf.name,
+			UID:               uid,
+			CreationTimestamp: metav1.Now(),
+		},
+	}
+
+	if conf.allocs != nil {
+		var allocs []ipam_types.IPAMPoolAllocation
+		for pool, cidrs := range conf.allocs {
+			poolCIDRs := []ipam_types.IPAMPodCIDR{}
+			for _, c := range cidrs {
+				poolCIDRs = append(poolCIDRs, ipam_types.IPAMPodCIDR(c))
+			}
+			alloc := ipam_types.IPAMPoolAllocation{
+				Pool:  pool,
+				CIDRs: poolCIDRs,
+			}
+			allocs = append(allocs, alloc)
+		}
+		obj.Spec.IPAM.Pools.Allocated = allocs
+	}
+
+	return obj
 }

--- a/pkg/ipam/types/types.go
+++ b/pkg/ipam/types/types.go
@@ -5,6 +5,7 @@ package types
 
 import (
 	"fmt"
+	"net/netip"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/lock"
@@ -55,6 +56,19 @@ type AllocationMap map[string]AllocationIP
 //
 // +kubebuilder:validation:Format=cidr
 type IPAMPodCIDR string
+
+func (c *IPAMPodCIDR) ToPrefix() (*netip.Prefix, error) {
+	if c == nil {
+		return nil, fmt.Errorf("nil ipam cidr")
+	}
+
+	prefix, err := netip.ParsePrefix(string(*c))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ipam cidr %v: %w", c, err)
+	}
+
+	return &prefix, nil
+}
 
 // IPAMPoolAllocation describes an allocation of an IPAM pool from the operator to the
 // node. It contains the assigned PodCIDRs allocated from this pool

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -393,6 +393,62 @@ spec:
                         type: object
                       minItems: 1
                       type: array
+                    podIPPoolSelector:
+                      description: "PodIPPoolSelector selects CiliumPodIPPools based
+                        on labels. The virtual router will announce allocated CIDRs
+                        of matching CiliumPodIPPools. \n If empty / nil no CiliumPodIPPools
+                        will be announced."
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                enum:
+                                - In
+                                - NotIn
+                                - Exists
+                                - DoesNotExist
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            description: MatchLabelsValue represents the value from
+                              the MatchLabels {key,value} pair.
+                            maxLength: 63
+                            pattern: ^(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?$
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
                     serviceSelector:
                       description: "ServiceSelector selects a group of load balancer
                         services which this virtual router will announce. The loadBalancerClass

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -272,6 +272,13 @@ type CiliumBGPVirtualRouter struct {
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default=false
 	ExportPodCIDR *bool `json:"exportPodCIDR,omitempty"`
+	// PodIPPoolSelector selects CiliumPodIPPools based on labels. The virtual
+	// router will announce allocated CIDRs of matching CiliumPodIPPools.
+	//
+	// If empty / nil no CiliumPodIPPools will be announced.
+	//
+	// +kubebuilder:validation:Optional
+	PodIPPoolSelector *slimv1.LabelSelector `json:"podIPPoolSelector,omitempty"`
 	// ServiceSelector selects a group of load balancer services which this
 	// virtual router will announce. The loadBalancerClass for a service must
 	// be nil or specify a class supported by Cilium, e.g. "io.cilium/bgp-control-plane".

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepcopy.go
@@ -265,6 +265,11 @@ func (in *CiliumBGPVirtualRouter) DeepCopyInto(out *CiliumBGPVirtualRouter) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PodIPPoolSelector != nil {
+		in, out := &in.PodIPPoolSelector, &out.PodIPPoolSelector
+		*out = new(v1.LabelSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ServiceSelector != nil {
 		in, out := &in.ServiceSelector, &out.ServiceSelector
 		*out = new(v1.LabelSelector)

--- a/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/zz_generated.deepequal.go
@@ -292,6 +292,14 @@ func (in *CiliumBGPVirtualRouter) DeepEqual(other *CiliumBGPVirtualRouter) bool 
 		}
 	}
 
+	if (in.PodIPPoolSelector == nil) != (other.PodIPPoolSelector == nil) {
+		return false
+	} else if in.PodIPPoolSelector != nil {
+		if !in.PodIPPoolSelector.DeepEqual(other.PodIPPoolSelector) {
+			return false
+		}
+	}
+
 	if (in.ServiceSelector == nil) != (other.ServiceSelector == nil) {
 		return false
 	} else if in.ServiceSelector != nil {


### PR DESCRIPTION
Adds Support for Multi-Pool IPAM:

- Adds `PodIPPoolSelector` to `CiliumBGPVirtualRouter` for defining a label selector for advertising routes from allocated IPAM pools.
- Adds `LocalCiliumNodeResource ` to the BGP CP `Controller` to provide a stream of events for changes to the local CiliumNode resource.
- Adds `PodIPPoolAnnouncements` to `ServerWithConfig` for holding all the announced multi-pool IPAM CIDRs.
- Adds `PodIPPoolReconciler` to advertise IPAM pool CIDRs of a matching CiliumBGPPeeringPolicy.
- Updates BGP CP unit and integration tests.

Fixes: #26937

```release-note
The podIPPoolSelector field has been added to CiliumBGPVirtualRouter for selectively advertising multi-pool IPAM CIDRs.
```
