### PR TITLE
Extend API/CLI to support updating policy by label

### DIFF
--- a/Documentation/cmdref/cilium_policy_import.md
+++ b/Documentation/cmdref/cilium_policy_import.md
@@ -18,9 +18,11 @@ cilium policy import <path> [flags]
 ### Options
 
 ```
-  -h, --help            help for import
-  -o, --output string   json| yaml| jsonpath='{}'
-      --print           Print policy after import
+  -h, --help                          help for import
+  -o, --output string                 json| yaml| jsonpath='{}'
+      --print                         Print policy after import
+      --replace                       Replace existing policy
+      --replace-with-labels strings   Replace existing policies that match given labels
 ```
 
 ### Options inherited from parent commands

--- a/api/v1/client/policy/put_policy_parameters.go
+++ b/api/v1/client/policy/put_policy_parameters.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-openapi/runtime"
 	cr "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 )
 
 // NewPutPolicyParams creates a new PutPolicyParams object,
@@ -69,6 +70,18 @@ type PutPolicyParams struct {
 	   Policy rules
 	*/
 	Policy string
+
+	/* Replace.
+
+	   If true, indicates that existing rules with identical labels should be replaced.
+	*/
+	Replace *bool
+
+	/* ReplaceWithLabels.
+
+	   If present, indicates that existing rules with the given labels should be deleted.
+	*/
+	ReplaceWithLabels []string
 
 	timeout    time.Duration
 	Context    context.Context
@@ -134,6 +147,28 @@ func (o *PutPolicyParams) SetPolicy(policy string) {
 	o.Policy = policy
 }
 
+// WithReplace adds the replace to the put policy params
+func (o *PutPolicyParams) WithReplace(replace *bool) *PutPolicyParams {
+	o.SetReplace(replace)
+	return o
+}
+
+// SetReplace adds the replace to the put policy params
+func (o *PutPolicyParams) SetReplace(replace *bool) {
+	o.Replace = replace
+}
+
+// WithReplaceWithLabels adds the replaceWithLabels to the put policy params
+func (o *PutPolicyParams) WithReplaceWithLabels(replaceWithLabels []string) *PutPolicyParams {
+	o.SetReplaceWithLabels(replaceWithLabels)
+	return o
+}
+
+// SetReplaceWithLabels adds the replaceWithLabels to the put policy params
+func (o *PutPolicyParams) SetReplaceWithLabels(replaceWithLabels []string) {
+	o.ReplaceWithLabels = replaceWithLabels
+}
+
 // WriteToRequest writes these params to a swagger request
 func (o *PutPolicyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
@@ -145,8 +180,53 @@ func (o *PutPolicyParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Reg
 		return err
 	}
 
+	if o.Replace != nil {
+
+		// query param replace
+		var qrReplace bool
+
+		if o.Replace != nil {
+			qrReplace = *o.Replace
+		}
+		qReplace := swag.FormatBool(qrReplace)
+		if qReplace != "" {
+
+			if err := r.SetQueryParam("replace", qReplace); err != nil {
+				return err
+			}
+		}
+	}
+
+	if o.ReplaceWithLabels != nil {
+
+		// binding items for replace-with-labels
+		joinedReplaceWithLabels := o.bindParamReplaceWithLabels(reg)
+
+		// query array param replace-with-labels
+		if err := r.SetQueryParam("replace-with-labels", joinedReplaceWithLabels...); err != nil {
+			return err
+		}
+	}
+
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
 	return nil
+}
+
+// bindParamPutPolicy binds the parameter replace-with-labels
+func (o *PutPolicyParams) bindParamReplaceWithLabels(formats strfmt.Registry) []string {
+	replaceWithLabelsIR := o.ReplaceWithLabels
+
+	var replaceWithLabelsIC []string
+	for _, replaceWithLabelsIIR := range replaceWithLabelsIR { // explode []string
+
+		replaceWithLabelsIIV := replaceWithLabelsIIR // string as string
+		replaceWithLabelsIC = append(replaceWithLabelsIC, replaceWithLabelsIIV)
+	}
+
+	// items.CollectionFormat: ""
+	replaceWithLabelsIS := swag.JoinByFormat(replaceWithLabelsIC, "")
+
+	return replaceWithLabelsIS
 }

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -572,6 +572,8 @@ paths:
       - policy
       parameters:
       - "$ref": "#/parameters/policy-rules"
+      - "$ref": "#/parameters/policy-replace"
+      - "$ref": "#/parameters/policy-replace-with-labels"
       responses:
         '200':
           description: Success
@@ -1193,6 +1195,20 @@ parameters:
     required: true
     in: body
     schema:
+      type: string
+  policy-replace:
+    name: replace
+    description: If true, indicates that existing rules with identical labels should be replaced.
+    required: false
+    in: query
+    type: boolean
+  policy-replace-with-labels:
+    name: replace-with-labels
+    description: If present, indicates that existing rules with the given labels should be deleted.
+    required: false
+    in: query
+    type: array
+    items:
       type: string
   pod-name:
     name: pod

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -1286,6 +1286,12 @@ func init() {
         "parameters": [
           {
             "$ref": "#/parameters/policy-rules"
+          },
+          {
+            "$ref": "#/parameters/policy-replace"
+          },
+          {
+            "$ref": "#/parameters/policy-replace-with-labels"
           }
         ],
         "responses": {
@@ -5147,6 +5153,21 @@ func init() {
       "in": "path",
       "required": true
     },
+    "policy-replace": {
+      "type": "boolean",
+      "description": "If true, indicates that existing rules with identical labels should be replaced.",
+      "name": "replace",
+      "in": "query"
+    },
+    "policy-replace-with-labels": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "If present, indicates that existing rules with the given labels should be deleted.",
+      "name": "replace-with-labels",
+      "in": "query"
+    },
     "policy-rules": {
       "description": "Policy rules",
       "name": "policy",
@@ -6653,6 +6674,21 @@ func init() {
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "type": "boolean",
+            "description": "If true, indicates that existing rules with identical labels should be replaced.",
+            "name": "replace",
+            "in": "query"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "If present, indicates that existing rules with the given labels should be deleted.",
+            "name": "replace-with-labels",
+            "in": "query"
           }
         ],
         "responses": {
@@ -11080,6 +11116,21 @@ func init() {
       "name": "pod",
       "in": "path",
       "required": true
+    },
+    "policy-replace": {
+      "type": "boolean",
+      "description": "If true, indicates that existing rules with identical labels should be replaced.",
+      "name": "replace",
+      "in": "query"
+    },
+    "policy-replace-with-labels": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "If present, indicates that existing rules with the given labels should be deleted.",
+      "name": "replace-with-labels",
+      "in": "query"
     },
     "policy-rules": {
       "description": "Policy rules",

--- a/cilium/cmd/policy_import.go
+++ b/cilium/cmd/policy_import.go
@@ -15,6 +15,8 @@ import (
 )
 
 var printPolicy bool
+var replacePolicy bool
+var replaceWithLabels []string
 
 // policyImportCmd represents the policy_import command
 var policyImportCmd = &cobra.Command{
@@ -46,7 +48,7 @@ var policyImportCmd = &cobra.Command{
 			if err != nil {
 				Fatalf("Cannot marshal policy: %s\n", err)
 			}
-			if resp, err := client.PolicyPut(string(jsonPolicy)); err != nil {
+			if resp, err := client.PolicyReplace(string(jsonPolicy), replacePolicy, replaceWithLabels); err != nil {
 				Fatalf("Cannot import policy: %s\n", err)
 			} else if command.OutputOption() {
 				if err := command.PrintOutput(resp); err != nil {
@@ -64,5 +66,7 @@ var policyImportCmd = &cobra.Command{
 func init() {
 	PolicyCmd.AddCommand(policyImportCmd)
 	policyImportCmd.Flags().BoolVarP(&printPolicy, "print", "", false, "Print policy after import")
+	policyImportCmd.Flags().BoolVarP(&replacePolicy, "replace", "", false, "Replace existing policy")
+	policyImportCmd.Flags().StringSliceVarP(&replaceWithLabels, "replace-with-labels", "", []string{}, "Replace existing policies that match given labels")
 	command.AddOutputOption(policyImportCmd)
 }

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -644,8 +644,16 @@ func putPolicyHandler(d *Daemon, params PutPolicyParams) middleware.Responder {
 		}
 	}
 
+	replace := false
+	if params.Replace != nil {
+		replace = *params.Replace
+	}
+	replaceWithLabels := labels.ParseSelectLabelArrayFromArray(params.ReplaceWithLabels)
+
 	rev, err := d.PolicyAdd(rules, &policy.AddOptions{
-		Source: source.LocalAPI,
+		Replace:           replace,
+		ReplaceWithLabels: replaceWithLabels,
+		Source:            source.LocalAPI,
 	})
 	if err != nil {
 		metrics.PolicyImportErrorsTotal.Inc() // Deprecated in Cilium 1.14, to be removed in 1.15.

--- a/pkg/client/policy.go
+++ b/pkg/client/policy.go
@@ -19,6 +19,16 @@ func (c *Client) PolicyPut(policyJSON string) (*models.Policy, error) {
 	return resp.Payload, nil
 }
 
+// PolicyReplace replaces the `policyJSON`
+func (c *Client) PolicyReplace(policyJSON string, replace bool, replaceWithLabels []string) (*models.Policy, error) {
+	params := policy.NewPutPolicyParams().WithPolicy(policyJSON).WithReplace(&replace).WithReplaceWithLabels(replaceWithLabels).WithTimeout(api.ClientTimeout)
+	resp, err := c.Policy.PutPolicy(params)
+	if err != nil {
+		return nil, Hint(err)
+	}
+	return resp.Payload, nil
+}
+
 // PolicyGet returns policy rules
 func (c *Client) PolicyGet(labels []string) (*models.Policy, error) {
 	params := policy.NewGetPolicyParams().WithLabels(labels).WithTimeout(api.ClientTimeout)


### PR DESCRIPTION
This change extends the HTTP API to allow updating the agent policy repository by label. This is existing functionality that this change just exposes over the HTTP API as well.

The `cilium policy import` command has been updated to make this functionality available from the CLI.

```release-note
cli: Update `cilium policy import` to allow policy replacement by label
```
