### PR TITLE
Add docs on first and last IP of LB-IPAM pool

### DIFF
--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -379,6 +379,9 @@ multiple IPs to be requested at once.
 The service selector of the IP Pool still applies, requested IPs will not be allocated or assigned
 if the services don't match the pool's selector.
 
+Don't configure the annotation to request the first or last IP of an IP pool. They are reserved 
+for the network and broadcast addresses respectively.
+
 .. code-block:: yaml
 
     apiVersion: v1


### PR DESCRIPTION
The first and last IP in a LB-IPAM pool are reserved for the network and broadcast address and can thus not be requested.
