### PR TITLE
CI: Link checker script

### DIFF
--- a/Documentation/check-build.sh
+++ b/Documentation/check-build.sh
@@ -87,10 +87,6 @@ build_with_spellchecker() {
         -E -n --color -w "${warnings}" -W --keep-going 2>/dev/null
 }
 
-build_with_linkchecker() {
-    sphinx-build -b linkcheck -d "${build_dir}/doctrees" . "${spelldir}" -q -E
-}
-
 run_linter() {
     local CONF_PY_ROLES CONF_PY_SUBSTITUTIONS ignored_messages
 
@@ -154,15 +150,6 @@ else
   fi
 fi
 
-# TODO: Fix broken links and re-enable this
-# (https://github.com/cilium/cilium/issues/10601)
-# echo "Checking links..."
-# if ! build_with_linkchecker ; then
-#     echo "Link check failed!"
-#     exit 1
-# fi
-
-echo ""
 echo "Building documentation (${target})..."
 sphinx-build -M "${target}" "${script_dir}" "${build_dir}" $@ \
     ${read_all_opt} -n --color -w "${warnings}" 2>/dev/null

--- a/Documentation/check-links.sh
+++ b/Documentation/check-links.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+echo "WARNING: There is a bug in docutils which may result in failure of this script. For ref: https://github.com/cilium/cilium/pull/27116#issuecomment-1752760611"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+build_dir="${script_dir}/_build"
+warnings="${build_dir}/links_warnings.txt"
+filtered_warnings="${build_dir}/filtered_links_warnings.txt"
+linksdir="${build_dir}/links"
+
+cd "${script_dir}"
+mkdir -p "${build_dir}"
+rm -f -- "${warnings}"
+rm -f -- "${filtered_warnings}"
+
+filter_warnings() {
+    [ -s "${warnings}" ] || return
+    grep -v -E \
+        -e "/_api/v1/.*/README\.md:[0-9]+: WARNING: 'myst' reference target not found:" \
+        -e "/.*:[0-9]+: WARNING: circular inclusion in \"include\" directive" \
+        "${warnings}"
+}
+
+has_build_warnings() {
+    filter_warnings > /dev/null
+}
+
+build_with_linkchecker() {
+    rm -rf "${linksdir}"
+
+    sphinx-build -b linkcheck -d "${build_dir}/doctrees" . "${linksdir}" \
+        --color -E -w "${warnings}" -W --keep-going 2>/dev/null
+}
+
+echo "Checking links..."
+if ! build_with_linkchecker ; then
+    if has_build_warnings; then
+        printf "\nPlease fix the following documentation warnings:\n"
+        filter_warnings
+        printf "\nAdding the warnings to the file.\n"
+        filter_warnings | sed 's/\x1B\[[0-9;]*[a-zA-Z]//g' > "${filtered_warnings}"
+        exit 1
+    fi
+fi
+echo "Done checking links."

--- a/Documentation/community/governance/commit_access.rst
+++ b/Documentation/community/governance/commit_access.rst
@@ -136,7 +136,7 @@ Code of Conduct violator is a Maintainer, the Maintainers will instead
 designate two Maintainers to work with the `CNCF CoC Committee`_.
 
 .. _Code of Conduct: https://github.com/cilium/cilium/blob/main/CODE_OF_CONDUCT.md
-.. _CNCF CoC Committee: https://www.cncf.io/conduct/procedures/
+.. _CNCF CoC Committee: https://www.cncf.io/conduct/committee/
 
 Granting Commit Access
 ----------------------

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -270,6 +270,31 @@ http_strict_mode = False
 # Try as hard as possible to find references
 default_role = 'any'
 
+# -- Options for Link Check output ----------------------------------------
+
+linkcheck_ignore = [
+    # Local links
+    'http://127.0.0.1',
+    'http://localhost',
+    'http://192.168.60.13',
+    'https://192.168.60.11',
+
+    # URLs that are not reachable(invalid or test links)
+    'https://bookinfo.cilium.rocks',
+    'dns:query',
+
+    # Needs authentication
+    'https://github.com/cilium/cilium/projects/new',
+    'https://github.com/cilium/cilium/settings/branches',
+    'https://jenkins.cilium.io/job/',
+    'https://jenkins.cilium.io/view/'
+]
+
+linkcheck_anchors = False
+linkcheck_retries = 5
+
+tls_verify = False
+
 def setup(app):
     app.add_css_file('parsed-literal.css')
     app.add_css_file('copybutton.css')

--- a/Documentation/configuration/verify-image-signatures.rst
+++ b/Documentation/configuration/verify-image-signatures.rst
@@ -53,5 +53,5 @@ Let's verify a Cilium image's signature using the ``cosign verify`` command:
     from the Github build images release workflow.
     
 
-.. _`Keyless Signatures`: https://docs.sigstore.dev/cosign/keyless/
+.. _`Keyless Signatures`: https://docs.sigstore.dev/cosign/overview/#keyless-signing-of-a-container
 .. _`Cilium workflows`: https://github.com/cilium/cilium/tree/main/.github/workflows

--- a/Documentation/contributing/development/reviewers_committers/review_process.rst
+++ b/Documentation/contributing/development/reviewers_committers/review_process.rst
@@ -134,7 +134,7 @@ to add or remove yourself from any team, please submit a PR against the
 `community repository`_.
 
 Once a contributor opens a PR, GitHub automatically picks which `teams
-<cilium_teams>`_ should review the PR using the ``CODEOWNERS`` file. Each
+<cilium_teams_>`_ should review the PR using the ``CODEOWNERS`` file. Each
 reviewer can see the PRs they need to review by filtering by reviews
 requested. A good filter is provided in this `link <user_review_filter_>`_ so
 make sure to bookmark it.

--- a/Documentation/installation/alibabacloud-eni.rst
+++ b/Documentation/installation/alibabacloud-eni.rst
@@ -1,5 +1,3 @@
-.. _k8s_alibabacloud_eni:
-
 To install Cilium on `ACK (Alibaba Cloud Container Service for Kubernetes) <https://www.alibabacloud.com/help/doc-detail/86745.htm>`_, perform the following steps:
 
 **Disable ACK CNI (ACK Only):**
@@ -106,7 +104,6 @@ As soon as you have the access tokens, the following secret needs to be added,
 with each empty string replaced by the associated value as a base64-encoded string:
 
 .. code-block:: yaml
-    :name: cilium-secret.yaml
 
     apiVersion: v1
     kind: Secret


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
Enabling the link checker for the CI.
- There is know issue of warning: Circular inclusion in the include directive example: WARNING: circular inclusion in "include" directive. Not able to find the circular inclusion in the docs files. There is an open issue on the same : https://github.com/sphinx-doc/sphinx/issues/10951
- myst not able to parse the #anchor in the Documentation. example: 'myst' reference target not found. This has been disabled using the `ref.myst` in the suppress_warning for sphinx.
Note: This is dependent on merge of PR: https://github.com/cilium/cilium/issues/10601 to make sure CI passes


```release-note
ci: Enable link checker to ensure that all links in documentation are valid
```

Related: #10601

