### PR TITLE
ldelossa/register bgpserver fix

### DIFF
--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -224,7 +224,7 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context, c *v2alpha1api
 				AdvertiseInactiveRoutes: true,
 			},
 		},
-		CState: &agent.ControlPlaneState{},
+		CState: cstate,
 	}
 
 	if s, err = NewServerWithConfig(ctx, globalConfig); err != nil {


### PR DESCRIPTION
Fixes an issue where an empty ControlPlaneState was used during registration of BGP speakers. 

```release-note
Fixes an issue where an empty ControlPlaneState was used during registration of BGP speakers. This would cause reconciliation issues as the current state would be unknown.
```
