### PR TITLE
docs: Replace non-portable "sed -i" in Makefile

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -105,13 +105,14 @@ M2R := $(DOCKER_CTR) $(HELM_TOOLBOX_IMAGE) python3 /usr/bin/m2r2
 .PHONY: update-helm-values FORCE
 $(HELM_VALUES): TMP_FILE_1 := helm-values.tmp
 $(HELM_VALUES): TMP_FILE_2 := helm-values.awk
+$(HELM_VALUES): TMP_FILE_3 := helm-values.sed
 $(HELM_VALUES): FORCE
 	$(QUIET)$(HELM_DOCS) -d -c $(HELM_DOCS_CHARTS_DIR) -t $(HELM_DOCS_OUTPUT_DIR)/$(TMP_FILE_1).tmpl > $(TMP_FILE_1)
 	$(QUIET)awk -F'|' '{print "|"$$2"|"$$5"|"$$3"|"$$4"|"}' $(TMP_FILE_1) > $(TMP_FILE_2)
 	$(QUIET)$(M2R) --overwrite $(TMP_FILE_2)
-	$(QUIET)sed -i 's/^\(   \* - \)\([[:print:]]\+\)$$/\1:spelling:ignore:`\2`/' $@
-	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $@)" > $@
-	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2)
+	$(QUIET)$(SED) 's/^\(   \* - \)\([[:print:]]\+\)$$/\1:spelling:ignore:`\2`/' $@ > $(TMP_FILE_3)
+	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $(TMP_FILE_3))" > $@
+	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2) $(TMP_FILE_3)
 
 epub latex html: builder-image update-helm-values ## Check documentation and render it under the specified format.
 	@$(ECHO_GEN)_build/$@

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -37,7 +37,7 @@ CONTAINER_ENGINE?=docker
 DOCKER_FLAGS?=
 DOCKER_BUILD_FLAGS?=
 
-# use gsed if avaiable, otherwise use sed.
+# use gsed if available, otherwise use sed.
 # gsed is needed for MacOS to make in-place replacement work correctly.
 SED ?= $(if $(shell command -v gsed),gsed,sed)
 


### PR DESCRIPTION
We recently added a call to `sed` in Documentation's Makefile, as part of the generation process for the Helm reference. We use the `-i` option to edit the file in-place; but this option is not portable, and the command fails when running BSD versions of sed, for example on MacOS, as opposed to GNU sed.

Let's fix the command by using an additional temporary file.

Fixes: 2e9b20fcf1a7 ("docs: Ignore Helm value names for spellcheck")