### PR TITLE
l4lb: add health-probe support for DSR-Geneve configs

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -162,7 +162,7 @@ jobs:
         env:
           # Disable coverage report for these test cases since they are hitting
           # https://github.com/cilium/coverbee/issues/7
-          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|l4lb_ipip_health_check_host.o|nodeport_geneve_dsr_*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|tc_nodeport_lb6_dsr_backend.o|tc_nodeport_lb6_dsr_lb.o|xdp_egressgw_reply.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o|xdp_nodeport_lb6_dsr_lb.o|bpf_nat_tests.o"
+          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|l4lb_geneve_health_check_host.o|l4lb_ipip_health_check_host.o|nodeport_geneve_dsr_*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|tc_nodeport_lb6_dsr_backend.o|tc_nodeport_lb6_dsr_lb.o|xdp_egressgw_reply.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o|xdp_nodeport_lb6_dsr_lb.o|bpf_nat_tests.o"
         run: |
           make -C test run_bpf_tests COVER=1 NOCOVER="$NOCOVER_PATTERN" || (echo "Run 'make -C test run_bpf_tests COVER=1 NOCOVER=\"$NOCOVER_PATTERN\"' locally to investigate failures"; exit 1)
       - name: Archive code coverage results

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -686,11 +686,11 @@ enum metric_dir {
  */
 #define MARK_MAGIC_WG_ENCRYPTED		0x1E00
 
-/* MARK_MAGIC_HEALTH_IPIP_DONE can overlap with MARK_MAGIC_SNAT_DONE with both
+/* MARK_MAGIC_HEALTH_LB_DONE can overlap with MARK_MAGIC_SNAT_DONE with both
  * being mutual exclusive given former is only under DSR. Used to push health
- * probe packets to ipip tunnel device & to avoid looping back.
+ * probe packets to tunnel device & to avoid looping back.
  */
-#define MARK_MAGIC_HEALTH_IPIP_DONE	MARK_MAGIC_SNAT_DONE
+#define MARK_MAGIC_HEALTH_LB_DONE	MARK_MAGIC_SNAT_DONE
 
 /* MARK_MAGIC_HEALTH can overlap with MARK_MAGIC_DECRYPT with both being
  * mutual exclusive. Note, MARK_MAGIC_HEALTH is user-facing UAPI for LB!

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -3154,6 +3154,85 @@ health_encap_v6(struct __ctx_buff *ctx, const struct lb6_health *val,
 
 	return ctx_redirect(ctx, ENCAP6_IFINDEX, 0);
 }
+# elif DSR_ENCAP_MODE == DSR_ENCAP_GENEVE
+static __always_inline int
+health_encap_v4(struct __ctx_buff *ctx, const struct lb4_health *val,
+		__u32 src_sec_identity)
+{
+	struct remote_endpoint_info *info __maybe_unused;
+	struct ipv4_ct_tuple tuple = {};
+	struct geneve_dsr_opt4 opt;
+	__be32 tunnel_endpoint;
+	__u32 dst_sec_identity;
+	void *data, *data_end;
+	bool need_opt = true;
+	int ifindex = 0, ret;
+	struct iphdr *ip4;
+	int l4_off;
+
+	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+		return DROP_INVALID;
+
+	ret = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
+	if (IS_ERR(ret))
+		return ret;
+
+	/* DNAT the packet to the selected backend: */
+	ret = snat_v4_rewrite_headers(ctx, tuple.nexthdr, ipv4_has_l4_header(ip4), l4_off,
+				      tuple.daddr, val->peer.address, offsetof(struct iphdr, daddr),
+				      tuple.sport, val->peer.port, TCP_DPORT_OFF);
+	if (IS_ERR(ret))
+		return ret;
+
+#ifdef ENABLE_HIGH_SCALE_IPCACHE
+	tunnel_endpoint = val->peer.address;
+	dst_sec_identity = 0;
+#else
+	info = lookup_ip4_remote_endpoint(val->peer.address, 0);
+	if (!info || info->tunnel_endpoint == 0)
+		return DROP_NO_TUNNEL_ENDPOINT;
+
+	tunnel_endpoint = info->tunnel_endpoint;
+	dst_sec_identity = info->sec_identity;
+#endif
+
+	if (tuple.nexthdr == IPPROTO_TCP) {
+		union tcp_flags tcp_flags = {};
+
+		if (l4_load_tcp_flags(ctx, l4_off, &tcp_flags) < 0)
+			return DROP_CT_INVALID_HDR;
+
+		if (!(tcp_flags.value & TCP_FLAG_SYN))
+			need_opt = false;
+	}
+
+	if (need_opt) {
+		set_geneve_dsr_opt4(tuple.sport, tuple.daddr, &opt);
+		ret = nodeport_add_tunnel_encap_opt(ctx, 0, 0, tunnel_endpoint,
+						    src_sec_identity, dst_sec_identity,
+						    &opt, sizeof(opt),
+						    (enum trace_reason)CT_NEW,
+						    TRACE_PAYLOAD_LEN, &ifindex);
+	} else {
+		ret = nodeport_add_tunnel_encap(ctx, 0, 0, tunnel_endpoint,
+						src_sec_identity, dst_sec_identity,
+						(enum trace_reason)CT_NEW,
+						TRACE_PAYLOAD_LEN, &ifindex);
+	}
+
+	if (IS_ERR(ret))
+		return ret;
+
+	return ctx_redirect(ctx, ifindex, 0);
+}
+
+static __always_inline int
+health_encap_v6(struct __ctx_buff *ctx __maybe_unused,
+		const struct lb6_health *val __maybe_unused,
+		__u32 seclabel __maybe_unused)
+{
+	return DROP_NO_TUNNEL_ENDPOINT;
+}
 # else
 # error "Invalid load balancer DSR encapsulation mode for LB Health-check!"
 # endif

--- a/bpf/tests/l4lb_geneve_health_check_host.c
+++ b/bpf/tests/l4lb_geneve_health_check_host.c
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_IPIP		2
+#define DSR_ENCAP_GENEVE	3
+#define DSR_ENCAP_MODE		DSR_ENCAP_GENEVE
+#define ENABLE_HIGH_SCALE_IPCACHE 1
+#define ENABLE_HEALTH_CHECK	1
+
+#define DISABLE_LOOPBACK_LB
+
+#define CLIENT_IP		v4_pod_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define ENCAP_IFINDEX		25
+
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_PORT		__bpf_htons(80)
+
+#define BACKEND_IP		v4_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define SOCKET_COOKIE		1
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *backend_mac = mac_two;
+
+#define get_socket_cookie mock_get_socket_cookie
+
+__u64 mock_get_socket_cookie(const struct __sk_buff *ctx __maybe_unused)
+{
+	return SOCKET_COOKIE;
+}
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if (ifindex == ENCAP_IFINDEX)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_DROP;
+}
+
+#define skb_set_tunnel_key mock_skb_set_tunnel_key
+
+int mock_skb_set_tunnel_key(__maybe_unused struct __sk_buff *skb,
+			    __maybe_unused const struct bpf_tunnel_key *from,
+			    __maybe_unused __u32 size,
+			    __maybe_unused __u32 flags)
+{
+	if (from->tunnel_id != 0)
+		return -1;
+	if (from->local_ipv4 != 0)
+		return -2;
+	if (from->remote_ipv4 != bpf_ntohl(BACKEND_IP))
+		return -3;
+	return 0;
+}
+
+#define skb_set_tunnel_opt mock_skb_set_tunnel_opt
+
+int mock_skb_set_tunnel_opt(__maybe_unused struct __sk_buff *skb,
+			    void *opt, __u32 opt_len)
+{
+	struct geneve_dsr_opt4 *gopt = opt;
+
+	if (opt_len != sizeof(*gopt))
+		return -1;
+	if (gopt->addr != FRONTEND_IP)
+		return -2;
+	if (gopt->port != FRONTEND_PORT)
+		return -3;
+	return 0;
+}
+
+#define SECCTX_FROM_IPCACHE 1
+
+#include "bpf_host.c"
+
+#define TO_NETDEV	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Test that a health-check request to a remote backend is GENEVE-encapsulated. */
+PKTGEN("tc", "l4lb_geneve_health_check_host")
+int l4lb_geneve_health_check_host_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)backend_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = FRONTEND_IP;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = FRONTEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "l4lb_geneve_health_check_host")
+int l4lb_geneve_health_check_host_setup(struct __ctx_buff *ctx)
+{
+	__sock_cookie key = SOCKET_COOKIE;
+	struct lb4_health value = {
+		.peer = {
+			.address = BACKEND_IP,
+			.port = BACKEND_PORT,
+		}
+	};
+
+	map_update_elem(&LB4_HEALTH_MAP, &key, &value, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "l4lb_geneve_health_check_host")
+int l4lb_geneve_health_check_host_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the client MAC")
+	if (memcmp(l2->h_dest, (__u8 *)backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the backend MAC")
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP)
+		test_fatal("dst IP hasn't been DNATed");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port hasn't been DNATed");
+
+	test_finish();
+}

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -253,7 +253,8 @@ func initKubeProxyReplacementOptions() error {
 		option.Config.EnableHealthDatapath =
 			option.Config.DatapathMode == datapathOption.DatapathModeLBOnly &&
 				option.Config.NodePortMode == option.NodePortModeDSR &&
-				option.Config.LoadBalancerDSRDispatch == option.DSRDispatchIPIP
+				(option.Config.LoadBalancerDSRDispatch == option.DSRDispatchIPIP ||
+					option.Config.LoadBalancerDSRDispatch == option.DSRDispatchGeneve)
 	}
 
 	if option.Config.InstallNoConntrackIptRules {

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -317,7 +317,8 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	case option.Config.TunnelingEnabled():
 		mode = tunnelMode
 		encapProto = option.Config.TunnelProtocol
-	case option.Config.EnableHealthDatapath:
+	case option.Config.EnableHealthDatapath &&
+		option.Config.LoadBalancerDSRDispatch == option.DSRDispatchIPIP:
 		mode = option.DSRDispatchIPIP
 		sysSettings = append(sysSettings,
 			sysctl.Setting{Name: "net.core.fb_tunnels_only_for_init_net",

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1986,7 +1986,7 @@ type DaemonConfig struct {
 	// EnableSVCSourceRangeCheck enables check of loadBalancerSourceRanges
 	EnableSVCSourceRangeCheck bool
 
-	// EnableHealthDatapath enables IPIP health probes data path
+	// EnableHealthDatapath enables Standalone-LB health probes data path
 	EnableHealthDatapath bool
 
 	// EnableHostPort enables k8s Pod's hostPort mapping through BPF


### PR DESCRIPTION
This extends the health-probe feature in the L4LB to also support DSR with Geneve-dispatch (currently it's limited to IPIP dispatch). The main use-case is for high-scale ipcache, so I didn't bother with adding IPv6 support at this point.

The Geneve path is a bit more involved than the IPIP one, to DNAT the packet & insert the DSR option. There's a good amount of overlap with `encap_geneve_dsr_opt4()` here, so I'll see if it's worth extracting a shared helper (in a follow-on PR).