### PR TITLE
test: Enable IPv6 BPF masquerading for upgrade tests

### DIFF
--- a/test/helpers/cons.go
+++ b/test/helpers/cons.go
@@ -175,9 +175,9 @@ const (
 
 	// CiliumStableHelmChartVersion should be the chart version that points
 	// to the v1.X branch
-	CiliumStableHelmChartVersion = "1.13"
+	CiliumStableHelmChartVersion = "1.14"
 	CiliumStableVersion          = "v" + CiliumStableHelmChartVersion
-	CiliumLatestHelmChartVersion = "1.14.0-dev"
+	CiliumLatestHelmChartVersion = "1.15.0-dev"
 
 	MonitorLogFileName = "monitor.log"
 

--- a/test/k8s/updates.go
+++ b/test/k8s/updates.go
@@ -243,13 +243,6 @@ func InstallAndValidateCiliumUpgrades(kubectl *helpers.Kubectl, oldHelmChartVers
 			"hubble.relay.image.repository":          "quay.io/cilium/hubble-relay-ci",
 			"clustermesh.apiserver.image.repository": "quay.io/cilium/clustermesh-apiserver-ci",
 		}
-		if helpers.RunsOn419OrLaterKernel() {
-			// Cilium v1.12, v1.13 don't support IPv6 BPF masquerade.
-			// This can be removed once v1.14 is released.
-			hasIPv6Masquerade := versioncheck.MustCompile(">=1.13.90")
-			Expect(hasIPv6Masquerade(versioncheck.MustVersion(oldHelmChartVersion))).To(BeFalse())
-			opts["enableIPv6Masquerade"] = "false"
-		}
 
 		hasNewHelmValues := versioncheck.MustCompile(">=1.12.90")
 		if hasNewHelmValues(versioncheck.MustVersion(newHelmChartVersion)) {


### PR DESCRIPTION
Now that Cilium v1.14, with support for IPv6 BPF masquerading, has been released, we can enable IPv6 BPF masquerading in the upgrade tests, and lift the restriction introduced in commit d6f4c53ba443.

To do that, we first need to update the version from which we upgrade: It's time to test upgrades from 1.14 in the CI.