### PR TITLE
refactor: stale services GC to be executed in hive jobs

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -105,8 +105,6 @@ const (
 	ConfigModifyQueueSize = 10
 
 	syncHostIPsController = "sync-host-ips"
-
-	daemonJobs = "daemon-jobs"
 )
 
 // Daemon is the cilium daemon that is in charge of perform all necessary plumbing,
@@ -518,8 +516,9 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	jobGroup := params.JobRegistry.NewGroup(
-		job.WithLogger(log.WithField(logfields.JobName, daemonJobs)),
+		job.WithLogger(log),
 	)
+	params.Lifecycle.Append(jobGroup)
 
 	d := Daemon{
 		ctx:               ctx,

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -49,6 +49,7 @@ import (
 	"github.com/cilium/cilium/pkg/flowdebug"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/hubble/exporter/exporteroption"
 	"github.com/cilium/cilium/pkg/hubble/observer/observeroption"
 	"github.com/cilium/cilium/pkg/identity"
@@ -1643,6 +1644,7 @@ type daemonParams struct {
 	Settings             cellSettings
 	HealthProvider       cell.Health
 	HealthReporter       cell.HealthReporter
+	JobRegistry          job.Registry
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -732,7 +732,4 @@ const (
 
 	// State is the state of an individual component (apiserver, kvstore etc)
 	State = "state"
-
-	// JobName is the name of the job
-	JobName = "jobName"
 )

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -732,4 +732,7 @@ const (
 
 	// State is the state of an individual component (apiserver, kvstore etc)
 	State = "state"
+
+	// JobName is the name of the job
+	JobName = "jobName"
 )


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
This change will remove controller based retry to GC leftover k8s services instead uses a hive job to achieve the same. 
Also adds a jobGroup to daemon for any later needs of jobs to be done in daemon. 

Fixes: #27012 

```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
