### PR TITLE
Add note to the quick install documentation for increasing inotify limits

### DIFF
--- a/Documentation/installation/cli-connectivity-test.rst
+++ b/Documentation/installation/cli-connectivity-test.rst
@@ -12,4 +12,11 @@ connectivity:
    ---------------------------------------------------------------------------------------------------------------------
    ✅ 69/69 tests successful (0 warnings)
 
+.. note::
+
+   The connectivity test may fail to deploy due to too many open files in one
+   or more of the pods. If you notice this error, you can increase the
+   ``inotify`` resource limits on your host machine (see
+   `Pod errors due to "too many open files" <https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files>`_).
+
 Congratulations! You have a fully functional Kubernetes cluster with Cilium. 🎉


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Many systems have low inotify resource limits which can cause errors
when deploying enough pods. This issue has been encountered while
running the Cilium connectivity test (see: #22585). This commit adds a
note after the connectivity test instructions to help people increase
inotify limits if they experience this issue.

This commit at least partially fixes #22585, there may be more
work (e.g. CI).


Tested by building the docs locally.
