### PR TITLE
bpf: small improvements in TTL / hoplimit handling

### DIFF
--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -54,7 +54,7 @@ static __always_inline int ipv4_load_daddr(struct __ctx_buff *ctx, int off,
 }
 
 static __always_inline int ipv4_dec_ttl(struct __ctx_buff *ctx, int off,
-					const struct iphdr *ip4)
+					struct iphdr *ip4)
 {
 	__u8 new_ttl, ttl = ip4->ttl;
 
@@ -62,9 +62,10 @@ static __always_inline int ipv4_dec_ttl(struct __ctx_buff *ctx, int off,
 		return 1;
 
 	new_ttl = ttl - 1;
+	ip4->ttl = new_ttl;
+
 	/* l3_csum_replace() takes at min 2 bytes, zero extended. */
 	ipv4_csum_update_by_value(ctx, off, ttl, new_ttl, 2);
-	ctx_store_bytes(ctx, off + offsetof(struct iphdr, ttl), &new_ttl, sizeof(new_ttl), 0);
 
 	return 0;
 }

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -59,7 +59,7 @@ static __always_inline int ipv4_dec_ttl(struct __ctx_buff *ctx, int off,
 	__u8 new_ttl, ttl = ip4->ttl;
 
 	if (ttl <= 1)
-		return 1;
+		return DROP_TTL_EXCEEDED;
 
 	new_ttl = ttl - 1;
 	ip4->ttl = new_ttl;

--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -65,7 +65,8 @@ static __always_inline int ipv4_dec_ttl(struct __ctx_buff *ctx, int off,
 	ip4->ttl = new_ttl;
 
 	/* l3_csum_replace() takes at min 2 bytes, zero extended. */
-	ipv4_csum_update_by_value(ctx, off, ttl, new_ttl, 2);
+	if (ipv4_csum_update_by_value(ctx, off, ttl, new_ttl, 2) < 0)
+		return DROP_CSUM_L3;
 
 	return 0;
 }

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -136,7 +136,7 @@ static __always_inline int ipv6_dec_hoplimit(struct __ctx_buff *ctx, int off)
 		return DROP_INVALID;
 
 	if (hl <= 1)
-		return 1;
+		return DROP_TTL_EXCEEDED;
 	hl--;
 	if (ctx_store_bytes(ctx, off + offsetof(struct ipv6hdr, hop_limit),
 			    &hl, sizeof(hl), BPF_F_RECOMPUTE_CSUM) < 0)

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -143,7 +143,6 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 
 	cilium_dbg(ctx, DBG_LOCAL_DELIVERY, ep->lxc_id, seclabel);
 
-	/* This will invalidate the size check */
 	ret = ipv6_l3(ctx, l3_off, (__u8 *)&router_mac, (__u8 *)&lxc_mac, direction);
 	if (ret != CTX_ACT_OK)
 		return ret;


### PR DESCRIPTION
Clean up a few papercuts in the L3 code that updates the TTL / hoplimit.