### PR TITLE
v1.14 backports 2023-07-31

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -88,6 +88,9 @@ jobs:
       - name: Set Environment Variables
         uses: ./.github/actions/set-env-variables
 
+      # If any of these steps are modified, please update the copy of these
+      # steps further down under the 'setup-and-test' jobs.
+
       # Load Ginkgo build from GitHub
       - name: Load ginkgo runtime from GH cache
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -249,6 +252,39 @@ jobs:
         with:
           path: /tmp/.ginkgo-build/
           key: ${{ runner.os }}-ginkgo-runtime-${{ hashFiles('**/*.go') }}
+
+      - name: Install Go
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+        with:
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.20.6
+
+      - name: Build Ginkgo
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+          mkdir -p /tmp/.ginkgo-build
+
+      - name: Build Test
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          cd test
+          /home/runner/go/bin/ginkgo build
+          strip test.test
+          tar -cz test.test -f test.tgz
+
+      - name: Store Ginkgo Test in GitHub cache path
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.ginkgo-build/
+          if [ -f test/test.tgz ]; then
+            cp test/test.tgz /tmp/.ginkgo-build/
+            echo "file copied"
+          fi
 
       - name: Copy Ginkgo binary
         shell: bash

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -162,7 +162,7 @@ jobs:
         env:
           # Disable coverage report for these test cases since they are hitting
           # https://github.com/cilium/coverbee/issues/7
-          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|nodeport_geneve_dsr_*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|tc_nodeport_lb6_dsr_backend.o|tc_nodeport_lb6_dsr_lb.o|xdp_egressgw_reply.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o|xdp_nodeport_lb6_dsr_lb.o|bpf_nat_tests.o"
+          NOCOVER_PATTERN: "inter_cluster_snat_clusterip.*|l4lb_ipip_health_check_host.o|nodeport_geneve_dsr_*|session_affinity_test.o|tc_egressgw_redirect.o|tc_egressgw_snat.o|tc_nodeport_lb4_dsr_backend.o|tc_nodeport_lb4_dsr_lb.o|tc_nodeport_lb4_nat_backend.o|tc_nodeport_lb4_nat_lb.o|tc_nodeport_lb6_dsr_backend.o|tc_nodeport_lb6_dsr_lb.o|xdp_egressgw_reply.o|xdp_nodeport_lb4_dsr_lb.o|xdp_nodeport_lb4_nat_backend.o|xdp_nodeport_lb4_nat_lb.o|xdp_nodeport_lb4_test.o|xdp_nodeport_lb6_dsr_lb.o|bpf_nat_tests.o"
         run: |
           make -C test run_bpf_tests COVER=1 NOCOVER="$NOCOVER_PATTERN" || (echo "Run 'make -C test run_bpf_tests COVER=1 NOCOVER=\"$NOCOVER_PATTERN\"' locally to investigate failures"; exit 1)
       - name: Archive code coverage results

--- a/Documentation/bpf/resources.rst
+++ b/Documentation/bpf/resources.rst
@@ -307,7 +307,7 @@ surrounding ecosystem in user space.
 
 All BPF update newsletters (01 - 12) can be found here:
 
-     https://cilium.io/blog/categories/eBPF/
+     https://cilium.io/blog/categories/technology/5/
 
 And for the news on the latest resources and developments in the eBPF world,
 please refer to the link here:
@@ -577,7 +577,7 @@ related to BPF and XDP:
      Polytechnique Montreal,
      Trace Aggregation and Collection with eBPF,
      Suchakra Sharma,
-     https://nova.polymtl.ca/~suchakra/eBPF-5May2017.pdf
+     https://hsdm.dorsal.polymtl.ca/system/files/eBPF-5May2017%20(1).pdf
 
 40. Apr 2017,
      DockerCon, Austin,

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -265,7 +265,6 @@ http_strict_mode = False
 # Try as hard as possible to find references
 default_role = 'any'
 
-
 def setup(app):
     app.add_css_file('parsed-literal.css')
     app.add_css_file('copybutton.css')

--- a/Documentation/configuration/argocd-issues.rst
+++ b/Documentation/configuration/argocd-issues.rst
@@ -26,7 +26,7 @@ causing one or more of the following issues:
 Solution
 --------
 
-To prevent these issues, declare resource exclusions in the Argo CD ``ConfigMap`` by following `these instructions <https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#resource-exclusioninclusion>`__.
+To prevent these issues, declare resource exclusions in the Argo CD ``ConfigMap`` by following `these instructions <https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#resource-exclusioninclusion>`__.
 
 Here is an example snippet:
 

--- a/Documentation/contributing/development/hive.rst
+++ b/Documentation/contributing/development/hive.rst
@@ -903,7 +903,7 @@ test against and allows central control over what data (and at what rate)
 is pulled from the api-server and how it’s stored (in-memory or persisted).
 
 The resources are usually made available centrally for the application,
-e.g. in cilium-agent they’re provided from `pkg/k8s/shared_resources.go <https://github.com/cilium/cilium/blob/main/pkg/k8s/shared_resources.go>`_.
+e.g. in cilium-agent they’re provided from `pkg/k8s/resource.go <https://github.com/cilium/cilium/blob/main/daemon/k8s/resources.go>`_.
 See also the runnable example in `pkg/k8s/resource/example <https://github.com/cilium/cilium/tree/main/pkg/k8s/resource/example>`_.
 
 .. code-block:: go

--- a/Documentation/contributing/testing/e2e_legacy.rst
+++ b/Documentation/contributing/testing/e2e_legacy.rst
@@ -18,7 +18,7 @@ It offers instructions on setting up and running tests in these modes.
 
 Before proceeding, it is recommended to familiarize yourself with Ginkgo by
 reading the `Ginkgo Getting-Started Guide
-<https://onsi.github.io/ginkgo/#getting-started-writing-your-first-test>`_. You
+<https://onsi.github.io/ginkgo/#getting-started>`_. You
 can also run the `example tests
 <https://github.com/onsi/composition-ginkgo-example>`_ to get a feel for the
 Ginkgo workflow.
@@ -549,7 +549,7 @@ following files currently are generated depending upon the test suite that is ra
 Best Practices for Writing Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Provide informative output to console during a test using the `By construct <https://onsi.github.io/ginkgo/#documenting-complex-its-by>`_. This helps with debugging and gives those who did not write the test a good idea of what is going on. The lower the barrier of entry is for understanding tests, the better our tests will be!
+* Provide informative output to console during a test using the `By construct <https://onsi.github.io/ginkgo/#documenting-complex-specs-by>`_. This helps with debugging and gives those who did not write the test a good idea of what is going on. The lower the barrier of entry is for understanding tests, the better our tests will be!
 * Leave the testing environment in the same state that it was in when the test started by deleting resources, resetting configuration, etc.
 * Gather logs in the case that a test fails. If a test fails while running on Jenkins, a postmortem needs to be done to analyze why. So, dumping logs to a location where Jenkins can pick them up is of the highest imperative. Use the following code in an ``AfterFailed`` method:
 
@@ -574,7 +574,7 @@ This method is an equivalent to ``SetUp`` or initialize functions in common
 unit test frameworks.
 
 .. _BeforeEach: https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach
-.. _Describe or Context: https://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context
+.. _Describe or Context: https://onsi.github.io/ginkgo/#organizing-specs-with-container-nodes
 
 AfterAll
 ^^^^^^^^

--- a/Documentation/installation/k8s-install-openshift-okd.rst
+++ b/Documentation/installation/k8s-install-openshift-okd.rst
@@ -18,7 +18,7 @@ OpenShift Requirements
 
 2. Read `OpenShift documentation <https://docs.okd.io/latest/welcome/index.html>`_ to find out about provider-specific prerequisites.
 
-3. `Get OpenShift Installer <https://github.com/openshift/okd#getting-started>`_.
+3. `Get OpenShift Installer <https://github.com/okd-project/okd#getting-started>`_.
 
 .. note::
 

--- a/Documentation/network/kubernetes/compatibility.rst
+++ b/Documentation/network/kubernetes/compatibility.rst
@@ -40,4 +40,4 @@ validation version:
 
 .. include:: compatibility-table.rst
 
-.. _networking.k8s.io/v1: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicy-v1-networking-k8s-io
+.. _networking.k8s.io/v1: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#networkpolicy-v1-networking-k8s-io

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -1308,7 +1308,7 @@ the check when running on some cloud providers. E.g. `Amazon NLB
 <https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support>`__
 natively implements the check, so the kube-proxy replacement's feature can be disabled.
 Meanwhile `GKE internal TCP/UDP load balancer
-<https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#lb_source_ranges>`__
+<https://cloud.google.com/kubernetes-engine/docs/how-to/service-parameters#lb_source_ranges>`__
 does not, so the feature must be kept enabled in order to restrict the access.
 
 Service Proxy Name Configuration

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -678,9 +678,6 @@ each underlying device's driver must have native XDP support on all Cilium manag
 nodes. In addition, for performance reasons we recommend kernel >= 5.5 for
 the multi-device XDP acceleration.
 
-NodePort acceleration can be used with either direct routing (``routingMode=native``)
-or tunnel mode. Direct routing is recommended to achieve optimal performance.
-
 A list of drivers supporting XDP can be found in :ref:`the XDP documentation<xdp_drivers>`.
 
 The current Cilium kube-proxy XDP acceleration mode can also be introspected through

--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -16,7 +16,7 @@ tests are passed.
 - `GatewayClass <https://gateway-api.sigs.k8s.io/api-types/gatewayclass/>`_
 - `Gateway <https://gateway-api.sigs.k8s.io/api-types/gateway/>`_
 - `HTTPRoute <https://gateway-api.sigs.k8s.io/api-types/httproute/>`_
-- `TLSRoute (experimental) <https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2.TLSRoute/>`_
+- `TLSRoute (experimental) <https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1alpha2.TLSRoute>`__
 - `ReferenceGrant <https://gateway-api.sigs.k8s.io/api-types/referencegrant/>`_
 
 .. include:: installation.rst

--- a/Documentation/operations/performance/benchmark.rst
+++ b/Documentation/operations/performance/benchmark.rst
@@ -310,7 +310,7 @@ All tests are performed using regular off-the-shelf hardware.
 ============  ======================================================================================================================================================
 Item          Description
 ============  ======================================================================================================================================================
-CPU           `AMD Ryzen 9 3950x <https://www.amd.com/en/products/cpu/amd-ryzen-9-3950x>`_, AM4 platform, 3.5GHz, 16 cores / 32 threads
+CPU           `AMD Ryzen 9 3950x <https://www.amd.com/en/support/cpu/amd-ryzen-processors/amd-ryzen-9-desktop-processors/amd-ryzen-9-3950x>`_, AM4 platform, 3.5GHz, 16 cores / 32 threads
 Mainboard     `x570 Aorus Master <https://www.gigabyte.com/us/Motherboard/X570-AORUS-MASTER-rev-11-12/sp#sp>`_, PCIe 4.0 x16 support
 Memory        `HyperX Fury DDR4-3200 <https://www.hyperxgaming.com/us/memory/fury-ddr4>`_ 128GB, XMP clocked to 3.2GHz
 Network Card  `Intel E810-CQDA2 <https://ark.intel.com/content/www/us/en/ark/products/192558/intel-ethernet-network-adapter-e810-cqda2.html>`_, dual port, 100Gbit/s per port, PCIe 4.0 x16
@@ -343,7 +343,7 @@ be found in `cilium/cilium-perf-networking <https://github.com/cilium/cilium-per
 All scripts in this document refer to this repository. Specifically, we use
 `Terraform <https://www.terraform.io/>`_ and `Ansible
 <https://www.ansible.com/>`_ to setup the environment and execute benchmarks.
-We use `Packet <https://www.packet.com/>`_ bare metal servers as our hardware
+We use `Packet <https://deploy.equinix.com/>`_ bare metal servers as our hardware
 platform, but the guide is structured so that it can be easily adapted to other
 environments.
 
@@ -359,7 +359,7 @@ Packet Servers
 
 To evaluate both :ref:`arch_overlay` and :ref:`native_routing`, we configure
 the Packet machines to use a `"Mixed/Hybrid"
-<https://www.packet.com/developers/docs/network/advanced/layer-2/>`_ network
+<https://deploy.equinix.com/developers/docs/metal/layer2-networking/overview/>`_ network
 mode, where the secondary interfaces of the machines share a flat L2 network.
 While this can be done on the Packet web UI, we include appropriate Terraform
 (version 0.13) files to automate this process.
@@ -401,7 +401,7 @@ interfaces of the machines. This will destroy the ``bond0`` interface and
 configure the first physical interface with the public and private IPs
 (``prv_ip``) and the second with the node IP (``node_ip``) that will be used
 for our evaluations (see `Packet documentation
-<https://www.packet.com/resources/guides/layer-2-configurations/>`_ and our
+<https://deploy.equinix.com/developers/docs/metal/layer2-networking/overview/>`_ and our
 scripts for more info).
 
 .. code-block:: shell-session

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -361,7 +361,7 @@ likely it is that various datapath optimizations can be used.
 
 In our Cilium release blogs, we also regularly highlight some of the eBPF based
 kernel work we conduct which implicitly helps Cilium's datapath performance
-such as `replacing retpolines with direct jumps in the eBPF JIT <https://cilium.io/blog/2020/02/18/cilium-17#linux-kernel-changes>`_.
+such as `replacing retpolines with direct jumps in the eBPF JIT <https://cilium.io/blog/2020/02/18/cilium-17#upstream-linux>`_.
 
 Moreover, the kernel allows to configure several options which will help maximize
 network performance.

--- a/Documentation/security/aws.rst
+++ b/Documentation/security/aws.rst
@@ -35,7 +35,7 @@ AWS Access keys and IAM role
 ------------------------------
 
 To create a new access token the `following guide can be used
-<https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config>`_.
+<https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html>`_.
 These keys need to have certain permissions set:
 
 .. code-block:: javascript

--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -211,14 +211,24 @@ Troubleshooting
 
  * All XFRM errors correspond to a packet drop in the kernel. Except for
    ``XfrmFwdHdrError`` and ``XfrmInError``, all XFRM errors indicate a bug in
-   Cilium or an operational mistake. ``XfrmOutStateSeqError`` and
-   ``XfrmInStateProtoError`` may be caused by operational mistakes, as detailed
-   in the following points.
+   Cilium or an operational mistake. ``XfrmOutStateSeqError``,
+   ``XfrmInStateProtoError``, and ``XfrmInNoStates`` may be caused by
+   operational mistakes, as detailed in the following points.
 
  * If the sequence number reaches its maximum value for any XFRM OUT state, it
    will result in packet drops and XFRM errors of type
    ``XfrmOutStateSeqError``. A key rotation resets all sequence numbers.
    Rotate keys frequently to avoid this issue.
+
+ * After a key rotation, if the old key is cleaned up before the
+   configuration of the new key is installed on all nodes, it results in
+   ``XfrmInNoStates`` errors. The old key is removed from nodes after a default
+   interval of 5 minutes by default. By default, all agents watch for key
+   updates and update their configuration within 1 minute after the key is
+   changed, leaving plenty of time before the old key is removed. If you expect
+   the key rotation to take longer for some reason (for example, in the case of
+   Cluster Mesh if several clusters need to be updated), you can increase the
+   delay before cleanup with agent flag ``ipsec-key-rotation-duration``.
 
  * ``XfrmInStateProtoError`` errors can happen if the key is updated without
    incrementing the SPI (also called ``KEYID`` in :ref:`ipsec_key_rotation`

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1493,6 +1493,12 @@ out:
 					      METRIC_EGRESS);
 #endif /* ENABLE_SRV6 */
 
+#ifdef ENABLE_HEALTH_CHECK
+	ret = lb_handle_health(ctx);
+	if (ret != CTX_ACT_OK)
+		goto exit;
+#endif
+
 #ifdef ENABLE_NODEPORT
 	if (!ctx_snat_done(ctx)) {
 		/*
@@ -1506,12 +1512,11 @@ out:
 						      METRIC_EGRESS);
 	}
 #endif
-#ifdef ENABLE_HEALTH_CHECK
-	ret = lb_handle_health(ctx);
+
+__maybe_unused exit:
 	if (IS_ERR(ret))
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
 					      METRIC_EGRESS);
-#endif
 	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0,
 			  0, trace.reason, trace.monitor);
 

--- a/bpf/tests/l4lb_ipip_health_check_host.c
+++ b/bpf/tests/l4lb_ipip_health_check_host.c
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Cilium */
+
+#include "common.h"
+
+#include <bpf/ctx/skb.h>
+#include "pktgen.h"
+
+/* Set ETH_HLEN to 14 to indicate that the packet has a 14 byte ethernet header */
+#define ETH_HLEN 14
+
+/* Enable code paths under test */
+#define ENABLE_IPV4		1
+#define ENABLE_IPV6		1
+#define ENABLE_NODEPORT		1
+#define ENABLE_DSR		1
+#define DSR_ENCAP_IPIP		2
+#define DSR_ENCAP_MODE		DSR_ENCAP_IPIP
+#define ENABLE_HEALTH_CHECK	1
+
+#define DISABLE_LOOPBACK_LB
+
+#define CLIENT_IP		v4_pod_one
+#define CLIENT_PORT		__bpf_htons(111)
+
+#define ENCAP_IFINDEX		25
+
+#define FRONTEND_IP		v4_svc_one
+#define FRONTEND_PORT		__bpf_htons(80)
+
+#define BACKEND_IP		v4_pod_two
+#define BACKEND_PORT		__bpf_htons(8080)
+
+#define ENCAP4_IFINDEX		42
+#define ENCAP6_IFINDEX		42
+
+#define SOCKET_COOKIE		1
+
+static volatile const __u8 *client_mac = mac_one;
+static volatile const __u8 *backend_mac = mac_two;
+
+#define get_socket_cookie mock_get_socket_cookie
+
+__u64 mock_get_socket_cookie(const struct __sk_buff *ctx __maybe_unused)
+{
+	return SOCKET_COOKIE;
+}
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	if (ifindex == ENCAP4_IFINDEX)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_DROP;
+}
+
+#define skb_set_tunnel_key mock_skb_set_tunnel_key
+
+int mock_skb_set_tunnel_key(__maybe_unused struct __sk_buff *skb,
+			    __maybe_unused const struct bpf_tunnel_key *from,
+			    __maybe_unused __u32 size,
+			    __maybe_unused __u32 flags)
+{
+	if (from->tunnel_id != 0)
+		return -1;
+	if (from->local_ipv4 != 0)
+		return -2;
+	if (from->remote_ipv4 != bpf_ntohl(BACKEND_IP))
+		return -3;
+	return 0;
+}
+
+#define SECCTX_FROM_IPCACHE 1
+
+#include "bpf_host.c"
+
+#define TO_NETDEV	0
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(max_entries, 1);
+	__array(values, int());
+} entry_call_map __section(".maps") = {
+	.values = {
+		[TO_NETDEV] = &cil_to_netdev,
+	},
+};
+
+/* Test that a health-check request to a remote backend is IPIP-encapsulated. */
+PKTGEN("tc", "l4lb_health_check_host")
+int l4lb_health_check_host_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)backend_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP;
+	l3->daddr = FRONTEND_IP;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = FRONTEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "l4lb_health_check_host")
+int l4lb_health_check_host_setup(struct __ctx_buff *ctx)
+{
+	__sock_cookie key = SOCKET_COOKIE;
+	struct lb4_health value = {
+		.peer = {
+			.address = BACKEND_IP,
+		}
+	};
+
+	map_update_elem(&LB4_HEALTH_MAP, &key, &value, 0);
+
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "l4lb_health_check_host")
+int l4lb_health_check_host_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the client MAC")
+	if (memcmp(l2->h_dest, (__u8 *)backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the backend MAC")
+
+	if (l3->saddr != CLIENT_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != FRONTEND_IP)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != FRONTEND_PORT)
+		test_fatal("dst port has changed");
+
+	test_finish();
+}

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -45,6 +45,7 @@ import (
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/k8s/apis"
+	k8sconstv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -646,13 +647,29 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 	}
 
 	if legacy.clientset.IsEnabled() {
-		if operatorOption.Config.EndpointGCInterval != 0 {
+		// Conditionally start the CiliumEndpoint garbage collector.
+		// The GC needs to continually run long-term if EndpointGCInterval is non-zero and if CiliumEndpoint CRDs
+		// are enabled. Otherwise, the GC still needs to run once to account for the case in which a user transitions
+		// from CiliumEndpoint CRD mode to kvstore mode, and to check if there are any stale CEPs that need to be
+		// purged.
+		if operatorOption.Config.EndpointGCInterval != 0 && !option.Config.DisableCiliumEndpointCRD {
 			enableCiliumEndpointSyncGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer, false)
 		} else {
-			// Even if the EndpointGC is disabled we still want it to run at least
-			// once. This is to prevent leftover CEPs from populating ipcache with
-			// stale entries.
-			enableCiliumEndpointSyncGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer, true)
+			// Check if CEP CRD is available, as it could be missing if CEPs are not enabled.
+			// If the CRD is not available, then no garbage collection needs to be done.
+			_, err := legacy.clientset.ApiextensionsV1().CustomResourceDefinitions().Get(
+				legacy.ctx, k8sconstv2.CEPName, metav1.GetOptions{ResourceVersion: "0"},
+			)
+
+			if err == nil {
+				enableCiliumEndpointSyncGC(legacy.ctx, &legacy.wg, legacy.clientset, ciliumNodeSynchronizer, true)
+			} else if k8sErrors.IsNotFound(err) {
+				log.WithError(err).Info("CiliumEndpoint CRD cannot be found, skipping garbage collection")
+			} else {
+				log.WithError(err).Error(
+					"Unable to determine if CiliumEndpoint CRD is installed, cannot start garbage collector",
+				)
+			}
 		}
 
 		err = enableCNPWatcher(legacy.ctx, &legacy.wg, legacy.clientset)


### PR DESCRIPTION
- [x] #27091 -- docs: kpr: remove caveat about XDP + tunnel performance (@julianwiedmann)
 - [ ] #26880 -- Documentation: fix the broken links/dead links (@vipul-21)
 - [x] #27015 -- bpf: l4lb: fix IPIP health-check path (@julianwiedmann)
 - [x] #26809 -- docs/ipsec: Extend troubleshooting for long key rotations (@pchaigno)
 - [ ] #25324 -- operator: Adjust CiliumEndpoint GC to only run once in kvstore mode (@learnitall)
 - [x] #27158 -- .github: rebuild ginkgo tests in case of cache miss (@sayboras)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 27091 26880 27015 26809 25324 27158; do contrib/backporting/set-labels.py $pr done 1.14; done
```