### PR TITLE
v1.12 backports 2023-07-31

### DIFF
--- a/Documentation/concepts/kubernetes/compatibility.rst
+++ b/Documentation/concepts/kubernetes/compatibility.rst
@@ -40,4 +40,4 @@ validation version:
 
 .. include:: compatibility-table.rst
 
-.. _networking.k8s.io/v1: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#networkpolicy-v1-networking-k8s-io
+.. _networking.k8s.io/v1: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#networkpolicy-v1-networking-k8s-io

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -266,7 +266,6 @@ http_strict_mode = False
 # Try as hard as possible to find references
 default_role = 'any'
 
-
 def setup(app):
     app.add_css_file('parsed-literal.css')
     app.add_css_file('copybutton.css')

--- a/Documentation/configuration/argocd-issues.rst
+++ b/Documentation/configuration/argocd-issues.rst
@@ -26,7 +26,7 @@ causing one or more of the following issues:
 Solution
 --------
 
-To prevent these issues, declare resource exclusions in the Argo CD ``ConfigMap`` by following `these instructions <https://argoproj.github.io/argo-cd/operator-manual/declarative-setup/#resource-exclusioninclusion>`__.
+To prevent these issues, declare resource exclusions in the Argo CD ``ConfigMap`` by following `these instructions <https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/#resource-exclusioninclusion>`__.
 
 Here is an example snippet:
 

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -20,7 +20,7 @@ are built on top of Ginkgo. Ginkgo provides a rich framework for developing
 tests alongside the benefits of Golang (compilation-time checks, types, etc.).
 To get accustomed to the basics of Ginkgo, we recommend reading the `Ginkgo
 Getting-Started Guide
-<https://onsi.github.io/ginkgo/#getting-started-writing-your-first-test>`_ , as
+<https://onsi.github.io/ginkgo/#getting-started>`_ , as
 well as running `example tests
 <https://github.com/onsi/composition-ginkgo-example>`_ to get a feel for the
 Ginkgo workflow.
@@ -309,7 +309,7 @@ following files currently are generated depending upon the test suite that is ra
 Best Practices for Writing Tests
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* Provide informative output to console during a test using the `By construct <https://onsi.github.io/ginkgo/#documenting-complex-its-by>`_. This helps with debugging and gives those who did not write the test a good idea of what is going on. The lower the barrier of entry is for understanding tests, the better our tests will be!
+* Provide informative output to console during a test using the `By construct <https://onsi.github.io/ginkgo/#documenting-complex-specs-by>`_. This helps with debugging and gives those who did not write the test a good idea of what is going on. The lower the barrier of entry is for understanding tests, the better our tests will be!
 * Leave the testing environment in the same state that it was in when the test started by deleting resources, resetting configuration, etc.
 * Gather logs in the case that a test fails. If a test fails while running on Jenkins, a postmortem needs to be done to analyze why. So, dumping logs to a location where Jenkins can pick them up is of the highest imperative. Use the following code in an ``AfterFailed`` method:
 
@@ -334,7 +334,7 @@ This method is an equivalent to ``SetUp`` or initialize functions in common
 unit test frameworks.
 
 .. _BeforeEach: https://onsi.github.io/ginkgo/#extracting-common-setup-beforeeach
-.. _Describe or Context: https://onsi.github.io/ginkgo/#organizing-specs-with-containers-describe-and-context
+.. _Describe or Context: https://onsi.github.io/ginkgo/#organizing-specs-with-container-nodes
 
 AfterAll
 ^^^^^^^^

--- a/Documentation/gettingstarted/aws.rst
+++ b/Documentation/gettingstarted/aws.rst
@@ -35,7 +35,7 @@ AWS Access keys and IAM role
 ------------------------------
 
 To create a new access token the `following guide can be used
-<https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config>`_.
+<https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html>`_.
 These keys need to have certain permissions set:
 
 .. code-block:: javascript

--- a/Documentation/gettingstarted/k8s-install-openshift-okd.rst
+++ b/Documentation/gettingstarted/k8s-install-openshift-okd.rst
@@ -18,7 +18,7 @@ OpenShift Requirements
 
 2. Read `OpenShift documentation <https://docs.okd.io/latest/welcome/index.html>`_ to find out about provider-specific prerequisites.
 
-3. `Get OpenShift Installer <https://github.com/openshift/okd#getting-started>`_.
+3. `Get OpenShift Installer <https://github.com/okd-project/okd#getting-started>`_.
 
 .. note::
 

--- a/Documentation/gettingstarted/kubeproxy-free.rst
+++ b/Documentation/gettingstarted/kubeproxy-free.rst
@@ -1264,7 +1264,7 @@ the check when running on some cloud providers. E.g. `Amazon NLB
 <https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support>`__
 natively implements the check, so the kube-proxy replacement's feature can be disabled.
 Meanwhile `GKE internal TCP/UDP load balancer
-<https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#lb_source_ranges>`__
+<https://cloud.google.com/kubernetes-engine/docs/how-to/service-parameters#lb_source_ranges>`__
 does not, so the feature must be kept enabled in order to restrict the access.
 
 Service Proxy Name Configuration

--- a/Documentation/operations/performance/benchmark.rst
+++ b/Documentation/operations/performance/benchmark.rst
@@ -304,7 +304,7 @@ All tests are performed using regular off-the-shelf hardware.
 ============  ======================================================================================================================================================
 Item          Description
 ============  ======================================================================================================================================================
-CPU           `AMD Ryzen 9 3950x <https://www.amd.com/en/products/cpu/amd-ryzen-9-3950x>`_, AM4 platform, 3.5GHz, 16 cores / 32 threads
+CPU           `AMD Ryzen 9 3950x <https://www.amd.com/en/support/cpu/amd-ryzen-processors/amd-ryzen-9-desktop-processors/amd-ryzen-9-3950x>`_, AM4 platform, 3.5GHz, 16 cores / 32 threads
 Mainboard     `x570 Aorus Master <https://www.gigabyte.com/us/Motherboard/X570-AORUS-MASTER-rev-11-12/sp#sp>`_, PCIe 4.0 x16 support
 Memory        `HyperX Fury DDR4-3200 <https://www.hyperxgaming.com/us/memory/fury-ddr4>`_ 128GB, XMP clocked to 3.2GHz
 Network Card  `Intel E810-CQDA2 <https://ark.intel.com/content/www/us/en/ark/products/192558/intel-ethernet-network-adapter-e810-cqda2.html>`_, dual port, 100Gbit/s per port, PCIe 4.0 x16
@@ -337,7 +337,7 @@ be found in `cilium/cilium-perf-networking <https://github.com/cilium/cilium-per
 All scripts in this document refer to this repository. Specifically, we use
 `Terraform <https://www.terraform.io/>`_ and `Ansible
 <https://www.ansible.com/>`_ to setup the environment and execute benchmarks.
-We use `Packet <https://www.packet.com/>`_ bare metal servers as our hardware
+We use `Packet <https://deploy.equinix.com/>`_ bare metal servers as our hardware
 platform, but the guide is structured so that it can be easily adapted to other
 environments.
 
@@ -353,7 +353,7 @@ Packet Servers
 
 To evaluate both :ref:`arch_overlay` and :ref:`native_routing`, we configure
 the Packet machines to use a `"Mixed/Hybrid"
-<https://www.packet.com/developers/docs/network/advanced/layer-2/>`_ network
+<https://deploy.equinix.com/developers/docs/metal/layer2-networking/overview/>`_ network
 mode, where the secondary interfaces of the machines share a flat L2 network.
 While this can be done on the Packet web UI, we include appropriate Terraform
 (version 0.13) files to automate this process.
@@ -395,7 +395,7 @@ interfaces of the machines. This will destroy the ``bond0`` interface and
 configure the first physical interface with the public and private IPs
 (``prv_ip``) and the second with the node IP (``node_ip``) that will be used
 for our evaluations (see `Packet documentation
-<https://www.packet.com/resources/guides/layer-2-configurations/>`_ and our
+<https://deploy.equinix.com/developers/docs/metal/layer2-networking/overview/>`_ and our
 scripts for more info).
 
 .. code-block:: shell-session

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -246,7 +246,7 @@ likely it is that various datapath optimizations can be used.
 
 In our Cilium release blogs, we also regularly highlight some of the eBPF based
 kernel work we conduct which implicitly helps Cilium's datapath performance
-such as `replacing retpolines with direct jumps in the eBPF JIT <https://cilium.io/blog/2020/02/18/cilium-17#linux-kernel-changes>`_.
+such as `replacing retpolines with direct jumps in the eBPF JIT <https://cilium.io/blog/2020/02/18/cilium-17#upstream-linux>`_.
 
 Moreover, the kernel allows to configure several options which will help maximize
 network performance.


### PR DESCRIPTION
- [x] #26880 -- Documentation: fix the broken links/dead links (@vipul-21)
- [x] #25324 -- operator: Adjust CiliumEndpoint GC to only run once in kvstore mode (@learnitall)
  - :warning: conflict due to hive and cell refactoring

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 26880 25324; do contrib/backporting/set-labels.py $pr done 1.12; done
```