### PR TITLE
statedb v2.0 with per-table locks and delete tracking

### DIFF
--- a/pkg/lock/sortable_mutex.go
+++ b/pkg/lock/sortable_mutex.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 // sortableMutexSeq is a global sequence counter for the creation of new
@@ -16,11 +17,20 @@ var sortableMutexSeq atomic.Uint64
 // sortableMutex implements SortableMutex. Not exported as the only way to
 // initialize it is via NewSortableMutex().
 type sortableMutex struct {
-	*sync.Mutex
-	seq uint64
+	sync.Mutex
+	seq             uint64
+	acquireDuration time.Duration
 }
 
-func (s sortableMutex) Seq() uint64 { return s.seq }
+func (s *sortableMutex) Lock() {
+	start := time.Now()
+	s.Mutex.Lock()
+	s.acquireDuration += time.Since(start)
+}
+
+func (s *sortableMutex) Seq() uint64 { return s.seq }
+
+func (s *sortableMutex) AcquireDuration() time.Duration { return s.acquireDuration }
 
 // SortableMutex provides a Mutex that can be globally sorted with other
 // sortable mutexes. This allows deadlock-safe locking of a set of mutexes
@@ -28,6 +38,7 @@ func (s sortableMutex) Seq() uint64 { return s.seq }
 type SortableMutex interface {
 	sync.Locker
 	Seq() uint64
+	AcquireDuration() time.Duration // The amount of time it took to acquire the lock
 }
 
 // SortableMutexes is a set of mutexes that can be locked in a safe order.
@@ -69,8 +80,7 @@ var _ sort.Interface = SortableMutexes{}
 
 func NewSortableMutex() SortableMutex {
 	seq := sortableMutexSeq.Add(1)
-	return sortableMutex{
-		Mutex: new(sync.Mutex),
-		seq:   seq,
+	return &sortableMutex{
+		seq: seq,
 	}
 }

--- a/pkg/lock/sortable_mutex.go
+++ b/pkg/lock/sortable_mutex.go
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lock
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+)
+
+// sortableMutexSeq is a global sequence counter for the creation of new
+// SortableMutex's with unique sequence numbers.
+var sortableMutexSeq atomic.Uint64
+
+// sortableMutex implements SortableMutex. Not exported as the only way to
+// initialize it is via NewSortableMutex().
+type sortableMutex struct {
+	*sync.Mutex
+	seq uint64
+}
+
+func (s sortableMutex) Seq() uint64 { return s.seq }
+
+// SortableMutex provides a Mutex that can be globally sorted with other
+// sortable mutexes. This allows deadlock-safe locking of a set of mutexes
+// as it guarantees consistent lock ordering.
+type SortableMutex interface {
+	sync.Locker
+	Seq() uint64
+}
+
+// SortableMutexes is a set of mutexes that can be locked in a safe order.
+// Once Lock() is called it must not be mutated!
+type SortableMutexes []SortableMutex
+
+// Len implements sort.Interface.
+func (s SortableMutexes) Len() int {
+	return len(s)
+}
+
+// Less implements sort.Interface.
+func (s SortableMutexes) Less(i int, j int) bool {
+	return s[i].Seq() < s[j].Seq()
+}
+
+// Swap implements sort.Interface.
+func (s SortableMutexes) Swap(i int, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Lock sorts the mutexes, and then locks them in order. If any lock cannot be acquired,
+// this will block while holding the locks with a lower sequence number.
+func (s SortableMutexes) Lock() {
+	sort.Sort(s)
+	for _, mu := range s {
+		mu.Lock()
+	}
+}
+
+// Unlock locks the sorted set of mutexes locked by prior call to Lock().
+func (s SortableMutexes) Unlock() {
+	for _, mu := range s {
+		mu.Unlock()
+	}
+}
+
+var _ sort.Interface = SortableMutexes{}
+
+func NewSortableMutex() SortableMutex {
+	seq := sortableMutexSeq.Add(1)
+	return sortableMutex{
+		Mutex: new(sync.Mutex),
+		seq:   seq,
+	}
+}

--- a/pkg/lock/sortable_mutex_test.go
+++ b/pkg/lock/sortable_mutex_test.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lock
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+func TestSortableMutex(t *testing.T) {
+	smu1 := NewSortableMutex()
+	smu2 := NewSortableMutex()
+	require.Greater(t, smu2.Seq(), smu1.Seq())
+	smu1.Lock()
+	smu2.Lock()
+	smu1.Unlock()
+	smu2.Unlock()
+	smus := SortableMutexes{smu1, smu2}
+	smus.Lock()
+	smus.Unlock()
+	smus.Lock()
+	smus.Unlock()
+}
+
+func TestSortableMutex_Chaos(t *testing.T) {
+	smus := SortableMutexes{
+		NewSortableMutex(),
+		NewSortableMutex(),
+		NewSortableMutex(),
+		NewSortableMutex(),
+		NewSortableMutex(),
+	}
+
+	nMonkeys := 10
+	iterations := 100
+	var wg sync.WaitGroup
+	wg.Add(nMonkeys)
+
+	monkey := func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			// Take a random subset of the sortable mutexes.
+			subSmus := slices.Clone(smus)
+			rand.Shuffle(len(subSmus), func(i, j int) {
+				subSmus[i], subSmus[j] = subSmus[j], subSmus[i]
+			})
+			n := rand.Intn(len(subSmus))
+			subSmus = subSmus[:n]
+
+			time.Sleep(time.Microsecond)
+			subSmus.Lock()
+			time.Sleep(time.Microsecond)
+			subSmus.Unlock()
+			time.Sleep(time.Microsecond)
+		}
+	}
+
+	for i := 0; i < nMonkeys; i++ {
+		go monkey()
+	}
+
+	wg.Wait()
+}

--- a/pkg/statedb2/cell.go
+++ b/pkg/statedb2/cell.go
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+// This module provides an in-memory database built on top of immutable radix trees
+// As the database is based on an immutable data structure, the objects inserted into
+// the database MUST NOT be mutated, but rather copied first!
+//
+// For example use see pkg/statedb/example.
+var Cell = cell.Module(
+	"statedb",
+	"In-memory transactional database",
+
+	cell.Provide(newHiveDB),
+)
+
+type tablesIn struct {
+	cell.In
+
+	TableMetas []TableMeta `group:"statedb-tables"`
+}
+
+func newHiveDB(lc hive.Lifecycle, tablesIn tablesIn) (*DB, error) {
+	db, err := NewDB(tablesIn.TableMetas)
+	if err != nil {
+		return nil, err
+	}
+	lc.Append(db)
+	return db, nil
+}
+
+type tableOut[Obj any] struct {
+	cell.Out
+	Table Table[Obj]
+	Meta  TableMeta `group:"statedb-tables"`
+}
+
+// NewTableCell creates a cell for creating and registering a statedb Table[Obj].
+func NewTableCell[Obj any](
+	tableName TableName,
+	primaryIndexer Indexer[Obj],
+	secondaryIndexers ...Indexer[Obj],
+) cell.Cell {
+	return cell.Provide(func() (tableOut[Obj], error) {
+		if table, err := NewTable(tableName, primaryIndexer, secondaryIndexers...); err != nil {
+			return tableOut[Obj]{}, err
+		} else {
+			return tableOut[Obj]{Table: table, Meta: table}, nil
+		}
+	})
+}

--- a/pkg/statedb2/cell.go
+++ b/pkg/statedb2/cell.go
@@ -18,16 +18,18 @@ var Cell = cell.Module(
 	"In-memory transactional database",
 
 	cell.Provide(newHiveDB),
+	cell.Metric(NewMetrics),
 )
 
 type tablesIn struct {
 	cell.In
 
 	TableMetas []TableMeta `group:"statedb-tables"`
+	Metrics    Metrics
 }
 
 func newHiveDB(lc hive.Lifecycle, tablesIn tablesIn) (*DB, error) {
-	db, err := NewDB(tablesIn.TableMetas)
+	db, err := NewDB(tablesIn.TableMetas, tablesIn.Metrics)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/statedb2/db.go
+++ b/pkg/statedb2/db.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import (
+	"errors"
+	"fmt"
+	"sync/atomic"
+
+	iradix "github.com/hashicorp/go-immutable-radix/v2"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// DB provides an in-memory transaction database built on top of immutable radix
+// trees. The database supports multiple tables, each with one or more user-defined
+// indexes. Readers can access the data locklessly with a simple atomic pointer read
+// to obtain a snapshot. On writes to the database table-level locks are acquired
+// on target tables and on write transaction commit a root lock is taken to swap
+// in the new root with the modified tables.
+//
+// As data is stored in immutable data structures any objects inserted into
+// it MUST NOT be mutated afterwards.
+//
+// DB holds the "root" tree of tables with each table holding a tree of indexes:
+//
+//	           root
+//	          /    \
+//	         ba    T(foo)
+//	       /   \
+//	   T(bar)  T(baz)
+//
+//	      T(bar).indexes
+//		   /  \
+//		  i    I(byRevision)
+//		/   \
+//	   I(id)    I(ip)
+//
+//	          I(ip)
+//	          /  \
+//	        192  172
+//	        /     ...
+//	    bar(192.168.1.1)
+//
+// T = tableEntry
+// I = indexTree
+//
+// To lookup:
+//  1. Create a read (or write) transaction
+//  2. Find the table from the root tree
+//  3. Find the index from the table's index tree
+//  4. Find the object from the index
+//
+// To insert:
+//  1. Create write transaction against the target table
+//  2. Find the table from the root tree
+//  3. Create/reuse write transaction on primary index
+//  4. Insert/replace the object into primary index
+//  5. Create/reuse write transaction on revision index
+//  6. If old object existed, remove from revision index
+//  7. If old object existed, remove from graveyard
+//  8. Update each secondary index
+//  9. Commit transaction by committing each index to
+//     the table and then committing table to the root.
+//     Swap the root atomic pointer to new root and
+//     notify by closing channels of all modified nodes.
+//
+// To observe deletions:
+//  1. Create write transaction against the target table
+//  2. Create new delete tracker and add it to the table
+//  3. Commit the write transaction to update the table
+//     with the new delete tracker
+//  4. Query the graveyard by revision, starting from the
+//     revision of the write transaction at which it was
+//     created.
+//  5. For each successfully processed deletion, mark the
+//     revision to set low watermark for garbage collection.
+//  6. Periodically garbage collect the graveyard by finding
+//     the lowest revision of all delete trackers.
+type DB struct {
+	tables    map[TableName]TableMeta
+	mu        lock.Mutex // sequences modifications to the root tree
+	root      atomic.Pointer[iradix.Tree[tableEntry]]
+	gcTrigger chan struct{} // trigger for graveyard garbage collection
+	gcExited  chan struct{}
+}
+
+func NewDB(tables []TableMeta) (*DB, error) {
+	txn := iradix.New[tableEntry]().Txn()
+	db := &DB{
+		tables:    make(map[TableName]TableMeta),
+		gcTrigger: make(chan struct{}, 1),
+		gcExited:  make(chan struct{}),
+	}
+	for _, t := range tables {
+		name := t.Name()
+		if _, ok := db.tables[name]; ok {
+			return nil, fmt.Errorf("table %q already exists", name)
+		}
+		db.tables[name] = t
+		var table tableEntry
+		table.meta = t
+		table.deleteTrackers = iradix.New[deleteTracker]()
+		indexTxn := iradix.New[indexTree]().Txn()
+		indexTxn.Insert([]byte(t.primaryIndexer().name), iradix.New[object]())
+		indexTxn.Insert([]byte(RevisionIndex), iradix.New[object]())
+		indexTxn.Insert([]byte(GraveyardIndex), iradix.New[object]())
+		indexTxn.Insert([]byte(GraveyardRevisionIndex), iradix.New[object]())
+		for index := range t.secondaryIndexers() {
+			indexTxn.Insert([]byte(index), iradix.New[object]())
+		}
+		table.indexes = indexTxn.CommitOnly()
+		txn.Insert(t.tableKey(), table)
+	}
+	db.root.Store(txn.CommitOnly())
+
+	return db, nil
+}
+
+// ReadTxn constructs a new read transaction for performing reads against
+// a snapshot of the database.
+//
+// ReadTxn is not thread-safe!
+func (db *DB) ReadTxn() ReadTxn {
+	return &txn{
+		db:          db,
+		rootReadTxn: db.root.Load().Txn(),
+	}
+}
+
+// WriteTxn constructs a new write transaction against the given set of tables.
+// Each table is locked, which may block until the table locks are acquired.
+// The modifications performed in the write transaction are not visible outside
+// it until Commit() is called. To discard the changes call Abort().
+//
+// WriteTxn is not thread-safe!
+func (db *DB) WriteTxn(table TableMeta, tables ...TableMeta) WriteTxn {
+	allTables := append(tables, table)
+	smus := lock.SortableMutexes{}
+	for _, table := range allTables {
+		smus = append(smus, table.sortableMutex())
+	}
+	smus.Lock()
+
+	rootReadTxn := db.root.Load().Txn()
+	tableEntries := make(map[TableName]*tableEntry, len(tables))
+	for _, table := range allTables {
+		tableEntry, ok := rootReadTxn.Get(table.tableKey())
+		if !ok {
+			panic("BUG: Table '" + table.Name() + "' not found")
+		}
+		tableEntries[table.Name()] = &tableEntry
+	}
+	return &txn{
+		db:          db,
+		rootReadTxn: rootReadTxn,
+		tables:      tableEntries,
+		writeTxns:   make(map[tableIndex]*iradix.Txn[object]),
+		smus:        smus,
+	}
+}
+
+func (db *DB) Start(hive.HookContext) error {
+	go graveyardWorker(db)
+	return nil
+}
+
+func (db *DB) Stop(ctx hive.HookContext) error {
+	close(db.gcTrigger)
+	select {
+	case <-ctx.Done():
+		return errors.New("timed out waiting for graveyard worker to exit")
+	case <-db.gcExited:
+	}
+	return nil
+}

--- a/pkg/statedb2/db.go
+++ b/pkg/statedb2/db.go
@@ -90,9 +90,7 @@ type DB struct {
 func NewDB(tables []TableMeta) (*DB, error) {
 	txn := iradix.New[tableEntry]().Txn()
 	db := &DB{
-		tables:    make(map[TableName]TableMeta),
-		gcTrigger: make(chan struct{}, 1),
-		gcExited:  make(chan struct{}),
+		tables: make(map[TableName]TableMeta),
 	}
 	for _, t := range tables {
 		name := t.Name()
@@ -163,6 +161,8 @@ func (db *DB) WriteTxn(table TableMeta, tables ...TableMeta) WriteTxn {
 }
 
 func (db *DB) Start(hive.HookContext) error {
+	db.gcTrigger = make(chan struct{}, 1)
+	db.gcExited = make(chan struct{})
 	go graveyardWorker(db)
 	return nil
 }

--- a/pkg/statedb2/db_test.go
+++ b/pkg/statedb2/db_test.go
@@ -624,3 +624,10 @@ func BenchmarkDB_FullIteration(b *testing.B) {
 		}
 	})
 }
+
+func Test_callerPackage(t *testing.T) {
+	pkg := func() string {
+		return callerPackage()
+	}()
+	require.Equal(t, "pkg/statedb2", pkg)
+}

--- a/pkg/statedb2/db_test.go
+++ b/pkg/statedb2/db_test.go
@@ -1,0 +1,626 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import (
+	"bytes"
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	iradix "github.com/hashicorp/go-immutable-radix/v2"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/statedb2/index"
+)
+
+func TestMain(m *testing.M) {
+	// Catch any leaks of goroutines from these tests.
+	goleak.VerifyTestMain(m)
+}
+
+type testObject struct {
+	ID   uint64
+	Tags []string
+}
+
+var (
+	idIndex = Index[testObject, uint64]{
+		Name: "id",
+		FromObject: func(t testObject) index.KeySet {
+			return index.NewKeySet(index.Uint64(t.ID))
+		},
+		FromKey: func(n uint64) []byte {
+			return index.Uint64(n)
+		},
+		Unique: true,
+	}
+
+	tagsIndex = Index[testObject, string]{
+		Name: "tags",
+		FromObject: func(t testObject) index.KeySet {
+			return index.StringSlice(t.Tags)
+		},
+		FromKey: func(tag string) []byte {
+			return index.String(tag)
+		},
+		Unique: false,
+	}
+)
+
+func testWithDB(t testing.TB, withTags bool, test func(db *DB, table Table[testObject])) {
+	var (
+		db    *DB
+		table Table[testObject]
+	)
+
+	logging.SetLogLevel(logrus.ErrorLevel)
+	defer logging.SetLogLevel(logrus.InfoLevel)
+
+	secondaryIndexers := []Indexer[testObject]{}
+	if withTags {
+		secondaryIndexers = append(secondaryIndexers, tagsIndex)
+	}
+
+	h := hive.New(
+		Cell, // DB
+		NewTableCell[testObject](
+			"test",
+			idIndex,
+			secondaryIndexers...,
+		),
+
+		cell.Invoke(func(db_ *DB, table_ Table[testObject]) {
+			db = db_
+			table = table_
+		}),
+	)
+
+	require.NoError(t, h.Start(context.TODO()))
+	t.Cleanup(func() {
+		assert.NoError(t, h.Stop(context.TODO()))
+	})
+	test(db, table)
+}
+
+func TestDB_LowerBound_ByRevision(t *testing.T) {
+	testWithDB(t, true, func(db *DB, table Table[testObject]) {
+		{
+			txn := db.WriteTxn(table)
+			table.Insert(txn, testObject{ID: 42, Tags: []string{"hello", "world"}})
+			txn.Commit()
+
+			txn = db.WriteTxn(table)
+			table.Insert(txn, testObject{ID: 71, Tags: []string{"foo"}})
+			txn.Commit()
+		}
+
+		txn := db.ReadTxn()
+
+		iter, watch := table.LowerBound(txn, ByRevision[testObject](0))
+		obj, rev, ok := iter.Next()
+		require.True(t, ok, "expected ByRevision(rev1) to return results")
+		require.EqualValues(t, 42, obj.ID)
+		prevRev := rev
+		obj, rev, ok = iter.Next()
+		require.True(t, ok)
+		require.EqualValues(t, 71, obj.ID)
+		require.Greater(t, rev, prevRev)
+		_, _, ok = iter.Next()
+		require.False(t, ok)
+
+		iter, _ = table.LowerBound(txn, ByRevision[testObject](prevRev+1))
+		obj, _, ok = iter.Next()
+		require.True(t, ok, "expected ByRevision(rev2) to return results")
+		require.EqualValues(t, 71, obj.ID)
+		_, _, ok = iter.Next()
+		require.False(t, ok)
+
+		select {
+		case <-watch:
+			t.Fatalf("expected LowerBound watch to not be closed before changes")
+		default:
+		}
+
+		{
+			txn := db.WriteTxn(table)
+			table.Insert(txn, testObject{ID: 71, Tags: []string{"foo", "modified"}})
+			txn.Commit()
+		}
+
+		select {
+		case <-watch:
+		case <-time.After(time.Second):
+			t.Fatalf("expected LowerBound watch to close after changes")
+		}
+
+		txn = db.ReadTxn()
+		iter, _ = table.LowerBound(txn, ByRevision[testObject](rev+1))
+		obj, _, ok = iter.Next()
+		require.True(t, ok, "expected ByRevision(rev2+1) to return results")
+		require.EqualValues(t, 71, obj.ID)
+		_, _, ok = iter.Next()
+		require.False(t, ok)
+
+	})
+}
+
+func TestDB_DeleteTracker(t *testing.T) {
+	testWithDB(t, true, func(db *DB, table Table[testObject]) {
+		{
+			txn := db.WriteTxn(table)
+			table.Insert(txn, testObject{ID: 42, Tags: []string{"hello", "world"}})
+			table.Insert(txn, testObject{ID: 71, Tags: []string{"foo"}})
+			txn.Commit()
+		}
+
+		txn := db.ReadTxn()
+		iter, watch := table.All(txn)
+		obj, _, ok := iter.Next()
+		require.True(t, ok)
+		require.EqualValues(t, 42, obj.ID)
+		obj, _, ok = iter.Next()
+		require.True(t, ok)
+		require.EqualValues(t, 71, obj.ID)
+		_, _, ok = iter.Next()
+		require.False(t, ok)
+
+		iter, _ = table.Get(txn, tagsIndex.Query("hello"))
+		obj, rev, ok := iter.Next()
+		require.True(t, ok)
+		require.EqualValues(t, 42, obj.ID)
+		require.EqualValues(t, 1, rev)
+		_, _, ok = iter.Next()
+		require.False(t, ok)
+
+		iter, _ = table.Get(txn, tagsIndex.Query("world"))
+		obj, rev, ok = iter.Next()
+		require.True(t, ok)
+		require.EqualValues(t, 42, obj.ID)
+		require.EqualValues(t, 1, rev)
+		_, _, ok = iter.Next()
+		require.False(t, ok)
+
+		wtxn := db.WriteTxn(table)
+		deleteTracker, err := table.DeleteTracker(wtxn, "test")
+		require.NoError(t, err, "failed to create DeleteTracker")
+		wtxn.Commit()
+
+		{
+			txn := db.WriteTxn(table)
+			old, deleted, err := table.Delete(txn, testObject{ID: 42})
+			require.True(t, deleted)
+			require.EqualValues(t, 42, old.ID)
+			require.NoError(t, err)
+			old, deleted, err = table.Delete(txn, testObject{ID: 71})
+			require.True(t, deleted)
+			require.EqualValues(t, 71, old.ID)
+			require.NoError(t, err)
+			txn.Commit()
+		}
+
+		// Wait for the table to change.
+		<-watch
+
+		// No objects should exist.
+		txn = db.ReadTxn()
+		iter, _ = table.All(txn)
+		_, _, ok = iter.Next()
+		require.False(t, ok)
+
+		nExist := 0
+		nDeleted := 0
+		rev, _, err = deleteTracker.Process(
+			txn,
+			0,
+			func(obj testObject, deleted bool, _ Revision) error {
+				if deleted {
+					nDeleted++
+				} else {
+					nExist++
+				}
+				return nil
+			})
+		require.NoError(t, err)
+		require.Equal(t, nDeleted, 2)
+		require.Equal(t, nExist, 0)
+		require.Equal(t, table.Revision(txn), rev-1)
+
+		require.Eventually(t,
+			db.graveyardIsEmpty,
+			5*time.Second,
+			100*time.Millisecond,
+			"graveyard not garbage collected")
+	})
+}
+
+func TestDB_All(t *testing.T) {
+	testWithDB(t, true, func(db *DB, table Table[testObject]) {
+		{
+			txn := db.WriteTxn(table)
+			table.Insert(txn, testObject{ID: uint64(1)})
+			table.Insert(txn, testObject{ID: uint64(2)})
+			table.Insert(txn, testObject{ID: uint64(3)})
+			iter, _ := table.All(txn)
+			objs := Collect(iter)
+			require.Len(t, objs, 3)
+			require.EqualValues(t, 1, objs[0].ID)
+			require.EqualValues(t, 2, objs[1].ID)
+			require.EqualValues(t, 3, objs[2].ID)
+			txn.Commit()
+		}
+
+		txn := db.ReadTxn()
+		iter, watch := table.All(txn)
+		objs := Collect(iter)
+		require.Len(t, objs, 3)
+		require.EqualValues(t, 1, objs[0].ID)
+		require.EqualValues(t, 2, objs[1].ID)
+		require.EqualValues(t, 3, objs[2].ID)
+
+		select {
+		case <-watch:
+			t.Fatalf("expected All() watch channel to not close before changes")
+		default:
+		}
+
+		{
+			txn := db.WriteTxn(table)
+			table.Delete(txn, testObject{ID: uint64(1)})
+			txn.Commit()
+		}
+
+		select {
+		case <-watch:
+		case <-time.After(time.Second):
+			t.Fatalf("expceted All() watch channel to close after changes")
+		}
+	})
+}
+
+func TestDB_FirstLast(t *testing.T) {
+	testWithDB(t, true, func(db *DB, table Table[testObject]) {
+		// Write test objects 1..10 to table with odd/even/odd/... tags.
+		{
+			txn := db.WriteTxn(table)
+			for i := 1; i <= 10; i++ {
+				tag := "odd"
+				if i%2 == 0 {
+					tag = "even"
+				}
+				_, _, err := table.Insert(txn, testObject{ID: uint64(i), Tags: []string{tag}})
+				require.NoError(t, err)
+			}
+			// Check that we can query the not-yet-committed write transaction.
+			obj, rev, ok := table.First(txn, idIndex.Query(1))
+			require.True(t, ok, "expected First(1) to return result")
+			require.NotZero(t, rev, "expected non-zero revision")
+			require.EqualValues(t, obj.ID, 1, "expected first obj.ID to equal 1")
+			obj, rev, ok = table.Last(txn, idIndex.Query(1))
+			require.True(t, ok, "expected Last(1) to return result")
+			require.NotZero(t, rev, "expected non-zero revision")
+			require.EqualValues(t, obj.ID, 1, "expected last obj.ID to equal 1")
+			txn.Commit()
+		}
+
+		txn := db.ReadTxn()
+
+		// Test First/FirstWatch and Last/LastWatch against the ID index.
+
+		_, _, ok := table.First(txn, idIndex.Query(0))
+		require.False(t, ok, "expected First(0) to not return result")
+
+		_, _, ok = table.Last(txn, idIndex.Query(0))
+		require.False(t, ok, "expected Last(0) to not return result")
+
+		obj, rev, ok := table.First(txn, idIndex.Query(1))
+		require.True(t, ok, "expected First(1) to return result")
+		require.NotZero(t, rev, "expected non-zero revision")
+		require.EqualValues(t, obj.ID, 1, "expected first obj.ID to equal 1")
+
+		obj, rev, ok = table.Last(txn, idIndex.Query(1))
+		require.True(t, ok, "expected Last(1) to return result")
+		require.NotZero(t, rev, "expected non-zero revision")
+		require.EqualValues(t, obj.ID, 1, "expected last obj.ID to equal 1")
+
+		obj, rev, firstWatch, ok := table.FirstWatch(txn, idIndex.Query(2))
+		require.True(t, ok, "expected FirstWatch(2) to return result")
+		require.NotZero(t, rev, "expected non-zero revision")
+		require.EqualValues(t, obj.ID, 2, "expected obj.ID to equal 2")
+
+		obj, rev, lastWatch, ok := table.LastWatch(txn, idIndex.Query(2))
+		require.True(t, ok, "expected LastWatch(2) to return result")
+		require.NotZero(t, rev, "expected non-zero revision")
+		require.EqualValues(t, obj.ID, 2, "expected obj.ID to equal 2")
+
+		select {
+		case <-firstWatch:
+			t.Fatalf("FirstWatch channel closed before changes")
+		case <-lastWatch:
+			t.Fatalf("LastWatch channel closed before changes")
+		default:
+		}
+
+		// Modify the testObject(2) to trigger closing of the watch channels.
+		wtxn := db.WriteTxn(table)
+		_, hadOld, err := table.Insert(wtxn, testObject{ID: uint64(2), Tags: []string{"even", "modified"}})
+		require.True(t, hadOld)
+		require.NoError(t, err)
+		wtxn.Commit()
+
+		select {
+		case <-firstWatch:
+		case <-time.After(time.Second):
+			t.Fatalf("FirstWatch channel not closed after change")
+		}
+		select {
+		case <-lastWatch:
+		case <-time.After(time.Second):
+			t.Fatalf("LastWatch channel not closed after change")
+		}
+
+		// Since we modified the database, grab a fresh read transaction.
+		txn = db.ReadTxn()
+
+		// Test First and Last against the tags multi-index which will
+		// return multiple results.
+
+		obj, rev, _, ok = table.FirstWatch(txn, tagsIndex.Query("even"))
+		require.True(t, ok, "expected First(even) to return result")
+		require.NotZero(t, rev, "expected non-zero revision")
+		require.ElementsMatch(t, obj.Tags, []string{"even", "modified"})
+		require.EqualValues(t, 2, obj.ID)
+
+		obj, rev, _, ok = table.LastWatch(txn, tagsIndex.Query("odd"))
+		require.True(t, ok, "expected First(even) to return result")
+		require.NotZero(t, rev, "expected non-zero revision")
+		require.ElementsMatch(t, obj.Tags, []string{"odd"})
+		require.EqualValues(t, 9, obj.ID)
+	})
+}
+
+func TestWriteJSON(t *testing.T) {
+	testWithDB(t, true, func(db *DB, table Table[testObject]) {
+		buf := new(bytes.Buffer)
+		err := db.ReadTxn().WriteJSON(buf)
+		require.NoError(t, err)
+
+		txn := db.WriteTxn(table)
+		for i := 1; i <= 10; i++ {
+			_, _, err := table.Insert(txn, testObject{ID: uint64(i)})
+			require.NoError(t, err)
+		}
+		txn.Commit()
+
+	})
+}
+
+func BenchmarkDB_WriteTxn_1(b *testing.B) {
+	testWithDB(b, false, func(db *DB, table Table[testObject]) {
+		for i := 0; i < b.N; i++ {
+			txn := db.WriteTxn(table)
+			_, _, err := table.Insert(txn, testObject{ID: 123, Tags: nil})
+			require.NoError(b, err)
+			txn.Commit()
+		}
+	})
+}
+
+func BenchmarkDB_WriteTxn_10(b *testing.B) {
+	testWithDB(b, false, func(db *DB, table Table[testObject]) {
+		n := b.N
+		for n > 0 {
+			txn := db.WriteTxn(table)
+			for j := 0; j < 10; j++ {
+				_, _, err := table.Insert(txn, testObject{ID: uint64(j), Tags: nil})
+				require.NoError(b, err)
+			}
+			txn.Commit()
+			n -= 10
+		}
+		txn := db.WriteTxn(table)
+		for j := 0; j < n; j++ {
+			_, _, err := table.Insert(txn, testObject{ID: uint64(j), Tags: nil})
+			require.NoError(b, err)
+		}
+		txn.Commit()
+	})
+}
+
+func BenchmarkDB_RandomInsert(b *testing.B) {
+	testWithDB(b, false, func(db *DB, table Table[testObject]) {
+		ids := []uint64{}
+		for i := 0; i < b.N; i++ {
+			ids = append(ids, uint64(i))
+		}
+		rand.Shuffle(b.N, func(i, j int) {
+			ids[i], ids[j] = ids[j], ids[i]
+		})
+		b.ResetTimer()
+		txn := db.WriteTxn(table)
+		for _, id := range ids {
+			_, _, err := table.Insert(txn, testObject{ID: id, Tags: nil})
+			require.NoError(b, err)
+		}
+		txn.Commit()
+		b.StopTimer()
+
+		iter, _ := table.All(db.ReadTxn())
+		require.Len(b, Collect(iter), b.N)
+	})
+}
+
+func BenchmarkDB_SequentialInsert(b *testing.B) {
+	testWithDB(b, false, func(db *DB, table Table[testObject]) {
+		b.ResetTimer()
+		txn := db.WriteTxn(table)
+		for id := uint64(0); id < uint64(b.N); id++ {
+			_, _, err := table.Insert(txn, testObject{ID: id, Tags: nil})
+			require.NoError(b, err)
+		}
+		txn.Commit()
+		b.StopTimer()
+
+		iter, _ := table.All(db.ReadTxn())
+		require.Len(b, Collect(iter), b.N)
+	})
+}
+
+func BenchmarkDB_Baseline_SingleRadix_Insert(b *testing.B) {
+	tree := iradix.New[uint64]()
+	txn := tree.Txn()
+	for i := uint64(0); i < uint64(b.N); i++ {
+		txn.Insert(index.Uint64(i), i)
+	}
+	txn.Commit()
+}
+
+func BenchmarkDB_Baseline_Hashmap_Insert(b *testing.B) {
+	m := map[uint64]uint64{}
+	for i := uint64(0); i < uint64(b.N); i++ {
+		m[i] = i
+	}
+}
+
+func BenchmarkDB_Baseline_Hashmap_Lookup(b *testing.B) {
+	m := map[uint64]uint64{}
+	for i := uint64(0); i < uint64(b.N); i++ {
+		m[i] = i
+	}
+	b.ResetTimer()
+	for i := uint64(0); i < uint64(b.N); i++ {
+		require.Equal(b, m[i], i)
+	}
+}
+
+func BenchmarkDB_DeleteTracker_Baseline(b *testing.B) {
+	testWithDB(b, false, func(db *DB, table Table[testObject]) {
+		// Create b.N objects
+		txn := db.WriteTxn(table)
+		for i := 0; i < b.N; i++ {
+			_, _, err := table.Insert(txn, testObject{ID: uint64(i), Tags: nil})
+			require.NoError(b, err)
+		}
+		txn.Commit()
+		b.ResetTimer()
+
+		// Start the timer and delete all objects to time
+		// the baseline without deletion tracking.
+		txn = db.WriteTxn(table)
+		table.DeleteAll(txn)
+		txn.Commit()
+	})
+}
+
+func BenchmarkDB_DeleteTracker(b *testing.B) {
+	testWithDB(b, false, func(db *DB, table Table[testObject]) {
+		// Start tracking deletions from the start
+
+		// Create b.N objects
+		txn := db.WriteTxn(table)
+		dt, err := table.DeleteTracker(txn, "test")
+		require.NoError(b, err)
+		defer dt.Close()
+		for i := 0; i < b.N; i++ {
+			_, _, err := table.Insert(txn, testObject{ID: uint64(i), Tags: nil})
+			require.NoError(b, err)
+		}
+		txn.Commit()
+		b.ResetTimer()
+
+		// Start the timer and delete all objects to time the cost for
+		// deletion tracking.
+		txn = db.WriteTxn(table)
+		table.DeleteAll(txn)
+		txn.Commit()
+
+		nDeleted := 0
+		dt.Process(
+			db.ReadTxn(),
+			0,
+			func(obj testObject, deleted bool, _ Revision) error {
+				nDeleted++
+				return nil
+			})
+		require.EqualValues(b, nDeleted, b.N)
+		b.StopTimer()
+
+		require.Eventually(b,
+			db.graveyardIsEmpty,
+			10*time.Millisecond,
+			100*time.Millisecond,
+			"graveyard not garbage collected")
+	})
+}
+
+func BenchmarkDB_RandomLookup(b *testing.B) {
+	testWithDB(b, false, func(db *DB, table Table[testObject]) {
+		wtxn := db.WriteTxn(table)
+		ids := []uint64{}
+		for i := 0; i < b.N; i++ {
+			ids = append(ids, uint64(i))
+			_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: nil})
+			require.NoError(b, err)
+		}
+		wtxn.Commit()
+		rand.Shuffle(b.N, func(i, j int) {
+			ids[i], ids[j] = ids[j], ids[i]
+		})
+		b.ResetTimer()
+
+		txn := db.ReadTxn()
+		for _, id := range ids {
+			_, _, ok := table.First(txn, idIndex.Query(id))
+			require.True(b, ok)
+		}
+	})
+}
+
+func BenchmarkDB_SequentialLookup(b *testing.B) {
+	testWithDB(b, false, func(db *DB, table Table[testObject]) {
+		wtxn := db.WriteTxn(table)
+		ids := []uint64{}
+		for i := 0; i < b.N; i++ {
+			ids = append(ids, uint64(i))
+			_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: nil})
+			require.NoError(b, err)
+		}
+		wtxn.Commit()
+		b.ResetTimer()
+
+		txn := db.ReadTxn()
+		for _, id := range ids {
+			obj, _, ok := table.First(txn, idIndex.Query(id))
+			require.True(b, ok)
+			require.Equal(b, obj.ID, id)
+		}
+	})
+}
+
+func BenchmarkDB_FullIteration(b *testing.B) {
+	testWithDB(b, false, func(db *DB, table Table[testObject]) {
+		wtxn := db.WriteTxn(table)
+		for i := 0; i < b.N; i++ {
+			_, _, err := table.Insert(wtxn, testObject{ID: uint64(i), Tags: nil})
+			require.NoError(b, err)
+		}
+		wtxn.Commit()
+		b.ResetTimer()
+
+		txn := db.ReadTxn()
+		iter, _ := table.All(txn)
+		i := uint64(0)
+		for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+			require.Equal(b, obj.ID, i)
+			i++
+		}
+	})
+}

--- a/pkg/statedb2/deletetracker.go
+++ b/pkg/statedb2/deletetracker.go
@@ -6,6 +6,8 @@ package statedb2
 import (
 	"sync/atomic"
 
+	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/cilium/cilium/pkg/statedb2/index"
 )
 
@@ -56,6 +58,9 @@ func (dt *DeleteTracker[Obj]) Close() {
 	table := txn.getTable(dt.table.Name())
 	table.deleteTrackers, _, _ = table.deleteTrackers.Delete([]byte(dt.trackerName))
 	txn.Commit()
+	txn.db.metrics.TableDeleteTrackerCount.With(prometheus.Labels{
+		"table": dt.table.Name(),
+	}).Dec()
 
 	// Trigger garbage collection without this delete tracker to garbage
 	// collect any deleted objects that may not have been consumed.

--- a/pkg/statedb2/deletetracker.go
+++ b/pkg/statedb2/deletetracker.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import (
+	"sync/atomic"
+
+	"github.com/cilium/cilium/pkg/statedb2/index"
+)
+
+type DeleteTracker[Obj any] struct {
+	db          *DB
+	trackerName string
+	table       Table[Obj]
+	revision    atomic.Uint64
+}
+
+// setRevision is called to set the starting low watermark when
+// this deletion tracker is inserted into the table.
+func (dt *DeleteTracker[Obj]) setRevision(rev uint64) {
+	dt.revision.Store(rev)
+}
+
+// getRevision is called by the graveyard garbage collector to
+// compute the global low watermark.
+func (dt *DeleteTracker[Obj]) getRevision() uint64 {
+	return dt.revision.Load()
+}
+
+// Deleted returns an iterator for deleted objects in this table starting from
+// 'minRevision'. The deleted objects are not garbage-collected unless 'Mark' is
+// called!
+func (dt *DeleteTracker[Obj]) Deleted(txn ReadTxn, minRevision Revision) Iterator[Obj] {
+	indexTxn := txn.getTxn().indexReadTxn(dt.table.Name(), GraveyardRevisionIndex)
+	iter := indexTxn.Root().Iterator()
+	iter.SeekLowerBound(index.Uint64(minRevision))
+	return &iterator[Obj]{iter}
+}
+
+// Mark the revision up to which deleted objects have been processed. This sets
+// the low watermark for deleted object garbage collection.
+func (dt *DeleteTracker[Obj]) Mark(txn ReadTxn, upTo Revision) {
+	// Store the new low watermark and trigger a round of garbage collection.
+	dt.revision.Store(upTo)
+	select {
+	case txn.getTxn().db.gcTrigger <- struct{}{}:
+	default:
+	}
+}
+
+func (dt *DeleteTracker[Obj]) Close() {
+	// Remove the delete tracker from the table.
+	txn := dt.db.WriteTxn(dt.table).getTxn()
+	db := txn.db
+	table := txn.getTable(dt.table.Name())
+	table.deleteTrackers, _, _ = table.deleteTrackers.Delete([]byte(dt.trackerName))
+	txn.Commit()
+
+	// Trigger garbage collection without this delete tracker to garbage
+	// collect any deleted objects that may not have been consumed.
+	select {
+	case db.gcTrigger <- struct{}{}:
+	default:
+	}
+
+}
+
+// Process is a helper to iterate updates and deletes to a table in revision order.
+//
+// The 'processFn' is called for each updated or deleted object in order. If an error
+// is returned by the function the iteration is stopped and the revision at which
+// processing failed and the error is returned. The caller can then retry processing
+// again from this revision by providing it as the 'minRevision'.
+func (dt *DeleteTracker[Obj]) Process(txn ReadTxn, minRevision Revision, processFn func(obj Obj, deleted bool, rev Revision) error) (Revision, <-chan struct{}, error) {
+	upTo := dt.table.Revision(txn)
+
+	// Get all new and updated objects with revision number equal or
+	// higher than 'minRevision'.
+	// The returned watch channel watches the whole table and thus
+	// is closed when either insert or delete happens.
+	updatedIter, watch := dt.table.LowerBound(txn, ByRevision[Obj](minRevision))
+
+	// Get deleted objects with revision equal or higher than 'minRevision'.
+	deletedIter := dt.Deleted(txn.getTxn(), minRevision)
+
+	// Combine the iterators into one. This can be done as insert and delete
+	// both assign the object a new fresh monotonically increasing revision
+	// number.
+	iter := NewDualIterator[Obj](deletedIter, updatedIter)
+
+	for obj, rev, isDeleted, ok := iter.Next(); ok; obj, rev, isDeleted, ok = iter.Next() {
+		err := processFn(obj, isDeleted, rev)
+		if err != nil {
+			// Mark deleted objects processed up to previous revision since we may
+			// not have processed all objects with this revision fully yet.
+			dt.Mark(txn.getTxn(), rev-1)
+
+			// Processing failed, stop here and try again from this same revision.
+			closedWatch := make(chan struct{})
+			close(closedWatch)
+			return rev, closedWatch, err
+		}
+
+	}
+
+	// Fully processed up to latest table revision. GC deleted objects
+	// and return the next revision.
+	dt.Mark(txn.getTxn(), upTo)
+	return upTo + 1, watch, nil
+}

--- a/pkg/statedb2/doc.go
+++ b/pkg/statedb2/doc.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// The statedb package provides a transactional in-memory database with per-table locking
+// built on top of the go-immutable-radix library.
+//
+// As this is built around an immutable data structure and objects may have lockless readers
+// the stored objects MUST NOT be mutated, but instead a copy must be made prior to mutation
+// and insertion.
+//
+// See pkg/statedb/example for an example how to construct an application that uses this library.
+package statedb2

--- a/pkg/statedb2/example/control.go
+++ b/pkg/statedb2/example/control.go
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"context"
+	"math/rand"
+	"net/netip"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/statedb2"
+)
+
+var controlCell = cell.Module(
+	"control-plane",
+	"Backends control-plane",
+
+	cell.Invoke(registerControl),
+)
+
+type controlParams struct {
+	cell.In
+
+	Backends  statedb2.Table[Backend]
+	DB        *statedb2.DB
+	Lifecycle hive.Lifecycle
+	Log       logrus.FieldLogger
+	Registry  job.Registry
+}
+
+func registerControl(p controlParams) {
+	g := p.Registry.NewGroup()
+	c := &control{p}
+	g.Add(job.OneShot("control-loop", c.controlLoop))
+	p.Lifecycle.Append(g)
+}
+
+type control struct {
+	controlParams
+}
+
+func (c *control) controlLoop(ctx context.Context) error {
+	tick := time.NewTicker(100 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-tick.C:
+		}
+
+		txn := c.DB.WriteTxn(c.Backends)
+
+		switch rand.Intn(3) {
+		case 0:
+			c.deleteBackend(txn)
+		case 1:
+			c.mutateBackend(txn)
+		case 2:
+			c.createBackend(txn)
+		}
+
+		txn.Commit()
+	}
+}
+
+func (c *control) createBackend(txn statedb2.WriteTxn) {
+	b := Backend{
+		ID:   BackendID(uuid.NewString()),
+		IP:   randomIP(),
+		Port: uint16(rand.Uint32()),
+	}
+	c.Backends.Insert(txn, b)
+}
+
+func (c *control) mutateBackend(txn statedb2.WriteTxn) {
+	iter, _ := c.Backends.All(txn)
+	all := statedb2.Collect(iter)
+	if len(all) > 0 {
+		i := rand.Intn(len(all))
+		b := all[i]
+		b.Port = uint16(rand.Uint32())
+		c.Backends.Insert(txn, b)
+	}
+}
+
+func (c *control) deleteBackend(txn statedb2.WriteTxn) {
+	iter, _ := c.Backends.All(txn)
+	all := statedb2.Collect(iter)
+	if len(all) > 0 {
+		i := rand.Intn(len(all))
+		c.Backends.Delete(txn, all[i])
+	}
+}
+
+func randomIP() netip.Addr {
+	n := rand.Uint32()
+	return netip.AddrFrom4([4]byte{
+		uint8(n & 0xff),
+		uint8(n >> 8),
+		uint8(n >> 16),
+		uint8(n >> 24),
+	})
+}

--- a/pkg/statedb2/example/main.go
+++ b/pkg/statedb2/example/main.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/statedb2"
+)
+
+var Hive = hive.New(
+	// job provides management for background workers and timers.
+	job.Cell,
+
+	// StateDB provides a transactional database to access and modify tables.
+	statedb2.Cell,
+
+	// The backends table stores the desired state of the backends.
+	BackendTableCell,
+
+	// Control-plane simulation for the backends table to provide the
+	// desired state.
+	controlCell,
+
+	// Datapath simulation to reconcile the desired state to the datapath.
+	reconcilerCell,
+
+	// Report the health status to stdout once a second.
+	cell.Invoke(reportHealth),
+)
+
+func main() {
+	if err := Hive.Run(); err != nil {
+		logging.DefaultLogger.Fatalf("Run failed: %s", err)
+	}
+}
+
+func reportHealth(health cell.Health, log logrus.FieldLogger, jobs job.Registry, lc hive.Lifecycle) {
+	g := jobs.NewGroup()
+	reportHealth := func(ctx context.Context) error {
+		for _, status := range health.All() {
+			log.Info(status.String())
+		}
+		return nil
+	}
+	g.Add(job.Timer("health-reporter", reportHealth, time.Second))
+	lc.Append(g)
+}

--- a/pkg/statedb2/example/reconcile.go
+++ b/pkg/statedb2/example/reconcile.go
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/statedb2"
+)
+
+var reconcilerCell = cell.Module(
+	"reconciler",
+	"Backend reconciler",
+	cell.Invoke(registerReconciler),
+)
+
+type reconcilerParams struct {
+	cell.In
+
+	Backends  statedb2.Table[Backend]
+	DB        *statedb2.DB
+	Lifecycle hive.Lifecycle
+	Log       logrus.FieldLogger
+	Registry  job.Registry
+	Reporter  cell.HealthReporter
+}
+
+func registerReconciler(p reconcilerParams) {
+	g := p.Registry.NewGroup()
+	r := &reconciler{
+		reconcilerParams: p,
+		handle:           &backendsHandle{backends: sets.New[BackendID]()},
+	}
+	g.Add(job.OneShot("reconcile-loop", r.reconcileLoop))
+	p.Lifecycle.Append(g)
+}
+
+type reconciler struct {
+	reconcilerParams
+
+	handle *backendsHandle
+}
+
+func (r *reconciler) reconcileLoop(ctx context.Context) error {
+	defer r.Reporter.Stopped("Stopped")
+
+	wtxn := r.DB.WriteTxn(r.Backends)
+	deleteTracker, err := r.Backends.DeleteTracker(wtxn, "backends-reconciler")
+	wtxn.Commit()
+	if err != nil {
+		return err
+	}
+	defer deleteTracker.Close()
+
+	txn := r.DB.ReadTxn()
+	minRevision := statedb2.Revision(0)
+
+	// Limit processing rate to 10 op/s.
+	burst := int64(10)
+	limiter := rate.NewLimiter(time.Second, burst)
+
+	// Backoff on failures.
+	backoff := backoff.Exponential{
+		Min: 100 * time.Millisecond,
+		Max: time.Second,
+	}
+
+	for {
+		tableRevision := r.Backends.Revision(txn)
+		r.Log.WithField("minRevision", minRevision).Info("Reconciling backends")
+
+		// Process upserts and deletions between minRevision..maxRevision.
+		// Returns the new revision to run the next query from.
+		newRevision, watch, processErr := deleteTracker.Process(
+			txn,
+			minRevision,
+			func(be Backend, deleted bool, rev statedb2.Revision) error {
+				if err := limiter.Wait(ctx); err != nil {
+					return err
+				}
+				if deleted {
+					err := r.handle.Delete(be)
+					if err != nil {
+						r.Log.WithError(err).WithField("revision", rev).WithField("id", be.ID).Warn("Failed to delete backend")
+					}
+					return err
+				} else {
+					err := r.handle.Insert(be)
+					if err != nil {
+						r.Log.WithError(err).WithField("revision", rev).WithField("id", be.ID).Warn("Failed to insert backend")
+					}
+					return err
+				}
+			},
+		)
+
+		minRevision = newRevision
+
+		if processErr != nil {
+			r.Reporter.Degraded(fmt.Sprintf("Failure at revision %d, latest is %d", minRevision, tableRevision), processErr)
+			if err := backoff.Wait(ctx); err != nil {
+				return err
+			}
+		} else {
+			backoff.Reset()
+			r.Reporter.OK(fmt.Sprintf("All processed up to %d", minRevision))
+
+			fmt.Printf(">>> validate revision %d\n", newRevision)
+			r.validate(txn)
+		}
+
+		// Wait until something changes or we're being stopped.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-watch:
+		}
+
+		// Refresh the read transaction to read the new version of the state.
+		txn = r.DB.ReadTxn()
+	}
+}
+
+func (r *reconciler) validate(txn statedb2.ReadTxn) {
+
+	iter, _ := r.Backends.All(txn)
+	n := 0
+	objs := []Backend{}
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		n++
+		objs = append(objs, obj)
+	}
+	if n != r.handle.backends.Len() {
+		panic(fmt.Sprintf("validate failed, expected %+v, seeing %+v", objs, r.handle.backends))
+	}
+}
+
+// backendsHandle implements a fake "BPF map" implementation
+// that fails often.
+type backendsHandle struct {
+	backends sets.Set[BackendID]
+}
+
+func maybeFail(op string, id BackendID) error {
+	// Fails 10% of the time
+	if rand.Intn(10) == 0 {
+		return fmt.Errorf("failure to %s %s", op, id)
+	}
+	return nil
+}
+
+func (h *backendsHandle) Insert(b Backend) error {
+	if err := maybeFail("Insert", b.ID); err != nil {
+		return err
+	}
+	fmt.Printf(">>> Insert %s\n", b.ID)
+	h.backends.Insert(b.ID)
+	return nil
+}
+
+func (h *backendsHandle) Delete(b Backend) error {
+	if err := maybeFail("Delete", b.ID); err != nil {
+		return err
+	}
+	fmt.Printf(">>> Delete %s\n", b.ID)
+	h.backends.Delete(b.ID)
+	return nil
+}

--- a/pkg/statedb2/example/tables.go
+++ b/pkg/statedb2/example/tables.go
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"net/netip"
+
+	"github.com/cilium/cilium/pkg/statedb2"
+	"github.com/cilium/cilium/pkg/statedb2/index"
+)
+
+type BackendID string
+
+type Backend struct {
+	ID   BackendID
+	IP   netip.Addr
+	Port uint16
+}
+
+var (
+	BackendIDIndex = statedb2.Index[Backend, BackendID]{
+		Name: "id",
+		FromObject: func(b Backend) index.KeySet {
+			return index.NewKeySet(index.String(string(b.ID)))
+		},
+		FromKey: func(id BackendID) []byte {
+			return index.String(string(id))
+		},
+		Unique: true,
+	}
+
+	BackendIPIndex = statedb2.Index[Backend, netip.Addr]{
+		Name: "ip",
+		FromObject: func(b Backend) index.KeySet {
+			return index.NewKeySet(index.NetIPAddr(b.IP))
+		},
+		FromKey: func(ip netip.Addr) index.Key {
+			return index.NetIPAddr(ip)
+		},
+		Unique: false,
+	}
+
+	BackendPortIndex = statedb2.Index[Backend, uint16]{
+		Name: "port",
+		FromObject: func(b Backend) index.KeySet {
+			return index.NewKeySet(index.Uint16(b.Port))
+		},
+		FromKey: func(port uint16) index.Key {
+			return index.Uint16(port)
+		},
+		Unique: true,
+	}
+
+	BackendTableCell = statedb2.NewTableCell[Backend](
+		"backends",
+		BackendIDIndex,
+		BackendIPIndex,
+		BackendPortIndex,
+	)
+)

--- a/pkg/statedb2/fuzz_test.go
+++ b/pkg/statedb2/fuzz_test.go
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/statedb2"
+	"github.com/cilium/cilium/pkg/statedb2/index"
+)
+
+// Run test with "--debug" for log output.
+var debug = flag.Bool("debug", false, "Enable debug logging")
+
+type debugLogger struct {
+	l *log.Logger
+}
+
+func (l *debugLogger) log(fmt string, args ...any) {
+	if l == nil {
+		return
+	}
+	l.l.Printf(fmt, args...)
+}
+
+func newDebugLogger(worker int) *debugLogger {
+	if !*debug {
+		return nil
+	}
+	logger := log.New(os.Stdout, fmt.Sprintf("worker[%03d] | ", worker), 0)
+	return &debugLogger{logger}
+}
+
+const (
+	numUniqueIDs  = 20
+	numWorkers    = 10
+	numIterations = 1000
+)
+
+type fuzzObj struct {
+	id    uint64
+	value uint64
+}
+
+func mkID() uint64 {
+	return uint64(rand.Int63n(numUniqueIDs))
+}
+
+var idIndex = statedb2.Index[fuzzObj, uint64]{
+	Name: "id",
+	FromObject: func(obj fuzzObj) index.KeySet {
+		return index.NewKeySet(index.Uint64(obj.id))
+	},
+	FromKey: func(n uint64) []byte {
+		return index.Uint64(n)
+	},
+	Unique: true,
+}
+
+var (
+	tableFuzz1, _ = statedb2.NewTable[fuzzObj]("fuzz1", idIndex)
+	tableFuzz2, _ = statedb2.NewTable[fuzzObj]("fuzz2", idIndex)
+	tableFuzz3, _ = statedb2.NewTable[fuzzObj]("fuzz3", idIndex)
+	fuzzTables    = []statedb2.TableMeta{tableFuzz1, tableFuzz2, tableFuzz3}
+	fuzzDB, _     = statedb2.NewDB(fuzzTables)
+)
+
+func randomSubset[T any](xs []T) []T {
+	xs = slices.Clone(xs)
+	rand.Shuffle(len(xs), func(i, j int) {
+		xs[i], xs[j] = xs[j], xs[i]
+	})
+	n := 1 + rand.Intn(len(xs)-1)
+	return xs[:n]
+}
+
+type actionLog interface {
+	append(actionLogEntry)
+}
+
+type realActionLog struct {
+	lock.Mutex
+	log []actionLogEntry
+}
+
+func (a *realActionLog) append(e actionLogEntry) {
+	a.Lock()
+	a.log = append(a.log, e)
+	a.Unlock()
+}
+
+func (a *realActionLog) validate(db *statedb2.DB, t *testing.T) {
+	a.Lock()
+	defer a.Unlock()
+
+	// Collapse the log down to objects that are alive at the end.
+	alive := map[statedb2.Table[fuzzObj]]sets.Set[uint64]{}
+	for _, e := range a.log {
+		aliveThis, ok := alive[e.table]
+		if !ok {
+			aliveThis = sets.New[uint64]()
+			alive[e.table] = aliveThis
+		}
+		switch e.act {
+		case actInsert:
+			aliveThis.Insert(e.id)
+		case actDelete:
+			aliveThis.Delete(e.id)
+		case actDeleteAll:
+			aliveThis.Clear()
+		}
+	}
+
+	for table, expected := range alive {
+		txn := db.ReadTxn()
+		iter, _ := table.All(txn)
+		actual := sets.New[uint64]()
+		for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+			actual.Insert(obj.id)
+		}
+		require.True(t, expected.Equal(actual), "validate failed, mismatching ids: %v", actual.SymmetricDifference(expected))
+	}
+}
+
+type nopActionLog struct {
+}
+
+func (nopActionLog) append(e actionLogEntry) {}
+
+const (
+	actInsert = iota
+	actDelete
+	actDeleteAll
+)
+
+type actionLogEntry struct {
+	table statedb2.Table[fuzzObj]
+	act   int
+	id    uint64
+	value uint64
+}
+
+type action func(log *debugLogger, actLog actionLog, txn statedb2.WriteTxn, target statedb2.Table[fuzzObj])
+
+func insertAction(log *debugLogger, actLog actionLog, txn statedb2.WriteTxn, table statedb2.Table[fuzzObj]) {
+	id := mkID()
+	value := rand.Uint64()
+	log.log("%s: Insert %d", table.Name(), id)
+	table.Insert(txn, fuzzObj{id, value})
+	actLog.append(actionLogEntry{table, actInsert, id, value})
+}
+
+func deleteAction(log *debugLogger, actLog actionLog, txn statedb2.WriteTxn, table statedb2.Table[fuzzObj]) {
+	id := mkID()
+	log.log("%s: Delete %d", table.Name(), id)
+	table.Delete(txn, fuzzObj{id, 0})
+	actLog.append(actionLogEntry{table, actDelete, id, 0})
+}
+
+func deleteAllAction(log *debugLogger, actLog actionLog, txn statedb2.WriteTxn, table statedb2.Table[fuzzObj]) {
+	log.log("%s: DeleteAll", table.Name())
+	table.DeleteAll(txn)
+	actLog.append(actionLogEntry{table, actDeleteAll, 0, 0})
+}
+
+func allAction(log *debugLogger, _ actionLog, txn statedb2.WriteTxn, table statedb2.Table[fuzzObj]) {
+	iter, _ := table.All(txn)
+	log.log("%s: All => %d found", table.Name(), len(statedb2.Collect(iter)))
+}
+
+func getAction(log *debugLogger, _ actionLog, txn statedb2.WriteTxn, table statedb2.Table[fuzzObj]) {
+	id := mkID()
+	iter, _ := table.Get(txn, idIndex.Query(mkID()))
+	log.log("%s: Get(%d) => %d found", table.Name(), id, len(statedb2.Collect(iter)))
+}
+
+func firstAction(log *debugLogger, _ actionLog, txn statedb2.WriteTxn, table statedb2.Table[fuzzObj]) {
+	id := mkID()
+	_, rev, ok := table.First(txn, idIndex.Query(id))
+	log.log("%s: First(%d) => rev=%d, ok=%v", table.Name(), id, rev, ok)
+}
+
+func lastAction(log *debugLogger, _ actionLog, txn statedb2.WriteTxn, table statedb2.Table[fuzzObj]) {
+	id := mkID()
+	_, rev, ok := table.First(txn, idIndex.Query(id))
+	log.log("%s: First(%d) => rev=%d, ok=%v", table.Name(), id, rev, ok)
+}
+
+func lowerboundAction(log *debugLogger, _ actionLog, txn statedb2.WriteTxn, table statedb2.Table[fuzzObj]) {
+	id := mkID()
+	iter, _ := table.LowerBound(txn, idIndex.Query(id))
+	log.log("%s: LowerBound(%d) => %d found", table.Name(), id, len(statedb2.Collect(iter)))
+}
+
+var actions = []action{
+	insertAction,
+	insertAction,
+	insertAction,
+	insertAction,
+	insertAction,
+	insertAction,
+	insertAction,
+
+	deleteAction,
+	deleteAction,
+	deleteAllAction,
+
+	allAction,
+	getAction,
+	firstAction,
+	lastAction,
+	lowerboundAction,
+
+	allAction,
+	getAction,
+	firstAction,
+	lastAction,
+	lowerboundAction,
+}
+
+func randomAction() action {
+	return actions[rand.Intn(len(actions))]
+}
+
+func fuzzWorker(realActionLog *realActionLog, worker int, iterations int) {
+	log := newDebugLogger(worker)
+	for iterations > 0 {
+		targets := randomSubset(fuzzTables)
+		txn := fuzzDB.WriteTxn(targets[0], targets[1:]...)
+
+		// Try to run other goroutines with write lock held.
+		runtime.Gosched()
+
+		var actLog actionLog = realActionLog
+		abort := false
+		if rand.Intn(10) == 0 {
+			abort = true
+			actLog = nopActionLog{}
+		}
+
+		for _, target := range targets {
+			act := randomAction()
+			act(log, actLog, txn, target.(statedb2.Table[fuzzObj]))
+			runtime.Gosched()
+		}
+		runtime.Gosched()
+
+		if abort {
+			log.log("Abort")
+			txn.Abort()
+		} else {
+			log.log("Commit")
+			txn.Commit()
+		}
+		iterations--
+	}
+}
+
+func TestDB_Fuzz(t *testing.T) {
+	fuzzDB.Start(context.TODO())
+	defer fuzzDB.Stop(context.TODO())
+
+	var actionLog realActionLog
+	var wg sync.WaitGroup
+	wg.Add(numWorkers)
+	for i := 0; i < numWorkers; i++ {
+		i := i
+		go func() {
+			fuzzWorker(&actionLog, i, numIterations)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	actionLog.validate(fuzzDB, t)
+}

--- a/pkg/statedb2/fuzz_test.go
+++ b/pkg/statedb2/fuzz_test.go
@@ -76,7 +76,7 @@ var (
 	tableFuzz2, _ = statedb2.NewTable[fuzzObj]("fuzz2", idIndex)
 	tableFuzz3, _ = statedb2.NewTable[fuzzObj]("fuzz3", idIndex)
 	fuzzTables    = []statedb2.TableMeta{tableFuzz1, tableFuzz2, tableFuzz3}
-	fuzzDB, _     = statedb2.NewDB(fuzzTables)
+	fuzzDB, _     = statedb2.NewDB(fuzzTables, statedb2.NewMetrics())
 )
 
 func randomSubset[T any](xs []T) []T {
@@ -286,4 +286,5 @@ func TestDB_Fuzz(t *testing.T) {
 	}
 	wg.Wait()
 	actionLog.validate(fuzzDB, t)
+
 }

--- a/pkg/statedb2/graveyard.go
+++ b/pkg/statedb2/graveyard.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/cilium/cilium/pkg/rate"
+)
+
+const (
+	// gcRateLimitInterval is the minium interval between garbage collections
+	gcRateLimitInterval = time.Second
+)
+
+func graveyardWorker(db *DB) {
+	limiter := rate.NewLimiter(gcRateLimitInterval, 1)
+	defer limiter.Stop()
+	defer close(db.gcExited)
+
+	for {
+		// Wait for delete trackers.
+		if _, ok := <-db.gcTrigger; !ok {
+			// Trigger closed, we're stopping.
+			return
+		}
+
+		// Throttle garbage collection.
+		limiter.Wait(context.Background())
+
+		type deadObjectRevisionKey = []byte
+		toBeDeleted := map[TableMeta][]deadObjectRevisionKey{}
+
+		// Do a lockless read transaction to find potential dead objects.
+		txn := db.ReadTxn().getTxn()
+		tableIter := txn.rootReadTxn.Root().Iterator()
+		for name, table, ok := tableIter.Next(); ok; name, table, ok = tableIter.Next() {
+			// Find the low watermark
+			lowWatermark := table.revision
+			dtIter := table.deleteTrackers.Root().Iterator()
+			for _, dt, ok := dtIter.Next(); ok; _, dt, ok = dtIter.Next() {
+				rev := dt.getRevision()
+				if rev < lowWatermark {
+					lowWatermark = rev
+				}
+			}
+			// Find objects to be deleted by iterating over the graveyard revision index up
+			// to the low watermark.
+			indexTree, ok := txn.getTable(string(name)).indexes.Get([]byte(GraveyardRevisionIndex))
+			if !ok {
+				panic("BUG: Index " + GraveyardRevisionIndex + " not found")
+			}
+			objIter := indexTree.Root().Iterator()
+			for key, obj, ok := objIter.Next(); ok; key, obj, ok = objIter.Next() {
+				if obj.revision > lowWatermark {
+					break
+				}
+				toBeDeleted[table.meta] = append(toBeDeleted[table.meta], key)
+			}
+		}
+
+		if len(toBeDeleted) == 0 {
+			continue
+		}
+
+		// Dead objects found, do a write transaction against all tables with dead objects in them.
+		tablesToModify := maps.Keys(toBeDeleted)
+		txn = db.WriteTxn(tablesToModify[0], tablesToModify[1:]...).getTxn()
+		for meta, deadObjs := range toBeDeleted {
+			numCollected := 0
+			tableName := meta.Name()
+			for _, key := range deadObjs {
+				_, existed := txn.indexWriteTxn(tableName, GraveyardRevisionIndex).Delete(key)
+				if existed {
+					// The dead object still existed (and wasn't replaced by a create->delete),
+					// delete it from the primary index.
+					txn.indexWriteTxn(tableName, GraveyardIndex).Delete(key[8:])
+					numCollected++
+				}
+			}
+		}
+		txn.Commit()
+
+	}
+}
+
+// graveyardIsEmpty returns true if no objects exist in the graveyard of any table.
+// Used in tests.
+func (db *DB) graveyardIsEmpty() bool {
+	txn := db.ReadTxn().getTxn()
+	tableIter := txn.rootReadTxn.Root().Iterator()
+	for name, _, ok := tableIter.Next(); ok; name, _, ok = tableIter.Next() {
+		indexTree, ok := txn.getTable(string(name)).indexes.Get([]byte(GraveyardIndex))
+		if !ok {
+			panic("BUG: Index " + GraveyardIndex + " not found")
+		}
+		if indexTree.Len() != 0 {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/statedb2/index/int.go
+++ b/pkg/statedb2/index/int.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package index
+
+import "encoding/binary"
+
+func Uint64(n uint64) Key {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, n)
+	return buf
+}
+
+func Uint16(n uint16) Key {
+	buf := make([]byte, 2)
+	binary.BigEndian.PutUint16(buf, n)
+	return buf
+}

--- a/pkg/statedb2/index/keyset.go
+++ b/pkg/statedb2/index/keyset.go
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package index
+
+import "bytes"
+
+type Key = []byte
+
+// KeySet is a sequence of (length, byte slice) pairs.
+// length is encoded as 16-bit big-endian unsigned int.
+type KeySet struct {
+	buf Key
+}
+
+func NewKeySet(keys ...Key) KeySet {
+	size := 2 * len(keys)
+	for _, k := range keys {
+		size += len(k)
+	}
+	ks := KeySet{make([]byte, 0, size)}
+	for _, k := range keys {
+		ks.Append(k)
+	}
+	return ks
+}
+
+func (ks KeySet) First() Key {
+	if len(ks.buf) < 2 {
+		return nil
+	}
+	length := uint16(ks.buf[0])<<8 | uint16(ks.buf[1])
+	return ks.buf[2 : 2+length]
+}
+
+func (ks *KeySet) Append(k Key) {
+	if len(k) > 2<<16 {
+		panic("keyset.Append: key too long, maximum is 64kB")
+	}
+	ks.buf = append(append(ks.buf, byte(len(k)>>8), byte(len(k)&0xff)), k...)
+}
+
+func (ks KeySet) Foreach(fn func(Key)) {
+	for len(ks.buf) >= 2 {
+		length := uint16(ks.buf[0])<<8 | uint16(ks.buf[1])
+		fn(append([]byte(nil), ks.buf[2:2+length]...))
+		ks.buf = ks.buf[2+length:]
+	}
+}
+
+func (ks KeySet) Exists(k Key) bool {
+	buf := ks.buf
+	for len(buf) >= 2 {
+		length := uint16(buf[0])<<8 | uint16(buf[1])
+		k2 := buf[2 : 2+length]
+		if bytes.Equal(k, k2) {
+			return true
+		}
+		buf = buf[2+length:]
+	}
+	return false
+}

--- a/pkg/statedb2/index/keyset_test.go
+++ b/pkg/statedb2/index/keyset_test.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package index_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/cilium/cilium/pkg/statedb2/index"
+)
+
+func TestKeySet_FromEmpty(t *testing.T) {
+	ks := index.NewKeySet()
+	require.Nil(t, ks.First())
+	ks.Foreach(func(_ []byte) {
+		t.Fatalf("Foreach on NewKeySet called function")
+	})
+	require.False(t, ks.Exists(nil))
+	require.False(t, ks.Exists([]byte{1, 2, 3}))
+
+	ks.Append([]byte("foo"))
+	require.EqualValues(t, "foo", ks.First())
+	ks.Foreach(func(bs []byte) {
+		require.EqualValues(t, "foo", ks.First())
+	})
+	require.True(t, ks.Exists([]byte("foo")))
+
+	ks.Append([]byte("bar"))
+	require.EqualValues(t, "foo", ks.First())
+	vs := [][]byte{}
+	ks.Foreach(func(bs []byte) {
+		vs = append(vs, bs)
+	})
+	require.ElementsMatch(t, vs, [][]byte{[]byte("foo"), []byte("bar")})
+	require.True(t, ks.Exists([]byte("foo")))
+	require.True(t, ks.Exists([]byte("bar")))
+	require.False(t, ks.Exists([]byte("baz")))
+}
+
+func TestKeySet_FromNonEmpty(t *testing.T) {
+	ks := index.NewKeySet([]byte("baz"), []byte("quux"))
+	require.EqualValues(t, "baz", ks.First())
+	require.True(t, ks.Exists([]byte("baz")))
+	require.True(t, ks.Exists([]byte("quux")))
+	require.False(t, ks.Exists([]byte("foo")))
+	vs := [][]byte{}
+	ks.Foreach(func(bs []byte) {
+		vs = append(vs, bs)
+	})
+	require.ElementsMatch(t, vs, [][]byte{[]byte("baz"), []byte("quux")})
+}

--- a/pkg/statedb2/index/map.go
+++ b/pkg/statedb2/index/map.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package index
+
+func StringMap[V any](m map[string]V) KeySet {
+	ks := KeySet{}
+	for k := range m {
+		ks.Append(String(k))
+	}
+	return ks
+}

--- a/pkg/statedb2/index/netip.go
+++ b/pkg/statedb2/index/netip.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package index
+
+import (
+	"bytes"
+	"net"
+	"net/netip"
+)
+
+func NetIP(ip net.IP) Key {
+	return bytes.Clone(ip)
+}
+
+func NetIPAddr(addr netip.Addr) Key {
+	buf, _ := addr.MarshalBinary()
+	return buf
+}
+
+func NetIPPrefix(prefix netip.Prefix) Key {
+	buf, _ := prefix.MarshalBinary()
+	return buf
+}

--- a/pkg/statedb2/index/string.go
+++ b/pkg/statedb2/index/string.go
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package index
+
+func String(s string) []byte {
+	return []byte(s)
+}
+
+func StringSlice(ss []string) KeySet {
+	ks := KeySet{}
+	for _, s := range ss {
+		ks.Append(String(s))
+	}
+	return ks
+}

--- a/pkg/statedb2/iterator.go
+++ b/pkg/statedb2/iterator.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import "fmt"
+
+func Collect[Obj any](iter Iterator[Obj]) []Obj {
+	objs := []Obj{}
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		objs = append(objs, obj)
+	}
+	return objs
+}
+
+// ProcessEach invokes the given function for each object provided by the iterator.
+func ProcessEach[Obj any, It Iterator[Obj]](iter It, fn func(Obj, Revision) error) (err error) {
+	for obj, rev, ok := iter.Next(); ok; obj, rev, ok = iter.Next() {
+		err = fn(obj, rev)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// iterator adapts the "any" object iterator to a typed object.
+type iterator[Obj any] struct {
+	iter interface{ Next() ([]byte, object, bool) }
+}
+
+func (it *iterator[Obj]) Next() (obj Obj, revision uint64, ok bool) {
+	_, iobj, ok := it.iter.Next()
+	if ok {
+		obj = iobj.data.(Obj)
+		revision = iobj.revision
+	}
+	return
+}
+
+func NewDualIterator[Obj any](left, right Iterator[Obj]) *DualIterator[Obj] {
+	return &DualIterator[Obj]{
+		left:  iterState[Obj]{iter: left},
+		right: iterState[Obj]{iter: right},
+	}
+}
+
+type iterState[Obj any] struct {
+	iter Iterator[Obj]
+	obj  Obj
+	rev  Revision
+	ok   bool
+}
+
+// DualIterator allows iterating over two iterators in revision order.
+// Meant to be used for combined iteration of LowerBound(ByRevision)
+// and Deleted().
+type DualIterator[Obj any] struct {
+	left  iterState[Obj]
+	right iterState[Obj]
+}
+
+func (it *DualIterator[Obj]) Next() (obj Obj, revision uint64, fromLeft, ok bool) {
+	// Advance the iterators
+	if !it.left.ok && it.left.iter != nil {
+		it.left.obj, it.left.rev, it.left.ok = it.left.iter.Next()
+		if !it.left.ok {
+			it.left.iter = nil
+		}
+	}
+	if !it.right.ok && it.right.iter != nil {
+		it.right.obj, it.right.rev, it.right.ok = it.right.iter.Next()
+		if !it.right.ok {
+			it.right.iter = nil
+		}
+	}
+
+	// Find the lowest revision object
+	switch {
+	case !it.left.ok && !it.right.ok:
+		ok = false
+		return
+	case it.left.ok && !it.right.ok:
+		it.left.ok = false
+		return it.left.obj, it.left.rev, true, true
+	case it.right.ok && !it.left.ok:
+		it.right.ok = false
+		return it.right.obj, it.right.rev, false, true
+	case it.left.rev <= it.right.rev:
+		it.left.ok = false
+		return it.left.obj, it.left.rev, true, true
+	case it.right.rev <= it.left.rev:
+		it.right.ok = false
+		return it.right.obj, it.right.rev, false, true
+	default:
+		panic(fmt.Sprintf("BUG: Unhandled case: %+v", it))
+	}
+}

--- a/pkg/statedb2/metrics.go
+++ b/pkg/statedb2/metrics.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type Metrics struct {
+	// How long a read transaction was held.
+	WriteTxnDuration metric.Vec[metric.Observer]
+	// How long it took to acquire a write transaction for all tables.
+	WriteTxnAcquisition metric.Vec[metric.Observer]
+	// How long writers were blocked while waiting to acquire a write transaction for a specific table.
+	TableContention metric.Vec[metric.Gauge]
+	// The amount of objects in a given table.
+	TableObjectCount metric.Vec[metric.Gauge]
+	// The current revision of a given table.
+	TableRevision metric.Vec[metric.Gauge]
+	// The amount of delete trackers for a given table.
+	TableDeleteTrackerCount metric.Vec[metric.Gauge]
+	// The amount of objects in the graveyard for a given table.
+	TableGraveyardObjects metric.Vec[metric.Gauge]
+	// The lowest revision of a given table that has been processed by the graveyard garbage collector.
+	TableGraveyardLowWatermark metric.Vec[metric.Gauge]
+	// The time it took to clean the graveyard for a given table.
+	TableGraveyardCleaningDuration metric.Vec[metric.Observer]
+}
+
+func NewMetrics() Metrics {
+	return Metrics{
+		WriteTxnDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.CiliumAgentNamespace,
+			Subsystem: "statedb",
+			Name:      "write_txn_duration_seconds",
+			Help:      "How long a write transaction was held.",
+		}, []string{"tables", "package"}),
+		WriteTxnAcquisition: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.CiliumAgentNamespace,
+			Subsystem: "statedb",
+			Name:      "write_txn_acquisition_seconds",
+			Help:      "How long it took to acquire a write transaction for all tables.",
+		}, []string{"tables", "package"}),
+		TableContention: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumAgentNamespace,
+			Subsystem: "statedb",
+			Name:      "table_contention_seconds",
+			Help:      "How long writers were blocked while waiting to acquire a write transaction for a specific table.",
+		}, []string{"table"}),
+		TableObjectCount: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumAgentNamespace,
+			Subsystem: "statedb",
+			Name:      "table_objects_total",
+			Help:      "The amount of objects in a given table.",
+		}, []string{"table"}),
+		TableRevision: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumAgentNamespace,
+			Subsystem: "statedb",
+			Name:      "table_revision",
+			Help:      "The current revision of a given table.",
+		}, []string{"table"}),
+		TableDeleteTrackerCount: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumAgentNamespace,
+			Subsystem: "statedb",
+			Name:      "table_delete_trackers_total",
+			Help:      "The amount of delete trackers for a given table.",
+		}, []string{"table"}),
+		TableGraveyardObjects: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumAgentNamespace,
+			Subsystem: "statedb",
+			Name:      "table_graveyard_objects_total",
+			Help:      "The amount of objects in the graveyard for a given table.",
+		}, []string{"table"}),
+		TableGraveyardLowWatermark: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumAgentNamespace,
+			Subsystem: "statedb",
+			Name:      "table_graveyard_low_watermark",
+			Help:      "The lowest revision of a given table that has been processed by the graveyard garbage collector.",
+		}, []string{"table"}),
+		TableGraveyardCleaningDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.CiliumAgentNamespace,
+			Subsystem: "statedb",
+			Name:      "table_graveyard_cleaning_duration_seconds",
+			Help:      "The time it took to clean the graveyard for a given table.",
+		}, []string{"table"}),
+	}
+}

--- a/pkg/statedb2/table.go
+++ b/pkg/statedb2/table.go
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/statedb2/index"
+)
+
+func NewTable[Obj any](
+	tableName TableName,
+	primaryIndexer Indexer[Obj],
+	secondaryIndexers ...Indexer[Obj],
+) (Table[Obj], error) {
+	toAnyIndexer := func(idx Indexer[Obj]) anyIndexer {
+		return anyIndexer{
+			name: idx.indexName(),
+			fromObject: func(iobj object) index.KeySet {
+				return idx.fromObject(iobj.data.(Obj))
+			},
+			unique: idx.isUnique(),
+		}
+	}
+
+	table := &genTable[Obj]{
+		table:                tableName,
+		smu:                  lock.NewSortableMutex(),
+		primaryAnyIndexer:    toAnyIndexer(primaryIndexer),
+		secondaryAnyIndexers: make(map[string]anyIndexer, len(secondaryIndexers)),
+	}
+
+	for _, indexer := range secondaryIndexers {
+		table.secondaryAnyIndexers[indexer.indexName()] = toAnyIndexer(indexer)
+	}
+
+	// Primary index must always be unique
+	if !primaryIndexer.isUnique() {
+		return nil, fmt.Errorf("primary index %q must be unique", primaryIndexer.indexName())
+	}
+
+	// Validate that indexes have unique ids.
+	indexNames := sets.New[string]()
+	indexNames.Insert(primaryIndexer.indexName())
+	for _, indexer := range secondaryIndexers {
+		if indexNames.Has(indexer.indexName()) {
+			return nil, fmt.Errorf("index %q already declared", indexer.indexName())
+		}
+		indexNames.Insert(indexer.indexName())
+	}
+	for name := range indexNames {
+		if strings.HasPrefix(name, reservedIndexPrefix) {
+			return nil, fmt.Errorf("index %q uses reserved prefix %q", name, reservedIndexPrefix)
+		}
+	}
+	return table, nil
+}
+
+type genTable[Obj any] struct {
+	table                TableName
+	smu                  lock.SortableMutex
+	primaryAnyIndexer    anyIndexer
+	secondaryAnyIndexers map[string]anyIndexer
+}
+
+func (t *genTable[Obj]) tableKey() index.Key {
+	return index.String(t.table)
+}
+
+func (t *genTable[Obj]) primaryIndexer() anyIndexer {
+	return t.primaryAnyIndexer
+}
+
+func (t *genTable[Obj]) secondaryIndexers() map[string]anyIndexer {
+	return t.secondaryAnyIndexers
+}
+
+func (t *genTable[Obj]) Name() string {
+	return t.table
+}
+
+func (t *genTable[Obj]) Revision(txn ReadTxn) Revision {
+	return txn.getTxn().GetRevision(t.table)
+}
+
+func (t *genTable[Obj]) First(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, ok bool) {
+	obj, revision, _, ok = t.FirstWatch(txn, q)
+	return
+}
+
+func (t *genTable[Obj]) FirstWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
+	indexTxn := txn.getTxn().indexReadTxn(t.table, q.index)
+	if indexTxn == nil {
+		panic("BUG: No index for " + q.index)
+	}
+	iter := indexTxn.Root().Iterator()
+	watch = iter.SeekPrefixWatch(q.key)
+	_, iobj, ok := iter.Next()
+	if ok {
+		obj = iobj.data.(Obj)
+		revision = iobj.revision
+	}
+	return
+}
+
+func (t *genTable[Obj]) Last(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, ok bool) {
+	obj, revision, _, ok = t.LastWatch(txn, q)
+	return
+}
+
+func (t *genTable[Obj]) LastWatch(txn ReadTxn, q Query[Obj]) (obj Obj, revision uint64, watch <-chan struct{}, ok bool) {
+	indexTxn := txn.getTxn().indexReadTxn(t.table, q.index)
+	if indexTxn == nil {
+		panic("BUG: No index for " + q.index)
+	}
+
+	iter := indexTxn.Root().ReverseIterator()
+	watch = iter.SeekPrefixWatch(q.key)
+	_, iobj, ok := iter.Previous()
+	if ok {
+		obj = iobj.data.(Obj)
+		revision = iobj.revision
+	}
+	return
+}
+
+func (t *genTable[Obj]) LowerBound(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-chan struct{}) {
+	indexTxn := txn.getTxn().indexReadTxn(t.table, q.index)
+	root := indexTxn.Root()
+
+	// Since LowerBound query may be invalidated by changes in another branch
+	// of the tree, we cannot just simply watch the node we seeked to. Instead
+	// we watch the whole table for changes.
+	watch, _, _ := root.GetWatch([]byte(t.table))
+	iter := root.Iterator()
+	iter.SeekLowerBound(q.key)
+	return &iterator[Obj]{iter}, watch
+}
+
+func (t *genTable[Obj]) All(txn ReadTxn) (Iterator[Obj], <-chan struct{}) {
+	indexTxn := txn.getTxn().indexReadTxn(t.table, t.primaryAnyIndexer.name)
+	if indexTxn == nil {
+		panic("BUG: Missing primary index " + t.primaryAnyIndexer.name)
+	}
+	root := indexTxn.Root()
+	// Grab the watch channel for the root node
+	watchCh, _, _ := root.GetWatch(nil)
+	return &iterator[Obj]{root.Iterator()}, watchCh
+}
+
+func (t *genTable[Obj]) Get(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-chan struct{}) {
+	indexTxn := txn.getTxn().indexReadTxn(t.table, q.index)
+	if indexTxn == nil {
+		panic("BUG: Missing index " + q.index)
+	}
+	iter := indexTxn.Root().Iterator()
+	watchCh := iter.SeekPrefixWatch(q.key)
+	return &iterator[Obj]{iter}, watchCh
+}
+
+// Insert implements Table
+func (t *genTable[Obj]) Insert(txn WriteTxn, obj Obj) (oldObj Obj, hadOld bool, err error) {
+	var data any
+	data, hadOld, err = txn.getTxn().Insert(t, obj)
+	if err == nil && hadOld {
+		oldObj = data.(Obj)
+	}
+	return
+}
+
+func (t *genTable[Obj]) Delete(txn WriteTxn, obj Obj) (oldObj Obj, hadOld bool, err error) {
+	var data any
+	data, hadOld, err = txn.getTxn().Delete(t, obj)
+	if err == nil && hadOld {
+		oldObj = data.(Obj)
+	}
+	return
+}
+
+func (t *genTable[Obj]) DeleteAll(txn WriteTxn) error {
+	iter, _ := t.All(txn)
+	itxn := txn.getTxn()
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		_, _, err := itxn.Delete(t, obj)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *genTable[Obj]) DeleteTracker(txn WriteTxn, trackerName string) (*DeleteTracker[Obj], error) {
+	dt := &DeleteTracker[Obj]{
+		db:          txn.getTxn().db,
+		trackerName: trackerName,
+		table:       t,
+	}
+	err := txn.getTxn().addDeleteTracker(t, trackerName, dt)
+	if err != nil {
+		return nil, err
+	}
+	return dt, nil
+}
+
+func (t *genTable[Obj]) sortableMutex() lock.SortableMutex {
+	return t.smu
+}
+
+var _ Table[bool] = &genTable[bool]{}

--- a/pkg/statedb2/txn.go
+++ b/pkg/statedb2/txn.go
@@ -9,19 +9,26 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	iradix "github.com/hashicorp/go-immutable-radix/v2"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/cilium/pkg/lock"
 )
 
 type txn struct {
-	db               *DB
-	rootReadTxn      *iradix.Txn[tableEntry]            // read transaction onto the tree of tables
-	lastIndexReadTxn lastIndexReadTxn                   // memoized result of the last indexReadTxn()
-	writeTxns        map[tableIndex]*iradix.Txn[object] // opened per-index write transactions
-	tables           map[TableName]*tableEntry          // table entries being modified
-	smus             lock.SortableMutexes               // the (sorted) table locks
+	db                     *DB
+	rootReadTxn            *iradix.Txn[tableEntry]            // read transaction onto the tree of tables
+	lastIndexReadTxn       lastIndexReadTxn                   // memoized result of the last indexReadTxn()
+	writeTxns              map[tableIndex]*iradix.Txn[object] // opened per-index write transactions
+	tables                 map[TableName]*tableEntry          // table entries being modified
+	smus                   lock.SortableMutexes               // the (sorted) table locks
+	acquiredAt             time.Time                          // the time at which the transaction acquired the locks
+	tableNames             string                             // plus-separated list of table names
+	packageName            string                             // name of the package that created the transaction
+	pendingObjectDeltas    map[TableName]float64              // the change in the number of objects made by this txn
+	pendingGraveyardDeltas map[TableName]float64              // the change in the number of graveyard objects made by this txn
 }
 
 type tableIndex struct {
@@ -123,6 +130,9 @@ func (txn *txn) newRevision(tableName TableName) (Revision, error) {
 		return 0, fmt.Errorf("table %q not locked for writing", tableName)
 	}
 	table.revision++
+	txn.db.metrics.TableRevision.With(prometheus.Labels{
+		"table": tableName,
+	}).Set(float64(table.revision))
 	return table.revision, nil
 }
 
@@ -154,14 +164,18 @@ func (txn *txn) Insert(meta TableMeta, data any) (any, bool, error) {
 		if !ok {
 			panic("BUG: Old revision index entry not found")
 		}
+
+		txn.pendingObjectDeltas[tableName]--
 	}
 	revIndexTree.Insert(revisionKey(revision, idKey), obj)
+	txn.pendingObjectDeltas[tableName]++
 
 	// If it's new, possibly remove an older deleted object with the same
 	// primary key from the graveyard.
 	if !oldExists && txn.hasDeleteTrackers(tableName) {
 		if old, existed := txn.indexWriteTxn(tableName, GraveyardIndex).Delete(idKey); existed {
 			txn.indexWriteTxn(tableName, GraveyardRevisionIndex).Delete(revisionKey(old.revision, idKey))
+			txn.pendingGraveyardDeltas[tableName]--
 		}
 	}
 
@@ -221,6 +235,9 @@ func (txn *txn) addDeleteTracker(meta TableMeta, trackerName string, dt deleteTr
 	}
 	dt.setRevision(table.revision)
 	table.deleteTrackers, _, _ = table.deleteTrackers.Insert([]byte(trackerName), dt)
+	txn.db.metrics.TableDeleteTrackerCount.With(prometheus.Labels{
+		"table": meta.Name(),
+	}).Inc()
 	return nil
 
 }
@@ -246,6 +263,8 @@ func (txn *txn) Delete(meta TableMeta, data any) (any, bool, error) {
 		return nil, false, fmt.Errorf("object not found")
 	}
 
+	txn.pendingObjectDeltas[tableName]--
+
 	// Update revision index.
 	indexTree := txn.indexWriteTxn(tableName, RevisionIndex)
 	if _, ok := indexTree.Delete(revisionKey(obj.revision, idKey)); !ok {
@@ -268,14 +287,21 @@ func (txn *txn) Delete(meta TableMeta, data any) (any, bool, error) {
 		obj.revision = revision
 		if old, existed := graveyardIndex.Insert(idKey, obj); existed {
 			txn.indexWriteTxn(tableName, GraveyardRevisionIndex).Delete(revisionKey(old.revision, idKey))
+			txn.pendingGraveyardDeltas[tableName]--
 		}
 		txn.indexWriteTxn(tableName, GraveyardRevisionIndex).Insert(revisionKey(revision, idKey), obj)
+		txn.pendingGraveyardDeltas[tableName]++
 	}
 
 	return obj.data, true, nil
 }
 
 func (txn *txn) Abort() {
+	txn.db.metrics.WriteTxnDuration.With(prometheus.Labels{
+		"tables":  txn.tableNames,
+		"package": txn.packageName,
+	}).Observe(time.Since(txn.acquiredAt).Seconds())
+
 	if txn.writeTxns == nil {
 		return
 	}
@@ -323,6 +349,11 @@ func (txn *txn) Commit() {
 	rootTxn.Notify()
 
 	txn.smus.Unlock()
+	for name, delta := range txn.pendingObjectDeltas {
+		db.metrics.TableObjectCount.With(prometheus.Labels{
+			"table": name,
+		}).Add(delta)
+	}
 	*txn = zeroTxn
 }
 

--- a/pkg/statedb2/txn.go
+++ b/pkg/statedb2/txn.go
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	iradix "github.com/hashicorp/go-immutable-radix/v2"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type txn struct {
+	db               *DB
+	rootReadTxn      *iradix.Txn[tableEntry]            // read transaction onto the tree of tables
+	lastIndexReadTxn lastIndexReadTxn                   // memoized result of the last indexReadTxn()
+	writeTxns        map[tableIndex]*iradix.Txn[object] // opened per-index write transactions
+	tables           map[TableName]*tableEntry          // table entries being modified
+	smus             lock.SortableMutexes               // the (sorted) table locks
+}
+
+type tableIndex struct {
+	table TableName
+	index IndexName
+}
+
+type lastIndexReadTxn struct {
+	table TableName
+	index IndexName
+	txn   *iradix.Txn[object]
+}
+
+var zeroTxn = txn{}
+
+func revisionKey(rev uint64, idKey []byte) []byte {
+	buf := make([]byte, 8+len(idKey))
+	binary.BigEndian.PutUint64(buf, rev)
+	copy(buf[8:], idKey)
+	return buf
+}
+
+// txn fulfills the ReadTxn/WriteTxn interface.
+func (txn *txn) getTxn() *txn {
+	return txn
+}
+
+func (txn *txn) GetRevision(name TableName) Revision {
+	if table, ok := txn.tables[name]; ok {
+		// This is a write transaction preparing to modify the table with a
+		// new revision.
+		return table.revision
+	}
+
+	// This is either a read transaction, or a write transaction to tables
+	// other than this table. Look up the revision from the index.
+	table, ok := txn.rootReadTxn.Get([]byte(name))
+	if !ok {
+		panic("BUG: Table " + name + " not found")
+	}
+	return table.revision
+}
+
+// indexReadTxn returns a transaction to read from the specific index.
+func (txn *txn) indexReadTxn(name TableName, index IndexName) *iradix.Txn[object] {
+	if txn.writeTxns != nil {
+		indexTxn, ok := txn.writeTxns[tableIndex{name, index}]
+		if ok {
+			return indexTxn.Clone()
+		}
+		if _, ok := txn.tables[name]; ok {
+			// We're writing into this table, create a write transaction
+			// instead.
+			return txn.indexWriteTxn(name, index).Clone()
+		}
+	}
+
+	if txn.lastIndexReadTxn.table == name && txn.lastIndexReadTxn.index == index {
+		return txn.lastIndexReadTxn.txn
+	}
+
+	table, ok := txn.rootReadTxn.Get([]byte(name))
+	if !ok {
+		panic("BUG: Table '" + name + "' not found")
+	}
+	indexTree, ok := table.indexes.Get([]byte(index))
+	if !ok {
+		panic(fmt.Sprintf("BUG: Index %s/%s not found", name, index))
+	}
+
+	indexTxn := indexTree.Txn()
+	txn.lastIndexReadTxn = lastIndexReadTxn{table: name, index: index, txn: indexTxn}
+	return indexTxn
+}
+
+// indexWriteTxn returns a transaction to read/write to a specific index.
+// The created transaction is memoized and used for subsequent reads and/or writes.
+func (txn *txn) indexWriteTxn(name TableName, index IndexName) *iradix.Txn[object] {
+	if indexTreeTxn, ok := txn.writeTxns[tableIndex{name, index}]; ok {
+		return indexTreeTxn
+	}
+	table, ok := txn.tables[name]
+	if !ok {
+		panic("BUG: Table '" + name + "' not found")
+	}
+	indexTree, ok := table.indexes.Get([]byte(index))
+	if !ok {
+		panic(fmt.Sprintf("BUG: Index %s/%s not found", name, index))
+	}
+	indexTreeTxn := indexTree.Txn()
+	indexTreeTxn.TrackMutate(true)
+	txn.writeTxns[tableIndex{name, index}] = indexTreeTxn
+	return indexTreeTxn
+}
+
+func (txn *txn) newRevision(tableName TableName) (Revision, error) {
+	table, ok := txn.tables[tableName]
+	if !ok {
+		return 0, fmt.Errorf("table %q not locked for writing", tableName)
+	}
+	table.revision++
+	return table.revision, nil
+}
+
+func (txn *txn) Insert(meta TableMeta, data any) (any, bool, error) {
+	if txn.rootReadTxn == nil {
+		return nil, false, fmt.Errorf("transaction is closed")
+	}
+
+	tableName := meta.Name()
+	revision, err := txn.newRevision(tableName)
+	if err != nil {
+		return nil, false, err
+	}
+
+	obj := object{
+		revision: revision,
+		data:     data,
+	}
+
+	// Update the primary index first
+	idKey := meta.primaryIndexer().fromObject(obj).First()
+	idIndexTree := txn.indexWriteTxn(tableName, meta.primaryIndexer().name)
+	oldObj, oldExists := idIndexTree.Insert(idKey, obj)
+
+	// Update revision index
+	revIndexTree := txn.indexWriteTxn(tableName, RevisionIndex)
+	if oldExists {
+		_, ok := revIndexTree.Delete(revisionKey(oldObj.revision, idKey))
+		if !ok {
+			panic("BUG: Old revision index entry not found")
+		}
+	}
+	revIndexTree.Insert(revisionKey(revision, idKey), obj)
+
+	// If it's new, possibly remove an older deleted object with the same
+	// primary key from the graveyard.
+	if !oldExists && txn.hasDeleteTrackers(tableName) {
+		if old, existed := txn.indexWriteTxn(tableName, GraveyardIndex).Delete(idKey); existed {
+			txn.indexWriteTxn(tableName, GraveyardRevisionIndex).Delete(revisionKey(old.revision, idKey))
+		}
+	}
+
+	// Then update secondary indexes
+	for index, indexer := range meta.secondaryIndexers() {
+		indexTree := txn.indexWriteTxn(tableName, index)
+		newKeys := indexer.fromObject(obj)
+
+		if oldExists {
+			// If the object already existed it might've invalidated the
+			// non-primary indexes. Compute the old key for this index and
+			// if the new key is different delete the old entry.
+			indexer.fromObject(oldObj).Foreach(func(oldKey []byte) {
+				if !indexer.unique {
+					oldKey = append(oldKey, idKey...)
+				}
+				if !newKeys.Exists(oldKey) {
+					indexTree.Delete(oldKey)
+				}
+			})
+		}
+		newKeys.Foreach(func(newKey []byte) {
+			// Non-unique secondary indexes are formed by concatenating them
+			// with the primary key.
+			if !indexer.unique {
+				newKey = append(newKey, idKey...)
+			}
+			indexTree.Insert(newKey, obj)
+		})
+	}
+
+	return oldObj.data, oldExists, nil
+}
+
+func (txn *txn) hasDeleteTrackers(name TableName) bool {
+	return txn.getTable(name).deleteTrackers.Len() > 0
+}
+
+func (txn *txn) getTable(name TableName) *tableEntry {
+	table, ok := txn.tables[name]
+	if ok {
+		return table
+	}
+	if t, ok := txn.rootReadTxn.Get([]byte(name)); ok {
+		return &t
+	}
+	panic(fmt.Sprintf("BUG: table %q not found", name))
+}
+
+func (txn *txn) addDeleteTracker(meta TableMeta, trackerName string, dt deleteTracker) error {
+	if txn.rootReadTxn == nil {
+		return fmt.Errorf("transaction is closed")
+	}
+	table, ok := txn.tables[meta.Name()]
+	if !ok {
+		return fmt.Errorf("table %q not locked for writing", meta.Name())
+	}
+	dt.setRevision(table.revision)
+	table.deleteTrackers, _, _ = table.deleteTrackers.Insert([]byte(trackerName), dt)
+	return nil
+
+}
+
+func (txn *txn) Delete(meta TableMeta, data any) (any, bool, error) {
+	if txn.rootReadTxn == nil {
+		return nil, false, fmt.Errorf("transaction is closed")
+	}
+
+	tableName := meta.Name()
+	revision, err := txn.newRevision(tableName)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Delete from the primary index first to grab the object.
+	// We assume that "data" has only enough defined fields to
+	// compute the primary key.
+	idKey := meta.primaryIndexer().fromObject(object{data: data}).First()
+	idIndexTree := txn.indexWriteTxn(tableName, meta.primaryIndexer().name)
+	obj, existed := idIndexTree.Delete(idKey)
+	if !existed {
+		return nil, false, fmt.Errorf("object not found")
+	}
+
+	// Update revision index.
+	indexTree := txn.indexWriteTxn(tableName, RevisionIndex)
+	if _, ok := indexTree.Delete(revisionKey(obj.revision, idKey)); !ok {
+		panic("BUG: Revision entry not found")
+	}
+
+	// Then update secondary indexes.
+	for index, indexer := range meta.secondaryIndexers() {
+		indexer.fromObject(obj).Foreach(func(key []byte) {
+			if !indexer.unique {
+				key = append(key, idKey...)
+			}
+			txn.indexWriteTxn(tableName, index).Delete(key)
+		})
+	}
+
+	// And finally insert the object into the graveyard.
+	if txn.hasDeleteTrackers(tableName) {
+		graveyardIndex := txn.indexWriteTxn(tableName, GraveyardIndex)
+		obj.revision = revision
+		if old, existed := graveyardIndex.Insert(idKey, obj); existed {
+			txn.indexWriteTxn(tableName, GraveyardRevisionIndex).Delete(revisionKey(old.revision, idKey))
+		}
+		txn.indexWriteTxn(tableName, GraveyardRevisionIndex).Insert(revisionKey(revision, idKey), obj)
+	}
+
+	return obj.data, true, nil
+}
+
+func (txn *txn) Abort() {
+	if txn.writeTxns == nil {
+		return
+	}
+	txn.smus.Unlock()
+	*txn = zeroTxn
+}
+
+func (txn *txn) Commit() {
+	if txn.writeTxns == nil {
+		return
+	}
+
+	// Commit each individual changed index to each table.
+	// We don't notify yet (CommitOnly) as the root needs to be updated
+	// first.
+	for tableIndex, subTxn := range txn.writeTxns {
+		table, ok := txn.tables[tableIndex.table]
+		if !ok {
+			panic("BUG: Table " + tableIndex.table + " not cached")
+		}
+		table.indexes, _, _ =
+			table.indexes.Insert([]byte(tableIndex.index), subTxn.CommitOnly())
+	}
+
+	db := txn.db
+
+	// Acquire the lock on the root tree to sequence the updates to it.
+	db.mu.Lock()
+	rootTxn := db.root.Load().Txn()
+
+	// Insert the modified tables into the root.
+	for name, table := range txn.tables {
+		rootTxn.Insert([]byte(name), *table)
+	}
+
+	// Commit the new root.
+	newRoot := rootTxn.CommitOnly()
+	db.root.Store(newRoot)
+	db.mu.Unlock()
+
+	// Now that new root is available notify of the changes by closing the watch channels.
+	for _, subTxn := range txn.writeTxns {
+		subTxn.Notify()
+	}
+	rootTxn.Notify()
+
+	txn.smus.Unlock()
+	*txn = zeroTxn
+}
+
+// WriteJSON marshals out the whole database as JSON into the given writer.
+func (txn *txn) WriteJSON(w io.Writer) error {
+	buf := bufio.NewWriter(w)
+	buf.WriteString("{\n")
+	first := true
+	for _, table := range txn.db.tables {
+		if !first {
+			buf.WriteString(",\n")
+		} else {
+			first = false
+		}
+
+		indexTxn := txn.getTxn().indexReadTxn(table.Name(), table.primaryIndexer().name)
+		if indexTxn == nil {
+			panic("BUG: Missing primary index " + table.primaryIndexer().name)
+		}
+		root := indexTxn.Root()
+		iter := root.Iterator()
+
+		buf.WriteString("  \"" + table.Name() + "\": [\n")
+
+		_, obj, ok := iter.Next()
+		for ok {
+			buf.WriteString("    ")
+			bs, err := json.Marshal(obj.data)
+			if err != nil {
+				return err
+			}
+			buf.Write(bs)
+			_, obj, ok = iter.Next()
+			if ok {
+				buf.WriteString(",\n")
+			} else {
+				buf.WriteByte('\n')
+			}
+		}
+		buf.WriteString("  ]")
+	}
+	buf.WriteString("\n}\n")
+	return buf.Flush()
+}

--- a/pkg/statedb2/types.go
+++ b/pkg/statedb2/types.go
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package statedb2
+
+import (
+	"io"
+
+	iradix "github.com/hashicorp/go-immutable-radix/v2"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/statedb2/index"
+)
+
+type (
+	TableName = string
+	IndexName = string
+	Revision  = uint64
+)
+
+type Table[Obj any] interface {
+	// TableMeta for querying table metadata that is independent of
+	// 'Obj' type. Provides the database access to table's indexers.
+	TableMeta
+
+	// Revision of the table. Constant for a read transaction, but
+	// increments in a write transaction on each Insert and Delete.
+	Revision(ReadTxn) Revision
+
+	// All returns an iterator for all objects in the table and a watch
+	// channel that is closed when the table changes.
+	All(ReadTxn) (Iterator[Obj], <-chan struct{})
+
+	// Get returns an iterator for all objects matching the given query
+	// and a watch channel that is closed if the query results are
+	// invalidated by a write to the table.
+	Get(ReadTxn, Query[Obj]) (Iterator[Obj], <-chan struct{})
+
+	// First returns the first matching object for the query.
+	First(ReadTxn, Query[Obj]) (obj Obj, rev Revision, found bool)
+
+	// FirstWatch return the first matching object and a watch channel
+	// that is closed if the query is invalidated.
+	FirstWatch(ReadTxn, Query[Obj]) (obj Obj, rev Revision, watch <-chan struct{}, found bool)
+
+	// Last returns the last matching object.
+	Last(ReadTxn, Query[Obj]) (obj Obj, rev Revision, found bool)
+
+	// LastWatch returns the last matching object and a watch channel
+	// that is closed if the query is invalidated.
+	LastWatch(ReadTxn, Query[Obj]) (obj Obj, rev Revision, watch <-chan struct{}, found bool)
+
+	// LowerBound returns an iterator for objects that have a key
+	// greater or equal to the query. The returned watch channel is closed
+	// when anything in the table changes as more fine-grained notifications
+	// are not possible with a lower bound search.
+	LowerBound(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
+
+	// Insert an object into the table. Returns the object that was
+	// replaced if there was one. Error may be returned if the table
+	// is not locked for writing or if the write transaction has already
+	// been committed or aborted.
+	//
+	// Each inserted or updated object will be assigned a new unique
+	// revision.
+	Insert(WriteTxn, Obj) (oldObj Obj, hadOld bool, err error)
+
+	// Delete an object from the table. Returns the object that was
+	// deleted if there was one. Error may be returned if the table
+	// is not locked for writing or if the write transaction has already
+	// been committed or aborted.
+	//
+	// If the table is being tracked for deletions via DeleteTracker()
+	// the deleted object is inserted into a graveyard index and garbage
+	// collected when all delete trackers have consumed it. Each deleted
+	// object in the graveyard has unique revision allowing interleaved
+	// iteration of updates and deletions (see (*DeleteTracker[Obj]).Process).
+	Delete(WriteTxn, Obj) (oldObj Obj, hadOld bool, err error)
+
+	DeleteAll(WriteTxn) error
+
+	// DeleteTracker creates a new delete tracker for the table
+	// starting from the given revision.
+	DeleteTracker(txn WriteTxn, trackerName string) (*DeleteTracker[Obj], error)
+}
+
+// TableMeta provides information about the table that is independent of
+// the object type (the 'Obj' constraint).
+type TableMeta interface {
+	Name() TableName                          // The name of the table
+	tableKey() index.Key                      // The radix key for the table in the root tree
+	primaryIndexer() anyIndexer               // The untyped primary indexer for the table
+	secondaryIndexers() map[string]anyIndexer // Secondary indexers (if any)
+	sortableMutex() lock.SortableMutex        // The sortable mutex for locking the table for writing
+}
+
+// Iterator for iterating objects returned from queries.
+type Iterator[Obj any] interface {
+	// Next returns the next object its revision if ok is true, otherwise
+	// zero values to mean that the iteration has finished.
+	Next() (obj Obj, rev Revision, ok bool)
+}
+
+type ReadTxn interface {
+	getTxn() *txn
+
+	// WriteJSON writes the contents of the database as JSON.
+	WriteJSON(io.Writer) error
+}
+
+type WriteTxn interface {
+	ReadTxn
+	Abort()
+	Commit()
+}
+
+type Query[Obj any] struct {
+	index  IndexName
+	unique bool
+	key    []byte
+}
+
+// ByRevision constructs a revision query. Applicable to any table.
+func ByRevision[Obj any](rev uint64) Query[Obj] {
+	return Query[Obj]{
+		index:  RevisionIndex,
+		unique: false,
+		key:    index.Uint64(rev),
+	}
+}
+
+// Index implements the indexing of objects (FromObjects) and querying of objects from the index (FromKey)
+type Index[Obj any, Key any] struct {
+	Name       string
+	FromObject func(obj Obj) index.KeySet
+	FromKey    func(key Key) []byte
+	Unique     bool
+}
+
+var _ Indexer[struct{}] = &Index[struct{}, bool]{}
+
+//nolint:unused
+func (i Index[Key, Obj]) indexName() string {
+	return i.Name
+}
+
+//nolint:unused
+func (i Index[Obj, Key]) fromObject(obj Obj) index.KeySet {
+	return i.FromObject(obj)
+}
+
+//nolint:unused
+func (i Index[Obj, Key]) isUnique() bool {
+	return i.Unique
+}
+
+// Query constructs a query against this index from a key.
+func (i Index[Obj, Key]) Query(key Key) Query[Obj] {
+	return Query[Obj]{
+		index:  i.Name,
+		unique: i.isUnique(),
+		key:    i.FromKey(key),
+	}
+}
+
+// Indexer is the "FromObject" subset of Index[Obj, Key]
+// without the 'Key' constraint.
+type Indexer[Obj any] interface {
+	indexName() string
+	isUnique() bool
+	fromObject(obj Obj) index.KeySet
+}
+
+//
+// Internal types and constants.
+//
+
+const (
+	reservedIndexPrefix    = "__"
+	RevisionIndex          = "__revision__"
+	GraveyardIndex         = "__graveyard__"
+	GraveyardRevisionIndex = "__graveyard_revision__"
+)
+
+// object is the format in which data is stored in the tables.
+type object struct {
+	revision uint64
+	data     any
+}
+
+// anyIndexer is an untyped indexer. The user-defined 'Index[Obj,Key]'
+// is converted to this form.
+type anyIndexer struct {
+	// name is the indexer name.
+	name string
+
+	// fromObject returns the key (or keys for multi-index) to index the
+	// object with.
+	fromObject func(object) index.KeySet
+
+	// unique if true will index the object solely on the
+	// values returned by fromObject. If false the primary
+	// key of the object will be appended to the key.
+	unique bool
+}
+
+type deleteTracker interface {
+	setRevision(uint64)
+	getRevision() uint64
+}
+
+type indexTree = *iradix.Tree[object]
+
+type tableEntry struct {
+	meta           TableMeta
+	indexes        *iradix.Tree[indexTree]
+	deleteTrackers *iradix.Tree[deleteTracker]
+	revision       uint64
+}


### PR DESCRIPTION
"StateDB v2.0" reimplements pkg/statedb to introduce per-table locking, built-in revision numbers and ability to track objects being deleted from tables. It moves away from the go-memdb library and implements directly on top of the immutable-radix-tree library, with the biggest visible change being that indexes are no longer defined using reflection, but with type-safe functions.

To make reviewing easier the new version is first introduced as `pkg/statedb2` and then in a follow-up PR the uses of `pkg/statedb` are converted over to the new API and old code replaced.

See `pkg/statedb2/example` for an overview of how the new API looks like.

