### PR TITLE
fix: add check if debug is enabled when adding trace levels to envoy deamonset. 

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -65,7 +65,7 @@ spec:
         args:
         - '-c /var/run/cilium/envoy/bootstrap-config.json'
         - '--base-id 0'
-        {{- if and (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "envoy" ( splitList "," .Values.debug.verbose )) }}
+        {{- if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "envoy" ( splitList "," .Values.debug.verbose )) }}
         - '--log-level trace'
         {{- else if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "flow" ( splitList "," .Values.debug.verbose )) }}
         - '--log-level debug'


### PR DESCRIPTION
The proposed change should resolve the following issue noticed during the upgrade of my cilium installation to 1.14.0: 

```
Error: template: cilium/templates/cilium-envoy/daemonset.yaml:68:112: executing "cilium/templates/cilium-envoy/daemonset.yaml" at <.Values.debug.verbose>: wrong type for value; expected string; got interface {}
```

This was observed using the default debug values as set in the official chart and just setting `envoy.enabled` to `true`