### PR TITLE
repository: shard rules by namespace

### DIFF
--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -1543,7 +1543,7 @@ func (ds *PolicyTestSuite) TestRemoveIdentityFromRuleDenyCaches(c *C) {
 		},
 	}})
 
-	addedRule := testRepo.rules[0]
+	addedRule := testRepo.getInternalRules()[0]
 
 	selectedEpLabels := labels.ParseSelectLabel("id=a")
 	selectedIdentity := identity.NewIdentity(54321, labels.Labels{selectedEpLabels.Key: selectedEpLabels})

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -2596,8 +2596,8 @@ func (ds *PolicyTestSuite) TestMatches(c *C) {
 		},
 	})
 
-	epRule := repo.rules[0]
-	hostRule := repo.rules[1]
+	epRule := repo.getInternalRules()[0]
+	hostRule := repo.getInternalRules()[1]
 
 	selectedEpLabels := labels.ParseSelectLabel("id=a")
 	selectedIdentity := identity.NewIdentity(54321, labels.Labels{selectedEpLabels.Key: selectedEpLabels})


### PR DESCRIPTION
This central ruleSlice has for us been one of the main bottle necks for throughput, and one of the main contributors to cpu usage. With this patch, we will now shard it by namespace transparently, so that we don't need to evaluate rules unnecessary. The main benefit is that when calculating rules for pod X in namespace A, we don't need to evaluate rules only applying to pods in namespace B. The same applies to the rule add and remove; when a rule is removed in namespace B, we don't need to evaluate rules in namespace A.

This is all transparent to users, and an implementation detail, so the sharding mechanism can easily be changed at a later stage.

**TBD**: Still some stuff missing here, so mostly a proof-of-concept.

Based on the BenchmarkParseLabel with 10 namespaces/shards, this is the benchstat diff;
```
name          old time/op    new time/op    delta
ParseLabel-7     5.21s ±33%     1.02s ±40%  -80.36%  (p=0.000 n=10+10)

name          old alloc/op   new alloc/op   delta
ParseLabel-7    26.9MB ± 0%    26.9MB ± 0%   -0.33%  (p=0.001 n=9+10)

name          old allocs/op  new allocs/op  delta
ParseLabel-7      520k ± 0%      520k ± 0%   +0.02%  (p=0.000 n=9+9)
```

The more rules, the higher bigger the gain will be! We also see that the locking `(*Repository) getMatchingRules` is also a huge chuck of cpu time, as well as a lot of lock contention. 

```release-note
Improve performance of Network Policy calculation
```
