### PR TITLE
ipsec: discard trace events when monitor aggregation is enabled

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -123,8 +123,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		ctx_change_type(ctx, PACKET_HOST);
 
 		send_trace_notify(ctx, TRACE_TO_STACK, *identity, 0, 0,
-				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
-				  TRACE_PAYLOAD_LEN);
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED, 0);
 
 		return CTX_ACT_OK;
 	}
@@ -401,8 +400,7 @@ skip_vtep:
 		ctx_change_type(ctx, PACKET_HOST);
 
 		send_trace_notify(ctx, TRACE_TO_STACK, *identity, 0, 0,
-				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
-				  TRACE_PAYLOAD_LEN);
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED, 0);
 
 		return CTX_ACT_OK;
 	}
@@ -581,8 +579,7 @@ int cil_from_overlay(struct __ctx_buff *ctx)
 #ifdef ENABLE_IPSEC
 	if (is_esp(ctx, proto))
 		send_trace_notify(ctx, TRACE_FROM_OVERLAY, 0, 0, 0,
-				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
-				  TRACE_PAYLOAD_LEN);
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED, 0);
 	else
 #endif
 	{


### PR DESCRIPTION
ipsec: discard trace events when monitor aggregation is enabled

This commit modifies calls to `send_trace_notify` in IPSec contexts
where connection tracking information is not availble to drop events
when monitor aggregation is enabled.

Benchmarks were performed on a two node, e2-custom-4-8192,
cluster, using pod to pod netperf stream, RR and CRR tests. Cilium
v1.14.0 was installed using unstripped images with IPSec, VXLAN
tunnel mode, and Hubble enabled. Tests were performed in the order
of stream, RR and CRR for each configuration. Between each test,
the netserver was reset and each node's conntrack tables were
cleared.

Pod to pod netperf stream test on v1.14.0, one client per core:

```csv
Throughput,Throughput Units,Elapsed Time (sec)
464.06,10^6bits/s,180.04
461.25,10^6bits/s,180.02
441.73,10^6bits/s,180.00
482.26,10^6bits/s,180.04
```

Client FlameGraph:
![v1.14.0 upstream client](https://github.com/cilium/cilium/assets/13142290/b4962a0e-7086-42d6-935b-e11dad1c358e)

Server FlameGraph:
![v1.14.0 upstream server](https://github.com/cilium/cilium/assets/13142290/17d544a3-cb0f-4676-9f7d-36dcf3f6d877)

Pod to pod netperf stream test on this commit, one client per core:

```csv
Throughput,Throughput Units,Elapsed Time (sec)
698.48,10^6bits/s,180.03
643.81,10^6bits/s,180.05
780.22,10^6bits/s,180.05
552.11,10^6bits/s,180.03
```

Client FlameGraph
![Patched Client FlameGraph](https://github.com/cilium/cilium/assets/13142290/f5884c4f-a32c-4f1e-a0bf-8f352b65a0ce)

Server FlameGraph
![Patched Server FlameGraph](https://github.com/cilium/cilium/assets/13142290/a86d6530-561e-4c35-b62f-4d6e11c04005)

Taking the average of each client's throughput, this change leads to
an increase in throughput by +45%.

Pod to pod netperf RR test on v1.14.0, one client per core:

```csv
50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Round Trip Latency usec/tran,Request Size Bytes,Response Size Bytes,Elapsed Time (sec)
302,486,1350,361.258,1,1,180.00
312,501,1304,372.272,1,1,180.00
320,530,1338,383.703,1,1,180.00
302,459,1286,355.595,1,1,180.00
```

Client FlameGraph
![v1.14.0 Client FlameGraph](https://github.com/cilium/cilium/assets/13142290/ef888d47-bf77-4340-a511-e398e46b07d9)

Server FlameGraph
![v1.14.0 Server FlameGraph](https://github.com/cilium/cilium/assets/13142290/4dc00060-4c10-4470-a5c7-c228924eff2c)

Pod to pod netperf RR test on this commit, one client per core:

```csv
50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Round Trip Latency usec/tran,Request Size Bytes,Response Size Bytes,Elapsed Time (sec)
199,256,370,213.484,1,1,180.00
198,254,366,212.594,1,1,180.00
202,261,371,216.930,1,1,180.00
199,257,366,213.430,1,1,180.00
```

Client FlameGraph
![Patched Client FlameGraph](https://github.com/cilium/cilium/assets/13142290/a54916e8-a6bc-4a1a-a78a-9a9ca4a57c1c)

Server FlameGraph
![Patched Server FlameGraph](https://github.com/cilium/cilium/assets/13142290/a4428efb-2417-421a-a407-963c99de4df2)

Taking the worst 99th percentile latency from each test, this change
leads to a reduction in p99 latency by 76.5%.

Pod to pod netperf CRR test on v1.14.0, one client per core:

```csv
50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Round Trip Latency usec/tran,Request Size Bytes,Response Size Bytes,Elapsed Time (sec)
935,3910,6920,3337.723,1,1,180.00
914,3308,6432,2502.398,1,1,180.00
933,3797,6843,3199.433,1,1,180.00
927,3761,6812,2855.196,1,1,180.00
```

Client FlameGraph
![v1.14.0 Client FlameGraph](https://github.com/cilium/cilium/assets/13142290/4511ee15-ad97-405b-9fbf-a5f1f7f1c926)

Server FlameGraph
![v1.14.0 Server FlameGraph](https://github.com/cilium/cilium/assets/13142290/b843265d-fbea-4b34-8393-8a6867c3ddcb)

Pod to pod netperf CRR test on this commit, one client per core:

```csv
50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Round Trip Latency usec/tran,Request Size Bytes,Response Size Bytes,Elapsed Time (sec)
683,4680,5803,3155.128,1,1,180.00
678,4627,5782,2958.921,1,1,180.00
683,4658,5830,3095.390,1,1,180.00
680,4646,5787,3092.147,1,1,180.00
```

Client FlameGraph
![Patched Client FlameGraph](https://github.com/cilium/cilium/assets/13142290/8fe41105-bf8c-4bcd-9178-f0d9392c5a71)

Server FlameGraph
![Patched Server FlameGraph](https://github.com/cilium/cilium/assets/13142290/0e11f637-52b9-4e45-9e4e-4ad65617e849)

Taking the worst 99th percentile latency from each test, this change
leads to a reduction in p99 latency by 15.8%.

Release Note:

```release-note
Fix bug limiting pod-to-pod network performance under high load when tunneling and IPSec are both enabled.
```

Fixes: #26648