### PR TITLE
helm: use local etcd client certificate when kvstoremesh is enabled

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-config/_helpers.tpl
@@ -4,10 +4,10 @@
 {{- $hasCustomCACert := index . 2 -}}
 {{- $override := index . 3 -}}
 {{- /* The parenthesis around $cluster.tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
-{{- $prefix := ternary "common-" (printf "%s." $cluster.name) (or (empty ($cluster.tls).cert) (empty ($cluster.tls).key)) -}}
+{{- $prefix := ternary "common-" (printf "%s." $cluster.name) (or (ne $override "") (empty ($cluster.tls).cert) (empty ($cluster.tls).key)) -}}
 
 endpoints:
-{{- if $override }}
+{{- if ne $override "" }}
 - {{ $override }}
 {{- else if $cluster.ips }}
 - https://{{ $cluster.name }}.{{ $domain }}:{{ $cluster.port }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -11,7 +11,7 @@ data:
   {{- $hasCustomCACert := or (.tls).caCert $.Values.clustermesh.apiserver.tls.ca.cert }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $hasCustomCACert $override) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
-  {{- if and (.tls).cert (.tls).key }}
+  {{- if and (eq $override "") (.tls).cert (.tls).key }}
   {{- if $hasCustomCACert }}
   {{ .name }}.etcd-client-ca.crt: {{ .tls.caCert | default $.Values.clustermesh.apiserver.tls.ca.cert }}
   {{- end }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/kvstoremesh-secret.yaml
@@ -11,7 +11,9 @@ data:
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $hasCustomCACert "") | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}
   {{- if and (.tls).cert (.tls).key }}
+  {{- if $hasCustomCACert }}
   {{ .name }}.etcd-client-ca.crt: {{ .tls.caCert | default $.Values.clustermesh.apiserver.tls.ca.cert }}
+  {{- end }}
   {{ .name }}.etcd-client.key: {{ .tls.key }}
   {{ .name }}.etcd-client.crt: {{ .tls.cert }}
   {{- end }}


### PR DESCRIPTION
When kvstoremesh is enabled, local agents connect to the local clustermesh-apiserver instance, rather than the remote one. Yet, when the TLS key/certificate pair of a remote cluster is manually specified, the helm chart currently configures it both to connect to the remote clustermesh-apiserver instance (which is correct) and to the local one (which prevents the connection from being established correctly as it is signed with a different CA).

Let's fix this making sure that we always use the local TLS key/certificate pair when connecting to the local
clustermesh-apiserver instance.

<!-- Description of change -->

```release-note
Fix generation of the clustermesh config through Helm when kvstoremesh is enabled, and the TLS key/cert pair is manually specified for a given remote cluster
```
