### PR TITLE
bpf: nat: enable CT-driven trace aggregation

### DIFF
--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -22,6 +22,7 @@
 #include "icmp6.h"
 #include "nat_46x64.h"
 #include "stubs.h"
+#include "trace.h"
 
 enum  nat_dir {
 	NAT_DIR_EGRESS  = TUPLE_F_OUT,
@@ -265,6 +266,7 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 			   struct ipv4_nat_entry *tmp,
 			   __u32 off,
 			   const struct ipv4_nat_target *target,
+			   struct trace_ctx *trace,
 			   __s8 *ext_err)
 {
 	bool needs_ct = target->needs_ct;
@@ -279,7 +281,6 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 	if (needs_ct) {
 		struct ipv4_ct_tuple tuple_snat;
 		struct ct_state ct_state = {};
-		__u32 monitor = 0;
 		int ret;
 
 		memcpy(&tuple_snat, tuple, sizeof(tuple_snat));
@@ -288,10 +289,11 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_snat), &tuple_snat,
 				      ctx, off, has_l4_header, ct_action, CT_EGRESS,
-				      SCOPE_FORWARD, &ct_state, &monitor);
+				      SCOPE_FORWARD, &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
 
+		trace->reason = (enum trace_reason)ret;
 		if (ret == CT_NEW) {
 			ret = ct_create4(get_ct_map4(&tuple_snat), NULL,
 					 &tuple_snat, ctx, CT_EGRESS,
@@ -905,14 +907,15 @@ snat_v4_nat_handle_icmp_frag_needed(struct __ctx_buff *ctx, __u64 off,
 static __always_inline int
 __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 	      bool has_l4_header, int l4_off, enum ct_action action,
-	      bool update_tuple,
-	      const struct ipv4_nat_target *target, __s8 *ext_err)
+	      bool update_tuple, const struct ipv4_nat_target *target,
+	      struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ipv4_nat_entry *state, tmp;
 	int ret;
 
 	ret = snat_v4_nat_handle_mapping(ctx, tuple, has_l4_header, action,
-					 &state, &tmp, l4_off, target, ext_err);
+					 &state, &tmp, l4_off, target,
+					 trace, ext_err);
 	if (ret < 0)
 		return ret;
 
@@ -928,7 +931,8 @@ __snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 
 static __always_inline __maybe_unused int
 snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
-	    bool has_l4_header, const struct ipv4_nat_target *target, __s8 *ext_err)
+	    bool has_l4_header, const struct ipv4_nat_target *target,
+	    struct trace_ctx *trace, __s8 *ext_err)
 {
 	enum ct_action ct_action = ACTION_UNSPEC;
 	struct icmphdr icmphdr __align_stack_8;
@@ -983,7 +987,7 @@ snat_v4_nat(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple, int off,
 		return NAT_PUNT_TO_STACK;
 
 	return __snat_v4_nat(ctx, tuple, has_l4_header, off, ct_action,
-			     false, target, ext_err);
+			     false, target, trace, ext_err);
 }
 
 static __always_inline __maybe_unused int
@@ -1306,6 +1310,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 			   struct ipv6_nat_entry *tmp,
 			   __u32 off,
 			   const struct ipv6_nat_target *target,
+			   struct trace_ctx *trace,
 			   __s8 *ext_err)
 {
 	bool needs_ct = target->needs_ct;
@@ -1315,7 +1320,6 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 	if (needs_ct) {
 		struct ipv6_ct_tuple tuple_snat;
 		struct ct_state ct_state = {};
-		__u32 monitor = 0;
 		int ret;
 
 		memcpy(&tuple_snat, tuple, sizeof(tuple_snat));
@@ -1324,10 +1328,11 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple_snat), &tuple_snat,
 				      ctx, off, ct_action, CT_EGRESS,
-				      SCOPE_FORWARD, &ct_state, &monitor);
+				      SCOPE_FORWARD, &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
 
+		trace->reason = (enum trace_reason)ret;
 		if (ret == CT_NEW) {
 			ret = ct_create6(get_ct_map6(&tuple_snat), NULL,
 					 &tuple_snat, ctx, CT_EGRESS,
@@ -1696,13 +1701,14 @@ snat_v6_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 static __always_inline int
 __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	      int l4_off, enum ct_action action, bool update_tuple,
-	      const struct ipv6_nat_target *target, __s8 *ext_err)
+	      const struct ipv6_nat_target *target,
+	      struct trace_ctx *trace, __s8 *ext_err)
 {
 	struct ipv6_nat_entry *state, tmp;
 	int ret;
 
 	ret = snat_v6_nat_handle_mapping(ctx, tuple, action, &state, &tmp,
-					 l4_off, target, ext_err);
+					 l4_off, target, trace, ext_err);
 	if (ret < 0)
 		return ret;
 
@@ -1718,7 +1724,8 @@ __snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 
 static __always_inline __maybe_unused int
 snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
-	    const struct ipv6_nat_target *target, __s8 *ext_err)
+	    const struct ipv6_nat_target *target, struct trace_ctx *trace,
+	    __s8 *ext_err)
 {
 	enum ct_action ct_action = ACTION_UNSPEC;
 	struct icmp6hdr icmp6hdr __align_stack_8;
@@ -1766,7 +1773,8 @@ snat_v6_nat(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple, int off,
 	if (snat_v6_nat_can_skip(target, tuple))
 		return NAT_PUNT_TO_STACK;
 
-	return __snat_v6_nat(ctx, tuple, off, ct_action, false, target, ext_err);
+	return __snat_v6_nat(ctx, tuple, off, ct_action, false, target,
+			     trace, ext_err);
 }
 
 static __always_inline __maybe_unused int

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -568,6 +568,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	assert(ret == 0);
 
 	struct ipv4_ct_tuple icmp_tuple = {};
+	struct trace_ctx trace;
 	void *data, *data_end;
 	struct iphdr *ip4;
 	int l4_off;
@@ -580,7 +581,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	 * snat_v4_nat().
 	 */
 	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
-			  &target, NULL);
+			  &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -682,6 +683,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	assert(ret == 0);
 
 	struct ipv4_ct_tuple icmp_tuple = {};
+	struct trace_ctx trace;
 	void *data, *data_end;
 	struct iphdr *ip4;
 	int l4_off;
@@ -694,7 +696,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	 * snat_v4_nat().
 	 */
 	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
-			  &target, NULL);
+			  &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -795,6 +797,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	assert(ret == 0);
 
 	struct ipv4_ct_tuple icmp_tuple = {};
+	struct trace_ctx trace;
 	void *data, *data_end;
 	struct iphdr *ip4;
 	int l4_off;
@@ -807,7 +810,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	 * snat_v4_nat().
 	 */
 	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
-			  &target, NULL);
+			  &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -897,6 +900,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	assert(ret == 0);
 
 	struct ipv4_ct_tuple icmp_tuple = {};
+	struct trace_ctx trace;
 	void *data, *data_end;
 	struct iphdr *ip4;
 	int l4_off;
@@ -909,7 +913,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	 * snat_v4_nat().
 	 */
 	ret = snat_v4_nat(ctx, &icmp_tuple, l4_off, ipv4_has_l4_header(ip4),
-			  &target, NULL);
+			  &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;


### PR DESCRIPTION
When the NAT code creates a CT entry for a SNATed connection (for instance for EgressGW traffic), pass back the resulting trace information to tail_handle_snat_fwd_ipv*().

Note that this also wires up the path from tail_nodeport_nat_egress_ipv*(), but those connections never require CT on the NAT level.