### PR TITLE
datapath: configure linux node config writer through hive

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/l2responder"
 	"github.com/cilium/cilium/pkg/datapath/link"
 	linuxdatapath "github.com/cilium/cilium/pkg/datapath/linux"
+	dpcfg "github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/datapath/linux/utime"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -67,6 +68,9 @@ var Cell = cell.Module(
 
 	// Gratuitous ARP event processor emits GARP packets on k8s pod creation events.
 	garp.Cell,
+
+	// This cell provides the object used to write the headers for datapath program types.
+	dpcfg.Cell,
 
 	cell.Provide(func(dp types.Datapath) types.NodeIDHandler {
 		return dp.NodeIDs()
@@ -129,7 +133,7 @@ func newDatapath(params datapathParams) types.Datapath {
 			return nil
 		}})
 
-	datapath := linuxdatapath.NewDatapath(datapathConfig, iptablesManager, params.WgAgent, params.NodeMap)
+	datapath := linuxdatapath.NewDatapath(datapathConfig, iptablesManager, params.WgAgent, params.NodeMap, params.ConfigWriter)
 
 	params.LC.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
@@ -157,4 +161,6 @@ type datapathParams struct {
 	// This is required until option.Config.GetDevices() has been removed and
 	// uses of it converted to Table[Device].
 	DeviceManager *linuxdatapath.DeviceManager
+
+	ConfigWriter types.ConfigWriter
 }

--- a/pkg/datapath/linux/config/cell.go
+++ b/pkg/datapath/linux/config/cell.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package config
+
+import (
+	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
+	dptypes "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+var Cell = cell.Module(
+	"datapath-config-writer",
+	"Generate and write the configuration for datapath program types",
+
+	cell.Provide(
+		func(in struct {
+			cell.In
+			NodeExtraDefines []dpdef.Fn `group:"header-node-defines"`
+		}) dptypes.ConfigWriter {
+			return &HeaderfileWriter{nodeExtraDefines: in.NodeExtraDefines}
+		},
+	),
+)

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -13,10 +13,12 @@ import (
 	"testing"
 
 	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/ebpf/rlimit"
 
+	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
@@ -43,21 +45,24 @@ var (
 
 func (s *ConfigSuite) SetUpSuite(c *C) {
 	testutils.PrivilegedTest(c)
-
-	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 }
 
-func (s *ConfigSuite) SetUpTest(c *C) {
-	err := rlimit.RemoveMemlock()
-	c.Assert(err, IsNil)
+func setup(tb testing.TB) {
+	tb.Helper()
+
+	require.NoError(tb, rlimit.RemoveMemlock(), "Failed to remove memory limits")
+	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+
 	node.SetTestLocalNodeStore()
 	node.InitDefaultPrefix("")
 	node.SetInternalIPv4Router(ipv4DummyAddr.AsSlice())
 	node.SetIPv4Loopback(ipv4DummyAddr.AsSlice())
+
+	tb.Cleanup(node.UnsetTestLocalNodeStore)
 }
 
-func (s *ConfigSuite) TearDownTest(c *C) {
-	node.UnsetTestLocalNodeStore()
+func (s *ConfigSuite) SetUpTest(c *C) {
+	setup(c)
 }
 
 type badWriter struct{}
@@ -326,4 +331,42 @@ return false;`, main1.Index, main2.Index))
 	m, err = vlanFilterMacros()
 	c.Assert(err, IsNil)
 	c.Assert(m, Equals, "return true")
+}
+
+func TestWriteNodeConfigExtraDefines(t *testing.T) {
+	testutils.PrivilegedTest(t)
+	setup(t)
+
+	var buffer bytes.Buffer
+
+	// Assert that configurations are propagated when all generated extra defines are valid
+	cfg := HeaderfileWriter{nodeExtraDefines: []dpdef.Fn{
+		func() (dpdef.Map, error) { return dpdef.Map{"FOO": "0x1", "BAR": "0x2"}, nil },
+		func() (dpdef.Map, error) { return dpdef.Map{"BAZ": "0x3"}, nil },
+	}}
+
+	buffer.Reset()
+	require.NoError(t, cfg.WriteNodeConfig(&buffer, &dummyNodeCfg))
+
+	output := buffer.String()
+	require.Contains(t, output, "define FOO 0x1\n")
+	require.Contains(t, output, "define BAR 0x2\n")
+	require.Contains(t, output, "define BAZ 0x3\n")
+
+	// Assert that an error is returned when one extra define function returns an error
+	cfg = HeaderfileWriter{nodeExtraDefines: []dpdef.Fn{
+		func() (dpdef.Map, error) { return nil, errors.New("failing on purpose") },
+	}}
+
+	buffer.Reset()
+	require.Error(t, cfg.WriteNodeConfig(&buffer, &dummyNodeCfg))
+
+	// Assert that an error is returned when one extra define would overwrite an already existing entry
+	cfg = HeaderfileWriter{nodeExtraDefines: []dpdef.Fn{
+		func() (dpdef.Map, error) { return dpdef.Map{"FOO": "0x1", "BAR": "0x2"}, nil },
+		func() (dpdef.Map, error) { return dpdef.Map{"FOO": "0x3"}, nil },
+	}}
+
+	buffer.Reset()
+	require.Error(t, cfg.WriteNodeConfig(&buffer, &dummyNodeCfg))
 }

--- a/pkg/datapath/linux/config/defines/defines.go
+++ b/pkg/datapath/linux/config/defines/defines.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package defines
+
+import "github.com/cilium/cilium/pkg/hive/cell"
+
+// Map is the type containing the key-value pairs representing extra define
+// directives for datapath node configuration.
+type Map map[string]string
+
+// Fn is a function returning the key-value pairs representing extra define
+// directives for datapath node configuration.
+type Fn func() (Map, error)
+
+type NodeFnOut struct {
+	cell.Out
+	Fn `group:"header-node-defines"`
+}
+
+// NewNodeFnOut wraps a function returning the key-value pairs representing
+// extra define directives for datapath node configuration, so that it can be
+// provided through the hive framework.
+func NewNodeFnOut(fn Fn) NodeFnOut {
+	return NodeFnOut{Fn: fn}
+}

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -4,7 +4,6 @@
 package linux
 
 import (
-	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
@@ -32,9 +31,10 @@ type linuxDatapath struct {
 }
 
 // NewDatapath creates a new Linux datapath
-func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager, wgAgent datapath.WireguardAgent, nodeMap nodemap.Map) datapath.Datapath {
+func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager, wgAgent datapath.WireguardAgent,
+	nodeMap nodemap.Map, writer datapath.ConfigWriter) datapath.Datapath {
 	dp := &linuxDatapath{
-		ConfigWriter:    &config.HeaderfileWriter{},
+		ConfigWriter:    writer,
 		IptablesManager: ruleManager,
 		nodeAddressing:  NewNodeAddressing(),
 		config:          cfg,

--- a/pkg/datapath/linux/datapath_test.go
+++ b/pkg/datapath/linux/datapath_test.go
@@ -18,7 +18,7 @@ type linuxTestSuite struct{}
 var _ = check.Suite(&linuxTestSuite{})
 
 func (s *linuxTestSuite) TestNewDatapath(c *check.C) {
-	dp := NewDatapath(DatapathConfiguration{}, nil, nil, nil)
+	dp := NewDatapath(DatapathConfiguration{}, nil, nil, nil, nil)
 	c.Assert(dp, check.Not(check.IsNil))
 
 	c.Assert(dp.Node(), check.Not(check.IsNil))

--- a/pkg/endpoint/bpf_test.go
+++ b/pkg/endpoint/bpf_test.go
@@ -12,6 +12,7 @@ import (
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
@@ -31,7 +32,7 @@ func BenchmarkWriteHeaderfile(b *testing.B) {
 	testutils.IntegrationTest(b)
 
 	e := NewEndpointWithState(&suite, &suite, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
-	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil, nil)
+	dp := linux.NewDatapath(linux.DatapathConfiguration{}, nil, nil, nil, &config.HeaderfileWriter{})
 
 	targetComments := func(w io.Writer) error {
 		return e.writeInformationalComments(w)

--- a/pkg/endpoint/restore_test.go
+++ b/pkg/endpoint/restore_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	linuxDatapath "github.com/cilium/cilium/pkg/datapath/linux"
+	"github.com/cilium/cilium/pkg/datapath/linux/config"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/mac"
@@ -81,7 +82,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNames(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil)
+	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil, &config.HeaderfileWriter{})
 
 	epsWanted, _ := ds.createEndpoints()
 	tmpDir, err := os.MkdirTemp("", "cilium-tests")
@@ -151,7 +152,7 @@ func (ds *EndpointSuite) TestReadEPsFromDirNamesWithRestoreFailure(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil)
+	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil, &config.HeaderfileWriter{})
 
 	eps, _ := ds.createEndpoints()
 	ep := eps[0]
@@ -217,7 +218,7 @@ func (ds *EndpointSuite) BenchmarkReadEPsFromDirNames(c *C) {
 	defer func() {
 		ds.datapath = oldDatapath
 	}()
-	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil)
+	ds.datapath = linuxDatapath.NewDatapath(linuxDatapath.DatapathConfiguration{}, nil, nil, nil, &config.HeaderfileWriter{})
 
 	epsWanted, _ := ds.createEndpoints()
 	tmpDir, err := os.MkdirTemp("", "cilium-tests")


### PR DESCRIPTION
Currently, the logic in charge of writing the header file containing the local node configuration is entirely defined as part of a single function, which has grown significantly in size, and depends on a large set of global variables. Overall, this leads to additional friction when extending it with new options, especially as it does not play well with the recently introduced hive framework.

This PR implements a first step to address this issue, enabling the possibility of providing through hive a set of extra functions returning subsets of configurations, which are then merged to form the final header file. Overall, this allows to break down the generation process in smaller chunks, with each module defining its own specific settings (e.g., based on user configurations and internal state), reducing at the same time the dependency on global variables.

<!-- Description of change -->

```release-note
Configure the linux node config writer through Hive
```
