### PR TITLE
bpf: gate egressgw datapath on separate defines

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1075,15 +1075,7 @@ ct_recreate4:
 		if (identity_is_cluster(*dst_sec_identity))
 			goto skip_egress_gateway;
 
-		/* If the packet is a reply or is related, it means that outside
-		 * has initiated the connection, and so we should skip egress
-		 * gateway, since an egress policy is only matching connections
-		 * originating from a pod.
-		 */
-		if (ct_status == CT_REPLY || ct_status == CT_RELATED)
-			goto skip_egress_gateway;
-
-		if (egress_gw_request_needs_redirect(ip4, &tunnel_endpoint)) {
+		if (egress_gw_request_needs_redirect(ip4, ct_status, &tunnel_endpoint)) {
 			if (tunnel_endpoint == EGRESS_GATEWAY_NO_GATEWAY) {
 				/* Special case for no gateway to drop the traffic */
 				return DROP_NO_EGRESS_GATEWAY;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1065,7 +1065,7 @@ ct_recreate4:
 		}
 	}
 
-#ifdef ENABLE_EGRESS_GATEWAY
+#ifdef ENABLE_EGRESS_GATEWAY_COMMON
 	{
 		/* If the packet is destined to an entity inside the cluster,
 		 * either EP or node, it should not be forwarded to an egress
@@ -1230,7 +1230,7 @@ pass_to_stack:
 #endif
 	}
 
-#if defined(TUNNEL_MODE) || defined(ENABLE_EGRESS_GATEWAY) || defined(ENABLE_HIGH_SCALE_IPCACHE)
+#if defined(TUNNEL_MODE) || defined(ENABLE_EGRESS_GATEWAY_COMMON) || defined(ENABLE_HIGH_SCALE_IPCACHE)
 encrypt_to_stack:
 #endif
 	send_trace_notify(ctx, TRACE_TO_STACK, SECLABEL, *dst_sec_identity, 0, 0,

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -47,7 +47,7 @@
 #define CONDITIONAL_PREALLOC BPF_F_NO_PREALLOC
 #endif
 
-#if defined(ENCAP_IFINDEX) || defined(ENABLE_EGRESS_GATEWAY) || \
+#if defined(ENCAP_IFINDEX) || defined(ENABLE_EGRESS_GATEWAY_COMMON) || \
     (defined(ENABLE_DSR) && DSR_ENCAP_MODE == DSR_ENCAP_GENEVE)
 #define HAVE_ENCAP
 

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -8,7 +8,11 @@
 
 #include "maps.h"
 
-#ifdef ENABLE_EGRESS_GATEWAY
+#if defined(ENABLE_EGRESS_GATEWAY)
+#define ENABLE_EGRESS_GATEWAY_COMMON
+#endif
+
+#ifdef ENABLE_EGRESS_GATEWAY_COMMON
 
 /* EGRESS_STATIC_PREFIX represents the size in bits of the static prefix part of
  * an egress policy key (i.e. the source IP).
@@ -36,6 +40,7 @@ struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 
 static __always_inline
 bool egress_gw_request_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint)
 {
+#if defined(ENABLE_EGRESS_GATEWAY)
 	struct egress_gw_policy_entry *egress_gw_policy;
 	struct endpoint_info *gateway_node_ep;
 
@@ -65,11 +70,15 @@ bool egress_gw_request_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint)
 
 	*tunnel_endpoint = egress_gw_policy->gateway_ip;
 	return true;
+#else
+	return false;
+#endif /* ENABLE_EGRESS_GATEWAY */
 }
 
 static __always_inline
 bool egress_gw_snat_needed(__be32 saddr, __be32 daddr, __be32 *snat_addr)
 {
+#if defined(ENABLE_EGRESS_GATEWAY)
 	struct egress_gw_policy_entry *egress_gw_policy;
 
 	egress_gw_policy = lookup_ip4_egress_gw_policy(saddr, daddr);
@@ -82,12 +91,16 @@ bool egress_gw_snat_needed(__be32 saddr, __be32 daddr, __be32 *snat_addr)
 
 	*snat_addr = egress_gw_policy->egress_ip;
 	return true;
+#else
+	return false;
+#endif /* ENABLE_EGRESS_GATEWAY */
 }
 
 static __always_inline
 bool egress_gw_reply_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint,
 				    __u32 *dst_sec_identity)
 {
+#if defined(ENABLE_EGRESS_GATEWAY)
 	struct egress_gw_policy_entry *egress_policy;
 	struct remote_endpoint_info *info;
 
@@ -107,7 +120,10 @@ bool egress_gw_reply_needs_redirect(struct iphdr *ip4, __u32 *tunnel_endpoint,
 	*tunnel_endpoint = info->tunnel_endpoint;
 	*dst_sec_identity = info->sec_identity;
 	return true;
+#else
+	return false;
+#endif /* ENABLE_EGRESS_GATEWAY */
 }
 
-#endif /* ENABLE_EGRESS_GATEWAY */
+#endif /* ENABLE_EGRESS_GATEWAY_COMMON */
 #endif /* __LIB_EGRESS_GATEWAY_H_ */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -609,7 +609,7 @@ snat_v4_nat_can_skip(const struct ipv4_nat_target *target, const struct ipv4_ct_
 {
 	__u16 sport = bpf_ntohs(tuple->sport);
 
-#if defined(ENABLE_EGRESS_GATEWAY) && defined(IS_BPF_HOST)
+#if defined(ENABLE_EGRESS_GATEWAY_COMMON) && defined(IS_BPF_HOST)
 	if (target->egress_gateway)
 		return false;
 #endif
@@ -744,7 +744,7 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
  * the destination may be in the SNAT exclusion CIDR but regardless of that we
  * always want to SNAT a packet if it's matched by an egress NAT policy.
  */
-#if defined(ENABLE_EGRESS_GATEWAY)
+#if defined(ENABLE_EGRESS_GATEWAY_COMMON)
 	/* If the packet is destined to an entity inside the cluster, either EP
 	 * or node, skip SNAT since only traffic leaving the cluster is supposed
 	 * to be masqueraded with an egress IP.

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2421,7 +2421,7 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 	 * CALL_IPV4_FROM_NETDEV in the code above.
 	 */
 #if !defined(ENABLE_DSR) || (defined(ENABLE_DSR) && defined(ENABLE_DSR_HYBRID)) ||	\
-    (defined(ENABLE_EGRESS_GATEWAY) && !defined(IS_BPF_OVERLAY) && !defined(TUNNEL_MODE))
+    (defined(ENABLE_EGRESS_GATEWAY_COMMON) && !defined(IS_BPF_OVERLAY) && !defined(TUNNEL_MODE))
 	/* If we're not in full DSR mode, reply traffic from remote backends
 	 * might pass back through the LB node and requires revDNAT.
 	 *
@@ -2891,14 +2891,14 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 			return ret;
 	}
 
-#if defined(ENABLE_EGRESS_GATEWAY) && !defined(IS_BPF_OVERLAY) && !defined(TUNNEL_MODE)
+#if defined(ENABLE_EGRESS_GATEWAY_COMMON) && !defined(IS_BPF_OVERLAY) && !defined(TUNNEL_MODE)
 	/* If we are not using TUNNEL_MODE, the gateway node needs to manually steer
 	 * any reply traffic for a remote pod into the tunnel (to avoid iptables
 	 * potentially dropping the packets).
 	 */
 	if (egress_gw_reply_needs_redirect(ip4, &tunnel_endpoint, &dst_sec_identity))
 		goto encap_redirect;
-#endif /* ENABLE_EGRESS_GATEWAY */
+#endif /* ENABLE_EGRESS_GATEWAY_COMMON */
 
 	if (!check_revdnat)
 		goto out;
@@ -2940,7 +2940,7 @@ out:
 	ctx_skip_nodeport_set(ctx);
 	ep_tail_call(ctx, CILIUM_CALL_IPV4_FROM_NETDEV);
 	return DROP_MISSED_TAIL_CALL;
-#if (defined(ENABLE_EGRESS_GATEWAY) && !defined(IS_BPF_OVERLAY)) || defined(TUNNEL_MODE)
+#if (defined(ENABLE_EGRESS_GATEWAY_COMMON) && !defined(IS_BPF_OVERLAY)) || defined(TUNNEL_MODE)
 encap_redirect:
 	src_port = tunnel_gen_src_port_v4(&tuple);
 
@@ -3069,7 +3069,7 @@ declare_tailcall_if(__or4(__and(is_defined(ENABLE_IPV4),
 				is_defined(IS_BPF_HOST)),
 			  __and(is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING),
 				is_defined(ENABLE_INTER_CLUSTER_SNAT)),
-			  __and(is_defined(ENABLE_EGRESS_GATEWAY),
+			  __and(is_defined(ENABLE_EGRESS_GATEWAY_COMMON),
 				is_defined(IS_BPF_HOST))),
 		    CILIUM_CALL_IPV4_NODEPORT_NAT_FWD)
 int tail_handle_nat_fwd_ipv4(struct __ctx_buff *ctx)
@@ -3216,7 +3216,7 @@ static __always_inline int handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_
 						     is_defined(IS_BPF_HOST)),
 					       __and(is_defined(ENABLE_CLUSTER_AWARE_ADDRESSING),
 						     is_defined(ENABLE_INTER_CLUSTER_SNAT)),
-					       __and(is_defined(ENABLE_EGRESS_GATEWAY),
+					       __and(is_defined(ENABLE_EGRESS_GATEWAY_COMMON),
 						     is_defined(IS_BPF_HOST))),
 					 CILIUM_CALL_IPV4_NODEPORT_NAT_FWD,
 					 handle_nat_fwd_ipv4);


### PR DESCRIPTION
bpf: gate egressgw datapath on separate defines

    Add a new define ENABLE_EGRESS_GATEWAY_COMMON which enables the common
    egress gateway code. The existing ENABLE_EGRESS_GATEWAY flag now controls
    whether to check for egress gateway policies with static gateway IPs. This
    makes it easier to extend the codebase to with alternative implementations.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

bpf: move CT checks into egress_gw_request_needs_redirect

    Move the CT reply check into egress_gw_request_needs_redirect so that
    alternative implementations can have their own CT state handling.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
