### PR TITLE
bpf: nodeport: improve tracing for inlined RevDNAT processing

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1389,8 +1389,8 @@ int cil_to_netdev(struct __ctx_buff *ctx __maybe_unused)
 	};
 	__u32 __maybe_unused vlan_id;
 	int ret = CTX_ACT_OK;
-#ifdef ENABLE_HOST_FIREWALL
 	__s8 ext_err = 0;
+#ifdef ENABLE_HOST_FIREWALL
 	__u16 proto = 0;
 #endif
 
@@ -1517,12 +1517,7 @@ out:
 		 * handle_nat_fwd tail calls in the majority of cases,
 		 * so control might never return to this program.
 		 */
-		ret = handle_nat_fwd(ctx, 0);
-		if (IS_ERR(ret))
-			return send_drop_notify_error(ctx, 0, ret,
-						      CTX_ACT_DROP,
-						      METRIC_EGRESS);
-
+		ret = handle_nat_fwd(ctx, 0, &trace, &ext_err);
 		if (ret == CTX_ACT_REDIRECT)
 			return ret;
 	}
@@ -1530,8 +1525,8 @@ out:
 
 __maybe_unused exit:
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
-					      METRIC_EGRESS);
+		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_EGRESS);
 	send_trace_notify(ctx, TRACE_TO_NETWORK, 0, 0, 0,
 			  0, trace.reason, trace.monitor);
 

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -665,8 +665,10 @@ out:
 __section_entry
 int cil_to_overlay(struct __ctx_buff *ctx)
 {
+	struct trace_ctx __maybe_unused trace;
 	int ret = TC_ACT_OK;
 	__u32 cluster_id __maybe_unused = 0;
+	__s8 ext_err = 0;
 
 	/* When WireGuard strict mode is enabled, we have additional information
 	 * regarding to which CIDRs packets must encrypted. We have to check the
@@ -708,11 +710,12 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
 	cluster_id = ctx_get_cluster_id_mark(ctx);
 #endif
-	ret = handle_nat_fwd(ctx, cluster_id);
+	ret = handle_nat_fwd(ctx, cluster_id, &trace, &ext_err);
 out:
 #endif
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_EGRESS);
+		return send_drop_notify_error_ext(ctx, 0, ret, ext_err,
+						  CTX_ACT_DROP, METRIC_EGRESS);
 	return ret;
 }
 

--- a/bpf/lib/tailcall.h
+++ b/bpf/lib/tailcall.h
@@ -111,4 +111,15 @@
 #define invoke_tailcall_if(COND, NAME, FUNC)  \
 	__eval(__invoke_tailcall_if_, COND)(NAME, FUNC)
 
+#define __invoke_traced_tailcall_if_0(NAME, FUNC, TRACE, EXT_ERR)	\
+	FUNC(ctx, TRACE, EXT_ERR)
+#define __invoke_traced_tailcall_if_1(NAME, FUNC, TRACE, EXT_ERR)	\
+	({								\
+		ep_tail_call(ctx, NAME);				\
+		DROP_MISSED_TAIL_CALL;					\
+	})
+#define invoke_traced_tailcall_if(COND, NAME, FUNC, TRACE, EXT_ERR)	\
+	__eval(__invoke_traced_tailcall_if_, COND)(NAME, FUNC, TRACE,	\
+						   EXT_ERR)
+
 #endif /* TAILCALL_H */


### PR DESCRIPTION
In configurations where handle_nat_fwd() inlines the call to handle_nat_fwd_ipv*() (and thus the service RevDNAT processing), the calling programs (to-overlay / to-netdev) currently don't have access to (1) CT-driven trace information and
(2) detailed drop information (ext_err).

Add a special variant of the conditional-tailcall macro that accepts *trace_ctx and *ext_err parameters, so this information can flow back. This allows for better trace & error reporting in the callers.