### PR TITLE
srv6: Add constructor and CRUD helpers for SID map

### DIFF
--- a/pkg/maps/srv6map/sid.go
+++ b/pkg/maps/srv6map/sid.go
@@ -4,6 +4,8 @@
 package srv6map
 
 import (
+	"fmt"
+	"net"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -33,6 +35,15 @@ func NewSIDKey(sid types.IPv6) SIDKey {
 	result := SIDKey{}
 	result.SID = sid
 	return result
+}
+
+func NewSIDKeyFromIP(ip *net.IP) (*SIDKey, error) {
+	if ip.To4() != nil {
+		return nil, fmt.Errorf("ip must be an IPv6 address")
+	}
+	result := &SIDKey{}
+	copy(result.SID[:], []byte(*ip))
+	return result, nil
 }
 
 type SIDValue struct {
@@ -80,6 +91,15 @@ func CreateSIDMap() error {
 
 func OpenSIDMap() error {
 	return initSIDMap(false)
+}
+
+func (m *srv6SIDMap) Update(key SIDKey, vrfID uint32) error {
+	val := SIDValue{VRFID: vrfID}
+	return m.Map.Update(key, val, 0)
+}
+
+func (m *srv6SIDMap) Delete(key SIDKey) error {
+	return m.Map.Delete(key)
 }
 
 // SRv6SIDIterateCallback represents the signature of the callback function


### PR DESCRIPTION
This commit adds some quality of life methods.

First is a constructor which creates a key for the SID map from a `net.IP`.

Second we add update and delete methods for the map to create a namespace for CRUD operations on the map.

```release-note
SRv6: Add quality of life methods for SID map usage. 
```
