### PR TITLE
pkg/datapath/loader: ApplySettings returns an unchecked error

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -344,7 +344,9 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	}
 
 	// Any code that relies on sysctl settings being applied needs to be called after this.
-	sysctl.ApplySettings(sysSettings)
+	if err := sysctl.ApplySettings(sysSettings); err != nil {
+		return err
+	}
 
 	// add internal ipv4 and ipv6 addresses to cilium_host
 	if err := addHostDeviceAddr(hostDev1, nodeIPv4, nodeIPv6); err != nil {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

During reinitialization, the datapath loader makes a call to ApplySettings
to set sysctl options. This call could return an error that is currently
unchecked.

```release-note
Add error check during datapath/loader reinitialization as ApplySettings could return an error while applying sysctl settings.
```

Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>

