### PR TITLE
CI: Add IPsec key rotation test

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -284,7 +284,39 @@ jobs:
               --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
               --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})"
 
-            ./contrib/scripts/kind-down.sh
+      - name: Rotate IPsec Key & Test (${{ join(matrix.*, ', ') }})
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@48023b9f6df4fffa80162f418ae2344d33e36b11
+        with:
+          job-name: conformance-ipsec-e2e-key-rotation-${{ matrix.name }}
+          operation-cmd: |
+            cd /host/
+
+            KEYID=\$(kubectl get secret -n kube-system cilium-ipsec-keys -o go-template --template={{.data.keys}} | base64 -d | cut -c 1)
+            if [[ \$KEYID -ge 15 ]]; then KEYID=0; fi
+            data=\$(echo "{\"stringData\":{\"keys\":\"\$(((\$KEYID+1))) "rfc4106\(gcm\(aes\)\)" 59f4d92cccede1b1abc920104ca61cd552782e12 128\"}}")
+            kubectl patch secret -n kube-system cilium-ipsec-keys -p="\$data" -v=1
+
+            # Wait until key rotation starts
+            while true; do
+              keys_in_use=\$(kubectl -n kube-system exec daemonset/cilium -- cilium encrypt status | awk '/Keys in use/ {print \$NF}')
+              if [[ \$keys_in_use == 2 ]]; then
+                break
+              fi
+              echo "Waiting until key rotation starts"
+              sleep 30s
+            done
+
+            # Wait until key rotation completes
+            # By default the key rotation cleanup delay is 5min, let's sleep 4min before actively polling
+            sleep \$((4*60))
+            while true; do
+              keys_in_use=\$(kubectl -n kube-system exec daemonset/cilium -- cilium encrypt status | awk '/Keys in use/ {print \$NF}')
+              if [[ \$keys_in_use == 1 ]]; then
+                break
+              fi
+              echo "Waiting until key rotation completes"
+              sleep 30s
+            done
 
       - name: Fetch artifacts
         if: ${{ !success() }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -218,7 +218,7 @@ jobs:
 
           CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
-          
+
           JUNIT=""
           for NAME in ${{ matrix.kube-proxy }} ${{ matrix.tunnel }} ${{ matrix.lb-mode }} ${{ matrix.encryption }} ${{ matrix.endpoint-routes }}; do
             if [[ "${NAME}" != "" ]] && [[ "${NAME}" != "disabled" ]] && [[ "${NAME}" != "none" ]]; then
@@ -330,11 +330,14 @@ jobs:
             # interruption in such flows.
             ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
 
-      - name: Upgrade Cilium (${{ matrix.name }})
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
+      - name: Upgrade Cilium & Test (${{ matrix.name }})
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@48023b9f6df4fffa80162f418ae2344d33e36b11
         with:
-          provision: 'false'
-          cmd: |
+          job-name: ipsec-upgrade-${{ matrix.name }}
+          # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
+          # Disable check-log-errors due to https://github.com/cilium/cilium-cli/issues/1858
+          extra-connectivity-test-flags: --test '!no-missed-tail-calls,!check-log-errors'
+          operation-cmd: |
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
@@ -345,32 +348,14 @@ jobs:
             kubectl get pods --all-namespaces -o wide
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
-      - name: Test Cilium after upgrade (${{ matrix.name }})
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
+      - name: Downgrade Cilium to ${{ env.cilium_stable_version }} & Test (${{ matrix.name }})
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@48023b9f6df4fffa80162f418ae2344d33e36b11
         with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
-            # Disable check-log-errors due to https://github.com/cilium/cilium-cli/issues/1858
-            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-              --include-conn-disrupt-test \
-              --test '!no-missed-tail-calls,!check-log-errors' \
-              --flush-ct \
-              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests upgrade 2 (${{ join(matrix.*, ', ') }})"
-
-            # --flush-ct interrupts the flows, so we need to set up again.
-            ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
-
-      - name: Downgrade Cilium ${{ env.cilium_stable_version }} (${{ matrix.name }})
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
-        with:
-          provision: 'false'
-          cmd: |
+          job-name: ipsec-downgrade-${{ matrix.name }}
+          # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
+          # Disable check-log-errors due to https://github.com/cilium/cilium-cli/issues/1858
+          extra-connectivity-test-flags: --test '!no-missed-tail-calls,!check-log-errors'
+          operation-cmd: |
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
@@ -380,22 +365,6 @@ jobs:
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide
             kubectl -n kube-system exec daemonset/cilium -- cilium status
-
-      - name: Test Cilium after downgrade to ${{ env.cilium_stable_version }} (${{ matrix.name }})
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
-              --include-conn-disrupt-test \
-              --test '!no-missed-tail-calls,!check-log-errors' \
-              --flush-ct \
-              --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
-              --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
-              --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests upgrade 3 (${{ join(matrix.*, ', ') }})"
 
       - name: Fetch artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
This PR adds IPsec key rotation test in `conformance-ipsec-e2e.yaml` (ci-ipsec-e2e). A new github action `conn-disrupt-test` is also used to reduce duplication for this test as well as IPsec upgrade test.

Fixes: #26350

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>