### PR TITLE
Fix cilium-envoy ServiceMonitor port name

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/servicemonitor.yaml
@@ -22,7 +22,7 @@ spec:
     matchNames:
     - {{ .Release.Namespace }}
   endpoints:
-  - port: metrics
+  - port: envoy-metrics
     interval: {{ .Values.envoy.prometheus.serviceMonitor.interval | quote }}
     honorLabels: true
     path: /metrics


### PR DESCRIPTION
Fixes the ServiceMonitor port so that Prometheus can scrape the service.

Fixes: #27206
