### PR TITLE
redirectpolicy: Fixed excidental conflict between #27032 and #27115

### DIFF
--- a/pkg/redirectpolicy/manager_test.go
+++ b/pkg/redirectpolicy/manager_test.go
@@ -82,6 +82,11 @@ func (ps *fakePodStore) GetByKey(key resource.Key) (item *slimcorev1.Pod, exists
 }
 func (ps *fakePodStore) CacheStore() cache.Store { return nil }
 
+func (ps *fakePodStore) IndexKeys(indexName, indexedValue string) ([]string, error) { return nil, nil }
+func (ps *fakePodStore) ByIndex(indexName, indexedValue string) ([]*slimcorev1.Pod, error) {
+	return nil, nil
+}
+
 var (
 	tcpStr    = "TCP"
 	udpStr    = "UDP"


### PR DESCRIPTION
CI runs on both were green, but when merged into main they conflicted.

```release-note
Fixed conflicting PRs in main
```
