### PR TITLE
Docs: Fix ipam_nodes metric description

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -570,7 +570,7 @@ Name                                     Labels                                 
 ``ipam_release_duration_seconds``        ``type``, ``status``, ``subnet_id``                               Enabled    Release ip or interface latency in seconds
 ``ipam_allocation_duration_seconds``     ``type``, ``status``, ``subnet_id``                               Enabled    Allocation ip or interface latency in seconds
 ``ipam_available_interfaces``                                                                              Enabled    Number of interfaces with addresses available
-``ipam_nodes_at_capacity``                                                                                 Enabled    Number of nodes unable to allocate more addresses
+``ipam_nodes``                           ``category``                                                      Enabled    Number of nodes by category { total | in-deficit | at-capacity }
 ``ipam_resync_total``                                                                                      Enabled    Number of synchronization operations with external IPAM API
 ``ipam_api_duration_seconds``            ``operation``, ``response_code``                                  Enabled    Duration of interactions with external IPAM API.
 ``ipam_api_rate_limit_duration_seconds`` ``operation``                                                     Enabled    Duration of rate limiting while accessing external IPAM API


### PR DESCRIPTION
The metric description was out-of-date: the `ipam_nodes_at_capacity` metric doesn't exist anymore, the new one is called `ipam_nodes` and it is labeled with the `at-capacity` category.

The code is here:
https://github.com/cilium/cilium/blob/6df9d10323083f55615e4fa98417f0060e6613a5/pkg/ipam/metrics/metrics.go#L129-L134 
https://github.com/cilium/cilium/blob/7a062e399fd44b24c9dce0231ced2d453f6bd994/pkg/ipam/node_manager.go#L535-L537

Example `curl` of the metric endpoint on the Operator (version 1.12.11):
```
[...]
# HELP cilium_operator_ipam_nodes Number of nodes by category { total | in-deficit | at-capacity }
# TYPE cilium_operator_ipam_nodes gauge
cilium_operator_ipam_nodes{category="at-capacity"} 0
cilium_operator_ipam_nodes{category="in-deficit"} 0
cilium_operator_ipam_nodes{category="total"} 18
[...]
```