### PR TITLE
bpf: egressgw: set trace reason for reply traffic

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2896,8 +2896,10 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 	 * any reply traffic for a remote pod into the tunnel (to avoid iptables
 	 * potentially dropping the packets).
 	 */
-	if (egress_gw_reply_needs_redirect(ip4, &tunnel_endpoint, &dst_sec_identity))
+	if (egress_gw_reply_needs_redirect(ip4, &tunnel_endpoint, &dst_sec_identity)) {
+		reason = TRACE_REASON_CT_REPLY;
 		goto encap_redirect;
+	}
 #endif /* ENABLE_EGRESS_GATEWAY_COMMON */
 
 	if (!check_revdnat)


### PR DESCRIPTION
When redirecting EgressGW replies to the tunnel interface, we don't have a CT lookup to determine the trace reason. But we still know it's a reply, so we can set the reason manually.