### PR TITLE
egressgw: tidy up Config handling

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -954,22 +954,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			}
 		}
 	}
-	if option.Config.EnableIPv4EgressGateway {
-		// datapath code depends on remote node identities to distinguish between cluser-local and
-		// cluster-egress traffic
-		if !option.Config.EnableRemoteNodeIdentity {
-			log.WithError(err).Errorf("egress gateway requires remote node identities (--%s=\"true\").",
-				option.EnableRemoteNodeIdentity)
-			return nil, nil, fmt.Errorf("egress gateway requires remote node identities (--%s=\"true\").",
-				option.EnableRemoteNodeIdentity)
-		}
 
-		if option.Config.EnableL7Proxy {
-			log.WithField(logfields.URL, "https://github.com/cilium/cilium/issues/19642").
-				Warningf("both egress gateway and L7 proxy (--%s) are enabled. This is currently not fully supported: "+
-					"if the same endpoint is selected both by an egress gateway and a L7 policy, endpoint traffic will not go through egress gateway.", option.EnableL7Proxy)
-		}
-	}
 	if option.Config.MasqueradingEnabled() && option.Config.EnableBPFMasquerade {
 		// TODO(brb) nodeport constraints will be lifted once the SNAT BPF code has been refactored
 		if err := node.InitBPFMasqueradeAddrs(option.Config.GetDevices()); err != nil {
@@ -979,9 +964,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	} else if option.Config.EnableIPMasqAgent {
 		log.WithError(err).Errorf("BPF ip-masq-agent requires (--%s=\"true\" or --%s=\"true\") and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade, option.EnableBPFMasquerade)
 		return nil, nil, fmt.Errorf("BPF ip-masq-agent requires (--%s=\"true\" or --%s=\"true\") and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableIPv6Masquerade, option.EnableBPFMasquerade)
-	} else if option.Config.EnableIPv4EgressGateway {
-		log.WithError(err).Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
-		return nil, nil, fmt.Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 	} else if !option.Config.MasqueradingEnabled() && option.Config.EnableBPFMasquerade {
 		log.Infof("Auto-disabling %q feature since IPv4 and IPv6 masquerading are disabled",
 			option.EnableBPFMasquerade)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1424,9 +1424,6 @@ func initEnv(vp *viper.Viper) {
 		if option.Config.TunnelingEnabled() {
 			log.Fatal("The high-scale IPcache mode requires native routing.")
 		}
-		if option.Config.EnableIPv4EgressGateway {
-			log.Fatal("The egress gateway is not supported in high scale IPcache mode.")
-		}
 		if option.Config.EnableIPSec {
 			log.Fatal("IPsec is not supported in high scale IPcache mode.")
 		}
@@ -1540,12 +1537,6 @@ func initEnv(vp *viper.Viper) {
 					"bypass.",
 				option.BypassIPAvailabilityUponRestore,
 			)
-		}
-	}
-
-	if option.Config.IdentityAllocationMode == option.IdentityAllocationModeKVstore {
-		if option.Config.EnableIPv4EgressGateway {
-			log.Fatal("The egress gateway is not supported in KV store identity allocation mode.")
 		}
 	}
 }

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -408,7 +408,7 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initArgDevices] = "<nil>"
 
 	if !option.Config.TunnelingEnabled() {
-		if option.Config.EnableIPv4EgressGateway || option.Config.EnableHighScaleIPcache {
+		if option.Config.EgressGatewayCommonEnabled() || option.Config.EnableHighScaleIPcache {
 			// Tunnel is required for egress traffic under this config
 			encapProto = option.Config.TunnelProtocol
 		}

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -134,9 +134,14 @@ func (k *EgressGatewayTestSuite) SetUpTest(c *C) {
 
 	var err error
 	k.manager, err = NewEgressGatewayManager(Params{
-		Lifecycle:         lc,
-		Config:            Config{true, 1 * time.Millisecond},
-		DaemonConfig:      &option.DaemonConfig{EnableIPv4EgressGateway: true},
+		Lifecycle: lc,
+		Config:    Config{true, 1 * time.Millisecond},
+		DaemonConfig: &option.DaemonConfig{
+			EnableIPv4EgressGateway:  true,
+			EnableIPv4Masquerade:     true,
+			EnableBPFMasquerade:      true,
+			EnableRemoteNodeIdentity: true,
+		},
 		CacheStatus:       k.cacheStatus,
 		IdentityAllocator: identityAllocator,
 		PolicyMap:         policyMap,

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2611,7 +2611,7 @@ func (c *DaemonConfig) TunnelDevice() string {
 // takes care of the MTU overhead. So no need to take it into account here.
 // See encap_geneve_dsr_opt[4,6] in nodeport.h
 func (c *DaemonConfig) TunnelExists() bool {
-	return c.TunnelingEnabled() || c.EnableIPv4EgressGateway || c.EnableHighScaleIPcache
+	return c.TunnelingEnabled() || c.EgressGatewayCommonEnabled() || c.EnableHighScaleIPcache
 }
 
 // AreDevicesRequired returns true if the agent needs to attach to the native
@@ -2760,6 +2760,12 @@ func (c *DaemonConfig) K8sIngressControllerEnabled() bool {
 // K8sGatewayAPIEnabled returns true if Gateway API feature is enabled in Cilium
 func (c *DaemonConfig) K8sGatewayAPIEnabled() bool {
 	return c.EnableGatewayAPI
+}
+
+// EgressGatewayCommonEnabled returns true if at least one egress gateway implementation
+// is enabled.
+func (c *DaemonConfig) EgressGatewayCommonEnabled() bool {
+	return c.EnableIPv4EgressGateway
 }
 
 // DirectRoutingDeviceRequired return whether the Direct Routing Device is needed under


### PR DESCRIPTION
egressgw: move Config sanity checks into the manager

    Move all the scattered config validation into the egress gateway manager. 
    This serves as self documentation and makes it less likely that the warnings
    will get out of date.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

egressgw: gate common checks using method on Config

    Call a method on Config instead of gating common checks required for egress
    gateway on EnableIPv4EgressGateway. This allows introducing additional
    implementations without changing code everywhere.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
