### PR TITLE
docs: Clean up prerequisites for the Ingress Controller

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -10,7 +10,7 @@
 Kubernetes Ingress Support
 **************************
 
-Cilium uses the standard Kubernetes Ingress resource definition, with
+Cilium uses the standard `Kubernetes Ingress`_ resource definition, with
 an ``ingressClassName`` of ``cilium``. This can be used for path-based
 routing and for TLS termination. For backwards compatibility, the
 ``kubernetes.io/ingress.class`` annotation with value of ``cilium``
@@ -43,14 +43,17 @@ path prefix) between resources.
 This is a step-by-step guide on how to enable the Ingress Controller in
 an existing K8s cluster with Cilium installed.
 
+.. _Kubernetes Ingress: https://kubernetes.io/docs/concepts/services-networking/ingress/
+
 Prerequisites
 #############
 
-* Cilium must be configured with ``kubeProxyReplacement`` as partial
-  or strict. Please refer to :ref:`kube-proxy replacement <kubeproxy-free>`
-  for more details.
-* Cilium must be configured with the L7 proxy enabled using the ``--enable-l7-proxy`` flag (enabled by default).
-* The minimum supported Kubernetes version for Ingress is 1.19.
+* Cilium must be configured with NodePort enabled, using
+  ``nodePort.enabled=true`` or by enabling the kube-proxy replacement with
+  ``kubeProxyReplacement=true``. For more information, see :ref:`kube-proxy
+  replacement <kubeproxy-free>`.
+* Cilium must be configured with the L7 proxy enabled using ``l7Proxy=true``
+  (enabled by default).
 
 .. include:: installation.rst
 


### PR DESCRIPTION
This commit brings various minor improvements to the intro and prerequisites for the Ingress Controller documentation:

- Add a link to Kubernetes' documentation for Ingress, given that we never define or explain what Kubernetes Ingress is
- Instruct users to "enable" kube-proxy replacement, given that the values "strict" or "partial" are deprecated.
- Use the Helm value instead of the agent flag for the L7 proxy configuration, simply to remain consistent with the item above (KPR).
- Remove the requirement on Kubernetes 1.19+, given that 1.19 is now the minimum version supported by Cilium.

**NOTE**: `kubeProxyReplacement=true` is equivalent to the legacy `strict` mode, but not to the `partial` mode. It's likely that the full KPR is not necessary for running the Ingress Controller, but I wasn't able to find the exact subset of options that are required. @sayboras (you authored this requirement in the first place), do you know?
