### PR TITLE
bgpv1: Use Path type in AdvertisePath & WithdrawPath

### DIFF
--- a/pkg/bgpv1/gobgp/conversions.go
+++ b/pkg/bgpv1/gobgp/conversions.go
@@ -43,6 +43,7 @@ func ToGoBGPPath(p *types.Path) (*gobgp.Path, error) {
 		Age:    ageTimestamp,
 		Best:   p.Best,
 		Family: family,
+		Uuid:   p.UUID,
 	}, nil
 }
 
@@ -69,6 +70,7 @@ func ToAgentPath(p *gobgp.Path) (*types.Path, error) {
 		PathAttributes: pattrs,
 		AgeNanoseconds: ageNano,
 		Best:           p.Best,
+		UUID:           p.Uuid,
 	}, nil
 }
 

--- a/pkg/bgpv1/gobgp/state_test.go
+++ b/pkg/bgpv1/gobgp/state_test.go
@@ -392,16 +392,12 @@ func TestGetRoutes(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = testSC.AdvertisePath(context.TODO(), types.PathRequest{
-		Advert: types.Advertisement{
-			Prefix: netip.MustParsePrefix("10.0.0.0/24"),
-		},
+		Path: types.NewPathForPrefix(netip.MustParsePrefix("10.0.0.0/24")),
 	})
 	require.NoError(t, err)
 
 	_, err = testSC.AdvertisePath(context.TODO(), types.PathRequest{
-		Advert: types.Advertisement{
-			Prefix: netip.MustParsePrefix("fd00::/64"),
-		},
+		Path: types.NewPathForPrefix(netip.MustParsePrefix("fd00::/64")),
 	})
 	require.NoError(t, err)
 

--- a/pkg/bgpv1/manager/instance.go
+++ b/pkg/bgpv1/manager/instance.go
@@ -31,10 +31,10 @@ type ServerWithConfig struct {
 	Config *v2alpha1api.CiliumBGPVirtualRouter
 
 	// Holds any announced PodCIDR routes.
-	PodCIDRAnnouncements []types.Advertisement
+	PodCIDRAnnouncements []*types.Path
 
 	// Holds any announced Service routes.
-	ServiceAnnouncements map[resource.Key][]types.Advertisement
+	ServiceAnnouncements map[resource.Key][]*types.Path
 }
 
 // NewServerWithConfig will start an underlying BgpServer utilizing types.ServerParameters
@@ -54,7 +54,7 @@ func NewServerWithConfig(ctx context.Context, params types.ServerParameters) (*S
 	return &ServerWithConfig{
 		Server:               s,
 		Config:               nil,
-		PodCIDRAnnouncements: []types.Advertisement{},
-		ServiceAnnouncements: make(map[resource.Key][]types.Advertisement),
+		PodCIDRAnnouncements: []*types.Path{},
+		ServiceAnnouncements: make(map[resource.Key][]*types.Path),
 	}, nil
 }

--- a/pkg/bgpv1/manager/reconcile.go
+++ b/pkg/bgpv1/manager/reconcile.go
@@ -171,7 +171,7 @@ func preflightReconciler(
 
 	// Clear the shadow state since any advertisements will be gone now that the server has been recreated.
 	sc.PodCIDRAnnouncements = nil
-	sc.ServiceAnnouncements = make(map[resource.Key][]types.Advertisement)
+	sc.ServiceAnnouncements = make(map[resource.Key][]*types.Path)
 
 	return nil
 }
@@ -366,13 +366,13 @@ func exportPodCIDRReconciler(
 		return fmt.Errorf("attempted pod CIDR advertisements reconciliation with nil ControlPlaneState")
 	}
 
-	toAdvertise := []netip.Prefix{}
+	var toAdvertise []*types.Path
 	for _, cidr := range cstate.PodCIDRs {
 		prefix, err := netip.ParsePrefix(cidr)
 		if err != nil {
 			return fmt.Errorf("failed to parse prefix %s: %w", cidr, err)
 		}
-		toAdvertise = append(toAdvertise, prefix)
+		toAdvertise = append(toAdvertise, types.NewPathForPrefix(prefix))
 	}
 
 	advertisements, err := exportAdvertisementsReconciler(&advertisementsReconcilerParams{
@@ -681,22 +681,20 @@ func (r *LBServiceReconciler) reconcileService(ctx context.Context, sc *ServerWi
 
 	for _, desiredCidr := range desiredCidrs {
 		// If this route has already been announced, don't add it again
-		if slices.IndexFunc(sc.ServiceAnnouncements[svcKey], func(existing types.Advertisement) bool {
-			return desiredCidr == existing.Prefix
+		if slices.IndexFunc(sc.ServiceAnnouncements[svcKey], func(existing *types.Path) bool {
+			return desiredCidr.String() == existing.NLRI.String()
 		}) != -1 {
 			continue
 		}
 
 		// Advertise the new cidr
 		advertPathResp, err := sc.Server.AdvertisePath(ctx, types.PathRequest{
-			Advert: types.Advertisement{
-				Prefix: desiredCidr,
-			},
+			Path: types.NewPathForPrefix(desiredCidr),
 		})
 		if err != nil {
 			return fmt.Errorf("failed to advertise service route %v: %w", desiredCidr, err)
 		}
-		sc.ServiceAnnouncements[svcKey] = append(sc.ServiceAnnouncements[svcKey], advertPathResp.Advert)
+		sc.ServiceAnnouncements[svcKey] = append(sc.ServiceAnnouncements[svcKey], advertPathResp.Path)
 	}
 
 	// Loop over announcements in reverse order so we can delete entries without effecting iteration.
@@ -704,13 +702,13 @@ func (r *LBServiceReconciler) reconcileService(ctx context.Context, sc *ServerWi
 		announcement := sc.ServiceAnnouncements[svcKey][i]
 		// If the announcement is within the list of desired routes, don't remove it
 		if slices.IndexFunc(desiredCidrs, func(existing netip.Prefix) bool {
-			return existing == announcement.Prefix
+			return existing.String() == announcement.NLRI.String()
 		}) != -1 {
 			continue
 		}
 
-		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Advert: announcement}); err != nil {
-			return fmt.Errorf("failed to withdraw service route %s: %w", announcement, err)
+		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: announcement}); err != nil {
+			return fmt.Errorf("failed to withdraw service route %s: %w", announcement.NLRI, err)
 		}
 
 		// Delete announcement from slice
@@ -726,10 +724,10 @@ func (r *LBServiceReconciler) withdrawService(ctx context.Context, sc *ServerWit
 	// Loop in reverse order so we can delete without effect to the iteration.
 	for i := len(advertisements) - 1; i >= 0; i-- {
 		advertisement := advertisements[i]
-		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Advert: advertisement}); err != nil {
+		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: advertisement}); err != nil {
 			// Persist remaining advertisements
 			sc.ServiceAnnouncements[key] = advertisements
-			return fmt.Errorf("failed to withdraw deleted service route: %v: %w", advertisement.Prefix, err)
+			return fmt.Errorf("failed to withdraw deleted service route: %v: %w", advertisement.NLRI, err)
 		}
 
 		// Delete the advertisement after each withdraw in case we error half way through

--- a/pkg/bgpv1/manager/reconcile_test.go
+++ b/pkg/bgpv1/manager/reconcile_test.go
@@ -479,14 +479,12 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 			testSC.Config = oldc
 			for _, cidr := range tt.advertised {
 				advrtResp, err := testSC.Server.AdvertisePath(context.Background(), types.PathRequest{
-					Advert: types.Advertisement{
-						Prefix: cidr,
-					},
+					Path: types.NewPathForPrefix(cidr),
 				})
 				if err != nil {
 					t.Fatalf("failed to advertise initial pod cidr routes: %v", err)
 				}
-				testSC.PodCIDRAnnouncements = append(testSC.PodCIDRAnnouncements, advrtResp.Advert)
+				testSC.PodCIDRAnnouncements = append(testSC.PodCIDRAnnouncements, advrtResp.Path)
 			}
 
 			newc := &v2alpha1api.CiliumBGPVirtualRouter{
@@ -519,7 +517,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				prefix := netip.MustParsePrefix(cidr)
 				var seen bool
 				for _, advrt := range testSC.PodCIDRAnnouncements {
-					if advrt.Prefix == prefix {
+					if advrt.NLRI.String() == prefix.String() {
 						seen = true
 					}
 				}
@@ -533,7 +531,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 			for _, advrt := range testSC.PodCIDRAnnouncements {
 				var seen bool
 				for _, cidr := range tt.updated {
-					if advrt.Prefix == netip.MustParsePrefix(cidr) {
+					if advrt.NLRI.String() == cidr {
 						seen = true
 					}
 				}
@@ -1069,15 +1067,13 @@ func TestLBServiceReconciler(t *testing.T) {
 				for _, cidr := range cidrs {
 					prefix := netip.MustParsePrefix(cidr)
 					advrtResp, err := testSC.Server.AdvertisePath(context.Background(), types.PathRequest{
-						Advert: types.Advertisement{
-							Prefix: prefix,
-						},
+						Path: types.NewPathForPrefix(prefix),
 					})
 					if err != nil {
 						t.Fatalf("failed to advertise initial svc lb cidr routes: %v", err)
 					}
 
-					testSC.ServiceAnnouncements[svcKey] = append(testSC.ServiceAnnouncements[svcKey], advrtResp.Advert)
+					testSC.ServiceAnnouncements[svcKey] = append(testSC.ServiceAnnouncements[svcKey], advrtResp.Path)
 				}
 			}
 
@@ -1130,7 +1126,7 @@ func TestLBServiceReconciler(t *testing.T) {
 					prefix := netip.MustParsePrefix(cidr)
 					var seen bool
 					for _, advrt := range testSC.ServiceAnnouncements[svcKey] {
-						if advrt.Prefix == prefix {
+						if advrt.NLRI.String() == prefix.String() {
 							seen = true
 						}
 					}
@@ -1146,7 +1142,7 @@ func TestLBServiceReconciler(t *testing.T) {
 				for _, advrt := range advrts {
 					var seen bool
 					for _, cidr := range tt.updated[svcKey] {
-						if advrt.Prefix == netip.MustParsePrefix(cidr) {
+						if advrt.NLRI.String() == cidr {
 							seen = true
 						}
 					}

--- a/pkg/bgpv1/types/utils.go
+++ b/pkg/bgpv1/types/utils.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"net/netip"
+
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
+)
+
+// NewPathForPrefix returns a Path that can be used to advertise the provided
+// IP prefix by the underlying BGP implementation.
+//
+// The prefix can be either IPv4 or IPv6 and this function will handle the differences
+// between MP BGP and BGP.
+//
+// The next hop of the path will always be set to "0.0.0.0" for IPv4 and "::" for IPv6,
+// so the underlying BGP implementation selects appropriate actual nexthop address when advertising it.
+func NewPathForPrefix(prefix netip.Prefix) (path *Path) {
+	originAttr := bgp.NewPathAttributeOrigin(0)
+
+	// Currently, we only support advertising locally originated paths (the paths generated in Cilium
+	// node itself, not the paths received from another BGP Peer or redistributed from another routing
+	// protocol. In this case, the nexthop address should be the address used for peering. That means
+	// the nexthop address can be changed depending on the neighbor.
+	//
+	// For example, when the Cilium node is connected to two subnets 10.0.0.0/24 and 10.0.1.0/24 with
+	// local address 10.0.0.1 and 10.0.1.1 respectively, the nexthop should be advertised for 10.0.0.0/24
+	// peers is 10.0.0.1. On the other hand, we should advertise 10.0.1.1 as a nexthop for 10.0.1.0/24.
+	//
+	// Fortunately, GoBGP takes care of resolving appropriate nexthop address for each peers when we
+	// specify an zero IP address (0.0.0.0 for IPv4 and :: for IPv6). So, we can just rely on that.
+	//
+	// References:
+	// - RFC4271 Section 5.1.3 (NEXT_HOP)
+	// - RFC4760 Section 3 (Multiprotocol Reachable NLRI - MP_REACH_NLRI (Type Code 14))
+
+	switch {
+	case prefix.Addr().Is4():
+		nlri := bgp.NewIPAddrPrefix(uint8(prefix.Bits()), prefix.Addr().String())
+		nextHopAttr := bgp.NewPathAttributeNextHop("0.0.0.0")
+		path = &Path{
+			NLRI: nlri,
+			PathAttributes: []bgp.PathAttributeInterface{
+				originAttr,
+				nextHopAttr,
+			},
+		}
+	case prefix.Addr().Is6():
+		nlri := bgp.NewIPv6AddrPrefix(uint8(prefix.Bits()), prefix.Addr().String())
+		mpReachNLRIAttr := bgp.NewPathAttributeMpReachNLRI("::", []bgp.AddrPrefixInterface{nlri})
+		path = &Path{
+			NLRI: nlri,
+			PathAttributes: []bgp.PathAttributeInterface{
+				originAttr,
+				mpReachNLRIAttr,
+			},
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
This PR makes the `AdvertisePath()` and `WithdrawPath()` methods of the `Router` interface use the `Path` datatype introduced in https://github.com/cilium/cilium/pull/26803

This makes the `bgpv1/gobgp` package more generic and allows advertising routes with more fine-grained NLRI and Path Attributes in the future.