### PR TITLE
Refactor datapath initialization and recreate cilium_lxc map on startup

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1706,7 +1706,6 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		<-params.CacheStatus
 	}
 	bootstrapStats.k8sInit.End(true)
-	restoreComplete := d.initRestore(restoredEndpoints)
 
 	if params.WGAgent != nil {
 		if err := params.WGAgent.RestoreFinished(); err != nil {
@@ -1735,10 +1734,6 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	}
 
 	go func() {
-		if restoreComplete != nil {
-			<-restoreComplete
-		}
-
 		// Only attempt CEP cleanup if cilium endpoint CRD is not disabled, otherwise the cep/ces
 		// watchers/indexers will not be initialized.
 		if params.Clientset.IsEnabled() && option.Config.EnableStaleCiliumEndpointCleanup && !option.Config.DisableCiliumEndpointCRD {
@@ -1754,9 +1749,6 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		}
 	}()
 	go func() {
-		if restoreComplete != nil {
-			<-restoreComplete
-		}
 		d.dnsNameManager.CompleteBootstrap()
 
 		ms := maps.NewMapSweeper(&EndpointMapManager{

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -306,7 +306,7 @@ func (d *Daemon) initMaps() error {
 		return nil
 	}
 
-	if err := lxcmap.LXCMap().OpenOrCreate(); err != nil {
+	if err := lxcmap.LXCMap().Recreate(); err != nil {
 		return fmt.Errorf("initializing lxc map: %w", err)
 	}
 

--- a/pkg/datapath/fake/datapath.go
+++ b/pkg/datapath/fake/datapath.go
@@ -153,3 +153,10 @@ func (f *fakeLoader) CustomCallsMapPath(id uint16) string {
 func (f *fakeLoader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, deviceMTU int, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
 	return nil
 }
+
+func (f *fakeLoader) InitializeBaseDatapath(ctx context.Context, o datapath.BaseProgramOwner, deviteMTU int) error {
+	return nil
+}
+func (f *fakeLoader) ConfigureBaseDatapath(ctx context.Context, o datapath.BaseProgramOwner, iptMgr datapath.IptablesManager, p datapath.Proxy) error {
+	return nil
+}

--- a/pkg/datapath/types/loader.go
+++ b/pkg/datapath/types/loader.go
@@ -22,6 +22,8 @@ type Loader interface {
 	EndpointHash(cfg EndpointConfiguration) (string, error)
 	Unload(ep Endpoint)
 	Reinitialize(ctx context.Context, o BaseProgramOwner, deviceMTU int, iptMgr IptablesManager, p Proxy) error
+	InitializeBaseDatapath(ctx context.Context, o BaseProgramOwner, deviteMTU int) error
+	ConfigureBaseDatapath(ctx context.Context, o BaseProgramOwner, iptMgr IptablesManager, p Proxy) error
 }
 
 // BaseProgramOwner is any type for which a loader is building base programs.


### PR DESCRIPTION
agent startup: wait for endpoints to be restored before compiling datapath
    
    On agent restart we rely on the existing cilium_lxc map pin to avoid
    interrupting connections, even though endpoints are restored from the
    state directory on disk.
    
    This commit is in preparation to remove the use of the existing
    cilium_lxc map pin and instead recreate the map on startup. Endpoint
    restoration is a 3 part process:
    
    1. Fetching the endpoints to restore
    2. Reserving their IP addresses and adding them to the endpoints list
    3. Regenerating their BPF programs and inserting them into the cilium_lxc map.
    
    We currently perform steps 1 and 2 prior to reinitializing the base
    datapath. In order to recreate the cilium_lxc map on restart it must be
    populated with restored endpoints before recompiling and loading the
    base datapath programs that reference it. In order to accomplish this
    the datapath Reinitialize() method was split into 2 parts so that
    endpoint restoration could be completed during daemon initialization
    before compiling and loading the base datapath programs.
    
    Datapath initialization is now performed in 2 steps:
    
    1. Initializing the loader, base datapath interfaces, and writing header files
    2. Compiling and loading the base datapath BPF programs and inserting netfilter rules.

```release-note
Refactor datapath initialization and recreate cilium_lxc map on startup
```
