### PR TITLE
ci-ipsec-upgrade: Bump CLI to v0.15.5

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -52,9 +52,8 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version:
-  # until https://github.com/cilium/cilium-cli/pull/1854 has been released
-  cilium_cli_ci_version: 8c624e141844a19a6b2e21d5255f3ca6195c996d
+  cilium_cli_version: v0.15.5
+  cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   cilium_stable_version: 1.14
 


### PR DESCRIPTION
Some tests are still failing due to https://github.com/cilium/cilium/issues/27276.