### PR TITLE
Clearify QPS and BURST are ment to be variables in the given l2-announcements documentation example

### DIFF
--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -41,8 +41,8 @@ The L2 Announcements feature and all the requirements can be enabled as follows:
                --namespace kube-system \\
                --reuse-values \\
                --set l2announcements.enabled=true \\
-               --set k8sClientRateLimit.qps={QPS} \\
-               --set k8sClientRateLimit.burst={BURST} \\
+               --set k8sClientRateLimit.qps=${QPS} \\
+               --set k8sClientRateLimit.burst=${BURST} \\
                --set kubeProxyReplacement=strict \\
                --set k8sServiceHost=${API_SERVER_IP} \\
                --set k8sServicePort=${API_SERVER_PORT}
@@ -54,8 +54,8 @@ The L2 Announcements feature and all the requirements can be enabled as follows:
 
             enable-l2-announcements: true
             kube-proxy-replacement: strict
-            k8s-client-qps: {QPS}
-            k8s-client-burst: {BURST}
+            k8s-client-qps: ${QPS}
+            k8s-client-burst: ${BURST}
 
 .. warning::
   Sizing the client rate limit (``k8sClientRateLimit.qps`` and ``k8sClientRateLimit.burst``) 


### PR DESCRIPTION
The current example gives the impression that the actual QPS and BURST variables are supposed to be provided within curly brackets while in fact in the Helm chart they're simply used as integers. I suppose this was a simple typo and both those params are ment to be variables in the given example, similar to the existing KUBERNETES_API_SERVER_ADDRESS and KUBERNETES_API_SERVER_PORT variables provided in the same example.
