### PR TITLE
CODEOWNERS: remove stale cilium_egress_gateway_policy.go entry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -440,7 +440,6 @@ jenkinsfiles @cilium/ci-structure
 /pkg/k8s/watchers/cilium_network_policy.go @cilium/sig-policy
 /pkg/k8s/watchers/cilium_cidr_group.go @cilium/sig-policy
 /pkg/k8s/watchers/cilium_cidr_group_test.go @cilium/sig-policy
-/pkg/k8s/watchers/cilium_egress_gateway_policy.go @cilium/egress-gateway @cilium/sig-k8s
 /pkg/k8s/apis/cilium.io/client/crds/v2/ @cilium/sig-k8s
 /pkg/k8s/apis/cilium.io/client/crds/v2/ciliumegressgatewaypolicies.yaml @cilium/egress-gateway
 /pkg/k8s/apis/cilium.io/v2/cegp_types.go @cilium/egress-gateway


### PR DESCRIPTION
The `pkg/k8s/watchers/cilium_egress_gateway_policy.go` file has been deleted in ebabe7032b3f ("egressgw: use Resource[T] to consume CiliumEgressGatewayPolicy"). Hence, let's remove the corresponding entry in the CODEOWNERS file.