### PR TITLE
Fix agent panic in case of malformed objects retrieved from the kvstore, and improve validation

### DIFF
--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -561,7 +561,14 @@ func (s *ServiceCache) mergeServiceUpdateLocked(service *serviceStore.ClusterSer
 		scopedLog.Debugf("Updating backends to %+v", service.Backends)
 		backends := map[cmtypes.AddrCluster]*Backend{}
 		for ipString, portConfig := range service.Backends {
-			backends[cmtypes.MustParseAddrCluster(ipString)] = &Backend{Ports: portConfig}
+			addr, err := cmtypes.ParseAddrCluster(ipString)
+			if err != nil {
+				scopedLog.WithField(logfields.IPAddr, ipString).
+					Error("Skipping service backend due to invalid IP address")
+				continue
+			}
+
+			backends[addr] = &Backend{Ports: portConfig}
 		}
 		externalEndpoints.endpoints[service.Cluster] = &Endpoints{
 			Backends: backends,

--- a/pkg/node/types/node_test.go
+++ b/pkg/node/types/node_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/pkg/annotation"
@@ -241,4 +242,34 @@ func (s *NodeSuite) TestNode_ToCiliumNode(c *C) {
 			NodeIdentity: uint64(12345),
 		},
 	})
+}
+
+func TestClusterServiceValidate(t *testing.T) {
+	tests := []struct {
+		name   string
+		node   Node
+		assert assert.ErrorAssertionFunc
+	}{
+		{
+			name:   "empty cluster ID",
+			node:   Node{},
+			assert: assert.NoError,
+		},
+		{
+			name:   "valid cluster ID",
+			node:   Node{ClusterID: 99},
+			assert: assert.NoError,
+		},
+		{
+			name:   "invalid cluster ID",
+			node:   Node{ClusterID: 260},
+			assert: assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assert(t, tt.node.validate())
+		})
+	}
 }


### PR DESCRIPTION
This PR adds extra validation to prevent processing invalid node and service objects retrieved from the kvstore, which could trigger unexpected behavior.

<!-- Description of change -->

```release-note
Fix agent panic in case malformed objects are retrieved from the kvstore, and improve validation
```
