### PR TITLE
Re-auth if signal got send again after added to cache

### DIFF
--- a/pkg/auth/authmap.go
+++ b/pkg/auth/authmap.go
@@ -20,6 +20,11 @@ type authMap interface {
 	All() (map[authKey]authInfo, error)
 }
 
+type authMapCacher interface {
+	authMap
+	GetCacheInfo(key authKey) (authInfoCache, error)
+}
+
 type authKey struct {
 	localIdentity  identity.NumericIdentity
 	remoteIdentity identity.NumericIdentity
@@ -33,6 +38,11 @@ func (r authKey) String() string {
 
 type authInfo struct {
 	expiration time.Time
+}
+
+type authInfoCache struct {
+	authInfo
+	storedAt time.Time
 }
 
 func (r authInfo) String() string {

--- a/pkg/auth/authmap_cache_test.go
+++ b/pkg/auth/authmap_cache_test.go
@@ -28,7 +28,7 @@ func Test_authMapCache_restoreCache(t *testing.T) {
 				},
 			},
 		},
-		cacheEntries: map[authKey]authInfo{},
+		cacheEntries: map[authKey]authInfoCache{},
 	}
 
 	err := am.restoreCache()
@@ -52,14 +52,15 @@ func Test_authMapCache_allReturnsCopy(t *testing.T) {
 		authmap: &fakeAuthMap{
 			entries: map[authKey]authInfo{},
 		},
-		cacheEntries: map[authKey]authInfo{
+		cacheEntries: map[authKey]authInfoCache{
 			{
 				localIdentity:  1,
 				remoteIdentity: 2,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
-				expiration: time.Now().Add(10 * time.Minute),
+				authInfo: authInfo{time.Now().Add(10 * time.Minute)},
+				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 		},
 	}
@@ -96,14 +97,15 @@ func Test_authMapCache_Delete(t *testing.T) {
 	am := authMapCache{
 		logger:  logrus.New(),
 		authmap: fakeMap,
-		cacheEntries: map[authKey]authInfo{
+		cacheEntries: map[authKey]authInfoCache{
 			{
 				localIdentity:  1,
 				remoteIdentity: 2,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
-				expiration: time.Now().Add(10 * time.Minute),
+				authInfo: authInfo{time.Now().Add(10 * time.Minute)},
+				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 			{
 				localIdentity:  3,
@@ -111,7 +113,8 @@ func Test_authMapCache_Delete(t *testing.T) {
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
-				expiration: time.Now().Add(10 * time.Minute),
+				authInfo: authInfo{time.Now().Add(10 * time.Minute)},
+				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 			{
 				localIdentity:  4,
@@ -119,7 +122,8 @@ func Test_authMapCache_Delete(t *testing.T) {
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
-				expiration: time.Now().Add(10 * time.Minute),
+				authInfo: authInfo{time.Now().Add(10 * time.Minute)},
+				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 		},
 	}
@@ -171,14 +175,15 @@ func Test_authMapCache_DeleteIf(t *testing.T) {
 	am := authMapCache{
 		logger:  logrus.New(),
 		authmap: fakeMap,
-		cacheEntries: map[authKey]authInfo{
+		cacheEntries: map[authKey]authInfoCache{
 			{
 				localIdentity:  1,
 				remoteIdentity: 2,
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
-				expiration: time.Now().Add(10 * time.Minute),
+				authInfo: authInfo{time.Now().Add(10 * time.Minute)},
+				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 			{
 				localIdentity:  3,
@@ -186,7 +191,8 @@ func Test_authMapCache_DeleteIf(t *testing.T) {
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
-				expiration: time.Now().Add(10 * time.Minute),
+				authInfo: authInfo{time.Now().Add(10 * time.Minute)},
+				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 			{
 				localIdentity:  4,
@@ -194,7 +200,8 @@ func Test_authMapCache_DeleteIf(t *testing.T) {
 				remoteNodeID:   10,
 				authType:       policy.AuthTypeDisabled,
 			}: {
-				expiration: time.Now().Add(10 * time.Minute),
+				authInfo: authInfo{time.Now().Add(10 * time.Minute)},
+				storedAt: time.Now().Add(-10 * time.Minute),
 			},
 		},
 	}

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -28,10 +28,11 @@ func (key signalAuthKey) String() string {
 }
 
 type AuthManager struct {
-	logger        logrus.FieldLogger
-	nodeIDHandler types.NodeIDHandler
-	authHandlers  map[policy.AuthType]authHandler
-	authmap       authMap
+	logger                logrus.FieldLogger
+	nodeIDHandler         types.NodeIDHandler
+	authHandlers          map[policy.AuthType]authHandler
+	authmap               authMapCacher
+	authSignalBackoffTime time.Duration
 
 	mutex                    lock.Mutex
 	pending                  map[authKey]struct{}
@@ -56,7 +57,7 @@ type authResponse struct {
 	expirationTime time.Time
 }
 
-func newAuthManager(logger logrus.FieldLogger, authHandlers []authHandler, authmap authMap, nodeIDHandler types.NodeIDHandler) (*AuthManager, error) {
+func newAuthManager(logger logrus.FieldLogger, authHandlers []authHandler, authmap authMapCacher, nodeIDHandler types.NodeIDHandler, authSignalBackoffTime time.Duration) (*AuthManager, error) {
 	ahs := map[policy.AuthType]authHandler{}
 	for _, ah := range authHandlers {
 		if ah == nil {
@@ -75,6 +76,7 @@ func newAuthManager(logger logrus.FieldLogger, authHandlers []authHandler, authm
 		nodeIDHandler:            nodeIDHandler,
 		pending:                  make(map[authKey]struct{}),
 		handleAuthenticationFunc: handleAuthentication,
+		authSignalBackoffTime:    authSignalBackoffTime,
 	}, nil
 }
 
@@ -130,10 +132,15 @@ func handleAuthentication(a *AuthManager, k authKey, reAuth bool) {
 			// Check if the auth is actually required, as we might have
 			// updated the authmap since the datapath issued the auth
 			// required signal.
-			if i, err := a.authmap.Get(key); err == nil && i.expiration.After(time.Now()) {
+			// If the entry was cached more than authSignalBackoffTime
+			// it will authenticate again, this is to make sure that
+			// we re-authenticate if the authmap was updated by an
+			// external source.
+			if i, err := a.authmap.GetCacheInfo(key); err == nil && i.expiration.After(time.Now()) && time.Now().Before(i.storedAt.Add(a.authSignalBackoffTime)) {
 				a.logger.
 					WithField("key", key).
-					Debug("Already authenticated, skipping authentication")
+					WithField("storedAt", i.storedAt).
+					Debugf("Already authenticated in the past %s, skipping authentication", a.authSignalBackoffTime.String())
 				return
 			}
 		}


### PR DESCRIPTION
This change will re-trigger the auth mechanism if a signal got send but the entry was already in cache.
It adds a 1 second backoff time to allow for the backend map to finish updating, which is why it was added in the first place.

Why does this happen? If somebody removes the entry in the bpf map that is not notified to the cell cache (meaning an external actor) we currently refuse to do the auth handshake again till the entry in the cache is gone.

It does add a small backoff time to not cause un-needed handshakes when data arrives and signals auth_needed between the mutex being released and the datapath getting the update. The current time it will allow for that is 1 second which seems to be okay. It is currently not configurable as it is quite an internal complexity. However I am open to reasons we should export it.

Fixes: https://github.com/cilium/cilium/issues/27183

```release-note
Do mutual authentication handshake again if mismatch between bpf map and cached map happens
```
