### PR TITLE
Make it easier to depend on clustermesh types outside of its package

### DIFF
--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -4,7 +4,7 @@
 package clustermesh
 
 import (
-	"github.com/cilium/cilium/pkg/clustermesh/internal"
+	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -34,8 +34,8 @@ var Cell = cell.Module(
 	}),
 	cell.ProvidePrivate(idsMgrProvider),
 
-	cell.Config(internal.Config{}),
+	cell.Config(common.Config{}),
 
 	cell.Metric(newMetrics),
-	cell.Metric(internal.MetricsProvider(subsystem)),
+	cell.Metric(common.MetricsProvider(subsystem)),
 )

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -36,6 +36,6 @@ var Cell = cell.Module(
 
 	cell.Config(common.Config{}),
 
-	cell.Metric(newMetrics),
+	cell.Metric(NewMetrics),
 	cell.Metric(common.MetricsProvider(subsystem)),
 )

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -133,7 +133,7 @@ func NewClusterMesh(lifecycle hive.Lifecycle, c Configuration) *ClusterMesh {
 		ClusterSizeDependantInterval: c.ClusterSizeDependantInterval,
 		ServiceIPGetter:              c.ServiceIPGetter,
 
-		NewRemoteCluster: cm.newRemoteCluster,
+		NewRemoteCluster: cm.NewRemoteCluster,
 
 		NodeName: nodeName,
 		Metrics:  c.CommonMetrics,
@@ -143,7 +143,7 @@ func NewClusterMesh(lifecycle hive.Lifecycle, c Configuration) *ClusterMesh {
 	return cm
 }
 
-func (cm *ClusterMesh) newRemoteCluster(name string, status common.StatusFunc) common.RemoteCluster {
+func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) common.RemoteCluster {
 	rc := &remoteCluster{
 		name:    name,
 		mesh:    cm,

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/cilium/cilium/pkg/clustermesh/internal"
+	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
@@ -140,7 +140,7 @@ func TestClusterMesh(t *testing.T) {
 
 	usedIDs := NewClusterMeshUsedIDs()
 	cm := NewClusterMesh(hivetest.Lifecycle(t), Configuration{
-		Config:                internal.Config{ClusterMeshConfig: dir},
+		Config:                common.Config{ClusterMeshConfig: dir},
 		ClusterIDName:         types.ClusterIDName{ClusterID: 255, ClusterName: "test2"},
 		NodeKeyCreator:        testNodeCreator,
 		NodeObserver:          &testObserver{},
@@ -148,7 +148,7 @@ func TestClusterMesh(t *testing.T) {
 		IPCache:               ipc,
 		ClusterIDsManager:     usedIDs,
 		Metrics:               newMetrics(),
-		InternalMetrics:       internal.MetricsProvider(subsystem)(),
+		CommonMetrics:         common.MetricsProvider(subsystem)(),
 	})
 	require.NotNil(t, cm, "Failed to initialize clustermesh")
 

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -147,7 +147,7 @@ func TestClusterMesh(t *testing.T) {
 		RemoteIdentityWatcher: mgr,
 		IPCache:               ipc,
 		ClusterIDsManager:     usedIDs,
-		Metrics:               newMetrics(),
+		Metrics:               NewMetrics(),
 		CommonMetrics:         common.MetricsProvider(subsystem)(),
 	})
 	require.NotNil(t, cm, "Failed to initialize clustermesh")

--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package internal
+package common
 
 import (
 	"fmt"

--- a/pkg/clustermesh/common/config.go
+++ b/pkg/clustermesh/common/config.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package internal
+package common
 
 import (
 	"crypto/sha256"

--- a/pkg/clustermesh/common/config_test.go
+++ b/pkg/clustermesh/common/config_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package internal
+package common
 
 import (
 	"context"

--- a/pkg/clustermesh/common/logfields.go
+++ b/pkg/clustermesh/common/logfields.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package internal
+package common
 
 import (
 	"github.com/cilium/cilium/pkg/logging"

--- a/pkg/clustermesh/common/metrics.go
+++ b/pkg/clustermesh/common/metrics.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package internal
+package common
 
 import (
 	"github.com/cilium/cilium/pkg/metrics"

--- a/pkg/clustermesh/common/remote_cluster.go
+++ b/pkg/clustermesh/common/remote_cluster.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package internal
+package common
 
 import (
 	"context"

--- a/pkg/clustermesh/kvstoremesh/cell.go
+++ b/pkg/clustermesh/kvstoremesh/cell.go
@@ -4,7 +4,7 @@
 package kvstoremesh
 
 import (
-	"github.com/cilium/cilium/pkg/clustermesh/internal"
+	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/hive/cell"
 )
 
@@ -14,7 +14,7 @@ var Cell = cell.Module(
 
 	cell.Provide(newKVStoreMesh),
 
-	cell.Config(internal.Config{}),
+	cell.Config(common.Config{}),
 
-	cell.Metric(internal.MetricsProvider("")),
+	cell.Metric(common.MetricsProvider("")),
 )

--- a/pkg/clustermesh/metrics.go
+++ b/pkg/clustermesh/metrics.go
@@ -16,7 +16,7 @@ type Metrics struct {
 	TotalGlobalServices metric.Vec[metric.Gauge]
 }
 
-func newMetrics() Metrics {
+func NewMetrics() Metrics {
 	return Metrics{
 		TotalNodes: metric.NewGaugeVec(metric.GaugeOpts{
 			ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_nodes",

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
-	"github.com/cilium/cilium/pkg/clustermesh/internal"
+	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	identityCache "github.com/cilium/cilium/pkg/identity/cache"
@@ -22,7 +22,7 @@ import (
 )
 
 // remoteCluster implements the clustermesh business logic on top of
-// internal.RemoteCluster.
+// common.RemoteCluster.
 type remoteCluster struct {
 	// name is the name of the cluster
 	name string
@@ -58,8 +58,8 @@ type remoteCluster struct {
 	// allocations in the remote cluster
 	remoteIdentityCache *allocator.RemoteCache
 
-	// status is the function which fills the internal part of the status.
-	status internal.StatusFunc
+	// status is the function which fills the common part of the status.
+	status common.StatusFunc
 
 	swg *lock.StoppableWaitGroup
 }

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -149,7 +149,7 @@ func TestRemoteClusterRun(t *testing.T) {
 					IPCache:               &ipc,
 					RemoteIdentityWatcher: allocator,
 					ClusterIDsManager:     NewClusterMeshUsedIDs(),
-					Metrics:               newMetrics(),
+					Metrics:               NewMetrics(),
 				},
 				globalServices: newGlobalServiceCache(metrics.NoOpGauge),
 			}

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -153,7 +153,7 @@ func TestRemoteClusterRun(t *testing.T) {
 				},
 				globalServices: newGlobalServiceCache(metrics.NoOpGauge),
 			}
-			rc := cm.newRemoteCluster("foo", nil).(*remoteCluster)
+			rc := cm.NewRemoteCluster("foo", nil).(*remoteCluster)
 			ready := make(chan error)
 
 			remoteClient := &remoteEtcdClientWrapper{

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/clustermesh/internal"
+	"github.com/cilium/cilium/pkg/clustermesh/common"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
@@ -106,7 +106,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	defer ipc.Shutdown()
 
 	s.mesh = NewClusterMesh(hivetest.Lifecycle(c), Configuration{
-		Config:                internal.Config{ClusterMeshConfig: dir},
+		Config:                common.Config{ClusterMeshConfig: dir},
 		ClusterIDName:         types.ClusterIDName{ClusterID: 255, ClusterName: "test2"},
 		NodeKeyCreator:        testNodeCreator,
 		NodeObserver:          &testObserver{},
@@ -115,7 +115,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 		IPCache:               ipc,
 		ClusterIDsManager:     NewClusterMeshUsedIDs(),
 		Metrics:               newMetrics(),
-		InternalMetrics:       internal.MetricsProvider(subsystem)(),
+		CommonMetrics:         common.MetricsProvider(subsystem)(),
 	})
 	c.Assert(s.mesh, Not(IsNil))
 

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -114,7 +114,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 		RemoteIdentityWatcher: mgr,
 		IPCache:               ipc,
 		ClusterIDsManager:     NewClusterMeshUsedIDs(),
-		Metrics:               newMetrics(),
+		Metrics:               NewMetrics(),
 		CommonMetrics:         common.MetricsProvider(subsystem)(),
 	})
 	c.Assert(s.mesh, Not(IsNil))


### PR DESCRIPTION
Please refer to the respective commit descriptions for additional details.
