### PR TITLE
Enable strict validation of cluster config for clustermesh

### DIFF
--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -61,6 +61,10 @@ type Configuration struct {
 	// ServiceIPGetter, if not nil, is used to create a custom dialer for service resolution.
 	ServiceIPGetter k8s.ServiceIPGetter
 
+	// ConfigValidationMode defines whether the CiliumClusterConfig is always
+	// expected to be exposed by remote clusters.
+	ConfigValidationMode types.ValidationMode `optional:"true"`
+
 	// IPCacheWatcherExtraOpts returns extra options for watching ipcache entries.
 	IPCacheWatcherExtraOpts IPCacheWatcherOptsFn `optional:"true"`
 

--- a/pkg/clustermesh/internal/config_test.go
+++ b/pkg/clustermesh/internal/config_test.go
@@ -37,8 +37,9 @@ type fakeRemoteCluster struct{}
 func (*fakeRemoteCluster) Run(_ context.Context, _ kvstore.BackendOperations, _ *types.CiliumClusterConfig, ready chan<- error) {
 	close(ready)
 }
-func (*fakeRemoteCluster) Stop()   {}
-func (*fakeRemoteCluster) Remove() {}
+func (*fakeRemoteCluster) ClusterConfigRequired() bool { return false }
+func (*fakeRemoteCluster) Stop()                       {}
+func (*fakeRemoteCluster) Remove()                     {}
 
 func writeFile(c *C, name, content string) {
 	err := os.WriteFile(name, []byte(content), 0644)

--- a/pkg/clustermesh/internal/remote_cluster.go
+++ b/pkg/clustermesh/internal/remote_cluster.go
@@ -32,6 +32,10 @@ type RemoteCluster interface {
 	// The ready channel shall be closed when the initialization tasks completed, possibly returning an error.
 	Run(ctx context.Context, backend kvstore.BackendOperations, config *types.CiliumClusterConfig, ready chan<- error)
 
+	// ClusterConfigRequired returns whether the CiliumClusterConfig is always
+	// expected to be exposed by remote clusters.
+	ClusterConfigRequired() bool
+
 	Stop()
 	Remove()
 }
@@ -168,7 +172,7 @@ func (rc *remoteCluster) restartRemoteConnection() {
 
 				rc.getLogger().Info("Connection to remote cluster established")
 
-				config, err := rc.getClusterConfig(ctx, backend, false)
+				config, err := rc.getClusterConfig(ctx, backend, rc.ClusterConfigRequired())
 				if err == nil && config == nil {
 					rc.getLogger().Warning("Remote cluster doesn't have cluster configuration, falling back to the old behavior. This is expected when connecting to the old cluster running Cilium without cluster configuration feature.")
 				} else if err == nil {

--- a/pkg/clustermesh/kvstoremesh/remote_cluster.go
+++ b/pkg/clustermesh/kvstoremesh/remote_cluster.go
@@ -110,6 +110,8 @@ func (rc *remoteCluster) Remove() {
 	// disappear once the associated lease expires.
 }
 
+func (rc *remoteCluster) ClusterConfigRequired() bool { return false }
+
 type reflector struct {
 	watcher store.WatchStore
 	syncer  syncer

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -65,7 +65,7 @@ type remoteCluster struct {
 }
 
 func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperations, config *cmtypes.CiliumClusterConfig, ready chan<- error) {
-	if err := config.Validate(); err != nil {
+	if err := config.Validate(rc.mesh.conf.ConfigValidationMode); err != nil {
 		ready <- err
 		close(ready)
 		return
@@ -166,6 +166,10 @@ func (rc *remoteCluster) Status() *models.RemoteCluster {
 		status.Synced.Identities && status.Synced.Endpoints
 
 	return status
+}
+
+func (rc *remoteCluster) ClusterConfigRequired() bool {
+	return rc.mesh.conf.ConfigValidationMode == types.Strict
 }
 
 func (rc *remoteCluster) onUpdateConfig(newConfig *cmtypes.CiliumClusterConfig) error {

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 )
 
@@ -43,16 +44,24 @@ type CiliumClusterConfigCapabilities struct {
 	Cached bool `json:"cached,omitempty"`
 }
 
-func (c *CiliumClusterConfig) Validate() error {
+// ValidationMode defines if a missing CiliumClusterConfig should be allowed for
+// backward compatibility, or it should be flagged as an error.
+type ValidationMode bool
+
+const (
+	BackwardCompatible ValidationMode = false
+	Strict             ValidationMode = true
+)
+
+// Validate validates the configuration correctness. When the validation mode
+// is BackwardCompatible, a missing configuration or with ID=0 is allowed for
+// backward compatibility, otherwise it is flagged as an error.
+func (c *CiliumClusterConfig) Validate(mode ValidationMode) error {
 	if c == nil || c.ID == 0 {
-		// When remote cluster doesn't have cluster config, we
-		// currently just bypass the validation for compatibility.
-		// Otherwise, we cannot connect with older cluster which
-		// doesn't support cluster config feature.
-		//
-		// When we introduce a new cluster config can't be ignored,
-		// we should properly check it here and return error. Now
-		// we only have ClusterID which used to be ignored.
+		if mode == Strict {
+			return errors.New("remote cluster is missing cluster configuration")
+		}
+
 		return nil
 	}
 

--- a/pkg/clustermesh/types/types_test.go
+++ b/pkg/clustermesh/types/types_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCiliumClusterConfigValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *CiliumClusterConfig
+		mode      ValidationMode
+		assertion func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool
+	}{
+		{
+			name:      "Nil config (Backward)",
+			cfg:       nil,
+			mode:      BackwardCompatible,
+			assertion: assert.NoError,
+		},
+		{
+			name:      "Nil config (Strict)",
+			cfg:       nil,
+			mode:      Strict,
+			assertion: assert.Error,
+		},
+		{
+			name:      "Empty config (Backward)",
+			cfg:       &CiliumClusterConfig{},
+			mode:      BackwardCompatible,
+			assertion: assert.NoError,
+		},
+		{
+			name:      "Empty config (Strict)",
+			cfg:       &CiliumClusterConfig{},
+			mode:      Strict,
+			assertion: assert.Error,
+		},
+		{
+			name:      "Valid config (Backward)",
+			cfg:       &CiliumClusterConfig{ID: 255},
+			mode:      BackwardCompatible,
+			assertion: assert.NoError,
+		},
+		{
+			name:      "Valid config (Strict)",
+			cfg:       &CiliumClusterConfig{ID: 255},
+			mode:      Strict,
+			assertion: assert.NoError,
+		},
+		{
+			name:      "Invalid config (Backward)",
+			cfg:       &CiliumClusterConfig{ID: 256},
+			mode:      BackwardCompatible,
+			assertion: assert.Error,
+		},
+		{
+			name:      "Invalid config (Strict)",
+			cfg:       &CiliumClusterConfig{ID: 256},
+			mode:      Strict,
+			assertion: assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assertion(t, tt.cfg.Validate(tt.mode))
+		})
+	}
+}


### PR DESCRIPTION
Currently, the cluster config validation function always adopts a loose approach for backward compatibility, allowing nil/empty configurations as valid. As new features may depend on the config presence, let's make this configurable.

<!-- Description of change -->

```release-note
Enable strict validation of cluster config for clustermesh
```
