### PR TITLE
Generalize ClusterID reservation mechanism for clustermesh

### DIFF
--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -32,6 +32,7 @@ var Cell = cell.Module(
 	cell.ProvidePrivate(func(cfg *option.DaemonConfig) types.ClusterIDName {
 		return types.ClusterIDName{ClusterID: cfg.ClusterID, ClusterName: cfg.ClusterName}
 	}),
+	cell.ProvidePrivate(idsMgrProvider),
 
 	cell.Config(internal.Config{}),
 

--- a/pkg/clustermesh/idsmgr.go
+++ b/pkg/clustermesh/idsmgr.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh
+
+import (
+	"fmt"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+type ClusterIDsManager interface {
+	ReserveClusterID(clusterID uint32) error
+	ReleaseClusterID(clusterID uint32)
+}
+
+// clusterIDsManager is an alias of ClusterIDsManager, which is used to break
+// the circular dependency during injection and support defaulting it if not
+// already provided externally.
+type clusterIDsManager ClusterIDsManager
+
+type idsMgrProviderParams struct {
+	cell.In
+	Manager ClusterIDsManager `optional:"true"`
+}
+
+// idsMgrProvider constructs a default instance of the ClusterIDsManager,
+// unless it is already provided externally.
+func idsMgrProvider(params idsMgrProviderParams) clusterIDsManager {
+	if params.Manager != nil {
+		return params.Manager
+	}
+
+	return NewClusterMeshUsedIDs()
+}
+
+type ClusterMeshUsedIDs struct {
+	UsedClusterIDs      map[uint32]struct{}
+	UsedClusterIDsMutex lock.RWMutex
+}
+
+func NewClusterMeshUsedIDs() *ClusterMeshUsedIDs {
+	return &ClusterMeshUsedIDs{
+		UsedClusterIDs: make(map[uint32]struct{}),
+	}
+}
+
+func (cm *ClusterMeshUsedIDs) ReserveClusterID(clusterID uint32) error {
+	cm.UsedClusterIDsMutex.Lock()
+	defer cm.UsedClusterIDsMutex.Unlock()
+
+	if _, ok := cm.UsedClusterIDs[clusterID]; ok {
+		return fmt.Errorf("clusterID %d is already used", clusterID)
+	}
+
+	cm.UsedClusterIDs[clusterID] = struct{}{}
+
+	return nil
+}
+
+func (cm *ClusterMeshUsedIDs) ReleaseClusterID(clusterID uint32) {
+	cm.UsedClusterIDsMutex.Lock()
+	defer cm.UsedClusterIDsMutex.Unlock()
+
+	delete(cm.UsedClusterIDs, clusterID)
+}

--- a/pkg/clustermesh/idsmgr_test.go
+++ b/pkg/clustermesh/idsmgr_test.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package clustermesh
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClusterIDsManagerProvisioner(t *testing.T) {
+	mgr := idsMgrProvider(idsMgrProviderParams{})
+	require.NotNil(t, mgr, "A non-nil instance of the default implementation should be returned")
+	require.NoError(t, mgr.ReserveClusterID(10), "Reserving a cluster ID should succeed")
+
+	mgr2 := idsMgrProvider(idsMgrProviderParams{Manager: mgr})
+	require.Equal(t, mgr, mgr2, "The specified implementation should be propagated")
+	require.NoError(t, mgr.ReserveClusterID(11), "Reserving a cluster ID should succeed")
+}
+
+func TestClusterMeshUsedIDs(t *testing.T) {
+	mgr := NewClusterMeshUsedIDs()
+
+	require.NoError(t, mgr.ReserveClusterID(10), "Reserving a cluster ID should succeed")
+	require.NoError(t, mgr.ReserveClusterID(250), "Reserving another cluster ID should succeed")
+	require.Error(t, mgr.ReserveClusterID(250), "Attempting to reserve again the same cluster ID should fail")
+
+	mgr.ReleaseClusterID(250)
+	require.NoError(t, mgr.ReserveClusterID(55), "Reserving a released cluster ID should succeed")
+}

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -34,7 +34,7 @@ type remoteCluster struct {
 	// mesh is the cluster mesh this remote cluster belongs to
 	mesh *ClusterMesh
 
-	usedIDs *ClusterMeshUsedIDs
+	usedIDs ClusterIDsManager
 
 	// mutex protects the following variables:
 	// - remoteIdentityCache
@@ -139,7 +139,7 @@ func (rc *remoteCluster) Remove() {
 	rc.mesh.globalServices.onClusterDelete(rc.name)
 
 	if rc.config != nil {
-		rc.usedIDs.releaseClusterID(rc.config.ID)
+		rc.usedIDs.ReleaseClusterID(rc.config.ID)
 	}
 }
 
@@ -175,12 +175,12 @@ func (rc *remoteCluster) onUpdateConfig(newConfig *cmtypes.CiliumClusterConfig) 
 		return nil
 	}
 	if newConfig != nil {
-		if err := rc.usedIDs.reserveClusterID(newConfig.ID); err != nil {
+		if err := rc.usedIDs.ReserveClusterID(newConfig.ID); err != nil {
 			return err
 		}
 	}
 	if oldConfig != nil {
-		rc.usedIDs.releaseClusterID(oldConfig.ID)
+		rc.usedIDs.ReleaseClusterID(oldConfig.ID)
 	}
 	rc.config = newConfig
 

--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -148,10 +148,10 @@ func TestRemoteClusterRun(t *testing.T) {
 					NodeObserver:          &testObserver{},
 					IPCache:               &ipc,
 					RemoteIdentityWatcher: allocator,
+					ClusterIDsManager:     NewClusterMeshUsedIDs(),
 					Metrics:               newMetrics(),
 				},
 				globalServices: newGlobalServiceCache(metrics.NoOpGauge),
-				usedIDs:        newClusterMeshUsedIDs(),
 			}
 			rc := cm.newRemoteCluster("foo", nil).(*remoteCluster)
 			ready := make(chan error)

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -113,6 +113,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 		ServiceMerger:         s.svcCache,
 		RemoteIdentityWatcher: mgr,
 		IPCache:               ipc,
+		ClusterIDsManager:     NewClusterMeshUsedIDs(),
 		Metrics:               newMetrics(),
 		InternalMetrics:       internal.MetricsProvider(subsystem)(),
 	})


### PR DESCRIPTION
766e62b83c20 ("clustermesh: Introduce ClusterID reservation mechanism") recently implemented a ClusterID reservation mechanism to ensure the uniqueness of the ClusterIDs associated with remote clusters. Let's generalize a bit this approach so that we can optionally replace the current implementation with different ones if necessary.
