### PR TITLE
docs: Have Makefile print generated image tags when running with V=0

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -16,7 +16,7 @@ SPHINX_OPTS := "-j=auto"
 default: html
 
 define build_image
-  $(ECHO_DOCKER)
+  $(ECHO_DOCKER) $(3)
   # Pre-pull FROM docker image due to Buildkit sometimes failing to pull them.
   grep -m 1 "^FROM " $(1) | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
   $(QUIET)tar c $(REQUIREMENTS) Dockerfile \


### PR DESCRIPTION
When building Docker images for documentation with `V=0`, the Makefile for documentation does not print the name of the generated images.

One particular example of calling the Makefile with `V=0` is for Cilium's runtime tests in CI, with .travis/build.sh calling:

    `V=0` make -j 2 --quiet

This calls the default target for Cilium's main Makefile, which relies (among others) on the `postcheck` target, which in turns calls the `check` target from Documentation/Makefile, passing the `V=0` flag. The absence of the `docs-builder` string from the logs make it harder to figure out whether the workflow successfully built the image.

This commit simply adds the image tag (passed to Docker with `--tag`, but not actually containing the version tag) to the invocation of `$(ECHO_DOCKER)`, so that Documentation/Makefile can print it when we request a non-verbose build with `V=0`.
