### PR TITLE
gateway-api: Merge externally annotations and labels for kubernetes types

### DIFF
--- a/operator/pkg/gateway-api/gateway_reconcile.go
+++ b/operator/pkg/gateway-api/gateway_reconcile.go
@@ -168,8 +168,7 @@ func (r *gatewayReconciler) ensureService(ctx context.Context, desired *corev1.S
 
 	temp := existing.DeepCopy()
 	temp.Spec = desired.Spec
-	temp.SetAnnotations(desired.GetAnnotations())
-	temp.SetLabels(desired.GetLabels())
+	setMergedLabelsAndAnnotations(temp, desired)
 
 	return r.Client.Patch(ctx, temp, client.MergeFrom(existing))
 }
@@ -186,8 +185,7 @@ func (r *gatewayReconciler) ensureEndpoints(ctx context.Context, desired *corev1
 
 	temp := existing.DeepCopy()
 	temp.Subsets = desired.Subsets
-	temp.SetAnnotations(desired.GetAnnotations())
-	temp.SetLabels(desired.GetLabels())
+	setMergedLabelsAndAnnotations(temp, desired)
 
 	return r.Client.Patch(ctx, temp, client.MergeFrom(existing))
 }
@@ -203,8 +201,7 @@ func (r *gatewayReconciler) ensureEnvoyConfig(ctx context.Context, desired *cili
 	}
 	temp := existing.DeepCopy()
 	temp.Spec = desired.Spec
-	temp.SetAnnotations(desired.GetAnnotations())
-	temp.SetLabels(desired.GetLabels())
+	setMergedLabelsAndAnnotations(temp, desired)
 
 	return r.Client.Patch(ctx, temp, client.MergeFrom(existing))
 }

--- a/operator/pkg/gateway-api/gateway_reconcile_test.go
+++ b/operator/pkg/gateway-api/gateway_reconcile_test.go
@@ -40,6 +40,16 @@ var gwFixture = []client.Object{
 		},
 	},
 
+	&corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cilium-gateway-valid-gateway",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"pre-existing-annotation": "true",
+			},
+		},
+	},
+
 	// Service in another namespace
 	&corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -278,6 +288,7 @@ func Test_gatewayReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, corev1.ServiceTypeLoadBalancer, lb.Spec.Type)
 		require.Equal(t, "valid-gateway", lb.Labels["io.cilium.gateway/owning-gateway"])
+		require.Equal(t, "true", lb.Annotations["pre-existing-annotation"])
 
 		// Update LB status
 		lb.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{

--- a/operator/pkg/gateway-api/helpers.go
+++ b/operator/pkg/gateway-api/helpers.go
@@ -160,3 +160,19 @@ func getGatewayKindForObject(obj metav1.Object) gatewayv1beta1.Kind {
 		return "Unknown"
 	}
 }
+
+func mergeMap(left, right map[string]string) map[string]string {
+	if left == nil {
+		return right
+	} else {
+		for key, value := range right {
+			left[key] = value
+		}
+	}
+	return left
+}
+
+func setMergedLabelsAndAnnotations(temp, desired client.Object) {
+	temp.SetAnnotations(mergeMap(temp.GetAnnotations(), desired.GetAnnotations()))
+	temp.SetLabels(mergeMap(temp.GetLabels(), desired.GetLabels()))
+}


### PR DESCRIPTION
We are currently using Metallb and in combination with Cilium. Metallb is adding automatically annotations labels for the selected pools and the gateway reconciler did remove these annotations again.


Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #24584

```release-note
gateway-api: Merge externally annotations and labels for kubernetes types
```
