### PR TITLE
Add time wrapper to test agent delays in CI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -496,6 +496,7 @@ Makefile* @cilium/build
 /pkg/stream @cilium/sig-foundations
 /pkg/sysctl @cilium/sig-datapath
 /pkg/testutils/ @cilium/ci-structure
+/pkg/time @cilium/sig-agent
 /pkg/tuple @cilium/sig-datapath
 /pkg/types/ @cilium/sig-datapath
 /pkg/wireguard @cilium/wireguard

--- a/Makefile
+++ b/Makefile
@@ -822,6 +822,8 @@ ifeq ($(SKIP_CUSTOMVET_CHECK),"false")
 endif
 	@$(ECHO_CHECK) contrib/scripts/rand-check.sh
 	$(QUIET) contrib/scripts/rand-check.sh
+	@$(ECHO_CHECK) contrib/scripts/check-time.sh
+	$(QUIET) contrib/scripts/check-time.sh
 
 check-sources:
 	@$(ECHO_CHECK) pkg/datapath/loader/check-sources.sh

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
@@ -40,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/pidfile"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/sysctl"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/cilium-health/launch/launcher.go
+++ b/cilium-health/launch/launcher.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"time"
 
 	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/models"
@@ -21,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // CiliumHealth launches and polls the cilium-health daemon

--- a/contrib/scripts/check-time.sh
+++ b/contrib/scripts/check-time.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# Copyright Authors of Cilium
+
+set -eu
+
+GOIMPORTS=("golang.org/x/tools/cmd/goimports" "-w")
+MATCH="^[^a-zA-Z]*\"time\"$"
+EXCLUDED_DIRS=(
+  # Wrapper directories
+  "time"
+
+  # Generated directories
+  "api"
+  "client"
+  "slim"
+
+  # Not Go source
+  ".git"
+  "_build"
+  "contrib"
+  "externalversions"
+  "examples"
+  "install"
+  "Documentation"
+
+  # Not for cilium-agent
+  "bugtool"
+  "cilium-dbg"
+  "clustermesh"
+  "clustermesh-apiserver"
+  "health"
+  "operator"
+  "plugins"
+  "tools"
+  "test"
+  "testutils"
+  "vendor"
+
+  # Source shared with other binaries
+  "hive"
+  "lock"
+
+  # Skip override (not applicable)
+  "defaults"
+  "loadinfo"
+  "logging"
+  "metric"
+  "probes"
+  "rand"
+  "types"
+
+  # May need subsequent evaluation to detect resiliency issues in CI
+  "contexthelpers"
+  "rate"
+  "resiliency"
+)
+
+find_match() {
+  local target="."
+
+  # shellcheck disable=2046
+  grep "$@" -r --include \*.go \
+       $(printf "%s\n" "${EXCLUDED_DIRS[@]}" \
+         | xargs -I{} echo '--exclude-dir={}') \
+       --exclude \*_test.go \
+       -i "$MATCH" \
+       "$target"
+}
+
+check() {
+  # Used to cause failure when pkg/time is not used
+  if find_match ; then
+    >&2 echo "Found match for '$MATCH'. Please use pkg/time instead to improve ordering and consistency testing.";
+    >&2 echo "Run '$0 update' to update most instances automatically."
+    exit 1
+  fi
+}
+
+update() {
+  local files=()
+
+  while IFS='' read -r line; do
+    files+=("$line");
+  done < <(find_match -l | sort -u)
+  if [ "${#files[@]}" -eq 0 ]; then
+      return
+  fi
+
+  # Add a cilium pkg/time input next to the other imports
+  sed -i '/'"$MATCH"'/d; /"github.com\/cilium\/cilium\/.*"/a\
+	"github.com/cilium/cilium/pkg/time"' \
+      "${files[@]}"
+
+  # Fix up imports formatting
+  printf "%s\n" "${files[@]}" \
+  | xargs dirname \
+  | sort -u \
+  | xargs go run "${GOIMPORTS[@]}"
+}
+
+main() {
+  if [ $# -ge 1 ] && [ "$1" == "update" ]; then
+      update
+  fi
+
+  check
+}
+
+main "$@"

--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/fsnotify/fsnotify"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/time"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -94,6 +93,7 @@ import (
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/status"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1196,6 +1196,7 @@ func initDaemonConfig(vp *viper.Viper) {
 		lbmap.SizeofSockRevNat6Key+lbmap.SizeofSockRevNat6Value)
 
 	option.Config.Populate(vp)
+
 	time.MaxInternalTimerDelay = vp.GetDuration(option.MaxInternalTimerDelay)
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
@@ -95,6 +94,7 @@ import (
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/sysctl"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
 	wireguard "github.com/cilium/cilium/pkg/wireguard/agent"
 )
@@ -1143,6 +1143,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.PolicyCIDRMatchMode, defaults.PolicyCIDRMatchMode, "The entities that can be selected by CIDR policy. Supported values: 'nodes'")
 	option.BindEnv(vp, option.PolicyCIDRMatchMode)
 
+	flags.Duration(option.MaxInternalTimerDelay, defaults.MaxInternalTimerDelay, "Maximum internal timer value across the entire agent. Use in test environments to detect race conditions in agent logic.")
+	flags.MarkHidden(option.MaxInternalTimerDelay)
+	option.BindEnv(vp, option.MaxInternalTimerDelay)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}
@@ -1192,6 +1196,7 @@ func initDaemonConfig(vp *viper.Viper) {
 		lbmap.SizeofSockRevNat6Key+lbmap.SizeofSockRevNat6Value)
 
 	option.Config.Populate(vp)
+	time.MaxInternalTimerDelay = vp.GetDuration(option.MaxInternalTimerDelay)
 }
 
 func initEnv(vp *viper.Viper) {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -9,7 +9,6 @@ import (
 	"net/netip"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -48,6 +47,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var metricsmapBPFPromSyncControllerGroup = controller.NewGroup("metricsmap-bpf-prom-sync")

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"runtime"
 	"sync"
-	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
@@ -40,6 +39,7 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var errEndpointNotFound = errors.New("endpoint not found")

--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/cilium/dns"
 	"github.com/go-openapi/runtime/middleware"
@@ -43,6 +42,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
 	proxytypes "github.com/cilium/cilium/pkg/proxy/types"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 

--- a/daemon/cmd/health.go
+++ b/daemon/cmd/health.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"time"
 
 	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	health "github.com/cilium/cilium/cilium-health/launch"
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pidfile"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var healthControllerGroup = controller.NewGroup("cilium-health")

--- a/daemon/cmd/hubble.go
+++ b/daemon/cmd/hubble.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/netip"
 	"strings"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
@@ -46,6 +45,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func (d *Daemon) getHubbleStatus(ctx context.Context) *models.HubbleStatus {

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/swag"
@@ -27,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Handle incoming requests address allocation requests for the daemon.

--- a/daemon/cmd/kube_proxy_healthz.go
+++ b/daemon/cmd/kube_proxy_healthz.go
@@ -9,12 +9,12 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // DaemonInterface to help with testing.

--- a/daemon/cmd/metrics.go
+++ b/daemon/cmd/metrics.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/cilium/cilium/pkg/api"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func getMetricsHandler(_ *Daemon, params restapi.GetMetricsParams) middleware.Responder {

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"net/netip"
 	"sync"
-	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/google/uuid"
@@ -42,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/safetime"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/stream"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/daemon/cmd/root.go
+++ b/daemon/cmd/root.go
@@ -6,13 +6,13 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
 )
 

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
@@ -37,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/status"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
 )
 

--- a/daemon/cmd/vitals.go
+++ b/daemon/cmd/vitals.go
@@ -4,14 +4,13 @@
 package cmd
 
 import (
-	"time"
-
 	"github.com/go-openapi/runtime/middleware"
 	"k8s.io/apimachinery/pkg/util/duration"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type getHealth struct {

--- a/daemon/cmd/watchdogs.go
+++ b/daemon/cmd/watchdogs.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"context"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -17,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const epBPFProgWatchdog = "ep-bpf-prog-watchdog"

--- a/daemon/k8s/init.go
+++ b/daemon/k8s/init.go
@@ -7,7 +7,6 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -20,6 +19,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func retrieveNodeInformation(ctx context.Context, log logrus.FieldLogger, localNodeResource LocalNodeResource, localCiliumNodeResource LocalCiliumNodeResource) *nodeTypes.Node {

--- a/daemon/restapi/api_limits.go
+++ b/daemon/restapi/api_limits.go
@@ -4,13 +4,12 @@
 package restapi
 
 import (
-	"time"
-
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/rate"
 	ratemetrics "github.com/cilium/cilium/pkg/rate/metrics"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var rateLimiterCell = cell.Module(

--- a/pkg/alibabacloud/eni/instances.go
+++ b/pkg/alibabacloud/eni/instances.go
@@ -5,7 +5,6 @@ package eni
 
 import (
 	"context"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -15,6 +14,7 @@ import (
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // AlibabaCloudAPI is the API surface used of the ECS API

--- a/pkg/alibabacloud/metadata/metadata.go
+++ b/pkg/alibabacloud/metadata/metadata.go
@@ -7,9 +7,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/cilium/cilium/pkg/safeio"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -21,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/allocator/cache.go
+++ b/pkg/allocator/cache.go
@@ -6,7 +6,6 @@ package allocator
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/stream"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // backendOpTimeout is the time allowed for operations sent to backends in

--- a/pkg/auth/always_pass_authhandler.go
+++ b/pkg/auth/always_pass_authhandler.go
@@ -4,13 +4,12 @@
 package auth
 
 import (
-	"time"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/auth/certs"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // alwaysPassAuthHandler implements an authHandler by just authenticate every request

--- a/pkg/auth/authmap.go
+++ b/pkg/auth/authmap.go
@@ -5,10 +5,10 @@ package auth
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // authMap provides an abstraction for the BPF map "auth"

--- a/pkg/auth/authmap_cache.go
+++ b/pkg/auth/authmap_cache.go
@@ -6,7 +6,6 @@ package auth
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/sirupsen/logrus"
@@ -15,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type authMapCache struct {

--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -6,7 +6,6 @@ package auth
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/manager"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type authMapGarbageCollector struct {

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -6,7 +6,6 @@ package auth
 import (
 	"fmt"
 	"runtime/pprof"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -23,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/signal"
 	"github.com/cilium/cilium/pkg/stream"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Cell provides AuthManager which is responsible for request authentication.

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -6,7 +6,6 @@ package auth
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // signalAuthKey used in the signalmap. Must reflect struct auth_key in the datapath

--- a/pkg/auth/mutual_authhandler.go
+++ b/pkg/auth/mutual_authhandler.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"net"
 	"strconv"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -25,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type endpointGetter interface {

--- a/pkg/auth/spire/delegate.go
+++ b/pkg/auth/spire/delegate.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
 	spiffeTypes "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
@@ -27,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type SpireDelegateClient struct {

--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/cilium/cilium/pkg/api/helpers"
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipam/service/ipallocator"
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"

--- a/pkg/aws/eni/eni_gc.go
+++ b/pkg/aws/eni/eni_gc.go
@@ -6,10 +6,10 @@ package eni
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/ipam/types"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const gcENIControllerName = "ipam-eni-gc"

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -7,7 +7,6 @@ package eni
 
 import (
 	"context"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -17,6 +16,7 @@ import (
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // EC2API is the API surface used of the EC2 API

--- a/pkg/azure/ipam/instances.go
+++ b/pkg/azure/ipam/instances.go
@@ -5,7 +5,6 @@ package ipam
 
 import (
 	"context"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -13,6 +12,7 @@ import (
 	ipamTypes "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // AzureAPI is the API surface used of the Azure API

--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -15,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/rand"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/bgpv1/gobgp/conversions.go
+++ b/pkg/bgpv1/gobgp/conversions.go
@@ -6,7 +6,6 @@ package gobgp
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	gobgp "github.com/osrg/gobgp/v3/api"
 	"github.com/osrg/gobgp/v3/pkg/apiutil"
@@ -14,6 +13,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/cilium/cilium/pkg/bgpv1/types"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // ToGoBGPPath converts the Agent Path type to the GoBGP Path type

--- a/pkg/bgpv1/gobgp/state.go
+++ b/pkg/bgpv1/gobgp/state.go
@@ -6,11 +6,11 @@ package gobgp
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/time"
 
 	gobgp "github.com/osrg/gobgp/v3/api"
 )

--- a/pkg/bpf/events.go
+++ b/pkg/bpf/events.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/cilium/cilium/pkg/container"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Action describes an action for map buffer events.

--- a/pkg/bpf/map.go
+++ b/pkg/bpf/map.go
@@ -5,9 +5,9 @@ package bpf
 
 import (
 	"regexp"
-	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -14,7 +14,6 @@ import (
 	"path"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/sirupsen/logrus"
@@ -26,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/bpf/stats_linux.go
+++ b/pkg/bpf/stats_linux.go
@@ -6,7 +6,7 @@
 package bpf
 
 import (
-	"time"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // DumpStats tracks statistics over the dump of a map.

--- a/pkg/command/exec/exec.go
+++ b/pkg/command/exec/exec.go
@@ -10,9 +10,10 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func warnToLog(cmd *exec.Cmd, out []byte, scopedLog *logrus.Entry, err error) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -6,7 +6,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -14,6 +13,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/crypto/certloader/watcher.go
+++ b/pkg/crypto/certloader/watcher.go
@@ -5,13 +5,13 @@ package certloader
 
 import (
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/fswatcher"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const watcherEventCoalesceWindow = 100 * time.Millisecond

--- a/pkg/datapath/agentliveness/agent_liveness.go
+++ b/pkg/datapath/agentliveness/agent_liveness.go
@@ -7,13 +7,13 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/maps/configmap"
+	"github.com/cilium/cilium/pkg/time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -4,8 +4,6 @@
 package fake
 
 import (
-	"time"
-
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -13,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/authmap"
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
+	"github.com/cilium/cilium/pkg/time"
 
 	fakeauthmap "github.com/cilium/cilium/pkg/maps/authmap/fake"
 	fakesignalmap "github.com/cilium/cilium/pkg/maps/signalmap/fake"

--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/mattn/go-shellwords"
@@ -37,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
 

--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/netip"
 	"runtime/pprof"
-	"time"
 
 	"github.com/cilium/cilium/pkg/datapath/garp"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -19,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/maps/l2respondermap"
 	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/types"
 
 	"github.com/sirupsen/logrus"

--- a/pkg/datapath/link/link.go
+++ b/pkg/datapath/link/link.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -12,7 +12,6 @@ import (
 	"net/netip"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -33,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // DevicesControllerCell registers a controller that subscribes to network devices

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
@@ -35,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/nodediscovery"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/resiliency"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type IPSecDir string

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -14,7 +14,6 @@ import (
 	"path/filepath"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -40,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/node/types"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/datapath/linux/route/route_linux.go
+++ b/pkg/datapath/linux/route/route_linux.go
@@ -9,12 +9,12 @@ import (
 	"fmt"
 	"net"
 	"sort"
-	"time"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/datapath/linux/utime/cell.go
+++ b/pkg/datapath/linux/utime/cell.go
@@ -6,12 +6,12 @@ package utime
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/maps/configmap"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/datapath/linux/utime/utime.go
+++ b/pkg/datapath/linux/utime/utime.go
@@ -8,11 +8,11 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"time"
 
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/maps/configmap"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sys/unix"
@@ -24,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const qdiscClsact = "clsact"

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -178,6 +178,10 @@ const (
 	// ExecTimeout is a timeout for executing commands.
 	ExecTimeout = 300 * time.Second
 
+	// MaxInternalTimerDelay does not enforce a maximum on timer values in
+	// the agent by default.
+	MaxInternalTimerDelay = 0 * time.Second
+
 	// StatusCollectorInterval is the interval between a probe invocations
 	StatusCollectorInterval = 5 * time.Second
 

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -35,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/egressmap"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/google/renameio/v2"
 	"github.com/sirupsen/logrus"
@@ -37,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
 )
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -57,6 +56,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 	"github.com/cilium/cilium/pkg/types"
 )

--- a/pkg/endpoint/endpoint_status.go
+++ b/pkg/endpoint/endpoint_status.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/identity"
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // StatusNA is value of fields in the output of 'kubectl get cep' in case of disabled "--endpoint-status"

--- a/pkg/endpoint/fqdn.go
+++ b/pkg/endpoint/fqdn.go
@@ -5,7 +5,8 @@ package endpoint
 
 import (
 	"net/netip"
-	"time"
+
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const logSubsys = "fqdn"

--- a/pkg/endpoint/metrics.go
+++ b/pkg/endpoint/metrics.go
@@ -4,14 +4,13 @@
 package endpoint
 
 import (
-	"time"
-
 	"github.com/cilium/cilium/api/v1/models"
 	loaderMetrics "github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var endpointPolicyStatus endpointPolicyStatusMap

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/sirupsen/logrus"
@@ -36,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )

--- a/pkg/endpoint/regenerator.go
+++ b/pkg/endpoint/regenerator.go
@@ -6,7 +6,6 @@ package endpoint
 import (
 	"context"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
@@ -14,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/clustermesh"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/mac"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/endpoint/status.go
+++ b/pkg/endpoint/status.go
@@ -5,10 +5,10 @@ package endpoint
 
 import (
 	"sort"
-	"time"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type StatusCode int

--- a/pkg/endpoint/test_utils.go
+++ b/pkg/endpoint/test_utils.go
@@ -4,9 +4,8 @@
 package endpoint
 
 import (
-	"time"
-
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // WaitForIdentity waits for up to timeoutDuration amount of time for the

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"net/netip"
 	"sync"
-	"time"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
@@ -20,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Cell provides the EndpointManager which maintains the collection of locally

--- a/pkg/endpointmanager/config.go
+++ b/pkg/endpointmanager/config.go
@@ -4,11 +4,10 @@
 package endpointmanager
 
 import (
-	"time"
-
 	"github.com/spf13/pflag"
 
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type EndpointManagerConfig struct {

--- a/pkg/endpointmanager/endpointsynchronizer.go
+++ b/pkg/endpointmanager/endpointsynchronizer.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
@@ -29,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net/netip"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/endpointmanager/policymap_pressure.go
+++ b/pkg/endpointmanager/policymap_pressure.go
@@ -5,12 +5,12 @@ package endpointmanager
 
 import (
 	"sync/atomic"
-	"time"
 
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"syscall"
-	"time"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
@@ -24,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/proxy/logger"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type AccessLogServer struct {

--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -6,7 +6,6 @@ package envoy
 import (
 	"context"
 	"fmt"
-	"time"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_cluster "github.com/cilium/proxy/go/envoy/config/cluster/v3"
@@ -27,6 +26,7 @@ import (
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const anyPort = "*"

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/cilium/lumberjack/v2"
 	cilium "github.com/cilium/proxy/go/cilium/api"
@@ -34,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "envoy-manager")

--- a/pkg/envoy/versioncheck.go
+++ b/pkg/envoy/versioncheck.go
@@ -7,7 +7,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
+
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // requiredEnvoyVersionSHA is set during build

--- a/pkg/envoy/xds/stream.go
+++ b/pkg/envoy/xds/stream.go
@@ -7,9 +7,10 @@ import (
 	"context"
 	"errors"
 	"io"
-	"time"
 
 	envoy_service_discovery "github.com/cilium/proxy/go/envoy/service/discovery/v3"
+
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Stream is the subset of the gRPC bi-directional stream types which is used

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -9,7 +9,6 @@ import (
 	"net/netip"
 	"regexp"
 	"sort"
-	"time"
 	"unsafe"
 
 	"github.com/cilium/cilium/pkg/fqdn/matchpattern"
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/slices"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // cacheEntry objects hold data passed in via DNSCache.Update, nominally

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"sync/atomic"
 	"syscall"
-	"time"
 
 	"github.com/cilium/dns"
 	"github.com/sirupsen/logrus"
@@ -37,6 +36,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/fqdn/name_manager.go
+++ b/pkg/fqdn/name_manager.go
@@ -9,7 +9,6 @@ import (
 	"net/netip"
 	"regexp"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // NameManager maintains state DNS names, via FQDNSelector or exact match for

--- a/pkg/hubble/container/ring.go
+++ b/pkg/hubble/container/ring.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"strings"
 	"sync/atomic"
-	"time"
 	"unsafe"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -19,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/math"
 	"github.com/cilium/cilium/pkg/hubble/metrics"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Capacity is the interface that wraps Cap.

--- a/pkg/hubble/metrics/http/handler.go
+++ b/pkg/hubble/metrics/http/handler.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type httpHandler struct {

--- a/pkg/hubble/metrics/kafka/handler.go
+++ b/pkg/hubble/metrics/kafka/handler.go
@@ -5,12 +5,12 @@ package kafka
 
 import (
 	"context"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type kafkaHandler struct {

--- a/pkg/hubble/metrics/metrics.go
+++ b/pkg/hubble/metrics/metrics.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,6 +28,7 @@ import (
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/port-distribution" // invoke init
 	_ "github.com/cilium/cilium/pkg/hubble/metrics/tcp"               // invoke init
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type PodDeletionHandler struct {

--- a/pkg/hubble/monitor/consumer.go
+++ b/pkg/hubble/monitor/consumer.go
@@ -5,7 +5,6 @@ package monitor
 
 import (
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -17,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	monitorConsumer "github.com/cilium/cilium/pkg/monitor/agent/consumer"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Observer is the receiver of MonitorEvents

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
@@ -29,6 +28,7 @@ import (
 	parserErrors "github.com/cilium/cilium/pkg/hubble/parser/errors"
 	"github.com/cilium/cilium/pkg/hubble/parser/fieldmask"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // DefaultOptions to include in the server. Other packages may extend this

--- a/pkg/hubble/observer/namespace_manager.go
+++ b/pkg/hubble/observer/namespace_manager.go
@@ -6,10 +6,10 @@ package observer
 import (
 	"context"
 	"sort"
-	"time"
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var _ NamespaceManager = &namespaceManager{}

--- a/pkg/hubble/parser/agent/parser.go
+++ b/pkg/hubble/parser/agent/parser.go
@@ -6,13 +6,13 @@ package agent
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func notifyTimeNotificationToProto(typ flowpb.AgentEventType, n monitorAPI.TimeNotification) *flowpb.AgentEvent {

--- a/pkg/hubble/parser/seven/http.go
+++ b/pkg/hubble/parser/seven/http.go
@@ -8,12 +8,12 @@ import (
 	"net/url"
 	"sort"
 	"strings"
-	"time"
 
 	flowpb "github.com/cilium/cilium/api/v1/flow"
 	"github.com/cilium/cilium/pkg/hubble/defaults"
 	"github.com/cilium/cilium/pkg/hubble/parser/options"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func decodeHTTP(flowType accesslog.FlowType, http *accesslog.LogRecordHTTP, opts *options.Options) *flowpb.Layer7_Http {

--- a/pkg/hubble/parser/seven/parser.go
+++ b/pkg/hubble/parser/seven/parser.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/netip"
 	"sort"
-	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/sirupsen/logrus"
@@ -21,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 

--- a/pkg/hubble/peer/types/client.go
+++ b/pkg/hubble/peer/types/client.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"io"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -16,6 +15,7 @@ import (
 	peerpb "github.com/cilium/cilium/api/v1/peer"
 	"github.com/cilium/cilium/pkg/crypto/certloader"
 	hubbleopts "github.com/cilium/cilium/pkg/hubble/server/serveroption"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Client defines an interface that Peer service client should implement.

--- a/pkg/hubble/recorder/pcap/pcap.go
+++ b/pkg/hubble/recorder/pcap/pcap.go
@@ -6,9 +6,9 @@ package pcap
 import (
 	"io"
 	"net"
-	"time"
 
 	"github.com/cilium/cilium/pkg/byteorder"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Datalink defines the type of the first layer of the captured packet

--- a/pkg/hubble/recorder/service.go
+++ b/pkg/hubble/recorder/service.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -27,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/recorder"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 

--- a/pkg/hubble/recorder/sink/dispatch.go
+++ b/pkg/hubble/recorder/sink/dispatch.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"runtime"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -19,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "recorder-sink")

--- a/pkg/hubble/recorder/sink/sink.go
+++ b/pkg/hubble/recorder/sink/sink.go
@@ -5,10 +5,10 @@ package sink
 
 import (
 	"context"
-	"time"
 
 	"github.com/cilium/cilium/pkg/hubble/recorder/pcap"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // sink wraps a pcap.RecordWriter by adding a queue and managing its statistics

--- a/pkg/hubble/relay/observer/observer.go
+++ b/pkg/hubble/relay/observer/observer.go
@@ -6,7 +6,6 @@ package observer
 import (
 	"context"
 	"io"
-	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
@@ -19,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/relay/queue"
 	"github.com/cilium/cilium/pkg/inctimer"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func isAvailable(conn poolTypes.ClientConn) bool {

--- a/pkg/hubble/relay/observer/option.go
+++ b/pkg/hubble/relay/observer/option.go
@@ -5,7 +5,6 @@ package observer
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -15,6 +14,7 @@ import (
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type observerClientBuilder interface {

--- a/pkg/hubble/relay/pool/backoff.go
+++ b/pkg/hubble/relay/pool/backoff.go
@@ -4,7 +4,7 @@
 package pool
 
 import (
-	"time"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // BackoffDuration wraps Duration.

--- a/pkg/hubble/relay/pool/client.go
+++ b/pkg/hubble/relay/pool/client.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -16,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/crypto/certloader"
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	hubbleopts "github.com/cilium/cilium/pkg/hubble/server/serveroption"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // GRPCClientConnBuilder is a generic ClientConnBuilder implementation.

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -18,6 +17,7 @@ import (
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type peer struct {

--- a/pkg/hubble/relay/pool/option.go
+++ b/pkg/hubble/relay/pool/option.go
@@ -4,8 +4,6 @@
 package pool
 
 import (
-	"time"
-
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -16,6 +14,7 @@ import (
 	poolTypes "github.com/cilium/cilium/pkg/hubble/relay/pool/types"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // defaultOptions is the reference point for default values.

--- a/pkg/hubble/relay/queue/priority_queue.go
+++ b/pkg/hubble/relay/queue/priority_queue.go
@@ -5,9 +5,9 @@ package queue
 
 import (
 	"container/heap"
-	"time"
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // PriorityQueue is a priority queue of observerpb.GetFlowsResponse. It

--- a/pkg/hubble/relay/server/option.go
+++ b/pkg/hubble/relay/server/option.go
@@ -5,7 +5,6 @@ package server
 
 import (
 	"crypto/tls"
-	"time"
 
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/sirupsen/logrus"
@@ -16,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/relay/observer"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // MinTLSVersion defines the minimum TLS version clients are expected to

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -8,12 +8,12 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/ipam/allocator/multipool/node_handler.go
+++ b/pkg/ipam/allocator/multipool/node_handler.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -17,6 +16,7 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type NodeHandler struct {

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cilium/cilium/pkg/ipam/allocator/clusterpool/cidralloc"
-
 	"github.com/sirupsen/logrus"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -19,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	ipPkg "github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/ipam/allocator/clusterpool/cidralloc"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"

--- a/pkg/ipam/allocator/podcidr/podcidr.go
+++ b/pkg/ipam/allocator/podcidr/podcidr.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/ipam/allocator/provider.go
+++ b/pkg/ipam/allocator/provider.go
@@ -5,10 +5,10 @@ package allocator
 
 import (
 	"context"
-	"time"
 
 	"github.com/cilium/cilium/pkg/ipam"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // AllocatorProvider defines the functions of IPAM provider front-end

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -11,7 +11,6 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
@@ -34,6 +33,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/ipam/crd_eni.go
+++ b/pkg/ipam/crd_eni.go
@@ -7,13 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"time"
 
 	eniTypes "github.com/cilium/cilium/pkg/aws/eni/types"
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/defaults"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -4,11 +4,10 @@
 package metrics
 
 import (
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/cilium/operator/metrics"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -10,7 +10,6 @@ import (
 	"slices"
 	"sort"
 	"strconv"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -8,7 +8,6 @@ package ipam
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/cache"
@@ -25,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/math"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/semaphore"
@@ -21,6 +20,7 @@ import (
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/ipam/service/allocator/bitmap.go
+++ b/pkg/ipam/service/allocator/bitmap.go
@@ -7,10 +7,10 @@ package allocator
 import (
 	"errors"
 	"math/big"
-	"time"
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/rand"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // AllocationBitmap is a contiguous block of resources that can be allocated atomically.

--- a/pkg/ipcache/gc.go
+++ b/pkg/ipcache/gc.go
@@ -6,13 +6,13 @@ package ipcache
 import (
 	"context"
 	"net/netip"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"net/netip"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -24,6 +23,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/types"
 )
 

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/netip"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/k8s/apis/crdhelpers/register.go
+++ b/pkg/k8s/apis/crdhelpers/register.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	goerrors "errors"
 	"fmt"
-	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
@@ -20,6 +19,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
 

--- a/pkg/k8s/ccnpstatus.go
+++ b/pkg/k8s/ccnpstatus.go
@@ -5,12 +5,12 @@ package k8s
 
 import (
 	"path"
-	"time"
 
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // CCNPStatusesPath is the KVStore key prefix for CCNP status

--- a/pkg/k8s/cnp.go
+++ b/pkg/k8s/cnp.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"path"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -27,6 +26,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // CNPStatusUpdateContext is the context required to update the status of a

--- a/pkg/k8s/cnpstatus.go
+++ b/pkg/k8s/cnpstatus.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
@@ -21,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // CNPStatusEventHandler handles status updates events for all CNPs in the

--- a/pkg/k8s/error_helpers.go
+++ b/pkg/k8s/error_helpers.go
@@ -5,9 +5,9 @@ package k8s
 
 import (
 	"strings"
-	"time"
 
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/k8s/informer/informer.go
+++ b/pkg/k8s/informer/informer.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	utilRuntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "k8s")

--- a/pkg/k8s/metrics/metrics.go
+++ b/pkg/k8s/metrics/metrics.go
@@ -4,9 +4,8 @@
 package metrics
 
 import (
-	"time"
-
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/k8s/resource/example/main.go
+++ b/pkg/k8s/resource/example/main.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"time"
 
 	"github.com/cilium/workerpool"
 	"github.com/spf13/pflag"
@@ -22,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // PrintServices for the pkg/k8s/resource which observers pods and services and once a second prints the list of

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -8,7 +8,6 @@ package synced
 import (
 	"context"
 	"errors"
-	"time"
 
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +25,7 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/k8s/synced/resources.go
+++ b/pkg/k8s/synced/resources.go
@@ -5,13 +5,13 @@ package synced
 
 import (
 	"fmt"
-	"time"
 
 	"golang.org/x/sync/errgroup"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Resources maps resource names to channels that are closed upon initial

--- a/pkg/k8s/watchers/cilium_cidr_group.go
+++ b/pkg/k8s/watchers/cilium_cidr_group.go
@@ -6,7 +6,6 @@ package watchers
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/policy/api"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 func (k *K8sWatcher) onUpsertCIDRGroup(

--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
@@ -4,8 +4,6 @@
 package watchers
 
 import (
-	"time"
-
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/endpoint"
@@ -15,6 +13,7 @@ import (
 	k8sUtils "github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type endpointWatcher interface {

--- a/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
+++ b/pkg/k8s/watchers/cilium_endpoint_slice_subscriber.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/endpoint"
-
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/types"

--- a/pkg/k8s/watchers/cilium_network_policy.go
+++ b/pkg/k8s/watchers/cilium_network_policy.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var syncCNPStatusControllerGroup = controller.NewGroup("sync-cnp-policy-status")

--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -58,6 +57,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 	ciliumTypes "github.com/cilium/cilium/pkg/types"
 	"github.com/cilium/cilium/pkg/u8proto"
 )

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -54,6 +53,7 @@ import (
 	"github.com/cilium/cilium/pkg/redirectpolicy"
 	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/kvstore/backend.go
+++ b/pkg/kvstore/backend.go
@@ -5,9 +5,10 @@ package kvstore
 
 import (
 	"context"
-	"time"
 
 	"google.golang.org/grpc"
+
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type backendOption struct {

--- a/pkg/kvstore/cell.go
+++ b/pkg/kvstore/cell.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/spf13/pflag"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Cell returns a cell which provides a promise for the global kvstore client.

--- a/pkg/kvstore/client.go
+++ b/pkg/kvstore/client.go
@@ -6,9 +6,9 @@ package kvstore
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/kvstore/consul.go
+++ b/pkg/kvstore/consul.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	consulAPI "github.com/hashicorp/consul/api"
 	"github.com/sirupsen/logrus"
@@ -23,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/kvstore/dummy.go
+++ b/pkg/kvstore/dummy.go
@@ -6,9 +6,9 @@ package kvstore
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // SetupDummy sets up kvstore for tests. A lock mechanism it used to prevent

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/sirupsen/logrus"
@@ -41,6 +40,7 @@ import (
 	ciliumrate "github.com/cilium/cilium/pkg/rate"
 	ciliumratemetrics "github.com/cilium/cilium/pkg/rate/metrics"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/versioncheck"
 )
 

--- a/pkg/kvstore/etcd_lease.go
+++ b/pkg/kvstore/etcd_lease.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	v3rpcErrors "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // etcdLeaseClient represents the subset of the etcd client methods used to handle the leases lifecycle.

--- a/pkg/kvstore/heartbeat/heartbeat.go
+++ b/pkg/kvstore/heartbeat/heartbeat.go
@@ -5,13 +5,13 @@ package heartbeat
 
 import (
 	"context"
-	"time"
 
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "kvstore-heartbeat")

--- a/pkg/kvstore/kvstore.go
+++ b/pkg/kvstore/kvstore.go
@@ -5,7 +5,8 @@ package kvstore
 
 import (
 	"strings"
-	"time"
+
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Value is an abstraction of the data stored in the kvstore as well as the

--- a/pkg/kvstore/lock.go
+++ b/pkg/kvstore/lock.go
@@ -6,7 +6,6 @@ package kvstore
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
@@ -16,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/kvstore/metrics.go
+++ b/pkg/kvstore/metrics.go
@@ -6,9 +6,9 @@ package kvstore
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/kvstore/store/store.go
+++ b/pkg/kvstore/store/store.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/kvstore/store/syncstore.go
+++ b/pkg/kvstore/store/syncstore.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -20,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // SyncStore abstracts the operations allowing to synchronize key/value pairs

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -14,7 +14,6 @@ import (
 	"runtime/pprof"
 	"slices"
 	"strings"
-	"time"
 
 	daemon_k8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/datapath/tables"
@@ -33,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"

--- a/pkg/maps/bwmap/bwmap.go
+++ b/pkg/maps/bwmap/bwmap.go
@@ -6,12 +6,12 @@ package bwmap
 import (
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/ebpf"
 	"github.com/cilium/cilium/pkg/maps/lxcmap"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -27,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/nat"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/tuple"
 	"github.com/cilium/cilium/pkg/u8proto"
 )

--- a/pkg/maps/ctmap/gc/gc.go
+++ b/pkg/maps/ctmap/gc/gc.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/netip"
 	"os"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type Enabler interface {

--- a/pkg/maps/signalmap/fake/signalmap.go
+++ b/pkg/maps/signalmap/fake/signalmap.go
@@ -5,12 +5,12 @@ package fake
 
 import (
 	"os"
-	"time"
 
 	"github.com/cilium/ebpf/perf"
 
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/maps/signalmap"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type fakeSignalMap struct {

--- a/pkg/metrics/bpf.go
+++ b/pkg/metrics/bpf.go
@@ -8,10 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type bpfCollector struct {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -12,7 +12,6 @@ package metrics
 
 import (
 	"context"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
@@ -21,6 +20,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/promise"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
 )
 

--- a/pkg/monitor/agent/agent.go
+++ b/pkg/monitor/agent/agent.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/perf"
@@ -26,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/monitor/agent/listener"
 	"github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/monitor/payload"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // isCtxDone is a utility function that returns true when the context's Done()

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -4,14 +4,13 @@
 package manager
 
 import (
-	"time"
-
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // Cell provides the NodeManager, which manages information about Cilium nodes

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
-	"time"
 
 	"slices"
 
@@ -38,6 +37,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/node/store/store.go
+++ b/pkg/node/store/store.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"time"
 
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -15,6 +14,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/nodediscovery/nodediscovery.go
+++ b/pkg/nodediscovery/nodediscovery.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,6 +40,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 	cnitypes "github.com/cilium/cilium/plugins/cilium-cni/types"
 )
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -18,7 +18,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/shirou/gopsutil/v3/mem"
 	"github.com/sirupsen/logrus"
@@ -40,6 +39,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/mac"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
 )
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -532,6 +532,10 @@ const (
 	// compatible with Tunnel=TunnelDisabled
 	SingleClusterRouteName = "single-cluster-route"
 
+	// MaxInternalTimerDelay sets a maximum on all periodic timers in
+	// the agent in order to flush out timer-related bugs in the agent.
+	MaxInternalTimerDelay = "max-internal-timer-delay"
+
 	// MonitorAggregationName specifies the MonitorAggregationLevel on the
 	// comandline.
 	MonitorAggregationName = "monitor-aggregation"
@@ -1556,6 +1560,10 @@ type DaemonConfig struct {
 	CTMapEntriesTimeoutSVCAny      time.Duration
 	CTMapEntriesTimeoutSYN         time.Duration
 	CTMapEntriesTimeoutFIN         time.Duration
+
+	// MaxInternalTimerDelay sets a maximum on all periodic timers in
+	// the agent in order to flush out timer-related bugs in the agent.
+	MaxInternalTimerDelay time.Duration
 
 	// MonitorAggregationInterval configures the interval between monitor
 	// messages when monitor aggregation is enabled.

--- a/pkg/option/resolver/resolver.go
+++ b/pkg/option/resolver/resolver.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +26,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/policy/config.go
+++ b/pkg/policy/config.go
@@ -4,14 +4,13 @@
 package policy
 
 import (
-	"time"
-
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/source"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/policy/trigger.go
+++ b/pkg/policy/trigger.go
@@ -6,11 +6,11 @@ package policy
 import (
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/trigger"
 )
 

--- a/pkg/proxy/logger/logger.go
+++ b/pkg/proxy/logger/logger.go
@@ -6,7 +6,6 @@ package logger
 import (
 	"net"
 	"strconv"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -6,7 +6,6 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy/types"
 	"github.com/cilium/cilium/pkg/rand"
 	"github.com/cilium/cilium/pkg/revert"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/rate/api_limiter.go
+++ b/pkg/rate/api_limiter.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -19,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "rate")

--- a/pkg/safetime/safetime.go
+++ b/pkg/safetime/safetime.go
@@ -5,11 +5,11 @@ package safetime
 
 import (
 	"runtime"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // TimeSinceSafe returns the duration since t. If the duration is negative,

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -10,7 +10,6 @@ import (
 	"net/netip"
 	"strconv"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -36,6 +35,7 @@ import (
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/service/healthserver"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const anyPort = "*"

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -4,12 +4,11 @@
 package service
 
 import (
-	"time"
-
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // ServiceManager provides an interface for service related operations.

--- a/pkg/spanstat/spanstat.go
+++ b/pkg/spanstat/spanstat.go
@@ -4,12 +4,11 @@
 package spanstat
 
 import (
-	"time"
-
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/safetime"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var (

--- a/pkg/statedb/db.go
+++ b/pkg/statedb/db.go
@@ -9,13 +9,13 @@ import (
 	"runtime"
 	"strings"
 	"sync/atomic"
-	"time"
 
 	iradix "github.com/hashicorp/go-immutable-radix/v2"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // DB provides an in-memory transaction database built on top of immutable radix

--- a/pkg/statedb/example/control.go
+++ b/pkg/statedb/example/control.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"math/rand"
 	"net/netip"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
@@ -16,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var controlCell = cell.Module(

--- a/pkg/statedb/example/main.go
+++ b/pkg/statedb/example/main.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var Hive = hive.New(

--- a/pkg/statedb/example/reconcile.go
+++ b/pkg/statedb/example/reconcile.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -18,6 +17,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/job"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 var reconcilerCell = cell.Module(

--- a/pkg/statedb/graveyard.go
+++ b/pkg/statedb/graveyard.go
@@ -5,13 +5,13 @@ package statedb
 
 import (
 	"context"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"golang.org/x/exp/maps"
 
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/spanstat"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/statedb/txn.go
+++ b/pkg/statedb/txn.go
@@ -9,12 +9,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"time"
 
 	iradix "github.com/hashicorp/go-immutable-radix/v2"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 type txn struct {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"runtime/pprof"
 	"sync/atomic"
-	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 const (

--- a/pkg/stream/operators.go
+++ b/pkg/stream/operators.go
@@ -5,9 +5,10 @@ package stream
 
 import (
 	"context"
-	"time"
 
 	"golang.org/x/time/rate"
+
+	"github.com/cilium/cilium/pkg/time"
 )
 
 //

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -41,16 +41,12 @@ const (
 )
 
 var (
-	After                  = time.After
-	Sleep                  = time.Sleep
-	Tick                   = time.Tick
 	ParseDuration          = time.ParseDuration
 	Since                  = time.Since
 	Until                  = time.Until
 	FixedZone              = time.FixedZone
 	LoadLocation           = time.LoadLocation
 	LoadLocationFromTZData = time.LoadLocationFromTZData
-	NewTicker              = time.NewTicker
 	Date                   = time.Date
 	Now                    = time.Now
 	Parse                  = time.Parse
@@ -58,8 +54,6 @@ var (
 	Unix                   = time.Unix
 	UnixMicro              = time.UnixMicro
 	UnixMilli              = time.UnixMilli
-	AfterFunc              = time.AfterFunc
-	NewTimer               = time.NewTimer
 )
 
 type (
@@ -72,3 +66,58 @@ type (
 	Timer      = time.Timer
 	Weekday    = time.Weekday
 )
+
+var (
+	MaxInternalTimerDelay time.Duration
+)
+
+// After overrides the stdlib time.After to enforce maximum sleepiness via
+// option.MaxInternalTimerDelay.
+func After(d Duration) <-chan Time {
+	if MaxInternalTimerDelay > 0 && d > MaxInternalTimerDelay {
+		d = MaxInternalTimerDelay
+	}
+	return time.After(d)
+}
+
+// Sleep overrides the stdlib time.Sleep to enforce maximum sleepiness via
+// option.MaxInternalTimerDelay.
+func Sleep(d time.Duration) {
+	if MaxInternalTimerDelay > 0 && d > MaxInternalTimerDelay {
+		d = MaxInternalTimerDelay
+	}
+	time.Sleep(d)
+}
+
+// Tick overrides the stdlib time.Tick to enforce maximum sleepiness via
+// option.MaxInternalTimerDelay.
+func Tick(d Duration) <-chan time.Time {
+	return NewTicker(d).C
+}
+
+// NewTicker overrides the stdlib time.NewTicker to enforce maximum sleepiness
+// via option.MaxInternalTimerDelay.
+func NewTicker(d Duration) *time.Ticker {
+	if MaxInternalTimerDelay > 0 && d > MaxInternalTimerDelay {
+		d = MaxInternalTimerDelay
+	}
+	return time.NewTicker(d)
+}
+
+// NewTimer overrides the stdlib time.NewTimer to enforce maximum sleepiness
+// va option.MaxInternalTimerDelay.
+func NewTimer(d Duration) *time.Timer {
+	if MaxInternalTimerDelay > 0 && d > MaxInternalTimerDelay {
+		d = MaxInternalTimerDelay
+	}
+	return time.NewTimer(d)
+}
+
+// AfterFunc overrides the stdlib time.AfterFunc to enforce maximum sleepiness
+// via option.MaxInternalTimerDelay.
+func AfterFunc(d Duration, f func()) *time.Timer {
+	if MaxInternalTimerDelay > 0 && d > MaxInternalTimerDelay {
+		d = MaxInternalTimerDelay
+	}
+	return time.AfterFunc(d, f)
+}

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// package time is a wrapper for the stdlib time library that aliases most
+// underlying types, but allows overrides for testing purposes.
+//
+// Synced to go-1.20.7.
+package time
+
+import (
+	"time"
+)
+
+const (
+	Layout      = time.Layout
+	ANSIC       = time.ANSIC
+	UnixDate    = time.UnixDate
+	RubyDate    = time.RubyDate
+	RFC822      = time.RFC822
+	RFC822Z     = time.RFC822Z
+	RFC850      = time.RFC850
+	RFC1123     = time.RFC1123
+	RFC1123Z    = time.RFC1123Z
+	RFC3339     = time.RFC3339
+	RFC3339Nano = time.RFC3339Nano
+	Kitchen     = time.Kitchen
+	Stamp       = time.Stamp
+	StampMilli  = time.StampMilli
+	StampMicro  = time.StampMicro
+	StampNano   = time.StampNano
+	DateTime    = time.DateTime
+	DateOnly    = time.DateOnly
+	TimeOnly    = time.TimeOnly
+
+	Nanosecond  = time.Nanosecond
+	Microsecond = time.Microsecond
+	Millisecond = time.Millisecond
+	Second      = time.Second
+	Minute      = time.Minute
+	Hour        = time.Hour
+)
+
+var (
+	After                  = time.After
+	Sleep                  = time.Sleep
+	Tick                   = time.Tick
+	ParseDuration          = time.ParseDuration
+	Since                  = time.Since
+	Until                  = time.Until
+	FixedZone              = time.FixedZone
+	LoadLocation           = time.LoadLocation
+	LoadLocationFromTZData = time.LoadLocationFromTZData
+	NewTicker              = time.NewTicker
+	Date                   = time.Date
+	Now                    = time.Now
+	Parse                  = time.Parse
+	ParseInLocation        = time.ParseInLocation
+	Unix                   = time.Unix
+	UnixMicro              = time.UnixMicro
+	UnixMilli              = time.UnixMilli
+	AfterFunc              = time.AfterFunc
+	NewTimer               = time.NewTimer
+)
+
+type (
+	Duration   = time.Duration
+	Location   = time.Location
+	Month      = time.Month
+	ParseError = time.ParseError
+	Ticker     = time.Ticker
+	Time       = time.Time
+	Timer      = time.Timer
+	Weekday    = time.Weekday
+)

--- a/pkg/trigger/trigger.go
+++ b/pkg/trigger/trigger.go
@@ -5,10 +5,10 @@ package trigger
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/time"
 )
 
 // MetricsObserver is the interface a metrics collector has to implement in

--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -122,6 +122,8 @@ var (
 		"ipv6NativeRoutingCIDR":  IPv6NativeRoutingCIDR,
 
 		"ipam.operator.clusterPoolIPv6PodCIDRList": "fd02::/112",
+
+		"extraConfig.max-internal-timer-delay": "5s",
 	}
 
 	eksChainingHelmOverrides = map[string]string{


### PR DESCRIPTION
Cilium's internal business logic relies on a highly parallel combination of reactive handlers for incoming information, "triggers" that ratelimit requests for processing to ensure Cilium does not over-consume resources, and "controllers" that periodically perform updates or resiliency checks of configured state. While in general most things are "eventually consistent", the presence of time-based triggers and controllers can introduce challenges when evaluating how Cilium will perform once the "eventual consistency" is resolved.

Taking an example of a situation where this eventual consistency caused issues that were not identified during pre-release testing, consider the issue fixed by https://github.com/cilium/cilium/pull/27327 . Cilium v1.14.0 was released with a bug where Cilium appeared to work correctly for the first several minutes following startup, then afterwards introduced connectivity disruption to specific peers. This was traced down to a logic delay tied to a 10 minute timer following startup which caused some state to be recomputed & configured in the system, ultimately causing the packet loss.

While better unit testing for the individual package could have caught this issue earlier, the issue was also triggered by the integration between the specific package and other logic in other packages. It is quite difficult to systematically identify time-based errors across the entire agent by relying purely on such testing in each package. This PR attempts to provide a more systematic safety net for timer-based issues by providing a hidden flag to override all timers within Cilium and ensuring that Cilium's CI runs with these timers set to a minimal value.

One of the interesting challenges with this PR is that it can be tempting for developers to rely on time-based tricks in order to ensure the execution order of specific pieces of logic. However, when the system is highly loaded, such mechanisms can become unreliable as an ordering enforcement mechanism. As a side-objective, this PR also hopes to make such tricks less viable on order to incentivize implementing better ordering mechanisms.

Review tips: The `treewide` commit has about 2/3 of the changes but is generated almost entirely from a script, so can be overlooked for initial review:
```
    treewide: Wrap time package with internal wrapper
...
178 files changed, 186 insertions(+), 191 deletions(-)
```

Related: https://github.com/cilium/cilium/issues/28844