### PR TITLE
Convert daemon identity restore logic over to newer IPCache APIs

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -104,6 +104,12 @@ func (f *FakeRefcountingIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context
 	}
 }
 
+func (f *FakeRefcountingIdentityAllocator) ReleaseCIDRs(ctx context.Context, prefixes []netip.Prefix) {
+	for _, prefix := range prefixes {
+		f.identityCount.Delete(int(f.ipToIdentity[prefix.Addr().String()]))
+	}
+}
+
 func (f *FakeRefcountingIdentityAllocator) IdentityReferenceCounter() counter.IntCounter {
 	return f.identityCount
 }

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -122,6 +122,15 @@ func (m *metadata) enqueuePrefixUpdates(prefixes ...netip.Prefix) {
 }
 
 func (m *metadata) upsertLocked(prefix netip.Prefix, src source.Source, resource types.ResourceID, info ...IPMetadata) {
+	if option.Config.Debug {
+		log.WithFields(logrus.Fields{
+			logfields.Prefix:   prefix,
+			logfields.Source:   src,
+			logfields.Resource: resource,
+			logfields.Value:    info,
+		}).Debug("Associating prefix to metadata")
+	}
+
 	if _, ok := m.m[prefix]; !ok {
 		m.m[prefix] = make(PrefixInfo)
 	}
@@ -615,6 +624,14 @@ func (m *metadata) filterByLabels(filter labels.Labels) []netip.Prefix {
 //
 // This function assumes that the ipcache metadata lock is held for writing.
 func (m *metadata) remove(prefix netip.Prefix, resource types.ResourceID, aux ...IPMetadata) {
+	if option.Config.Debug {
+		log.WithFields(logrus.Fields{
+			logfields.Prefix:   prefix,
+			logfields.Resource: resource,
+			logfields.Value:    aux,
+		}).Debug("Removing metadata association for prefix")
+	}
+
 	info, ok := m.m[prefix]
 	if !ok || info[resource] == nil {
 		return

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
 	"k8s.io/klog/v2"
 
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -274,4 +275,29 @@ func CanLogAt(logger *logrus.Logger, level logrus.Level) bool {
 // GetLevel returns the log level of the given logger.
 func GetLevel(logger *logrus.Logger) logrus.Level {
 	return logrus.Level(atomic.LoadUint32((*uint32)(&logger.Level)))
+}
+
+// SampleMap takes a limited sample of the entries in the specified map in
+// order to avoid spamming the logs with too much data. In general the goal
+// should be to avoid logging unbounded data into logs, however there may be
+// scenarios where a map is sufficient to provide some datapoints for
+// debugging. For a more comprehensive approach, users should consider exposing
+// the data separately, for instance via local agent APIs.
+func SampleMapKeys[K comparable, V any](m map[K]V) []K {
+	keys := maps.Keys(m)
+	return SampleSlice(keys)
+}
+
+// SampleSlice takes a limited sample of the entries in the specified slice
+// in order to avoid spamming the logs with too much data. In general the goal
+// should be to avoid logging unbounded data into logs, however there may be
+// scenarios where a slice is sufficient to provide some datapoints for
+// debugging. For a more comprehensive approach, users should consider exposing
+// the data separately, for instance via local agent APIs.
+func SampleSlice[C comparable](slice []C) []C {
+	n := len(slice)
+	if n < 10 {
+		return slice
+	}
+	return slice[:10]
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -277,7 +277,7 @@ func GetLevel(logger *logrus.Logger) logrus.Level {
 	return logrus.Level(atomic.LoadUint32((*uint32)(&logger.Level)))
 }
 
-// SampleMap takes a limited sample of the entries in the specified map in
+// SampleMapKeys takes a limited sample of the entries in the specified map in
 // order to avoid spamming the logs with too much data. In general the goal
 // should be to avoid logging unbounded data into logs, however there may be
 // scenarios where a map is sufficient to provide some datapoints for


### PR DESCRIPTION
This PR introduces logic to restore identity references into the name manager cache during startup and converts one of the older ipcache API users over to the newer async ipcache interface. The goal is to align more of the logic towards the new model for interacting with the ipcache, which should eventually result in a simpler codebase with fewer bugs.

Tasks:
- [x] Test the fixes using #27253
  - #27253 fails on its own against the main branch.
  - The final commit fix from this PR by itself also fails, but for a different test around ToFQDNs.
  - With all commits, this resolves the initial report as well as the hidden ToFQDNs reference tracking bug that was revealed through testing on top of #27253 .
- [x] Manual testing
- [x] Rebase against main
- [x] Create hotfix image for user testing
- [x] List all related filed issues
- [x] Investigate more surgical fix (https://github.com/cilium/cilium/pull/27327)
- [x] Review release note
- [ ] Review hard dependencies between identity restore and ipcache
- [ ] Review hard dependencies between ipcache and datapath
- [ ] Revisit whether each individual change is comprehensive enough to improve the tree
- [ ] Rewrite each commit message now that this is a code health change and not a bugfix

Related: https://github.com/cilium/cilium/pull/27327