### PR TITLE
Fix endpoint logger not formatting logs as JSON when daemon log format is set to JSON

### DIFF
--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -98,6 +98,11 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 	// default to a new default logger
 	baseLogger := logging.InitializeDefaultLogger()
 
+	// Set log format based on daemon config
+	baseLogger.SetFormatter(logging.GetFormatter(
+		logging.LogOptions(option.Config.LogOpt).GetLogFormat(),
+	))
+
 	// If this endpoint is set to debug ensure it will print debug by giving it
 	// an independent logger.
 	// If this endpoint is not set to debug, it will use the log level set by the user.

--- a/pkg/endpoint/log_test.go
+++ b/pkg/endpoint/log_test.go
@@ -17,6 +17,23 @@ import (
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
 
+func (s *EndpointSuite) TestEndpointLogFormat(c *C) {
+	// Default log format is text
+	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	ep := NewEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+
+	_, ok := ep.getLogger().Logger.Formatter.(*logrus.TextFormatter)
+	c.Assert(ok, Equals, true)
+
+	// Log format is JSON when configured
+	option.Config.LogOpt["format"] = "json"
+	do = &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
+	ep = NewEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+
+	_, ok = ep.getLogger().Logger.Formatter.(*logrus.JSONFormatter)
+	c.Assert(ok, Equals, true)
+}
+
 func (s *EndpointSuite) TestPolicyLog(c *C) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
 	ep := NewEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Use daemon log format config option when setting up individual endpoint loggers so that endpoint loggers use the same log format as the rest of the daemon.

Fixes: #26942

I added a test to check for the config. If tests like that are not desired, I can remove it.