### PR TITLE
bpf: xdp: remove unused XFER_ENCAP_* enums

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -67,11 +67,6 @@ enum {
 /* For use in ctx_get_xfer(), after XDP called ctx_move_xfer(). */
 enum {
 	XFER_FLAGS = 0,		/* XFER_PKT_* */
-	XFER_ENCAP_NODEID = 1,
-	XFER_ENCAP_SECLABEL = 2,
-	XFER_ENCAP_DSTID = 3,
-	XFER_ENCAP_PORT = 4,
-	XFER_ENCAP_ADDR = 5,
 };
 
 /* FIB errors from BPF neighbor map. */


### PR DESCRIPTION
These were used to transfer encap information from XDP to TC. They are no longer used since https://github.com/cilium/cilium/pull/24422 added support for in-XDP tunnel encapsulation.