### PR TITLE
datapath: Fix TestNodeChurnXFRMLeaks

### DIFF
--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -752,7 +752,6 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateIDs(c *check.C) {
 
 // Tests that we don't leak XFRM policies and states as nodes come and go.
 func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(c *check.C) {
-	externalNodeDevice := "ipsec_interface"
 
 	// Cover the XFRM configuration for IPAM modes cluster-pool, kubernetes, etc.
 	config := datapath.LocalNodeConfiguration{
@@ -760,7 +759,20 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeChurnXFRMLeaks(c *check.C) {
 		EnableIPv6:  s.enableIPv6,
 		EnableIPSec: true,
 	}
-	//s.testNodeChurnXFRMLeaksWithConfig(c, config)
+	s.testNodeChurnXFRMLeaksWithConfig(c, config)
+}
+
+// Tests the same as linuxPrivilegedBaseTestSuite.TestNodeChurnXFRMLeaks just
+// for the subnet encryption. IPv4-only because of https://github.com/cilium/cilium/issues/27280.
+func (s *linuxPrivilegedIPv4OnlyTestSuite) TestNodeChurnXFRMLeaks(c *check.C) {
+	externalNodeDevice := "ipsec_interface"
+
+	// Cover the XFRM configuration for IPAM modes cluster-pool, kubernetes, etc.
+	config := datapath.LocalNodeConfiguration{
+		EnableIPv4:  s.enableIPv4,
+		EnableIPSec: true,
+	}
+	s.testNodeChurnXFRMLeaksWithConfig(c, config)
 
 	// In the case of subnet encryption (tested below), the IPsec logic
 	// retrieves the IP address of the encryption interface directly so we need


### PR DESCRIPTION
This commit fixes the following issues:

* Missed enablement of the churn tests in the non-subnet mode.
* The subnet mode being broken when v4 and v6 enabled \[1\].

\[1\]: https://github.com/cilium/cilium/issues/27280

Fixes: 9207b7898 ("datapath: Cover subnet encryption in XFRM leak test")

Fix: #27268
 