### PR TITLE
maps: do not depend on global variable to initialize CT maps

### DIFF
--- a/cilium/cmd/bpf_ct.go
+++ b/cilium/cmd/bpf_ct.go
@@ -7,7 +7,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/maps/ctmap"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 // BPFCtCmd represents the bpf_ct command
@@ -17,6 +16,6 @@ var BPFCtCmd = &cobra.Command{
 }
 
 func init() {
-	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+	ctmap.InitMapInfo(true, true, true)
 	BPFCmd.AddCommand(BPFCtCmd)
 }

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -431,8 +431,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		return nil, nil, fmt.Errorf("unable to initialize kube-proxy replacement options: %w", err)
 	}
 
-	ctmap.InitMapInfo(option.Config.CTMapEntriesGlobalTCP, option.Config.CTMapEntriesGlobalAny,
-		option.Config.EnableIPv4, option.Config.EnableIPv6, option.Config.EnableNodePort)
+	ctmap.InitMapInfo(option.Config.EnableIPv4, option.Config.EnableIPv6, option.Config.EnableNodePort)
 	policymap.InitMapInfo(option.Config.PolicyMapEntries)
 
 	lbmapInitParams := lbmap.InitParams{

--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -21,7 +21,6 @@ import (
 	dpdef "github.com/cilium/cilium/pkg/datapath/linux/config/defines"
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
-	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -51,7 +50,6 @@ func setup(tb testing.TB) {
 	tb.Helper()
 
 	require.NoError(tb, rlimit.RemoveMemlock(), "Failed to remove memory limits")
-	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 
 	node.SetTestLocalNodeStore()
 	node.InitDefaultPrefix("")

--- a/pkg/datapath/loader/doc_test.go
+++ b/pkg/datapath/loader/doc_test.go
@@ -6,13 +6,10 @@ package loader
 import (
 	. "github.com/cilium/checkmate"
 
-	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 func (s *LoaderTestSuite) SetUpTest(c *C) {
-	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	node.InitDefaultPrefix("")
 	node.SetInternalIPv4Router(templateIPv4[:])
 	node.SetIPv4Loopback(templateIPv4[:])

--- a/pkg/datapath/loader/loader_test.go
+++ b/pkg/datapath/loader/loader_test.go
@@ -21,10 +21,8 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/loader/metrics"
 	"github.com/cilium/cilium/pkg/elf"
 	"github.com/cilium/cilium/pkg/maps/callsmap"
-	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 )
 
@@ -77,8 +75,6 @@ func (s *LoaderTestSuite) SetUpSuite(c *C) {
 		}
 		return os.RemoveAll(tmpDir)
 	}
-
-	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 
 	SetTestIncludes([]string{
 		fmt.Sprintf("-I%s", bpfDir),

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/maps/ctmap"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
@@ -66,7 +65,6 @@ var _ = Suite(&suite)
 func (s *EndpointSuite) SetUpSuite(c *C) {
 	testutils.IntegrationTest(c)
 
-	ctmap.InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
 	s.repo = policy.NewPolicyRepository(nil, nil, nil, nil)
 	// GetConfig the default labels prefix filter
 	err := labelsfilter.ParseLabelPrefixCfg(nil, "")

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/sirupsen/logrus"
 
@@ -99,15 +98,8 @@ const (
 )
 
 var globalDeleteLock [mapTypeMax]lock.Mutex
-var natMapsLock [mapTypeMax]*lock.Mutex
 
 type mapAttributes struct {
-	mapKey     bpf.MapKey
-	keySize    int
-	mapValue   bpf.MapValue
-	valueSize  int
-	maxEntries int
-	bpfDefine  string
 	natMapLock *lock.Mutex // Serializes concurrent accesses to natMap
 	natMap     *nat.Map
 }
@@ -130,77 +122,20 @@ type CtMapRecord struct {
 	Value CtEntry
 }
 
-func setupMapInfo(m mapType, define string, mapKey bpf.MapKey, keySize int, maxEntries int, nat *nat.Map) {
-	mapInfo[m] = mapAttributes{
-		bpfDefine: define,
-		mapKey:    mapKey,
-		keySize:   keySize,
-		// the value type is CtEntry for all CT maps
-		mapValue:   &CtEntry{},
-		valueSize:  SizeofCtEntry,
-		maxEntries: maxEntries,
-		natMapLock: natMapsLock[m],
-		natMap:     nat,
-	}
-}
-
 // InitMapInfo builds the information about different CT maps for the
-// combination of L3/L4 protocols, using the specified limits on TCP vs non-TCP
-// maps.
-func InitMapInfo(tcpMaxEntries, anyMaxEntries int, v4, v6, nodeport bool) {
-	mapInfo = make(map[mapType]mapAttributes, mapTypeMax)
-
+// combination of L3/L4 protocols.
+func InitMapInfo(v4, v6, nodeport bool) {
 	global4Map, global6Map := nat.GlobalMaps(v4, v6, nodeport)
-
-	// SNAT also only works if the CT map is global so all local maps will be nil
-	natMaps := map[mapType]*nat.Map{
-		mapTypeIPv4TCPLocal:  nil,
-		mapTypeIPv6TCPLocal:  nil,
-		mapTypeIPv4TCPGlobal: global4Map,
-		mapTypeIPv6TCPGlobal: global6Map,
-		mapTypeIPv4AnyLocal:  nil,
-		mapTypeIPv6AnyLocal:  nil,
-		mapTypeIPv4AnyGlobal: global4Map,
-		mapTypeIPv6AnyGlobal: global6Map,
-	}
 	global4MapLock := &lock.Mutex{}
 	global6MapLock := &lock.Mutex{}
-	natMapsLock[mapTypeIPv4TCPGlobal] = global4MapLock
-	natMapsLock[mapTypeIPv6TCPGlobal] = global6MapLock
-	natMapsLock[mapTypeIPv4AnyGlobal] = global4MapLock
-	natMapsLock[mapTypeIPv6AnyGlobal] = global6MapLock
 
-	setupMapInfo(mapTypeIPv4TCPLocal, "CT_MAP_TCP4",
-		&CtKey4{}, int(unsafe.Sizeof(CtKey4{})),
-		mapNumEntriesLocal, natMaps[mapTypeIPv4TCPLocal])
-
-	setupMapInfo(mapTypeIPv6TCPLocal, "CT_MAP_TCP6",
-		&CtKey6{}, int(unsafe.Sizeof(CtKey6{})),
-		mapNumEntriesLocal, natMaps[mapTypeIPv6TCPLocal])
-
-	setupMapInfo(mapTypeIPv4TCPGlobal, "CT_MAP_TCP4",
-		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
-		tcpMaxEntries, natMaps[mapTypeIPv4TCPGlobal])
-
-	setupMapInfo(mapTypeIPv6TCPGlobal, "CT_MAP_TCP6",
-		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
-		tcpMaxEntries, natMaps[mapTypeIPv6TCPGlobal])
-
-	setupMapInfo(mapTypeIPv4AnyLocal, "CT_MAP_ANY4",
-		&CtKey4{}, int(unsafe.Sizeof(CtKey4{})),
-		mapNumEntriesLocal, natMaps[mapTypeIPv4AnyLocal])
-
-	setupMapInfo(mapTypeIPv6AnyLocal, "CT_MAP_ANY6",
-		&CtKey6{}, int(unsafe.Sizeof(CtKey6{})),
-		mapNumEntriesLocal, natMaps[mapTypeIPv6AnyLocal])
-
-	setupMapInfo(mapTypeIPv4AnyGlobal, "CT_MAP_ANY4",
-		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
-		anyMaxEntries, natMaps[mapTypeIPv4AnyGlobal])
-
-	setupMapInfo(mapTypeIPv6AnyGlobal, "CT_MAP_ANY6",
-		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
-		anyMaxEntries, natMaps[mapTypeIPv6AnyGlobal])
+	// SNAT also only works if the CT map is global so all local maps will be nil
+	mapInfo = map[mapType]mapAttributes{
+		mapTypeIPv4TCPGlobal: {natMap: global4Map, natMapLock: global4MapLock},
+		mapTypeIPv6TCPGlobal: {natMap: global6Map, natMapLock: global6MapLock},
+		mapTypeIPv4AnyGlobal: {natMap: global4Map, natMapLock: global4MapLock},
+		mapTypeIPv6AnyGlobal: {natMap: global6Map, natMapLock: global6MapLock},
+	}
 }
 
 // CtEndpoint represents an endpoint for the functions required to manage
@@ -334,13 +269,13 @@ func newMap(mapName string, m mapType) *Map {
 	result := &Map{
 		Map: *bpf.NewMap(mapName,
 			ebpf.LRUHash,
-			mapInfo[m].mapKey,
-			mapInfo[m].mapValue,
-			mapInfo[m].maxEntries,
+			m.key(),
+			m.value(),
+			m.maxEntries(),
 			0,
 		),
 		mapType: m,
-		define:  mapInfo[m].bpfDefine,
+		define:  m.bpfDefine(),
 	}
 	return result
 }
@@ -809,9 +744,9 @@ func WriteBPFMacros(fw io.Writer, e CtEndpoint) {
 	for _, m := range maps(e, true, true) {
 		fmt.Fprintf(fw, "#define %s %s\n", m.define, m.Name())
 		if m.mapType.isTCP() {
-			mapEntriesTCP = mapInfo[m.mapType].maxEntries
+			mapEntriesTCP = m.mapType.maxEntries()
 		} else {
-			mapEntriesAny = mapInfo[m.mapType].maxEntries
+			mapEntriesAny = m.mapType.maxEntries()
 		}
 	}
 	fmt.Fprintf(fw, "#define CT_MAP_SIZE_TCP %d\n", mapEntriesTCP)

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -4,15 +4,12 @@
 package ctmap
 
 import (
-	"unsafe"
-
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/ebpf/rlimit"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/maps/nat"
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/tuple"
 	"github.com/cilium/cilium/pkg/types"
@@ -25,7 +22,7 @@ type CTMapPrivilegedTestSuite struct{}
 var _ = Suite(&CTMapPrivilegedTestSuite{})
 
 func init() {
-	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+	InitMapInfo(true, true, true)
 }
 
 func (k *CTMapPrivilegedTestSuite) SetUpSuite(c *C) {
@@ -103,9 +100,9 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 	defer natMap.Map.Unpin()
 
 	ctMapName := MapNameAny4Global + "_test"
-	setupMapInfo(mapTypeIPv4AnyGlobal, ctMapName,
-		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
-		100, natMap)
+	mapInfo[mapTypeIPv4AnyGlobal] = mapAttributes{
+		natMap: natMap, natMapLock: mapInfo[mapTypeIPv4AnyGlobal].natMapLock,
+	}
 
 	ctMap := newMap(ctMapName, mapTypeIPv4AnyGlobal)
 	err = ctMap.OpenOrCreate()
@@ -212,18 +209,18 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	defer natMap.Map.Unpin()
 
 	ctMapAnyName := MapNameAny4Global + "_test"
-	setupMapInfo(mapTypeIPv4AnyGlobal, ctMapAnyName,
-		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
-		100, natMap)
+	mapInfo[mapTypeIPv4AnyGlobal] = mapAttributes{
+		natMap: natMap, natMapLock: mapInfo[mapTypeIPv4AnyGlobal].natMapLock,
+	}
 	ctMapAny := newMap(ctMapAnyName, mapTypeIPv4AnyGlobal)
 	err = ctMapAny.OpenOrCreate()
 	c.Assert(err, IsNil)
 	defer ctMapAny.Map.Unpin()
 
 	ctMapTCPName := MapNameTCP4Global + "_test"
-	setupMapInfo(mapTypeIPv4TCPGlobal, ctMapTCPName,
-		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
-		100, natMap)
+	mapInfo[mapTypeIPv4TCPGlobal] = mapAttributes{
+		natMap: natMap, natMapLock: mapInfo[mapTypeIPv4TCPGlobal].natMapLock,
+	}
 	ctMapTCP := newMap(ctMapTCPName, mapTypeIPv4TCPGlobal)
 	err = ctMapTCP.OpenOrCreate()
 	c.Assert(err, IsNil)
@@ -502,18 +499,18 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	defer natMapV6.Map.Unpin()
 
 	ctMapAnyName = MapNameAny6Global + "_test"
-	setupMapInfo(mapTypeIPv6AnyGlobal, ctMapAnyName,
-		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
-		100, natMapV6)
+	mapInfo[mapTypeIPv6AnyGlobal] = mapAttributes{
+		natMap: natMapV6, natMapLock: mapInfo[mapTypeIPv6AnyGlobal].natMapLock,
+	}
 	ctMapAnyV6 := newMap(ctMapAnyName, mapTypeIPv6AnyGlobal)
 	err = ctMapAnyV6.OpenOrCreate()
 	c.Assert(err, IsNil)
 	defer ctMapAnyV6.Map.Unpin()
 
 	ctMapTCPName = MapNameTCP6Global + "_test"
-	setupMapInfo(mapTypeIPv6TCPGlobal, ctMapTCPName,
-		&CtKey6Global{}, int(unsafe.Sizeof(CtKey6Global{})),
-		100, natMapV6)
+	mapInfo[mapTypeIPv6TCPGlobal] = mapAttributes{
+		natMap: natMapV6, natMapLock: mapInfo[mapTypeIPv6TCPGlobal].natMapLock,
+	}
 	ctMapTCPV6 := newMap(ctMapTCPName, mapTypeIPv6TCPGlobal)
 	err = ctMapTCP.OpenOrCreate()
 	c.Assert(err, IsNil)

--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -4,16 +4,12 @@
 package ctmap
 
 import (
-	"strings"
 	"testing"
 	"time"
-	"unsafe"
 
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/cilium/pkg/defaults"
-	"github.com/cilium/cilium/pkg/option"
-	"github.com/cilium/cilium/pkg/tuple"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -22,41 +18,11 @@ type CTMapTestSuite struct{}
 var _ = Suite(&CTMapTestSuite{})
 
 func init() {
-	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
+	InitMapInfo(true, true, true)
 }
 
 func Test(t *testing.T) {
 	TestingT(t)
-}
-
-func (t *CTMapTestSuite) TestInit(c *C) {
-	InitMapInfo(option.CTMapEntriesGlobalTCPDefault, option.CTMapEntriesGlobalAnyDefault, true, true, true)
-	for mapType := mapType(0); mapType < mapTypeMax; mapType++ {
-		info := mapInfo[mapType]
-		if mapType.isIPv6() {
-			c.Assert(info.keySize, Equals, int(unsafe.Sizeof(tuple.TupleKey6{})))
-			c.Assert(strings.Contains(info.bpfDefine, "6"), Equals, true)
-		}
-		if mapType.isIPv4() {
-			c.Assert(info.keySize, Equals, int(unsafe.Sizeof(tuple.TupleKey4{})))
-			c.Assert(strings.Contains(info.bpfDefine, "4"), Equals, true)
-		}
-		if mapType.isTCP() {
-			c.Assert(strings.Contains(info.bpfDefine, "TCP"), Equals, true)
-		} else {
-			c.Assert(strings.Contains(info.bpfDefine, "ANY"), Equals, true)
-		}
-		if mapType.isLocal() {
-			c.Assert(info.maxEntries, Equals, mapNumEntriesLocal)
-		}
-		if mapType.isGlobal() {
-			if mapType.isTCP() {
-				c.Assert(info.maxEntries, Equals, option.CTMapEntriesGlobalTCPDefault)
-			} else {
-				c.Assert(info.maxEntries, Equals, option.CTMapEntriesGlobalAnyDefault)
-			}
-		}
-	}
 }
 
 func (t *CTMapTestSuite) TestCalculateInterval(c *C) {

--- a/pkg/maps/ctmap/per_cluster_ctmap.go
+++ b/pkg/maps/ctmap/per_cluster_ctmap.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"reflect"
 	"strconv"
 
 	"golang.org/x/sys/unix"
@@ -474,11 +475,12 @@ func (gm *dummyPerClusterCTMaps) Cleanup() {
 }
 
 func newPerClusterCTMap(name string, m mapType) (*PerClusterCTMap, error) {
+	keySize := reflect.Indirect(reflect.ValueOf(m.key())).Type().Size()
 	inner := &ebpf.MapSpec{
 		Type:       ebpf.LRUHash,
-		KeySize:    uint32(mapInfo[m].keySize),
-		ValueSize:  uint32(mapInfo[m].valueSize),
-		MaxEntries: uint32(mapInfo[m].maxEntries),
+		KeySize:    uint32(keySize),
+		ValueSize:  uint32(SizeofCtEntry),
+		MaxEntries: uint32(m.maxEntries()),
 	}
 
 	om := bpf.NewMapWithInnerSpec(

--- a/pkg/maps/ctmap/types_test.go
+++ b/pkg/maps/ctmap/types_test.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ctmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/option"
+)
+
+func TestMapKey(t *testing.T) {
+	for mapType := mapType(0); mapType < mapTypeMax; mapType++ {
+		assert.NotNil(t, mapType.key())
+	}
+
+	assert.Panics(t, func() { mapType(-1).key() })
+	assert.Panics(t, func() { mapTypeMax.key() })
+}
+
+func TestMapBPFDefine(t *testing.T) {
+	for mapType := mapType(0); mapType < mapTypeMax; mapType++ {
+		if mapType.isIPv6() {
+			assert.Contains(t, mapType.bpfDefine(), "6")
+		}
+		if mapType.isIPv4() {
+			assert.Contains(t, mapType.bpfDefine(), "4")
+		}
+
+		if mapType.isTCP() {
+			assert.Contains(t, mapType.bpfDefine(), "TCP")
+		} else {
+			assert.Contains(t, mapType.bpfDefine(), "ANY")
+		}
+	}
+
+	assert.Panics(t, func() { mapType(-1).bpfDefine() })
+	assert.Panics(t, func() { mapTypeMax.bpfDefine() })
+}
+
+func TestMaxEntries(t *testing.T) {
+	tests := []struct {
+		name       string
+		tcp, any   int
+		etcp, eany int
+	}{
+		{
+			name: "defaults",
+			etcp: option.CTMapEntriesGlobalTCPDefault,
+			eany: option.CTMapEntriesGlobalAnyDefault,
+		},
+		{
+			name: "configured",
+			tcp:  0x12345,
+			etcp: 0x12345,
+			any:  0x67890,
+			eany: 0x67890,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			option.Config.CTMapEntriesGlobalTCP = tt.tcp
+			option.Config.CTMapEntriesGlobalAny = tt.any
+
+			for mapType := mapType(0); mapType < mapTypeMax; mapType++ {
+				if mapType.isLocal() {
+					assert.Equal(t, mapNumEntriesLocal, mapType.maxEntries())
+				}
+
+				if mapType.isGlobal() {
+					if mapType.isTCP() {
+						assert.Equal(t, tt.etcp, mapType.maxEntries())
+					} else {
+						assert.Equal(t, tt.eany, mapType.maxEntries())
+					}
+				}
+			}
+
+			assert.Panics(t, func() { mapType(-1).maxEntries() })
+			assert.Panics(t, func() { mapTypeMax.maxEntries() })
+		})
+	}
+}


### PR DESCRIPTION
Currently, the creation of a new CT map depends on the `mapInfo` global variable. Yet, this is suboptimal, as it always requires that variable to be initialized beforehand, which might be tricky in combination with the Hive framework. Additionally, all the necessary information is either known at compile time or depends on user configurations only. Hence, let's update that logic to remove the dependency on the global variable.