### PR TITLE
k8s: fix incorrect EndpointSlice API version

### DIFF
--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -467,10 +467,10 @@ func (k *K8sWatcher) resourceGroups() (beforeNodeInitGroups, afterNodeInitGroups
 
 	// To perform the service translation and have the BPF LB datapath
 	// with the right service -> backend (k8s endpoints) translation.
-	if k8s.SupportsEndpointSlice() {
-		k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointSliceV1Beta1Discovery)
-	} else if k8s.SupportsEndpointSliceV1() {
+	if k8s.SupportsEndpointSliceV1() {
 		k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointSliceV1Discovery)
+	} else if k8s.SupportsEndpointSlice() {
+		k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointSliceV1Beta1Discovery)
 	}
 	k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointV1Core)
 	ciliumResources := synced.AgentCRDResourceNames()


### PR DESCRIPTION
This PR fixes a bug that k8s watcher incorrectly chooses the discovery/v1beta1 EndpointSlice in environments where discovery/v1 EndpointSlice is available. The agent doesn't wait for the discovery/v1 EndpointSlice to be received on its restart and ends up removing live services because of this bug.

The issue happens in the following scenario:

1. The agent initializes and runs the informers for Service and EndpointSlice.
2. The reflectors list the resources from kube-apiserver and replace DeltaFIFO.
3. The informers pop items from the DeltaFIFO and call the onAdd handler one by one.
4. If the Service handler is called first, ServiceCache.UpdateService doesn't emit the UpdateService event, because the service is not ready. (No backend)
5. The EndpointSlice handler is called next, ServiceCache.updateEndpoints emits UpdateService event.
6. The agent doesn't wait until the event triggered at step 5 is processed, and calls SyncWithK8sFinished.
7. The agent removes live services because it hasn't heard about them. (It is supposed to hear about those services in the event process triggered at step 5)

This issue doesn't persist in v1.14 and later because `K8sAPIGroupEndpointSliceOrEndpoint` is used in those versions. The affected versions are v1.13 and v1.12.

Fixes: #27215

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
