### PR TITLE
.github: add workflow to track replied issues

### DIFF
--- a/.github/workflows/needs-more-info.yaml
+++ b/.github/workflows/needs-more-info.yaml
@@ -1,0 +1,18 @@
+name: Issue Info Complete
+
+# This workflow is triggered on issue comments.
+on:
+  issue_comment:
+    types: created
+
+jobs:
+  applyNeedsAttentionLabel:
+    name: Apply Info Complete Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply Needs Attention Label
+        uses: hramos/needs-attention@v1
+        with:
+            repo-token: ${{ secrets.GITHUB_TOKEN }}
+            response-required-label: 'need-more-info'
+            needs-attention-label: 'info-completed'


### PR DESCRIPTION
With this GH workflow we will be able to track which GH issues were replied by the users after we have requested a "need-more-info" label.

Once the user replies to the GH issue, the "need-more-info" label is removed and the "info-completed" label will be added.