### PR TITLE
[v1.14] Fix bug where restored CIDR identities would be incorrectly released, leading to packet loss

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -57,7 +57,7 @@ import (
 	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
-	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -597,7 +597,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	// same numeric IDs as before, but the restored identities are to be upsterted to the new
 	// (datapath) ipcache after it has been initialized below. This is accomplished by passing
 	// 'restoredCIDRidentities' to AllocateCIDRs() and then calling
-	// UpsertGeneratedIdentities(restoredCIDRidentities) after initMaps() below.
+	// UpsertPrefixes(d.restoredCIDRs) after initMaps() below.
 	restoredCIDRidentities := make(map[netip.Prefix]*identity.Identity)
 	if len(d.restoredCIDRs) > 0 {
 		log.Infof("Restoring %d old CIDR identities", len(d.restoredCIDRs))
@@ -715,8 +715,17 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		return nil, nil, fmt.Errorf("error while opening/creating BPF maps: %w", err)
 	}
 	// Upsert restored CIDRs after the new ipcache has been opened above
-	if len(restoredCIDRidentities) > 0 {
-		d.ipcache.UpsertGeneratedIdentities(restoredCIDRidentities, nil)
+	restoredResource := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindDaemon, "", "")
+	if len(d.restoredCIDRs) > 0 {
+		// Asynchronously upsert the prefixes into the new ipcache map.
+		// By the time the datapath gets initialized to consume this
+		// map, ipcache should have completed the async work. If this
+		// doesn't occur, it will result in temporary drops in the
+		// time between datapath initialization until this async
+		// process completes.
+		// TODO: Add signalling mechanism to pass to the datapath to
+		//       ensure this ordering property.
+		d.ipcache.UpsertPrefixes(d.restoredCIDRs, source.Restored, restoredResource)
 	}
 	// Upsert restored local Ingress IPs
 	for _, ingressIP := range oldIngressIPs {
@@ -724,7 +733,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			ingressIP,
 			labels.LabelIngress,
 			source.Restored,
-			ipcachetypes.NewResourceID(ipcachetypes.ResourceKindDaemon, "", ""),
+			restoredResource,
 		)
 	}
 	if len(oldIngressIPs) > 0 {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -56,6 +56,7 @@ import (
 	ipamMetadata "github.com/cilium/cilium/pkg/ipam/metadata"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/ipmasq"
 	"github.com/cilium/cilium/pkg/k8s"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -86,6 +87,7 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/slices"
+	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/version"
@@ -1766,7 +1768,17 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 			// (re-)allocate the restored identities before we release them.
 			time.Sleep(option.Config.IdentityRestoreGracePeriod)
 			log.Debugf("Releasing reference counts for %d restored CIDR identities", len(d.restoredCIDRs))
-			d.ipcache.ReleaseCIDRIdentitiesByCIDR(d.restoredCIDRs)
+			// Release the CIDR identity references acquired by
+			// the corresponding AllocateCIDRs() call from when
+			// d.restoredCIDRs was initialized.
+			// Remove the ipcache CIDR associations from the
+			// corresponding UpsertPrefixes() call.
+			d.identityAllocator.ReleaseCIDRs(d.ctx, d.restoredCIDRs)
+			d.ipcache.RemovePrefixes(
+				d.restoredCIDRs,
+				source.Restored,
+				ipcachetypes.NewResourceID(ipcachetypes.ResourceKindDaemon, "", ""),
+			)
 			// release the memory held by restored CIDRs
 			d.restoredCIDRs = nil
 

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -104,6 +104,12 @@ func (f *FakeRefcountingIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context
 	}
 }
 
+func (f *FakeRefcountingIdentityAllocator) ReleaseCIDRs(ctx context.Context, prefixes []netip.Prefix) {
+	for _, prefix := range prefixes {
+		f.identityCount.Delete(int(f.ipToIdentity[prefix.Addr().String()]))
+	}
+}
+
 func (f *FakeRefcountingIdentityAllocator) IdentityReferenceCounter() counter.IntCounter {
 	return f.identityCount
 }

--- a/daemon/cmd/identity.go
+++ b/daemon/cmd/identity.go
@@ -9,6 +9,7 @@ import (
 	"net/netip"
 
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
@@ -20,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -94,6 +96,7 @@ type CachingIdentityAllocator interface {
 	cache.IdentityAllocator
 	clustermesh.RemoteIdentityWatcher
 
+	ReleaseCIDRs(context.Context, []netip.Prefix)
 	InitIdentityAllocator(versioned.Interface) <-chan struct{}
 	Close()
 }
@@ -109,4 +112,23 @@ func (c cachingIdentityAllocator) AllocateCIDRsForIPs(ips []net.IP, newlyAllocat
 
 func (c cachingIdentityAllocator) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
 	c.ipcache.ReleaseCIDRIdentitiesByID(ctx, identities)
+}
+
+func (c *cachingIdentityAllocator) ReleaseCIDRs(ctx context.Context, prefixes []netip.Prefix) {
+	for _, prefix := range prefixes {
+		lbls := cidr.GetCIDRLabels(prefix)
+		id := c.LookupIdentity(ctx, lbls)
+		if id == nil {
+			log.WithFields(logrus.Fields{
+				logfields.CIDR: prefix.String(),
+			}).Warning("Restored Identity for CIDR cannot be found")
+			continue
+		}
+		if _, err := c.Release(ctx, id, false); err != nil {
+			log.WithFields(logrus.Fields{
+				logfields.Identity: id,
+				logfields.CIDR:     prefix,
+			}).WithError(err).Warning("Unable to release restored CIDR identity.")
+		}
+	}
 }

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -145,3 +145,19 @@ func SubsetOf[S ~[]T, T comparable](a, b S) (bool, []T) {
 	d := Diff(a, b)
 	return len(d) == 0, d
 }
+
+// NFromMap takes a map of elements and returns a slice of N of them.
+func NFromMap[K comparable, V any](m map[K]V, n uint) []K {
+	max := n
+	result := make([]K, 0, max)
+	i := uint(0)
+	for k := range m {
+		if i >= max {
+			break
+		}
+		result[i] = k
+		i++
+	}
+
+	return result
+}


### PR DESCRIPTION
This is a v1.14 branch backport for #27255 -- Fix bug where restored CIDR identities would be incorrectly released, leading to packet loss.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 27255; do contrib/backporting/set-labels.py $pr done 1.14; done
```
