### PR TITLE
docs: Remove proxylib limitation in observability section

### DIFF
--- a/Documentation/observability/visibility.rst
+++ b/Documentation/observability/visibility.rst
@@ -119,8 +119,3 @@ Limitations
 * Visibility annotations do not apply if rules are imported which select the pod
   which is annotated.
 * DNS visibility is available on egress only.
-* Proxylib parsers are not supported, including Kafka. To gain visibility on
-  these protocols, you must create a network policy that allows all of the
-  traffic at L7, either by following :ref:`l7_policy`
-  (:ref:`Kafka <kafka_policy>`) or the :ref:`envoy` proxylib extensions guide.
-  This limitation is tracked by :gh-issue:`14072`.


### PR DESCRIPTION
This removes the proxylib limitation from the observability documentation that seems to now be fixed according to the last few messages in #14072

