### PR TITLE
bpf: lxc: fix L4 offset in RevNAT path for IPv6 extension headers

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -509,6 +509,7 @@ ct_recreate6:
 	case CT_REPLY:
 		policy_mark_skip(ctx);
 
+		tuple->nexthdr = ip6->nexthdr;
 		hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);
 		if (hdrlen < 0)
 			return hdrlen;
@@ -1458,6 +1459,7 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 		if (unlikely(ct_state->rev_nat_index)) {
 			int ret2, l4_off;
 
+			tuple->nexthdr = ip6->nexthdr;
 			hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);
 			if (hdrlen < 0)
 				return hdrlen;


### PR DESCRIPTION
The typical pattern to determine the L4 offset of an IPv6 packet is

	tuple->nexthdr = ip6->nexthdr;
	hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);
	if (hdrlen < 0)
		return hdrlen;
	l4_off = ETH_HLEN + hdrlen;

ipv6_hdrlen() then walks the extension headers and adds up their length, until it reaches the TCP/UDP/... header.

For bpf_lxc, 38b4a615bb27 ("bpf: Split CT lookup to its own tail call") split off the CT lookup into a separate tail-call. Subsequent code retrieves the lookup result and a fully populated CT tuple from the CT_TAIL_CALL_BUFFER6.

For the IPv6 paths this means that tuple->nexthdr already contains the L4 proto. When ipv6_hdrlen() is called a second time with this value, it believes that the packet has no extension headers and returns a wrong L4 offset.

Go for the minimal fix and re-initialize tuple->nexthdr in the affected paths.

```release-note
Fix a bug that affected the RevDNAT translation of IPv6 packets with extension headers.
```
