### PR TITLE
bpf: avoid calculating L4 offset

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -458,7 +458,7 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	 * within the cluster, it must match policy or be dropped. If it's
 	 * bound for the host/outside, perform the CIDR policy check.
 	 */
-	verdict = policy_can_egress6(ctx, tuple, SECLABEL, *dst_sec_identity,
+	verdict = policy_can_egress6(ctx, tuple, l4_off, SECLABEL, *dst_sec_identity,
 				     &policy_match_type, &audited, ext_err, &proxy_port);
 
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
@@ -883,7 +883,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	 * within the cluster, it must match policy or be dropped. If it's
 	 * bound for the host/outside, perform the CIDR policy check.
 	 */
-	verdict = policy_can_egress4(ctx, tuple, SECLABEL, *dst_sec_identity,
+	verdict = policy_can_egress4(ctx, tuple, l4_off, SECLABEL, *dst_sec_identity,
 				     &policy_match_type, &audited, ext_err, &proxy_port);
 
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
@@ -1467,7 +1467,7 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 		goto skip_policy_enforcement;
 
 	verdict = policy_can_access_ingress(ctx, src_label, SECLABEL,
-					    tuple->dport, tuple->nexthdr, false,
+					    tuple->dport, tuple->nexthdr, l4_off, false,
 					    &policy_match_type, &audited, ext_err, proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		struct remote_endpoint_info *sep = lookup_ip6_remote_endpoint(&orig_sip, 0);
@@ -1792,7 +1792,7 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 #endif /* ENABLE_PER_PACKET_LB && !DISABLE_LOOPBACK_LB */
 
 	verdict = policy_can_access_ingress(ctx, src_label, SECLABEL,
-					    tuple->dport, tuple->nexthdr,
+					    tuple->dport, tuple->nexthdr, l4_off,
 					    is_untracked_fragment,
 					    &policy_match_type, &audited, ext_err, proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -35,6 +35,7 @@ struct ct_buffer4 {
 	struct ct_state ct_state;
 	__u32 monitor;
 	int ret;
+	int l4_off;
 };
 #endif
 
@@ -44,6 +45,7 @@ struct ct_buffer6 {
 	struct ct_state ct_state;
 	__u32 monitor;
 	int ret;
+	int l4_off;
 };
 #endif
 

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -76,8 +76,9 @@ __ipv6_host_policy_egress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		return CTX_ACT_OK;
 
 	/* Perform policy lookup. */
-	verdict = policy_can_egress6(ctx, tuple, HOST_ID, dst_sec_identity,
-				     &policy_match_type, &audited, ext_err, &proxy_port);
+	verdict = policy_can_egress6(ctx, tuple, ct_buffer->l4_off, HOST_ID,
+				     dst_sec_identity, &policy_match_type,
+				     &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
 		verdict = auth_lookup(ctx, HOST_ID, dst_sec_identity, tunnel_endpoint, auth_type);
@@ -193,7 +194,7 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 
 	/* Perform policy lookup */
 	verdict = policy_can_access_ingress(ctx, *src_sec_identity, HOST_ID, tuple->dport,
-					    tuple->nexthdr, false,
+					    tuple->nexthdr, ct_buffer->l4_off, false,
 					    &policy_match_type, &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
@@ -349,8 +350,9 @@ __ipv4_host_policy_egress(struct __ctx_buff *ctx, bool is_host_id __maybe_unused
 		return CTX_ACT_OK;
 
 	/* Perform policy lookup. */
-	verdict = policy_can_egress4(ctx, tuple, HOST_ID, dst_sec_identity,
-				     &policy_match_type, &audited, ext_err, &proxy_port);
+	verdict = policy_can_egress4(ctx, tuple, ct_buffer->l4_off, HOST_ID,
+				     dst_sec_identity, &policy_match_type,
+				     &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
 		verdict = auth_lookup(ctx, HOST_ID, dst_sec_identity, tunnel_endpoint, auth_type);
@@ -469,7 +471,7 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 
 	/* Perform policy lookup */
 	verdict = policy_can_access_ingress(ctx, *src_sec_identity, HOST_ID, tuple->dport,
-					    tuple->nexthdr,
+					    tuple->nexthdr, ct_buffer->l4_off,
 					    is_untracked_fragment,
 					    &policy_match_type, &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -20,8 +20,8 @@ ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 			       struct ipv6hdr *ip6,
 			       struct ct_buffer6 *ct_buffer)
 {
-	int l3_off = ETH_HLEN, l4_off, hdrlen;
 	struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
+	int l3_off = ETH_HLEN, hdrlen;
 
 	/* Only enforce host policies for packets from host IPs. */
 	if (src_sec_identity != HOST_ID)
@@ -36,9 +36,9 @@ ipv6_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 		ct_buffer->ret = hdrlen;
 		return true;
 	}
-	l4_off = l3_off + hdrlen;
-	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, l4_off, CT_EGRESS,
-				    &ct_buffer->ct_state, &ct_buffer->monitor);
+	ct_buffer->l4_off = l3_off + hdrlen;
+	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, ct_buffer->l4_off,
+				    CT_EGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
 	return true;
 }
 
@@ -127,10 +127,10 @@ static __always_inline bool
 ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 				struct ct_buffer6 *ct_buffer)
 {
-	int l4_off, hdrlen;
 	__u32 dst_sec_identity = WORLD_ID;
 	struct remote_endpoint_info *info;
 	struct ipv6_ct_tuple *tuple = &ct_buffer->tuple;
+	int hdrlen;
 
 	/* Retrieve destination identity. */
 	ipv6_addr_copy(&tuple->daddr, (union v6addr *)&ip6->daddr);
@@ -152,9 +152,9 @@ ipv6_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		ct_buffer->ret = hdrlen;
 		return true;
 	}
-	l4_off = ETH_HLEN + hdrlen;
-	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, l4_off, CT_INGRESS,
-				    &ct_buffer->ct_state, &ct_buffer->monitor);
+	ct_buffer->l4_off = ETH_HLEN + hdrlen;
+	ct_buffer->ret = ct_lookup6(get_ct_map6(tuple), tuple, ctx, ct_buffer->l4_off,
+				    CT_INGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
 
 	return true;
 }
@@ -286,8 +286,8 @@ ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 			       __u32 ipcache_srcid, struct iphdr *ip4,
 			       struct ct_buffer4 *ct_buffer)
 {
-	int l4_off, l3_off = ETH_HLEN;
 	struct ipv4_ct_tuple *tuple = &ct_buffer->tuple;
+	int l3_off = ETH_HLEN;
 
 	/* Further action is needed in two cases:
 	 * 1. Packets from host IPs: need to enforce host policies.
@@ -302,9 +302,9 @@ ipv4_host_policy_egress_lookup(struct __ctx_buff *ctx, __u32 src_sec_identity,
 	tuple->nexthdr = ip4->protocol;
 	tuple->daddr = ip4->daddr;
 	tuple->saddr = ip4->saddr;
-	l4_off = l3_off + ipv4_hdrlen(ip4);
-	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, l4_off, CT_EGRESS,
-				    &ct_buffer->ct_state, &ct_buffer->monitor);
+	ct_buffer->l4_off = l3_off + ipv4_hdrlen(ip4);
+	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ct_buffer->l4_off,
+				    CT_EGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
 	return true;
 }
 
@@ -400,10 +400,10 @@ static __always_inline bool
 ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
 				struct ct_buffer4 *ct_buffer)
 {
-	int l4_off, l3_off = ETH_HLEN;
 	__u32 dst_sec_identity = WORLD_ID;
 	struct remote_endpoint_info *info;
 	struct ipv4_ct_tuple *tuple = &ct_buffer->tuple;
+	int l3_off = ETH_HLEN;
 
 	/* Retrieve destination identity. */
 	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
@@ -420,9 +420,9 @@ ipv4_host_policy_ingress_lookup(struct __ctx_buff *ctx, struct iphdr *ip4,
 	tuple->nexthdr = ip4->protocol;
 	tuple->daddr = ip4->daddr;
 	tuple->saddr = ip4->saddr;
-	l4_off = l3_off + ipv4_hdrlen(ip4);
-	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, l4_off, CT_INGRESS,
-				    &ct_buffer->ct_state, &ct_buffer->monitor);
+	ct_buffer->l4_off = l3_off + ipv4_hdrlen(ip4);
+	ct_buffer->ret = ct_lookup4(get_ct_map4(tuple), tuple, ctx, ct_buffer->l4_off,
+				    CT_INGRESS, &ct_buffer->ct_state, &ct_buffer->monitor);
 
 	return true;
 }

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -33,8 +33,8 @@ __account_and_check(struct __ctx_buff *ctx, struct policy_entry *policy,
 
 static __always_inline int
 __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
-		    __u32 remote_id, __u16 dport, __u8 proto, int dir,
-		    bool is_untracked_fragment, __u8 *match_type, __s8 *ext_err,
+		    __u32 remote_id, __u16 dport, __u8 proto, int off __maybe_unused,
+		    int dir, bool is_untracked_fragment, __u8 *match_type, __s8 *ext_err,
 		    __u16 *proxy_port)
 {
 	struct policy_entry *policy;
@@ -53,15 +53,8 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 	 * of ICMP type 3 code 4 - Fragmentation Needed.
 	 */
 	if (proto == IPPROTO_ICMP) {
-		void *data, *data_end;
 		struct icmphdr icmphdr __align_stack_8;
-		struct iphdr *ip4;
-		__u32 off;
 
-		if (!revalidate_data(ctx, &data, &data_end, &ip4))
-			return DROP_INVALID;
-
-		off = ((void *)ip4 - data) + ipv4_hdrlen(ip4);
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
 			return DROP_INVALID;
 
@@ -75,14 +68,8 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 
 #ifdef ENABLE_ICMP_RULE
 	if (proto == IPPROTO_ICMP) {
-		void *data, *data_end;
-		struct iphdr *ip4;
 		struct icmphdr icmphdr __align_stack_8;
-		__u32 off;
 
-		if (!revalidate_data(ctx, &data, &data_end, &ip4))
-			return DROP_INVALID;
-		off = ((void *)ip4 - data) + ipv4_hdrlen(ip4);
 		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
 			return DROP_INVALID;
 
@@ -92,17 +79,8 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		 */
 		key.dport = (__u16)(icmphdr.type << 8);
 	} else if (proto == IPPROTO_ICMPV6) {
-		void *data, *data_end;
-		struct ipv6hdr *ip6;
-		__u32 off;
 		__u8 icmp_type;
-		__u8 nexthdr;
 
-		if (!revalidate_data(ctx, &data, &data_end, &ip6))
-			return DROP_INVALID;
-
-		nexthdr = ip6->nexthdr;
-		off = ((void *)ip6 - data) + ipv6_hdrlen(ctx, &nexthdr);
 		if (ctx_load_bytes(ctx, off, &icmp_type, sizeof(icmp_type)) < 0)
 			return DROP_INVALID;
 
@@ -201,6 +179,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
  * @arg dst_id		Destination security identity for this packet
  * @arg dport		Destination port of this packet
  * @arg proto		L3 Protocol of this packet
+ * @arg l4_off		Offset to L4 header of this packet
  * @arg is_untracked_fragment	True if packet is a TCP/UDP datagram fragment
  *				AND IPv4 fragment tracking is disabled
  * @arg match_type		Pointer to store layers used for policy match
@@ -213,13 +192,13 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
  */
 static __always_inline int
 policy_can_access_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
-			  __u16 dport, __u8 proto, bool is_untracked_fragment,
+			  __u16 dport, __u8 proto, int l4_off, bool is_untracked_fragment,
 			  __u8 *match_type, __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
 {
 	int ret;
 
 	ret = __policy_can_access(&POLICY_MAP, ctx, dst_id, src_id, dport,
-				  proto, CT_INGRESS, is_untracked_fragment,
+				  proto, l4_off, CT_INGRESS, is_untracked_fragment,
 				  match_type, ext_err, proxy_port);
 	if (ret >= CTX_ACT_OK)
 		return ret;
@@ -246,8 +225,8 @@ static __always_inline bool is_encap(__u16 dport, __u8 proto)
 
 static __always_inline int
 policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
-		  __u16 dport, __u8 proto, __u8 *match_type, __u8 *audited, __s8 *ext_err,
-		  __u16 *proxy_port)
+		  __u16 dport, __u8 proto, int l4_off, __u8 *match_type,
+		  __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
 {
 	int ret;
 
@@ -256,7 +235,8 @@ policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 		return DROP_ENCAP_PROHIBITED;
 #endif
 	ret = __policy_can_access(&POLICY_MAP, ctx, src_id, dst_id, dport,
-				  proto, CT_EGRESS, false, match_type, ext_err, proxy_port);
+				  proto, l4_off, CT_EGRESS, false, match_type,
+				  ext_err, proxy_port);
 	if (ret >= 0)
 		return ret;
 	cilium_dbg(ctx, DBG_POLICY_DENIED, src_id, dst_id);
@@ -272,22 +252,24 @@ policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 
 static __always_inline int policy_can_egress6(struct __ctx_buff *ctx,
 					      const struct ipv6_ct_tuple *tuple,
-					      __u32 src_id, __u32 dst_id,
+					      int l4_off, __u32 src_id, __u32 dst_id,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,
 					      __u16 *proxy_port)
 {
 	return policy_can_egress(ctx, src_id, dst_id, tuple->dport,
-				 tuple->nexthdr, match_type, audited, ext_err, proxy_port);
+				 tuple->nexthdr, l4_off, match_type, audited,
+				 ext_err, proxy_port);
 }
 
 static __always_inline int policy_can_egress4(struct __ctx_buff *ctx,
 					      const struct ipv4_ct_tuple *tuple,
-					      __u32 src_id, __u32 dst_id,
+					      int l4_off, __u32 src_id, __u32 dst_id,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,
 					      __u16 *proxy_port)
 {
 	return policy_can_egress(ctx, src_id, dst_id, tuple->dport,
-				 tuple->nexthdr, match_type, audited, ext_err, proxy_port);
+				 tuple->nexthdr, l4_off, match_type, audited,
+				 ext_err, proxy_port);
 }
 
 /**


### PR DESCRIPTION
Clean up some `ipv6_hdrlen()` calls, which can be replaced by just passing the available L4 offset through.

Each `ipv6_hdrlen()` call is worth around 150 instructions, so this nicely helps with reducing program size.
