### PR TITLE
docs: Clean up mentions to KPR=partial|strict

### DIFF
--- a/Documentation/configuration/per-node-config.rst
+++ b/Documentation/configuration/per-node-config.rst
@@ -62,7 +62,7 @@ Example: KubeProxyReplacement Rollout
 
 To roll out :ref:`kube-proxy replacement <kubeproxy-free>` in a gradual manner,
 you may also wish to use the CiliumNodeConfig feature. This will label all migrated
-nodes with ``io.cilium.migration/kube-proxy-replacement: strict``
+nodes with ``io.cilium.migration/kube-proxy-replacement: true``
 
 .. warning::
 
@@ -76,9 +76,9 @@ nodes with ``io.cilium.migration/kube-proxy-replacement: strict``
 
     .. code-block:: shell-session
 
-        kubectl -n kube-system patch daemonset kube-proxy --patch '{"spec": {"template": {"spec": {"affinity": {"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms": [{"matchExpressions": [{"key": "io.cilium.migration/kube-proxy-replacement", "operator": "NotIn", "values": ["strict"]}]}]}}}}}}}'
+        kubectl -n kube-system patch daemonset kube-proxy --patch '{"spec": {"template": {"spec": {"affinity": {"nodeAffinity": {"requiredDuringSchedulingIgnoredDuringExecution": {"nodeSelectorTerms": [{"matchExpressions": [{"key": "io.cilium.migration/kube-proxy-replacement", "operator": "NotIn", "values": ["true"]}]}]}}}}}}}'
 
-#. Configure Cilium to use strict kube-proxy on migrated nodes
+#. Configure Cilium to use kube-proxy replacement on migrated nodes
 
     .. code-block:: shell-session
 
@@ -87,13 +87,13 @@ nodes with ``io.cilium.migration/kube-proxy-replacement: strict``
         kind: CiliumNodeConfig
         metadata:
           namespace: kube-system
-          name: kube-proxy-replacement-strict
+          name: kube-proxy-replacement
         spec:
           nodeSelector:
             matchLabels:
-              io.cilium.migration/kube-proxy-replacement: strict
+              io.cilium.migration/kube-proxy-replacement: true
           defaults:
-            kube-proxy-replacement: strict
+            kube-proxy-replacement: true
             kube-proxy-replacement-healthz-bind-address: "0.0.0.0:10256"
 
         EOF
@@ -103,7 +103,7 @@ nodes with ``io.cilium.migration/kube-proxy-replacement: strict``
     .. code-block:: shell-session
 
         export NODE=kind-worker
-        kubectl label node $NODE --overwrite 'io.cilium.migration/kube-proxy-replacement=strict'
+        kubectl label node $NODE --overwrite 'io.cilium.migration/kube-proxy-replacement=true'
         kubectl cordon $NODE
 
 #. Delete Cilium DaemonSet to reload configuration:
@@ -118,7 +118,7 @@ nodes with ``io.cilium.migration/kube-proxy-replacement: strict``
 
         kubectl -n kube-system exec $(kubectl -n kube-system get pod -l k8s-app=cilium --field-selector spec.nodeName=$NODE -o name) -c cilium-agent -- \
             cilium config get kube-proxy-replacement
-        strict
+        true
 
 #. Uncordon node
 
@@ -130,9 +130,9 @@ nodes with ``io.cilium.migration/kube-proxy-replacement: strict``
 
     .. code-block:: shell-session
 
-        cilium config set --restart=false kube-proxy-replacement strict
+        cilium config set --restart=false kube-proxy-replacement true
         cilium config set --restart=false kube-proxy-replacement-healthz-bind-address "0.0.0.0:10256"
-        kubectl -n kube-system delete ciliumnodeconfig kube-proxy-replacement-strict
+        kubectl -n kube-system delete ciliumnodeconfig kube-proxy-replacement
 
 #. Cleanup: delete kube-proxy daemonset, unlabel nodes
 

--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -93,7 +93,7 @@ The egress gateway feature and all the requirements can be enabled as follow:
                --reuse-values \\
                --set egressGateway.enabled=true \\
                --set bpf.masquerade=true \\
-               --set kubeProxyReplacement=strict \\
+               --set kubeProxyReplacement=true \\
                --set l7Proxy=false
 
     .. group-tab:: ConfigMap
@@ -103,7 +103,7 @@ The egress gateway feature and all the requirements can be enabled as follow:
             enable-bpf-masquerade: true
             enable-ipv4-egress-gateway: true
             enable-l7-proxy: false
-            kube-proxy-replacement: strict
+            kube-proxy-replacement: true
 
 Rollout both the agent pods and the operator pods to make the changes effective:
 

--- a/Documentation/network/kubernetes/ipam-multi-pool.rst
+++ b/Documentation/network/kubernetes/ipam-multi-pool.rst
@@ -29,7 +29,7 @@ Enable Multi-pool IPAM mode
    * ``--set ipv4NativeRoutingCIDR=10.0.0.0/8``
    * ``--set endpointRoutes.enabled=true``
    * ``--set-string extraConfig.enable-local-node-route=false``
-   * ``--set kubeProxyReplacement=strict``
+   * ``--set kubeProxyReplacement=true``
    * ``--set bpf.masquerade=true``
 
    For more details on why each of these options are needed, please refer to

--- a/Documentation/network/kubernetes/kata.rst
+++ b/Documentation/network/kubernetes/kata.rst
@@ -78,9 +78,9 @@ Deploy Cilium release via Helm:
 .. warning::
 
    Kata containers do not work with the socket-level loadbalancer, or with
-   :ref:`kube-proxy replacement <kubeproxy-free>` in strict mode. These
+   :ref:`kube-proxy replacement <kubeproxy-free>` enabled. These
    features should be disabled with ``--set socketLB.enabled=false``
-   (default) and ``--set kubeProxyReplacement=disabled`` (or ``partial``).
+   (default) and ``--set kubeProxyReplacement=false``.
 
    Both features rely on socket-based load-balancing, which is not possible
    given that Kata containers are virtual machines running with their own

--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -43,7 +43,7 @@ The L2 Announcements feature and all the requirements can be enabled as follows:
                --set l2announcements.enabled=true \\
                --set k8sClientRateLimit.qps={QPS} \\
                --set k8sClientRateLimit.burst={BURST} \\
-               --set kubeProxyReplacement=strict \\
+               --set kubeProxyReplacement=true \\
                --set k8sServiceHost=${API_SERVER_IP} \\
                --set k8sServicePort=${API_SERVER_PORT}
                
@@ -53,7 +53,7 @@ The L2 Announcements feature and all the requirements can be enabled as follows:
         .. code-block:: yaml
 
             enable-l2-announcements: true
-            kube-proxy-replacement: strict
+            kube-proxy-replacement: true
             k8s-client-qps: {QPS}
             k8s-client-burst: {BURST}
 
@@ -64,7 +64,8 @@ The L2 Announcements feature and all the requirements can be enabled as follows:
 Prerequisites
 #############
 
-* Kube Proxy replacement mode must be enabled and set to ``strict`` mode, see :ref:`kubeproxy-free` for details.
+* Kube Proxy replacement mode must be enabled. For more information, see
+  :ref:`kubeproxy-free`.
 
 * All devices on which L2 Aware LB will be announced should be enabled and included in the 
   ``--devices`` flag or ``devices`` Helm option if explicitly set, see :ref:`NodePort Devices`.
@@ -300,7 +301,7 @@ There are three Helm options that can be tuned with regards to leases:
                --namespace kube-system \\
                --reuse-values \\
                --set l2announcements.enabled=true \\
-               --set kubeProxyReplacement=strict \\
+               --set kubeProxyReplacement=true \\
                --set k8sServiceHost=${API_SERVER_IP} \\
                --set k8sServicePort=${API_SERVER_PORT} \\
                --set k8sClientRateLimit.qps={QPS} \\
@@ -314,7 +315,7 @@ There are three Helm options that can be tuned with regards to leases:
         .. code-block:: yaml
 
             enable-l2-announcements: true
-            kube-proxy-replacement: strict
+            kube-proxy-replacement: true
             l2-announcements-lease-duration: 3s
             l2-announcements-renew-deadline: 1s
             l2-announcements-retry-period: 200ms

--- a/Documentation/network/servicemesh/l7-traffic-management.rst
+++ b/Documentation/network/servicemesh/l7-traffic-management.rst
@@ -16,10 +16,10 @@ and CiliumClusterwideEnvoyConfig).
 Prerequisites
 #############
 
-* Cilium must be configured with ``kubeProxyReplacement`` as ``true``.
-  Please refer to :ref:`kube-proxy replacement <kubeproxy-free>`
-  for more details.
-* The minimum supported Kubernetes version for Ingress is 1.19.
+* Cilium must be configured with NodePort enabled, using
+  ``nodePort.enabled=true`` or by enabling the kube-proxy replacement with
+  ``kubeProxyReplacement=true``. For more information, see :ref:`kube-proxy
+  replacement <kubeproxy-free>`.
 
 Caveats
 #######

--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -70,7 +70,7 @@ this attribute can also be set via helm option ``--set labels=<values>``.
     apiVersion: v1
     data:
     ...
-      kube-proxy-replacement: partial
+      kube-proxy-replacement: "true"
       labels:  "k8s:io.kubernetes\\.pod\\.namespace k8s:k8s-app k8s:app k8s:name"
       enable-ipv4-masquerade: "true"
       monitor-aggregation: medium

--- a/Documentation/operations/performance/tuning.rst
+++ b/Documentation/operations/performance/tuning.rst
@@ -88,7 +88,7 @@ To enable IPv6 BIG TCP:
              --set bpf.masquerade=true \\
              --set ipv6.enabled=true \\
              --set enableIPv6BIGTCP=true \\
-             --set kubeProxyReplacement=strict
+             --set kubeProxyReplacement=true
 
 Note that after toggling the IPv6 BIG TCP option the Kubernetes Pods must be
 restarted for the changes to take effect.
@@ -145,7 +145,7 @@ To enable IPv4 BIG TCP:
              --set bpf.masquerade=true \\
              --set ipv4.enabled=true \\
              --set enableIPv4BIGTCP=true \\
-             --set kubeProxyReplacement=strict
+             --set kubeProxyReplacement=true
 
 Note that after toggling the IPv4 BIG TCP option the Kubernetes Pods
 must be restarted for the changes to take effect.
@@ -257,7 +257,7 @@ To enable the Bandwidth Manager:
            helm install cilium |CHART_RELEASE| \\
              --namespace kube-system \\
              --set bandwidthManager.enabled=true \\
-             --set kubeProxyReplacement=strict
+             --set kubeProxyReplacement=true
 
 To validate whether your installation is running with Bandwidth Manager,
 run ``cilium status`` in any of the Cilium pods and look for the line
@@ -305,7 +305,7 @@ To enable the Bandwidth Manager with BBR for Pods:
              --namespace kube-system \\
              --set bandwidthManager.enabled=true \\
              --set bandwidthManager.bbr=true \\
-             --set kubeProxyReplacement=strict
+             --set kubeProxyReplacement=true
 
 To validate whether your installation is running with BBR for Pods,
 run ``cilium status`` in any of the Cilium pods and look for the line

--- a/Documentation/operations/troubleshooting_servicemesh.rst
+++ b/Documentation/operations/troubleshooting_servicemesh.rst
@@ -20,15 +20,18 @@ Generic
 Manual Verification of Setup
 ----------------------------
 
- #. Validate that the ``kubeProxyReplacement`` is set to either partial or strict.
+ #. Validate that ``nodePort.enabled`` is true.
 
     .. code-block:: shell-session
 
-        $ kubectl exec -n kube-system ds/cilium -- cilium status
+        $ kubectl exec -n kube-system ds/cilium -- cilium status --verbose
         ...
-        KVStore:                 Ok   Disabled
-        Kubernetes:              Ok   1.23 (v1.23.6) [linux/amd64]
-        KubeProxyReplacement:    True   [eth0 192.168.49.2]
+        KubeProxyReplacement Details:
+        ...
+          Services:
+          - ClusterIP:      Enabled
+          - NodePort:       Enabled (Range: 30000-32767)
+        ...
 
  #. Validate that runtime the values of ``enable-envoy-config`` and ``enable-ingress-controller``
     are true. Ingress controller flag is optional if customer only uses ``CiliumEnvoyConfig`` or

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -205,7 +205,7 @@ version which was installed in this cluster.
         mode: "kubernetes"
       k8sServiceHost: "API_SERVER_IP"
       k8sServicePort: "API_SERVER_PORT"
-      kubeProxyReplacement: "strict"
+      kubeProxyReplacement: "true"
 
    You can then upgrade using this values file by running:
 


### PR DESCRIPTION
Follow-up to https://github.com/cilium/cilium/pull/27222.
Similar to https://github.com/cilium/cilium/pull/26577.

- docs: Replace mentions to KPR strict mode for per-node-config docs
- docs: Replace deprecated "kubeProxyReplacement=strict" with "...=true"
- docs: Update references to legacy kube-proxy replacement modes

Requirement on NodePort only in Documentation/network/servicemesh/l7-traffic-management.rst and Documentation/operations/troubleshooting_servicemesh.rst to be confirmed.

```release-note
docs: Clean up references to deprecated modes "strict" and "partial" for kube-proxy replacement feature flag
```