### PR TITLE
ipsec: fixes for key rotation

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -497,6 +497,9 @@ func setupIPSec() (int, uint8, error) {
 	if err != nil {
 		return 0, 0, err
 	}
+	if err := ipsec.SetIPSecSPI(spi); err != nil {
+		return 0, 0, err
+	}
 	node.SetIPsecKeyIdentity(spi)
 	return authKeySize, spi, nil
 }

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -513,6 +513,9 @@ func (c *clusterNodesClient) NodeDelete(node nodeTypes.Node) error {
 	return nil
 }
 
+func (c *clusterNodesClient) AllNodeValidateImplementation() {
+}
+
 func (c *clusterNodesClient) NodeValidateImplementation(node nodeTypes.Node) error {
 	// no-op
 	return nil

--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -131,6 +131,9 @@ func (r *authMapGarbageCollector) NodeDelete(deletedNode nodeTypes.Node) error {
 	return nil
 }
 
+func (r *authMapGarbageCollector) AllNodeValidateImplementation() {
+}
+
 func (r *authMapGarbageCollector) NodeValidateImplementation(node nodeTypes.Node) error {
 	return nil
 }

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -53,6 +53,9 @@ func (n *FakeNodeHandler) NodeDelete(node nodeTypes.Node) error {
 	return nil
 }
 
+func (n *FakeNodeHandler) AllNodeValidateImplementation() {
+}
+
 func (n *FakeNodeHandler) NodeValidateImplementation(node nodeTypes.Node) error {
 	return nil
 }

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -933,11 +933,11 @@ func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath
 			// package
 			node.SetIPsecKeyIdentity(spi)
 
-			// NodeValidateImplementation will eventually call
+			// AllNodeValidateImplementation will eventually call
 			// nodeUpdate(), which is responsible for updating the
 			// IPSec policies and states for all the different EPs
 			// with ipsec.UpsertIPsecEndpoint()
-			nodeHandler.NodeValidateImplementation(*nodediscovery.LocalNode())
+			nodeHandler.AllNodeValidateImplementation()
 
 			// Publish the updated node information to k8s/KVStore
 			nodediscovery.UpdateLocalNode()

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -66,10 +66,14 @@ func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {
 
 func (p *IPSecSuitePrivileged) TestLoadKeys(c *C) {
 	keys := bytes.NewReader(keysDat)
-	_, _, err := LoadIPSecKeys(keys)
+	_, spi, err := LoadIPSecKeys(keys)
+	c.Assert(err, IsNil)
+	err = SetIPSecSPI(spi)
 	c.Assert(err, IsNil)
 	keys = bytes.NewReader(keysAeadDat)
-	_, _, err = LoadIPSecKeys(keys)
+	_, spi, err = LoadIPSecKeys(keys)
+	c.Assert(err, IsNil)
+	err = SetIPSecSPI(spi)
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1906,6 +1906,16 @@ func (n *linuxNodeHandler) NodeValidateImplementation(nodeToValidate nodeTypes.N
 	return n.nodeUpdate(nil, &nodeToValidate, false)
 }
 
+// AllNodeValidateImplementation is called to validate the implementation of the
+// node in the datapath for all existing nodes
+func (n *linuxNodeHandler) AllNodeValidateImplementation() {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	for _, updateNode := range n.nodes {
+		n.nodeUpdate(nil, updateNode, false)
+	}
+}
+
 // NodeNeighDiscoveryEnabled returns whether node neighbor discovery is enabled
 func (n *linuxNodeHandler) NodeNeighDiscoveryEnabled() bool {
 	return n.enableNeighDiscovery

--- a/pkg/datapath/types/node.go
+++ b/pkg/datapath/types/node.go
@@ -121,6 +121,10 @@ type NodeHandler interface {
 	// NodeDelete is called after a node has been deleted
 	NodeDelete(node nodeTypes.Node) error
 
+	// AllNodeValidateImplementation is called to validate the implementation
+	// of all nodes in the node cache.
+	AllNodeValidateImplementation()
+
 	// NodeValidateImplementation is called to validate the implementation of
 	// the node in the datapath. This function is intended to be run on an
 	// interval to ensure that the datapath is consistently converged.

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -97,6 +97,10 @@ func (h *handler) NodeDelete(n types.Node) error {
 	return nil
 }
 
+// AllNodeValidateImplementation implements
+func (h handler) AllNodeValidateImplementation() {
+}
+
 // NodeValidateImplementation implements
 // datapath.NodeHandler.NodeValidateImplementation. It is a no-op.
 func (h handler) NodeValidateImplementation(_ types.Node) error {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -176,6 +176,9 @@ func (n *signalNodeHandler) NodeDelete(node nodeTypes.Node) error {
 	return n.NodeDeleteEventError
 }
 
+func (n *signalNodeHandler) AllNodeValidateImplementation() {
+}
+
 func (n *signalNodeHandler) NodeValidateImplementation(node nodeTypes.Node) error {
 	if n.EnableNodeValidateImplementationEvent {
 		n.NodeValidateImplementationEvent <- node

--- a/pkg/wireguard/agent/node_handler.go
+++ b/pkg/wireguard/agent/node_handler.go
@@ -30,6 +30,11 @@ func (a *Agent) NodeDelete(node nodeTypes.Node) error {
 	return a.DeletePeer(node.Fullname())
 }
 
+// AllNodeValidateImplementation is called to validate the implementation of
+// all nodes in the datapath.
+func (a *Agent) AllNodeValidateImplementation() {
+}
+
 // NodeValidateImplementation is called to validate the implementation of
 // the node in the datapath. This function is intended to be run on an
 // interval to ensure that the datapath is consistently converged.


### PR DESCRIPTION
Fixups to ensure keys are correctly in place before deleting the old key.

1. Instantiate all xfrm rules when new key shows up instead of waiting for nodeUpdate events through validator to happen. Its not always the case on larger clusters that the nodeUpdate logic will trigger before the key retention logic triggers to delete old keys. In this case we may be missing xfrm rules for new keys for some nodes.

2. Ensure rules are in place before key is updated. Current logic updates datapath key before updating the BPF maps creating smallish window where pkts can be marked for the new key but the BPF maps and datapath wont have the mapping to do this yet resulting in dropped pkts.

Both of these intend to address an increased policy block counter in recent versions.
```release-note
Fix bug that could cause packet drops of type XfrmOutPolBlock while rotating the IPsec key.
```