### PR TITLE
datapath: fix NodePort to remote hostns backend with tunnel config

### DIFF
--- a/pkg/datapath/linux/config/config_test.go
+++ b/pkg/datapath/linux/config/config_test.go
@@ -51,6 +51,7 @@ func setup(tb testing.TB) {
 
 	require.NoError(tb, rlimit.RemoveMemlock(), "Failed to remove memory limits")
 
+	option.Config.EnableHostLegacyRouting = true // Disable obtaining direct routing device.
 	node.SetTestLocalNodeStore()
 	node.InitDefaultPrefix("")
 	node.SetInternalIPv4Router(ipv4DummyAddr.AsSlice())

--- a/pkg/datapath/linux/devices_test.go
+++ b/pkg/datapath/linux/devices_test.go
@@ -30,16 +30,17 @@ import (
 )
 
 type DevicesSuite struct {
-	currentNetNS                   netns.NsHandle
-	prevConfigDevices              []string
-	prevConfigDirectRoutingDevice  string
-	prevConfigIPv6MCastDevice      string
-	prevConfigEnableIPv4           bool
-	prevConfigEnableIPv6           bool
-	prevConfigEnableNodePort       bool
-	prevConfigNodePortAcceleration string
-	prevConfigRoutingMode          string
-	prevConfigEnableIPv6NDP        bool
+	currentNetNS                      netns.NsHandle
+	prevConfigDevices                 []string
+	prevConfigDirectRoutingDevice     string
+	prevConfigIPv6MCastDevice         string
+	prevConfigEnableIPv4              bool
+	prevConfigEnableIPv6              bool
+	prevConfigEnableHostLegacyRouting bool
+	prevConfigEnableNodePort          bool
+	prevConfigNodePortAcceleration    string
+	prevConfigRoutingMode             string
+	prevConfigEnableIPv6NDP           bool
 }
 
 var _ = Suite(&DevicesSuite{})
@@ -74,6 +75,7 @@ func (s *DevicesSuite) TearDownTest(c *C) {
 	option.Config.EnableIPv4 = s.prevConfigEnableIPv4
 	option.Config.EnableIPv6 = s.prevConfigEnableIPv6
 	option.Config.EnableNodePort = s.prevConfigEnableNodePort
+	option.Config.EnableHostLegacyRouting = s.prevConfigEnableHostLegacyRouting
 	option.Config.NodePortAcceleration = s.prevConfigNodePortAcceleration
 	option.Config.RoutingMode = s.prevConfigRoutingMode
 	option.Config.EnableIPv6NDP = s.prevConfigEnableIPv6NDP
@@ -86,20 +88,22 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		option.Config.DirectRoutingDevice = ""
 		option.Config.EnableNodePort = true
 		option.Config.NodePortAcceleration = option.NodePortAccelerationDisabled
+		option.Config.EnableHostLegacyRouting = true
+		option.Config.EnableNodePort = false
 
-		// No devices, nothing to detect.
+		// 1. No devices, nothing to detect.
 		dm, err := newDeviceManagerForTests()
 		c.Assert(err, IsNil)
 
 		devices, err := dm.Detect(false)
 		c.Assert(err, IsNil)
-		c.Assert(devices, checker.DeepEquals, []string{})
+		c.Assert(devices, checker.DeepEquals, []string(nil))
 		dm.Stop()
 
-		// Node IP not set, can still detect. Direct routing device shouldn't be detected.
+		// 2. Nodeport, detection is performed:
 		option.Config.EnableNodePort = true
 		c.Assert(createDummy("dummy0", "192.168.0.1/24", false), IsNil)
-		nodeSetIP(nil)
+		nodeSetIP(net.ParseIP("192.168.0.1"))
 
 		dm, err = newDeviceManagerForTests()
 		c.Assert(err, IsNil)
@@ -107,7 +111,8 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(devices, checker.DeepEquals, []string{"dummy0"})
 		c.Assert(option.Config.GetDevices(), checker.DeepEquals, devices)
-		c.Assert(option.Config.DirectRoutingDevice, Equals, "")
+		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
+		option.Config.DirectRoutingDevice = ""
 		dm.Stop()
 
 		// Manually specified devices, no detection is performed
@@ -122,8 +127,9 @@ func (s *DevicesSuite) TestDetect(c *C) {
 		c.Assert(err, IsNil)
 		c.Assert(devices, checker.DeepEquals, []string{"dummy0"})
 		c.Assert(option.Config.GetDevices(), checker.DeepEquals, devices)
-		c.Assert(option.Config.DirectRoutingDevice, Equals, "")
+		c.Assert(option.Config.DirectRoutingDevice, Equals, "dummy0")
 		option.Config.SetDevices([]string{})
+		option.Config.DirectRoutingDevice = ""
 
 		// Direct routing mode, should find all devices and set direct
 		// routing device to the one with k8s node ip.
@@ -263,6 +269,7 @@ func (s *DevicesSuite) TestExpandDevices(c *C) {
 
 		// 1. Check expansion works and non-matching prefixes are ignored
 		option.Config.SetDevices([]string{"dummy+", "missing+", "other0+" /* duplicates: */, "dum+", "other0", "other1"})
+		option.Config.DirectRoutingDevice = "dummy0"
 		dm, err := newDeviceManagerForTests()
 		c.Assert(err, IsNil)
 		devs, err := dm.Detect(true)
@@ -425,6 +432,7 @@ func (s *DevicesSuite) TestListenAfterDelete(c *C) {
 		timeout := time.After(time.Second * 5)
 
 		option.Config.SetDevices([]string{"dummy+"})
+		option.Config.DirectRoutingDevice = "dummy0"
 		c.Assert(createDummy("dummy0", "192.168.1.2/24", false), IsNil)
 		c.Assert(createDummy("dummy1", "2001:db8::face/64", true), IsNil)
 

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2806,7 +2806,7 @@ func (c *DaemonConfig) DirectRoutingDeviceRequired() bool {
 		return true
 	}
 
-	return (c.EnableNodePort || BPFHostRoutingEnabled || Config.EnableWireguard) && !c.TunnelingEnabled()
+	return c.EnableNodePort || BPFHostRoutingEnabled || Config.EnableWireguard
 }
 
 func (c *DaemonConfig) validateIPv6ClusterAllocCIDR() error {


### PR DESCRIPTION
When forwarding external service requests to a remote backend in hostNetwork, the NodePort code in tail_nodeport_nat_egress_ipv4() doesn't redirect into the tunnel (as it's effectively a host-to-host connection).

Therefore it uses IPV4_DIRECT_ROUTING as src address. So if we're not populating IPV4_DIRECT_ROUTING, such forwarded requests end up being SNATed with 0.0.0.0.

This is a copy of #22738 by jwi@isovalent.com, reopening to debug test failures.

Fixes: #22557
Fixes: 5283ec9 ("datapath: Introduce DirectRoutingDeviceRequired helper")