### PR TITLE
ipcache: Skip conflict logging for tunnelpeer if native routing

### DIFF
--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -13,6 +13,7 @@ import (
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/types"
 )
@@ -257,13 +258,15 @@ func (s PrefixInfo) logConflicts(scopedLog *logrus.Entry) {
 
 		if info.tunnelPeer.IsValid() {
 			if tunnelPeer.IsValid() {
-				scopedLog.WithFields(logrus.Fields{
-					logfields.TunnelPeer:            tunnelPeer.String(),
-					logfields.Resource:              tunnelPeerResourceID,
-					logfields.ConflictingTunnelPeer: info.tunnelPeer.String(),
-					logfields.ConflictingResource:   resourceID,
-				}).Warning("Detected conflicting tunnel peer for prefix. " +
-					"This may cause connectivity issues for this address.")
+				if option.Config.TunnelingEnabled() {
+					scopedLog.WithFields(logrus.Fields{
+						logfields.TunnelPeer:            tunnelPeer.String(),
+						logfields.Resource:              tunnelPeerResourceID,
+						logfields.ConflictingTunnelPeer: info.tunnelPeer.String(),
+						logfields.ConflictingResource:   resourceID,
+					}).Warning("Detected conflicting tunnel peer for prefix. " +
+						"This may cause connectivity issues for this address.")
+				}
 			} else {
 				tunnelPeer = info.tunnelPeer
 				tunnelPeerResourceID = resourceID


### PR DESCRIPTION
See https://github.com/cilium/cilium/issues/26817 and specifically
https://github.com/cilium/cilium/issues/26817#issuecomment-1668628719
for more details.

In summary, it is safe to skip logging the tunnelpeer conflict if Cilium
is configured with native routing, because the tunnel is not used at all
anyway.

The log msg was triggered in the case that the router IP was configured
to be the same across all nodes, a la `--local-router-ip`, in native
routing mode.

Fixes: https://github.com/cilium/cilium/issues/26817
Suggested-by: Tamilmani Manoharan <tamanoha@microsoft.com>
Signed-off-by: Chris Tarazi <chris@isovalent.com>
