### PR TITLE
clustermesh: make extra ipcache watcher options configurable

### DIFF
--- a/pkg/clustermesh/remote_cluster_test.go
+++ b/pkg/clustermesh/remote_cluster_test.go
@@ -196,3 +196,38 @@ func TestRemoteClusterRun(t *testing.T) {
 		})
 	}
 }
+
+func TestIPCacheWatcherOpts(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *types.CiliumClusterConfig
+		extra    IPCacheWatcherOptsFn
+		expected int
+	}{
+		{
+			name:     "nil config",
+			expected: 0,
+		},
+		{
+			name:     "non-nil config",
+			config:   &types.CiliumClusterConfig{},
+			expected: 1,
+		},
+		{
+			name: "with extra opts",
+			extra: func(config *types.CiliumClusterConfig) []ipcache.IWOpt {
+				return []ipcache.IWOpt{ipcache.WithClusterID(10), ipcache.WithSelfDeletionProtection()}
+			},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rc := remoteCluster{ipCacheWatcherExtraOpts: tt.extra}
+			// Asserting the number of returned options, because it is not
+			// possible to compare them, being functions.
+			assert.Len(t, rc.ipCacheWatcherOpts(tt.config), tt.expected)
+		})
+	}
+}


### PR DESCRIPTION
Let's allow to inject extra options for the ipcache watcher used by clustermesh through Hive, to allow for additional customizations by external consumers of this module.

