### PR TITLE
ipcache: propagate cluster ID as part of the key

### DIFF
--- a/pkg/datapath/ipcache/listener.go
+++ b/pkg/datapath/ipcache/listener.go
@@ -139,7 +139,7 @@ func (l *BPFListener) OnIPIdentityCacheChange(modType ipcache.CacheModification,
 
 	// Update BPF Maps.
 
-	key := ipcacheMap.NewKey(cidr.IP, cidr.Mask, 0)
+	key := ipcacheMap.NewKey(cidr.IP, cidr.Mask, uint8(cidrCluster.ClusterID()))
 
 	switch modType {
 	case ipcache.Upsert:


### PR DESCRIPTION
Insert the cluster ID associated with a given CIDR as part of the ipcache key. No behavioral change is introduced when the cluster ID is 0, which is the default.