### PR TITLE
ci: set timeout on build images workflows

### DIFF
--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -19,6 +19,7 @@ permissions:
 
 jobs:
   build-and-push:
+    timeout-minutes: 45
     environment: release-beta-images
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -34,6 +34,7 @@ concurrency:
 
 jobs:
   build-and-push-prs:
+    timeout-minutes: 45
     runs-on: ubuntu-20.04
     strategy:
       matrix:

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   build-and-push:
+    timeout-minutes: 45
     environment: release-developer-images
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build-and-push:
+    timeout-minutes: 45
     environment: release
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
Due to the lack of a global timeout in the build images GHA workflows, some steps might take forever.

Therefore, this commit introduces a global timeout of 45 minutes. (already used in `build-images-base.yaml`)

Example of a hanging workflow run: https://github.com/cilium/cilium/actions/runs/5793333705/job/15700948511