### PR TITLE
Add source and destination workload_kind context labels (Hubble).

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -673,21 +673,23 @@ Hubble metrics can also be configured with a ``labelsContext`` which allows prov
 that should be added to the metric. Unlike ``sourceContext`` and ``destinationContext``, instead
 of different values being put into the same metric label, the ``labelsContext`` puts them into different label values.
 
-========================= ===============================================================================
-Option Value              Description
-========================= ===============================================================================
-``source_ip``             The source IP of the flow.
-``source_namespace``      The namespace of the pod if the flow source is from a Kubernetes pod.
-``source_pod``            The pod name if the flow source is from a Kubernetes pod.
-``source_workload``       The name of the source pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).
-``source_app``            The app name of the source pod, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
-``destination_ip``        The destination IP of the flow.
-``destination_namespace`` The namespace of the pod if the flow destination is from a Kubernetes pod.
-``destination_pod``       The pod name if the flow destination is from a Kubernetes pod.
-``destination_workload``  The name of the destination pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).
-``destination_app``       The app name of the source pod, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
-``traffic_direction``     Identifies the traffic direction of the flow. Possible values are ``ingress``, ``egress`` and ``unknown``.
-========================= ===============================================================================
+============================== ===============================================================================
+Option Value                   Description
+============================== ===============================================================================
+``source_ip``                  The source IP of the flow.
+``source_namespace``           The namespace of the pod if the flow source is from a Kubernetes pod.
+``source_pod``                 The pod name if the flow source is from a Kubernetes pod.
+``source_workload``            The name of the source pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).
+``source_workload_kind``       The kind of the source pod's workload, for example, Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift).
+``source_app``                 The app name of the source pod, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
+``destination_ip``             The destination IP of the flow.
+``destination_namespace``      The namespace of the pod if the flow destination is from a Kubernetes pod.
+``destination_pod``            The pod name if the flow destination is from a Kubernetes pod.
+``destination_workload``       The name of the destination pod's workload (Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift)).
+``destination_workload_kind``  The kind of the destination pod's workload, for example, Deployment, Statefulset, Daemonset, ReplicationController, CronJob, Job, DeploymentConfig (OpenShift).
+``destination_app``            The app name of the source pod, derived from pod labels (``app.kubernetes.io/name``, ``k8s-app``, or ``app``).
+``traffic_direction``          Identifies the traffic direction of the flow. Possible values are ``ingress``, ``egress`` and ``unknown``.
+============================== ===============================================================================
 
 When specifying the flow context, multiple values can be specified by separating them via the ``,`` symbol.
 All labels listed are included in the metric, even if empty. For example, a metric configuration of

--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -56,8 +56,8 @@ const ContextOptionsHelp = `
  destinationEgressContext  ::= identifier , { "|", identifier }
  destinationIngressContext ::= identifier , { "|", identifier }
  labels                    ::= label , { ",", label }
- identifier             ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
- label                     ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
+ identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
+ label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | traffic_direction
 `
 
 var (
@@ -69,11 +69,13 @@ var (
 		"source_pod",
 		"source_namespace",
 		"source_workload",
+		"source_workload_kind",
 		"source_app",
 		"destination_ip",
 		"destination_pod",
 		"destination_namespace",
 		"destination_workload",
+		"destination_workload_kind",
 		"destination_app",
 		"traffic_direction",
 	}
@@ -309,6 +311,10 @@ func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *p
 				if workloads := source.GetWorkloads(); len(workloads) != 0 {
 					labelValue = workloads[0].Name
 				}
+			case "source_workload_kind":
+				if workloads := source.GetWorkloads(); len(workloads) != 0 {
+					labelValue = workloads[0].Kind
+				}
 			case "source_app":
 				labelValue = getK8sAppFromLabels(source.GetLabels())
 			case "destination_ip":
@@ -320,6 +326,10 @@ func labelsContext(invertSourceDestination bool, wantedLabels labelsSet, flow *p
 			case "destination_workload":
 				if workloads := destination.GetWorkloads(); len(workloads) != 0 {
 					labelValue = workloads[0].Name
+				}
+			case "destination_workload_kind":
+				if workloads := destination.GetWorkloads(); len(workloads) != 0 {
+					labelValue = workloads[0].Kind
 				}
 			case "destination_app":
 				labelValue = getK8sAppFromLabels(destination.GetLabels())

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -75,7 +75,7 @@ func TestParseContextOptions(t *testing.T) {
 	// All of the labelsContext options should work
 	opts, err = ParseContextOptions(Options{"labelsContext": strings.Join(contextLabelsList, ",")})
 	assert.NoError(t, err)
-	assert.EqualValues(t, "labels=source_ip,source_pod,source_namespace,source_workload,source_app,destination_ip,destination_pod,destination_namespace,destination_workload,destination_app,traffic_direction", opts.Status())
+	assert.EqualValues(t, "labels=source_ip,source_pod,source_namespace,source_workload,source_workload_kind,source_app,destination_ip,destination_pod,destination_namespace,destination_workload,destination_workload_kind,destination_app,traffic_direction", opts.Status())
 	assert.EqualValues(t, contextLabelsList, opts.GetLabelNames())
 
 	opts, err = ParseContextOptions(Options{"labelsContext": "non_existent_label"})
@@ -233,7 +233,7 @@ func TestParseGetLabelValues(t *testing.T) {
 		PodName:   "bar-deploy-pod",
 		Workloads: []*pb.Workload{{
 			Name: "bar-deploy",
-			Kind: "Deployment",
+			Kind: "StatefulSet",
 		}},
 		Labels: []string{
 			"k8s:app=barapp",
@@ -251,10 +251,10 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.EqualValues(t,
 		mustGetLabelValues(opts, flow),
 		[]string{
-			// source_ip, source_pod, source_namespace, source_workload, source_app
-			"1.2.3.4", "foo-deploy-pod", "foo-ns", "foo-deploy", "fooapp",
-			// destination_ip, destination_pod, destination_namespace, destination_workload, destination_app
-			"5.6.7.8", "bar-deploy-pod", "bar-ns", "bar-deploy", "barapp",
+			// source_ip, source_pod, source_namespace, source_workload, source_workload_kind , source_app
+			"1.2.3.4", "foo-deploy-pod", "foo-ns", "foo-deploy", "Deployment", "fooapp",
+			// destination_ip, destination_pod, destination_namespace, destination_workload, destination_workload_kind, destination_app
+			"5.6.7.8", "bar-deploy-pod", "bar-ns", "bar-deploy", "StatefulSet", "barapp",
 			// traffic_direction
 			"ingress",
 		},
@@ -265,8 +265,8 @@ func TestParseGetLabelValues(t *testing.T) {
 	assert.EqualValues(t,
 		mustGetLabelValues(opts, &pb.Flow{}),
 		[]string{
-			"", "", "", "", "",
-			"", "", "", "", "",
+			"", "", "", "", "", "",
+			"", "", "", "", "", "",
 			"unknown",
 		},
 	)

--- a/pkg/hubble/metrics/http/plugin_test.go
+++ b/pkg/hubble/metrics/http/plugin_test.go
@@ -27,8 +27,8 @@ Options:
  destinationEgressContext  ::= identifier , { "|", identifier }
  destinationIngressContext ::= identifier , { "|", identifier }
  labels                    ::= label , { ",", label }
- identifier             ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
- label                     ::= source_ip | source_pod | source_namespace | source_workload | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_app | traffic_direction
+ identifier                ::= identity | namespace | pod | pod-name | dns | ip | reserved-identity | workload | workload-name | app
+ label                     ::= source_ip | source_pod | source_namespace | source_workload | source_workload_kind | source_app | destination_ip | destination_pod | destination_namespace | destination_workload | destination_workload_kind | destination_app | traffic_direction
 `
 	assert.Equal(t, expected, plugin.HelpText())
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Thanks for contributing!

Add source and destination workload_kind context labels (Hubble).

```release-note
Add source and destination workload_kind context labels (Hubble).
```

recreated https://github.com/cilium/cilium/pull/25715 because of CI issues  @ldelossa 