### PR TITLE
Fix deletion of tunnel map entries when node has non-zero cluster ID.

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1427,8 +1427,8 @@ func (n *linuxNodeHandler) nodeDelete(oldNode *nodeTypes.Node) error {
 	}
 
 	if n.nodeConfig.EnableEncapsulation {
-		oldPrefix4 := cmtypes.PrefixClusterFromCIDR(oldNode.IPv4AllocCIDR, oldNode.ClusterID)
-		oldPrefix6 := cmtypes.PrefixClusterFromCIDR(oldNode.IPv6AllocCIDR, oldNode.ClusterID)
+		oldPrefix4 := cmtypes.PrefixClusterFromCIDR(oldNode.IPv4AllocCIDR, 0)
+		oldPrefix6 := cmtypes.PrefixClusterFromCIDR(oldNode.IPv6AllocCIDR, 0)
 		if err := deleteTunnelMapping(oldPrefix4, false); err != nil {
 			errs = errors.Join(errs, fmt.Errorf("failed to remove old encapsulation config: deleting tunnel mapping for ipv4: %w", err))
 		}

--- a/pkg/datapath/linux/node_linux_test.go
+++ b/pkg/datapath/linux/node_linux_test.go
@@ -405,7 +405,8 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	// nodev1: ip4Alloc1, ip6alloc1 => externalNodeIP1
 	nodev1 := nodeTypes.Node{
-		Name: "node1",
+		Name:      "node1",
+		ClusterID: 11,
 		IPAddresses: []nodeTypes.Address{
 			{IP: externalNodeIP1, Type: nodeaddressing.NodeInternalIP},
 		},
@@ -443,7 +444,8 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	// nodev2: ip4Alloc1, ip6alloc1 => externalNodeIP2
 	nodev2 := nodeTypes.Node{
-		Name: "node1",
+		Name:      "node1",
+		ClusterID: 11,
 		IPAddresses: []nodeTypes.Address{
 			{IP: externalNodeIP2, Type: nodeaddressing.NodeInternalIP},
 		},
@@ -482,7 +484,8 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	// nodev3: ip4Alloc2, ip6alloc2 => externalNodeIP1
 	nodev3 := nodeTypes.Node{
-		Name: "node1",
+		Name:      "node1",
+		ClusterID: 11,
 		IPAddresses: []nodeTypes.Address{
 			{IP: externalNodeIP1, Type: nodeaddressing.NodeInternalIP},
 		},
@@ -541,7 +544,8 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	// nodev4: stop announcing CIDRs
 	nodev4 := nodeTypes.Node{
-		Name: "node1",
+		Name:      "node1",
+		ClusterID: 11,
 		IPAddresses: []nodeTypes.Address{
 			{IP: externalNodeIP1, Type: nodeaddressing.NodeInternalIP},
 		},
@@ -572,7 +576,8 @@ func (s *linuxPrivilegedBaseTestSuite) TestNodeUpdateEncapsulation(c *check.C) {
 
 	// nodev5: re-announce CIDRs
 	nodev5 := nodeTypes.Node{
-		Name: "node1",
+		Name:      "node1",
+		ClusterID: 11,
 		IPAddresses: []nodeTypes.Address{
 			{IP: externalNodeIP1, Type: nodeaddressing.NodeInternalIP},
 		},


### PR DESCRIPTION
Given that tunnel mapping entries are currently inserted without specifying the cluster ID, we should do the same during the removal phase. Otherwise, we fail to remove the entries if the node is associated with a non-zero cluster ID. Let's additionally update the test so that it would catch future regressions.

```release-note
Fix deletion of tunnel map entries when node has non-zero cluster ID.
```
