### PR TITLE
Read FQDNRejectResponseCode from config

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3363,6 +3363,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.DNSProxyConcurrencyProcessingGracePeriod = vp.GetDuration(DNSProxyConcurrencyProcessingGracePeriod)
 	c.DNSProxyLockCount = vp.GetInt(DNSProxyLockCount)
 	c.DNSProxyLockTimeout = vp.GetDuration(DNSProxyLockTimeout)
+	c.FQDNRejectResponse = vp.GetString(FQDNRejectResponseCode)
 
 	// Convert IP strings into net.IPNet types
 	subnets, invalid := ip.ParseCIDRs(vp.GetStringSlice(IPv4PodSubnets))


### PR DESCRIPTION
Currently dnsProxy.dnsRejectResponseCode helm value is ignored because FQDNRejectResponseCode is not populated from viper
