### PR TITLE
bpf: policy: cleanups to reduce program size

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1466,9 +1466,8 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 	if (skip_ingress_proxy)
 		goto skip_policy_enforcement;
 
-	verdict = policy_can_access_ingress(ctx, src_label, SECLABEL,
-					    tuple->dport, tuple->nexthdr, l4_off, false,
-					    &policy_match_type, &audited, ext_err, proxy_port);
+	verdict = policy_can_ingress6(ctx, tuple, l4_off, src_label, SECLABEL,
+				      &policy_match_type, &audited, ext_err, proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		struct remote_endpoint_info *sep = lookup_ip6_remote_endpoint(&orig_sip, 0);
 
@@ -1791,10 +1790,9 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 		goto skip_policy_enforcement;
 #endif /* ENABLE_PER_PACKET_LB && !DISABLE_LOOPBACK_LB */
 
-	verdict = policy_can_access_ingress(ctx, src_label, SECLABEL,
-					    tuple->dport, tuple->nexthdr, l4_off,
-					    is_untracked_fragment,
-					    &policy_match_type, &audited, ext_err, proxy_port);
+	verdict = policy_can_ingress4(ctx, tuple, l4_off, is_untracked_fragment, src_label,
+				      SECLABEL, &policy_match_type, &audited, ext_err,
+				      proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		struct remote_endpoint_info *sep = lookup_ip4_remote_endpoint(orig_sip, 0);
 

--- a/bpf/lib/host_firewall.h
+++ b/bpf/lib/host_firewall.h
@@ -193,9 +193,8 @@ __ipv6_host_policy_ingress(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
 		goto out;
 
 	/* Perform policy lookup */
-	verdict = policy_can_access_ingress(ctx, *src_sec_identity, HOST_ID, tuple->dport,
-					    tuple->nexthdr, ct_buffer->l4_off, false,
-					    &policy_match_type, &audited, ext_err, &proxy_port);
+	verdict = policy_can_ingress6(ctx, tuple, ct_buffer->l4_off, *src_sec_identity, HOST_ID,
+				      &policy_match_type, &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
 		verdict = auth_lookup(ctx, HOST_ID, *src_sec_identity, tunnel_endpoint, auth_type);
@@ -470,10 +469,9 @@ __ipv4_host_policy_ingress(struct __ctx_buff *ctx, struct iphdr *ip4,
 #  endif
 
 	/* Perform policy lookup */
-	verdict = policy_can_access_ingress(ctx, *src_sec_identity, HOST_ID, tuple->dport,
-					    tuple->nexthdr, ct_buffer->l4_off,
-					    is_untracked_fragment,
-					    &policy_match_type, &audited, ext_err, &proxy_port);
+	verdict = policy_can_ingress4(ctx, tuple, ct_buffer->l4_off, is_untracked_fragment,
+				      *src_sec_identity, HOST_ID, &policy_match_type,
+				      &audited, ext_err, &proxy_port);
 	if (verdict == DROP_POLICY_AUTH_REQUIRED) {
 		auth_type = (__u8)*ext_err;
 		verdict = auth_lookup(ctx, HOST_ID, *src_sec_identity, tunnel_endpoint, auth_type);

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -33,8 +33,9 @@ __account_and_check(struct __ctx_buff *ctx, struct policy_entry *policy,
 
 static __always_inline int
 __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
-		    __u32 remote_id, __u16 dport, __u8 proto, int off __maybe_unused,
-		    int dir, bool is_untracked_fragment, __u8 *match_type, __s8 *ext_err,
+		    __u32 remote_id, __u16 ethertype __maybe_unused, __u16 dport,
+		    __u8 proto, int off __maybe_unused, int dir,
+		    bool is_untracked_fragment, __u8 *match_type, __s8 *ext_err,
 		    __u16 *proxy_port)
 {
 	struct policy_entry *policy;
@@ -48,49 +49,56 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
 		.dport = dport,
 	};
 
-#ifdef ALLOW_ICMP_FRAG_NEEDED
-	/* When ALLOW_ICMP_FRAG_NEEDED is defined we allow all packets
-	 * of ICMP type 3 code 4 - Fragmentation Needed.
-	 */
-	if (proto == IPPROTO_ICMP) {
-		struct icmphdr icmphdr __align_stack_8;
+#if defined(ALLOW_ICMP_FRAG_NEEDED) || defined(ENABLE_ICMP_RULE)
+	switch (ethertype) {
+	case ETH_P_IP:
+		if (proto == IPPROTO_ICMP) {
+			struct icmphdr icmphdr __align_stack_8;
 
-		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
-			return DROP_INVALID;
+			if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
+				return DROP_INVALID;
 
-		if (icmphdr.type == ICMP_DEST_UNREACH &&
-		    icmphdr.code == ICMP_FRAG_NEEDED) {
-			*proxy_port = 0;
-			return CTX_ACT_OK;
+# if defined(ALLOW_ICMP_FRAG_NEEDED)
+			if (icmphdr.type == ICMP_DEST_UNREACH &&
+			    icmphdr.code == ICMP_FRAG_NEEDED) {
+				*proxy_port = 0;
+				return CTX_ACT_OK;
+			}
+# endif
+
+# if defined(ENABLE_ICMP_RULE)
+			/* Convert from unsigned char to unsigned short
+			 * considering byte order(little-endian).
+			 * In the little-endian case, for example, 2byte data "AB"
+			 * convert to "BA".
+			 * Therefore, the "icmp_type" should be shifted not just casting.
+			 */
+			key.dport = (__u16)(icmphdr.type << 8);
+# endif
 		}
+		break;
+	case ETH_P_IPV6:
+# if defined(ENABLE_ICMP_RULE)
+		if (proto == IPPROTO_ICMPV6) {
+			__u8 icmp_type;
+
+			if (ctx_load_bytes(ctx, off, &icmp_type, sizeof(icmp_type)) < 0)
+				return DROP_INVALID;
+
+			/* Convert from unsigned char to unsigned short
+			 * considering byte order(little-endian).
+			 * In the little-endian case, for example, 2byte data "AB"
+			 * convert to "BA".
+			 * Therefore, the "icmp_type" should be shifted not just casting.
+			 */
+			key.dport = (__u16)(icmp_type << 8);
+		}
+# endif
+		break;
+	default:
+		break;
 	}
-#endif /* ALLOW_ICMP_FRAG_NEEDED */
-
-#ifdef ENABLE_ICMP_RULE
-	if (proto == IPPROTO_ICMP) {
-		struct icmphdr icmphdr __align_stack_8;
-
-		if (ctx_load_bytes(ctx, off, &icmphdr, sizeof(icmphdr)) < 0)
-			return DROP_INVALID;
-
-		/* Convert from unsigned char to unsigned short considering byte order(little-endian).
-		 * In the little-endian case, for example, 2byte data "AB" convert to "BA".
-		 * Therefore, the "icmp_type" should be shifted not just casting.
-		 */
-		key.dport = (__u16)(icmphdr.type << 8);
-	} else if (proto == IPPROTO_ICMPV6) {
-		__u8 icmp_type;
-
-		if (ctx_load_bytes(ctx, off, &icmp_type, sizeof(icmp_type)) < 0)
-			return DROP_INVALID;
-
-		/* Convert from unsigned char to unsigned short considering byte order(little-endian).
-		 * In the little-endian case, for example, 2byte data "AB" convert to "BA".
-		 * Therefore, the "icmp_type" should be shifted not just casting.
-		 */
-		key.dport = (__u16)(icmp_type << 8);
-	}
-#endif /* ENABLE_ICMP_RULE */
+#endif /* ALLOW_ICMP_FRAG_NEEDED || ENABLE_ICMP_RULE */
 
 	/* Policy match precedence:
 	 * 1. id/proto/port  (L3/L4)
@@ -177,6 +185,7 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
  * @arg ctx		Packet to allow or deny
  * @arg src_id		Source security identity for this packet
  * @arg dst_id		Destination security identity for this packet
+ * @arg ethertype	Ethertype of this packet
  * @arg dport		Destination port of this packet
  * @arg proto		L3 Protocol of this packet
  * @arg l4_off		Offset to L4 header of this packet
@@ -191,13 +200,13 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
  *   - Negative error code if the packet should be dropped
  */
 static __always_inline int
-policy_can_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
+policy_can_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id, __u16 ethertype,
 		   __u16 dport, __u8 proto, int l4_off, bool is_untracked_fragment,
 		   __u8 *match_type, __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
 {
 	int ret;
 
-	ret = __policy_can_access(&POLICY_MAP, ctx, dst_id, src_id, dport,
+	ret = __policy_can_access(&POLICY_MAP, ctx, dst_id, src_id, ethertype, dport,
 				  proto, l4_off, CT_INGRESS, is_untracked_fragment,
 				  match_type, ext_err, proxy_port);
 	if (ret >= CTX_ACT_OK)
@@ -222,7 +231,7 @@ static __always_inline int policy_can_ingress6(struct __ctx_buff *ctx,
 					       __u8 *match_type, __u8 *audited,
 					       __s8 *ext_err, __u16 *proxy_port)
 {
-	return policy_can_ingress(ctx, src_id, dst_id, tuple->dport,
+	return policy_can_ingress(ctx, src_id, dst_id, ETH_P_IPV6, tuple->dport,
 				 tuple->nexthdr, l4_off, false, match_type, audited,
 				 ext_err, proxy_port);
 }
@@ -234,7 +243,7 @@ static __always_inline int policy_can_ingress4(struct __ctx_buff *ctx,
 					       __u8 *match_type, __u8 *audited,
 					       __s8 *ext_err, __u16 *proxy_port)
 {
-	return policy_can_ingress(ctx, src_id, dst_id, tuple->dport,
+	return policy_can_ingress(ctx, src_id, dst_id, ETH_P_IP, tuple->dport,
 				 tuple->nexthdr, l4_off, is_untracked_fragment,
 				 match_type, audited, ext_err, proxy_port);
 }
@@ -247,7 +256,7 @@ static __always_inline bool is_encap(__u16 dport, __u8 proto)
 #endif
 
 static __always_inline int
-policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
+policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id, __u16 ethertype,
 		  __u16 dport, __u8 proto, int l4_off, __u8 *match_type,
 		  __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
 {
@@ -257,7 +266,7 @@ policy_can_egress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 	if (src_id != HOST_ID && is_encap(dport, proto))
 		return DROP_ENCAP_PROHIBITED;
 #endif
-	ret = __policy_can_access(&POLICY_MAP, ctx, src_id, dst_id, dport,
+	ret = __policy_can_access(&POLICY_MAP, ctx, src_id, dst_id, ethertype, dport,
 				  proto, l4_off, CT_EGRESS, false, match_type,
 				  ext_err, proxy_port);
 	if (ret >= 0)
@@ -279,7 +288,7 @@ static __always_inline int policy_can_egress6(struct __ctx_buff *ctx,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,
 					      __u16 *proxy_port)
 {
-	return policy_can_egress(ctx, src_id, dst_id, tuple->dport,
+	return policy_can_egress(ctx, src_id, dst_id, ETH_P_IPV6, tuple->dport,
 				 tuple->nexthdr, l4_off, match_type, audited,
 				 ext_err, proxy_port);
 }
@@ -290,7 +299,7 @@ static __always_inline int policy_can_egress4(struct __ctx_buff *ctx,
 					      __u8 *match_type, __u8 *audited, __s8 *ext_err,
 					      __u16 *proxy_port)
 {
-	return policy_can_egress(ctx, src_id, dst_id, tuple->dport,
+	return policy_can_egress(ctx, src_id, dst_id, ETH_P_IP, tuple->dport,
 				 tuple->nexthdr, l4_off, match_type, audited,
 				 ext_err, proxy_port);
 }

--- a/bpf/lib/policy.h
+++ b/bpf/lib/policy.h
@@ -191,9 +191,9 @@ __policy_can_access(const void *map, struct __ctx_buff *ctx, __u32 local_id,
  *   - Negative error code if the packet should be dropped
  */
 static __always_inline int
-policy_can_access_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
-			  __u16 dport, __u8 proto, int l4_off, bool is_untracked_fragment,
-			  __u8 *match_type, __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
+policy_can_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
+		   __u16 dport, __u8 proto, int l4_off, bool is_untracked_fragment,
+		   __u8 *match_type, __u8 *audited, __s8 *ext_err, __u16 *proxy_port)
 {
 	int ret;
 
@@ -214,6 +214,29 @@ policy_can_access_ingress(struct __ctx_buff *ctx, __u32 src_id, __u32 dst_id,
 #endif
 
 	return ret;
+}
+
+static __always_inline int policy_can_ingress6(struct __ctx_buff *ctx,
+					       const struct ipv6_ct_tuple *tuple,
+					       int l4_off,  __u32 src_id, __u32 dst_id,
+					       __u8 *match_type, __u8 *audited,
+					       __s8 *ext_err, __u16 *proxy_port)
+{
+	return policy_can_ingress(ctx, src_id, dst_id, tuple->dport,
+				 tuple->nexthdr, l4_off, false, match_type, audited,
+				 ext_err, proxy_port);
+}
+
+static __always_inline int policy_can_ingress4(struct __ctx_buff *ctx,
+					       const struct ipv4_ct_tuple *tuple,
+					       int l4_off, bool is_untracked_fragment,
+					       __u32 src_id, __u32 dst_id,
+					       __u8 *match_type, __u8 *audited,
+					       __s8 *ext_err, __u16 *proxy_port)
+{
+	return policy_can_ingress(ctx, src_id, dst_id, tuple->dport,
+				 tuple->nexthdr, l4_off, is_untracked_fragment,
+				 match_type, audited, ext_err, proxy_port);
 }
 
 #ifdef HAVE_ENCAP


### PR DESCRIPTION
This brings a bit of innocent fine-tuning for the BPF policy code.

For the example of `bpf_host`'s `tail_rev_nodeport_lb6()` (containing HostFW policy code), it shaves off around 100 instructions.