### PR TITLE
Replace metricsmap-bpf-prom-sync with Prometheus Collector pattern

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/l2announcer"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/maps/metricsmap"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	nodeManager "github.com/cilium/cilium/pkg/node/manager"
@@ -79,6 +80,9 @@ var (
 
 		// Provide the modular metrics registry, metric HTTP server and legacy metrics cell.
 		metrics.Cell,
+
+		// Provides cilium_datapath_drop/forward Prometheus metrics.
+		metricsmap.Cell,
 
 		// Provide option.Config via hive so cells can depend on the agent config.
 		cell.Provide(func() *option.DaemonConfig { return option.Config }),

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -14,7 +14,6 @@ import (
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/cidr"
-	"github.com/cilium/cilium/pkg/controller"
 	datapathIpcache "github.com/cilium/cilium/pkg/datapath/ipcache"
 	"github.com/cilium/cilium/pkg/datapath/linux/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
@@ -47,10 +46,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
-	"github.com/cilium/cilium/pkg/time"
 )
-
-var metricsmapBPFPromSyncControllerGroup = controller.NewGroup("metricsmap-bpf-prom-sync")
 
 // LocalConfig returns the local configuration of the daemon's nodediscovery.
 func (d *Daemon) LocalConfig() *datapath.LocalNodeConfiguration {
@@ -450,17 +446,6 @@ func (d *Daemon) initMaps() error {
 			}
 		}
 	}
-
-	// Start the controller for periodic sync of the metrics map with
-	// the prometheus server.
-	controller.NewManager().UpdateController(
-		"metricsmap-bpf-prom-sync",
-		controller.ControllerParams{
-			Group:       metricsmapBPFPromSyncControllerGroup,
-			DoFunc:      metricsmap.SyncMetricsMap,
-			RunInterval: 5 * time.Second,
-			Context:     d.ctx,
-		})
 
 	if !option.Config.RestoreState {
 		// If we are not restoring state, all endpoints can be


### PR DESCRIPTION
Previously, the 'metricsmap-bpf-prom-sync' controller was responsible for periodically collecting cilium_datapath drop
and forward metrics.
This PR introduces the metricsmapCollector, which implements the Prometheus Collector interface within the
metricsmap package. As a result, the aforementioned controller has been removed.
The metricsmapCollector is registered within the global Prometheus registry during the initialization of metricsmap.
The metrics.Register function has been modified to propagate errors from the registry.Register function instead of
simply overriding it with nil.
The metricsmapCollector comprises two metrics maps: forwardedMetricsMap and droppedMetricsMap.
These maps are populated within a callback function passed to the IterateWithCallback function.
This approach serves two primary purposes:
1. Separation of Map Iteration and Metric Update: By separating the iteration over the BPF map and the updating of
    Prometheus metrics, the implementation ensures that no partial metrics are exposed in case of map iteration failure.
2. Normalization of exposed Metrics: Unlike the statement in the bpf/lib/metrics.h comments, which suggests exposing
    only one reason label for forwarded metrics, the eBPF code exposes multiple reasons. Through testing, it was found
    that reasons 0 and 3 were exposed which triggered this error in prometheus client:
    https://github.com/prometheus/client_golang/issues/242

Furthermore, cilium command has an indirect dependency on metricsmap package. To prevent metrics map initialization
from happening each time cilium command is executed, metricsmap is converted to hive Cell and injected in cilium daemon
Infrastructure module. For details see this comment: https://github.com/cilium/cilium/pull/27370#issuecomment-1710805663.

Fixes: #27058

Signed-off-by: Boris Petrovic <carnerito.b@gmail.com>