### PR TITLE
cleanup: can clean the bpf filters created by the cilium agent with lower version

### DIFF
--- a/cilium/cmd/cleanup.go
+++ b/cilium/cmd/cleanup.go
@@ -530,7 +530,10 @@ func getTCFilters(link netlink.Link) ([]*netlink.BpfFilter, error) {
 					strings.Contains(bpfFilter.Name, "bpf_overlay") ||
 					// Filters created by the Go bpf loader contain the bpf function and
 					// interface name, like cil_from_netdev-eth0.
-					strings.Contains(bpfFilter.Name, "cil_") {
+					strings.Contains(bpfFilter.Name, "cil_") ||
+					// Filters created by the cilium agent whose version is lower than 1.13.1
+					// are prefixed with cilium
+					strings.Contains(bpfFilter.Name, "cilium") {
 					allFilters = append(allFilters, bpfFilter)
 				}
 			}


### PR DESCRIPTION
This commit  https://github.com/cilium/cilium/commit/44bb57425a312146d4632451b8062b71713d1e17 changes the bpf program names' prefixes and the relative cleanup func. 
```
-		Name:         fmt.Sprintf("cilium-%s", link.Attrs().Name),
+		Name:         fmt.Sprintf("%s-%s", progName, link.Attrs().Name),
```
But it will cause that cleanup command cannot clean the bpf programs which are already created by the cilium agent with prefix `cilium`.

Fixes: (https://github.com/cilium/cilium/issues/26472)


```release-note
cleanup: can clean the bpf filters created by the cilium agent with lower version
```

