### PR TITLE
k8s: fix incorrect EndpointSlice API version [1.12]

### DIFF
--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -419,10 +419,10 @@ func (k *K8sWatcher) resourceGroups() (beforeNodeInitGroups, afterNodeInitGroups
 
 	// To perform the service translation and have the BPF LB datapath
 	// with the right service -> backend (k8s endpoints) translation.
-	if k8s.SupportsEndpointSlice() {
-		k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointSliceV1Beta1Discovery)
-	} else if k8s.SupportsEndpointSliceV1() {
+	if k8s.SupportsEndpointSliceV1() {
 		k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointSliceV1Discovery)
+	} else if k8s.SupportsEndpointSlice() {
+		k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointSliceV1Beta1Discovery)
 	}
 	k8sGroups = append(k8sGroups, resources.K8sAPIGroupEndpointV1Core)
 	ciliumResources := synced.AgentCRDResourceNames()


### PR DESCRIPTION
This is a backport of https://github.com/cilium/cilium/pull/27277 to 1.12 branch.



This commit fixes a bug that k8s watcher incorrectly chooses the discovery/v1beta1 EndpointSlice in environments where discovery/v1 EndpointSlice is available.
The agent doesn't wait for the discovery/v1 EndpointSlice to be received and ends up removing live services because of this bug.

The issue happens in the following scenario:

1. The agent initializes and runs the informers for Service and EndpointSlice.
2. The reflectors list the resources from kube-apiserver and replace DeltaFIFO.
3. The informers pop items from the DeltaFIFO and call the onAdd handler one by one.
4. If the Service handler is called first, ServiceCache.UpdateService doesn't emit the UpdateService event, because the service is not ready. (No backend)
5. The EndpointSlice handler is called next, ServiceCache.updateEndpoints emits UpdateService event.
6. The agent doesn't wait until the event triggered at step 5 is processed, and calls SyncWithK8sFinished.
7. The agent removes live services because it hasn't heard about it. (It is supposed to hear about those services in the event process triggered at step 5)

fixes: #27215

