### PR TITLE
[v1.14] bpf: nodeport: add RevDNAT-based FIB lookup for reply traffic 

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1508,6 +1508,9 @@ out:
 			return send_drop_notify_error(ctx, 0, ret,
 						      CTX_ACT_DROP,
 						      METRIC_EGRESS);
+
+		if (ret == CTX_ACT_REDIRECT)
+			return ret;
 	}
 #endif
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -989,7 +989,9 @@ ct_recreate4:
 
 		if (ct_state->rev_nat_index) {
 			ret = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
-					  ct_state, tuple, 0, has_l4_header);
+					  ct_state->rev_nat_index,
+					  ct_state->loopback,
+					  tuple, 0, has_l4_header);
 			if (IS_ERR(ret))
 				return ret;
 		}
@@ -1796,8 +1798,9 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, enum ct_status
 			has_l4_header = ipv4_has_l4_header(ip4);
 
 			ret2 = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
-					   ct_state, tuple,
-					   REV_NAT_F_TUPLE_SADDR, has_l4_header);
+					   ct_state->rev_nat_index, false,
+					   tuple, REV_NAT_F_TUPLE_SADDR,
+					   has_l4_header);
 			if (IS_ERR(ret2))
 				return ret2;
 		}

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1526,7 +1526,7 @@ skip_policy_enforcement:
 		{
 			bool node_port =
 				ct_has_nodeport_egress_entry6(get_ct_map6(tuple),
-							      tuple, false);
+							      tuple, NULL, false);
 
 			ct_state_new.node_port = node_port;
 			if (ret == CT_REOPENED &&
@@ -1854,7 +1854,7 @@ skip_policy_enforcement:
 		{
 			bool node_port =
 				ct_has_nodeport_egress_entry4(get_ct_map4(tuple),
-							      tuple, false);
+							      tuple, NULL, false);
 
 			ct_state_new.node_port = node_port;
 			if (ret == CT_REOPENED &&

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -461,6 +461,14 @@ static __always_inline int __lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 	return 0;
 }
 
+static __always_inline struct lb6_reverse_nat *
+lb6_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
+{
+	cilium_dbg_lb(ctx, DBG_LB6_REVERSE_NAT_LOOKUP, index, 0);
+
+	return map_lookup_elem(&LB6_REVERSE_NAT_MAP, &index);
+}
+
 /** Perform IPv6 reverse NAT based on reverse NAT index
  * @arg ctx		packet
  * @arg l4_off		offset to L4
@@ -473,8 +481,7 @@ static __always_inline int lb6_rev_nat(struct __ctx_buff *ctx, int l4_off,
 {
 	struct lb6_reverse_nat *nat;
 
-	cilium_dbg_lb(ctx, DBG_LB6_REVERSE_NAT_LOOKUP, index, 0);
-	nat = map_lookup_elem(&LB6_REVERSE_NAT_MAP, &index);
+	nat = lb6_lookup_rev_nat_entry(ctx, index);
 	if (nat == NULL)
 		return 0;
 
@@ -1104,6 +1111,13 @@ static __always_inline int __lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int
 	return 0;
 }
 
+static __always_inline struct lb4_reverse_nat *
+lb4_lookup_rev_nat_entry(struct __ctx_buff *ctx __maybe_unused, __u16 index)
+{
+	cilium_dbg_lb(ctx, DBG_LB4_REVERSE_NAT_LOOKUP, index, 0);
+
+	return map_lookup_elem(&LB4_REVERSE_NAT_MAP, &index);
+}
 
 /** Perform IPv4 reverse NAT based on reverse NAT index
  * @arg ctx		packet
@@ -1118,8 +1132,7 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 {
 	struct lb4_reverse_nat *nat;
 
-	cilium_dbg_lb(ctx, DBG_LB4_REVERSE_NAT_LOOKUP, ct_state->rev_nat_index, 0);
-	nat = map_lookup_elem(&LB4_REVERSE_NAT_MAP, &ct_state->rev_nat_index);
+	nat = lb4_lookup_rev_nat_entry(ctx, ct_state->rev_nat_index);
 	if (nat == NULL)
 		return 0;
 

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -83,6 +83,7 @@ __snat_update(const void *map, const void *otuple, const void *ostate,
 struct ipv4_nat_entry {
 	struct nat_entry common;
 	union {
+		struct lb4_reverse_nat nat_info;
 		struct {
 			__be32 to_saddr;
 			__be16 to_sport;
@@ -1212,6 +1213,7 @@ int snat_v4_rev_nat(struct __ctx_buff *ctx __maybe_unused,
 struct ipv6_nat_entry {
 	struct nat_entry common;
 	union {
+		struct lb6_reverse_nat nat_info;
 		struct {
 			union v6addr to_saddr;
 			__be16       to_sport;
@@ -1279,7 +1281,7 @@ get_cluster_snat_map_v6(__u32 cluster_id __maybe_unused)
 }
 
 static __always_inline
-struct ipv6_nat_entry *snat_v6_lookup(struct ipv6_ct_tuple *tuple)
+struct ipv6_nat_entry *snat_v6_lookup(const struct ipv6_ct_tuple *tuple)
 {
 	return __snat_lookup(&SNAT_MAPPING_IPV6, tuple);
 }

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2666,8 +2666,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 
 		/* Reply by local backend: */
 		if (ct_state.node_port && ct_state.rev_nat_index) {
-			ret = lb4_rev_nat(ctx, l3_off, l4_off, &ct_state,
-					  &tuple, REV_NAT_F_TUPLE_SADDR,
+			ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index,
+					  false, &tuple, REV_NAT_F_TUPLE_SADDR,
 					  has_l4_header);
 			if (IS_ERR(ret))
 				return ret;
@@ -2774,8 +2774,8 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 			      ACTION_CREATE, CT_INGRESS, SCOPE_REVERSE, &ct_state, &monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		reason = TRACE_REASON_CT_REPLY;
-		ret = lb4_rev_nat(ctx, l3_off, l4_off, &ct_state, &tuple,
-				  REV_NAT_F_TUPLE_SADDR, has_l4_header);
+		ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index, false,
+				  &tuple, REV_NAT_F_TUPLE_SADDR, has_l4_header);
 		if (IS_ERR(ret))
 			return ret;
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2681,12 +2681,9 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace)
 			if (ctx_get_tunnel_key(ctx, &key, sizeof(key), 0) < 0)
 				return DROP_NO_TUNNEL_KEY;
 
-			if (!revalidate_data(ctx, &data, &data_end, &ip4))
-				return DROP_INVALID;
-
 			/* kernel returns addresses in flipped locations: */
 			key.remote_ipv4 = key.local_ipv4;
-			key.local_ipv4 = bpf_ntohl(ip4->saddr);
+			key.local_ipv4 = bpf_ntohl(nat_info->address);
 
 			if (ctx_set_tunnel_key(ctx, &key, sizeof(key),
 					       BPF_F_ZERO_CSUM_TX) < 0)

--- a/bpf/tests/tc_nodeport_lb4_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb4_dsr_backend.c
@@ -24,6 +24,7 @@
 
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_PORT		__bpf_htons(111)
+#define CLIENT_IP_2		v4_ext_two
 
 #define FRONTEND_IP		v4_svc_one
 #define FRONTEND_PORT		tcp_svc_one
@@ -31,9 +32,57 @@
 #define BACKEND_IP		v4_pod_one
 #define BACKEND_PORT		__bpf_htons(8080)
 
+#define NATIVE_DEV_IFINDEX	24
+#define DEFAULT_IFACE		NATIVE_DEV_IFINDEX
+#define BACKEND_IFACE		25
+#define SVC_EGRESS_IFACE	26
+
 static volatile const __u8 *client_mac = mac_one;
 static volatile const __u8 *node_mac = mac_three;
 static volatile const __u8 *backend_mac = mac_four;
+
+#define fib_lookup mock_fib_lookup
+
+long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
+		     __maybe_unused int plen, __maybe_unused __u32 flags)
+{
+	params->ifindex = DEFAULT_IFACE;
+
+	if (params->ipv4_src == FRONTEND_IP && params->ipv4_dst == CLIENT_IP_2) {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)node_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)client_mac, ETH_ALEN);
+		params->ifindex = SVC_EGRESS_IFACE;
+	}
+
+	return BPF_FIB_LKUP_RET_SUCCESS;
+}
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	void *data = (void *)(long)ctx_data(ctx);
+	void *data_end = (void *)(long)ctx->data_end;
+	struct iphdr *ip4;
+
+	ip4 = data + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		return CTX_ACT_DROP;
+
+	/* Forward to backend: */
+	if (ip4->saddr == CLIENT_IP && ifindex == BACKEND_IFACE)
+		return CTX_ACT_REDIRECT;
+	if (ip4->saddr == CLIENT_IP_2 && ifindex == BACKEND_IFACE)
+		return CTX_ACT_REDIRECT;
+
+	/* Redirected reply: */
+	if (ip4->daddr == CLIENT_IP_2 && ifindex == SVC_EGRESS_IFACE)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_DROP;
+}
 
 #define SECCTX_FROM_IPCACHE 1
 
@@ -115,7 +164,9 @@ SETUP("tc", "tc_nodeport_dsr_backend")
 int nodeport_dsr_backend_setup(struct __ctx_buff *ctx)
 {
 	/* add local backend */
-	struct endpoint_info ep_value = {};
+	struct endpoint_info ep_value = {
+		.ifindex = BACKEND_IFACE,
+	};
 
 	memcpy(&ep_value.mac, (__u8 *)backend_mac, ETH_ALEN);
 	memcpy(&ep_value.node_mac, (__u8 *)node_mac, ETH_ALEN);
@@ -357,4 +408,275 @@ CHECK("tc", "tc_nodeport_dsr_backend_reply")
 int nodeport_dsr_backend_reply_check(const struct __ctx_buff *ctx)
 {
 	return check_reply(ctx);
+}
+
+/* Same scenario as above, but for a different CLIENT_IP_2. Here replies
+ * should leave via a non-default interface.
+ */
+PKTGEN("tc", "tc_nodeport_dsr_backend_redirect")
+int nodeport_dsr_backend_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	struct dsr_opt_v4 *opt;
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)node_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr_with_options(&builder, 2);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP_2;
+	l3->daddr = BACKEND_IP;
+
+	opt = (void *)l3 + sizeof(*l3);
+	opt->type = DSR_IPV4_OPT_TYPE;
+	opt->len = sizeof(*opt);
+	opt->port = bpf_ntohs(FRONTEND_PORT);
+	opt->addr = bpf_ntohl(FRONTEND_IP);
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = BACKEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_dsr_backend_redirect")
+int nodeport_dsr_backend_redirect_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_dsr_backend_redirect")
+int nodeport_dsr_backend_redirect_check(struct __ctx_buff *ctx)
+{
+	struct dsr_opt_v4 *opt;
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	opt = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)opt + 2 * sizeof(__u32) > data_end)
+		test_fatal("l3 DSR option out of bounds");
+
+	l4 = (void *)opt + sizeof(*opt);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the node MAC")
+	if (memcmp(l2->h_dest, (__u8 *)backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the endpoint MAC")
+
+	if (l3->saddr != CLIENT_IP_2)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP)
+		test_fatal("dst IP has changed");
+
+	if (opt->type != DSR_IPV4_OPT_TYPE)
+		test_fatal("type in DSR IP option has changed")
+	if (opt->len != 8)
+		test_fatal("length in DSR IP option has changed")
+	if (opt->port != __bpf_ntohs(FRONTEND_PORT))
+		test_fatal("port in DSR IP option has changed")
+	if (opt->addr != __bpf_ntohl(FRONTEND_IP))
+		test_fatal("addr in DSR IP option has changed")
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst port has changed");
+
+	struct ipv4_ct_tuple tuple;
+	struct ct_entry *ct_entry;
+	int l4_off, ret;
+
+	ret = lb4_extract_tuple(ctx, l3, sizeof(*status_code) + ETH_HLEN,
+				&l4_off, &tuple);
+	assert(!IS_ERR(ret));
+
+	tuple.flags = TUPLE_F_IN;
+	ipv4_ct_tuple_reverse(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT entry for DSR found");
+	if (!ct_entry->dsr)
+		test_fatal("CT entry doesn't have the .dsr flag set");
+
+	struct ipv4_nat_entry *nat_entry;
+
+	tuple.sport = BACKEND_PORT;
+	tuple.dport = CLIENT_PORT;
+
+	nat_entry = snat_v4_lookup(&tuple);
+	if (!nat_entry)
+		test_fatal("no SNAT entry for DSR found");
+	if (nat_entry->to_saddr != FRONTEND_IP)
+		test_fatal("SNAT entry has wrong address");
+	if (nat_entry->to_sport != FRONTEND_PORT)
+		test_fatal("SNAT entry has wrong port");
+
+	test_finish();
+}
+
+PKTGEN("tc", "tc_nodeport_dsr_backend_redirect_reply")
+int nodeport_dsr_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)node_mac, (__u8 *)client_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = BACKEND_IP;
+	l3->daddr = CLIENT_IP_2;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = BACKEND_PORT;
+	l4->dest = CLIENT_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_dsr_backend_redirect_reply")
+int nodeport_dsr_backend_redirect_reply_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+/* Test that to-netdev respects the routing needed for CLIENT_IP_2,
+ * and redirects the packet to the correct egress interface.
+ */
+CHECK("tc", "tc_nodeport_dsr_backend_redirect_reply")
+int nodeport_dsr_backend_redirect_reply_check(struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the node MAC")
+	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the client MAC")
+
+	if (l3->saddr != BACKEND_IP)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != CLIENT_IP_2)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != BACKEND_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != CLIENT_PORT)
+		test_fatal("dst port has changed");
+
+	test_finish();
 }

--- a/bpf/tests/tc_nodeport_lb4_nat_lb.c
+++ b/bpf/tests/tc_nodeport_lb4_nat_lb.c
@@ -22,6 +22,7 @@
 
 #define CLIENT_IP		v4_ext_one
 #define CLIENT_PORT		__bpf_htons(111)
+#define CLIENT_IP_2		v4_ext_two
 
 #define FRONTEND_IP_LOCAL	v4_svc_one
 #define FRONTEND_IP_REMOTE	v4_svc_two
@@ -33,6 +34,11 @@
 #define BACKEND_IP_LOCAL	v4_pod_one
 #define BACKEND_IP_REMOTE	v4_pod_two
 #define BACKEND_PORT		__bpf_htons(8080)
+
+#define NATIVE_DEV_IFINDEX	24
+#define DEFAULT_IFACE		NATIVE_DEV_IFINDEX
+#define BACKEND_IFACE		25
+#define SVC_EGRESS_IFACE	26
 
 #define fib_lookup mock_fib_lookup
 
@@ -46,21 +52,61 @@ static volatile const __u8 *remote_backend_mac = mac_five;
 static __be16 nat_source_port;
 static bool fail_fib;
 
+#define fib_lookup mock_fib_lookup
+
 long mock_fib_lookup(__maybe_unused void *ctx, struct bpf_fib_lookup *params,
 		     __maybe_unused int plen, __maybe_unused __u32 flags)
 {
 	if (fail_fib)
 		return BPF_FIB_LKUP_RET_NO_NEIGH;
 
+	params->ifindex = DEFAULT_IFACE;
+
 	if (params->ipv4_dst == BACKEND_IP_REMOTE) {
 		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
 		__bpf_memcpy_builtin(params->dmac, (__u8 *)remote_backend_mac, ETH_ALEN);
+	} else if (params->ipv4_src == FRONTEND_IP_LOCAL &&
+		   params->ipv4_dst == CLIENT_IP_2) {
+		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
+		__bpf_memcpy_builtin(params->dmac, (__u8 *)client_mac, ETH_ALEN);
+		params->ifindex = SVC_EGRESS_IFACE;
 	} else {
 		__bpf_memcpy_builtin(params->smac, (__u8 *)lb_mac, ETH_ALEN);
 		__bpf_memcpy_builtin(params->dmac, (__u8 *)client_mac, ETH_ALEN);
 	}
 
 	return 0;
+}
+
+#define ctx_redirect mock_ctx_redirect
+
+static __always_inline __maybe_unused int
+mock_ctx_redirect(const struct __sk_buff *ctx __maybe_unused,
+		  int ifindex __maybe_unused, __u32 flags __maybe_unused)
+{
+	void *data = (void *)(long)ctx_data(ctx);
+	void *data_end = (void *)(long)ctx->data_end;
+	struct iphdr *ip4;
+
+	ip4 = data + sizeof(struct ethhdr);
+	if ((void *)ip4 + sizeof(*ip4) > data_end)
+		return CTX_ACT_DROP;
+
+	/* Forward to backend: */
+	if (ip4->saddr == CLIENT_IP && ifindex == BACKEND_IFACE)
+		return CTX_ACT_REDIRECT;
+	if (ip4->saddr == CLIENT_IP_2 && ifindex == BACKEND_IFACE)
+		return CTX_ACT_REDIRECT;
+	if (ip4->saddr == LB_IP && ifindex == DEFAULT_IFACE)
+		return CTX_ACT_REDIRECT;
+
+	/* Redirected reply: */
+	if (ip4->daddr == CLIENT_IP_2 && ifindex == SVC_EGRESS_IFACE)
+		return CTX_ACT_REDIRECT;
+	if (ip4->saddr == FRONTEND_IP_REMOTE && ifindex == DEFAULT_IFACE)
+		return CTX_ACT_REDIRECT;
+
+	return CTX_ACT_DROP;
 }
 
 #define SECCTX_FROM_IPCACHE 1
@@ -182,7 +228,9 @@ int nodeport_local_backend_setup(struct __ctx_buff *ctx)
 	map_update_elem(&LB4_BACKEND_MAP, &lb_svc_value.backend_id, &backend, BPF_ANY);
 
 	/* add local backend */
-	struct endpoint_info ep_value = {};
+	struct endpoint_info ep_value = {
+		.ifindex = BACKEND_IFACE,
+	};
 
 	memcpy(&ep_value.mac, (__u8 *)local_backend_mac, ETH_ALEN);
 	memcpy(&ep_value.node_mac, (__u8 *)node_mac, ETH_ALEN);
@@ -370,6 +418,226 @@ int nodeport_local_backend_reply_check(const struct __ctx_buff *ctx)
 	test_finish();
 }
 
+/* Same scenario as above, but for a different CLIENT_IP_2. Here replies
+ * should leave via a non-default interface.
+ */
+PKTGEN("tc", "tc_nodeport_local_backend_redirect")
+int nodeport_local_backend_redirect_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)client_mac, (__u8 *)lb_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = CLIENT_IP_2;
+	l3->daddr = FRONTEND_IP_LOCAL;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = CLIENT_PORT;
+	l4->dest = FRONTEND_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_local_backend_redirect")
+int nodeport_local_backend_redirect_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_local_backend_redirect")
+int nodeport_local_backend_redirect_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)node_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the node MAC")
+	if (memcmp(l2->h_dest, (__u8 *)local_backend_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the endpoint MAC")
+
+	if (l3->saddr != CLIENT_IP_2)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != BACKEND_IP_LOCAL)
+		test_fatal("dst IP hasn't been NATed to local backend IP");
+
+	if (l4->source != CLIENT_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != BACKEND_PORT)
+		test_fatal("dst TCP port hasn't been NATed to backend port");
+
+	test_finish();
+}
+
+/* Test that to-netdev respects the routing needed for CLIENT_IP_2,
+ * and redirects the packet to the correct egress interface.
+ */
+PKTGEN("tc", "tc_nodeport_local_backend_redirect_reply")
+int nodeport_local_backend_redirect_reply_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)lb_mac, (__u8 *)client_mac);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = BACKEND_IP_LOCAL;
+	l3->daddr = CLIENT_IP_2;
+
+	/* Push TCP header */
+	l4 = pktgen__push_default_tcphdr(&builder);
+	if (!l4)
+		return TEST_ERROR;
+
+	l4->source = BACKEND_PORT;
+	l4->dest = CLIENT_PORT;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "tc_nodeport_local_backend_redirect_reply")
+int nodeport_local_backend_redirect_reply_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, TO_NETDEV);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "tc_nodeport_local_backend_redirect_reply")
+int nodeport_local_backend_redirect_reply_check(const struct __ctx_buff *ctx)
+{
+	void *data, *data_end;
+	__u32 *status_code;
+	struct tcphdr *l4;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+
+	test_init();
+
+	data = (void *)(long)ctx_data(ctx);
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == CTX_ACT_REDIRECT);
+
+	l2 = data + sizeof(__u32);
+	if ((void *)l2 + sizeof(struct ethhdr) > data_end)
+		test_fatal("l2 out of bounds");
+
+	l3 = (void *)l2 + sizeof(struct ethhdr);
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (memcmp(l2->h_source, (__u8 *)lb_mac, ETH_ALEN) != 0)
+		test_fatal("src MAC is not the LB MAC")
+	if (memcmp(l2->h_dest, (__u8 *)client_mac, ETH_ALEN) != 0)
+		test_fatal("dst MAC is not the client MAC")
+
+	if (l3->saddr != BACKEND_IP_LOCAL)
+		test_fatal("src IP has changed");
+
+	if (l3->daddr != CLIENT_IP_2)
+		test_fatal("dst IP has changed");
+
+	if (l4->source != BACKEND_PORT)
+		test_fatal("src port has changed");
+
+	if (l4->dest != CLIENT_PORT)
+		test_fatal("dst port has changed");
+
+	test_finish();
+}
+
 /* Test that a SVC request (UDP) to a local backend
  * - gets DNATed (but not SNATed)
  * - gets redirected by TC (as ENABLE_HOST_ROUTING is set)
@@ -468,28 +736,6 @@ int nodeport_udp_local_backend_setup(struct __ctx_buff *ctx)
 		.flags = BE_STATE_ACTIVE,
 	};
 	map_update_elem(&LB4_BACKEND_MAP, &lb_svc_value.backend_id, &backend, BPF_ANY);
-
-	/* add local backend */
-	struct endpoint_info ep_value = {};
-
-	memcpy(&ep_value.mac, (__u8 *)local_backend_mac, ETH_ALEN);
-	memcpy(&ep_value.node_mac, (__u8 *)node_mac, ETH_ALEN);
-
-	struct endpoint_key ep_key = {
-		.family = ENDPOINT_KEY_IPV4,
-		.ip4 = BACKEND_IP_LOCAL,
-	};
-	map_update_elem(&ENDPOINTS_MAP, &ep_key, &ep_value, BPF_ANY);
-
-	struct ipcache_key cache_key = {
-		.lpm_key.prefixlen = IPCACHE_PREFIX_LEN(32),
-		.family = ENDPOINT_KEY_IPV4,
-		.ip4 = BACKEND_IP_LOCAL,
-	};
-	struct remote_endpoint_info cache_value = {
-		.sec_identity = 112233,
-	};
-	map_update_elem(&IPCACHE_MAP, &cache_key, &cache_value, BPF_ANY);
 
 	/* Jump into the entrypoint */
 	tail_call_static(ctx, &entry_call_map, FROM_NETDEV);

--- a/bpf/tests/tc_nodeport_lb6_dsr_backend.c
+++ b/bpf/tests/tc_nodeport_lb6_dsr_backend.c
@@ -17,6 +17,7 @@
 #define ENABLE_HOST_ROUTING
 
 #define DISABLE_LOOPBACK_LB
+#define ENABLE_SKIP_FIB		1
 
 /* Skip ingress policy checks, not needed to validate hairpin flow */
 #define USE_BPF_PROG_FOR_INGRESS_POLICY


### PR DESCRIPTION
Manual backport due to smaller conflicts / missing test infrastructure of

- [ ] #26852
- [ ] #26638


Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 26852 26638; do contrib/backporting/set-labels.py $pr done 1.14; done
```
or with
```
make add-labels BRANCH=v1.14 ISSUES=26852,26638
```