### PR TITLE
gh/workflows: Fix setting endpoint routes in ci-e2e

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -223,7 +223,7 @@ jobs:
           image-tag: ${{ steps.vars.outputs.sha }}
           chart-dir: './install/kubernetes/cilium'
           tunnel: ${{ matrix.tunnel }}
-          endpoint-routes: ${{ matrix.endoint-routes }}
+          endpoint-routes: ${{ matrix.endpoint-routes }}
           ipv6: ${{ matrix.ipv6 }}
           kpr: ${{ matrix.kpr }}
           lb-mode: ${{ matrix.lb-mode }}


### PR DESCRIPTION
Fixes: 89004fbb2 ("gh/workflows: Use cilium-config action in ci-e2e")