### PR TITLE
helm: Fix typo in cilium chart's description

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -4,7 +4,7 @@
 
 # upgradeCompatibility helps users upgrading to ensure that the configMap for
 # Cilium will not change critical values to ensure continued operation
-# This is flag is not required for new installations.
+# This flag is not required for new installations.
 # For example: 1.7, 1.8, 1.9
 # upgradeCompatibility: '1.8'
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1,7 +1,7 @@
 
 # upgradeCompatibility helps users upgrading to ensure that the configMap for
 # Cilium will not change critical values to ensure continued operation
-# This is flag is not required for new installations.
+# This flag is not required for new installations.
 # For example: 1.7, 1.8, 1.9
 # upgradeCompatibility: '1.8'
 


### PR DESCRIPTION
Just noticed what I believe is a typo in both [values.yaml](install/kubernetes/cilium/values.yaml) and [values.yaml.tmpl](install/kubernetes/cilium/values.yaml.tmpl).