### PR TITLE
.github: write the right regex for little-vm-images versioning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -354,7 +354,7 @@
       "matchDepNames": [
         "quay.io/lvh-images/kind"
       ],
-      "versioning": "regex:^((?<compatibility>[a-z-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
+      "versioning": "regex:^((?<compatibility>[a-z-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-latest\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
       "groupName": "all lvh-images main",


### PR DESCRIPTION
The versioning are meant to be
```
<kernel-version>-latest-<date>.<hour>
```