### PR TITLE
v1.12 Backports 2023-08-09

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,13 +1,10 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.22"
-    zone: northamerica-northeast1-c
-    vmIndex: 1
   - version: "1.23"
     zone: europe-west6-b
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.24"
     zone: us-west2-a
-    vmIndex: 3
+    vmIndex: 2
     default: true

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -52,9 +52,8 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version:
-  # until https://github.com/cilium/cilium-cli/pull/1854 has been released
-  cilium_cli_ci_version: 8c624e141844a19a6b2e21d5255f3ca6195c996d
+  cilium_cli_version: v0.15.5
+  cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
   cilium_stable_version: 1.11
 

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -16,7 +16,7 @@ SPHINX_OPTS := "-j=auto"
 default: html
 
 define build_image
-  $(ECHO_DOCKER)
+  $(ECHO_DOCKER) $(3)
   # Pre-pull FROM docker image due to Buildkit sometimes failing to pull them.
   grep -m 1 "^FROM " $(1) | tr -d '\r' | cut -d ' ' -f2 | xargs -n1 $(CONTAINER_ENGINE) pull
   $(QUIET)tar c $(REQUIREMENTS) Dockerfile \

--- a/Documentation/gettingstarted/encryption-ipsec.rst
+++ b/Documentation/gettingstarted/encryption-ipsec.rst
@@ -257,6 +257,16 @@ Troubleshooting
                             allocate memory.
    =======================  ==================================================
 
+ * In addition to the above XFRM errors, packet drops of type ``No node ID
+   found`` (code 197) may also occur under normal operations. These drops can
+   happen if a pod attempts to send traffic to a pod on a new node for which
+   the Cilium agent didn't yet receive the CiliumNode object. It can also
+   happen if the IP address of the destination node changed and the agent
+   didn't receive the updated CiliumNode object yet. In both cases, the IPsec
+   configuration in the kernel isn't ready yet, so Cilium drops the packets at
+   the source. These drops will stop once the CiliumNode information is
+   propagated across the cluster.
+
 Disabling Encryption
 ====================
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -378,6 +378,7 @@ ct_recreate6:
 	case CT_REPLY:
 		policy_mark_skip(ctx);
 
+		tuple->nexthdr = ip6->nexthdr;
 		hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);
 		if (hdrlen < 0)
 			return hdrlen;
@@ -1448,6 +1449,7 @@ ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 		struct csum_offset csum_off = {};
 		int ret2, l4_off;
 
+		tuple->nexthdr = ip6->nexthdr;
 		hdrlen = ipv6_hdrlen(ctx, &tuple->nexthdr);
 		if (hdrlen < 0)
 			return hdrlen;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -122,8 +122,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		ctx_change_type(ctx, PACKET_HOST);
 
 		send_trace_notify(ctx, TRACE_TO_STACK, *identity, 0, 0,
-				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
-				  TRACE_PAYLOAD_LEN);
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED, 0);
 
 		return CTX_ACT_OK;
 	}
@@ -283,8 +282,7 @@ skip_vtep:
 		ctx_change_type(ctx, PACKET_HOST);
 
 		send_trace_notify(ctx, TRACE_TO_STACK, *identity, 0, 0,
-				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
-				  TRACE_PAYLOAD_LEN);
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED, 0);
 
 		return CTX_ACT_OK;
 	}
@@ -465,8 +463,7 @@ int from_overlay(struct __ctx_buff *ctx)
 #ifdef ENABLE_IPSEC
 	if (is_esp(ctx, proto))
 		send_trace_notify(ctx, TRACE_FROM_OVERLAY, 0, 0, 0,
-				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED,
-				  TRACE_PAYLOAD_LEN);
+				  ctx->ingress_ifindex, TRACE_REASON_ENCRYPTED, 0);
 	else
 #endif
 	{


### PR DESCRIPTION
 * [ ] #27184 (@pchaigno) (:warning: minor conflict solved, file had been renamed)
 * [x] #27250 (@qmonnet)
 * [x] #27168 (@learnitall)
 * [x] #27312 (@julianwiedmann) (:warning: minor conflict, different indent, probably OK?)
 * [x] #27230 (@brb)
 * [x] #27365 (@mhofstetter)

PRs skipped due to conflicts:

 * #27346 (@qmonnet)
 * [ ] #27193 (@nbusseneau)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27184 27250 27168 27312 27230 27365; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
make add-labels BRANCH=v1.12 ISSUES=27184,27250,27168,27312,27230,27365
```
