### PR TITLE
Don't retry one shot jobs during hive shutdown

### DIFF
--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -313,11 +313,9 @@ func (h *Hive) fatalOnTimeout(ctx context.Context) chan struct{} {
 
 		// Context was cancelled. Give 5 more seconds and then
 		// go fatal.
-		time.Sleep(5 * time.Second)
-
 		select {
 		case <-terminated:
-		default:
+		case <-time.After(5 * time.Second):
 			log.Fatal("Start or stop failed to finish on time, aborting forcefully.")
 		}
 	}()

--- a/pkg/hive/job/job.go
+++ b/pkg/hive/job/job.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/internal"
+	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/spanstat"
 	"github.com/cilium/cilium/pkg/stream"
@@ -277,15 +278,24 @@ func (jos *jobOneShot) start(ctx context.Context, wg *sync.WaitGroup, options op
 
 	stat := &spanstat.SpanStat{}
 
+	timer, cancel := inctimer.New()
+	cancel()
+
 	var err error
 	for i := 0; i <= jos.retry; i++ {
+		var timeout time.Duration
 		if i != 0 {
-			timeout := jos.backoff.When(jos)
+			timeout = jos.backoff.When(jos)
 			l.WithFields(logrus.Fields{
 				"backoff":     timeout,
 				"retry-count": i,
 			}).Debug("Delaying retry attempt")
-			time.Sleep(timeout)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.After(timeout):
 		}
 
 		l.Debug("Starting one-shot job")

--- a/pkg/hive/job/job.go
+++ b/pkg/hive/job/job.go
@@ -279,7 +279,7 @@ func (jos *jobOneShot) start(ctx context.Context, wg *sync.WaitGroup, options op
 	stat := &spanstat.SpanStat{}
 
 	timer, cancel := inctimer.New()
-	cancel()
+	defer cancel()
 
 	var err error
 	for i := 0; i <= jos.retry; i++ {


### PR DESCRIPTION
Stop retrying to execute the function of a one shot job as soon as the job context is canceled, as the hive is already shutting down at that point. Indeed, the expectation is that the function exits immediately when the context expires, and it is most likely to return an error in that condition. Retrying would only delay the hive shutdown (also due to the additional backoff delay between consecutive attempts).
