### PR TITLE
gha: fix waiting for images in conformance-gingko

### DIFF
--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
-        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7  
+        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
         with:
           sha: ${{ inputs.SHA || github.sha }}
 
@@ -149,7 +149,7 @@ jobs:
   wait-for-images:
     needs: setup-vars
     runs-on: ubuntu-latest
-    name: Build Ginkgo E2E
+    name: Wait for images
     timeout-minutes: 30
     steps:
       - name: Checkout context ref (trusted)
@@ -223,7 +223,7 @@ jobs:
           echo "matrix=$(jq -c . < /tmp/merged.json)" >> $GITHUB_OUTPUT
 
   setup-and-test:
-    needs: [setup-vars, build-ginkgo-binary, generate-matrix]
+    needs: [setup-vars, build-ginkgo-binary, generate-matrix, wait-for-images]
     runs-on:
       group: ginkgo-runners
     timeout-minutes: 35
@@ -462,8 +462,21 @@ jobs:
     needs: setup-and-test
     runs-on: ubuntu-latest
     steps:
+      - name: Determine final commit status
+        id: commit-status
+        shell: bash
+        run: |
+          # When one of the prerequisites of setup-and-test fails, then that
+          # job gets skipped. Let's convert the status so that we correctly
+          # report that as a proper failure.
+          if [ "${{ needs.setup-and-test.result }}" != "skipped" ]; then
+            echo "status=${{ needs.setup-and-test.result }}" >> $GITHUB_OUTPUT
+          else
+            echo "status=failure" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7  
+        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
         with:
           sha: ${{ inputs.SHA || github.sha }}
-          status: ${{ needs.setup-and-test.result }}
+          status: ${{ steps.commit-status.outputs.status }}


### PR DESCRIPTION
Let's add an explicit dependency to the wait-for-images job, so that subsequent jobs are not started until the images are actually available. This also prevents starting the full matrix jobs if the images don't get ready in time.

Example run after the fix (with reduce timeout to trigger failure): https://github.com/cilium/cilium/actions/runs/5812104573/job/15756825851