### PR TITLE
Handle `.status.conditions` on `Service`s using in accordance with KEP-1623

### DIFF
--- a/Documentation/network/lb-ipam.rst
+++ b/Documentation/network/lb-ipam.rst
@@ -135,7 +135,7 @@ The reason for the conflict is stated in the status and can be accessed like so
 
 .. code-block:: shell-session
 
-    $ kubectl get ippools/red-pool -o jsonpath='{.status.conditions[?(@.type=="io.cilium/conflict")].message}'
+    $ kubectl get ippools/red-pool -o jsonpath='{.status.conditions[?(@.type=="cilium.io/PoolConflict")].message}'
     Pool conflicts since CIDR '20.0.10.0/24' overlaps CIDR '20.0.10.0/24' from IP Pool 'blue-pool'
 
 or
@@ -153,7 +153,7 @@ or
             Observed Generation:   1
             Reason:                cidr_overlap
             Status:                True
-            Type:                  io.cilium/conflict
+            Type:                  cilium.io/PoolConflict
         #[...]
 
 Disabling a Pool
@@ -188,14 +188,14 @@ the amount of used and available IPs. A machine parsable output can be obtained 
 
 .. code-block:: shell-session
 
-    $ kubectl get ippools -o jsonpath='{.items[*].status.conditions[?(@.type!="io.cilium/conflict")]}' | jq
+    $ kubectl get ippools -o jsonpath='{.items[*].status.conditions[?(@.type!="cilium.io/PoolConflict")]}' | jq
     {
       "lastTransitionTime": "2022-10-25T14:08:55Z",
       "message": "254",
       "observedGeneration": 1,
       "reason": "noreason",
       "status": "Unknown",
-      "type": "io.cilium/ips-total"
+      "type": "cilium.io/IPsTotal"
     }
     {
       "lastTransitionTime": "2022-10-25T14:08:55Z",
@@ -203,7 +203,7 @@ the amount of used and available IPs. A machine parsable output can be obtained 
       "observedGeneration": 1,
       "reason": "noreason",
       "status": "Unknown",
-      "type": "io.cilium/ips-available"
+      "type": "cilium.io/IPsAvailable"
     }
     {
       "lastTransitionTime": "2022-10-25T14:08:55Z",
@@ -211,7 +211,7 @@ the amount of used and available IPs. A machine parsable output can be obtained 
       "observedGeneration": 1,
       "reason": "noreason",
       "status": "Unknown",
-      "type": "io.cilium/ips-used"
+      "type": "cilium.io/IPsUsed"
     }
 
 Or human readable output like so
@@ -234,19 +234,19 @@ Or human readable output like so
         Observed Generation:   1
         Reason:                noreason
         Status:                Unknown
-        Type:                  io.cilium/ips-total
+        Type:                  cilium.io/IPsTotal
         Last Transition Time:  2022-10-25T14:08:55Z
         Message:               254
         Observed Generation:   1
         Reason:                noreason
         Status:                Unknown
-        Type:                  io.cilium/ips-available
+        Type:                  cilium.io/IPsAvailable
         Last Transition Time:  2022-10-25T14:08:55Z
         Message:               0
         Observed Generation:   1
         Reason:                noreason
         Status:                Unknown
-        Type:                  io.cilium/ips-used
+        Type:                  cilium.io/IPsUsed
 
 Services
 ########

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -37,12 +37,12 @@ import (
 
 const (
 	// The condition added to services to indicate if a request for IPs could be satisfied or not
-	ciliumSvcRequestSatisfiedCondition = "io.cilium/lb-ipam-request-satisfied"
+	ciliumSvcRequestSatisfiedCondition = "cilium.io/IPAMRequestSatisfied"
 
-	ciliumPoolIPsTotalCondition     = "io.cilium/ips-total"
-	ciliumPoolIPsAvailableCondition = "io.cilium/ips-available"
-	ciliumPoolIPsUsedCondition      = "io.cilium/ips-used"
-	ciliumPoolConflict              = "io.cilium/conflict"
+	ciliumPoolIPsTotalCondition     = "cilium.io/IPsTotal"
+	ciliumPoolIPsAvailableCondition = "cilium.io/IPsAvailable"
+	ciliumPoolIPsUsedCondition      = "cilium.io/IPsUsed"
+	ciliumPoolConflict              = "cilium.io/PoolConflict"
 
 	// The annotation LB IPAM will look for when searching for requested IPs
 	ciliumSvcLBIPSAnnotation = "io.cilium/lb-ipam-ips"

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumloadbalancerippools.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumloadbalancerippools.yaml
@@ -26,10 +26,10 @@ spec:
     - jsonPath: .spec.disabled
       name: Disabled
       type: boolean
-    - jsonPath: .status.conditions[?(@.type=="io.cilium/conflict")].status
+    - jsonPath: .status.conditions[?(@.type=="cilium.io/PoolConflict")].status
       name: Conflicting
       type: string
-    - jsonPath: .status.conditions[?(@.type=="io.cilium/ips-available")].message
+    - jsonPath: .status.conditions[?(@.type=="cilium.io/IPsAvailable")].message
       name: IPs Available
       type: string
     - jsonPath: .metadata.creationTimestamp

--- a/pkg/k8s/apis/cilium.io/v2alpha1/lbipam_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/lbipam_types.go
@@ -14,8 +14,8 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:categories={cilium},singular="ciliumloadbalancerippool",path="ciliumloadbalancerippools",scope="Cluster",shortName={ippools,ippool,lbippool,lbippools}
 // +kubebuilder:printcolumn:JSONPath=".spec.disabled",name="Disabled",type=boolean
-// +kubebuilder:printcolumn:name="Conflicting",type=string,JSONPath=`.status.conditions[?(@.type=="io.cilium/conflict")].status`
-// +kubebuilder:printcolumn:name="IPs Available",type=string,JSONPath=`.status.conditions[?(@.type=="io.cilium/ips-available")].message`
+// +kubebuilder:printcolumn:name="Conflicting",type=string,JSONPath=`.status.conditions[?(@.type=="cilium.io/PoolConflict")].status`
+// +kubebuilder:printcolumn:name="IPs Available",type=string,JSONPath=`.status.conditions[?(@.type=="cilium.io/IPsAvailable")].message`
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type=date
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion

--- a/pkg/k8s/slim/README.md
+++ b/pkg/k8s/slim/README.md
@@ -54,6 +54,8 @@ curl "${url}/staging/src/k8s.io/api/networking/v1/well_known_annotations.go" > p
 curl "${url}/staging/src/k8s.io/apimachinery/pkg/selection/operator.go" > pkg/k8s/slim/k8s/apis/selection/operator.go
 
 curl "${url}/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go" > pkg/k8s/slim/k8s/apis/util/intstr/intstr.go
+
+curl "${url}/staging/src/k8s.io/apimachinery/pkg/api/meta/conditions.go" > pkg/k8s/slim/k8s/apis/api/meta/conditions.go
 ```
 
 All fields of the copied structures are exactly the same as the ones available

--- a/pkg/k8s/slim/k8s/apis/api/meta/conditions.go
+++ b/pkg/k8s/slim/k8s/apis/api/meta/conditions.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// Copyright 2020 The Kubernetes Authors.
+
+package meta
+
+import (
+	"time"
+
+	metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
+)
+
+// SetStatusCondition sets the corresponding condition in conditions to newCondition.
+// conditions must be non-nil.
+//  1. if the condition of the specified type already exists (all fields of the existing condition are updated to
+//     newCondition, LastTransitionTime is set to now if the new status differs from the old status)
+//  2. if a condition of the specified type does not exist (LastTransitionTime is set to now() if unset, and newCondition is appended)
+func SetStatusCondition(conditions *[]metav1.Condition, newCondition metav1.Condition) {
+	if conditions == nil {
+		return
+	}
+	existingCondition := FindStatusCondition(*conditions, newCondition.Type)
+	if existingCondition == nil {
+		if newCondition.LastTransitionTime.IsZero() {
+			newCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		}
+		*conditions = append(*conditions, newCondition)
+		return
+	}
+
+	if existingCondition.Status != newCondition.Status {
+		existingCondition.Status = newCondition.Status
+		if !newCondition.LastTransitionTime.IsZero() {
+			existingCondition.LastTransitionTime = newCondition.LastTransitionTime
+		} else {
+			existingCondition.LastTransitionTime = metav1.NewTime(time.Now())
+		}
+	}
+
+	existingCondition.Reason = newCondition.Reason
+	existingCondition.Message = newCondition.Message
+	existingCondition.ObservedGeneration = newCondition.ObservedGeneration
+}
+
+// RemoveStatusCondition removes the corresponding conditionType from conditions.
+// conditions must be non-nil.
+func RemoveStatusCondition(conditions *[]metav1.Condition, conditionType string) {
+	if conditions == nil || len(*conditions) == 0 {
+		return
+	}
+	newConditions := make([]metav1.Condition, 0, len(*conditions)-1)
+	for _, condition := range *conditions {
+		if condition.Type != conditionType {
+			newConditions = append(newConditions, condition)
+		}
+	}
+
+	*conditions = newConditions
+}
+
+// FindStatusCondition finds the conditionType in conditions.
+func FindStatusCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+
+	return nil
+}
+
+// IsStatusConditionTrue returns true when the conditionType is present and set to `metav1.ConditionTrue`
+func IsStatusConditionTrue(conditions []metav1.Condition, conditionType string) bool {
+	return IsStatusConditionPresentAndEqual(conditions, conditionType, metav1.ConditionTrue)
+}
+
+// IsStatusConditionFalse returns true when the conditionType is present and set to `metav1.ConditionFalse`
+func IsStatusConditionFalse(conditions []metav1.Condition, conditionType string) bool {
+	return IsStatusConditionPresentAndEqual(conditions, conditionType, metav1.ConditionFalse)
+}
+
+// IsStatusConditionPresentAndEqual returns true when conditionType is present and equal to status.
+func IsStatusConditionPresentAndEqual(conditions []metav1.Condition, conditionType string, status metav1.ConditionStatus) bool {
+	for _, condition := range conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Currently the lbipam controller creates multiple `.status.conditions` per `type` of condition on the `Service`s it updates. This conflicts with what's expected, as the `ServiceStatus.Conditions` is [defined](https://github.com/kubernetes/api/blob/v0.26.0/core/v1/types.go#LL4416C1-L4419C21) as a `// +listType=map` and `// +listMapKey=type`.

While the Kubernetes API server seems to not notice, tooling that utilizes strategic merge patches on the in-cluster resources will encounter errors such as `error: failed to create manager for existing fields: failed to convert new object (network-cluster/nginx-ingress-controller; /v1, Kind=Service) to smd typed: .status.conditions: duplicate entries for key [type="io.cilium/lb-ipam-request-satisfied"]`.

Not quite sure if copy-pasting the required code for `github.com/cilium/cilium/pkg/k8s/slim/k8s/apimachinery/pkg/api/meta`  from the apimachinery master branch and modifying the header is the correct way of doing things. Is that supposed to follow some specific version or be tracked somehow?

Haven't dug into building an image locally for testing, but at least `go test ./operator/pkg/lbipam` passes.

Fixes: #24945