### PR TITLE
.github: set lvh image tags with `-latest`

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -13,53 +13,53 @@ include:
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.26.4@sha256:f4c0d87be03d6bea69f5e5dc0adb678bb498a190ee5c38422bf751541cebe92e"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+    kernel: "4.19-latest-20230808.142051@sha256:01f6353004ae2e4606e88f0d4118ec4530fa74cbf76c689e3eb148629adc622a"
 
   - k8s-version: "1.25"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.25.9@sha256:c08d6c52820aa42e533b70bce0c2901183326d86dcdcbedecc9343681db45161"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "5.4-20230526.105339@sha256:523ff0c81ed9be73a2d0d02a64c72655225efdd32e35220f530ca3eff3eada3c"
+    kernel: "5.4-latest-20230808.142051@sha256:6dd65b9350696cf4e40ea1b3837b76b7264f10a2b370e182a7e2ccae2c58df1b"
 
   - k8s-version: "1.24"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.24.13@sha256:cea86276e698af043af20143f4bf0509e730ec34ed3b7fa790cc0bea091bc5dd"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+    kernel: "4.19-latest-20230808.142051@sha256:01f6353004ae2e4606e88f0d4118ec4530fa74cbf76c689e3eb148629adc622a"
 
   - k8s-version: "1.23"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.23.17@sha256:f77f8cf0b30430ca4128cc7cfafece0c274a118cd0cdb251049664ace0dee4ff"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+    kernel: "4.19-latest-20230808.142051@sha256:01f6353004ae2e4606e88f0d4118ec4530fa74cbf76c689e3eb148629adc622a"
 
   - k8s-version: "1.22"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.22.17@sha256:9af784f45a584f6b28bce2af84c494d947a05bd709151466489008f80a9ce9d5"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+    kernel: "4.19-latest-20230808.142051@sha256:01f6353004ae2e4606e88f0d4118ec4530fa74cbf76c689e3eb148629adc622a"
 
   - k8s-version: "1.21"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.21.14@sha256:220cfafdf6e3915fbce50e13d1655425558cb98872c53f802605aa2fb2d569cf"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+    kernel: "4.19-latest-20230808.142051@sha256:01f6353004ae2e4606e88f0d4118ec4530fa74cbf76c689e3eb148629adc622a"
 
   - k8s-version: "1.20"
     ip-family: "dual"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.20.15@sha256:a32bf55309294120616886b5338f95dd98a2f7231519c7dedcec32ba29699394"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+    kernel: "4.19-latest-20230808.142051@sha256:01f6353004ae2e4606e88f0d4118ec4530fa74cbf76c689e3eb148629adc622a"
 
   - k8s-version: "1.19"
     ip-family: "ipv4"
     # renovate: datasource=docker
     kube-image: "kindest/node:v1.19.16@sha256:476cb3269232888437b61deca013832fee41f9f074f9bed79f57e4280f7c48b7"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
-    kernel: "4.19-20230526.105339@sha256:cca7436d6c9f08bd218ac12347eb76616ad1a276282806239a93035033b35efe"
+    kernel: "4.19-latest-20230808.142051@sha256:01f6353004ae2e4606e88f0d4118ec4530fa74cbf76c689e3eb148629adc622a"

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -79,21 +79,21 @@ jobs:
 
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20230420.212204'
+            kernel: '4.19-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
 
           - name: '3'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
@@ -101,7 +101,7 @@ jobs:
 
           - name: '4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'true'
             tunnel: 'vxlan'
@@ -111,7 +111,7 @@ jobs:
 
           - name: '5'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20230420.212204'
+            kernel: '5.15-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'true'
             tunnel: 'disabled'
@@ -122,7 +122,7 @@ jobs:
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.0-20230420.212204'
+            kernel: '6.0-latest-20230808.142051'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'vxlan'
@@ -151,7 +151,7 @@ jobs:
 
           - name: '9'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20230420.212204'
+            kernel: '4.19-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
@@ -160,7 +160,7 @@ jobs:
 
           - name: '10'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
@@ -169,7 +169,7 @@ jobs:
 
           - name: '11'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
@@ -179,7 +179,7 @@ jobs:
 
           - name: '12'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'true'
             tunnel: 'vxlan'
@@ -191,7 +191,7 @@ jobs:
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20230420.212204'
+            kernel: '5.15-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'true'
             tunnel: 'disabled'
@@ -203,7 +203,7 @@ jobs:
 
           - name: '14'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.0-20230420.212204'
+            kernel: '6.0-latest-20230808.142051'
             kube-proxy: 'none'
             kpr: 'true'
             tunnel: 'vxlan'

--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -70,16 +70,16 @@ jobs:
       matrix:
         include:
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          - kernel: '4.19-20230420.212204'
+          - kernel: '4.19-latest-20230808.142051'
             ci-kernel: '419'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          - kernel: '5.4-20230420.212204'
+          - kernel: '5.4-latest-20230808.142051'
             ci-kernel: '54'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          - kernel: '5.10-20230420.212204'
+          - kernel: '5.10-latest-20230808.142051'
             ci-kernel: '510'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-          - kernel: '5.15-20230420.212204'
+          - kernel: '5.15-latest-20230808.142051'
             ci-kernel: '510'
             # We don't want to update bpf-next after branching
           - kernel: 'bpf-next-20230420.212204'

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -79,7 +79,7 @@ jobs:
         include:
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -91,7 +91,7 @@ jobs:
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'


### PR DESCRIPTION
Since lvh image changed their tags to include `-latest` we need to update them manually so that renovate bot can pick them up automatically.