### PR TITLE
.github: set lvh image tags with `-latest`

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -78,21 +78,21 @@ jobs:
           # See https://github.com/cilium/cilium/issues/20606 for configuration table
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20230420.212204'
+            kernel: '4.19-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
 
           - name: '3'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -100,7 +100,7 @@ jobs:
 
           - name: '4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -110,7 +110,7 @@ jobs:
 
           - name: '5'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20230420.212204'
+            kernel: '5.15-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'
@@ -121,7 +121,7 @@ jobs:
 
           - name: '6'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.0-20230420.212204'
+            kernel: '6.0-latest-20230808.142051'
             kube-proxy: 'none'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -150,7 +150,7 @@ jobs:
 
           - name: '9'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20230420.212204'
+            kernel: '4.19-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'vxlan'
@@ -160,7 +160,7 @@ jobs:
 
           - name: '10'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -169,7 +169,7 @@ jobs:
 
           - name: '11'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -179,7 +179,7 @@ jobs:
 
           - name: '12'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'vxlan'
@@ -191,7 +191,7 @@ jobs:
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20230420.212204'
+            kernel: '5.15-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'strict'
             tunnel: 'disabled'

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -79,7 +79,7 @@ jobs:
         include:
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -91,7 +91,7 @@ jobs:
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'


### PR DESCRIPTION
Since lvh image changed their tags to include `-latest` we need to update them manually so that renovate bot can pick them up automatically.