### PR TITLE
.github: set lvh image tags with `-latest`

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -79,7 +79,7 @@ jobs:
         include:
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20230420.212204'
+            kernel: '5.4-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'
@@ -91,7 +91,7 @@ jobs:
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230420.212204'
+            kernel: '5.10-latest-20230808.142051'
             kube-proxy: 'iptables'
             kpr: 'disabled'
             tunnel: 'disabled'


### PR DESCRIPTION
Since lvh image changed their tags to include `-latest` we need to update them manually so that renovate bot can pick them up automatically.