### PR TITLE
.github: add Dockerfile for hubble-relay image in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -187,6 +187,7 @@
         "contrib/coccinelle/Dockerfile",
         "images/cache/Dockerfile",
         "images/clustermesh-apiserver/Dockerfile",
+        "images/hubble-relay/Dockerfile",
         "images/operator/Dockerfile",
         "images/kvstoremesh/Dockerfile"
       ],


### PR DESCRIPTION
This commit adds the Dockerfile for the `hubble-relay` image to the group "alpine-images" so that the alpine updates are grouped together in a single PR instead of separate PRs.