### PR TITLE
[v1.12] Remove remote-node labels from ipcache on node delete

### DIFF
--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -491,10 +491,6 @@ func (ipc *IPCache) deleteLocked(ip string, source source.Source) (namedPortsCha
 	delete(ipc.ipToHostIPCache, ip)
 	delete(ipc.ipToK8sMetadata, ip)
 
-	// this removes the IP from the metadata map
-	// this prevents old assigned labels from being re-used
-	ipc.metadata.delete(ip)
-
 	// Update named ports
 	namedPortsChanged = false
 	if oldK8sMeta != nil && len(oldK8sMeta.NamedPorts) > 0 {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -79,12 +79,6 @@ func (m *metadata) upsert(prefix string, lbls labels.Labels) {
 	m.Unlock()
 }
 
-func (m *metadata) delete(prefix string) {
-	m.Lock()
-	delete(m.m, prefix)
-	m.Unlock()
-}
-
 // GetIDMetadataByIP returns the associated labels with an IP. The caller must
 // not modifying the returned object as it's a live reference to the underlying
 // map.

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -79,6 +79,14 @@ func (m *metadata) upsert(prefix string, lbls labels.Labels) {
 	m.Unlock()
 }
 
+func (ipc *IPCache) RemoveMetadata(prefix string, lbls labels.Labels, src source.Source) {
+	ipc.metadata.Lock()
+	ipc.Lock()
+	_ = ipc.removeLabels(prefix, lbls, src)
+	ipc.Unlock()
+	ipc.metadata.Unlock()
+}
+
 // GetIDMetadataByIP returns the associated labels with an IP. The caller must
 // not modifying the returned object as it's a live reference to the underlying
 // map.

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -87,6 +87,9 @@ func (i *ipcacheMock) TriggerLabelInjection(s source.Source) {
 func (i *ipcacheMock) UpsertMetadata(string, labels.Labels) {
 }
 
+func (i *ipcacheMock) RemoveMetadata(string, labels.Labels, source.Source) {
+}
+
 type signalNodeHandler struct {
 	EnableNodeAddEvent                    bool
 	NodeAddEvent                          chan nodeTypes.Node


### PR DESCRIPTION
Previously the node manager code only ever performed upserts into the
ipcache for remote-node labels on node creation/update events. However,
it never cleaned up these labels upon delete. As a result, if a node was
ever removed, then Cilium would continue to consider traffic towards
that IP as traffic reaching towards a remote node. In extreme cases,
this IP could be reallocated to another host in the network which could
cause connectivity disruption to that peer, particularly if the new peer
is subject to CIDR or Entities based policies.

Commits:
- Revert #26958
- node: Remove labels from ipcache on delete events

Related: https://github.com/cilium/cilium/pull/26958
Fixes: https://github.com/cilium/cilium/issues/27382

Passes the first two test cases here:
https://gist.github.com/joestringer/d7f55da5dd2f33be6148dd52a96a4a54