### PR TITLE
docs: Improve wording in contributions guide

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -231,15 +231,12 @@ requirements have been met:
    .. image:: https://i1.wp.com/user-images.githubusercontent.com/3477155/52671177-5d0e0100-2ee8-11e9-8645-bdd923b7d93b.gif
        :align: center
 
-#. Once the PR is ready for review you can click the "Ready for review" button
-   at the bottom of the page and GitHub will notify reviewers that the PR is
-   ready to be reviewed.
+#. To notify reviewers that the PR is ready for review, click **Ready for
+   review** at the bottom of the page.
 
-#. Engage in the discussions raised by reviewers and address any feedback where
-   changes are requested. When you are actively changing your PR, set the PR to
-   draft PR mode to signal that reviewers do not need to actively review the PR
-   right now. When it is ready for review again, click "Ready for review", and
-   re-request review from the reviewers:
+#. Engage in any discussions raised by reviewers and address any changes
+   requested. Set the PR to draft PR mode while you address changes, then click
+   **Ready for review** to re-request review.
 
    .. image:: /images/cilium_request_review.png
 
@@ -249,7 +246,7 @@ Getting a pull request merged
 #. As you submit the pull request as described in the section :ref:`submit_pr`.
    One of the reviewers will start a CI run by replying with a comment
    ``/test`` as described in :ref:`trigger_phrases`. If you are an
-   `organization member`_, you may trigger the CI run yourself. CI consists of:
+   `organization member`_, you can trigger the CI run yourself. CI consists of:
 
    #. Static code analysis by Github Actions and Travis CI. Golang linter
       suggestions are added in-line on PRs. For other failed jobs, please refer

--- a/Documentation/contributing/development/reviewers_committers/review_process.rst
+++ b/Documentation/contributing/development/reviewers_committers/review_process.rst
@@ -98,24 +98,21 @@ Review process
    | ``upgrade-impact``       | The code changes have a potential upgrade impact                          |
    +--------------------------+---------------------------------------------------------------------------+
 
-#. When submitting a review, provide explicit approval or request for changes
-   whenever possible. This provides clear feedback to contributors about
-   whether they must take action to resolve the comments before the PR can be
-   merged.
+#. When submitting a review, provide explicit approval or request specific
+   changes whenever possible. Clear feedback indicates whether contributors
+   must take action before a PR can merge.
 
-   If you are in doubt regarding the comments or review, you may leave comments
-   without explicit approval. If you do not explicitly approve or request
-   changes, it's best practice to raise awareness about the discussion so that
-   others can participate and clarify expectations to the contributor. Here are
-   some ways that you can raise awareness:
+   If you need more information before you can approve or request changes, you
+   can leave comments seeking clarity. If you do not explicitly approve or
+   request changes, it's best practice to raise awareness about the discussion
+   so that others can participate. Here are some ways you can raise awareness:
 
-   - Re-request the review of your codeowners in the PR
+   - Re-request review from codeowners in the PR
    - Raise the topic for discussion in Slack or during community meetings
 
-   When requesting changes, consider leaving a summary comment for the overall
-   PR that provides an overview of your feedback, what you think may be
-   important for the contributor to consider, and/or encouragement regarding
-   aspects of the PR that are of benefit to the project.
+   When requesting changes, summarize your feedback for the PR, including
+   overall issues for a contributor to consider and/or encouragement for what a
+   contributor is already doing well.
 
 #. When all review objectives for all ``CODEOWNERS`` are met, all CI tests have
    passed, and all reviewers have approved the requested changes, you can merge
@@ -133,7 +130,7 @@ Reviewer Teams
 
 Every reviewer, including committers in the `committers team`_, belongs to `one
 or more teams in the Cilium organization <cilium_teams_>`_. If you would like
-to be added or removed from any team, please submit a PR against the
+to add or remove yourself from any team, please submit a PR against the
 `community repository`_.
 
 Once a contributor opens a PR, GitHub automatically picks which `teams


### PR DESCRIPTION
This commit follows up on later feedback on the previous PR in this area to
tighten the wording and improve comprehension.

Related: https://github.com/cilium/cilium/pull/27324
