### PR TITLE
Revert ".github: write the right regex for little-vm-images versioning"

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -355,7 +355,7 @@
       "matchDepNames": [
         "quay.io/lvh-images/kind"
       ],
-      "versioning": "regex:^((?<compatibility>[a-z-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-latest\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
+      "versioning": "regex:^((?<compatibility>[a-z-]+)|((?<major>\\d+)\\.(?<minor>\\d+)))\\-(?<patch>\\d+)\\.(?<build>\\d+)(@(?<currentDigest>sha256:[a-f0-9]+))?$"
     },
     {
       "groupName": "all lvh-images main",


### PR DESCRIPTION
This reverts commit 9234967e365d9884a82ffc6eaef86cdea98437e7.

We have to switch back and use the tags without `-latest` since this was causing failures in the GH actions as the image tags are used to retrieve the kernel image from within the docker image.

```
Status: Downloaded newer image for quay.io/lvh-images/kind@sha256:245e193b00269c7670b763f622ccb5e474710315ef1dbee91609deb455985f43
cp: can't stat '/data/images/kind_bpf-next-latest.qcow2.zst': No such file or directory
```

from https://github.com/cilium/cilium/actions/runs/5813991492/job/15762882633#step:7:505