### PR TITLE
endpointmanager: unexport and inline functions only used in the package

### DIFF
--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -203,10 +203,10 @@ func (mgr *endpointManager) InitMetrics(registry *metrics.Registry) {
 	})
 }
 
-// AllocateID checks if the ID can be reused. If it cannot, returns an error.
+// allocateID checks if the ID can be reused. If it cannot, returns an error.
 // If an ID of 0 is provided, a new ID is allocated. If a new ID cannot be
 // allocated, returns an error.
-func (mgr *endpointManager) AllocateID(currID uint16) (uint16, error) {
+func (mgr *endpointManager) allocateID(currID uint16) (uint16, error) {
 	var newID uint16
 	if currID != 0 {
 		if err := idallocator.Reuse(currID); err != nil {
@@ -599,7 +599,7 @@ func (mgr *endpointManager) GetPolicyEndpoints() map[policy.Endpoint]struct{} {
 }
 
 func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
-	newID, err := mgr.AllocateID(ep.ID)
+	newID, err := mgr.allocateID(ep.ID)
 	if err != nil {
 		return err
 	}

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -379,7 +379,7 @@ func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
 
 	// This must be done before the ID is released for the endpoint!
 	mgr.removeIDLocked(ep.ID)
-	mgr.RemoveIPv6Address(ep.IPv6)
+	mgr.mcastManager.RemoveAddress(ep.IPv6)
 
 	// We haven't yet allocated the ID for a restoring endpoint, so no
 	// need to release it.
@@ -528,16 +528,6 @@ func (mgr *endpointManager) removeReferencesLocked(identifiers endpointid.Identi
 	}
 }
 
-// AddIPv6Address notifies an addition of an IPv6 address
-func (mgr *endpointManager) AddIPv6Address(ipv6 netip.Addr) {
-	mgr.mcastManager.AddAddress(ipv6)
-}
-
-// RemoveAIPv6ddress notifies a removal of an IPv6 address
-func (mgr *endpointManager) RemoveIPv6Address(ipv6 netip.Addr) {
-	mgr.mcastManager.RemoveAddress(ipv6)
-}
-
 // RegenerateAllEndpoints calls a setState for each endpoint and
 // regenerates if state transaction is valid. During this process, the endpoint
 // list is locked and cannot be modified.
@@ -618,7 +608,7 @@ func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 	// Get a copy of the identifiers before exposing the endpoint
 	identifiers := ep.IdentifiersLocked()
 	ep.Start(newID)
-	mgr.AddIPv6Address(ep.IPv6)
+	mgr.mcastManager.AddAddress(ep.IPv6)
 	mgr.updateIDReferenceLocked(ep)
 	mgr.updateReferencesLocked(ep, identifiers)
 	mgr.mutex.Unlock()


### PR DESCRIPTION
Unexport and/or inline some functions that are only used in `pkg/endpointmanager`.

See commit messages for details.
