### PR TITLE
Log endpoint instead of pod names where appropriate

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -199,7 +199,7 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) er
 	for _, ep := range state.possible {
 		scopedLog := log.WithField(logfields.EndpointID, ep.ID)
 		if d.clientset.IsEnabled() {
-			scopedLog = scopedLog.WithField("k8sPodName", ep.GetK8sNamespaceAndPodName())
+			scopedLog = scopedLog.WithField(logfields.CEPName, ep.GetK8sNamespaceAndCEPName())
 		}
 
 		// We have to set the allocator for identities here during the Endpoint
@@ -419,7 +419,7 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 			log.WithError(err).WithFields(logrus.Fields{
 				logfields.IPAddr:     ep.IPv4,
 				logfields.EndpointID: ep.ID,
-				logfields.K8sPodName: ep.GetK8sNamespaceAndPodName(),
+				logfields.CEPName:    ep.GetK8sNamespaceAndCEPName(),
 			}).Warn(
 				"Bypassing IP not available error on endpoint restore. This is " +
 					"to prevent errors upon Cilium upgrade and should not be " +

--- a/pkg/endpoint/log.go
+++ b/pkg/endpoint/log.go
@@ -117,6 +117,7 @@ func (e *Endpoint) UpdateLogger(fields map[string]interface{}) {
 		logfields.IPv4:                   e.GetIPv4Address(),
 		logfields.IPv6:                   e.GetIPv6Address(),
 		logfields.K8sPodName:             e.GetK8sNamespaceAndPodName(),
+		logfields.CEPName:                e.GetK8sNamespaceAndCEPName(),
 	}
 
 	if e.SecurityIdentity != nil {

--- a/pkg/endpointmanager/gc.go
+++ b/pkg/endpointmanager/gc.go
@@ -76,6 +76,7 @@ func (mgr *endpointManager) sweepEndpoints(markedEndpoints []uint16) {
 			logfields.EndpointID:  ep.StringID(),
 			logfields.ContainerID: ep.GetShortContainerID(),
 			logfields.K8sPodName:  ep.GetK8sNamespaceAndPodName(),
+			logfields.CEPName:     ep.GetK8sNamespaceAndCEPName(),
 			logfields.URL:         "https://github.com/kubernetes/kubernetes/issues/86944",
 		}).Warning("Stray endpoint found. You may be affected by upstream Kubernetes issue #86944.")
 		errs := mgr.RemoveEndpoint(ep, endpoint.DeleteConfig{

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -650,6 +650,7 @@ func (mgr *endpointManager) AddEndpoint(owner regeneration.Owner, ep *endpoint.E
 		logfields.IPv4:        ep.GetIPv4Address(),
 		logfields.IPv6:        ep.GetIPv6Address(),
 		logfields.K8sPodName:  ep.GetK8sNamespaceAndPodName(),
+		logfields.CEPName:     ep.GetK8sNamespaceAndCEPName(),
 	})
 
 	err = mgr.expose(ep)


### PR DESCRIPTION
After commit ced01f656f03 ("endpoint: Allow multiple endpoints per pod"), there might be multiple endpoints per pod, i.e. there no longer is a clear 1:1 mapping from pod <-> CEP. Amend and/or replace some logs with the endpoint name.

See commits for details.

Fixes: ced01f656f03 ("endpoint: Allow multiple endpoints per pod")