### PR TITLE
egressgw: test for conflicting IP rules in ENI mode

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
-	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/hivetest"
 	"github.com/cilium/cilium/pkg/identity"
@@ -556,7 +555,7 @@ func tryAssertIPRules(rules []ipRule) error {
 		parsedRules = append(parsedRules, parseIPRule(r.sourceIP, r.destCIDR, r.egressIP, r.ifaceIndex))
 	}
 
-	installedRules, err := route.ListRules(netlink.FAMILY_V4, &route.Rule{Priority: linux_defaults.RulePriorityEgressGateway})
+	installedRules, err := listEgressIpRules()
 	if err != nil {
 		panic("Cannot list IP rules")
 	}

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -46,9 +46,10 @@ const (
 	ep1IP = "10.0.0.1"
 	ep2IP = "10.0.0.2"
 
-	destCIDR      = "1.1.1.0/24"
-	excludedCIDR1 = "1.1.1.22/32"
-	excludedCIDR2 = "1.1.1.240/30"
+	destCIDR        = "1.1.1.0/24"
+	allZeroDestCIDR = "0.0.0.0/0"
+	excludedCIDR1   = "1.1.1.22/32"
+	excludedCIDR2   = "1.1.1.240/30"
 
 	egressIP1   = "192.168.101.1"
 	egressCIDR1 = "192.168.101.1/24"
@@ -163,13 +164,15 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	egressGatewayManager.OnUpdateNode(node2)
 
 	// Create a new policy
-	addPolicy(c, k.policies, &policyParams{
+	policy1 := policyParams{
 		name:            "policy-1",
 		endpointLabels:  ep1Labels,
 		destinationCIDR: destCIDR,
 		nodeLabels:      nodeGroup1Labels,
 		iface:           testInterface1,
-	})
+	}
+
+	addPolicy(c, k.policies, &policy1)
 
 	assertEgressRules(c, policyMap, []egressRule{})
 	assertIPRules(c, []ipRule{})
@@ -202,6 +205,23 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	assertIPRules(c, []ipRule{
 		{ep1IP, destCIDR, egressCIDR1, testInterface1Idx},
 	})
+
+	// Changing the DestCIDR to 0.0.0.0 results in a conflict with
+	// the existing IP rules. Test that the manager is able to
+	// resolve this conflict.
+	policy1.destinationCIDR = allZeroDestCIDR
+	addPolicy(c, k.policies, &policy1)
+
+	assertEgressRules(c, policyMap, []egressRule{
+		{ep1IP, allZeroDestCIDR, egressIP1, node1IP},
+	})
+	assertIPRules(c, []ipRule{
+		{ep1IP, allZeroDestCIDR, egressCIDR1, testInterface1Idx},
+	})
+
+	// Restore old DestCIDR
+	policy1.destinationCIDR = destCIDR
+	addPolicy(c, k.policies, &policy1)
 
 	// Create a new policy
 	addPolicy(c, k.policies, &policyParams{


### PR DESCRIPTION
When the DestCIDR of a policy changes, we first add the new IP rules before
deleting the old ones. But if the new DestCIDR is 0.0.0.0, attempting to
install the matching IP rules results in an -EEXIST error.

To deal with this, addMissingIpRulesAndRoutes() returns a `shouldRetry`
value. If it is set, we retry the installation after
removeUnusedIpRulesAndRoutes() has deleted the unused rules.

Add a test for this scenario.