### PR TITLE
Refactor the per-cluster NAT maps manager

### DIFF
--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -36,7 +36,7 @@ var bpfNatListCmd = &cobra.Command{
 				cmd.PrintErrf("Invalid ClusterID: %s", err.Error())
 				return
 			}
-			ipv4, ipv6, err := nat.ClusterMaps(uint32(clusterID), true, false)
+			ipv4, ipv6, err := nat.ClusterMaps(uint32(clusterID), true, getIpv6EnableStatus())
 			if err != nil {
 				cmd.PrintErrf("Failed to retrieve cluster maps: %s", err.Error())
 				return

--- a/cilium/cmd/bpf_nat_list.go
+++ b/cilium/cmd/bpf_nat_list.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/maps/nat"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 // bpfNatListCmd represents the bpf_nat_list command
@@ -32,11 +31,6 @@ var bpfNatListCmd = &cobra.Command{
 			globalMaps[1] = ipv6
 			dumpNat(globalMaps)
 		} else if len(args) == 2 && args[0] == "cluster" {
-			err := nat.InitPerClusterNATMaps(nat.PerClusterNATOuterMapPrefix, true, getIpv6EnableStatus(), option.LimitTableMax)
-			if err != nil {
-				cmd.PrintErrf("Failed to initialize per-cluster SNAT maps: %s\n", err.Error())
-				return
-			}
 			clusterID, err := strconv.ParseUint(args[1], 10, 32)
 			if err != nil {
 				cmd.PrintErrf("Invalid ClusterID: %s", err.Error())

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -303,13 +303,11 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 		natMap = ctMap.natMap
 	} else {
 		// per-cluster map handling
-		if nat.PerClusterNATMaps != nil {
-			natm, err := nat.PerClusterNATMaps.GetClusterNATMap(m.clusterID, nat.IPv6)
-			if err != nil {
-				log.WithError(err).Error("Unable to get per-cluster NAT map")
-			} else {
-				natMap = natm
-			}
+		natm, err := nat.GetClusterNATMap(m.clusterID, nat.IPv6)
+		if err != nil {
+			log.WithError(err).Error("Unable to get per-cluster NAT map")
+		} else {
+			natMap = natm
 		}
 	}
 
@@ -404,13 +402,11 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 		natMap = ctMap.natMap
 	} else {
 		// per-cluster map handling
-		if nat.PerClusterNATMaps != nil {
-			natm, err := nat.PerClusterNATMaps.GetClusterNATMap(m.clusterID, nat.IPv4)
-			if err != nil {
-				log.WithError(err).Error("Unable to get per-cluster NAT map")
-			} else {
-				natMap = natm
-			}
+		natm, err := nat.GetClusterNATMap(m.clusterID, nat.IPv4)
+		if err != nil {
+			log.WithError(err).Error("Unable to get per-cluster NAT map")
+		} else {
+			natMap = natm
 		}
 	}
 

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -304,7 +304,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 	} else {
 		// per-cluster map handling
 		if nat.PerClusterNATMaps != nil {
-			natm, err := nat.PerClusterNATMaps.GetClusterNATMap(m.clusterID, false)
+			natm, err := nat.PerClusterNATMaps.GetClusterNATMap(m.clusterID, nat.IPv6)
 			if err != nil {
 				log.WithError(err).Error("Unable to get per-cluster NAT map")
 			} else {
@@ -405,7 +405,7 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 	} else {
 		// per-cluster map handling
 		if nat.PerClusterNATMaps != nil {
-			natm, err := nat.PerClusterNATMaps.GetClusterNATMap(m.clusterID, true)
+			natm, err := nat.PerClusterNATMaps.GetClusterNATMap(m.clusterID, nat.IPv4)
 			if err != nil {
 				log.WithError(err).Error("Unable to get per-cluster NAT map")
 			} else {

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -94,7 +94,7 @@ func (k *CTMapPrivilegedTestSuite) Benchmark_MapUpdate(c *C) {
 // their CT entry (GH#12625).
 func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 	// Init maps
-	natMap := nat.NewMap("cilium_nat_any4_test", true, 1000)
+	natMap := nat.NewMap("cilium_nat_any4_test", nat.IPv4, 1000)
 	err := natMap.OpenOrCreate()
 	c.Assert(err, IsNil)
 	defer natMap.Map.Unpin()
@@ -203,7 +203,7 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 // TestOrphanNat checks whether dangling NAT entries are GC'd (GH#12686)
 func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	// Init maps
-	natMap := nat.NewMap("cilium_nat_any4_test", true, 1000)
+	natMap := nat.NewMap("cilium_nat_any4_test", nat.IPv4, 1000)
 	err := natMap.OpenOrCreate()
 	c.Assert(err, IsNil)
 	defer natMap.Map.Unpin()
@@ -493,7 +493,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 
 	// Let's check IPv6
 
-	natMapV6 := nat.NewMap("cilium_nat_any6_test", false, 1000)
+	natMapV6 := nat.NewMap("cilium_nat_any6_test", nat.IPv6, 1000)
 	err = natMapV6.OpenOrCreate()
 	c.Assert(err, IsNil)
 	defer natMapV6.Map.Unpin()

--- a/pkg/maps/nat/fake/per_cluster.go
+++ b/pkg/maps/nat/fake/per_cluster.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package nat
+
+import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/maps/nat"
+)
+
+// A structure that implements PerClusterNATMapper for testing purposes.
+type PerClusterMaps struct {
+	lock.RWMutex
+	ids sets.Set[uint32]
+}
+
+var _ nat.PerClusterNATMapper = (*PerClusterMaps)(nil)
+
+func NewPerClusterMaps() *PerClusterMaps {
+	return &PerClusterMaps{ids: sets.New[uint32]()}
+}
+
+func (maps *PerClusterMaps) OpenOrCreate() error { return nil }
+func (maps *PerClusterMaps) Close() error        { return nil }
+
+func (maps *PerClusterMaps) CreateClusterNATMaps(clusterID uint32) error {
+	maps.Lock()
+	defer maps.Unlock()
+	maps.ids.Insert(clusterID)
+	return nil
+}
+
+func (maps *PerClusterMaps) DeleteClusterNATMaps(clusterID uint32) error {
+	maps.Lock()
+	defer maps.Unlock()
+	maps.ids.Delete(clusterID)
+	return nil
+}
+
+func (maps *PerClusterMaps) Has(clusterID uint32) bool {
+	maps.RLock()
+	defer maps.RUnlock()
+	return maps.ids.Has(clusterID)
+}

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -289,36 +289,35 @@ func GlobalMaps(ipv4, ipv6, nodeport bool) (ipv4Map, ipv6Map *Map) {
 	if !nodeport {
 		return
 	}
-	entries := option.Config.NATMapEntriesGlobal
-	if entries == 0 {
-		entries = option.LimitTableMax
-	}
 	if ipv4 {
-		ipv4Map = NewMap(MapNameSnat4Global, IPv4, entries)
+		ipv4Map = NewMap(MapNameSnat4Global, IPv4, maxEntries())
 	}
 	if ipv6 {
-		ipv6Map = NewMap(MapNameSnat6Global, IPv6, entries)
+		ipv6Map = NewMap(MapNameSnat6Global, IPv6, maxEntries())
 	}
 	return
 }
 
 // ClusterMaps returns all NAT maps for given clusters
 func ClusterMaps(clusterID uint32, ipv4, ipv6 bool) (ipv4Map, ipv6Map *Map, err error) {
-	if PerClusterNATMaps == nil {
-		err = fmt.Errorf("Per-cluster NAT maps are not initialized")
-		return
-	}
 	if ipv4 {
-		ipv4Map, err = PerClusterNATMaps.GetClusterNATMap(clusterID, IPv4)
+		ipv4Map, err = GetClusterNATMap(clusterID, IPv4)
 		if err != nil {
 			return
 		}
 	}
 	if ipv6 {
-		ipv6Map, err = PerClusterNATMaps.GetClusterNATMap(clusterID, IPv6)
+		ipv6Map, err = GetClusterNATMap(clusterID, IPv6)
 		if err != nil {
 			return
 		}
 	}
 	return
+}
+
+func maxEntries() int {
+	if option.Config.NATMapEntriesGlobal != 0 {
+		return option.Config.NATMapEntriesGlobal
+	}
+	return option.LimitTableMax
 }

--- a/pkg/maps/nat/per_cluster_nat_test.go
+++ b/pkg/maps/nat/per_cluster_nat_test.go
@@ -45,7 +45,7 @@ func (k *PerClusterNATMapPrivilegedTestSuite) TearDownTest(c *C) {
 }
 
 func (k *PerClusterNATMapPrivilegedTestSuite) TestPerClusterCtMap(c *C) {
-	om, err := newPerClusterNATMap(testPerClusterNATMapNamePrefix+perClusterNATIPv4OuterMapSuffix, true, option.NATMapEntriesGlobalDefault)
+	om, err := newPerClusterNATMap(testPerClusterNATMapNamePrefix+perClusterNATIPv4OuterMapSuffix, IPv4, option.NATMapEntriesGlobalDefault)
 	c.Assert(err, IsNil)
 
 	defer om.Unpin()
@@ -107,7 +107,7 @@ func (k *PerClusterNATMapPrivilegedTestSuite) TestPerClusterNATMaps(c *C) {
 	c.Assert(err, NotNil)
 	err = gm.DeleteClusterNATMaps(0)
 	c.Assert(err, NotNil)
-	_, err = gm.GetClusterNATMap(0, true)
+	_, err = gm.GetClusterNATMap(0, IPv4)
 	c.Assert(err, NotNil)
 
 	// ClusterID beyond the ClusterIDMax should never be used
@@ -115,7 +115,7 @@ func (k *PerClusterNATMapPrivilegedTestSuite) TestPerClusterNATMaps(c *C) {
 	c.Assert(err, NotNil)
 	err = gm.DeleteClusterNATMaps(cmtypes.ClusterIDMax + 1)
 	c.Assert(err, NotNil)
-	_, err = gm.GetClusterNATMap(cmtypes.ClusterIDMax+1, true)
+	_, err = gm.GetClusterNATMap(cmtypes.ClusterIDMax+1, IPv4)
 	c.Assert(err, NotNil)
 
 	// Basic update
@@ -136,19 +136,19 @@ func (k *PerClusterNATMapPrivilegedTestSuite) TestPerClusterNATMaps(c *C) {
 	}
 
 	// Basic get
-	im, err := gm.GetClusterNATMap(1, true)
+	im, err := gm.GetClusterNATMap(1, IPv4)
 	c.Assert(err, IsNil)
 	im.Close()
 
-	im, err = gm.GetClusterNATMap(1, false)
+	im, err = gm.GetClusterNATMap(1, IPv6)
 	c.Assert(err, IsNil)
 	im.Close()
 
-	im, err = gm.GetClusterNATMap(cmtypes.ClusterIDMax, true)
+	im, err = gm.GetClusterNATMap(cmtypes.ClusterIDMax, IPv4)
 	c.Assert(err, IsNil)
 	im.Close()
 
-	im, err = gm.GetClusterNATMap(cmtypes.ClusterIDMax, false)
+	im, err = gm.GetClusterNATMap(cmtypes.ClusterIDMax, IPv6)
 	c.Assert(err, IsNil)
 	im.Close()
 

--- a/pkg/maps/nat/types.go
+++ b/pkg/maps/nat/types.go
@@ -12,6 +12,23 @@ import (
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
+// IPFamily represents an IP family (i.e., either IPv4 or IPv6).
+type IPFamily bool
+
+const (
+	// IPv4 represents the IPv4 IP family.
+	IPv4 = IPFamily(true)
+	// IPv6 represents the IPv6 IP family.
+	IPv6 = IPFamily(false)
+)
+
+func (family IPFamily) String() string {
+	if family == IPv4 {
+		return "ipv4"
+	}
+	return "ipv6"
+}
+
 type NatKey interface {
 	bpf.MapKey
 


### PR DESCRIPTION
Let's simplify the per-cluster NAT maps management logic, removing the dependency on the global variable (which does not play well with the hive framework) and splitting the creation/removal tasks from the retrieval of inner maps.

While being at it, let's also slightly improve the performance around these operations by avoiding to attempt opening the inner maps when not strictly necessary.

Finally, let's also move the fake implementation for testing purposes to a separate package, for better separation.

