### PR TITLE
egressgw: back out test for policy conflict in ENI mode

### DIFF
--- a/pkg/egressgateway/helpers_test.go
+++ b/pkg/egressgateway/helpers_test.go
@@ -68,16 +68,6 @@ func addPolicy(tb testing.TB, policies fakeResource[*Policy], params *policyPara
 	})
 }
 
-func deletePolicy(tb testing.TB, policies fakeResource[*Policy], params *policyParams) {
-	tb.Helper()
-
-	policy, _ := newCEGP(params)
-	policies.process(tb, resource.Event[*Policy]{
-		Kind:   resource.Delete,
-		Object: policy,
-	})
-}
-
 type policyParams struct {
 	name            string
 	endpointLabels  map[string]string


### PR DESCRIPTION
https://github.com/cilium/cilium/issues/27431 points out that we can't really tell which policy is going to be processed first (and wins the conflict). Revert the test until we have a mechanism to do so.