### PR TITLE
Allow Golang bump to v1.20 on Cilium v1.12 and v1.13

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -238,9 +238,7 @@
         "docker.io/library/golang",
         "go"
       ],
-      // Golang 1.20.0 had a regression which prevented us from upgrading it
-      // to 1.20 before the 1.13 release.
-      "allowedVersions": "<1.20",
+      "allowedVersions": "<1.21",
       "matchBaseBranches": [
         "v1.13"
       ]
@@ -250,7 +248,7 @@
         "docker.io/library/golang",
         "go"
       ],
-      "allowedVersions": "<1.20",
+      "allowedVersions": "<1.21",
       "matchBaseBranches": [
         "v1.12"
       ]


### PR DESCRIPTION
Now that Golang v1.19 is no longer receiving updates, allow Renovate to bump the Golang version, following the Golang update policy defined in:
https://docs.cilium.io/en/latest/contributing/development/dev_setup/#update-a-golang-version
