### PR TITLE
[DRAFT] policy: lock the SelectorCache for reading only

### DIFF
--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -200,8 +200,8 @@ func (p *EndpointPolicy) computeDirectionL4PolicyMapEntries(policyMapState MapSt
 // have completed.
 // PolicyOwner (aka Endpoint) is also locked during this call.
 func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
-	p.selectorPolicy.SelectorCache.mutex.Lock()
-	defer p.selectorPolicy.SelectorCache.mutex.Unlock()
+	p.selectorPolicy.SelectorCache.mutex.RLock()
+	defer p.selectorPolicy.SelectorCache.mutex.RUnlock()
 	return p.policyMapChanges.consumeMapChanges(p.PolicyMapState, p.SelectorCache)
 }
 


### PR DESCRIPTION
ConsumeMapChanges and it's call tree below only require read access to the selector cache. Hence, avoid serialising all calls to ConsumeMapChanges by acquiring the full (write) lock.
