### PR TITLE
envoy: fix panic writing accesslog without L7 tags

### DIFF
--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -170,7 +170,8 @@ func logRecord(pblog *cilium.LogEntry) *logger.LogRecord {
 	var kafkaRecord *accesslog.LogRecordKafka
 	var kafkaTopics []string
 
-	var l7tags logger.LogTag
+	var l7tags logger.LogTag = func(lr *logger.LogRecord) {}
+
 	if httpLogEntry := pblog.GetHttp(); httpLogEntry != nil {
 		l7tags = logger.LogTags.HTTP(&accesslog.LogRecordHTTP{
 			Method:          httpLogEntry.Method,
@@ -222,7 +223,9 @@ func logRecord(pblog *cilium.LogEntry) *logger.LogRecord {
 	r := logger.NewLogRecord(flowType, pblog.IsIngress,
 		logger.LogTags.Timestamp(time.Unix(int64(pblog.Timestamp/1000000000), int64(pblog.Timestamp%1000000000))),
 		logger.LogTags.Verdict(GetVerdict(pblog), pblog.CiliumRuleRef),
-		logger.LogTags.Addressing(addrInfo), l7tags)
+		logger.LogTags.Addressing(addrInfo),
+		l7tags,
+	)
 	r.Log()
 
 	// Each kafka topic needs to be logged separately, log the rest if any


### PR DESCRIPTION
PR #24649 removed the deprecated support for adding fallback HTTP log tags if the access log entry wasn't of type HTTP, Kafka or GenericL7.

This removal leads to panics when the l7Tags function (`nil`) is called while trying to enrich the log entry in cases where no L7 tags are available.

Therefore, this commit changes the behaviour by defaulting to an noop l7Tags function if no specific L7 information are present.

Needs backport to v1.14 & v1.13 (#26722)

Fixes: #27442