### PR TITLE
CI: Update tested k8s version for aks

### DIFF
--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,13 +1,13 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.24"
+  - version: "1.25"
     location: westeurope
     index: 1
-  - version: "1.25"
+  - version: "1.26"
     location: westus
     index: 2
-  - version: "1.26"
+  - version: "1.27"
     location: eastasia
     index: 3
     default: true


### PR DESCRIPTION
AKS-supported k8s versions changed.
This PR update tested k8s versions for AKS according to the latest support [matrix](https://learn.microsoft.com/en-gb/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar)

Successful [run](https://github.com/cilium/cilium/actions/runs/5832556356/job/15818223068)

Fixes: #27443 
