### PR TITLE
Migrate Identity GC to use CEP and CES from hive.

### DIFF
--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -5,16 +5,17 @@ package identitygc
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
 	"github.com/cilium/cilium/operator/metrics"
-	"github.com/cilium/cilium/operator/pkg/ciliumendpointslice"
-	"github.com/cilium/cilium/operator/watchers"
 	"github.com/cilium/cilium/pkg/controller"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/identitybackend"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -68,13 +69,11 @@ func (igc *GC) runHeartbeatUpdater(ctx context.Context) error {
 // since HeartbeatTimeout.
 func (igc *GC) gc(ctx context.Context) error {
 	igc.logger.Debug("Running CRD identity garbage collector")
-
-	select {
-	case <-watchers.CiliumEndpointsSynced:
-	case <-ctx.Done():
-		return nil
+	cepStore, err := igc.ciliumEndpoint.Store(ctx)
+	if err != nil {
+		igc.logger.WithError(err).Error("unable to get CEP store")
+		return err
 	}
-
 	identitiesStore, err := igc.identity.Store(ctx)
 	if err != nil {
 		igc.logger.WithError(err).Error("unable to get Cilium identities from local store")
@@ -84,7 +83,12 @@ func (igc *GC) gc(ctx context.Context) error {
 	var idsInCESs map[string]bool
 	cesEnabled := option.Config.EnableCiliumEndpointSlice
 	if cesEnabled {
-		idsInCESs = ciliumendpointslice.UsedIdentitiesInCESs()
+		cesStore, err := igc.ciliumEndpointSlice.Store(ctx)
+		if err != nil {
+			igc.logger.WithError(err).Warning("unable to get CES  store")
+		} else {
+			idsInCESs = usedIdentitiesInCESs(cesStore)
+		}
 	}
 
 	identities := identitiesStore.List()
@@ -98,7 +102,7 @@ func (igc *GC) gc(ctx context.Context) error {
 			_, foundInCES = idsInCESs[identity.Name]
 		}
 		// The identity is definitely alive if there's a CE or CES using it.
-		alive := foundInCES || watchers.HasCEWithIdentity(identity.Name)
+		alive := foundInCES || hasCEWithIdentity(cepStore, identity.Name)
 
 		if alive {
 			igc.heartbeatStore.markAlive(identity.Name, timeNow)
@@ -211,4 +215,21 @@ func (igc *GC) updateIdentity(ctx context.Context, identity *v2.CiliumIdentity) 
 	log.WithField(logfields.Identity, identity.GetName()).Debug("Updated identity")
 
 	return nil
+}
+
+func hasCEWithIdentity(cepStore resource.Store[*v2.CiliumEndpoint], identity string) bool {
+	ces, _ := cepStore.IndexKeys(operatorK8s.CiliumEndpointIndexIdentity, identity)
+	return len(ces) != 0
+}
+
+func usedIdentitiesInCESs(cesStore resource.Store[*v2alpha1.CiliumEndpointSlice]) map[string]bool {
+	usedIdentities := make(map[string]bool)
+	cesObjList := cesStore.List()
+	for _, ces := range cesObjList {
+		for _, cep := range ces.Endpoints {
+			id := strconv.FormatInt(cep.IdentityID, 10)
+			usedIdentities[id] = true
+		}
+	}
+	return usedIdentities
 }

--- a/operator/identitygc/crd_gc_test.go
+++ b/operator/identitygc/crd_gc_test.go
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package identitygc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+)
+
+func TestUsedIdentitiesInCESs(t *testing.T) {
+	wait := make(chan struct{})
+	var fakeClient k8sClient.FakeClientset
+	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	hive := hive.New(
+		k8sClient.FakeClientCell,
+		k8s.ResourcesCell,
+		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+			fakeClient = *c
+			ciliumEndpointSlice = ces
+			close(wait)
+			return nil
+		}),
+	)
+	hive.Start(context.Background())
+	<-wait
+
+	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
+
+	// Empty store.
+	gotIdentities := usedIdentitiesInCESs(cesStore)
+	wantIdentities := make(map[string]bool)
+	assertEqualIDs(t, wantIdentities, gotIdentities)
+
+	// 5 IDs in the store.
+	cesA := createCESWithIDs("cesA", []int64{1, 2, 3, 4, 5})
+	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(context.Background(), cesA, meta_v1.CreateOptions{})
+	time.Sleep(50 * time.Millisecond)
+	wantIdentities["1"] = true
+	wantIdentities["2"] = true
+	wantIdentities["3"] = true
+	wantIdentities["4"] = true
+	wantIdentities["5"] = true
+	gotIdentities = usedIdentitiesInCESs(cesStore)
+	assertEqualIDs(t, wantIdentities, gotIdentities)
+
+	// 10 IDs in the store.
+	cesB := createCESWithIDs("cesB", []int64{10, 20, 30, 40, 50})
+	fakeClient.CiliumV2alpha1().CiliumEndpointSlices().Create(context.Background(), cesB, meta_v1.CreateOptions{})
+	time.Sleep(50 * time.Millisecond)
+	wantIdentities["10"] = true
+	wantIdentities["20"] = true
+	wantIdentities["30"] = true
+	wantIdentities["40"] = true
+	wantIdentities["50"] = true
+	gotIdentities = usedIdentitiesInCESs(cesStore)
+	assertEqualIDs(t, wantIdentities, gotIdentities)
+
+	hive.Stop(context.Background())
+}
+
+func createCESWithIDs(cesName string, ids []int64) *cilium_v2a1.CiliumEndpointSlice {
+	ces := &cilium_v2a1.CiliumEndpointSlice{ObjectMeta: meta_v1.ObjectMeta{Name: cesName}}
+	for _, id := range ids {
+		cep := cilium_v2a1.CoreCiliumEndpoint{IdentityID: id}
+		ces.Endpoints = append(ces.Endpoints, cep)
+	}
+	return ces
+}
+
+func assertEqualIDs(t *testing.T, wantIdentities, gotIdentities map[string]bool) {
+	t.Helper()
+	if diff := cmp.Diff(wantIdentities, gotIdentities); diff != "" {
+		t.Errorf("Unexpected Identites in the CES store (-want +got): \n%s", diff)
+	}
+}

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package k8s
+
+import (
+	"github.com/cilium/cilium/pkg/hive"
+	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CiliumEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumEndpoint], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](cs.CiliumV2().CiliumEndpoints("")),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2.CiliumEndpoint](lc, lw, resource.WithMetric("CiliumEndpoint")), nil
+}

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -4,13 +4,19 @@
 package k8s
 
 import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/utils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func CiliumEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumEndpoint], error) {
@@ -21,7 +27,24 @@ func CiliumEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...func
 		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumEndpointList](cs.CiliumV2().CiliumEndpoints("")),
 		opts...,
 	)
-	return resource.New[*cilium_api_v2.CiliumEndpoint](lc, lw, resource.WithMetric("CiliumEndpoint")), nil
+	indexers := cache.Indexers{
+		cache.NamespaceIndex:        cache.MetaNamespaceIndexFunc,
+		CiliumEndpointIndexIdentity: identityIndexFunc,
+	}
+	return resource.New[*cilium_api_v2.CiliumEndpoint](
+		lc, lw, resource.WithMetric("CiliumEndpoint"), resource.WithIndexers(indexers)), nil
+}
+
+func identityIndexFunc(obj interface{}) ([]string, error) {
+	switch t := obj.(type) {
+	case *cilium_api_v2.CiliumEndpoint:
+		if t.Status.Identity != nil {
+			id := strconv.FormatInt(t.Status.Identity.ID, 10)
+			return []string{id}, nil
+		}
+		return []string{"0"}, nil
+	}
+	return nil, fmt.Errorf("%w - found %T", errors.New("object is not a *cilium_api_v2.CiliumEndpoint"), obj)
 }
 
 func CiliumEndpointSliceResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -6,6 +6,7 @@ package k8s
 import (
 	"github.com/cilium/cilium/pkg/hive"
 	cilium_api_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/k8s/utils"
@@ -21,4 +22,15 @@ func CiliumEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...func
 		opts...,
 	)
 	return resource.New[*cilium_api_v2.CiliumEndpoint](lc, lw, resource.WithMetric("CiliumEndpoint")), nil
+}
+
+func CiliumEndpointSliceResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2alpha1.CiliumEndpointSliceList](cs.CiliumV2alpha1().CiliumEndpointSlices()),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](lc, lw, resource.WithMetric("CiliumEndpointSlice")), nil
 }

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -28,6 +28,7 @@ var (
 			k8s.LBIPPoolsResource,
 			k8s.CiliumIdentityResource,
 			k8s.CiliumPodIPPoolResource,
+			CiliumEndpointResource,
 		),
 	)
 )
@@ -41,4 +42,5 @@ type Resources struct {
 	LBIPPools        resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]
 	Identities       resource.Resource[*cilium_api_v2.CiliumIdentity]
 	CiliumPodIPPools resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool]
+	CiliumEndpoints  resource.Resource[*cilium_api_v2.CiliumEndpoint]
 }

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -29,6 +29,7 @@ var (
 			k8s.CiliumIdentityResource,
 			k8s.CiliumPodIPPoolResource,
 			CiliumEndpointResource,
+			CiliumEndpointSliceResource,
 		),
 	)
 )
@@ -37,10 +38,11 @@ var (
 type Resources struct {
 	cell.In
 
-	Services         resource.Resource[*slim_corev1.Service]
-	Endpoints        resource.Resource[*k8s.Endpoints]
-	LBIPPools        resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]
-	Identities       resource.Resource[*cilium_api_v2.CiliumIdentity]
-	CiliumPodIPPools resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool]
-	CiliumEndpoints  resource.Resource[*cilium_api_v2.CiliumEndpoint]
+	Services             resource.Resource[*slim_corev1.Service]
+	Endpoints            resource.Resource[*k8s.Endpoints]
+	LBIPPools            resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]
+	Identities           resource.Resource[*cilium_api_v2.CiliumIdentity]
+	CiliumPodIPPools     resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool]
+	CiliumEndpoints      resource.Resource[*cilium_api_v2.CiliumEndpoint]
+	CiliumEndpointSlices resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice]
 }

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -12,6 +12,10 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
 
+const (
+	CiliumEndpointIndexIdentity = "identity"
+)
+
 var (
 	// ResourcesCell provides a set of handles to Kubernetes resources used throughout the
 	// operator. Each of the resources share a client-go informer and backing store so we only


### PR DESCRIPTION
operator: Migrate Identity GC to use CEP and CES from hive.

```release-note
Operator Identity GC stops using legacy CEP and CES watchers.
```
