### PR TITLE
Makefile: remove check-go-version target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,6 @@ SKIP_CUSTOMVET_CHECK ?= "false"
 
 JOB_BASE_NAME ?= cilium_test
 
-GO_MAJOR_AND_MINOR_VERSION := $(shell awk '/^go/ { print $$2 }' go.mod)
-GO_INSTALLED_MAJOR_AND_MINOR_VERSION := $(shell $(GO) version | sed 's/go version go\([0-9]\+\).\([0-9]\+\)\(.[0-9]\+\)\?.*/\1.\2/')
-
 TEST_LDFLAGS=-ldflags "-X github.com/cilium/cilium/pkg/kvstore.consulDummyAddress=https://consul:8443 \
 	-X github.com/cilium/cilium/pkg/kvstore.etcdDummyAddress=http://etcd:4002 \
 	-X github.com/cilium/cilium/pkg/datapath.DatapathSHA256=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -635,7 +632,7 @@ kind-debug: ## Create a local kind development environment with cilium-agent & c
 	@echo " - 23411: cilium-agent    (kind-worker)"
 	@echo " - 23511: cilium-operator (kind-worker)"
 
-precheck: check-go-version logging-subsys-field ## Peform build precheck for the source code.
+precheck: logging-subsys-field ## Peform build precheck for the source code.
 ifeq ($(SKIP_K8S_CODE_GEN_CHECK),"false")
 	@$(ECHO_CHECK) contrib/scripts/check-k8s-code-gen.sh
 	$(QUIET) contrib/scripts/check-k8s-code-gen.sh
@@ -709,14 +706,6 @@ postcheck: build ## Run Cilium build postcheck (update-cmdref, build documentati
 
 licenses-all: ## Generate file with all the License from dependencies.
 	@$(GO) run ./tools/licensegen > LICENSE.all || ( rm -f LICENSE.all ; false )
-
-check-go-version: ## Check locally install Go version against required Go version.
-ifneq ($(GO_MAJOR_AND_MINOR_VERSION),$(GO_INSTALLED_MAJOR_AND_MINOR_VERSION))
-	@echo "Installed Go version $(GO_INSTALLED_MAJOR_AND_MINOR_VERSION) does not match requested Go version $(GO_MAJOR_AND_MINOR_VERSION)"
-	@exit 1
-else
-	@$(ECHO_CHECK) "Installed Go version $(GO_INSTALLED_MAJOR_AND_MINOR_VERSION) matches required version $(GO_MAJOR_AND_MINOR_VERSION)"
-endif
 
 dev-doctor: ## Run Cilium dev-doctor to validate local development environment.
 	$(QUIET)$(GO) version 2>/dev/null || ( echo "go not found, see https://golang.org/doc/install" ; false )


### PR DESCRIPTION
From the Go 1.21 release notes [1]:

> To improve forwards compatibility, Go 1.21 now reads the go line in a
> go.work or go.mod file as a strict minimum requirement: go 1.21.0
> means that the workspace or module cannot be used with Go 1.20 or with
> Go 1.21rc1. This allows projects that depend on fixes made in later
> versions of Go to ensure that they are not used with earlier versions.

[1] https://go.dev/doc/go1.21#tools

This means the Go toolchain will now check the local Go version and automatically install the necessary toolchain if needed. Go was recently bumped to 1.21 in commit 244d29ca9ec0 ("chore(deps): update go to v1.21.0"), so we can get rid of the manual check in the Makefile and rely on the version check in the Go toolchain.

Suggested-by: @lmb
