### PR TITLE
Fixes typo and unclear sentence in BGP Control Plane Docs

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -447,8 +447,8 @@ and a ``Operator-Side`` control plane (not yet implemented).
 Both control planes are implemented by a ``Controller`` which follows
 the ``Kubernetes`` controller pattern.
 
-Both control planes primary listen for ``CiliumBGPPeeringPolicy`` CRDs,
-long with other Cilium and Kubernetes resources useful for implementing
+Both control planes primarily listen for ``CiliumBGPPeeringPolicy`` CRDs,
+along with other Cilium and Kubernetes resources used for implementing
 a BGP control plane.
 
 Agent-Side Architecture


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

The original sentence for the BGP Control Plane architecture had some typos and wasn't clearly ended. I updated the sentence to address typos and clarify the sentence a bit.

**Original:** 
`Both control planes primary listen for CiliumBGPPeeringPolicy CRDs, long with other Cilium and Kubernetes resources useful for implementing a BGP control plane.`

**Proposed:**
`Both control planes primarily listen for CiliumBGPPeeringPolicy CRDs, along with other Cilium and Kubernetes resources used for implementing a BGP control plane.`


```release-note
docs: Fix a typo and improve readability of a control plane architecture description in BGP Control Plane documentation
```