### PR TITLE
Allow selecting nodes by CIDR policy

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -279,6 +279,7 @@ cilium-agent [flags]
       --node-port-bind-protection                                 Reject application bind(2) requests to service ports in the NodePort range (default true)
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --policy-audit-mode                                         Enable policy audit (non-drop) mode
+      --policy-cidr-match-mode strings                            The entities that can be selected by CIDR policy. Supported values: 'world', 'world,remote-node' (default [world])
       --policy-queue-size int                                     Size of queues for policy-related events (default 100)
       --pprof                                                     Enable serving pprof debugging API
       --pprof-address string                                      Address that pprof listens on (default "localhost")

--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -279,7 +279,7 @@ cilium-agent [flags]
       --node-port-bind-protection                                 Reject application bind(2) requests to service ports in the NodePort range (default true)
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
       --policy-audit-mode                                         Enable policy audit (non-drop) mode
-      --policy-cidr-match-mode strings                            The entities that can be selected by CIDR policy. Supported values: 'world', 'world,remote-node' (default [world])
+      --policy-cidr-match-mode strings                            The entities that can be selected by CIDR policy. Supported values: 'nodes'
       --policy-queue-size int                                     Size of queues for policy-related events (default 100)
       --pprof                                                     Enable serving pprof debugging API
       --pprof-address string                                      Address that pprof listens on (default "localhost")

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2452,6 +2452,10 @@
      - Security Context for cilium-agent pods.
      - object
      - ``{}``
+   * - :spelling:ignore:`policyCIDRMatchMode`
+     - policyCIDRMatchMode is a list of entities that may be selected by CIDR selector. The possible value is "nodes".
+     - string
+     - ``nil``
    * - :spelling:ignore:`policyEnforcementMode`
      - The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
      - string

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -527,6 +527,7 @@ pluggable
 pmdabcc
 png
 podCIDR
+policyCIDRMatchMode
 policymap
 poller
 portmap

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -555,7 +555,8 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			k := key.(*ipcachemap.Key)
 			v := value.(*ipcachemap.RemoteEndpointInfo)
 			nid := identity.NumericIdentity(v.SecurityIdentity)
-			if nid.HasLocalScope() {
+			if scope := nid.Scope(); scope == identity.IdentityScopeLocal ||
+				(scope == identity.IdentityScopeRemoteNode && option.Config.PolicyCIDRMatchesNodes()) {
 				d.restoredCIDRs = append(d.restoredCIDRs, k.Prefix())
 				oldNIDs = append(oldNIDs, nid)
 			} else if nid == identity.ReservedIdentityIngress && v.TunnelEndpoint.IsZero() {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1143,6 +1143,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.EnableK8sNetworkPolicy)
 	option.BindEnv(vp, option.EnableK8sNetworkPolicy)
 
+	flags.StringSlice(option.PolicyCIDRMatchMode, defaults.PolicyCIDRMatchMode, "The entities that can be selected by CIDR policy. Supported values: 'nodes'")
+	option.BindEnv(vp, option.PolicyCIDRMatchMode)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		log.Fatalf("BindPFlags failed: %s", err)
 	}

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -663,6 +663,7 @@ contributors across the globe, there is almost always someone available to help.
 | podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | podLabels | object | `{}` | Labels to be added to agent pods |
 | podSecurityContext | object | `{}` | Security Context for cilium-agent pods. |
+| policyCIDRMatchMode | string | `nil` | policyCIDRMatchMode is a list of entities that may be selected by CIDR selector. The possible value is "nodes". |
 | policyEnforcementMode | string | `"default"` | The agent can be put into one of the three policy enforcement modes: default, always and never. ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes |
 | pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-agent |
 | pprof.enabled | bool | `false` | Enable pprof for cilium-agent |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -189,6 +189,11 @@ data:
   enable-policy: "{{ lower .Values.policyEnforcementMode }}"
 {{- end }}
 
+{{- if hasKey .Values "policyCIDRMatchMode" }}
+  policy-cidr-match-mode: {{ join " " .Values.policyCIDRMatchMode | quote }}
+{{- end}}
+
+
 {{- if .Values.prometheus.enabled }}
   # If you want metrics enabled in all of your Cilium agents, set the port for
   # which the Cilium agents will have their metrics exposed.

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1811,6 +1811,10 @@ nodePort:
 # ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
 policyEnforcementMode: "default"
 
+# -- policyCIDRMatchMode is a list of entities that may be selected by CIDR selector.
+# The possible value is "nodes".
+policyCIDRMatchMode:
+
 pprof:
   # -- Enable pprof for cilium-agent
   enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1808,6 +1808,10 @@ nodePort:
 # ref: https://docs.cilium.io/en/stable/security/policy/intro/#policy-enforcement-modes
 policyEnforcementMode: "default"
 
+# -- policyCIDRMatchMode is a list of entities that may be selected by CIDR selector.
+# The possible value is "nodes".
+policyCIDRMatchMode:
+
 pprof:
   # -- Enable pprof for cilium-agent
   enabled: false

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -576,4 +576,6 @@ var (
 		"cilium_lb6_source_range":   "enabled,128,0",
 		"cilium_lb6_affinity_match": "enabled,128,0",
 	}
+
+	PolicyCIDRMatchMode = []string{}
 )

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -376,7 +376,7 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 			name: "World shadows CIDR ingress",
 			args: []args{
 				{uint32(identity.ReservedIdentityWorld), 0, 0, trafficdirection.Ingress},
-				{uint32(identity.LocalIdentityFlag), 0, 0, trafficdirection.Ingress},
+				{uint32(identity.IdentityScopeLocal), 0, 0, trafficdirection.Ingress},
 			},
 			ingressResult: []apiResult{
 				{"reserved:world", uint64(identity.ReservedIdentityWorld), 0, 0},
@@ -387,7 +387,7 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 			name: "World shadows CIDR egress",
 			args: []args{
 				{uint32(identity.ReservedIdentityWorld), 0, 0, trafficdirection.Egress},
-				{uint32(identity.LocalIdentityFlag), 0, 0, trafficdirection.Egress},
+				{uint32(identity.IdentityScopeLocal), 0, 0, trafficdirection.Egress},
 			},
 			ingressResult: nil,
 			egressResult: []apiResult{

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -515,8 +515,8 @@ func TestDecodeDropReason(t *testing.T) {
 func TestDecodeLocalIdentity(t *testing.T) {
 	tn := monitor.TraceNotifyV0{
 		Type:     byte(monitorAPI.MessageTypeTrace),
-		SrcLabel: 123 | identity.LocalIdentityFlag,
-		DstLabel: 456 | identity.LocalIdentityFlag,
+		SrcLabel: 123 | identity.IdentityScopeLocal,
+		DstLabel: 456 | identity.IdentityScopeLocal,
 	}
 	data, err := testutils.CreateL3L4Payload(tn)
 	require.NoError(t, err)

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -208,7 +208,8 @@ func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labe
 		return reservedIdentity
 	}
 
-	if !identity.RequiresGlobalIdentity(lbls) {
+	switch identity.ScopeForLabels(lbls) {
+	case identity.IdentityScopeLocal:
 		return m.localIdentities.lookup(lbls)
 	}
 
@@ -247,7 +248,8 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 		return identity
 	}
 
-	if id.HasLocalScope() {
+	switch id.Scope() {
+	case identity.IdentityScopeLocal:
 		return m.localIdentities.lookupByID(id)
 	}
 

--- a/pkg/identity/cache/cache.go
+++ b/pkg/identity/cache/cache.go
@@ -72,6 +72,9 @@ func (m *CachingIdentityAllocator) GetIdentityCache() IdentityCache {
 	for _, identity := range m.localIdentities.GetIdentities() {
 		cache[identity.ID] = identity.Labels.LabelArray()
 	}
+	for _, identity := range m.localNodeIdentities.GetIdentities() {
+		cache[identity.ID] = identity.Labels.LabelArray()
+	}
 
 	return cache
 }
@@ -94,6 +97,9 @@ func (m *CachingIdentityAllocator) GetIdentities() IdentitiesModel {
 	})
 
 	for _, v := range m.localIdentities.GetIdentities() {
+		identities = append(identities, identitymodel.CreateModel(v))
+	}
+	for _, v := range m.localNodeIdentities.GetIdentities() {
 		identities = append(identities, identitymodel.CreateModel(v))
 	}
 
@@ -211,6 +217,8 @@ func (m *CachingIdentityAllocator) LookupIdentity(ctx context.Context, lbls labe
 	switch identity.ScopeForLabels(lbls) {
 	case identity.IdentityScopeLocal:
 		return m.localIdentities.lookup(lbls)
+	case identity.IdentityScopeRemoteNode:
+		return m.localNodeIdentities.lookup(lbls)
 	}
 
 	if !m.isGlobalIdentityAllocatorInitialized() {
@@ -251,6 +259,8 @@ func (m *CachingIdentityAllocator) LookupIdentityByID(ctx context.Context, id id
 	switch id.Scope() {
 	case identity.IdentityScopeLocal:
 		return m.localIdentities.lookupByID(id)
+	case identity.IdentityScopeRemoteNode:
+		return m.localNodeIdentities.lookupByID(id)
 	}
 
 	if !m.isGlobalIdentityAllocatorInitialized() {

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -20,16 +20,18 @@ type localIdentityCache struct {
 	identitiesByID      map[identity.NumericIdentity]*identity.Identity
 	identitiesByLabels  map[string]*identity.Identity
 	nextNumericIdentity identity.NumericIdentity
+	scope               identity.NumericIdentity
 	minID               identity.NumericIdentity
 	maxID               identity.NumericIdentity
 	events              allocator.AllocatorEventSendChan
 }
 
-func newLocalIdentityCache(minID, maxID identity.NumericIdentity, events allocator.AllocatorEventSendChan) *localIdentityCache {
+func newLocalIdentityCache(scope, minID, maxID identity.NumericIdentity, events allocator.AllocatorEventSendChan) *localIdentityCache {
 	return &localIdentityCache{
 		identitiesByID:      map[identity.NumericIdentity]*identity.Identity{},
 		identitiesByLabels:  map[string]*identity.Identity{},
 		nextNumericIdentity: minID,
+		scope:               scope,
 		minID:               minID,
 		maxID:               maxID,
 		events:              events,
@@ -50,16 +52,16 @@ func (l *localIdentityCache) bumpNextNumericIdentity() {
 // The l.mutex must be held
 func (l *localIdentityCache) getNextFreeNumericIdentity(idCandidate identity.NumericIdentity) (identity.NumericIdentity, error) {
 	// Try first with the given candidate
-	if idCandidate.HasLocalScope() {
+	if idCandidate.Scope() == l.scope {
 		if _, taken := l.identitiesByID[idCandidate]; !taken {
 			// let nextNumericIdentity be, allocated identities will be skipped anyway
-			log.Debugf("Reallocated restored CIDR identity: %d", idCandidate)
+			log.Debugf("Reallocated restored local identity: %d", idCandidate)
 			return idCandidate, nil
 		}
 	}
 	firstID := l.nextNumericIdentity
 	for {
-		idCandidate = l.nextNumericIdentity | identity.LocalIdentityFlag
+		idCandidate = l.nextNumericIdentity | l.scope
 		if _, taken := l.identitiesByID[idCandidate]; !taken {
 			l.bumpNextNumericIdentity()
 			return idCandidate, nil

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -197,14 +197,10 @@ func (l *localIdentityCache) GetIdentities() map[identity.NumericIdentity]*ident
 	return cache
 }
 
-// close closes the events channel. The local identity cache is the writing
-// party, hence also needs to close the channel.
+// close removes the events channel.
 func (l *localIdentityCache) close() {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if l.events != nil {
-		close(l.events)
-		l.events = nil
-	}
+	l.events = nil
 }

--- a/pkg/identity/cache/local_test.go
+++ b/pkg/identity/cache/local_test.go
@@ -15,7 +15,8 @@ import (
 
 func (s *IdentityCacheTestSuite) TestBumpNextNumericIdentity(c *C) {
 	minID, maxID := identity.NumericIdentity(1), identity.NumericIdentity(5)
-	cache := newLocalIdentityCache(minID, maxID, nil)
+	scope := identity.NumericIdentity(0x42_00_00_00)
+	cache := newLocalIdentityCache(scope, minID, maxID, nil)
 
 	for i := minID; i <= maxID; i++ {
 		c.Assert(cache.nextNumericIdentity, Equals, i)
@@ -28,7 +29,8 @@ func (s *IdentityCacheTestSuite) TestBumpNextNumericIdentity(c *C) {
 
 func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	minID, maxID := identity.NumericIdentity(1), identity.NumericIdentity(5)
-	cache := newLocalIdentityCache(minID, maxID, nil)
+	scope := identity.NumericIdentity(0x42_00_00_00)
+	cache := newLocalIdentityCache(scope, minID, maxID, nil)
 
 	identities := map[identity.NumericIdentity]*identity.Identity{}
 
@@ -38,6 +40,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 		id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)}), identity.InvalidIdentity)
 		c.Assert(err, IsNil)
 		c.Assert(isNew, Equals, true)
+		c.Assert(id.ID, Equals, scope+i)
 		identities[id.ID] = id
 	}
 
@@ -64,7 +67,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	// lookup must still be successful
 	for i := minID; i <= maxID; i++ {
 		c.Assert(cache.lookup(labels.NewLabelsFromModel([]string{fmt.Sprintf("%d", i)})), Not(IsNil))
-		c.Assert(cache.lookupByID(i|identity.LocalIdentityFlag), Not(IsNil))
+		c.Assert(cache.lookupByID(i|scope), Not(IsNil))
 	}
 
 	// release the identities a second time, this must cause the identity
@@ -82,7 +85,7 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	}
 
 	// release a random identity in the middle
-	randomID := identity.NumericIdentity(3) | identity.LocalIdentityFlag
+	randomID := identity.NumericIdentity(3) | scope
 	c.Assert(cache.release(identities[randomID]), Equals, true)
 
 	id, isNew, err := cache.lookupOrCreate(labels.NewLabelsFromModel([]string{"foo"}), identity.InvalidIdentity)

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -180,18 +180,26 @@ func (pair *IPIdentityPair) PrefixString() string {
 // RequiresGlobalIdentity returns true if the label combination requires a
 // global identity
 func RequiresGlobalIdentity(lbls labels.Labels) bool {
-	needsGlobal := true
+	return ScopeForLabels(lbls) == IdentityScopeGlobal
+}
+
+// ScopeForLabels returns the identity scope to be used for the label set.
+// If all labels are either CIDR or reserved, then returns the CIDR scope.
+// Note: This assumes the caller has already called LookupReservedIdentityByLabels;
+// it does not handle that case.
+func ScopeForLabels(lbls labels.Labels) NumericIdentity {
+	scope := IdentityScopeGlobal
 
 	for _, label := range lbls {
 		switch label.Source {
 		case labels.LabelSourceCIDR, labels.LabelSourceReserved:
-			needsGlobal = false
+			scope = IdentityScopeLocal
 		default:
-			return true
+			return IdentityScopeGlobal
 		}
 	}
 
-	return needsGlobal
+	return scope
 }
 
 // AddUserDefinedNumericIdentitySet adds all key-value pairs from the given map

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *IdentityTestSuite) TestLocalIdentity(c *C) {
-	localID := NumericIdentity(LocalIdentityFlag | 1)
+	localID := NumericIdentity(IdentityScopeLocal | 1)
 	c.Assert(localID.HasLocalScope(), Equals, true)
 
 	maxClusterID := NumericIdentity(types.ClusterIDMax | 1)

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -438,6 +438,14 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 		lbls.MergeLabels(cidrLabels)
 	}
 
+	// If we are restoring a host identity and policy-cidr-match-mode includes "nodes"
+	// then merge the CIDR-label.
+	if lbls.Has(labels.LabelHost[labels.IDNameHost]) &&
+		option.Config.PolicyCIDRMatchesNodes() {
+		cidrLabels := cidrlabels.GetCIDRLabels(prefix)
+		lbls.MergeLabels(cidrLabels)
+	}
+
 	// If the prefix is associated with the host or remote-node, then
 	// force-remove the world label.
 	if lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) ||

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -346,7 +346,7 @@ func TestRemoveLabelsFromIPs(t *testing.T) {
 	assert.Len(t, remaining, 0)
 	id := IPIdentityCache.IdentityAllocator.LookupIdentityByID(
 		context.TODO(),
-		identity.LocalIdentityFlag, // we assume first local ID
+		identity.IdentityScopeLocal, // we assume first local ID
 	)
 	assert.NotNil(t, id)
 	assert.Equal(t, 1, id.ReferenceCount)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1208,6 +1208,9 @@ const (
 
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy = "enable-k8s-networkpolicy"
+
+	// PolicyCIDRMatchMode defines the entities that CIDR selectors can reach
+	PolicyCIDRMatchMode = "policy-cidr-match-mode"
 )
 
 // Default string arguments
@@ -2473,6 +2476,12 @@ type DaemonConfig struct {
 
 	// EnableK8sNetworkPolicy enables support for K8s NetworkPolicy.
 	EnableK8sNetworkPolicy bool
+
+	// PolicyCIDRMatchMode is the list of entities that can be selected by CIDR policy.
+	// Currently supported values:
+	// - world
+	// - world, remote-node
+	PolicyCIDRMatchMode []string
 }
 
 var (
@@ -2523,6 +2532,7 @@ var (
 		EnableVTEP:             defaults.EnableVTEP,
 		EnableBGPControlPlane:  defaults.EnableBGPControlPlane,
 		EnableK8sNetworkPolicy: defaults.EnableK8sNetworkPolicy,
+		PolicyCIDRMatchMode:    defaults.PolicyCIDRMatchMode,
 	}
 )
 
@@ -2791,6 +2801,28 @@ func (c *DaemonConfig) EgressGatewayCommonEnabled() bool {
 	return c.EnableIPv4EgressGateway
 }
 
+func (c *DaemonConfig) PolicyCIDRMatchesNodes() bool {
+	for _, mode := range c.PolicyCIDRMatchMode {
+		if mode == "nodes" {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *DaemonConfig) validatePolicyCIDRMatchMode() error {
+	// Currently, the only acceptable values is "nodes".
+	for _, mode := range c.PolicyCIDRMatchMode {
+		switch mode {
+		case "nodes":
+			continue
+		default:
+			return fmt.Errorf("unknown CIDR match mode: %s", mode)
+		}
+	}
+	return nil
+}
+
 // DirectRoutingDeviceRequired return whether the Direct Routing Device is needed under
 // the current configuration.
 func (c *DaemonConfig) DirectRoutingDeviceRequired() bool {
@@ -2928,6 +2960,10 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 		if err != nil {
 			return fmt.Errorf("Failed to validate VTEP configuration: %w", err)
 		}
+	}
+
+	if err := c.validatePolicyCIDRMatchMode(); err != nil {
+		return err
 	}
 
 	return nil
@@ -3617,6 +3653,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 
 	// To support K8s NetworkPolicy
 	c.EnableK8sNetworkPolicy = vp.GetBool(EnableK8sNetworkPolicy)
+	c.PolicyCIDRMatchMode = vp.GetStringSlice(PolicyCIDRMatchMode)
 }
 
 func (c *DaemonConfig) populateDevices(vp *viper.Viper) {

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func localIdentity(n uint32) identity.NumericIdentity {
-	return identity.NumericIdentity(n) | identity.LocalIdentityFlag
+	return identity.NumericIdentity(n) | identity.IdentityScopeLocal
 
 }
 func (s *DistilleryTestSuite) TestCacheManagement(c *C) {

--- a/pkg/testutils/identity/allocator.go
+++ b/pkg/testutils/identity/allocator.go
@@ -43,7 +43,7 @@ func NewMockIdentityAllocator(c cache.IdentityCache) *MockIdentityAllocator {
 		IdentityCache: c,
 
 		currentID:        1000,
-		localID:          int(identity.LocalIdentityFlag),
+		localID:          int(identity.IdentityScopeLocal),
 		ipToIdentity:     make(map[string]int),
 		idToIdentity:     make(map[int]*identity.Identity),
 		labelsToIdentity: make(map[string]int),


### PR DESCRIPTION
This PR adds a new option, `policy-cidr-selects-nodes`, which means that cluster nodes can be selected by CIDR network policies. Normally nodes are only accessible via `remote-node` entity selectors.

**How it works:**
We already have the notion of an "identity scope" -- if the top 8 bits of the 32-bit identity are 0, we assume the ID is global. If the top bits are 0x01, then the ID is a local CIDR identity. This PR declares the scope 0x02 to be for node identities.

A separate identity scope is needed because the datapath needs to be able to quickly determine if a given identity corresponds to a remote node. Previously, all nodes had reserved identities 4 or 7. By using a separate identity scope, a fast bit comparison can be done without any additional map lookups.

So, most of this PR consists of refactoring commits to prepare for scoped local identity allocators. Then, a few commits at the end enable the behavior, switching nodes to the new identity scope and attaching `cidr:` labels to the local-node identity.

---

Fixes: https://github.com/cilium/cilium/issues/20550
