### PR TITLE
datapath/linux: select devices only if required

### DIFF
--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -35,6 +35,10 @@ func (dm *DeviceManager) Detect(k8sEnabled bool) ([]string, error) {
 		hasWildcard = hasWildcard || strings.HasSuffix(name, "+")
 	}
 
+	if len(userDevices) == 0 && !option.Config.AreDevicesRequired() {
+		return nil, nil
+	}
+
 	devs, _ := tables.SelectedDevices(dm.params.DeviceTable.Reader(dm.params.DB.ReadTxn()))
 	names := tables.DeviceNames(devs)
 

--- a/pkg/datapath/linux/devices_test.go
+++ b/pkg/datapath/linux/devices_test.go
@@ -83,6 +83,7 @@ func (s *DevicesSuite) TestDetect(c *C) {
 	s.withFixture(c, func() {
 		option.Config.SetDevices([]string{})
 		option.Config.DirectRoutingDevice = ""
+		option.Config.EnableNodePort = true
 		option.Config.NodePortAcceleration = option.NodePortAccelerationDisabled
 
 		// No devices, nothing to detect.
@@ -315,6 +316,7 @@ func (s *DevicesSuite) TestListenForNewDevices(c *C) {
 		timeout := time.After(10 * time.Second)
 
 		option.Config.SetDevices([]string{})
+		option.Config.EnableNodePort = true
 		c.Assert(createDummy("dummy0", "192.168.1.2/24", false), IsNil)
 
 		dm, err := newDeviceManagerForTests()


### PR DESCRIPTION
In the prevous commit (https://github.com/cilium/cilium/commit/03ad61b6b356cc47996dabfd7832053223b36ef4), "cil_from_netdev" is unconditionally attached to eth0. By design, "cil_from_netdev" should be used for eth0 only if host firewall / nodeport / wireguard is enabled, and this commit makes sure those conditions are checked.


Fixes: https://github.com/cilium/cilium/issues/27276
Fixes: https://github.com/cilium/cilium/commit/03ad61b6b356cc47996dabfd7832053223b36ef4

```release-note
Fix connection disruption for IPsec during downgrade to v1.14 by attaching correct bpf program to devices.
```

Suggested-by: Jussi Maki <jussi@isovalent.com>
Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>