### PR TITLE
bpf: nodeport: integrate Ingress RevSNAT and RevDNAT paths

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -220,12 +220,13 @@ static __always_inline int handle_inter_cluster_revsnat(struct __ctx_buff *ctx,
 	       .max_port = NODEPORT_PORT_MAX_NAT,
 	       .cluster_id = cluster_id_from_identity,
 	};
+	struct trace_ctx trace;
 
 	ctx_store_meta(ctx, CB_SRC_LABEL, 0);
 
 	*src_sec_identity = identity;
 
-	ret = snat_v4_rev_nat(ctx, &target, ext_err);
+	ret = snat_v4_rev_nat(ctx, &target, &trace, ext_err);
 	if (ret != NAT_PUNT_TO_STACK && ret != DROP_NAT_NO_MAPPING) {
 		if (IS_ERR(ret))
 			return ret;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -1729,7 +1729,7 @@ snat_v6_rev_nat(struct __ctx_buff *ctx, const struct ipv6_nat_target *target,
 		__s8 *ext_err __maybe_unused)
 {
 	struct icmp6hdr icmp6hdr __align_stack_8;
-	struct ipv6_nat_entry *state;
+	struct ipv6_nat_entry *state = NULL;
 	struct ipv6_ct_tuple tuple = {};
 	__u32 off, inner_l3_off;
 	void *data, *data_end;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1083,14 +1083,14 @@ int tail_nodeport_nat_ingress_ipv6(struct __ctx_buff *ctx)
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 	};
-	struct trace_ctx trace __maybe_unused = {
+	struct trace_ctx trace = {
 		.reason = TRACE_REASON_CT_REPLY,
 		.monitor = TRACE_PAYLOAD_LEN,
 	};
 	__s8 ext_err = 0;
 	int ret;
 
-	ret = snat_v6_rev_nat(ctx, &target, &ext_err);
+	ret = snat_v6_rev_nat(ctx, &target, &trace, &ext_err);
 	if (IS_ERR(ret)) {
 		if (ret == NAT_PUNT_TO_STACK ||
 		    /* DROP_NAT_NO_MAPPING is unwanted behavior in a
@@ -2527,14 +2527,14 @@ int tail_nodeport_nat_ingress_ipv4(struct __ctx_buff *ctx)
 		.min_port = NODEPORT_PORT_MIN_NAT,
 		.max_port = NODEPORT_PORT_MAX_NAT,
 	};
-	struct trace_ctx trace __maybe_unused = {
+	struct trace_ctx trace = {
 		.reason = TRACE_REASON_UNKNOWN,
 		.monitor = TRACE_PAYLOAD_LEN,
 	};
 	__s8 ext_err = 0;
 	int ret;
 
-	ret = snat_v4_rev_nat(ctx, &target, &ext_err);
+	ret = snat_v4_rev_nat(ctx, &target, &trace, &ext_err);
 	if (IS_ERR(ret)) {
 		if (ret == NAT_PUNT_TO_STACK ||
 		    /* DROP_NAT_NO_MAPPING is unwanted behavior in a

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -187,6 +187,7 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 		.max_port = NODEPORT_PORT_MIN_NAT + 1,
 	};
 	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -195,7 +196,7 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -296,6 +297,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 		.max_port = NODEPORT_PORT_MIN_NAT + 1,
 	};
 	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -304,7 +306,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -404,6 +406,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 		.max_port = NODEPORT_PORT_MIN_NAT + 1,
 	};
 	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -412,7 +415,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -501,6 +504,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 		.max_port = NODEPORT_PORT_MIN_NAT + 1,
 	};
 	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -509,7 +513,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_rev_nat().
 	 */
-	ret = snat_v4_rev_nat(ctx, &target, NULL);
+	ret = snat_v4_rev_nat(ctx, &target, &trace, NULL);
 	assert(ret == DROP_CSUM_L4);
 
 	/* nothing really change with udp/tcp */


### PR DESCRIPTION
The Ingress RevSNAT and RevDNAT handling is currently split into two separate tail-calls. Which means that if the RevSNAT code performs a CT lookup and receives trace information, then we can't easily pass the corresponding `trace_ctx` to the `TO_OVERLAY` trace event in the RevDNAT code.

In practice this means that when in direct-routing mode, the trace events for EgressGW reply traffic don't benefit from CT-driven aggregation.

This PR refactors the relevant code paths, and turns the RevDNAT path into a conditional tail-call. On newer kernels it gets inlined into `tail_nodeport_nat_ingress_ipv4()`, and we can pass through the `trace_ctx` struct all the way to the `send_trace_notify()`.