### PR TITLE
egressgw: refactor check for conflicting egress IPs

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -4,6 +4,7 @@
 package egressgateway
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -683,10 +684,40 @@ func (manager *Manager) policyMatchesMinusExcludedCIDRs(sourceIP net.IP, f func(
 }
 
 func (manager *Manager) regenerateGatewayConfigs() {
-	policyByInterfaceIndex := make(map[int]*PolicyConfig)
-
 	for _, policyConfig := range manager.policyConfigs {
-		policyConfig.regenerateGatewayConfig(manager, policyByInterfaceIndex)
+		policyConfig.regenerateGatewayConfig(manager)
+	}
+
+	if !manager.installRoutes {
+		return
+	}
+
+	// We can only have one default route per interface. Warn if there are
+	// conflicts on the desired egress IP per interface.
+	policyByInterfaceIndex := make(map[int]*PolicyConfig)
+	for _, policyConfig := range manager.policyConfigs {
+		gwc := policyConfig.gatewayConfig
+
+		if !gwc.localNodeConfiguredAsGateway {
+			continue
+		}
+
+		currentPolicy := policyByInterfaceIndex[gwc.ifaceIndex]
+		if currentPolicy == nil {
+			policyByInterfaceIndex[gwc.ifaceIndex] = policyConfig
+			continue
+		}
+
+		currentEgressIP := currentPolicy.gatewayConfig.egressIP
+		if gwc.egressIP.IP.Equal(currentEgressIP.IP) && bytes.Equal(gwc.egressIP.Mask, currentEgressIP.Mask) {
+			continue
+		}
+
+		log.WithFields(logrus.Fields{
+			logfields.CiliumEgressGatewayPolicyName: policyConfig.id,
+			logfields.Interface:                     policyConfig.policyGwConfig.iface,
+			logfields.EgressIP:                      policyConfig.policyGwConfig.egressIP,
+		}).Errorf("Conflict with policy %s: Selects the same egress interface but uses a different egress IP (%s).", currentPolicy.id, currentEgressIP.String())
 	}
 }
 

--- a/pkg/egressgateway/policy.go
+++ b/pkg/egressgateway/policy.go
@@ -4,7 +4,6 @@
 package egressgateway
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 
@@ -99,7 +98,7 @@ func (config *policyGatewayConfig) selectsNodeAsGateway(node nodeTypes.Node) boo
 	return config.nodeSelector.Matches(k8sLabels.Set(node.Labels))
 }
 
-func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager, policyByInterfaceIndex map[int]*PolicyConfig) {
+func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager) {
 	gwc := gatewayConfig{
 		egressIP:  net.IPNet{IP: net.IPv4zero, Mask: net.CIDRMask(0, 0)},
 		gatewayIP: GatewayNotFoundIPv4,
@@ -116,37 +115,14 @@ func (config *PolicyConfig) regenerateGatewayConfig(manager *Manager, policyByIn
 
 		if node.IsLocal() {
 			err := gwc.deriveFromPolicyGatewayConfig(policyGwc)
-			logger := log.WithFields(logrus.Fields{
-				logfields.CiliumEgressGatewayPolicyName: config.id,
-				logfields.Interface:                     policyGwc.iface,
-				logfields.EgressIP:                      policyGwc.egressIP,
-			})
-
 			if err != nil {
+				logger := log.WithFields(logrus.Fields{
+					logfields.CiliumEgressGatewayPolicyName: config.id,
+					logfields.Interface:                     policyGwc.iface,
+					logfields.EgressIP:                      policyGwc.egressIP,
+				})
 				logger.WithError(err).Error("Failed to derive policy gateway configuration")
-				break
 			}
-
-			if !manager.installRoutes {
-				break
-			}
-
-			// We can only have one default route per interface. Enforce that all
-			// policies on an interface use the same EgressIP (== default route).
-			currentPolicy := policyByInterfaceIndex[gwc.ifaceIndex]
-			if currentPolicy == nil {
-				policyByInterfaceIndex[gwc.ifaceIndex] = config
-				break
-			}
-
-			currentEgressIP := currentPolicy.gatewayConfig.egressIP
-			if gwc.egressIP.IP.Equal(currentEgressIP.IP) && bytes.Equal(gwc.egressIP.Mask, currentEgressIP.Mask) {
-				break
-			}
-
-			gwc.localNodeConfiguredAsGateway = false
-			gwc.gatewayIP = GatewayNotFoundIPv4
-			logger.Errorf("Conflict with policy %s: Selects the same egress interface but uses a different egress IP (%s).", currentPolicy.id, currentEgressIP.String())
 		}
 
 		break


### PR DESCRIPTION
The egressgateway code currently doesn't handle some configurations correctly when using ip rules and routes to steer traffic. We've recently added some logic to detect this error. The approach was to only install rules for the first non-conflicting policy.

The problem with this approach is that the egress gateway doesn't process policies in a deterministic fashion. So in the case of a conflict we will choose different "first" policies for each reconciliation. The end result is no better than what we had before, where the "last" policy would win.
The check also can't address the fact that other nodes in the cluster will still send traffic to the "misconfigured" gatewaty.

Refactor the existing check into a separate piece of code, which makes it easier to understand. Also drop the logic which attempts to remove conflicting policies, since it doesn't have the desired effect and complicates behaviour.

Fixes: 76c9822440 ("egressgw: detect conflicting configurations in ENI mode")