### PR TITLE
fix: Helm Docs makefile to be compatible with macOs

### DIFF
--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -110,7 +110,7 @@ $(HELM_VALUES): FORCE
 	$(QUIET)$(HELM_DOCS) -d -c $(HELM_DOCS_CHARTS_DIR) -t $(HELM_DOCS_OUTPUT_DIR)/$(TMP_FILE_1).tmpl > $(TMP_FILE_1)
 	$(QUIET)awk -F'|' '{print "|"$$2"|"$$5"|"$$3"|"$$4"|"}' $(TMP_FILE_1) > $(TMP_FILE_2)
 	$(QUIET)$(M2R) --overwrite $(TMP_FILE_2)
-	$(QUIET)$(SED) 's/^\(   \* - \)\([[:print:]]\+\)$$/\1:spelling:ignore:`\2`/' $@ > $(TMP_FILE_3)
+	$(QUIET)$(SED) 's/^\(   \* - \)\([[:print:]]\{1,\}\)$$/\1:spelling:ignore:`\2`/' $@ > $(TMP_FILE_3)
 	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $(TMP_FILE_3))" > $@
 	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2) $(TMP_FILE_3)
 


### PR DESCRIPTION
- Currently [Documentation/Makefile](https://github.com/cilium/cilium/blob/e25bd055436a658a0f3ef2d2821e7a4a00ae5696/Documentation/Makefile#L113) is using `$(QUIET)$(SED) 's/^\(   \* - \)\([[:print:]]\+\)$$/\1:spelling:ignore:`\2`/' $@ > $(TMP_FILE_3)` where sed has incompatible syntax in macOS. This does not add `:spelling:ignore:` string in between the $1 and $2 capture groups.

More detailed discussion took place at:
- https://github.com/cilium/cilium/pull/27363#discussion_r1293317258 

```release-note
docs: Fix Documentation Makefile to make Helm reference updates compatible with macOS
```

Fixes: https://github.com/cilium/cilium/pull/27122
Fixes: https://github.com/cilium/cilium/pull/26759

Change from 

```bash
$(QUIET)$(SED) 's/^\(   \* - \)\([[:print:]]\+\)$$/\1:spelling:ignore:`\2`/' $@ > $(TMP_FILE_3)
```

To

```bash
$(QUIET)$(SED) 's/^\(   \* - \)\([[:print:]]\{1,\}\)$$/\1:spelling:ignore:`\2`/' $@ > $(TMP_FILE_3)
```
<details>

<summary>Click to view the simulation of the Issue in commands</summary>

```bash
╰─$ uname -a ; which sed 
Darwin <MACBOOK_NAME> Darwin Kernel Version 22.5.0: Thu Jun  8 22:22:19 PDT 2023; root:xnu-8796.121.3~7/RELEASE_ARM64_T8103 arm64
/usr/bin/sed
╰─$ pwd
<PATH_TO_CILLIUM_FORK>/cilium
╰─$ sed 's/^\(   \* - \)\([[:print:]]\+\)$/\1:spelling:ignore:\2/' Documentation/helm-values.rst > helm-values.sed | grep "spelling"   
╭─is@CDT-MB-20200016 ~/Documents/Personal-GitHub/cilium ‹feat/enable-podsecuritycontext-on-spire-server●› 
╰─$ echo $?                                                                                                                            1 ↵
1
```
</details>

<details>
<summary> Click to View the change working </summary>

```bash
╰─$ sed 's/^\(   \* - \)\([[:print:]]\{1,\}\)$/\1:spelling:ignore:`\2`/' Documentation/helm-values.rst > helm-values_local.sed | grep -i "spelling" | head -n 5
   * - :spelling:ignore:`Key`
   * - :spelling:ignore:`MTU`
   * - :spelling:ignore:`affinity`
   * - :spelling:ignore:`agent`
   * - :spelling:ignore:`agentNotReadyTaintKey`
╰─$ echo $?
0
 ```
</details>