### PR TITLE
docs: Correct comment on toFQDN API definition

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -278,7 +278,7 @@ spec:
                         type: string
                       type: array
                     toFQDNs:
-                      description: "ToFQDN allows whitelisting DNS names in place
+                      description: 'ToFQDN allows whitelisting DNS names in place
                         of IPs. The IPs that result from DNS resolution of `ToFQDN.MatchName`s
                         are added to the same EgressRule object as ToCIDRSet entries,
                         and behave accordingly. Any L4 and L7 rules within this EgressRule
@@ -291,15 +291,7 @@ spec:
                         egress policy when PolicyEnforcment=default. Note: If the
                         resolved IPs are IPs within the kubernetes cluster, the ToFQDN
                         rule will not apply to that IP. Note: ToFQDN cannot occur
-                        in the same policy as other To* rules. \n The current implementation
-                        has a number of limitations: - The DNS resolution originates
-                        from cilium-agent, and not from the pods. Differences between
-                        the responses seen by cilium agent and a particular pod will
-                        whitelist the incorrect IP. - DNS TTLs are ignored, and cilium-agent
-                        will repoll on a short interval (5 seconds). Each change to
-                        the DNS data will trigger a policy regeneration. This may
-                        result in delayed updates to the policy for an endpoint when
-                        the data changes often or the system is under load."
+                        in the same policy as other To* rules.'
                       items:
                         properties:
                           matchName:
@@ -2817,7 +2809,7 @@ spec:
                           type: string
                         type: array
                       toFQDNs:
-                        description: "ToFQDN allows whitelisting DNS names in place
+                        description: 'ToFQDN allows whitelisting DNS names in place
                           of IPs. The IPs that result from DNS resolution of `ToFQDN.MatchName`s
                           are added to the same EgressRule object as ToCIDRSet entries,
                           and behave accordingly. Any L4 and L7 rules within this
@@ -2830,16 +2822,7 @@ spec:
                           and will enforce egress policy when PolicyEnforcment=default.
                           Note: If the resolved IPs are IPs within the kubernetes
                           cluster, the ToFQDN rule will not apply to that IP. Note:
-                          ToFQDN cannot occur in the same policy as other To* rules.
-                          \n The current implementation has a number of limitations:
-                          - The DNS resolution originates from cilium-agent, and not
-                          from the pods. Differences between the responses seen by
-                          cilium agent and a particular pod will whitelist the incorrect
-                          IP. - DNS TTLs are ignored, and cilium-agent will repoll
-                          on a short interval (5 seconds). Each change to the DNS
-                          data will trigger a policy regeneration. This may result
-                          in delayed updates to the policy for an endpoint when the
-                          data changes often or the system is under load."
+                          ToFQDN cannot occur in the same policy as other To* rules.'
                         items:
                           properties:
                             matchName:

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -282,7 +282,7 @@ spec:
                         type: string
                       type: array
                     toFQDNs:
-                      description: "ToFQDN allows whitelisting DNS names in place
+                      description: 'ToFQDN allows whitelisting DNS names in place
                         of IPs. The IPs that result from DNS resolution of `ToFQDN.MatchName`s
                         are added to the same EgressRule object as ToCIDRSet entries,
                         and behave accordingly. Any L4 and L7 rules within this EgressRule
@@ -295,15 +295,7 @@ spec:
                         egress policy when PolicyEnforcment=default. Note: If the
                         resolved IPs are IPs within the kubernetes cluster, the ToFQDN
                         rule will not apply to that IP. Note: ToFQDN cannot occur
-                        in the same policy as other To* rules. \n The current implementation
-                        has a number of limitations: - The DNS resolution originates
-                        from cilium-agent, and not from the pods. Differences between
-                        the responses seen by cilium agent and a particular pod will
-                        whitelist the incorrect IP. - DNS TTLs are ignored, and cilium-agent
-                        will repoll on a short interval (5 seconds). Each change to
-                        the DNS data will trigger a policy regeneration. This may
-                        result in delayed updates to the policy for an endpoint when
-                        the data changes often or the system is under load."
+                        in the same policy as other To* rules.'
                       items:
                         properties:
                           matchName:
@@ -2821,7 +2813,7 @@ spec:
                           type: string
                         type: array
                       toFQDNs:
-                        description: "ToFQDN allows whitelisting DNS names in place
+                        description: 'ToFQDN allows whitelisting DNS names in place
                           of IPs. The IPs that result from DNS resolution of `ToFQDN.MatchName`s
                           are added to the same EgressRule object as ToCIDRSet entries,
                           and behave accordingly. Any L4 and L7 rules within this
@@ -2834,16 +2826,7 @@ spec:
                           and will enforce egress policy when PolicyEnforcment=default.
                           Note: If the resolved IPs are IPs within the kubernetes
                           cluster, the ToFQDN rule will not apply to that IP. Note:
-                          ToFQDN cannot occur in the same policy as other To* rules.
-                          \n The current implementation has a number of limitations:
-                          - The DNS resolution originates from cilium-agent, and not
-                          from the pods. Differences between the responses seen by
-                          cilium agent and a particular pod will whitelist the incorrect
-                          IP. - DNS TTLs are ignored, and cilium-agent will repoll
-                          on a short interval (5 seconds). Each change to the DNS
-                          data will trigger a policy regeneration. This may result
-                          in delayed updates to the policy for an endpoint when the
-                          data changes often or the system is under load."
+                          ToFQDN cannot occur in the same policy as other To* rules.'
                         items:
                           properties:
                             matchName:

--- a/pkg/policy/api/egress.go
+++ b/pkg/policy/api/egress.go
@@ -148,15 +148,6 @@ type EgressRule struct {
 	// ToFQDN rule will not apply to that IP.
 	// Note: ToFQDN cannot occur in the same policy as other To* rules.
 	//
-	// The current implementation has a number of limitations:
-	// - The DNS resolution originates from cilium-agent, and not from the pods.
-	// Differences between the responses seen by cilium agent and a particular
-	// pod will whitelist the incorrect IP.
-	// - DNS TTLs are ignored, and cilium-agent will repoll on a short interval
-	// (5 seconds). Each change to the DNS data will trigger a policy
-	// regeneration. This may result in delayed updates to the policy for an
-	// endpoint when the data changes often or the system is under load.
-	//
 	// +kubebuilder:validation:Optional
 	ToFQDNs FQDNSelectorSlice `json:"toFQDNs,omitempty"`
 


### PR DESCRIPTION
This comment was added 5 years ago, and is no longer correct. Removing as discussed in slack conversation: https://cilium.slack.com/archives/C01JALNQAR1/p1692007243176749

This is a change in a comment to a file, so should need no release notes, or testing, just validation that the removal is correct.