### PR TITLE
docs: Fix the typo for SPIRE PVC installation option name

### DIFF
--- a/Documentation/network/servicemesh/mutual-authentication/installation.rst
+++ b/Documentation/network/servicemesh/mutual-authentication/installation.rst
@@ -12,7 +12,7 @@ Installation
     The default installation requires `PersistentVolumeClaim <https://kubernetes.io/docs/concepts/storage/persistent-volumes/>`_
     support in the cluster, so please check with your cluster provider if it's supported or how to enable it.
 
-    For lab or local cluster, you can switch to in-memory storage by passing ``authentication.mutual.spire.server.datastorage.enabled=false``
+    For lab or local cluster, you can switch to in-memory storage by passing ``authentication.mutual.spire.install.server.dataStorage.enabled=false``
     to the installation command, at the cost of re-creating all data when the SPIRE server pod is restarted.
 
 


### PR DESCRIPTION
Sync the PersistentVolumeClaim installation option name as Helm document.

Fixes: 1c8157706df4 ("mutual-auth: Add note for PVC requirement")