### PR TITLE
bpf: nat: use common set of rewrite helpers

### DIFF
--- a/bpf/lib/ipv4.h
+++ b/bpf/lib/ipv4.h
@@ -9,6 +9,9 @@
 #include "dbg.h"
 #include "metrics.h"
 
+#define IPV4_SADDR_OFF		offsetof(struct iphdr, saddr)
+#define IPV4_DADDR_OFF		offsetof(struct iphdr, daddr)
+
 struct ipv4_frag_id {
 	__be32	daddr;
 	__be32	saddr;

--- a/bpf/lib/ipv6.h
+++ b/bpf/lib/ipv6.h
@@ -28,6 +28,9 @@
 
 #define NEXTHDR_MAX             255
 
+#define IPV6_SADDR_OFF		offsetof(struct ipv6hdr, saddr)
+#define IPV6_DADDR_OFF		offsetof(struct ipv6hdr, daddr)
+
 static __always_inline int ipv6_optlen(const struct ipv6_opt_hdr *opthdr)
 {
 	return (opthdr->hdrlen + 1) << 3;

--- a/bpf/lib/l4.h
+++ b/bpf/lib/l4.h
@@ -29,6 +29,12 @@ static __always_inline __u8 tcp_flags_to_u8(__be32 value)
 	return ((union tcp_flags)value).lower_bits;
 }
 
+static __always_inline int
+l4_store_port(struct __ctx_buff *ctx, int l4_off, int port_off, __be16 port)
+{
+	return ctx_store_bytes(ctx, l4_off + port_off, &port, sizeof(port), 0);
+}
+
 /**
  * Modify L4 port and correct checksum
  * @arg ctx:      packet

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1019,8 +1019,8 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 	if (unlikely(ret != CTX_ACT_OK))
 		goto drop_err;
 
-	ret = __snat_v6_nat(ctx, &tuple, l4_off, true, &target, &trace,
-			    &ext_err);
+	ret = __snat_v6_nat(ctx, &tuple, l4_off, true, &target, TCP_SPORT_OFF,
+			    &trace, &ext_err);
 	if (IS_ERR(ret))
 		goto drop_err;
 
@@ -2451,7 +2451,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 		goto drop_err;
 
 	ret = __snat_v4_nat(ctx, &tuple, has_l4_header, l4_off,
-			    true, &target, &trace, &ext_err);
+			    true, &target, TCP_SPORT_OFF, &trace, &ext_err);
 	if (IS_ERR(ret))
 		goto drop_err;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -574,7 +574,9 @@ static __always_inline int xlate_dsr_v6(struct __ctx_buff *ctx,
 		return 0;
 
 	ctx_snat_done_set(ctx);
-	return snat_v6_rewrite_egress(ctx, &nat_tup, entry, l4_off);
+	return snat_v6_rewrite_headers(ctx, nat_tup.nexthdr, ETH_HLEN, l4_off,
+				       &nat_tup.saddr, &entry->to_saddr, IPV6_SADDR_OFF,
+				       nat_tup.sport, entry->to_sport, TCP_SPORT_OFF);
 }
 
 static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
@@ -2053,7 +2055,9 @@ static __always_inline int xlate_dsr_v4(struct __ctx_buff *ctx,
 		return 0;
 
 	ctx_snat_done_set(ctx);
-	return snat_v4_rewrite_egress(ctx, &nat_tup, entry, l4_off, has_l4_header);
+	return snat_v4_rewrite_headers(ctx, nat_tup.nexthdr, ETH_HLEN, has_l4_header, l4_off,
+				       nat_tup.saddr, entry->to_saddr, IPV4_SADDR_OFF,
+				       nat_tup.sport, entry->to_sport, TCP_SPORT_OFF);
 }
 
 static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,


### PR DESCRIPTION
We've grown way too many variants of helpers that rewrite the packet
headers for NAT purposes. They all slightly differ in terms of what
input parameters they expect, and what types of ICMP packets they support.

This PR introduces a generic set of flexible helpers to rule them all, and converts over many of the old paths.

There's a few more places to convert, but I believe this is good enough for a first shot. I'll take on the others as a follow-on.
