### PR TITLE
proxy: fix multiple envoy listeners for same proxyType

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -576,6 +576,8 @@ func (p *Proxy) createNewRedirect(
 				return 0, fmt.Errorf("failed to create redirect implementation: %w", err), nil, nil
 			}
 		}
+
+		break
 	}
 
 	scopedLog.


### PR DESCRIPTION
Proxy refactoring #26839 missed introducing breaking the redirect-creation-loop in case of successfully creating the redirect.

This leads to creating a Envoy listener for all redirect creation attemts (5x) per proxy type.

This commit fixes this by exiting the loop if the redirect was created successfully

Fixes: #26839