### PR TITLE
Replace some usages of fmt.Sprintf with more efficient string concatenation

### DIFF
--- a/operator/pkg/model/ingestion/ingress.go
+++ b/operator/pkg/model/ingestion/ingress.go
@@ -4,7 +4,6 @@
 package ingestion
 
 import (
-	"fmt"
 	"sort"
 
 	"github.com/cilium/cilium/operator/pkg/ingress/annotations"
@@ -87,7 +86,7 @@ func Ingress(ing slim_networkingv1.Ingress, defaultSecretNamespace, defaultSecre
 		l.Port = 80
 		l.Sources = model.AddSource(l.Sources, sourceResource)
 		if !ok {
-			l.Name = fmt.Sprintf("ing-%s-%s-%s", ing.Name, ing.Namespace, host)
+			l.Name = "ing-" + ing.Name + "-" + ing.Namespace + "-" + host
 		}
 
 		l.Hostname = host

--- a/pkg/endpoint/cache.go
+++ b/pkg/endpoint/cache.go
@@ -4,8 +4,8 @@
 package endpoint
 
 import (
-	"fmt"
 	"net/netip"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 
@@ -105,7 +105,7 @@ func (ep *epInfoCache) GetID() uint64 {
 
 // StringID returns the endpoint's ID in a string.
 func (ep *epInfoCache) StringID() string {
-	return fmt.Sprintf("%d", ep.id)
+	return strconv.FormatUint(ep.id, 10)
 }
 
 // GetIdentity returns the security identity of the endpoint.

--- a/pkg/endpoint/id/id.go
+++ b/pkg/endpoint/id/id.go
@@ -81,7 +81,7 @@ const (
 
 // NewCiliumID returns a new endpoint identifier of type CiliumLocalIdPrefix
 func NewCiliumID(id int64) string {
-	return fmt.Sprintf("%s:%d", CiliumLocalIdPrefix, id)
+	return NewID(CiliumLocalIdPrefix, strconv.FormatInt(id, 10))
 }
 
 // NewID returns a new endpoint identifier

--- a/pkg/endpoint/status.go
+++ b/pkg/endpoint/status.go
@@ -4,7 +4,6 @@
 package endpoint
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -57,7 +56,7 @@ func (s Status) String() string {
 	if s.Msg == "" {
 		return s.Code.String()
 	}
-	return fmt.Sprintf("%s - %s", s.Code, s.Msg)
+	return s.Code.String() + " - " + s.Msg
 }
 
 type StatusResponse struct {

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -214,6 +214,10 @@ type Configuration interface {
 	LocalClusterID() uint32
 }
 
+func k8sLabel(key string, value string) string {
+	return "k8s:" + key + "=" + value
+}
+
 // InitWellKnownIdentities establishes all well-known identities. Returns the
 // number of well-known identities initialized.
 func InitWellKnownIdentities(c Configuration) int {
@@ -224,13 +228,13 @@ func InitWellKnownIdentities(c Configuration) int {
 	//   k8s:io.cilium.k8s.policy.cluster=default
 	etcdOperatorLabels := []string{
 		"k8s:io.cilium/app=etcd-operator",
-		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceLabel, c.CiliumNamespaceName()),
-		fmt.Sprintf("k8s:%s=cilium-etcd-sa", api.PolicyLabelServiceAccount),
-		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, c.LocalClusterName()),
+		k8sLabel(api.PodNamespaceLabel, c.CiliumNamespaceName()),
+		k8sLabel(api.PolicyLabelServiceAccount, "cilium-etcd-sa"),
+		k8sLabel(api.PolicyLabelCluster, c.LocalClusterName()),
 	}
 	WellKnown.add(ReservedETCDOperator, etcdOperatorLabels)
 	WellKnown.add(ReservedETCDOperator2, append(etcdOperatorLabels,
-		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
+		k8sLabel(api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
 
 	// cilium-etcd labels
 	//   k8s:app=etcd
@@ -246,13 +250,13 @@ func InitWellKnownIdentities(c Configuration) int {
 		"k8s:app=etcd",
 		"k8s:etcd_cluster=cilium-etcd",
 		"k8s:io.cilium/app=etcd-operator",
-		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceLabel, c.CiliumNamespaceName()),
-		fmt.Sprintf("k8s:%s=default", api.PolicyLabelServiceAccount),
-		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, c.LocalClusterName()),
+		k8sLabel(api.PodNamespaceLabel, c.CiliumNamespaceName()),
+		k8sLabel(api.PolicyLabelServiceAccount, "default"),
+		k8sLabel(api.PolicyLabelCluster, c.LocalClusterName()),
 	}
 	WellKnown.add(ReservedCiliumKVStore, ciliumEtcdLabels)
 	WellKnown.add(ReservedCiliumKVStore2, append(ciliumEtcdLabels,
-		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
+		k8sLabel(api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
 
 	// kube-dns labels
 	//   k8s:io.cilium.k8s.policy.serviceaccount=kube-dns
@@ -261,13 +265,13 @@ func InitWellKnownIdentities(c Configuration) int {
 	//   k8s:io.cilium.k8s.policy.cluster=default
 	kubeDNSLabels := []string{
 		"k8s:k8s-app=kube-dns",
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
-		fmt.Sprintf("k8s:%s=kube-dns", api.PolicyLabelServiceAccount),
-		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, c.LocalClusterName()),
+		k8sLabel(api.PodNamespaceLabel, "kube-system"),
+		k8sLabel(api.PolicyLabelServiceAccount, "kube-dns"),
+		k8sLabel(api.PolicyLabelCluster, c.LocalClusterName()),
 	}
 	WellKnown.add(ReservedKubeDNS, kubeDNSLabels)
 	WellKnown.add(ReservedKubeDNS2, append(kubeDNSLabels,
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceMetaNameLabel)))
+		k8sLabel(api.PodNamespaceMetaNameLabel, "kube-system")))
 
 	// kube-dns EKS labels
 	//   k8s:io.cilium.k8s.policy.serviceaccount=kube-dns
@@ -278,13 +282,13 @@ func InitWellKnownIdentities(c Configuration) int {
 	eksKubeDNSLabels := []string{
 		"k8s:k8s-app=kube-dns",
 		"k8s:eks.amazonaws.com/component=kube-dns",
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
-		fmt.Sprintf("k8s:%s=kube-dns", api.PolicyLabelServiceAccount),
-		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, c.LocalClusterName()),
+		k8sLabel(api.PodNamespaceLabel, "kube-system"),
+		k8sLabel(api.PolicyLabelServiceAccount, "kube-dns"),
+		k8sLabel(api.PolicyLabelCluster, c.LocalClusterName()),
 	}
 	WellKnown.add(ReservedEKSKubeDNS, eksKubeDNSLabels)
 	WellKnown.add(ReservedEKSKubeDNS2, append(eksKubeDNSLabels,
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceMetaNameLabel)))
+		k8sLabel(api.PodNamespaceMetaNameLabel, "kube-system")))
 
 	// CoreDNS EKS labels
 	//   k8s:io.cilium.k8s.policy.serviceaccount=coredns
@@ -295,13 +299,13 @@ func InitWellKnownIdentities(c Configuration) int {
 	eksCoreDNSLabels := []string{
 		"k8s:k8s-app=kube-dns",
 		"k8s:eks.amazonaws.com/component=coredns",
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
-		fmt.Sprintf("k8s:%s=coredns", api.PolicyLabelServiceAccount),
-		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, c.LocalClusterName()),
+		k8sLabel(api.PodNamespaceLabel, "kube-system"),
+		k8sLabel(api.PolicyLabelServiceAccount, "coredns"),
+		k8sLabel(api.PolicyLabelCluster, c.LocalClusterName()),
 	}
 	WellKnown.add(ReservedEKSCoreDNS, eksCoreDNSLabels)
 	WellKnown.add(ReservedEKSCoreDNS2, append(eksCoreDNSLabels,
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceMetaNameLabel)))
+		k8sLabel(api.PodNamespaceMetaNameLabel, "kube-system")))
 
 	// CoreDNS labels
 	//   k8s:io.cilium.k8s.policy.serviceaccount=coredns
@@ -310,13 +314,13 @@ func InitWellKnownIdentities(c Configuration) int {
 	//   k8s:io.cilium.k8s.policy.cluster=default
 	coreDNSLabels := []string{
 		"k8s:k8s-app=kube-dns",
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceLabel),
-		fmt.Sprintf("k8s:%s=coredns", api.PolicyLabelServiceAccount),
-		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, c.LocalClusterName()),
+		k8sLabel(api.PodNamespaceLabel, "kube-system"),
+		k8sLabel(api.PolicyLabelServiceAccount, "coredns"),
+		k8sLabel(api.PolicyLabelCluster, c.LocalClusterName()),
 	}
 	WellKnown.add(ReservedCoreDNS, coreDNSLabels)
 	WellKnown.add(ReservedCoreDNS2, append(coreDNSLabels,
-		fmt.Sprintf("k8s:%s=kube-system", api.PodNamespaceMetaNameLabel)))
+		k8sLabel(api.PodNamespaceMetaNameLabel, "kube-system")))
 
 	// CiliumOperator labels
 	//   k8s:io.cilium.k8s.policy.serviceaccount=cilium-operator
@@ -331,13 +335,13 @@ func InitWellKnownIdentities(c Configuration) int {
 		"k8s:io.cilium/app=operator",
 		"k8s:app.kubernetes.io/part-of=cilium",
 		"k8s:app.kubernetes.io/name=cilium-operator",
-		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceLabel, c.CiliumNamespaceName()),
-		fmt.Sprintf("k8s:%s=cilium-operator", api.PolicyLabelServiceAccount),
-		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, c.LocalClusterName()),
+		k8sLabel(api.PodNamespaceLabel, c.CiliumNamespaceName()),
+		k8sLabel(api.PolicyLabelServiceAccount, "cilium-operator"),
+		k8sLabel(api.PolicyLabelCluster, c.LocalClusterName()),
 	}
 	WellKnown.add(ReservedCiliumOperator, ciliumOperatorLabels)
 	WellKnown.add(ReservedCiliumOperator2, append(ciliumOperatorLabels,
-		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
+		k8sLabel(api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
 
 	// cilium-etcd-operator labels
 	//   k8s:io.cilium.k8s.policy.cluster=default
@@ -352,13 +356,13 @@ func InitWellKnownIdentities(c Configuration) int {
 		"k8s:io.cilium/app=etcd-operator",
 		"k8s:app.kubernetes.io/name: cilium-etcd-operator",
 		"k8s:app.kubernetes.io/part-of: cilium",
-		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceLabel, c.CiliumNamespaceName()),
-		fmt.Sprintf("k8s:%s=cilium-etcd-operator", api.PolicyLabelServiceAccount),
-		fmt.Sprintf("k8s:%s=%s", api.PolicyLabelCluster, c.LocalClusterName()),
+		k8sLabel(api.PodNamespaceLabel, c.CiliumNamespaceName()),
+		k8sLabel(api.PolicyLabelServiceAccount, "cilium-etcd-operator"),
+		k8sLabel(api.PolicyLabelCluster, c.LocalClusterName()),
 	}
 	WellKnown.add(ReservedCiliumEtcdOperator, ciliumEtcdOperatorLabels)
 	WellKnown.add(ReservedCiliumEtcdOperator2, append(ciliumEtcdOperatorLabels,
-		fmt.Sprintf("k8s:%s=%s", api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
+		k8sLabel(api.PodNamespaceMetaNameLabel, c.CiliumNamespaceName())))
 
 	InitMinMaxIdentityAllocation(c)
 

--- a/pkg/kvstore/allocator/allocator.go
+++ b/pkg/kvstore/allocator/allocator.go
@@ -393,7 +393,7 @@ func (k *kvstoreBackend) RunLocksGC(ctx context.Context, staleKeysPrevRound map[
 	for key, v := range allocated {
 		scopedLog := log.WithFields(logrus.Fields{
 			fieldKey:     key,
-			fieldLeaseID: fmt.Sprintf("%x", v.LeaseID),
+			fieldLeaseID: strconv.FormatUint(uint64(v.LeaseID), 16),
 		})
 		// Only delete if this key was previously marked as to be deleted
 		if modRev, ok := staleKeysPrevRound[key]; ok &&
@@ -443,7 +443,7 @@ func (k *kvstoreBackend) RunGC(
 
 	min := uint64(minID)
 	max := uint64(maxID)
-	reasonOutOfRange := fmt.Sprintf("out of local cluster identity range [%d,%d]", min, max)
+	reasonOutOfRange := "out of local cluster identity range [" + strconv.FormatUint(min, 10) + "," + strconv.FormatUint(max, 10) + "]"
 
 	// iterate over /id/
 	for key, v := range allocated {

--- a/pkg/kvstore/etcd.go
+++ b/pkg/kvstore/etcd.go
@@ -828,7 +828,7 @@ func connectEtcdClient(ctx context.Context, config *client.Config, cfgPath strin
 // clusterName is expected to be empty for main kvstore connection
 func makeSessionName(sessionPrefix string, opts *ExtraOptions) string {
 	if opts != nil && opts.ClusterName != "" {
-		return fmt.Sprintf("%s-%s", sessionPrefix, opts.ClusterName)
+		return sessionPrefix + "-" + opts.ClusterName
 	}
 	return sessionPrefix
 }

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -739,9 +740,9 @@ func (a *L3n4Addr) String() string {
 		scope = "/i"
 	}
 	if a.IsIPv6() {
-		return fmt.Sprintf("[%s]:%d%s", a.AddrCluster.String(), a.Port, scope)
+		return "[" + a.AddrCluster.String() + "]:" + strconv.FormatUint(uint64(a.Port), 10) + scope
 	}
-	return fmt.Sprintf("%s:%d%s", a.AddrCluster.String(), a.Port, scope)
+	return a.AddrCluster.String() + ":" + strconv.FormatUint(uint64(a.Port), 10) + scope
 }
 
 // StringWithProtocol returns the L3n4Addr in the "IPv4:Port/Protocol[/Scope]"
@@ -752,9 +753,9 @@ func (a *L3n4Addr) StringWithProtocol() string {
 		scope = "/i"
 	}
 	if a.IsIPv6() {
-		return fmt.Sprintf("[%s]:%d/%s%s", a.AddrCluster.String(), a.Port, a.Protocol, scope)
+		return "[" + a.AddrCluster.String() + "]:" + strconv.FormatUint(uint64(a.Port), 10) + "/" + a.Protocol + scope
 	}
-	return fmt.Sprintf("%s:%d/%s%s", a.AddrCluster.String(), a.Port, a.Protocol, scope)
+	return a.AddrCluster.String() + ":" + strconv.FormatUint(uint64(a.Port), 10) + "/" + a.Protocol + scope
 }
 
 // StringID returns the L3n4Addr as string to be used for unique identification

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -464,6 +464,7 @@ func TestServiceFlags_String(t *testing.T) {
 }
 
 func benchmarkHash(b *testing.B, addr *L3n4Addr) {
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		addr.Hash()
@@ -488,4 +489,40 @@ func BenchmarkL3n4Addr_Hash_IPv6_Long(b *testing.B) {
 func BenchmarkL3n4Addr_Hash_IPv6_Max(b *testing.B) {
 	addr := NewL3n4Addr(TCP, cmtypes.MustParseAddrCluster("1020:3040:5060:7080:90a0:b0c0:d0e0:f000"), 30303, 100)
 	benchmarkHash(b, addr)
+}
+
+func benchmarkString(b *testing.B, addr *L3n4Addr) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr.String()
+	}
+}
+
+func BenchmarkL3n4Addr_String_IPv4(b *testing.B) {
+	addr := NewL3n4Addr(TCP, cmtypes.MustParseAddrCluster("192.168.123.210"), 8080, ScopeInternal)
+	benchmarkString(b, addr)
+}
+
+func BenchmarkL3n4Addr_String_IPv6_Max(b *testing.B) {
+	addr := NewL3n4Addr(TCP, cmtypes.MustParseAddrCluster("1020:3040:5060:7080:90a0:b0c0:d0e0:f000"), 30303, 100)
+	benchmarkString(b, addr)
+}
+
+func benchmarkStringWithProtocol(b *testing.B, addr *L3n4Addr) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		addr.StringWithProtocol()
+	}
+}
+
+func BenchmarkL3n4Addr_StringWithProtocol_IPv4(b *testing.B) {
+	addr := NewL3n4Addr(TCP, cmtypes.MustParseAddrCluster("192.168.123.210"), 8080, ScopeInternal)
+	benchmarkStringWithProtocol(b, addr)
+}
+
+func BenchmarkL3n4Addr_StringWithProtocol_IPv6_Max(b *testing.B) {
+	addr := NewL3n4Addr(TCP, cmtypes.MustParseAddrCluster("1020:3040:5060:7080:90a0:b0c0:d0e0:f000"), 30303, 100)
+	benchmarkStringWithProtocol(b, addr)
 }

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -213,6 +213,154 @@ func TestL3n4AddrID_Equals(t *testing.T) {
 	}
 }
 
+func TestL3n4AddrID_Strings(t *testing.T) {
+	tests := []struct {
+		name               string
+		fields             *L3n4AddrID
+		string             string
+		stringWithProtocol string
+	}{
+		{
+			name: "IPv4 no protocol",
+			fields: &L3n4AddrID{
+				L3n4Addr: L3n4Addr{
+					L4Addr: L4Addr{
+						Protocol: NONE,
+						Port:     9876,
+					},
+					AddrCluster: cmtypes.MustParseAddrCluster("1.1.1.1"),
+				},
+				ID: 1,
+			},
+			string:             "1.1.1.1:9876",
+			stringWithProtocol: "1.1.1.1:9876/NONE",
+		},
+		{
+			name: "IPv4 TCP",
+			fields: &L3n4AddrID{
+				L3n4Addr: L3n4Addr{
+					L4Addr: L4Addr{
+						Protocol: TCP,
+						Port:     9876,
+					},
+					AddrCluster: cmtypes.MustParseAddrCluster("2.2.2.2"),
+					Scope:       ScopeExternal,
+				},
+				ID: 1,
+			},
+			string:             "2.2.2.2:9876",
+			stringWithProtocol: "2.2.2.2:9876/TCP",
+		},
+		{
+			name: "IPv4 UDP",
+			fields: &L3n4AddrID{
+				L3n4Addr: L3n4Addr{
+					L4Addr: L4Addr{
+						Protocol: UDP,
+						Port:     9876,
+					},
+					AddrCluster: cmtypes.MustParseAddrCluster("3.3.3.3"),
+					Scope:       ScopeInternal,
+				},
+				ID: 1,
+			},
+			string:             "3.3.3.3:9876/i",
+			stringWithProtocol: "3.3.3.3:9876/UDP/i",
+		},
+		{
+			name: "IPv4 SCTP",
+			fields: &L3n4AddrID{
+				L3n4Addr: L3n4Addr{
+					L4Addr: L4Addr{
+						Protocol: SCTP,
+						Port:     9876,
+					},
+					AddrCluster: cmtypes.MustParseAddrCluster("4.4.4.4"),
+				},
+				ID: 1,
+			},
+			string:             "4.4.4.4:9876",
+			stringWithProtocol: "4.4.4.4:9876/SCTP",
+		},
+		{
+			name: "IPv6 no protocol",
+			fields: &L3n4AddrID{
+				L3n4Addr: L3n4Addr{
+					L4Addr: L4Addr{
+						Protocol: NONE,
+						Port:     9876,
+					},
+					AddrCluster: cmtypes.MustParseAddrCluster("1020:3040:5060:7080:90a0:b0c0:d0e0:f000"),
+				},
+				ID: 1,
+			},
+			string:             "[1020:3040:5060:7080:90a0:b0c0:d0e0:f000]:9876",
+			stringWithProtocol: "[1020:3040:5060:7080:90a0:b0c0:d0e0:f000]:9876/NONE",
+		},
+		{
+			name: "IPv6 TCP",
+			fields: &L3n4AddrID{
+				L3n4Addr: L3n4Addr{
+					L4Addr: L4Addr{
+						Protocol: TCP,
+						Port:     9876,
+					},
+					AddrCluster: cmtypes.MustParseAddrCluster("1020:3040:5060:7080:90a0:b0c0:d0e0:f000"),
+					Scope:       ScopeExternal,
+				},
+				ID: 1,
+			},
+			string:             "[1020:3040:5060:7080:90a0:b0c0:d0e0:f000]:9876",
+			stringWithProtocol: "[1020:3040:5060:7080:90a0:b0c0:d0e0:f000]:9876/TCP",
+		},
+		{
+			name: "IPv6 UDP",
+			fields: &L3n4AddrID{
+				L3n4Addr: L3n4Addr{
+					L4Addr: L4Addr{
+						Protocol: UDP,
+						Port:     9876,
+					},
+					AddrCluster: cmtypes.MustParseAddrCluster("1020:3040:5060:7080:90a0:b0c0:d0e0:f000"),
+					Scope:       ScopeInternal,
+				},
+				ID: 1,
+			},
+			string:             "[1020:3040:5060:7080:90a0:b0c0:d0e0:f000]:9876/i",
+			stringWithProtocol: "[1020:3040:5060:7080:90a0:b0c0:d0e0:f000]:9876/UDP/i",
+		},
+		{
+			name: "IPv6 SCTP",
+			fields: &L3n4AddrID{
+				L3n4Addr: L3n4Addr{
+					L4Addr: L4Addr{
+						Protocol: SCTP,
+						Port:     9876,
+					},
+					AddrCluster: cmtypes.MustParseAddrCluster("1020:3040:5060:7080:90a0:b0c0:d0e0:f000"),
+				},
+				ID: 1,
+			},
+			string:             "[1020:3040:5060:7080:90a0:b0c0:d0e0:f000]:9876",
+			stringWithProtocol: "[1020:3040:5060:7080:90a0:b0c0:d0e0:f000]:9876/SCTP",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := tt.fields
+			string := f.String()
+			if string != tt.string {
+				t.Errorf("L3n4AddrID.String() = %s, want %s", string, tt.string)
+			}
+			strWithProtocol := f.StringWithProtocol()
+			if strWithProtocol != tt.stringWithProtocol {
+				t.Errorf("L3n4AddrID.StringWithProtocol() = %s, want %s", strWithProtocol, tt.stringWithProtocol)
+			}
+		})
+	}
+}
+
 func TestNewSvcFlag(t *testing.T) {
 	type args struct {
 		svcType     SVCType
@@ -494,8 +642,9 @@ func BenchmarkL3n4Addr_Hash_IPv6_Max(b *testing.B) {
 func benchmarkString(b *testing.B, addr *L3n4Addr) {
 	b.ReportAllocs()
 	b.ResetTimer()
+	var length int
 	for i := 0; i < b.N; i++ {
-		addr.String()
+		length += len(addr.String())
 	}
 }
 

--- a/pkg/policy/groups/actions.go
+++ b/pkg/policy/groups/actions.go
@@ -5,7 +5,6 @@ package groups
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,7 +41,7 @@ func AddDerivativeCNPIfNeeded(clientset client.Clientset, cnp *cilium_v2.CiliumN
 		return true
 	}
 	controllerManager.UpdateController(
-		fmt.Sprintf("add-derivative-cnp-%s", cnp.ObjectMeta.Name),
+		"add-derivative-cnp-"+cnp.ObjectMeta.Name,
 		controller.ControllerParams{
 			Group: addDerivativeCNPControllerGroup,
 			DoFunc: func(ctx context.Context) error {
@@ -64,7 +63,7 @@ func AddDerivativeCCNPIfNeeded(clientset client.Clientset, cnp *cilium_v2.Cilium
 		return true
 	}
 	controllerManager.UpdateController(
-		fmt.Sprintf("add-derivative-ccnp-%s", cnp.ObjectMeta.Name),
+		"add-derivative-ccnp-"+cnp.ObjectMeta.Name,
 		controller.ControllerParams{
 			Group: addDerivativeCCNPControllerGroup,
 			DoFunc: func(ctx context.Context) error {
@@ -88,7 +87,7 @@ func UpdateDerivativeCNPIfNeeded(clientset client.Clientset, newCNP *cilium_v2.C
 		}).Info("New CNP does not have derivative policy, but old had. Deleting old policies")
 
 		controllerManager.UpdateController(
-			fmt.Sprintf("delete-derivative-cnp-%s", oldCNP.ObjectMeta.Name),
+			"delete-derivative-cnp-"+oldCNP.ObjectMeta.Name,
 			controller.ControllerParams{
 				Group: deleteDerivativeCNPControllerGroup,
 				DoFunc: func(ctx context.Context) error {
@@ -103,7 +102,7 @@ func UpdateDerivativeCNPIfNeeded(clientset client.Clientset, newCNP *cilium_v2.C
 	}
 
 	controllerManager.UpdateController(
-		fmt.Sprintf("update-derivative-cnp-%s", newCNP.ObjectMeta.Name),
+		"update-derivative-cnp-"+newCNP.ObjectMeta.Name,
 		controller.ControllerParams{
 			Group: updateDerivativeCNPControllerGroup,
 			DoFunc: func(ctx context.Context) error {
@@ -126,7 +125,7 @@ func UpdateDerivativeCCNPIfNeeded(clientset client.Clientset, newCCNP *cilium_v2
 		}).Info("New CCNP does not have derivative policy, but old had. Deleting old policies")
 
 		controllerManager.UpdateController(
-			fmt.Sprintf("delete-derivative-ccnp-%s", oldCCNP.ObjectMeta.Name),
+			"delete-derivative-ccnp-"+oldCCNP.ObjectMeta.Name,
 			controller.ControllerParams{
 				Group: deleteDerivativeCCNPControllerGroup,
 				DoFunc: func(ctx context.Context) error {
@@ -141,7 +140,7 @@ func UpdateDerivativeCCNPIfNeeded(clientset client.Clientset, newCCNP *cilium_v2
 	}
 
 	controllerManager.UpdateController(
-		fmt.Sprintf("update-derivative-ccnp-%s", newCCNP.ObjectMeta.Name),
+		"update-derivative-ccnp-"+newCCNP.ObjectMeta.Name,
 		controller.ControllerParams{
 			Group: updateDerivativeCCNPControllerGroup,
 			DoFunc: func(ctx context.Context) error {
@@ -173,7 +172,7 @@ func DeleteDerivativeCNP(ctx context.Context, clientset client.Clientset, cnp *c
 	err := clientset.CiliumV2().CiliumNetworkPolicies(cnp.ObjectMeta.Namespace).DeleteCollection(
 		ctx,
 		v1.DeleteOptions{},
-		v1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", parentCNP, cnp.ObjectMeta.UID)})
+		v1.ListOptions{LabelSelector: parentCNP + "=" + string(cnp.ObjectMeta.UID)})
 
 	if err != nil {
 		return err
@@ -198,7 +197,7 @@ func DeleteDerivativeCCNP(ctx context.Context, clientset client.Clientset, ccnp 
 	err := clientset.CiliumV2().CiliumClusterwideNetworkPolicies().DeleteCollection(
 		ctx,
 		v1.DeleteOptions{},
-		v1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", parentCNP, ccnp.ObjectMeta.UID)})
+		v1.ListOptions{LabelSelector: parentCNP + "=" + string(ccnp.ObjectMeta.UID)})
 	if err != nil {
 		return err
 	}

--- a/pkg/policy/groups/helpers.go
+++ b/pkg/policy/groups/helpers.go
@@ -22,9 +22,7 @@ const (
 )
 
 func getDerivativeName(obj v1.Object) string {
-	return fmt.Sprintf("%s-togroups-%s",
-		obj.GetName(),
-		obj.GetUID())
+	return obj.GetName() + "-togroups-" + string(obj.GetUID())
 }
 
 // createDerivativeCNP will return a new CNP based on the given rule.

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -254,7 +254,7 @@ func (a AuthType) String() string {
 	case AuthTypeAlwaysFail:
 		return "test-always-fail"
 	}
-	return fmt.Sprintf("Unknown-auth-type-%d", a.Uint8())
+	return "Unknown-auth-type-" + strconv.FormatUint(uint64(a.Uint8()), 10)
 }
 
 // IsRedirect returns true if the L7Rules are a redirect.
@@ -1138,32 +1138,35 @@ func (l4 L4PolicyMap) containsAllL3L4(labels labels.LabelArray, ports []*models.
 	for _, l4Ctx := range ports {
 		portStr := l4Ctx.Name
 		if !iana.IsSvcName(portStr) {
-			portStr = fmt.Sprintf("%d", l4Ctx.Port)
+			portStr = strconv.FormatUint(uint64(l4Ctx.Port), 10)
 		}
 		lwrProtocol := l4Ctx.Protocol
 		var isUDPDeny, isTCPDeny, isSCTPDeny bool
 		switch lwrProtocol {
 		case "", models.PortProtocolANY:
-			tcpPort := fmt.Sprintf("%s/TCP", portStr)
+			tcpPort := portStr + "/TCP"
 			tcpFilter, tcpmatch := l4[tcpPort]
 			if tcpmatch {
 				tcpmatch, isTCPDeny = tcpFilter.matchesLabels(labels)
 			}
-			udpPort := fmt.Sprintf("%s/UDP", portStr)
+
+			udpPort := portStr + "/UDP"
 			udpFilter, udpmatch := l4[udpPort]
 			if udpmatch {
 				udpmatch, isUDPDeny = udpFilter.matchesLabels(labels)
 			}
-			sctpPort := fmt.Sprintf("%s/SCTP", portStr)
+
+			sctpPort := portStr + "/SCTP"
 			sctpFilter, sctpmatch := l4[sctpPort]
 			if sctpmatch {
 				sctpmatch, isSCTPDeny = sctpFilter.matchesLabels(labels)
 			}
+
 			if (!tcpmatch && !udpmatch && !sctpmatch) || (isTCPDeny && isUDPDeny && isSCTPDeny) {
 				return api.Denied
 			}
 		default:
-			port := fmt.Sprintf("%s/%s", portStr, lwrProtocol)
+			port := portStr + "/" + lwrProtocol
 			filter, match := l4[port]
 			if !match {
 				return api.Denied

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -6,6 +6,7 @@ package policy
 import (
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
@@ -71,7 +72,10 @@ type Key struct {
 
 // String returns a string representation of the Key
 func (k Key) String() string {
-	return fmt.Sprintf("Identity=%d,DestPort=%d,Nexthdr=%d,TrafficDirection=%d", k.Identity, k.DestPort, k.Nexthdr, k.TrafficDirection)
+	return "Identity=" + strconv.FormatUint(uint64(k.Identity), 10) +
+		",DestPort=" + strconv.FormatUint(uint64(k.DestPort), 10) +
+		",Nexthdr=" + strconv.FormatUint(uint64(k.Nexthdr), 10) +
+		",TrafficDirection=" + strconv.FormatUint(uint64(k.TrafficDirection), 10)
 }
 
 // IsIngress returns true if the key refers to an ingress policy key
@@ -382,7 +386,10 @@ func (e *MapStateEntry) DeepEqual(o *MapStateEntry) bool {
 
 // String returns a string representation of the MapStateEntry
 func (e MapStateEntry) String() string {
-	return fmt.Sprintf("ProxyPort=%d,IsDeny=%t,AuthType=%s,DerivedFromRules=%v", e.ProxyPort, e.IsDeny, e.AuthType.String(), e.DerivedFromRules)
+	return "ProxyPort=" + strconv.FormatUint(uint64(e.ProxyPort), 10) +
+		",IsDeny=" + strconv.FormatBool(e.IsDeny) +
+		",AuthType=" + e.AuthType.String() +
+		",DerivedFromRules=" + fmt.Sprintf("%v", e.DerivedFromRules)
 }
 
 // denyPreferredInsert inserts a key and entry into the map by given preference

--- a/pkg/policy/proxyid.go
+++ b/pkg/policy/proxyid.go
@@ -18,7 +18,7 @@ func ProxyID(endpointID uint16, ingress bool, protocol string, port uint16) stri
 	if ingress {
 		direction = "ingress"
 	}
-	return fmt.Sprintf("%d:%s:%s:%d", endpointID, direction, protocol, port)
+	return strconv.FormatUint(uint64(endpointID), 10) + ":" + direction + ":" + protocol + ":" + strconv.FormatUint(uint64(port), 10)
 }
 
 // ProxyIDFromKey returns a unique string to identify a proxy mapping.

--- a/pkg/policy/proxyid_test.go
+++ b/pkg/policy/proxyid_test.go
@@ -4,15 +4,40 @@
 package policy
 
 import (
+	"math/rand"
+	"strconv"
+	"testing"
+
 	. "github.com/cilium/checkmate"
 )
 
 func (s *PolicyTestSuite) TestProxyID(c *C) {
 	id := ProxyID(123, true, "TCP", uint16(8080))
+	c.Assert("123:ingress:TCP:8080", Equals, id)
 	endpointID, ingress, protocol, port, err := ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))
 	c.Assert(ingress, Equals, true)
 	c.Assert(protocol, Equals, "TCP")
 	c.Assert(port, Equals, uint16(8080))
 	c.Assert(err, IsNil)
+}
+
+func BenchmarkProxyID(b *testing.B) {
+	r := rand.New(rand.NewSource(42))
+	id := uint16(r.Intn(65535))
+	port := uint16(r.Intn(65535))
+
+	b.ReportAllocs()
+	for i := 0; i < 1000; i++ {
+		b.StartTimer()
+		proxyID := ProxyID(id, true, "TCP", port)
+		if proxyID != strconv.FormatInt(int64(id), 10)+"ingress:TCP:8080" {
+			b.Failed()
+		}
+		_, _, _, _, err := ParseProxyID(proxyID)
+		if err != nil {
+			b.Failed()
+		}
+		b.StopTimer()
+	}
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
@@ -345,7 +346,7 @@ func rulePortsCoverSearchContext(ports []api.PortProtocol, ctx *SearchContext) b
 			if dp.Name != "" {
 				tracePort.Port = dp.Name
 			} else {
-				tracePort.Port = fmt.Sprintf("%d", dp.Port)
+				tracePort.Port = strconv.FormatUint(uint64(dp.Port), 10)
 			}
 			if p.Covers(tracePort) {
 				return true

--- a/pkg/policy/visibility.go
+++ b/pkg/policy/visibility.go
@@ -105,7 +105,7 @@ func NewVisibilityPolicy(anno string) (*VisibilityPolicy, error) {
 		}
 
 		for _, prot := range protos {
-			pp := fmt.Sprintf("%d/%s", portInt, prot.String())
+			pp := strconv.FormatUint(portInt, 10) + "/" + prot.String()
 			if res, ok := dvp[pp]; ok {
 				if res.Parser != l7Protocol {
 					return nil, fmt.Errorf("duplicate annotations with different L7 protocols %s and %s for %s", res.Parser, l7Protocol, pp)


### PR DESCRIPTION
As mentioned in https://github.com/cilium/cilium/issues/19571 `fmt.Sprintf()` is well-known for not being opimal in terms of CPU and memory allocations. This PR replaces some usages of `fmt.Sprintf` on possible hot code paths with more efficient string concatenation.

* [pkg/policy] Benchmark ProxyID
* [pkg/policy] ProxyID uses string concat instead of Sprintf
* [pkg/policy] L4PolicyMap uses string concatenation
* [pkg/policy] map state uses string concatenation
* [pkg/policy] rulePortsCoverSearchContext uses string concatenation
* [pkg/policy] NewVisibilityPolicy uses string concatenation
* [pkg/policy] groups use string concatenation
* [pkg/loadbalancer] Benchmark L3n4Addr String and StringWithProtocol
* [pkg/loadbalancer] L3n4Addr String and StringWithProtocol use string concatenation
* [pkg/kvstore] makeSessionName and RunLocksGC use string concatenation
* [pkg/endpoint] Use string concatenation
* [operator/pkg/model] Ingress listener name uses string concatenation

Related: https://github.com/cilium/cilium/issues/19571



- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!


```release-note
Replace some usages of fmt.Sprintf with more efficient string concatenation
```
