### PR TITLE
Structured Health Reporter + EndpointManager Modular Health Checks 

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1665,6 +1665,7 @@ type daemonParams struct {
 	AuthManager          *auth.AuthManager
 	Settings             cellSettings
 	HealthProvider       cell.Health
+	HealthScope          cell.Scope
 	DeviceManager        *linuxdatapath.DeviceManager `optional:"true"`
 	// Grab the GC object so that we can start the CT/NAT map garbage collection.
 	// This is currently necessary because these maps have not yet been modularized,

--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -105,7 +105,7 @@ func TestMain(m *testing.M) {
 
 type dummyEpSyncher struct{}
 
-func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr cell.HealthReporter) {
 }
 
 func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {

--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -129,7 +129,7 @@ func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
 		Cache:           fqdn.NewDNSCache(0),
 		UpdateSelectors: d.updateSelectors,
 	})
-	d.endpointManager = endpointmanager.New(&dummyEpSyncher{})
+	d.endpointManager = endpointmanager.New(&dummyEpSyncher{}, nil)
 	d.policy.GetSelectorCache().SetLocalIdentityNotifier(d.dnsNameManager)
 	d.ipcache = ipcache.NewIPCache(&ipcache.Configuration{
 		Context:           context.TODO(),

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/checker"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/hivetest"
 	"github.com/cilium/cilium/pkg/mtu"
 	"github.com/cilium/cilium/pkg/node/manager"
@@ -36,7 +37,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.New(&fakeConfig.Config{}, nil, manager.NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	nm, err = manager.New(&fakeConfig.Config{}, nil, manager.NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1397,9 +1397,9 @@ func (e *Endpoint) startSyncPolicyMapController() {
 	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
 	e.controllers.CreateController(ctrlName,
 		controller.ControllerParams{
-			Group: syncPolicymapControllerGroup,
+			Group:          syncPolicymapControllerGroup,
+			HealthReporter: e.GetReporter("policy map sync"),
 			DoFunc: func(ctx context.Context) error {
-				// Failure to lock is not an error, it means
 				// that the endpoint was disconnected and we
 				// should exit gracefully.
 				if err := e.lockAlive(); err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cilium/cilium/pkg/eventqueue"
 	"github.com/cilium/cilium/pkg/fqdn"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/identity/identitymanager"
@@ -384,6 +385,28 @@ type Endpoint struct {
 
 	// mutable! must hold the endpoint lock to read
 	ciliumEndpointUID k8sTypes.UID
+
+	// Root scope for all of this endpoints reporters.
+	reporterScope       cell.Scope
+	closeHealthReporter func()
+}
+
+func (e *Endpoint) GetReporter(name string) cell.HealthReporter {
+	return cell.GetHealthReporter(e.reporterScope, name)
+}
+
+func (e *Endpoint) InitEndpointScope(parent cell.Scope) {
+	s := cell.GetSubScope(parent, fmt.Sprintf("cilium-endpoint-%d (%s)", e.ID, e.GetK8sNamespaceAndPodName()))
+	if s != nil {
+		e.closeHealthReporter = s.Close
+		e.reporterScope = s
+	}
+}
+
+func (e *Endpoint) Close() {
+	if e.closeHealthReporter != nil {
+		e.closeHealthReporter()
+	}
 }
 
 type namedPortsGetter interface {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -657,6 +657,7 @@ func (e *Endpoint) RegenerateIfAlive(regenMetadata *regeneration.ExternalRegener
 // Should only be called with e.state at StateWaitingToRegenerate,
 // StateWaitingForIdentity, or StateRestoring
 func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMetadata) <-chan bool {
+	hr := e.GetReporter("datapath-regenerate")
 	done := make(chan bool, 1)
 
 	var (
@@ -707,7 +708,9 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 
 			if regenError != nil && !errors.Is(regenError, context.Canceled) {
 				e.getLogger().WithError(regenError).Error("endpoint regeneration failed")
+				hr.Degraded("Endpoint regeneration failed", regenError)
 			}
+			hr.OK(("Endpoint regeneration successful"))
 		} else {
 			// This may be unnecessary(?) since 'closing' of the results
 			// channel means that event has been cancelled?

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -188,6 +188,7 @@ type endpointManagerParams struct {
 	Config          EndpointManagerConfig
 	Clientset       client.Clientset
 	MetricsRegistry *metrics.Registry
+	Scope           cell.Scope
 }
 
 type endpointManagerOut struct {
@@ -201,7 +202,7 @@ type endpointManagerOut struct {
 func newDefaultEndpointManager(p endpointManagerParams) endpointManagerOut {
 	checker := endpoint.CheckHealth
 
-	mgr := New(&watchers.EndpointSynchronizer{Clientset: p.Clientset})
+	mgr := New(&watchers.EndpointSynchronizer{Clientset: p.Clientset}, p.Scope)
 	if p.Config.EndpointGCInterval > 0 {
 		ctx, cancel := context.WithCancel(context.Background())
 		p.Lifecycle.Append(hive.Hook{

--- a/pkg/endpointmanager/gc_test.go
+++ b/pkg/endpointmanager/gc_test.go
@@ -25,7 +25,7 @@ func fakeCheck(ep *endpoint.Endpoint) error {
 
 func (s *EndpointManagerSuite) TestmarkAndSweep(c *C) {
 	// Open-code WithPeriodicGC() to avoid running the controller
-	mgr := New(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{}, nil)
 	mgr.checkHealth = fakeCheck
 	mgr.deleteEndpoint = endpointDeleteFunc(mgr.waitEndpointRemoved)
 

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -19,6 +19,7 @@ import (
 	endpointid "github.com/cilium/cilium/pkg/endpoint/id"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s/watchers/subscriber"
@@ -48,6 +49,8 @@ var _ subscriber.Node = (*endpointManager)(nil)
 // endpointManager is a structure designed for containing state about the
 // collection of locally running endpoints.
 type endpointManager struct {
+	reporterScope cell.Scope
+
 	// mutex protects endpoints and endpointsAux
 	mutex lock.RWMutex
 
@@ -91,7 +94,7 @@ type endpointManager struct {
 // EndpointResourceSynchronizer is an interface which synchronizes CiliumEndpoint
 // resources with Kubernetes.
 type EndpointResourceSynchronizer interface {
-	RunK8sCiliumEndpointSync(ep *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration)
+	RunK8sCiliumEndpointSync(ep *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr cell.HealthReporter)
 	DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint)
 }
 
@@ -100,8 +103,9 @@ type EndpointResourceSynchronizer interface {
 type endpointDeleteFunc func(*endpoint.Endpoint, endpoint.DeleteConfig) []error
 
 // New creates a new endpointManager.
-func New(epSynchronizer EndpointResourceSynchronizer) *endpointManager {
+func New(epSynchronizer EndpointResourceSynchronizer, reporterScope cell.Scope) *endpointManager {
 	mgr := endpointManager{
+		reporterScope:                reporterScope,
 		endpoints:                    make(map[uint16]*endpoint.Endpoint),
 		endpointsAux:                 make(map[string]*endpoint.Endpoint),
 		mcastManager:                 mcastmanager.New(option.Config.IPv6MCastDevice),
@@ -120,10 +124,11 @@ func (mgr *endpointManager) WithPeriodicEndpointGC(ctx context.Context, checkHea
 	mgr.checkHealth = checkHealth
 	mgr.controllers.UpdateController("endpoint-gc",
 		controller.ControllerParams{
-			Group:       endpointGCControllerGroup,
-			DoFunc:      mgr.markAndSweep,
-			RunInterval: interval,
-			Context:     ctx,
+			Group:          endpointGCControllerGroup,
+			DoFunc:         mgr.markAndSweep,
+			RunInterval:    interval,
+			Context:        ctx,
+			HealthReporter: cell.GetHealthReporter(mgr.reporterScope, "endpoint-gc"),
 		})
 	return mgr
 }
@@ -383,7 +388,9 @@ func (mgr *endpointManager) ReleaseID(ep *endpoint.Endpoint) error {
 // unexpose removes the endpoint from the endpointmanager, so subsequent
 // lookups will no longer find the endpoint.
 func (mgr *endpointManager) unexpose(ep *endpoint.Endpoint) {
+	defer ep.Close()
 	identifiers := ep.Identifiers()
+
 	previousState := ep.GetState()
 
 	mgr.mutex.Lock()
@@ -623,7 +630,8 @@ func (mgr *endpointManager) expose(ep *endpoint.Endpoint) error {
 	mgr.updateReferencesLocked(ep, identifiers)
 	mgr.mutex.Unlock()
 
-	mgr.RunK8sCiliumEndpointSync(ep, option.Config)
+	ep.InitEndpointScope(mgr.reporterScope)
+	mgr.RunK8sCiliumEndpointSync(ep, option.Config, ep.GetReporter("cep-k8s-sync"))
 
 	return nil
 }

--- a/pkg/endpointmanager/manager_test.go
+++ b/pkg/endpointmanager/manager_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/endpointmanager/idallocator"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
@@ -111,7 +112,7 @@ func (d *DummyRuleCacheOwner) ClearPolicyConsumers(id uint16) *sync.WaitGroup {
 
 type dummyEpSyncher struct{}
 
-func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
+func (epSync *dummyEpSyncher) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr cell.HealthReporter) {
 }
 
 func (epSync *dummyEpSyncher) DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint) {
@@ -423,7 +424,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 	for _, tt := range tests {
 		ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), &tt.cm)
 		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
-		mgr := New(&dummyEpSyncher{})
+		mgr := New(&dummyEpSyncher{}, nil)
 
 		err = mgr.expose(ep)
 		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
@@ -442,7 +443,7 @@ func (s *EndpointManagerSuite) TestLookup(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
-	mgr := New(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{}, nil)
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 2, endpoint.StateReady)
 	type args struct {
 		id uint16
@@ -509,7 +510,7 @@ func (s *EndpointManagerSuite) TestLookupCiliumID(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupCNIAttachmentID(c *C) {
-	mgr := New(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{}, nil)
 	ep, err := endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), &apiv1.EndpointChangeRequest{
 		ContainerID:            "foo",
 		ContainerInterfaceName: "bar",
@@ -528,7 +529,7 @@ func (s *EndpointManagerSuite) TestLookupCNIAttachmentID(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
-	mgr := New(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{}, nil)
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 4, endpoint.StateReady)
 	type args struct {
 		ip string
@@ -593,7 +594,7 @@ func (s *EndpointManagerSuite) TestLookupIPv4(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestLookupCEPName(c *C) {
-	mgr := New(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{}, nil)
 	type args struct {
 		podName string
 	}
@@ -719,7 +720,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 		var err error
 		ep, err = endpoint.NewEndpointFromChangeModel(context.Background(), s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), &tt.cm)
 		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
-		mgr := New(&dummyEpSyncher{})
+		mgr := New(&dummyEpSyncher{}, nil)
 
 		err = mgr.expose(ep)
 		c.Assert(err, IsNil, Commentf("Test Name: %s", tt.name))
@@ -748,7 +749,7 @@ func (s *EndpointManagerSuite) TestUpdateReferences(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestRemove(c *C) {
-	mgr := New(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{}, nil)
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 7, endpoint.StateReady)
 	type args struct {
 	}
@@ -788,7 +789,7 @@ func (s *EndpointManagerSuite) TestRemove(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
-	mgr := New(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{}, nil)
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type want struct {
 		result bool
@@ -849,7 +850,7 @@ func (s *EndpointManagerSuite) TestHasGlobalCT(c *C) {
 }
 
 func (s *EndpointManagerSuite) TestWaitForEndpointsAtPolicyRev(c *C) {
-	mgr := New(&dummyEpSyncher{})
+	mgr := New(&dummyEpSyncher{}, nil)
 	ep := endpoint.NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &endpoint.FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 1, endpoint.StateReady)
 	type args struct {
 		ctx    context.Context

--- a/pkg/health/client/modules.go
+++ b/pkg/health/client/modules.go
@@ -6,6 +6,7 @@ package client
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -32,7 +33,11 @@ func GetAndFormatModulesHealth(w io.Writer, clt ModulesHealth, verbose bool) {
 	if verbose {
 		fmt.Fprintf(w, "\n  Module\tStatus\tMessage\tLast Updated\n")
 		for _, m := range resp.Payload.Modules {
-			fmt.Fprintf(w, "  %s\t%s\t%s\t%12s\n", m.ModuleID, m.Level, m.Message, m.LastUpdated)
+			if strings.Contains(m.Message, "\n") {
+				fmt.Fprintf(w, "  %s\t%s\t%12s\n%s", m.ModuleID, m.Level, m.LastUpdated, m.Message)
+			} else {
+				fmt.Fprintf(w, "  %s\t%s\t%s\t%12s\n", m.ModuleID, m.Level, m.Message, m.LastUpdated)
+			}
 		}
 		return
 	}

--- a/pkg/hive/cell/health.go
+++ b/pkg/hive/cell/health.go
@@ -47,6 +47,8 @@ type HealthReporter interface {
 
 	// Stopped reports that a module has completed, and will no longer report any
 	// health status.
+	// Implementations should differentiate that a stopped module may also be OK or Degraded.
+	// Stopping a reporting should only affect future updates.
 	Stopped(reason string)
 
 	// Degraded declares that a module has entered a degraded state.
@@ -81,6 +83,7 @@ type Update struct {
 	Level
 	FullModuleID FullModuleID
 	Message      string
+	Timestamp    time.Time
 	Err          error
 }
 

--- a/pkg/hive/cell/lifecycle/lifecycle.go
+++ b/pkg/hive/cell/lifecycle/lifecycle.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package lifecycle
+
+import "context"
+
+// HookContext is a context passed to a lifecycle hook that is cancelled
+// in case of timeout. Hooks that perform long blocking operations directly
+// in the start or stop function (e.g. connecting to external services to
+// initialize) must abort any such operation if this context is cancelled.
+type HookContext context.Context
+
+// HookInterface mirrors the Hook interface from pkg/hive/lifecycle.go.
+// Because pkg/hive/cell depends on HookInterface then we need to have a
+// copy of it here.
+// Hive provides a "cell" version of this HookInterface interface that does
+// not depend on pkg/hive/lifecycle.go thus allowing the cell package to define
+// lifecycle hooks.
+type HookInterface interface {
+	Start(HookContext) error
+	Stop(HookContext) error
+}
+
+// Lifecycle enables cells to register start and stop hooks, either
+// from a constructor or an invoke function.
+type Lifecycle interface {
+	Append(HookInterface)
+}

--- a/pkg/hive/cell/structured.go
+++ b/pkg/hive/cell/structured.go
@@ -1,0 +1,565 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"text/tabwriter"
+	"time"
+
+	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/lock"
+
+	"golang.org/x/exp/maps"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type children sets.Set[string]
+
+// reporterMinTimeout is the minimum time between status realizations, this
+// prevents excessive reporter tree walks which hold the lock.
+// This also acts as a rate limiter for status updates, if a update is not realized
+// because the minimum timeout has not elapsed, it will eventually be realized by
+// a periodic wakeup of the same interval.
+//
+// HealthReporting is not intendeds to capture high frequency events, but rather provide
+// a structured view of the health of the system.
+var reporterMinTimeout = time.Millisecond * 500
+
+// Scope provides a node in the structured health reporter tree that is
+// serves only as a parent for other nodes (scopes or reporters), and is
+// used to group related reporters together.
+type Scope interface {
+	// Name returns the name of the scope.
+	Name() string
+
+	// Close removes the scope from the tree, and stops all reporters under this scope.
+	// Using a reporter that is under this scope after Close has been called will result
+	// in a noop update and warning log.
+	// Thus it is preferable for all reporters to be Stopped first, before calling Close.
+	Close()
+
+	scope() *subReporter
+}
+
+// GetSubScope creates a new reporter scope under the given parent scope.
+// This creates a new node in the structured health reporter tree, and any calls
+// to GetSubScope or GetHealthReporter from the returned scope will return a child node
+// of this reporter tree.
+//
+// GetSubScope can be chained together to create various levels of sub reporters.
+//
+// Example:
+//
+// 1. Init root scope (note: this is provided to modules automatically).
+// root := rootScope(hr)
+//
+//	root
+//
+// 2. Create endpoint-manager subscope, and reporter under that scope (with ok!)
+//
+// endpointManagerScope := GetSubScope(root, "endpoint-manager")
+// GetHealthReporter(endpointManagerScope, "endpoint-000").OK("it works!")
+//
+//	 root(OK)
+//		└── scope(endpoint-manager, OK)
+//			└── reporter(endpoint-000, OK)
+//
+// 3. Create another reporter under that scope with degraded
+// GetHealthReporter(endpointManagerScope, "endpoint-000").Degraded("oh no!")
+//
+//	 root(Degraded)
+//		└── scope(endpoint-manager, Degraded)
+//			└── reporter(endpoint-000, OK)
+//			└── reporter(endpoint-000, Degraded)
+//
+// 4. Close the endpoint-manager scope
+// s.Close()
+//
+//	root(OK) 	// status has been reported, but we no longer have any degraded status
+//				// default to ok status.
+func GetSubScope(parent Scope, name string) Scope {
+	if parent == nil {
+		return nil
+	}
+	return createSubScope(parent, name)
+}
+
+// GetHealthReporter creates a new reporter under the given parent scope.
+func GetHealthReporter(parent Scope, name string) HealthReporter {
+	if parent == nil {
+		return &noopReporter{}
+	}
+	return getSubReporter(parent, name, true)
+}
+
+// TestScope exposes creating a root scope for testing purposes only.
+func TestScope(hr HealthReporter) Scope {
+	switch hr.(type) {
+	case *reporter, *subReporter:
+		panic("test scope should only be used on test health reporter implementations")
+	}
+	s := rootScope(hr)
+	s.start()
+	return s
+}
+
+func rootScope(hr HealthReporter) *scope {
+	r := &subReporter{
+		base: &subreporterBase{
+			hr:           hr,
+			idToChildren: map[string]children{},
+			nodes:        map[string]*node{},
+			wakeup:       make(chan struct{}, 16),
+		},
+	}
+	// create root node, required in case reporters are created without any subscopes.
+	r.id = r.base.addChild("", "", false)
+	r.base.rootID = r.id
+
+	// Realize walks the tree and creates a updated status for the reporter.
+	// Because this is blocking and can be expensive, we have a reconcile loop
+	// that only performs this if the revision has changed.
+	realize := func() {
+		statusTree := r.base.getStatusTreeLocked(r.base.rootID)
+		if r.base.stopped {
+			r.base.hr.Stopped("stopping scoped health reporter")
+			return
+		}
+		if r.base.revision.Load() == 0 {
+			return
+		}
+		if statusTree.allOk() {
+			r.base.hr.OK(statusTree.toString(2))
+		} else {
+			r.base.hr.Degraded(statusTree.toString(2), nil)
+		}
+	}
+
+	r.scheduleRealize = func() {
+		r.base.revision.Add(1)
+		r.base.wakeup <- struct{}{}
+	}
+	r.realizeSync = realize
+
+	return &scope{subReporter: r}
+}
+
+func (r *scope) start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		var rev uint64
+		var lastUpdate time.Time
+		for {
+			select {
+			case <-inctimer.After(reporterMinTimeout):
+			case <-r.base.wakeup:
+			case <-ctx.Done():
+			}
+			if rev < r.base.revision.Load() && time.Since(lastUpdate) > reporterMinTimeout {
+				rev = r.base.revision.Load()
+				r.base.Lock()
+				r.realizeSync()
+				r.base.Unlock()
+				lastUpdate = time.Now()
+			}
+			if ctx.Err() != nil {
+				return
+			}
+		}
+	}()
+	r.closeReconciler = cancel
+}
+
+// Flushes out any remaining unprocessed updates and closes the reporter tree.
+// Used to finalize any remaining status updates before the module is stopped.
+// This will allow for collecting of health status during shutdown.
+func flushAndClose(rs Scope, reason string) {
+	rs.scope().base.Lock()
+	defer rs.scope().base.Unlock()
+
+	// Stop reconciler loop, flush any pending updates synchronously.
+	rs.scope().closeReconciler()
+
+	// Realize and flush the final status.
+	rs.scope().realizeSync()
+
+	// Mark the module as stopped, and emit a stopped status.
+	rs.scope().base.stopped = true
+	rs.scope().base.hr.Stopped(reason)
+	rs.scope().base.removeTreeLocked(rs.scope().id)
+}
+
+type scope struct {
+	*subReporter
+}
+
+func (s *scope) Close() {
+	s.base.Lock()
+	s.base.removeRefLocked(s.id)
+	if s.base.canRemoveTreeLocked(s.id) {
+		s.base.removeTreeLocked(s.id)
+	}
+	s.base.Unlock()
+	s.scheduleRealize()
+}
+
+// A scope can be removed if it has no references and all child scopes can be removed.
+// Reporter leaf nodes are always immediately removed when Stopped. Thus if the condition
+// holds that all subtrees of the scope can be removed, then the scope can be removed.
+func (s *subreporterBase) canRemoveTreeLocked(id string) bool {
+	if _, ok := s.nodes[id]; ok {
+		node := s.nodes[id]
+		if (node.isReporter) || s.nodes[id].refs > 0 {
+			return false
+		}
+		for child := range s.idToChildren[id] {
+			if !s.canRemoveTreeLocked(child) {
+				return false
+			}
+		}
+	}
+	// If it does not exist, we assume it's ok to remove (noop).
+	return true
+}
+
+func (s *scope) scope() *subReporter {
+	return s.subReporter
+}
+
+func (s *scope) Name() string {
+	return s.name
+}
+
+// When a scope is orphaned and garbage collected, we want to remove it from the tree if
+// the following condition is met:
+//  1. All scopes under this scope also have no references.
+//  2. There are no reporters under this scope (reporters are always removed immediately
+//     after they are stopped).
+//
+// This means that scopes are only kept in the tree if they either have referenced subscopes,
+// or if they have reporters under them.
+// If a scope is orphaned, and all it's children are orphaned, and it has no reporter children
+// then it is impossible for any new reporters to be created under this scope.
+//
+// Because reporters are only removed when they are explicitly stopped, this means that if a
+// reporter node emits a ok/degraded status and then is orphaned.
+// This is ok, because we're primarily interested in ensure that ephemerally created scopes that
+// are never reported upon and then lost do not grow the tree indefinitely.
+func createSubScope(parent Scope, name string) *scope {
+	s := &scope{
+		subReporter: getSubReporter(parent, name, false),
+	}
+	runtime.SetFinalizer(s, func(s *scope) {
+		s.base.Lock()
+		s.base.removeRefLocked(s.id)
+		if s.base.canRemoveTreeLocked(s.id) {
+			s.base.removeTreeLocked(s.id)
+		}
+		s.base.Unlock()
+		runtime.SetFinalizer(s, nil)
+	})
+	return s
+}
+
+func getSubReporter(parent Scope, name string, isReporter bool) *subReporter {
+	return scopeFromParent(parent, name, isReporter)
+}
+
+func scopeFromParent(parent Scope, name string, isReporter bool) *subReporter {
+	r := parent.scope()
+	r.base.Lock()
+	defer r.base.Unlock()
+
+	// If such a reporter already exists at this scope, we just return the same reporter
+	// by recreating the subreporter.
+	for cid := range r.base.idToChildren[r.id] {
+		child := r.base.nodes[cid]
+		if child.name == name {
+			r.base.addRefLocked(cid)
+			return &subReporter{
+				base:            r.base,
+				id:              cid,
+				scheduleRealize: r.scheduleRealize,
+				name:            name,
+			}
+		}
+	}
+
+	id := r.base.addChild(r.id, name, isReporter)
+
+	return &subReporter{
+		base:            r.base,
+		id:              id,
+		scheduleRealize: r.scheduleRealize,
+		name:            name,
+	}
+}
+
+// subreporterBase is the base implementation of a structured health reporter.
+// Each node in a reporter tree (i.e. for each cell.Module) has a pointer to
+// the single subreporterBase.
+// subreporterBase maintains the tree structure, as well as is responsible for
+// realizing the status tree, and emitting the status to the module HealthReporter.
+type subreporterBase struct {
+	lock.Mutex
+
+	// Module level health reporter, all realized status is emitted to this reporter.
+	hr HealthReporter
+
+	// idToChildren is the adjacency map of parentID to children IDs.
+	idToChildren map[string]children
+	nodes        map[string]*node
+
+	// rootID is the root node of the tree, it should always exist in idToChildren and nodes.
+	rootID string
+
+	stopped bool
+
+	// Variables used for realization loop, because realization involves traversing the tree
+	// we only perform this when the revision has changed.
+	revision atomic.Uint64
+	counter  atomic.Int32
+	wakeup   chan struct{}
+}
+
+func (s *subreporterBase) addNode(n *node) {
+	if _, ok := s.idToChildren[n.parentID]; !ok {
+		s.idToChildren[n.parentID] = children{}
+	}
+	s.idToChildren[n.parentID][n.id] = struct{}{}
+	s.idToChildren[n.id] = children{}
+	s.nodes[n.id] = n
+}
+
+func (s *subreporterBase) addChild(pid string, name string, isReporter bool) string {
+	id := strconv.Itoa(int(s.counter.Add(1))) + "-" + name
+	s.addNode(&node{
+		id:       id,
+		parentID: pid,
+		count:    1,
+		Update: Update{
+			Level:     StatusUnknown,
+			Timestamp: time.Now(),
+		},
+		name:       name,
+		isReporter: isReporter,
+		refs:       1,
+	})
+	return id
+}
+
+func (s *subreporterBase) setStatus(id string, level Level, message string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.stopped {
+		return fmt.Errorf("reporter tree %s has been stopped", id)
+	}
+
+	if _, ok := s.nodes[id]; !ok {
+		return fmt.Errorf("reporter %s has been stopped", id)
+	}
+
+	n := s.nodes[id]
+
+	if n.Level == level && n.Message == message {
+		n.count++
+	} else {
+		n.count = 1
+	}
+
+	n.Level = level
+	n.Message = message
+	return nil
+}
+
+func (s *subreporterBase) removeTreeLocked(rid string) {
+	for child := range s.idToChildren[rid] {
+		s.removeTreeLocked(child)
+	}
+	// Safely remove parents reference to this node.
+	if _, ok := s.nodes[rid]; ok {
+		pid := s.nodes[rid].parentID
+		delete(s.idToChildren[pid], rid)
+	}
+	delete(s.idToChildren, rid)
+	delete(s.nodes, rid)
+}
+
+// StatusNode is a model struct for a status tree realization result.
+// It is created upon status tree realization, for now it is only used for
+// for generating a plaintext representation of the status tree.
+// In the future we will want to use this to generate a structured JSON representation
+// of the status tree.
+type StatusNode struct {
+	ID          string        `json:"id"`
+	Level       Level         `json:"level,omitempty"`
+	Name        string        `json:"name"`
+	Message     string        `json:"message,omitempty"`
+	Timestamp   time.Time     `json:"timestamp"`
+	Count       int           `json:"count"`
+	SubStatuses []*StatusNode `json:"sub_statuses,omitempty"`
+}
+
+func (s *StatusNode) allOk() bool {
+	return s.Level == StatusOK
+}
+
+func (s *StatusNode) writeTo(w io.Writer, d int) {
+	if len(s.SubStatuses) == 0 {
+		fmt.Fprintf(w, "%s%s\t%s\t%s\t%s ago\t(x%d)\n", strings.Repeat("\t", d), s.Name, s.Level, s.Message, time.Since(s.Timestamp), s.Count)
+	} else {
+		fmt.Fprintf(w, "%s%s\n", strings.Repeat("\t", d), s.Name)
+		for _, ss := range s.SubStatuses {
+			ss.writeTo(w, d+1)
+		}
+	}
+}
+
+func (s *StatusNode) toString(ident int) string {
+	if s == nil {
+		return ""
+	}
+	buf := bytes.NewBuffer(nil)
+	w := tabwriter.NewWriter(buf, 0, 0, 1, ' ', 0)
+	s.writeTo(w, ident)
+	w.Flush()
+	return buf.String()
+}
+
+func (s *StatusNode) String() string {
+	return s.toString(0)
+}
+
+func (s *subreporterBase) getStatusTreeLocked(nid string) *StatusNode {
+	if children, ok := s.idToChildren[nid]; ok {
+		rn := s.nodes[nid]
+		n := &StatusNode{
+			ID:        nid,
+			Message:   rn.Message,
+			Name:      rn.name,
+			Timestamp: rn.Timestamp,
+			Count:     rn.count,
+		}
+		allok := true
+		childIDs := maps.Keys(children)
+		sort.Strings(childIDs)
+		for _, child := range childIDs {
+			cn := s.getStatusTreeLocked(child)
+			if cn == nil {
+				log.Errorf("failed to get status for node %s", child)
+				continue
+			}
+			n.SubStatuses = append(n.SubStatuses, cn)
+			if !cn.allOk() {
+				allok = false
+			}
+		}
+		// If this is not a leaf and all children are ok then report ok.
+		// case 1: Non-reporter, has no children, should be ok?
+		// case 2: Non-reporter, has children, defer down to children.
+		if rn.isReporter {
+			n.Level = rn.Level
+		} else {
+			if allok {
+				n.Level = StatusOK
+			} else {
+				n.Level = StatusDegraded
+			}
+		}
+
+		return n
+	}
+	return nil
+}
+
+type node struct {
+	id         string
+	name       string
+	parentID   string
+	isReporter bool
+	count      int
+	refs       int
+	Update
+}
+
+func (b *subreporterBase) removeRefLocked(id string) {
+	if _, ok := b.nodes[id]; ok {
+		if b.nodes[id].refs > 0 {
+			b.nodes[id].refs--
+		}
+	}
+}
+
+func (b *subreporterBase) addRefLocked(id string) {
+	if _, ok := b.nodes[id]; ok {
+		b.nodes[id].refs++
+	}
+}
+
+// subReporter represents both reporter "leaf" nodes and intermediate
+// "scope" nodes.
+// subReporter only has a pointer to the base, thus copying a subReporter
+// by value yields the same "reporter".
+type subReporter struct {
+	base *subreporterBase
+	// Triggers realization asynchronously, should not hold lock when calling.
+	scheduleRealize func()
+	// Triggers realization synchronously, base lock must be held when calling.
+	// Use for final status flushes.
+	realizeSync func()
+
+	closeReconciler func()
+	id              string
+	name            string
+}
+
+func (s *subReporter) OK(message string) {
+	if err := s.base.setStatus(s.id, StatusOK, message); err != nil {
+		log.WithError(err).Warnf("could not set OK status on subreporter %q", s.id)
+		return
+	}
+	s.scheduleRealize()
+}
+
+func (s *subReporter) Degraded(message string, err error) {
+	var m string
+	// TODO: For now, we just append the error to the message, this won't be ideal
+	// for longer errs. Figure out a better way to bubble up errors.
+	if err != nil {
+		m = message + ": " + err.Error()
+	} else {
+		m = message
+	}
+	if err := s.base.setStatus(s.id, StatusDegraded, m); err != nil {
+		log.WithError(err).Warnf("could not set degraded status on subreporter %q", s.id)
+		return
+	}
+	s.scheduleRealize()
+}
+
+// Stopped marks the subreporter as stopped by removing it from the tree.
+// Stopped reporters can immediately be removed from the tree, since they do
+// not have any children.
+func (s *subReporter) Stopped(message string) {
+	s.base.Lock()
+	s.base.removeTreeLocked(s.id)
+	s.base.Unlock()
+	s.scheduleRealize()
+}
+
+type noopReporter struct{}
+
+func (s *noopReporter) OK(message string)                  {}
+func (s *noopReporter) Degraded(message string, err error) {}
+func (s *noopReporter) Stopped(message string)             {}

--- a/pkg/hive/cell/structured_test.go
+++ b/pkg/hive/cell/structured_test.go
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cell
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+func init() {
+	reporterMinTimeout = time.Millisecond * 10
+}
+
+func createRoot(hr HealthReporter) (Scope, func()) {
+	s := rootScope(hr)
+	s.start()
+	return s, func() {
+		flushAndClose(s, "test is done")
+	}
+}
+
+func createMockReporter(assert *assert.Assertions) (*mockReporter, func(), func(), func()) {
+
+	l := new(lock.Mutex)
+	last := new(Level)
+	*last = StatusUnknown
+	hr := &mockReporter{
+		ok: func(s string) {
+			l.Lock()
+			defer l.Unlock()
+			*last = StatusOK
+		},
+		degraded: func(s string) {
+			l.Lock()
+			defer l.Unlock()
+			*last = StatusDegraded
+		},
+		stopped: func(s string) {
+			l.Lock()
+			defer l.Unlock()
+			*last = StatusStopped
+		},
+	}
+
+	assertOK := func() {
+		assert.Eventually(func() bool {
+			l.Lock()
+			defer l.Unlock()
+			return *last == StatusOK
+		}, time.Second*5, time.Millisecond*10)
+	}
+	assertDegraded := func() {
+		assert.Eventually(func() bool {
+			l.Lock()
+			defer l.Unlock()
+			return *last == StatusDegraded
+		}, time.Second*5, time.Millisecond*10)
+	}
+	assertUnknown := func() {
+		assert.Eventually(func() bool {
+			l.Lock()
+			defer l.Unlock()
+			return *last == StatusUnknown
+		}, time.Second*5, time.Millisecond*10)
+	}
+	return hr, assertOK, assertDegraded, assertUnknown
+}
+
+func TestCloseEmpty(t *testing.T) {
+	hr, _, _, assertUnknown := createMockReporter(assert.New(t))
+	_, done := createRoot(hr)
+	defer done()
+	assertUnknown()
+}
+
+func TestReporterV2(t *testing.T) {
+	hr, assertOk, assertDegraded, _ := createMockReporter(assert.New(t))
+	s, done := createRoot(hr)
+	defer done()
+
+	hs := GetSubScope(s, "test_scope")
+	hs2 := GetSubScope(s, "test_scope2")
+	GetHealthReporter(hs2, "foo").OK("ok")
+	GetHealthReporter(hs, "test").OK("ok")
+	GetHealthReporter(hs, "test").OK("ok")
+	assertOk()
+	GetHealthReporter(hs, "test").Degraded("oops", nil)
+	assertDegraded()
+}
+
+func TestSubreporter(t *testing.T) {
+	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
+	s, done := createRoot(hr)
+	defer done()
+
+	fooScope := GetSubScope(s, "foo")
+	GetHealthReporter(fooScope, "1").OK("ok")
+	GetHealthReporter(fooScope, "2").OK("ok")
+	GetHealthReporter(fooScope, "3").OK("ok")
+	assertOK()
+	GetHealthReporter(fooScope, "1").Degraded("oops", nil)
+	assertDegraded()
+	GetHealthReporter(fooScope, "1").Stopped("")
+	assertOK()
+
+	foo2Scope := GetSubScope(s, "foo2")
+	GetHealthReporter(foo2Scope, "1").OK("ok")
+	assertOK()
+	barScope := GetSubScope(s, "bar")
+	GetHealthReporter(barScope, "1").Degraded("boom", nil)
+	assertDegraded()
+	GetHealthReporter(barScope, "1").Stopped("")
+	assertOK()
+}
+
+func TestStructuredReporterCancel(t *testing.T) {
+	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
+	s, done := createRoot(hr)
+	defer done()
+
+	epmScope := GetSubScope(s, "endpoint-manager")
+	ep000Scope := GetSubScope(epmScope, "endpoint-000")
+	GetHealthReporter(ep000Scope, "k8s-sync").Degraded("nooo", nil)
+	GetHealthReporter(ep000Scope, "k8s-sync2").OK("nooo")
+	assertDegraded()
+	GetHealthReporter(ep000Scope, "k8s-sync").Stopped("no more")
+	assertOK()
+}
+
+func TestWithBaseReporter(t *testing.T) {
+	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
+	s, done := createRoot(hr)
+	defer done()
+	GetHealthReporter(s, "test").OK("")
+	assertOK()
+	GetHealthReporter(s, "test").Degraded("", nil)
+	assertDegraded()
+}
+
+func TestStopped(t *testing.T) {
+	hr, assertOK, assertDegraded, _ := createMockReporter(assert.New(t))
+	var s Scope
+	s, done := createRoot(hr)
+	defer done()
+	s = GetSubScope(s, "foo")
+	GetHealthReporter(s, "test").Degraded("", nil)
+	assertDegraded()
+	GetHealthReporter(s, "test").Stopped("")
+	assertOK()
+}
+
+// This test validates that:
+//  1. A scope that is orphaned and then garbage collected, that satisifies the
+//     constraint that it or none of its children are referenced, is removed.
+func TestUnreferencedScope(t *testing.T) {
+	assert := assert.New(t)
+	hr, assertOK, _, assertUnknown := createMockReporter(assert)
+	r, done := createRoot(hr)
+	defer done()
+
+	// Create two orphaned scopes, one is a child of the other.
+	func() {
+		type closureScope struct {
+			s Scope
+		}
+		c := &closureScope{s: GetSubScope(GetSubScope(r, "orphan0"), "orphan1")}
+		// This temporarily prevents the scope from being garbage collected so
+		// we can validate the base reporter graph.
+		runtime.SetFinalizer(c, func(s *closureScope) {})
+		defer runtime.SetFinalizer(c, nil)
+		assertUnknown()
+		r.scope().base.Lock()
+		assert.Equal(1, r.scope().base.nodes["2-orphan0"].refs, "should have one ref")
+		assert.Equal(1, r.scope().base.nodes["3-orphan1"].refs, "should have one ref")
+		r.scope().base.Unlock()
+	}()
+
+	// Create referenced scope.
+	s2 := GetSubScope(r, "foo2")
+	assertUnknown()
+	r.scope().base.Lock()
+	assert.Equal(1, r.scope().base.nodes["4-foo2"].refs, "should have one ref")
+	r.scope().base.Unlock()
+
+	// Create unreferenced scope, with unreferenced child, but with a reporter
+	// leaf.
+	GetHealthReporter(GetSubScope(GetSubScope(r, "orphan2"), "orphan3"), "bar").OK("")
+	r.scope().base.Lock()
+	assert.Contains(r.scope().base.nodes, "5-orphan2")
+	assert.Contains(r.scope().base.nodes, "6-orphan3")
+	r.scope().base.Unlock()
+
+	// Force GC.
+	runtime.GC()
+
+	r.scope().base.Lock()
+	assert.NotContains(r.scope().base.nodes, "2-this-one-should-be-gone", "should have been removed")
+	assert.Contains(r.scope().base.nodes, "4-foo2", "")
+
+	assert.Contains(r.scope().base.nodes, "5-orphan2")
+	assert.Contains(r.scope().base.nodes, "6-orphan3")
+	r.scope().base.Unlock()
+
+	GetHealthReporter(s2, "bar").OK("")
+	assertOK()
+}
+
+func TestDuplicateReporters(t *testing.T) {
+	assert := assert.New(t)
+	hr, assertOK, _, _ := createMockReporter(assert)
+	s, done := createRoot(hr)
+	defer done()
+
+	fooScope := GetSubScope(s, "foo")
+	for i := 0; i < 10; i++ {
+		GetHealthReporter(fooScope, "test").OK("")
+	}
+	assertOK()
+	base := fooScope.(*scope).base
+	assert.Len(base.nodes, 3, "should have root, foo and just one test")
+	assert.Len(base.idToChildren[base.rootID], 1, "root should have only one (foo)")
+	GetHealthReporter(fooScope, "test2").OK("")
+	assert.Len(base.nodes, 4, "should have root, foo, test, test2")
+}
+
+func BenchmarkStructuredReporter(b *testing.B) {
+	wg := &sync.WaitGroup{}
+	hr, _, _, _ := createMockReporter(nil)
+	s, done := createRoot(hr)
+	defer done()
+	ctx, cancel := context.WithCancel(context.Background())
+	// 10^6 reporters
+	recurse(ctx, 4, 10, s, wg)
+	wg.Wait()
+	cancel()
+}
+
+var count atomic.Uint32
+
+func recurse(ctx context.Context, d, factor int, s Scope, wg *sync.WaitGroup) {
+	type frame struct {
+		d, factor int
+		s         Scope
+	}
+	stack := []frame{
+		{
+			d:      d,
+			factor: factor,
+			s:      s,
+		},
+	}
+	for len(stack) != 0 {
+		s := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if s.d == 0 {
+			wg.Add(1)
+			go func() {
+				defer func() {
+					wg.Done()
+				}()
+				hr := GetHealthReporter(s.s, "foo")
+				fmt.Println("Starting:", count.Add(1))
+				for i := 0; i < 100; i++ {
+					select {
+					case <-ctx.Done():
+						return
+					default:
+						hr.OK("yay")
+					}
+				}
+			}()
+			continue
+		} else {
+			for i := 0; i < s.factor; i++ {
+				stack = append(stack, frame{
+					d:      s.d - 1,
+					factor: s.factor,
+					s:      s.s,
+				})
+			}
+		}
+	}
+}
+
+type mockReporter struct {
+	ok, degraded, stopped func(string)
+}
+
+func (s *mockReporter) OK(message string) {
+	if s.ok != nil {
+		s.ok(message)
+	}
+}
+
+func (s *mockReporter) Degraded(message string, err error) {
+	if s.degraded != nil {
+		s.degraded(message)
+	}
+}
+
+func (s *mockReporter) Stopped(message string) {
+	if s.stopped != nil {
+		s.stopped(message)
+	}
+}

--- a/pkg/hive/lifecycle.go
+++ b/pkg/hive/lifecycle.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cilium/cilium/pkg/hive/cell/lifecycle"
 	"github.com/cilium/cilium/pkg/hive/internal"
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -17,7 +18,7 @@ import (
 // in case of timeout. Hooks that perform long blocking operations directly
 // in the start or stop function (e.g. connecting to external services to
 // initialize) must abort any such operation if this context is cancelled.
-type HookContext context.Context
+type HookContext lifecycle.HookContext
 
 // Hook is a pair of start and stop callbacks. Both are optional.
 // They're paired up to make sure that on failed start all corresponding

--- a/pkg/k8s/watchers/endpointsynchronizer.go
+++ b/pkg/k8s/watchers/endpointsynchronizer.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/client"
@@ -48,7 +49,7 @@ type EndpointSynchronizer struct {
 // has 1 controller that updates it, and a local copy is retained and only
 // updates are pushed up.
 // CiliumEndpoint objects have the same name as the pod they represent.
-func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration) {
+func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr cell.HealthReporter) {
 	var (
 		endpointID     = e.ID
 		controllerName = endpoint.EndpointSyncControllerName(endpointID)
@@ -59,11 +60,13 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 	)
 
 	if option.Config.DisableCiliumEndpointCRD {
+		hr.Stopped("ciliumendpoint CRD disabled")
 		scopedLog.Debug("Not running controller. CEP CRD synchronization is disabled")
 		return
 	}
 
 	if !epSync.Clientset.IsEnabled() {
+		hr.Stopped("k8s client-set disabled")
 		scopedLog.Debug("Not starting controller because k8s is disabled")
 		return
 	}
@@ -73,6 +76,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 	// The health endpoint doesn't really exist in k8s and updates to it caused
 	// arbitrary errors. Disable the controller for these endpoints.
 	if isHealthEP := e.HasLabels(pkgLabels.LabelHealth); isHealthEP {
+		hr.Stopped("cilium health has no cep k8s sync")
 		scopedLog.Debug("Not starting unnecessary CEP controller for cilium-health endpoint")
 		return
 	}
@@ -81,6 +85,7 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 	// They should always be available if an endpoint belongs to a pod.
 	cepName := e.GetK8sCEPName()
 	if cepName == "" {
+		hr.Stopped("cilium health has no cep k8s sync")
 		scopedLog.Debug("Skipping CiliumEndpoint update because it has no k8s cep name")
 		return
 	}
@@ -95,8 +100,9 @@ func (epSync *EndpointSynchronizer) RunK8sCiliumEndpointSync(e *endpoint.Endpoin
 	// NOTE: The controller functions do NOT hold the endpoint locks
 	e.UpdateController(controllerName,
 		controller.ControllerParams{
-			Group:       ciliumEndpointToK8sSyncControllerGroup,
-			RunInterval: 10 * time.Second,
+			Group:          ciliumEndpointToK8sSyncControllerGroup,
+			RunInterval:    10 * time.Second,
+			HealthReporter: hr,
 			DoFunc: func(ctx context.Context) (err error) {
 				// Update logger as scopeLog might not have the podName when it
 				// was created.

--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -65,8 +65,8 @@ type NodeManager interface {
 	StartNeighborRefresh(nh datapath.NodeNeighbors)
 }
 
-func newAllNodeManager(lc hive.Lifecycle, ipCache *ipcache.IPCache, nodeMetrics *nodeMetrics, healthReporter cell.HealthReporter) (NodeManager, error) {
-	mngr, err := New(option.Config, ipCache, nodeMetrics, healthReporter)
+func newAllNodeManager(lc hive.Lifecycle, ipCache *ipcache.IPCache, nodeMetrics *nodeMetrics, healthScope cell.Scope) (NodeManager, error) {
+	mngr, err := New(option.Config, ipCache, nodeMetrics, healthScope)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -870,11 +870,11 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 	go func() {
 		<-nh1.NodeValidateImplementationEvent
 		s := <-hr.Wait()
-		assert.Error(s.Err)
+		assert.Equal(s.Event, "Degraded")
 		nh1.NodeValidateImplementationEventError = nil
 		<-nh1.NodeValidateImplementationEvent
 		s = <-hr.Wait()
-		assert.NoError(s.Err)
+		assert.Equal(s.Event, "OK")
 		close(done)
 	}()
 	// Start the manager

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/datapath/fake"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/hive/hivetest"
 	"github.com/cilium/cilium/pkg/inctimer"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -207,7 +208,7 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)
 
@@ -279,7 +280,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -361,7 +362,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -382,7 +383,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -414,7 +415,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	mngr.Subscribe(signalNodeHandler)
 	c.Assert(err, check.IsNil)
 	defer mngr.Stop(context.TODO())
@@ -458,7 +459,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 func (s *managerTestSuite) TestIpcache(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -506,7 +507,7 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -582,7 +583,7 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{RemoteNodeIdentity: true}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{RemoteNodeIdentity: true}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -658,7 +659,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -753,7 +754,7 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), &hivetest.MockHealthReporter{})
+	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope(&hivetest.MockHealthReporter{}))
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -849,7 +850,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 
 	baseBackgroundSyncInterval = 1 * time.Millisecond
 	hr := hivetest.NewMockHealthReporter()
-	m, err := New(&configMock{}, newIPcacheMock(), NewNodeMetrics(), hr)
+	m, err := New(&configMock{}, newIPcacheMock(), NewNodeMetrics(), cell.TestScope(hr))
 	assert.NoError(err)
 
 	m.nodes[nodeTypes.Identity{


### PR DESCRIPTION
Adds "structured health reporter" which builds on top of existing cell.HealthReporter type. 

The intention is to provide a mechanism to do health status reporting on more complex modules, namely ones with many sub-components that all need to be health checked as well. 

Subsequent commits in this pull request use the structured reporter to create health status reporting for the endpointmanager module to provide better visibility into the runtime status of endpointmanager/endpoints in a Cilium Agent.

The structured health reporter uses a tree structured to aggregate sub-reporters up to a top level report, which is ultimately passed to the "module" scoped health reporter to declare the status of the module component.

This PR adds the structured health reporter, and in subsequent commits implements structured health reporting on the endpointmanager module to provide better insight in the system health of Endpoints/EndpointManager.

```
> cilium status --verbose

  ...
Modules Health:
  Module             Status    Message                  Last Updated
  daemon             Unknown   No status reported yet            n/a
  endpoint-manager   OK                  9s
  
   cilium-endpoint-1058
    cep-k8s-sync        OK sync-to-k8s-ciliumendpoint (1058) 3m10.022180274s ago (x20)
    datapath-regenerate OK Endpoint regeneration successful  3m10.016021308s ago (x2)
    policy map sync     OK sync-policymap-1058               3m6.639716331s ago  (x5)
   cilium-endpoint-1488
    cep-k8s-sync        OK sync-to-k8s-ciliumendpoint (1488) 3m10.022419627s ago (x20)
    datapath-regenerate OK Endpoint regeneration successful  3m10.014718641s ago (x2)
    policy map sync     OK sync-policymap-1488               3m6.633931551s ago  (x5)
   cilium-endpoint-1704
    cep-k8s-sync        OK sync-to-k8s-ciliumendpoint (1704) 3m10.022513188s ago (x20)
    datapath-regenerate OK Endpoint regeneration successful  3m10.014787702s ago (x2)
    policy map sync     OK sync-policymap-1704               3m6.632632525s ago  (x5)
   cilium-endpoint-2366
    cep-k8s-sync        OK sync-to-k8s-ciliumendpoint (2366) 3m10.023392989s ago (x20)
    datapath-regenerate OK Endpoint regeneration successful  3m10.021365103s ago (x1)
...
```

Follow up work:
* Add metrics