### PR TITLE
[v1.14] bpf: EgressGW-related tracing improvements

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2682,8 +2682,10 @@ static __always_inline int rev_nodeport_lb4(struct __ctx_buff *ctx, __s8 *ext_er
 	 * any reply traffic for a remote pod into the tunnel (to avoid iptables
 	 * potentially dropping the packets).
 	 */
-	if (egress_gw_reply_needs_redirect(ip4, &tunnel_endpoint, &dst_sec_identity))
+	if (egress_gw_reply_needs_redirect(ip4, &tunnel_endpoint, &dst_sec_identity)) {
+		reason = TRACE_REASON_CT_REPLY;
 		goto redirect;
+	}
 #endif /* ENABLE_EGRESS_GATEWAY */
 
 	if (!check_revdnat)

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -189,8 +189,7 @@ int test_nat4_icmp_error_tcp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -299,8 +298,7 @@ int test_nat4_icmp_error_udp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -408,8 +406,7 @@ int test_nat4_icmp_error_icmp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -506,8 +503,7 @@ int test_nat4_icmp_error_sctp(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -568,8 +564,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -678,8 +673,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -787,8 +781,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling
@@ -885,8 +878,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	struct ipv4_nat_entry state;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
-				  snat_v4_needs_ct(&tuple, &target),
-				  NULL);
+				  false, NULL);
 	assert(ret == 0);
 
 	/* This is the entry-point of the test, calling

--- a/bpf/tests/bpf_nat_tests.c
+++ b/bpf/tests/bpf_nat_tests.c
@@ -562,6 +562,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 		.max_port = NODEPORT_PORT_MIN_NAT,
 	};
 	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -570,7 +571,7 @@ int test_nat4_icmp_error_tcp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	ret = snat_v4_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -671,6 +672,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	    .max_port = NODEPORT_PORT_MIN_NAT,
 	};
 	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -679,7 +681,7 @@ int test_nat4_icmp_error_udp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	ret = snat_v4_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -779,6 +781,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	    .max_port = NODEPORT_PORT_MIN_NAT,
 	};
 	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -787,7 +790,7 @@ int test_nat4_icmp_error_icmp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	ret = snat_v4_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;
@@ -876,6 +879,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	    .max_port = NODEPORT_PORT_MIN_NAT,
 	};
 	struct ipv4_nat_entry state;
+	struct trace_ctx trace;
 
 	ret = snat_v4_new_mapping(ctx, &tuple, &state, &target,
 				  false, NULL);
@@ -884,7 +888,7 @@ int test_nat4_icmp_error_sctp_egress(__maybe_unused struct __ctx_buff *ctx)
 	/* This is the entry-point of the test, calling
 	 * snat_v4_nat().
 	 */
-	ret = snat_v4_nat(ctx, &target, NULL);
+	ret = snat_v4_nat(ctx, &target, &trace, NULL);
 	assert(ret == 0);
 
 	__u16 proto;


### PR DESCRIPTION
Manual backport (due to complexity troubles and smaller contextual conflicts) of

* [ ] https://github.com/cilium/cilium/pull/27079
* [ ] https://github.com/cilium/cilium/pull/27178
* [ ] https://github.com/cilium/cilium/pull/27218


Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27079 27178 27218; do contrib/backporting/set-labels.py $pr done 1.14; done
```
or with
```
make add-labels BRANCH=v1.14 ISSUES=27079,27178,27218
```