### PR TITLE
add metrics for CT_SERVICE in conntrack

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -292,7 +292,7 @@ __ct_lookup(const void *map, struct __ctx_buff *ctx, const void *tuple,
 		if (dir == CT_INGRESS) {
 			__sync_fetch_and_add(&entry->rx_packets, 1);
 			__sync_fetch_and_add(&entry->rx_bytes, ctx_full_len(ctx));
-		} else if (dir == CT_EGRESS) {
+		} else if (dir == CT_EGRESS || dir == CT_SERVICE) {
 			__sync_fetch_and_add(&entry->tx_packets, 1);
 			__sync_fetch_and_add(&entry->tx_bytes, ctx_full_len(ctx));
 		}
@@ -932,13 +932,15 @@ static __always_inline int ct_create6(const void *map_main, const void *map_rela
 	seen_flags.value |= is_tcp ? TCP_FLAG_SYN : 0;
 	ct_update_timeout(&entry, is_tcp, dir, seen_flags);
 
+#ifdef CONNTRACK_ACCOUNTING
 	if (dir == CT_INGRESS) {
 		entry.rx_packets = 1;
 		entry.rx_bytes = ctx_full_len(ctx);
-	} else if (dir == CT_EGRESS) {
+	} else if (dir == CT_EGRESS || dir == CT_SERVICE) {
 		entry.tx_packets = 1;
 		entry.tx_bytes = ctx_full_len(ctx);
 	}
+#endif
 
 	cilium_dbg3(ctx, DBG_CT_CREATED6, entry.rev_nat_index, ct_state->src_sec_id, 0);
 
@@ -1009,13 +1011,15 @@ static __always_inline int ct_create4(const void *map_main,
 	seen_flags.value |= is_tcp ? TCP_FLAG_SYN : 0;
 	ct_update_timeout(&entry, is_tcp, dir, seen_flags);
 
+#ifdef CONNTRACK_ACCOUNTING
 	if (dir == CT_INGRESS) {
 		entry.rx_packets = 1;
 		entry.rx_bytes = ctx_full_len(ctx);
-	} else if (dir == CT_EGRESS) {
+	} else if (dir == CT_EGRESS || dir == CT_SERVICE) {
 		entry.tx_packets = 1;
 		entry.tx_bytes = ctx_full_len(ctx);
 	}
+#endif
 
 	cilium_dbg3(ctx, DBG_CT_CREATED4, entry.rev_nat_index,
 		    ct_state->src_sec_id, 0);

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1315,7 +1315,7 @@ func initEnv(vp *viper.Viper) {
 	option.Config.Opts.SetBool(option.TraceNotify, true)
 	option.Config.Opts.SetBool(option.PolicyVerdictNotify, true)
 	option.Config.Opts.SetBool(option.PolicyTracing, option.Config.EnableTracing)
-	option.Config.Opts.SetBool(option.ConntrackAccounting, true)
+	option.Config.Opts.SetBool(option.ConntrackAccounting, false)
 	option.Config.Opts.SetBool(option.ConntrackLocal, false)
 	option.Config.Opts.SetBool(option.PolicyAuditMode, option.Config.PolicyAuditMode)
 	option.Config.Opts.SetBool(option.SourceIPVerification, true)

--- a/test/k8s/service_helpers.go
+++ b/test/k8s/service_helpers.go
@@ -272,6 +272,12 @@ func doFragmentedRequest(kubectl *helpers.Kubectl, srcPod string, srcPort, dstPo
 	ciliumPodK8s2, err := kubectl.GetCiliumPodOnNode(helpers.K8s2)
 	ExpectWithOffset(2, err).Should(BeNil(), "Cannot get cilium pod on k8s2")
 
+	res := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, "cilium config  get ConntrackAccounting")
+	res.ExpectContains("Enabled")
+
+	res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s2, "cilium config  get ConntrackAccounting")
+	res.ExpectContains("Enabled")
+
 	_, dstPodIPK8s1 := kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s1, testDS, 1)
 	_, dstPodIPK8s2 := kubectl.GetPodOnNodeLabeledWithOffset(helpers.K8s2, testDS, 1)
 
@@ -287,7 +293,7 @@ func doFragmentedRequest(kubectl *helpers.Kubectl, srcPod string, srcPort, dstPo
 	endpointK8s1 := net.JoinHostPort(dstPodIPK8s1, fmt.Sprintf("%d", dstPodPort))
 	patternInK8s1 := fmt.Sprintf("UDP IN [^:]+:%d -> %s", srcPort, endpointK8s1)
 	cmdInK8s1 := fmt.Sprintf(cmdIn, patternInK8s1)
-	res := kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, cmdInK8s1)
+	res = kubectl.CiliumExecMustSucceed(context.TODO(), ciliumPodK8s1, cmdInK8s1)
 	countInK8s1, _ := strconv.Atoi(strings.TrimSpace(res.Stdout()))
 
 	endpointK8s2 := net.JoinHostPort(dstPodIPK8s2, fmt.Sprintf("%d", dstPodPort))

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -629,7 +629,12 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 				options["gke.enabled"] = "false"
 				options["routingMode"] = "native"
 			}
+
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, options)
+
+			cmd := fmt.Sprintf("cilium config %s=%s", helpers.OptionConntrackAccounting, helpers.OptionEnabled)
+			kubectl.CiliumExecMustSucceedOnAll(context.TODO(), cmd, "Unable to enable ConntrackAccounting option")
+			kubectl.CiliumPreFlightCheck()
 			testIPv4FragmentSupport(kubectl, ni)
 		})
 


### PR DESCRIPTION
Add metrics for dir=CT_SERVICE

Fixes: [#27452](https://github.com/cilium/cilium/issues/27452)

```release-note
Add metrics count for dir=CT_SERVICE and disable conntrack metrics by default
```
