### PR TITLE
bpf: dsr: don't track ifindex of ingress interface

### DIFF
--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -791,7 +791,6 @@ create_ct:
 
 		ct_state_new.src_sec_id = WORLD_ID;
 		ct_state_new.dsr = 1;
-		ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 		ret = ct_create6(get_ct_map6(tuple), NULL, tuple, ctx,
 				 CT_EGRESS, &ct_state_new, false, false, ext_err);
 		if (!IS_ERR(ret))
@@ -2263,7 +2262,6 @@ create_ct:
 
 		ct_state_new.src_sec_id = WORLD_ID;
 		ct_state_new.dsr = 1;
-		ct_state_new.ifindex = (__u16)NATIVE_DEV_IFINDEX;
 		ret = ct_create4(get_ct_map4(tuple), NULL, tuple, ctx,
 				 CT_EGRESS, &ct_state_new, false, false, ext_err);
 		if (!IS_ERR(ret))


### PR DESCRIPTION
As part of handling inbound DSR-ed requests at the backend node, we create a CT entry. The relevant code originated from nodeport_lb*(), where we also set the CT entry's ifindex. There it is used by the LB to route replies by local / NAT backends back to the client via the ingress interface.

But for DSR it makes little sense to track the ingress interface at the backend. It's how the backend would reach the LB, not the client. And it's perfectly fine to route replies to the client through a different interface.

Remove this tracking for DSR connections. Note that it's currently unused, it was merely added to have fully populated CT entries in case the ifindex would have ever been needed.