### PR TITLE
plugins/cilium-cni: make error formatting consistent

### DIFF
--- a/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
+++ b/plugins/cilium-cni/chaining/generic-veth/generic-veth.go
@@ -109,7 +109,7 @@ func (f *GenericVethChainer) Add(ctx context.Context, pluginCtx chainingapi.Plug
 		}
 
 		if !linkFound {
-			return fmt.Errorf("no link found inside container")
+			return errors.New("no link found inside container")
 		}
 
 		if pluginCtx.NetConf.EnableRouteMTU {

--- a/plugins/cilium-cni/lib/deletion_queue.go
+++ b/plugins/cilium-cni/lib/deletion_queue.go
@@ -6,6 +6,7 @@ package lib
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -121,7 +122,7 @@ func (dc *DeletionFallbackClient) EndpointDelete(id string) error {
 		return dc.enqueueDeletionRequestLocked(id)
 	}
 
-	return fmt.Errorf("attempt to delete with no valid connection")
+	return errors.New("attempt to delete with no valid connection")
 }
 
 // EndpointDeleteMany deletes multiple endpoints based on the endpoint deletion request,
@@ -141,7 +142,7 @@ func (dc *DeletionFallbackClient) EndpointDeleteMany(req *models.EndpointBatchDe
 		return dc.enqueueDeletionRequestLocked(string(b))
 	}
 
-	return fmt.Errorf("attempt to delete with no valid connection")
+	return errors.New("attempt to delete with no valid connection")
 }
 
 // enqueueDeletionRequestLocked enqueues the encoded endpoint deletion request into the


### PR DESCRIPTION
Consistently use the `%w` verb in `fmt.Errorf` to return wrapped errors. While at it, also convert a few cases of inline string quoting to use the `%q` verb.

See https://pkg.go.dev/fmt#hdr-Printing for a description of the formatting verbs.

In a few cases, errors got created using `fmt.Errorf` but they don't have any formatting directives. Convert these to use `errors.New` to avoid needlessly parsing the error string.

Also consistenly use the term "Cilium agent" in error messages rather than a mixture of "cilium-agent", "Cilium daemon" and "Cilium agent".

Suggested by @christarazi