### PR TITLE
docs: Fix config option for spelling filters

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -172,7 +172,7 @@ todo_include_todos = False
 spelling_exclude_patterns = ['_api/v1/*/README.md']
 
 # Add custom filters for spell checks.
-spelling_filters = [cilium_spellfilters.WireGuardFilter]
+spelling_filters = ["cilium_spellfilters.WireGuardFilter"]
 
 # Ignore some warnings from MyST parser
 suppress_warnings = ['myst.header']


### PR DESCRIPTION
We've been using a custom spelling filter to make sure that "WireGuard" is spelled correctly, with the proper case. As it turns out, passing this filter to the Sphinx configuration, in the conf.py file, makes Sphinx re-read all sources and re-write all output files, as can be observed when running sphinx-build multiple times, without suppressing the output:

    $ sphinx-build -M html . _build
    [...]
    updating environment: [config changed ('spelling_filters')] 472 added, 30 changed, 0 removed
    [...]

This is because in conf.py, we pass the filter directly as a function. When Sphinx writes its environment.pickle file to keep track of the configuration in use, it discards values that cannot be serialised, including the filter, `<class 'cilium_spellfilters.WireGuardFilter'>`, of instance `type` ([ref][0]). So the value for the configuration option `spelling_filters` is not saved, and as Sphinx believes that the configuration has changed, it reads and rebuilds everything.

In fact, the issue has been reported before, and solved in the spellchecker ([ref][1]). We need to set the configuration with a string instead of the direct function object, and the extension is able to load it from there. Let's adjust accordingly, to save cycles when building the docs more than once.

[0]: https://github.com/sphinx-doc/sphinx/blob/v7.1.2/sphinx/config.py#L323
[1]: https://github.com/sphinx-contrib/spelling/pull/40
