### PR TITLE
add lint-go to merge queue check

### DIFF
--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - ft/main/**
+  # Add this workflow to be triggered by merge queue events
+  merge_group:
 
 permissions: read-all
 


### PR DESCRIPTION
To prevent breaking the main branch after merging two PRs that passed CI but conflicted which each other, we should enable merge queue which should prevent this from ever happening.

More info: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue