### PR TITLE
Make ci-ipsec-upgrade a part of /test

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -16,6 +16,7 @@ triggers:
     - integration-test.yaml
     - tests-datapath-verifier.yaml
     - tests-l4lb.yaml
+    - tests-ipsec-upgrade.yaml
   /ci-aks:
     workflows:
     - conformance-aks.yaml


### PR DESCRIPTION
As #27276 was fixed, it's time to make ci-ipsec-upgrade a part of /test.

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>
