### PR TITLE
codeowners: include sig-servicemesh into cilium envoy & spire helm

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -362,6 +362,8 @@ Makefile* @cilium/build
 /images/hubble-relay @cilium/sig-hubble
 /images/runtime/update-cilium-runtime-image.sh @cilium/github-sec
 /install/kubernetes/ @cilium/sig-k8s @cilium/helm
+/install/kubernetes/cilium/**/cilium-envoy @cilium/sig-k8s @cilium/helm @cilium/sig-servicemesh
+/install/kubernetes/cilium/**/spire @cilium/sig-k8s @cilium/helm @cilium/sig-servicemesh
 /install/kubernetes/cilium/templates/hubble* @cilium/sig-k8s @cilium/helm @cilium/sig-hubble
 /kvstoremesh @cilium/sig-clustermesh
 /LICENSE @cilium/tophat


### PR DESCRIPTION
This commit adds the team cilium/sig-servicemesh to the list of codeowners for helm chart changes specific to the cilium-envoy & cilium-spire deployments (whether in subdirectory `templates` or `files`).

Example PR: https://github.com/cilium/cilium/pull/27363#pullrequestreview-1580762044