### PR TITLE
cgroups: Fix race to load cgroup.hostRoot option

### DIFF
--- a/pkg/cgroups/manager/provider.go
+++ b/pkg/cgroups/manager/provider.go
@@ -14,7 +14,6 @@ import (
 )
 
 var (
-	cgroupRoot = cgroups.GetCgroupRoot()
 	// example default cgroup path in kubernetes environments
 	// /kubepods/burstable/pod1858680e-b044-4fd5-9dd4-f137e30e2180/e275d1a37782ab30008aa3ae6666cccefe53b3a14a2ab5a8dc459939107c8c0
 	defaultCgroupBasePath = "/kubepods"
@@ -164,7 +163,7 @@ func getSystemdContainerPathCommon(subPaths []string, podId string, containerId 
 }
 
 func validateCgroupPath(path string) (string, error) {
-	fullPath := cgroupRoot + path
+	fullPath := cgroups.GetCgroupRoot() + path
 
 	if _, err := fschecker.Stat(fullPath); err == nil {
 		return fullPath, nil

--- a/pkg/cgroups/manager/provider_test.go
+++ b/pkg/cgroups/manager/provider_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/cilium/checkmate"
 
+	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/checker"
 	v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 )
@@ -30,6 +31,7 @@ var (
 	fsMockSystemdNested = fsMock{
 		getFullPath(nestedSystemdCgroupBasePath): struct{}{},
 	}
+	cgroupRoot             = cgroups.GetCgroupRoot()
 	cDefaultPath           = cgroupRoot + "/kubepods/burstable/pod1858680e-b044-4fd5-9dd4-f137e30e2180/" + c1Id
 	cDefaultGuaranteedPath = cgroupRoot + "/kubepods/pod1858680e-b044-4fd5-9dd4-f137e30e2180/" + c1Id
 	cSystemdPath           = cgroupRoot + "/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod1858680e_b044_4fd5_9dd4_f137e30e2180.slice/" + "cri-containerd-" + c1Id + ".scope"


### PR DESCRIPTION
While loading, the package `pkg/cgroups/manager` sets the global variable `cgroupRoot` from the `pkg/cgroups` package.
This occurs before the configuration is fully loaded and the correct path is set in the `pkg/cgroups` package.

This variable is later used by the `validateCgroupPath` function.
As a result, the `validateCgroupPath` function always works with the default value instead of the user-defined one.


While using `--set cgroup.autoMount.enabled=false` and `--set cgroup.hostRoot=/sys/fs/cgroup` options, this might lead strange errors like:

```
level=info msg="  --cgroup-root='/sys/fs/cgroup'" subsys=daemon
level=info msg="Mounted cgroupv2 filesystem at /sys/fs/cgroup" subsys=cgroups
level=warning msg="No valid cgroup base path found: socket load-balancing tracing with Hubble will not work.See the kubeproxy-free guide for more details." subsys=cgroup-manager
```

And path `/sys/fs/cgroup/kubepods` correctly existing.

```release-note
cgroups: Fix race to load cgroup.hostRoot option
```
