### PR TITLE
Use Go 1.19 atomic types

### DIFF
--- a/pkg/bgp/speaker/events.go
+++ b/pkg/bgp/speaker/events.go
@@ -103,7 +103,7 @@ func (s *MetalLBSpeaker) run(ctx context.Context) {
 		// previous to this iteration, we processed an event
 		// which indicates the speaker should yield. shut
 		// it down.
-		if s.shutdown > 0 { // atomic load not necessary, we are the only writer.
+		if s.shutdown.Load() {
 			l.Info("speaker shutting down.")
 			return
 		}

--- a/pkg/bgp/speaker/pod_cidr.go
+++ b/pkg/bgp/speaker/pod_cidr.go
@@ -5,7 +5,6 @@ package speaker
 
 import (
 	"sync"
-	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 	metallbbgp "go.universe.tf/metallb/pkg/bgp"
@@ -63,7 +62,7 @@ func (s *MetalLBSpeaker) withdraw() {
 	)
 	// flip this bool so we start rejecting new events from
 	// entering the queue.
-	atomic.AddInt32(&s.shutdown, 1)
+	s.shutdown.Store(true)
 	var wg sync.WaitGroup // waitgroup here since we don't care about errors
 	for _, session := range s.speaker.PeerSessions() {
 		wg.Add(1)

--- a/pkg/bgp/speaker/speaker.go
+++ b/pkg/bgp/speaker/speaker.go
@@ -91,11 +91,11 @@ type MetalLBSpeaker struct {
 	// Speaker will shut itself down when this is 1,
 	// ensuring no other events are processed after the
 	// final withdraw of routes.
-	shutdown int32
+	shutdown atomic.Bool
 }
 
 func (s *MetalLBSpeaker) shutDown() bool {
-	return atomic.LoadInt32(&s.shutdown) > 0
+	return s.shutdown.Load()
 }
 
 // OnUpdateService notifies the Speaker of an update to a service.

--- a/pkg/bgp/speaker/speaker_test.go
+++ b/pkg/bgp/speaker/speaker_test.go
@@ -314,9 +314,9 @@ func TestSpeakerOnUpdateNode(t *testing.T) {
 	// MockSession.Set
 	// MockMetalLBSpeaker.SetNodeLabels
 	// MockMetalLBSpeaker.PeerSession
-	var callCount int32
+	var callCount atomic.Int32
 	go func() {
-		for atomic.LoadInt32(&callCount) != 3 {
+		for callCount.Load() != 3 {
 			// should be a very short spin if tests are
 			// passing.
 		}
@@ -332,7 +332,7 @@ func TestSpeakerOnUpdateNode(t *testing.T) {
 			rr.Lock()
 			rr.advs = advs
 			rr.Unlock()
-			atomic.AddInt32(&callCount, 1)
+			callCount.Add(1)
 			return nil
 		},
 	}
@@ -346,11 +346,11 @@ func TestSpeakerOnUpdateNode(t *testing.T) {
 			rr.Lock()
 			rr.labels = labels
 			rr.Unlock()
-			atomic.AddInt32(&callCount, 1)
+			callCount.Add(1)
 			return types.SyncStateSuccess
 		},
 		GetBGPController_: func() *metallbspr.BGPController {
-			atomic.AddInt32(&callCount, 1)
+			callCount.Add(1)
 			return &metallbspr.BGPController{
 				SvcAds: make(map[string][]*metallbbgp.Advertisement),
 				Peers: []*metallbspr.Peer{
@@ -424,9 +424,9 @@ func TestSpeakerOnDeleteNode(t *testing.T) {
 	// the 2 calls we expect:
 	// MockSession.Set
 	// MockMetalLBSpeaker.PeerSession
-	var callCount int32
+	var callCount atomic.Int32
 	go func() {
-		for atomic.LoadInt32(&callCount) != 2 {
+		for callCount.Load() != 2 {
 			// should be a very short spin if tests are
 			// passing.
 		}
@@ -442,7 +442,7 @@ func TestSpeakerOnDeleteNode(t *testing.T) {
 			rr.Lock()
 			rr.advs = advs
 			rr.Unlock()
-			atomic.AddInt32(&callCount, 1)
+			callCount.Add(1)
 			return nil
 		},
 	}
@@ -451,7 +451,7 @@ func TestSpeakerOnDeleteNode(t *testing.T) {
 	// will return our mock session.
 	mock := &mock.MockMetalLBSpeaker{
 		PeerSession_: func() []metallbspr.Session {
-			atomic.AddInt32(&callCount, 1)
+			callCount.Add(1)
 			return []metallbspr.Session{mockSession}
 		},
 		GetBGPController_: func() *metallbspr.BGPController {

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -35,7 +35,7 @@ func EnableMapPreAllocation() {
 // take effect in that case. Also note that this does not take effect on
 // existing map although could be recreated later when objCheck() runs.
 func DisableMapPreAllocation() {
-	atomic.StoreUint32(&preAllocateMapSetting, 1)
+	atomic.StoreUint32(&preAllocateMapSetting, BPF_F_NO_PREALLOC)
 }
 
 // GetPreAllocateMapFlags returns the map flags for map which use conditional

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -55,14 +55,14 @@ func (b *ControllerSuite) TestStopFunc(c *C) {
 }
 
 func (b *ControllerSuite) TestSelfExit(c *C) {
-	var iterations uint32
+	var iterations atomic.Uint32
 	waitChan := make(chan bool)
 
 	mngr := Manager{}
 	mngr.UpdateController("test", ControllerParams{
 		RunInterval: 100 * time.Millisecond,
 		DoFunc: func(ctx context.Context) error {
-			atomic.AddUint32(&iterations, 1)
+			iterations.Add(1)
 			return NewExitReason("test exit")
 		},
 		StopFunc: func(ctx context.Context) error {
@@ -75,7 +75,7 @@ func (b *ControllerSuite) TestSelfExit(c *C) {
 		c.Error("Controller exited")
 	case <-time.After(time.Second):
 	}
-	c.Assert(atomic.LoadUint32(&iterations), Equals, uint32(1))
+	c.Assert(iterations.Load(), Equals, uint32(1))
 
 	// The controller is inactive, and waiting for the next update or stop.
 	// A controller will only stop when explicitly removed and stopped.

--- a/pkg/envoy/xds/server.go
+++ b/pkg/envoy/xds/server.go
@@ -73,7 +73,7 @@ type Server struct {
 
 	// lastStreamID is the identifier of the last processed stream.
 	// It is incremented atomically when starting the handling of a new stream.
-	lastStreamID uint64
+	lastStreamID atomic.Uint64
 }
 
 // ResourceTypeConfiguration is the configuration of the XDS server for a
@@ -120,7 +120,7 @@ func getXDSRequestFields(req *envoy_service_discovery.DiscoveryRequest) logrus.F
 // HandleRequestStream receives and processes the requests from an xDS stream.
 func (s *Server) HandleRequestStream(ctx context.Context, stream Stream, defaultTypeURL string) error {
 	// increment stream count
-	streamID := atomic.AddUint64(&s.lastStreamID, 1)
+	streamID := s.lastStreamID.Add(1)
 
 	reqStreamLog := log.WithField(logfields.XDSStreamID, streamID)
 

--- a/pkg/eventqueue/eventqueue.go
+++ b/pkg/eventqueue/eventqueue.go
@@ -103,7 +103,7 @@ func (q *EventQueue) Enqueue(ev *Event) (<-chan interface{}, error) {
 	}
 
 	// Events can only be enqueued once.
-	if atomic.AddInt32(&ev.enqueued, 1) > 1 {
+	if !ev.enqueued.CompareAndSwap(false, true) {
 		return nil, fmt.Errorf("unable to Enqueue event; event has already had Enqueue called on it")
 	}
 
@@ -158,9 +158,8 @@ type Event struct {
 	// enqueued, dequeued, etc.
 	stats eventStatistics
 
-	// enqueued is an atomic boolean that specifies whether this event has
-	// been enqueued on an EventQueue.
-	enqueued int32
+	// enqueued specifies whether this event has been enqueued on an EventQueue.
+	enqueued atomic.Bool
 }
 
 type eventStatistics struct {

--- a/pkg/hubble/container/ring_test.go
+++ b/pkg/hubble/container/ring_test.go
@@ -384,11 +384,11 @@ func TestRing_Read(t *testing.T) {
 			r := &Ring{
 				mask:      tt.fields.mask,
 				data:      tt.fields.data,
-				write:     tt.fields.write,
 				dataLen:   uint64(len(tt.fields.data)),
 				cycleExp:  tt.fields.cycleExp,
 				cycleMask: ^uint64(0) >> tt.fields.cycleExp,
 			}
+			r.write.Store(tt.fields.write)
 			got, got1 := r.read(tt.args.read)
 			if tt.want.GetLostEvent() != nil {
 				assert.NotNil(t, got)
@@ -479,16 +479,16 @@ func TestRing_Write(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Ring{
-				mask:  tt.fields.len,
-				data:  tt.fields.data,
-				write: tt.fields.write,
+				mask: tt.fields.len,
+				data: tt.fields.data,
 			}
+			r.write.Store(tt.fields.write)
 			r.Write(tt.args.event)
 			want := &Ring{
-				mask:  tt.want.len,
-				data:  tt.want.data,
-				write: tt.want.write,
+				mask: tt.want.len,
+				data: tt.want.data,
 			}
+			want.write.Store(tt.want.write)
 			reflect.DeepEqual(want, r)
 		})
 	}
@@ -525,10 +525,10 @@ func TestRing_LastWriteParallel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Ring{
-				mask:  tt.fields.len,
-				data:  tt.fields.data,
-				write: tt.fields.write,
+				mask: tt.fields.len,
+				data: tt.fields.data,
 			}
+			r.write.Store(tt.fields.write)
 			if got := r.LastWriteParallel(); got != tt.want {
 				t.Errorf("Ring.LastWriteParallel() = %v, want %v", got, tt.want)
 			}
@@ -567,10 +567,10 @@ func TestRing_LastWrite(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Ring{
-				mask:  tt.fields.len,
-				data:  tt.fields.data,
-				write: tt.fields.write,
+				mask: tt.fields.len,
+				data: tt.fields.data,
 			}
+			r.write.Store(tt.fields.write)
 			if got := r.LastWrite(); got != tt.want {
 				t.Errorf("Ring.LastWrite() = %v, want %v", got, tt.want)
 			}

--- a/pkg/hubble/observer/local_observer.go
+++ b/pkg/hubble/observer/local_observer.go
@@ -61,7 +61,7 @@ type LocalObserverServer struct {
 	startTime time.Time
 
 	// numObservedFlows counts how many flows have been observed
-	numObservedFlows uint64
+	numObservedFlows atomic.Uint64
 
 	namespaceManager NamespaceManager
 }
@@ -159,7 +159,7 @@ nextEvent:
 				}
 			}
 
-			atomic.AddUint64(&s.numObservedFlows, 1)
+			s.numObservedFlows.Add(1)
 		}
 
 		for _, f := range s.opts.OnDecodedEvent {
@@ -214,7 +214,7 @@ func (s *LocalObserverServer) ServerStatus(
 		Version:   build.ServerVersion.String(),
 		MaxFlows:  s.GetRingBuffer().Cap(),
 		NumFlows:  s.GetRingBuffer().Len(),
-		SeenFlows: atomic.LoadUint64(&s.numObservedFlows),
+		SeenFlows: s.numObservedFlows.Load(),
 		UptimeNs:  uint64(time.Since(s.startTime).Nanoseconds()),
 	}, nil
 }

--- a/pkg/lock/stoppable_waitgroup_test.go
+++ b/pkg/lock/stoppable_waitgroup_test.go
@@ -20,22 +20,22 @@ func (s *SemaphoredMutexSuite) TestAdd(c *C) {
 	l := NewStoppableWaitGroup()
 
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(1))
+	c.Assert(l.i.Load(), Equals, int64(1))
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(2))
+	c.Assert(l.i.Load(), Equals, int64(2))
 	close(l.noopAdd)
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(2))
+	c.Assert(l.i.Load(), Equals, int64(2))
 }
 
 func (s *SemaphoredMutexSuite) TestDone(c *C) {
 	l := NewStoppableWaitGroup()
 
-	atomic.StoreInt64(l.i, 4)
+	l.i.Store(4)
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(3))
+	c.Assert(l.i.Load(), Equals, int64(3))
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(2))
+	c.Assert(l.i.Load(), Equals, int64(2))
 	close(l.noopAdd)
 	select {
 	case _, ok := <-l.noopDone:
@@ -45,7 +45,7 @@ func (s *SemaphoredMutexSuite) TestDone(c *C) {
 	}
 
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(1))
+	c.Assert(l.i.Load(), Equals, int64(1))
 	select {
 	case _, ok := <-l.noopDone:
 		// channel should not have been closed
@@ -54,7 +54,7 @@ func (s *SemaphoredMutexSuite) TestDone(c *C) {
 	}
 
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(0))
+	c.Assert(l.i.Load(), Equals, int64(0))
 	select {
 	case _, ok := <-l.noopDone:
 		c.Assert(ok, Equals, false)
@@ -64,19 +64,19 @@ func (s *SemaphoredMutexSuite) TestDone(c *C) {
 	}
 
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(0))
+	c.Assert(l.i.Load(), Equals, int64(0))
 }
 
 func (s *SemaphoredMutexSuite) TestStop(c *C) {
 	l := NewStoppableWaitGroup()
 
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(1))
+	c.Assert(l.i.Load(), Equals, int64(1))
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(2))
+	c.Assert(l.i.Load(), Equals, int64(2))
 	l.Stop()
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(2))
+	c.Assert(l.i.Load(), Equals, int64(2))
 }
 
 func (s *SemaphoredMutexSuite) TestWait(c *C) {
@@ -89,15 +89,15 @@ func (s *SemaphoredMutexSuite) TestWait(c *C) {
 	}()
 
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(1))
+	c.Assert(l.i.Load(), Equals, int64(1))
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(2))
+	c.Assert(l.i.Load(), Equals, int64(2))
 	l.Stop()
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(2))
+	c.Assert(l.i.Load(), Equals, int64(2))
 
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(1))
+	c.Assert(l.i.Load(), Equals, int64(1))
 	select {
 	case _, ok := <-waitClosed:
 		// channel should not have been closed
@@ -106,7 +106,7 @@ func (s *SemaphoredMutexSuite) TestWait(c *C) {
 	}
 
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(0))
+	c.Assert(l.i.Load(), Equals, int64(0))
 	select {
 	case _, ok := <-waitClosed:
 		// channel should have been closed
@@ -115,22 +115,22 @@ func (s *SemaphoredMutexSuite) TestWait(c *C) {
 	}
 
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(0))
+	c.Assert(l.i.Load(), Equals, int64(0))
 }
 
 func (s *SemaphoredMutexSuite) TestWaitChannel(c *C) {
 	l := NewStoppableWaitGroup()
 
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(1))
+	c.Assert(l.i.Load(), Equals, int64(1))
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(2))
+	c.Assert(l.i.Load(), Equals, int64(2))
 	l.Stop()
 	l.Add()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(2))
+	c.Assert(l.i.Load(), Equals, int64(2))
 
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(1))
+	c.Assert(l.i.Load(), Equals, int64(1))
 	select {
 	case _, ok := <-l.WaitChannel():
 		// channel should not have been closed
@@ -139,7 +139,7 @@ func (s *SemaphoredMutexSuite) TestWaitChannel(c *C) {
 	}
 
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(0))
+	c.Assert(l.i.Load(), Equals, int64(0))
 	select {
 	case _, ok := <-l.WaitChannel():
 		// channel should have been closed
@@ -148,7 +148,7 @@ func (s *SemaphoredMutexSuite) TestWaitChannel(c *C) {
 	}
 
 	l.Done()
-	c.Assert(atomic.LoadInt64(l.i), Equals, int64(0))
+	c.Assert(l.i.Load(), Equals, int64(0))
 }
 
 func (s *SemaphoredMutexSuite) TestParallelism(c *C) {
@@ -170,7 +170,7 @@ func (s *SemaphoredMutexSuite) TestParallelism(c *C) {
 			}
 		}
 	}()
-	adds := int64(0)
+	var adds atomic.Int64
 	var wg sync.WaitGroup
 	wg.Add(10)
 	for i := 0; i < 10; i++ {
@@ -178,11 +178,11 @@ func (s *SemaphoredMutexSuite) TestParallelism(c *C) {
 			defer wg.Done()
 			for a := range in {
 				if a == 0 {
-					atomic.AddInt64(&adds, 1)
+					adds.Add(1)
 					l.Add()
 				} else {
 					l.Done()
-					atomic.AddInt64(&adds, -1)
+					adds.Add(-1)
 				}
 			}
 		}()
@@ -191,15 +191,14 @@ func (s *SemaphoredMutexSuite) TestParallelism(c *C) {
 	time.Sleep(time.Duration(rand.Intn(3-0)) * time.Second)
 	close(stop)
 	wg.Wait()
-	add := atomic.LoadInt64(&adds)
-	for ; add != 0; add = atomic.LoadInt64(&adds) {
+	for add := adds.Load(); add != 0; add = adds.Load() {
 		switch {
 		case add < 0:
-			atomic.AddInt64(&adds, 1)
+			adds.Add(1)
 			l.Add()
 		case add > 0:
 			l.Done()
-			atomic.AddInt64(&adds, -1)
+			adds.Add(-1)
 		}
 	}
 	l.Stop()

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -83,7 +83,7 @@ func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
 
 func (s *DistilleryTestSuite) TestCachePopulation(c *C) {
 	repo := NewPolicyRepository(nil, nil, nil, nil)
-	repo.revision = 42
+	repo.revision.Store(42)
 	cache := repo.policyCache
 
 	identity1 := ep1.GetSecurityIdentity()

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -47,7 +47,7 @@ func (s *StatusTestSuite) Config() (c Config) {
 }
 
 func (s *StatusTestSuite) TestVariableProbeInterval(c *C) {
-	var runs, ok uint64
+	var runs, ok atomic.Uint64
 
 	p := []Probe{
 		{
@@ -62,8 +62,7 @@ func (s *StatusTestSuite) TestVariableProbeInterval(c *C) {
 			},
 			Probe: func(ctx context.Context) (interface{}, error) {
 				// Let 5 runs fail and then succeed
-				atomic.AddUint64(&runs, 1)
-				if atomic.LoadUint64(&runs) < 5 {
+				if runs.Add(1) < 5 {
 					return nil, fmt.Errorf("still failing")
 				}
 
@@ -71,7 +70,7 @@ func (s *StatusTestSuite) TestVariableProbeInterval(c *C) {
 			},
 			OnStatusUpdate: func(status Status) {
 				if status.Data == nil && status.Err == nil {
-					atomic.AddUint64(&ok, 1)
+					ok.Add(1)
 				}
 			},
 		},
@@ -83,12 +82,12 @@ func (s *StatusTestSuite) TestVariableProbeInterval(c *C) {
 	// wait for 5 probe intervals to occur with 1 millisecond interval
 	// until we reach success
 	c.Assert(testutils.WaitUntil(func() bool {
-		return atomic.LoadUint64(&ok) >= 1
+		return ok.Load() >= 1
 	}, 1*time.Second), IsNil)
 }
 
 func (s *StatusTestSuite) TestCollectorFailureTimeout(c *C) {
-	var ok uint64
+	var ok atomic.Uint64
 
 	p := []Probe{
 		{
@@ -101,7 +100,7 @@ func (s *StatusTestSuite) TestCollectorFailureTimeout(c *C) {
 					if strings.Contains(status.Err.Error(),
 						fmt.Sprintf("within %v seconds", s.Config().FailureThreshold.Seconds())) {
 
-						atomic.AddUint64(&ok, 1)
+						ok.Add(1)
 					}
 				}
 			},
@@ -113,30 +112,30 @@ func (s *StatusTestSuite) TestCollectorFailureTimeout(c *C) {
 
 	// wait for the failure timeout to kick in
 	c.Assert(testutils.WaitUntil(func() bool {
-		return atomic.LoadUint64(&ok) >= 1
+		return ok.Load() >= 1
 	}, 1*time.Second), IsNil)
 	c.Assert(collector.GetStaleProbes(), HasLen, 1)
 }
 
 func (s *StatusTestSuite) TestCollectorSuccess(c *C) {
-	var ok, errs uint64
+	var ok, errs atomic.Uint64
 	err := fmt.Errorf("error")
 
 	p := []Probe{
 		{
 			Probe: func(ctx context.Context) (interface{}, error) {
-				if atomic.LoadUint64(&ok) > 3 {
+				if ok.Load() > 3 {
 					return nil, err
 				}
 				return "testData", nil
 			},
 			OnStatusUpdate: func(status Status) {
 				if !errors.Is(status.Err, err) {
-					atomic.AddUint64(&errs, 1)
+					errs.Add(1)
 				}
 				if !status.StaleWarning && status.Data != nil && status.Err == nil {
 					if s, isString := status.Data.(string); isString && s == "testData" {
-						atomic.AddUint64(&ok, 1)
+						ok.Add(1)
 					}
 				}
 			},
@@ -148,27 +147,27 @@ func (s *StatusTestSuite) TestCollectorSuccess(c *C) {
 
 	// wait for the probe to succeed 3 times and to return the error 3 times
 	c.Assert(testutils.WaitUntil(func() bool {
-		return atomic.LoadUint64(&ok) >= 3 && atomic.LoadUint64(&errs) >= 3
+		return ok.Load() >= 3 && errs.Load() >= 3
 	}, 1*time.Second), IsNil)
 	c.Assert(collector.GetStaleProbes(), HasLen, 0)
 }
 
 func (s *StatusTestSuite) TestCollectorSuccessAfterTimeout(c *C) {
-	var ok, timeout uint64
+	var ok, timeout atomic.Uint64
 
 	p := []Probe{
 		{
 			Probe: func(ctx context.Context) (interface{}, error) {
-				if atomic.LoadUint64(&timeout) == 0 {
+				if timeout.Load() == 0 {
 					time.Sleep(2 * s.Config().FailureThreshold)
 				}
 				return nil, nil
 			},
 			OnStatusUpdate: func(status Status) {
 				if status.StaleWarning {
-					atomic.AddUint64(&timeout, 1)
+					timeout.Add(1)
 				} else {
-					atomic.AddUint64(&ok, 1)
+					ok.Add(1)
 				}
 
 			},
@@ -180,7 +179,7 @@ func (s *StatusTestSuite) TestCollectorSuccessAfterTimeout(c *C) {
 
 	// wait for the probe to timeout (warning and failure) and then to succeed
 	c.Assert(testutils.WaitUntil(func() bool {
-		return atomic.LoadUint64(&timeout) == 1 && atomic.LoadUint64(&ok) > 0
+		return timeout.Load() == 1 && ok.Load() > 0
 	}, 1*time.Second), IsNil)
 	c.Assert(collector.GetStaleProbes(), HasLen, 0)
 }

--- a/pkg/stream/sources_test.go
+++ b/pkg/stream/sources_test.go
@@ -30,7 +30,7 @@ func TestMulticast(t *testing.T) {
 	subErrs := make(chan error, numSubs)
 	defer close(subErrs)
 
-	numReady := int32(0)
+	var numReady atomic.Uint32
 
 	for i := 0; i < numSubs; i++ {
 		go func() {
@@ -43,7 +43,7 @@ func TestMulticast(t *testing.T) {
 				case item := <-items:
 					if item == 0 {
 						if !ready {
-							atomic.AddInt32(&numReady, 1)
+							numReady.Add(1)
 							ready = true
 						}
 					} else {
@@ -65,7 +65,7 @@ func TestMulticast(t *testing.T) {
 	connect(ctx)
 
 	// Synchronize with the subscriptions
-	for atomic.LoadInt32(&numReady) != int32(numSubs) {
+	for numReady.Load() != uint32(numSubs) {
 		in <- 0
 	}
 


### PR DESCRIPTION
These make working with atomically accessed variables type-safe and more ergonomic.

See https://go.dev/doc/go1.19#atomic_types and
https://pkg.go.dev/sync/atomic#pkg-types for details.