### PR TITLE
CI: Add conn-disrupt-test action for reuse

### DIFF
--- a/.github/actions/conn-disrupt-test/action.yaml
+++ b/.github/actions/conn-disrupt-test/action.yaml
@@ -1,0 +1,49 @@
+name: Cilium Conn Disrupt Test
+description: Setup and test cilium connectivity and connection disruption status after a caller-provided risky operation, such as upgrade or IPsec key rotation.
+
+inputs:
+  job-name:
+    required: true
+    type: string
+  operation-cmd:
+    required: true
+    type: string
+  extra-connectivity-test-flags:
+    required: false
+    type: string
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Conn Disrupt Test
+      uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
+      with:
+        provision: 'false'
+        cmd: |
+          cd /host/
+          # Create pods which establish long lived connections. It will be used by
+          # subsequent connectivity tests with --include-conn-disrupt-test to catch any
+          # interruption in such flows.
+          ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
+
+    - name: Operate Cilium
+      uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
+      with:
+        provision: 'false'
+        cmd: |
+          ${{ inputs.operation-cmd }}
+
+    - name: Perform Conn Disrupt Test
+      uses: cilium/little-vm-helper@0fcaa3fed17811fcd8b6f1b0dc1f24e5f4ff6b13 # v0.0.7
+      with:
+        provision: 'false'
+        cmd: |
+          cd /host/
+          ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
+            --include-conn-disrupt-test \
+            --flush-ct \
+            --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
+            --sysdump-output-filename "cilium-sysdump-${{ inputs.job-name }}-<ts>" \
+            --junit-file "cilium-junits/${{ inputs.job-name }}.xml" \
+            ${{ inputs.extra-connectivity-test-flags }} \
+            --junit-property github_job_step="Run conn disrupt tests (${{ inputs.job-name }})"


### PR DESCRIPTION
This commit makes conn-disrupt-test a github action, so upgrade test and IPsec key rotation test don't have to copy and paste everywhere.

The idea is to allow caller workflow to specify the commands to execute, then this action will follow the steps:
1. Run "cilium-cli connectivity test --conn-disrupt-test-setup";
2. Run whatever caller workflow passes: could be upgrade operation or IPsec key rotation;
3. Run "cilium-cli connectivity test --include-conn-disrupt-test";

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>