### PR TITLE
bgpv1: Consolidate reconciler-specific maps into generic ReconcilerMetadata

### DIFF
--- a/pkg/bgpv1/manager/instance.go
+++ b/pkg/bgpv1/manager/instance.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/resource"
 )
 
 // ServerWithConfig is a container for providing interface with underlying router implementation
@@ -30,17 +29,9 @@ type ServerWithConfig struct {
 	// configuration applied to it.
 	Config *v2alpha1api.CiliumBGPVirtualRouter
 
-	// Holds any announced PodCIDR routes.
-	PodCIDRAnnouncements []*types.Path
-
-	// Holds any announced pod ip pool CIDRs keyed by pool name of the backing CiliumPodIPPool.
-	PodIPPoolAnnouncements map[resource.Key][]*types.Path
-
-	// Holds any announced Service routes.
-	ServiceAnnouncements map[resource.Key][]*types.Path
-
-	// Holds routing policies configured by the policy reconciler.
-	RoutePolicies map[string]*types.RoutePolicy
+	// ReconcilerMetadata holds reconciler-specific metadata keyed by the reconciler name,
+	// opaque outside the respective reconciler.
+	ReconcilerMetadata map[string]any
 }
 
 // NewServerWithConfig will start an underlying BgpServer utilizing types.ServerParameters
@@ -58,11 +49,8 @@ func NewServerWithConfig(ctx context.Context, params types.ServerParameters) (*S
 	}
 
 	return &ServerWithConfig{
-		Server:                 s,
-		Config:                 nil,
-		PodCIDRAnnouncements:   []*types.Path{},
-		ServiceAnnouncements:   make(map[resource.Key][]*types.Path),
-		RoutePolicies:          make(map[string]*types.RoutePolicy),
-		PodIPPoolAnnouncements: make(map[resource.Key][]*types.Path),
+		Server:             s,
+		Config:             nil,
+		ReconcilerMetadata: make(map[string]any),
 	}, nil
 }

--- a/pkg/bgpv1/manager/reconcile.go
+++ b/pkg/bgpv1/manager/reconcile.go
@@ -36,6 +36,8 @@ type ReconcileParams struct {
 // ConfigReconciler is a interface for reconciling a particular aspect
 // of an old and new *v2alpha1api.CiliumBGPVirtualRouter
 type ConfigReconciler interface {
+	// Name returns the name of a reconciler.
+	Name() string
 	// Priority is used to determine the order in which reconcilers are called. Reconcilers are called from lowest to
 	// highest.
 	Priority() int
@@ -76,6 +78,10 @@ func NewPreflightReconciler() PreflightReconcilerOut {
 	return PreflightReconcilerOut{
 		Reconciler: &PreflightReconciler{},
 	}
+}
+
+func (r *PreflightReconciler) Name() string {
+	return "Preflight"
 }
 
 func (r *PreflightReconciler) Priority() int {
@@ -175,10 +181,7 @@ func (r *PreflightReconciler) Reconcile(ctx context.Context, p ReconcileParams) 
 	p.CurrentServer.Config = nil
 
 	// Clear the shadow state since any advertisements will be gone now that the server has been recreated.
-	p.CurrentServer.PodCIDRAnnouncements = nil
-	p.CurrentServer.PodIPPoolAnnouncements = make(map[resource.Key][]*types.Path)
-	p.CurrentServer.ServiceAnnouncements = make(map[resource.Key][]*types.Path)
-	p.CurrentServer.RoutePolicies = make(map[string]*types.RoutePolicy)
+	p.CurrentServer.ReconcilerMetadata = make(map[string]any)
 
 	return nil
 }
@@ -197,6 +200,10 @@ func NewNeighborReconciler() NeighborReconcilerOut {
 	return NeighborReconcilerOut{
 		Reconciler: &NeighborReconciler{},
 	}
+}
+
+func (r *NeighborReconciler) Name() string {
+	return "Neighbor"
 }
 
 // Priority of neighbor reconciler is higher than pod/service announcements.
@@ -334,10 +341,17 @@ type ExportPodCIDRReconcilerOut struct {
 // advertisement of the private Kubernetes PodCIDR block.
 type ExportPodCIDRReconciler struct{}
 
+// ExportPodCIDRReconcilerMetadata keeps a list of all advertised Paths
+type ExportPodCIDRReconcilerMetadata []*types.Path
+
 func NewExportPodCIDRReconciler() ExportPodCIDRReconcilerOut {
 	return ExportPodCIDRReconcilerOut{
 		Reconciler: &ExportPodCIDRReconciler{},
 	}
+}
+
+func (r *ExportPodCIDRReconciler) Name() string {
+	return "ExportPodCIDR"
 }
 
 func (r *ExportPodCIDRReconciler) Priority() int {
@@ -373,7 +387,7 @@ func (r *ExportPodCIDRReconciler) Reconcile(ctx context.Context, p ReconcilePara
 		sc:   p.CurrentServer,
 		newc: p.DesiredConfig,
 
-		currentAdvertisements: p.CurrentServer.PodCIDRAnnouncements,
+		currentAdvertisements: r.getMetadata(p.CurrentServer),
 		toAdvertise:           toAdvertise,
 	})
 
@@ -383,8 +397,19 @@ func (r *ExportPodCIDRReconciler) Reconcile(ctx context.Context, p ReconcilePara
 
 	// Update the server config's list of current advertisements only if the
 	// reconciliation logic didn't return any error
-	p.CurrentServer.PodCIDRAnnouncements = advertisements
+	r.storeMetadata(p.CurrentServer, advertisements)
 	return nil
+}
+
+func (r *ExportPodCIDRReconciler) getMetadata(sc *ServerWithConfig) ExportPodCIDRReconcilerMetadata {
+	if _, found := sc.ReconcilerMetadata[r.Name()]; !found {
+		sc.ReconcilerMetadata[r.Name()] = make(ExportPodCIDRReconcilerMetadata, 0)
+	}
+	return sc.ReconcilerMetadata[r.Name()].(ExportPodCIDRReconcilerMetadata)
+}
+
+func (r *ExportPodCIDRReconciler) storeMetadata(sc *ServerWithConfig, meta ExportPodCIDRReconcilerMetadata) {
+	sc.ReconcilerMetadata[r.Name()] = meta
 }
 
 type LBServiceReconcilerOut struct {
@@ -397,6 +422,9 @@ type LBServiceReconciler struct {
 	diffStore   DiffStore[*slim_corev1.Service]
 	epDiffStore DiffStore[*k8s.Endpoints]
 }
+
+// LBServiceReconcilerMetadata keeps a map of services to the respective advertised Paths
+type LBServiceReconcilerMetadata map[resource.Key][]*types.Path
 
 type localServices map[k8s.ServiceID]struct{}
 
@@ -411,6 +439,10 @@ func NewLBServiceReconciler(diffStore DiffStore[*slim_corev1.Service], epDiffSto
 			epDiffStore: epDiffStore,
 		},
 	}
+}
+
+func (r *LBServiceReconciler) Name() string {
+	return "LBService"
 }
 
 func (r *LBServiceReconciler) Priority() int {
@@ -447,6 +479,13 @@ func (r *LBServiceReconciler) Reconcile(ctx context.Context, p ReconcileParams) 
 	}
 
 	return nil
+}
+
+func (r *LBServiceReconciler) getMetadata(sc *ServerWithConfig) LBServiceReconcilerMetadata {
+	if _, found := sc.ReconcilerMetadata[r.Name()]; !found {
+		sc.ReconcilerMetadata[r.Name()] = make(LBServiceReconcilerMetadata)
+	}
+	return sc.ReconcilerMetadata[r.Name()].(LBServiceReconcilerMetadata)
 }
 
 func (r *LBServiceReconciler) resolveSvcFromEndpoints(eps *k8s.Endpoints) (*slim_corev1.Service, bool, error) {
@@ -505,7 +544,8 @@ func hasLocalEndpoints(svc *slim_corev1.Service, ls localServices) bool {
 // thus should be avoided if partial reconciliation is an option.
 func (r *LBServiceReconciler) fullReconciliation(ctx context.Context, sc *ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, ls localServices) error {
 	// Loop over all existing announcements, delete announcements for services which no longer exist
-	for svcKey := range sc.ServiceAnnouncements {
+	serviceAnnouncements := r.getMetadata(sc)
+	for svcKey := range serviceAnnouncements {
 		_, found, err := r.diffStore.GetByKey(svcKey)
 		if err != nil {
 			return fmt.Errorf("diffStore.GetByKey(); %w", err)
@@ -663,6 +703,7 @@ func (r *LBServiceReconciler) svcDesiredRoutes(newc *v2alpha1api.CiliumBGPVirtua
 // reconcileService gets the desired routes of a given service and makes sure that is what is being announced.
 // Adding missing announcements or withdrawing unwanted ones.
 func (r *LBServiceReconciler) reconcileService(ctx context.Context, sc *ServerWithConfig, newc *v2alpha1api.CiliumBGPVirtualRouter, svc *slim_corev1.Service, ls localServices) error {
+	serviceAnnouncements := r.getMetadata(sc)
 	svcKey := resource.NewKey(svc)
 
 	desiredCidrs, err := r.svcDesiredRoutes(newc, svc, ls)
@@ -672,7 +713,7 @@ func (r *LBServiceReconciler) reconcileService(ctx context.Context, sc *ServerWi
 
 	for _, desiredCidr := range desiredCidrs {
 		// If this route has already been announced, don't add it again
-		if slices.IndexFunc(sc.ServiceAnnouncements[svcKey], func(existing *types.Path) bool {
+		if slices.IndexFunc(serviceAnnouncements[svcKey], func(existing *types.Path) bool {
 			return desiredCidr.String() == existing.NLRI.String()
 		}) != -1 {
 			continue
@@ -685,12 +726,12 @@ func (r *LBServiceReconciler) reconcileService(ctx context.Context, sc *ServerWi
 		if err != nil {
 			return fmt.Errorf("failed to advertise service route %v: %w", desiredCidr, err)
 		}
-		sc.ServiceAnnouncements[svcKey] = append(sc.ServiceAnnouncements[svcKey], advertPathResp.Path)
+		serviceAnnouncements[svcKey] = append(serviceAnnouncements[svcKey], advertPathResp.Path)
 	}
 
 	// Loop over announcements in reverse order so we can delete entries without effecting iteration.
-	for i := len(sc.ServiceAnnouncements[svcKey]) - 1; i >= 0; i-- {
-		announcement := sc.ServiceAnnouncements[svcKey][i]
+	for i := len(serviceAnnouncements[svcKey]) - 1; i >= 0; i-- {
+		announcement := serviceAnnouncements[svcKey][i]
 		// If the announcement is within the list of desired routes, don't remove it
 		if slices.IndexFunc(desiredCidrs, func(existing netip.Prefix) bool {
 			return existing.String() == announcement.NLRI.String()
@@ -703,7 +744,7 @@ func (r *LBServiceReconciler) reconcileService(ctx context.Context, sc *ServerWi
 		}
 
 		// Delete announcement from slice
-		sc.ServiceAnnouncements[svcKey] = slices.Delete(sc.ServiceAnnouncements[svcKey], i, i+1)
+		serviceAnnouncements[svcKey] = slices.Delete(serviceAnnouncements[svcKey], i, i+1)
 	}
 
 	return nil
@@ -711,13 +752,14 @@ func (r *LBServiceReconciler) reconcileService(ctx context.Context, sc *ServerWi
 
 // withdrawService removes all announcements for the given service
 func (r *LBServiceReconciler) withdrawService(ctx context.Context, sc *ServerWithConfig, key resource.Key) error {
-	advertisements := sc.ServiceAnnouncements[key]
+	serviceAnnouncements := r.getMetadata(sc)
+	advertisements := serviceAnnouncements[key]
 	// Loop in reverse order so we can delete without effect to the iteration.
 	for i := len(advertisements) - 1; i >= 0; i-- {
 		advertisement := advertisements[i]
 		if err := sc.Server.WithdrawPath(ctx, types.PathRequest{Path: advertisement}); err != nil {
 			// Persist remaining advertisements
-			sc.ServiceAnnouncements[key] = advertisements
+			serviceAnnouncements[key] = advertisements
 			return fmt.Errorf("failed to withdraw deleted service route: %v: %w", advertisement.NLRI, err)
 		}
 
@@ -726,7 +768,7 @@ func (r *LBServiceReconciler) withdrawService(ctx context.Context, sc *ServerWit
 	}
 
 	// If all were withdrawn without error, we can delete the whole svc from the map
-	delete(sc.ServiceAnnouncements, key)
+	delete(serviceAnnouncements, key)
 
 	return nil
 }

--- a/pkg/bgpv1/manager/route_policy_reconciler.go
+++ b/pkg/bgpv1/manager/route_policy_reconciler.go
@@ -34,12 +34,19 @@ type RoutePolicyReconciler struct {
 	ipPoolStore BGPCPResourceStore[*v2alpha1api.CiliumLoadBalancerIPPool]
 }
 
+// RoutePolicyReconcilerMetadata holds routing policies configured by the policy reconciler keyed by policy name.
+type RoutePolicyReconcilerMetadata map[string]*types.RoutePolicy
+
 func NewRoutePolicyReconciler(ipPoolStore BGPCPResourceStore[*v2alpha1api.CiliumLoadBalancerIPPool]) RoutePolicyReconcilerOut {
 	return RoutePolicyReconcilerOut{
 		Reconciler: &RoutePolicyReconciler{
 			ipPoolStore: ipPoolStore,
 		},
 	}
+}
+
+func (r *RoutePolicyReconciler) Name() string {
+	return "RoutePolicy"
 }
 
 func (r *RoutePolicyReconciler) Priority() int {
@@ -64,7 +71,7 @@ func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileP
 	}
 
 	// take currently configured policies from cache
-	currentPolicies := params.CurrentServer.RoutePolicies
+	currentPolicies := r.getMetadata(params.CurrentServer)
 
 	// compile set of desired policies
 	desiredPolicies := make(map[string]*types.RoutePolicy)
@@ -113,7 +120,7 @@ func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileP
 		// As proper implementation of an update operation for complex policies would be quite involved,
 		// we resort to recreating the policies that need an update here.
 		l.Infof("Updating (re-creating) route policy %s in vrouter %d", p.Name, params.DesiredConfig.LocalASN)
-		existing := params.CurrentServer.RoutePolicies[p.Name]
+		existing := currentPolicies[p.Name]
 		err := params.CurrentServer.Server.RemoveRoutePolicy(ctx, types.RoutePolicyRequest{Policy: existing})
 		if err != nil {
 			return fmt.Errorf("failed removing route policy %v from vrouter %d: %w", existing.Name, params.DesiredConfig.LocalASN, err)
@@ -149,9 +156,20 @@ func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileP
 		}
 	}
 
-	// reconciliation successful, update the cache of configured policies
-	params.CurrentServer.RoutePolicies = desiredPolicies
+	// reconciliation successful, update the cache of configured policies which is now equal to desired polices
+	r.storeMetadata(params.CurrentServer, desiredPolicies)
 	return nil
+}
+
+func (r *RoutePolicyReconciler) getMetadata(sc *ServerWithConfig) RoutePolicyReconcilerMetadata {
+	if _, found := sc.ReconcilerMetadata[r.Name()]; !found {
+		sc.ReconcilerMetadata[r.Name()] = make(RoutePolicyReconcilerMetadata)
+	}
+	return sc.ReconcilerMetadata[r.Name()].(RoutePolicyReconcilerMetadata)
+}
+
+func (r *RoutePolicyReconciler) storeMetadata(sc *ServerWithConfig, meta RoutePolicyReconcilerMetadata) {
+	sc.ReconcilerMetadata[r.Name()] = meta
 }
 
 func (r *RoutePolicyReconciler) pathAttributesToPolicy(attrs v2alpha1api.CiliumBGPPathAttributes, neighborAddress string, params ReconcileParams) (*types.RoutePolicy, error) {

--- a/pkg/bgpv1/manager/route_policy_reconciler_test.go
+++ b/pkg/bgpv1/manager/route_policy_reconciler_test.go
@@ -357,7 +357,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 				store.Upsert(obj)
 			}
 
-			policyReconciler := NewRoutePolicyReconciler(store).Reconciler
+			policyReconciler := NewRoutePolicyReconciler(store).Reconciler.(*RoutePolicyReconciler)
 			params := ReconcileParams{
 				CurrentServer: testSC,
 				DesiredConfig: testSC.Config,
@@ -377,7 +377,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 			require.NoError(t, err)
 
 			// validate cached vs. expected policies
-			validatePoliciesMatch(t, testSC.RoutePolicies, tt.initial.expectedPolicies)
+			validatePoliciesMatch(t, policyReconciler.getMetadata(testSC), tt.initial.expectedPolicies)
 
 			if tt.updated == nil {
 				return // not testing update / remove
@@ -393,7 +393,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 			require.NoError(t, err)
 
 			// validate cached vs. expected policies
-			validatePoliciesMatch(t, testSC.RoutePolicies, tt.updated.expectedPolicies)
+			validatePoliciesMatch(t, policyReconciler.getMetadata(testSC), tt.updated.expectedPolicies)
 		})
 	}
 }


### PR DESCRIPTION
This PR finishes the efforts of making the BGP reconcilers independent and plugable / separateable by removing reconciler-specific maps from the BGP Manager's `ServerWithConfig` struct. Instead of that, all reconcilers can keep their metadata in a common `ReconcilerMetadata` map, keyed by the reconciler name.

As a side effect, the reconciler interface gets a new `Name()` method that can be used to retrieve reconciler's name.