### PR TITLE
[v1.14] doc: Migrate to .readthedocs.yaml v2 configuration and upgrade from Python 3.7 to 3.11 

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           persist-credentials: false
-      - uses: docker://cilium/docs-builder:2023-03-01@sha256:36b233afd73482c2bc7ed43f7a1537f09962015c34679b86c4ca1fa618d67b95
+      - uses: docker://quay.io/cilium/docs-builder:d5505e230c0164b51855b002c2a0abeeff78870c@sha256:95940ef277ae14c745769e332c968d8357a43e363eab0b088c5d5efa22089260
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/.readthedocs.yaml
+++ b/Documentation/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation with Sphinx
+sphinx:
+  configuration: Documentation/conf.py
+  builder: "dirhtml"
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: Documentation/requirements.txt

--- a/Documentation/Dockerfile
+++ b/Documentation/Dockerfile
@@ -1,5 +1,5 @@
 # Python version should match the one in use in Read The Docs
-FROM docker.io/library/python:3.7.9-alpine3.13 AS docs-base
+FROM docker.io/library/python:3.11-alpine3.17 AS docs-base
 
 LABEL maintainer="maintainer@cilium.io"
 
@@ -31,4 +31,4 @@ ENV MAKE_GIT_REPO_SAFE=1
 ## Workaround odd behaviour of sphinx versionwarning extension. It wants to
 ## write runtime data inside a system directory.
 ## We do rely on this extension, so we cannot just drop it.
-RUN install -m 0777 -d /usr/local/lib/python3.7/site-packages/versionwarning/_static/data
+RUN install -m 0777 -d /usr/local/lib/python3.11/site-packages/versionwarning/_static/data


### PR DESCRIPTION
Migrate to .readthedocs.yaml configuration file v2 before it becomes necessary to render documentation and upgrade Python from 3.7 to 3.11.

Backport commits from cilium/cilium#27532

Fixes: #26299

```release-note
doc: Migrate to .readthedocs.yaml configuration file v2 
```