### PR TITLE
fqdn: fix broken sorting algorithm for DNSZombies

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -863,16 +863,29 @@ func (zombies *DNSZombieMappings) isZombieAlive(zombie *DNSZombieMapping, aliveN
 	return alive, overLimit
 }
 
-// sortZombieMappingSlice sorts the provided slice by whether the connection is
-// marked alive or not, the oldest created connections, and tie-break by the
-// number of DNS names for that IP.
+// sortZombieMappingSlice sorts the provided slice so that less important
+// zombies shuffle to the front of the slice (from where they are eliminated).
+// To achieve this, it sorts by three criteria, in order of priority:
 //
-// Important zombies shuffle to the end of the slice.
+// 1. when the connection was last marked alive (earlier == less important)
+// 2. when this ip was last scheduled for deletion (earlier == less important)
+// 3. tie-break by number of DNS names for that IP
 func sortZombieMappingSlice(alive []*DNSZombieMapping) {
 	sort.Slice(alive, func(i, j int) bool {
-		return alive[i].AliveAt.Before(alive[j].AliveAt) ||
-			alive[i].DeletePendingAt.Before(alive[j].DeletePendingAt) ||
-			len(alive[i].Names) < len(alive[j].Names)
+		switch {
+		case alive[i].AliveAt.Before(alive[j].AliveAt):
+			return true
+		case alive[i].AliveAt.After(alive[j].AliveAt):
+			return false
+		// We have AliveAt equality after this point.
+		case alive[i].DeletePendingAt.Before(alive[j].DeletePendingAt):
+			return true
+		case alive[i].DeletePendingAt.After(alive[j].DeletePendingAt):
+			return false
+		// DeletePendingAt is also equal. Tie-break by number of Names.
+		default:
+			return len(alive[i].Names) < len(alive[j].Names)
+		}
 	})
 }
 

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 	"regexp"
 	"sort"
+	"testing"
 	"time"
 
 	. "github.com/cilium/checkmate"
@@ -1108,4 +1109,172 @@ func (ds *DNSCacheTestSuite) TestOverlimitPreferNewerEntries(c *C) {
 		"1.1.1.9":  {name},
 		"1.1.1.10": {name},
 	})
+}
+
+// Define a test-only string representation to make the output below more readable.
+func (z *DNSZombieMapping) String() string {
+	return fmt.Sprintf(
+		"DNSZombieMapping{AliveAt: %s, DeletePendingAt: %s, Names: %v}",
+		z.AliveAt, z.DeletePendingAt, z.Names,
+	)
+}
+
+func validateZombieSort(t *testing.T, zombies []*DNSZombieMapping) {
+	t.Helper()
+	sl := len(zombies)
+
+	logFailure := func(t *testing.T, zs []*DNSZombieMapping, prop string, i, j int) {
+		t.Helper()
+		t.Logf("order property fail %v: want zombie[i] < zombie[j]", prop)
+		t.Log("zombie[i]: ", zombies[i])
+		t.Log("zombie[j]: ", zombies[j])
+		t.Log("all mappings: ")
+		for i, z := range zombies {
+			t.Log(fmt.Sprintf("%2d", i), z)
+		}
+	}
+	// Don't try to be efficient, just check that the properties we want hold
+	// for every pair of zombie mappings.
+	for i := 0; i < sl; i++ {
+		for j := i + 1; j < sl; j++ {
+			if zombies[i].AliveAt.Before(zombies[j].AliveAt) {
+				continue
+			} else if zombies[i].AliveAt.After(zombies[j].AliveAt) {
+				logFailure(t, zombies, "AliveAt", i, j)
+				t.Fatalf("order wrong: AliveAt: %v is after %v", zombies[i].AliveAt, zombies[j].AliveAt)
+				return
+			}
+
+			if zombies[i].DeletePendingAt.Before(zombies[j].DeletePendingAt) {
+				continue
+			} else if zombies[i].DeletePendingAt.After(zombies[j].DeletePendingAt) {
+				logFailure(t, zombies, "DeletePendingAt", i, j)
+				t.Fatalf("order wrong: DeletePendingAt: %v is after %v", zombies[i].DeletePendingAt, zombies[j].DeletePendingAt)
+				return
+			}
+
+			if len(zombies[i].Names) > len(zombies[j].Names) {
+				logFailure(t, zombies, "len(names)", i, j)
+				t.Fatalf("order wrong: len(names): %v is longer than %v", zombies[i].Names, zombies[j].Names)
+			}
+		}
+	}
+}
+
+func Test_sortZombieMappingSlice(t *testing.T) {
+	// Create three moments in time, so we can have before, equal and after.
+	moments := []time.Time{
+		time.Date(2001, time.January, 1, 1, 1, 1, 0, time.Local),
+		time.Date(2002, time.February, 2, 2, 2, 2, 0, time.Local),
+		time.Date(2003, time.March, 3, 3, 3, 3, 0, time.Local),
+	}
+
+	// Couple of edge cases/hand-picked scenarios. To be complemented by the
+	// randomly generated ones, below.
+	type args struct {
+		zombies []*DNSZombieMapping
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			"empty",
+			args{zombies: nil},
+		},
+		{
+			"single",
+			args{zombies: []*DNSZombieMapping{{
+				Names:           []string{"test.com"},
+				AliveAt:         moments[0],
+				DeletePendingAt: moments[1],
+			}}},
+		},
+		{
+			"swapped alive at",
+			args{zombies: []*DNSZombieMapping{
+				{
+					AliveAt: moments[2],
+				},
+				{
+					AliveAt: moments[0],
+				},
+			}},
+		},
+		{
+			"equal alive, swapped delete pending at",
+			args{zombies: []*DNSZombieMapping{
+				{
+					AliveAt:         moments[0],
+					DeletePendingAt: moments[2],
+				},
+				{
+					AliveAt:         moments[0],
+					DeletePendingAt: moments[1],
+				},
+			}},
+		},
+		{
+			"swapped equal times, tiebreaker",
+			args{zombies: []*DNSZombieMapping{
+				{
+					Names:           []string{"test.com", "test2.com"},
+					AliveAt:         moments[0],
+					DeletePendingAt: moments[1],
+				},
+				{
+					Names:           []string{"test.com"},
+					AliveAt:         moments[0],
+					DeletePendingAt: moments[1],
+				},
+			}},
+		},
+	}
+
+	// Generate zombie mappings which cover all cases of the two times
+	// being either moment 0, 1 or 2, as well as with 0, 1 or 2 names.
+	names := []string{"example.org", "test.com"}
+	nMoments := len(moments)
+	allMappings := make([]*DNSZombieMapping, 0, nMoments*nMoments*nMoments)
+	for _, mi := range moments {
+		for _, mj := range moments {
+			for k := range names {
+				m := DNSZombieMapping{
+					AliveAt:         mi,
+					DeletePendingAt: mj,
+					Names:           names[:k],
+				}
+				allMappings = append(allMappings, &m)
+			}
+		}
+	}
+
+	// Five random tests:
+	for i := 0; i < 5; i++ {
+		ts := make([]*DNSZombieMapping, len(allMappings))
+		copy(ts, allMappings)
+		rand.Shuffle(len(ts), func(i, j int) {
+			ts[i], ts[j] = ts[j], ts[i]
+		})
+		tests = append(tests, struct {
+			name string
+			args args
+		}{
+			name: "Randomised sorting test",
+			args: args{
+				zombies: ts,
+			},
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ol := len(tt.args.zombies)
+			sortZombieMappingSlice(tt.args.zombies)
+			if len(tt.args.zombies) != ol {
+				t.Fatalf("length of slice changed by sorting")
+			}
+			validateZombieSort(t, tt.args.zombies)
+		})
+	}
 }


### PR DESCRIPTION
The sorting function for DNSZombies was subtly broken, and didn't do what it advertised. Write some tests to confirm the suspicion and fix the function.

Reported-by: Jussi Maki <joamaki@isovalent.com>

```release-note
Prioritization of which DNS mappings to keep was suboptimal, leading to evictions of mappings related to alive connections, worsening performance of fqdn policies and causing spurious logging.
```
