### PR TITLE
egressgw: small test fixes

### DIFF
--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -28,16 +28,16 @@ enum egressgw_test {
 };
 
 struct egressgw_test_ctx {
-	enum egressgw_test test;
+	__u16 test;
 	enum ct_dir dir;
 	__u64 tx_packets;
 	__u64 rx_packets;
 	__u32 status_code;
 };
 
-static __always_inline __be16 client_port(enum egressgw_test t)
+static __always_inline __be16 client_port(__u16 t)
 {
-	return CLIENT_PORT + (__be16)t;
+	return CLIENT_PORT + bpf_htons(t);
 }
 
 #ifdef ENABLE_EGRESS_GATEWAY

--- a/bpf/tests/lib/egressgw.h
+++ b/bpf/tests/lib/egressgw.h
@@ -40,6 +40,7 @@ static __always_inline __be16 client_port(enum egressgw_test t)
 	return CLIENT_PORT + (__be16)t;
 }
 
+#ifdef ENABLE_EGRESS_GATEWAY
 static __always_inline void add_egressgw_policy_entry(__be32 saddr, __be32 daddr, __u8 cidr,
 						      __be32 gateway_ip, __be32 egress_ip)
 {
@@ -67,6 +68,7 @@ static __always_inline void del_egressgw_policy_entry(__be32 saddr, __be32 daddr
 
 	map_delete_elem(&EGRESS_POLICY_MAP, &in_key);
 }
+#endif /* ENABLE_EGRESS_GATEWAY */
 
 static __always_inline int egressgw_pktgen(struct __ctx_buff *ctx,
 					   struct egressgw_test_ctx test_ctx)

--- a/bpf/tests/tc_egressgw_redirect.c
+++ b/bpf/tests/tc_egressgw_redirect.c
@@ -84,7 +84,7 @@ PKTGEN("tc", "tc_egressgw_skip_excluded_cidr_redirect")
 int egressgw_skip_excluded_cidr_redirect_pktgen(struct __ctx_buff *ctx)
 {
 	return egressgw_pktgen(ctx, (struct egressgw_test_ctx) {
-			.test = TEST_REDIRECT,
+			.test = TEST_REDIRECT_EXCL_CIDR,
 		});
 }
 

--- a/bpf/tests/tc_egressgw_snat.c
+++ b/bpf/tests/tc_egressgw_snat.c
@@ -191,6 +191,8 @@ int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
 
 	test_init();
 
+	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
+
 	data = (void *)(long)ctx_data(ctx);
 	data_end = (void *)(long)ctx->data_end;
 
@@ -229,8 +231,6 @@ int egressgw_skip_excluded_cidr_snat_check(const struct __ctx_buff *ctx)
 
 	if (l4->dest != EXTERNAL_SVC_PORT)
 		test_fatal("dst port has changed");
-
-	del_egressgw_policy_entry(CLIENT_IP, EXTERNAL_SVC_IP, 32);
 
 	test_finish();
 }


### PR DESCRIPTION
bpf, egressgw: gate use of EGRESS_POLICY_MAP on define

    EGRESS_POLICY_MAP is only defined if the egress gateway is enabled. Allow
    including egressgw.h even if that is not the case, so that the helpers can
    be reused.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

bpf, egressgw: make it easier to correlate test cases with debug msg

    When an egressgw BPF unit test fails it helpfully dumps any cilium debug 
    messages with the test. The messages often contain port numbers which can be
    used to infer which subtest generated them. Make it easier to go from port
    number to subtest by accounting for endiannness in client_port().

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

bpf, egressgw: fix tc_egressgw_skip_excluded_cidr_redirect case

    Use the correct test enum in tc_egressgw_skip_excluded_cidr_redirect to
    avoid tests interfering with each other.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

bpf, egressgw: always clear excluded cidr at end of snat test

    Always clear the exclude CIDR rule, regardless of whether the test succeeds
    or not. Otherwise subsequent tests will fail due to the presence of the
    exclude rule.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
