### PR TITLE
Fix possible cross-cluster connection drops on agents restart when clustermesh is enabled

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -63,6 +63,7 @@ cilium-agent [flags]
       --cluster-id int                                            Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
+      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -15,6 +15,7 @@ cilium-agent hive [flags]
       --api-rate-limit stringToString                             API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
+      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -21,6 +21,7 @@ cilium-agent hive dot-graph [flags]
       --api-rate-limit stringToString                             API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
+      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -21,6 +21,7 @@ import (
 	dptypes "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/egressgateway"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/gops"
@@ -185,6 +186,9 @@ var (
 		// L2announcer resolves l2announcement policies, services, node labels and devices into a list of IPs+netdevs
 		// which need to be announced on the local network.
 		l2announcer.Cell,
+
+		// RegeneratorCell provides extra options and utilities for endpoints regeneration.
+		endpoint.RegeneratorCell,
 	)
 )
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1728,9 +1728,11 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 	restoreComplete := d.initRestore(restoredEndpoints, params.EndpointRegenerator)
 
 	if params.WGAgent != nil {
-		if err := params.WGAgent.RestoreFinished(); err != nil {
-			log.WithError(err).Error("Failed to set up WireGuard peers")
-		}
+		go func() {
+			if err := params.WGAgent.RestoreFinished(d.clustermesh); err != nil {
+				log.WithError(err).Error("Failed to set up WireGuard peers")
+			}
+		}()
 	}
 
 	if d.endpointManager.HostEndpointExists() {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -447,10 +447,10 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 
 		go func() {
 			if d.clientset.IsEnabled() {
-				// Also wait for all cluster mesh to be synchronized with the
+				// Also wait for all shared services to be synchronized with the
 				// datapath before proceeding.
 				if d.clustermesh != nil {
-					err := d.clustermesh.ClustersSynced(d.ctx)
+					err := d.clustermesh.ServicesSynced(d.ctx)
 					if err != nil {
 						log.WithError(err).Fatal("timeout while waiting for all clusters to be locally synchronized")
 					}

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -264,7 +264,7 @@ func (d *Daemon) restoreOldEndpoints(state *endpointRestoreState, clean bool) er
 	return nil
 }
 
-func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (restoreComplete chan struct{}) {
+func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState, endpointsRegenerator *endpoint.Regenerator) (restoreComplete chan struct{}) {
 	restoreComplete = make(chan struct{})
 
 	log.WithField("numRestored", len(state.restored)).Info("Regenerating restored endpoints")
@@ -317,9 +317,14 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		// for that to succeed, it must be reloaded first, before the bpf_lxc
 		// programs stop writing the IP into skb->cb.
 		for _, ep := range state.restored {
+			// Cap the timeout used to wait for remote cluster synchronization
+			// to avoid blocking the agent startup, as this regeneration is
+			// performed synchronously.
+			endpointsRegenerator.CapTimeoutForSynchronousRegeneration()
+
 			if ep.IsHost() {
 				log.WithField(logfields.EndpointID, ep.ID).Info("Successfully restored endpoint. Scheduling regeneration")
-				if err := ep.RegenerateAfterRestore(); err != nil {
+				if err := ep.RegenerateAfterRestore(endpointsRegenerator); err != nil {
 					log.WithField(logfields.EndpointID, ep.ID).WithError(err).Debug("error regenerating restored host endpoint")
 					epRegenerated <- false
 				} else {
@@ -337,7 +342,7 @@ func (d *Daemon) regenerateRestoredEndpoints(state *endpointRestoreState) (resto
 		}
 		log.WithField(logfields.EndpointID, ep.ID).Info("Successfully restored endpoint. Scheduling regeneration")
 		go func(ep *endpoint.Endpoint, epRegenerated chan<- bool) {
-			if err := ep.RegenerateAfterRestore(); err != nil {
+			if err := ep.RegenerateAfterRestore(endpointsRegenerator); err != nil {
 				log.WithField(logfields.EndpointID, ep.ID).WithError(err).Debug("error regenerating during restore")
 				epRegenerated <- false
 				return
@@ -436,14 +441,14 @@ func (d *Daemon) allocateIPsLocked(ep *endpoint.Endpoint) (err error) {
 	return nil
 }
 
-func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struct{} {
+func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState, endpointsRegenerator *endpoint.Regenerator) chan struct{} {
 	bootstrapStats.restore.Start()
 	var restoreComplete chan struct{}
 	if option.Config.RestoreState {
-		// When we regenerate restored endpoints, it is guaranteed tha we have
+		// When we regenerate restored endpoints, it is guaranteed that we have
 		// received the full list of policies present at the time the daemon
 		// is bootstrapped.
-		restoreComplete = d.regenerateRestoredEndpoints(restoredEndpoints)
+		restoreComplete = d.regenerateRestoredEndpoints(restoredEndpoints, endpointsRegenerator)
 
 		go func() {
 			if d.clientset.IsEnabled() {

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -157,6 +157,7 @@ func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) c
 		name,
 		cm.conf.NodeKeyCreator,
 		cm.conf.NodeObserver,
+		store.RWSWithOnSyncCallback(func(ctx context.Context) { close(rc.synced.nodes) }),
 		store.RWSWithEntriesMetric(cm.conf.Metrics.TotalNodes.WithLabelValues(cm.conf.ClusterName, cm.nodeName, rc.name)),
 	)
 
@@ -185,6 +186,12 @@ func (cm *ClusterMesh) NumReadyClusters() int {
 // SyncedWaitFn is the type of a function to wait for the initial synchronization
 // of a given resource type from all remote clusters.
 type SyncedWaitFn func(ctx context.Context) error
+
+// NodesSynced returns after that the initial list of nodes has been received
+// from all remote clusters, and synchronized with the different subscribers.
+func (cm *ClusterMesh) NodesSynced(ctx context.Context) error {
+	return cm.synced(ctx, func(rc *remoteCluster) SyncedWaitFn { return rc.synced.Nodes })
+}
 
 // ServicesSynced returns after that the initial list of shared services has been
 // received from all remote clusters, and synchronized with the BPF datapath.

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -5,6 +5,7 @@ package clustermesh
 
 import (
 	"context"
+	"errors"
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/allocator"
@@ -17,7 +18,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
-	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -150,8 +150,8 @@ func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) c
 		mesh:         cm,
 		usedIDs:      cm.conf.ClusterIDsManager,
 		status:       status,
-		swg:          lock.NewStoppableWaitGroup(),
 		storeFactory: cm.conf.StoreFactory,
+		synced:       newSynced(),
 	}
 	rc.remoteNodes = cm.conf.StoreFactory.NewWatchStore(
 		name,
@@ -163,8 +163,8 @@ func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) c
 	rc.remoteServices = cm.conf.StoreFactory.NewWatchStore(
 		name,
 		func() store.Key { return new(serviceStore.ClusterService) },
-		&remoteServiceObserver{remoteCluster: rc, swg: rc.swg},
-		store.RWSWithOnSyncCallback(func(ctx context.Context) { rc.swg.Stop() }),
+		&remoteServiceObserver{remoteCluster: rc, swg: rc.synced.services},
+		store.RWSWithOnSyncCallback(func(ctx context.Context) { rc.synced.services.Stop() }),
 	)
 
 	rc.ipCacheWatcher = ipcache.NewIPIdentityWatcher(name, cm.conf.IPCache, cm.conf.StoreFactory)
@@ -179,21 +179,31 @@ func (cm *ClusterMesh) NumReadyClusters() int {
 	return cm.common.NumReadyClusters()
 }
 
-// ClustersSynced returns after all clusters were synchronized with the bpf
-// datapath.
-func (cm *ClusterMesh) ClustersSynced(ctx context.Context) error {
-	swgs := make([]*lock.StoppableWaitGroup, 0)
+// SyncedWaitFn is the type of a function to wait for the initial synchronization
+// of a given resource type from all remote clusters.
+type SyncedWaitFn func(ctx context.Context) error
+
+// ServicesSynced returns after that the initial list of shared services has been
+// received from all remote clusters, and synchronized with the BPF datapath.
+func (cm *ClusterMesh) ServicesSynced(ctx context.Context) error {
+	return cm.synced(ctx, func(rc *remoteCluster) SyncedWaitFn { return rc.synced.Services })
+}
+
+func (cm *ClusterMesh) synced(ctx context.Context, toWaitFn func(*remoteCluster) SyncedWaitFn) error {
+	waiters := make([]SyncedWaitFn, 0)
 	cm.common.ForEachRemoteCluster(func(rci common.RemoteCluster) error {
 		rc := rci.(*remoteCluster)
-		swgs = append(swgs, rc.swg)
+		waiters = append(waiters, toWaitFn(rc))
 		return nil
 	})
 
-	for _, swg := range swgs {
-		select {
-		case <-swg.WaitChannel():
-		case <-ctx.Done():
-			return ctx.Err()
+	for _, wait := range waiters {
+		err := wait(ctx)
+
+		// Ignore the error in case the given cluster was disconnected in
+		// the meanwhile, as we do not longer care about it.
+		if err != nil && !errors.Is(err, ErrRemoteClusterDisconnected) {
+			return err
 		}
 	}
 	return nil

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -167,7 +167,10 @@ func (cm *ClusterMesh) NewRemoteCluster(name string, status common.StatusFunc) c
 		store.RWSWithOnSyncCallback(func(ctx context.Context) { rc.synced.services.Stop() }),
 	)
 
-	rc.ipCacheWatcher = ipcache.NewIPIdentityWatcher(name, cm.conf.IPCache, cm.conf.StoreFactory)
+	rc.ipCacheWatcher = ipcache.NewIPIdentityWatcher(
+		name, cm.conf.IPCache, cm.conf.StoreFactory,
+		store.RWSWithOnSyncCallback(func(ctx context.Context) { close(rc.synced.ipcache) }),
+	)
 	rc.ipCacheWatcherExtraOpts = cm.conf.IPCacheWatcherExtraOpts
 
 	return rc
@@ -187,6 +190,13 @@ type SyncedWaitFn func(ctx context.Context) error
 // received from all remote clusters, and synchronized with the BPF datapath.
 func (cm *ClusterMesh) ServicesSynced(ctx context.Context) error {
 	return cm.synced(ctx, func(rc *remoteCluster) SyncedWaitFn { return rc.synced.Services })
+}
+
+// IPIdentitiesSynced returns after that the initial list of ipcache entries and
+// identities has been received from all remote clusters, and synchronized with
+// the BPF datapath.
+func (cm *ClusterMesh) IPIdentitiesSynced(ctx context.Context) error {
+	return cm.synced(ctx, func(rc *remoteCluster) SyncedWaitFn { return rc.synced.IPIdentities })
 }
 
 func (cm *ClusterMesh) synced(ctx context.Context, toWaitFn func(*remoteCluster) SyncedWaitFn) error {

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -122,7 +122,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 	})
 
 	mgr.Register(adapter(identityCache.IdentitiesPath), func(ctx context.Context) {
-		rc.remoteIdentityCache.Watch(ctx, func(ctx context.Context) {})
+		rc.remoteIdentityCache.Watch(ctx, func(context.Context) { rc.synced.identities.Done() })
 	})
 
 	close(ready)
@@ -218,14 +218,26 @@ var (
 )
 
 type synced struct {
-	services *lock.StoppableWaitGroup
-	stopped  chan struct{}
+	services   *lock.StoppableWaitGroup
+	ipcache    chan struct{}
+	identities *lock.StoppableWaitGroup
+	stopped    chan struct{}
 }
 
 func newSynced() synced {
+	// Use a StoppableWaitGroup for identities, instead of a plain channel to
+	// avoid having to deal with the possibility of a closed channel if already
+	// synced (as the callback is executed every time the etcd connection
+	// is restarted, differently from the other resource types).
+	idswg := lock.NewStoppableWaitGroup()
+	idswg.Add()
+	idswg.Stop()
+
 	return synced{
-		services: lock.NewStoppableWaitGroup(),
-		stopped:  make(chan struct{}),
+		services:   lock.NewStoppableWaitGroup(),
+		ipcache:    make(chan struct{}),
+		identities: idswg,
+		stopped:    make(chan struct{}),
 	}
 }
 
@@ -234,6 +246,14 @@ func newSynced() synced {
 // the remote cluster is disconnected, or the given context is canceled.
 func (s *synced) Services(ctx context.Context) error {
 	return s.wait(ctx, s.services.WaitChannel())
+}
+
+// IPIdentities returns after that the initial list of ipcache entries and
+// identities has been received from the remote cluster, and synchronized
+// with the BPF datapath, the remote cluster is disconnected, or the given
+// context is canceled.
+func (s *synced) IPIdentities(ctx context.Context) error {
+	return s.wait(ctx, s.ipcache, s.identities.WaitChannel())
 }
 
 func (s *synced) wait(ctx context.Context, chs ...<-chan struct{}) error {

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -5,6 +5,7 @@ package clustermesh
 
 import (
 	"context"
+	"errors"
 	"path"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -61,9 +62,10 @@ type remoteCluster struct {
 	// status is the function which fills the common part of the status.
 	status common.StatusFunc
 
-	swg *lock.StoppableWaitGroup
-
 	storeFactory store.Factory
+
+	// synced tracks the initial synchronization with the remote cluster.
+	synced synced
 }
 
 func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperations, config *cmtypes.CiliumClusterConfig, ready chan<- error) {
@@ -127,7 +129,9 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 	mgr.Run(ctx)
 }
 
-func (rc *remoteCluster) Stop() {}
+func (rc *remoteCluster) Stop() {
+	rc.synced.stop()
+}
 
 func (rc *remoteCluster) Remove() {
 	// Draining shall occur only when the configuration for the remote cluster
@@ -205,4 +209,48 @@ func (rc *remoteCluster) ipCacheWatcherOpts(config *cmtypes.CiliumClusterConfig)
 	}
 
 	return opts
+}
+
+var (
+	// ErrRemoteClusterDisconnected is the error returned by wait for sync
+	// operations if the remote cluster is disconnected while still waiting.
+	ErrRemoteClusterDisconnected = errors.New("remote cluster disconnected")
+)
+
+type synced struct {
+	services *lock.StoppableWaitGroup
+	stopped  chan struct{}
+}
+
+func newSynced() synced {
+	return synced{
+		services: lock.NewStoppableWaitGroup(),
+		stopped:  make(chan struct{}),
+	}
+}
+
+// Services returns after that the initial list of shared services has been
+// received from the remote cluster, and synchronized with the BPF datapath,
+// the remote cluster is disconnected, or the given context is canceled.
+func (s *synced) Services(ctx context.Context) error {
+	return s.wait(ctx, s.services.WaitChannel())
+}
+
+func (s *synced) wait(ctx context.Context, chs ...<-chan struct{}) error {
+	for _, ch := range chs {
+		select {
+		case <-ch:
+			continue
+		case <-s.stopped:
+			return ErrRemoteClusterDisconnected
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+func (s *synced) stop() {
+	close(s.stopped)
 }

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -120,7 +120,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 	})
 
 	mgr.Register(adapter(identityCache.IdentitiesPath), func(ctx context.Context) {
-		rc.remoteIdentityCache.Watch(ctx)
+		rc.remoteIdentityCache.Watch(ctx, func(ctx context.Context) {})
 	})
 
 	close(ready)

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -219,6 +219,7 @@ var (
 
 type synced struct {
 	services   *lock.StoppableWaitGroup
+	nodes      chan struct{}
 	ipcache    chan struct{}
 	identities *lock.StoppableWaitGroup
 	stopped    chan struct{}
@@ -235,10 +236,18 @@ func newSynced() synced {
 
 	return synced{
 		services:   lock.NewStoppableWaitGroup(),
+		nodes:      make(chan struct{}),
 		ipcache:    make(chan struct{}),
 		identities: idswg,
 		stopped:    make(chan struct{}),
 	}
+}
+
+// Nodes returns after that the initial list of nodes has been received
+// from the remote cluster, and synchronized with the different subscribers,
+// the remote cluster is disconnected, or the given context is canceled.
+func (s *synced) Nodes(ctx context.Context) error {
+	return s.wait(ctx, s.nodes)
 }
 
 // Services returns after that the initial list of shared services has been

--- a/pkg/endpoint/regenerator.go
+++ b/pkg/endpoint/regenerator.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoint
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/clustermesh"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	RegeneratorCell = cell.Module(
+		"endpoint-regeneration",
+		"Endpoints regeneration",
+
+		cell.Config(RegeneratorConfigDefault),
+		cell.Provide(newRegenerator),
+	)
+)
+
+// Regenerator wraps additional functionalities for endpoint regeneration.
+type Regenerator struct {
+	RegeneratorConfig
+
+	cmWaitFn clustermesh.SyncedWaitFn
+
+	logger        logrus.FieldLogger
+	cmSyncLogOnce sync.Once
+}
+
+type RegeneratorConfig struct {
+	// ClusterMeshIPIdentitiesSyncTimeout is the timeout when waiting for the
+	// initial synchronization of ipcache entries and identities from all remote
+	// clusters before regenerating the local endpoints.
+	ClusterMeshIPIdentitiesSyncTimeout time.Duration
+}
+
+func (def RegeneratorConfig) Flags(flags *pflag.FlagSet) {
+	flags.Duration("clustermesh-ip-identities-sync-timeout", def.ClusterMeshIPIdentitiesSyncTimeout,
+		"Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration")
+}
+
+var RegeneratorConfigDefault = RegeneratorConfig{
+	ClusterMeshIPIdentitiesSyncTimeout: 1 * time.Minute,
+}
+
+func newRegenerator(in struct {
+	cell.In
+
+	Logger logrus.FieldLogger
+
+	Config      RegeneratorConfig
+	ClusterMesh *clustermesh.ClusterMesh
+}) *Regenerator {
+	waitFn := func(context.Context) error { return nil }
+	if in.ClusterMesh != nil {
+		waitFn = in.ClusterMesh.IPIdentitiesSynced
+	}
+
+	return &Regenerator{
+		RegeneratorConfig: in.Config,
+		logger:            in.Logger,
+		cmWaitFn:          waitFn,
+	}
+}
+
+// CapTimeoutForSynchronousRegeneration caps the timeout to a value suitable in
+// case the regeneration of an endpoint needs to be performed synchronously
+// (currently required when IPSec is enabled). In particular, this is necessary
+// to not block the agent bootstrap, as that prevents the scheduling of new
+// workloads. This logic is implemented as a separate function to avoid
+// forgetting to remove it when the synchronous regeneration is removed.
+func (r *Regenerator) CapTimeoutForSynchronousRegeneration() {
+	const maxTimeout = 5 * time.Second
+	if r.ClusterMeshIPIdentitiesSyncTimeout > maxTimeout {
+		r.ClusterMeshIPIdentitiesSyncTimeout = maxTimeout
+		r.logger.WithField(logfields.Value, maxTimeout).
+			Info("Capped clustermesh-ip-identities-sync-timeout because endpoint regeneration needs to be performed synchronously")
+	}
+}
+
+func (r *Regenerator) WaitForClusterMeshIPIdentitiesSync(ctx context.Context) error {
+	wctx, cancel := context.WithTimeout(ctx, r.ClusterMeshIPIdentitiesSyncTimeout)
+	defer cancel()
+	err := r.cmWaitFn(wctx)
+
+	switch {
+	case ctx.Err() != nil:
+		// The context associated with the endpoint has been canceled.
+		return ErrNotAlive
+	case err != nil:
+		// We don't return an error in case the wait operation timed out, as we can
+		// continue with the endpoint regeneration, although at the cost of possible
+		// connectivity drops for cross-cluster connections. We additionally print
+		// the warning message only once, to avoid repeating it for every endpoint.
+		r.cmSyncLogOnce.Do(func() {
+			r.logger.Warning("Failed waiting for clustermesh IPs and identities synchronization before regenerating endpoints, expect possible disruption of cross-cluster connections")
+		})
+	}
+
+	return nil
+}

--- a/pkg/endpoint/regenerator_test.go
+++ b/pkg/endpoint/regenerator_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoint
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegeneratorWaitForIPCacheSync(t *testing.T) {
+	regenerator := Regenerator{
+		logger: func() logrus.FieldLogger {
+			logger := logrus.New()
+			logger.SetLevel(logrus.FatalLevel)
+			return logger
+		}(),
+
+		cmWaitFn: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+
+		RegeneratorConfig: RegeneratorConfig{
+			ClusterMeshIPIdentitiesSyncTimeout: 10 * time.Millisecond,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		ctx    context.Context
+		assert assert.ErrorAssertionFunc
+	}{
+		{
+			name:   "valid context",
+			ctx:    context.Background(),
+			assert: assert.NoError,
+		},
+		{
+			name: "expired context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			assert: assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assert(t, regenerator.WaitForClusterMeshIPIdentitiesSync(tt.ctx))
+		})
+	}
+}

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -177,7 +177,7 @@ type IPCacher interface {
 }
 
 // NewIPIdentityWatcher creates a new IPIdentityWatcher for the given cluster.
-func NewIPIdentityWatcher(clusterName string, ipc IPCacher, factory storepkg.Factory) *IPIdentityWatcher {
+func NewIPIdentityWatcher(clusterName string, ipc IPCacher, factory storepkg.Factory, opts ...storepkg.RWSOpt) *IPIdentityWatcher {
 	watcher := IPIdentityWatcher{
 		ipcache:     ipc,
 		clusterName: clusterName,
@@ -189,7 +189,7 @@ func NewIPIdentityWatcher(clusterName string, ipc IPCacher, factory storepkg.Fac
 		clusterName,
 		func() storepkg.Key { return &identity.IPIdentityPair{} },
 		&watcher,
-		storepkg.RWSWithOnSyncCallback(watcher.onSync),
+		append(opts, storepkg.RWSWithOnSyncCallback(watcher.onSync))...,
 	)
 	return &watcher
 }

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -637,7 +637,7 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 
 	wg.Add(1)
 	go func() {
-		rc.Watch(ctx)
+		rc.Watch(ctx, func(ctx context.Context) {})
 		wg.Done()
 	}()
 

--- a/pkg/wireguard/agent/agent.go
+++ b/pkg/wireguard/agent/agent.go
@@ -7,6 +7,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -27,6 +28,7 @@ import (
 
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/clustermesh"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
@@ -275,7 +277,13 @@ func (a *Agent) Init(ipcache *ipcache.IPCache, mtuConfig mtu.Configuration) erro
 	return nil
 }
 
-func (a *Agent) RestoreFinished() error {
+func (a *Agent) RestoreFinished(cm *clustermesh.ClusterMesh) error {
+	if cm != nil {
+		// Wait until we received the initial list of nodes from all remote clusters,
+		// otherwise we might remove valid peers and disrupt existing connections.
+		cm.NodesSynced(context.Background())
+	}
+
 	a.Lock()
 	defer a.Unlock()
 


### PR DESCRIPTION
This PR modifies the endpoint regeneration logic to additional wait for remote clusters ipcache synchronization before performing the datapath regeneration, to make sure that the new ipcache map starts to be used only when it has been completely populated. 

A user-configurable timeout (defaulting to one minute) limits the maximum wait interval, to prevent blocking the local endpoints regeneration process for an extended period of time if a remote cluster is not ready (which could also lead to checken-and-egg dependencies). A special case is IPSec enabled, as this currently requires a synchronous regeneration of the host endpoint: here, we limit the timeout to at most 5 seconds, to not block the agent startup process.

In addition, when WireGuard is enabled, the deletion of obsolete peers is now performed after listing all nodes from remote clusters, again to prevent possible connectivity drops on agent restart.

Please refer to the individual commit messages for additional details.

Tested with https://github.com/cilium/cilium/pull/27232: https://github.com/cilium/cilium/actions/runs/5949436519
The downgrade test was based on the current tip of v1.14 with these changes on top; hence, I'm marking this PR for backport to v1.14 (and backport/author given that I've already the PR for that). 

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/26462

```release-note
Fix possible cross-cluster connection drops on agents restart when clustermesh is enabled
```
