### PR TITLE
ipcache: Deprecate old API

### DIFF
--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -34,6 +34,8 @@ import (
 //
 // Upon success, the caller must also arrange for the resulting identities to
 // be released via a subsequent call to ReleaseCIDRIdentitiesByCIDR().
+//
+// Deprecated: Prefer UpsertLabels() instead.
 func (ipc *IPCache) AllocateCIDRs(
 	prefixes []netip.Prefix, oldNIDs []identity.NumericIdentity, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity,
 ) ([]*identity.Identity, error) {
@@ -96,6 +98,8 @@ func (ipc *IPCache) AllocateCIDRs(
 //
 // Upon success, the caller must also arrange for the resulting identities to
 // be released via a subsequent call to ReleaseCIDRIdentitiesByID().
+//
+// Deprecated: Prefer UpsertLabels() instead.
 func (ipc *IPCache) AllocateCIDRsForIPs(
 	prefixes []net.IP, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity,
 ) ([]*identity.Identity, error) {
@@ -128,6 +132,8 @@ func cidrLabelToPrefix(id *identity.Identity) (prefix netip.Prefix, ok bool) {
 // that were not already upserted. If any 'usedIdentities' are upserted, these
 // are counted separately as they may provide an indication of another logic
 // error elsewhere in the codebase that is causing premature ipcache deletions.
+//
+// Deprecated: Prefer UpsertLabels() instead.
 func (ipc *IPCache) UpsertGeneratedIdentities(newlyAllocatedIdentities map[netip.Prefix]*identity.Identity, usedIdentities []*identity.Identity) {
 	for prefix, id := range newlyAllocatedIdentities {
 		ipc.Upsert(prefix.String(), nil, 0, nil, Identity{
@@ -208,12 +214,16 @@ func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, prefixes []netip.
 
 // ReleaseCIDRIdentitiesByCIDR releases the identities of a list of CIDRs.
 // When the last use of the identity is released, the ipcache entry is deleted.
+//
+// Deprecated: Prefer RemoveLabels() or RemoveIdentity() instead.
 func (ipc *IPCache) ReleaseCIDRIdentitiesByCIDR(prefixes []netip.Prefix) {
 	ipc.deferredPrefixRelease.enqueue(prefixes, "cidr-prefix-release")
 }
 
 // ReleaseCIDRIdentitiesByID releases the specified identities.
 // When the last use of the identity is released, the ipcache entry is deleted.
+//
+// Deprecated: Prefer RemoveLabels() or RemoveIdentity() instead.
 func (ipc *IPCache) ReleaseCIDRIdentitiesByID(ctx context.Context, identities []identity.NumericIdentity) {
 	prefixes := make([]netip.Prefix, 0, len(identities))
 	for _, nid := range identities {


### PR DESCRIPTION
The following commits have introduced a new API for interacting with the
ipcache, which is now preferred for all future interactions:

- Commit e63781492e1d ("ipcache: Introduce new asynchronous API")
- Commit b6cef9292b94 ("ipcache: Add new {Upsert,Remove}Prefixes() APIs")
- Commit f9173b7191fe ("ipcache: Add ability to override identity via UpsertIdentity")

Mark the older APIs as deprecated in order to help to slowly phase out
future usage of those APIs. For more details, see GitHub issue #21142.

Note that there are still various paths using the older APIs to insert
ipcache entries. If an entry is inserted using the older API, then the
corresponding delete event should likewise use the same older API to
delete the entry. Future users should both insert and delete using the
newer API. Do not mix and match the upserts and deletes from deprecated
APIs and non-deprecated APIs for the same event type / resource update
into ipcache.

PR https://github.com/cilium/cilium/pull/27327 recently fixed bugs in
the case of fixed APIs and added unit tests for those cases, but still
it's better for all future users to focus on using the newer APIs for
better internal feature compatibility rather than mixing and matching.

Suggested-by: Aditi Ghag <aditi@cilium.io>
Signed-off-by: Joe Stringer <joe@cilium.io>
