### PR TITLE
fix: mTLS does not work when kubelet does not listen on 127.0.0.1

### DIFF
--- a/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
@@ -50,6 +50,11 @@ spec:
               readOnly: false
             - name: spire-agent
               mountPath: /var/run/secrets/tokens
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
           livenessProbe:
             httpGet:
               path: /live


### PR DESCRIPTION
## bug description
with latest version v1.14.1, when kubelet listens on a specified local ip address but not 0.0.0.0, spire agent will fail to contact local kubelet with 127.0.0.1:10250, and mTLS feature does not work at all.

## some log on issue enviroment:

when node has multiple network interface, kubelet listens on a specified local address `172.16.1.11` but not `0.0.0.0`

```

[root@master1 ~]# cat /etc/kubernetes/kubelet-config.yaml
apiVersion: kubelet.config.k8s.io/v1beta1
kind: KubeletConfiguration
nodeStatusUpdateFrequency: "10s"
failSwapOn: True
authentication:
  anonymous:
    enabled: false
  webhook:
    enabled: True
  x509:
    clientCAFile: /etc/kubernetes/ssl/ca.crt
authorization:
  mode: Webhook
staticPodPath: /etc/kubernetes/manifests
cgroupDriver: systemd
containerLogMaxFiles: 5
containerLogMaxSize: 10Mi
maxPods: 110
podPidsLimit: -1
address: 172.16.1.11
readOnlyPort: 0
healthzPort: 10248
healthzBindAddress: 127.0.0.1
kubeletCgroups: /system.slice/kubelet.service
clusterDomain: cluster.local
protectKernelDefaults: true
rotateCertificates: true
clusterDNS:
- 172.26.0.3
resolvConf: "/run/systemd/resolve/resolv.conf"
eventRecordQPS: 5
shutdownGracePeriod: 60s
shutdownGracePeriodCriticalPods: 20s

[root@master1 ~]# ss -lntp
LISTEN          0               4096                         172.16.1.11:10250                          0.0.0.0:*              users:(("kubelet",pid=1625,fd=22))

```

the spire agent fails to contact kubelet of its local node

```
[root@master1 ~]# kubectl logs -n cilium-spire   spire-agent-pjpsb
Defaulted container "spire-agent" out of: spire-agent, init (init)
time="2023-08-18T08:49:12Z" level=error msg="Failed to collect all selectors for PID" error="workload attestor \"k8s\" failed: rpc error: code = Internal desc = workloadattestor(k8s): unable to perform request: Get \"https://127.0.0.1:10250/pods\": dial tcp 127.0.0.1:10250: connect: connection refused" pid=8491 subsystem_name=workload_attestor
time="2023-08-18T08:49:13Z" level=error msg="Failed to collect all selectors for PID" error="workload attestor \"k8s\" failed: rpc error: code = Internal desc = workloadattestor(k8s): unable to perform request: Get \"https://127.0.0.1:10250/pods\": dial tcp 127.0.0.1:10250: connect: connection refused" pid=6845 subsystem_name=workload_attestor
time="2023-08-18T08:49:13Z" level=error msg="no identity issued" method=SubscribeToX509SVIDs service=spire.api.agent.delegatedidentity.v1.DelegatedIdentity subsystem_name=debug_api


[root@master1 ~]# kubectl logs -n kube-system    cilium-l5dk4
level=error msg="Error in delegate stream, restarting" error="rpc error: code = PermissionDenied desc = no identity issued" subsys=spire-delegate


```

it could not find any SPIFFE ID with following command , and mTLS could not work at all

```
kubectl exec -n cilium-spire spire-server-0 -c spire-server -- /opt/spire/bin/spire-server entry show -selector cilium:mutual-auth

```

## how to fix

referring to [spire doc](https://github.com/spiffe/spire/blob/main/doc/plugin_agent_workloadattestor_k8s.md
) and [spire code](https://github.com/spiffe/spire/blob/main/pkg/agent/plugin/workloadattestor/k8s/k8s.go#L519) , spire support to specify the kubelet address with an enviroment named "MY_NODE_NAME" 

no matter what the local address listened by the kubelet, the spire agent could succeed to contact its local kubelet with status.hostIP

with this fix, it works well

```release-note
Fix behavior where SPIRE doesn't work when kubelet does not listen on 127.0.0.1
```
