### PR TITLE
contrib: Make hint command copy and paste friendly

### DIFF
--- a/contrib/scripts/check-k8s-code-gen.sh
+++ b/contrib/scripts/check-k8s-code-gen.sh
@@ -27,7 +27,7 @@ diff="$(git diff)"
 if [ -n "$diff" ]; then
 	echo "Ungenerated source code:"
 	echo "$diff"
-	echo "Please run make generate-k8s-api & make manifests and submit your changes"
+	echo "Please run make 'generate-k8s-api && make manifests' and submit your changes"
 	exit 1
 fi
 


### PR DESCRIPTION
This is to make it easier for contributor to copy and paste in case of failure. Similar was done in other scripts like below

https://github.com/cilium/cilium/blob/cda37f604391d676e0812cda6e9510530acb976e/contrib/scripts/check-api-code-gen.sh#L46