### PR TITLE
Backport v1.12: ipsec: fixes for key rotation

### DIFF
--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -518,6 +518,9 @@ func setupIPSec() (int, uint8, error) {
 	if err != nil {
 		return 0, 0, err
 	}
+	if err := ipsec.SetIPSecSPI(spi); err != nil {
+		return 0, 0, err
+	}
 	node.SetIPsecKeyIdentity(spi)
 	return authKeySize, spi, nil
 }

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -499,6 +499,9 @@ func (c *clusterNodesClient) NodeDelete(node nodeTypes.Node) error {
 	return nil
 }
 
+func (c *clusterNodesClient) AllNodeValidateImplementation() {
+}
+
 func (c *clusterNodesClient) NodeValidateImplementation(node nodeTypes.Node) error {
 	// no-op
 	return nil

--- a/pkg/datapath/fake/node.go
+++ b/pkg/datapath/fake/node.go
@@ -30,6 +30,9 @@ func (n *fakeNodeHandler) NodeDelete(node nodeTypes.Node) error {
 	return nil
 }
 
+func (n *fakeNodeHandler) AllNodeValidateImplementation() {
+}
+
 func (n *fakeNodeHandler) NodeValidateImplementation(node nodeTypes.Node) error {
 	return nil
 }

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -925,11 +925,11 @@ func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath
 			// package
 			node.SetIPsecKeyIdentity(spi)
 
-			// NodeValidateImplementation will eventually call
+			// AllNodeValidateImplementation will eventually call
 			// nodeUpdate(), which is responsible for updating the
 			// IPSec policies and states for all the different EPs
 			// with ipsec.UpsertIPsecEndpoint()
-			nodeHandler.NodeValidateImplementation(*nodediscovery.LocalNode())
+			nodeHandler.AllNodeValidateImplementation()
 
 			// Publish the updated node information to k8s/KVStore
 			nodediscovery.UpdateLocalNode()

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -759,7 +759,6 @@ func LoadIPSecKeysFile(path string) (int, uint8, error) {
 func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 	var spi uint8
 	var keyLen int
-	scopedLog := log
 
 	ipSecLock.Lock()
 	defer ipSecLock.Unlock()
@@ -877,11 +876,17 @@ func loadIPSecKeys(r io.Reader) (int, uint8, error) {
 		ipSecKeysRemovalTime[oldSpi] = time.Now()
 		ipSecCurrentKeySPI = spi
 	}
+	return keyLen, spi, nil
+}
+
+func SetIPSecSPI(spi uint8) error {
+	scopedLog := log
+
 	if err := encrypt.MapUpdateContext(0, spi); err != nil {
 		scopedLog.WithError(err).Warn("cilium_encrypt_state map updated failed:")
-		return 0, 0, err
+		return err
 	}
-	return keyLen, spi, nil
+	return nil
 }
 
 // DeleteIPsecEncryptRoute removes nodes in main routing table by walking
@@ -934,6 +939,12 @@ func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath
 			// Publish the updated node information to k8s/KVStore
 			nodediscovery.UpdateLocalNode()
 
+			// Push SPI update into BPF datapath now that XFRM state
+			// is configured.
+			if err := SetIPSecSPI(spi); err != nil {
+				log.WithError(err).Errorf("Failed to set IPsec SPI")
+				continue
+			}
 		case err := <-watcher.Errors:
 			log.WithError(err).WithField(logfields.Path, keyfilePath).
 				Warning("Error encountered while watching file with fsnotify")

--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -63,10 +63,14 @@ func (p *IPSecSuitePrivileged) TestInvalidLoadKeys(c *C) {
 
 func (p *IPSecSuitePrivileged) TestLoadKeys(c *C) {
 	keys := bytes.NewReader(keysDat)
-	_, _, err := loadIPSecKeys(keys)
+	_, spi, err := loadIPSecKeys(keys)
+	c.Assert(err, IsNil)
+	err = SetIPSecSPI(spi)
 	c.Assert(err, IsNil)
 	keys = bytes.NewReader(keysAeadDat)
-	_, _, err = loadIPSecKeys(keys)
+	_, spi, err = loadIPSecKeys(keys)
+	c.Assert(err, IsNil)
+	err = SetIPSecSPI(spi)
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -1713,6 +1713,16 @@ func (n *linuxNodeHandler) NodeValidateImplementation(nodeToValidate nodeTypes.N
 	return n.nodeUpdate(nil, &nodeToValidate, false)
 }
 
+// AllNodeValidateImplementation is called to validate the implementation of the
+// node in the datapath for all existing nodes
+func (n *linuxNodeHandler) AllNodeValidateImplementation() {
+	n.mutex.Lock()
+	defer n.mutex.Unlock()
+	for _, updateNode := range n.nodes {
+		n.nodeUpdate(nil, updateNode, false)
+	}
+}
+
 // NodeNeighDiscoveryEnabled returns whether node neighbor discovery is enabled
 func (n *linuxNodeHandler) NodeNeighDiscoveryEnabled() bool {
 	return n.enableNeighDiscovery

--- a/pkg/datapath/node.go
+++ b/pkg/datapath/node.go
@@ -117,6 +117,10 @@ type NodeHandler interface {
 	// NodeDelete is called after a node has been deleted
 	NodeDelete(node nodeTypes.Node) error
 
+	// AllNodeValidateImplementation is called to validate the implementation
+	// of all nodes in the node cache.
+	AllNodeValidateImplementation()
+
 	// NodeValidateImplementation is called to validate the implementation of
 	// the node in the datapath. This function is intended to be run on an
 	// interval to ensure that the datapath is consistently converged.

--- a/pkg/hubble/peer/handler.go
+++ b/pkg/hubble/peer/handler.go
@@ -90,6 +90,10 @@ func (h *handler) NodeDelete(n types.Node) error {
 	return nil
 }
 
+// AllNodeValidateImplementation implements
+func (h handler) AllNodeValidateImplementation() {
+}
+
 // NodeValidateImplementation implements
 // datapath.NodeHandler.NodeValidateImplementation. It is a no-op.
 func (h handler) NodeValidateImplementation(_ types.Node) error {

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -131,6 +131,9 @@ func (n *signalNodeHandler) NodeDelete(node nodeTypes.Node) error {
 	return nil
 }
 
+func (n *signalNodeHandler) AllNodeValidateImplementation() {
+}
+
 func (n *signalNodeHandler) NodeValidateImplementation(node nodeTypes.Node) error {
 	if n.EnableNodeValidateImplementationEvent {
 		n.NodeValidateImplementationEvent <- node

--- a/pkg/wireguard/agent/node_handler.go
+++ b/pkg/wireguard/agent/node_handler.go
@@ -30,6 +30,11 @@ func (a *Agent) NodeDelete(node nodeTypes.Node) error {
 	return a.DeletePeer(node.Fullname())
 }
 
+// AllNodeValidateImplementation is called to validate the implementation of
+// all nodes in the datapath.
+func (a *Agent) AllNodeValidateImplementation() {
+}
+
 // NodeValidateImplementation is called to validate the implementation of
 // the node in the datapath. This function is intended to be run on an
 // interval to ensure that the datapath is consistently converged.


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/27319

```upstream-prs
for pr in 27319; do contrib/backporting/set-labels.py $pr done 1.12; done
```

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>