### PR TITLE
bpf: static data: use inline asm to access static data

### DIFF
--- a/bpf/include/bpf/compiler.h
+++ b/bpf/include/bpf/compiler.h
@@ -53,10 +53,6 @@
 # define __stringify(X)		#X
 #endif
 
-#ifndef __fetch
-# define __fetch(X)		(__u64)(&(X))
-#endif
-
 #ifndef __aligned
 # define __aligned(X)		__attribute__((aligned(X)))
 #endif

--- a/bpf/lib/drop.h
+++ b/bpf/lib/drop.h
@@ -105,14 +105,6 @@ _send_drop_notify(__u8 file, __u16 line, struct __ctx_buff *ctx,
 	    !__builtin_constant_p(line) || line > 0xffff)
 		__throw_build_bug();
 
-/* Clang 14 or higher fails for constant check, so skip it right now.
- * Enable again once we have more understanding why.
- */
-#if __clang_major__ < 14
-	if (!__builtin_constant_p(dst_id))
-		__throw_build_bug();
-#endif
-
 	/* Non-zero 'dst_id' is only to be used for ingress. */
 	if (dst_id != 0 && (!__builtin_constant_p(direction) || direction != METRIC_INGRESS))
 		__throw_build_bug();

--- a/bpf/lib/static_data.h
+++ b/bpf/lib/static_data.h
@@ -1,46 +1,121 @@
 /* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
 /* Copyright Authors of Cilium */
 
-#ifndef __LIB_STATIC_DATA_H_
-#define __LIB_STATIC_DATA_H_
+#pragma once
 
 #include <bpf/ctx/ctx.h>
 #include <bpf/api.h>
 
 #include "endian.h"
 
-/* fetch_* macros assist in fetching variously sized static data */
-#define fetch_u16(x) (__u16)__fetch(x)
-#define fetch_u32(x) (__u32)__fetch(x)
-#define fetch_u32_i(x, i) fetch_u32(x ## _ ## i)
-#define fetch_u64(x) __fetch(x)
-#define fetch_u64_i(x, i) fetch_u64(x ## _ ## i)
-#define fetch_ipv6(x) fetch_u64_i(x, 1), fetch_u64_i(x, 2)
-#define fetch_mac(x) { { fetch_u32_i(x, 1), (__u16)fetch_u32_i(x, 2) } }
+/* Declare a global configuration variable that can be modified at runtime,
+ * without needing to recompile the datapath. Access the variable using the
+ * CONFIG() macro.
+ */
+#define DECLARE_CONFIG(type, name, description) \
+	/* Emit the variable to the .rodata.config section. The compiler will emit a
+	 * BTF Datasec referring to all variables in this section, making them
+	 * convenient to iterate through for generating config scaffolding in Go.
+	 * ebpf-go will expose this section as a MapSpec when loading a
+	 * CollectionSpec.
+	 */ \
+	__section(".rodata.config") \
+	/* Assign the config variable a BTF decl tag containing its description. This
+	 * allows including doc comments in code generated from BTF. Uncomment this
+	 * when upgrading to LLVM 14:
+	 */ \
+	/* __attribute__((btf_decl_tag(description))) */ \
+	/* Declare a global variable of the given name and type. */ \
+	static const type __config_##name;
 
-#define SEC_DEFINE __section(".data")
-/* DEFINE_* macros help to declare static data. */
-#define DEFINE_U16(NAME, value) SEC_DEFINE volatile __u16 NAME = value
-#define DEFINE_U32(NAME, value) SEC_DEFINE volatile __u32 NAME = value
-#define DEFINE_U32_I(NAME, i) SEC_DEFINE volatile __u32 NAME ## _ ## i
-#define DEFINE_U64(NAME, value) SEC_DEFINE volatile __u64 NAME = value
-#define DEFINE_U64_I(NAME, i) SEC_DEFINE volatile __u64 NAME ## _ ## i
+/* Hardcode config values at compile time, e.g. from per-endpoint headers.
+ * Can be used only once per config variable within a single compilation unit.
+ */
+#define ASSIGN_CONFIG(type, name, value) \
+	static const type __config_##name = value;
 
-#define DEFINE_IPV6(NAME, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) \
-DEFINE_U64_I(NAME, 1) = bpf_cpu_to_be64( \
+/* Access a global configuration variable declared using DECLARE_CONFIG(). All
+ * access must be done through this macro to ensure the loader can correctly
+ * find and update all instructions that refer to the variable.
+ */
+#define CONFIG(name) ({ \
+	/* Variable used as output operand for the asm snippet. Type needs to match
+	 * the width of the instruction in the snippet or some compilers will
+	 * complain (notably arm64).
+	 */ \
+	__u64 out; \
+	/* In BPF, referring to a global variable directly from C code will generally
+	 * result in 2 instructions: 1) loading an array map pointer into a register,
+	 * and 2) dereferencing the map pointer at the offset where the variable is
+	 * located. The first instruction carries a relocation entry against the map,
+	 * so the loader can update the instruction to carry the map's file
+	 * descriptor after the map has been created, before loading the program.
+	 *
+	 * For security and efficiency purposes, we want to use global constants,
+	 * populated by the agent before loading the program, remaining immutable
+	 * thereafter. Native 'static const' are implemented by the compiler using the
+	 * mechanism previously described, with variables emitted to the .rodata map,
+	 * which gets frozen after being populated. This makes the verifier treat its
+	 * values as constant, enabling dead code elimination and JIT optimizations.
+	 * Unfortunately, this is only supported on kernels 5.2 and later, so we need
+	 * a user space implementation in the meantime.
+	 *
+	 * This asm snippet emits a single dword load instruction with a symbol
+	 * reference to .rodata.config, with the offset of the variable within the
+	 * datasec stored in its instruction constant. This is no different from a
+	 * regular static var access in bpf, with one difference: with a regular var,
+	 * the compiler still takes the liberty of taking out a map pointer and using
+	 * it multiple times, and/or pushing the register holding the variable to the
+	 * stack, making it nearly impossible to correctly track and modify.
+	 *
+	 * To emulate the readonly map behaviour on older kernels, the ELF loader then
+	 * rewrites all instructions referring to the map to simple ldimm64 with a
+	 * constant provided by the agent at runtime.
+	 */ \
+	asm volatile("%[out] = __config_" #name " ll" : [out]"=r"(out)); \
+	(typeof(__config_##name))out; \
+})
+
+/* Deprecated, use CONFIG instead. */
+#define fetch_u16(x) CONFIG(x)
+#define fetch_u32(x) CONFIG(x)
+#define fetch_ipv6(x) CONFIG(x ## _1), CONFIG(x ## _2)
+#define fetch_mac(x) { { CONFIG(x ## _1), (__u16)CONFIG(x ## _2) } }
+
+/* Deprecated, use DECLARE_CONFIG instead. */
+#define DEFINE_U16(name, value) \
+	DECLARE_CONFIG(__u16, name, "Constant " #name " declared using DEFINE_U16") \
+	ASSIGN_CONFIG(__u16, name, value)
+#define DEFINE_U32(name, value) \
+	DECLARE_CONFIG(__u32, name, "Constant " #name " declared using DEFINE_U32") \
+	ASSIGN_CONFIG(__u32, name, value)
+
+/* DEFINE_IPV6 and DEFINE_MAC are used to assign values to global constants from
+ * C headers generated at runtime before the datapath is compiled. This data
+ * ends up in .rodata.config in the ELF and is also inlined by the Go loader,
+ * even though it's not handled by ELF variable substitution.
+ *
+ * Variables relying on this are NODE_MAC, LXC_IP, IPV6_MASQUERADE, ROUTER_IP
+ * and HOST_IP.
+ */
+#define DEFINE_IPV6(name, a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16) \
+	DECLARE_CONFIG(__u64, name##_1, "First half of ipv6 address " #name) \
+	DECLARE_CONFIG(__u64, name##_2, "Second half of ipv6 address " #name) \
+	ASSIGN_CONFIG(__u64, name##_1, bpf_cpu_to_be64( \
 			(__u64)(__u8)(a1) << 56 | (__u64)(__u8)(a2) << 48 | \
 			(__u64)(__u8)(a3) << 40 | (__u64)(__u8)(a4) << 32 | \
 			(__u64)(__u8)(a5) << 24 | (__u64)(__u8)(a6) << 16 | \
-			(__u64)(__u8)(a7) << 8  | (__u64)(__u8)(a8)); \
-DEFINE_U64_I(NAME, 2) = bpf_cpu_to_be64( \
+			(__u64)(__u8)(a7) << 8  | (__u64)(__u8)(a8))); \
+	ASSIGN_CONFIG(__u64, name##_2, bpf_cpu_to_be64( \
 			(__u64)(__u8)(a9) << 56  | (__u64)(__u8)(a10) << 48 | \
 			(__u64)(__u8)(a11) << 40 | (__u64)(__u8)(a12) << 32 | \
 			(__u64)(__u8)(a13) << 24 | (__u64)(__u8)(a14) << 16 | \
-			(__u64)(__u8)(a15) << 8  | (__u64)(__u8)(a16));
+			(__u64)(__u8)(a15) << 8  | (__u64)(__u8)(a16)));
 
-#define DEFINE_MAC(NAME, a1, a2, a3, a4, a5, a6) \
-DEFINE_U32_I(NAME, 1) = (__u32)(__u8)(a1) << 24 | (__u32)(__u8)(a2) << 16 | \
-			(__u32)(__u8)(a3) << 8  | (__u32)(__u8)(a4); \
-DEFINE_U32_I(NAME, 2) = (__u32)(__u8)(a5) << 8  | (__u32)(__u8)(a6)
-
-#endif /* __LIB_STATIC_DATA_H_ */
+#define DEFINE_MAC(name, a1, a2, a3, a4, a5, a6) \
+	DECLARE_CONFIG(__u32, name##_1, "First 32 bits of mac address " #name) \
+	DECLARE_CONFIG(__u32, name##_2, "Remaining 16 bits of mac address " #name) \
+	ASSIGN_CONFIG(__u32, name##_1, \
+			(__u32)(__u8)(a1) << 24 | (__u32)(__u8)(a2) << 16 | \
+			(__u32)(__u8)(a3) << 8  | (__u32)(__u8)(a4)) \
+	ASSIGN_CONFIG(__u32, name##_2, (__u32)(__u8)(a5) << 8  | (__u32)(__u8)(a6))

--- a/bpf/tests/config_replacement.h
+++ b/bpf/tests/config_replacement.h
@@ -87,11 +87,6 @@
 
 #endif /* ___EP_CONFIG____ */
 
-#define DEFINE_MAC(NAME, a1, a2, a3, a4, a5, a6) \
-DEFINE_U32_I(NAME, 1) = (__u32)(__u8)(a1) << 24 | (__u32)(__u8)(a2) << 16 | \
-			(__u32)(__u8)(a3) << 8  | (__u32)(__u8)(a4); \
-DEFINE_U32_I(NAME, 2) = (__u32)(__u8)(a5) << 8  | (__u32)(__u8)(a6)
-
 #ifndef NODE_MAC
 #define NODE_MAC_1 (0xde) << 24 | (0xad) << 16 | (0xbe) << 8 | (0xef)
 #define NODE_MAC_2 (0xc0) << 8 | (0xde)

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -241,18 +241,9 @@ func inlineGlobalData(spec *ebpf.CollectionSpec) error {
 		return nil
 	}
 
-	// Don't attempt to create an empty map .bss in the kernel.
-	delete(spec.Maps, ".bss")
-
 	for _, prog := range spec.Programs {
 		for i, ins := range prog.Instructions {
 			if !ins.IsLoadFromMap() || ins.Src != asm.PseudoMapValue {
-				continue
-			}
-
-			// The compiler inserts relocations for .bss for zero values.
-			if ins.Reference() == ".bss" {
-				prog.Instructions[i] = asm.LoadImm(ins.Dst, 0, asm.DWord)
 				continue
 			}
 

--- a/pkg/bpf/collection.go
+++ b/pkg/bpf/collection.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cilium/ebpf/btf"
 )
 
-const globalDataMap = ".data"
+const globalDataMap = ".rodata.config"
 
 // LoadCollectionSpec loads the eBPF ELF at the given path and parses it into
 // a CollectionSpec. This spec is only a blueprint of the contents of the ELF
@@ -230,9 +230,7 @@ func classifyProgramTypes(spec *ebpf.CollectionSpec) error {
 // loader. This is done for compatibility with kernels that don't support
 // global data maps yet.
 //
-// This works in conjunction with the __fetch macros in the datapath, which
-// emit direct array accesses instead of memory loads with an offset from the
-// map's pointer.
+// This code interacts with the DECLARE_CONFIG macro in the BPF C code base.
 func inlineGlobalData(spec *ebpf.CollectionSpec) error {
 	vars, err := globalData(spec)
 	if err != nil {

--- a/pkg/elf/elf_test.go
+++ b/pkg/elf/elf_test.go
@@ -235,7 +235,7 @@ func (elf *ELF) findString(key string) error {
 }
 
 func (elf *ELF) readOption(key string) (result uint64, err error) {
-	opt, exists := elf.symbols.data[key]
+	opt, exists := elf.symbols.data[configPrefix+key]
 	if !exists {
 		return 0, fmt.Errorf("no such option %q in ELF", key)
 	}

--- a/pkg/elf/symbols.go
+++ b/pkg/elf/symbols.go
@@ -101,14 +101,14 @@ func (s *symbols) sort() symbolSlice {
 	return result.sort()
 }
 
-// isGlobalData returns true if the symbol meets all of the following criteria:
-// - symbol is of type STT_NOTYPE or STT_OBJECT
-// - symbol has a global binding (STB_GLOBAL)
+// canReplace returns true if the symbol meets all of the following criteria:
+// - symbol is of type STT_OBJECT
+// - symbol has a local (STB_LOCAL) or global (STB_GLOBAL) binding
 // - symbol has default visibility (STV_DEFAULT)
-func isGlobalData(sym elf.Symbol) bool {
-	return (elf.ST_TYPE(sym.Info) == elf.STT_NOTYPE ||
-		elf.ST_TYPE(sym.Info) == elf.STT_OBJECT) &&
-		elf.ST_BIND(sym.Info) == elf.STB_GLOBAL &&
+func canReplace(sym elf.Symbol) bool {
+	return (elf.ST_TYPE(sym.Info) == elf.STT_OBJECT) &&
+		(elf.ST_BIND(sym.Info) == elf.STB_GLOBAL ||
+			elf.ST_BIND(sym.Info) == elf.STB_LOCAL) &&
 		elf.ST_VISIBILITY(sym.Other) == elf.STV_DEFAULT
 }
 
@@ -162,9 +162,8 @@ func (s *symbols) extractFrom(e *elf.File) error {
 		case section.Flags&elf.SHF_COMPRESSED > 0:
 			return fmt.Errorf("compressed %s section not supported", section.Name)
 
-		// Skip local symbols that are objects or untyped. These are usually
-		// program segments referred to using long jumps in bytecode.
-		case !isGlobalData(sym):
+		// Only consider local and global OBJECT symbols.
+		case !canReplace(sym):
 			// Some symbols don't have names and 'LBB0 is a common llvm symbol prefix
 			// (basic block). Don't flood the logs with messages about them.
 			if sym.Name != "" && !strings.HasPrefix(sym.Name, "LBB") {

--- a/pkg/elf/symbols.go
+++ b/pkg/elf/symbols.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	dataSection   = ".data"
+	dataSection   = ".rodata.config"
+	configPrefix  = "__config_"
 	mapSection    = "maps"
 	btfMapSection = ".maps"
 
@@ -175,7 +176,7 @@ func (s *symbols) extractFrom(e *elf.File) error {
 		// in the .data section.
 		// This implements substitution of static data.
 		case section.Name == dataSection:
-			// Offset from start of binary to variable inside .data
+			// Offset from start of binary to variable inside .rodata.config
 			offset := section.Offset + sym.Value
 			dataOffsets[sym.Name] = newVariable(sym.Name, offset, sym.Size)
 			log.WithField(fieldSymbol, sym.Name).Debugf("Found variable with offset %d", offset)


### PR DESCRIPTION
The new static data approach is fully documented in the code. Using a volatile inline asm block makes for a more predictable outcome in the bytecode, meaning we can simplify the substitution logic on the Go side and start using runtime-provided constants for user space dead code elimination.

Part of: https://github.com/cilium/cilium/issues/27320

```release-note
bpf: static data: use inline asm to access static data
```
