### PR TITLE
Fix a bug where cilium host IP is not read from k8s node annotations

### DIFF
--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -161,6 +161,7 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 
 	k8sNodeAddHostIP(annotation.CiliumHostIP, annotation.CiliumHostIPAlias)
 	k8sNodeAddHostIP(annotation.CiliumHostIPv6, annotation.CiliumHostIPv6Alias)
+	newNode.IPAddresses = addrs
 
 	if key, ok := annotation.Get(k8sNode, annotation.CiliumEncryptionKey, annotation.CiliumEncryptionKeyAlias); ok {
 		if u, err := strconv.ParseUint(key, 10, 8); err == nil {

--- a/pkg/k8s/node_test.go
+++ b/pkg/k8s/node_test.go
@@ -29,8 +29,10 @@ func (s *K8sSuite) TestParseNode(c *C) {
 		ObjectMeta: slim_metav1.ObjectMeta{
 			Name: "node1",
 			Annotations: map[string]string{
-				annotation.V4CIDRName: "10.254.0.0/16",
-				annotation.V6CIDRName: "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
+				annotation.V4CIDRName:     "10.254.0.0/16",
+				annotation.V6CIDRName:     "f00d:aaaa:bbbb:cccc:dddd:eeee::/112",
+				annotation.CiliumHostIP:   "10.254.9.9",
+				annotation.CiliumHostIPv6: "fd00:10:244:1::8ace",
 			},
 			Labels: map[string]string{
 				"type": "m5.xlarge",
@@ -48,6 +50,11 @@ func (s *K8sSuite) TestParseNode(c *C) {
 	c.Assert(n.IPv6AllocCIDR, NotNil)
 	c.Assert(n.IPv6AllocCIDR.String(), Equals, "f00d:aaaa:bbbb:cccc:dddd:eeee::/112")
 	c.Assert(n.Labels["type"], Equals, "m5.xlarge")
+	c.Assert(len(n.IPAddresses), Equals, 2)
+	c.Assert(n.IPAddresses[0].IP.String(), Equals, "10.254.9.9")
+	c.Assert(n.IPAddresses[0].Type, Equals, nodeAddressing.NodeCiliumInternalIP)
+	c.Assert(n.IPAddresses[1].IP.String(), Equals, "fd00:10:244:1::8ace")
+	c.Assert(n.IPAddresses[1].Type, Equals, nodeAddressing.NodeCiliumInternalIP)
 
 	// No IPv6 annotation
 	k8sNode = &slim_corev1.Node{


### PR DESCRIPTION
After https://github.com/cilium/cilium/commit/0696874a932a07f9a5ed2b7a5f7aeb2db0757379 refactored the logic to read annotations and change the default behavior, addrs array was never assigned to newNode.IPAddresses after it was populated.

Fixes: #27439 partly,  there seem to be a race between when `n.localNode.IPAddresses` is populated and when the first ciliumnode(CN) update is made after an agent restart. In our fork we temporarily [added a behavior to retain host IP](https://github.com/DataDog/cilium/pull/517) from ciliumnode when localNode hasn't yet been populated to avoid the double writes. This isn't perfect because in the rare event where `cilium_host`'s router IP has been removed, it would not be updated on the CN.

Open Questions : 
* The daemon initialization process already seems to have strict requirements in what order restoration should happen. Can the order be improved so that we don't update CN before localNode.IPAddresses are populated ?

Thanks to @jaredledvina  for identifying the duplicate writes
