### PR TITLE
k8s: Replace generate-internal-groups.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,7 @@ generate-hubble-api: api/v1/flow/flow.proto api/v1/peer/peer.proto api/v1/observ
 
 define generate_k8s_api
 	$(QUIET) cd "./vendor/k8s.io/code-generator" && \
-	bash ./generate-internal-groups.sh $(1) \
+	bash ./kube_codegen.sh $(1) \
 	    $(2) \
 	    "" \
 	    $(3) \


### PR DESCRIPTION
This commit is to change to kube_codegen.sh as per the suggestion in the output.

```
$ make generate-k8s-api
...
WARNING: generate-internal-groups.sh is deprecated.
WARNING: Please use k8s.io/code-generator/kube_codegen.sh instead.
..
```

Relates: https://github.com/kubernetes/code-generator/commit/13056260ff7da3927a710f720f22440f65b4bf8a
