### PR TITLE
Resiliency: Add retry logic to stale ceps checks

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	healthApi "github.com/cilium/cilium/api/v1/health/server"
 	"github.com/cilium/cilium/api/v1/server"
@@ -89,6 +90,7 @@ import (
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/version"
@@ -1765,8 +1767,7 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 		if restoreComplete != nil {
 			<-restoreComplete
 		}
-
-		// Only attempt CEP cleanup if cilium endpoint CRD is not disabled, otherwise the cep/ces
+		// Only attempt CEP cleanup if cilium endpoint CRD is enabled, otherwise the cep/ces
 		// watchers/indexers will not be initialized.
 		if params.Clientset.IsEnabled() && option.Config.EnableStaleCiliumEndpointCleanup && !option.Config.DisableCiliumEndpointCRD {
 			// Use restored endpoints to delete local CiliumEndpoints which are not in the restored endpoint cache.
@@ -1775,11 +1776,33 @@ func startDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *da
 			// This must wait for both K8s watcher caches to be synced and local endpoint restoration to be complete.
 			// Note: Synchronization of endpoints to their CEPs may not be complete at this point, but we only have to
 			// know what endpoints exist post-restoration in our endpointManager cache to perform cleanup.
-			if err := d.cleanStaleCEPs(context.Background(), d.endpointManager, params.Clientset.CiliumV2(), option.Config.EnableCiliumEndpointSlice); err != nil {
-				log.WithError(err).Error("Failed to clean up stale CEPs")
+			var (
+				retries int
+				bo      = wait.Backoff{
+					Duration: 500 * time.Millisecond,
+					Factor:   1,
+					Jitter:   0.1,
+					Steps:    5,
+					Cap:      0,
+				}
+			)
+			err := wait.ExponentialBackoffWithContext(context.Background(), bo, func(ctx context.Context) (done bool, err error) {
+				if err := d.cleanStaleCEPs(ctx, d.endpointManager, d.clientset.CiliumV2(), option.Config.EnableCiliumEndpointSlice); err != nil {
+					retries++
+					log.WithError(err).WithField(logfields.Attempt, retries).Error("Failed to clean up stale CEPs")
+					if resiliency.IsRetryable(err) {
+						return false, nil
+					}
+					return true, err
+				}
+				return true, nil
+			})
+			if err != nil {
+				log.WithError(err).Error("Failed to clean up stale CEPs after multiple attempts")
 			}
 		}
 	}()
+
 	go func() {
 		if restoreComplete != nil {
 			<-restoreComplete


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Resiliency: Add retry logic to stale CEPS checks

> NOTE: Depends on PR: #27614 

When the cilium agent starts it attempts to reconcile CEPS from loaded state. 
If a failure occurs no further attempts will take place, thus stale CEPS could remain on the cluster.

- Add retry logic to allow retries to take place should errors occur during CEPS reconciliation.

Fixes: #issue-number

```release-note
During startup, the agent attempts to clear out any obsolete CiliumEndpoints. 
Add retry logic to ensure this process is attempted more than once should errors occur during reconciliation.
```

Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>
