### PR TITLE
proxy: Ignore visibility annotation if proxy is disabled

### DIFF
--- a/Documentation/observability/visibility.rst
+++ b/Documentation/observability/visibility.rst
@@ -10,6 +10,10 @@
 Layer 7 Protocol Visibility
 ***************************
 
+.. note::
+
+    This feature requires enabling L7 Proxy support. Without it, the visibility annotation is ignored.
+
 While :ref:`monitor` provides introspection into datapath state, by default it
 will only provide visibility into L3/L4 packet events. If :ref:`l7_policy` are
 configured, one can get visibility into L7 protocols, but this requires the full

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -475,7 +475,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		return d.errorDuringCreation(ep, fmt.Errorf("unable to insert endpoint into manager: %s", err))
 	}
 
-	// We need to update the the visibility policy after adding the endpoint in
+	// We need to update the visibility policy after adding the endpoint in
 	// the endpoint manager because the endpoint manager create the endpoint
 	// queue of the endpoint. If we execute this function before the endpoint
 	// manager creates the endpoint queue the operation will fail.
@@ -488,6 +488,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 			value, _ := annotation.Get(p, annotation.ProxyVisibility, annotation.ProxyVisibilityAlias)
 			return value, nil
 		})
+
 		ep.UpdateBandwidthPolicy(func(ns, podName string) (bandwidthEgress string, err error) {
 			_, p, err := d.endpointMetadataFetcher.Fetch(ns, podName)
 			if err != nil {

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -48,10 +48,10 @@
   {{- end }}
 {{- end }}
 
-{{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled }}
+{{- if or .Values.ingressController.enabled .Values.gatewayAPI.enabled (eq .Values.loadBalancer.l7.backend "envoy") }}
   {{- if hasKey .Values "l7Proxy" }}
     {{- if not .Values.l7Proxy }}
-      {{ fail "Ingress or Gateway API controller requires .Values.l7Proxy to be set to 'true'" }}
+      {{ fail "Ingress or Gateway API controller or Envoy L7 Load Balancer  requires .Values.l7Proxy to be set to 'true'" }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -202,7 +202,7 @@ func (e *Endpoint) GetLabelsLocked(id identity.NumericIdentity) labels.LabelArra
 // problem that occurred while adding an l7 redirect for the specified policy.
 // Must be called with endpoint.mutex Lock()ed.
 func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
-	if option.Config.DryMode || e.isProxyDisabled() {
+	if option.Config.DryMode || e.IsProxyDisabled() {
 		return nil, nil, nil
 	}
 
@@ -310,7 +310,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 		}
 	)
 
-	if e.visibilityPolicy == nil {
+	if e.visibilityPolicy == nil || e.IsProxyDisabled() {
 		return nil, finalizeList.Finalize, revertStack.Revert
 	}
 

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -226,6 +226,15 @@ func (ev *EndpointPolicyVisibilityEvent) Handle(res chan interface{}) {
 		return
 	}
 	if proxyVisibility != "" {
+		if e.IsProxyDisabled() {
+			e.getLogger().
+				WithField(logfields.EndpointID, e.GetID()).
+				Warn("ignoring L7 proxy visibility policy as L7 proxy is disabled")
+			res <- &EndpointRegenerationResult{
+				err: nil,
+			}
+			return
+		}
 		e.getLogger().Debug("creating visibility policy")
 		nvp, err = policy.NewVisibilityPolicy(proxyVisibility)
 		if err != nil {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -121,7 +121,7 @@ func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (re
 		return nil, nil
 	}
 
-	if e.isProxyDisabled() {
+	if e.IsProxyDisabled() {
 		return nil, nil
 	}
 

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -30,7 +30,7 @@ import (
 
 func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil, nil)}
-	ep := NewEndpointWithState(do, do, testipcache.NewMockIPCache(), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(do, do, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 	ep.UpdateVisibilityPolicy(func(_, _ string) (string, error) {
 		return "", nil
 	})

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -29,13 +29,13 @@ func (e *Endpoint) SetProxy(p EndpointProxy) {
 }
 
 func (e *Endpoint) removeNetworkPolicy() {
-	if e.isProxyDisabled() {
+	if e.IsProxyDisabled() {
 		return
 	}
 	e.proxy.RemoveNetworkPolicy(e)
 }
 
-func (e *Endpoint) isProxyDisabled() bool {
+func (e *Endpoint) IsProxyDisabled() bool {
 	return e.proxy == nil || reflect.ValueOf(e.proxy).IsNil()
 }
 


### PR DESCRIPTION
### Description


This is to avoid the below error if proxy is disabled as part of
installation, but the visibility annotation is added to pods later.

```console
2023-08-11T12:42:41.390575371Z goroutine 1522 [running]:
2023-08-11T12:42:41.390581994Z github.com/cilium/cilium/pkg/proxy.(*Proxy).CreateOrUpdateRedirect(0x0, {0x3ae74b8, 0xc000650280}, {0x3aeb440?, 0xc0016e4560?}, {0xc0010ba1b0, 0x12}, {0x3afd260, 0xc000982000}, 0xc001c9c980)
2023-08-11T12:42:41.390589198Z  github.com/cilium/cilium/pkg/proxy/proxy.go:459 +0xb7
2023-08-11T12:42:41.390596081Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).addVisibilityRedirects(0xc000982000, 0x1, 0xc001874ba0?, 0xc001c9c980?)
2023-08-11T12:42:41.390602613Z  github.com/cilium/cilium/pkg/endpoint/bpf.go:343 +0x443
2023-08-11T12:42:41.390614345Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).addNewRedirects(0xc000982000, 0xc001874870?)
2023-08-11T12:42:41.390651325Z  github.com/cilium/cilium/pkg/endpoint/bpf.go:424 +0x3c5
2023-08-11T12:42:41.390658068Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).runPreCompilationSteps(0xc000982000, 0xc000e31800, 0x0)
2023-08-11T12:42:41.390663999Z  github.com/cilium/cilium/pkg/endpoint/bpf.go:802 +0x4fe
2023-08-11T12:42:41.390669690Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerateBPF(0xc000982000, 0xc000e31800)
2023-08-11T12:42:41.390675451Z  github.com/cilium/cilium/pkg/endpoint/bpf.go:542 +0x1a5
2023-08-11T12:42:41.390681112Z github.com/cilium/cilium/pkg/endpoint.(*Endpoint).regenerate(0xc000982000, 0xc000e31800)
2023-08-11T12:42:41.390686893Z  github.com/cilium/cilium/pkg/endpoint/policy.go:467 +0x9c6
2023-08-11T12:42:41.390692564Z github.com/cilium/cilium/pkg/endpoint.(*EndpointRegenerationEvent).Handle(0xc000131b50, 0x0?)
2023-08-11T12:42:41.390698385Z  github.com/cilium/cilium/pkg/endpoint/events.go:53 +0x325
2023-08-11T12:42:41.390704045Z github.com/cilium/cilium/pkg/eventqueue.(*EventQueue).run.func1()
2023-08-11T12:42:41.390709716Z  github.com/cilium/cilium/pkg/eventqueue/eventqueue.go:245 +0x142
```
    
Fixes: #27594

### Testing

Testing was done locally with l7Proxy=false, and then annotate a pod with visibility annotation

```console
$ k annotate pod client-77bf9989dc-984xp policy.cilium.io/proxy-visibility="<Egress/80/TCP/HTTP>" --overwrite
pod/client-77bf9989dc-984xp annotate
$ ksyslo ds/cilium --timestamps | zgrep "ignoring L7 proxy visibility policy as L7 proxy is disabled"
2023-08-20T13:02:08.241508927Z level=warning msg="ignoring L7 proxy visibility policy as L7 proxy is disabled" ciliumEndpointName=default/client-77bf9989dc-984xp containerID=1ea0a77f5d containerInterface=eth0 datapathPolicyRevision=0 desiredPolicyRevision=0 endpointID=759 identity=831 ipv4=10.244.0.19 ipv6= k8sPodName=default/client-77bf9989dc-984xp subsys=endpoint
```