### PR TITLE
bpf: lxc: remove unused IPv6 loopback code

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -324,7 +324,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		}
 #endif
 		return ipv6_local_delivery(ctx, l3_off, secctx, ep,
-					   METRIC_INGRESS, from_host, false);
+					   METRIC_INGRESS, from_host);
 	}
 
 	/* Below remainder is only relevant when traffic is pushed via cilium_host.

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -532,15 +532,7 @@ ct_recreate6:
 			return DROP_MISSED_TAIL_CALL;
 		}
 #endif /* ENABLE_NODEPORT */
-
-		if (ct_state->rev_nat_index) {
-			ret = lb6_rev_nat(ctx, l4_off,
-					  ct_state->rev_nat_index, tuple, 0);
-			if (IS_ERR(ret))
-				return ret;
-		}
 		break;
-
 	default:
 		return DROP_UNKNOWN_CT;
 	}
@@ -973,6 +965,7 @@ ct_recreate4:
 
 #endif /* ENABLE_NODEPORT */
 
+		/* RevNAT for replies on a loopback connection: */
 		if (ct_state->rev_nat_index) {
 			ret = lb4_rev_nat(ctx, ETH_HLEN, l4_off,
 					  ct_state->rev_nat_index,

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -137,7 +137,7 @@ not_esp:
 	ep = lookup_ip6_endpoint(ip6);
 	if (ep && !(ep->flags & ENDPOINT_F_HOST))
 		return ipv6_local_delivery(ctx, l3_off, *identity, ep,
-					   METRIC_INGRESS, false, false);
+					   METRIC_INGRESS, false);
 
 	/* A packet entering the node from the tunnel and not going to a local
 	 * endpoint has to be going to the local host.

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -134,8 +134,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel,
 					       const struct endpoint_info *ep,
-					       __u8 direction, bool from_host,
-					       bool hairpin_flow)
+					       __u8 direction, bool from_host)
 {
 	mac_t router_mac = ep->node_mac;
 	mac_t lxc_mac = ep->mac;
@@ -147,7 +146,7 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 	if (ret != CTX_ACT_OK)
 		return ret;
 
-	return l3_local_delivery(ctx, seclabel, ep, direction, from_host, hairpin_flow,
+	return l3_local_delivery(ctx, seclabel, ep, direction, from_host, false,
 				 false, 0);
 }
 #endif /* ENABLE_IPV6 */


### PR DESCRIPTION
Cilium currently doesn't support per-packet service loopback (a client connecting to itself through a service) for IPv6 connections. Remove the unused code from the IPv6 packet path until it becomes relevant.