### PR TITLE
bpf: lxc: defer CT_INGRESS entry creation for loopback connections

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1022,6 +1022,16 @@ ct_recreate4:
 	 */
 	if (is_defined(ENABLE_ROUTING) || hairpin_flow ||
 	    is_defined(ENABLE_HOST_ROUTING)) {
+		/* Hairpin requests need to pass through the backend's to-container
+		 * path, to create a CT_INGRESS entry with .lb_loopback set. This
+		 * drives RevNAT in the backend's from-container path.
+		 *
+		 * Hairpin replies are fully RevNATed in the backend's from-container
+		 * path. Thus they don't match the CT_EGRESS entry, and we can't rely
+		 * on a CT_REPLY result that would provide bypass of ingress policy.
+		 * Thus manually skip the ingress policy path.
+		 */
+		bool bypass_ingress_policy = hairpin_flow && ct_status == CT_REPLY;
 		struct endpoint_info *ep;
 
 		/* Lookup IPv4 address, this will return a match if:
@@ -1047,8 +1057,8 @@ ct_recreate4:
 			policy_clear_mark(ctx);
 			/* If the packet is from L7 LB it is coming from the host */
 			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL_IPV4, ip4,
-						   ep, METRIC_EGRESS, from_l7lb, hairpin_flow,
-						   false, 0);
+						   ep, METRIC_EGRESS, from_l7lb,
+						   bypass_ingress_policy, false, 0);
 		}
 	}
 
@@ -1793,7 +1803,19 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 	 * define policy rules to allow pods to talk to themselves. We still
 	 * want to execute the conntrack logic so that replies can be correctly
 	 * matched.
+	 *
+	 * If ip4.saddr is IPV4_LOOPBACK, this is almost certainly a loopback
+	 * connection. Populate
+	 * - .loopback, so that policy enforcement is bypassed, and
+	 * - .rev_nat_index, so that replies can be RevNATed.
 	 */
+	if (ret == CT_NEW && ip4->saddr == IPV4_LOOPBACK &&
+	    ct_has_loopback_egress_entry4(get_ct_map4(tuple), tuple,
+					  &ct_state_new.rev_nat_index)) {
+		ct_state_new.loopback = true;
+		goto skip_policy_enforcement;
+	}
+
 	if (unlikely(ct_state->loopback))
 		goto skip_policy_enforcement;
 #endif /* ENABLE_PER_PACKET_LB && !DISABLE_LOOPBACK_LB */

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -46,6 +46,7 @@ struct {
 } entry_call_map __section(".maps") = {
 	.values = {
 		[0] = &cil_from_container,
+		[1] = &cil_to_container,
 	},
 };
 
@@ -165,8 +166,98 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
+/* Let backend's ingress path create its CT own entry: */
+PKTGEN("tc", "hairpin_sctp_flow_2_forward_ingress_v4")
+int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
+	struct iphdr *l3;
+	struct sctphdr *l4;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l3 = pktgen__push_ipv4_packet(&builder, (__u8 *)src, (__u8 *)dst,
+				      IPV4_LOOPBACK, v4_pod_one);
+	if (!l3)
+		return TEST_ERROR;
+
+	/* Push SCTP header */
+	l4 = pktgen__push_sctphdr(&builder);
+
+	if (!l4)
+		return TEST_ERROR;
+	if ((void *)l4 + sizeof(struct sctphdr) > ctx_data_end(ctx))
+		return TEST_ERROR;
+
+	l4->source = tcp_src_one;
+	l4->dest = tcp_svc_one;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hairpin_sctp_flow_2_forward_ingress_v4")
+int hairpin_flow_forward_ingress_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, 1);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hairpin_sctp_flow_2_forward_ingress_v4")
+int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct sctphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == TC_ACT_OK);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != IPV4_LOOPBACK)
+		test_fatal("src IP changed");
+
+	if (l3->daddr != v4_pod_one)
+		test_fatal("dest IP changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct sctphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_src_one)
+		test_fatal("src SCTP port changed");
+
+	if (l4->dest != tcp_svc_one)
+		test_fatal("dst SCTP port changed");
+
+	test_finish();
+}
+
 /* Test that a packet in the reverse direction gets translated back. */
-SETUP("tc", "hairpin_sctp_flow_2_reverse_v4")
+SETUP("tc", "hairpin_sctp_flow_3_reverse_v4")
 int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -214,7 +305,7 @@ int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "hairpin_sctp_flow_2_reverse_v4")
+CHECK("tc", "hairpin_sctp_flow_3_reverse_v4")
 int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -79,9 +79,13 @@ static volatile const __u8 v6_node_three[] = {0xfd, 0x07, 0, 0, 0, 0, 0, 0,
 					   0, 0, 0, 0, 0, 0, 0, 3};
 
 /* Source port to be used by a client */
-#define tcp_src_one	__bpf_htons(22334)
-#define tcp_src_two	__bpf_htons(33445)
-#define tcp_src_three	__bpf_htons(44556)
+#define tcp_src_one	__bpf_htons(22330)
+#define tcp_src_two	__bpf_htons(33440)
+#define tcp_src_three	__bpf_htons(44550)
+
+#define tcp_dst_one	__bpf_htons(22331)
+#define tcp_dst_two	__bpf_htons(33441)
+#define tcp_dst_three	__bpf_htons(44551)
 
 #define tcp_svc_one	__bpf_htons(80)
 #define tcp_svc_two	__bpf_htons(443)

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -103,7 +103,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 
 	lb_v4_add_service(v4_svc_one, tcp_svc_one, 1, revnat_id);
 	lb_v4_add_backend(v4_svc_one, tcp_svc_one, 1, 124,
-			  v4_pod_one, tcp_svc_one, IPPROTO_TCP, 0);
+			  v4_pod_one, tcp_dst_one, IPPROTO_TCP, 0);
 
 	/* Add an IPCache entry for pod 1 */
 	ipcache_v4_add_entry(v4_pod_one, 0, 112233, 0, 0);
@@ -156,7 +156,7 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->source != tcp_src_one)
 		test_fatal("src TCP port was changed");
 
-	if (l4->dest != tcp_svc_one)
+	if (l4->dest != tcp_dst_one)
 		test_fatal("dst TCP port incorrect");
 
 	struct ipv4_ct_tuple tuple = {};
@@ -183,7 +183,7 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	tuple.saddr = IPV4_LOOPBACK;
 	tuple.sport = tcp_src_one;
 	tuple.daddr = v4_pod_one;
-	tuple.dport = tcp_svc_one;
+	tuple.dport = tcp_dst_one;
 
 	/* Addrs are stored in reverse order: */
 	ipv4_ct_tuple_swap_addrs(&tuple);
@@ -213,7 +213,7 @@ int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
 	l4 = pktgen__push_ipv4_tcp_packet(&builder,
 					  (__u8 *)src, (__u8 *)dst,
 					  IPV4_LOOPBACK, v4_pod_one,
-					  tcp_src_one, tcp_svc_one);
+					  tcp_src_one, tcp_dst_one);
 	if (!l4)
 		return TEST_ERROR;
 
@@ -278,7 +278,7 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 	if (l4->source != tcp_src_one)
 		test_fatal("src TCP port changed");
 
-	if (l4->dest != tcp_svc_one)
+	if (l4->dest != tcp_dst_one)
 		test_fatal("dst TCP port changed");
 
 	struct ipv4_ct_tuple tuple = {};
@@ -290,7 +290,7 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 	tuple.saddr = IPV4_LOOPBACK;
 	tuple.sport = tcp_src_one;
 	tuple.daddr = v4_pod_one;
-	tuple.dport = tcp_svc_one;
+	tuple.dport = tcp_dst_one;
 
 	/* Addrs are stored in reverse order: */
 	ipv4_ct_tuple_swap_addrs(&tuple);
@@ -319,7 +319,7 @@ int hairpin_flow_reverse_pktgen(struct __ctx_buff *ctx)
 	l4 = pktgen__push_ipv4_tcp_packet(&builder,
 					  (__u8 *)src, (__u8 *)dst,
 					  v4_pod_one, IPV4_LOOPBACK,
-					  tcp_svc_one, tcp_src_one);
+					  tcp_dst_one, tcp_src_one);
 	if (!l4)
 		return TEST_ERROR;
 

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -46,6 +46,7 @@ struct {
 } entry_call_map __section(".maps") = {
 	.values = {
 		[0] = &cil_from_container,
+		[1] = &cil_to_container,
 	},
 };
 
@@ -158,10 +159,152 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->dest != tcp_svc_one)
 		test_fatal("dst TCP port incorrect");
 
+	struct ipv4_ct_tuple tuple = {};
+	struct ct_entry *ct_entry;
+
+	/* Match the packet headers: */
+	tuple.flags = TUPLE_F_SERVICE;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.saddr = v4_pod_one;
+	tuple.sport = tcp_src_one;
+	tuple.daddr = v4_svc_one;
+	tuple.dport = tcp_svc_one;
+
+	/* Ports are stored in reverse order: */
+	ipv4_ct_tuple_swap_ports(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT_SERVICE entry found");
+
+	/* Match the packet headers: */
+	tuple.flags = TUPLE_F_OUT;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.saddr = IPV4_LOOPBACK;
+	tuple.sport = tcp_src_one;
+	tuple.daddr = v4_pod_one;
+	tuple.dport = tcp_svc_one;
+
+	/* Addrs are stored in reverse order: */
+	ipv4_ct_tuple_swap_addrs(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT_EGRESS entry found");
+	if (!ct_entry->lb_loopback)
+		test_fatal("CT_EGRESS entry doesn't have loopback flag");
+
 	test_finish();
 }
 
-PKTGEN("tc", "hairpin_flow_2_reverse_v4")
+/* Let backend's ingress path create its own CT entry: */
+PKTGEN("tc", "hairpin_flow_2_forward_ingress_v4")
+int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
+	struct tcphdr *l4;
+	void *data;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	l4 = pktgen__push_ipv4_tcp_packet(&builder,
+					  (__u8 *)src, (__u8 *)dst,
+					  IPV4_LOOPBACK, v4_pod_one,
+					  tcp_src_one, tcp_svc_one);
+	if (!l4)
+		return TEST_ERROR;
+
+	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
+
+	if (!data)
+		return TEST_ERROR;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+/* Test that a packet in the forward direction is good. */
+SETUP("tc", "hairpin_flow_2_forward_ingress_v4")
+int hairpin_flow_forward_ingress_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, 1);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hairpin_flow_2_forward_ingress_v4")
+int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct tcphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == TC_ACT_OK);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != IPV4_LOOPBACK)
+		test_fatal("src IP changed");
+
+	if (l3->daddr != v4_pod_one)
+		test_fatal("dest IP changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct tcphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_src_one)
+		test_fatal("src TCP port changed");
+
+	if (l4->dest != tcp_svc_one)
+		test_fatal("dst TCP port changed");
+
+	struct ipv4_ct_tuple tuple = {};
+	struct ct_entry *ct_entry;
+
+	/* Match the packet headers: */
+	tuple.flags = TUPLE_F_IN;
+	tuple.nexthdr = IPPROTO_TCP;
+	tuple.saddr = IPV4_LOOPBACK;
+	tuple.sport = tcp_src_one;
+	tuple.daddr = v4_pod_one;
+	tuple.dport = tcp_svc_one;
+
+	/* Addrs are stored in reverse order: */
+	ipv4_ct_tuple_swap_addrs(&tuple);
+
+	ct_entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+	if (!ct_entry)
+		test_fatal("no CT_INGRESS entry found");
+	if (!ct_entry->lb_loopback)
+		test_fatal("CT_INGRESS entry doesn't have loopback flag");
+
+	test_finish();
+}
+
+PKTGEN("tc", "hairpin_flow_3_reverse_v4")
 int hairpin_flow_reverse_pktgen(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -194,7 +337,7 @@ int hairpin_flow_reverse_pktgen(struct __ctx_buff *ctx)
 }
 
 /* Test that a packet in the reverse direction gets translated back. */
-SETUP("tc", "hairpin_flow_2_reverse_v4")
+SETUP("tc", "hairpin_flow_3_reverse_v4")
 int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 {
 	/* Jump into the entrypoint */
@@ -203,7 +346,7 @@ int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "hairpin_flow_2_reverse_v4")
+CHECK("tc", "hairpin_flow_3_reverse_v4")
 int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;


### PR DESCRIPTION
Currently the CT_INGRESS entry for a loopback connection is already created when the first request leaves the client, as from-container creates the CT_EGRESS entry (see the loopback handling in ct_create4() for details).

This is unusual - we would normally just create the CT_INGRESS entry as the first packet passes through to-container into the backend. But for loopback connections it is needed, so that
1.) to-container finds a CT entry with .loopback set, and thus skips
    network policy enforcement even for the first packet, and
2.) the CT entry has its rev_nat_index field populated, and thus can
    RevNAT replies in from-container.

This approach conflicts with the fact that loopback replies skip the client's to-container path (to avoid network policy enforcement).

Once the loopback connection is closed, the backend's from-container path observes the FIN / RST, and __ct_lookup4() updates the CT_INGRESS entry's lifetime to CT_CLOSE_TIMEOUT. But the client's to-container path will not observe the FIN / RST, and thus the CT_EGRESS entry's lifetime remains as CT_CONNECTION_LIFETIME_TCP. Therefore the CT_INGRESS entry will expire earlier, and potentially gets garbage-collected while the CT_EGRESS entry stays in place.

If the same loopback connection is subsequently re-opened, the client's from-container path finds the CT_EGRESS entry and thus will *not* call ct_create4(). Consequently the CT_INGRESS entry is not created, and the backend will not apply the loopback-specific handling described above. Inbound requests are potentially dropped (due to network policy), and/or replies are not RevNATed.

Fix this up by letting the backend path create its CT_INGRESS entry as usual. It just needs a bit of detection code in its CT_NEW handling to understand that the first packet belongs to a .loopback connection, and populate its own CT_INGRESS entry accordingly.

```release-note
Fix connectivity issues caused by missing conntrack entry when service pod connects to itself via clusterIP.
```
