### PR TITLE
daemon: remove redundant wait on restoreComplete

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -444,9 +444,6 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 		// received the full list of policies present at the time the daemon
 		// is bootstrapped.
 		restoreComplete = d.regenerateRestoredEndpoints(restoredEndpoints)
-		go func() {
-			<-restoreComplete
-		}()
 
 		go func() {
 			if d.clientset.IsEnabled() {


### PR DESCRIPTION
Follow-up to commit 2551942 ("bpf: Map: remove Parallel mode and NonPersistent in favor of Recreate()"). Multiple goroutines wait on restoreComplete to close in order to proceed, so there are no messages to consume. This goroutine existed purely for ending parallel mode.