### PR TITLE
bpf,tests: Change makefile cache to rebuild on header changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.a
 *.so
 *.so.*
+*.d
 
 # LLVM IR files
 *.ll

--- a/bpf/tests/Makefile
+++ b/bpf/tests/Makefile
@@ -19,6 +19,8 @@ CLANG_FLAGS += -Wno-unknown-warning-option
 CLANG_FLAGS += -Wno-gnu-variable-sized-type-not-at-end
 CLANG_FLAGS += -Wimplicit-int-conversion -Wenum-conversion
 CLANG_FLAGS += -Wimplicit-fallthrough
+# Create dependency files for each .o file.
+CLANG_FLAGS += -MD
 LLC_FLAGS := -march=bpf
 # Mimics the mcpu values set by cilium-agent. See GetBPFCPU().
 ifeq ("$(KERNEL)","netnext")
@@ -29,10 +31,12 @@ endif
 
 .PHONY: all clean
 
-TEST_OBJECTS = $(patsubst %.c, %.o, $(wildcard *.c)) $(patsubst %c, %i, $(wildcard *.c))
+TEST_OBJECTS = $(patsubst %.c, %.o, $(wildcard *.c))
 
-%.o: %.ll $(LIB)
+%.o: %.ll %.i $(LIB)
 	$(ECHO_CC)
+	# Remove the .o file to force recompilation, only rely on make's caching, not clangs
+	rm -f $@
 	$(QUIET) ${LLC} ${LLC_FLAGS} -filetype=obj -o $@ $<
 
 %.ll: %.c
@@ -49,3 +53,6 @@ clean:
 	rm -f $(wildcard *.ll)
 	rm -f $(wildcard *.o)
 	rm -f $(wildcard *.i)
+	rm -f $(wildcard *.d)
+
+-include $(TEST_OBJECTS:.o=.d)


### PR DESCRIPTION
During BPF test development, it is common to make changes in dependencies of the test C file and then re-test. However, because we don't explicitly list header files and don't use them in the traditional way of only containing forward declarations and using other C files for the contents, the makefile doesn't understand it needs to rebuild.

This commit makes clang emit a dependency file for each C file, this dependency file is then fed into `make` so it is aware of all files that contribute to the test C file, this makes it so any changes to any dependent file including .h files will invalidate the `make` cache.

```release-note
Change makefile cache to rebuild on header changes
```
