### PR TITLE
bpf: nodeport: constrain CT lookups to relevant entry types

### DIFF
--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -29,6 +29,12 @@ enum ct_scope {
 	SCOPE_BIDIR,
 };
 
+enum ct_entry_type {
+	CT_ENTRY_ANY		= 0,
+	CT_ENTRY_NODEPORT	= (1 << 0),
+	CT_ENTRY_DSR		= (1 << 1),
+};
+
 #ifdef ENABLE_IPV4
 struct ct_buffer4 {
 	struct ipv4_ct_tuple tuple;
@@ -210,11 +216,33 @@ ct_entry_expired_rebalance(const struct ct_entry *entry)
 	return READ_ONCE(entry->last_tx_report) + wait_time <= bpf_mono_now();
 }
 
+static __always_inline bool
+ct_entry_matches_types(const struct ct_entry *entry __maybe_unused,
+		       __u32 ct_entry_types)
+{
+	if (ct_entry_types == CT_ENTRY_ANY)
+		return true;
+
+#ifdef ENABLE_NODEPORT
+	if ((ct_entry_types & CT_ENTRY_NODEPORT) &&
+	    entry->node_port && entry->rev_nat_index)
+		return true;
+
+# ifdef ENABLE_DSR
+	if ((ct_entry_types & CT_ENTRY_DSR) && entry->dsr)
+		return true;
+# endif
+#endif
+
+	return false;
+}
+
 /* Returns CT_NEW, CT_REOPENED or CT_ESTABLISHED. */
 static __always_inline enum ct_status
 __ct_lookup(const void *map, struct __ctx_buff *ctx, const void *tuple,
-	    enum ct_action action, enum ct_dir dir, struct ct_state *ct_state,
-	    bool is_tcp, union tcp_flags seen_flags, __u32 *monitor)
+	    enum ct_action action, enum ct_dir dir, __u32 ct_entry_types,
+	    struct ct_state *ct_state, bool is_tcp, union tcp_flags seen_flags,
+	    __u32 *monitor)
 {
 	bool syn = seen_flags.value & TCP_FLAG_SYN;
 	struct ct_entry *entry;
@@ -223,6 +251,9 @@ __ct_lookup(const void *map, struct __ctx_buff *ctx, const void *tuple,
 
 	entry = map_lookup_elem(map, tuple);
 	if (entry) {
+		if (!ct_entry_matches_types(entry, ct_entry_types))
+			goto ct_new;
+
 		cilium_dbg(ctx, DBG_CT_MATCH, entry->lifetime, entry->rev_nat_index);
 #ifdef HAVE_LARGE_INSN_LIMIT
 		if (dir == CT_SERVICE && syn &&
@@ -494,7 +525,7 @@ DEFINE_FUNC_CT_IS_REPLY(6)
 
 static __always_inline int
 __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ctx,
-	     int l4_off, enum ct_dir dir, enum ct_scope scope,
+	     int l4_off, enum ct_dir dir, enum ct_scope scope, __u32 ct_entry_types,
 	     struct ct_state *ct_state, __u32 *monitor)
 {
 	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
@@ -520,8 +551,8 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ct
 	case SCOPE_REVERSE:
 	case SCOPE_BIDIR:
 		/* Lookup in the reverse direction first: */
-		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state, is_tcp,
-				  tcp_flags, monitor);
+		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_entry_types,
+				  ct_state, is_tcp, tcp_flags, monitor);
 		if (ret != CT_NEW) {
 			if (likely(ret == CT_ESTABLISHED || ret == CT_REOPENED)) {
 				if (unlikely(tuple->flags & TUPLE_F_RELATED))
@@ -539,8 +570,8 @@ __ct_lookup6(const void *map, struct ipv6_ct_tuple *tuple, struct __ctx_buff *ct
 		ipv6_ct_tuple_reverse(tuple);
 		fallthrough;
 	case SCOPE_FORWARD:
-		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
-				  is_tcp, tcp_flags, monitor);
+		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_entry_types,
+				  ct_state, is_tcp, tcp_flags, monitor);
 	}
 
 out:
@@ -552,11 +583,13 @@ out:
 static __always_inline int
 ct_lazy_lookup6(const void *map, struct ipv6_ct_tuple *tuple,
 		struct __ctx_buff *ctx, int l4_off, enum ct_dir dir,
-		enum ct_scope scope, struct ct_state *ct_state, __u32 *monitor)
+		enum ct_scope scope, __u32 ct_entry_types,
+		struct ct_state *ct_state, __u32 *monitor)
 {
 	tuple->flags = ct_lookup_select_tuple_type(dir, scope);
 
-	return __ct_lookup6(map, tuple, ctx, l4_off, dir, scope, ct_state, monitor);
+	return __ct_lookup6(map, tuple, ctx, l4_off, dir, scope,
+			    ct_entry_types, ct_state, monitor);
 }
 
 /* Offset must point to IPv6 */
@@ -575,7 +608,7 @@ static __always_inline int ct_lookup6(const void *map,
 		return ret;
 
 	return __ct_lookup6(map, tuple, ctx, l4_off, dir, SCOPE_BIDIR,
-			    ct_state, monitor);
+			    CT_ENTRY_ANY, ct_state, monitor);
 }
 
 static __always_inline int
@@ -757,7 +790,7 @@ DEFINE_FUNC_CT_IS_REPLY(4)
 static __always_inline int
 __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ctx,
 	     int l4_off, bool has_l4_header, enum ct_dir dir, enum ct_scope scope,
-	     struct ct_state *ct_state, __u32 *monitor)
+	     __u32 ct_entry_types, struct ct_state *ct_state, __u32 *monitor)
 {
 	bool is_tcp = tuple->nexthdr == IPPROTO_TCP;
 	union tcp_flags tcp_flags = { .value = 0 };
@@ -784,8 +817,8 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ct
 	case SCOPE_REVERSE:
 	case SCOPE_BIDIR:
 		/* Lookup in the reverse direction first: */
-		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state, is_tcp,
-				  tcp_flags, monitor);
+		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_entry_types,
+				  ct_state, is_tcp, tcp_flags, monitor);
 		if (ret != CT_NEW) {
 			if (likely(ret == CT_ESTABLISHED || ret == CT_REOPENED)) {
 				if (unlikely(tuple->flags & TUPLE_F_RELATED))
@@ -803,8 +836,8 @@ __ct_lookup4(const void *map, struct ipv4_ct_tuple *tuple, struct __ctx_buff *ct
 		ipv4_ct_tuple_reverse(tuple);
 		fallthrough;
 	case SCOPE_FORWARD:
-		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_state,
-				  is_tcp, tcp_flags, monitor);
+		ret = __ct_lookup(map, ctx, tuple, action, dir, ct_entry_types,
+				  ct_state, is_tcp, tcp_flags, monitor);
 	}
 
 out:
@@ -821,6 +854,8 @@ out:
  * @arg dir		lookup direction
  * @arg scope		CT scope. For SCOPE_FORWARD, the tuple also needs to
  *			be in forward layout.
+ * @arg ct_entry_types	a mask of CT_ENTRY_* values that selects the expected
+ *			entry type(s)
  * @arg ct_state	returned CT entry
  * @arg monitor		monitor feedback for trace aggregation
  *
@@ -835,13 +870,13 @@ out:
 static __always_inline int
 ct_lazy_lookup4(const void *map, struct ipv4_ct_tuple *tuple,
 		struct __ctx_buff *ctx, int l4_off, bool has_l4_header,
-		enum ct_dir dir, enum ct_scope scope,
+		enum ct_dir dir, enum ct_scope scope, __u32 ct_entry_types,
 		struct ct_state *ct_state, __u32 *monitor)
 {
 	tuple->flags = ct_lookup_select_tuple_type(dir, scope);
 
 	return __ct_lookup4(map, tuple, ctx, l4_off, has_l4_header,
-			    dir, scope, ct_state, monitor);
+			    dir, scope, ct_entry_types, ct_state, monitor);
 }
 
 /* Offset must point to IPv4 header */
@@ -860,7 +895,7 @@ static __always_inline int ct_lookup4(const void *map,
 		return ret;
 
 	return __ct_lookup4(map, tuple, ctx, off, has_l4_header,
-			    dir, SCOPE_BIDIR, ct_state, monitor);
+			    dir, SCOPE_BIDIR, CT_ENTRY_ANY, ct_state, monitor);
 }
 
 /* Offset must point to IPv6 */

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -870,7 +870,7 @@ static __always_inline int lb6_local(const void *map, struct __ctx_buff *ctx,
 
 	/* See lb4_local comments re svc endpoint lookup process */
 	ret = ct_lazy_lookup6(map, tuple, ctx, l4_off, CT_SERVICE,
-			      SCOPE_REVERSE, state, &monitor);
+			      SCOPE_REVERSE, CT_ENTRY_ANY, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY
@@ -1554,7 +1554,7 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 		return DROP_NO_SERVICE;
 
 	ret = ct_lazy_lookup4(map, tuple, ctx, l4_off, has_l4_header,
-			      CT_SERVICE, SCOPE_REVERSE, state, &monitor);
+			      CT_SERVICE, SCOPE_REVERSE, CT_ENTRY_ANY, state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 #ifdef ENABLE_SESSION_AFFINITY

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -288,7 +288,8 @@ snat_v4_nat_handle_mapping(struct __ctx_buff *ctx,
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_snat), &tuple_snat,
 				      ctx, off, has_l4_header, CT_EGRESS,
-				      SCOPE_FORWARD, &ct_state, &trace->monitor);
+				      SCOPE_FORWARD, CT_ENTRY_ANY,
+				      &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
 
@@ -342,7 +343,8 @@ snat_v4_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple_revsnat), &tuple_revsnat,
 				      ctx, off, has_l4_header, CT_INGRESS,
-				      SCOPE_REVERSE, &ct_state, &trace->monitor);
+				      SCOPE_REVERSE, CT_ENTRY_ANY,
+				      &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
 
@@ -1257,7 +1259,7 @@ snat_v6_nat_handle_mapping(struct __ctx_buff *ctx,
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple_snat), &tuple_snat,
 				      ctx, off, CT_EGRESS, SCOPE_FORWARD,
-				      &ct_state, &trace->monitor);
+				      CT_ENTRY_ANY, &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
 
@@ -1303,7 +1305,7 @@ snat_v6_rev_nat_handle_mapping(struct __ctx_buff *ctx,
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple_revsnat), &tuple_revsnat,
 				      ctx, off, CT_INGRESS, SCOPE_REVERSE,
-				      &ct_state, &trace->monitor);
+				      CT_ENTRY_ANY, &ct_state, &trace->monitor);
 		if (ret < 0)
 			return ret;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -783,7 +783,7 @@ nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	__ipv6_ct_tuple_reverse(tuple);
 
 	ret = ct_lazy_lookup6(get_ct_map6(tuple), tuple, ctx, l4_off,
-			      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_ANY,
+			      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_DSR,
 			      &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
@@ -803,7 +803,7 @@ create_ct:
 			return ret;
 		break;
 	case CT_ESTABLISHED:
-		if ((tuple->nexthdr == IPPROTO_TCP && port) || !ct_state.dsr)
+		if (tuple->nexthdr == IPPROTO_TCP && port)
 			goto create_ct;
 		break;
 	default:
@@ -2280,7 +2280,7 @@ nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 
 	ret = ct_lazy_lookup4(get_ct_map4(tuple), tuple, ctx, l4_off,
 			      has_l4_header, CT_EGRESS, SCOPE_FORWARD,
-			      CT_ENTRY_ANY, &ct_state, &monitor);
+			      CT_ENTRY_DSR, &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	/* Maybe we can be a bit more selective about CT_REOPENED?
@@ -2312,7 +2312,7 @@ create_ct:
 		 * Otherwise we tolerate DSR info on an established connection.
 		 * TODO: how do we know if we need to refresh the SNAT entry?
 		 */
-		if ((tuple->nexthdr == IPPROTO_TCP && port) || !ct_state.dsr)
+		if (tuple->nexthdr == IPPROTO_TCP && port)
 			goto create_ct;
 		break;
 	default:

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -946,13 +946,10 @@ nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		return ret;
 	}
 
-	if (!ct_has_nodeport_egress_entry6(get_ct_map6(&tuple), &tuple, NULL, false))
-		goto out;
-
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
-			      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_ANY,
+			      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_NODEPORT,
 			      &ct_state, &trace->monitor);
-	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
+	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		ret = ipv6_l3(ctx, ETH_HLEN, NULL, NULL, METRIC_EGRESS);
 		if (unlikely(ret != CTX_ACT_OK))
@@ -2414,13 +2411,10 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	if (!check_revdnat)
 		goto out;
 
-	if (!ct_has_nodeport_egress_entry4(get_ct_map4(&tuple), &tuple, NULL, false))
-		goto out;
-
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_ANY,
+			      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_NODEPORT,
 			      &ct_state, &trace->monitor);
-	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
+	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index, false,
 				  &tuple, REV_NAT_F_TUPLE_SADDR, has_l4_header);

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -783,7 +783,8 @@ nodeport_dsr_ingress_ipv6(struct __ctx_buff *ctx, struct ipv6_ct_tuple *tuple,
 	__ipv6_ct_tuple_reverse(tuple);
 
 	ret = ct_lazy_lookup6(get_ct_map6(tuple), tuple, ctx, l4_off,
-			      CT_EGRESS, SCOPE_FORWARD, &ct_state, &monitor);
+			      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_ANY,
+			      &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	case CT_REOPENED:
@@ -949,7 +950,8 @@ nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		goto out;
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
-			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &trace->monitor);
+			      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_ANY,
+			      &ct_state, &trace->monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		ret = ipv6_l3(ctx, ETH_HLEN, NULL, NULL, METRIC_EGRESS);
@@ -1389,7 +1391,8 @@ skip_service_lookup:
 		__ipv6_ct_tuple_reverse(&tuple);
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
-				      CT_EGRESS, SCOPE_FORWARD, &ct_state, &monitor);
+				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_ANY,
+				      &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
 redo:
@@ -1497,7 +1500,7 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 #endif
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
-			      SCOPE_REVERSE, &ct_state, &trace->monitor);
+			      SCOPE_REVERSE, CT_ENTRY_ANY, &ct_state, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -2279,7 +2282,7 @@ nodeport_dsr_ingress_ipv4(struct __ctx_buff *ctx, struct ipv4_ct_tuple *tuple,
 
 	ret = ct_lazy_lookup4(get_ct_map4(tuple), tuple, ctx, l4_off,
 			      has_l4_header, CT_EGRESS, SCOPE_FORWARD,
-			      &ct_state, &monitor);
+			      CT_ENTRY_ANY, &ct_state, &monitor);
 	switch (ret) {
 	case CT_NEW:
 	/* Maybe we can be a bit more selective about CT_REOPENED?
@@ -2414,7 +2417,8 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		goto out;
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &trace->monitor);
+			      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_ANY,
+			      &ct_state, &trace->monitor);
 	if (ret == CT_REPLY && ct_state.node_port == 1 && ct_state.rev_nat_index != 0) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		ret = lb4_rev_nat(ctx, l3_off, l4_off, ct_state.rev_nat_index, false,
@@ -2887,7 +2891,8 @@ skip_service_lookup:
 		__ipv4_ct_tuple_reverse(&tuple);
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-				      CT_EGRESS, SCOPE_FORWARD, &ct_state, &monitor);
+				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_ANY,
+				      &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
 redo:
@@ -2989,7 +2994,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 #endif
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      CT_INGRESS, SCOPE_REVERSE, &ct_state, &trace->monitor);
+			      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_ANY,
+			      &ct_state, &trace->monitor);
 
 	/* nodeport_rev_dnat_get_info_ipv4() just checked that such a
 	 * CT entry exists:

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1391,7 +1391,7 @@ skip_service_lookup:
 		__ipv6_ct_tuple_reverse(&tuple);
 
 		ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off,
-				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_ANY,
+				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_NODEPORT,
 				      &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:
@@ -2891,7 +2891,7 @@ skip_service_lookup:
 		__ipv4_ct_tuple_reverse(&tuple);
 
 		ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_ANY,
+				      CT_EGRESS, SCOPE_FORWARD, CT_ENTRY_NODEPORT,
 				      &ct_state, &monitor);
 		switch (ret) {
 		case CT_NEW:

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1500,7 +1500,8 @@ nodeport_rev_dnat_fwd_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 #endif
 
 	ret = ct_lazy_lookup6(get_ct_map6(&tuple), &tuple, ctx, l4_off, CT_INGRESS,
-			      SCOPE_REVERSE, CT_ENTRY_ANY, &ct_state, &trace->monitor);
+			      SCOPE_REVERSE, CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
+			      &ct_state, &trace->monitor);
 	if (ret == CT_REPLY) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 
@@ -2994,7 +2995,8 @@ nodeport_rev_dnat_fwd_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 #endif
 
 	ret = ct_lazy_lookup4(get_ct_map4(&tuple), &tuple, ctx, l4_off, has_l4_header,
-			      CT_INGRESS, SCOPE_REVERSE, CT_ENTRY_ANY,
+			      CT_INGRESS, SCOPE_REVERSE,
+			      CT_ENTRY_NODEPORT | CT_ENTRY_DSR,
 			      &ct_state, &trace->monitor);
 
 	/* nodeport_rev_dnat_get_info_ipv4() just checked that such a

--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -121,7 +121,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		/* First packet is monitored */
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_SYN_TIMEOUT));
@@ -132,7 +132,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		advance_time();
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_SYN_TIMEOUT));
@@ -142,7 +142,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value &= ~TCP_FLAG_SYN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -152,7 +152,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value |= TCP_FLAG_FIN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -162,7 +162,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value &= ~TCP_FLAG_FIN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -175,7 +175,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value |= TCP_FLAG_FIN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_EGRESS,
-				  &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_CLOSE_TIMEOUT));
@@ -186,7 +186,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value &= ~TCP_FLAG_FIN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_EGRESS,
-				  &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_ESTABLISHED);
 		assert(monitor == 0);
 		assert(timeout_in(entry, CT_CLOSE_TIMEOUT - 1));
@@ -197,7 +197,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value = TCP_FLAG_SYN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_EGRESS,
-				  &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_REOPENED);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 		assert(timeout_in(entry, CT_CONNECTION_LIFETIME_TCP));
@@ -207,7 +207,7 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		seen_flags.value = TCP_FLAG_SYN;
 		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
 				  ct_tcp_select_action(seen_flags), CT_INGRESS,
-				  &ct_state, true, seen_flags, &monitor);
+				  CT_ENTRY_ANY, &ct_state, true, seen_flags, &monitor);
 		assert(res == CT_NEW);
 		assert(monitor == TRACE_PAYLOAD_LEN);
 	});


### PR DESCRIPTION
The nodeport code typically only cares about specific types of CT entries
(those that have the .nodeport and/or .dsr flags set). It carries all sorts
of cruft to deal with aliased / stale entries.

As we can't bake the .nodeport / .dsr flags into the actual CT map key
(it's not flexible enough, and would break compatibility), do the next
best thing and teach the low-level CT lookup code about such constraints.
If the caller specifies a set of CT_ENTRY_* types, then the lookup code
will validate the matched entry accordingly.

If the matched entry doesn't match any of the types, it's treated as
CT_NEW. This for instance avoids any unwanted update to the entry's
statistics.

Note that ideally the "generic" CT lookups (bpf_lxc, HostFW, SNAT) would have the opposite behaviour, and exclude the nodeport-specific entry types from their lookup. Future work.

