### PR TITLE
Fix possible cross-cluster connection drops on agents restart when clustermesh is enabled

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -63,6 +63,7 @@ cilium-agent [flags]
       --cluster-id int                                            Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
+      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -14,6 +14,7 @@ cilium-agent hive [flags]
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
+      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -20,6 +20,7 @@ cilium-agent hive dot-graph [flags]
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
+      --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -16,6 +16,7 @@ import (
 	dptypes "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/egressgateway"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/gops"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -149,5 +150,8 @@ var (
 		// L2announcer resolves l2announcement policies, services, node labels and devices into a list of IPs+netdevs
 		// which need to be announced on the local network.
 		l2announcer.Cell,
+
+		// RegeneratorCell provides extra options and utilities for endpoints regeneration.
+		endpoint.RegeneratorCell,
 	)
 )

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1702,9 +1702,11 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 	restoreComplete := d.initRestore(restoredEndpoints, params.EndpointRegenerator)
 
 	if params.WGAgent != nil {
-		if err := params.WGAgent.RestoreFinished(); err != nil {
-			log.WithError(err).Error("Failed to set up wireguard peers")
-		}
+		go func() {
+			if err := params.WGAgent.RestoreFinished(d.clustermesh); err != nil {
+				log.WithError(err).Error("Failed to set up wireguard peers")
+			}
+		}()
 	}
 
 	if d.endpointManager.HostEndpointExists() {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -46,6 +46,7 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/egressgateway"
+	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpointmanager"
 	"github.com/cilium/cilium/pkg/envoy"
 	"github.com/cilium/cilium/pkg/flowdebug"
@@ -1621,6 +1622,7 @@ type daemonParams struct {
 	L2Announcer          *l2announcer.L2Announcer
 	L7Proxy              *proxy.Proxy
 	DB                   statedb.DB
+	EndpointRegenerator  *endpoint.Regenerator
 	AuthManager          *auth.AuthManager
 }
 
@@ -1697,7 +1699,7 @@ func runDaemon(d *Daemon, restoredEndpoints *endpointRestoreState, cleaner *daem
 		<-params.CacheStatus
 	}
 	bootstrapStats.k8sInit.End(true)
-	restoreComplete := d.initRestore(restoredEndpoints)
+	restoreComplete := d.initRestore(restoredEndpoints, params.EndpointRegenerator)
 
 	if params.WGAgent != nil {
 		if err := params.WGAgent.RestoreFinished(); err != nil {

--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -450,10 +450,10 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState) chan struc
 
 		go func() {
 			if d.clientset.IsEnabled() {
-				// Also wait for all cluster mesh to be synchronized with the
+				// Also wait for all shared services to be synchronized with the
 				// datapath before proceeding.
 				if d.clustermesh != nil {
-					err := d.clustermesh.ClustersSynced(d.ctx)
+					err := d.clustermesh.ServicesSynced(d.ctx)
 					if err != nil {
 						log.WithError(err).Fatal("timeout while waiting for all clusters to be locally synchronized")
 					}

--- a/pkg/clustermesh/clustermesh.go
+++ b/pkg/clustermesh/clustermesh.go
@@ -176,6 +176,7 @@ func (cm *ClusterMesh) newRemoteCluster(name string, status internal.StatusFunc)
 		name,
 		cm.conf.NodeKeyCreator,
 		cm.conf.NodeObserver,
+		store.RWSWithOnSyncCallback(func(ctx context.Context) { close(rc.synced.nodes) }),
 		store.RWSWithEntriesMetric(cm.conf.Metrics.TotalNodes.WithLabelValues(cm.conf.ClusterName, cm.nodeName, rc.name)),
 	)
 
@@ -203,6 +204,12 @@ func (cm *ClusterMesh) NumReadyClusters() int {
 // SyncedWaitFn is the type of a function to wait for the initial synchronization
 // of a given resource type from all remote clusters.
 type SyncedWaitFn func(ctx context.Context) error
+
+// NodesSynced returns after that the initial list of nodes has been received
+// from all remote clusters, and synchronized with the different subscribers.
+func (cm *ClusterMesh) NodesSynced(ctx context.Context) error {
+	return cm.synced(ctx, func(rc *remoteCluster) SyncedWaitFn { return rc.synced.Nodes })
+}
 
 // ServicesSynced returns after that the initial list of shared services has been
 // received from all remote clusters, and synchronized with the BPF datapath.

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -196,6 +196,7 @@ var (
 
 type synced struct {
 	services   *lock.StoppableWaitGroup
+	nodes      chan struct{}
 	ipcache    chan struct{}
 	identities *lock.StoppableWaitGroup
 	stopped    chan struct{}
@@ -212,10 +213,18 @@ func newSynced() synced {
 
 	return synced{
 		services:   lock.NewStoppableWaitGroup(),
+		nodes:      make(chan struct{}),
 		ipcache:    make(chan struct{}),
 		identities: idswg,
 		stopped:    make(chan struct{}),
 	}
+}
+
+// Nodes returns after that the initial list of nodes has been received
+// from the remote cluster, and synchronized with the different subscribers,
+// the remote cluster is disconnected, or the given context is canceled.
+func (s *synced) Nodes(ctx context.Context) error {
+	return s.wait(ctx, s.nodes)
 }
 
 // Services returns after that the initial list of shared services has been

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -117,7 +117,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 	})
 
 	mgr.Register(adapter(identityCache.IdentitiesPath), func(ctx context.Context) {
-		rc.remoteIdentityCache.Watch(ctx, func(ctx context.Context) {})
+		rc.remoteIdentityCache.Watch(ctx, func(context.Context) { rc.synced.identities.Done() })
 	})
 
 	close(ready)
@@ -195,14 +195,26 @@ var (
 )
 
 type synced struct {
-	services *lock.StoppableWaitGroup
-	stopped  chan struct{}
+	services   *lock.StoppableWaitGroup
+	ipcache    chan struct{}
+	identities *lock.StoppableWaitGroup
+	stopped    chan struct{}
 }
 
 func newSynced() synced {
+	// Use a StoppableWaitGroup for identities, instead of a plain channel to
+	// avoid having to deal with the possibility of a closed channel if already
+	// synced (as the callback is executed every time the etcd connection
+	// is restarted, differently from the other resource types).
+	idswg := lock.NewStoppableWaitGroup()
+	idswg.Add()
+	idswg.Stop()
+
 	return synced{
-		services: lock.NewStoppableWaitGroup(),
-		stopped:  make(chan struct{}),
+		services:   lock.NewStoppableWaitGroup(),
+		ipcache:    make(chan struct{}),
+		identities: idswg,
+		stopped:    make(chan struct{}),
 	}
 }
 
@@ -211,6 +223,14 @@ func newSynced() synced {
 // the remote cluster is disconnected, or the given context is canceled.
 func (s *synced) Services(ctx context.Context) error {
 	return s.wait(ctx, s.services.WaitChannel())
+}
+
+// IPIdentities returns after that the initial list of ipcache entries and
+// identities has been received from the remote cluster, and synchronized
+// with the BPF datapath, the remote cluster is disconnected, or the given
+// context is canceled.
+func (s *synced) IPIdentities(ctx context.Context) error {
+	return s.wait(ctx, s.ipcache, s.identities.WaitChannel())
 }
 
 func (s *synced) wait(ctx context.Context, chs ...<-chan struct{}) error {

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -5,6 +5,7 @@ package clustermesh
 
 import (
 	"context"
+	"errors"
 	"path"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -58,7 +59,8 @@ type remoteCluster struct {
 	// status is the function which fills the internal part of the status.
 	status internal.StatusFunc
 
-	swg *lock.StoppableWaitGroup
+	// synced tracks the initial synchronization with the remote cluster.
+	synced synced
 }
 
 func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperations, config *cmtypes.CiliumClusterConfig, ready chan<- error) {
@@ -122,7 +124,9 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 	mgr.Run(ctx)
 }
 
-func (rc *remoteCluster) Stop() {}
+func (rc *remoteCluster) Stop() {
+	rc.synced.stop()
+}
 
 func (rc *remoteCluster) Remove() {
 	// Draining shall occur only when the configuration for the remote cluster
@@ -182,4 +186,48 @@ func (rc *remoteCluster) onUpdateConfig(newConfig *cmtypes.CiliumClusterConfig) 
 	rc.config = newConfig
 
 	return nil
+}
+
+var (
+	// ErrRemoteClusterDisconnected is the error returned by wait for sync
+	// operations if the remote cluster is disconnected while still waiting.
+	ErrRemoteClusterDisconnected = errors.New("remote cluster disconnected")
+)
+
+type synced struct {
+	services *lock.StoppableWaitGroup
+	stopped  chan struct{}
+}
+
+func newSynced() synced {
+	return synced{
+		services: lock.NewStoppableWaitGroup(),
+		stopped:  make(chan struct{}),
+	}
+}
+
+// Services returns after that the initial list of shared services has been
+// received from the remote cluster, and synchronized with the BPF datapath,
+// the remote cluster is disconnected, or the given context is canceled.
+func (s *synced) Services(ctx context.Context) error {
+	return s.wait(ctx, s.services.WaitChannel())
+}
+
+func (s *synced) wait(ctx context.Context, chs ...<-chan struct{}) error {
+	for _, ch := range chs {
+		select {
+		case <-ch:
+			continue
+		case <-s.stopped:
+			return ErrRemoteClusterDisconnected
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}
+
+func (s *synced) stop() {
+	close(s.stopped)
 }

--- a/pkg/clustermesh/remote_cluster.go
+++ b/pkg/clustermesh/remote_cluster.go
@@ -115,7 +115,7 @@ func (rc *remoteCluster) Run(ctx context.Context, backend kvstore.BackendOperati
 	})
 
 	mgr.Register(adapter(identityCache.IdentitiesPath), func(ctx context.Context) {
-		rc.remoteIdentityCache.Watch(ctx)
+		rc.remoteIdentityCache.Watch(ctx, func(ctx context.Context) {})
 	})
 
 	close(ready)

--- a/pkg/endpoint/regenerator.go
+++ b/pkg/endpoint/regenerator.go
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoint
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/clustermesh"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+)
+
+var (
+	RegeneratorCell = cell.Module(
+		"endpoint-regeneration",
+		"Endpoints regeneration",
+
+		cell.Config(RegeneratorConfigDefault),
+		cell.Provide(newRegenerator),
+	)
+)
+
+// Regenerator wraps additional functionalities for endpoint regeneration.
+type Regenerator struct {
+	RegeneratorConfig
+
+	cmWaitFn clustermesh.SyncedWaitFn
+
+	logger        logrus.FieldLogger
+	cmSyncLogOnce sync.Once
+}
+
+type RegeneratorConfig struct {
+	// ClusterMeshIPIdentitiesSyncTimeout is the timeout when waiting for the
+	// initial synchronization of ipcache entries and identities from all remote
+	// clusters before regenerating the local endpoints.
+	ClusterMeshIPIdentitiesSyncTimeout time.Duration
+}
+
+func (def RegeneratorConfig) Flags(flags *pflag.FlagSet) {
+	flags.Duration("clustermesh-ip-identities-sync-timeout", def.ClusterMeshIPIdentitiesSyncTimeout,
+		"Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration")
+}
+
+var RegeneratorConfigDefault = RegeneratorConfig{
+	ClusterMeshIPIdentitiesSyncTimeout: 1 * time.Minute,
+}
+
+func newRegenerator(in struct {
+	cell.In
+
+	Logger logrus.FieldLogger
+
+	Config      RegeneratorConfig
+	ClusterMesh *clustermesh.ClusterMesh
+}) *Regenerator {
+	waitFn := func(context.Context) error { return nil }
+	if in.ClusterMesh != nil {
+		waitFn = in.ClusterMesh.IPIdentitiesSynced
+	}
+
+	return &Regenerator{
+		RegeneratorConfig: in.Config,
+		logger:            in.Logger,
+		cmWaitFn:          waitFn,
+	}
+}
+
+// CapTimeoutForSynchronousRegeneration caps the timeout to a value suitable in
+// case the regeneration of an endpoint needs to be performed synchronously
+// (currently required when IPSec is enabled). In particular, this is necessary
+// to not block the agent bootstrap, as that prevents the scheduling of new
+// workloads. This logic is implemented as a separate function to avoid
+// forgetting to remove it when the synchronous regeneration is removed.
+func (r *Regenerator) CapTimeoutForSynchronousRegeneration() {
+	const maxTimeout = 5 * time.Second
+	if r.ClusterMeshIPIdentitiesSyncTimeout > maxTimeout {
+		r.ClusterMeshIPIdentitiesSyncTimeout = maxTimeout
+		r.logger.WithField(logfields.Value, maxTimeout).
+			Info("Capped clustermesh-ip-identities-sync-timeout because endpoint regeneration needs to be performed synchronously")
+	}
+}
+
+func (r *Regenerator) WaitForClusterMeshIPIdentitiesSync(ctx context.Context) error {
+	wctx, cancel := context.WithTimeout(ctx, r.ClusterMeshIPIdentitiesSyncTimeout)
+	defer cancel()
+	err := r.cmWaitFn(wctx)
+
+	switch {
+	case ctx.Err() != nil:
+		// The context associated with the endpoint has been canceled.
+		return ErrNotAlive
+	case err != nil:
+		// We don't return an error in case the wait operation timed out, as we can
+		// continue with the endpoint regeneration, although at the cost of possible
+		// connectivity drops for cross-cluster connections. We additionally print
+		// the warning message only once, to avoid repeating it for every endpoint.
+		r.cmSyncLogOnce.Do(func() {
+			r.logger.Warning("Failed waiting for clustermesh IPs and identities synchronization before regenerating endpoints, expect possible disruption of cross-cluster connections")
+		})
+	}
+
+	return nil
+}

--- a/pkg/endpoint/regenerator_test.go
+++ b/pkg/endpoint/regenerator_test.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package endpoint
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegeneratorWaitForIPCacheSync(t *testing.T) {
+	regenerator := Regenerator{
+		logger: func() logrus.FieldLogger {
+			logger := logrus.New()
+			logger.SetLevel(logrus.FatalLevel)
+			return logger
+		}(),
+
+		cmWaitFn: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+
+		RegeneratorConfig: RegeneratorConfig{
+			ClusterMeshIPIdentitiesSyncTimeout: 10 * time.Millisecond,
+		},
+	}
+
+	tests := []struct {
+		name   string
+		ctx    context.Context
+		assert assert.ErrorAssertionFunc
+	}{
+		{
+			name:   "valid context",
+			ctx:    context.Background(),
+			assert: assert.NoError,
+		},
+		{
+			name: "expired context",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			assert: assert.Error,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.assert(t, regenerator.WaitForClusterMeshIPIdentitiesSync(tt.ctx))
+		})
+	}
+}

--- a/pkg/endpoint/restore.go
+++ b/pkg/endpoint/restore.go
@@ -188,8 +188,8 @@ func partitionEPDirNamesByRestoreStatus(eptsDirNames []string) (complete []strin
 // * regenerates the endpoint
 // Returns an error if any operation fails while trying to perform the above
 // operations.
-func (e *Endpoint) RegenerateAfterRestore() error {
-	if err := e.restoreIdentity(); err != nil {
+func (e *Endpoint) RegenerateAfterRestore(regenerator *Regenerator) error {
+	if err := e.restoreIdentity(regenerator); err != nil {
 		return err
 	}
 
@@ -210,7 +210,7 @@ func (e *Endpoint) RegenerateAfterRestore() error {
 	return nil
 }
 
-func (e *Endpoint) restoreIdentity() error {
+func (e *Endpoint) restoreIdentity(regenerator *Regenerator) error {
 	if err := e.rlockAlive(); err != nil {
 		e.logDisconnectedMutexAction(err, "before filtering labels during regenerating restored endpoint")
 		return err
@@ -292,6 +292,12 @@ func (e *Endpoint) restoreIdentity() error {
 	// the regenerated datapath always lookups from a ready ipcache map.
 	if option.Config.KVStore != "" {
 		ipcache.WaitForKVStoreSync()
+	}
+
+	// Wait for ipcache and identities synchronization from all remote clusters,
+	// to prevent disrupting cross-cluster connections on endpoint regeneration.
+	if err := regenerator.WaitForClusterMeshIPIdentitiesSync(e.aliveCtx); err != nil {
+		return err
 	}
 
 	if err := e.lockAlive(); err != nil {

--- a/pkg/ipcache/kvstore.go
+++ b/pkg/ipcache/kvstore.go
@@ -177,7 +177,7 @@ type IPCacher interface {
 }
 
 // NewIPIdentityWatcher creates a new IPIdentityWatcher for the given cluster.
-func NewIPIdentityWatcher(clusterName string, ipc IPCacher) *IPIdentityWatcher {
+func NewIPIdentityWatcher(clusterName string, ipc IPCacher, opts ...storepkg.RWSOpt) *IPIdentityWatcher {
 	watcher := IPIdentityWatcher{
 		ipcache:     ipc,
 		clusterName: clusterName,
@@ -189,7 +189,7 @@ func NewIPIdentityWatcher(clusterName string, ipc IPCacher) *IPIdentityWatcher {
 		clusterName,
 		func() storepkg.Key { return &identity.IPIdentityPair{} },
 		&watcher,
-		storepkg.RWSWithOnSyncCallback(watcher.onSync),
+		append(opts, storepkg.RWSWithOnSyncCallback(watcher.onSync))...,
 	)
 	return &watcher
 }

--- a/pkg/kvstore/allocator/allocator_test.go
+++ b/pkg/kvstore/allocator/allocator_test.go
@@ -637,7 +637,7 @@ func (s *AllocatorSuite) TestRemoteCache(c *C) {
 
 	wg.Add(1)
 	go func() {
-		rc.Watch(ctx)
+		rc.Watch(ctx, func(ctx context.Context) {})
 		wg.Done()
 	}()
 


### PR DESCRIPTION
Backported manually, due to a few conflicts and to additionally test it through https://github.com/cilium/cilium/pull/27232. 

- [x] #27575 -- https://github.com/cilium/cilium/pull/27575 (@giorio94)
     - A few small conflicts resolved in the different commits (and detailed in the commit descriptions themselves).

Successful clustermesh upgrade/downgrade run: https://github.com/cilium/cilium/actions/runs/6035564385/job/16376157031

