### PR TITLE
envoy: fix init order between accesslog and xDS server

### DIFF
--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -27,15 +27,15 @@ import (
 )
 
 type AccessLogServer struct {
-	socketPath string
-	xdsServer  XDSServer
-	stopCh     chan struct{}
+	socketPath         string
+	localEndpointStore *LocalEndpointStore
+	stopCh             chan struct{}
 }
 
-func newAccessLogServer(envoySocketDir string, xdsServer XDSServer) *AccessLogServer {
+func newAccessLogServer(envoySocketDir string, localEndpointStore *LocalEndpointStore) *AccessLogServer {
 	return &AccessLogServer{
-		socketPath: getAccessLogSocketPath(envoySocketDir),
-		xdsServer:  xdsServer,
+		socketPath:         getAccessLogSocketPath(envoySocketDir),
+		localEndpointStore: localEndpointStore,
 	}
 }
 
@@ -152,7 +152,7 @@ func (s *AccessLogServer) handleConn(ctx context.Context, conn *net.UnixConn) {
 		r := logRecord(&pblog)
 
 		// Update proxy stats for the endpoint if it still exists
-		localEndpoint := s.xdsServer.getLocalEndpoint(pblog.PolicyName)
+		localEndpoint := s.localEndpointStore.getLocalEndpoint(pblog.PolicyName)
 		if localEndpoint != nil {
 			// Update stats for the endpoint.
 			ingress := r.ObservationPoint == accesslog.Ingress

--- a/pkg/envoy/accesslog_server.go
+++ b/pkg/envoy/accesslog_server.go
@@ -51,6 +51,7 @@ func (s *AccessLogServer) start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
+		log.Infof("Envoy: Starting access log server listening on %s", socketListener.Addr())
 		for {
 			// Each Envoy listener opens a new connection over the Unix domain socket.
 			// Multiple worker threads serving the listener share that same connection

--- a/pkg/envoy/embedded_envoy_test.go
+++ b/pkg/envoy/embedded_envoy_test.go
@@ -62,7 +62,9 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 
 	log.Debugf("run directory: %s", testRunDir)
 
-	xdsServer, err := newXDSServer(testRunDir, testipcache.NewMockIPCache())
+	localEndpointStore := newLocalEndpointStore()
+
+	xdsServer, err := newXDSServer(testRunDir, testipcache.NewMockIPCache(), localEndpointStore)
 	c.Assert(xdsServer, NotNil)
 	c.Assert(err, IsNil)
 
@@ -70,7 +72,7 @@ func (s *EnvoySuite) TestEnvoy(c *C) {
 	c.Assert(err, IsNil)
 	defer xdsServer.stop()
 
-	accessLogServer := newAccessLogServer(testRunDir, xdsServer)
+	accessLogServer := newAccessLogServer(testRunDir, localEndpointStore)
 	c.Assert(accessLogServer, NotNil)
 	err = accessLogServer.start()
 	c.Assert(err, IsNil)
@@ -153,14 +155,16 @@ func (s *EnvoySuite) TestEnvoyNACK(c *C) {
 
 	log.Debugf("run directory: %s", testRunDir)
 
-	xdsServer, err := newXDSServer(testRunDir, testipcache.NewMockIPCache())
+	localEndpointStore := newLocalEndpointStore()
+
+	xdsServer, err := newXDSServer(testRunDir, testipcache.NewMockIPCache(), localEndpointStore)
 	c.Assert(xdsServer, NotNil)
 	c.Assert(err, IsNil)
 	err = xdsServer.start()
 	c.Assert(err, IsNil)
 	defer xdsServer.stop()
 
-	accessLogServer := newAccessLogServer(testRunDir, xdsServer)
+	accessLogServer := newAccessLogServer(testRunDir, localEndpointStore)
 	c.Assert(accessLogServer, NotNil)
 	err = accessLogServer.start()
 	c.Assert(err, IsNil)

--- a/pkg/envoy/localendpointstore.go
+++ b/pkg/envoy/localendpointstore.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package envoy
+
+import (
+	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/proxy/endpoint"
+)
+
+// LocalEndpointStore tracks the mapping between a given endpoint IP and the actual local endpoint.
+type LocalEndpointStore struct {
+	// mutex protects accesses to the configuration resources below.
+	mutex lock.RWMutex
+
+	// networkPolicyEndpoints maps endpoint IP to the info on the local endpoint.
+	// mutex must be held when accessing this.
+	networkPolicyEndpoints map[string]endpoint.EndpointUpdater
+}
+
+// getLocalEndpoint returns the endpoint info for the local endpoint on which
+// the network policy of the given name if enforced, or nil if not found.
+func (s *LocalEndpointStore) getLocalEndpoint(endpointIP string) endpoint.EndpointUpdater {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	return s.networkPolicyEndpoints[endpointIP]
+}
+
+// setLocalEndpoint maps the given IP to the local endpoint.
+func (s *LocalEndpointStore) setLocalEndpoint(endpointIP string, ep endpoint.EndpointUpdater) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.networkPolicyEndpoints[endpointIP] = ep
+}
+
+// removeLocalEndpoint delete the mapping for the given endpoint IP
+func (s *LocalEndpointStore) removeLocalEndpoint(endpointIP string) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	delete(s.networkPolicyEndpoints, endpointIP)
+}


### PR DESCRIPTION
Currently, the envoy accesslog server depends on the xDS server to get information about local endpoints. This leads to the xDS server being initialized and started before the accesslog server. Therefore, the accesslog server might not be ready when Envoy is receiving the xDS resources and starts to initialize Cilium components in envoy. This results in silent errors of the form `Cilium filter can not open access log socket` (e.g. [Cilium L7 policy filter](https://github.com/cilium/proxy/blob/f4eb004fd81e38ad05d4014fd5f5ff8e9bbf6fe8/cilium/l7policy.cc#L57)).

This commit introduces the LocalEndPointStore which contains this information and is shared between the two components. The direct dependency between the accesslog server and xDS server can be replaced - and the components start initializing at the same time.

In addition, the dependency from the xDS server to the accesslog server gets introduced.

This dependency only serves the purpose of enforcing the accesslog server being initialized first before the xDS server is starting up.