### PR TITLE
typo in the debug document

### DIFF
--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -76,7 +76,7 @@ Manual Verification of Setup
 
     If the configuration is not found, check the following:
 
-    * The Kubernetes secret ``clustermesh-secrets`` is imported correctly.
+    * The Kubernetes secret ``cilium-clustermesh`` is imported correctly.
 
     * The secret contains a file for each remote cluster with the filename
       matching the name of the remote cluster.
@@ -111,7 +111,7 @@ Manual Verification of Setup
       control plane available.
 
     * Validate that a local node in the source cluster can reach the IP
-      specified in the ``hostAliases`` section. The ``clustermesh-secrets``
+      specified in the ``hostAliases`` section. The ``cilium-clustermesh``
       secret contains a configuration file for each remote cluster, it will
       point to a logical name representing the remote cluster:
 


### PR DESCRIPTION
there is no secret named 'clustermesh-secrets' , it should be  cilium-clustermesh

```
[root@master10 ~]# kubectl get secrets -n kube-system cilium-clustermesh
NAME                 TYPE     DATA   AGE
cilium-clustermesh   Opaque   1      39m

[root@master10 ~]# kubectl get secrets -n kube-system clustermesh-secrets
Error from server (NotFound): secrets "clustermesh-secrets" not found

```

actually 'clustermesh-secrets' is the name of the volume mounting the secret
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: cilium
    .......
        - name: clustermesh-secrets
          mountPath: /var/lib/cilium/clustermesh
          readOnly: true
      ........
        # To read the clustermesh configuration
      - name: clustermesh-secrets
        projected:
          # note: the leading zero means this number is in octal representation: do not remove it
          defaultMode: 0400
          sources:
          - secret:
              name: cilium-clustermesh
              optional: true
              # note: items are not explicitly listed here, since the entries of this secret
              # depend on the peers configured, and that would cause a restart of all agents
              # at every addition/removal. Leaving the field empty makes each secret entry
              # to be automatically projected into the volume as a file whose name is the key.
```
