### PR TITLE
renovate: ignore all gops updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -145,7 +145,7 @@
       "matchPackagePatterns": [
         // We can't update these libraries until github.com/shoenig/go-m1cpu
         // is added as an exception to the list of licenses into CNCF.
-        "github.com/google/gops/*",
+        "*google/gops/*",
         // We can't update these libraries until github.com/shoenig/go-m1cpu
         // is added as an exception to the list of licenses into CNCF.
         "github.com/shirou/gopsutil/*",


### PR DESCRIPTION
Otherwise the gops version in images/runtime/build-gops.sh will still be bumped, see https://github.com/cilium/cilium/pull/27624

Fixes: 14760a1b2ffb ("vendor: downgrade github.com/shirou/gopsutil/v3 to v3.23.2")