### PR TITLE
Resiliency: Add retry logic to attempt to clear out stale hostip

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/sync/semaphore"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/cilium/cilium/api/v1/models"
 	health "github.com/cilium/cilium/cilium-health/launch"
@@ -87,6 +88,7 @@ import (
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/recorder"
 	"github.com/cilium/cilium/pkg/redirectpolicy"
+	"github.com/cilium/cilium/pkg/resiliency"
 	"github.com/cilium/cilium/pkg/service"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 	"github.com/cilium/cilium/pkg/source"
@@ -316,7 +318,7 @@ func createPrefixLengthCounter() *counter.PrefixLengthCounter {
 // that the most up-to-date information has been retrieved. At this point, the
 // daemon is aware of all the necessary information to restore the appropriate
 // IP.
-func (d *Daemon) restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
+func (d *Daemon) restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) error {
 	var (
 		cidrs  []*cidr.CIDR
 		fromFS net.IP
@@ -347,12 +349,8 @@ func (d *Daemon) restoreCiliumHostIPs(ipv6 bool, fromK8s net.IP) {
 	}
 
 	restoredIP := node.RestoreHostIPs(ipv6, fromK8s, fromFS, cidrs)
-	if err := removeOldRouterState(ipv6, restoredIP); err != nil {
-		log.WithError(err).Warnf(
-			"Failed to remove old router IPs (restored IP: %s) from cilium_host. Manual intervention is required to remove all other old IPs.",
-			restoredIP,
-		)
-	}
+
+	return removeOldRouterState(ipv6, restoredIP)
 }
 
 // removeOldRouterState will try to ensure that the only IP assigned to the
@@ -395,11 +393,8 @@ func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 			errs = append(errs, fmt.Errorf("failed to remove IP %s: %w", a.IP, err))
 		}
 	}
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to remove all old router IPs: %v", errs)
-	}
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // newDaemon creates and returns a new Daemon with the parameters set in c.
@@ -1066,11 +1061,29 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	// router IPs from the K8s resources if we weren't able to restore them
 	// from the fs. We must do this after IPAM because we must wait until the
 	// K8s resources have been synced. Part 2/2 of restoration.
-	if option.Config.EnableIPv4 {
-		d.restoreCiliumHostIPs(false, router4FromK8s)
-	}
+	ipv6, router := false, router4FromK8s
 	if option.Config.EnableIPv6 {
-		d.restoreCiliumHostIPs(true, router6FromK8s)
+		ipv6, router = true, router6FromK8s
+	}
+
+	bo := wait.Backoff{
+		Duration: 500 * time.Millisecond,
+		Factor:   1,
+		Jitter:   0.1,
+		Steps:    3,
+	}
+	err = wait.ExponentialBackoffWithContext(ctx, bo, func(ctx context.Context) (done bool, err error) {
+		if err = d.restoreCiliumHostIPs(ipv6, router); err != nil {
+			if resiliency.IsRetryable(err) {
+				log.WithError(err).Warnf("Failed to remove old router IPs from cilium_host. Retrying...")
+				return false, err
+			}
+			return true, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		log.WithError(err).Error("Restore host ips failed. Manual intervention is required to remove all other old IPs.")
 	}
 
 	// restore endpoints before any IPs are allocated to avoid eventual IP

--- a/pkg/resiliency/types.go
+++ b/pkg/resiliency/types.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resiliency
+
+// Category tracks error type resiliency classification.
+type Category int
+
+const (
+	// ResUnavailable tracks external manipulation (manual or accidental)
+	ResUnavailable Category = iota
+
+	// ResExt tracks unavailability of external resource (malicious or accidental)
+	ResExt
+
+	// ResLimit tracks constraint on resources or API
+	ResLimit
+
+	// ResDpath tracks datapath misbehavior
+	ResDpath
+
+	// ResCplane tracks control plane misbehavior
+	ResCplane
+
+	// ExtSys track failure of system interactions
+	ExtSys
+)
+
+// Retryer represents class of errors that could be retried.
+type Retryer interface {
+
+	// Retryable checks if error is retryable or not.
+	Retryable() bool
+}

--- a/pkg/resiliency/wrap.go
+++ b/pkg/resiliency/wrap.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resiliency
+
+import (
+	"errors"
+)
+
+// RetryableErr represents an error that can possibly be retried.
+type RetryableErr struct {
+	error
+
+	Kind Category
+}
+
+// Retry checks whether error could be retried.
+// TODO will need m'o tuning..
+func (b RetryableErr) Retryable() bool {
+	switch b.Kind {
+	case ResLimit:
+		return false
+	default:
+		return true
+	}
+}
+
+// Wrap returns a new instance.
+func Wrap(e error, k Category) RetryableErr {
+	return RetryableErr{
+		error: e,
+		Kind:  k,
+	}
+}
+
+// WrapResExt returns a new resExt error.
+func WrapResExt(e error) RetryableErr {
+	return Wrap(e, ResExt)
+}
+
+// WrapResLimit returns a new resLimit error.
+func WrapResLimit(e error) RetryableErr {
+	return Wrap(e, ResLimit)
+}
+
+// WrapExtSys returns a new extSys error.
+func WrapExtSys(e error) RetryableErr {
+	return Wrap(e, ExtSys)
+}
+
+// IsRetryable checks if an error is retryable.
+func IsRetryable(e error) bool {
+	re := new(RetryableErr)
+
+	errs, ok := e.(interface {
+		Unwrap() []error
+	})
+	if !ok {
+		return errors.As(e, re) && e.(RetryableErr).Retryable()
+	}
+	for _, err := range errs.Unwrap() {
+		if errors.As(err, re) {
+			return err.(RetryableErr).Retryable()
+		}
+	}
+
+	return false
+}

--- a/pkg/resiliency/wrap_test.go
+++ b/pkg/resiliency/wrap_test.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resiliency_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/resiliency"
+)
+
+func TestIsRetryable(t *testing.T) {
+	uu := map[string]struct {
+		e error
+		b bool
+	}{
+		"none": {},
+		"plain": {
+			e: errors.New("blee"),
+		},
+		"res_ext": {
+			e: resiliency.WrapResExt(errors.New("blee")),
+			b: true,
+		},
+		"res_limit": {
+			e: resiliency.WrapResLimit(errors.New("blee")),
+		},
+		"multi-plain": {
+			e: errors.Join(
+				errors.New("blee"),
+				errors.New("fred"),
+			),
+		},
+		"multi-res-ext": {
+			e: errors.Join(
+				resiliency.WrapResExt(errors.New("blee")),
+				errors.New("fred"),
+			),
+			b: true,
+		},
+		"multi-res-limit": {
+			e: errors.Join(
+				resiliency.WrapResLimit(errors.New("blee")),
+				errors.New("fred"),
+			),
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.b, resiliency.IsRetryable(u.e))
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Add a retry on the daemon to attempt to clear out stale host ips
    
> NOTE! Not super sure on the best way to handle this use case??
      This will potentially put the brakes while constructing the daemon.
      This ctor code is currently very procedural (not to mention
      insanely long!) as each step depends on the resolution of the previous one??
    
Signed-off-by: Fernand Galiana <fernand.galiana@gmail.com>
    
Fixes: #issue-number
