### PR TITLE
feat: Add annotation propagation from Gateway to Load Balancer service

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -256,6 +256,8 @@ data:
   enable-gateway-api: "true"
   enable-gateway-api-secrets-sync: {{ .Values.gatewayAPI.secretsNamespace.sync | quote }}
   gateway-api-secrets-namespace: {{ .Values.gatewayAPI.secretsNamespace.name | quote }}
+  ingress-lb-annotation-prefixes: {{ .Values.gatewayAPI.gatewayLBAnnotationPrefixes | join " " | quote }}
+
 {{- end }}
 
 {{- if hasKey .Values "loadBalancer" }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -768,6 +768,10 @@ gatewayAPI:
     # If disabled, TLS secrets must be maintained externally.
     sync: true
 
+  # -- GatewayLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate
+  # from Gateway to the Load Balancer service
+  gatewayLBAnnotationPrefixes: [ 'service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com' ]
+
 # -- Enables the fallback compatibility solution for when the xt_socket kernel
 # module is missing and it is needed for the datapath L7 redirection to work
 # properly. See documentation for details on when this can be disabled:

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -731,6 +731,7 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 			operatorOption.Config.EnableGatewayAPISecretsSync,
 			operatorOption.Config.GatewayAPISecretsNamespace,
 			operatorOption.Config.ProxyIdleTimeoutSeconds,
+			operatorOption.Config.GatewayLBAnnotationPrefixes,
 		)
 		if err != nil {
 			log.WithError(err).WithField(logfields.LogSubsys, gatewayapi.Subsys).Fatal(

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -19,6 +19,8 @@ var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "option")
 
 var IngressLBAnnotationsDefault = []string{"service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"}
 
+var GatewayLBAnnotationsDefault = []string{"service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"}
+
 const (
 	// EndpointGCIntervalDefault is the default time for the CEP GC
 	EndpointGCIntervalDefault = 5 * time.Minute
@@ -288,6 +290,10 @@ const (
 
 	// GatewayAPISecretsNamespace is the namespace having tls secrets used by GatewayAPI and CEC.
 	GatewayAPISecretsNamespace = "gateway-api-secrets-namespace"
+
+	// GatewayLBAnnotationPrefixes are the annotations which are needed to propagate
+	// from Ingress to the Load Balancer
+	GatewayLBAnnotationPrefixes = "gateway-lb-annotation-prefixes"
 
 	// ProxyIdleTimeoutSeconds is the idle timeout for proxy connections to upstream clusters
 	ProxyIdleTimeoutSeconds = "proxy-idle-timeout-seconds"
@@ -564,6 +570,10 @@ type OperatorConfig struct {
 	// GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC for Gateway API.
 	GatewayAPISecretsNamespace string
 
+	// GatewayLBAnnotationPrefixes GatewayLBAnnotations are the annotation prefixes,
+	// which are used to filter annotations to propagate from Gateway to the Load Balancer
+	GatewayLBAnnotationPrefixes []string
+
 	// ProxyIdleTimeoutSeconds is the idle timeout for the proxy to upstream cluster
 	ProxyIdleTimeoutSeconds int
 
@@ -638,6 +648,10 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.EnforceIngressHTTPS = vp.GetBool(EnforceIngressHttps)
 	c.IngressSecretsNamespace = vp.GetString(IngressSecretsNamespace)
 	c.GatewayAPISecretsNamespace = vp.GetString(GatewayAPISecretsNamespace)
+	c.GatewayLBAnnotationPrefixes = vp.GetStringSlice(GatewayLBAnnotationPrefixes)
+	if len(c.GatewayLBAnnotationPrefixes) == 0 {
+		c.GatewayLBAnnotationPrefixes = GatewayLBAnnotationsDefault
+	}
 	c.ProxyIdleTimeoutSeconds = vp.GetInt(ProxyIdleTimeoutSeconds)
 	if c.ProxyIdleTimeoutSeconds == 0 {
 		c.ProxyIdleTimeoutSeconds = DefaultProxyIdleTimeoutSeconds

--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -56,7 +56,7 @@ type Controller struct {
 
 // NewController returns a new gateway controller, which is implemented
 // using the controller-runtime library.
-func NewController(enableSecretSync bool, secretsNamespace string, idleTimeoutSeconds int) (*Controller, error) {
+func NewController(enableSecretSync bool, secretsNamespace string, idleTimeoutSeconds int, lbAnnotationPrefixes []string) (*Controller, error) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,
 		// Disable controller metrics server in favour of cilium's metrics server.
@@ -79,12 +79,13 @@ func NewController(enableSecretSync bool, secretsNamespace string, idleTimeoutSe
 	}
 
 	gwReconciler := &gatewayReconciler{
-		Client:             mgr.GetClient(),
-		Scheme:             mgr.GetScheme(),
-		SecretsNamespace:   secretsNamespace,
-		Model:              m,
-		controllerName:     controllerName,
-		IdleTimeoutSeconds: idleTimeoutSeconds,
+		Client:               mgr.GetClient(),
+		Scheme:               mgr.GetScheme(),
+		SecretsNamespace:     secretsNamespace,
+		Model:                m,
+		controllerName:       controllerName,
+		lbAnnotationPrefixes: lbAnnotationPrefixes,
+		IdleTimeoutSeconds:   idleTimeoutSeconds,
 	}
 	if err = gwReconciler.SetupWithManager(mgr); err != nil {
 		return nil, err

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -38,6 +38,8 @@ type gatewayReconciler struct {
 	SecretsNamespace   string
 	IdleTimeoutSeconds int
 
+	lbAnnotationPrefixes []string
+
 	controllerName string
 	Model          *internalModel
 }


### PR DESCRIPTION
Now annotations from Gateway prefixed by prefixes defined in config will be propagated to Service. I followed actual ingress controller implementation for such feature and made it similar way

Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

<!-- Description of change -->

Fixes: #25357

```release-note
Annotations prefixed by `gateway-lb-annotation-prefixes` flag value will be propagated to underlying Load Balancer Service
```
