### PR TITLE
pkg/cidr: Move linux specific variable references from netlink

### DIFF
--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -96,6 +96,7 @@ jobs:
         with:
           filters: |
             src:
+              - 'pkg/**'
               - 'test/**'
 
       # Runs only if code under test/ is changed.

--- a/pkg/cidr/cidr.go
+++ b/pkg/cidr/cidr.go
@@ -7,8 +7,6 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-
-	"github.com/vishvananda/netlink"
 )
 
 // NewCIDR returns a new CIDR using a net.IPNet
@@ -105,12 +103,12 @@ func Equal(n, o *net.IPNet) bool {
 // ZeroNet generates a zero net.IPNet object for the given address family
 func ZeroNet(family int) *net.IPNet {
 	switch family {
-	case netlink.FAMILY_V4:
+	case FAMILY_V4:
 		return &net.IPNet{
 			IP:   net.IPv4zero,
 			Mask: net.CIDRMask(0, 8*net.IPv4len),
 		}
-	case netlink.FAMILY_V6:
+	case FAMILY_V6:
 		return &net.IPNet{
 			IP:   net.IPv6zero,
 			Mask: net.CIDRMask(0, 8*net.IPv6len),

--- a/pkg/cidr/cidr_linux.go
+++ b/pkg/cidr/cidr_linux.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cidr
+
+import "github.com/vishvananda/netlink/nl"
+
+// Family type definitions
+const (
+	FAMILY_ALL  = nl.FAMILY_ALL
+	FAMILY_V4   = nl.FAMILY_V4
+	FAMILY_V6   = nl.FAMILY_V6
+	FAMILY_MPLS = nl.FAMILY_MPLS
+)

--- a/pkg/cidr/cidr_unspecified.go
+++ b/pkg/cidr/cidr_unspecified.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+//go:build !linux
+
+package cidr
+
+// Dummy values on non-linux platform
+const (
+	FAMILY_V4 = iota
+	FAMILY_V6
+)


### PR DESCRIPTION
Commit e731cbe27e added references to linux specific consts from the netlink package, and it broke the ginkgo compilation on darwin targets - https://github.com/cilium/cilium/actions/runs/5944152105/job/16120804454?pr=27520. 

/cc @borkmann 

Reported-by: Tim Horner <timothy.horner@isovalent.com>
Fixes: e731cbe27e "cilium, iptables: Support option to masquerade source IP from routing layer"