### PR TITLE
bgpv1: BGP speaker OnFibEvent

### DIFF
--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
+	"github.com/cilium/cilium/pkg/bgpv1/agent/signaler"
 	"github.com/cilium/cilium/pkg/bgpv1/api"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -42,7 +43,8 @@ type LocalASNMap map[int64]*ServerWithConfig
 type bgpRouterManagerParams struct {
 	cell.In
 
-	Reconcilers []ConfigReconciler `group:"bgp-config-reconciler"`
+	Reconcilers   []ConfigReconciler `group:"bgp-config-reconciler"`
+	BGPCPSignaler *signaler.BGPCPSignaler
 }
 
 // BGPRouterManager implements the pkg.bgpv1.agent.BGPRouterManager interface.
@@ -78,6 +80,7 @@ type BGPRouterManager struct {
 	lock.RWMutex
 	Servers     LocalASNMap
 	Reconcilers []ConfigReconciler
+	signaler    *signaler.BGPCPSignaler
 }
 
 // NewBGPRouterManager constructs a GoBGP-backed BGPRouterManager.
@@ -235,6 +238,9 @@ func (m *BGPRouterManager) registerBGPServer(ctx context.Context, c *v2alpha1api
 			RouteSelectionOptions: &types.RouteSelectionOptions{
 				AdvertiseInactiveRoutes: true,
 			},
+		},
+		OnFIBEvent: func() {
+			m.signaler.Event(struct{}{})
 		},
 	}
 

--- a/pkg/bgpv1/manager/reconcile_test.go
+++ b/pkg/bgpv1/manager/reconcile_test.go
@@ -129,7 +129,7 @@ func TestPreflightReconciler(t *testing.T) {
 				LocalASN: 64125,
 			}
 
-			preflightReconciler := NewPreflightReconciler().Reconciler
+			preflightReconciler := NewPreflightReconciler(PreflightReconcilerParams{}).Reconciler
 			params := ReconcileParams{
 				CurrentServer: testSC,
 				DesiredConfig: newc,
@@ -1325,7 +1325,7 @@ func TestReconcileAfterServerReinit(t *testing.T) {
 		"cilium.io/bgp-virtual-router.64125": fmt.Sprintf("router-id=%s,local-port=%d", newRouterID, localPort),
 	}
 
-	preflightReconciler := NewPreflightReconciler().Reconciler
+	preflightReconciler := NewPreflightReconciler(PreflightReconcilerParams{}).Reconciler
 
 	// Trigger pre flight reconciler
 	err = preflightReconciler.Reconcile(context.Background(), params)

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -69,7 +69,8 @@ type GetBGPResponse struct {
 
 // ServerParameters contains information for underlying bgp implementation layer to initializing BGP process.
 type ServerParameters struct {
-	Global BGPGlobal
+	Global     BGPGlobal
+	OnFIBEvent func()
 }
 
 // Family holds Address Family Indicator (AFI) and Subsequent Address Family Indicator for Multi-Protocol BGP


### PR DESCRIPTION
This commit adds a `OnFibEvent` function to types.ServerParameters.

This function is called when the instantiated BGP speaker experiences a
fib event.

When a FIB even occurs BGP-CP will be triggered for reconciliation.

This will be useful in future commits when we also learn routes from the
upstream peer.

Signed-off-by: Louis DeLosSantos <louis.delos@isovalent.com>

```release-note
bgpv1: add controller reconciliation on FIB events
```
