### PR TITLE
docs: Update the mutual authentication key format

### DIFF
--- a/Documentation/network/servicemesh/mutual-authentication/mutual-authentication-example.rst
+++ b/Documentation/network/servicemesh/mutual-authentication/mutual-authentication-example.rst
@@ -231,10 +231,10 @@ For brevity, you can search for some specific log messages:
 .. code-block:: shell-session
 
     $ kubectl -n kube-system -c cilium-agent logs cilium-9pshw --timestamps=true | grep "Policy is requiring authentication\|Validating Server SNI\|Validated certificate\|Successfully authenticated"
-    2023-07-04T17:58:28.795760597Z level=debug msg="Policy is requiring authentication" auth_type=spire local_identity=17947 remote_identity=39239 subsys=auth
+    2023-07-04T17:58:28.795760597Z level=debug msg="Policy is requiring authentication" key="localIdentity=17947, remoteIdentity=39239, remoteNodeID=54264, authType=spire" subsys=auth
     2023-07-04T17:58:28.800509503Z level=debug msg="Validating Server SNI" SNI ID=39239 subsys=auth
     2023-07-04T17:58:28.800525190Z level=debug msg="Validated certificate" subsys=auth uri-san="[spiffe://spiffe.cilium/identity/39239]"
-    2023-07-04T17:58:28.801441968Z level=debug msg="Successfully authenticated" auth_type=spire local_identity=17947 remote_identity=39239 remote_node_ip=10.0.1.175 subsys=auth
+    2023-07-04T17:58:28.801441968Z level=debug msg="Successfully authenticated" key="localIdentity=17947, remoteIdentity=39239, remoteNodeID=54264, authType=spire" remote_node_ip=10.0.1.175 subsys=auth
 
 When you apply a mutual authentication policy, the agent retrieves the identity of the source Pod, 
 connects to the node where the destination Pod is running and performs a mutual TLS handshake (with 


### PR DESCRIPTION
The commit 31592e7ce066 ("auth: optimize log output for pending auth") adds new field 'key' to beautify the log message.

So update the authentication key format according to the real log message captured:
	2023-08-23T10:22:04.308373113+08:00 level=debug msg="Policy is requiring authentication" key="localIdentity=13137, remoteIdentity=43715, remoteNodeID=54264, authType=spire" subsys=auth
	2023-08-23T10:22:04.313513823+08:00 level=debug msg="Validating Server SNI" SNI ID=43715 subsys=auth
	2023-08-23T10:22:04.313513823+08:00 level=debug msg="Validated certificate" subsys=auth uri-san="[spiffe://spiffe.cilium/identity/43715]"
	2023-08-23T10:22:04.314043168+08:00 level=debug msg="Successfully authenticated" key="localIdentity=13137, remoteIdentity=43715, remoteNodeID=54264, authType=spire" remote_node_ip=10.10.10.1 subsys=auth
