### PR TITLE
Set kvstoremesh image when pushing the development helm chart

### DIFF
--- a/.github/workflows/push-chart-ci.yaml
+++ b/.github/workflows/push-chart-ci.yaml
@@ -120,7 +120,11 @@ jobs:
             "hubble.relay.image.repository": "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci",
             "hubble.relay.image.tag": "${{ steps.get-ref.outputs.sha }}",
             "clustermesh.apiserver.image.repository": "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci",
-            "clustermesh.apiserver.image.tag": "${{ steps.get-ref.outputs.sha }}"
+            "clustermesh.apiserver.image.tag": "${{ steps.get-ref.outputs.sha }}",
+            "clustermesh.apiserver.kvstoremesh.image.repository": "quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/kvstoremesh-ci",
+            "clustermesh.apiserver.kvstoremesh.image.tag": "${{ steps.get-ref.outputs.sha }}",
+            "clustermesh.apiserver.kvstoremesh.image.digest": "",
+            "clustermesh.apiserver.kvstoremesh.image.useDigest": false
           }
         registry: quay.io
         registry_namespace: ${{ env.QUAY_CHARTS_ORGANIZATION_DEV }}


### PR DESCRIPTION
Configure the kvstoremesh repository and tag to match the one of the other cilium components. Additionally, explicitly disable the digest, which is otherwise configured in stable branches.

Outcome with this change:

```
$ helm show values -n kube-system oci://quay.io/cilium-charts-dev/cilium \
      --version 1.15.0-dev-dev.725-pr-giorio94-main-gha-push-chart-kvstoremesh-3a6c2670f8 | \
      grep 'kvstoremesh:' -A12 -m 1

kvstoremesh:
  # -- Enable KVStoreMesh. KVStoreMesh caches the information retrieved
  # from the remote clusters in the local etcd instance.
  enabled: false
  # -- KVStoreMesh image.
  image:
    override: ~
    repository: "quay.io/cilium/kvstoremesh-ci"
    tag: "3a6c2670f89bbc8b9de6ebf69cae1aab4f9f2718"
    # kvstoremesh-digest
    digest: ""
    useDigest: false
    pullPolicy: "Always"

```