### PR TITLE
Enable prometheus metrics for cilium-operator and clustermesh's Etcd by default

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -475,7 +475,7 @@
    * - :spelling:ignore:`clustermesh.apiserver.metrics.etcd.enabled`
      - Enables exporting etcd metrics in OpenMetrics format.
      - bool
-     - ``false``
+     - ``true``
    * - :spelling:ignore:`clustermesh.apiserver.metrics.etcd.mode`
      - Set level of detail for etcd metrics; specify 'extensive' to include server side gRPC histogram metrics.
      - string
@@ -2363,7 +2363,7 @@
    * - :spelling:ignore:`operator.prometheus`
      - Enable prometheus metrics for cilium-operator on the configured port at /metrics
      - object
-     - ``{"enabled":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}``
+     - ``{"enabled":true,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}``
    * - :spelling:ignore:`operator.prometheus.serviceMonitor.annotations`
      - Annotations to add to ServiceMonitor cilium-operator
      - object

--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -37,8 +37,8 @@ Installation
 ------------
 
 You can enable metrics for ``cilium-agent`` (including Envoy) with the Helm value
-``prometheus.enabled=true``. To enable metrics for ``cilium-operator``,
-use ``operator.prometheus.enabled=true``.
+``prometheus.enabled=true``. ``cilium-operator`` metrics are enabled by default,
+if you want to disable them, set Helm value ``operator.prometheus.enabled=false``.
 
 .. parsed-literal::
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -362,6 +362,10 @@ Helm Options
   changed their type from a string to a structured definition that decouples repository and tag. This improves the
   usage in offline environments.
 
+* Prometheus metrics for cilium-operator and clustermesh's kvstore are now enabled by default.
+  If you want to disable these prometheus metrics, set ``operator.prometheus.enabled=false``
+  and ``clustermesh.apiserver.metrics.etcd.enabled=false`` respectively.
+
 Added Metrics
 ~~~~~~~~~~~~~
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -168,7 +168,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.kvstoremesh.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | KVStoreMesh Security context |
 | clustermesh.apiserver.lifecycle | object | `{}` | lifecycle setting for the apiserver container |
 | clustermesh.apiserver.metrics.enabled | bool | `true` | Enables exporting apiserver metrics in OpenMetrics format. |
-| clustermesh.apiserver.metrics.etcd.enabled | bool | `false` | Enables exporting etcd metrics in OpenMetrics format. |
+| clustermesh.apiserver.metrics.etcd.enabled | bool | `true` | Enables exporting etcd metrics in OpenMetrics format. |
 | clustermesh.apiserver.metrics.etcd.mode | string | `"basic"` | Set level of detail for etcd metrics; specify 'extensive' to include server side gRPC histogram metrics. |
 | clustermesh.apiserver.metrics.etcd.port | int | `9963` | Configure the port the etcd metric server listens on. |
 | clustermesh.apiserver.metrics.kvstoremesh.enabled | bool | `true` | Enables exporting KVStoreMesh metrics in OpenMetrics format. |
@@ -640,7 +640,7 @@ contributors across the globe, there is almost always someone available to help.
 | operator.pprof.enabled | bool | `false` | Enable pprof for cilium-operator |
 | operator.pprof.port | int | `6061` | Configure pprof listen port for cilium-operator |
 | operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
-| operator.prometheus | object | `{"enabled":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
+| operator.prometheus | object | `{"enabled":true,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
 | operator.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-operator |
 | operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | operator.prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2445,7 +2445,7 @@ operator:
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics
   prometheus:
-    enabled: false
+    enabled: true
     port: 9963
     serviceMonitor:
       # -- Enable service monitors.
@@ -3044,7 +3044,7 @@ clustermesh:
 
       etcd:
         # -- Enables exporting etcd metrics in OpenMetrics format.
-        enabled: false
+        enabled: true
         # -- Set level of detail for etcd metrics; specify 'extensive' to include server side gRPC histogram metrics.
         mode: basic
         # -- Configure the port the etcd metric server listens on.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2442,7 +2442,7 @@ operator:
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics
   prometheus:
-    enabled: false
+    enabled: true
     port: 9963
     serviceMonitor:
       # -- Enable service monitors.
@@ -3041,7 +3041,7 @@ clustermesh:
 
       etcd:
         # -- Enables exporting etcd metrics in OpenMetrics format.
-        enabled: false
+        enabled: true
         # -- Set level of detail for etcd metrics; specify 'extensive' to include server side gRPC histogram metrics.
         mode: basic
         # -- Configure the port the etcd metric server listens on.


### PR DESCRIPTION
Enable prometheus metrics for cilium-operator and clustermesh's Etcd by default.

Related: https://github.com/cilium/cilium-cli/pull/1927

```release-note
Cilium-operator and clustermesh's kvstore metrics are now enabled by default in Helm.
```
