### PR TITLE
Fix computation of IPsec max. sequence number

### DIFF
--- a/cilium/cmd/encrypt_status.go
+++ b/cilium/cmd/encrypt_status.go
@@ -89,14 +89,9 @@ func countUniqueIPsecKeys() int {
 	return len(keys)
 }
 
-func maxSequenceNumber() string {
+func extractMaxSequenceNumber(ipOutput string) string {
 	maxSeqNum := "0"
-	out, err := exec.Command("ip", "xfrm", "state", "list", "reqid", ciliumReqId).Output()
-	if err != nil {
-		Fatalf("Cannot get xfrm states: %s", err)
-	}
-	commandOutput := string(out)
-	lines := strings.Split(commandOutput, "\n")
+	lines := strings.Split(ipOutput, "\n")
 	for _, line := range lines {
 		matched := regex.FindStringSubmatchIndex(line)
 		if matched != nil {
@@ -106,6 +101,16 @@ func maxSequenceNumber() string {
 			}
 		}
 	}
+	return maxSeqNum
+}
+
+func maxSequenceNumber() string {
+	out, err := exec.Command("ip", "xfrm", "state", "list", "reqid", ciliumReqId).Output()
+	if err != nil {
+		Fatalf("Cannot get xfrm states: %s", err)
+	}
+	commandOutput := string(out)
+	maxSeqNum := extractMaxSequenceNumber(commandOutput)
 	if maxSeqNum == "0" {
 		return "N/A"
 	}

--- a/cilium/cmd/encrypt_status_test.go
+++ b/cilium/cmd/encrypt_status_test.go
@@ -119,3 +119,43 @@ func (s *EncryptStatusSuite) TestGetXfrmStats(c *C) {
 	}
 	c.Assert(currentCount, Equals, errCount)
 }
+
+func (s *EncryptStatusSuite) TestExtractMaxSequenceNumber(c *C) {
+	ipOutput := `src 10.84.1.32 dst 10.84.0.30
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0x3cb23e00/0xffffff00 output-mark 0xe00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0xc3, bitmap 0x00000000
+	sel src 0.0.0.0/0 dst 0.0.0.0/0
+src 0.0.0.0 dst 10.84.1.32
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0xd00/0xf00 output-mark 0xd00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0x1410, bitmap 0x00000000
+	sel src 0.0.0.0/0 dst 0.0.0.0/0
+src 10.84.1.32 dst 10.84.2.145
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0x7e63e00/0xffffff00 output-mark 0xe00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0x13e0, bitmap 0x00000000
+	sel src 0.0.0.0/0 dst 0.0.0.0/0`
+
+	maxSeqNumber := extractMaxSequenceNumber(ipOutput)
+	c.Assert(maxSeqNumber, Equals, int64(0x1410))
+}
+
+// Attempt to simulate a case where the output would be interrupted mid-sentence.
+func (s *EncryptStatusSuite) TestExtractMaxSequenceNumberError(c *C) {
+	ipOutput := `src 10.84.1.32 dst 10.84.0.30
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0x3cb23e00/0xffffff00 output-mark 0xe00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0x`
+
+	maxSeqNumber := extractMaxSequenceNumber(ipOutput)
+	c.Assert(maxSeqNumber, Equals, int64(0))
+}


### PR DESCRIPTION
See commits for details. First commit refactors to allow for subsequent unit test; second fixes the bug. third adds a unit test.

```release-note
Fix a bug that could cause an incorrect max. sequence number to be reported by `cilium encrypt status` when IPsec is enabled.
```
