### PR TITLE
typo: the clustermesh secret name

### DIFF
--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -53,10 +53,10 @@ Manual Verification of Setup
  #. Validate that required TLS secrets are setup properly. By default, the below
     TLS secrets must be available in cilium installed namespace
 
-    * clustermesh-apiserver-admin-certs, which is used by etcd container in clustermesh-apiserver deployment.
+    * clustermesh-apiserver-admin-cert, which is used by etcd container in clustermesh-apiserver deployment.
       Not applicable if external etcd cluster is used.
 
-    * clustermesh-apiserver-client-certs, which is used by apiserver container in clustermesh-apiserver deployment
+    * clustermesh-apiserver-client-cert, which is used by apiserver container in clustermesh-apiserver deployment
       to establish connection to etcd cluster (either internal or external).
 
     * cilium-ca, which is CA used to generate the above two certs.


### PR DESCRIPTION
when debugged the clustermesh, I found typos 

```
[root@master10 ~]# kubectl get secret -n kube-system clustermesh-apiserver-admin-certs
Error from server (NotFound): secrets "clustermesh-apiserver-admin-certs" not found

[root@master10 ~]# kubectl get secret -n kube-system clustermesh-apiserver-admin-cert
NAME                               TYPE                DATA   AGE
clustermesh-apiserver-admin-cert   kubernetes.io/tls   3      28h
```

the chart code
```
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: clustermesh-apiserver-client-cert
  namespace: {{ .Release.Namespace }}
spec:
  issuerRef:
    {{- toYaml .Values.clustermesh.apiserver.tls.auto.certManagerIssuerRef | nindent 4 }}
  secretName: clustermesh-apiserver-client-cert
  commonName: externalworkload
  duration: {{ printf "%dh0m0s" (mul .Values.clustermesh.apiserver.tls.auto.certValidityDuration 24) }}
{{- end }}
```

```
---
apiVersion: v1
kind: Secret
metadata:
  name: clustermesh-apiserver-admin-cert
  namespace: {{ .Release.Namespace }}
type: kubernetes.io/tls
data:
  ca.crt:  {{ .commonCA.Cert | b64enc }}
  tls.crt: {{ $cert.Cert | b64enc }}
  tls.key: {{ $cert.Key  | b64enc }}
{{- end }}
```