### PR TITLE
v1.12 Backports 2023-08-23

### DIFF
--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -1,7 +1,7 @@
 # List of k8s version for AKS tests
 ---
 include:
-  - version: "1.24"
+  - version: "1.25"
     location: westeurope
     index: 1
     default: true

--- a/Documentation/Makefile
+++ b/Documentation/Makefile
@@ -94,7 +94,7 @@ $(HELM_VALUES): FORCE
 	$(QUIET)$(HELM_DOCS) -d -c $(HELM_DOCS_CHARTS_DIR) -t $(HELM_DOCS_OUTPUT_DIR)/$(TMP_FILE_1).tmpl > $(TMP_FILE_1)
 	$(QUIET)awk -F'|' '{print "|"$$2"|"$$5"|"$$3"|"$$4"|"}' $(TMP_FILE_1) > $(TMP_FILE_2)
 	$(QUIET)$(M2R) --overwrite $(TMP_FILE_2)
-	$(QUIET)$(SED) 's/^\(   \* - \)\([[:print:]]\+\)$$/\1:spelling:ignore:`\2`/' $@ > $(TMP_FILE_3)
+	$(QUIET)$(SED) 's/^\(   \* - \)\([[:print:]]\{1,\}\)$$/\1:spelling:ignore:`\2`/' $@ > $(TMP_FILE_3)
 	$(QUIET)printf '..\n  %s\n\n%s\n' "AUTO-GENERATED. Please DO NOT edit manually." "$$(cat $(TMP_FILE_3))" > $@
 	$(QUIET)$(RM) -- $(TMP_FILE_1) $(TMP_FILE_2) $(TMP_FILE_3)
 

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -168,7 +168,7 @@ todo_include_todos = False
 spelling_exclude_patterns = ['_api/v1/*/README.md']
 
 # Add custom filters for spell checks.
-spelling_filters = [cilium_spellfilters.WireGuardFilter]
+spelling_filters = ["cilium_spellfilters.WireGuardFilter"]
 
 # Ignore some warnings from MyST parser
 suppress_warnings = ['myst.header']

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -116,7 +116,7 @@
    * - :spelling:ignore:`certgen`
      - Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually.
      - object
-     - ``{"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}``
+     - ``{"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.1.9@sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f"},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}``
    * - :spelling:ignore:`certgen.extraVolumeMounts`
      - Additional certgen volumeMounts.
      - list

--- a/Documentation/policy/visibility.rst
+++ b/Documentation/policy/visibility.rst
@@ -10,6 +10,10 @@
 Layer 7 Protocol Visibility
 ***************************
 
+.. note::
+
+    This feature requires enabling L7 Proxy support. Without it, the visibility annotation is ignored.
+
 While :ref:`monitor` provides introspection into datapath state, by default it
 will only provide visibility into L3/L4 packet events. If :ref:`l7_policy` are
 configured, one can get visibility into L7 protocols, but this requires the full

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -442,7 +442,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		return d.errorDuringCreation(ep, fmt.Errorf("unable to insert endpoint into manager: %s", err))
 	}
 
-	// We need to update the the visibility policy after adding the endpoint in
+	// We need to update the visibility policy after adding the endpoint in
 	// the endpoint manager because the endpoint manager create the endpoint
 	// queue of the endpoint. If we execute this function before the endpoint
 	// manager creates the endpoint queue the operation will fail.
@@ -454,6 +454,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 			}
 			return p.Annotations[annotation.ProxyVisibility], nil
 		})
+
 		ep.UpdateBandwidthPolicy(func(ns, podName string) (bandwidthEgress string, err error) {
 			p, err := d.k8sWatcher.GetCachedPod(ns, podName)
 			if err != nil {

--- a/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
@@ -23,6 +23,8 @@ spec:
           skip_xff_append: true
           http_filters:
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
     name: prometheus_route
     virtual_hosts:

--- a/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-traffic-management-test.yaml
@@ -23,6 +23,8 @@ spec:
                 skip_xff_append: true
                 http_filters:
                   - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
     - "@type": type.googleapis.com/envoy.config.route.v3.RouteConfiguration
       name: lb_route
       virtual_hosts:

--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -12,7 +12,7 @@ export CILIUM_REPO:=quay.io/cilium/cilium
 export CLUSTERMESH_APISERVER_REPO:=quay.io/cilium/clustermesh-apiserver
 
 export CERTGEN_REPO:=quay.io/cilium/certgen
-export CERTGEN_VERSION:=v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd
+export CERTGEN_VERSION:=v0.1.9@sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f
 
 export CILIUM_ETCD_OPERATOR_REPO:=quay.io/cilium/cilium-etcd-operator
 export CILIUM_ETCD_OPERATOR_VERSION:=v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -79,7 +79,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |
-| certgen | object | `{"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen | object | `{"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.1.9@sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f"},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.extraVolumeMounts | list | `[]` | Additional certgen volumeMounts. |
 | certgen.extraVolumes | list | `[]` | Additional certgen volumes. |
 | certgen.podLabels | object | `{}` | Labels to be added to hubble-certgen pods |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -669,7 +669,7 @@ certgen:
   image:
     override: ~
     repository: "quay.io/cilium/certgen"
-    tag: "v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"
+    tag: "v0.1.9@sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f"
     pullPolicy: "IfNotPresent"
   # -- Seconds after which the completed job pod will be deleted
   ttlSecondsAfterFinished: 1800

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -219,7 +219,7 @@ func (p *policyIdentitiesLabelLookup) GetLabels(id identity.NumericIdentity) lab
 // problem that occurred while adding an l7 redirect for the specified policy.
 // Must be called with endpoint.mutex Lock()ed.
 func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirects map[string]bool, proxyWaitGroup *completion.WaitGroup) (error, revert.FinalizeFunc, revert.RevertFunc) {
-	if option.Config.DryMode || e.isProxyDisabled() {
+	if option.Config.DryMode || e.IsProxyDisabled() {
 		return nil, nil, nil
 	}
 
@@ -349,7 +349,7 @@ func (e *Endpoint) addVisibilityRedirects(ingress bool, desiredRedirects map[str
 		oldValues    = make(policy.MapState)
 	)
 
-	if e.visibilityPolicy == nil {
+	if e.visibilityPolicy == nil || e.IsProxyDisabled() {
 		return nil, finalizeList.Finalize, revertStack.Revert
 	}
 

--- a/pkg/endpoint/events.go
+++ b/pkg/endpoint/events.go
@@ -228,6 +228,15 @@ func (ev *EndpointPolicyVisibilityEvent) Handle(res chan interface{}) {
 		return
 	}
 	if proxyVisibility != "" {
+		if e.IsProxyDisabled() {
+			e.getLogger().
+				WithField(logfields.EndpointID, e.GetID()).
+				Warn("ignoring L7 proxy visibility policy as L7 proxy is disabled")
+			res <- &EndpointRegenerationResult{
+				err: nil,
+			}
+			return
+		}
 		e.getLogger().Debug("creating visibility policy")
 		nvp, err = policy.NewVisibilityPolicy(proxyVisibility)
 		if err != nil {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -133,7 +133,7 @@ func (e *Endpoint) updateNetworkPolicy(proxyWaitGroup *completion.WaitGroup) (re
 		return nil, nil
 	}
 
-	if e.isProxyDisabled() {
+	if e.IsProxyDisabled() {
 		return nil, nil
 	}
 

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -16,7 +16,7 @@ import (
 
 func (s *EndpointSuite) TestUpdateVisibilityPolicy(c *check.C) {
 	do := &DummyOwner{repo: policy.NewPolicyRepository(nil, nil, nil)}
-	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(nil), nil, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
+	ep := NewEndpointWithState(do, do, ipcache.NewIPCache(nil), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 12345, StateReady)
 	ep.UpdateVisibilityPolicy(func(_, _ string) (string, error) {
 		return "", nil
 	})

--- a/pkg/endpoint/proxy.go
+++ b/pkg/endpoint/proxy.go
@@ -29,13 +29,13 @@ func (e *Endpoint) SetProxy(p EndpointProxy) {
 }
 
 func (e *Endpoint) removeNetworkPolicy() {
-	if e.isProxyDisabled() {
+	if e.IsProxyDisabled() {
 		return
 	}
 	e.proxy.RemoveNetworkPolicy(e)
 }
 
-func (e *Endpoint) isProxyDisabled() bool {
+func (e *Endpoint) IsProxyDisabled() bool {
 	return e.proxy == nil || reflect.ValueOf(e.proxy).IsNil()
 }
 


### PR DESCRIPTION
 * [ ] #27495 (@ishuar)
 * [x] #27409 (@tanjunchen)
   * :warning: minor conflict, resolved by omitting changes to non-existent files
   * (tam) I have verified this backport commit.
 * [x] #27457 (@brlbil)
   * :warning: minor conflicts
 * [ ] #27537 (@qmonnet)
 * [x] ~#27532 (@doniacld)~ already backported by author
 * [x] #27511 (@rolinh)
   * :warning: minor conflicts in files generated from helm values. Resolved by regenerating
 * [x] #27597 (@sayboras)
   * :warning: conflict in `install/kubernetes/cilium/templates/validate.yaml`,skipped 2nd commit per https://github.com/cilium/cilium/pull/27660#issuecomment-1689981684

PRs skipped due to conflicts:

 * #27346 (@qmonnet)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27495 27409 27457 27537 27511 27597; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
make add-labels BRANCH=v1.12 ISSUES=27495,27409,27457,27537,27511,27597
```
