### PR TITLE
Delete auth map entries of deleted SVID

### DIFF
--- a/pkg/auth/certs/provider.go
+++ b/pkg/auth/certs/provider.go
@@ -13,6 +13,7 @@ import (
 
 type CertificateRotationEvent struct {
 	Identity identity.NumericIdentity
+	Deleted  bool
 }
 
 type CertificateProvider interface {

--- a/pkg/auth/manager.go
+++ b/pkg/auth/manager.go
@@ -110,7 +110,16 @@ func (a *AuthManager) handleCertificateRotationEvent(_ context.Context, event ce
 
 	for k := range all {
 		if k.localIdentity == event.Identity || k.remoteIdentity == event.Identity {
-			a.handleAuthenticationFunc(a, k, true)
+			if event.Deleted {
+				a.logger.
+					WithField("key", k).
+					Debug("Certificate delete event: deleting auth map entry")
+				if err := a.authmap.Delete(k); err != nil {
+					return fmt.Errorf("failed to delete auth map entry: %w", err)
+				}
+			} else {
+				a.handleAuthenticationFunc(a, k, true)
+			}
 		}
 	}
 


### PR DESCRIPTION
This change adds a watcher on the SPIRE updates for deleted SVIDs. If one is deleted it will be signaled over the rotation channel. Should the ID be present in the auth map it will be immediately removed.

```release-note
Delete auth map entries for removed Security IDs in SPIRE
```
