### PR TITLE
policy: Move getNets to selector cache

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -27,8 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
@@ -174,28 +172,6 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	return f.CloseAtomicallyReplace()
 }
 
-// GetLabelsLocked implements the policy.Identites interface{} method GetLabelsLocked, which allows
-// Endpoint.addNewRedirectsFromDesiredPolicy to call `UpdateRedirects` with a label cache. This
-// enables `UpdateRedirects` to call `toMapState` to look up CIDRs associated with identites to make
-// a final determination about whether they should even be inserted into an Endpoint's policy map.
-//
-// Note that while other policy implementations use the SelectorCache as the underlying source for
-// labels during calls to ToMapState(), this implementation uses the identity allocator. This means
-// that the locking patterns from this code path will differ from the other policy calculation
-// cases!
-//
-// This is needed due to the endpoint being locked when UpdateRedirects is called so that selector
-// cache can not be used for this function, as it will lock the endpoint via the ip cache.
-//
-// Called with the Endpoint locked.
-func (e *Endpoint) GetLabelsLocked(id identity.NumericIdentity) labels.LabelArray {
-	ident := e.allocator.LookupIdentityByID(context.Background(), id)
-	if ident != nil {
-		return ident.LabelArray
-	}
-	return nil
-}
-
 // addNewRedirectsFromDesiredPolicy must be called while holding the endpoint lock for
 // writing. On success, returns nil; otherwise, returns an error indicating the
 // problem that occurred while adding an l7 redirect for the specified policy.
@@ -216,7 +192,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 		Old:  make(policy.MapState),
 	}
 
-	e.desiredPolicy.UpdateRedirects(ingress, e,
+	e.desiredPolicy.UpdateRedirects(ingress,
 		func(l4 *policy.L4Filter) (uint16, bool) {
 			var redirectPort uint16
 			// Only create a redirect if the proxy is NOT running in a sidecar container

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -488,7 +488,7 @@ type ChangeState struct {
 // 'p.PolicyMapState' using denyPreferredInsertWithChanges().
 // Keys and old values of any added or deleted entries are added to 'changes'.
 // The implementation of 'identities' is also in a locked state.
-func (l4Filter *L4Filter) toMapState(p *EndpointPolicy, identities Identities, features policyFeatures, entryCb entryCallback, changes ChangeState) {
+func (l4Filter *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, entryCb entryCallback, changes ChangeState) {
 	port := uint16(l4Filter.Port)
 	proto := uint8(l4Filter.U8Proto)
 
@@ -552,7 +552,7 @@ func (l4Filter *L4Filter) toMapState(p *EndpointPolicy, identities Identities, f
 		if cs.IsWildcard() {
 			keyToAdd.Identity = 0
 			if entryCb(keyToAdd, &entry) {
-				p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, identities, features, changes)
+				p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 
 				if port == 0 {
 					// Allow-all
@@ -582,18 +582,18 @@ func (l4Filter *L4Filter) toMapState(p *EndpointPolicy, identities Identities, f
 		for _, id := range idents {
 			keyToAdd.Identity = id.Uint32()
 			if entryCb(keyToAdd, &entry) {
-				p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, identities, features, changes)
+				p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 				// If Cilium is in dual-stack mode then the "World" identity
 				// needs to be split into two identities to represent World
 				// IPv6 and IPv4 traffic distinctly from one another.
 				if id == identity.ReservedIdentityWorld && option.Config.IsDualStack() {
 					keyToAdd.Identity = identity.ReservedIdentityWorldIPv4.Uint32()
 					if entryCb(keyToAdd, &entry) {
-						p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, identities, features, changes)
+						p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 					}
 					keyToAdd.Identity = identity.ReservedIdentityWorldIPv6.Uint32()
 					if entryCb(keyToAdd, &entry) {
-						p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, identities, features, changes)
+						p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 					}
 				}
 			}

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -161,7 +161,9 @@ type identitySelector interface {
 type scIdentity struct {
 	NID       identity.NumericIdentity
 	lbls      labels.LabelArray
-	namespace string // value of the namespace label, or ""
+	nets      []*net.IPNet // Most specific CIDR for the identity, if any.
+	computed  bool         // nets has been computed
+	namespace string       // value of the namespace label, or ""
 }
 
 // scIdentityCache is a cache of Identities keyed by the numeric identity
@@ -171,8 +173,35 @@ func newIdentity(nid identity.NumericIdentity, lbls labels.LabelArray) scIdentit
 	return scIdentity{
 		NID:       nid,
 		lbls:      lbls,
+		nets:      getLocalScopeNets(nid, lbls),
 		namespace: lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceLabel),
+		computed:  true,
 	}
+}
+
+// getLocalScopeNets returns the most specific CIDR for a local scope identity.
+func getLocalScopeNets(id identity.NumericIdentity, lbls labels.LabelArray) []*net.IPNet {
+	if id.HasLocalScope() {
+		var (
+			maskSize         int
+			mostSpecificCidr *net.IPNet
+		)
+		for _, lbl := range lbls {
+			if lbl.Source == labels.LabelSourceCIDR {
+				_, netIP, err := net.ParseCIDR(lbl.Key)
+				if err == nil {
+					if ms, _ := netIP.Mask.Size(); ms > maskSize {
+						mostSpecificCidr = netIP
+						maskSize = ms
+					}
+				}
+			}
+		}
+		if mostSpecificCidr != nil {
+			return []*net.IPNet{mostSpecificCidr}
+		}
+	}
+	return nil
 }
 
 func getIdentityCache(ids cache.IdentityCache) scIdentityCache {
@@ -1093,11 +1122,18 @@ func (sc *SelectorCache) RemoveIdentitiesFQDNSelectors(fqdnSels []api.FQDNSelect
 	sc.releaseIdentityMappings(identitiesToRelease)
 }
 
-// GetLabels must be called while holding sc.mutex!
-func (sc *SelectorCache) GetLabelsLocked(id identity.NumericIdentity) labels.LabelArray {
+// GetNetsLocked returns the most specific CIDR for an identity. For the "World" identity
+// it returns both IPv4 and IPv6.
+func (sc *SelectorCache) GetNetsLocked(id identity.NumericIdentity) []*net.IPNet {
 	ident, ok := sc.idCache[id]
 	if !ok {
-		return labels.LabelArray{}
+		return nil
 	}
-	return ident.lbls
+	if !ident.computed {
+		log.WithFields(logrus.Fields{
+			logfields.Identity: id,
+			logfields.Labels:   ident.lbls,
+		}).Warning("GetNetsLocked: Identity with missing nets!")
+	}
+	return ident.nets
 }


### PR DESCRIPTION
Precompute the most specific subnet for each identity added to the selectorcache so that this computation need not be repeated for each MapStateEntry separately.

To make this possible Endpoint's implementation of GetLabelsLocked() is removed in the first commit.

This should speed up deny policy computation a bit and also makes MapStateEntries a bit smaller.