### PR TITLE
Resiliency: Add retry logic to attempt to clear out stale hostip

### DIFF
--- a/daemon/cmd/ciliumendpoints.go
+++ b/daemon/cmd/ciliumendpoints.go
@@ -100,7 +100,7 @@ func (d *Daemon) deleteCiliumEndpoint(
 				return nil
 			}
 			logwf.WithError(err).Error("Failed to get possibly stale ciliumendpoints from apiserver")
-			return resiliency.NewRetryableErr(err)
+			return resiliency.Retryable(err)
 		}
 		if cep.Status.Networking.NodeIP != node.GetCiliumEndpointNodeIP() {
 			logwf.WithError(err).Debug("Stale CEP fetched apiserver no longer references this Node, skipping.")
@@ -127,7 +127,7 @@ func (d *Daemon) deleteCiliumEndpoint(
 			return nil
 		}
 		logwf.Error("Could not delete stale CEP")
-		return resiliency.NewRetryableErr(err)
+		return resiliency.Retryable(err)
 	}
 
 	return nil

--- a/pkg/resiliency/error.go
+++ b/pkg/resiliency/error.go
@@ -3,12 +3,12 @@
 
 package resiliency
 
-// RetryableErr tracks errors that could be retried.
-type RetryableErr struct {
+// retryableErr tracks errors that could be retried.
+type retryableErr struct {
 	error
 }
 
-// NewRetryableErr returns a new instance.
-func NewRetryableErr(e error) RetryableErr {
-	return RetryableErr{error: e}
+// Retryable returns a new instance.
+func Retryable(e error) retryableErr {
+	return retryableErr{error: e}
 }

--- a/pkg/resiliency/helpers.go
+++ b/pkg/resiliency/helpers.go
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resiliency
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// RetryFunc tracks resiliency retry calls.
+type RetryFunc func(ctx context.Context, retries int) (bool, error)
+
+// Retry retries the provided call using exponential retries given an initial duration for up to max retries count.
+func Retry(ctx context.Context, duration time.Duration, maxRetries int, fn RetryFunc) error {
+	bo := wait.Backoff{
+		Duration: duration,
+		Factor:   1,
+		Jitter:   0.1,
+		Steps:    maxRetries,
+	}
+
+	var retries int
+	f := func(ctx context.Context) (bool, error) {
+		retries++
+		return fn(ctx, retries)
+	}
+
+	return wait.ExponentialBackoffWithContext(ctx, bo, f)
+}

--- a/pkg/resiliency/helpers_test.go
+++ b/pkg/resiliency/helpers_test.go
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resiliency_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/resiliency"
+)
+
+func TestRetries(t *testing.T) {
+	var maxRetries int
+
+	uu := map[string]struct {
+		d   time.Duration
+		m   int
+		f   resiliency.RetryFunc
+		err error
+		e   int
+	}{
+		"no-retries": {
+			d: 10 * time.Millisecond,
+			m: 3,
+			f: func(ctx context.Context, retries int) (bool, error) {
+				maxRetries = retries
+				return true, nil
+			},
+			e: 1,
+		},
+		"happy": {
+			d: 10 * time.Millisecond,
+			m: 3,
+			f: func(ctx context.Context, retries int) (bool, error) {
+				maxRetries = retries
+				if retries < 3 {
+					return false, nil
+				}
+				return true, nil
+			},
+			e: 3,
+		},
+		"error-complete": {
+			d: 10 * time.Millisecond,
+			m: 3,
+			f: func(ctx context.Context, retries int) (bool, error) {
+				maxRetries = retries
+				return true, errors.New("boom")
+			},
+			err: errors.New("boom"),
+			e:   1,
+		},
+		"error-retry": {
+			d: 10 * time.Millisecond,
+			m: 3,
+			f: func(ctx context.Context, retries int) (bool, error) {
+				maxRetries = retries
+				return false, errors.New("boom")
+			},
+			err: errors.New("boom"),
+			e:   1,
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		maxRetries = 0
+		t.Run(k, func(t *testing.T) {
+			err := resiliency.Retry(context.Background(), u.d, u.m, u.f)
+			if err != nil {
+				assert.Equal(t, u.err, err)
+			}
+			assert.Equal(t, u.e, maxRetries)
+		})
+	}
+}

--- a/pkg/resiliency/retry.go
+++ b/pkg/resiliency/retry.go
@@ -9,5 +9,5 @@ import (
 
 // IsRetryable checks if an error can be retried.
 func IsRetryable(e error) bool {
-	return errors.As(e, new(RetryableErr))
+	return errors.As(e, new(retryableErr))
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Resiliency: Add retry logic to attempt to clear out stale hostip

NOTE: Depends on PR: https://github.com/cilium/cilium/pull/27614

When the daemon initializes it attempts to clean out stale host ips. 
This process only occurs one time irregardless of errors occurring during that reconciliation.

- Add retry logic on the daemon to attempt to clear out stale host ips should errors occurred during that process.
    
> NOTE: Not super sure on the best way to handle this use case??
This will potentially put the brakes on while constructing the daemon.
This ctor code is currently very procedural (not to mention a mile long!) 
as each step depends on the resolution of the previous one?
    
Fixes: #issue-number

Signed-off-by: Fernand Galiana <fernand.galiana@gmail.com>
