### PR TITLE
Fix KVStoreMesh metric's ConfigName

### DIFF
--- a/pkg/clustermesh/common/metrics.go
+++ b/pkg/clustermesh/common/metrics.go
@@ -23,35 +23,31 @@ func MetricsProvider(subsystem string) func() Metrics {
 	return func() Metrics {
 		return Metrics{
 			TotalRemoteClusters: metric.NewGaugeVec(metric.GaugeOpts{
-				ConfigName: metrics.Namespace + "_" + subsystem + "_remote_clusters",
-				Namespace:  metrics.Namespace,
-				Subsystem:  subsystem,
-				Name:       "remote_clusters",
-				Help:       "The total number of remote clusters meshed with the local cluster",
+				Namespace: metrics.Namespace,
+				Subsystem: subsystem,
+				Name:      "remote_clusters",
+				Help:      "The total number of remote clusters meshed with the local cluster",
 			}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName}),
 
 			LastFailureTimestamp: metric.NewGaugeVec(metric.GaugeOpts{
-				ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_last_failure_ts",
-				Namespace:  metrics.Namespace,
-				Subsystem:  subsystem,
-				Name:       "remote_cluster_last_failure_ts",
-				Help:       "The timestamp of the last failure of the remote cluster",
+				Namespace: metrics.Namespace,
+				Subsystem: subsystem,
+				Name:      "remote_cluster_last_failure_ts",
+				Help:      "The timestamp of the last failure of the remote cluster",
 			}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
 
 			ReadinessStatus: metric.NewGaugeVec(metric.GaugeOpts{
-				ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_readiness_status",
-				Namespace:  metrics.Namespace,
-				Subsystem:  subsystem,
-				Name:       "remote_cluster_readiness_status",
-				Help:       "The readiness status of the remote cluster",
+				Namespace: metrics.Namespace,
+				Subsystem: subsystem,
+				Name:      "remote_cluster_readiness_status",
+				Help:      "The readiness status of the remote cluster",
 			}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
 
 			TotalFailures: metric.NewGaugeVec(metric.GaugeOpts{
-				ConfigName: metrics.Namespace + "_" + subsystem + "_remote_cluster_failures",
-				Namespace:  metrics.Namespace,
-				Subsystem:  subsystem,
-				Name:       "remote_cluster_failures",
-				Help:       "The total number of failures related to the remote cluster",
+				Namespace: metrics.Namespace,
+				Subsystem: subsystem,
+				Name:      "remote_cluster_failures",
+				Help:      "The total number of failures related to the remote cluster",
 			}, []string{metrics.LabelSourceCluster, metrics.LabelSourceNodeName, metrics.LabelTargetCluster}),
 		}
 	}

--- a/pkg/metrics/metric/metric.go
+++ b/pkg/metrics/metric/metric.go
@@ -189,3 +189,10 @@ type Opts struct {
 	// If true, the metric has to be explicitly enabled via config or flags
 	Disabled bool
 }
+
+func (b Opts) GetConfigName() string {
+	if b.ConfigName == "" {
+		return prometheus.BuildFQName(b.Namespace, b.Subsystem, b.Name)
+	}
+	return b.ConfigName
+}

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -130,7 +130,7 @@ func (r *Registry) Reinitialize() {
 
 	metrics := make(map[string]metricpkg.WithMetadata)
 	for i, autoMetric := range r.params.AutoMetrics {
-		metrics[autoMetric.Opts().ConfigName] = r.params.AutoMetrics[i]
+		metrics[autoMetric.Opts().GetConfigName()] = r.params.AutoMetrics[i]
 	}
 
 	// This is a bodge for a very specific feature, inherited from the old `Daemon.additionalMetrics`.


### PR DESCRIPTION
Description in commit messages.

```release-note
Fixes name used for disabling KVStoreMesh metrics.
```
