### PR TITLE
daemon: don't wait for presence of unused CNC CRD

### DIFF
--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -42,7 +42,6 @@ func agentCRDResourceNames() []string {
 		CRDResourceName(v2.CCNPName),
 		CRDResourceName(v2.CNName),
 		CRDResourceName(v2.CIDName),
-		CRDResourceName(v2alpha1.CNCName),
 		CRDResourceName(v2alpha1.CCGName),
 		CRDResourceName(v2alpha1.CPIPName),
 	}
@@ -100,6 +99,7 @@ func AllCiliumCRDResourceNames() []string {
 	return append(
 		AgentCRDResourceNames(),
 		CRDResourceName(v2.CEWName),
+		CRDResourceName(v2alpha1.CNCName),
 	)
 }
 


### PR DESCRIPTION
Currently, cilium-agent waits for the presence of the CiliumNodeConfig CRD but it doesn't need to. The commit allows for the agent to function even if the CRD is not present in the cluster.

Fixes: #27683

```release-note
daemon: don't wait for presence of unused CiliumNodeConfig CRD
```
