### PR TITLE
envoy: optimise getWildcardNetworkPolicyRule()

### DIFF
--- a/daemon/cmd/policy_test.go
+++ b/daemon/cmd/policy_test.go
@@ -351,8 +351,8 @@ func (ds *DaemonSuite) TestUpdateConsumerMap(c *C) {
 		uint32(qaFooSecLblsCtx.ID),
 		// The prodFoo* identities are allowed by FromEndpoints but rejected by
 		// FromRequires, so they are not included in the remote policies:
-		// uint64(prodFooSecLblsCtx.ID),
-		// uint64(prodFooJoeSecLblsCtx.ID),
+		// uint32(prodFooSecLblsCtx.ID),
+		// uint32(prodFooJoeSecLblsCtx.ID),
 	}
 	sort.Slice(expectedRemotePolicies, func(i, j int) bool {
 		return expectedRemotePolicies[i] < expectedRemotePolicies[j]

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1305,14 +1305,14 @@ func getPortNetworkPolicyRule(sel policy.CachedSelector, wildcard bool, l7Parser
 	// Optimize the policy if the endpoint selector is a wildcard by
 	// keeping remote policies list empty to match all remote policies.
 	if !wildcard {
-		for _, id := range sel.GetSelections() {
-			r.RemotePolicies = append(r.RemotePolicies, (uint32)(id))
-		}
+		selections := sel.GetSelections()
 
 		// No remote policies would match this rule. Discard it.
-		if len(r.RemotePolicies) == 0 {
+		if len(selections) == 0 {
 			return nil, true
 		}
+
+		r.RemotePolicies = selections.AsUint32Slice()
 	}
 
 	if l7Rules == nil {
@@ -1398,13 +1398,8 @@ func getWildcardNetworkPolicyRule(selectors policy.L7DataMap) *cilium.PortNetwor
 				// No remote policies would match this rule. Discard it.
 				return nil
 			}
-			// convert from []uint32 to []uint64
-			remotePolicies := make([]uint32, len(selections))
-			for i, id := range selections {
-				remotePolicies[i] = uint32(id)
-			}
 			return &cilium.PortNetworkPolicyRule{
-				RemotePolicies: remotePolicies,
+				RemotePolicies: selections.AsUint32Slice(),
 			}
 		}
 	}

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1404,17 +1405,14 @@ func getWildcardNetworkPolicyRule(selectors policy.L7DataMap) *cilium.PortNetwor
 		}
 	}
 
-	// Use map to remove duplicates
-	remoteMap := make(map[uint32]struct{})
+	// Get selections for each selector and count how many there are
+	sels := make([][]uint32, 0, len(selectors))
 	wildcardFound := false
+	var count int
 	for sel, l7 := range selectors {
 		if sel.IsWildcard() {
 			wildcardFound = true
 			break
-		}
-
-		for _, id := range sel.GetSelections() {
-			remoteMap[uint32(id)] = struct{}{}
 		}
 
 		if l7.IsRedirect() {
@@ -1423,26 +1421,32 @@ func getWildcardNetworkPolicyRule(selectors policy.L7DataMap) *cilium.PortNetwor
 			// l7.IsRedirect() will always return false.
 			log.Warningf("L3-only rule for selector %v surprisingly requires proxy redirection (%v)!", sel, *l7)
 		}
+
+		selections := sel.GetSelections()
+		if len(selections) == 0 {
+			continue
+		}
+		count += len(selections)
+		sels = append(sels, selections.AsUint32Slice())
 	}
+
+	var remotePolicies []uint32
 
 	if wildcardFound {
 		// Optimize the policy if the endpoint selector is a wildcard by
 		// keeping remote policies list empty to match all remote policies.
-		remoteMap = nil
-	} else if len(remoteMap) == 0 {
+	} else if count == 0 {
 		// No remote policies would match this rule. Discard it.
 		return nil
+	} else {
+		// allocate slice and copy selected identities
+		remotePolicies = make([]uint32, 0, count)
+		for _, selections := range sels {
+			remotePolicies = append(remotePolicies, selections...)
+		}
+		slices.Sort(remotePolicies)
+		remotePolicies = slices.Compact(remotePolicies)
 	}
-
-	// Convert to a sorted slice
-	remotePolicies := make([]uint32, 0, len(remoteMap))
-	for id := range remoteMap {
-		remotePolicies = append(remotePolicies, id)
-	}
-	sort.Slice(remotePolicies, func(i, j int) bool {
-		return remotePolicies[i] < remotePolicies[j]
-	})
-
 	return &cilium.PortNetworkPolicyRule{
 		RemotePolicies: remotePolicies,
 	}

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -615,7 +615,7 @@ var ExpectedPerPortPoliciesL7 = []*cilium.PortNetworkPolicy{
 		Port:     9090,
 		Protocol: envoy_config_core.SocketAddress_TCP,
 		Rules: []*cilium.PortNetworkPolicyRule{{
-			// RemotePolicies: []uint64{1001, 1002}, // Effective wildcard due to only one selector in the policy
+			// RemotePolicies: []uint32{1001, 1002}, // Effective wildcard due to only one selector in the policy
 			L7Proto: "tester",
 			L7: &cilium.PortNetworkPolicyRule_L7Rules{
 				L7Rules: &cilium.L7NetworkPolicyRules{
@@ -667,7 +667,7 @@ var ExpectedPerPortPoliciesKafka = []*cilium.PortNetworkPolicy{
 		Port:     9092,
 		Protocol: envoy_config_core.SocketAddress_TCP,
 		Rules: []*cilium.PortNetworkPolicyRule{{
-			// RemotePolicies: []uint64{1001, 1002}, // Effective wildcard due to only one selector in the policy
+			// RemotePolicies: []uint32{1001, 1002}, // Effective wildcard due to only one selector in the policy
 			L7Proto: "kafka",
 			L7: &cilium.PortNetworkPolicyRule_KafkaRules{
 				KafkaRules: &cilium.KafkaNetworkPolicyRules{
@@ -724,7 +724,7 @@ var ExpectedPerPortPoliciesMySQL = []*cilium.PortNetworkPolicy{
 		Port:     3306,
 		Protocol: envoy_config_core.SocketAddress_TCP,
 		Rules: []*cilium.PortNetworkPolicyRule{{
-			// RemotePolicies: []uint64{1001, 1002}, // Effective wildcard due to only one selector in the policy
+			// RemotePolicies: []uint32{1001, 1002}, // Effective wildcard due to only one selector in the policy
 			L7Proto: "envoy.filters.network.mysql_proxy",
 			L7: &cilium.PortNetworkPolicyRule_L7Rules{
 				L7Rules: &cilium.L7NetworkPolicyRules{

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -463,6 +463,31 @@ func (s *ServerSuite) TestGetHTTPRule(c *C) {
 	c.Assert(canShortCircuit, Equals, true)
 }
 
+func (s *ServerSuite) Test_getWildcardNetworkPolicyRule(c *C) {
+	perSelectorPoliciesWithWildcard := policy.L7DataMap{
+		cachedSelector1:           nil,
+		cachedRequiresV2Selector1: nil,
+		wildcardCachedSelector:    nil,
+	}
+
+	obtained := getWildcardNetworkPolicyRule(perSelectorPoliciesWithWildcard)
+	c.Assert(obtained, checker.ExportedEquals,
+		&cilium.PortNetworkPolicyRule{})
+
+	// both cachedSelector2 and cachedSelector2 select identity 1001, but duplicates must have been removed
+	perSelectorPolicies := policy.L7DataMap{
+		cachedSelector2:           nil,
+		cachedSelector1:           nil,
+		cachedRequiresV2Selector1: nil,
+	}
+
+	obtained = getWildcardNetworkPolicyRule(perSelectorPolicies)
+	c.Assert(obtained, checker.ExportedEquals,
+		&cilium.PortNetworkPolicyRule{
+			RemotePolicies: []uint32{1001, 1002, 1003},
+		})
+}
+
 func (s *ServerSuite) TestGetPortNetworkPolicyRule(c *C) {
 	obtained, canShortCircuit := getPortNetworkPolicyRule(cachedSelector1, cachedSelector1.IsWildcard(), policy.ParserTypeHTTP, L7Rules12)
 	c.Assert(obtained, checker.ExportedEquals, ExpectedPortNetworkPolicyRule12)

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -210,7 +210,7 @@ type MockCachedSelector struct {
 	key string
 }
 
-func (m MockCachedSelector) GetSelections() []identity.NumericIdentity {
+func (m MockCachedSelector) GetSelections() identity.NumericIdentitySlice {
 	return nil
 }
 

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -1092,7 +1092,7 @@ type selectorMock struct {
 	key string
 }
 
-func (t selectorMock) GetSelections() []identity.NumericIdentity {
+func (t selectorMock) GetSelections() identity.NumericIdentitySlice {
 	panic("implement me")
 }
 

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"sort"
 	"strconv"
+	"unsafe"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -480,6 +481,17 @@ type NumericIdentity uint32
 
 // MaxNumericIdentity is the maximum value of a NumericIdentity.
 const MaxNumericIdentity = math.MaxUint32
+
+type NumericIdentitySlice []NumericIdentity
+
+// AsUint32Slice returns the NumericIdentitySlice as a slice of uint32 without copying any data.
+// This is safe as long as the underlying type stays as uint32.
+func (nids NumericIdentitySlice) AsUint32Slice() []uint32 {
+	if len(nids) == 0 {
+		return nil
+	}
+	return unsafe.Slice((*uint32)(&nids[0]), len(nids))
+}
 
 func ParseNumericIdentity(id string) (NumericIdentity, error) {
 	nid, err := strconv.ParseUint(id, 0, 32)

--- a/pkg/identity/numericidentity_test.go
+++ b/pkg/identity/numericidentity_test.go
@@ -69,3 +69,13 @@ func TestGetAllReservedIdentities(t *testing.T) {
 		require.Equal(t, uint32(i+1), id.Uint32())
 	}
 }
+
+func TestAsUint32Slice(t *testing.T) {
+	nids := NumericIdentitySlice{2, 42, 42, 1, 1024, 1}
+	uint32Slice := nids.AsUint32Slice()
+	require.NotNil(t, uint32Slice)
+	require.Len(t, uint32Slice, len(nids))
+	for i, nid := range nids {
+		require.Equal(t, nid.Uint32(), uint32Slice[i])
+	}
+}

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -205,7 +205,7 @@ func (cs *testCachedSelector) deleteSelections(selections ...int) (deletes []ide
 
 // CachedSelector interface
 
-func (cs *testCachedSelector) GetSelections() []identity.NumericIdentity {
+func (cs *testCachedSelector) GetSelections() identity.NumericIdentitySlice {
 	return cs.selections
 }
 func (cs *testCachedSelector) Selects(nid identity.NumericIdentity) bool {


### PR DESCRIPTION
Introduce `identity.NumericIdentitySlice` to be used instead of bare `[]identity.NumericIdentity`. This allows use of the new `NumericIdentitySlice.AsUint32Slice()` function, that returns the slice of numeric identities as a slice of `uint32`s without allocating and copying memory. This is possible since `identity.NumericIdentity` is defined as `uint32`.

Use this new `NumericIdentitySlice.AsUint32Slice()` in Envoy policy updates to make them more efficient.

Optimise `getWildcardNetworkPolicyRule()` by not using a map to dedup numeric identities, but using the new generic `SortAndDedupSlice()` to sort and deduplicate in place.
