### PR TITLE
ci: add scheduled runs for Ariane workflows

### DIFF
--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -1,0 +1,46 @@
+name: Ariane scheduled workflows
+
+on:
+  # Run every 6 hours
+  schedule:
+    - cron: '0 */6 * * *'
+
+permissions:
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To trigger workflows via workflow_dispatch
+  actions: write
+
+jobs:
+  ariane-scheduled:
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: 
+          - "1.12"
+          - "1.13"
+          - "1.14"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          ref: v${{ matrix.branch }}
+          persist-credentials: false
+
+      - name: Manually run Ariane workflows from the branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REF="v${{ matrix.branch }}"
+          SHA=$(git rev-parse ${REF})
+          readarray workflows < <(yq '.triggers["/test-backport-${{ matrix.branch }}"].workflows[]' .github/ariane-config.yaml)
+
+          for workflow in ${workflows[@]}; do
+            echo triggering ${workflow}
+            gh workflow run ${workflow} \
+              --ref ${REF} \
+              -f PR-number=${REF/./-} \
+              -f context-ref=${REF} \
+              -f SHA=${SHA}
+          done


### PR DESCRIPTION
In 9949c5a1891aff8982bfc19e7fc195e7ecc2abf1, we introduced Ariane to handle CI workflows via `workflow_dispatch` events. One of the nice consequences was that we could finally move CI workflows for stable branches to the appropriate stable branch, instead of having to keep them in `main`.

However, this had the side effect of disabling running these workflows on a schedule, since the `schedule` events are only triggered for files present in the `main` branch.

In this commit, we introduce a `schedule`-based workflow on `main` whose sole purpose is to trigger these missing tests. It automatically detects which workflows to run based on the current Ariane configuration in that branch, and thus the only need in terms of maintenance for us should be to add / remove stable branches in the matrix as appropriate.