### PR TITLE
clean-up: remove check for permissive CCNPs

### DIFF
--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -6,18 +6,13 @@ package validator
 import (
 	"encoding/json"
 	"fmt"
-	"sync"
 
-	"github.com/sirupsen/logrus"
 	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
-	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/policy/api"
 )
 
 // NPValidator is a validator structure used to validate CNP and CCNP.
@@ -104,19 +99,6 @@ func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
 	return nil
 }
 
-var (
-	// We can remove the check for this warning once 1.9 is the oldest supported Cilium version.
-	errWildcardToFromEndpointMessage = "It seems you have a CiliumClusterwideNetworkPolicy " +
-		"with a wildcard to/from endpoint selector. The behavior of this selector has been " +
-		"changed. The selector now only allows traffic to/from Cilium managed K8s endpoints, " +
-		"instead of acting as a truly empty endpoint selector allowing all traffic. To " +
-		"ensure that the policy behavior does not affect your workloads, consider adding " +
-		"another policy that allows traffic to/from world and cluster entities. For a more " +
-		"detailed discussion on the topic, see https://github.com/cilium/cilium/issues/12844"
-
-	logOnce sync.Once
-)
-
 // ValidateCCNP validates the given CCNP accordingly the CCNP validation schema.
 func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
 	if errs := validation.ValidateCustomResource(nil, &ccnp, n.ccnpValidator); len(errs) > 0 {
@@ -127,86 +109,5 @@ func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
 		return err
 	}
 
-	if err := checkWildCardToFromEndpoint(ccnp); err != nil {
-		return err
-	}
-
 	return nil
-}
-
-func checkWildCardToFromEndpoint(ccnp *unstructured.Unstructured) error {
-	logger := log.WithFields(logrus.Fields{
-		logfields.CiliumClusterwideNetworkPolicyName: ccnp.GetName(),
-	})
-
-	// At this point we have validated the custom resource with the new CRV.
-	// We can try converting it to the new CCNP type.
-	// This should not fail, so we are not returning any errors, just logging
-	// a warning.
-	ccnpBytes, err := ccnp.MarshalJSON()
-	if err != nil {
-		return err
-	}
-
-	resCCNP := cilium_v2.CiliumClusterwideNetworkPolicy{}
-	err = json.Unmarshal(ccnpBytes, &resCCNP)
-	if err != nil {
-		return err
-	}
-
-	// Print the warninig only once per CCNP.
-	if resCCNP.Spec != nil {
-		if containsWildcardToFromEndpoint(resCCNP.Spec) {
-			logOnce.Do(func() {
-				logger.Error(errWildcardToFromEndpointMessage)
-			})
-			return fmt.Errorf("use of empty toEndpoints/fromEndpoints selector")
-		}
-	}
-
-	if resCCNP.Specs != nil {
-		for _, rule := range resCCNP.Specs {
-			if containsWildcardToFromEndpoint(rule) {
-				logOnce.Do(func() {
-					logger.Error(errWildcardToFromEndpointMessage)
-				})
-				return fmt.Errorf("use of empty toEndpoints/fromEndpoints selector")
-			}
-		}
-	}
-
-	return nil
-}
-
-// containsWildcardToFromEndpoint returns true if a CCNP contains an empty endpoint selector
-// in ingress/egress rules.
-// For more information - https://github.com/cilium/cilium/issues/12844#issuecomment-672074170
-func containsWildcardToFromEndpoint(rule *api.Rule) bool {
-	if len(rule.Ingress) > 0 {
-		for _, r := range rule.Ingress {
-			// We only check for the presence of wildcard to/fromEndpoints
-			// in the network policy spec.
-			if len(r.FromEndpoints) > 0 {
-				for _, epSel := range r.FromEndpoints {
-					if epSel.IsWildcard() {
-						return true
-					}
-				}
-			}
-		}
-	}
-
-	if len(rule.Egress) > 0 {
-		for _, r := range rule.Egress {
-			if len(r.ToEndpoints) > 0 {
-				for _, epSel := range r.ToEndpoints {
-					if epSel.IsWildcard() {
-						return true
-					}
-				}
-			}
-		}
-	}
-
-	return false
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

This check was designed to inform users of CCNP that the behaviour
changed around the timeframe of v1.9. However, the actual check is
complaining about policy that is valid. At this point there is no need
to warn users during preflight checks that they are using empty endpoint
selectors in CCNPs, because this can validly be used to select all Pods
within the cluster. Remove the check.

Fixes: #27689
