### PR TITLE
[Docs] Clarify ClusterMesh troubleshooting steps when KVStoreMesh is enabled

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -331,6 +331,7 @@ Makefile* @cilium/build
 /Documentation/observability/ @cilium/sig-policy @cilium/docs-structure
 /Documentation/operations/performance/ @cilium/sig-datapath @cilium/docs-structure
 /Documentation/operations/system_requirements.rst @cilium/sig-datapath @cilium/docs-structure
+/Documentation/operations/troubleshooting_clustermesh.rst @cilium/sig-clustermesh @cilium/docs-structure
 /Documentation/overview/component-overview.rst @cilium/docs-structure
 /Documentation/overview/intro.rst @cilium/docs-structure
 /Documentation/requirements.txt @cilium/docs-structure

--- a/Documentation/operations/troubleshooting_clustermesh.rst
+++ b/Documentation/operations/troubleshooting_clustermesh.rst
@@ -106,14 +106,16 @@ Manual Verification of Setup
 
     If the connection fails, check the following:
 
-    * Validate that the ``hostAliases`` section in the Cilium DaemonSet maps
+    * When KVStoreMesh is disabled, validate that the ``hostAliases`` section in the Cilium DaemonSet maps
       each remote cluster to the IP of the LoadBalancer that makes the remote
-      control plane available.
+      control plane available; When KVStoreMesh is enabled,
+      validate that the ``hostAliases`` section in the clustermesh-apiserver Deployment.
 
     * Validate that a local node in the source cluster can reach the IP
-      specified in the ``hostAliases`` section. The ``cilium-clustermesh``
+      specified in the ``hostAliases`` section. When KVStoreMesh is disabled, the ``cilium-clustermesh``
       secret contains a configuration file for each remote cluster, it will
-      point to a logical name representing the remote cluster:
+      point to a logical name representing the remote cluster;
+      When KVStoreMesh is enabled, it exists in the ``cilium-kvstoremesh`` secret.
 
     .. code-block:: yaml
 
@@ -122,8 +124,9 @@ Manual Verification of Setup
 
       The name will *NOT* be resolvable via DNS outside of the cilium pod. The
       name is mapped to an IP using ``hostAliases``. Run ``kubectl -n
-      kube-system get ds cilium -o yaml`` and grep for the FQDN to retrieve the
-      IP that is configured. Then use ``curl`` to validate that the port is
+      kube-system get daemonset cilium -o yaml`` when KVStoreMesh is disabled,
+      or run ``kubectl -n kube-system get deployment clustermesh-apiserver -o yaml`` when KVStoreMesh is enabled,
+      grep for the FQDN to retrieve the IP that is configured. Then use ``curl`` to validate that the port is
       reachable.
 
     * A firewall between the local cluster and the remote cluster may drop the


### PR DESCRIPTION
when the KVStoreMesh is on, I find the debug steps are not in line with the facts, the `hostAliases` does not exist in Cilium DaemonSet, but exist in the clustermesh-apiserver deployment

the chart code

```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: cilium
  namespace: {{ .Release.Namespace }}
  labels:
    k8s-app: cilium
    .....
      {{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.config.enabled (not .Values.clustermesh.apiserver.kvstoremesh.enabled) }}
      hostAliases:
      {{- range $cluster := .Values.clustermesh.config.clusters }}
      {{- range $ip := $cluster.ips }}
      - ip: {{ $ip }}
        hostnames: [ "{{ $cluster.name }}.{{ $.Values.clustermesh.config.domain }}" ]
      {{- end }}
```

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: clustermesh-apiserver
  .......
      hostAliases:
      {{- range $cluster := .Values.clustermesh.config.clusters }}
      {{- range $ip := $cluster.ips }}
      - ip: {{ $ip }}
        hostnames: [ "{{ $cluster.name }}.{{ $.Values.clustermesh.config.domain }}" ]
      {{- end }}
```


and the remote cluster address does not exist in the secret `cilium-clustermesh`, but exist in the secret `cilium-kvstoremesh`

```
[root@master1 ~]# kubectl get secret -n kube-system cilium-clustermesh -o yaml | yq '.data' | awk '{print $2}' | base64 -d
endpoints:
- https://clustermesh-apiserver.kube-system.svc:2379
trusted-ca-file: /var/lib/cilium/clustermesh/common-etcd-client-ca.crt
key-file: /var/lib/cilium/clustermesh/common-etcd-client.key
cert-file: /var/lib/cilium/clustermesh/common-etcd-client.crt

[root@master1 ~]# kubectl get secret -n kube-system cilium-kvstoremesh -o yaml | yq '.data' | awk '{print $2}' | base64 -d
endpoints:
- https://cluster2.mesh.cilium.io:32379
trusted-ca-file: /var/lib/cilium/clustermesh/common-etcd-client-ca.crt
key-file: /var/lib/cilium/clustermesh/common-etcd-client.key
cert-file: /var/lib/cilium/clustermesh/common-etcd-client.crt

```