### PR TITLE
bpf: ct: document some unused fields in ct_entry struct

### DIFF
--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -934,7 +934,7 @@ struct ct_entry {
 	__u32 lifetime;
 	__u16 rx_closing:1,
 	      tx_closing:1,
-	      nat46:1,
+	      unused_nat46:1,	/* unused since v1.12 / 81dee05e82fb */
 	      lb_loopback:1,
 	      seen_non_syn:1,
 	      node_port:1,

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -947,6 +947,7 @@ struct ct_entry {
 	__u16 rev_nat_index;
 	/* In the kernel ifindex is u32, so we need to check in cilium-agent
 	 * that ifindex of a NodePort device is <= MAX(u16).
+	 * Unused when HAVE_FIB_INDEX is available.
 	 */
 	__u16 ifindex;
 


### PR DESCRIPTION
Update the `ct_entry` struct to point out some (potentially) unused fields.