### PR TITLE
endpoint: Only perform full synchronization periodically

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -840,6 +840,10 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Int(option.PolicyMapEntriesName, policymap.MaxEntries, "Maximum number of entries in endpoint policy map (per endpoint)")
 	option.BindEnv(vp, option.PolicyMapEntriesName)
 
+	flags.Duration(option.PolicyMapFullReconciliationIntervalName, 15*time.Minute, "Interval for full reconciliation of endpoint policy map")
+	option.BindEnv(vp, option.PolicyMapFullReconciliationIntervalName)
+	flags.MarkHidden(option.PolicyMapFullReconciliationIntervalName)
+
 	flags.Int(option.SockRevNatEntriesName, option.SockRevNATMapEntriesDefault, "Maximum number of entries for the SockRevNAT BPF map")
 	option.BindEnv(vp, option.SockRevNatEntriesName)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -31,6 +31,31 @@ func (b *ControllerSuite) TestUpdateRemoveController(c *C) {
 	c.Assert(mngr.RemoveController("not-exist"), Not(IsNil))
 }
 
+func (b *ControllerSuite) TestCreateController(c *C) {
+	var iterations atomic.Uint32
+	mngr := NewManager()
+	created := mngr.CreateController("test", ControllerParams{
+		DoFunc: func(ctx context.Context) error {
+			iterations.Add(1)
+			return nil
+		},
+	})
+	c.Assert(created, Equals, true)
+
+	// Second creation is a no-op.
+	created = mngr.CreateController("test", ControllerParams{
+		DoFunc: func(ctx context.Context) error {
+			iterations.Add(1)
+			return nil
+		},
+	})
+	c.Assert(created, Equals, false)
+
+	c.Assert(mngr.RemoveControllerAndWait("test"), IsNil)
+
+	c.Assert(iterations.Load(), Equals, uint32(1))
+}
+
 func (b *ControllerSuite) TestStopFunc(c *C) {
 	stopFuncRan := false
 	waitChan := make(chan struct{})

--- a/pkg/controller/manager.go
+++ b/pkg/controller/manager.go
@@ -56,6 +56,7 @@ func (m *Manager) updateController(name string, params ControllerParams) *manage
 	start := time.Now()
 
 	m.mutex.Lock()
+	defer m.mutex.Unlock()
 
 	if m.controllers == nil {
 		m.controllers = controllerMap{}
@@ -77,35 +78,57 @@ func (m *Manager) updateController(name string, params ControllerParams) *manage
 		case ctrl.update <- ctrl.params:
 		default:
 		}
-		m.mutex.Unlock()
 
 		ctrl.getLogger().Debug("Controller update time: ", time.Since(start))
 	} else {
-		ctrl = &managedController{
-			controller: controller{
-				name:       name,
-				group:      params.Group,
-				uuid:       uuid.New().String(),
-				stop:       make(chan struct{}),
-				update:     make(chan ControllerParams, 1),
-				trigger:    make(chan struct{}, 1),
-				terminated: make(chan struct{}),
-			},
-		}
-		ctrl.updateParamsLocked(params)
-		ctrl.getLogger().Debug("Starting new controller")
-
-		m.controllers[ctrl.name] = ctrl
-		m.mutex.Unlock()
-
-		globalStatus.mutex.Lock()
-		globalStatus.controllers[ctrl.uuid] = ctrl
-		globalStatus.mutex.Unlock()
-
-		go ctrl.runController(ctrl.params)
+		return m.createControllerLocked(name, params)
 	}
 
 	return ctrl
+}
+
+func (m *Manager) createControllerLocked(name string, params ControllerParams) *managedController {
+	ctrl := &managedController{
+		controller: controller{
+			name:       name,
+			group:      params.Group,
+			uuid:       uuid.New().String(),
+			stop:       make(chan struct{}),
+			update:     make(chan ControllerParams, 1),
+			trigger:    make(chan struct{}, 1),
+			terminated: make(chan struct{}),
+		},
+	}
+	ctrl.updateParamsLocked(params)
+	ctrl.getLogger().Debug("Starting new controller")
+
+	m.controllers[ctrl.name] = ctrl
+
+	globalStatus.mutex.Lock()
+	globalStatus.controllers[ctrl.uuid] = ctrl
+	globalStatus.mutex.Unlock()
+
+	go ctrl.runController(ctrl.params)
+	return ctrl
+}
+
+// CreateController installs a new controller in the
+// manager.  If a controller with the name already exists
+// this method returns false without triggering, otherwise
+// creates the controller and runs it immediately.
+func (m *Manager) CreateController(name string, params ControllerParams) bool {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.controllers != nil {
+		if _, exists := m.controllers[name]; exists {
+			return false
+		}
+	} else {
+		m.controllers = controllerMap{}
+	}
+	m.createControllerLocked(name, params)
+	return true
 }
 
 func (m *Manager) removeController(ctrl *managedController) {

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1277,18 +1277,24 @@ func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 	return currentMap, err
 }
 
-// syncPolicyMapWithDump attempts to synchronize the PolicyMap for this endpoint to
-// contain the set of PolicyKeys represented by the endpoint's desiredMapState.
-// It checks the current contents of the endpoint's PolicyMap and deletes any
-// PolicyKeys that are not present in the endpoint's desiredMapState. It then
-// adds any keys that are not present in the map. When a key from desiredMapState
-// is inserted successfully to the endpoint's BPF PolicyMap, it is added to the
-// endpoint's realizedMapState field. Returns an error if the endpoint's BPF
-// PolicyMap is unable to be dumped, or any update operation to the map fails.
+// syncPolicyMapWithDump is invoked periodically to perform a full reconciliation
+// of the endpoint's PolicyMap against the BPF maps to catch cases where either
+// due to kernel issue or user intervention the agent's view of the PolicyMap
+// state has diverged from the kernel. A warning is logged if this method finds
+// such an discrepancy.
+//
+// Returns an error if the endpoint's BPF PolicyMap is unable to be dumped,
+// or any update operation to the map fails.
 // Must be called with e.mutex Lock()ed.
 func (e *Endpoint) syncPolicyMapWithDump() error {
 	if e.policyMap == nil {
 		return fmt.Errorf("not syncing PolicyMap state for endpoint because PolicyMap is nil")
+	}
+
+	// Endpoint not yet fully initialized or currently regenerating. Skip the check
+	// this round.
+	if e.getState() != StateReady {
+		return nil
 	}
 
 	// Apply pending policy map changes first so that desired map is up-to-date before
@@ -1339,12 +1345,18 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	return err
 }
 
-func (e *Endpoint) syncPolicyMapController() {
+const (
+	// syncPolicyMapInterval is the interval for periodic full reconciliation of
+	// the policy map to catch unexpected discrepancies with agent and kernel state.
+	syncPolicyMapInterval = 15 * time.Minute
+)
+
+func (e *Endpoint) startSyncPolicyMapController() {
 	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
-	e.controllers.UpdateController(ctrlName,
+	e.controllers.CreateController(ctrlName,
 		controller.ControllerParams{
 			Group: syncPolicymapControllerGroup,
-			DoFunc: func(ctx context.Context) (reterr error) {
+			DoFunc: func(ctx context.Context) error {
 				// Failure to lock is not an error, it means
 				// that the endpoint was disconnected and we
 				// should exit gracefully.
@@ -1354,7 +1366,7 @@ func (e *Endpoint) syncPolicyMapController() {
 				defer e.unlock()
 				return e.syncPolicyMapWithDump()
 			},
-			RunInterval: 1 * time.Minute,
+			RunInterval: syncPolicyMapInterval,
 			Context:     e.aliveCtx,
 		},
 	)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -526,9 +526,10 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
 	}
 
-	// Keep PolicyMap for this endpoint in sync with desired / realized state.
+	// Start periodic background full reconciliation of the policy map.
+	// Does nothing if it has already been started.
 	if !option.Config.DryMode {
-		e.syncPolicyMapController()
+		e.startSyncPolicyMapController()
 	}
 
 	if e.desiredPolicy != e.realizedPolicy {

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -658,6 +658,10 @@ const (
 	// PolicyMapEntriesName configures max entries for BPF policymap.
 	PolicyMapEntriesName = "bpf-policy-map-max"
 
+	// PolicyMapFullReconciliationInterval sets the interval for performing the full
+	// reconciliation of the endpoint policy map.
+	PolicyMapFullReconciliationIntervalName = "bpf-policy-map-full-reconciliation-interval"
+
 	// SockRevNatEntriesName configures max entries for BPF sock reverse nat
 	// entries.
 	SockRevNatEntriesName = "bpf-sock-rev-map-max"
@@ -1581,6 +1585,10 @@ type DaemonConfig struct {
 	// PolicyMapEntries is the maximum number of peer identities that an
 	// endpoint may allow traffic to exchange traffic with.
 	PolicyMapEntries int
+
+	// PolicyMapFullReconciliationInterval is the interval at which to perform
+	// the full reconciliation of the endpoint policy map.
+	PolicyMapFullReconciliationInterval time.Duration
 
 	// SockRevNatEntries is the maximum number of sock rev nat mappings
 	// allowed in the BPF rev nat table
@@ -3869,6 +3877,7 @@ func (c *DaemonConfig) calculateBPFMapSizes(vp *viper.Viper) error {
 	c.NATMapEntriesGlobal = vp.GetInt(NATMapEntriesGlobalName)
 	c.NeighMapEntriesGlobal = vp.GetInt(NeighMapEntriesGlobalName)
 	c.PolicyMapEntries = vp.GetInt(PolicyMapEntriesName)
+	c.PolicyMapFullReconciliationInterval = vp.GetDuration(PolicyMapFullReconciliationIntervalName)
 	c.SockRevNatEntries = vp.GetInt(SockRevNatEntriesName)
 	c.LBMapEntries = vp.GetInt(LBMapEntriesName)
 	c.LBServiceMapEntries = vp.GetInt(LBServiceMapMaxEntries)


### PR DESCRIPTION
Performing a full dump of the policy map on every policy map synchronization
is expensive and is only necessary to catch rare cases where the agent's view
of the policy map has diverged from the kernel's view which should only happen
either due to kernel or other bugs or some other application modifying the
endpoint policy map.

To reduce the cost of synchronizing large endpoint policy maps perform the
full synchronization only periodically. The full synchronization is defaults
to 15 minutes. Configurable with the hidden option
"--policy-map-full-reconciliation-interval".

Fixes: 9dc1350fdb ("endpoint: Enhance policy map sync")

```release-note
endpoint: Only perform the full policy map synchronization periodically (every 15 minutes) to reduce overhead with large endpoint policy maps
```
