### PR TITLE
Revert "make fsnotify event more readable"

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -923,7 +923,7 @@ func keyfileWatcher(ctx context.Context, watcher *fswatcher.Watcher, keyfilePath
 	for {
 		select {
 		case event := <-watcher.Events:
-			if !event.Op.Has(fsnotify.Create) || !event.Op.Has(fsnotify.Write) {
+			if event.Op&(fsnotify.Create|fsnotify.Write) == 0 {
 				continue
 			}
 


### PR DESCRIPTION
This reverts commit 479fb7d6d5db9b89447900b8eb62d598f6ca2a62.

The code changes are not equivalent. For example, event.Op=fsnotify.Create has different results.

Fixes: https://github.com/cilium/cilium/pull/22903

```release-note
Fixes a issue that IPsec key rotation can't be triggered.
```

Signed-off-by: Zhichuan Liang <gray.liang@isovalent.com>