### PR TITLE
GatewayAPI: Fix listener parsing

### DIFF
--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -19,12 +19,12 @@ type Model struct {
 func (m *Model) GetListeners() []Listener {
 	var listeners []Listener
 
-	for _, l := range m.HTTP {
-		listeners = append(listeners, &l)
+	for i := range m.HTTP {
+		listeners = append(listeners, &m.HTTP[i])
 	}
 
-	for _, l := range m.TLS {
-		listeners = append(listeners, &l)
+	for i := range m.TLS {
+		listeners = append(listeners, &m.TLS[i])
 	}
 
 	return listeners

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -13,8 +13,18 @@ var testTLSListener = TLSListener{
 	Port: 443,
 }
 
+var testTLSListener2 = TLSListener{
+	Name: "test-tls-listener2",
+	Port: 443,
+}
+
 var testHTTPListener = HTTPListener{
 	Name: "test-http-listener",
+	Port: 80,
+}
+
+var testHTTPListener2 = HTTPListener{
+	Name: "test-http-listener2",
 	Port: 80,
 }
 
@@ -31,24 +41,24 @@ func TestModel_GetListeners(t *testing.T) {
 		{
 			name: "Combine HTTP and TLS listeners",
 			fields: fields{
-				HTTP: []HTTPListener{testHTTPListener},
-				TLS:  []TLSListener{testTLSListener},
+				HTTP: []HTTPListener{testHTTPListener, testHTTPListener2},
+				TLS:  []TLSListener{testTLSListener, testTLSListener2},
 			},
-			want: []Listener{&testHTTPListener, &testTLSListener},
+			want: []Listener{&testHTTPListener, &testHTTPListener2, &testTLSListener, &testTLSListener2},
 		},
 		{
 			name: "Only HTTP listeners",
 			fields: fields{
-				HTTP: []HTTPListener{testHTTPListener},
+				HTTP: []HTTPListener{testHTTPListener, testHTTPListener2},
 			},
-			want: []Listener{&testHTTPListener},
+			want: []Listener{&testHTTPListener, &testHTTPListener2},
 		},
 		{
 			name: "Only TLS listeners",
 			fields: fields{
-				TLS: []TLSListener{testTLSListener},
+				TLS: []TLSListener{testTLSListener, testTLSListener2},
 			},
-			want: []Listener{&testTLSListener},
+			want: []Listener{&testTLSListener, &testTLSListener2},
 		},
 		{
 			name:   "No listeners",


### PR DESCRIPTION
Previously, parsing the listeners of a Gateway object only worked correctly, if only one listener of a given type (HTTP or TLS) was present, as looping over them was incorrectly handled.

Fixes: #27533
Fixes: 677e8b49481c ("Implement TLSRoute")

```release-note
Fix Gateway managed services not exposing all ports
```
