### PR TITLE
helm: fix envoy daemonset loglevel with multiple verbose debug groups

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -65,9 +65,9 @@ spec:
         args:
         - '-c /var/run/cilium/envoy/bootstrap-config.json'
         - '--base-id 0'
-        {{- if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "envoy" ( splitList "," .Values.debug.verbose )) }}
+        {{- if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "envoy" ( splitList " " .Values.debug.verbose )) }}
         - '--log-level trace'
-        {{- else if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "flow" ( splitList "," .Values.debug.verbose )) }}
+        {{- else if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "flow" ( splitList " " .Values.debug.verbose )) }}
         - '--log-level debug'
         {{- else }}
         - '--log-level info'


### PR DESCRIPTION
Currently, the Envoy DaemonSet loglevel is not set correctly if multiple verbose debug groups are passed as helm values. 

-> `Unknown verbose debug group: <...>` in Cilium Agent log

The problem is that the comma is used as group separator instead of a space. (Got confused because Go Viper flags are separated by a comma.)

This commit fixes this by changing the separator.