### PR TITLE
helm: Add support of servicePort in hubble ui service

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1815,7 +1815,7 @@
    * - :spelling:ignore:`hubble.ui.service`
      - hubble-ui service configuration.
      - object
-     - ``{"annotations":{},"nodePort":31235,"type":"ClusterIP"}``
+     - ``{"annotations":{},"nodePort":31235,"servicePort":80,"type":"ClusterIP"}``
    * - :spelling:ignore:`hubble.ui.service.annotations`
      - Annotations to be added for the Hubble UI service
      - object
@@ -1824,6 +1824,10 @@
      - - The port to use when the service type is set to NodePort.
      - int
      - ``31235``
+   * - :spelling:ignore:`hubble.ui.service.servicePort`
+     - - The service port to use by Hubble UI service
+     - int
+     - ``80``
    * - :spelling:ignore:`hubble.ui.service.type`
      - - The type of service used for Hubble UI access, either ClusterIP or NodePort.
      - string

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -503,9 +503,10 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.replicas | int | `1` | The number of replicas of Hubble UI to deploy. |
 | hubble.ui.rollOutPods | bool | `false` | Roll out Hubble-ui pods automatically when configmap is updated. |
 | hubble.ui.securityContext | object | `{"fsGroup":1001,"runAsGroup":1001,"runAsUser":1001}` | Security context to be added to Hubble UI pods |
-| hubble.ui.service | object | `{"annotations":{},"nodePort":31235,"type":"ClusterIP"}` | hubble-ui service configuration. |
+| hubble.ui.service | object | `{"annotations":{},"nodePort":31235,"servicePort":80,"type":"ClusterIP"}` | hubble-ui service configuration. |
 | hubble.ui.service.annotations | object | `{}` | Annotations to be added for the Hubble UI service |
 | hubble.ui.service.nodePort | int | `31235` | - The port to use when the service type is set to NodePort. |
+| hubble.ui.service.servicePort | int | `80` | - The service port to use by Hubble UI service |
 | hubble.ui.service.type | string | `"ClusterIP"` | - The type of service used for Hubble UI access, either ClusterIP or NodePort. |
 | hubble.ui.standalone.enabled | bool | `false` | When true, it will allow installing the Hubble UI only, without checking dependencies. It is useful if a cluster already has cilium and Hubble relay installed and you just want Hubble UI to be deployed. When installed via helm, installing UI should be done via `helm upgrade` and when installed via the cilium cli, then `cilium hubble enable --ui` |
 | hubble.ui.standalone.tls.certsVolume | object | `{}` | When deploying Hubble UI in standalone, with tls enabled for Hubble relay, it is required to provide a volume for mounting the client certificates. |

--- a/install/kubernetes/cilium/templates/hubble-ui/service.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/service.yaml
@@ -18,7 +18,7 @@ spec:
     k8s-app: hubble-ui
   ports:
     - name: http
-      port: 80
+      port: {{ .Values.hubble.ui.service.servicePort }}
       targetPort: 8081
       {{- if and (eq "NodePort" .Values.hubble.ui.service.type) .Values.hubble.ui.service.nodePort }}
       nodePort: {{ .Values.hubble.ui.service.nodePort }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1483,6 +1483,8 @@ hubble:
       type: ClusterIP
       # --- The port to use when the service type is set to NodePort.
       nodePort: 31235
+      # --- The service port to use by Hubble UI service
+      servicePort: 80
 
     # -- Defines base url prefix for all hubble-ui http requests.
     # It needs to be changed in case if ingress for hubble-ui is configured under some sub-path.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1480,6 +1480,8 @@ hubble:
       type: ClusterIP
       # --- The port to use when the service type is set to NodePort.
       nodePort: 31235
+      # --- The service port to use by Hubble UI service
+      servicePort: 80
 
     # -- Defines base url prefix for all hubble-ui http requests.
     # It needs to be changed in case if ingress for hubble-ui is configured under some sub-path.


### PR DESCRIPTION
Signed-off-by: Nishant Shekhar <nishant.ranjanasaxena@gmail.com>

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

The changes in this PR is for adding support to define servicePort of hubble-ui service.

Fixes: #issue-number

```release-note
helm: Add support of servicePort in hubble ui service
```
