### PR TITLE
ipam, metrics: Add new capacity metric

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -477,6 +477,7 @@ IPAM
 ======================================== ============================================ ========== ========================================================
 Name                                     Labels                                       Default    Description
 ======================================== ============================================ ========== ========================================================
+``ipam_capacity``                        ``family``                                   Enabled    Total number of IPs in the IPAM pool labeled by family
 ``ipam_events_total``                                                                 Enabled    Number of IPAM events received labeled by action and datapath family type
 ``ip_addresses``                         ``family``                                   Enabled    Number of allocated IP addresses
 ======================================== ============================================ ========== ========================================================

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -315,7 +315,7 @@ Annotations:
   Upgrading from Cilium 1.14.x or earlier to 1.15.y or later does not
   trigger this problem. Downgrading from Cilium 1.15.y or later to Cilium
   1.14.x or earlier may trigger this problem.
-  
+
 .. _upgrade_cilium_cli_helm_mode:
 
 Cilium CLI
@@ -339,6 +339,11 @@ Helm Options
 * Values ``clustermesh.apiserver.tls.ca.cert`` and ``clustermesh.apiserver.tls.ca.key``
   were deprecated in Cilium 1.14 in favor of ``tls.ca.cert`` and ``tls.ca.key`` respectively,
   and have been removed. The ```clustermesh-apiserver-ca-cert`` secret is no longer generated.
+
+Added Metrics
+~~~~~~~~~~~~~
+
+* ``cilium_ipam_capacity``
 
 Changed Metrics
 ~~~~~~~~~~~~~~~

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -127,7 +127,7 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 	}).Debugf("Allocated specific IP")
 
 	ipam.registerIPOwner(ip, owner, pool)
-	metrics.IpamEvent.WithLabelValues(metricAllocate, string(family)).Inc()
+	metrics.IPAMEvent.WithLabelValues(metricAllocate, string(family)).Inc()
 	return
 }
 
@@ -181,7 +181,7 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 				"owner": owner,
 			}).Debugf("Allocated random IP")
 			ipam.registerIPOwner(result.IP, owner, pool)
-			metrics.IpamEvent.WithLabelValues(metricAllocate, string(family)).Inc()
+			metrics.IPAMEvent.WithLabelValues(metricAllocate, string(family)).Inc()
 			return
 		}
 
@@ -298,8 +298,8 @@ func (ipam *IPAM) releaseIPLocked(ip net.IP, pool Pool) error {
 	}).Debugf("Released IP")
 	delete(ipam.expirationTimers, ip.String())
 
-	metrics.IpamEvent.WithLabelValues(metricRelease, string(family)).Inc()
-	metrics.IpamEvent.WithLabelValues(metricRelease, string(family)).Inc()
+	metrics.IPAMEvent.WithLabelValues(metricRelease, string(family)).Inc()
+	metrics.IPAMEvent.WithLabelValues(metricRelease, string(family)).Inc()
 	return nil
 }
 

--- a/pkg/ipam/clusterpool.go
+++ b/pkg/ipam/clusterpool.go
@@ -419,6 +419,11 @@ func (c *clusterPoolAllocator) Dump() (map[string]string, string) {
 	return ipToOwner, fmt.Sprintf("%d/%d allocated from %d pod CIDRs", usedIPs, availableIPs, numPodCIDRs)
 }
 
+func (c *clusterPoolAllocator) Capacity() uint64 {
+	_, _, availableIPs, _, _ := c.pool.dump()
+	return uint64(availableIPs)
+}
+
 func (c *clusterPoolAllocator) RestoreFinished() {
 	sharedCRDWatcher.restoreFinished()
 }

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -890,6 +890,12 @@ func (a *crdAllocator) Dump() (map[string]string, string) {
 	return allocs, status
 }
 
+func (a *crdAllocator) Capacity() uint64 {
+	a.mutex.RLock()
+	defer a.mutex.RUnlock()
+	return uint64(a.store.totalPoolSize(a.family))
+}
+
 // RestoreFinished marks the status of restoration as done
 func (a *crdAllocator) RestoreFinished() {
 	a.store.restoreCloseOnce.Do(func() {

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -89,5 +89,9 @@ func (h *hostScopeAllocator) Dump() (map[string]string, string) {
 	return alloc, status
 }
 
+func (h *hostScopeAllocator) Capacity() uint64 {
+	return ip.CountIPsInCIDR(h.allocCIDR).Uint64()
+}
+
 // RestoreFinished marks the status of restoration as done
 func (h *hostScopeAllocator) RestoreFinished() {}

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -120,6 +120,10 @@ func (f fakePoolAllocator) Dump() (map[string]string, string) {
 	return result, fmt.Sprintf("%d pools", len(f.pools))
 }
 
+func (f fakePoolAllocator) Capacity() uint64 {
+	return uint64(0)
+}
+
 func (f fakePoolAllocator) RestoreFinished() {}
 
 func (s *IPAMSuite) TestLock(c *C) {

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -718,6 +718,24 @@ func (c *multiPoolAllocator) Dump() (map[string]string, string) {
 	return c.manager.dump(c.family)
 }
 
+func (c *multiPoolAllocator) Capacity() uint64 {
+	var capacity uint64
+	for _, pool := range c.manager.pools {
+		var p *podCIDRPool
+		switch c.family {
+		case IPv4:
+			p = pool.v4
+		case IPv6:
+			p = pool.v6
+		}
+		if p == nil {
+			continue
+		}
+		capacity += uint64(p.capacity())
+	}
+	return uint64(capacity)
+}
+
 func (c *multiPoolAllocator) RestoreFinished() {
 	c.manager.restoreFinished(c.family)
 }

--- a/pkg/ipam/noop_allocator.go
+++ b/pkg/ipam/noop_allocator.go
@@ -39,5 +39,9 @@ func (n *noOpAllocator) Dump() (map[string]string, string) {
 	return nil, "delegated to plugin"
 }
 
+func (n *noOpAllocator) Capacity() uint64 {
+	return uint64(0)
+}
+
 func (n *noOpAllocator) RestoreFinished() {
 }

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -74,6 +74,10 @@ type Allocator interface {
 	// overall health information if available.
 	Dump() (map[string]string, string)
 
+	// Capacity returns the total IPAM allocator capacity (not the current
+	// available).
+	Capacity() uint64
+
 	// RestoreFinished marks the status of restoration as done
 	RestoreFinished()
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -465,6 +465,11 @@ var (
 	// datapath family type
 	IpamEvent = NoOpCounterVec
 
+	// IPAMCapacity tracks the total number of IPs that could be allocated. To
+	// get the current number of available IPs, it would be this metric
+	// subtracted by IPAMEvent{allocated}.
+	IPAMCapacity = NoOpGaugeVec
+
 	// KVstore events
 
 	// KVStoreOperationsDuration records the duration of kvstore operations
@@ -622,6 +627,7 @@ type LegacyMetrics struct {
 	KubernetesCNPStatusCompletion    metric.Vec[metric.Observer]
 	TerminatingEndpointsEvents       metric.Counter
 	IpamEvent                        metric.Vec[metric.Counter]
+	IPAMCapacity                     metric.Vec[metric.Gauge]
 	KVStoreOperationsDuration        metric.Vec[metric.Observer]
 	KVStoreEventsQueueDuration       metric.Vec[metric.Observer]
 	KVStoreQuorumErrors              metric.Vec[metric.Counter]
@@ -1046,6 +1052,13 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Help:       "Number of IPAM events received labeled by action and datapath family type",
 		}, []string{LabelAction, LabelDatapathFamily}),
 
+		IPAMCapacity: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: Namespace + "_ipam_capacity",
+			Namespace:  Namespace,
+			Name:       "ipam_capacity",
+			Help:       "Total number of IPs in the IPAM pool labeled by family",
+		}, []string{LabelDatapathFamily}),
+
 		KVStoreOperationsDuration: metric.NewHistogramVec(metric.HistogramOpts{
 			ConfigName: Namespace + "_" + SubsystemKVStore + "_operations_duration_seconds",
 			Namespace:  Namespace,
@@ -1350,6 +1363,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	KubernetesCNPStatusCompletion = lm.KubernetesCNPStatusCompletion
 	TerminatingEndpointsEvents = lm.TerminatingEndpointsEvents
 	IpamEvent = lm.IpamEvent
+	IPAMCapacity = lm.IPAMCapacity
 	KVStoreOperationsDuration = lm.KVStoreOperationsDuration
 	KVStoreEventsQueueDuration = lm.KVStoreEventsQueueDuration
 	KVStoreQuorumErrors = lm.KVStoreQuorumErrors

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -461,9 +461,9 @@ var (
 
 	// IPAM events
 
-	// IpamEvent is the number of IPAM events received labeled by action and
+	// IPAMEvent is the number of IPAM events received labeled by action and
 	// datapath family type
-	IpamEvent = NoOpCounterVec
+	IPAMEvent = NoOpCounterVec
 
 	// IPAMCapacity tracks the total number of IPs that could be allocated. To
 	// get the current number of available IPs, it would be this metric
@@ -626,7 +626,7 @@ type LegacyMetrics struct {
 	KubernetesAPICallsTotal          metric.Vec[metric.Counter]
 	KubernetesCNPStatusCompletion    metric.Vec[metric.Observer]
 	TerminatingEndpointsEvents       metric.Counter
-	IpamEvent                        metric.Vec[metric.Counter]
+	IPAMEvent                        metric.Vec[metric.Counter]
 	IPAMCapacity                     metric.Vec[metric.Gauge]
 	KVStoreOperationsDuration        metric.Vec[metric.Observer]
 	KVStoreEventsQueueDuration       metric.Vec[metric.Observer]
@@ -1045,7 +1045,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 			Help:       "Number of terminating endpoint events received from Kubernetes",
 		}),
 
-		IpamEvent: metric.NewCounterVec(metric.CounterOpts{
+		IPAMEvent: metric.NewCounterVec(metric.CounterOpts{
 			ConfigName: Namespace + "_ipam_events_total",
 			Namespace:  Namespace,
 			Name:       "ipam_events_total",
@@ -1362,7 +1362,7 @@ func NewLegacyMetrics() *LegacyMetrics {
 	KubernetesAPICallsTotal = lm.KubernetesAPICallsTotal
 	KubernetesCNPStatusCompletion = lm.KubernetesCNPStatusCompletion
 	TerminatingEndpointsEvents = lm.TerminatingEndpointsEvents
-	IpamEvent = lm.IpamEvent
+	IPAMEvent = lm.IPAMEvent
 	IPAMCapacity = lm.IPAMCapacity
 	KVStoreOperationsDuration = lm.KVStoreOperationsDuration
 	KVStoreEventsQueueDuration = lm.KVStoreEventsQueueDuration


### PR DESCRIPTION
- ipam, metrics: Add new capacity metric
- ipam, metrics: Rename metric for consistency

Followups following the merge of this PR: https://github.com/cilium/cilium/issues/27716

--- 

Most important commit for convenience:  

> ipam, metrics: Add new capacity metric
>     
> This commit implements a new metric which tracks the total IPAM
> capacity, which to be clear is not the current capacity, but rather size
> of the IPAM pool.
>     
> Users can now track the currently allocated count of IPs across all IPAM
> modes by taking this metric and subtracting by number of IPs allocated.
>     
> Previously, this information was only visible from `cilium status`.
>     
> In Prometheus, the query would be:
>     
> ```
> cilium_ipam_capacity{family=~"*"} - cilium_ip_addresses{family=~"*"}
> ```
>     
> Signed-off-by: Chris Tarazi <chris@isovalent.com>

---

Fixes: https://github.com/cilium/cilium/issues/27166