### PR TITLE
Resiliency: Node manager reconciliation path yields unchecked errors

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux_test.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux_test.go
@@ -42,7 +42,7 @@ func (p *IPSecSuitePrivileged) SetUpTest(c *C) {
 }
 
 func (p *IPSecSuitePrivileged) TearDownTest(c *C) {
-	DeleteXfrm()
+	_ = DeleteXfrm()
 }
 
 func (p *IPSecSuitePrivileged) TestLoadKeysNoFile(c *C) {

--- a/pkg/resiliency/errorset.go
+++ b/pkg/resiliency/errorset.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resiliency
+
+import (
+	"errors"
+	"fmt"
+)
+
+type tuple struct {
+	index int
+	err   error
+}
+
+// ErrorSet tracks a collection of unique errors.
+type ErrorSet struct {
+	total, failed int
+	msg           string
+	errs          map[string]tuple
+}
+
+// NewErrorSet returns a new instance.
+func NewErrorSet(msg string, c int) *ErrorSet {
+	return &ErrorSet{
+		msg:   msg,
+		total: c,
+		errs:  make(map[string]tuple),
+	}
+}
+
+// Add adds one or more errors to the set.
+func (e *ErrorSet) Add(errs ...error) {
+	for _, err := range errs {
+		if err == nil {
+			continue
+		}
+		if _, ok := e.errs[err.Error()]; ok {
+			continue
+		}
+		e.errs[err.Error()] = tuple{index: e.failed, err: err}
+		e.failed++
+	}
+}
+
+// Error returns a list of unique errors or nil.
+func (e *ErrorSet) Errors() []error {
+	if len(e.errs) == 0 {
+		return nil
+	}
+	errs := make([]error, len(e.errs)+1)
+	errs[0] = fmt.Errorf("%s (%d/%d) failed", e.msg, e.failed, e.total)
+	for _, t := range e.errs {
+		errs[t.index+1] = t.err
+	}
+
+	return errs
+}
+
+// Error returns a new composite error or nil.
+func (e *ErrorSet) Error() error {
+	return errors.Join(e.Errors()...)
+}

--- a/pkg/resiliency/errorset_test.go
+++ b/pkg/resiliency/errorset_test.go
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package resiliency_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/resiliency"
+)
+
+func TestErrorJoin(t *testing.T) {
+	uu := map[string]struct {
+		errs  []error
+		total int
+		e     string
+	}{
+		"none": {},
+		"nils": {
+			errs: []error{nil, nil},
+		},
+		"plain": {
+			errs:  []error{errors.New("e1"), errors.New("e2"), errors.New("e3")},
+			total: 3,
+			e:     "test (3/3) failed\ne1\ne2\ne3",
+		},
+		"dups": {
+			errs:  []error{errors.New("e1"), errors.New("e2"), errors.New("e1")},
+			total: 3,
+			e:     "test (2/3) failed\ne1\ne2",
+		},
+		"mix": {
+			errs:  []error{errors.New("e1"), errors.New("e2"), errors.New("e1"), nil, errors.New("e2")},
+			total: 5,
+			e:     "test (2/5) failed\ne1\ne2",
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			es := resiliency.NewErrorSet("test", len(u.errs))
+			es.Add(u.errs...)
+			if es.Error() != nil {
+				assert.Equal(t, u.e, errors.Join(es.Error()).Error())
+			}
+		})
+	}
+}
+
+func TestErrorSetAdd(t *testing.T) {
+	uu := map[string]struct {
+		errs []error
+		e    string
+	}{
+		"none": {},
+		"nils": {
+			errs: []error{nil, nil},
+		},
+		"plain": {
+			errs: []error{errors.New("e1"), errors.New("e2"), errors.New("e3")},
+			e:    "test (3/3) failed\ne1\ne2\ne3",
+		},
+		"dups": {
+			errs: []error{errors.New("e1"), errors.New("e2"), errors.New("e1")},
+			e:    "test (2/3) failed\ne1\ne2",
+		},
+		"mix": {
+			errs: []error{errors.New("e1"), errors.New("e2"), errors.New("e1"), nil, errors.New("e2")},
+			e:    "test (2/5) failed\ne1\ne2",
+		},
+	}
+
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			es := resiliency.NewErrorSet("test", len(u.errs))
+			es.Add(u.errs...)
+			if es.Error() != nil {
+				assert.Equal(t, u.e, es.Error().Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

> NOTE: Initial pass!

Found several places in the node manager control loop where we are ignoring potential errors and either not logging them or worth not bubbling up to their respective call sites.

> NOTE! Please go thru this PR with a fine comb as I don't quite have the necessary chops on whether some of these should be hard errors or not. 
Thank you!!

Fixes: #issue-number

Signed-off-by: Fernand Galiana <fernand.galiana@gmail.com>