### PR TITLE
ipsec: Fix Godoc document comment typo

### DIFF
--- a/pkg/datapath/linux/ipsec/doc.go
+++ b/pkg/datapath/linux/ipsec/doc.go
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-// Package ipsec provides the Linux datpaath specific abstraction and
+// Package ipsec provides the Linux datapath specific abstraction and
 // useful helpers to manage IPSec via Linux xfrm.
 package ipsec


### PR DESCRIPTION
Fix the only one doc comment word typo.