### PR TITLE
.github: fix renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -145,7 +145,7 @@
       "matchPackagePatterns": [
         // We can't update these libraries until github.com/shoenig/go-m1cpu
         // is added as an exception to the list of licenses into CNCF.
-        "*google/gops/*",
+        ".*google/gops/*",
         // We can't update these libraries until github.com/shoenig/go-m1cpu
         // is added as an exception to the list of licenses into CNCF.
         "github.com/shirou/gopsutil/*",


### PR DESCRIPTION
The regex defined in the renovate config is not valid and it's causing renovate to not being able to read it.

Fixes: 9c47083781f7 ("renovate: ignore all gops updates")

Fixes https://github.com/cilium/cilium/issues/23230