### PR TITLE
envoy: introduce artifact copier

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -175,6 +175,9 @@ spec:
         - name: envoy-sockets
           mountPath: /var/run/cilium/envoy/sockets
           readOnly: false
+        - name: envoy-artifacts
+          mountPath: /var/run/cilium/envoy/artifacts
+          readOnly: true
         - name: envoy-config
           mountPath: /var/run/cilium/envoy/
           readOnly: true
@@ -223,6 +226,10 @@ spec:
       - name: envoy-sockets
         hostPath:
           path: "{{ .Values.daemon.runPath }}/envoy/sockets"
+          type: DirectoryOrCreate
+      - name: envoy-artifacts
+        hostPath:
+          path: "{{ .Values.daemon.runPath }}/envoy/artifacts"
           type: DirectoryOrCreate
       - name: envoy-config
         configMap:

--- a/pkg/envoy/artifact_copier.go
+++ b/pkg/envoy/artifact_copier.go
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package envoy
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// ArtifactCopier provides support for copying artifacts from a given source directory to a target directory.
+// This is mainly used to copy additional artifacts referenced by the Envoy proxy configuration from the Cilium agent
+// container to the config directory that is shared with the Envoy container if Envoy is running in a dedicated DaemonSet.
+type ArtifactCopier struct {
+	sourcePath string
+	targetPath string
+}
+
+// Copy copies all files within the given sourcePath directory into the targetPath directory.
+//
+// If targetPath already exists, all existing files within the directory are deleted before starting the copy process.
+// If targetPath doesn't exist, it gets created automatically before starting the copy process.
+func (r *ArtifactCopier) Copy() (err error) {
+	if _, err := os.Stat(r.sourcePath); os.IsNotExist(err) {
+		log.WithField("source-path", r.sourcePath).
+			Debugf("Envoy: No artifacts to copy to envoy - source path doesn't exist")
+		return nil
+	}
+
+	// Wipe target directory if it exists
+	if ti, err := os.Stat(r.targetPath); err == nil && ti.IsDir() {
+		log.WithField("target-path", r.sourcePath).
+			Debugf("Envoy: Clean target directory")
+
+		if err := r.cleanTargetDirectory(); err != nil {
+			return fmt.Errorf("failed to clean target directory: %w", err)
+		}
+	}
+
+	log.WithField("source-path", r.sourcePath).
+		WithField("target-path", r.targetPath).
+		Infof("Envoy: Copy artifacts to envoy")
+
+	return r.copyFiles(r.sourcePath, r.targetPath)
+}
+
+func (r *ArtifactCopier) cleanTargetDirectory() error {
+	entries, err := os.ReadDir(r.targetPath)
+	if err != nil {
+		return fmt.Errorf("failed to get target directory content: %w", err)
+	}
+
+	for _, entry := range entries {
+		path := filepath.Join(r.targetPath, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("failed to delete existing content in target directory: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *ArtifactCopier) copyFiles(src string, dst string) error {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
+
+	si, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !si.IsDir() {
+		return fmt.Errorf("source is not a directory")
+	}
+
+	if _, err := os.Stat(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to get source directory info: %w", err)
+	}
+
+	if err := os.MkdirAll(dst, si.Mode()); err != nil {
+		return fmt.Errorf("failed to create target directory: %w", err)
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return fmt.Errorf("failed to read directory content: %w", err)
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		dstPath := filepath.Join(dst, entry.Name())
+
+		if !entry.IsDir() {
+			// Skip symlinks.
+			if entry.Type()&os.ModeSymlink != 0 {
+				continue
+			}
+
+			if err = r.copyFile(srcPath, dstPath); err != nil {
+				return fmt.Errorf("failed to copy file: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r *ArtifactCopier) copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("failed to open source file: %w", err)
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return fmt.Errorf("failed to create target file: %w", err)
+	}
+	defer out.Close()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return fmt.Errorf("failed to copy file content: %w", err)
+	}
+
+	if err = out.Sync(); err != nil {
+		return fmt.Errorf("failed to sync file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/envoy/artifact_copier_test.go
+++ b/pkg/envoy/artifact_copier_test.go
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package envoy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArtifactCopier_Copy_SourceDirDoesntExist(t *testing.T) {
+	sourceTempDir := "/tmp/not-existing"
+	targetTempDir := t.TempDir()
+
+	r := &ArtifactCopier{
+		sourcePath: sourceTempDir,
+		targetPath: targetTempDir,
+	}
+
+	err := r.Copy()
+	assert.NoError(t, err)
+
+	files, err := os.ReadDir(targetTempDir)
+	assert.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestArtifactCopier_Copy_EmptySourceDir(t *testing.T) {
+	sourceTempDir := t.TempDir()
+	targetTempDir := t.TempDir()
+
+	r := &ArtifactCopier{
+		sourcePath: sourceTempDir,
+		targetPath: targetTempDir,
+	}
+
+	err := r.Copy()
+	assert.NoError(t, err)
+
+	files, err := os.ReadDir(targetTempDir)
+	assert.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestArtifactCopier_Copy_CopyFiles(t *testing.T) {
+	sourceTempDir := t.TempDir()
+	targetTempDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(sourceTempDir, "test.txt"), []byte("testcontent"), os.ModePerm)
+	assert.NoError(t, err)
+
+	r := &ArtifactCopier{
+		sourcePath: sourceTempDir,
+		targetPath: targetTempDir,
+	}
+
+	err = r.Copy()
+	assert.NoError(t, err)
+
+	files, err := os.ReadDir(targetTempDir)
+	assert.NoError(t, err)
+	assert.Len(t, files, 1)
+	assert.Equal(t, "test.txt", files[0].Name())
+
+	fileContent, err := os.ReadFile(filepath.Join(targetTempDir, files[0].Name()))
+	assert.NoError(t, err)
+	assert.Equal(t, "testcontent", string(fileContent))
+}
+
+func TestArtifactCopier_Copy_DontCopySymlinks(t *testing.T) {
+	sourceTempDir := t.TempDir()
+	targetTempDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(sourceTempDir, "test.txt"), []byte("testcontent"), os.ModePerm)
+	assert.NoError(t, err)
+
+	err = os.Symlink(filepath.Join(sourceTempDir, "test.txt"), filepath.Join(sourceTempDir, "symlink"))
+	assert.NoError(t, err)
+
+	r := &ArtifactCopier{
+		sourcePath: sourceTempDir,
+		targetPath: targetTempDir,
+	}
+
+	err = r.Copy()
+	assert.NoError(t, err)
+
+	files, err := os.ReadDir(targetTempDir)
+	assert.NoError(t, err)
+	assert.Len(t, files, 1)
+	assert.Equal(t, "test.txt", files[0].Name())
+}
+
+func TestArtifactCopier_Copy_DontCopyDirectories(t *testing.T) {
+	sourceTempDir := t.TempDir()
+	targetTempDir := t.TempDir()
+
+	err := os.Mkdir(filepath.Join(sourceTempDir, "sub-directory"), os.ModePerm)
+	assert.NoError(t, err)
+
+	r := &ArtifactCopier{
+		sourcePath: sourceTempDir,
+		targetPath: targetTempDir,
+	}
+
+	err = r.Copy()
+	assert.NoError(t, err)
+
+	files, err := os.ReadDir(targetTempDir)
+	assert.NoError(t, err)
+	assert.Empty(t, files)
+}
+
+func TestArtifactCopier_Copy_CleanupExistingContent(t *testing.T) {
+	sourceTempDir := t.TempDir()
+	targetTempDir := t.TempDir()
+
+	err := os.WriteFile(filepath.Join(sourceTempDir, "new-file.txt"), []byte("testcontent"), os.ModePerm)
+	assert.NoError(t, err)
+
+	err = os.WriteFile(filepath.Join(targetTempDir, "existing-file.txt"), []byte("testcontent"), os.ModePerm)
+	assert.NoError(t, err)
+
+	err = os.Mkdir(filepath.Join(targetTempDir, "sub-directory"), os.ModePerm)
+	assert.NoError(t, err)
+
+	r := &ArtifactCopier{
+		sourcePath: sourceTempDir,
+		targetPath: targetTempDir,
+	}
+
+	err = r.Copy()
+	assert.NoError(t, err)
+
+	files, err := os.ReadDir(targetTempDir)
+	assert.NoError(t, err)
+	assert.Len(t, files, 1)
+	assert.Equal(t, "new-file.txt", files[0].Name())
+
+	fileContent, err := os.ReadFile(filepath.Join(targetTempDir, files[0].Name()))
+	assert.NoError(t, err)
+	assert.Equal(t, "testcontent", string(fileContent))
+}


### PR DESCRIPTION
This commit introduces the Envoy artifact copier that provides the possibility to make artifacts from within the Cilium Agent image available to the Cilium Proxy (Envoy) by copying files from the source-directory `/envoy-artifacts/` to
`/var/run/cilium/envoy/artifacts`. This ensures that the files are accessible by Cilium Proxy independent whether deployed in embedded (same container as Cilium Agent) or daemonset (separate Pod - with a volumemount between the Cilium Agent & Proxy Pod) mode.