### PR TITLE
.github: use kindest/node instead of quay.io/cilium/kindest-node

### DIFF
--- a/.github/actions/ginkgo/main-k8s-versions.yaml
+++ b/.github/actions/ginkgo/main-k8s-versions.yaml
@@ -4,7 +4,7 @@ include:
   - k8s-version: "1.28"
     ip-family: "dual"
     # renovate: datasource=docker
-    kube-image: "quay.io/cilium/kindest-node:v1.28.0-rc.0@sha256:a8cdbdd4998d6eb150c12091444a5412b2aac939bac1299c897cdad3604f47d2"
+    kube-image: "kindest/node:v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31"
     # renovate: datasource=docker depName=quay.io/lvh-images/kind
     kernel: "bpf-next-20230810.091425@sha256:a6c92f0161046b889c616e58e85539f5b50200d4109c559f33b7282caee7e27e"
 

--- a/.github/kind-config-ipv6.yaml
+++ b/.github/kind-config-ipv6.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: quay.io/cilium/kindest-node:v1.28.0-rc.0
+    image: kindest/node:v1.28.0
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +12,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: quay.io/cilium/kindest-node:v1.28.0-rc.0
+    image: kindest/node:v1.28.0
 networking:
   ipFamily: ipv6
   disableDefaultCNI: true

--- a/.github/kind-config.yaml
+++ b/.github/kind-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: quay.io/cilium/kindest-node:v1.28.0-rc.0
+    image: kindest/node:v1.28.0
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +12,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: quay.io/cilium/kindest-node:v1.28.0-rc.0
+    image: kindest/node:v1.28.0
 networking:
   disableDefaultCNI: true
   podSubnet: "10.244.0.0/16"

--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: quay.io/cilium/kindest-node:${K8S_VERSION}
+    image: kindest/node:${K8S_VERSION}
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +12,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: quay.io/cilium/kindest-node:${K8S_VERSION}
+    image: kindest/node:${K8S_VERSION}
 networking:
   disableDefaultCNI: true
   ipFamily: ${IPFAMILY}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -53,8 +53,8 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.20.0
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.28.0-rc.0
+  # renovate: datasource=docker depName=kindest/node
+  k8s_version: v1.28.0
   # renovate: datasource=github-releases depName=cilium/cilium-cli
   cilium_cli_version: v0.15.6
   cilium_cli_ci_version:

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -28,8 +28,8 @@ env:
   cilium_cli_version: v0.15.6
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.28.0-rc.0
+  # renovate: datasource=docker depName=kindest/node
+  k8s_version: v1.28.0
 
 jobs:
   kubernetes-e2e-net-conformance:
@@ -82,7 +82,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image quay.io/cilium/kindest-node:${{ env.k8s_version }}  \
+            --image kindest/node:${{ env.k8s_version }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -28,8 +28,8 @@ env:
   cilium_cli_version: v0.15.6
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
-  k8s_version: v1.28.0-rc.0
+  # renovate: datasource=docker depName=kindest/node
+  k8s_version: v1.28.0
 
 jobs:
   kubernetes-e2e:
@@ -82,7 +82,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image quay.io/cilium/kindest-node:${{ env.k8s_version }}  \
+            --image kindest/node:${{ env.k8s_version }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -20,7 +20,7 @@ env:
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
-  KIND_VERSION: v0.17.0
+  KIND_VERSION: v0.20.0
   KIND_CONFIG: .github/kind-config-ipv6.yaml
   # Skip external traffic (e.g. 1.1.1.1 and www.google.com) due to no support for IPv6 in github action
   CONFORMANCE_TEMPLATE: examples/kubernetes/connectivity-check/connectivity-check-internal.yaml


### PR DESCRIPTION
With the new minor k8s version being released in kindest/node, we don't need to keep using quay.io/cilium/kindest-node as it was primarily used to test RCs.