### PR TITLE
mlh: use a regexp to check signed-off-by

### DIFF
--- a/.github/maintainers-little-helper.yaml
+++ b/.github/maintainers-little-helper.yaml
@@ -30,7 +30,7 @@ move-to-projects-for-labels-xored:
       project: "https://github.com/cilium/cilium/projects/248"
       column: "Backport done to v1.12"
 require-msgs-in-commit:
-  - msg: "Signed-off-by"
+  - regexpMsg: "(?m)^Signed-off-by:"
     helper: "https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#developer-s-certificate-of-origin"
     set-labels:
       - "dont-merge/needs-sign-off"


### PR DESCRIPTION
Before this patch, mlh would accept PRs containing "Signed-off-by" in the commit title (rather than as a "trailer" in the commit description).

Note that this improvement is not bullet-proof, e.g. a commit with "Signed-off-by:" as title would still pass the check (but hopefully not the review).