### PR TITLE
ci-e2e: Add secondary network NodePort tests

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -152,9 +152,8 @@ include:
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort with sessionAffinity from outside
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests security id propagation in N/S LB requests fwd-ed over tunnel
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct routing and DSR
-  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with secondary NodePort device
   - focus: "f12-datapath-service-ns-misc"
-    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs|K8sDatapathServicesTest Checks N/S loadbalancing Tests GH|K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort|K8sDatapathServicesTest Checks N/S loadbalancing Tests security|K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct|K8sDatapathServicesTest Checks N/S loadbalancing Tests with secondary|K8sDatapathServicesTest Checks N/S loadbalancing with"
+    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs|K8sDatapathServicesTest Checks N/S loadbalancing Tests GH|K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort|K8sDatapathServicesTest Checks N/S loadbalancing Tests security|K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct|K8sDatapathServicesTest Checks N/S loadbalancing with"
 
   ###
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR and Maglev

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -52,7 +52,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.15.6
+  cilium_cli_version: v0.15.7
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -105,6 +105,8 @@ jobs:
             kernel: '5.10-20230810.091425'
             kube-proxy: 'iptables'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'vxlan'
             lb-mode: 'snat'
             endpoint-routes: 'true'
@@ -115,6 +117,8 @@ jobs:
             kernel: '5.15-20230810.091425'
             kube-proxy: 'iptables'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'disabled'
             lb-mode: 'dsr'
             endpoint-routes: 'true'
@@ -137,6 +141,8 @@ jobs:
             kernel: 'bpf-next-20230810.091425'
             kube-proxy: 'none'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'disabled'
             lb-mode: 'snat'
             egress-gateway: 'true'
@@ -155,6 +161,8 @@ jobs:
             kernel: '5.10-20230810.091425'
             kube-proxy: 'iptables'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'vxlan'
             encryption: 'wireguard'
             encryption-node: 'false'
@@ -167,6 +175,8 @@ jobs:
             kernel: '5.15-20230810.091425'
             kube-proxy: 'iptables'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'disabled'
             encryption: 'wireguard'
             encryption-node: 'false'
@@ -179,6 +189,8 @@ jobs:
             kernel: '6.0-20230810.091425'
             kube-proxy: 'none'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'vxlan'
             encryption: 'wireguard'
             encryption-node: 'true'
@@ -190,6 +202,8 @@ jobs:
             kernel: 'bpf-next-20230810.091425'
             kube-proxy: 'none'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'disabled'
             encryption: 'wireguard'
             encryption-node: 'true'
@@ -224,6 +238,7 @@ jobs:
           image-tag: ${{ steps.vars.outputs.sha }}
           chart-dir: './install/kubernetes/cilium'
           tunnel: ${{ matrix.tunnel }}
+          devices: ${{ matrix.devices }}
           endpoint-routes: ${{ matrix.endpoint-routes }}
           ipv6: ${{ matrix.ipv6 }}
           kpr: ${{ matrix.kpr }}
@@ -310,11 +325,17 @@ jobs:
           cmd: |
             cd /host/
 
+            EXTRA=""
+            if [ "${{ matrix.secondary-network }}" = "true" ]; then
+              EXTRA="--secondary-network-iface=eth1"
+            fi
+
             ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
               --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})"
+              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+              \$EXTRA
 
             ./contrib/scripts/kind-down.sh
 

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -424,18 +424,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			}
 		})
 
-		SkipItIf(func() bool {
-			// Currently, KIND doesn't support multiple interfaces among nodes
-			return helpers.IsIntegration(helpers.CIIntegrationKind)
-		}, "Tests with secondary NodePort device", func() {
-			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-				"loadBalancer.mode": "snat",
-				"devices":           fmt.Sprintf(`'{%s,%s}'`, ni.PrivateIface, helpers.SecondaryIface),
-			})
-
-			testNodePortExternal(kubectl, ni, true, false, false)
-		})
-
 		It("Tests with direct routing and DSR", func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 				"loadBalancer.mode":    "dsr",


### PR DESCRIPTION
Successful run of new tests - https://github.com/cilium/cilium/actions/runs/6046909722/job/16409351135