### PR TITLE
v1.12 Backports 2023-08-28

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -15,7 +15,7 @@ triggers:
   /ci-awscni:
     workflows:
     - conformance-aws-cni.yaml
-  /ci-multicluster:
+  /ci-clustermesh:
     workflows:
     - conformance-clustermesh.yaml
   /ci-ipsec-upgrade:

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -51,3 +51,5 @@ workflows:
     paths-ignore-regex: (test|Documentation)/
   tests-l4lb.yaml:
     paths-regex: (bpf|daemon|images|pkg|test/l4lb|vendor)/
+  tests-ipsec-upgrade.yaml:
+    paths-ignore-regex: (test|Documentation)/

--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   build-and-push:
+    name: Build and Push Images
     timeout-minutes: 30
     environment: release-base-images
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-images-beta.yaml
+++ b/.github/workflows/build-images-beta.yaml
@@ -15,6 +15,7 @@ permissions: read-all
 
 jobs:
   build-and-push:
+    name: Build and Push Images
     environment: release-beta-images
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   build-and-push-prs:
+    name: Build and Push Images
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -227,6 +228,7 @@ jobs:
   # which requires qemu setup in order to avoid x86/arm64 binaries mixups
   # note: we only build on pushes to v1.12 branch
   build-and-push-with-qemu:
+    name: Build and Push with qemu
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/build-images-hotfixes.yaml
+++ b/.github/workflows/build-images-hotfixes.yaml
@@ -9,6 +9,7 @@ permissions: read-all
 
 jobs:
   build-and-push:
+    name: Build and Push Images
     environment: release-developer-images
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/build-images-releases.yaml
+++ b/.github/workflows/build-images-releases.yaml
@@ -10,6 +10,7 @@ permissions: read-all
 
 jobs:
   build-and-push:
+    name: Build and Push Images
     environment: release
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -1,4 +1,4 @@
-name: ConformanceAKS (ci-aks)
+name: Conformance AKS (ci-aks)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -62,6 +62,7 @@ env:
 
 jobs:
   commit-status-start:
+    name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
@@ -70,6 +71,7 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   generate-matrix:
+    name: Generate Matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -104,7 +106,7 @@ jobs:
           echo "matrix=$(jq -c . < /tmp/matrix.json)" >> $GITHUB_OUTPUT
 
   installation-and-connectivity:
-    name: "Installation and Connectivity Test"
+    name: Installation and Connectivity Test
     needs: generate-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -330,6 +332,7 @@ jobs:
 
   commit-status-final:
     if: ${{ always() }}
+    name: Commit Status Final
     needs: installation-and-connectivity
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -61,6 +61,7 @@ env:
 
 jobs:
   commit-status-start:
+    name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
@@ -69,6 +70,7 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   generate-matrix:
+    name: Generate Matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -103,7 +105,7 @@ jobs:
           echo "matrix=$(jq -c . < /tmp/matrix.json)" >> $GITHUB_OUTPUT
 
   installation-and-connectivity:
-    name: "Installation and Connectivity Test"
+    name: Installation and Connectivity Test
     needs: generate-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -294,6 +296,7 @@ jobs:
 
   commit-status-final:
     if: ${{ always() }}
+    name: Commit Status Final
     needs: installation-and-connectivity
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -1,4 +1,4 @@
-name: ClusterMesh (ci-multicluster)
+name: Conformance Cluster Mesh (ci-clustermesh)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -65,6 +65,7 @@ env:
 
 jobs:
   commit-status-start:
+    name: Commmit Status Start
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
@@ -73,7 +74,7 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   installation-and-connectivity:
-    name: "Installation and Connectivity Test"
+    name: Installation and Connectivity Test
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -448,6 +449,7 @@ jobs:
 
   commit-status-final:
     if: ${{ always() }}
+    name: Commit Status Final
     needs: installation-and-connectivity
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -1,4 +1,4 @@
-name: ConformanceEKS (ci-eks)
+name: Conformance EKS (ci-eks)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -61,6 +61,7 @@ env:
 
 jobs:
   commit-status-start:
+    name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
@@ -69,6 +70,7 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   generate-matrix:
+    name: Generate Matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -103,7 +105,7 @@ jobs:
           echo "matrix=$(jq -c . < /tmp/matrix.json)" >> $GITHUB_OUTPUT
 
   installation-and-connectivity:
-    name: "Installation and Connectivity Test"
+    name: Installation and Connectivity Test
     needs: generate-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 75
@@ -315,6 +317,7 @@ jobs:
 
   commit-status-final:
     if: ${{ always() }}
+    name: Commit Status Final
     needs: installation-and-connectivity
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -1,4 +1,4 @@
-name: External workloads (ci-external-workloads)
+name: Conformance External Workloads (ci-external-workloads)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -62,6 +62,7 @@ env:
 
 jobs:
   commit-status-start:
+    name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
@@ -70,6 +71,7 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   generate-matrix:
+    name: Generate Matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -104,7 +106,7 @@ jobs:
           echo "matrix=$(jq -c . < /tmp/matrix.json)" >> $GITHUB_OUTPUT
 
   installation-and-connectivity:
-    name: "Installation and Connectivity Test"
+    name: Installation and Connectivity Test
     needs: generate-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -346,6 +348,7 @@ jobs:
 
   commit-status-final:
     if: ${{ always() }}
+    name: Commit Status Final
     needs: installation-and-connectivity
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -1,4 +1,4 @@
-name: ConformanceGKE (ci-gke)
+name: Conformance GKE (ci-gke)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -60,6 +60,7 @@ env:
 
 jobs:
   commit-status-start:
+    name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
@@ -68,6 +69,7 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   generate-matrix:
+    name: Generate Matrix
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -109,7 +111,7 @@ jobs:
           echo "matrix=$(jq -c . < /tmp/matrix.json)" >> $GITHUB_OUTPUT
 
   installation-and-connectivity:
-    name: "Installation and Connectivity Test"
+    name: Installation and Connectivity Test
     needs: generate-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 75
@@ -306,6 +308,7 @@ jobs:
 
   commit-status-final:
     if: ${{ always() }}
+    name: Commit Status Final
     needs: installation-and-connectivity
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -1,4 +1,4 @@
-name: ConformanceIngress
+name: Conformance Ingress
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -61,6 +61,7 @@ env:
 
 jobs:
   commit-status-start:
+    name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
@@ -69,6 +70,7 @@ jobs:
           sha: ${{ inputs.SHA || github.sha }}
 
   ingress-conformance-test:
+    name: Ingress Conformance Test
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -201,6 +203,7 @@ jobs:
 
   commit-status-final:
     if: ${{ always() }}
+    name: Commit Status Final
     needs: ingress-conformance-test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/conformance-kind.yaml
+++ b/.github/workflows/conformance-kind.yaml
@@ -1,4 +1,4 @@
-name: ConformanceKind1.19
+name: Conformance Kind 1.19
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -27,6 +27,7 @@ env:
 
 jobs:
   installation-and-connectivity:
+    name: Installation and Connectivity Test
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -53,10 +53,12 @@ jobs:
     name: Validate & Build HTML
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
-      - uses: docker://quay.io/cilium/docs-builder:d5505e230c0164b51855b002c2a0abeeff78870c@sha256:95940ef277ae14c745769e332c968d8357a43e363eab0b088c5d5efa22089260
+      - name: Build HTML
+        uses: docker://quay.io/cilium/docs-builder:d5505e230c0164b51855b002c2a0abeeff78870c@sha256:95940ef277ae14c745769e332c968d8357a43e363eab0b088c5d5efa22089260
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/.github/workflows/external-contribution-labeler.yaml
+++ b/.github/workflows/external-contribution-labeler.yaml
@@ -15,6 +15,7 @@ jobs:
         (github.event.pull_request.author_association != 'MEMBER')
       )
     runs-on: ubuntu-latest
+    name: Label PRs
     permissions:
       pull-requests: write
     steps:
@@ -62,7 +63,8 @@ jobs:
           echo author_association_from_event=${{ github.event.pull_request.author_association }}
           echo author_association_from_api=${{ steps.author_association.outputs.result }}
 
-      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+      - name: Set label
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         if: ${{ steps.check_secret.outputs.is_CHECK_TEAM_ORG_APP_ID_set == 'true' && steps.author_association.outputs.result != 'true' }}
         with:
           script: |

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -1,4 +1,4 @@
-name: BPF checks
+name: BPF Checks
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -41,7 +41,7 @@ jobs:
               - 'contrib/coccinelle/**'
 
   checkpatch:
-    name: checkpatch
+    name: Check Patch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -57,13 +57,15 @@ jobs:
   coccicheck:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.bpf-tree == 'true' || needs.check_changes.outputs.coccinelle == 'true' }}
-    name: coccicheck
+    name: Run coccicheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Checout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
-      - uses: docker://cilium/coccicheck:2.0@sha256:6f0369994c426d0bc013fc443cc6a48a0734fb35467955d10f3fc9f7cbd9c7fe
+      - name: Run coccicheck
+        uses: docker://cilium/coccicheck:2.0@sha256:6f0369994c426d0bc013fc443cc6a48a0734fb35467955d10f3fc9f7cbd9c7fe
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
 
@@ -81,7 +83,7 @@ jobs:
   build_all:
     needs: [check_changes, set_clang_dir]
     if: ${{ needs.check_changes.outputs.bpf-tree == 'true' }}
-    name: build datapath
+    name: Build Datapath
     runs-on: ubuntu-22.04
     steps:
       - name: Install Go

--- a/.github/workflows/lint-build-commits.yaml
+++ b/.github/workflows/lint-build-commits.yaml
@@ -1,4 +1,4 @@
-name: build-commits
+name: Build Commits
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on: [pull_request]

--- a/.github/workflows/lint-codeql.yaml
+++ b/.github/workflows/lint-codeql.yaml
@@ -1,4 +1,4 @@
-name: codeql
+name: CodeQL
 
 on:
   pull_request:
@@ -36,6 +36,7 @@ jobs:
   analyze:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.go-changes == 'true' || github.event_name != 'pull_request' }}
+    name: Analyze
     runs-on: ubuntu-22.04
     permissions:
       security-events: write

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -1,4 +1,4 @@
-name: Go-related checks
+name: Go Related Checks
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   go-mod:
+    name: Check Go Modules
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -33,7 +34,7 @@ jobs:
           test -z "$(git status --porcelain)" || (echo "please run 'go mod tidy && go mod vendor', and submit your changes"; exit 1)
 
   golangci:
-    name: lint
+    name: Lint Source Code
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -52,6 +53,7 @@ jobs:
 
   precheck:
     runs-on: ubuntu-latest
+    name: Precheck
     steps:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
@@ -70,6 +72,7 @@ jobs:
 
   generate-api:
     runs-on: ubuntu-latest
+    name: Generate API
     steps:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
@@ -88,6 +91,7 @@ jobs:
 
   generate-k8s-api:
     runs-on: ubuntu-latest
+    name: Generate k8s API
     steps:
       - name: Install Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0

--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -23,7 +23,8 @@ jobs:
     name: Lint image build logic
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Checout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -59,6 +59,7 @@ env:
 
 jobs:
   commit-status-start:
+    name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
@@ -433,6 +434,7 @@ jobs:
 
   commit-status-final:
     if: ${{ always() }}
+    name: Commit Status Final
     needs: setup-and-test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -58,6 +58,7 @@ env:
 
 jobs:
   commit-status-start:
+    name: Commit Status Start
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
@@ -132,6 +133,7 @@ jobs:
 
   commit-status-final:
     if: ${{ always() }}
+    name: Commit Status Final
     needs: setup-and-test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests-smoke-ipv6.yaml
+++ b/.github/workflows/tests-smoke-ipv6.yaml
@@ -50,6 +50,7 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-22.04
+    name: Installation and Conformance Test
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -1,4 +1,4 @@
-name: Smoke test
+name: Smoke Test
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -48,8 +48,10 @@ jobs:
 
   preflight-clusterrole:
     runs-on: ubuntu-latest
+    name: Preflight Clusterrole Check
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Checout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
 
@@ -66,6 +68,7 @@ jobs:
 
   helm-charts:
     runs-on: ubuntu-latest
+    name: Helm Charts Check
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -81,6 +84,7 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.tested == 'true' }}
     runs-on: ubuntu-latest
+    name: Installation and Conformance Test
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0


### PR DESCRIPTION
 * [x] #27644 (@brb)
 * [x] #27391 (@brlbil)
   * :warning: merge conflicts due to missing workflow files in v1.12 branch:
     - .github/workflows/build-images-docs-builder.yaml
     - .github/workflows/ci-images-cache-cleaner.yaml
     - .github/workflows/ci-images-garbage-collect.yaml
     - .github/workflows/close-stale-issues.yaml
     - .github/workflows/conformance-e2e.yaml
     - .github/workflows/conformance-gateway-api.yaml
     - .github/workflows/conformance-ginkgo.yaml
     - .github/workflows/conformance-ipsec-e2e.yaml
     - .github/workflows/conformance-k8s-kind-network-policies.yaml
     - .github/workflows/conformance-k8s-kind.yaml
     - .github/workflows/conformance-k8s-network-policies.yaml
     - .github/workflows/conformance-kind-proxy-daemonset.yaml
     - .github/workflows/conformance-multi-pool.yaml
     - .github/workflows/conformance-runtime.yaml
     - .github/workflows/container-scan.yaml
     - .github/workflows/integration-test.yaml
     - .github/workflows/lint-codeowners.yaml
     - .github/workflows/lint-workflows.yaml
     - .github/workflows/push-chart-ci.yaml
     - .github/workflows/tests-cifuzz.yaml
     - .github/workflows/tests-datapath-verifier.yaml

PRs skipped due to conflicts:

 * #27346 (@qmonnet)
 * #27646 (@giorio94)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27644 27391; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
make add-labels BRANCH=v1.12 ISSUES=27644,27391
```
