### PR TITLE
daemon: Do not require native routing CIDR if ipmasq-agent is enabled

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -91,9 +91,8 @@ jobs:
             --helm-set=kubeProxyReplacement=strict \
             --helm-set=bpf.masquerade=true \
             --helm-set=bpf.hostLegacyRouting=true\
-            --helm-set=ipv4NativeRoutingCIDR=10.0.0.0/8 \
             --helm-set=ipMasqAgent.enabled=true \
-            --helm-set=ipMasqAgent.config.nonMasqueradeCIDRs='{192.168.0.0/16}' \
+            --helm-set=ipMasqAgent.config.nonMasqueradeCIDRs='{10.0.0.0/8,192.168.0.0/16}' \
             --helm-set=ipam.mode=multi-pool \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.cidrs='{10.10.0.0/16}' \
             --helm-set=ipam.operator.autoCreateCiliumPodIPPools.default.ipv4.maskSize=24 \

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -3772,29 +3772,52 @@ func (c *DaemonConfig) checkMapSizeLimits() error {
 }
 
 func (c *DaemonConfig) checkIPv4NativeRoutingCIDR() error {
-	if c.GetIPv4NativeRoutingCIDR() == nil && c.EnableIPv4Masquerade && !c.TunnelingEnabled() &&
-		c.IPAMMode() != ipamOption.IPAMENI && c.EnableIPv4 && c.IPAMMode() != ipamOption.IPAMAlibabaCloud {
-		return fmt.Errorf(
-			"native routing cidr must be configured with option --%s "+
-				"in combination with --%s --%s=%s --%s=%s --%s=true",
-			IPv4NativeRoutingCIDR, EnableIPv4Masquerade, RoutingMode, RoutingModeNative,
-			IPAM, c.IPAMMode(), EnableIPv4Name)
+	if c.GetIPv4NativeRoutingCIDR() != nil {
+		return nil
+	}
+	if !c.EnableIPv4 || !c.EnableIPv4Masquerade {
+		return nil
+	}
+	if c.EnableIPMasqAgent {
+		return nil
+	}
+	if c.TunnelingEnabled() {
+		return nil
+	}
+	if c.IPAMMode() == ipamOption.IPAMENI || c.IPAMMode() == ipamOption.IPAMAlibabaCloud {
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf(
+		"native routing cidr must be configured with option --%s "+
+			"in combination with --%s=true --%s=true --%s=false --%s=%s --%s=%s",
+		IPv4NativeRoutingCIDR,
+		EnableIPv4Name, EnableIPv4Masquerade,
+		EnableIPMasqAgent,
+		RoutingMode, RoutingModeNative,
+		IPAM, c.IPAMMode())
 }
 
 func (c *DaemonConfig) checkIPv6NativeRoutingCIDR() error {
-	if c.GetIPv6NativeRoutingCIDR() == nil && c.EnableIPv6Masquerade && !c.TunnelingEnabled() &&
-		c.EnableIPv6 {
-		return fmt.Errorf(
-			"native routing cidr must be configured with option --%s "+
-				"in combination with --%s --%s=%s --%s=true",
-			IPv6NativeRoutingCIDR, EnableIPv6Masquerade, RoutingMode, RoutingModeNative,
-			EnableIPv6Name)
+	if c.GetIPv6NativeRoutingCIDR() != nil {
+		return nil
 	}
-
-	return nil
+	if !c.EnableIPv6 || !c.EnableIPv6Masquerade {
+		return nil
+	}
+	if c.EnableIPMasqAgent {
+		return nil
+	}
+	if c.TunnelingEnabled() {
+		return nil
+	}
+	return fmt.Errorf(
+		"native routing cidr must be configured with option --%s "+
+			"in combination with --%s=true --%s=true --%s=false --%s=%s",
+		IPv6NativeRoutingCIDR,
+		EnableIPv6Name, EnableIPv6Masquerade,
+		EnableIPMasqAgent,
+		RoutingMode, RoutingModeNative)
 }
 
 func (c *DaemonConfig) checkIPAMDelegatedPlugin() error {

--- a/pkg/option/config_test.go
+++ b/pkg/option/config_test.go
@@ -571,6 +571,18 @@ func TestCheckIPv4NativeRoutingCIDR(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "without native routing cidr and tunnel disabled, but ipmasq-agent",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade: true,
+				EnableIPv6Masquerade: true,
+				RoutingMode:          RoutingModeNative,
+				IPAM:                 ipamOption.IPAMKubernetes,
+				EnableIPv4:           true,
+				EnableIPMasqAgent:    true,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -632,6 +644,17 @@ func TestCheckIPv6NativeRoutingCIDR(t *testing.T) {
 				EnableIPv6:           true,
 			},
 			wantErr: true,
+		},
+		{
+			name: "without native routing cidr and tunnel disabled, but ipmasq-agent",
+			d: &DaemonConfig{
+				EnableIPv4Masquerade: true,
+				EnableIPv6Masquerade: true,
+				RoutingMode:          RoutingModeNative,
+				EnableIPv6:           true,
+				EnableIPMasqAgent:    true,
+			},
+			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
When running with ipmasq-agent-based eBPF masquerading, there should be no need to mandatory require a native routing CIDR, since all CIDRs can be configured via the BPF map instead.

This PR therefore does not set the `IPV4_SNAT_EXCLUSION_DST_CIDR` field if no native routing CIDR is set. Notably, it also does not fall back on the local pod CIDR like we do in regular BPF masquearding, since in many IPAM modes there is no local pod CIDR to begin with.

Note that this change is backwards-compatible, because we have a check that ensures that the native routing CIDR is always set if BPF masquerading is enabled. So all existing users of ip-masq-agent already have a native routing CIDR set. This PR also removes that check, thus allowing future uses to not set a native routing CIDR when running with ipmasq-agent based masquerading.