### PR TITLE
docs-builder image: Only build from cilium/cilium

### DIFF
--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   build-and-push:
     name: Build and Push Image
+    if: github.repository_owner == 'cilium'
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     environment: docs-builder


### PR DESCRIPTION
Most forks don't need to run this workflow. Check the repository owner and only build from cilium/cilium.