### PR TITLE
bpf: minor loopback cleanups

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -806,7 +806,7 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 
 #ifdef ENABLE_PER_PACKET_LB
 	/* Restore ct_state from per packet lb handling in the previous tail call. */
-	lb4_ctx_restore_state(ctx, &ct_state_new, ip4->daddr, &proxy_port, &cluster_id);
+	lb4_ctx_restore_state(ctx, &ct_state_new, &proxy_port, &cluster_id);
 	hairpin_flow = ct_state_new.loopback;
 #endif /* ENABLE_PER_PACKET_LB */
 

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -1137,10 +1137,6 @@ struct ct_state {
 	      reserved1:1,	/* Was auth_required, not used in production anywhere */
 	      from_tunnel:1,	/* Connection is from tunnel */
 	      reserved:8;
-#ifndef DISABLE_LOOPBACK_LB
-	__be32 addr;
-	__be32 svc_addr;
-#endif
 	__u32 src_sec_id;
 #ifndef HAVE_FIB_IFINDEX
 	__u16 ifindex;

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1676,7 +1676,6 @@ static __always_inline int lb4_local(const void *map, struct __ctx_buff *ctx,
 	if (saddr == backend->address) {
 		new_saddr = IPV4_LOOPBACK;
 		state->loopback = 1;
-		state->svc_addr = saddr;
 	}
 
 	if (!state->loopback)
@@ -1728,16 +1727,12 @@ static __always_inline void lb4_ctx_store_state(struct __ctx_buff *ctx,
  */
 static __always_inline void
 lb4_ctx_restore_state(struct __ctx_buff *ctx, struct ct_state *state,
-		       __u32 daddr __maybe_unused, __u16 *proxy_port,
-		       __u32 *cluster_id __maybe_unused)
+		       __u16 *proxy_port, __u32 *cluster_id __maybe_unused)
 {
 	__u32 meta = ctx_load_meta(ctx, CB_CT_STATE);
 #ifndef DISABLE_LOOPBACK_LB
-	if (meta & 1) {
+	if (meta & 1)
 		state->loopback = 1;
-		state->addr = IPV4_LOOPBACK;
-		state->svc_addr = daddr; /* backend address after xlate */
-	}
 #endif
 	state->rev_nat_index = meta >> 16;
 

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -177,8 +177,6 @@ int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
 
 	if (!l4)
 		return TEST_ERROR;
-	if ((void *)l4 + sizeof(struct sctphdr) > ctx_data_end(ctx))
-		return TEST_ERROR;
 
 	l4->source = tcp_src_one;
 	l4->dest = tcp_svc_one;
@@ -265,7 +263,7 @@ int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 	/* Push SCTP header */
 	l4 = pktgen__push_sctphdr(&builder);
 
-	if (!l4 || (void *)l4 + sizeof(struct sctphdr) > ctx_data_end(ctx))
+	if (!l4)
 		return TEST_ERROR;
 
 	l4->source = tcp_svc_one;


### PR DESCRIPTION
A few follow-on cleanups for https://github.com/cilium/cilium/pull/27602.

Rip out some now-unused loopback code, and apply some minor cleanups to the SCTP hairpin integration test.