### PR TITLE
policy: remove strict custom listener validation on ingress CNP

### DIFF
--- a/pkg/policy/api/rule_validation.go
+++ b/pkg/policy/api/rule_validation.go
@@ -383,11 +383,11 @@ func (pr *PortRule) sanitize(ingress bool) error {
 
 	listener := pr.Listener
 	if listener != nil {
-		// For now we have only tested custom listener support on the egress path.  TODO
-		// (jrajahalme): Lift this limitation in follow-up work once proper testing has been
-		// done on the ingress path.
+		// Autoconfiguration for CEC defaults to direction 'egress' for BPF metadata listener filter and listener socket mark options.
+		// In case of direction 'ingress', these two configurations need to be provided by the listener defined in the CiliumEnvoyConfig.
+		// Therefore, a warning gets emitted if an ingress CNP references a custom listener.
 		if ingress {
-			return fmt.Errorf("Listener is not allowed on ingress (%s)", listener.Name)
+			log.Warnf("Custom Listener %s is used on the ingress path. Please ensure that it contains the Cilium BPF Metadata listener filter and socket mark options.", listener.Name)
 		}
 		// There is no quarantee that Listener will support Cilium policy enforcement.  Even
 		// now proxylib-based enforcement (e.g, Kafka) may work, but has not been tested.

--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -416,32 +416,6 @@ func (s *PolicyAPITestSuite) TestL7RulesWithNonTCPProtocols(c *C) {
 	err = validPortRule.Sanitize()
 	c.Assert(err, IsNil)
 
-	// Rule is invalid because Listener is not allowed on ingress (yet)
-	invalidPortRule = Rule{
-		EndpointSelector: WildcardEndpointSelector,
-		Ingress: []IngressRule{
-			{
-				IngressCommonRule: IngressCommonRule{
-					FromEndpoints: []EndpointSelector{WildcardEndpointSelector},
-				},
-				ToPorts: []PortRule{{
-					Ports: []PortProtocol{
-						{Port: "443", Protocol: ProtoTCP},
-					},
-					Listener: &Listener{
-						EnvoyConfig: &EnvoyConfig{
-							Name: "test-config",
-						},
-						Name: "myCustomListener",
-					},
-				}},
-			},
-		},
-	}
-	err = invalidPortRule.Sanitize()
-	c.Assert(err, Not(IsNil))
-	c.Assert(err.Error(), Equals, "Listener is not allowed on ingress (myCustomListener)")
-
 	// Rule is invalid because Listener is not allowed with L7 rules
 	invalidPortRule = Rule{
 		EndpointSelector: WildcardEndpointSelector,


### PR DESCRIPTION
Currently, setting a custom listener on an ingress CNP is not supported because this have not been tested yet.

Manual tests have shown that the only problem is that the CEC autoconfiguration defaults to configure the Cilium BPF metadata listener filter and liistener socket mark options for the egress case.

In case of ingress, the referenced listener in the CiliumEnvoyConfig needs to have these configuration included.

Therefore, the strict validation gets removed and replaced with a warning that the CiliumEnvoyConfig needs to contain the configuration.