### PR TITLE
pkg/aws: Improve event driven instance resync for AWS IPAM

### DIFF
--- a/pkg/aws/ec2/mock/mock.go
+++ b/pkg/aws/ec2/mock/mock.go
@@ -524,6 +524,39 @@ func (e *API) UnassignENIPrefixes(ctx context.Context, eniID string, prefixes []
 	return fmt.Errorf("Unable to find ENI with ID %s", eniID)
 }
 
+func (e *API) GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error) {
+	instance := ipamTypes.Instance{}
+	instance.Interfaces = map[string]ipamTypes.InterfaceRevision{}
+
+	e.mutex.RLock()
+	defer e.mutex.RUnlock()
+
+	for id, enis := range e.enis {
+		if id != instanceID {
+			continue
+		}
+		for ifaceID, eni := range enis {
+			if subnets != nil {
+				if subnet, ok := subnets[eni.Subnet.ID]; ok && subnet.CIDR != nil {
+					eni.Subnet.CIDR = subnet.CIDR.String()
+				}
+			}
+
+			if vpcs != nil {
+				if vpc, ok := vpcs[eni.VPC.ID]; ok {
+					eni.VPC.PrimaryCIDR = vpc.PrimaryCIDR
+					eni.VPC.CIDRs = vpc.CIDRs
+				}
+			}
+
+			eniRevision := ipamTypes.InterfaceRevision{Resource: eni.DeepCopy()}
+			instance.Interfaces[ifaceID] = eniRevision
+		}
+	}
+
+	return &instance, nil
+}
+
 func (e *API) GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error) {
 	instances := ipamTypes.NewInstanceMap()
 

--- a/pkg/aws/eni/instances.go
+++ b/pkg/aws/eni/instances.go
@@ -21,6 +21,7 @@ import (
 
 // EC2API is the API surface used of the EC2 API
 type EC2API interface {
+	GetInstance(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap, instanceID string) (*ipamTypes.Instance, error)
 	GetInstances(ctx context.Context, vpcs ipamTypes.VirtualNetworkMap, subnets ipamTypes.SubnetMap) (*ipamTypes.InstanceMap, error)
 	GetSubnets(ctx context.Context) (ipamTypes.SubnetMap, error)
 	GetVpcs(ctx context.Context) (ipamTypes.VirtualNetworkMap, error)
@@ -40,6 +41,7 @@ type EC2API interface {
 // by calling resync() regularly.
 type InstancesManager struct {
 	mutex          lock.RWMutex
+	resyncLock     lock.RWMutex
 	instances      *ipamTypes.InstanceMap
 	subnets        ipamTypes.SubnetMap
 	vpcs           ipamTypes.VirtualNetworkMap
@@ -169,6 +171,14 @@ func (m *InstancesManager) FindSecurityGroupByTags(vpcID string, required ipamTy
 // cache in the instanceManager. It returns the time when the resync has
 // started or time.Time{} if it did not complete.
 func (m *InstancesManager) Resync(ctx context.Context) time.Time {
+	// Full API resync should block the instance incremental resync from all nodes.
+	m.resyncLock.Lock()
+	defer m.resyncLock.Unlock()
+	// An empty instanceID indicates the full resync.
+	return m.resync(ctx, "")
+}
+
+func (m *InstancesManager) resync(ctx context.Context, instanceID string) time.Time {
 	resyncStart := time.Now()
 
 	vpcs, err := m.api.GetVpcs(ctx)
@@ -189,32 +199,58 @@ func (m *InstancesManager) Resync(ctx context.Context) time.Time {
 		return time.Time{}
 	}
 
-	instances, err := m.api.GetInstances(ctx, vpcs, subnets)
-	if err != nil {
-		log.WithError(err).Warning("Unable to synchronize EC2 interface list")
-		return time.Time{}
+	// An empty instanceID indicates that this is full resync, ENIs from all instances
+	// will be refetched from EC2 API and updated to the local cache. Otherwise only
+	// the given instance will be updated.
+	if instanceID == "" {
+		instances, err := m.api.GetInstances(ctx, vpcs, subnets)
+		if err != nil {
+			log.WithError(err).Warning("Unable to synchronize EC2 interface list")
+			return time.Time{}
+		}
+
+		log.WithFields(logrus.Fields{
+			"numInstances":      instances.NumInstances(),
+			"numVPCs":           len(vpcs),
+			"numSubnets":        len(subnets),
+			"numSecurityGroups": len(securityGroups),
+		}).Info("Synchronized ENI information")
+
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+		m.instances = instances
+	} else {
+		instance, err := m.api.GetInstance(ctx, vpcs, subnets, instanceID)
+		if err != nil {
+			log.WithError(err).Warning("Unable to synchronize EC2 interface list")
+			return time.Time{}
+		}
+
+		log.WithFields(logrus.Fields{
+			"instance":          instanceID,
+			"numVPCs":           len(vpcs),
+			"numSubnets":        len(subnets),
+			"numSecurityGroups": len(securityGroups),
+		}).Info("Synchronized ENI information for the corresponding instance")
+
+		m.mutex.Lock()
+		defer m.mutex.Unlock()
+		m.instances.UpdateInstance(instanceID, instance)
 	}
 
-	log.WithFields(logrus.Fields{
-		"numInstances":      instances.NumInstances(),
-		"numVPCs":           len(vpcs),
-		"numSubnets":        len(subnets),
-		"numSecurityGroups": len(securityGroups),
-	}).Info("Synchronized ENI information")
-
-	m.mutex.Lock()
-	m.instances = instances
 	m.subnets = subnets
 	m.vpcs = vpcs
 	m.securityGroups = securityGroups
-	m.mutex.Unlock()
 
 	return resyncStart
 }
 
 func (m *InstancesManager) InstanceSync(ctx context.Context, instanceID string) time.Time {
-	// Resync for a separate instance is not implemented yet, fallback to full resync.
-	return m.Resync(ctx)
+	// Instance incremental resync from different nodes should be executed in parallel,
+	// but must block the full API resync.
+	m.resyncLock.RLock()
+	defer m.resyncLock.RUnlock()
+	return m.resync(ctx, instanceID)
 }
 
 // UpdateENI updates the ENI definition of an ENI for a particular instance. If


### PR DESCRIPTION
Currently in AWS ipam mode, every IP allocation/release event would trigger a resync and fetches all the ENIs from instance API. To avoid this unnecessary and costly full resync, we introduced InstanceSync method to fetch ENIs only on relevant instance.

This patch implements InstanceSync for AWS IPAM.

Related: #25073

```release-note
pkg/aws: Improve event driven instance resync for AWS IPAM
```
