### PR TITLE
Fix metrics labeling with only directed source/destination context op…

### DIFF
--- a/pkg/hubble/metrics/api/context.go
+++ b/pkg/hubble/metrics/api/context.go
@@ -441,10 +441,10 @@ func (o *ContextOptions) getLabelValues(invert bool, flow *pb.Flow) (labels []st
 	if invert {
 		sourceLabel, destinationLabel = destinationLabel, sourceLabel
 	}
-	if len(o.Source) != 0 {
+	if o.includeSourceLabel() {
 		labels = append(labels, sourceLabel)
 	}
-	if len(o.Destination) != 0 {
+	if o.includeDestinationLabel() {
 		labels = append(labels, destinationLabel)
 	}
 	return
@@ -514,15 +514,23 @@ func (o *ContextOptions) GetLabelNames() (labels []string) {
 		}
 	}
 
-	if len(o.Source) != 0 {
+	if o.includeSourceLabel() {
 		labels = append(labels, "source")
 	}
 
-	if len(o.Destination) != 0 {
+	if o.includeDestinationLabel() {
 		labels = append(labels, "destination")
 	}
 
 	return
+}
+
+func (o *ContextOptions) includeSourceLabel() bool {
+	return len(o.Source) != 0 || len(o.SourceIngress) != 0 || len(o.SourceEgress) != 0
+}
+
+func (o *ContextOptions) includeDestinationLabel() bool {
+	return len(o.Destination) != 0 || len(o.DestinationIngress) != 0 || len(o.DestinationEgress) != 0
 }
 
 // Status returns the configuration status of context options suitable for use

--- a/pkg/hubble/metrics/api/context_test.go
+++ b/pkg/hubble/metrics/api/context_test.go
@@ -180,8 +180,23 @@ func TestParseGetLabelValues(t *testing.T) {
 		"destinationIngressContext": "pod",
 	})
 	assert.Nil(t, err)
-	assert.Nil(t,
+	assert.EqualValues(t,
+		[]string{""},
 		mustGetLabelValues(opts, &pb.Flow{Destination: &pb.Endpoint{Namespace: "foo", PodName: "foo-123"}, TrafficDirection: pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
+
+	opts, err = ParseContextOptions(Options{
+		"sourceIngressContext": "pod",
+	})
+	assert.Nil(t, err)
+	assert.EqualValues(t,
+		[]string{""},
+		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "worker"}}}, TrafficDirection: pb.TrafficDirection_TRAFFIC_DIRECTION_UNKNOWN}))
+	assert.EqualValues(t,
+		[]string{""},
+		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "api"}}}, TrafficDirection: pb.TrafficDirection_EGRESS}))
+	assert.EqualValues(t,
+		[]string{"foo/foo-123"},
+		mustGetLabelValues(opts, &pb.Flow{Source: &pb.Endpoint{Namespace: "foo", PodName: "foo-123", Workloads: []*pb.Workload{{Name: "api"}}}, TrafficDirection: pb.TrafficDirection_INGRESS}))
 
 	opts, err = ParseContextOptions(Options{"sourceContext": "namespace|dns", "destinationContext": "identity|pod|ip"})
 	assert.Nil(t, err)


### PR DESCRIPTION
…tions set.

Fixes: #27717

Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.

In case only directed Source/Destination Ingress/Egress context options were specified, metrics were incorrectly labeled. this change ensures that correct labels are included when only directed options are specified in metrics configuration.

Fixes: #27717

```release-note
Fix hubble metric labeling when only directed Source/Destination Ingress/Egress options are specified.
```
