### PR TITLE
fqdn: Garbage collect FQDNs left by deleted endpoints

### DIFF
--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -595,6 +595,18 @@ func (c *DNSCache) ForceExpire(expireLookupsBefore time.Time, nameMatch *regexp.
 	return slices.Unique(namesAffected)
 }
 
+// Names returns the FQDN entries in the cache
+func (c *DNSCache) Names() (names []string) {
+	c.RLock()
+	defer c.RUnlock()
+
+	names = make([]string, 0, len(c.forward))
+	for name := range c.forward {
+		names = append(names, name)
+	}
+	return names
+}
+
 func (c *DNSCache) forceExpireByNames(expireLookupsBefore time.Time, names []string) (namesAffected []string) {
 	for _, name := range names {
 		entries, exists := c.forward[name]
@@ -768,6 +780,18 @@ func NewDNSZombieMappings(max, perHostLimit int) *DNSZombieMappings {
 		max:          max,
 		perHostLimit: perHostLimit,
 	}
+}
+
+// Names returns the FQDN entries referred to in the DNSZombieMappings
+func (zombies *DNSZombieMappings) Names() []string {
+	zombies.Lock()
+	defer zombies.Unlock()
+
+	names := make([]string, 0, len(zombies.deletes))
+	for _, zombie := range zombies.deletes {
+		names = append(names, zombie.Names...)
+	}
+	return slices.Unique(names)
 }
 
 // Upsert enqueues the ip -> qname as a possible deletion


### PR DESCRIPTION
If an FQDN policy applies to multiple pods, but only subset of them query a specific FQDN then the identities and policy map entries for that name and IPs may be left behind and not garbage collected until the remaining pods are either deleted or also query the name.

To reiterate with an example:
```
  NetworkPolicy:
    toFQDNs:
      matchName: foo.bar

  T0:
    pod1: queries foo.bar => 1.1.1.1
    pod1 policy map: "Allow 1.1.1.1"

    pod2: idles
    pod2 policy map: []

    identities: 1.1.1.1 => 167777217

  T+1: policy map regeneration
    DNS garbage collection:
      namesToClean = []
      for endpoint in [pod1, pod2]:
        namesToClean += "foo.bar"
      ForceGenerateDNS(namesToClean) // ["foo.bar"]

    pod1 policy map: "Allow 1.1.1.1"
    pod2 policy map: "Allow 1.1.1.1"

    identities: 1.1.1.1 => 167777217

  T+2:
    pod1: terminates
    pod2: idles

    pod2 policy map: "Allow 1.1.1.1"
    identities: 1.1.1.1 => 167777217

  T+3:
    DNS garbage collection:
      namesToClean = []
      for endpoint in [pod2]:
        pass, no FQDN entries
      ForceGenerateDNS(namesToClean) // []

    pod2 policy map: "Allow 1.1.1.1"
    identities: 1.1.1.1 => 167777217
```

Since the DNS garbage collection job only collects from existing endpoints the name "foo.bar" and identity for 1.1.1.1 are never released.

To fix the issue, the FQDN GC subscribes to endpoint deletions and stores all FQDN names that have been mentioned in deleted endpoints and will use that information on the next GC round:
```
  T+2:
    pod1: terminates
    namesFromDeletedEndpoints += "foo.bar"

  T+3:
    DNS garbage collection:
      namesToClean = namesFromDeletedEndpoints
      namesFromDeletedEndpoints = []
      for endpoint in [pod2]:
        pass, no FQDN entries

      ForceGenerateDNS(namesToClean) // ["foo.bar"]

    pod2 policy map: []
    identities: []
```

Fixes: f6ce522d55 ("FQDN: Added garbage collector functions.")

```release-note
Garbage collect FQDNs left behind by terminated pods that were kept alive by other pods sharing the same ToFQDN policy.
```
