### PR TITLE
identity/cache: only call SortedList for release

### DIFF
--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -81,11 +81,15 @@ func (l *localIdentityCache) getNextFreeNumericIdentity(idCandidate identity.Num
 // in as the 'oldNID' parameter; identity.InvalidIdentity must be passed if no
 // previous numeric identity exists. 'oldNID' will be reallocated if available.
 func (l *localIdentityCache) lookupOrCreate(lbls labels.Labels, oldNID identity.NumericIdentity) (*identity.Identity, bool, error) {
+	// Not converting to string saves an allocation, as byte key lookups into
+	// string maps are optimized by the compiler, see
+	// https://github.com/golang/go/issues/3512.
+	repr := lbls.SortedList()
+
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	stringRepresentation := string(lbls.SortedList())
-	if id, ok := l.identitiesByLabels[stringRepresentation]; ok {
+	if id, ok := l.identitiesByLabels[string(repr)]; ok {
 		id.ReferenceCount++
 		return id, false, nil
 	}
@@ -102,7 +106,7 @@ func (l *localIdentityCache) lookupOrCreate(lbls labels.Labels, oldNID identity.
 		ReferenceCount: 1,
 	}
 
-	l.identitiesByLabels[stringRepresentation] = id
+	l.identitiesByLabels[string(repr)] = id
 	l.identitiesByID[numericIdentity] = id
 
 	if l.events != nil {
@@ -123,7 +127,7 @@ func (l *localIdentityCache) release(id *identity.Identity) bool {
 	l.mutex.Lock()
 	defer l.mutex.Unlock()
 
-	if id, ok := l.identitiesByLabels[string(id.Labels.SortedList())]; ok {
+	if id, ok := l.identitiesByID[id.ID]; ok {
 		switch {
 		case id.ReferenceCount > 1:
 			id.ReferenceCount--
@@ -132,8 +136,7 @@ func (l *localIdentityCache) release(id *identity.Identity) bool {
 		case id.ReferenceCount == 1:
 			// Release is only attempted once, when the reference count is
 			// hitting the last use
-			stringRepresentation := string(id.Labels.SortedList())
-			delete(l.identitiesByLabels, stringRepresentation)
+			delete(l.identitiesByLabels, string(id.Labels.SortedList()))
 			delete(l.identitiesByID, id.ID)
 
 			if l.events != nil {

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -296,6 +296,19 @@ func BenchmarkGetCIDRLabels(b *testing.B) {
 	}
 }
 
+// This benchmarks Labels.SortedList(), but cannot live in the labels package
+// without causing an import cycle. We want to benchmark this specific case, as
+// it is excercised by toFQDN policies.
+func BenchmarkLabels_SortedListCIDRIDs(b *testing.B) {
+	lbls := GetCIDRLabels(netip.MustParsePrefix("123.123.123.123/32"))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = lbls.SortedList()
+	}
+}
+
 func BenchmarkIPStringToLabel(b *testing.B) {
 	for _, ip := range []string{
 		"0.0.0.0/0",

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -483,13 +483,24 @@ func (l Label) FormatForKVStore() []byte {
 	// kvstore.prefixMatchesKey())
 	b := make([]byte, 0, len(l.Source)+len(l.Key)+len(l.Value)+3)
 	buf := bytes.NewBuffer(b)
+	l.formatForKVStoreInto(buf)
+	return buf.Bytes()
+}
+
+// formatForKVStoreInto writes the label as a formatted string, ending in
+// a semicolon into buf.
+//
+// DO NOT BREAK THE FORMAT OF THIS. THE RETURNED STRING IS USED AS
+// PART OF THE KEY IN THE KEY-VALUE STORE.
+//
+// Non-pointer receiver allows this to be called on a value in a map.
+func (l Label) formatForKVStoreInto(buf *bytes.Buffer) {
 	buf.WriteString(l.Source)
 	buf.WriteRune(':')
 	buf.WriteString(l.Key)
 	buf.WriteRune('=')
 	buf.WriteString(l.Value)
 	buf.WriteRune(';')
-	return buf.Bytes()
 }
 
 // SortedList returns the labels as a sorted list, separated by semicolon
@@ -503,10 +514,21 @@ func (l Labels) SortedList() []byte {
 	}
 	sort.Strings(keys)
 
-	b := make([]byte, 0, len(keys)*2)
+	// Labels can have arbitrary size. However, when many CIDR identities are in
+	// the system, for example due to a FQDN policy matching S3, CIDR labels
+	// dominate in number. IPv4 CIDR labels in serialized form are max 25 bytes
+	// long. Allocate slightly more to avoid having a realloc if there's some
+	// other labels which may longer, since the cost of allocating a few bytes
+	// more is dominated by a second allocation, especially since these
+	// allocations are short-lived.
+	//
+	// cidr:123.123.123.123/32=;
+	// 0        1         2
+	// 1234567890123456789012345
+	b := make([]byte, 0, len(keys)*30)
 	buf := bytes.NewBuffer(b)
 	for _, k := range keys {
-		buf.Write(l[k].FormatForKVStore())
+		l[k].formatForKVStoreInto(buf)
 	}
 
 	return buf.Bytes()


### PR DESCRIPTION
First commit introduces a specific benchmark, the next two commits are optimizations. Commit msgs should be descriptive. The first optimization commit does not improve benchmark time as the benchmark doesn't exercise that path, but the second optimization clearly improves benchmark time.

Below the metrics of a kind cluster which runs 10 pods which send a single UDP packet to `host1.test.org.`, while having a custom DNS server which responds with 5 random IPs for `host1.test.org.` with a TTL of 5 seconds. This mimicks S3 behaviour.

In the graph, you can see that there's a doubling of identities, that's the identity restoration grace period of 10 minutes; it shows when the pods were restarted with the two commits of this PR applied. They show an approximate reduction of 5MiB/s and 50KHz allocations.
   
![image](https://github.com/cilium/cilium/assets/7094770/3dd9f9f1-7ecb-4921-b6a8-494e2bd3114b)


