### PR TITLE
docker: allow more non-quay registries

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -63,8 +63,8 @@ GIT_IGNORE_FILES := $(shell find . -not -path "./vendor*" -name .gitignore -prin
 		{DIR}.gitignore >> $@
 
 DOCKER_REGISTRY ?= quay.io
-ifeq ($(findstring /,$(DOCKER_DEV_ACCOUNT)),/)
-    # DOCKER_DEV_ACCOUNT already contains '/', assume it specifies a registry
+ifneq (,$(or $(findstring /,$(DOCKER_DEV_ACCOUNT)), $(findstring :,$(DOCKER_DEV_ACCOUNT))))
+    # DOCKER_DEV_ACCOUNT already contains '/' or ':' (like localhost:5000), assume it specifies a registry
     IMAGE_REPOSITORY := $(DOCKER_DEV_ACCOUNT)
 else
     IMAGE_REPOSITORY := $(DOCKER_REGISTRY)/$(DOCKER_DEV_ACCOUNT)


### PR DESCRIPTION
I would like to use `localhost:5000` as the docker destination. Currently, only registries with a `/` can be used, or they are interpretted as `quay.io/<registry>`.

This enhances this check to also treat anything with a `:` as non-quay.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

