### PR TITLE
cilium/cmd: make output of 'cilium policy selectors' sorted.

### DIFF
--- a/cilium/cmd/policy_selectors.go
+++ b/cilium/cmd/policy_selectors.go
@@ -6,6 +6,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -26,7 +27,10 @@ var policyCacheGetCmd = &cobra.Command{
 			}
 		} else if resp != nil {
 			w := tabwriter.NewWriter(os.Stdout, 5, 0, 3, ' ', 0)
-
+			// Sort to keep output stable
+			sort.Slice(resp, func(i, j int) bool {
+				return resp[i].Selector < resp[j].Selector
+			})
 			fmt.Fprintf(w, "SELECTOR\tUSERS\tIDENTITIES\n")
 			for _, mapping := range resp {
 				first := true


### PR DESCRIPTION
Previously, the output would be sent in no particular order, thus when running the 'policy selectors' command output would often be printed in different order. This makes it hard to compare subsequent outputs.

This PR simply sorts output by selector string before it is printed to make the ordering stable.