### PR TITLE
policy: Fix potential nil pointer deref in selectorManager.GetSelections

### DIFF
--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -369,7 +369,11 @@ func (s *selectorManager) Equal(b *selectorManager) bool {
 // of the selections. If the old version is returned, the user is
 // guaranteed to receive a notification including the update.
 func (s *selectorManager) GetSelections() []identity.NumericIdentity {
-	return *s.selections.Load()
+	selections := s.selections.Load()
+	if selections == nil {
+		return emptySelection
+	}
+	return *selections
 }
 
 // Selects return 'true' if the CachedSelector selects the given

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -610,6 +610,21 @@ func (ds *SelectorCacheTestSuite) TestIdentityUpdatesMultipleUsers(c *C) {
 	c.Assert(len(sc.selectors), Equals, 0)
 }
 
+func (ds *SelectorCacheTestSuite) TestSelectorManagerCanGetBeforeSet(c *C) {
+	defer func() {
+		r := recover()
+		c.Assert(r, Equals, nil)
+	}()
+
+	selectorManager := selectorManager{
+		key:   "test",
+		users: make(map[CachedSelectionUser]struct{}),
+	}
+	selections := selectorManager.GetSelections()
+	c.Assert(selections, Not(Equals), nil)
+	c.Assert(len(selections), Equals, 0)
+}
+
 func testNewSelectorCache(ids cache.IdentityCache) *SelectorCache {
 	sc := NewSelectorCache(testidentity.NewMockIdentityAllocator(ids), ids)
 	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!
  
This commit address the case in which `selectorManager.GetSelections` is called before `selectorManager.updateSelections` is called, which can cause a panic due to a nil pointer dereference in case the internal `selectorManager.selections` field is nil. To address this case, if the `selectorManager` has a nil value for its internal field `selections`, then `emptySelection` is returned.
    
The reason `GetSelections` cannot modify the internal `selections` field if it sees that it is nil is because `selectorManager.setSelections` requires the managing `SelectorCache.mutex` to be locked. This cannot be guaranteed inside a call to `selectorManager.GetSelections`, which does not require locking.

This needs to be backported to 1.14, 1.1,3 and 1.12, please. Versions 1.13 and 1.12 will have a merge conflict due to changes made in commit https://github.com/cilium/cilium/commit/9397655c7ce93eb5ecc7d518960f987cc5b0c3f4, which adjusted how the atomic pointer is loaded. The needed change for these versions should look something like this:

```diff
diff --git a/pkg/policy/selectorcache.go b/pkg/policy/selectorcache.go
index afcccc054b..a478519cf9 100644
--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -337,7 +337,12 @@ func (s *selectorManager) Equal(b *selectorManager) bool {
 // of the selections. If the old version is returned, the user is
 // guaranteed to receive a notification including the update.
 func (s *selectorManager) GetSelections() []identity.NumericIdentity {
-       return *(*[]identity.NumericIdentity)(atomic.LoadPointer(&s.selections))
+       selections := (*[]identity.NumericIdentity)(atomic.LoadPointer(&s.selections))
+       if selections == nil {
+               return emptySelection
+       }
+
+       return *selections
 }
 
 // Selects return 'true' if the CachedSelector selects the given
diff --git a/pkg/policy/selectorcache_test.go b/pkg/policy/selectorcache_test.go
index bc2fe04620..8fb47141db 100644
--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -610,6 +610,21 @@ func (ds *SelectorCacheTestSuite) TestIdentityUpdatesMultipleUsers(c *C) {
        c.Assert(len(sc.selectors), Equals, 0)
 }
 
+func (ds *SelectorCacheTestSuite) TestSelectorManagerCanGetBeforeSet(c *C) {
+       defer func() {
+               r := recover()
+               c.Assert(r, Equals, nil)
+       }()
+
+       selectorManager := selectorManager{
+               key:              "test",
+               users:            make(map[CachedSelectionUser]struct{}),
+       }
+       selections := selectorManager.GetSelections()
+       c.Assert(selections, Not(Equals), nil)
+       c.Assert(len(selections), Equals, 0)
+}
+
 func testNewSelectorCache(ids cache.IdentityCache) *SelectorCache {
        sc := NewSelectorCache(testidentity.NewMockIdentityAllocator(ids), ids)
        sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())
```

```release-note
Fix potential nil pointer dereference in SelectorManager implementation
```
