### PR TITLE
contrib: Add support for X.Y.Z-pre.N releases

### DIFF
--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -4,7 +4,8 @@
 
 set -e
 
-RELEASE_REGEX="[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(\(rc\)\|\(snapshot\)\)\(\.\)\?[0-9]\+\)\?$"
+RELEASE_REGEX="[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(\(rc\)\|\(pre\)\)\(\.\)\?[0-9]\+\)\?$"
+RELEASE_FORMAT_MSG="Expected X.Y.Z-[rc.N|pre.N]"
 
 get_remote () {
   local remote

--- a/contrib/release/prep-changelog.sh
+++ b/contrib/release/prep-changelog.sh
@@ -33,12 +33,12 @@ handle_args() {
 
     if ! echo "$1" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; Expected X.Y.Z[-rc.W|-snapshot.W]"
+        common::exit 1 "Invalid OLD-VERSION ARG \"$1\"; $RELEASE_FORMAT_MSG"
     fi
 
     if ! echo "$2" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid NEW-VERSION ARG \"$2\"; Expected X.Y.Z[-rc.W|-snapshot.W]"
+        common::exit 1 "Invalid NEW-VERSION ARG \"$2\"; $RELEASE_FORMAT_MSG"
     fi
 
     if [ "$#" -eq 3 ] && ! echo "$3" | grep -q "[0-9]\+\.[0-9]\+"; then

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -25,7 +25,7 @@ usage() {
 # $1 - VERSION
 version_is_prerelease() {
     case "$1" in
-        *rc*|*snapshot*)
+        *pre*|*rc*|*snapshot*)
             return 0
             ;;
         *)
@@ -47,7 +47,7 @@ handle_args() {
 
     if ! echo "$1" | grep -q "$RELEASE_REGEX"; then
         usage 2>&1
-        common::exit 1 "Invalid VERSION ARG \"$1\"; Expected X.Y.Z"
+        common::exit 1 "Invalid VERSION ARG \"$1\"; $RELEASE_FORMAT_MSG"
     fi
 
     if ! echo "$2" | grep -q "^[0-9]\+" && ! version_is_prerelease "$1"; then
@@ -84,7 +84,7 @@ main() {
     if [ "$branch" = "main" ]; then
         git checkout -b pr/prepare-$version $REMOTE/$branch
         if ! version_is_prerelease "$version"; then
-            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'rc\|snapshot' | sort -V | tail -n 1)"
+            old_version="$(git tag -l "$VERSION_GLOB" | grep -v 'pre\|rc\|snapshot' | sort -V | tail -n 1)"
         else
             old_version="$(git tag -l "$VERSION_GLOB" | sort -V | tail -n 1)"
         fi


### PR DESCRIPTION
Previously with "vX.Y.Z-snapshot.N" release tagging for monthly
snapshots, we found that this caused an ordering problem once we started
releasing "vX.Y.Z-rc.N" versions. This is because -snapshot is a higher
version than -rc. When other projects attempted to update their Go mod
dependencies for Cilium, it would select the previous month's snapshot
release instead of the new RC.

This commit therefore removes support for -snapshot and adds -pre
instead for periodic (monthly) snapshots of Cilium, starting during the
v1.15.0-dev development cycle. Commands that list previous tags need to
retain the "-snapshot" matches, but the input validation will no longer
allow this version format.

Related: https://github.com/cilium/cilium/issues/14157