### PR TITLE
Extend Integration Test timeout

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -107,7 +107,7 @@ jobs:
           ./.travis/prepare.sh
 
       - name: Run integration tests
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           export PATH=/usr/local/clang/bin:$PATH
           export V=0


### PR DESCRIPTION
We saw some timeouts.

```release-note
Extend Integration Test timeout
```
