### PR TITLE
docs: Update the microservices-demo link

### DIFF
--- a/Documentation/network/servicemesh/grpc.rst
+++ b/Documentation/network/servicemesh/grpc.rst
@@ -20,14 +20,14 @@ For this demo we will use `GCP's microservices demo app <https://github.com/Goog
 
 .. code-block:: shell-session
 
-    $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/release/kubernetes-manifests.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/release/kubernetes-manifests.yaml
 
 Since gRPC is binary-encoded, you also need the proto definitions for the gRPC
 services in order to make gRPC requests. Download this for the demo app:
 
 .. code-block:: shell-session
 
-    $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/pb/demo.proto
+    $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/protos/demo.proto
 
 
 Deploy GRPC Ingress

--- a/Documentation/network/servicemesh/tls-termination.rst
+++ b/Documentation/network/servicemesh/tls-termination.rst
@@ -104,7 +104,7 @@ Make HTTPS Requests
         .. code-block:: shell-session
 
             # Download demo.proto file if you have not done before
-            $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/pb/demo.proto
+            $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/protos/demo.proto
             $ grpcurl -proto ./demo.proto -cacert minica.pem hipstershop.cilium.rocks:443 hipstershop.ProductCatalogService/ListProducts
 
     .. group-tab:: Cert Manager


### PR DESCRIPTION
The demo.proto download directory has been renamed from 'pb' to 'protos' by the commit [1].

Also, update the microservices-demo brance name to 'main'.

[1]
https://github.com/GoogleCloudPlatform/microservices-demo/commit/76571f537c703c1409ae3186357d88f3e60deddc