### PR TITLE
ingress: fix panic on ingress rule without HTTPIngressRule

### DIFF
--- a/operator/pkg/model/ingestion/ingress.go
+++ b/operator/pkg/model/ingestion/ingress.go
@@ -90,6 +90,12 @@ func Ingress(ing slim_networkingv1.Ingress, defaultSecretNamespace, defaultSecre
 		}
 
 		l.Hostname = host
+		if rule.HTTP == nil {
+			log.WithField(logfields.Ingress, ing.Namespace+"/"+ing.Name).
+				Warn("Invalid Ingress rule without spec.rules.HTTP defined, skipping rule")
+			continue
+		}
+
 		for _, path := range rule.HTTP.Paths {
 
 			route := model.HTTPRoute{}


### PR DESCRIPTION
Currently, defining an `Ingress` without an `HTTPIngressRule` (e.g. only Host set) results in a panic in the Cilium Operator.

Therefore, this commit changes the ingress ingestion to process the HTTP paths only if the HTTPIngressRule is set on the rule.