### PR TITLE
go.mod, renovate: specify and update Go toolchain version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -482,6 +482,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+_VERSION=\"(?<currentValue>.*)\""
       ]
+    },
+    {
+      "fileMatch": [
+        "^go.mod$",
+      ],
+      "matchStrings": [
+        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+go (?<currentValue>.*)"
+      ]
     }
   ]
 }

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -53,6 +53,10 @@ concurrency:
     }}
   cancel-in-progress: true
 
+env:
+  # renovate: datasource=golang-version depName=go
+  go-version: 1.21.0
+
 jobs:
   commit-status-start:
     name: Commit Status Start
@@ -371,11 +375,15 @@ jobs:
           provision: 'false'
           cmd: |
             cd /host
+            # The LVH image might ship with an arbitrary Go toolchain version,
+            # install the same Go toolchain version as current HEAD.
+            go install golang.org/dl/go${{ env.go-version }}@latest
+            go${{ env.go-version }} download
             # Install go-junit-report to generate junit files for the
             # privileged tests.
-            go install github.com/jstemmer/go-junit-report/v2@7fde4641acef5b92f397a8baf8309d1a45d608cc
+            go${{ env.go-version}} install github.com/jstemmer/go-junit-report/v2@7fde4641acef5b92f397a8baf8309d1a45d608cc
             export GOTEST_FORMATTER="/root/go/bin/go-junit-report -set-exit-code -iocopy -out test/runtime.xml"
-            make tests-privileged NO_COLOR=1
+            make tests-privileged NO_COLOR=1 GO=go${{ env.go-version }}
 
       - name: Debug failure on VM
         # Only debug the failure on the LVH that have Cilium running as a service,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/cilium/cilium
 
-go 1.21
+// renovate: datasource=golang-version depName=go
+go 1.21.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24


### PR DESCRIPTION
According to [1] as of Go 1.21 we either need to specify the full toolchain version in the `go` directive or add a `toolchain` directive with the concrete toolchain version. Opt for the former and make sure it's kept up to date by renovate bot.

[1] https://github.com/golang/go/issues/62278#issuecomment-1693538776
