### PR TITLE
Add missing ariane trigger phrases

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -53,6 +53,9 @@ triggers:
   /ci-ingress:
     workflows:
     - conformance-ingress.yaml
+  /ci-integration:
+    workflows:
+    - integration-test.yaml
   /ci-runtime:
     workflows:
     - conformance-runtime.yaml

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -53,6 +53,9 @@ triggers:
   /ci-ingress:
     workflows:
     - conformance-ingress.yaml
+  /ci-runtime:
+    workflows:
+    - conformance-runtime.yaml
   /ci-verifier:
     workflows:
     - tests-datapath-verifier.yaml

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -1,4 +1,4 @@
-name: Conformance Ingress
+name: Conformance Ingress (ci-ingress)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -1,4 +1,4 @@
-name: Conformance Runtime
+name: Conformance Runtime (ci-runtime)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Integration Tests (ci-integration)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:


### PR DESCRIPTION
Currently, the integration and runtime tests cannot be triggered separately via ariane. Add the missing trigger phrases. Also add the missing trigger phrase to the conformance ingress workflow name. See commits for details.
