### PR TITLE
Register cluster-id and cluster-name flags through hive

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -60,7 +60,7 @@ cilium-agent [flags]
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
       --cgroup-root string                                        Path to Cgroup2 filesystem
       --cluster-health-port int                                   TCP port for cluster-wide network connectivity health API (default 4240)
-      --cluster-id int                                            Unique identifier of the cluster
+      --cluster-id uint32                                         Unique identifier of the cluster
       --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -14,6 +14,8 @@ cilium-agent hive [flags]
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit stringToString                             API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cluster-id uint32                                         Unique identifier of the cluster
+      --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -20,6 +20,8 @@ cilium-agent hive dot-graph [flags]
       --agent-liveness-update-interval duration                   Interval at which the agent updates liveness time for the datapath (default 1s)
       --api-rate-limit stringToString                             API rate limiting configuration (example: --api-rate-limit endpoint-create=rate-limit:10/m,rate-burst:2) (default [])
       --certificates-directory string                             Root directory to find certificates specified in L7 TLS policy enforcement (default "/var/run/cilium/certs")
+      --cluster-id uint32                                         Unique identifier of the cluster
+      --cluster-name string                                       Name of the cluster (default "default")
       --clustermesh-config string                                 Path to the ClusterMesh configuration directory
       --clustermesh-ip-identities-sync-timeout duration           Timeout waiting for the initial synchronization of IPs and identities from remote clusters before local endpoints regeneration (default 1m0s)
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -11,6 +11,8 @@ cilium-operator-alibabacloud hive [flags]
 ### Options
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -17,6 +17,8 @@ cilium-operator-alibabacloud hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -11,6 +11,8 @@ cilium-operator-aws hive [flags]
 ### Options
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -17,6 +17,8 @@ cilium-operator-aws hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -11,6 +11,8 @@ cilium-operator-azure hive [flags]
 ### Options
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -17,6 +17,8 @@ cilium-operator-azure hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -11,6 +11,8 @@ cilium-operator-generic hive [flags]
 ### Options
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -17,6 +17,8 @@ cilium-operator-generic hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -11,6 +11,8 @@ cilium-operator hive [flags]
 ### Options
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -17,6 +17,8 @@ cilium-operator hive dot-graph [flags]
 ### Options inherited from parent commands
 
 ```
+      --cluster-id uint32                                    Unique identifier of the cluster
+      --cluster-name string                                  Name of the cluster (default "default")
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-k8s                                           Enable the k8s clientset (default true)

--- a/clustermesh-apiserver/users_mgmt_test.go
+++ b/clustermesh-apiserver/users_mgmt_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/goleak"
 
 	"github.com/cilium/cilium/operator/watchers"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/kvstore"
@@ -80,6 +81,10 @@ func TestUsersManagement(t *testing.T) {
 				ClusterUsersEnabled:    true,
 				ClusterUsersConfigPath: cfgPath,
 			}
+		}),
+
+		cell.Provide(func() cmtypes.ClusterInfo {
+			return cmtypes.ClusterInfo{ID: 10, Name: "fred"}
 		}),
 
 		cell.Provide(func(lc hive.Lifecycle) promise.Promise[kvstore.BackendOperationsUserMgmt] {

--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/auth"
 	"github.com/cilium/cilium/pkg/bgpv1"
 	"github.com/cilium/cilium/pkg/clustermesh"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/crypto/certificatemanager"
 	"github.com/cilium/cilium/pkg/datapath"
@@ -181,6 +182,7 @@ var (
 		cell.Provide(func(dp dptypes.Datapath) *k8s.ServiceCache { return k8s.NewServiceCache(dp.LocalNodeAddressing()) }),
 
 		// ClusterMesh is the Cilium's multicluster implementation.
+		cell.Config(cmtypes.DefaultClusterInfo),
 		clustermesh.Cell,
 
 		// L2announcer resolves l2announcement policies, services, node labels and devices into a list of IPs+netdevs

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -498,7 +498,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	})
 	if option.Config.EnableWellKnownIdentities {
 		// Must be done before calling policy.NewPolicyRepository() below.
-		num := identity.InitWellKnownIdentities(option.Config)
+		num := identity.InitWellKnownIdentities(option.Config, params.ClusterInfo)
 		metrics.Identity.WithLabelValues(identity.WellKnownIdentityType).Add(float64(num))
 	}
 
@@ -812,7 +812,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	treatRemoteNodeAsHost := option.Config.AlwaysAllowLocalhost() && !option.Config.EnableRemoteNodeIdentity
-	policyAPI.InitEntities(option.Config.ClusterName, treatRemoteNodeAsHost)
+	policyAPI.InitEntities(params.ClusterInfo.Name, treatRemoteNodeAsHost)
 
 	bootstrapStats.restore.Start()
 	// fetch old endpoints before k8s is configured.
@@ -1055,7 +1055,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		d.nodeDiscovery.JoinCluster(nodeTypes.GetName())
 
 		// Start services watcher
-		serviceStore.JoinClusterServices(d.k8sWatcher.K8sSvcCache, option.Config)
+		serviceStore.JoinClusterServices(d.k8sWatcher.K8sSvcCache, option.Config.ClusterName)
 	}
 
 	// Start IPAM

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/cgroups"
 	"github.com/cilium/cilium/pkg/clustermesh"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/common"
 	"github.com/cilium/cilium/pkg/components"
 	"github.com/cilium/cilium/pkg/controller"
@@ -190,12 +191,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.String(option.CGroupRoot, "", "Path to Cgroup2 filesystem")
 	option.BindEnv(vp, option.CGroupRoot)
-
-	flags.Int(option.ClusterIDName, 0, "Unique identifier of the cluster")
-	option.BindEnv(vp, option.ClusterIDName)
-
-	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")
-	option.BindEnv(vp, option.ClusterName)
 
 	flags.StringSlice(option.CompilerFlags, []string{}, "Extra CFLAGS for BPF compilation")
 	flags.MarkHidden(option.CompilerFlags)
@@ -1659,6 +1654,7 @@ type daemonParams struct {
 	CTNATMapGC          gc.Enabler
 	StoreFactory        store.Factory
 	EndpointRegenerator *endpoint.Regenerator
+	ClusterInfo         cmtypes.ClusterInfo
 }
 
 func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {

--- a/kvstoremesh/main.go
+++ b/kvstoremesh/main.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
@@ -15,6 +14,7 @@ import (
 	kmopt "github.com/cilium/cilium/kvstoremesh/option"
 	"github.com/cilium/cilium/pkg/clustermesh/kvstoremesh"
 	"github.com/cilium/cilium/pkg/clustermesh/types"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
@@ -66,7 +66,8 @@ func init() {
 		kmmetrics.Cell,
 
 		cell.Config(kmopt.KVStoreMeshConfig{}),
-		cell.Provide(cfgAdapter),
+		cell.Config(cmtypes.DefaultClusterInfo),
+		cell.Invoke(registerClusterInfoValidator),
 
 		kvstore.Cell(kvstore.EtcdBackendName),
 		cell.Provide(func() *kvstore.ExtraOptions { return nil }),
@@ -79,30 +80,15 @@ func init() {
 	rootCmd.AddCommand(rootHive.Command())
 }
 
+func registerClusterInfoValidator(lc hive.Lifecycle, cinfo types.ClusterInfo) {
+	lc.Append(hive.Hook{
+		OnStart: func(hive.HookContext) error { return cinfo.ValidateStrict() },
+	})
+}
+
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-}
-
-func cfgAdapter(lc hive.Lifecycle, cfg kmopt.KVStoreMeshConfig) (types.ClusterIDName, error) {
-	lc.Append(hive.Hook{
-		OnStart: func(hive.HookContext) error {
-			if err := types.ValidateClusterID(cfg.ClusterID); err != nil {
-				return err
-			}
-
-			if cfg.ClusterName == "" {
-				return errors.New("ClusterName is unset")
-			}
-
-			return nil
-		},
-	})
-
-	return types.ClusterIDName{
-		ClusterID:   cfg.ClusterID,
-		ClusterName: cfg.ClusterName,
-	}, nil
 }

--- a/kvstoremesh/option/config.go
+++ b/kvstoremesh/option/config.go
@@ -20,13 +20,8 @@ const (
 // Config is the KVStoreMeshConfig configuration.
 type KVStoreMeshConfig struct {
 	Debug bool
-
-	ClusterName string
-	ClusterID   uint32
 }
 
 func (def KVStoreMeshConfig) Flags(flags *pflag.FlagSet) {
 	flags.BoolP(option.DebugArg, "D", def.Debug, "Enable debugging mode")
-	flags.String(option.ClusterName, def.ClusterName, "Name of the cluster")
-	flags.Uint32(option.ClusterIDName, def.ClusterID, "Unique identifier of the cluster")
 }

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -47,13 +47,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Int64(operatorOption.ParallelAllocWorkers, defaults.ParallelAllocWorkers, "Maximum number of parallel IPAM workers")
 	option.BindEnv(vp, operatorOption.ParallelAllocWorkers)
 
-	// Clustermesh dedicated flags
-	flags.Uint32(option.ClusterIDName, 0, "Unique identifier of the cluster")
-	option.BindEnv(vp, option.ClusterIDName)
-
-	flags.String(option.ClusterName, defaults.ClusterName, "Name of the cluster")
-	option.BindEnv(vp, option.ClusterName)
-
 	// Operator-specific flags
 	flags.String(option.ConfigFile, "", `Configuration file (default "$HOME/ciliumd.yaml")`)
 	option.BindEnv(vp, option.ConfigFile)

--- a/operator/identitygc/cell.go
+++ b/operator/identitygc/cell.go
@@ -82,13 +82,7 @@ type SharedConfig struct {
 	// EnableMetrics enables prometheus metrics
 	EnableMetrics bool
 
-	// ClusterName is the name of the cluster
-	ClusterName string
-
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
 	K8sNamespace string
-
-	// ClusterID is the unique identifier of the cluster
-	ClusterID uint32
 }

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cilium/cilium/operator/auth/spire"
 	"github.com/cilium/cilium/operator/k8s"
 	"github.com/cilium/cilium/operator/watchers"
-	"github.com/cilium/cilium/pkg/defaults"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -43,6 +43,8 @@ func TestIdentitiesGC(t *testing.T) {
 	var authIdentityClient authIdentity.Provider
 
 	hive := hive.New(
+		cell.Config(cmtypes.DefaultClusterInfo),
+
 		// provide a fake clientset
 		k8sClient.FakeClientCell,
 		// provide a fake spire client
@@ -64,9 +66,7 @@ func TestIdentitiesGC(t *testing.T) {
 			return SharedConfig{
 				IdentityAllocationMode: option.IdentityAllocationModeCRD,
 				EnableMetrics:          false,
-				ClusterName:            defaults.ClusterName,
 				K8sNamespace:           "",
-				ClusterID:              0,
 			}
 		}),
 

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -28,13 +28,13 @@ func (igc *GC) startKVStoreModeGC(ctx context.Context) error {
 		return fmt.Errorf("unable to initialize kvstore backend for identity allocation")
 	}
 
-	ciliumIdentity.InitMinMaxIdentityAllocation(igc.allocationCfg)
+	ciliumIdentity.InitMinMaxIdentityAllocation(igc.allocationCfg, igc.clusterInfo)
 	minID := idpool.ID(ciliumIdentity.MinimalAllocationIdentity)
 	maxID := idpool.ID(ciliumIdentity.MaximumAllocationIdentity)
 	log.WithFields(map[string]interface{}{
 		"min":        minID,
 		"max":        maxID,
-		"cluster-id": igc.allocationCfg.LocalClusterID(),
+		"cluster-id": igc.clusterInfo.ID,
 	}).Info("Garbage Collecting identities between range")
 
 	igc.allocator = allocator.NewAllocatorForGC(backend, allocator.WithMin(minID), allocator.WithMax(maxID))

--- a/pkg/clustermesh/cell.go
+++ b/pkg/clustermesh/cell.go
@@ -5,7 +5,6 @@ package clustermesh
 
 import (
 	"github.com/cilium/cilium/pkg/clustermesh/common"
-	"github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -13,7 +12,6 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	nodemanager "github.com/cilium/cilium/pkg/node/manager"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 var Cell = cell.Module(
@@ -29,9 +27,6 @@ var Cell = cell.Module(
 		return nodeStore.NewNodeObserver(mgr), mgr.ClusterSizeDependantInterval
 	}),
 	cell.ProvidePrivate(func() store.KeyCreator { return nodeStore.KeyCreator }),
-	cell.ProvidePrivate(func(cfg *option.DaemonConfig) types.ClusterIDName {
-		return types.ClusterIDName{ClusterID: cfg.ClusterID, ClusterName: cfg.ClusterName}
-	}),
 	cell.ProvidePrivate(idsMgrProvider),
 
 	cell.Config(common.Config{}),

--- a/pkg/clustermesh/clustermesh_test.go
+++ b/pkg/clustermesh/clustermesh_test.go
@@ -20,14 +20,12 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	cmutils "github.com/cilium/cilium/pkg/clustermesh/utils"
 	"github.com/cilium/cilium/pkg/hive/hivetest"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/lock"
 	nodeStore "github.com/cilium/cilium/pkg/node/store"
-	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/testutils"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 )
@@ -97,7 +95,6 @@ func TestClusterMesh(t *testing.T) {
 
 	kvstore.SetupDummy(t, "etcd")
 
-	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	<-mgr.InitIdentityAllocator(nil)
@@ -142,7 +139,7 @@ func TestClusterMesh(t *testing.T) {
 	storeFactory := store.NewFactory(store.MetricsProvider())
 	cm := NewClusterMesh(hivetest.Lifecycle(t), Configuration{
 		Config:                common.Config{ClusterMeshConfig: dir},
-		ClusterIDName:         types.ClusterIDName{ClusterID: 255, ClusterName: "test2"},
+		ClusterInfo:           types.ClusterInfo{ID: 255, Name: "test2"},
 		NodeKeyCreator:        testNodeCreator,
 		NodeObserver:          &testObserver{},
 		RemoteIdentityWatcher: mgr,

--- a/pkg/clustermesh/common/config_test.go
+++ b/pkg/clustermesh/common/config_test.go
@@ -119,7 +119,7 @@ func (s *ClusterMeshTestSuite) TestWatchConfigDirectory(c *C) {
 
 	gcm := NewClusterMesh(Configuration{
 		Config:           Config{ClusterMeshConfig: baseDir},
-		ClusterIDName:    types.ClusterIDName{ClusterID: 255, ClusterName: "test2"},
+		ClusterInfo:      types.ClusterInfo{ID: 255, Name: "test2"},
 		NewRemoteCluster: func(string, StatusFunc) RemoteCluster { return &fakeRemoteCluster{} },
 		Metrics:          MetricsProvider("clustermesh")(),
 	})

--- a/pkg/clustermesh/kvstoremesh/kvstoremesh.go
+++ b/pkg/clustermesh/kvstoremesh/kvstoremesh.go
@@ -33,7 +33,7 @@ type KVStoreMesh struct {
 type params struct {
 	cell.In
 
-	types.ClusterIDName
+	ClusterInfo types.ClusterInfo
 	common.Config
 
 	BackendPromise promise.Promise[kvstore.BackendOperations]
@@ -49,7 +49,7 @@ func newKVStoreMesh(lc hive.Lifecycle, params params) *KVStoreMesh {
 	}
 	km.common = common.NewClusterMesh(common.Configuration{
 		Config:           params.Config,
-		ClusterIDName:    params.ClusterIDName,
+		ClusterInfo:      params.ClusterInfo,
 		NewRemoteCluster: km.newRemoteCluster,
 		Metrics:          params.Metrics,
 	})

--- a/pkg/clustermesh/services_test.go
+++ b/pkg/clustermesh/services_test.go
@@ -21,7 +21,6 @@ import (
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/hive/hivetest"
-	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/k8s"
@@ -32,7 +31,6 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
-	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/rand"
 	serviceStore "github.com/cilium/cilium/pkg/service/store"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -76,7 +74,6 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 
 	kvstore.Client().DeletePrefix(context.TODO(), "cilium/state/services/v1/"+s.randomName)
 	s.svcCache = k8s.NewServiceCache(fakeDatapath.NewNodeAddressing())
-	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 
 	mgr := cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
@@ -108,7 +105,7 @@ func (s *ClusterMeshServicesTestSuite) SetUpTest(c *C) {
 	store := store.NewFactory(store.MetricsProvider())
 	s.mesh = NewClusterMesh(hivetest.Lifecycle(c), Configuration{
 		Config:                common.Config{ClusterMeshConfig: dir},
-		ClusterIDName:         types.ClusterIDName{ClusterID: 255, ClusterName: "test2"},
+		ClusterInfo:           types.ClusterInfo{ID: 255, Name: "test2"},
 		NodeKeyCreator:        testNodeCreator,
 		NodeObserver:          &testObserver{},
 		ServiceMerger:         s.svcCache,

--- a/pkg/clustermesh/types/option.go
+++ b/pkg/clustermesh/types/option.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/defaults"
+)
+
+const (
+	// OptClusterName is the name of the OptClusterName option
+	OptClusterName = "cluster-name"
+
+	// OptClusterID is the name of the OptClusterID option
+	OptClusterID = "cluster-id"
+)
+
+// ClusterInfo groups together the ClusterID and the ClusterName
+type ClusterInfo struct {
+	ID   uint32 `mapstructure:"cluster-id"`
+	Name string `mapstructure:"cluster-name"`
+}
+
+// DefaultClusterInfo represents the default ClusterInfo values.
+var DefaultClusterInfo = ClusterInfo{
+	ID:   0,
+	Name: defaults.ClusterName,
+}
+
+// Flags implements the cell.Flagger interface, to register the given flags.
+func (def ClusterInfo) Flags(flags *pflag.FlagSet) {
+	flags.Uint32(OptClusterID, def.ID, "Unique identifier of the cluster")
+	flags.String(OptClusterName, def.Name, "Name of the cluster")
+}
+
+// Validate validates that the ClusterID is in the valid range (including ClusterID == 0),
+// and that the ClusterName is different from the default value if the ClusterID != 0.
+func (c ClusterInfo) Validate() error {
+	if c.ID < ClusterIDMin || c.ID > ClusterIDMax {
+		return fmt.Errorf("invalid cluster id %d: must be in range %d..%d",
+			c.ID, ClusterIDMin, ClusterIDMax)
+	}
+
+	return c.validateName()
+}
+
+// ValidateStrict validates that the ClusterID is in the valid range, but not 0,
+// and that the ClusterName is different from the default value.
+func (c ClusterInfo) ValidateStrict() error {
+	if err := ValidateClusterID(c.ID); err != nil {
+		return err
+	}
+
+	return c.validateName()
+}
+
+func (c ClusterInfo) validateName() error {
+	if c.ID != 0 && c.Name == defaults.ClusterName {
+		return fmt.Errorf("cannot use default cluster name (%s) with option %s",
+			defaults.ClusterName, OptClusterID)
+	}
+
+	return nil
+}

--- a/pkg/clustermesh/types/option_test.go
+++ b/pkg/clustermesh/types/option_test.go
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterInfoValidate(t *testing.T) {
+	assert.NoError(t, ClusterInfo{ID: 0, Name: "default"}.Validate())
+	assert.NoError(t, ClusterInfo{ID: 0, Name: "foo"}.Validate())
+	assert.NoError(t, ClusterInfo{ID: 1, Name: "foo"}.Validate())
+	assert.NoError(t, ClusterInfo{ID: 255, Name: "foo"}.Validate())
+	assert.Error(t, ClusterInfo{ID: 74, Name: "default"}.Validate())
+	assert.Error(t, ClusterInfo{ID: 256, Name: "foo"}.Validate())
+
+	assert.Error(t, ClusterInfo{ID: 0, Name: "default"}.ValidateStrict())
+	assert.Error(t, ClusterInfo{ID: 0, Name: "foo"}.ValidateStrict())
+	assert.NoError(t, ClusterInfo{ID: 1, Name: "foo"}.ValidateStrict())
+	assert.NoError(t, ClusterInfo{ID: 255, Name: "foo"}.ValidateStrict())
+	assert.Error(t, ClusterInfo{ID: 74, Name: "default"}.ValidateStrict())
+	assert.Error(t, ClusterInfo{ID: 256, Name: "foo"}.ValidateStrict())
+}

--- a/pkg/clustermesh/types/types.go
+++ b/pkg/clustermesh/types/types.go
@@ -71,9 +71,3 @@ func (c *CiliumClusterConfig) Validate(mode ValidationMode) error {
 
 	return nil
 }
-
-// ClusterIDName groups together the ClusterID and the ClusterName
-type ClusterIDName struct {
-	ClusterID   uint32
-	ClusterName string
-}

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -31,7 +31,6 @@ import (
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
-	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -141,7 +140,6 @@ func NewCachingIdentityAllocator(owner cache.IdentityAllocatorOwner) fakeIdentit
 func (s *EndpointSuite) SetUpTest(c *C) {
 	/* Required to test endpoint CEP policy model */
 	kvstore.SetupDummy(c, "etcd")
-	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	<-mgr.InitIdentityAllocator(nil)

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/option"
-	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
@@ -136,7 +135,6 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	// Setup dependencies for endpoint.
 	kvstore.SetupDummy(c, "etcd")
 
-	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
 
 	mgr := NewCachingIdentityAllocator(idAllocatorOwner)
@@ -362,7 +360,6 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	defer policy.SetPolicyEnabled(oldPolicyEnable)
 	policy.SetPolicyEnabled(option.DefaultEnforcement)
 
-	identity.InitWellKnownIdentities(&fakeConfig.Config{})
 	idAllocatorOwner := &DummyIdentityAllocatorOwner{}
 
 	mgr := NewCachingIdentityAllocator(idAllocatorOwner)

--- a/pkg/identity/cache/allocation_test.go
+++ b/pkg/identity/cache/allocation_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/allocator"
 	"github.com/cilium/cilium/pkg/checker"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	cacheKey "github.com/cilium/cilium/pkg/identity/key"
 	"github.com/cilium/cilium/pkg/idpool"
@@ -228,7 +229,7 @@ func (ias *IdentityAllocatorSuite) TestEventWatcherBatching(c *C) {
 }
 
 func (ias *IdentityAllocatorSuite) TestGetIdentityCache(c *C) {
-	identity.InitWellKnownIdentities(&fakeConfig.Config{})
+	identity.InitWellKnownIdentities(&fakeConfig.Config{}, cmtypes.ClusterInfo{Name: "default", ID: 5})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(newDummyOwner())
 	<-mgr.InitIdentityAllocator(nil)
@@ -246,7 +247,7 @@ func (ias *IdentityAllocatorSuite) TestAllocator(c *C) {
 	lbls3 := labels.NewLabelsFromSortedList("id=bar;user=susan")
 
 	owner := newDummyOwner()
-	identity.InitWellKnownIdentities(&fakeConfig.Config{})
+	identity.InitWellKnownIdentities(&fakeConfig.Config{}, cmtypes.ClusterInfo{Name: "default", ID: 5})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(owner)
 	<-mgr.InitIdentityAllocator(nil)
@@ -331,7 +332,7 @@ func (ias *IdentityAllocatorSuite) TestLocalAllocation(c *C) {
 	lbls1 := labels.NewLabelsFromSortedList("cidr:192.0.2.3/32")
 
 	owner := newDummyOwner()
-	identity.InitWellKnownIdentities(&fakeConfig.Config{})
+	identity.InitWellKnownIdentities(&fakeConfig.Config{}, cmtypes.ClusterInfo{Name: "default", ID: 5})
 	// The nils are only used by k8s CRD identities. We default to kvstore.
 	mgr := NewCachingIdentityAllocator(owner)
 	<-mgr.InitIdentityAllocator(nil)

--- a/pkg/identity/cache/cache_test.go
+++ b/pkg/identity/cache/cache_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/cilium/checkmate"
 
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/labels"
 	fakeConfig "github.com/cilium/cilium/pkg/option/fake"
@@ -57,7 +58,7 @@ func (s *IdentityCacheTestSuite) TestLookupReservedIdentity(c *C) {
 	c.Assert(id, Not(IsNil))
 	c.Assert(id.ID, Equals, worldID)
 
-	identity.InitWellKnownIdentities(&fakeConfig.Config{})
+	identity.InitWellKnownIdentities(&fakeConfig.Config{}, cmtypes.ClusterInfo{Name: "default", ID: 5})
 
 	id = mgr.LookupIdentity(context.TODO(), kvstoreLabels)
 	c.Assert(id, Not(IsNil))

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -551,12 +551,6 @@ const (
 	// ciliumEnvPrefix is the prefix used for environment variables
 	ciliumEnvPrefix = "CILIUM_"
 
-	// ClusterName is the name of the ClusterName option
-	ClusterName = "cluster-name"
-
-	// ClusterIDName is the name of the ClusterID option
-	ClusterIDName = "cluster-id"
-
 	// CNIChainingMode configures which CNI plugin Cilium is chained with.
 	CNIChainingMode = "cni-chaining-mode"
 
@@ -2732,16 +2726,6 @@ func (c *DaemonConfig) EndpointStatusIsEnabled(option string) bool {
 	return ok
 }
 
-// LocalClusterName returns the name of the cluster Cilium is deployed in
-func (c *DaemonConfig) LocalClusterName() string {
-	return c.ClusterName
-}
-
-// LocalClusterID returns the ID of the cluster local to the Cilium agent.
-func (c *DaemonConfig) LocalClusterID() uint32 {
-	return c.ClusterID
-}
-
 // K8sServiceProxyName returns the required value for the
 // service.kubernetes.io/service-proxy-name label in order for services to be
 // handled.
@@ -2880,16 +2864,12 @@ func (c *DaemonConfig) Validate(vp *viper.Viper) error {
 			SingleClusterRouteName, RoutingMode, RoutingModeNative)
 	}
 
-	if c.ClusterID < clustermeshTypes.ClusterIDMin || c.ClusterID > clustermeshTypes.ClusterIDMax {
-		return fmt.Errorf("invalid cluster id %d: must be in range %d..%d",
-			c.ClusterID, clustermeshTypes.ClusterIDMin, clustermeshTypes.ClusterIDMax)
+	cinfo := clustermeshTypes.ClusterInfo{
+		ID:   c.ClusterID,
+		Name: c.ClusterName,
 	}
-
-	if c.ClusterID != 0 {
-		if c.ClusterName == defaults.ClusterName {
-			return fmt.Errorf("cannot use default cluster name (%s) with option %s",
-				defaults.ClusterName, ClusterIDName)
-		}
+	if err := cinfo.Validate(); err != nil {
+		return err
 	}
 
 	if err := c.checkMapSizeLimits(); err != nil {
@@ -3036,8 +3016,8 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.AutoCreateCiliumNodeResource = vp.GetBool(AutoCreateCiliumNodeResource)
 	c.BPFRoot = vp.GetString(BPFRoot)
 	c.CGroupRoot = vp.GetString(CGroupRoot)
-	c.ClusterID = vp.GetUint32(ClusterIDName)
-	c.ClusterName = vp.GetString(ClusterName)
+	c.ClusterID = vp.GetUint32(clustermeshTypes.OptClusterID)
+	c.ClusterName = vp.GetString(clustermeshTypes.OptClusterName)
 	c.DatapathMode = vp.GetString(DatapathMode)
 	c.Debug = vp.GetBool(DebugArg)
 	c.DebugVerbose = vp.GetStringSlice(DebugVerbose)

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -5,11 +5,6 @@ package fake
 
 type Config struct{}
 
-// LocalClusterName returns the name of the cluster Cilium is deployed in
-func (f *Config) LocalClusterName() string {
-	return "default"
-}
-
 // CiliumNamespaceName returns the name of the namespace in which Cilium is
 // deployed in
 func (f *Config) CiliumNamespaceName() string {
@@ -35,9 +30,4 @@ func (f *Config) EncryptionEnabled() bool {
 // NodeEncryptionEnabled returns true if node encryption is enabled
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true
-}
-
-// LocalClusterID returns a dummy cluster ID.
-func (f *Config) LocalClusterID() uint32 {
-	return 5
 }

--- a/pkg/service/store/store.go
+++ b/pkg/service/store/store.go
@@ -193,20 +193,14 @@ func (c *clusterServiceObserver) OnDelete(key store.NamedKey) {
 	}
 }
 
-// Configuration is the required configuration for the service store
-type Configuration interface {
-	// LocalClusterName must return the name of the local cluster
-	LocalClusterName() string
-}
-
 // JoinClusterServices starts a controller for syncing services from the kvstore
-func JoinClusterServices(merger ServiceMerger, cfg Configuration) {
+func JoinClusterServices(merger ServiceMerger, clusterName string) {
 	swg := lock.NewStoppableWaitGroup()
 
 	log.Info("Enumerating cluster services")
 	// JoinSharedStore performs initial sync of services
 	_, err := store.JoinSharedStore(store.Configuration{
-		Prefix: path.Join(ServiceStorePrefix, cfg.LocalClusterName()),
+		Prefix: path.Join(ServiceStorePrefix, clusterName),
 		KeyCreator: func() store.Key {
 			return &ClusterService{}
 		},


### PR DESCRIPTION
Currently, the clustermesh package already leverages a ClusterIDName struct to wrap the ClusterID and ClusterName information. Let's use it also to register the associated flags, so that we can directly depend on it on the different components, and reuse it for the kvstoremesh and clustermesh-apiserver binaries uniformly.

To avoid the need for modifying all usages, we preserve the current fields inside DaemonConfig, which continue to be populated as before.
