### PR TITLE
.github: do not upgrade ubuntu runner for integration tests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -85,6 +85,15 @@
       ]
     },
     {
+      "matchPaths": [
+        ".github/workflows/integration-test.yaml"
+      ],
+      matchPackageNames: [
+        "ubuntu"
+      ],
+      "allowedVersions": "20.04",
+    },
+    {
       "groupName": "all go dependencies main",
       "groupSlug": "all-go-deps-main",
       "matchFiles": [


### PR DESCRIPTION
The integration tests can't be upgraded to Ubuntu 22 since we are still using clang 10. Once we upgrade clang, we can remove this rule from renovate.

You can see the diff in https://github.com/aanm/cilium/pull/552 vs https://github.com/cilium/cilium/pull/27745