### PR TITLE
Fix propagation of namespace labels to CEP labels

### DIFF
--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -25,7 +25,6 @@ func (k *K8sWatcher) namespacesInit() {
 	apiGroup := k8sAPIGroupNamespaceV1Core
 
 	var synced atomic.Bool
-	synced.Store(false)
 
 	k.blockWaitGroupToSyncResources(
 		k.stop,

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -71,8 +71,9 @@ type namespaceUpdater struct {
 }
 
 func getNamespaceLabels(ns *slim_corev1.Namespace) labels.Labels {
-	labelMap := map[string]string{}
-	for k, v := range ns.GetLabels() {
+	lbls := ns.GetLabels()
+	labelMap := make(map[string]string, len(lbls))
+	for k, v := range lbls {
 		labelMap[policy.JoinPath(ciliumio.PodNamespaceMetaLabels, k)] = v
 	}
 	return labels.Map2Labels(labelMap, labels.LabelSourceK8s)

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -35,7 +35,7 @@ func (k *K8sWatcher) namespacesInit() {
 	k.k8sAPIGroups.AddAPI(apiGroup)
 
 	nsUpdater := namespaceUpdater{
-		oldLabels:       make(map[string]labels.Labels),
+		oldIdtyLabels:   make(map[string]labels.Labels),
 		endpointManager: k.endpointManager,
 	}
 
@@ -65,7 +65,7 @@ func (k *K8sWatcher) namespacesInit() {
 }
 
 type namespaceUpdater struct {
-	oldLabels map[string]labels.Labels
+	oldIdtyLabels map[string]labels.Labels
 
 	endpointManager endpointManager
 }
@@ -80,10 +80,9 @@ func getNamespaceLabels(ns *slim_corev1.Namespace) labels.Labels {
 }
 
 func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
-	oldLabels := u.oldLabels[newNS.Name]
 	newLabels := getNamespaceLabels(newNS)
 
-	oldIdtyLabels, _ := labelsfilter.Filter(oldLabels)
+	oldIdtyLabels := u.oldIdtyLabels[newNS.Name]
 	newIdtyLabels, _ := labelsfilter.Filter(newLabels)
 
 	// Do not perform any other operations if the old labels are the same as
@@ -108,7 +107,7 @@ func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
 	if failed {
 		return errors.New("unable to update some endpoints with new namespace labels")
 	}
-	u.oldLabels[newNS.Name] = newLabels
+	u.oldIdtyLabels[newNS.Name] = newIdtyLabels
 	return nil
 }
 

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -86,8 +86,8 @@ func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
 	oldIdtyLabels, _ := labelsfilter.Filter(oldLabels)
 	newIdtyLabels, _ := labelsfilter.Filter(newLabels)
 
-	// Do not perform any other operations the the old labels are the same as
-	// the new labels
+	// Do not perform any other operations if the old labels are the same as
+	// the new labels.
 	if oldIdtyLabels.DeepEqual(&newIdtyLabels) {
 		return nil
 	}
@@ -100,7 +100,7 @@ func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
 			err := ep.ModifyIdentityLabels(newIdtyLabels, oldIdtyLabels)
 			if err != nil {
 				log.WithError(err).WithField(logfields.EndpointID, ep.ID).
-					Warningf("unable to update endpoint with new namespace labels")
+					Warning("unable to update endpoint with new identity labels from namespace labels")
 				failed = true
 			}
 		}
@@ -108,6 +108,7 @@ func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
 	if failed {
 		return errors.New("unable to update some endpoints with new namespace labels")
 	}
+	u.oldLabels[newNS.Name] = newLabels
 	return nil
 }
 


### PR DESCRIPTION
Currently `(*namespaceUpdater).oldLabels` is never updated with the namespace's labels after they have been synced to endpoints. This can e.g. lead to updates mistakenly being skipped. This in turn can lead to situations as described in https://github.com/cilium/cilium/issues/27626 where namespace derived labels are not removed from CEPs when the corresponding label is removed from the namespace.
    
Fix this by always updating `(*namespaceUpdater).oldLabels` on successful endpoint label update.

Review by commit: The first two commits are preparatory cleanups. The third commit is the actual bug fix. The fourth commit is a small optimization.

Fixes: #27626
