### PR TITLE
metric: provide way to declare labels.

### DIFF
--- a/pkg/metrics/metric/collections/product.go
+++ b/pkg/metrics/metric/collections/product.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package collections
+
+// CartesianProduct returns the cartesian product of the input vectors as
+// a vector of vectors, each with length the same as the number of input vectors.
+func CartesianProduct[T any](vs ...[]T) [][]T {
+	if len(vs) == 0 {
+		return [][]T{}
+	}
+
+	dimension := len(vs) // Each output will be a vector of this length.
+	// Iterate to find out the number of output vectors.
+	size := len(vs[0])
+	for i := 1; i < len(vs); i++ {
+		size *= len(vs[i])
+	}
+
+	// Allocate the output vectors.
+	dst := make([][]T, size)
+	for i := range dst {
+		dst[i] = make([]T, dimension)
+	}
+
+	lastm := 1
+	for i := 0; i < dimension; i++ {
+		permuteColumn[T](dst, i, lastm, vs[i])
+		lastm = lastm * len(vs[i])
+	}
+	return dst
+}
+
+// permuteColumn fills in the nth column of the output vectors of the cartesian
+// product of the input vectors.
+//
+// leftPermSize is the number of vectors as a result of permuting 0,..,col-1 columns.
+// That is, this is the block size upon which we will repeat the values of v0 such that
+// every previous permutation is again permuted with each value of v0.
+//
+// For ex.
+// CartesianProduct[string]({"a", "b"}, {"x", "y", "z"})
+//
+// Iteration (i.e. col, leftPermSize=1) 1:
+//
+// dst = [
+// ["a"],
+// ["b"],
+// ["a"]
+// ["b"]
+// ["a"]
+// ["b"]
+// ]
+//
+// Iteration (leftPermSize=2):
+//
+// dst = [
+// ["a", "x"], // <- each elem of vec is repeated leftPermSize times.
+// ["b", "x"],
+// ["a", "y"]
+// ["b", "y"]
+// ["a", "z"]
+// ["b", "z"]
+// ]
+func permuteColumn[T any](dst [][]T, col int, leftPermSize int, vec []T) {
+	// Go down the column with the current lhs.
+	// You want to skip along, lastm elements at a time.
+	for i := 0; i < len(dst); i += leftPermSize { // So we're skipping n rows at a time,
+		vi := (i / leftPermSize) % len(vec)
+		for off := 0; off < leftPermSize; off++ { // this is a repeat
+			dst[i+off][col] = vec[vi]
+		}
+	}
+}

--- a/pkg/metrics/metric/collections/product_test.go
+++ b/pkg/metrics/metric/collections/product_test.go
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package collections
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIteratorProduct(t *testing.T) {
+	assert := assert.New(t)
+	p := CartesianProduct(
+		[]string{"CiliumNetworkPolicy", "CiliumClusterwideNetworkPolicy", "NetworkPolicyName"},
+		[]string{"update", "delete"},
+		[]string{"true", "false"},
+		[]string{"0", "1"},
+	)
+	assert.Len(p, 24, "Should be 3 * 2 * 2 * 2 = 24 permutations")
+	vs := map[string]any{}
+	for _, v := range p {
+		vs[fmt.Sprintf("%v", v)] = v
+	}
+	assert.Len(vs, 24, "Elements should be unique")
+}
+
+func TestIteratorProductElements(t *testing.T) {
+	assert := assert.New(t)
+	p := CartesianProduct(
+		[]string{"true", "false"},
+		[]string{"0", "1"},
+		[]string{"foo"},
+	)
+	assert.Equal(4, len(p), "Should be 2 * 2 * 1 = 4 permutations")
+	assert.Equal(len(p[0]), 3)
+	vs := map[string]any{}
+	for _, v := range p {
+		vs[fmt.Sprintf("%v", v)] = v
+	}
+	assert.Contains(vs, "[true 0 foo]")
+	assert.Contains(vs, "[true 1 foo]")
+	assert.Contains(vs, "[false 0 foo]")
+	assert.Contains(vs, "[false 1 foo]")
+}
+
+func TestIteratorProductEmpty(t *testing.T) {
+	assert := assert.New(t)
+	p := CartesianProduct(
+		[]string{"CiliumNetworkPolicy", "CiliumClusterwideNetworkPolicy", "NetworkPolicyName"},
+		[]string{},
+	)
+	assert.Empty(p)
+
+	p = CartesianProduct[string]()
+	assert.Empty(p)
+
+	assert.Empty(CartesianProduct([]string{}, []string{}, []string{}))
+	assert.Empty(0, CartesianProduct[int]())
+	assert.Len(CartesianProduct([]string{""}, []string{""}, []string{""}), 1)
+	CartesianProduct[interface{}](nil, nil) // Test some weird cases.
+}

--- a/pkg/metrics/metric/counter.go
+++ b/pkg/metrics/metric/counter.go
@@ -60,7 +60,9 @@ func (c *counter) Add(val float64) {
 	}
 }
 
-func NewCounterVec(opts CounterOpts, labelNames []string) DeletableVec[Counter] {
+// NewCounterVec creates a new DeletableVec[Counter] based on the provided CounterOpts and
+// partitioned by the given label names.
+func NewCounterVec(opts CounterOpts, labelNames []string) *counterVec {
 	return &counterVec{
 		CounterVec: prometheus.NewCounterVec(opts.toPrometheus(), labelNames),
 		metric: metric{
@@ -70,12 +72,47 @@ func NewCounterVec(opts CounterOpts, labelNames []string) DeletableVec[Counter] 
 	}
 }
 
+// NewCounterVecWithLabels creates a new DeletableVec[Counter] based on the provided CounterOpts and
+// partitioned by the given labels.
+// This will also initialize the labels with the provided values so that metrics with known label value
+// ranges can be pre-initialized to zero upon init.
+//
+// This should only be used when all label values are known at init, otherwise use of the
+// metric vector with uninitialized labels will result in warnings.
+//
+// Note: Disabled metrics will not have their label values initialized.
+//
+// For example:
+//
+//	NewCounterVecWithLabels(CounterOpts{
+//		Namespace: "cilium",
+//		Subsystem: "subsystem",
+//		Name:      "cilium_test",
+//		Disabled:  false,
+//	}, Labels{
+//		{Name: "foo", Values: NewValues("0", "1")},
+//		{Name: "bar", Values: NewValues("a", "b")},
+//	})
+//
+// Will initialize the following metrics to:
+//
+//	cilium_subsystem_cilium_test{foo="0", bar="a"} 0
+//	cilium_subsystem_cilium_test{foo="0", bar="b"} 0
+//	cilium_subsystem_cilium_test{foo="1", bar="a"} 0
+//	cilium_subsystem_cilium_test{foo="1", bar="b"} 0
+func NewCounterVecWithLabels(opts CounterOpts, labels Labels) *counterVec {
+	cv := NewCounterVec(opts, labels.labelNames())
+	initLabels[Counter](&cv.metric, labels, cv, opts.Disabled)
+	return cv
+}
+
 type counterVec struct {
 	*prometheus.CounterVec
 	metric
 }
 
 func (cv *counterVec) CurryWith(labels prometheus.Labels) (Vec[Counter], error) {
+	cv.checkLabels(labels)
 	vec, err := cv.CounterVec.CurryWith(labels)
 	if err == nil {
 		return &counterVec{CounterVec: vec, metric: cv.metric}, nil
@@ -118,6 +155,7 @@ func (cv *counterVec) GetMetricWithLabelValues(lvs ...string) (Counter, error) {
 }
 
 func (cv *counterVec) With(labels prometheus.Labels) Counter {
+	cv.checkLabels(labels)
 	if !cv.enabled {
 		return &counter{
 			metric: metric{enabled: false},
@@ -132,6 +170,7 @@ func (cv *counterVec) With(labels prometheus.Labels) Counter {
 }
 
 func (cv *counterVec) WithLabelValues(lvs ...string) Counter {
+	cv.checkLabelValues(lvs...)
 	if !cv.enabled {
 		return &counter{
 			metric: metric{enabled: false},

--- a/pkg/metrics/metric/counter_test.go
+++ b/pkg/metrics/metric/counter_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metric
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCounterWithLabels(t *testing.T) {
+	o := NewCounterVecWithLabels(CounterOpts{
+		Namespace: "cilium",
+		Subsystem: "subsystem",
+		Name:      "test",
+	}, Labels{
+		{Name: "foo", Values: NewValues("0", "1")},
+		{Name: "bar", Values: NewValues("a", "b")},
+	})
+	r := prometheus.NewRegistry()
+	r.MustRegister(o)
+	ms, err := dumpMetrics(o)
+	assert.NoError(t, err)
+	assert.Len(t, ms, 4)
+}

--- a/pkg/metrics/metric/gauge_test.go
+++ b/pkg/metrics/metric/gauge_test.go
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metric
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGaugeWithLabels(t *testing.T) {
+	o := NewGaugeVecWithLabels(GaugeOpts{
+		Namespace: "cilium",
+		Subsystem: "subsystem",
+		Name:      "test",
+	}, Labels{
+		{Name: "foo", Values: NewValues("0", "1")},
+		{Name: "bar", Values: NewValues("a", "b")},
+	})
+	r := prometheus.NewRegistry()
+	r.MustRegister(o)
+	ms, err := dumpMetrics(o)
+	assert.NoError(t, err)
+	assert.Len(t, ms, 4)
+}

--- a/pkg/metrics/metric/histogram_test.go
+++ b/pkg/metrics/metric/histogram_test.go
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metric
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHistogramWithLabels(t *testing.T) {
+	o := NewHistogramVecWithLabels(HistogramOpts{
+		Namespace: "cilium",
+		Subsystem: "subsystem",
+		Name:      "test",
+	}, Labels{
+		{Name: "foo", Values: NewValues("0", "1")},
+	})
+	r := prometheus.NewRegistry()
+	r.MustRegister(o)
+	o.WithLabelValues("1").Observe(1234)
+	ms, err := dumpMetrics(o)
+	assert.NoError(t, err)
+	assert.Len(t, ms, 2)
+	for _, m := range ms {
+		switch m.Label[0].GetValue() {
+		case "0":
+			assert.Zero(t, m.Histogram.GetSampleCount())
+		case "1":
+			assert.Equal(t, uint64(1), m.Histogram.GetSampleCount())
+		default:
+			assert.Fail(t, "unexpected label value")
+		}
+	}
+}

--- a/pkg/metrics/metric/metric.go
+++ b/pkg/metrics/metric/metric.go
@@ -4,8 +4,17 @@
 package metric
 
 import (
+	"fmt"
+
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/maps"
+
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics/metric/collections"
 )
+
+var logger = logrus.WithField(logfields.LogSubsys, "metric")
 
 // WithMetadata is the interface implemented by any metric defined in this package. These typically embed existing
 // prometheus metric types and add additional metadata. In addition, these metrics have the concept of being enabled
@@ -20,6 +29,44 @@ type WithMetadata interface {
 type metric struct {
 	enabled bool
 	opts    Opts
+	labels  *labelSet
+}
+
+// forEachLabelVector performs a product of all possible label value combinations
+// and calls the provided function for each combination.
+func (b *metric) forEachLabelVector(fn func(lvls []string)) {
+	if b.labels == nil {
+		return
+	}
+	var labelValues [][]string
+	for _, label := range b.labels.lbls {
+		labelValues = append(labelValues, maps.Keys(label.Values))
+	}
+	for _, labelVector := range collections.CartesianProduct(labelValues...) {
+		fn(labelVector)
+	}
+}
+
+// checkLabelValues checks that the provided label values are within the range
+// of provided label values, if labels where defined using the Labels type.
+// Violations are logged as errors for detection, but metrics should still
+// be collected as is.
+func (b *metric) checkLabelValues(lvs ...string) {
+	if b.labels == nil {
+		return
+	}
+	if err := b.labels.checkLabelValues(lvs); err != nil {
+		logger.WithError(err).Error("metric label constraints violated")
+	}
+}
+
+func (b *metric) checkLabels(labels prometheus.Labels) {
+	if b.labels == nil {
+		return
+	}
+	if err := b.labels.checkLabels(labels); err != nil {
+		logger.WithError(err).Error("metric label constraints violated")
+	}
 }
 
 func (b *metric) IsEnabled() bool {
@@ -195,4 +242,89 @@ func (b Opts) GetConfigName() string {
 		return prometheus.BuildFQName(b.Namespace, b.Subsystem, b.Name)
 	}
 	return b.ConfigName
+}
+
+// Label represents a metric label with a pre-defined range of values.
+// This is used with the NewxxxVecWithLabels metrics constructors to initialize
+// vector metrics with known label value ranges, avoiding empty metrics.
+type Label struct {
+	Name string
+	// If defined, only these values are allowed.
+	Values Values
+}
+
+// Values is a distinct set of possible label values for a particular Label.
+type Values map[string]struct{}
+
+// NewValues constructs a Values type from a set of strings.
+func NewValues(vs ...string) Values {
+	vals := Values{}
+	for _, v := range vs {
+		vals[v] = struct{}{}
+	}
+	return vals
+}
+
+type Labels []Label
+
+func (lbls Labels) labelNames() []string {
+	lns := make([]string, len(lbls))
+	for i, label := range lbls {
+		lns[i] = label.Name
+	}
+	return lns
+}
+
+type labelSet struct {
+	lbls Labels
+	m    map[string]map[string]struct{}
+}
+
+func (l *labelSet) namesToValues() map[string]map[string]struct{} {
+	if l.m != nil {
+		return l.m
+	}
+	l.m = make(map[string]map[string]struct{})
+	for _, label := range l.lbls {
+		l.m[label.Name] = label.Values
+	}
+	return l.m
+}
+
+func (l *labelSet) checkLabels(labels prometheus.Labels) error {
+	for name, value := range labels {
+		if lvs, ok := l.namesToValues()[name]; ok {
+			if _, ok := lvs[value]; !ok {
+				return fmt.Errorf("value %s not allowed for label %s (should be one of %v)", value, name, lvs)
+			}
+		} else {
+			return fmt.Errorf("invalid label name: %s", name)
+		}
+	}
+	return nil
+}
+
+func (l *labelSet) checkLabelValues(lvs []string) error {
+	if len(l.lbls) != len(lvs) {
+		return fmt.Errorf("invalid labels")
+	}
+	for i, label := range l.lbls {
+		if _, ok := label.Values[lvs[i]]; !ok {
+			return fmt.Errorf("invalid label value")
+		}
+	}
+	return nil
+}
+
+// initLabels is a helper function to initialize the labels of a metric.
+// It is used by xxxVecWithLabels metrics constructors to initialize the
+// labels of the metric and the vector (i.e. registering all possible label value combinations).
+func initLabels[T any](m *metric, labels Labels, vec Vec[T], disabled bool) {
+	if disabled {
+		return
+	}
+	m.labels = &labelSet{lbls: labels}
+	m.forEachLabelVector(func(vs []string) {
+		vec.WithLabelValues(vs...)
+	})
 }

--- a/pkg/metrics/metric/metric.go
+++ b/pkg/metrics/metric/metric.go
@@ -265,6 +265,8 @@ func NewValues(vs ...string) Values {
 	return vals
 }
 
+// Labels is a slice of labels that represents a label set for a vector type
+// metric.
 type Labels []Label
 
 func (lbls Labels) labelNames() []string {

--- a/pkg/metrics/metric/metric_test.go
+++ b/pkg/metrics/metric/metric_test.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metric
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func dumpMetrics(o prometheus.Collector) ([]*dto.Metric, error) {
+	ch := make(chan prometheus.Metric)
+	done := make(chan any)
+	ms := make([]prometheus.Metric, 0)
+	go func() {
+		for m := range ch {
+			ms = append(ms, m)
+		}
+		close(done)
+	}()
+
+	o.Collect(ch)
+	close(ch)
+	<-done
+	mtrcs := make([]*dto.Metric, 0, len(ms))
+	for _, m := range ms {
+		mtrc := &dto.Metric{}
+		if err := m.Write(mtrc); err != nil {
+			return nil, err
+		}
+		mtrcs = append(mtrcs, mtrc)
+	}
+	return mtrcs, nil
+}
+
+func TestLabelsnamesToValues(t *testing.T) {
+	ls := &labelSet{
+		lbls: Labels{
+			{Name: "foo", Values: NewValues("0", "1")},
+			{Name: "bar", Values: NewValues("2", "3", "4")},
+		},
+	}
+	ntov := ls.namesToValues()
+	assert.Equal(t, map[string]struct{}{
+		"0": {},
+		"1": {},
+	}, ntov["foo"])
+	assert.Equal(t, map[string]struct{}{
+		"2": {},
+		"3": {},
+		"4": {},
+	}, ntov["bar"])
+
+	assert.NoError(t, ls.checkLabels(map[string]string{
+		"foo": "0",
+		"bar": "2",
+	}))
+	assert.Error(t, ls.checkLabels(map[string]string{
+		"foo": "bad-val",
+		"bar": "2",
+	}))
+	assert.Error(t, ls.checkLabels(map[string]string{
+		"foo": "0",
+		"bar": "bad-val",
+	}))
+	assert.NoError(t, ls.checkLabelValues([]string{"1", "4"}))
+	assert.Error(t, ls.checkLabelValues([]string{"bad-val", "2"}))
+	assert.Error(t, ls.checkLabelValues([]string{"0", "bad-val"}))
+}


### PR DESCRIPTION
    metric: provide way to declare labels.
    
    Adds *WithLabels Vec[T] constructors for histogram/gauge/counter.
    This provides a mechanism to declare a metrics possible range of label values up front.
    The xxxWithLabels functions will automatically initialize such metrics
    such that they will be exported with zero values by the prometheus
    endpoint.
    
    One of the stated best practices for Prometheus instrumentation is
    avoiding missing metrics [1].
    
    This change will make it easier to provide metrics that are initialized
    correctly to produce more reliable metrics.
    
    [1] https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics


```release-note
Pre-initialize several known metric vectors to avoid empty metrics (specifically: endpoint_regenerations_total, policy_change_total,  policy_implementation_delay, policy_l7_total and kubernetes_events metrics). 
```
