### PR TITLE
api, cmd, policy: Show rule labels in `policy selectors` output

### DIFF
--- a/Documentation/cmdref/cilium_policy_selectors.md
+++ b/Documentation/cmdref/cilium_policy_selectors.md
@@ -13,6 +13,7 @@ cilium policy selectors [flags]
 ```
   -h, --help            help for selectors
   -o, --output string   json| yaml| jsonpath='{}'
+  -v, --verbose         Show the full labels
 ```
 
 ### Options inherited from parent commands

--- a/api/v1/models/selector_identity_mapping.go
+++ b/api/v1/models/selector_identity_mapping.go
@@ -23,6 +23,9 @@ type SelectorIdentityMapping struct {
 	// identities mapping to this selector
 	Identities []int64 `json:"identities"`
 
+	// Labels are the metadata labels associated with the selector
+	Labels interface{} `json:"labels,omitempty"`
+
 	// string form of selector
 	Selector string `json:"selector,omitempty"`
 

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2864,6 +2864,9 @@ definitions:
       selector:
         description: string form of selector
         type: string
+      labels:
+        description: Labels are the metadata labels associated with the selector
+        type: object
       identities:
         description: identities mapping to this selector
         type: array

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -4630,6 +4630,10 @@ func init() {
             "type": "integer"
           }
         },
+        "labels": {
+          "description": "Labels are the metadata labels associated with the selector",
+          "type": "object"
+        },
         "selector": {
           "description": "string form of selector",
           "type": "string"
@@ -10525,6 +10529,10 @@ func init() {
           "items": {
             "type": "integer"
           }
+        },
+        "labels": {
+          "description": "Labels are the metadata labels associated with the selector",
+          "type": "object"
         },
         "selector": {
           "description": "string form of selector",

--- a/cilium/cmd/policy_selectors.go
+++ b/cilium/cmd/policy_selectors.go
@@ -12,7 +12,11 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/pkg/command"
+	k8sconst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
+	"github.com/cilium/cilium/pkg/labels"
 )
+
+var verbosePolicySelectors bool
 
 // policyCacheGetCmd represents the policy selectors command
 var policyCacheGetCmd = &cobra.Command{
@@ -31,10 +35,22 @@ var policyCacheGetCmd = &cobra.Command{
 			sort.Slice(resp, func(i, j int) bool {
 				return resp[i].Selector < resp[j].Selector
 			})
-			fmt.Fprintf(w, "SELECTOR\tUSERS\tIDENTITIES\n")
+			fmt.Fprintf(w, "SELECTOR\tLABELS\tUSERS\tIDENTITIES\n")
+
 			for _, mapping := range resp {
+				lbls := constructLabelsArrayFromAPIType(mapping.Labels)
+
 				first := true
 				fmt.Fprintf(w, "%s", mapping.Selector)
+				if verbosePolicySelectors {
+					var lstr string
+					if len(lbls) != 0 {
+						lstr = lbls.Sort().String()
+					}
+					fmt.Fprintf(w, "\t%s", lstr)
+				} else {
+					fmt.Fprintf(w, "\t%s", getNameAndNamespaceFromLabels(lbls))
+				}
 				fmt.Fprintf(w, "\t%d", mapping.Users)
 				if len(mapping.Identities) == 0 {
 					fmt.Fprintf(w, "\t\n")
@@ -44,7 +60,7 @@ var policyCacheGetCmd = &cobra.Command{
 						fmt.Fprintf(w, "\t%d\t\n", idty)
 						first = false
 					} else {
-						fmt.Fprintf(w, "\t\t%d\t\n", idty)
+						fmt.Fprintf(w, "\t\t\t%d\t\n", idty)
 					}
 				}
 			}
@@ -54,7 +70,24 @@ var policyCacheGetCmd = &cobra.Command{
 	},
 }
 
+func getNameAndNamespaceFromLabels(lbls labels.LabelArray) string {
+	ns := lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sconst.PolicyLabelNamespace)
+	if ns == "" {
+		return ""
+	}
+	return ns + "/" + lbls.Get(labels.LabelSourceK8sKeyPrefix+k8sconst.PolicyLabelName)
+}
+
+func constructLabelsArrayFromAPIType(in interface{}) labels.LabelArray {
+	lbls, ok := in.(labels.LabelArray)
+	if !ok {
+		return nil
+	}
+	return lbls
+}
+
 func init() {
+	policyCacheGetCmd.Flags().BoolVarP(&verbosePolicySelectors, "verbose", "v", false, "Show the full labels")
 	PolicyCmd.AddCommand(policyCacheGetCmd)
 	command.AddOutputOption(policyCacheGetCmd)
 }

--- a/pkg/envoy/xds_server_test.go
+++ b/pkg/envoy/xds_server_test.go
@@ -206,24 +206,24 @@ var (
 	identityAllocator = testidentity.NewMockIdentityAllocator(IdentityCache)
 	testSelectorCache = policy.NewSelectorCache(identityAllocator, IdentityCache)
 
-	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)
+	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, api.WildcardEndpointSelector)
 
 	EndpointSelector1 = api.NewESFromLabels(
 		labels.NewLabel("app", "etcd", labels.LabelSourceK8s),
 	)
-	cachedSelector1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, EndpointSelector1)
+	cachedSelector1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, EndpointSelector1)
 
 	// EndpointSelector1 with FromRequires("k8s:version=v2") folded in
 	RequiresV2Selector1 = api.NewESFromLabels(
 		labels.NewLabel("app", "etcd", labels.LabelSourceK8s),
 		labels.NewLabel("version", "v2", labels.LabelSourceK8s),
 	)
-	cachedRequiresV2Selector1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, RequiresV2Selector1)
+	cachedRequiresV2Selector1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, RequiresV2Selector1)
 
 	EndpointSelector2 = api.NewESFromLabels(
 		labels.NewLabel("version", "v1", labels.LabelSourceK8s),
 	)
-	cachedSelector2, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, EndpointSelector2)
+	cachedSelector2, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, EndpointSelector2)
 )
 
 var L7Rules12 = &policy.PerSelectorPolicy{L7Rules: api.L7Rules{HTTP: []api.PortRuleHTTP{*PortRuleHTTP1, *PortRuleHTTP2}}}

--- a/pkg/fqdn/dnsproxy/helpers_test.go
+++ b/pkg/fqdn/dnsproxy/helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/fqdn/re"
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/policy"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -212,6 +213,10 @@ type MockCachedSelector struct {
 
 func (m MockCachedSelector) GetSelections() identity.NumericIdentitySlice {
 	return nil
+}
+
+func (m MockCachedSelector) GetMetadataLabels() labels.LabelArray {
+	panic("implement me")
 }
 
 func (m MockCachedSelector) Selects(_ identity.NumericIdentity) bool {

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -157,15 +157,15 @@ var (
 	testSelectorCache       = policy.NewSelectorCache(fakeAllocator, cacheAllocator.GetIdentityCache())
 	dummySelectorCacheUser  = &DummySelectorCacheUser{}
 	DstID1Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst1=test"))
-	cachedDstID1Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, DstID1Selector)
+	cachedDstID1Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, DstID1Selector)
 	DstID2Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst2=test"))
-	cachedDstID2Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, DstID2Selector)
+	cachedDstID2Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, DstID2Selector)
 	DstID3Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst3=test"))
-	cachedDstID3Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, DstID3Selector)
+	cachedDstID3Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, DstID3Selector)
 	DstID4Selector          = api.NewESFromLabels(labels.ParseSelectLabel("k8s:Dst4=test"))
-	cachedDstID4Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, DstID4Selector)
+	cachedDstID4Selector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, DstID4Selector)
 
-	cachedWildcardSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)
+	cachedWildcardSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, api.WildcardEndpointSelector)
 
 	epID1   = uint64(111)
 	epID2   = uint64(222)
@@ -1093,6 +1093,10 @@ type selectorMock struct {
 }
 
 func (t selectorMock) GetSelections() identity.NumericIdentitySlice {
+	panic("implement me")
+}
+
+func (t selectorMock) GetMetadataLabels() labels.LabelArray {
 	panic("implement me")
 }
 

--- a/pkg/k8s/network_policy_test.go
+++ b/pkg/k8s/network_policy_test.go
@@ -161,7 +161,7 @@ func (s *K8sSuite) TestParseNetworkPolicyIngress(c *C) {
 	c.Assert(repo.AllowsIngressRLocked(&ctx), Equals, api.Denied)
 
 	epSelector := api.NewESFromLabels(fromEndpoints...)
-	cachedEPSelector, _ := repo.GetSelectorCache().AddIdentitySelector(dummySelectorCacheUser, epSelector)
+	cachedEPSelector, _ := repo.GetSelectorCache().AddIdentitySelector(dummySelectorCacheUser, nil, epSelector)
 	defer func() { repo.GetSelectorCache().RemoveSelector(cachedEPSelector, dummySelectorCacheUser) }()
 
 	ingressL4Policy, err := repo.ResolveL4IngressPolicy(&ctx)
@@ -490,7 +490,7 @@ func (s *K8sSuite) TestParseNetworkPolicyEgress(c *C) {
 	c.Assert(repo.AllowsEgressRLocked(&ctx), Equals, api.Denied)
 
 	epSelector := api.NewESFromLabels(toEndpoints...)
-	cachedEPSelector, _ := repo.GetSelectorCache().AddIdentitySelector(dummySelectorCacheUser, epSelector)
+	cachedEPSelector, _ := repo.GetSelectorCache().AddIdentitySelector(dummySelectorCacheUser, nil, epSelector)
 	defer func() { repo.GetSelectorCache().RemoveSelector(cachedEPSelector, dummySelectorCacheUser) }()
 
 	egressL4Policy, err := repo.ResolveL4EgressPolicy(&ctx)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -30,24 +30,24 @@ var (
 	c                      = cache.NewCachingIdentityAllocator(&testidentity.IdentityAllocatorOwnerMock{})
 	testSelectorCache      = testNewSelectorCache(c.GetIdentityCache())
 
-	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, api.WildcardEndpointSelector)
+	wildcardCachedSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, api.WildcardEndpointSelector)
 
-	cachedSelectorA, _    = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, endpointSelectorA)
-	cachedSelectorC, _    = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, endpointSelectorC)
-	cachedSelectorHost, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, hostSelector)
+	cachedSelectorA, _    = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, endpointSelectorA)
+	cachedSelectorC, _    = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, endpointSelectorC)
+	cachedSelectorHost, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, hostSelector)
 
 	fooSelector = api.NewESFromLabels(labels.ParseSelectLabel("foo"))
 	bazSelector = api.NewESFromLabels(labels.ParseSelectLabel("baz"))
 
-	cachedFooSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, fooSelector)
-	cachedBazSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, bazSelector)
+	cachedFooSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, fooSelector)
+	cachedBazSelector, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, bazSelector)
 
 	selFoo  = api.NewESFromLabels(labels.ParseSelectLabel("id=foo"))
 	selBar1 = api.NewESFromLabels(labels.ParseSelectLabel("id=bar1"))
 	selBar2 = api.NewESFromLabels(labels.ParseSelectLabel("id=bar2"))
 
-	cachedSelectorBar1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, selBar1)
-	cachedSelectorBar2, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, selBar2)
+	cachedSelectorBar1, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, selBar1)
+	cachedSelectorBar2, _ = testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, selBar2)
 )
 
 type testPolicyContextType struct {

--- a/pkg/policy/repository_deny_test.go
+++ b/pkg/policy/repository_deny_test.go
@@ -707,7 +707,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressDenyFromRequires(c *C) {
 			Values:   []string{"bar2"},
 		},
 	})
-	expectedCachedSelector, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, expectedSelector)
+	expectedCachedSelector, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
 
 	expectedDenyPolicy := L4PolicyMap{
 		"80/TCP": &L4Filter{
@@ -787,8 +787,8 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressDenyFromRequires(c *C) {
 			Values:   []string{"bar2"},
 		},
 	})
-	expectedCachedSelector, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, expectedSelector)
-	expectedCachedSelector2, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, expectedSelector2)
+	expectedCachedSelector, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
+	expectedCachedSelector2, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector2)
 
 	expectedDenyPolicy := L4PolicyMap{
 		"0/ANY": &L4Filter{
@@ -1045,7 +1045,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgressDeny(c *C) {
 	cidrSelectors := cidrSlice.GetAsEndpointSelectors()
 	var cachedSelectors CachedSelectorSlice
 	for i := range cidrSelectors {
-		c, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, cidrSelectors[i])
+		c, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, cidrSelectors[i])
 		cachedSelectors = append(cachedSelectors, c)
 		defer testSelectorCache.RemoveSelector(c, dummySelectorCacheUser)
 	}

--- a/pkg/policy/repository_test.go
+++ b/pkg/policy/repository_test.go
@@ -1009,7 +1009,7 @@ func (ds *PolicyTestSuite) TestL3DependentL4IngressFromRequires(c *C) {
 			Values:   []string{"bar2"},
 		},
 	})
-	expectedCachedSelector, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, expectedSelector)
+	expectedCachedSelector, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
 
 	expectedPolicy := L4PolicyMap{
 		"80/TCP": &L4Filter{
@@ -1091,8 +1091,8 @@ func (ds *PolicyTestSuite) TestL3DependentL4EgressFromRequires(c *C) {
 			Values:   []string{"bar2"},
 		},
 	})
-	expectedCachedSelector, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, expectedSelector)
-	expectedCachedSelector2, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, expectedSelector2)
+	expectedCachedSelector, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector)
+	expectedCachedSelector2, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, expectedSelector2)
 
 	expectedPolicy := L4PolicyMap{
 		"0/ANY": &L4Filter{
@@ -1502,7 +1502,7 @@ func (ds *PolicyTestSuite) TestWildcardCIDRRulesEgress(c *C) {
 	cidrSelectors := cidrSlice.GetAsEndpointSelectors()
 	var cachedSelectors CachedSelectorSlice
 	for i := range cidrSelectors {
-		c, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, cidrSelectors[i])
+		c, _ := testSelectorCache.AddIdentitySelector(dummySelectorCacheUser, nil, cidrSelectors[i])
 		cachedSelectors = append(cachedSelectors, c)
 		defer testSelectorCache.RemoveSelector(c, dummySelectorCacheUser)
 	}

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -11,10 +11,12 @@ import (
 	. "github.com/cilium/checkmate"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/utils"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
@@ -93,11 +95,12 @@ func GenerateL3IngressRules(numRules int) api.Rules {
 	}
 
 	var rules api.Rules
+	uuid := k8stypes.UID("11bba160-ddca-13e8-b697-0800273b04ff")
 	for i := 1; i <= numRules; i++ {
-
 		rule := api.Rule{
 			EndpointSelector: fooSelector,
 			Ingress:          []api.IngressRule{ingRule},
+			Labels:           utils.GetPolicyLabels("default", "l3-ingress", uuid, utils.ResourceTypeCiliumNetworkPolicy),
 		}
 		rule.Sanitize()
 		rules = append(rules, &rule)
@@ -119,11 +122,12 @@ func GenerateL3EgressRules(numRules int) api.Rules {
 	}
 
 	var rules api.Rules
+	uuid := k8stypes.UID("13bba160-ddca-13e8-b697-0800273b04ff")
 	for i := 1; i <= numRules; i++ {
-
 		rule := api.Rule{
 			EndpointSelector: fooSelector,
 			Egress:           []api.EgressRule{egRule},
+			Labels:           utils.GetPolicyLabels("default", "l3-egress", uuid, utils.ResourceTypeCiliumNetworkPolicy),
 		}
 		rule.Sanitize()
 		rules = append(rules, &rule)
@@ -156,11 +160,12 @@ func GenerateCIDRRules(numRules int) api.Rules {
 	}
 
 	var rules api.Rules
+	uuid := k8stypes.UID("12bba160-ddca-13e8-b697-0800273b04ff")
 	for i := 1; i <= numRules; i++ {
-
 		rule := api.Rule{
 			EndpointSelector: fooSelector,
 			Egress:           []api.EgressRule{egRule},
+			Labels:           utils.GetPolicyLabels("default", "cidr", uuid, utils.ResourceTypeCiliumNetworkPolicy),
 		}
 		rule.Sanitize()
 		rules = append(rules, &rule)

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -277,6 +277,7 @@ func (sc *SelectorCache) GetModel() models.SelectorCache {
 			Selector:   selector,
 			Identities: ids,
 			Users:      int64(idSel.numUsers()),
+			Labels:     idSel.GetMetadataLabels(),
 		}
 		selCacheMdl = append(selCacheMdl, selMdl)
 	}

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -70,7 +70,7 @@ func (csu *cachedSelectionUser) AddIdentitySelector(sel api.EndpointSelector) Ca
 	csu.updateMutex.Lock()
 	defer csu.updateMutex.Unlock()
 
-	cached, added := csu.sc.AddIdentitySelector(csu, sel)
+	cached, added := csu.sc.AddIdentitySelector(csu, nil, sel)
 	csu.c.Assert(cached, Not(Equals), nil)
 
 	_, exists := csu.selections[cached]
@@ -88,7 +88,7 @@ func (csu *cachedSelectionUser) AddFQDNSelector(sel api.FQDNSelector) CachedSele
 	csu.updateMutex.Lock()
 	defer csu.updateMutex.Unlock()
 
-	cached, added := csu.sc.AddFQDNSelector(csu, sel)
+	cached, added := csu.sc.AddFQDNSelector(csu, nil, sel)
 	csu.c.Assert(cached, Not(Equals), nil)
 
 	_, exists := csu.selections[cached]
@@ -207,6 +207,9 @@ func (cs *testCachedSelector) deleteSelections(selections ...int) (deletes []ide
 
 func (cs *testCachedSelector) GetSelections() identity.NumericIdentitySlice {
 	return cs.selections
+}
+func (cs *testCachedSelector) GetMetadataLabels() labels.LabelArray {
+	return nil
 }
 func (cs *testCachedSelector) Selects(nid identity.NumericIdentity) bool {
 	for _, id := range cs.selections {
@@ -474,7 +477,7 @@ func (ds *SelectorCacheTestSuite) TestFQDNSelectorUpdates(c *C) {
 	c.Assert(len(sc.selectors), Equals, 0)
 
 	yahooSel := api.FQDNSelector{MatchName: "yahoo.com"}
-	_, added := sc.AddFQDNSelector(user1, yahooSel)
+	_, added := sc.AddFQDNSelector(user1, nil, yahooSel)
 	c.Assert(added, Equals, true)
 }
 


### PR DESCRIPTION
- policy: Plumb rule labels through selector cache
- api, cmd, policy: Show rule labels in `policy selectors` output

---

Commits for convenience of review:

> policy: Plumb rule labels through selector cache
>
> In order to make investigating the output of `cilium policy selectors`
> easier to understand, plumb the rule labels from KNP, CNP, and CCNPs.
> This makes it so that the user can very easily see which policy the
> selector came from.
>
> Benchmark results before and after given that selectorcache can be a hot
> path in the policy engine:
>
> ```
> $ go test -v ./pkg/policy -run '^$' -bench 'BenchmarkRegenerateL3EgressPolicyRules' -test.benchtime 100x -test.benchmem -test.count 10
> ...
> $ benchstat old.txt new.txt
> name                              old time/op    new time/op    delta
> RegenerateL3EgressPolicyRules-16    8.13ms ±13%    8.01ms ±11%     ~     (p=0.912 n=10+10)
>
> name                              old alloc/op   new alloc/op   delta
> RegenerateL3EgressPolicyRules-16    1.75MB ± 0%    1.94MB ± 0%  +10.78%  (p=0.000 n=10+9)
>
> name                              old allocs/op  new allocs/op  delta
> RegenerateL3EgressPolicyRules-16     24.1k ± 0%     25.1k ± 0%   +4.15%  (p=0.000 n=10+10)
> ```

> api, cmd, policy: Show rule labels in `policy selectors` output
>
> Use the functionality implemented in previous commits to output the rule
> labels in the selector output. This is useful for understanding which
> policy the selector comes from, which makes debugging issues much
> easier.
>
> Example output:
>
> ```
> root@kind-worker:/home/cilium# cilium policy selectors
> SELECTOR                                                                                                                                                            LABELS                          USERS   IDENTITIES
> &LabelSelector{MatchLabels:map[string]string{k8s.io.kubernetes.pod.namespace: kube-system,k8s.k8s-app: kube-dns,},MatchExpressions:[]LabelSelectorRequirement{},}   default/tofqdn-dns-visibility   1       16500
> &LabelSelector{MatchLabels:map[string]string{reserved.none: ,},MatchExpressions:[]LabelSelectorRequirement{},}                                                      default/tofqdn-dns-visibility   1
> MatchName: , MatchPattern: *                                                                                                                                        default/tofqdn-dns-visibility   1       16777217
>                                                                                                                                                                                                             16777218
>                                                                                                                                                                                                             16777219
> ```

```release-note
Improve the usability of the `cilium policy selectors` command by including the policy name and namespace in order to easily understand which selector comes from what policy
```

---

Related: https://github.com/cilium/cilium/issues/27804