### PR TITLE
CI: fix missing names

### DIFF
--- a/.github/workflows/ariane-scheduled.yaml
+++ b/.github/workflows/ariane-scheduled.yaml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   ariane-scheduled:
+    name: Run Scheduled Workflows
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -20,9 +20,11 @@ env:
 
 jobs:
   preflight-clusterrole:
+    name: Preflight Clusterrole Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Checout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
       - name: Check pre-flight clusterrole
@@ -37,6 +39,7 @@ jobs:
              cilium-preflight/clusterrole.yaml
 
   cyclonus-test:
+    name: Cyclonus Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main branch to access local actions

--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -61,13 +61,15 @@ jobs:
   coccicheck:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.bpf-tree == 'true' || needs.check_changes.outputs.coccinelle == 'true' }}
-    name: coccicheck
+    name: Run coccicheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
-      - uses: docker://cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
+      - name: Run coccicheck
+        uses: docker://cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
         # Note: Setting COCCINELLE_HOME can be removed, here and in the

--- a/.github/workflows/lint-images-base.yaml
+++ b/.github/workflows/lint-images-base.yaml
@@ -23,7 +23,8 @@ jobs:
     name: Lint image build logic
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/lint-workflows.yaml
+++ b/.github/workflows/lint-workflows.yaml
@@ -145,7 +145,8 @@ jobs:
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
           python-version: '3.10'
-      - run: pip install yamale
+      - name: Install yamela
+        run: pip install yamale
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -169,7 +170,8 @@ jobs:
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4.7.0
         with:
           python-version: '3.10'
-      - run: pip install yamale
+      - name: Install yamela
+        run: pip install yamale
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
@@ -192,3 +194,34 @@ jobs:
             fi
           done
 
+  name-validation:
+    name: Validate Workflow Names
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
+          # hard-code the path instead of using ${{ github.repository }} to make sure it works for forked repo as well
+          path: src/github.com/cilium/cilium
+
+      - name: Validate Job and Step names
+        shell: bash
+        run: |
+          EXIT=0
+          cd src/github.com/cilium/cilium/.github/workflows
+          for FILE in *.yaml;do
+            JOBS=$(yq '.jobs | to_entries | .[] | select(.value.name == null) | "  " + .key' $FILE)
+            STEPS=$(yq '.jobs | to_entries | .[] as $job | $job.value.steps[] | {"key": $job.key, "name": .name} | select(.name == null) | "  "+.key' $FILE)
+            if [ "${JOBS}" != "" ];then
+              echo Jobs are missing name field, in file $FILE
+              echo "${JOBS}" | awk '{for (i=1; i<=NF; i++) print "  " $i}'
+              EXIT=1
+            fi
+            if [ "${STEPS}" != "" ];then
+              echo Steps are missing name field, under these Jobs in file $FILE
+              echo "${STEPS}" | awk '{for (i=1; i<=NF; i++) print "  " $i}'
+              EXIT=1
+            fi
+          done
+          exit ${EXIT}

--- a/.github/workflows/push-chart-ci.yaml
+++ b/.github/workflows/push-chart-ci.yaml
@@ -91,7 +91,8 @@ jobs:
         ref: ${{ steps.get-ref.outputs.ref }}
         # required for git describe
         fetch-depth: 0
-    - id: get-version
+    - name: Get version
+      id: get-version
       run: |
         set -o pipefail
         set -e

--- a/.github/workflows/tests-smoke.yaml
+++ b/.github/workflows/tests-smoke.yaml
@@ -54,7 +54,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Preflight Clusterrole Check
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
This PR fixes name fields that are not handled with #27391 
Also, it adds a lint job to check for Jobs and Steps without a name

These issues were fixed during the backport process to stable branches.

Branch protection rules need to be adjusted.
To Remove
```
coccicheck
```

To Add
```
BPF Checks / Run coccicheck
```
