### PR TITLE
Mutual Auth: Perform policy check on mutual auth mTLS handshake

### DIFF
--- a/pkg/auth/certs/provider.go
+++ b/pkg/auth/certs/provider.go
@@ -25,6 +25,11 @@ type CertificateProvider interface {
 	// to send as trust chain for a certain identity as well as a private key
 	GetCertificateForIdentity(id identity.NumericIdentity) (*tls.Certificate, error)
 
+	// GetIdentityOfCertificate gives the identity that is encoded inside a certificate.
+	// it will not validate the certificate chain, it will only return the identity.
+	// To validate the certificate you should use ValidateIdentity.
+	GetIdentityOfCertificate(cert *x509.Certificate) (identity.NumericIdentity, error)
+
 	// ValidateIdentity will check if the SANs or other identity methods are valid
 	// for the given Cilium identity this function is needed as SPIFFE encodes the
 	// full ID in the URI SAN.

--- a/pkg/auth/spire/certificate_provider.go
+++ b/pkg/auth/spire/certificate_provider.go
@@ -126,3 +126,10 @@ func (s *SpireDelegateClient) Status() *models.Status {
 		State: models.StatusStateOk,
 	}
 }
+
+func (s *SpireDelegateClient) GetIdentityOfCertificate(cert *x509.Certificate) (identity.NumericIdentity, error) {
+	if len(cert.URIs) == 0 {
+		return 0, errors.New("certificate has no URI SAN")
+	}
+	return s.spiffeIDToNumericIdentity(cert.URIs[0].String())
+}


### PR DESCRIPTION
This adds a policy allowed check on the receiving end of the mTLS handshake.
The server will check in the local policy map if the two identities
have their auth type set to SPIRE.
If this isn't the case it will deny the handshake.


```release-note
Perform policy check on receiving side of Mutual Auth mTLS handshake
```
