### PR TITLE
Use Go 1.19 atomic types and their default value

### DIFF
--- a/pkg/bpf/events.go
+++ b/pkg/bpf/events.go
@@ -129,7 +129,7 @@ type eventsBuffer struct {
 // off the buffer (or is not reading off it fast enough).
 type Handle struct {
 	c      chan *Event
-	closed *atomic.Value
+	closed atomic.Bool
 	closer *sync.Once
 	err    error
 }
@@ -154,8 +154,7 @@ func (h *Handle) close(err error) {
 }
 
 func (h *Handle) isClosed() bool {
-	v := h.closed.Load()
-	return v.(bool)
+	return h.closed.Load()
 }
 
 func (h *Handle) isFull() bool {
@@ -199,12 +198,9 @@ func (eb *eventsBuffer) dumpAndSubscribe(callback EventCallbackFunc, follow bool
 		return nil, nil
 	}
 
-	closed := &atomic.Value{}
-	closed.Store(false)
 	h := &Handle{
 		c:      make(chan *Event, eventSubChanBufferSize),
 		closer: &sync.Once{},
-		closed: closed,
 	}
 
 	eb.subsLock.Lock()

--- a/pkg/k8s/watchers/endpoints.go
+++ b/pkg/k8s/watchers/endpoints.go
@@ -26,7 +26,6 @@ func (k *K8sWatcher) endpointsInit() {
 	apiGroup := resources.K8sAPIGroupEndpointSliceOrEndpoint
 
 	var synced atomic.Bool
-	synced.Store(false)
 
 	k.blockWaitGroupToSyncResources(
 		k.stop,

--- a/pkg/k8s/watchers/node.go
+++ b/pkg/k8s/watchers/node.go
@@ -41,7 +41,6 @@ func nodeEventsAreEqual(oldNode, newNode *slim_corev1.Node) bool {
 func (k *K8sWatcher) NodesInit(k8sClient client.Clientset) {
 	k.nodesInitOnce.Do(func() {
 		var synced atomic.Bool
-		synced.Store(false)
 		swg := lock.NewStoppableWaitGroup()
 		k.blockWaitGroupToSyncResources(
 			k.stop,

--- a/pkg/k8s/watchers/service.go
+++ b/pkg/k8s/watchers/service.go
@@ -17,7 +17,6 @@ import (
 
 func (k *K8sWatcher) servicesInit() {
 	var synced atomic.Bool
-	synced.Store(false)
 	swgSvcs := lock.NewStoppableWaitGroup()
 
 	k.blockWaitGroupToSyncResources(


### PR DESCRIPTION
Follow-up for https://github.com/cilium/cilium/pull/27563 fixing a few missed cases.

See commits for details.
