### PR TITLE
bpf: ct: reuse get_ct_map*() in get_cluster_ct_map*()

### DIFF
--- a/bpf/lib/conntrack_map.h
+++ b/bpf/lib/conntrack_map.h
@@ -88,10 +88,8 @@ get_cluster_ct_map6(const struct ipv6_ct_tuple *tuple, __u32 cluster_id __maybe_
 		return map_lookup_elem(&PER_CLUSTER_CT_ANY6, &cluster_id);
 	}
 #endif
-	if (tuple->nexthdr == IPPROTO_TCP)
-		return &CT_MAP_TCP6;
 
-	return &CT_MAP_ANY6;
+	return get_ct_map6(tuple);
 }
 
 static __always_inline void *
@@ -194,10 +192,8 @@ get_cluster_ct_map4(const struct ipv4_ct_tuple *tuple, __u32 cluster_id __maybe_
 		return map_lookup_elem(&PER_CLUSTER_CT_ANY4, &cluster_id);
 	}
 #endif
-	if (tuple->nexthdr == IPPROTO_TCP)
-		return &CT_MAP_TCP4;
 
-	return &CT_MAP_ANY4;
+	return get_ct_map4(tuple);
 }
 
 static __always_inline void *


### PR DESCRIPTION
Don't open-code the map selection, but use the standard helper. This avoids that the two code paths drift apart.