### PR TITLE
images: Support updating Envoy to PR images

### DIFF
--- a/images/scripts/update-cilium-envoy-image.sh
+++ b/images/scripts/update-cilium-envoy-image.sh
@@ -13,29 +13,37 @@ root_dir="$(git rev-parse --show-toplevel)"
 
 cd "${root_dir}"
 
-github_repo="cilium/proxy"
-github_branch="main"
+github_repo=${proxy_repo:-"cilium/proxy"}
+github_branch=${proxy_branch:-"main"}
+
+latest_commit_sha="$(curl -s https://api.github.com/repos/"${github_repo}"/commits/"${github_branch}" | jq -r --exit-status '.sha')"
+envoy_version="$(curl -s https://raw.githubusercontent.com/"${github_repo}"/"${latest_commit_sha}"/ENVOY_VERSION)"
+
 image="quay.io/cilium/cilium-envoy"
-
-latest_commit_sha="$(curl -s https://api.github.com/repos/${github_repo}/commits/${github_branch} | jq -r --exit-status '.sha')"
-envoy_version="$(curl -s https://raw.githubusercontent.com/${github_repo}/"${latest_commit_sha}"/ENVOY_VERSION)"
-
 image_tag="${envoy_version//envoy-/v}-${latest_commit_sha}"
+if [ "${github_branch}" != "main" ]; then
+    image="quay.io/cilium/cilium-envoy-dev"
+    image_tag="${latest_commit_sha}"
+fi
 
 image_full="${image}:${image_tag}"
 image_sha256=$("${script_dir}/get-image-digest.sh" "${image_full}" || echo "")
 if [ -n "${image_sha256}" ]; then
   image_full="${image_full}@${image_sha256}"
+else
+  echo "Digest is not (yet) available for image ${image_full}!"
+  exit 1
 fi
 
 echo "Latest image from branch ${github_branch}: ${image_full}"
 
 DOCKERFILEPATH="./images/cilium/Dockerfile"
 echo "Updating image in ${DOCKERFILEPATH}"
-sed -i -E "s|(FROM ${image}:)(.*)(@sha256:[0-9a-z]*)( as cilium-envoy)|\1${image_tag}@${image_sha256}\4|" ${DOCKERFILEPATH}
+sed -i -E "s|FROM quay.io/cilium/cilium-envoy.*:.*@sha256:[0-9a-z]* as cilium-envoy|FROM ${image}:${image_tag}@${image_sha256} as cilium-envoy|" ${DOCKERFILEPATH}
 
 MAKEFILEPATH="./install/kubernetes/Makefile.values"
 echo "Updating image in ${MAKEFILEPATH}"
+sed -i -E "s|export[[:space:]]+CILIUM_ENVOY_REPO:=.*|export CILIUM_ENVOY_REPO:=${image}|" ${MAKEFILEPATH}
 sed -i -E "s|export[[:space:]]+CILIUM_ENVOY_VERSION:=.*|export CILIUM_ENVOY_VERSION:=${image_tag}|" ${MAKEFILEPATH}
 sed -i -E "s|export[[:space:]]+CILIUM_ENVOY_DIGEST:=.*|export CILIUM_ENVOY_DIGEST:=${image_sha256}|" ${MAKEFILEPATH}
 
@@ -43,5 +51,5 @@ if git diff --exit-code ./install/kubernetes/Makefile.values ./images/cilium/Doc
   echo "The envoy image is already up to date"
 else
   echo "Updated the envoy image to be a latest version"
-  echo "Please don't forget to execute 'make -C Documentation update-helm-values && make -C install/kubernetes'"
+  echo "Please don't forget to execute 'make -C install/kubernetes && make -C Documentation update-helm-values'"
 fi


### PR DESCRIPTION
Update Envoy to PR build image when $proxy_branch is set to the PR branch name, e.g.:

  $ proxy_branch=pr/my/branch images/scripts/update-cilium-envoy-image.sh

This will result in the image being pulled from cilium-envoy-dev instead of cilium-envoy and the tag consisting only of the Git commit SHA (no Envoy version prefix). sed line for Dockerfile update needs to be more explicit so that the image repo name can be updated both ways.

The github repo can also be overridden, with `proxy_repo=my/repo` (default is `cilium/proxy`). Note that this still only supports PRs build by the main repo as otherwise the image would not be available in quay.io/cilium/cilium-envoy-dev.

Error out if sha256 digest for the image is not (yet) available, rather than continuing with an empty digest, as we still have "use digest" configured.

Also fix the recommended build order as install/kubernetes has to be built before Documentation.
