### PR TITLE
bpf: egressgw: pass IPv4 tuple to egress_gw_request_needs_redirect 

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1072,7 +1072,7 @@ ct_recreate4:
 		if (identity_is_cluster(*dst_sec_identity))
 			goto skip_egress_gateway;
 
-		if (egress_gw_request_needs_redirect(ip4, ct_status, &tunnel_endpoint)) {
+		if (egress_gw_request_needs_redirect(tuple, ct_status, &tunnel_endpoint)) {
 			if (tunnel_endpoint == EGRESS_GATEWAY_NO_GATEWAY) {
 				/* Special case for no gateway to drop the traffic */
 				return DROP_NO_EGRESS_GATEWAY;

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -651,6 +651,18 @@ ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 	ct_flip_tuple_dir4(tuple);
 }
 
+static __always_inline __be32
+ipv4_ct_reverse_tuple_saddr(const struct ipv4_ct_tuple *rtuple)
+{
+	return rtuple->daddr;
+}
+
+static __always_inline __be32
+ipv4_ct_reverse_tuple_daddr(const struct ipv4_ct_tuple *rtuple)
+{
+	return rtuple->saddr;
+}
+
 static __always_inline int ipv4_ct_extract_l4_ports(struct __ctx_buff *ctx,
 						    int off,
 						    enum ct_dir dir __maybe_unused,

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -36,7 +36,7 @@ struct egress_gw_policy_entry *lookup_ip4_egress_gw_policy(__be32 saddr, __be32 
 #endif /* ENABLE_EGRESS_GATEWAY */
 
 static __always_inline
-bool egress_gw_request_needs_redirect(struct iphdr *ip4 __maybe_unused,
+bool egress_gw_request_needs_redirect(struct ipv4_ct_tuple *rtuple __maybe_unused,
 				      int ct_status __maybe_unused,
 				      __u32 *tunnel_endpoint __maybe_unused)
 {
@@ -52,7 +52,8 @@ bool egress_gw_request_needs_redirect(struct iphdr *ip4 __maybe_unused,
 	if (ct_status == CT_REPLY || ct_status == CT_RELATED)
 		return false;
 
-	egress_gw_policy = lookup_ip4_egress_gw_policy(ip4->saddr, ip4->daddr);
+	egress_gw_policy = lookup_ip4_egress_gw_policy(ipv4_ct_reverse_tuple_saddr(rtuple),
+						       ipv4_ct_reverse_tuple_daddr(rtuple));
 	if (!egress_gw_policy)
 		return false;
 


### PR DESCRIPTION
pass the IPv4 tuple to egress_gw_request_needs_redirect instead of the
full IP header as only the source and destination addresses are needed
to match an egress gateway policy