### PR TITLE
pkg/node: Updates GetIPv6AllocCIDRs() to Properly Return Secondary CIDRs

### DIFF
--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -609,7 +609,7 @@ func (n *Node) GetIPv6AllocCIDRs() []*cidr.CIDR {
 	if n.IPv6AllocCIDR != nil {
 		result = append(result, n.IPv6AllocCIDR)
 	}
-	if len(n.IPv4SecondaryAllocCIDRs) > 0 {
+	if len(n.IPv6SecondaryAllocCIDRs) > 0 {
 		result = append(result, n.IPv6SecondaryAllocCIDRs...)
 	}
 	return result

--- a/pkg/node/types/node_test.go
+++ b/pkg/node/types/node_test.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -270,6 +271,118 @@ func TestClusterServiceValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.assert(t, tt.node.validate())
+		})
+	}
+}
+
+func TestGetIPv4AllocCIDRs(t *testing.T) {
+	var (
+		cidr1 = cidr.MustParseCIDR("1.0.0.0/24")
+		cidr2 = cidr.MustParseCIDR("2.0.0.0/24")
+		cidr3 = cidr.MustParseCIDR("3.0.0.0/24")
+	)
+
+	var tests = []struct {
+		// name of test
+		name string
+		// primary ipv4 allocation cidr
+		allocCIDR *cidr.CIDR
+		// secondary ipv4 allocation cidrs
+		secAllocCIDRs []*cidr.CIDR
+		// expected ipv4 cidrs
+		expectedCIDRs []*cidr.CIDR
+	}{
+		{
+			name:          "nil cidrs",
+			allocCIDR:     nil,
+			secAllocCIDRs: nil,
+			expectedCIDRs: make([]*cidr.CIDR, 0),
+		},
+		{
+			name:          "one primary and no secondary cidrs",
+			allocCIDR:     cidr1,
+			secAllocCIDRs: nil,
+			expectedCIDRs: []*cidr.CIDR{cidr1},
+		},
+		{
+			name:          "one primary and one secondary cidr",
+			allocCIDR:     cidr1,
+			secAllocCIDRs: []*cidr.CIDR{cidr2},
+			expectedCIDRs: []*cidr.CIDR{cidr1, cidr2},
+		},
+		{
+			name:          "one primary and multiple secondary cidrs",
+			allocCIDR:     cidr1,
+			secAllocCIDRs: []*cidr.CIDR{cidr2, cidr3},
+			expectedCIDRs: []*cidr.CIDR{cidr1, cidr2, cidr3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := Node{
+				Name:                    fmt.Sprintf("node-%s", tt.name),
+				IPv4AllocCIDR:           tt.allocCIDR,
+				IPv4SecondaryAllocCIDRs: tt.secAllocCIDRs,
+			}
+
+			actual := n.GetIPv4AllocCIDRs()
+			assert.Equal(t, actual, tt.expectedCIDRs)
+		})
+	}
+}
+
+func TestGetIPv6AllocCIDRs(t *testing.T) {
+	var (
+		cidr2001 = cidr.MustParseCIDR("2001:db8::/32")
+		cidr2002 = cidr.MustParseCIDR("2002:db8::/32")
+		cidr2003 = cidr.MustParseCIDR("2003:db8::/32")
+	)
+
+	var tests = []struct {
+		// name of test
+		name string
+		// primary ipv6 allocation cidr
+		allocCIDR *cidr.CIDR
+		// secondary ipv6 allocation cidrs
+		secAllocCIDRs []*cidr.CIDR
+		// expected ipv6 cidrs
+		expectedCIDRs []*cidr.CIDR
+	}{
+		{
+			name:          "nil cidrs",
+			allocCIDR:     nil,
+			secAllocCIDRs: nil,
+			expectedCIDRs: make([]*cidr.CIDR, 0),
+		},
+		{
+			name:          "one primary and no secondary cidrs",
+			allocCIDR:     cidr2001,
+			secAllocCIDRs: nil,
+			expectedCIDRs: []*cidr.CIDR{cidr2001},
+		},
+		{
+			name:          "one primary and one secondary cidr",
+			allocCIDR:     cidr2001,
+			secAllocCIDRs: []*cidr.CIDR{cidr2002},
+			expectedCIDRs: []*cidr.CIDR{cidr2001, cidr2002},
+		},
+		{
+			name:          "one primary and multiple secondary cidrs",
+			allocCIDR:     cidr2001,
+			secAllocCIDRs: []*cidr.CIDR{cidr2002, cidr2003},
+			expectedCIDRs: []*cidr.CIDR{cidr2001, cidr2002, cidr2003},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := Node{
+				Name:                    fmt.Sprintf("node-%s", tt.name),
+				IPv6AllocCIDR:           tt.allocCIDR,
+				IPv6SecondaryAllocCIDRs: tt.secAllocCIDRs,
+			}
+
+			actual := n.GetIPv6AllocCIDRs()
+			assert.Equal(t, actual, tt.expectedCIDRs)
 		})
 	}
 }


### PR DESCRIPTION
- Updates the GetIPv6AllocCIDRs() method to check the length of IPv6SecondaryAllocCIDRs instead of IPv4SecondaryAllocCIDRs.
- Adds test cases for GetIPv4AllocCIDRs() and GetIPv6AllocCIDRs() methods.

Fixes #27836