### PR TITLE
ci: run verifier tests with proper Go toolchain version

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -52,6 +52,8 @@ concurrency:
 
 env:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  # renovate: datasource=golang-version depName=go
+  go-version: 1.21.0
 
 jobs:
   commit-status-start:
@@ -108,6 +110,10 @@ jobs:
           cmd: |
             git config --global --add safe.directory /host
             uname -a
+            # The LVH image might ship with an arbitrary Go toolchain version,
+            # install the same Go toolchain version as current HEAD.
+            go install golang.org/dl/go${{ env.go-version }}@latest
+            go${{ env.go-version }} download
 
       - name: Run verifier tests
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
@@ -116,7 +122,7 @@ jobs:
           cmd: |
             cd /host/
             # Run with cgo disabled, LVH images don't ship with gcc.
-            CGO_ENABLED=0 go test -v -parallel=1 ./test/verifier -cilium-base-path /host -ci-kernel-version ${{ matrix.ci-kernel }}
+            CGO_ENABLED=0 go${{ env.go-version }} test -v -parallel=1 ./test/verifier -cilium-base-path /host -ci-kernel-version ${{ matrix.ci-kernel }}
 
       - name: Fetch artifacts
         if: ${{ !success() }}


### PR DESCRIPTION
Currently, the verifier tests are built and run with whatever Go toolchain version the LVH images ship. To make sure these tests are run with the same Go toolchain version as the rest of the tests install a copy of that Go toolchain before running the test.

This wasn't caught in CI on https://github.com/cilium/cilium/pull/27820 because the verifier workflow wasn't run passed on the ariane exclusion list.

Reported-by: @julianwiedmann