### PR TITLE
contrib: Move github draft release to post-release

### DIFF
--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -123,8 +123,6 @@ main() {
     logecho "  * If this is a prerelease, create a revert commit"
     logecho "* Push the PR to Github for review ('submit-release.sh')"
     logecho "* (After PR merge) Use 'tag-release.sh' to prepare tags/release"
-
-    # Leave $version-changes.txt around for prep-release.sh usage later
 }
 
 main "$@"

--- a/contrib/release/tag-release.sh
+++ b/contrib/release/tag-release.sh
@@ -53,10 +53,6 @@ main() {
     fi
     local version="v$ersion"
 
-    if [[ ! -e $version-changes.txt ]]; then
-        common::exit 1 "Generate release notes via contrib/release/start-release.sh"
-    fi
-
     git fetch $REMOTE
 
     local commit="$(git rev-parse HEAD)"
@@ -75,14 +71,6 @@ main() {
     logrun -s git tag -a $ersion -s -m "Release $version"
     logrun -s git tag -a $version -s -m "Release $version"
     logrun -s git push $REMOTE $version $ersion
-
-    # Leave $version-changes.txt around so we can generate release notes later
-    echo -e "$ersion\n" > $version-release-summary.txt
-    echo "We are pleased to release Cilium $version." >>  $version-release-summary.txt
-    tail -n+4 $version-changes.txt >> $version-release-summary.txt
-    logecho "Creating Github draft release"
-    logrun hub release create -d -F $version-release-summary.txt $version
-    logecho "Browse to $RELEASES_URL to see the draft release"
 
     logecho
     logecho "Next steps:"


### PR DESCRIPTION
There's a few suboptimal things with the current release process:
- If one contributor prepares part of the release but another person
  tags the release, then later steps in the process can fail because
  early scripts create local files that are required to complete the
  release. Those files won't be present on the second person's machine.
- Despite programmatically creating the release text, the workflow
  expects that a release preparer will manually pull the docker digests
  and insert it into the release text.

We can fix this by deferring the github release creation until the
post-release phase. At this point, the digests are known for the target
releases, so we can pull those from the specified target URL. At this
point, the changelog also includes all of the remaining details that we
need to prepare the release text.

As a side effect, this allows us to align the processes between the
patch versions and prereleases more closely.

Related: https://github.com/cilium/release/pull/141