### PR TITLE
fix duplicated ids in prerelease testing template

### DIFF
--- a/.github/ISSUE_TEMPLATE/prerelease-testing.yaml
+++ b/.github/ISSUE_TEMPLATE/prerelease-testing.yaml
@@ -83,7 +83,7 @@ body:
     validations:
       required: true
   - type: textarea
-    id: issue-filed
+    id: related-issues
     attributes:
       label: Related GitHub Issues
       description: |
@@ -91,7 +91,7 @@ body:
     validations:
       required: false
   - type: textarea
-    id: issue-filed
+    id: other-feedback
     attributes:
       label: Other Feedback
       description: |


### PR DESCRIPTION
This is a fix for a template syntax error that wasn't caught in the original PR.

I've subsequently tested that this template works in my fork of the repository as intended by enabling issues support in the fork to ensure there's not another syntax issue.

I generated https://github.com/jspaleta/cilium/issues/2  using the template.
