### PR TITLE
devices: Do not ignore link local addresses

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -379,10 +379,6 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 		for _, u := range updates {
 			switch u := u.(type) {
 			case netlink.AddrUpdate:
-				if u.Scope == unix.RT_SCOPE_LINK {
-					// Ignore link local addresses.
-					continue
-				}
 				addr := deviceAddressFromAddrUpdate(u)
 				if u.NewAddr {
 					d.Addrs = append(d.Addrs, addr)

--- a/pkg/datapath/linux/devices_controller_test.go
+++ b/pkg/datapath/linux/devices_controller_test.go
@@ -60,6 +60,17 @@ func devicesControllerTestSetup(t *testing.T) {
 	})
 }
 
+func containsAddress(dev *tables.Device, addrStr string) bool {
+	addr := netip.MustParseAddr(addrStr)
+	for _, a := range dev.Addrs {
+		if a.Addr == addr {
+			return true
+		}
+	}
+	return false
+
+}
+
 func TestDevicesController(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -139,8 +150,7 @@ func TestDevicesController(t *testing.T) {
 			func(t *testing.T, devs []*tables.Device, routes []*tables.Route) bool {
 				return len(devs) == 1 &&
 					"dummy1" == devs[0].Name &&
-					len(devs[0].Addrs) == 1 &&
-					devs[0].Addrs[0].Addr == netip.MustParseAddr("192.168.1.1")
+					containsAddress(devs[0], "192.168.1.1")
 			},
 		},
 
@@ -155,8 +165,7 @@ func TestDevicesController(t *testing.T) {
 					devs[0].Name == "dummy1" &&
 					devs[0].Selected &&
 					devs[1].Name == "veth0" &&
-					len(devs[1].Addrs) == 1 &&
-					devs[1].Addrs[0].Addr == netip.MustParseAddr("192.168.4.1") &&
+					containsAddress(devs[1], "192.168.4.1") &&
 					devs[1].Selected
 			},
 		},


### PR DESCRIPTION
The devices controller ignored link local addresses which usually are the automatically assigned fe80:: and 169.254.0.0/16. In some setups however link local addresses are used for K8s purposes and there is no good rational for ignoring them. The likely reason why they were initially ignored was to make the tests predictable by not having automatically assigned addresses on the test network devices.

This only affected the unreleased v1.15. 

```release-note
Do not ignore link local addresses when detecting network devices. This fixes a problem in setups where network devices that only had link local addresses were ignored.
```
