### PR TITLE
ci: disable cgo when installing Go toolchain

### DIFF
--- a/.github/workflows/tests-datapath-verifier.yaml
+++ b/.github/workflows/tests-datapath-verifier.yaml
@@ -112,7 +112,7 @@ jobs:
             uname -a
             # The LVH image might ship with an arbitrary Go toolchain version,
             # install the same Go toolchain version as current HEAD.
-            go install golang.org/dl/go${{ env.go-version }}@latest
+            CGO_ENABLED=0 go install golang.org/dl/go${{ env.go-version }}@latest
             go${{ env.go-version }} download
 
       - name: Run verifier tests


### PR DESCRIPTION
The LVH images don't have GCC, so we need to explicitly disable cgo. This fixes the following failure:

	# runtime/cgo
	_cgo_export.c:3:10: fatal error: stdlib.h: No such file or directory
	    3 | #include <stdlib.h>
	      |          ^~~~~~~~~~
	compilation terminated.

Fixes: bb3eec41c750 ("ci: run verifier tests with proper Go toolchain version")