### PR TITLE
examples: Fix YAML error backendRefs in HTTP Header Modifier

### DIFF
--- a/examples/kubernetes/gateway/request-header.yaml
+++ b/examples/kubernetes/gateway/request-header.yaml
@@ -32,5 +32,5 @@ spec:
               - name: my-header-name
                 value: my-header-value
       backendRefs:
-        - name: echo
+        - name: echo-1
           port: 8080


### PR DESCRIPTION
The commit bb50725cc304 ("Header Modifier and Splitting use cases") used wrong 'backendRefs' service name setting for Header Modifier HTTPRoute.

kubectl describe HTTPRoute header-http-echo
      Message:               Service "echo" not found
      Observed Generation:   1
      Reason:                BackendNotFound
      Status:                False

The demo has two services: "echo-1" with 8080, "echo-2" with 8090. Fix the wrong name:

kubectl describe HTTPRoute header-http-echo
      Message:               Service reference is valid
      Observed Generation:   1
      Reason:                ResolvedRefs
      Status:                True
      Type:                  ResolvedRefs

```release-note
examples: Fix YAML error backendRefs in HTTP Header Modifier
```
