### PR TITLE
contrib/kind: Log DNS queries in CoreDNS pods

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -196,10 +196,11 @@ if [ "${xdp}" = true ]; then
   done
 fi
 
-# Replace "forward . /etc/resolv.conf" in the coredns cm with "forward . 8.8.8.8".
+# 1) Replace "forward . /etc/resolv.conf" in the coredns cm with "forward . 8.8.8.8".
 # This is required because in case of BPF Host Routing we bypass iptables thus
 # breaking DNS. See https://github.com/cilium/cilium/issues/23330
-NewCoreFile=$(kubectl get cm -n kube-system coredns -o jsonpath='{.data.Corefile}' | "${SED}" 's,forward . /etc/resolv.conf,forward . 8.8.8.8,' | "${SED}" -z 's/\n/\\n/g')
+# 2) Enable the log plugin to log all DNS queries for debugging.
+NewCoreFile=$(kubectl get cm -n kube-system coredns -o jsonpath='{.data.Corefile}' | "${SED}" 's,forward . /etc/resolv.conf,forward . 8.8.8.8,' | "${SED}" 's/loadbalance/loadbalance\n    log/' | "${SED}" -z 's/\n/\\n/g')
 kubectl patch configmap/coredns -n kube-system --type merge -p '{"data":{"Corefile": "'"$NewCoreFile"'"}}'
 
 set +e


### PR DESCRIPTION
In CI, we currently collect CoreDNS logs as part of the sysdump. Those logs are however mostly useless after startup because we don't log the DNS queries. This commit fixes it. That provides for another data point when debugging failing DNS queries.