### PR TITLE
ci: Add a workflow to update labels of backported PRs

### DIFF
--- a/.github/workflows/update-label-backport-pr.yaml
+++ b/.github/workflows/update-label-backport-pr.yaml
@@ -1,0 +1,35 @@
+---
+    # A reusable workflow designed to be called from the context of a specific
+    # branch whenever a backport PR is merged. The workflow scans the backport PR
+    # body to get the list of the backported PRs and updates their labels, replacing
+    # all "backport-pending/<version>" with "backport-done/<version>".
+    name: Update labels of backported PRs
+    on:
+      workflow_call:
+        inputs:
+          pr-body:
+            required: true
+            type: string
+            description: "The PR description containing all the references to the backported PRs."
+          branch:
+            required: true
+            type: string
+            description: "The stable branch version."
+
+    jobs:
+      backport-label-updater:
+        name: Update labels of backported PRs
+        runs-on: ubuntu-latest
+        permissions:
+          pull-requests: write # Adding and removing labels
+        steps:
+          - name: Update labels in backported PRs
+            env:
+              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            run: |
+              echo '${{ inputs.pr-body }}' | sed -En "/upstream-prs/ { n; p }" | cut -d ';' -f 1 | grep -Eo '[0-9]+' | while read -r pr; do
+                echo "Removing label backport-pending/${{ inputs.branch }} from pr #${pr}."
+                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --remove-label backport-pending/"${{ inputs.branch }}"
+                echo "Adding label backport-done/${{ inputs.branch }} to pr #${pr}."
+                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --add-label backport-done/"${{ inputs.branch }}"
+              done

--- a/Documentation/contributing/development/reviewers_committers/review_process.rst
+++ b/Documentation/contributing/development/reviewers_committers/review_process.rst
@@ -118,13 +118,6 @@ Review process
    passed, and all reviewers have approved the requested changes, you can merge
    the PR by clicking on the "Rebase and merge" button.
 
-#. If the PR is a backport PR, update the labels of cherry-picked PRs with the
-   command included at the end of the original post. For example:
-
-   .. code-block:: shell-session
-
-       $ for pr in 26759 24099; do contrib/backporting/set-labels.py $pr done 1.13; done
-
 Reviewer Teams
 --------------
 

--- a/Documentation/contributing/release/backports.rst
+++ b/Documentation/contributing/release/backports.rst
@@ -165,9 +165,7 @@ tracked through the following links:
 
 Make sure that the Github labels are up-to-date, as this process will deal with
 all commits from PRs that have the ``needs-backport/X.Y`` label set (for a
-stable release version X.Y). If any PRs contain labels such as
-``backport-pending/X.Y``, ensure that the backport for that PR have been merged
-and if so, change the label to ``backport-done/X.Y``.
+stable release version X.Y).
 
 Creating the Backports Branch
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -309,9 +307,9 @@ Via GitHub Web Interface
 
           .. code-block:: RST
 
-                Once this PR is merged, you can update the PR labels via:
+                Once this PR is merged, a GitHub action will update the labels of these PRs:
                 ```upstream-prs
-                $ for pr in AAA BBB ; do contrib/backporting/set-labels.py $pr done VVV; done
+                AAA BBB
                 ```
 
        The ``upstream-prs`` tag `is required
@@ -341,15 +339,11 @@ The comment must not contain any other characters.
 After the Backports are Merged
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-After the backport PR is merged, if the person who merged the PR didn't take
-care of it already, mark all backported PRs with ``backport-done/X.Y`` label
-and clear the ``backport-pending/X.Y`` label(s). If the backport pull request
-description was generated using the scripts above, then the full command is
-listed in the pull request description.
-
-.. code-block:: shell-session
-
-   $ GITHUB_TOKEN=xxx for pr in 12589 12568; do contrib/backporting/set-labels.py $pr done 1.8; done
+After the backport PR is merged, the GH workflow "Call Backport Label Updater"
+should take care of marking all backported PRs with the ``backport-done/X.Y``
+label and clear the ``backport-pending/X.Y`` label(s).
+Verify that the workflow succeeded by looking `here
+<https://github.com/cilium/cilium/actions/workflows/call-backport-label-updater.yaml>`_.
 
 Backporting Guide for Others
 ----------------------------
@@ -369,13 +363,3 @@ be notified and asked to approve the backport commits. Confirm that:
 
 #. All the commits from the original PR have been indeed backported.
 #. In case of conflicts, the resulting changes look good.
-
-Merger
-~~~~~~
-
-When merging a backport PR, set the labels of the backported PRs to
-``done``. Typically, backport PRs include a line on how do that. E.g.,:
-
-.. code-block:: shell-session
-
-    $ GITHUB_TOKEN=xxx for pr in 12894 12621 12973 12977 12952; do contrib/backporting/set-labels.py $pr done 1.8; done

--- a/contrib/backporting/check-stable
+++ b/contrib/backporting/check-stable
@@ -206,12 +206,11 @@ if [[ ${#stable_prs[@]} > 0 ]]; then
     generate_commit_list_for_pr $pr $merged_at
     echo ""
   done
-  echo "When you have backported the above commits, you can update the PR labels via this command:"
-  echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr pending ${STABLE_BRANCH}; done"
+  echo "When you have backported the above commits, a GitHub action will automatically update the PR labels"
   if [[ ! -z $SUMMARY_LOG ]]; then
-    echo -e "\nOnce this PR is merged, you can update the PR labels via:" >> $SUMMARY_LOG
+    echo -e "\nOnce this PR is merged, a GitHub action will update the labels of these PRs:" >> $SUMMARY_LOG
     echo "\`\`\`upstream-prs" >> $SUMMARY_LOG
-    echo "$ for pr in ${stable_prs[@]}; do contrib/backporting/set-labels.py \$pr done ${STABLE_BRANCH}; done" >> $SUMMARY_LOG
+    echo "${stable_prs[@]}" >> $SUMMARY_LOG
     echo "\`\`\`" >> $SUMMARY_LOG
   fi
 fi

--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -19,15 +19,12 @@ except ImportError:
 
 parser = argparse.ArgumentParser()
 parser.add_argument('pr_number', type=int)
-actions = ["pending", "done"]
-parser.add_argument('action', type=str, choices=actions)
 parser.add_argument('version', type=str, default="1.0", nargs='?')
 
 args = parser.parse_args()
 
 token = os.environ["GITHUB_TOKEN"]
 pr_number = args.pr_number
-action = args.action
 version = args.version
 
 g = Github(token)
@@ -39,34 +36,18 @@ old_label_len = len(pr_labels)
 cilium_labels = cilium.get_labels()
 
 print("Setting labels for PR {}... ".format(pr_number), end="")
-if action == "pending":
-    pr_labels = [l for l in pr_labels
-                 if l.name != "needs-backport/"+version]
-    if old_label_len - 1 != len(pr_labels):
-        print("needs-backport/"+version+" label not found in PR, exiting")
-        sys.exit(1)
+pr_labels = [l for l in pr_labels
+                if l.name != "needs-backport/"+version]
+if old_label_len - 1 != len(pr_labels):
+    print("needs-backport/"+version+" label not found in PR, exiting")
+    sys.exit(1)
 
-    pr_labels.append(
-        [l for l in cilium_labels if l.name == "backport-pending/"+version][0])
+pr_labels.append(
+    [l for l in cilium_labels if l.name == "backport-pending/"+version][0])
 
-    if old_label_len != len(pr_labels):
-        print("error adding backport-pending/"+version+" label to PR, exiting")
-        sys.exit(2)
-    pr.set_labels(*pr_labels)
-
-if action == "done":
-    pr_labels = [l for l in pr_labels
-                 if l.name != "backport-pending/"+version]
-    if old_label_len - 1 != len(pr_labels):
-        print("backport-pending/"+version+" label not found in PR, exiting")
-        sys.exit(1)
-
-    pr_labels.append(
-        [l for l in cilium_labels if l.name == "backport-done/"+version][0])
-
-    if old_label_len != len(pr_labels):
-        print("error adding backport-done/"+version+" label to PR, exiting")
-        sys.exit(2)
-    pr.set_labels(*pr_labels)
+if old_label_len != len(pr_labels):
+    print("error adding backport-pending/"+version+" label to PR, exiting")
+    sys.exit(2)
+pr.set_labels(*pr_labels)
 
 print("✓")

--- a/contrib/backporting/submit-backport
+++ b/contrib/backporting/submit-backport
@@ -59,12 +59,12 @@ else
   hub pull-request -b "v$BRANCH" -l kind/backports,backport/$BRANCH -F $SUMMARY -r $REVIEWERS
 fi
 
-prs=$(grep "contrib/backporting/set-labels.py" $SUMMARY | sed -e 's/^.*for pr in \([0-9 ]\+\);.*$/\1/g')
+prs=$(sed -En "/upstream-prs/ { n; p }" < "$SUMMARY")
 echo -e "\nUpdating labels for PRs $prs\n" 2>&1
 echo -n "Set labels for all PRs above? [Y/n] "
 read set_all_labels
 if [ "$set_all_labels" != "n" ]; then
     for pr in $prs; do
-        $DIR/set-labels.py $pr pending $BRANCH;
+        $DIR/set-labels.py $pr $BRANCH;
     done
 fi


### PR DESCRIPTION
Add a reusable workflow to be called from stable branches whenever a backport PR is merged. The workflow scans the body of the backport PR (that is, a PR like [this one](https://github.com/cilium/cilium/pull/27739)) to get the list of the original PRs, and updates the label `backport-pending/<version>` to `backport-done/<version>` for each of them.

The list of PRs to be updated is fetched from the Backport PR body section labeled `upstream-prs`.

Fixes: https://github.com/cilium/github-actions/issues/12