### PR TITLE
[v1.14] ci: Add a call to the update label backport action

### DIFF
--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -1,0 +1,19 @@
+---
+    name: Call Backport Label Updater
+    on:
+      pull_request:
+        types:
+          - closed
+        branches:
+          - v1.14
+    jobs:
+      call-backport-label-updater:
+        if: |
+            github.event.pull_request.merged == true &&
+            contains(github.event.pull_request.body, 'upstream-prs') &&
+            contains(github.event.pull_request.labels.*.name, 'backport/1.14')
+        uses: cilium/cilium/.github/workflows/update-label-backport-pr.yaml@main
+        with:
+          pr-body: ${{ github.event.pull_request.body }}
+          branch: 1.14
+        secrets: inherit


### PR DESCRIPTION
Add an action to call the workflow that update the labels of backported PRs in v1.14 stable branch.

Depends on: #27875 
