### PR TITLE
egressgw: switch unit tests to reconciliationEventsCount

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -160,6 +160,10 @@ type Manager struct {
 	// the node with the desired egress gateway state.
 	// The trigger is used to batch multiple updates together
 	reconciliationTrigger *trigger.Trigger
+
+	// reconciliationEventsCount keeps track of how many reconciliation
+	// events have occoured
+	reconciliationEventsCount uint64
 }
 
 type Params struct {
@@ -1019,4 +1023,6 @@ func (manager *Manager) reconcileLocked() {
 
 	// clear the events bitmap
 	manager.eventsBitmap = 0
+
+	manager.reconciliationEventsCount += 1
 }


### PR DESCRIPTION
instead of just retrying to assert that egressgw bpf entries and IP
rules/routes are consistent with the expected state, use the newly
introduced reconciliationEventsCount manager's variable to ensure that
the manager has actually gone through a reconciliation round