### PR TITLE
Fix global service incompatibility when v1.14 agents connect to a v1.13 cluster

### DIFF
--- a/pkg/service/store/store.go
+++ b/pkg/service/store/store.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
-	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -124,9 +123,9 @@ func (s *ClusterService) Unmarshal(_ string, data []byte) error {
 }
 
 func (s *ClusterService) validate() error {
-	// Skip the ClusterID check if it matches the local one, as we assume that
-	// it has already been validated, and to allow it to be zero.
-	if s.ClusterID != option.Config.ClusterID {
+	// Explicitly allow the ClusterID to be zero for backward compatibility,
+	// as this field was not present in v1.13.
+	if s.ClusterID != 0 {
 		if err := cmtypes.ValidateClusterID(s.ClusterID); err != nil {
 			return err
 		}


### PR DESCRIPTION
Note: this fix targets v1.14 only, as the ClusterID field of the ClusterService struct has been introduced in v1.14, and thus on v1.15 we can safely assume that it is present (as we support one minor version skew between clusters).

2819d7c4cc27 ("service: add extra validation for global services") introduced a validation function to prevent unmarshalling invalid global service objects retrieved from remote clusters. In particular, it flags a ClusterID=0 as invalid, unless it matches the one of the local cluster (as that case is supported for external workloads).

Yet, the ClusterID field was not present as part of the ClusterService struct in v1.13, causing a failure when the v1.14 agents connect to a cluster still running the v1.13 clustermesh-apiserver. Hence, let's relax this validation to support ClusterID=0 and prevent issues during upgrades.

Fixes: 2819d7c4cc27 ("service: add extra validation for global services")
Reported-by:  @LukeFrostmourne

<!-- Description of change -->

```release-note
Fix global service incompatibility when v1.14 agents connect to a v1.13 cluster
```
