### PR TITLE
workflows/ipsec: Add missing `--flush-ct` for key rotation

### DIFF
--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -282,7 +282,8 @@ jobs:
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
               --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})"
+              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+              --flush-ct
 
       - name: Rotate IPsec Key & Test (${{ join(matrix.*, ', ') }})
         uses: cilium/cilium/.github/actions/conn-disrupt-test@d86f33b098a75f3d7d2dfd3ee6fa1ea033892de4


### PR DESCRIPTION
Now that we cover the key rotations in the IPsec e2e tests, we are running the connectivity test suite twice. That means we can run in the usual bug where an existing CT entry is reused and leads to us sending traffic to the proxy when we shouldn't (cf. https://github.com/cilium/cilium/issues/17459).

Thus, we need to flush the CT entries at the end of the first test run, with `--flush-ct`.

Fixes: de192decf1cf9 ("ci-ipsec-e2e: Add IPsec key rotation test")