### PR TITLE
external-workloads: do not automatically infer ClusterID/Name

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -320,6 +320,12 @@ Annotations:
   labels ``reserved:init``, these policies must be converted to
   ``CiliumClusterwideNetworkPolicy`` by changing the resource type for the
   policy.
+* Cluster name and ID are no longer automatically inferred by Cilium agents
+  running on :ref:`external workloads <external_workloads>`.
+  If the cluster name and ID are different from the default values, you must
+  specify them as parameters.
+  Generate the installation script using Cilium CLI >=v0.15.8 to automatically
+  include these parameters.
 
 .. _upgrade_cilium_cli_helm_mode:
 

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1055,7 +1055,9 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 
 		// This can override node addressing config, so do this before starting IPAM
 		log.WithField(logfields.NodeName, nodeTypes.GetName()).Debug("Calling JoinCluster()")
-		d.nodeDiscovery.JoinCluster(nodeTypes.GetName())
+		if err := d.nodeDiscovery.JoinCluster(nodeTypes.GetName()); err != nil {
+			return nil, nil, err
+		}
 
 		// Start services watcher
 		serviceStore.JoinClusterServices(d.k8sWatcher.K8sSvcCache, option.Config.ClusterName)


### PR DESCRIPTION
Currently, when the Cilium agent running on a VM joins an existing cluster, it automatically infers the corresponding ClusterID and ClusterName. Yet, this introduces a dependency order, because all consumers of that field need to be initialized after the connection to the remote cluster, which is especially problematic as more components get converted to cells. Additionally, this may also lead to possible user confusion, as the corresponding parameter is reported as not initialized in the logs.

Hence, let's require these parameters to be explicitly set, reporting a failure in case they don't match those automatically discovered.

Depends on https://github.com/cilium/cilium-cli/pull/1948

<!-- Description of change -->

```release-note
Don't automatically infer ClusterID and ClusterName for external workloads.
```
