### PR TITLE
hubble: Use protobuf GetType() helper in v1.FlowProtocol() to avoid possible panic

### DIFF
--- a/pkg/hubble/api/v1/flow.go
+++ b/pkg/hubble/api/v1/flow.go
@@ -11,7 +11,7 @@ import (
 // FlowProtocol returns the protocol best describing the flow. If available,
 // this is the L7 protocol name, then the L4 protocol name.
 func FlowProtocol(flow *pb.Flow) string {
-	switch flow.GetEventType().Type {
+	switch flow.GetEventType().GetType() {
 	case monitorAPI.MessageTypeAccessLog:
 		if l7 := flow.GetL7(); l7 != nil {
 			switch {


### PR DESCRIPTION
If the event type is unset, or the flow is nil, it's possible that FlowProtocol could panic. To avoid this, use the GetType() helper method which is nil safe.


```release-note
hubble: Use protobuf GetType() helper in v1.FlowProtocol() to avoid possible panic
```
