### PR TITLE
contrib: Fix remote detection for security branches

### DIFF
--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -12,7 +12,7 @@ get_remote () {
   local org=${1:-cilium}
   local repo=${2:-cilium}
   remote=$(git remote -v | \
-    grep "github.com[/:]${org}/${repo}" | \
+    grep "github.com[/:]${org}/${repo} " | \
     head -n1 | cut -f1)
   if [ -z "$remote" ]; then
       echo "No remote git@github.com:${org}/${repo}.git or https://github.com/${org}/${repo} found" 1>&2


### PR DESCRIPTION
Security trees can have remotes like cilium/cilium-ghsa-abcdef . Add a
space after the repo so that it matches the correct remote entry.
