### PR TITLE
Improve bump-readme.sh

### DIFF
--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -112,7 +112,7 @@ check_table "commits/v1"
 
 git add README.rst stable.txt Documentation/_static/stable-version.json $ACTS_YAML
 if ! git diff-index --quiet HEAD -- README.rst stable.txt Documentation/_static/stable-version.json $ACTS_YAML; then
-    git commit -s -m "Update stable releases"
+    git commit -s -m "README: Update releases"
     echo "README.rst and stable.txt updated, submit the PR now."
 else
     echo "No new releases found."

--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -6,6 +6,9 @@ DIR=$(dirname $(readlink -ne $BASH_SOURCE))
 source $DIR/lib/common.sh
 source $DIR/../backporting/common.sh
 
+set -e
+set -o pipefail
+
 MAJ_REGEX='[0-9]\+\.[0-9]\+'
 VER_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(pre\|rc\)\.[0-9]\+\)\?'
 PRE_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+-\(pre\|rc\)\.[0-9]\+'

--- a/contrib/release/bump-readme.sh
+++ b/contrib/release/bump-readme.sh
@@ -7,17 +7,51 @@ source $DIR/lib/common.sh
 source $DIR/../backporting/common.sh
 
 MAJ_REGEX='[0-9]\+\.[0-9]\+'
-MIN_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+'
+VER_REGEX='[0-9]\+\.[0-9]\+\.[0-9]\+\(-\(pre\|rc\)\.[0-9]\+\)\?'
 REGEX_FILTER_DATE='s/^\([-0-9]\+\).*/\1/'
 PROJECTS_REGEX='s/.*projects\/\([0-9]\+\).*/\1/'
 ACTS_YAML=".github/maintainers-little-helper.yaml"
 REMOTE="$(get_remote)"
 
 latest_stable=""
+
+# $1 - release branch
+# $2 - latest release for the target branch (maybe vX.Y+1* for prerelease)
+# #3 - git tree path to commit object, eg tree/ or commits/
+# $4 - regex to strip out constant release info from a release line
+update_release() {
+    old_branch="$1"
+    latest="$2"
+    obj_regex="$3"
+    rem_branch_regex="$4"
+
+    new_branch=$(echo $latest | sed 's/\('$MAJ_REGEX'\).*/v\1/')
+    current=$(grep "$obj_regex$old_branch" README.rst \
+              | sed 's/^.*'"$obj_regex"'.*tag\/v\('"$rem_branch_regex"'\).*$/\1/')
+    old_date=$(git log -1 -s --format="%cI" v$current | sed "$REGEX_FILTER_DATE")
+    new_date=$(git log -1 -s --format="%cI" $latest | sed "$REGEX_FILTER_DATE")
+    elease=$(echo $old_branch | sed 's/v//')
+    old_proj=$(grep -F "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
+               | sed "$PROJECTS_REGEX")
+    new_proj=$(git show $REMOTE/$old_branch:$ACTS_YAML | grep projects \
+               | sed "$PROJECTS_REGEX")
+
+    printf "%10s %10s %10s %10s\n" "current" "old_date" "new_date" "elease"
+    printf "%10s %10s %10s %10s\n" $current  $old_date  $new_date  $elease
+
+    echo "Updating $old_branch:"
+    echo "  $current on $old_date with project $old_proj to"
+    echo "  $latest on $new_date with project $new_proj"
+    sed -i '/'$obj_regex'/s/'$old_branch'\(.*\)'$old_date'/'$new_branch'\1'$new_date'/g' README.rst
+    sed -i '/'$obj_regex'/s/v'$current'/v'$latest'/g' README.rst
+    sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
+
+}
+
 for release in $(grep "Release Notes" README.rst \
                  | sed 's/.*tree\/\(v'"$MAJ_REGEX"'\).*/\1/'); do
     latest=$(git describe --tags $REMOTE/$release \
-             | sed 's/v//' | sed 's/\('"$MIN_REGEX"'\).*/\1/')
+             | sed 's/v//' | sed 's/\('"$VER_REGEX"'\).*/\1/')
     if [ -z "$latest_stable" ]; then
         # the first release in the list is the latest stable
         latest_stable=$latest
@@ -28,22 +62,7 @@ for release in $(grep "Release Notes" README.rst \
         continue
     fi
 
-    current=$(grep -F $release README.rst \
-              | sed 's/.*\('"$MIN_REGEX"'\).*/\1/' | head -n 1)
-    old_date=$(git log -1 -s --format="%cI" $current | sed "$REGEX_FILTER_DATE")
-    new_date=$(git log -1 -s --format="%cI" $latest | sed "$REGEX_FILTER_DATE")
-    elease=$(echo $release | sed 's/v//')
-    old_proj=$(grep -F "$elease" -A 1 $ACTS_YAML | grep projects | sort | uniq \
-               | sed "$PROJECTS_REGEX")
-    new_proj=$(git show $REMOTE/$release:$ACTS_YAML | grep projects \
-               | sed "$PROJECTS_REGEX")
-
-    echo "Updating $release:"
-    echo "  $current on $old_date with project $old_proj to"
-    echo "  $latest on $new_date with project $new_proj"
-    sed -i 's/\('$release'.*\)'$old_date'/\1'$new_date'/g' README.rst
-    sed -i 's/v'$current'/v'$latest'/g' README.rst
-    sed -i 's/\(projects\/\)'$old_proj'/\1'$new_proj'/g' $ACTS_YAML
+    update_release $release $latest "tree\/" "$VER_REGEX"
 done
 
 git add README.rst stable.txt Documentation/_static/stable-version.json $ACTS_YAML


### PR DESCRIPTION
This PR has two motivations:
- Add support for automatically bumping the latest "prerelease" version in the
  README.md so that prereleases can follow the same process as patch releases
- Add guardrails to prevent malformed tables from breaking the representation
  of the latest versions in the readme.

One of the problems we have occasionally is when a new version changes the
length of the line in the table in the README. This breaks the format of the
table, which then causes GitHub to stop rendering the table altogether. Ideally
we'd make the bump readme script smart enough to properly format the table, but
we should probably reimplement the whole thing in a real language like Go to
be able to reliably mutate the readme for this case. One step short of that is
to at least detect a malformed table and report an error to the user to then
fix it. So, go with that approach for now.

This PR also adds some default bash error checking options to properly fail out
when part of the process fails.
