### PR TITLE
Reduce "stale identity observed" warnings

### DIFF
--- a/pkg/hubble/parser/common/endpoint.go
+++ b/pkg/hubble/parser/common/endpoint.go
@@ -15,6 +15,14 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
+type DatapathContext struct {
+	SrcIP                 netip.Addr
+	SrcLabelID            uint32
+	DstIP                 netip.Addr
+	DstLabelID            uint32
+	TraceObservationPoint pb.TraceObservationPoint
+}
+
 type EndpointResolver struct {
 	log            logrus.FieldLogger
 	endpointGetter getters.EndpointGetter
@@ -36,7 +44,7 @@ func NewEndpointResolver(
 	}
 }
 
-func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdentity uint32) *pb.Endpoint {
+func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdentity uint32, context DatapathContext) *pb.Endpoint {
 	// The datapathSecurityIdentity parameter is the numeric security identity
 	// obtained from the datapath.
 	// The numeric identity from the datapath can differ from the one we obtain
@@ -45,29 +53,76 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 	// created and the time the event reaches the Hubble parser.
 	// To aid in troubleshooting, we want to preserve what the datapath observed
 	// when it made the policy decision.
-	resolveIdentityConflict := func(identity identity.NumericIdentity) uint32 {
+	resolveIdentityConflict := func(userspaceID identity.NumericIdentity, isLocalEndpoint bool) uint32 {
 		// if the datapath did not provide an identity (e.g. FROM_LXC trace
 		// points), use what we have in the user-space cache
-		userspaceSecurityIdentity := identity.Uint32()
-		if datapathSecurityIdentity == 0 {
-			return userspaceSecurityIdentity
+		datapathID := identity.NumericIdentity(datapathSecurityIdentity)
+		if datapathID == identity.IdentityUnknown {
+			return userspaceID.Uint32()
 		}
 
-		if datapathSecurityIdentity != userspaceSecurityIdentity {
-			r.log.WithFields(logrus.Fields{
-				logfields.Identity:    datapathSecurityIdentity,
-				logfields.OldIdentity: userspaceSecurityIdentity,
-				logfields.IPAddr:      ip,
-			}).Debugf("stale identity observed")
+		if datapathID != userspaceID {
+			if context.TraceObservationPoint == pb.TraceObservationPoint_TO_OVERLAY &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				datapathID == identity.ReservedIdentityRemoteNode &&
+				userspaceID == identity.ReservedIdentityHost {
+				// Ignore
+				//
+				// When encapsulating a packet for sending via the overlay network, if the source
+				// seclabel = HOST_ID, then we reassign seclabel with LOCAL_NODE_ID and then send
+				// a trace notify.
+			} else if context.TraceObservationPoint == pb.TraceObservationPoint_FROM_ENDPOINT &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				(datapathID == identity.ReservedIdentityHealth || !datapathID.IsReservedIdentity()) &&
+				userspaceID.IsWorld() {
+				// Ignore
+				//
+				// Sometimes packets from endpoint link-local addresses are intercepted by
+				// cil_from_container. Because link-local addresses are not stored in the IP cache,
+				// Hubble assigns them WORLD_ID.
+			} else if context.TraceObservationPoint == pb.TraceObservationPoint_FROM_HOST &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				datapathID.IsWorld() && userspaceID == identity.ReservedIdentityKubeAPIServer {
+				// Ignore
+				//
+				// When a pod sends a packet to the Kubernetes API, its IP is masqueraded and then
+				// when it receives a response and the masquerade is reversed, cil_from_host
+				// determines that the source ID is WORLD_ID because there is no packet mark.
+			} else if (context.TraceObservationPoint == pb.TraceObservationPoint_FROM_HOST ||
+				context.TraceObservationPoint == pb.TraceObservationPoint_TO_OVERLAY) &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				isLocalEndpoint && userspaceID == identity.ReservedIdentityHost {
+				// Ignore
+				//
+				// When proxied packets (via Cilium DNS proxy) are sent from the host their source
+				// IP is that of the host, yet their security identity is retained from the
+				// original source pod.
+			} else if context.TraceObservationPoint == pb.TraceObservationPoint_TO_ENDPOINT &&
+				ip == context.SrcIP && datapathID.Uint32() == context.SrcLabelID &&
+				!datapathID.IsReservedIdentity() &&
+				(userspaceID == identity.ReservedIdentityHost || userspaceID == identity.ReservedIdentityRemoteNode) {
+				// Ignore
+				//
+				// When proxied packets (via Cilium DNS proxy) are received by the destination
+				// host their source IP is that of the proxy, yet their security identity is
+				// retained from the original source pod. This is a similar case to #4, but on the
+				// receiving side.
+			} else {
+				r.log.WithFields(logrus.Fields{
+					logfields.Identity:    datapathID.Uint32(),
+					logfields.OldIdentity: userspaceID.Uint32(),
+					logfields.IPAddr:      ip,
+				}).Debugf("stale identity observed")
+			}
 		}
 
-		return datapathSecurityIdentity
+		return datapathID.Uint32()
 	}
 
 	// for local endpoints, use the available endpoint information
 	if r.endpointGetter != nil {
 		if ep, ok := r.endpointGetter.GetEndpointInfo(ip); ok {
-			epIdentity := resolveIdentityConflict(ep.GetIdentity())
+			epIdentity := resolveIdentityConflict(ep.GetIdentity(), true)
 			e := &pb.Endpoint{
 				ID:        uint32(ep.GetID()),
 				Identity:  epIdentity,
@@ -90,7 +145,7 @@ func (r *EndpointResolver) ResolveEndpoint(ip netip.Addr, datapathSecurityIdenti
 	var namespace, podName string
 	if r.ipGetter != nil {
 		if ipIdentity, ok := r.ipGetter.LookupSecIDByIP(ip); ok {
-			numericIdentity = resolveIdentityConflict(ipIdentity.ID)
+			numericIdentity = resolveIdentityConflict(ipIdentity.ID, false)
 		}
 		if meta := r.ipGetter.GetK8sMetadata(ip); meta != nil {
 			namespace, podName = meta.Namespace, meta.PodName

--- a/pkg/hubble/parser/sock/parser.go
+++ b/pkg/hubble/parser/sock/parser.go
@@ -91,8 +91,14 @@ func (p *Parser) Decode(data []byte, decoded *flowpb.Flow) error {
 	srcIP, _ := ippkg.AddrFromIP(epIP)
 	srcPort := uint16(0) // source port is not known for TraceSock events
 
-	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, 0)
-	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, 0)
+	datapathContext := common.DatapathContext{
+		SrcIP:      srcIP,
+		SrcLabelID: 0,
+		DstIP:      dstIP,
+		DstLabelID: 0,
+	}
+	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, 0, datapathContext)
+	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, 0, datapathContext)
 
 	// On the reverse path, source and destination IP of the packet are reversed
 	isRevNat := decodeRevNat(sock.XlatePoint)

--- a/pkg/hubble/parser/threefour/parser.go
+++ b/pkg/hubble/parser/threefour/parser.go
@@ -186,8 +186,15 @@ func (p *Parser) Decode(data []byte, decoded *pb.Flow) error {
 	}
 
 	srcLabelID, dstLabelID := decodeSecurityIdentities(dn, tn, pvn)
-	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, srcLabelID)
-	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, dstLabelID)
+	datapathContext := common.DatapathContext{
+		SrcIP:                 srcIP,
+		SrcLabelID:            srcLabelID,
+		DstIP:                 dstIP,
+		DstLabelID:            dstLabelID,
+		TraceObservationPoint: decoded.TraceObservationPoint,
+	}
+	srcEndpoint := p.epResolver.ResolveEndpoint(srcIP, srcLabelID, datapathContext)
+	dstEndpoint := p.epResolver.ResolveEndpoint(dstIP, dstLabelID, datapathContext)
 	var sourceService, destinationService *pb.Service
 	if p.serviceGetter != nil {
 		sourceService = p.serviceGetter.GetServiceByAddr(srcIP, srcPort)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

## Overview

Hi, I've been looking into the "stale identity observed" issues (https://github.com/cilium/cilium/issues/14427 and https://github.com/cilium/cilium/issues/15283) and documented some of the situations where I've seen these log messages in my setup. Ultimately, I think the log messages arise from a misunderstanding between the datapath and Hubble. In the cases I studied, the datapath looks like it's using an appropriate identity. However Hubble has a limited amount of information and isn't really aware of what the datapath is doing in these situations. It just recieves an IP and security identity from the datapath and warns if the security identity doesn't match the IP cache security identity. However, in some cases, the datapath doesn't use the IP cache security identity, or it sends trace notify events before resolving a security identity via the IP cache, or hardcodes an identity when tunneling a packet, or when a proxy is involved, the datapath doesn't know the original IP for a given security identity.

Currently, this warning is not very helpful. There are so many warnings that it's easy to ignore them.

One solution is to see if we can create various conditions on the Hubble side so that it can tell when to send a warning, such that the warnings are actually meaningful. That's what I've explored in this PR.

### Case 1

When encapsulating a packet for sending via the overlay network, if the source seclabel = HOST_ID, then we reassign seclabel with LOCAL_NODE_ID and then send a trace notify: https://github.com/cilium/cilium/blob/c7bf490b8e2feb141cc01e98763dbda313af0288/bpf/lib/encap.h#L39

In this case any packets with identity HOST_ID, are going to result in warnings from Hubble.

A simple solution is to ignore stale TRACE_TO_OVERLAY events when datapath security ID = remote_node && userspace security ID = host.

Here is an example:
```
2023-08-30T19:59:00.281808717Z stderr F level=debug msg="&{{4 4 4 3848637028 168 128 1 remote-node health 0 5 0 4} ::} 10.244.1.40 10.244.0.61 TO_OVERLAY" subsys=hubble
2023-08-30T19:59:00.281811808Z stderr F level=debug msg="stale identity observed" identity=6 ipAddr=10.244.1.40 oldIdentity=1 subsys=hubble
```

In this case 10.244.1.40 is the IP address of cilium_host.

### Case 2

Sometimes packets from endpoint link-local addresses are intercepted by cil_from_container. Because link-local addresses are not stored in the IP cache, Hubble assigns them ID 2 (WORLD_ID) (edit: now 9 or 10 for WORLD_IPV4/IPV6).

Here is an example:
```
2023-08-30T20:15:14.102227401Z stderr F level=debug msg="&{{4 5 1189 0 70 70 1 health unknown 0 5 0 0} ::} fe80::c809:60ff:fecd:ab08 ff02::2 FROM_ENDPOINT" subsys=hubble
2023-08-30T20:15:14.102232825Z stderr F level=debug msg="stale identity observed" identity=4 ipAddr="fe80::c809:60ff:fecd:ab08" oldIdentity=2 subsys=hubble
```
fe80::c809:60ff:fecd:ab08 is the link-local address of the cilium-health-responder namespace. I've also observed endpoint link-local addresses.

A simple solution is to ignore stale TRACE_FROM_ENDPOINT events when datapath source security ID = {4 | !reserved} && userspace security ID is a world ID. Alternatively, in this case, I wonder if we can just add link-local addresses to the IP cache or prevent endpoints from sending these packets.

### Case 3

When a pod sends a packet to the Kubernetes API its IP is masqueraded and then when it receives a response and the masquerade is reversed, cil_from_host determines that the source ID is 2 (edit: now 2, 9 or 10) because there is no packet mark.

Here is an example:
```
2023-08-31T23:21:50.489380414Z stderr F level=debug msg="&{{4 5 742 2245691099 201 128 1 60454 unknown 0 5 0 0} ::} 10.244.1.242 10.96.0.1 FROM_ENDPOINT" subsys=hubble
2023-08-31T23:21:50.489451772Z stderr F level=debug msg="&{{4 3 742 2245691099 201 128 1 60454 kube-apiserver 0 1 0 0} ::} 10.244.1.242 172.20.0.3 TO_STACK" subsys=hubble
2023-08-31T23:21:50.490396351Z stderr F level=debug msg="&{{4 10 4 1883766498 155 128 1 unknown unknown 0 5 0 6} ::} 172.20.0.3 172.20.0.2 FROM_NETWORK" subsys=hubble
2023-08-31T23:21:50.490422485Z stderr F level=debug msg="&{{4 7 4 1883766498 155 128 1 world unknown 0 5 0 6} ::} 172.20.0.3 10.244.1.242 FROM_HOST" subsys=hubble
2023-08-31T23:21:50.490448558Z stderr F level=debug msg="stale identity observed" identity=2 ipAddr=172.20.0.3 oldIdentity=7 subsys=hubble
2023-08-31T23:21:50.490659919Z stderr F level=debug msg="&{{4 0 742 1883766498 155 128 1 kube-apiserver 60454 742 2 0 9} ac14:3::} 172.20.0.3 10.244.1.242 TO_ENDPOINT" subsys=hubble
```
In this case, we can see 10.244.1.242 (a CoreDNS instance) is reaching out to 10.96.0.1 (the ClusterIP for the Kubernetes API). 10.96.0.1 get's resolved to 172.20.0.3. And then 10.244.1.242 get's masqueraded to 172.20.0.2 when it's being sent out via eth0. When the response is recieved, 172.20.0.2 is reversed to 10.244.1.242 and then it's routed to cilium_host. It's at this point that the datapath considers the ID as 2 because there isn't any mark on the packet.

A simple solution is to ignore stale TRACE_FROM_HOST events when datapath source security ID = 2 (edit: now 2, 9 or 10) and userspace security ID = 7. In general, if packets are picked up by cil_from_host and they do not have a packet mark, the TRACE_FROM_HOST event will contain ID = 2 (edit: now 2, 9 or 10), as that's the default in inherit_identity_from_host, and the trace happens before any IP cache resolution. Should inherit_identity_from_host return unknown by default?

### Case 4

When proxied packets (via Cilium DNS proxy) are sent from the host their source IP is that of the host, yet their security identity is retained from the original source pod.

Here is an example:
```
2023-09-01T01:51:37.455236212Z stderr F level=debug msg="&{{4 5 1825 2275186770 110 110 1 47432 unknown 0 5 0 0} ::} 10.244.1.11 10.96.0.10 FROM_ENDPOINT" subsys=hubble
2023-09-01T01:51:37.455330139Z stderr F level=debug msg="&{{4 1 1825 2275186770 110 110 1 47432 unknown 36245 0 0 0} ::} 10.244.1.11 10.244.0.127 TO_PROXY" subsys=hubble
2023-09-01T01:53:04.360088799Z stderr F level=debug msg="&{{4 7 4 3946258847 110 110 1 47432 unknown 0 5 0 0} ::} 10.244.1.40 10.244.0.127 FROM_HOST" subsys=hubble
2023-09-01T01:53:04.360106623Z stderr F level=debug msg="stale identity observed" identity=47432 ipAddr=10.244.1.40 oldIdentity=1 subsys=hubble
2023-09-01T01:53:04.360129059Z stderr F level=debug msg="&{{4 4 4 3946258847 110 110 1 47432 60454 0 5 0 4} ::} 10.244.1.40 10.244.0.127 TO_OVERLAY" subsys=hubble
2023-09-01T01:53:04.360136765Z stderr F level=debug msg="stale identity observed" identity=47432 ipAddr=10.244.1.40 oldIdentity=1 subsys=hubble
```
In this case, 10.244.1.11 sends a DNS request to 10.96.0.10, which get's resolved to 10.244.0.127. The Cilium DNS proxy recieves the packet and sends it back out via cilium_host with address 10.244.1.40. Since the packet retains it's original source security ID, we recieve a warning from both TRACE_FROM_HOST and TRACE_TO_OVERLAY events.

A simple solution is to ignore stale TRACE_FROM_HOST/TRACE_TO_OVERLAY events when datapath source security ID is a local endpoint ID and userspace security ID = 1.

### Case 5

When proxied packets (via Cilium DNS proxy) are recieved by the destination host their source IP is that of the proxy, yet their security identity is retained from the original source pod. This is a similar case to #4, but on the receiving side.

In one case, the packet is sent to a DNS instance on the same host:
```
2023-09-01T02:32:11.417310878Z stderr F level=debug msg="&{{4 0 742 2061866022 110 110 1 47432 60454 742 0 0 9} af4:128::} 10.244.1.40 10.244.1.242 TO_ENDPOINT" subsys=hubble
2023-09-01T02:32:11.417338717Z stderr F level=debug msg="stale identity observed" identity=47432 ipAddr=10.244.1.40 oldIdentity=1 subsys=hubble
```
And alternatively, to a separate host:
```
2023-09-01T02:32:12.267932053Z stderr F level=debug msg="&{{4 0 312 3008716175 110 110 1 47432 60454 312 0 0 11} af4:128::} 10.244.1.40 10.244.0.127 TO_ENDPOINT" subsys=hubble
2023-09-01T02:32:12.267936768Z stderr F level=debug msg="stale identity observed" identity=47432 ipAddr=10.244.1.40 oldIdentity=6 subsys=hubble
```
This results in a stale identity warning from TO_ENDPOINT when delivering to DNS servers on the same host and remote hosts.

A simple solution is to ignore stale TRACE_TO_ENDPOINT events where the datapath source security ID isn't reserved (must be an endpoint) and the userspace security ID is either 1 (host) or 6 (remote-node).

### Case 6

When reinstalling Cilium and the agent is just starting, packets arrive via tunnel for the health responder, for some reason instead of going directly to the health responder endpoint, they are passed to the stack.
```
2023-09-01T18:07:02.393926998Z stderr F level=debug msg="{{4 10 4 2383703504 124 124 1 unknown unknown 0 5 0 6} ::} 172.20.0.3 172.20.0.2 57885 8472 FROM_NETWORK" subsys=hubb
le
2023-09-01T18:07:02.393939748Z stderr F level=debug msg="{{4 9 0 2383703504 74 74 1 unknown unknown 0 5 0 4} ::} 10.244.0.186 10.244.1.104 35416 4240 FROM_OVERLAY" subsys=hub
ble
2023-09-01T18:07:02.393963115Z stderr F level=debug msg="{{4 3 4 2383703504 74 74 1 unknown unknown 0 5 0 3} ::} 10.244.0.186 10.244.1.104 35416 4240 TO_STACK" subsys=hubble
2023-09-01T18:07:02.393980895Z stderr F level=debug msg="{{4 7 4 2383703504 74 74 1 world unknown 0 5 0 3} ::} 10.244.0.186 10.244.1.104 35416 4240 FROM_HOST" subsys=hubble
2023-09-01T18:07:02.393993862Z stderr F level=debug msg="stale identity observed" identity=2 ipAddr=10.244.0.186 oldIdentity=6 subsys=hubble
```
In this case 10.244.1.104 is the health endpoint.

Perhaps because the endpoint map is not updated quickly enough, these packets get routed to the host and appear to enter a routing loop.
```
2023-09-01T18:07:02.394106942Z stderr F level=debug msg="{{4 3 4 2383703504 74 74 1 unknown unknown 0 5 0 3} ::} 10.244.0.186 10.244.1.104 35416 4240 TO_STACK" subsys=hubble
2023-09-01T18:07:02.394118785Z stderr F level=debug msg="{{4 7 4 2383703504 74 74 1 world unknown 0 5 0 2} ::} 10.244.0.186 10.244.1.104 35416 4240 FROM_HOST" subsys=hubble
2023-09-01T18:07:02.394130921Z stderr F level=debug msg="stale identity observed" identity=2 ipAddr=10.244.0.186 oldIdentity=6 subsys=hubble
2023-09-01T18:07:02.394144146Z stderr F level=debug msg="{{4 3 4 2383703504 74 74 1 unknown unknown 0 5 0 3} ::} 10.244.0.186 10.244.1.104 35416 4240 TO_STACK" subsys=hubble
2023-09-01T18:07:02.394160199Z stderr F level=debug msg="{{4 7 4 2383703504 74 74 1 world unknown 0 5 0 2} ::} 10.244.0.186 10.244.1.104 35416 4240 FROM_HOST" subsys=hubble
2023-09-01T18:07:02.394167603Z stderr F level=debug msg="stale identity observed" identity=2 ipAddr=10.244.0.186 oldIdentity=6 subsys=hubble
2023-09-01T18:07:02.394179001Z stderr F level=debug msg="{{4 3 4 2383703504 74 74 1 unknown unknown 0 5 0 3} ::} 10.244.0.186 10.244.1.104 35416 4240 TO_STACK" subsys=hubble
2023-09-01T18:07:02.394188292Z stderr F level=debug msg="{{4 7 4 2383703504 74 74 1 world unknown 0 5 0 2} ::} 10.244.0.186 10.244.1.104 35416 4240 FROM_HOST" subsys=hubble
2023-09-01T18:07:02.394190751Z stderr F level=debug msg="stale identity observed" identity=2 ipAddr=10.244.0.186 oldIdentity=6 subsys=hubble
```
The reason we get a warning is because at the beginning of cil_from_host, it only checks the packet mark for a security ID and then immediately sends a trace notify. These packets are coming from another host so they don't have a packet mark. After cilium get's up and going these warnings go away. In this instance I think we have an actual issue, due to a race condition at startup, though I'm not entirely sure how it could be solved or if it needs to be.

### Case 7

Link-local packets appear to be dropped and drop-notify events also cause stale identity (due to them missing from the ipcache). I haven't addressed this case yet.

## Alternatives

This PR does limit the warnings, but it seems like there is also a possibility that it limits legitimate warnings. I'm not sure I know enough about the various datapath cases to tell for sure. But, ignoring certain messages based on assumptions of how the datapath is working seems fragile. Just during the time I was preparing this PR, we added new identities for WORLD_IPV4 and WORLD_IPV6 which broke the logic. Perhaps a better solution would be to use different events besides trace/drop notify for these warnings. That way we can emit events from specific points in the datapath and warn on all of these events if they contain stale/incorrect information. It seems like another solution would be to potentially change some of the trace notify calls in the datapath, so they emit information that's more in sync with what userspace expects. But that seems like it would obscure the actual workings of the datapath.