### PR TITLE
bpf: l3: limit kube-proxy workaround in l3_local_delivery() to bpf_overlay

### DIFF
--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -90,7 +90,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 	ctx->mark |= MARK_MAGIC_IDENTITY;
 	set_identity_mark(ctx, seclabel);
 
-# if defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
+# if defined(IS_BPF_OVERLAY) && !defined(ENABLE_NODEPORT)
 	/* In tunneling mode, we execute this code to send the packet from
 	 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
 	 * redirect() because that would bypass conntrack and the reverse DNAT.
@@ -102,7 +102,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 	return CTX_ACT_OK;
 # else
 	return redirect_ep(ctx, ep->ifindex, from_host);
-# endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
+# endif /* IS_BPF_OVERLAY && !ENABLE_NODEPORT */
 #else
 # ifndef DISABLE_LOOPBACK_LB
 	/* Skip ingress policy enforcement for hairpin traffic. As the hairpin


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/22333 fixed a bug for configs with tunnel-routing and per-EP routes. Here ingress policy was applied twice: first via tail-call, and then a second time by the to-container program as the packet traverses the veth pair.

The fix was to avoid the tail-call, and only apply policy with the to-container program. But the tail-call also contains a kube-proxy workaround (potential service replies need to pass through kube-proxy for RevDNAT, so the tail-call punts them to the stack instead of calling redirect_ep() to forward them straight to the endpoint). So we copied that workaround into the l3_local_delivery() path.

The tail-call is compiled as part of bpf_lxc, and thus couldn't easily tell if a packet was received from the tunnel. But as l3_local_delivery() is inlined into bpf_overlay, we can now limit the work-around to IS_BPF_OVERLAY. This ensures that the workaround is not applied to eg. plain pod-to-pod traffic, where bpf_lxc also calls l3_local_delivery().

Fixes: 3d2ceaf3b24d ("bpf: Preserve overlay->lxc path with kube-proxy")

```release-note
Restore host-stack bypass for pod-to-pod traffic in a configuration with kube-proxy, tunnel routing and per-endpoint routes.
```
