### PR TITLE
pull skb data in cil_from_netdev path for HIGH_SCALE_IPCACHE mode

### DIFF
--- a/bpf/lib/high_scale_ipcache.h
+++ b/bpf/lib/high_scale_ipcache.h
@@ -67,7 +67,7 @@ decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 	if (proto != bpf_htons(ETH_P_IP))
 		return CTX_ACT_OK;
 
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
+	if (!revalidate_data_pull(ctx, &data, &data_end, &ip4))
 		return DROP_INVALID;
 	if (ip4->protocol != IPPROTO_UDP)
 		return CTX_ACT_OK;


### PR DESCRIPTION
Now we enabled the high scale ipcache mode. And on some nodes with Mellanox nic cards, we found that cilium dropped the icmp packets for path MTU discovery. So the packets will be dropped when the clients send huge packets. 
```
/# lspci | grep -i Mellanox
1f:00.0 Ethernet controller: Mellanox Technologies MT27520 Family [ConnectX-3 Pro]

xx drop (Invalid packet) flow 0xb18ed4da to endpoint 0, ifindex 4, file 1:1061, , identity unknown->unknown: 10.* -> 10.2* DestinationUnreachable(FragmentationNeeded)
```

```release-note
fix bug: pull skb data in cil_from_netdev path for HIGH_SCALE_IPCACHE mode
```
