### PR TITLE
spawn sync_endpoint_header_file goroutine out of createEndpoint func

### DIFF
--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -335,6 +335,7 @@ func LaunchAsEndpoint(baseCtx context.Context,
 		}
 	}
 
+	ep.InitDNSHistoryTrigger()
 	if err := epMgr.AddEndpoint(owner, ep, "Create cilium-health endpoint"); err != nil {
 		return nil, fmt.Errorf("Error while adding endpoint: %s", err)
 	}

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -469,6 +469,7 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		}
 	}
 
+	ep.InitDNSHistoryTrigger()
 	// e.ID assigned here
 	err = d.endpointManager.AddEndpoint(owner, ep, "Create endpoint from API PUT")
 	if err != nil {

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -476,6 +476,7 @@ func (e *Endpoint) waitForProxyCompletions(proxyWaitGroup *completion.WaitGroup)
 func NewEndpointWithState(owner regeneration.Owner, policyGetter policyRepoGetter, namedPortsGetter namedPortsGetter, proxy EndpointProxy, allocator cache.IdentityAllocator, ID uint16, state State) *Endpoint {
 	endpointQueueName := "endpoint-" + strconv.FormatUint(uint64(ID), 10)
 	ep := createEndpoint(owner, policyGetter, namedPortsGetter, proxy, allocator, ID, "")
+	ep.InitDNSHistoryTrigger()
 	ep.state = state
 	ep.eventQueue = eventqueue.NewEventQueueBuffered(endpointQueueName, option.Config.EndpointQueueSize)
 
@@ -510,8 +511,6 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 		noTrackPort:      0,
 	}
 
-	ep.initDNSHistoryTrigger()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	ep.aliveCancel = cancel
 	ep.aliveCtx = ctx
@@ -523,7 +522,7 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 	return ep
 }
 
-func (e *Endpoint) initDNSHistoryTrigger() {
+func (e *Endpoint) InitDNSHistoryTrigger() {
 	// Note: This can only fail if the trigger func is nil.
 	var err error
 	e.dnsHistoryTrigger, err = trigger.NewTrigger(trigger.Parameters{
@@ -861,7 +860,7 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter p
 		return nil, fmt.Errorf("failed to parse restored endpoint: %s", err)
 	}
 
-	ep.initDNSHistoryTrigger()
+	ep.InitDNSHistoryTrigger()
 
 	// Validate the options that were parsed
 	ep.SetDefaultOpts(ep.Options)

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -681,6 +681,8 @@ func (mgr *endpointManager) AddHostEndpoint(
 		return err
 	}
 
+	ep.InitDNSHistoryTrigger()
+
 	if err := mgr.AddEndpoint(owner, ep, reason); err != nil {
 		return err
 	}


### PR DESCRIPTION


<!-- Description of change -->

Fixes: #27371

```release-note
bug fix: sync_endpoint_header_file goroutines leaked if creating endpoints is failed because of invalidDataError
```
