### PR TITLE
v1.14 Backports 2023-09-04

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -37,6 +37,15 @@ inputs:
   host-fw:
     description: 'Enable host firewall'
     default: false
+  mutual-auth:
+    description: 'Enable mTLS-based Mutual Authentication'
+    default: true
+  devices:
+    description: 'List of native devices to attach datapath programs'
+    default: ''
+  misc:
+    description: 'Misc helm rarely set by a user coma separated values'
+    default: ''
 outputs:
   config:
     description: 'Cilium installation config'
@@ -63,14 +72,21 @@ runs:
             --helm-set=hubble.relay.image.useDigest=false \
             --helm-set=hubble.eventBufferCapacity=65535 \
             --helm-set=bpf.monitorAggregation=none \
-            --helm-set=authentication.mutual.spire.enabled=true \
+            --helm-set=cluster.name=default \
+            --helm-set=authentication.mutual.spire.enabled=${{ inputs.mutual-auth }} \
             --nodes-without-cilium=kind-worker3 \
-            --helm-set-string=kubeProxyReplacement=${{ inputs.kpr }}"
+            --helm-set-string=kubeProxyReplacement=${{ inputs.kpr }} \
+            --set='${{ inputs.misc }}'"
 
           TUNNEL="--helm-set-string=tunnelProtocol=${{ inputs.tunnel }}"
           if [ "${{ inputs.tunnel }}" == "disabled" ]; then
             TUNNEL="--helm-set-string=routingMode=native --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16 --helm-set-string=tunnel=disabled"
             TUNNEL="${TUNNEL} --helm-set-string=ipv6NativeRoutingCIDR=fd00:10:244::/56"
+          fi
+
+          DEVICES=""
+          if [ "${{ inputs.devices }}" != "" ]; then
+            DEVICES="--helm-set=devices='${{ inputs.devices }}'"
           fi
 
           LB_MODE=""
@@ -121,5 +137,5 @@ runs:
             HOST_FW="--helm-set=hostFirewall.enabled=true"
           fi
 
-          CONFIG="${DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
+          CONFIG="${DEFAULTS} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
           echo "config=${CONFIG}" >> $GITHUB_OUTPUT

--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -149,9 +149,8 @@ include:
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort with sessionAffinity from outside
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests security id propagation in N/S LB requests fwd-ed over tunnel
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct routing and DSR
-  # K8sDatapathServicesTest Checks N/S loadbalancing Tests with secondary NodePort device
   - focus: "f12-datapath-service-ns-misc"
-    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs|K8sDatapathServicesTest Checks N/S loadbalancing Tests GH|K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort|K8sDatapathServicesTest Checks N/S loadbalancing Tests security|K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct|K8sDatapathServicesTest Checks N/S loadbalancing Tests with secondary|K8sDatapathServicesTest Checks N/S loadbalancing with"
+    cliFocus: "K8sDatapathServicesTest Checks N/S loadbalancing Tests externalIPs|K8sDatapathServicesTest Checks N/S loadbalancing Tests GH|K8sDatapathServicesTest Checks N/S loadbalancing Tests NodePort|K8sDatapathServicesTest Checks N/S loadbalancing Tests security|K8sDatapathServicesTest Checks N/S loadbalancing Tests with direct|K8sDatapathServicesTest Checks N/S loadbalancing with"
 
   ###
   # K8sDatapathServicesTest Checks N/S loadbalancing Tests with XDP, direct routing, DSR and Maglev

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -42,6 +42,9 @@ triggers:
   /ci-gke:
     workflows:
     - conformance-gke.yaml
+  /ci-ingress:
+    workflows:
+    - conformance-ingress.yaml
   /ci-integration:
     workflows:
     - integration-test.yaml

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -42,6 +42,9 @@ triggers:
   /ci-gke:
     workflows:
     - conformance-gke.yaml
+  /ci-integration:
+    workflows:
+    - integration-test.yaml
   /ci-runtime:
     workflows:
     - conformance-runtime.yaml

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -42,6 +42,9 @@ triggers:
   /ci-gke:
     workflows:
     - conformance-gke.yaml
+  /ci-runtime:
+    workflows:
+    - conformance-runtime.yaml
   /ci-verifier:
     workflows:
     - tests-datapath-verifier.yaml

--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -215,7 +215,7 @@ jobs:
             --name ${{ env.name }}
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-azure-ci hubble-relay-ci ; do

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -215,7 +215,7 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.11/config/master/aws-k8s-cni.yaml
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -350,7 +350,7 @@ jobs:
           kubectl --context ${{ env.contextName2 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -105,6 +105,8 @@ jobs:
             kernel: '5.10-20230824.161940'
             kube-proxy: 'iptables'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'vxlan'
             lb-mode: 'snat'
             endpoint-routes: 'true'
@@ -115,6 +117,8 @@ jobs:
             kernel: '5.15-20230824.161940'
             kube-proxy: 'iptables'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'disabled'
             lb-mode: 'dsr'
             endpoint-routes: 'true'
@@ -137,6 +141,8 @@ jobs:
             kernel: 'bpf-next-20230420.212204'
             kube-proxy: 'none'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'disabled'
             lb-mode: 'snat'
             egress-gateway: 'true'
@@ -183,6 +189,8 @@ jobs:
             kernel: '5.10-20230824.161940'
             kube-proxy: 'iptables'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'vxlan'
             encryption: 'wireguard'
             encryption-node: 'false'
@@ -195,6 +203,8 @@ jobs:
             kernel: '5.15-20230824.161940'
             kube-proxy: 'iptables'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'disabled'
             encryption: 'wireguard'
             encryption-node: 'false'
@@ -207,6 +217,8 @@ jobs:
             kernel: '6.0-20230824.161940'
             kube-proxy: 'none'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'vxlan'
             encryption: 'wireguard'
             encryption-node: 'true'
@@ -218,6 +230,8 @@ jobs:
             kernel: 'bpf-next-20230420.212204'
             kube-proxy: 'none'
             kpr: 'true'
+            devices: '{eth0,eth1}'
+            secondary-network: 'true'
             tunnel: 'disabled'
             encryption: 'wireguard'
             encryption-node: 'true'
@@ -262,6 +276,7 @@ jobs:
           image-tag: ${{ steps.vars.outputs.sha }}
           chart-dir: './install/kubernetes/cilium'
           tunnel: ${{ matrix.tunnel }}
+          devices: ${{ matrix.devices }}
           endpoint-routes: ${{ matrix.endpoint-routes }}
           ipv6: ${{ matrix.ipv6 }}
           kpr: ${{ matrix.kpr }}
@@ -352,11 +367,17 @@ jobs:
           cmd: |
             cd /host/
 
+            EXTRA=""
+            if [ "${{ matrix.secondary-network }}" = "true" ]; then
+              EXTRA="--secondary-network-iface=eth1"
+            fi
+
             ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
               --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})"
+              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
+              \$EXTRA
 
             ./contrib/scripts/kind-down.sh
 

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -208,7 +208,7 @@ jobs:
           kubectl -n kube-system delete daemonset aws-node
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-aws-ci hubble-relay-ci ; do

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -247,7 +247,7 @@ jobs:
           gcloud container clusters get-credentials ${{ env.clusterName }} --zone ${{ matrix.zone }}
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do

--- a/.github/workflows/conformance-ginkgo.yaml
+++ b/.github/workflows/conformance-ginkgo.yaml
@@ -164,7 +164,7 @@ jobs:
         uses: ./.github/actions/set-env-variables
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -231,7 +231,7 @@ jobs:
           gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }}
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -1,4 +1,4 @@
-name: Conformance Ingress
+name: Conformance Ingress (ci-ingress)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -1,4 +1,4 @@
-name: Conformance E2E (ci-e2e)
+name: Conformance IPsec E2E (ci-ipsec-e2e)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:
@@ -62,13 +62,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set initial commit status
-        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7  
+        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
         with:
           sha: ${{ inputs.SHA || github.sha }}
 
   setup-and-test:
-    runs-on: ubuntu-latest-4cores-16gb
     name: 'Setup & Test'
+    runs-on: ubuntu-latest-4cores-16gb
     env:
       job_name: 'Setup & Test'
     strategy:
@@ -80,167 +80,35 @@ jobs:
 
           - name: '1'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20230824.161940'
+            kernel: '4.19-20230810.091425'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'vxlan'
+            encryption: 'ipsec'
+            encryption-node: 'false'
 
           - name: '2'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20230824.161940'
+            kernel: '5.4-20230810.091425'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
 
           - name: '3'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230824.161940'
+            kernel: '5.10-20230810.091425'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'disabled'
+            encryption: 'ipsec'
+            encryption-node: 'false'
             endpoint-routes: 'true'
 
           - name: '4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230824.161940'
-            kube-proxy: 'iptables'
-            kpr: 'true'
-            devices: '{eth0,eth1}'
-            secondary-network: 'true'
-            tunnel: 'vxlan'
-            lb-mode: 'snat'
-            endpoint-routes: 'true'
-            egress-gateway: 'true'
-
-          - name: '5'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20230824.161940'
-            kube-proxy: 'iptables'
-            kpr: 'true'
-            devices: '{eth0,eth1}'
-            secondary-network: 'true'
-            tunnel: 'disabled'
-            lb-mode: 'dsr'
-            endpoint-routes: 'true'
-            egress-gateway: 'true'
-            host-fw: 'true'
-
-          - name: '6'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.0-20230824.161940'
-            kube-proxy: 'none'
-            kpr: 'true'
-            tunnel: 'vxlan'
-            lb-mode: 'snat'
-            egress-gateway: 'true'
-            host-fw: 'true'
-            lb-acceleration: 'testing-only'
-
-          - name: '7'
-            # We don't want to update bpf-next after branching
-            kernel: 'bpf-next-20230420.212204'
-            kube-proxy: 'none'
-            kpr: 'true'
-            devices: '{eth0,eth1}'
-            secondary-network: 'true'
-            tunnel: 'disabled'
-            lb-mode: 'snat'
-            egress-gateway: 'true'
-            lb-acceleration: 'testing-only'
-
-          - name: '8'
-            # We don't want to update bpf-next after branching
-            kernel: 'bpf-next-20230420.212204'
-            kube-proxy: 'iptables'
-            kpr: 'false'
-            tunnel: 'geneve'
-            endpoint-routes: 'true'
-
-          - name: '9'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '4.19-20230824.161940'
-            kube-proxy: 'iptables'
-            kpr: 'false'
-            tunnel: 'vxlan'
-            encryption: 'ipsec'
-            encryption-node: 'false'
-
-          - name: '10'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.4-20230824.161940'
-            kube-proxy: 'iptables'
-            kpr: 'false'
-            tunnel: 'disabled'
-            encryption: 'ipsec'
-            encryption-node: 'false'
-
-          - name: '11'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230824.161940'
-            kube-proxy: 'iptables'
-            kpr: 'false'
-            tunnel: 'disabled'
-            encryption: 'ipsec'
-            encryption-node: 'false'
-            endpoint-routes: 'true'
-
-          - name: '12'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.10-20230824.161940'
-            kube-proxy: 'iptables'
-            kpr: 'true'
-            devices: '{eth0,eth1}'
-            secondary-network: 'true'
-            tunnel: 'vxlan'
-            encryption: 'wireguard'
-            encryption-node: 'false'
-            lb-mode: 'snat'
-            endpoint-routes: 'true'
-            egress-gateway: 'true'
-
-          - name: '13'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '5.15-20230824.161940'
-            kube-proxy: 'iptables'
-            kpr: 'true'
-            devices: '{eth0,eth1}'
-            secondary-network: 'true'
-            tunnel: 'disabled'
-            encryption: 'wireguard'
-            encryption-node: 'false'
-            lb-mode: 'dsr'
-            endpoint-routes: 'true'
-            egress-gateway: 'true'
-
-          - name: '14'
-            # renovate: datasource=docker depName=quay.io/lvh-images/kind
-            kernel: '6.0-20230824.161940'
-            kube-proxy: 'none'
-            kpr: 'true'
-            devices: '{eth0,eth1}'
-            secondary-network: 'true'
-            tunnel: 'vxlan'
-            encryption: 'wireguard'
-            encryption-node: 'true'
-            lb-mode: 'snat'
-            egress-gateway: 'true'
-
-          - name: '15'
-            # We don't want to update bpf-next after branching
-            kernel: 'bpf-next-20230420.212204'
-            kube-proxy: 'none'
-            kpr: 'true'
-            devices: '{eth0,eth1}'
-            secondary-network: 'true'
-            tunnel: 'disabled'
-            encryption: 'wireguard'
-            encryption-node: 'true'
-            lb-mode: 'snat'
-            egress-gateway: 'true'
-
-          - name: '16'
-            # We don't want to update bpf-next after branching
-            kernel: 'bpf-next-20230420.212204'
+            kernel: 'bpf-next-20230810.091425'
             kube-proxy: 'iptables'
             kpr: 'false'
             tunnel: 'geneve'
@@ -251,7 +119,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout context ref (trusted)
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ inputs.context-ref || github.sha }}
           persist-credentials: false
@@ -267,30 +135,94 @@ jobs:
           else
             SHA="${{ github.sha }}"
           fi
-          echo sha=${SHA} >> $GITHUB_OUTPUT
 
-      - name: Derive Cilium installation config and junit type
-        id: cilium-config
-        uses: ./.github/actions/cilium-config
-        with:
-          image-tag: ${{ steps.vars.outputs.sha }}
-          chart-dir: './install/kubernetes/cilium'
-          tunnel: ${{ matrix.tunnel }}
-          devices: ${{ matrix.devices }}
-          endpoint-routes: ${{ matrix.endpoint-routes }}
-          ipv6: ${{ matrix.ipv6 }}
-          kpr: ${{ matrix.kpr }}
-          lb-mode: ${{ matrix.lb-mode }}
-          lb-acceleration: ${{ matrix.lb-acceleration }}
-          encryption: ${{ matrix.encryption }}
-          encryption-node: ${{ matrix.encryption-node }}
-          egress-gateway: ${{ matrix.egress-gateway }}
-          host-fw: ${{ matrix.host-fw }}
+          CILIUM_INSTALL_DEFAULTS="--wait \
+            --chart-directory=./install/kubernetes/cilium \
+            --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+            --helm-set=image.useDigest=false \
+            --helm-set=image.tag=${SHA} \
+            --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+            --helm-set=operator.image.suffix=-ci \
+            --helm-set=operator.image.tag=${SHA} \
+            --helm-set=operator.image.useDigest=false \
+            --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
+            --helm-set=hubble.relay.image.tag=${SHA} \
+            --helm-set=hubble.eventBufferCapacity=65535 \
+            --helm-set=bpf.monitorAggregation=none \
+            --helm-set=authentication.mutual.spire.enabled=true \
+            --helm-set=authentication.mutual.spire.install.enabled=true \
+            --nodes-without-cilium=kind-worker3 \
+            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
+          TUNNEL="--helm-set-string=tunnelProtocol=${{ matrix.tunnel }}"
+          if [ "${{ matrix.tunnel }}" == "disabled" ]; then
+            TUNNEL="--helm-set-string=routingMode=native --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16 --helm-set-string=tunnel=disabled"
+            TUNNEL="${TUNNEL} --helm-set-string=ipv6NativeRoutingCIDR=fd00:10:244::/56"
+          fi
+          LB_MODE=""
+          if [ "${{ matrix.lb-mode }}" != "" ]; then
+            LB_MODE="--helm-set-string=loadBalancer.mode=${{ matrix.lb-mode }}"
+          fi
+          ENDPOINT_ROUTES=""
+          if [ "${{ matrix.endpoint-routes }}" == "true" ]; then
+            ENDPOINT_ROUTES="--helm-set-string=endpointRoutes.enabled=true"
+          fi
+          IPV6=""
+          if [ "${{ matrix.ipv6 }}" != "false" ]; then
+            IPV6="--helm-set=ipv6.enabled=true"
+          fi
+          MASQ=""
+          if [ "${{ matrix.kpr }}" == "true" ]; then
+            # BPF-masq requires KPR=true.
+            MASQ="--helm-set=bpf.masquerade=true"
+            if [ "${{ matrix.host-fw }}" == "true" ]; then
+              # BPF IPv6 masquerade not currently supported with host firewall - GH-26074
+              MASQ="${MASQ} --helm-set=enableIPv6Masquerade=false"
+            fi
+          fi
+          EGRESS_GATEWAY=""
+          if [ "${{ matrix.egress-gateway }}" == "true" ]; then
+            EGRESS_GATEWAY="--helm-set=egressGateway.enabled=true --helm-set=debug.enabled=true"
+          fi
+          LB_ACCELERATION=""
+          if [ "${{ matrix.lb-acceleration }}" != "" ]; then
+            LB_ACCELERATION="--helm-set=loadBalancer.acceleration=${{ matrix.lb-acceleration }}"
+          fi
+
+          ENCRYPT=""
+          if [ "${{ matrix.encryption }}" != "" ]; then
+            ENCRYPT="--helm-set=encryption.enabled=true --helm-set=encryption.type=${{ matrix.encryption }}"
+            if [ "${{ matrix.encryption-node }}" != "" ]; then
+              ENCRYPT+=" --helm-set=encryption.nodeEncryption=${{ matrix.encryption-node }}"
+            fi
+          fi
+
+          HOST_FW=""
+          if [ "${{ matrix.host-fw }}" == "true" ]; then
+            HOST_FW="--helm-set=hostFirewall.enabled=true"
+          fi
+
+          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
+          echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
+
+          JUNIT=""
+          for NAME in ${{ matrix.kube-proxy }} ${{ matrix.tunnel }} ${{ matrix.lb-mode }} ${{ matrix.encryption }} ${{ matrix.endpoint-routes }}; do
+            if [[ "${NAME}" != "" ]] && [[ "${NAME}" != "disabled" ]] && [[ "${NAME}" != "none" ]]; then
+              if [[ "${JUNIT}" != "" ]]; then
+                JUNIT+="-"
+              fi
+              if [[ "${NAME}" == "true" ]];then
+                NAME="endpoint-routes"
+              fi
+              JUNIT+="${NAME}"
+            fi
+          done
+          echo junit_type="${JUNIT}" >> $GITHUB_OUTPUT
+          echo sha=${SHA} >> $GITHUB_OUTPUT
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ steps.vars.outputs.sha }}
           persist-credentials: false
@@ -315,25 +247,6 @@ jobs:
           cmd: |
             git config --global --add safe.directory /host
 
-      - name: Setup K8s cluster (${{ join(matrix.*, ', ') }})
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            IP_FAM="dual"
-            if [ "${{ matrix.ipv6 }}" == "false" ]; then
-              IP_FAM="ipv4"
-            fi
-            ./contrib/scripts/kind.sh --xdp --secondary-network "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
-
-            kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
-            if [ "${{ matrix.encryption }}" == "ipsec" ]; then
-              kubectl create -n kube-system secret generic cilium-ipsec-keys \
-                --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
-            fi
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash
@@ -342,15 +255,20 @@ jobs:
             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
           done
 
-      - name: Install Cilium (${{ join(matrix.*, ', ') }})
+      - name: Run tests (${{ join(matrix.*, ', ') }})
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
           provision: 'false'
           cmd: |
             cd /host/
+            ./contrib/scripts/kind.sh --xdp "" 3 "" "" "${{ matrix.kube-proxy }}" "dual"
+
+            kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
+            kubectl create -n kube-system secret generic cilium-ipsec-keys \
+              --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
             export CILIUM_CLI_MODE=helm
-            ./cilium-cli install ${{ steps.cilium-config.outputs.config }}
+            ./cilium-cli install ${{ steps.vars.outputs.cilium_install_defaults }}
             kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-server --timeout=300s
             kubectl -n cilium-spire wait --for=condition=Ready pod -l app=spire-agent --timeout=300s
 
@@ -360,26 +278,45 @@ jobs:
 
             mkdir -p cilium-junits
 
-      - name: Run tests (${{ join(matrix.*, ', ') }})
-        uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
-        with:
-          provision: 'false'
-          cmd: |
-            cd /host/
-
-            EXTRA=""
-            if [ "${{ matrix.secondary-network }}" = "true" ]; then
-              EXTRA="--secondary-network-iface=eth1"
-            fi
-
             ./cilium-cli connectivity test --include-unsafe-tests --collect-sysdump-on-failure \
               --sysdump-hubble-flows-count=1000000 --sysdump-hubble-flows-timeout=5m \
               --sysdump-output-filename "cilium-sysdump-${{ matrix.name }}-<ts>" \
               --junit-file "cilium-junits/${{ env.job_name }} (${{ join(matrix.*, ', ') }}).xml" \
-              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})" \
-              \$EXTRA
+              --junit-property github_job_step="Run tests (${{ join(matrix.*, ', ') }})"
 
-            ./contrib/scripts/kind-down.sh
+      - name: Rotate IPsec Key & Test (${{ join(matrix.*, ', ') }})
+        uses: cilium/cilium/.github/actions/conn-disrupt-test@d86f33b098a75f3d7d2dfd3ee6fa1ea033892de4
+        with:
+          job-name: conformance-ipsec-e2e-key-rotation-${{ matrix.name }}
+          operation-cmd: |
+            cd /host/
+
+            KEYID=\$(kubectl get secret -n kube-system cilium-ipsec-keys -o go-template --template={{.data.keys}} | base64 -d | cut -c 1)
+            if [[ \$KEYID -ge 15 ]]; then KEYID=0; fi
+            data=\$(echo "{\"stringData\":{\"keys\":\"\$(((\$KEYID+1))) "rfc4106\(gcm\(aes\)\)" 59f4d92cccede1b1abc920104ca61cd552782e12 128\"}}")
+            kubectl patch secret -n kube-system cilium-ipsec-keys -p="\$data" -v=1
+
+            # Wait until key rotation starts
+            while true; do
+              keys_in_use=\$(kubectl -n kube-system exec daemonset/cilium -- cilium encrypt status | awk '/Keys in use/ {print \$NF}')
+              if [[ \$keys_in_use == 2 ]]; then
+                break
+              fi
+              echo "Waiting until key rotation starts"
+              sleep 30s
+            done
+
+            # Wait until key rotation completes
+            # By default the key rotation cleanup delay is 5min, let's sleep 4min before actively polling
+            sleep \$((4*60))
+            while true; do
+              keys_in_use=\$(kubectl -n kube-system exec daemonset/cilium -- cilium encrypt status | awk '/Keys in use/ {print \$NF}')
+              if [[ \$keys_in_use == 1 ]]; then
+                break
+              fi
+              echo "Waiting until key rotation completes"
+              sleep 30s
+            done
 
       - name: Fetch artifacts
         if: ${{ !success() }}
@@ -392,6 +329,8 @@ jobs:
             ./cilium-cli status
             mkdir -p cilium-sysdumps
             ./cilium-cli sysdump --output-filename cilium-sysdump-${{ matrix.name }}-final
+            # To debug https://github.com/cilium/cilium/issues/26062
+            head -n -0 /proc/buddyinfo /proc/pagetypeinfo
 
       - name: Upload artifacts
         if: ${{ !success() }}
@@ -422,7 +361,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set final commit status
-        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7  
+        uses: myrotvorets/set-commit-status-action@243b4f7e597f62335408d58001edf8a02cf3e1fd # v1.1.7
         with:
           sha: ${{ inputs.SHA || github.sha }}
           status: ${{ needs.setup-and-test.result }}

--- a/.github/workflows/conformance-k8s-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-network-policies.yaml
@@ -71,7 +71,7 @@ jobs:
           fi
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.tag }} &> /dev/null; do sleep 45s; done

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -1,4 +1,4 @@
-name: Conformance Runtime
+name: Conformance Runtime (ci-runtime)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: Integration Tests (ci-integration)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -221,7 +221,7 @@ jobs:
             mkdir -p cilium-junits
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -197,14 +197,6 @@ jobs:
           cmd: |
             git config --global --add safe.directory /host
 
-      - name: Wait for images to be available
-        timeout-minutes: 10
-        shell: bash
-        run: |
-          for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
-          done
-
       - name: Setup K8s cluster (${{ matrix.name }})
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
@@ -223,6 +215,14 @@ jobs:
                 --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
             mkdir -p cilium-junits
+
+      - name: Wait for images to be available
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+          done
 
       - name: Install Cilium ${{ env.cilium_stable_version }} (${{ matrix.name }})
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -144,6 +144,8 @@ jobs:
           encryption-node: ${{ matrix.encryption-node }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
+          mutual-auth: false
+          misc: 'bpfClockProbe=false,cni.uninstall=false'
 
       - name: Derive newest Cilium installation config
         id: cilium-newest-config
@@ -161,6 +163,8 @@ jobs:
           encryption-node: ${{ matrix.encryption-node }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
+          mutual-auth: false
+          misc: 'bpfClockProbe=false,cni.uninstall=false'
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -84,9 +84,6 @@ jobs:
             kpr: 'disabled'
             tunnel: 'disabled'
             encryption: 'ipsec'
-            encryption-node: 'false'
-            debug: 'true'
-            test-flow-interrupts: 'true'
             ipv6: 'false' # until https://github.com/cilium/cilium/issues/26944 resolved
 
           - name: '2'
@@ -96,9 +93,7 @@ jobs:
             kpr: 'disabled'
             tunnel: 'disabled'
             encryption: 'ipsec'
-            encryption-node: 'false'
             endpoint-routes: 'true'
-            test-flow-interrupts: 'true'
             ipv6: 'false' # until https://github.com/cilium/cilium/issues/26944 resolved
 
           - name: '3'
@@ -108,9 +103,7 @@ jobs:
             kpr: 'disabled'
             tunnel: 'vxlan'
             encryption: 'ipsec'
-            encryption-node: 'false'
             endpoint-routes: 'true'
-            test-flow-interrupts: 'true'
             ipv6: 'false' # until https://github.com/cilium/cilium/issues/26944 resolved
 
     timeout-minutes: 60
@@ -218,20 +211,7 @@ jobs:
 
           CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
-          
-          JUNIT=""
-          for NAME in ${{ matrix.kube-proxy }} ${{ matrix.tunnel }} ${{ matrix.lb-mode }} ${{ matrix.encryption }} ${{ matrix.endpoint-routes }}; do
-            if [[ "${NAME}" != "" ]] && [[ "${NAME}" != "disabled" ]] && [[ "${NAME}" != "none" ]]; then
-              if [[ "${JUNIT}" != "" ]]; then
-                JUNIT+="-"
-              fi
-              if [[ "${NAME}" == "true" ]];then
-                NAME="endpoint-routes"
-              fi
-              JUNIT+="${NAME}"
-            fi
-          done
-          echo junit_type="${JUNIT}" >> $GITHUB_OUTPUT
+
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
       - name: Checkout pull request for Helm chart

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -126,96 +126,46 @@ jobs:
             SHA="${{ github.sha }}"
           fi
 
-          # TODO(brb) move the settings derivation into a reusable GH workflow
-          CILIUM_STABLE_IMAGE_SETTINGS="--chart-directory=./cilium-${{ env.cilium_stable_version }}/install/kubernetes/cilium/ \
-            --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
-            --helm-set=image.useDigest=false \
-            --helm-set=image.tag=v${{ env.cilium_stable_version }} \
-            --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
-            --helm-set=operator.image.suffix=-ci \
-            --helm-set=operator.image.tag=v${{ env.cilium_stable_version }} \
-            --helm-set=operator.image.useDigest=false \
-            --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-            --helm-set=hubble.relay.image.tag=v${{ env.cilium_stable_version }}"
-          echo "cilium_stable_image_settings=${CILIUM_STABLE_IMAGE_SETTINGS}" >> $GITHUB_OUTPUT
-
-          CILIUM_MAIN_IMAGE_SETTINGS="--chart-directory=./install/kubernetes/cilium \
-            --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
-            --helm-set=image.useDigest=false \
-            --helm-set=image.tag=${SHA} \
-            --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
-            --helm-set=operator.image.suffix=-ci \
-            --helm-set=operator.image.tag=${SHA} \
-            --helm-set=operator.image.useDigest=false \
-            --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-            --helm-set=hubble.relay.image.tag=${SHA}"
-          echo "cilium_main_image_settings=${CILIUM_MAIN_IMAGE_SETTINGS}" >> $GITHUB_OUTPUT
-
-          CILIUM_INSTALL_DEFAULTS="--wait \
-            --helm-set=debug.enabled=true \
-            --helm-set=cni.uninstall=false \
-            --helm-set=cluster.name=default \
-            --helm-set=hubble.eventBufferCapacity=65535 \
-            --helm-set=bpf.monitorAggregation=none \
-            --nodes-without-cilium=kind-worker3 \
-            --helm-set=bpfClockProbe=false \
-            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
-
-          TUNNEL="--helm-set-string=tunnelProtocol=${{ matrix.tunnel }}"
-          if [ "${{ matrix.tunnel }}" == "disabled" ]; then
-            TUNNEL="--helm-set-string=routingMode=native --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16 --helm-set-string=tunnel=disabled"
-            TUNNEL="${TUNNEL} --helm-set-string=ipv6NativeRoutingCIDR=fd00:10:244::/56"
-          fi
-          LB_MODE=""
-          if [ "${{ matrix.lb-mode }}" != "" ]; then
-            LB_MODE="--helm-set-string=loadBalancer.mode=${{ matrix.lb-mode }}"
-          fi
-          ENDPOINT_ROUTES=""
-          if [ "${{ matrix.endpoint-routes }}" == "true" ]; then
-            ENDPOINT_ROUTES="--helm-set-string=endpointRoutes.enabled=true"
-          fi
-          IPV6=""
-          if [ "${{ matrix.ipv6 }}" != "false" ]; then
-            IPV6="--helm-set=ipv6.enabled=true"
-          fi
-          MASQ=""
-          if [ "${{ matrix.kpr }}" == "true" ] || [ "${{ matrix.kpr }}" == "strict" ]; then
-            # BPF-masq requires KPR=true.
-            MASQ="--helm-set=bpf.masquerade=true"
-            if [ "${{ matrix.host-fw }}" == "true" ]; then
-              # BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-              MASQ="${MASQ} --helm-set=enableIPv6Masquerade=false"
-            fi
-          fi
-          EGRESS_GATEWAY=""
-          if [ "${{ matrix.egress-gateway }}" == "true" ]; then
-            EGRESS_GATEWAY="--helm-set=egressGateway.enabled=true"
-          fi
-          LB_ACCELERATION=""
-          if [ "${{ matrix.lb-acceleration }}" != "" ]; then
-            LB_ACCELERATION="--helm-set=loadBalancer.acceleration=${{ matrix.lb-acceleration }}"
-          fi
-
-          ENCRYPT=""
-          if [ "${{ matrix.encryption }}" != "" ]; then
-            ENCRYPT="--helm-set=encryption.enabled=true --helm-set=encryption.type=${{ matrix.encryption }}"
-            if [ "${{ matrix.encryption-node }}" != "" ]; then
-              ENCRYPT+=" --helm-set=encryption.nodeEncryption=${{ matrix.encryption-node }}"
-            fi
-          fi
-
-          HOST_FW=""
-          if [ "${{ matrix.host-fw }}" == "true" ]; then
-            HOST_FW="--helm-set=hostFirewall.enabled=true"
-          fi
-
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
-          echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
-
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
-      - name: Checkout pull request for Helm chart
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Derive stable Cilium installation config
+        id: cilium-stable-config
+        uses: ./.github/actions/cilium-config
+        with:
+          image-tag: v${{ env.cilium_stable_version }}
+          chart-dir: './cilium-${{ env.cilium_stable_version }}/install/kubernetes/cilium/'
+          tunnel: ${{ matrix.tunnel }}
+          endpoint-routes: ${{ matrix.endpoint-routes }}
+          ipv6: ${{ matrix.ipv6 }}
+          kpr: ${{ matrix.kpr }}
+          lb-mode: ${{ matrix.lb-mode }}
+          lb-acceleration: ${{ matrix.lb-acceleration }}
+          encryption: ${{ matrix.encryption }}
+          encryption-node: ${{ matrix.encryption-node }}
+          egress-gateway: ${{ matrix.egress-gateway }}
+          host-fw: ${{ matrix.host-fw }}
+
+      - name: Derive newest Cilium installation config
+        id: cilium-newest-config
+        uses: ./.github/actions/cilium-config
+        with:
+          image-tag: ${{ steps.vars.outputs.sha }}
+          chart-dir: './install/kubernetes/cilium'
+          tunnel: ${{ matrix.tunnel }}
+          endpoint-routes: ${{ matrix.endpoint-routes }}
+          ipv6: ${{ matrix.ipv6 }}
+          kpr: ${{ matrix.kpr }}
+          lb-mode: ${{ matrix.lb-mode }}
+          lb-acceleration: ${{ matrix.lb-acceleration }}
+          encryption: ${{ matrix.encryption }}
+          encryption-node: ${{ matrix.encryption-node }}
+          egress-gateway: ${{ matrix.egress-gateway }}
+          host-fw: ${{ matrix.host-fw }}
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ steps.vars.outputs.sha }}
           persist-credentials: false
@@ -282,8 +232,7 @@ jobs:
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli install \
-              ${{ steps.vars.outputs.cilium_stable_image_settings }} \
-              ${{ steps.vars.outputs.cilium_install_defaults }}
+              ${{ steps.cilium-stable-config.outputs.config }}
 
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide
@@ -316,8 +265,7 @@ jobs:
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-              ${{ steps.vars.outputs.cilium_main_image_settings }} \
-              ${{ steps.vars.outputs.cilium_install_defaults }}
+              ${{ steps.cilium-newest-config.outputs.config }}
 
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide
@@ -352,8 +300,7 @@ jobs:
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-              ${{ steps.vars.outputs.cilium_stable_image_settings }} \
-              ${{ steps.vars.outputs.cilium_install_defaults }}
+              ${{ steps.cilium-stable-config.outputs.config }}
 
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide

--- a/Documentation/network/servicemesh/grpc.rst
+++ b/Documentation/network/servicemesh/grpc.rst
@@ -20,14 +20,14 @@ For this demo we will use `GCP's microservices demo app <https://github.com/Goog
 
 .. code-block:: shell-session
 
-    $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/release/kubernetes-manifests.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/release/kubernetes-manifests.yaml
 
 Since gRPC is binary-encoded, you also need the proto definitions for the gRPC
 services in order to make gRPC requests. Download this for the demo app:
 
 .. code-block:: shell-session
 
-    $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/pb/demo.proto
+    $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/protos/demo.proto
 
 
 Deploy GRPC Ingress

--- a/Documentation/network/servicemesh/tls-termination.rst
+++ b/Documentation/network/servicemesh/tls-termination.rst
@@ -104,7 +104,7 @@ Make HTTPS Requests
         .. code-block:: shell-session
 
             # Download demo.proto file if you have not done before
-            $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/pb/demo.proto
+            $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/protos/demo.proto
             $ grpcurl -proto ./demo.proto -cacert minica.pem hipstershop.cilium.rocks:443 hipstershop.ProductCatalogService/ListProducts
 
     .. group-tab:: Cert Manager

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -332,6 +332,11 @@ For IPSec enabled Cilium deployments, you need to ensure that the firewall
 allows ESP traffic through. For example, AWS Security Groups doesn't allow ESP
 traffic by default.
 
+If you are using WireGuard, you must allow UDP port 51871. Furthermore, if you
+have disabled node-to-node encryption and configured an overlay network mode
+(such as VXLAN or Geneve) in addition to WireGuard, then the overlay ports must
+also be allowed.
+
 If you are using VXLAN overlay network mode, Cilium uses Linux's default VXLAN
 port 8472 over UDP, unless Linux has been configured otherwise. In this case,
 UDP 8472 must be open among all nodes to enable VXLAN overlay mode. The same

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -315,17 +315,35 @@ LLVM.
 Firewall Rules
 ==============
 
-If you are running Cilium in an environment that requires firewall rules to enable connectivity, you will have to add the following rules to ensure Cilium works properly.
+If you are running Cilium in an environment that requires firewall rules to
+enable connectivity, you will have to add the following rules to ensure Cilium
+works properly.
 
-It is recommended but optional that all nodes running Cilium in a given cluster must be able to ping each other so ``cilium-health`` can report and monitor connectivity among nodes. This requires ICMP Type 0/8, Code 0 open among all nodes. TCP 4240 should also be open among all nodes for ``cilium-health`` monitoring. Note that it is also an option to only use one of these two methods to enable health monitoring. If the firewall does not permit either of these methods, Cilium will still operate fine but will not be able to provide health information.
+It is recommended but optional that all nodes running Cilium in a given cluster
+must be able to ping each other so ``cilium-health`` can report and monitor
+connectivity among nodes. This requires ICMP Type 0/8, Code 0 open among all
+nodes. TCP 4240 should also be open among all nodes for ``cilium-health``
+monitoring. Note that it is also an option to only use one of these two methods
+to enable health monitoring. If the firewall does not permit either of these
+methods, Cilium will still operate fine but will not be able to provide health
+information.
 
-For IPSec enabled Cilium deployments, you need to ensure that the firewall allows ESP traffic through. For example, AWS Security Groups doesn't allow ESP traffic by default.
+For IPSec enabled Cilium deployments, you need to ensure that the firewall
+allows ESP traffic through. For example, AWS Security Groups doesn't allow ESP
+traffic by default.
 
-If you are using VXLAN overlay network mode, Cilium uses Linux's default VXLAN port 8472 over UDP, unless Linux has been configured otherwise. In this case, UDP 8472 must be open among all nodes to enable VXLAN overlay mode. The same applies to Geneve overlay network mode, except the port is UDP 6081.
+If you are using VXLAN overlay network mode, Cilium uses Linux's default VXLAN
+port 8472 over UDP, unless Linux has been configured otherwise. In this case,
+UDP 8472 must be open among all nodes to enable VXLAN overlay mode. The same
+applies to Geneve overlay network mode, except the port is UDP 6081.
 
-If you are running in direct routing mode, your network must allow routing of pod IPs.
+If you are running in direct routing mode, your network must allow routing of
+pod IPs.
 
-As an example, if you are running on AWS with VXLAN overlay networking, here is a minimum set of AWS Security Group (SG) rules. It assumes a separation between the SG on the master nodes, ``master-sg``, and the worker nodes, ``worker-sg``. It also assumes ``etcd`` is running on the master nodes.
+As an example, if you are running on AWS with VXLAN overlay networking, here is
+a minimum set of AWS Security Group (SG) rules. It assumes a separation between
+the SG on the master nodes, ``master-sg``, and the worker nodes, ``worker-sg``.
+It also assumes ``etcd`` is running on the master nodes.
 
 Master Nodes (``master-sg``) Rules:
 

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -12,10 +12,10 @@ Layer 3 Examples
 The layer 3 policy establishes the base connectivity rules regarding which endpoints
 can talk to each other. Layer 3 policies can be specified using the following methods:
 
-* `Labels based`: This is used to describe the relationship if both endpoints
-  are managed by Cilium and are thus assigned labels. The big advantage of this
-  method is that IP addresses are not encoded into the policies and the policy is
-  completely decoupled from the addressing.
+* `Endpoints based`: This is used to describe the relationship if both
+  endpoints are managed by Cilium and are thus assigned labels. The
+  advantage of this method is that IP addresses are not encoded into the
+  policies and the policy is completely decoupled from the addressing.
 
 * `Services based`: This is an intermediate form between Labels and CIDR and
   makes use of the services concept in the orchestration system. A good example
@@ -39,14 +39,14 @@ can talk to each other. Layer 3 policies can be specified using the following me
   above. DNS information is acquired by routing DNS traffic via a proxy.
   DNS TTLs are respected.
 
-.. _Labels based:
+.. _Endpoints based:
 
-Labels Based
-------------
+Endpoints Based
+---------------
 
-Label-based L3 policy is used to establish policy between endpoints inside the
-cluster managed by Cilium. Label-based L3 policies are defined by using an
-`EndpointSelector` inside a rule to choose what kind of traffic that can be
+Endpoints-based L3 policy is used to establish rules between endpoints inside
+the cluster managed by Cilium. Endpoints-based L3 policies are defined by using
+an `EndpointSelector` inside a rule to select what kind of traffic can be
 received (on ingress), or sent (on egress). An empty `EndpointSelector` allows
 all traffic. The examples below demonstrate this in further detail.
 
@@ -258,7 +258,8 @@ Traffic from pods to services running in your cluster can be allowed via
 `Services without a Selector
 <https://kubernetes.io/docs/concepts/services-networking/service/#services-without-selectors>`_
 are supported when defined by their name and namespace or label selector.
-For services backed by pods, use `labels based` rules on the backend pod labels.
+For services backed by pods, use `Endpoints Based` rules on the backend pod
+labels.
 
 This example shows how to allow all endpoints with the label ``id=app2``
 to talk to all endpoints of kubernetes service ``myservice`` in kubernetes
@@ -533,13 +534,13 @@ a single egress rule.
    This includes DNS policies as well as :ref:`proxy_visibility` annotations.
 
 ``toFQDNs`` egress rules cannot contain any other L3 rules, such as
-``toEndpoints`` (under `Labels Based`_) and ``toCIDRs`` (under `CIDR Based`_).
+``toEndpoints`` (under `Endpoints Based`_) and ``toCIDRs`` (under `CIDR Based`_).
 They may contain L4/L7 rules, such as ``toPorts`` (see `Layer 4 Examples`_)
 with, optionally, ``HTTP`` and ``Kafka`` sections (see `Layer 7 Examples`_).
 
 .. note:: DNS based rules are intended for external connections and behave
           similarly to `CIDR based`_ rules. See `Services based`_ and
-          `Labels based`_ for cluster-internal traffic.
+          `Endpoints based`_ for cluster-internal traffic.
 
 IPs to be allowed are selected via:
 

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -253,6 +253,11 @@ accessible from endpoints that have both labels ``env=prod`` and
 Services based
 --------------
 
+.. note::
+
+	Services based rules rules will only take effect on Kubernetes services
+        without a selector.
+
 Traffic from pods to services running in your cluster can be allowed via
 ``toServices`` statements in Egress rules. Currently Kubernetes
 `Services without a Selector
@@ -264,11 +269,6 @@ labels.
 This example shows how to allow all endpoints with the label ``id=app2``
 to talk to all endpoints of kubernetes service ``myservice`` in kubernetes
 namespace ``default``.
-
-.. note::
-
-	These rules will only take effect on Kubernetes services without a
-	selector.
 
 .. only:: html
 

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -444,6 +444,9 @@ static __always_inline int handle_ipv6_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	if (ct_status == CT_REPLY || ct_status == CT_RELATED) {
 		/* Check if this is return traffic to an ingress proxy. */
 		if (ct_state->proxy_redirect) {
+			send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL,
+					  0, 0, 0, trace.reason,
+					  trace.monitor);
 			/* Stack will do a socket match and deliver locally. */
 			return ctx_redirect_to_proxy6(ctx, tuple, 0, false);
 		}
@@ -877,6 +880,9 @@ static __always_inline int handle_ipv4_from_lxc(struct __ctx_buff *ctx, __u32 *d
 	if (ct_status == CT_REPLY || ct_status == CT_RELATED) {
 		/* Check if this is return traffic to an ingress proxy. */
 		if (ct_state->proxy_redirect) {
+			send_trace_notify(ctx, TRACE_TO_PROXY, SECLABEL,
+					  0, 0, 0, trace.reason,
+					  trace.monitor);
 			/* Stack will do a socket match and deliver locally. */
 			return ctx_redirect_to_proxy4(ctx, tuple, 0, false);
 		}

--- a/cilium/cmd/encrypt_status.go
+++ b/cilium/cmd/encrypt_status.go
@@ -89,14 +89,9 @@ func countUniqueIPsecKeys() int {
 	return len(keys)
 }
 
-func maxSequenceNumber() string {
+func extractMaxSequenceNumber(ipOutput string) string {
 	maxSeqNum := "0"
-	out, err := exec.Command("ip", "xfrm", "state", "list", "reqid", ciliumReqId).Output()
-	if err != nil {
-		Fatalf("Cannot get xfrm states: %s", err)
-	}
-	commandOutput := string(out)
-	lines := strings.Split(commandOutput, "\n")
+	lines := strings.Split(ipOutput, "\n")
 	for _, line := range lines {
 		matched := regex.FindStringSubmatchIndex(line)
 		if matched != nil {
@@ -106,6 +101,16 @@ func maxSequenceNumber() string {
 			}
 		}
 	}
+	return maxSeqNum
+}
+
+func maxSequenceNumber() string {
+	out, err := exec.Command("ip", "xfrm", "state", "list", "reqid", ciliumReqId).Output()
+	if err != nil {
+		Fatalf("Cannot get xfrm states: %s", err)
+	}
+	commandOutput := string(out)
+	maxSeqNum := extractMaxSequenceNumber(commandOutput)
 	if maxSeqNum == "0" {
 		return "N/A"
 	}

--- a/cilium/cmd/encrypt_status_test.go
+++ b/cilium/cmd/encrypt_status_test.go
@@ -119,3 +119,43 @@ func (s *EncryptStatusSuite) TestGetXfrmStats(c *C) {
 	}
 	c.Assert(currentCount, Equals, errCount)
 }
+
+func (s *EncryptStatusSuite) TestExtractMaxSequenceNumber(c *C) {
+	ipOutput := `src 10.84.1.32 dst 10.84.0.30
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0x3cb23e00/0xffffff00 output-mark 0xe00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0xc3, bitmap 0x00000000
+	sel src 0.0.0.0/0 dst 0.0.0.0/0
+src 0.0.0.0 dst 10.84.1.32
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0xd00/0xf00 output-mark 0xd00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0x1410, bitmap 0x00000000
+	sel src 0.0.0.0/0 dst 0.0.0.0/0
+src 10.84.1.32 dst 10.84.2.145
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0x7e63e00/0xffffff00 output-mark 0xe00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0x13e0, bitmap 0x00000000
+	sel src 0.0.0.0/0 dst 0.0.0.0/0`
+
+	maxSeqNumber := extractMaxSequenceNumber(ipOutput)
+	c.Assert(maxSeqNumber, Equals, int64(0x1410))
+}
+
+// Attempt to simulate a case where the output would be interrupted mid-sentence.
+func (s *EncryptStatusSuite) TestExtractMaxSequenceNumberError(c *C) {
+	ipOutput := `src 10.84.1.32 dst 10.84.0.30
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0x3cb23e00/0xffffff00 output-mark 0xe00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0x`
+
+	maxSeqNumber := extractMaxSequenceNumber(ipOutput)
+	c.Assert(maxSeqNumber, Equals, int64(0))
+}

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -65,9 +65,9 @@ spec:
         args:
         - '-c /var/run/cilium/envoy/bootstrap-config.json'
         - '--base-id 0'
-        {{- if and (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "envoy" ( splitList "," .Values.debug.verbose )) }}
+        {{- if and (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "envoy" ( splitList " " .Values.debug.verbose )) }}
         - '--log-level trace'
-        {{- else if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "flow" ( splitList "," .Values.debug.verbose )) }}
+        {{- else if and (.Values.debug.enabled) (hasKey .Values.debug "verbose") (.Values.debug.verbose) (has "flow" ( splitList " " .Values.debug.verbose )) }}
         - '--log-level debug'
         {{- else }}
         - '--log-level info'

--- a/operator/pkg/model/ingestion/ingress.go
+++ b/operator/pkg/model/ingestion/ingress.go
@@ -91,6 +91,12 @@ func Ingress(ing slim_networkingv1.Ingress, defaultSecretNamespace, defaultSecre
 		}
 
 		l.Hostname = host
+		if rule.HTTP == nil {
+			log.WithField(logfields.Ingress, ing.Namespace+"/"+ing.Name).
+				Warn("Invalid Ingress rule without spec.rules.HTTP defined, skipping rule")
+			continue
+		}
+
 		for _, path := range rule.HTTP.Paths {
 
 			route := model.HTTPRoute{}

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -19,12 +19,12 @@ type Model struct {
 func (m *Model) GetListeners() []Listener {
 	var listeners []Listener
 
-	for _, l := range m.HTTP {
-		listeners = append(listeners, &l)
+	for i := range m.HTTP {
+		listeners = append(listeners, &m.HTTP[i])
 	}
 
-	for _, l := range m.TLS {
-		listeners = append(listeners, &l)
+	for i := range m.TLS {
+		listeners = append(listeners, &m.TLS[i])
 	}
 
 	return listeners

--- a/operator/pkg/model/model_test.go
+++ b/operator/pkg/model/model_test.go
@@ -13,8 +13,18 @@ var testTLSListener = TLSListener{
 	Port: 443,
 }
 
+var testTLSListener2 = TLSListener{
+	Name: "test-tls-listener2",
+	Port: 443,
+}
+
 var testHTTPListener = HTTPListener{
 	Name: "test-http-listener",
+	Port: 80,
+}
+
+var testHTTPListener2 = HTTPListener{
+	Name: "test-http-listener2",
 	Port: 80,
 }
 
@@ -31,24 +41,24 @@ func TestModel_GetListeners(t *testing.T) {
 		{
 			name: "Combine HTTP and TLS listeners",
 			fields: fields{
-				HTTP: []HTTPListener{testHTTPListener},
-				TLS:  []TLSListener{testTLSListener},
+				HTTP: []HTTPListener{testHTTPListener, testHTTPListener2},
+				TLS:  []TLSListener{testTLSListener, testTLSListener2},
 			},
-			want: []Listener{&testHTTPListener, &testTLSListener},
+			want: []Listener{&testHTTPListener, &testHTTPListener2, &testTLSListener, &testTLSListener2},
 		},
 		{
 			name: "Only HTTP listeners",
 			fields: fields{
-				HTTP: []HTTPListener{testHTTPListener},
+				HTTP: []HTTPListener{testHTTPListener, testHTTPListener2},
 			},
-			want: []Listener{&testHTTPListener},
+			want: []Listener{&testHTTPListener, &testHTTPListener2},
 		},
 		{
 			name: "Only TLS listeners",
 			fields: fields{
-				TLS: []TLSListener{testTLSListener},
+				TLS: []TLSListener{testTLSListener, testTLSListener2},
 			},
-			want: []Listener{&testTLSListener},
+			want: []Listener{&testTLSListener, &testTLSListener2},
 		},
 		{
 			name:   "No listeners",

--- a/pkg/fqdn/cache.go
+++ b/pkg/fqdn/cache.go
@@ -864,16 +864,29 @@ func (zombies *DNSZombieMappings) isZombieAlive(zombie *DNSZombieMapping, aliveN
 	return alive, overLimit
 }
 
-// sortZombieMappingSlice sorts the provided slice by whether the connection is
-// marked alive or not, the oldest created connections, and tie-break by the
-// number of DNS names for that IP.
+// sortZombieMappingSlice sorts the provided slice so that less important
+// zombies shuffle to the front of the slice (from where they are eliminated).
+// To achieve this, it sorts by three criteria, in order of priority:
 //
-// Important zombies shuffle to the end of the slice.
+// 1. when the connection was last marked alive (earlier == less important)
+// 2. when this ip was last scheduled for deletion (earlier == less important)
+// 3. tie-break by number of DNS names for that IP
 func sortZombieMappingSlice(alive []*DNSZombieMapping) {
 	sort.Slice(alive, func(i, j int) bool {
-		return alive[i].AliveAt.Before(alive[j].AliveAt) ||
-			alive[i].DeletePendingAt.Before(alive[j].DeletePendingAt) ||
-			len(alive[i].Names) < len(alive[j].Names)
+		switch {
+		case alive[i].AliveAt.Before(alive[j].AliveAt):
+			return true
+		case alive[i].AliveAt.After(alive[j].AliveAt):
+			return false
+		// We have AliveAt equality after this point.
+		case alive[i].DeletePendingAt.Before(alive[j].DeletePendingAt):
+			return true
+		case alive[i].DeletePendingAt.After(alive[j].DeletePendingAt):
+			return false
+		// DeletePendingAt is also equal. Tie-break by number of Names.
+		default:
+			return len(alive[i].Names) < len(alive[j].Names)
+		}
 	})
 }
 

--- a/pkg/fqdn/cache_test.go
+++ b/pkg/fqdn/cache_test.go
@@ -11,6 +11,7 @@ import (
 	"net/netip"
 	"regexp"
 	"sort"
+	"testing"
 	"time"
 
 	. "github.com/cilium/checkmate"
@@ -1108,4 +1109,172 @@ func (ds *DNSCacheTestSuite) TestOverlimitPreferNewerEntries(c *C) {
 		"1.1.1.9":  {name},
 		"1.1.1.10": {name},
 	})
+}
+
+// Define a test-only string representation to make the output below more readable.
+func (z *DNSZombieMapping) String() string {
+	return fmt.Sprintf(
+		"DNSZombieMapping{AliveAt: %s, DeletePendingAt: %s, Names: %v}",
+		z.AliveAt, z.DeletePendingAt, z.Names,
+	)
+}
+
+func validateZombieSort(t *testing.T, zombies []*DNSZombieMapping) {
+	t.Helper()
+	sl := len(zombies)
+
+	logFailure := func(t *testing.T, zs []*DNSZombieMapping, prop string, i, j int) {
+		t.Helper()
+		t.Logf("order property fail %v: want zombie[i] < zombie[j]", prop)
+		t.Log("zombie[i]: ", zombies[i])
+		t.Log("zombie[j]: ", zombies[j])
+		t.Log("all mappings: ")
+		for i, z := range zombies {
+			t.Log(fmt.Sprintf("%2d", i), z)
+		}
+	}
+	// Don't try to be efficient, just check that the properties we want hold
+	// for every pair of zombie mappings.
+	for i := 0; i < sl; i++ {
+		for j := i + 1; j < sl; j++ {
+			if zombies[i].AliveAt.Before(zombies[j].AliveAt) {
+				continue
+			} else if zombies[i].AliveAt.After(zombies[j].AliveAt) {
+				logFailure(t, zombies, "AliveAt", i, j)
+				t.Fatalf("order wrong: AliveAt: %v is after %v", zombies[i].AliveAt, zombies[j].AliveAt)
+				return
+			}
+
+			if zombies[i].DeletePendingAt.Before(zombies[j].DeletePendingAt) {
+				continue
+			} else if zombies[i].DeletePendingAt.After(zombies[j].DeletePendingAt) {
+				logFailure(t, zombies, "DeletePendingAt", i, j)
+				t.Fatalf("order wrong: DeletePendingAt: %v is after %v", zombies[i].DeletePendingAt, zombies[j].DeletePendingAt)
+				return
+			}
+
+			if len(zombies[i].Names) > len(zombies[j].Names) {
+				logFailure(t, zombies, "len(names)", i, j)
+				t.Fatalf("order wrong: len(names): %v is longer than %v", zombies[i].Names, zombies[j].Names)
+			}
+		}
+	}
+}
+
+func Test_sortZombieMappingSlice(t *testing.T) {
+	// Create three moments in time, so we can have before, equal and after.
+	moments := []time.Time{
+		time.Date(2001, time.January, 1, 1, 1, 1, 0, time.Local),
+		time.Date(2002, time.February, 2, 2, 2, 2, 0, time.Local),
+		time.Date(2003, time.March, 3, 3, 3, 3, 0, time.Local),
+	}
+
+	// Couple of edge cases/hand-picked scenarios. To be complemented by the
+	// randomly generated ones, below.
+	type args struct {
+		zombies []*DNSZombieMapping
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			"empty",
+			args{zombies: nil},
+		},
+		{
+			"single",
+			args{zombies: []*DNSZombieMapping{{
+				Names:           []string{"test.com"},
+				AliveAt:         moments[0],
+				DeletePendingAt: moments[1],
+			}}},
+		},
+		{
+			"swapped alive at",
+			args{zombies: []*DNSZombieMapping{
+				{
+					AliveAt: moments[2],
+				},
+				{
+					AliveAt: moments[0],
+				},
+			}},
+		},
+		{
+			"equal alive, swapped delete pending at",
+			args{zombies: []*DNSZombieMapping{
+				{
+					AliveAt:         moments[0],
+					DeletePendingAt: moments[2],
+				},
+				{
+					AliveAt:         moments[0],
+					DeletePendingAt: moments[1],
+				},
+			}},
+		},
+		{
+			"swapped equal times, tiebreaker",
+			args{zombies: []*DNSZombieMapping{
+				{
+					Names:           []string{"test.com", "test2.com"},
+					AliveAt:         moments[0],
+					DeletePendingAt: moments[1],
+				},
+				{
+					Names:           []string{"test.com"},
+					AliveAt:         moments[0],
+					DeletePendingAt: moments[1],
+				},
+			}},
+		},
+	}
+
+	// Generate zombie mappings which cover all cases of the two times
+	// being either moment 0, 1 or 2, as well as with 0, 1 or 2 names.
+	names := []string{"example.org", "test.com"}
+	nMoments := len(moments)
+	allMappings := make([]*DNSZombieMapping, 0, nMoments*nMoments*nMoments)
+	for _, mi := range moments {
+		for _, mj := range moments {
+			for k := range names {
+				m := DNSZombieMapping{
+					AliveAt:         mi,
+					DeletePendingAt: mj,
+					Names:           names[:k],
+				}
+				allMappings = append(allMappings, &m)
+			}
+		}
+	}
+
+	// Five random tests:
+	for i := 0; i < 5; i++ {
+		ts := make([]*DNSZombieMapping, len(allMappings))
+		copy(ts, allMappings)
+		rand.Shuffle(len(ts), func(i, j int) {
+			ts[i], ts[j] = ts[j], ts[i]
+		})
+		tests = append(tests, struct {
+			name string
+			args args
+		}{
+			name: "Randomised sorting test",
+			args: args{
+				zombies: ts,
+			},
+		})
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ol := len(tt.args.zombies)
+			sortZombieMappingSlice(tt.args.zombies)
+			if len(tt.args.zombies) != ol {
+				t.Fatalf("length of slice changed by sorting")
+			}
+			validateZombieSort(t, tt.args.zombies)
+		})
+	}
 }

--- a/pkg/ipam/metrics/metrics.go
+++ b/pkg/ipam/metrics/metrics.go
@@ -264,6 +264,15 @@ func (p *prometheusMetrics) SetIPNeeded(node string, usage int) {
 	p.NeededIPs.WithLabelValues(node).Set(float64(usage))
 }
 
+// DeleteNode removes all per-node metrics for a particular node (i.e. those labeled with "target_node").
+// This is to ensure that when a Node/CiliumNode delete event happens that the operator will no longer report
+// metrics for that node.
+func (p *prometheusMetrics) DeleteNode(node string) {
+	p.AvailableIPs.DeleteLabelValues(node)
+	p.UsedIPs.DeleteLabelValues(node)
+	p.NeededIPs.DeleteLabelValues(node)
+}
+
 type triggerMetrics struct {
 	total        prometheus.Counter
 	folds        prometheus.Gauge
@@ -349,6 +358,7 @@ func (m *NoOpMetrics) SetIPNeeded(node string, n int)                           
 func (m *NoOpMetrics) PoolMaintainerTrigger() trigger.MetricsObserver                            { return &NoOpMetricsObserver{} }
 func (m *NoOpMetrics) K8sSyncTrigger() trigger.MetricsObserver                                   { return &NoOpMetricsObserver{} }
 func (m *NoOpMetrics) ResyncTrigger() trigger.MetricsObserver                                    { return &NoOpMetricsObserver{} }
+func (m *NoOpMetrics) DeleteNode(n string)                                                       {}
 
 func merge(slices ...[]float64) []float64 {
 	result := make([]float64, 1)

--- a/pkg/ipam/metrics/mock/mock.go
+++ b/pkg/ipam/metrics/mock/mock.go
@@ -197,6 +197,30 @@ func (m *mockMetrics) SetIPNeeded(s string, n int) {
 	m.mutex.Unlock()
 }
 
+func (m *mockMetrics) GetPerNodeMetrics(n string) (*int, *int, *int) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var avail, used, needed *int
+	if c, ok := m.nodeIPAvailable[n]; ok {
+		avail = &c
+	}
+	if c, ok := m.nodeIPUsed[n]; ok {
+		used = &c
+	}
+	if c, ok := m.nodeIPNeeded[n]; ok {
+		needed = &c
+	}
+	return avail, used, needed
+}
+
+func (m *mockMetrics) DeleteNode(n string) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	delete(m.nodeIPAvailable, n)
+	delete(m.nodeIPUsed, n)
+	delete(m.nodeIPNeeded, n)
+}
+
 func (m *mockMetrics) PoolMaintainerTrigger() trigger.MetricsObserver {
 	return nil
 }

--- a/pkg/ipam/node_manager.go
+++ b/pkg/ipam/node_manager.go
@@ -151,6 +151,7 @@ type MetricsNodeAPI interface {
 	SetIPAvailable(node string, cap int)
 	SetIPUsed(node string, used int)
 	SetIPNeeded(node string, needed int)
+	DeleteNode(node string)
 }
 
 // nodeMap is a mapping of node names to ENI nodes
@@ -374,6 +375,9 @@ func (n *NodeManager) Delete(resource *v2.CiliumNode) {
 	n.mutex.Lock()
 
 	if node, ok := n.nodes[resource.Name]; ok {
+		// Stop target_node metrics related to this node being emitted.
+		n.metricsAPI.DeleteNode(node.name)
+
 		if node.poolMaintainer != nil {
 			node.poolMaintainer.Shutdown()
 		}

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -25,7 +25,6 @@ func (k *K8sWatcher) namespacesInit() {
 	apiGroup := k8sAPIGroupNamespaceV1Core
 
 	var synced atomic.Bool
-	synced.Store(false)
 
 	k.blockWaitGroupToSyncResources(
 		k.stop,

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -71,8 +71,9 @@ type namespaceUpdater struct {
 }
 
 func getNamespaceLabels(ns *slim_corev1.Namespace) labels.Labels {
-	labelMap := map[string]string{}
-	for k, v := range ns.GetLabels() {
+	lbls := ns.GetLabels()
+	labelMap := make(map[string]string, len(lbls))
+	for k, v := range lbls {
 		labelMap[policy.JoinPath(ciliumio.PodNamespaceMetaLabels, k)] = v
 	}
 	return labels.Map2Labels(labelMap, labels.LabelSourceK8s)

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -35,7 +35,7 @@ func (k *K8sWatcher) namespacesInit() {
 	k.k8sAPIGroups.AddAPI(apiGroup)
 
 	nsUpdater := namespaceUpdater{
-		oldLabels:       make(map[string]labels.Labels),
+		oldIdtyLabels:   make(map[string]labels.Labels),
 		endpointManager: k.endpointManager,
 	}
 
@@ -65,7 +65,7 @@ func (k *K8sWatcher) namespacesInit() {
 }
 
 type namespaceUpdater struct {
-	oldLabels map[string]labels.Labels
+	oldIdtyLabels map[string]labels.Labels
 
 	endpointManager endpointManager
 }
@@ -80,10 +80,9 @@ func getNamespaceLabels(ns *slim_corev1.Namespace) labels.Labels {
 }
 
 func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
-	oldLabels := u.oldLabels[newNS.Name]
 	newLabels := getNamespaceLabels(newNS)
 
-	oldIdtyLabels, _ := labelsfilter.Filter(oldLabels)
+	oldIdtyLabels := u.oldIdtyLabels[newNS.Name]
 	newIdtyLabels, _ := labelsfilter.Filter(newLabels)
 
 	// Do not perform any other operations if the old labels are the same as
@@ -108,7 +107,7 @@ func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
 	if failed {
 		return errors.New("unable to update some endpoints with new namespace labels")
 	}
-	u.oldLabels[newNS.Name] = newLabels
+	u.oldIdtyLabels[newNS.Name] = newIdtyLabels
 	return nil
 }
 

--- a/pkg/k8s/watchers/namespace.go
+++ b/pkg/k8s/watchers/namespace.go
@@ -86,8 +86,8 @@ func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
 	oldIdtyLabels, _ := labelsfilter.Filter(oldLabels)
 	newIdtyLabels, _ := labelsfilter.Filter(newLabels)
 
-	// Do not perform any other operations the the old labels are the same as
-	// the new labels
+	// Do not perform any other operations if the old labels are the same as
+	// the new labels.
 	if oldIdtyLabels.DeepEqual(&newIdtyLabels) {
 		return nil
 	}
@@ -100,7 +100,7 @@ func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
 			err := ep.ModifyIdentityLabels(newIdtyLabels, oldIdtyLabels)
 			if err != nil {
 				log.WithError(err).WithField(logfields.EndpointID, ep.ID).
-					Warningf("unable to update endpoint with new namespace labels")
+					Warning("unable to update endpoint with new identity labels from namespace labels")
 				failed = true
 			}
 		}
@@ -108,6 +108,7 @@ func (u *namespaceUpdater) update(newNS *slim_corev1.Namespace) error {
 	if failed {
 		return errors.New("unable to update some endpoints with new namespace labels")
 	}
+	u.oldLabels[newNS.Name] = newLabels
 	return nil
 }
 

--- a/test/k8s/services.go
+++ b/test/k8s/services.go
@@ -424,18 +424,6 @@ Secondary Interface %s :: IPv4: (%s, %s), IPv6: (%s, %s)`,
 			}
 		})
 
-		SkipItIf(func() bool {
-			// Currently, KIND doesn't support multiple interfaces among nodes
-			return helpers.IsIntegration(helpers.CIIntegrationKind)
-		}, "Tests with secondary NodePort device", func() {
-			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
-				"loadBalancer.mode": "snat",
-				"devices":           fmt.Sprintf(`'{%s,%s}'`, ni.PrivateIface, helpers.SecondaryIface),
-			})
-
-			testNodePortExternal(kubectl, ni, true, false, false)
-		})
-
 		It("Tests with direct routing and DSR", func() {
 			DeployCiliumOptionsAndDNS(kubectl, ciliumFilename, map[string]string{
 				"loadBalancer.mode":    "dsr",


### PR DESCRIPTION
 * [x] #27656 (@pchaigno)
 * [x] #27698 (@mhofstetter)
   * minor conflict, see first commit
 * [x] #27713 (@tommyp1ckles)
 * [x] #27695 (@Managarmrr)
 * [x] #27572 (@bimmlerd)
 * [x] #27822 (@tklauser)
   * minor conflict, see third commit
 * [x] #27171 (@joestringer)
 * [x] #27818 (@mhofstetter)
 * [x] #27416 (@brb)
 * [x] #27831 (@tklauser)
 * [x] #27814 (@haiyuewa)
 * [x] #27359 (@brb)
   * not sure I applied all changes correctly as the 2 workflows were a bit different, please double check
 * [x] #27738 (@brb)
 * [x] #27706 (@tklauser)
   * minor conflict, see first commit
 * [x] #27170 (@joestringer)
 * [x] #27872 (@pchaigno)
   * minor conflict, see first commit

PRs skipped due to conflicts:

 * #27602 (@julianwiedmann)
   * non obvious conflict due to the `#ifndef DISABLE_LOOPBACK_LB` block in lib/conntrack.h missing in v1.14
 * #26663 (@gandro)
   * non obvious conflicts as `enableIPSecIPv{4,6}` don't return an error in v1.14

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27656 27698 27713 27695 27572 27822 27171 27818 27416 27831 27814 27359 27738 27706 27170 27872; do contrib/backporting/set-labels.py $pr done 1.14; done
```
or with
```
make add-labels BRANCH=v1.14 ISSUES=27656,27698,27713,27695,27572,27822,27171,27818,27416,27831,27814,27359,27738,27706,27170,27872
```
