### PR TITLE
docs: egressgw: document incompatibility with Clustermesh

### DIFF
--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -76,6 +76,9 @@ Because egress gateway isn't compatible with identity allocation mode ``kvstore`
 you must use Kubernetes as Cilium's identity store (``identityAllocationMode``
 set to ``crd``). This is the default setting for new installations.
 
+Egress gateway is not compatible with the Cluster Mesh feature. The gateway selected
+by an egress gateway policy must be in the same cluster as the selected pods.
+
 Egress gateway is not supported for IPv6 traffic.
 
 Enable egress gateway


### PR DESCRIPTION
The current way of subscribing to node events is not compatible with Clustermesh (see https://github.com/cilium/cilium/pull/25794). Reflect this in the documentation.