### PR TITLE
envoy: fix lb backend endpoint calculation

### DIFF
--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -782,13 +782,25 @@ func (s *xdsServer) DeleteEnvoyResources(ctx context.Context, resources Resource
 
 func (s *xdsServer) UpsertEnvoyEndpoints(serviceName lb.ServiceName, backendMap map[string][]*lb.Backend) error {
 	var resources Resources
-	lbEndpoints := []*envoy_config_endpoint.LbEndpoint{}
+
+	resources.Endpoints = getEndpointsForLBBackends(serviceName, backendMap)
+
+	// Using context.TODO() is fine as we do not upsert listener resources here - the
+	// context ends up being used only if listener(s) are included in 'resources'.
+	return s.UpsertEnvoyResources(context.TODO(), resources, nil)
+}
+
+func getEndpointsForLBBackends(serviceName lb.ServiceName, backendMap map[string][]*lb.Backend) []*envoy_config_endpoint.ClusterLoadAssignment {
+	var endpoints []*envoy_config_endpoint.ClusterLoadAssignment
+
+	var lbEndpoints []*envoy_config_endpoint.LbEndpoint
 	for port, bes := range backendMap {
 		for _, be := range bes {
 			if be.Protocol != lb.TCP {
 				// Only TCP services supported with Envoy for now
 				continue
 			}
+
 			lbEndpoints = append(lbEndpoints, &envoy_config_endpoint.LbEndpoint{
 				HostIdentifier: &envoy_config_endpoint.LbEndpoint_Endpoint{
 					Endpoint: &envoy_config_endpoint.Endpoint{
@@ -806,6 +818,7 @@ func (s *xdsServer) UpsertEnvoyEndpoints(serviceName lb.ServiceName, backendMap 
 				},
 			})
 		}
+
 		endpoint := &envoy_config_endpoint.ClusterLoadAssignment{
 			ClusterName: fmt.Sprintf("%s:%s", serviceName.String(), port),
 			Endpoints: []*envoy_config_endpoint.LocalityLbEndpoints{
@@ -814,12 +827,12 @@ func (s *xdsServer) UpsertEnvoyEndpoints(serviceName lb.ServiceName, backendMap 
 				},
 			},
 		}
-		resources.Endpoints = append(resources.Endpoints, endpoint)
+		endpoints = append(endpoints, endpoint)
 
 		// for backward compatibility, if any port is allowed, publish one more
 		// endpoint having cluster name as service name.
 		if port == anyPort {
-			resources.Endpoints = append(resources.Endpoints, &envoy_config_endpoint.ClusterLoadAssignment{
+			endpoints = append(endpoints, &envoy_config_endpoint.ClusterLoadAssignment{
 				ClusterName: serviceName.String(),
 				Endpoints: []*envoy_config_endpoint.LocalityLbEndpoints{
 					{
@@ -829,9 +842,8 @@ func (s *xdsServer) UpsertEnvoyEndpoints(serviceName lb.ServiceName, backendMap 
 			})
 		}
 	}
-	// Using context.TODO() is fine as we do not upsert listener resources here - the
-	// context ends up being used only if listener(s) are included in 'resources'.
-	return s.UpsertEnvoyResources(context.TODO(), resources, nil)
+
+	return endpoints
 }
 
 func fillInTlsContextXDS(cecNamespace string, cecName string, tls *envoy_config_tls.CommonTlsContext) bool {

--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -793,8 +793,8 @@ func (s *xdsServer) UpsertEnvoyEndpoints(serviceName lb.ServiceName, backendMap 
 func getEndpointsForLBBackends(serviceName lb.ServiceName, backendMap map[string][]*lb.Backend) []*envoy_config_endpoint.ClusterLoadAssignment {
 	var endpoints []*envoy_config_endpoint.ClusterLoadAssignment
 
-	var lbEndpoints []*envoy_config_endpoint.LbEndpoint
 	for port, bes := range backendMap {
+		var lbEndpoints []*envoy_config_endpoint.LbEndpoint
 		for _, be := range bes {
 			if be.Protocol != lb.TCP {
 				// Only TCP services supported with Envoy for now


### PR DESCRIPTION
Currently, mapping loadbalancing backends to Envoy endpoints contains a bug that the LbEndpoints are kept/appended over the
whole backendMap. Therefore, later endpoints will contain the LBEndpoints of all previous backends.

This commit fixes this by putting the variable `lbEndpoints` into the right scope (per port).