### PR TITLE
Helm: Improved description for tunnel, tunnelProtocol, routingMode flags

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2653,7 +2653,7 @@
      - bool
      - ``false``
    * - :spelling:ignore:`routingMode`
-     - Enable native-routing mode or tunneling mode.
+     - Enable native-routing mode or tunneling mode. Possible values:   - ""   - native   - tunnel
      - string
      - ``"tunnel"``
    * - :spelling:ignore:`sctp`
@@ -2785,15 +2785,15 @@
      - list
      - ``[{"operator":"Exists"}]``
    * - :spelling:ignore:`tunnel`
-     - Configure the encapsulation configuration for communication between nodes. Possible values:   - disabled   - vxlan (default)   - geneve
+     - Configure the encapsulation configuration for communication between nodes. Deprecated in favor of tunnelProtocol and routingMode. To be removed in 1.15. Possible values:   - disabled   - vxlan   - geneve
      - string
-     - ``""``
+     - ``"vxlan"``
    * - :spelling:ignore:`tunnelPort`
      - Configure VXLAN and Geneve tunnel port.
      - int
      - Port 8472 for VXLAN, Port 6081 for Geneve
    * - :spelling:ignore:`tunnelProtocol`
-     - Tunneling protocol to use in tunneling mode and for ad-hoc tunnels.
+     - Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve
      - string
      - ``"vxlan"``
    * - :spelling:ignore:`updateStrategy`

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -586,6 +586,7 @@ rn
 roadmap
 rollout
 routable
+routingMode
 rst
 runnable
 runtimes
@@ -668,6 +669,7 @@ toolchain
 tracepoint
 tracepoints
 transpiling
+tunnelProtocol
 ubuntu
 udp
 ui

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -713,7 +713,7 @@ contributors across the globe, there is almost always someone available to help.
 | resourceQuotas | object | `{"cilium":{"hard":{"pods":"10k"}},"enabled":false,"operator":{"hard":{"pods":"15"}}}` | Enable resource quotas for priority classes used in the cluster. |
 | resources | object | `{}` | Agent resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | rollOutCiliumPods | bool | `false` | Roll out cilium agent pods automatically when configmap is updated. |
-| routingMode | string | `"tunnel"` | Enable native-routing mode or tunneling mode. |
+| routingMode | string | `"tunnel"` | Enable native-routing mode or tunneling mode. Possible values:   - ""   - native   - tunnel |
 | sctp | object | `{"enabled":false}` | SCTP Configuration Values |
 | sctp.enabled | bool | `false` | Enable SCTP support. NOTE: Currently, SCTP support does not support rewriting ports or multihoming. |
 | securityContext.capabilities.applySysctlOverwrites | list | `["SYS_ADMIN","SYS_CHROOT","SYS_PTRACE"]` | capabilities for the `apply-sysctl-overwrites` init container |
@@ -746,9 +746,9 @@ contributors across the globe, there is almost always someone available to help.
 | tls.caBundle.useSecret | bool | `false` | Use a Secret instead of a ConfigMap. |
 | tls.secretsBackend | string | `"local"` | This configures how the Cilium agent loads the secrets used TLS-aware CiliumNetworkPolicies (namely the secrets referenced by terminatingTLS and originatingTLS). Possible values:   - local   - k8s |
 | tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for agent scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
-| tunnel | string | `""` | Configure the encapsulation configuration for communication between nodes. Possible values:   - disabled   - vxlan (default)   - geneve |
+| tunnel | string | `"vxlan"` | Configure the encapsulation configuration for communication between nodes. Deprecated in favor of tunnelProtocol and routingMode. To be removed in 1.15. Possible values:   - disabled   - vxlan   - geneve |
 | tunnelPort | int | Port 8472 for VXLAN, Port 6081 for Geneve | Configure VXLAN and Geneve tunnel port. |
-| tunnelProtocol | string | `"vxlan"` | Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. |
+| tunnelProtocol | string | `"vxlan"` | Tunneling protocol to use in tunneling mode and for ad-hoc tunnels. Possible values:   - ""   - vxlan   - geneve |
 | updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":2},"type":"RollingUpdate"}` | Cilium agent update strategy |
 | vtep.cidr | string | `""` | A space separated list of VTEP device CIDRs, for example "1.1.1.0/24 1.1.2.0/24" |
 | vtep.enabled | bool | `false` | Enables VXLAN Tunnel Endpoint (VTEP) Integration (beta) to allow Cilium-managed pods to talk to third party VTEP devices over Cilium tunnel. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2164,17 +2164,27 @@ tls:
     #   -----END CERTIFICATE-----
 
 # -- Configure the encapsulation configuration for communication between nodes.
+# Deprecated in favor of tunnelProtocol and routingMode. To be removed in 1.15.
 # Possible values:
 #   - disabled
-#   - vxlan (default)
+#   - vxlan
 #   - geneve
+# @default -- `"vxlan"`
 tunnel: ""
 
 # -- Tunneling protocol to use in tunneling mode and for ad-hoc tunnels.
+# Possible values:
+#   - ""
+#   - vxlan
+#   - geneve
 # @default -- `"vxlan"`
 tunnelProtocol: ""
 
 # -- Enable native-routing mode or tunneling mode.
+# Possible values:
+#   - ""
+#   - native
+#   - tunnel
 # @default -- `"tunnel"`
 routingMode: ""
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2161,17 +2161,27 @@ tls:
     #   -----END CERTIFICATE-----
 
 # -- Configure the encapsulation configuration for communication between nodes.
+# Deprecated in favor of tunnelProtocol and routingMode. To be removed in 1.15.
 # Possible values:
 #   - disabled
-#   - vxlan (default)
+#   - vxlan
 #   - geneve
+# @default -- `"vxlan"`
 tunnel: ""
 
 # -- Tunneling protocol to use in tunneling mode and for ad-hoc tunnels.
+# Possible values:
+#   - ""
+#   - vxlan
+#   - geneve
 # @default -- `"vxlan"`
 tunnelProtocol: ""
 
 # -- Enable native-routing mode or tunneling mode.
+# Possible values:
+#   - ""
+#   - native
+#   - tunnel
 # @default -- `"tunnel"`
 routingMode: ""
 


### PR DESCRIPTION
- Improved description for tunnel, tunnelProtocol, routingMode flags to make it clearer for users to know the possible values.
- Added deprecation note for the tunnel flag to be in line with the [v1.14.0 release notes](https://github.com/cilium/cilium/releases/tag/v1.14.0) and #24561.

Please ensure your pull request adheres to the following guidelines:

- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.

```release-note
Helm: Improved description for tunnel, tunnelProtocol, routingMode flags
```

Internal Slack discussion: https://isovalent.slack.com/archives/C01742ANV9P/p1693834569477619