### PR TITLE
docker: Tame xargs warning

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -49,7 +49,7 @@ GIT_IGNORE_FILES := $(shell find . -not -path "./vendor*" -name .gitignore -prin
 	@echo "/hack" > $@
 	@echo ".git" >> $@
 	@echo "/Makefile.docker" >> $@
-	@echo $(dir $(GIT_IGNORE_FILES)) | tr ' ' '\n' | xargs -P1 -n1 -I {DIR} sed \
+	@echo $(dir $(GIT_IGNORE_FILES)) | tr ' ' '\n' | xargs -P1 -I {DIR} -n1 sed \
 		-e '# Remove lines with white space, comments and files that must be passed to docker, "$$" due to make. #' \
 			-e '/^[[:space:]]*$$/d' -e '/^#/d' -e '/GIT_VERSION/d' \
 		-e '# Apply pattern in all directories if it contains no "/", keep "!" up front. #' \


### PR DESCRIPTION
From xargs' manual page:

     The options --max-lines (-L, -l), --replace (-I, -i) and --max-args (-n)
     are mutually exclusive. If some of them are specified at the same time,
     then xargs will generally use the option specified last on the command
     line, i.e., it will reset the value of the offending option (given before)
     to its default value. Additionally, xargs will issue a warning diagnostic
     on stderr. The exception to this rule is that the special max-args value 1
     ('-n1') is ignored after the --replace option and its aliases -I and -i,
     because it would not actually conflict.

Just as the manual says, we're getting a warning from Makefile.docker because we use both `-n1` and `-I`, in this order. The options are not supposed to conflict in our case, but it so happens that for xargs to suppress the warning, order matters. It's trivial to tame the warning by moving the `-n1` option _after_ the `-I`.

We could just as well delete the `-n1`, but I thought keeping it shows the original intent of having just one argument per command.
