### PR TITLE
can create the directory for the customized cni conf and remove the cni conf file in cleanup command

### DIFF
--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -272,6 +272,11 @@ func (c *cniConfigManager) setupCNIConfFile() error {
 		}
 	}
 
+	err = ensureDirExists(c.cniConfDir)
+	if err != nil {
+		return fmt.Errorf("failed to create the dir %s of the CNI configuration file: %w", c.cniConfDir, err)
+	}
+
 	dest := path.Join(c.cniConfDir, c.cniConfFile)
 
 	// Check to see if existing file is the same; if so, do nothing
@@ -464,4 +469,12 @@ func (c *cniConfigManager) findCNINetwork(wantNetwork string) ([]byte, error) {
 		return json.Marshal(rawConfigList)
 	}
 	return nil, fmt.Errorf("no matching CNI configurations found (will retry)")
+}
+
+func ensureDirExists(dir string) error {
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil && os.IsExist(err) {
+		return nil
+	}
+	return err
 }

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -590,6 +590,12 @@ spec:
               name: cilium-config
               key: clean-cilium-bpf-state
               optional: true
+        - name: WRITE_CNI_CONF_WHEN_READY
+          valueFrom:
+            configMapKeyRef:
+              name: cilium-config
+              key: write-cni-conf-when-ready
+              optional: true
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.k8sServiceHost | quote }}


### PR DESCRIPTION
Usually we will write the customized cni conf file and write it into the directory `/etc/cni/net.d` in the host. For example, 
```
- mountPath: /host/etc/cni/net.d
          name: etc-cni-netd

- hostPath:
          path: /etc/cni/net.d
          type: DirectoryOrCreate
        name: etc-cni-netd
```
So the value of write-cni-conf-when-ready is `/host/etc/cni/net.d/xxx-cilium.conf`.
In the cleanup command, it will not remove this file. 

And sometimes we need to specify  write-cni-conf-when-ready  to any pathes, and the directory may not exist. So the writing cni file will fail. 

The commit is to solve these two issues above.

```release-note
can create the directory for the customized cni conf and remove the cni conf file in cleanup command
```
