### PR TITLE
v1.12 Backports 2023-09-04

### DIFF
--- a/.github/workflows/conformance-aks.yaml
+++ b/.github/workflows/conformance-aks.yaml
@@ -218,7 +218,7 @@ jobs:
             --name ${{ env.name }}
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-azure-ci hubble-relay-ci ; do

--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -216,7 +216,7 @@ jobs:
           kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.11/config/master/aws-k8s-cni.yaml
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -316,7 +316,7 @@ jobs:
         kubectl --context ${{ env.contextName2 }} patch deployment -n kube-system coredns --patch="$COREDNS_PATCH"
 
     - name: Wait for images to be available
-      timeout-minutes: 10
+      timeout-minutes: 30
       shell: bash
       run: |
         for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do

--- a/.github/workflows/conformance-eks.yaml
+++ b/.github/workflows/conformance-eks.yaml
@@ -207,7 +207,7 @@ jobs:
           kubectl -n kube-system delete daemonset aws-node
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-aws-ci hubble-relay-ci ; do

--- a/.github/workflows/conformance-externalworkloads.yaml
+++ b/.github/workflows/conformance-externalworkloads.yaml
@@ -245,7 +245,7 @@ jobs:
           gcloud container clusters get-credentials ${{ env.clusterName }} --zone ${{ matrix.zone }}
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci clustermesh-apiserver-ci ; do

--- a/.github/workflows/conformance-gke.yaml
+++ b/.github/workflows/conformance-gke.yaml
@@ -227,7 +227,7 @@ jobs:
           gcloud container clusters get-credentials ${{ env.clusterName }}-${{ matrix.config.index }} --zone ${{ matrix.k8s.zone }}
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -221,7 +221,7 @@ jobs:
             mkdir -p cilium-junits
 
       - name: Wait for images to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -196,14 +196,6 @@ jobs:
           cmd: |
             git config --global --add safe.directory /host
 
-      - name: Wait for images to be available
-        timeout-minutes: 10
-        shell: bash
-        run: |
-          for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
-          done
-
       - name: Setup K8s cluster (${{ matrix.name }})
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
@@ -223,6 +215,14 @@ jobs:
                 --from-literal=keys="3 rfc4106(gcm(aes)) $(echo $(dd if=/dev/urandom count=20 bs=1 2> /dev/null | xxd -p -c 64)) 128"
 
             mkdir -p cilium-junits
+
+      - name: Wait for images to be available
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+          done
 
       - name: Install Cilium ${{ env.cilium_stable_version }} (${{ matrix.name }})
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -84,9 +84,6 @@ jobs:
             kpr: 'disabled'
             tunnel: 'disabled'
             encryption: 'ipsec'
-            encryption-node: 'false'
-            debug: 'true'
-            test-flow-interrupts: 'true'
             ipv6: 'false' # until https://github.com/cilium/cilium/issues/26944 resolved
 
           - name: '2'
@@ -96,9 +93,7 @@ jobs:
             kpr: 'disabled'
             tunnel: 'disabled'
             encryption: 'ipsec'
-            encryption-node: 'false'
             endpoint-routes: 'true'
-            test-flow-interrupts: 'true'
             ipv6: 'false' # until https://github.com/cilium/cilium/issues/26944 resolved
 
           - name: '3'
@@ -108,9 +103,7 @@ jobs:
             kpr: 'disabled'
             tunnel: 'vxlan'
             encryption: 'ipsec'
-            encryption-node: 'false'
             endpoint-routes: 'false' # Due to https://github.com/cilium/cilium/pull/22333
-            test-flow-interrupts: 'true'
             ipv6: 'false' # until https://github.com/cilium/cilium/issues/26944 resolved
 
     timeout-minutes: 60
@@ -218,20 +211,6 @@ jobs:
 
           CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
           echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
-          
-          JUNIT=""
-          for NAME in ${{ matrix.kube-proxy }} ${{ matrix.tunnel }} ${{ matrix.lb-mode }} ${{ matrix.encryption }} ${{ matrix.endpoint-routes }}; do
-            if [[ "${NAME}" != "" ]] && [[ "${NAME}" != "disabled" ]] && [[ "${NAME}" != "none" ]]; then
-              if [[ "${JUNIT}" != "" ]]; then
-                JUNIT+="-"
-              fi
-              if [[ "${NAME}" == "true" ]];then
-                NAME="endpoint-routes"
-              fi
-              JUNIT+="${NAME}"
-            fi
-          done
-          echo junit_type="${JUNIT}" >> $GITHUB_OUTPUT
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
       - name: Checkout pull request for Helm chart

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -143,6 +143,8 @@ jobs:
           encryption-node: ${{ matrix.encryption-node }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
+          mutual-auth: false
+          misc: 'bpfClockProbe=false,cni.uninstall=false'
 
       - name: Derive newest Cilium installation config
         id: cilium-newest-config
@@ -160,6 +162,8 @@ jobs:
           encryption-node: ${{ matrix.encryption-node }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
+          mutual-auth: false
+          misc: 'bpfClockProbe=false,cni.uninstall=false'
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -125,95 +125,45 @@ jobs:
           else
             SHA="${{ github.sha }}"
           fi
-
-          # TODO(brb) move the settings derivation into a reusable GH workflow
-          CILIUM_STABLE_IMAGE_SETTINGS="--chart-directory=./cilium-${{ env.cilium_stable_version }}/install/kubernetes/cilium/ \
-            --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
-            --helm-set=image.useDigest=false \
-            --helm-set=image.tag=v${{ env.cilium_stable_version }} \
-            --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
-            --helm-set=operator.image.suffix=-ci \
-            --helm-set=operator.image.tag=v${{ env.cilium_stable_version }} \
-            --helm-set=operator.image.useDigest=false \
-            --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-            --helm-set=hubble.relay.image.tag=v${{ env.cilium_stable_version }}"
-          echo "cilium_stable_image_settings=${CILIUM_STABLE_IMAGE_SETTINGS}" >> $GITHUB_OUTPUT
-
-          CILIUM_MAIN_IMAGE_SETTINGS="--chart-directory=./install/kubernetes/cilium \
-            --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
-            --helm-set=image.useDigest=false \
-            --helm-set=image.tag=${SHA} \
-            --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
-            --helm-set=operator.image.suffix=-ci \
-            --helm-set=operator.image.tag=${SHA} \
-            --helm-set=operator.image.useDigest=false \
-            --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-            --helm-set=hubble.relay.image.tag=${SHA}"
-          echo "cilium_main_image_settings=${CILIUM_MAIN_IMAGE_SETTINGS}" >> $GITHUB_OUTPUT
-
-          CILIUM_INSTALL_DEFAULTS="--wait \
-            --helm-set=debug.enabled=true \
-            --helm-set=cni.uninstall=false \
-            --helm-set=cluster.name=default \
-            --helm-set=hubble.eventBufferCapacity=65535 \
-            --helm-set=bpf.monitorAggregation=none \
-            --nodes-without-cilium=kind-worker3 \
-            --helm-set=bpfClockProbe=false \
-            --helm-set-string=kubeProxyReplacement=${{ matrix.kpr }}"
-
-          TUNNEL="--helm-set-string=tunnelProtocol=${{ matrix.tunnel }}"
-          if [ "${{ matrix.tunnel }}" == "disabled" ]; then
-            TUNNEL="--helm-set-string=routingMode=native --helm-set-string=autoDirectNodeRoutes=true --helm-set-string=ipv4NativeRoutingCIDR=10.244.0.0/16 --helm-set-string=tunnel=disabled"
-            TUNNEL="${TUNNEL} --helm-set-string=ipv6NativeRoutingCIDR=fd00:10:244::/56"
-          fi
-          LB_MODE=""
-          if [ "${{ matrix.lb-mode }}" != "" ]; then
-            LB_MODE="--helm-set-string=loadBalancer.mode=${{ matrix.lb-mode }}"
-          fi
-          ENDPOINT_ROUTES=""
-          if [ "${{ matrix.endpoint-routes }}" == "true" ]; then
-            ENDPOINT_ROUTES="--helm-set-string=endpointRoutes.enabled=true"
-          fi
-          IPV6=""
-          if [ "${{ matrix.ipv6 }}" != "false" ]; then
-            IPV6="--helm-set=ipv6.enabled=true"
-          fi
-          MASQ=""
-          if [ "${{ matrix.kpr }}" == "true" ] || [ "${{ matrix.kpr }}" == "strict" ]; then
-            # BPF-masq requires KPR=true.
-            MASQ="--helm-set=bpf.masquerade=true"
-            if [ "${{ matrix.host-fw }}" == "true" ]; then
-              # BPF IPv6 masquerade not currently supported with host firewall - GH-26074
-              MASQ="${MASQ} --helm-set=enableIPv6Masquerade=false"
-            fi
-          fi
-          EGRESS_GATEWAY=""
-          if [ "${{ matrix.egress-gateway }}" == "true" ]; then
-            EGRESS_GATEWAY="--helm-set=egressGateway.enabled=true"
-          fi
-          LB_ACCELERATION=""
-          if [ "${{ matrix.lb-acceleration }}" != "" ]; then
-            LB_ACCELERATION="--helm-set=loadBalancer.acceleration=${{ matrix.lb-acceleration }}"
-          fi
-
-          ENCRYPT=""
-          if [ "${{ matrix.encryption }}" != "" ]; then
-            ENCRYPT="--helm-set=encryption.enabled=true --helm-set=encryption.type=${{ matrix.encryption }}"
-            if [ "${{ matrix.encryption-node }}" != "" ]; then
-              ENCRYPT+=" --helm-set=encryption.nodeEncryption=${{ matrix.encryption-node }}"
-            fi
-          fi
-
-          HOST_FW=""
-          if [ "${{ matrix.host-fw }}" == "true" ]; then
-            HOST_FW="--helm-set=hostFirewall.enabled=true"
-          fi
-
-          CONFIG="${CILIUM_INSTALL_DEFAULTS} ${TUNNEL} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
-          echo "cilium_install_defaults=${CONFIG}" >> $GITHUB_OUTPUT
           echo sha=${SHA} >> $GITHUB_OUTPUT
 
-      - name: Checkout pull request for Helm chart
+      - name: Derive stable Cilium installation config
+        id: cilium-stable-config
+        uses: ./.github/actions/cilium-config
+        with:
+          image-tag: v${{ env.cilium_stable_version }}
+          chart-dir: './cilium-${{ env.cilium_stable_version }}/install/kubernetes/cilium/'
+          tunnel: ${{ matrix.tunnel }}
+          endpoint-routes: ${{ matrix.endpoint-routes }}
+          ipv6: ${{ matrix.ipv6 }}
+          kpr: ${{ matrix.kpr }}
+          lb-mode: ${{ matrix.lb-mode }}
+          lb-acceleration: ${{ matrix.lb-acceleration }}
+          encryption: ${{ matrix.encryption }}
+          encryption-node: ${{ matrix.encryption-node }}
+          egress-gateway: ${{ matrix.egress-gateway }}
+          host-fw: ${{ matrix.host-fw }}
+
+      - name: Derive newest Cilium installation config
+        id: cilium-newest-config
+        uses: ./.github/actions/cilium-config
+        with:
+          image-tag: ${{ steps.vars.outputs.sha }}
+          chart-dir: './install/kubernetes/cilium'
+          tunnel: ${{ matrix.tunnel }}
+          endpoint-routes: ${{ matrix.endpoint-routes }}
+          ipv6: ${{ matrix.ipv6 }}
+          kpr: ${{ matrix.kpr }}
+          lb-mode: ${{ matrix.lb-mode }}
+          lb-acceleration: ${{ matrix.lb-acceleration }}
+          encryption: ${{ matrix.encryption }}
+          encryption-node: ${{ matrix.encryption-node }}
+          egress-gateway: ${{ matrix.egress-gateway }}
+          host-fw: ${{ matrix.host-fw }}
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           ref: ${{ steps.vars.outputs.sha }}
@@ -282,8 +232,7 @@ jobs:
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli install \
-              ${{ steps.vars.outputs.cilium_stable_image_settings }} \
-              ${{ steps.vars.outputs.cilium_install_defaults }}
+              ${{ steps.cilium-stable-config.outputs.config }}
 
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide
@@ -316,8 +265,7 @@ jobs:
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-              ${{ steps.vars.outputs.cilium_main_image_settings }} \
-              ${{ steps.vars.outputs.cilium_install_defaults }}
+              ${{ steps.cilium-newest-config.outputs.config }}
 
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide
@@ -352,8 +300,7 @@ jobs:
             cd /host/
 
             CILIUM_CLI_MODE=helm ./cilium-cli upgrade \
-              ${{ steps.vars.outputs.cilium_stable_image_settings }} \
-              ${{ steps.vars.outputs.cilium_install_defaults }}
+              ${{ steps.cilium-stable-config.outputs.config }}
 
             ./cilium-cli status --wait
             kubectl get pods --all-namespaces -o wide

--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -106,7 +106,7 @@ jobs:
           persist-credentials: false
 
       - name: Wait for image to be available
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: bash
         run: |
           until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done

--- a/Documentation/gettingstarted/servicemesh/grpc.rst
+++ b/Documentation/gettingstarted/servicemesh/grpc.rst
@@ -20,14 +20,14 @@ For this demo we will use `GCP's microservices demo app <https://github.com/Goog
 
 .. code-block:: shell-session
 
-    $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/release/kubernetes-manifests.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/release/kubernetes-manifests.yaml
 
 Since gRPC is binary-encoded, you also need the proto definitions for the gRPC
 services in order to make gRPC requests. Download this for the demo app:
 
 .. code-block:: shell-session
 
-    $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/pb/demo.proto
+    $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/protos/demo.proto
 
 
 Deploy GRPC Ingress

--- a/Documentation/gettingstarted/servicemesh/tls-termination.rst
+++ b/Documentation/gettingstarted/servicemesh/tls-termination.rst
@@ -143,7 +143,7 @@ Make HTTPS Requests
         .. code-block:: shell-session
 
             # Download demo.proto file if you have not done before
-            $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/master/pb/demo.proto
+            $ curl -o demo.proto https://raw.githubusercontent.com/GoogleCloudPlatform/microservices-demo/main/protos/demo.proto
             $ grpcurl -proto ./demo.proto -cacert minica.pem hipstershop.cilium.rocks:443 hipstershop.ProductCatalogService/ListProducts
 
     .. group-tab:: Cert Manager

--- a/cilium/cmd/encrypt_status.go
+++ b/cilium/cmd/encrypt_status.go
@@ -89,14 +89,9 @@ func countUniqueIPsecKeys() int {
 	return len(keys)
 }
 
-func maxSequenceNumber() string {
+func extractMaxSequenceNumber(ipOutput string) string {
 	maxSeqNum := "0"
-	out, err := exec.Command("ip", "xfrm", "state", "list", "reqid", ciliumReqId).Output()
-	if err != nil {
-		Fatalf("Cannot get xfrm states: %s", err)
-	}
-	commandOutput := string(out)
-	lines := strings.Split(commandOutput, "\n")
+	lines := strings.Split(ipOutput, "\n")
 	for _, line := range lines {
 		matched := regex.FindStringSubmatchIndex(line)
 		if matched != nil {
@@ -106,6 +101,16 @@ func maxSequenceNumber() string {
 			}
 		}
 	}
+	return maxSeqNum
+}
+
+func maxSequenceNumber() string {
+	out, err := exec.Command("ip", "xfrm", "state", "list", "reqid", ciliumReqId).Output()
+	if err != nil {
+		Fatalf("Cannot get xfrm states: %s", err)
+	}
+	commandOutput := string(out)
+	maxSeqNum := extractMaxSequenceNumber(commandOutput)
 	if maxSeqNum == "0" {
 		return "N/A"
 	}

--- a/cilium/cmd/encrypt_status_test.go
+++ b/cilium/cmd/encrypt_status_test.go
@@ -123,3 +123,43 @@ func (s *EncryptStatusSuite) TestGetXfrmStats(c *C) {
 	}
 	c.Assert(currentCount, Equals, errCount)
 }
+
+func (s *EncryptStatusSuite) TestExtractMaxSequenceNumber(c *C) {
+	ipOutput := `src 10.84.1.32 dst 10.84.0.30
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0x3cb23e00/0xffffff00 output-mark 0xe00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0xc3, bitmap 0x00000000
+	sel src 0.0.0.0/0 dst 0.0.0.0/0
+src 0.0.0.0 dst 10.84.1.32
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0xd00/0xf00 output-mark 0xd00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0x1410, bitmap 0x00000000
+	sel src 0.0.0.0/0 dst 0.0.0.0/0
+src 10.84.1.32 dst 10.84.2.145
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0x7e63e00/0xffffff00 output-mark 0xe00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0x13e0, bitmap 0x00000000
+	sel src 0.0.0.0/0 dst 0.0.0.0/0`
+
+	maxSeqNumber := extractMaxSequenceNumber(ipOutput)
+	c.Assert(maxSeqNumber, Equals, int64(0x1410))
+}
+
+// Attempt to simulate a case where the output would be interrupted mid-sentence.
+func (s *EncryptStatusSuite) TestExtractMaxSequenceNumberError(c *C) {
+	ipOutput := `src 10.84.1.32 dst 10.84.0.30
+	proto esp spi 0x00000003 reqid 1 mode tunnel
+	replay-window 0
+	mark 0x3cb23e00/0xffffff00 output-mark 0xe00/0xf00
+	aead rfc4106(gcm(aes)) 0x64ad37a9d8a8f20fb2e74ef6000f9d580898719f 128
+	anti-replay context: seq 0x0, oseq 0x`
+
+	maxSeqNumber := extractMaxSequenceNumber(ipOutput)
+	c.Assert(maxSeqNumber, Equals, int64(0))
+}


### PR DESCRIPTION
 * [ ] #27656 (@pchaigno)
 * [x] #27572 (@bimmlerd)
 * [x] #27814 (@haiyuewa)
 * [x] #27359 (@brb)
 * [x] #27706 (@tklauser)

PRs skipped due to conflicts:

 * #27831 (@tklauser)
 * #27798 (@ti-mo)
   * dropped while `lb4_extract_tuple()` gets backported to 1.12

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27656 27572 27814 27359 27706; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
make add-labels BRANCH=v1.12 ISSUES=27656,27572,27814,27359,27706
```
