### PR TITLE
golangci: enforce use of cilium/dns over miekg/dns

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,10 @@ linters-settings:
   gomodguard:
     blocked:
       modules:
+        - github.com/miekg/dns:
+            recommendations:
+              - github.com/cilium/dns
+            reason: "use the cilium fork directly to avoid replace directives in go.mod, see https://github.com/cilium/cilium/pull/27582"
         - gopkg.in/check.v1:
             recommendations:
               - testing


### PR DESCRIPTION
Commit 95e25bfb1327 ("go.mod, vendor: use github.com/cilium/dns fork directly") switched to use the cilium/dns fork directly instead of using a replace directive. Make sure that future changes don't introduce dependencies on miekg/dns again.