### PR TITLE
close status collector when daemon exits

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1694,6 +1694,9 @@ func newDaemonPromise(params daemonParams) promise.Promise[*Daemon] {
 		},
 		OnStop: func(hive.HookContext) error {
 			cancelDaemonCtx()
+			if daemon.statusCollector != nil {
+				daemon.statusCollector.Close()
+			}
 			cleaner.Clean()
 			wg.Wait()
 			return nil

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -115,7 +115,6 @@ func NewCollector(probes []Probe, config Config) *Collector {
 }
 
 // Close exits all probes and shuts down the collector
-// TODO(brb): call it when daemon exits (after GH#6248).
 func (c *Collector) Close() {
 	close(c.stop)
 }


### PR DESCRIPTION
```
level=info msg="Stop hook executed" duration="2.668µs" function="node.NewLocalNodeStore.func2 (local_node_store.go:96)" subsys=hive
level=debug msg="Executing stop hook" function="*resource.resource[*github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1.Node].Stop" subsys=hive
level=info msg="Stop hook executed" duration="145.804µs" function="*resource.resource[*github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1.Node].Stop" subsys=hive
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x14639c7]

goroutine 2567 [running]:
github.com/cilium/cilium/pkg/node.(*LocalNodeStore).Observe(0x3bc2950?, {0x3bc2918?, 0xc00202f1d0?}, 0x0?, 0x0?)
    <autogenerated>:1 +0x27
github.com/cilium/cilium/pkg/stream.First[...]({_, _}, {_, _})
    /go/src/github.com/cilium/cilium/pkg/stream/sinks.go:25 +0x1a3
github.com/cilium/cilium/pkg/node.(*LocalNodeStore).Get(...)
    /go/src/github.com/cilium/cilium/pkg/node/local_node_store.go:116
github.com/cilium/cilium/pkg/node.getLocalNode()
    /go/src/github.com/cilium/cilium/pkg/node/address.go:49 +0xad
github.com/cilium/cilium/pkg/node.GetInternalIPv4Router()
    /go/src/github.com/cilium/cilium/pkg/node/address.go:309 +0x2a
github.com/cilium/cilium/pkg/proxy.(*Proxy).GetStatusModel(0xc0017eb000)
    /go/src/github.com/cilium/cilium/pkg/proxy/proxy.go:726 +0x111
github.com/cilium/cilium/daemon/cmd.(*Daemon).startStatusCollector.func16({0x2b698c5?, 0x0?})
    /go/src/github.com/cilium/cilium/daemon/cmd/status.go:897 +0x2a
github.com/cilium/cilium/pkg/status.(*Collector).runProbe.func1()
    /go/src/github.com/cilium/cilium/pkg/status/status.go:181 +0x48
created by github.com/cilium/cilium/pkg/status.(*Collector).runProbe
    /go/src/github.com/cilium/cilium/pkg/status/status.go:180 +0x25a
```

```
func getLocalNode() LocalNode {
// panic -----> at here
	n, err := localNode.Get(context.TODO())
// <-------
	if err != nil {
		// Only expecting errors if we're called after LocalNodeStore has stopped, e.g.
		// we have a component that uses the legacy getters and setters here and does
		// not depend on LocalNodeStore.
		log.WithError(err).Fatal("getLocalNode: unexpected error")
	}
	return n
}
```

When the cilium agent is shut down gracefully, NewLocalNodeStore will set localNode to nil. And if at that time, daemon tries to do the probes, it will panic because of nil pointer


```release-note
bug fix: close status collector when daemon exits
```
