### PR TITLE
CFP: cilium ingress should have an option to set the number of trusted loadbalancer hops

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -50,6 +50,7 @@ cilium-operator-alibabacloud [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-lb-annotation-prefixes strings               Annotation prefixes for propagating from Ingress to the Load Balancer service (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "alibabacloud")

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -58,6 +58,7 @@ cilium-operator-aws [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-lb-annotation-prefixes strings               Annotation prefixes for propagating from Ingress to the Load Balancer service (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "eni")

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -53,6 +53,7 @@ cilium-operator-azure [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-lb-annotation-prefixes strings               Annotation prefixes for propagating from Ingress to the Load Balancer service (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "azure")

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -49,6 +49,7 @@ cilium-operator-generic [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-lb-annotation-prefixes strings               Annotation prefixes for propagating from Ingress to the Load Balancer service (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -63,6 +63,7 @@ cilium-operator [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
       --ingress-lb-annotation-prefixes strings               Annotation prefixes for propagating from Ingress to the Load Balancer service (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -325,6 +325,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(operatorOption.IngressLBAnnotationPrefixes, operatorOption.IngressLBAnnotationsDefault, "Annotation prefixes for propagating from Ingress to the Load Balancer service")
 	option.BindEnv(vp, operatorOption.IngressLBAnnotationPrefixes)
 
+	flags.Uint32(operatorOption.IngressDefaultXffNumTrustedHops, 0, "The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.")
+	option.BindEnv(vp, operatorOption.IngressDefaultXffNumTrustedHops)
+
 	flags.String(operatorOption.PodRestartSelector, "k8s-app=kube-dns", "cilium-operator will delete/restart any pods with these labels if the pod is not managed by Cilium. If this option is empty, then all pods may be restarted")
 	option.BindEnv(vp, operatorOption.PodRestartSelector)
 

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -332,6 +332,9 @@ const (
 	// IngressDefaultSecretName is the default secret name for Ingress.
 	IngressDefaultSecretName = "ingress-default-secret-name"
 
+	// IngressDefaultXffNumTrustedHops is the default XffNumTrustedHops value for Ingress.
+	IngressDefaultXffNumTrustedHops = "ingress-default-xff-num-trusted-hops"
+
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	// default values: k8s-app=kube-dns
 	PodRestartSelector = "pod-restart-selector"
@@ -603,6 +606,11 @@ type OperatorConfig struct {
 	// IngressDefaultLSecretName is the default secret name for Ingress.
 	IngressDefaultSecretName string
 
+	// IngressProxyXffNumTrustedHops The number of additional ingress proxy hops from the right side of the
+	// HTTP header to trust when determining the origin client's IP address.
+	//The default is zero if this option is not specified.
+	IngressProxyXffNumTrustedHops uint32
+
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
 	PodRestartSelector string
 }
@@ -653,6 +661,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.IngressDefaultLoadbalancerMode = vp.GetString(IngressDefaultLoadbalancerMode)
 	c.IngressDefaultSecretNamespace = vp.GetString(IngressDefaultSecretNamespace)
 	c.IngressDefaultSecretName = vp.GetString(IngressDefaultSecretName)
+	c.IngressProxyXffNumTrustedHops = vp.GetUint32(IngressDefaultXffNumTrustedHops)
 	c.PodRestartSelector = vp.GetString(PodRestartSelector)
 
 	c.CiliumK8sNamespace = vp.GetString(CiliumK8sNamespace)

--- a/operator/pkg/model/translation/envoy_http_connection_manager.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/envoy"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
@@ -55,4 +56,11 @@ func NewHTTPConnectionManager(name, routeName string, mutationFunc ...HttpConnec
 			Value:   connectionManagerBytes,
 		},
 	}, nil
+}
+
+func WithXffNumTrustedHops() func(*httpConnectionManagerv3.HttpConnectionManager) *httpConnectionManagerv3.HttpConnectionManager {
+	return func(connectionManager *httpConnectionManagerv3.HttpConnectionManager) *httpConnectionManagerv3.HttpConnectionManager {
+		connectionManager.XffNumTrustedHops = operatorOption.Config.IngressProxyXffNumTrustedHops
+		return connectionManager
+	}
 }

--- a/operator/pkg/model/translation/envoy_http_connection_manager_test.go
+++ b/operator/pkg/model/translation/envoy_http_connection_manager_test.go
@@ -9,6 +9,8 @@ import (
 	httpConnectionManagerv3 "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+
+	operatorOption "github.com/cilium/cilium/operator/option"
 )
 
 func TestNewHTTPConnectionManager(t *testing.T) {
@@ -30,4 +32,33 @@ func TestNewHTTPConnectionManager(t *testing.T) {
 
 	require.Len(t, httpConnectionManager.GetUpgradeConfigs(), 1)
 	require.Equal(t, "websocket", httpConnectionManager.GetUpgradeConfigs()[0].UpgradeType)
+}
+
+func TestNewHTTPConnectionManagerWithXffNumTrustedHops(t *testing.T) {
+	res, err := NewHTTPConnectionManager("dummy-name", "dummy-route-name", WithXffNumTrustedHops())
+	require.Nil(t, err)
+
+	httpConnectionManager := &httpConnectionManagerv3.HttpConnectionManager{}
+	err = proto.Unmarshal(res.Value, httpConnectionManager)
+	require.Nil(t, err)
+
+	// Default value is 0
+	require.Equal(t, uint32(0), httpConnectionManager.XffNumTrustedHops)
+
+	var xffNumTrustedHops = uint32(1)
+
+	operatorOption.Config.IngressProxyXffNumTrustedHops = xffNumTrustedHops
+
+	defer func() {
+		// Restore the value after the test
+		operatorOption.Config.IngressProxyXffNumTrustedHops = uint32(0)
+	}()
+	res, err = NewHTTPConnectionManager("dummy-name", "dummy-route-name", WithXffNumTrustedHops())
+	require.Nil(t, err)
+
+	httpConnectionManager = &httpConnectionManagerv3.HttpConnectionManager{}
+	err = proto.Unmarshal(res.Value, httpConnectionManager)
+	require.Nil(t, err)
+	// Now it should be 1
+	require.Equal(t, xffNumTrustedHops, httpConnectionManager.XffNumTrustedHops)
 }

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -103,7 +103,7 @@ func NewHTTPListener(name string, ciliumSecretNamespace string, tls map[model.TL
 	var filterChains []*envoy_config_listener.FilterChain
 
 	insecureHttpConnectionManagerName := fmt.Sprintf("%s-insecure", name)
-	insecureHttpConnectionManager, err := NewHTTPConnectionManager(insecureHttpConnectionManagerName, insecureHttpConnectionManagerName)
+	insecureHttpConnectionManager, err := NewHTTPConnectionManager(insecureHttpConnectionManagerName, insecureHttpConnectionManagerName, WithXffNumTrustedHops())
 	if err != nil {
 		return ciliumv2.XDSResource{}, err
 	}
@@ -122,7 +122,7 @@ func NewHTTPListener(name string, ciliumSecretNamespace string, tls map[model.TL
 
 	for secret, hostNames := range tls {
 		secureHttpConnectionManagerName := fmt.Sprintf("%s-secure", name)
-		secureHttpConnectionManager, err := NewHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName)
+		secureHttpConnectionManager, err := NewHTTPConnectionManager(secureHttpConnectionManagerName, secureHttpConnectionManagerName, WithXffNumTrustedHops())
 		if err != nil {
 			return ciliumv2.XDSResource{}, err
 		}


### PR DESCRIPTION


1. Add a new global config item that sets the number of trusted hops for external load balancers for Ingress (or Gateway API) config. Default to 0, which produces the current behavior.
2. Plumb that value to the relevant Envoy configs so that it takes effect for all ingress listeners. (As opposed to Layer 7 policy enforcement listeners)

Fixes: #24292

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
cilium ingress should have an option to set the number of trusted loadbalancer hops
```
