### PR TITLE
helm: set GOMEMLIMIT via k8s downward API

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -192,6 +192,10 @@ spec:
               fieldPath: metadata.namespace
         - name: CILIUM_CLUSTERMESH_CONFIG
           value: /var/lib/cilium/clustermesh/
+        - name: GOMEMLIMIT
+          valueFrom:
+            resourceFieldRef:
+              resource: limits.memory
         {{- if .Values.k8sServiceHost }}
         - name: KUBERNETES_SERVICE_HOST
           value: {{ .Values.k8sServiceHost | quote }}


### PR DESCRIPTION
The rationale for setting GOMEMLIMIT is to give the Go Garbage Collector (GC) more information about the potentially constrained environment it is running in. Without setting GOMEMLIMIT, scenarios can occur where the GC may consider it beneficial to _not_ run, when in fact the pod is about to be OOM-killed. This occurs since the GC doesn't understand container resource limits, and hence may let garbage balloon over the limit, since it continually must make a trade-off between the CPU overhead and the memory usage.

GOMEMLIMIT is a soft limit for the Go GC. It instructs the GC that it should try to keep the total memory usage of the Go runtime below said limit. You can learn more about it at https://pkg.go.dev/runtime, or specifically at https://pkg.go.dev/runtime/debug#SetMemoryLimit.

The K8s downward API allows setting environment variables based on values of the container specification, such as the memory limit in this case. If the limit isn't set, it will fall back to a sensible value, see https://kubernetes.io/docs/concepts/workloads/pods/downward-api/#fallback-information-for-resource-limits.

```release-note
The cilium-agent now sets GOMEMLIMIT to the container's memory resource limit, which helps the Go GC to avoid unnecessary OOMs.
```
