### PR TITLE
Fix cilium panic when HttpRoute with missing port.

### DIFF
--- a/operator/pkg/gateway-api/httproute_reconcile_test.go
+++ b/operator/pkg/gateway-api/httproute_reconcile_test.go
@@ -132,6 +132,7 @@ var (
 								BackendRef: gatewayv1beta1.BackendRef{
 									BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 										Name: "dummy-backend",
+										Port: model.AddressOf[gatewayv1beta1.PortNumber](8080),
 									},
 								},
 							},
@@ -162,6 +163,7 @@ var (
 								BackendRef: gatewayv1beta1.BackendRef{
 									BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 										Name: "nonexistent-backend",
+										Port: model.AddressOf[gatewayv1beta1.PortNumber](8080),
 									},
 								},
 							},
@@ -224,6 +226,7 @@ var (
 									BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 										Name:      "dummy-backend-grant",
 										Namespace: model.AddressOf[gatewayv1beta1.Namespace]("another-namespace"),
+										Port:      model.AddressOf[gatewayv1beta1.PortNumber](8080),
 									},
 								},
 							},
@@ -288,6 +291,37 @@ var (
 				},
 			},
 		},
+		// HTTPRoute missing port for backend Service
+		&gatewayv1beta1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "http-route-missing-port-for-backend-Service",
+				Namespace: "default",
+			},
+			Spec: gatewayv1beta1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
+					ParentRefs: []gatewayv1beta1.ParentReference{
+						{
+							Name: "dummy-gateway",
+						},
+					},
+				},
+				Rules: []gatewayv1beta1.HTTPRouteRule{
+					{
+						BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+							{
+								BackendRef: gatewayv1beta1.BackendRef{
+									BackendObjectReference: gatewayv1beta1.BackendObjectReference{
+										Name:  "missing-port-service-backend",
+										Group: GroupPtr(""),
+										Kind:  KindPtr("Service"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 
 		// HTTPRoute with non-existent gateway
 		&gatewayv1beta1.HTTPRoute{
@@ -310,6 +344,7 @@ var (
 								BackendRef: gatewayv1beta1.BackendRef{
 									BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 										Name: "dummy-backend",
+										Port: model.AddressOf[gatewayv1beta1.PortNumber](8080),
 									},
 								},
 							},
@@ -341,6 +376,7 @@ var (
 								BackendRef: gatewayv1beta1.BackendRef{
 									BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 										Name: "dummy-backend",
+										Port: model.AddressOf[gatewayv1beta1.PortNumber](8080),
 									},
 								},
 							},
@@ -374,6 +410,7 @@ var (
 								BackendRef: gatewayv1beta1.BackendRef{
 									BackendObjectReference: gatewayv1beta1.BackendObjectReference{
 										Name: "dummy-backend",
+										Port: model.AddressOf[gatewayv1beta1.PortNumber](8080),
 									},
 								},
 							},
@@ -633,5 +670,33 @@ func Test_httpRouteReconciler_Reconcile(t *testing.T) {
 		require.Equal(t, metav1.ConditionStatus("False"), route.Status.RouteStatus.Parents[0].Conditions[1].Status)
 		require.Equal(t, "InvalidKind", route.Status.RouteStatus.Parents[0].Conditions[1].Reason)
 		require.Equal(t, "Unsupported backend kind UnsupportedKind", route.Status.RouteStatus.Parents[0].Conditions[1].Message)
+	})
+
+	t.Run("http route missing port of Service backend", func(t *testing.T) {
+		key := types.NamespacedName{
+			Name:      "http-route-missing-port-for-backend-Service",
+			Namespace: "default",
+		}
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: key,
+		})
+
+		require.NoError(t, err, "Error reconciling httpRoute")
+		require.Equal(t, ctrl.Result{}, result, "Result should be empty")
+
+		route := &gatewayv1beta1.HTTPRoute{}
+		err = c.Get(context.Background(), key, route)
+
+		require.NoError(t, err)
+		require.Len(t, route.Status.RouteStatus.Parents, 1, "Should have 1 parent")
+		require.Len(t, route.Status.RouteStatus.Parents[0].Conditions, 2)
+
+		require.Equal(t, "Accepted", route.Status.RouteStatus.Parents[0].Conditions[0].Type)
+		require.Equal(t, metav1.ConditionStatus("True"), route.Status.RouteStatus.Parents[0].Conditions[0].Status)
+
+		require.Equal(t, "ResolvedRefs", route.Status.RouteStatus.Parents[0].Conditions[1].Type)
+		require.Equal(t, metav1.ConditionStatus("False"), route.Status.RouteStatus.Parents[0].Conditions[1].Status)
+		require.Equal(t, "InvalidKind", route.Status.RouteStatus.Parents[0].Conditions[1].Reason)
+		require.Equal(t, "Must have port for Service reference", route.Status.RouteStatus.Parents[0].Conditions[1].Message)
 	})
 }

--- a/operator/pkg/gateway-api/routechecks/route_checks.go
+++ b/operator/pkg/gateway-api/routechecks/route_checks.go
@@ -51,7 +51,17 @@ func CheckBackendIsService(input Input) (bool, error) {
 				})
 
 				continueChecks = false
+				continue
+			}
+			if be.BackendObjectReference.Port == nil {
+				input.SetAllParentCondition(metav1.Condition{
+					Type:    string(gatewayv1alpha2.RouteConditionResolvedRefs),
+					Status:  metav1.ConditionFalse,
+					Reason:  string(gatewayv1beta1.RouteReasonInvalidKind),
+					Message: "Must have port for Service reference",
+				})
 
+				continueChecks = false
 				continue
 			}
 		}

--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -73,6 +73,10 @@ func GatewayAPI(input Input) ([]model.HTTPListener, []model.TLSListener) {
 					if (be.Kind != nil && *be.Kind != "Service") || (be.Group != nil && *be.Group != corev1.GroupName) {
 						continue
 					}
+					if be.BackendRef.Port == nil {
+						// must have port for Service reference
+						continue
+					}
 					if serviceExists(string(be.Name), helpers.NamespaceDerefOr(be.Namespace, r.Namespace), input.Services) {
 						bes = append(bes, backendToModelBackend(be.BackendRef, r.Namespace))
 					}


### PR DESCRIPTION
Must have port for Service reference

Fixes: #27956

Refer to https://github.com/cilium/cilium/blob/main/vendor/sigs.k8s.io/gateway-api/apis/v1beta1/object_reference_types.go#L95


Fixes: #issue-number

```release-note
Must have port for Service reference
```
