### PR TITLE
bgpv1: Introduce ResetServer method for BGP reconcilers to avoid shared metadata

### DIFF
--- a/pkg/bgpv1/manager/instance.go
+++ b/pkg/bgpv1/manager/instance.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/gobgp"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/k8s/resource"
 )
 
 // ServerWithConfig is a container for providing interface with underlying router implementation
@@ -29,18 +28,6 @@ type ServerWithConfig struct {
 	// If this field is nil it means the above BgpServer has had no
 	// configuration applied to it.
 	Config *v2alpha1api.CiliumBGPVirtualRouter
-
-	// Holds any announced PodCIDR routes.
-	PodCIDRAnnouncements []*types.Path
-
-	// Holds any announced pod ip pool CIDRs keyed by pool name of the backing CiliumPodIPPool.
-	PodIPPoolAnnouncements map[resource.Key][]*types.Path
-
-	// Holds any announced Service routes.
-	ServiceAnnouncements map[resource.Key][]*types.Path
-
-	// Holds routing policies configured by the policy reconciler.
-	RoutePolicies map[string]*types.RoutePolicy
 }
 
 // NewServerWithConfig will start an underlying BgpServer utilizing types.ServerParameters
@@ -58,11 +45,7 @@ func NewServerWithConfig(ctx context.Context, params types.ServerParameters) (*S
 	}
 
 	return &ServerWithConfig{
-		Server:                 s,
-		Config:                 nil,
-		PodCIDRAnnouncements:   []*types.Path{},
-		ServiceAnnouncements:   make(map[resource.Key][]*types.Path),
-		RoutePolicies:          make(map[string]*types.RoutePolicy),
-		PodIPPoolAnnouncements: make(map[resource.Key][]*types.Path),
+		Server: s,
+		Config: nil,
 	}, nil
 }

--- a/pkg/bgpv1/manager/pod_ip_pool_reconciler_test.go
+++ b/pkg/bgpv1/manager/pod_ip_pool_reconciler_test.go
@@ -213,7 +213,7 @@ func TestPodIPPoolReconciler(t *testing.T) {
 			for _, obj := range tt.upsertedPools {
 				store.Upsert(obj)
 			}
-			reconciler := NewPodIPPoolReconciler(store).Reconciler
+			reconciler := NewPodIPPoolReconciler(store).Reconciler.(*PodIPPoolReconciler)
 
 			node := &node.LocalNode{
 				Node: nodeTypes.Node{
@@ -247,21 +247,23 @@ func TestPodIPPoolReconciler(t *testing.T) {
 				t.Fatalf("failed to reconcile pool cidr advertisements: %v", err)
 			}
 
+			podIPPoolAnnouncements := reconciler.getMetadata(testSC.Config.LocalASN)
+
 			// If the pool selector is disabled, ensure no advertisements are still present.
 			if tt.poolSelector == nil && tt.upsertedPools != nil {
-				if len(testSC.PodIPPoolAnnouncements) > 0 {
+				if len(podIPPoolAnnouncements) > 0 {
 					t.Fatal("disabled pool selector but pool cidr advertisements still present")
 				}
 			}
 
-			log.Printf("%+v %+v", testSC.PodIPPoolAnnouncements, tt.updated)
+			log.Printf("%+v %+v", podIPPoolAnnouncements, tt.updated)
 
 			// Ensure we see tt.updated in testSC.PodIPPoolAnnouncements
 			for poolKey, cidrs := range tt.updated {
 				for _, cidr := range cidrs {
 					prefix := netip.MustParsePrefix(cidr)
 					var seen bool
-					for _, advrt := range testSC.PodIPPoolAnnouncements[poolKey] {
+					for _, advrt := range podIPPoolAnnouncements[poolKey] {
 						if advrt.NLRI.String() == prefix.String() {
 							seen = true
 						}
@@ -274,7 +276,7 @@ func TestPodIPPoolReconciler(t *testing.T) {
 
 			// ensure testSC.PodIPPoolAnnouncements does not contain advertisements
 			// not in tt.updated
-			for poolKey, advrts := range testSC.PodIPPoolAnnouncements {
+			for poolKey, advrts := range podIPPoolAnnouncements {
 				for _, advrt := range advrts {
 					var seen bool
 					for _, cidr := range tt.updated[poolKey] {

--- a/pkg/bgpv1/manager/reconcile_test.go
+++ b/pkg/bgpv1/manager/reconcile_test.go
@@ -491,6 +491,8 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				t.Fatalf("failed to create test bgp server: %v", err)
 			}
 			testSC.Config = oldc
+			reconciler := NewExportPodCIDRReconciler().Reconciler.(*ExportPodCIDRReconciler)
+			podCIDRAnnouncements := reconciler.getMetadata(testSC.Config.LocalASN)
 			for _, cidr := range tt.advertised {
 				advrtResp, err := testSC.Server.AdvertisePath(context.Background(), types.PathRequest{
 					Path: types.NewPathForPrefix(cidr),
@@ -498,8 +500,9 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to advertise initial pod cidr routes: %v", err)
 				}
-				testSC.PodCIDRAnnouncements = append(testSC.PodCIDRAnnouncements, advrtResp.Path)
+				podCIDRAnnouncements = append(podCIDRAnnouncements, advrtResp.Path)
 			}
+			reconciler.storeMetadata(testSC.Config.LocalASN, podCIDRAnnouncements)
 
 			newc := &v2alpha1api.CiliumBGPVirtualRouter{
 				LocalASN:      64125,
@@ -507,7 +510,6 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				Neighbors:     []v2alpha1api.CiliumBGPNeighbor{},
 			}
 
-			exportPodCIDRReconciler := NewExportPodCIDRReconciler().Reconciler
 			params := ReconcileParams{
 				CurrentServer: testSC,
 				DesiredConfig: newc,
@@ -518,26 +520,27 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 				},
 			}
 
-			err = exportPodCIDRReconciler.Reconcile(context.Background(), params)
+			err = reconciler.Reconcile(context.Background(), params)
 			if err != nil {
 				t.Fatalf("failed to reconcile new pod cidr advertisements: %v", err)
 			}
+			podCIDRAnnouncements = reconciler.getMetadata(newc.LocalASN)
 
 			// if we disable exports of pod cidr ensure no advertisements are
 			// still present.
 			if tt.shouldEnable == false {
-				if len(testSC.PodCIDRAnnouncements) > 0 {
+				if len(podCIDRAnnouncements) > 0 {
 					t.Fatal("disabled export but advertisements till present")
 				}
 			}
 
-			log.Printf("%+v %+v", testSC.PodCIDRAnnouncements, tt.updated)
+			log.Printf("%+v %+v", podCIDRAnnouncements, tt.updated)
 
 			// ensure we see tt.updated in testSC.PodCIDRAnnoucements
 			for _, cidr := range tt.updated {
 				prefix := netip.MustParsePrefix(cidr.String())
 				var seen bool
-				for _, advrt := range testSC.PodCIDRAnnouncements {
+				for _, advrt := range podCIDRAnnouncements {
 					if advrt.NLRI.String() == prefix.String() {
 						seen = true
 					}
@@ -549,7 +552,7 @@ func TestExportPodCIDRReconciler(t *testing.T) {
 
 			// ensure testSC.PodCIDRAnnouncements does not contain advertisements
 			// not in tt.updated
-			for _, advrt := range testSC.PodCIDRAnnouncements {
+			for _, advrt := range podCIDRAnnouncements {
 				var seen bool
 				for _, cidr := range tt.updated {
 					if advrt.NLRI.String() == cidr.String() {
@@ -1138,25 +1141,6 @@ func TestLBServiceReconciler(t *testing.T) {
 				t.Fatalf("failed to create test bgp server: %v", err)
 			}
 			testSC.Config = oldc
-			for svcKey, cidrs := range tt.advertised {
-				for _, cidr := range cidrs {
-					prefix := netip.MustParsePrefix(cidr)
-					advrtResp, err := testSC.Server.AdvertisePath(context.Background(), types.PathRequest{
-						Path: types.NewPathForPrefix(prefix),
-					})
-					if err != nil {
-						t.Fatalf("failed to advertise initial svc lb cidr routes: %v", err)
-					}
-
-					testSC.ServiceAnnouncements[svcKey] = append(testSC.ServiceAnnouncements[svcKey], advrtResp.Path)
-				}
-			}
-
-			newc := &v2alpha1api.CiliumBGPVirtualRouter{
-				LocalASN:        64125,
-				Neighbors:       []v2alpha1api.CiliumBGPNeighbor{},
-				ServiceSelector: tt.newServiceSelector,
-			}
 
 			diffstore := newFakeDiffStore[*slim_corev1.Service]()
 			for _, obj := range tt.upsertedServices {
@@ -1171,7 +1155,29 @@ func TestLBServiceReconciler(t *testing.T) {
 				epDiffStore.Upsert(obj)
 			}
 
-			reconciler := NewLBServiceReconciler(diffstore, epDiffStore).Reconciler
+			reconciler := NewLBServiceReconciler(diffstore, epDiffStore).Reconciler.(*LBServiceReconciler)
+			serviceAnnouncements := reconciler.getMetadata(testSC.Config.LocalASN)
+
+			for svcKey, cidrs := range tt.advertised {
+				for _, cidr := range cidrs {
+					prefix := netip.MustParsePrefix(cidr)
+					advrtResp, err := testSC.Server.AdvertisePath(context.Background(), types.PathRequest{
+						Path: types.NewPathForPrefix(prefix),
+					})
+					if err != nil {
+						t.Fatalf("failed to advertise initial svc lb cidr routes: %v", err)
+					}
+
+					serviceAnnouncements[svcKey] = append(serviceAnnouncements[svcKey], advrtResp.Path)
+				}
+			}
+
+			newc := &v2alpha1api.CiliumBGPVirtualRouter{
+				LocalASN:        64125,
+				Neighbors:       []v2alpha1api.CiliumBGPNeighbor{},
+				ServiceSelector: tt.newServiceSelector,
+			}
+
 			err = reconciler.Reconcile(context.Background(), ReconcileParams{
 				CurrentServer: testSC,
 				DesiredConfig: newc,
@@ -1194,19 +1200,19 @@ func TestLBServiceReconciler(t *testing.T) {
 			// if we disable exports of pod cidr ensure no advertisements are
 			// still present.
 			if tt.newServiceSelector == nil && !containsLbClass(tt.upsertedServices) {
-				if len(testSC.ServiceAnnouncements) > 0 {
+				if len(serviceAnnouncements) > 0 {
 					t.Fatal("disabled export but advertisements still present")
 				}
 			}
 
-			log.Printf("%+v %+v", testSC.ServiceAnnouncements, tt.updated)
+			log.Printf("%+v %+v", serviceAnnouncements, tt.updated)
 
 			// ensure we see tt.updated in testSC.ServiceAnnouncements
 			for svcKey, cidrs := range tt.updated {
 				for _, cidr := range cidrs {
 					prefix := netip.MustParsePrefix(cidr)
 					var seen bool
-					for _, advrt := range testSC.ServiceAnnouncements[svcKey] {
+					for _, advrt := range serviceAnnouncements[svcKey] {
 						if advrt.NLRI.String() == prefix.String() {
 							seen = true
 						}
@@ -1219,7 +1225,7 @@ func TestLBServiceReconciler(t *testing.T) {
 
 			// ensure testSC.PodCIDRAnnouncements does not contain advertisements
 			// not in tt.updated
-			for svcKey, advrts := range testSC.ServiceAnnouncements {
+			for svcKey, advrts := range serviceAnnouncements {
 				for _, advrt := range advrts {
 					var seen bool
 					for _, cidr := range tt.updated[svcKey] {

--- a/pkg/bgpv1/manager/route_policy_reconciler_test.go
+++ b/pkg/bgpv1/manager/route_policy_reconciler_test.go
@@ -357,7 +357,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 				store.Upsert(obj)
 			}
 
-			policyReconciler := NewRoutePolicyReconciler(store).Reconciler
+			policyReconciler := NewRoutePolicyReconciler(store).Reconciler.(*RoutePolicyReconciler)
 			params := ReconcileParams{
 				CurrentServer: testSC,
 				DesiredConfig: testSC.Config,
@@ -377,7 +377,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 			require.NoError(t, err)
 
 			// validate cached vs. expected policies
-			validatePoliciesMatch(t, testSC.RoutePolicies, tt.initial.expectedPolicies)
+			validatePoliciesMatch(t, policyReconciler.getMetadata(params.CurrentServer.Config.LocalASN), tt.initial.expectedPolicies)
 
 			if tt.updated == nil {
 				return // not testing update / remove
@@ -393,7 +393,7 @@ func TestRoutePolicyReconciler(t *testing.T) {
 			require.NoError(t, err)
 
 			// validate cached vs. expected policies
-			validatePoliciesMatch(t, testSC.RoutePolicies, tt.updated.expectedPolicies)
+			validatePoliciesMatch(t, policyReconciler.getMetadata(params.CurrentServer.Config.LocalASN), tt.updated.expectedPolicies)
 		})
 	}
 }


### PR DESCRIPTION
In order to make BGP reconcilers completely generic and decoupled from the BGP manager, each reconciler keeps its state metadata privately within its own datastructure instead of the common `ServerWithConfig` struct.

As this data needs to be reset whenever the BGP server is recreated, this change introduces a new `ResetServer()` reconciler method, which is called whenever the reconcilers should reset their cached state.

This is an alternative to the original idea drafted in https://github.com/cilium/cilium/pull/27568
