### PR TITLE
ipam: report IP owner of non-default pool IPs in multi-pool IPAM

### DIFF
--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -312,6 +312,14 @@ func (ipam *IPAM) ReleaseIP(ip net.IP, pool Pool) error {
 	return ipam.releaseIPLocked(ip, pool)
 }
 
+func splitIPAndPool(ip string) (string, Pool) {
+	// IPs from non-default pools are prefixed with <pool name>/
+	if i := strings.LastIndexByte(ip, '/'); i >= 0 {
+		return ip[i+1:], Pool(ip[:i])
+	}
+	return ip, PoolDefault
+}
+
 // Dump dumps the list of allocated IP addresses
 func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, status string) {
 	var st4, st6 string
@@ -323,8 +331,8 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 		allocv4, st4 = ipam.IPv4Allocator.Dump()
 		st4 = "IPv4: " + st4
 		for ip := range allocv4 {
-			// XXX: only consider default pool for now
-			owner := ipam.getIPOwner(ip, PoolDefault)
+			onlyIP, pool := splitIPAndPool(ip)
+			owner := ipam.getIPOwner(onlyIP, pool)
 			// If owner is not available, report IP but leave owner empty
 			allocv4[ip] = owner
 		}
@@ -334,8 +342,8 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 		allocv6, st6 = ipam.IPv6Allocator.Dump()
 		st6 = "IPv6: " + st6
 		for ip := range allocv6 {
-			// XXX: only consider default pool for now
-			owner := ipam.getIPOwner(ip, PoolDefault)
+			onlyIP, pool := splitIPAndPool(ip)
+			owner := ipam.getIPOwner(onlyIP, pool)
 			// If owner is not available, report IP but leave owner empty
 			allocv6[ip] = owner
 		}


### PR DESCRIPTION
Before this change, only IPs from the default pool are reported in `cilium status --verbose` in the "Allocated addresses" section when using multi-pool IPAM mode. With this change, all IPs from non-default pools are reported as well by making use of the fact that the pool name is prepended to the IP in `(*multiPoolManager).dump`.

Example:

```
% ks exec -it cilium-n8xw7 -- cilium status --verbose
[...]
IPAM:                   IPv4: 2 IPAM pool(s) available,
Allocated addresses:
  10.10.0.46 (router)
  10.10.0.48 (kube-system/coredns-5d78c9869d-d4nts [restored])
  10.10.0.61 (kube-system/hubble-relay-597b7bdff8-pwl69 [restored])
  10.10.0.62 (health)
  jupiter/192.168.0.15 (default/nginx-jupiter)
[...]
```

Note that IPs from non-default pools (in this case the `jupiter` pool) are reported with the pool name prefixed.

For #25470