### PR TITLE
pkg/l2announcer: Adds Service LoadBalancerClass Support

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -899,7 +899,9 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	// which can be modified after the device detection.
 	var devices []string
 	if d.deviceManager != nil {
-		if _, err := d.deviceManager.Detect(params.Clientset.IsEnabled()); err != nil {
+		if detected, err := d.deviceManager.Detect(params.Clientset.IsEnabled()); err == nil {
+			devices = append(devices, detected...)
+		} else {
 			if option.Config.AreDevicesRequired() {
 				// Fail hard if devices are required to function.
 				return nil, nil, fmt.Errorf("failed to detect devices: %w", err)

--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -73,6 +73,10 @@ func newLBIPAM(params LBIPAMParams) *LBIPAM {
 		lbClasses = append(lbClasses, cilium_api_v2alpha1.BGPLoadBalancerClass)
 	}
 
+	if params.DaemonConfig.EnableL2Announcements {
+		lbClasses = append(lbClasses, cilium_api_v2alpha1.L2AnnounceLoadBalancerClass)
+	}
+
 	jobGroup := params.JobRegistry.NewGroup(
 		job.WithLogger(params.Logger),
 		job.WithPprofLabels(pprof.Labels("cell", "lbipam")),

--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliuml2announcementpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliuml2announcementpolicies.yaml
@@ -117,8 +117,11 @@ spec:
                 type: object
               serviceSelector:
                 description: "ServiceSelector selects a set of services which will
-                  be announced over L2 networks \n If nil this policy applies to all
-                  services."
+                  be announced over L2 networks. The loadBalancerClass for a service
+                  must be nil or specify a supported class, e.g. \"io.cilium/l2-announcer\".
+                  Refer to the following document for additional details regarding
+                  load balancer classes: \n https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
+                  \n If nil this policy applies to all services."
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/pkg/k8s/apis/cilium.io/v2alpha1/l2announcement_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/l2announcement_types.go
@@ -9,6 +9,9 @@ import (
 	slimv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
+// L2AnnounceLoadBalancerClass defines the L2 Announcer load balancer class for Services.
+const L2AnnounceLoadBalancerClass = "io.cilium/l2-announcer"
+
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -64,7 +67,12 @@ type CiliumL2AnnouncementPolicySpec struct {
 	//
 	// +kubebuilder:validation:Optional
 	NodeSelector *slimv1.LabelSelector `json:"nodeSelector"`
-	// ServiceSelector selects a set of services which will be announced over L2 networks
+	// ServiceSelector selects a set of services which will be announced over L2 networks.
+	// The loadBalancerClass for a service must be nil or specify a supported class, e.g.
+	// "io.cilium/l2-announcer". Refer to the following document for additional details
+	// regarding load balancer classes:
+	//
+	//   https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class
 	//
 	// If nil this policy applies to all services.
 	//

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -303,7 +303,13 @@ func (l2a *L2Announcer) processPolicyEvent(ctx context.Context, event resource.E
 }
 
 func (l2a *L2Announcer) upsertSvc(svc *slim_corev1.Service) error {
+	// Ignore services managed by an unsupported load balancer class.
 	key := serviceKey(svc)
+	if svc.Spec.LoadBalancerClass != nil &&
+		*svc.Spec.LoadBalancerClass != cilium_api_v2alpha1.L2AnnounceLoadBalancerClass {
+		return l2a.delSvc(key)
+	}
+
 	ss, found := l2a.selectedServices[key]
 	if found {
 		// Update service object, labels or IPs may have changed

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/pointer"
 )
 
 type fixture struct {
@@ -882,6 +883,60 @@ func TestUpdateService_NoMatch(t *testing.T) {
 
 	svc := blueService()
 	svc.Labels["color"] = "red"
+	fix.fakeSvcStore.slice = append(fix.fakeSvcStore.slice, svc)
+	err := fix.announcer.processSvcEvent(resource.Event[*slim_corev1.Service]{
+		Kind:   resource.Upsert,
+		Key:    resource.NewKey(svc),
+		Object: svc,
+		Done:   func(err error) {},
+	})
+	assert.NoError(t, err)
+
+	// Check that the entry got deleted
+	rtx := fix.stateDB.ReadTxn()
+	iter, _ := fix.proxyNeighborTable.All(rtx)
+	entries := statedb.Collect[*tables.L2AnnounceEntry](iter)
+	assert.Len(t, entries, 0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	fix.announcer.jobgroup.Stop(ctx)
+	cancel()
+}
+
+// Test that when a service load balancer class is set to a supported value,
+// it matches policies.
+func TestUpdateService_LoadBalancerClassMatch(t *testing.T) {
+	fix := baseUpdateSetup(t)
+
+	svc := blueService()
+	svc.Spec.LoadBalancerClass = pointer.String(v2alpha1.L2AnnounceLoadBalancerClass)
+	fix.fakeSvcStore.slice = append(fix.fakeSvcStore.slice, svc)
+	err := fix.announcer.processSvcEvent(resource.Event[*slim_corev1.Service]{
+		Kind:   resource.Upsert,
+		Key:    resource.NewKey(svc),
+		Object: svc,
+		Done:   func(err error) {},
+	})
+	assert.NoError(t, err)
+
+	// Check that the entry got deleted
+	rtx := fix.stateDB.ReadTxn()
+	iter, _ := fix.proxyNeighborTable.All(rtx)
+	entries := statedb.Collect[*tables.L2AnnounceEntry](iter)
+	assert.Len(t, entries, 1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	fix.announcer.jobgroup.Stop(ctx)
+	cancel()
+}
+
+// Test that when a service load balancer class is set to an unsupported value,
+// it no longer matches any policies.
+func TestUpdateService_LoadBalancerClassNotMatch(t *testing.T) {
+	fix := baseUpdateSetup(t)
+
+	svc := blueService()
+	svc.Spec.LoadBalancerClass = pointer.String("unsupported.io/lb-class")
 	fix.fakeSvcStore.slice = append(fix.fakeSvcStore.slice, svc)
 	err := fix.announcer.processSvcEvent(resource.Event[*slim_corev1.Service]{
 		Kind:   resource.Upsert,


### PR DESCRIPTION
- Adds `L2AnnounceLoadBalancerClass` constant to define the load balancer class supported by the L2 Announcer.
- Updates `upsertSvc()` to check the load balancer class of the provided service.
- Updates the `ServiceSelector` godocs to reflect the new API behavior.
- Updates operator LB IPAM pkg to support L2 Announcer LB class.
- Adds unit tests.

Fixes: #26556

```release-note
CiliumL2AnnouncementPolicy will only select Services that do not specify a LoadBalancerClass or specify a LoadBalancerClass of "io.cilium/l2-announcer".
```
