### PR TITLE
ci: add conformance-ginkgo-race

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -98,15 +98,19 @@ runs:
 
           IMAGE=""
           if [ "${{ inputs.image-tag }}" != "" ]; then
+            image_tag=${{ inputs.image-tag }}
+            if [ ${#image_tag} -gt 10 ]; then
+              image_tag="${image_tag}-race"
+            fi
             IMAGE="--helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \
-            --helm-set=image.tag=${{ inputs.image-tag }}-race \
+            --helm-set=image.tag=${image_tag} \
             --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
             --helm-set=operator.image.suffix=-ci \
-            --helm-set=operator.image.tag=${{ inputs.image-tag }}-race \
+            --helm-set=operator.image.tag=${image_tag} \
             --helm-set=operator.image.useDigest=false \
             --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-            --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }}-race \
+            --helm-set=hubble.relay.image.tag=${image_tag} \
             --helm-set=hubble.relay.image.useDigest=false"
           fi
 

--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -100,13 +100,13 @@ runs:
           if [ "${{ inputs.image-tag }}" != "" ]; then
             IMAGE="--helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
             --helm-set=image.useDigest=false \
-            --helm-set=image.tag=${{ inputs.image-tag }} \
+            --helm-set=image.tag=${{ inputs.image-tag }}-race \
             --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
             --helm-set=operator.image.suffix=-ci \
-            --helm-set=operator.image.tag=${{ inputs.image-tag }} \
+            --helm-set=operator.image.tag=${{ inputs.image-tag }}-race \
             --helm-set=operator.image.useDigest=false \
             --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-            --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }} \
+            --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }}-race \
             --helm-set=hubble.relay.image.useDigest=false"
           fi
 

--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -30,23 +30,24 @@ runs:
     - id: set-defaults
       shell: bash
       run: |
-        echo sha=${{ inputs.image-tag }} >> $GITHUB_OUTPUT
+        echo sha=${{ inputs.image-tag }}-race >> $GITHUB_OUTPUT
+        SHA="${SHA}-race"
 
         CILIUM_INSTALL_DEFAULTS="--chart-directory=${{ inputs.chart-dir }} \
           --helm-set=hubble.relay.retryTimeout=5s \
           --helm-set=debug.metricsSamplingInterval=30s \
           --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
           --helm-set=image.useDigest=false \
-          --helm-set=image.tag=${{ inputs.image-tag }} \
+          --helm-set=image.tag=${{ inputs.image-tag }}-race \
           --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
           --helm-set=operator.image.suffix=-ci \
-          --helm-set=operator.image.tag=${{ inputs.image-tag }} \
+          --helm-set=operator.image.tag=${{ inputs.image-tag }}-race \
           --helm-set=operator.image.useDigest=false \
           --helm-set=clustermesh.apiserver.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
-          --helm-set=clustermesh.apiserver.image.tag=${{ inputs.image-tag }} \
+          --helm-set=clustermesh.apiserver.image.tag=${{ inputs.image-tag }}-race \
           --helm-set=clustermesh.apiserver.image.useDigest=false \
           --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-          --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }} \
+          --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }}-race \
           --helm-set=hubble.relay.image.useDigest=false \
           --set-string=extraEnv[0].name=CILIUM_FEATURE_METRICS_WITH_DEFAULTS \
           --set-string=extraEnv[0].value=true \

--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -30,24 +30,27 @@ runs:
     - id: set-defaults
       shell: bash
       run: |
-        echo sha=${{ inputs.image-tag }}-race >> $GITHUB_OUTPUT
-        SHA="${SHA}-race"
+        echo sha=${{ inputs.image-tag }} >> $GITHUB_OUTPUT
+        image_tag="${{ inputs.image-tag }}"
+        if [[ "${{ inputs.chart-dir }}" =~ *"downgrade"* ]]; then
+          image_tag="${{ inputs.image-tag }}-race"
+        fi
 
         CILIUM_INSTALL_DEFAULTS="--chart-directory=${{ inputs.chart-dir }} \
           --helm-set=hubble.relay.retryTimeout=5s \
           --helm-set=debug.metricsSamplingInterval=30s \
           --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
           --helm-set=image.useDigest=false \
-          --helm-set=image.tag=${{ inputs.image-tag }}-race \
+          --helm-set=image.tag=${image_tag} \
           --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
           --helm-set=operator.image.suffix=-ci \
-          --helm-set=operator.image.tag=${{ inputs.image-tag }}-race \
+          --helm-set=operator.image.tag=${image_tag} \
           --helm-set=operator.image.useDigest=false \
           --helm-set=clustermesh.apiserver.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
-          --helm-set=clustermesh.apiserver.image.tag=${{ inputs.image-tag }}-race \
+          --helm-set=clustermesh.apiserver.image.tag=${image_tag} \
           --helm-set=clustermesh.apiserver.image.useDigest=false \
           --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-          --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }}-race \
+          --helm-set=hubble.relay.image.tag=${image_tag} \
           --helm-set=hubble.relay.image.useDigest=false \
           --set-string=extraEnv[0].name=CILIUM_FEATURE_METRICS_WITH_DEFAULTS \
           --set-string=extraEnv[0].value=true \

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -118,7 +118,7 @@ workflows:
   conformance-ginkgo.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md)$)
   conformance-ginkgo-race.yaml:
-    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|USERS.md)$)
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md)$)
   conformance-gke.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
   conformance-ingress.yaml:

--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -11,6 +11,7 @@ triggers:
     - conformance-eks.yaml
     - conformance-gateway-api.yaml
     - conformance-ginkgo.yaml
+    - conformance-ginkgo-race.yaml
     - conformance-ingress.yaml
     - conformance-multi-pool.yaml
     - conformance-runtime.yaml
@@ -50,6 +51,9 @@ triggers:
   /ci-ginkgo:
     workflows:
     - conformance-ginkgo.yaml
+  /ci-ginkgo-race:
+    workflows:
+    - conformance-ginkgo-race.yaml
   /ci-gke(?:\s+(versions=(all)|channel=(EXTENDED|REGULAR|STABLE|RAPID|NONE|extended|regular|stable|none)))?:
     workflows:
     - conformance-gke.yaml
@@ -113,6 +117,8 @@ workflows:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
   conformance-ginkgo.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md)$)
+  conformance-ginkgo-race.yaml:
+    paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|cilium-cli|Documentation|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|USERS.md)$)
   conformance-gke.yaml:
     paths-ignore-regex: ((bpf/complexity-tests|bpf/tests|test|Documentation|hubble|.github/actions/cl2-modules)/|(.github/renovate\.json5|README.rst|CODEOWNERS|stable.txt|.*\.md|.*_test\.go)$)
   conformance-ingress.yaml:

--- a/.github/workflows/conformance-delegated-ipam.yaml
+++ b/.github/workflows/conformance-delegated-ipam.yaml
@@ -280,7 +280,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }}-race &> /dev/null; do sleep 45s; done
           done
 
       - name: Wait for nodes to become ready

--- a/.github/workflows/conformance-ginkgo-race.yaml
+++ b/.github/workflows/conformance-ginkgo-race.yaml
@@ -23,7 +23,6 @@ on:
   # Run every 8 hours
   schedule:
     - cron:  '0 1/8 * * *'
-  pull_request: {}
 
 # By specifying the access of one of the scopes, all of those that are not
 # specified are set to 'none'.

--- a/.github/workflows/conformance-ginkgo-race.yaml
+++ b/.github/workflows/conformance-ginkgo-race.yaml
@@ -1,0 +1,570 @@
+name: Conformance Ginkgo Race Detection (ci-ginkgo-race)
+
+# Any change in triggers needs to be reflected in the concurrency group.
+on:
+  workflow_dispatch:
+    inputs:
+      PR-number:
+        description: "Pull request number."
+        required: true
+      context-ref:
+        description: "Context in which the workflow runs. If PR is from a fork, will be the PR target branch (general case). If PR is NOT from a fork, will be the PR branch itself (this allows committers to test changes to workflows directly from PRs)."
+        required: true
+      SHA:
+        description: "SHA under test (head of the PR branch)."
+        required: true
+      extra-args:
+        description: "[JSON object] Arbitrary arguments passed from the trigger comment via regex capture group. Parse with 'fromJson(inputs.extra-args).argName' in workflow."
+        required: false
+        default: '{}'
+  push:
+    branches:
+      - 'renovate/main-**'
+  # Run every 8 hours
+  schedule:
+    - cron:  '0 1/8 * * *'
+  pull_request: {}
+
+# By specifying the access of one of the scopes, all of those that are not
+# specified are set to 'none'.
+permissions:
+  # To read actions state with catchpoint/workflow-telemetry-action
+  actions: read
+  # To be able to access the repository with actions/checkout
+  contents: read
+  # To allow retrieving information from the PR API
+  pull-requests: read
+  # To be able to set commit status
+  statuses: write
+
+concurrency:
+  # Structure:
+  # - Workflow name
+  # - Event type
+  # - A unique identifier depending on event type:
+  #   - schedule: SHA
+  #   - workflow_dispatch: PR number
+  #
+  # This structure ensures a unique concurrency group name is generated for each
+  # type of testing, such that re-runs will cancel the previous run.
+  group: |
+    ${{ github.workflow }}
+    ${{ github.event_name }}
+    ${{
+      (github.event_name == 'push' && github.sha) ||
+      (github.event_name == 'schedule' && github.sha) ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.PR-number)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  echo-inputs:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    name: Echo Workflow Dispatch Inputs
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Echo Workflow Dispatch Inputs
+        run: |
+          echo '${{ tojson(inputs) }}'
+
+  setup-vars:
+    name: Setup Vars
+    runs-on: ubuntu-24.04
+    outputs:
+      SHA: ${{ steps.vars.outputs.SHA }}
+      context-ref: ${{ steps.vars.outputs.context-ref }}
+      owner: ${{ steps.vars.outputs.owner }}
+    steps:
+      - name: Set up job variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            SHA="${{ inputs.SHA }}"
+            CONTEXT_REF="${{ inputs.context-ref }}"
+            OWNER="${{ inputs.PR-number }}"
+          else
+            SHA="${{ github.sha }}"
+            CONTEXT_REF="${{ github.sha }}"
+            OWNER="${{ github.ref_name }}"
+            OWNER="${OWNER//[.\/]/-}"
+          fi
+
+          echo SHA=${SHA} >> $GITHUB_OUTPUT
+          echo context-ref=${CONTEXT_REF} >> $GITHUB_OUTPUT
+          echo owner=${OWNER} >> $GITHUB_OUTPUT
+
+  commit-status-start:
+    name: Commit Status Start
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Set initial commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+
+  # Pre-build the ginkgo binary so that we don't have to build it for all
+  # runners.
+  build-ginkgo-binary:
+    runs-on: ubuntu-24.04
+    name: Build Ginkgo E2E
+    timeout-minutes: 30
+    steps:
+      # If any of these steps are modified, please update the copy of these
+      # steps further down under the 'setup-and-test' jobs.
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.SHA || github.sha }}
+          persist-credentials: false
+
+      # Load Ginkgo build from GitHub
+      - name: Load ginkgo E2E from GH cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: cache
+        with:
+          path: /tmp/.ginkgo-build/
+          key: ${{ runner.os }}-ginkgo-e2e-${{ hashFiles('**/*.go') }}
+
+      - name: Install Go
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.24.2
+
+      - name: Build Ginkgo
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+          mkdir -p /tmp/.ginkgo-build
+
+      - name: Build Test
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          cd test
+          /home/runner/go/bin/ginkgo build
+          strip test.test
+          tar -cz test.test -f test.tgz
+
+      - name: Store Ginkgo Test in GitHub cache path
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.ginkgo-build/
+          if [ -f test/test.tgz ]; then
+            cp test/test.tgz /tmp/.ginkgo-build/
+            echo "file copied"
+          fi
+
+  wait-for-images:
+    needs: setup-vars
+    runs-on: ubuntu-24.04
+    name: Wait for images
+    timeout-minutes: 30
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      - name: Wait for images
+        uses: ./.github/actions/wait-for-images
+        with:
+          SHA: ${{ inputs.SHA || github.sha }}
+
+  generate-matrix:
+    name: Generate Job Matrix from YAMLs
+    needs: setup-vars
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Convert YAML to JSON
+        run: |
+          work_dir=".github/actions/ginkgo"
+          destination_directory="/tmp/generated/ginkgo"
+          mkdir -p "${destination_directory}"
+          for file in "${work_dir}"/main*.yaml; do
+              if [[ -f "$file" ]]; then
+                  filename=$(basename "$file")
+                  new_filename="${filename%.yaml}.json"
+
+                  yq -o=json "${file}" | jq . > "${destination_directory}/${new_filename}"
+              fi
+          done
+
+      - name: Generate Matrix
+        id: set-matrix
+        run: |
+          if ${{ github.event_name == 'schedule' }}; then
+            k8s_versions_to_run='main-scheduled.json'
+          else
+            k8s_versions_to_run='main-prs.json'
+          fi
+
+          # Generate a Matrix from all k8s versions defined in '${k8s_versions_to_run}'
+          # combined with 'main-focus.yaml'.
+          # Use 'main-k8s-versions.yaml' to
+          # retrieve which kernel versions should be used for which k8s version.
+
+          dir="/tmp/generated/ginkgo"
+          cd ${dir}
+          jq --argjson prs "$(jq '.["k8s-version"]' ${k8s_versions_to_run})" \
+            --slurpfile focus main-focus.json \
+            '.include |= map(select(.["k8s-version"] as $k | $prs[] | select($k == .))) + $focus[0].include |
+            . + {"k8s-version": $prs} |
+            .focus = $focus[0].focus | .exclude = $focus[0].exclude' \
+            main-k8s-versions.json> /tmp/merged.json
+          echo "Generated matrix:"
+          cat /tmp/merged.json
+          echo "matrix=$(jq -c . < /tmp/merged.json)" >> $GITHUB_OUTPUT
+
+  setup-and-test:
+    needs: [setup-vars, build-ginkgo-binary, generate-matrix, wait-for-images]
+    runs-on: ${{ vars.GH_RUNNER_EXTRA_POWER_UBUNTU_LATEST || 'ubuntu-24.04' }}
+    timeout-minutes: 45
+    name: "E2E Test (${{ matrix.k8s-version }}, ${{matrix.focus}})"
+    env:
+      job_name: "E2E Test (${{ matrix.k8s-version }}, ${{matrix.focus}})"
+    strategy:
+      fail-fast: false
+      max-parallel: 60
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+
+    steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@94c3c3d9567a0205de6da68a76c428ce4e769af1 # v2.0.0
+        with:
+          comment_on_pr: false
+
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+
+      - name: Cleanup Disk space in runner
+        if: runner.name == 'ubuntu-24.04'
+        uses: ./.github/actions/disk-cleanup
+
+      - name: Set Environment Variables
+        uses: ./.github/actions/set-env-variables
+
+      # Warning: since this is a privileged workflow, subsequent workflow job
+      # steps must take care not to execute untrusted code.
+      - name: Checkout pull request branch (NOT TRUSTED)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.SHA || github.sha }}
+          persist-credentials: false
+
+      - name: Install cilium-cli
+        uses: cilium/cilium-cli@e7f03e4ec38a7008f4f5b9855ca9df721a9db185 # v0.18.3
+        with:
+          skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
+          image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
+          image-tag: ${{ needs.setup-vars.outputs.SHA }}
+          repository: ${{ env.CILIUM_CLI_RELEASE_REPO }}
+          release-version: ${{ env.CILIUM_CLI_VERSION }}
+
+      - name: Copy cilium-cli
+        shell: bash
+        run: |
+          cp -f /usr/local/bin/cilium ./cilium-cli-bin
+
+      - name: Install helm
+        shell: bash
+        run: |
+          # renovate: datasource=github-releases depName=helm/helm
+          HELM_VERSION=v3.13.1
+          wget "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          tar -xf "helm-${HELM_VERSION}-linux-amd64.tar.gz"
+          mv ./linux-amd64/helm ./helm
+
+      - name: Provision LVH VMs
+        id: provision-vh-vms
+        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        with:
+          test-name: datapath-conformance
+          install-dependencies: true
+          image-version: ${{ matrix.kernel }}
+          images-folder-parent: "/tmp"
+          host-mount: ./
+          cpu: 4
+          mem: 12G
+          # renovate: datasource=github-tags depName=cilium/little-vm-helper
+          lvh-version: "v0.0.23"
+          cmd: |
+            git config --global --add safe.directory /host
+            mv /host/helm /usr/bin
+            cp /host/cilium-cli-bin /usr/bin/cilium-cli
+
+      - name: Provision kind
+        timeout-minutes: 5
+        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/
+            if [[ "${{ matrix.kernel-type }}" == latest ]]; then
+              ./contrib/scripts/kind.sh "" 2 "" "${{ matrix.kube-image }}" "none" "${{ matrix.ip-family }}"
+              kubectl label node kind-worker2 cilium.io/ci-node=kind-worker2
+              # Avoid re-labeling this node by setting "node-role.kubernetes.io/controlplane"
+              kubectl label node kind-worker2 node-role.kubernetes.io/controlplane=
+            else
+              ./contrib/scripts/kind.sh "" 1 "" "${{ matrix.kube-image }}" "iptables" "${{ matrix.ip-family }}"
+            fi
+            git config --add safe.directory /cilium
+
+      # Load Ginkgo build from GitHub
+      - name: Load ${{ matrix.name }} Ginkgo build from GitHub
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        id: cache
+        with:
+          path: /tmp/.ginkgo-build/
+          key: ${{ runner.os }}-ginkgo-e2e-${{ hashFiles('**/*.go') }}
+
+      # Re-build the tests if it was a cache miss.
+      - name: Install Go
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        with:
+          # renovate: datasource=golang-version depName=go
+          go-version: 1.24.2
+
+      - name: Build Ginkgo
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+          mkdir -p /tmp/.ginkgo-build
+
+      - name: Build Test
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          cd test
+          /home/runner/go/bin/ginkgo build
+          strip test.test
+          tar -cz test.test -f test.tgz
+
+      - name: Store Ginkgo Test in GitHub cache path
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        shell: bash
+        run: |
+          mkdir -p /tmp/.ginkgo-build/
+          if [ -f test/test.tgz ]; then
+            cp test/test.tgz /tmp/.ginkgo-build/
+            echo "file copied"
+          fi
+
+      - name: Copy Ginkgo binary
+        shell: bash
+        run: |
+          cd test/
+          tar -xf /tmp/.ginkgo-build/test.tgz
+
+      - name: Run tests
+        id: run-tests
+        timeout-minutes: 40
+        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host/test/
+            kubectl get ns -A -o wide
+            kubectl get pods -A -o wide
+            export K8S_NODES=2
+            export NETNEXT=0
+            if [[ "${{ matrix.kernel-type }}" == latest ]]; then
+               export KERNEL=net-next
+               export NETNEXT=1
+               export KUBEPROXY=0
+               export K8S_NODES=3
+               export NO_CILIUM_ON_NODES=kind-worker2
+            elif [[ "${{ matrix.kernel-type }}" == stable ]]; then
+               export KERNEL=54
+            fi
+            export K8S_VERSION=${{ matrix.k8s-version }}
+            export CNI_INTEGRATION=kind
+            export INTEGRATION_TESTS=true
+            # GitHub actions do not support IPv6 connectivity to outside
+            # world.
+            export CILIUM_NO_IPV6_OUTSIDE=true
+            # Race detection variables
+            export RACE=1
+            export LOCKDEBUG=1
+            echo "/root/go/bin/ginkgo \
+             --focus=\"${{ matrix.cliFocus }}\" \
+             --skip=\"${{ matrix.cliSkip }}\" \
+             --seed=1679952881 \
+             -v -- \
+             -cilium.provision=false \
+             -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+             -cilium.tag=${{ needs.setup-vars.outputs.SHA }}-race  \
+             -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+             -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }}-race \
+             -cilium.hubble-relay-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
+             -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }}-race \
+             -cilium.kubeconfig=/root/.kube/config \
+             -cilium.operator-suffix=-ci ${{ env.CILIUM_GINKGO_EXTRA_ARGS }}"
+
+              ./test.test \
+               --ginkgo.focus="${{ matrix.cliFocus }}" \
+               --ginkgo.skip="${{ matrix.cliSkip }}" \
+               --ginkgo.seed=1679952881 \
+               --ginkgo.v -- \
+               -cilium.provision=false \
+               -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
+               -cilium.tag=${{ needs.setup-vars.outputs.SHA }}-race  \
+               -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
+               -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }}-race \
+               -cilium.hubble-relay-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
+               -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }}-race \
+               -cilium.kubeconfig=/root/.kube/config \
+               -cilium.operator-suffix=-ci ${{ env.CILIUM_GINKGO_EXTRA_ARGS }}
+
+      - name: Fetch artifacts
+        if: ${{ !success() && steps.provision-vh-vms.outcome == 'success' }}
+        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host
+            kubectl get pods --all-namespaces -o wide
+            tar -zcf "test_results-${{ env.job_name }}.tar.gz" /host/test/test_results
+
+      - name: Prepare script to run inside lvm
+        if: ${{ always() && steps.provision-vh-vms.outcome == 'success' }}
+        shell: bash
+        run: |
+          cat <<EOF > run-in-lvm.sh
+          #!/usr/bin/env bash
+          cd /host
+          if ! find /host/test/test_results -type f -iname 'feature-status-*.json' | grep -q .; then
+            exit 0
+          fi
+          find . -type f -iname 'feature-status-*.json' | while IFS= read -r file; do
+            mv "\$file" "./${{ env.job_name }}-\${file##*/feature-status-}"
+          done
+          EOF
+          chmod +x run-in-lvm.sh
+
+      - name: Fetch features tested
+        if: ${{ always() && steps.provision-vh-vms.outcome == 'success' }}
+        continue-on-error: true
+        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        with:
+          provision: 'false'
+          cmd: |
+            cd /host
+            ./run-in-lvm.sh
+
+      - name: Upload artifacts
+        if: ${{ !success() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cilium-sysdumps-${{ matrix.k8s-version }}-${{matrix.focus}}
+          path: |
+            cilium-sysdump-*.zip
+            bugtool-*.tar.gz
+            test_results-*.tar.gz
+
+      - name: Fetch JUnits
+        if: ${{ always() && steps.run-tests.outcome != 'skipped' }}
+        shell: bash
+        run: |
+          mkdir -p cilium-junits
+          cd test/
+          junit_filename="${{ env.job_name }}.xml"
+          for filename in *.xml; do cp "${filename}" "../cilium-junits/${junit_filename}"; done;
+
+      - name: Upload JUnits [junit]
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cilium-junits-${{ matrix.k8s-version }}-${{matrix.focus}}
+          path: cilium-junits/*.xml
+
+      - name: Upload features tested
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: features-tested-${{ matrix.k8s-version }}-${{matrix.focus}}
+          path: ${{ env.job_name }}*.json
+
+      - name: Publish Test Results As GitHub Summary
+        if: ${{ always() }}
+        uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
+        with:
+          junit-directory: "cilium-junits"
+
+  merge-upload:
+    if: ${{ always() }}
+    name: Merge and Upload Artifacts
+    runs-on: ubuntu-24.04
+    needs: setup-and-test
+    steps:
+      - name: Checkout context ref (trusted)
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.context-ref || github.sha }}
+          persist-credentials: false
+      - name: Merge Sysdumps
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: cilium-sysdumps
+          pattern: cilium-sysdumps-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge JUnits
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: cilium-junits
+          pattern: cilium-junits-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge Features tested
+        uses: ./.github/actions/merge-artifacts
+        with:
+          name: features-tested
+          pattern: features-tested-*
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  commit-status-final:
+    if: ${{ always() }}
+    name: Commit Status Final
+    needs: setup-and-test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Determine final commit status
+        id: commit-status
+        shell: bash
+        run: |
+          # When one of the prerequisites of setup-and-test fails, then that
+          # job gets skipped. Let's convert the status so that we correctly
+          # report that as a proper failure.
+          if [ "${{ needs.setup-and-test.result }}" != "skipped" ]; then
+            echo "status=${{ needs.setup-and-test.result }}" >> $GITHUB_OUTPUT
+          else
+            echo "status=failure" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set final commit status
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f # v2.0.1
+        with:
+          sha: ${{ inputs.SHA || github.sha }}
+          status: ${{ steps.commit-status.outputs.status }}

--- a/.github/workflows/conformance-ginkgo-race.yaml
+++ b/.github/workflows/conformance-ginkgo-race.yaml
@@ -129,10 +129,10 @@ jobs:
 
       - name: Install Go
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           # renovate: datasource=golang-version depName=go
-          go-version: 1.24.2
+          go-version: 1.24.5
 
       - name: Build Ginkgo
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
@@ -258,7 +258,6 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Disk space in runner
-        if: runner.name == 'ubuntu-24.04'
         uses: ./.github/actions/disk-cleanup
 
       - name: Set Environment Variables
@@ -273,7 +272,7 @@ jobs:
           persist-credentials: false
 
       - name: Install cilium-cli
-        uses: cilium/cilium-cli@e7f03e4ec38a7008f4f5b9855ca9df721a9db185 # v0.18.3
+        uses: cilium/cilium-cli@746083db48591ffbebd37743873a91a13a6b04b8 # v0.18.6
         with:
           skip-build: ${{ env.CILIUM_CLI_SKIP_BUILD }}
           image-repo: ${{ env.CILIUM_CLI_IMAGE_REPO }}
@@ -297,7 +296,7 @@ jobs:
 
       - name: Provision LVH VMs
         id: provision-vh-vms
-        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        uses: cilium/little-vm-helper@9c1f3a549af06e213863d034c13ba1c5d1e3c667 # v0.0.26
         with:
           test-name: datapath-conformance
           install-dependencies: true
@@ -307,7 +306,7 @@ jobs:
           cpu: 4
           mem: 12G
           # renovate: datasource=github-tags depName=cilium/little-vm-helper
-          lvh-version: "v0.0.23"
+          lvh-version: "v0.0.26"
           cmd: |
             git config --global --add safe.directory /host
             mv /host/helm /usr/bin
@@ -315,7 +314,7 @@ jobs:
 
       - name: Provision kind
         timeout-minutes: 5
-        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        uses: cilium/little-vm-helper@9c1f3a549af06e213863d034c13ba1c5d1e3c667 # v0.0.26
         with:
           provision: 'false'
           cmd: |
@@ -341,10 +340,10 @@ jobs:
       # Re-build the tests if it was a cache miss.
       - name: Install Go
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           # renovate: datasource=golang-version depName=go
-          go-version: 1.24.2
+          go-version: 1.24.5
 
       - name: Build Ginkgo
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
@@ -381,7 +380,7 @@ jobs:
       - name: Run tests
         id: run-tests
         timeout-minutes: 40
-        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        uses: cilium/little-vm-helper@9c1f3a549af06e213863d034c13ba1c5d1e3c667 # v0.0.26
         with:
           provision: 'false'
           cmd: |
@@ -413,7 +412,6 @@ jobs:
              --skip=\"${{ matrix.cliSkip }}\" \
              --seed=1679952881 \
              -v -- \
-             -cilium.provision=false \
              -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
              -cilium.tag=${{ needs.setup-vars.outputs.SHA }}-race  \
              -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
@@ -428,7 +426,6 @@ jobs:
                --ginkgo.skip="${{ matrix.cliSkip }}" \
                --ginkgo.seed=1679952881 \
                --ginkgo.v -- \
-               -cilium.provision=false \
                -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
                -cilium.tag=${{ needs.setup-vars.outputs.SHA }}-race  \
                -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
@@ -440,7 +437,7 @@ jobs:
 
       - name: Fetch artifacts
         if: ${{ !success() && steps.provision-vh-vms.outcome == 'success' }}
-        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        uses: cilium/little-vm-helper@9c1f3a549af06e213863d034c13ba1c5d1e3c667 # v0.0.26
         with:
           provision: 'false'
           cmd: |
@@ -467,7 +464,7 @@ jobs:
       - name: Fetch features tested
         if: ${{ always() && steps.provision-vh-vms.outcome == 'success' }}
         continue-on-error: true
-        uses: cilium/little-vm-helper@e87948476ca97050b1f149ab2aec379d0de19b84 # v0.0.23
+        uses: cilium/little-vm-helper@9c1f3a549af06e213863d034c13ba1c5d1e3c667 # v0.0.26
         with:
           provision: 'false'
           cmd: |
@@ -524,12 +521,6 @@ jobs:
         with:
           ref: ${{ inputs.context-ref || github.sha }}
           persist-credentials: false
-      - name: Merge Sysdumps
-        uses: ./.github/actions/merge-artifacts
-        with:
-          name: cilium-sysdumps
-          pattern: cilium-sysdumps-*
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Merge JUnits
         uses: ./.github/actions/merge-artifacts
         with:

--- a/.github/workflows/conformance-kind-proxy-embedded.yaml
+++ b/.github/workflows/conformance-kind-proxy-embedded.yaml
@@ -121,7 +121,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }}-race &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -385,11 +385,11 @@ jobs:
           --ginkgo.seed=1679952881 \
           --ginkgo.v -- \
           -cilium.image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
-          -cilium.tag=${{ steps.vars.outputs.sha }}  \
+          -cilium.tag=${{ steps.vars.outputs.sha }}-race  \
           -cilium.operator-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
-          -cilium.operator-tag=${{ steps.vars.outputs.sha }} \
+          -cilium.operator-tag=${{ steps.vars.outputs.sha }}-race \
           -cilium.hubble-relay-image=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-          -cilium.hubble-relay-tag=${{ steps.vars.outputs.sha }} \
+          -cilium.hubble-relay-tag=${{ steps.vars.outputs.sha }}-race \
           -cilium.operator-suffix=-ci \
           -cilium.SSHConfig="cat ./cilium-ssh-config.txt" \
           -cilium.extra-opts="${{ env.CILIUM_RUNTIME_EXTRA_ARGS }}"

--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -165,7 +165,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }}-race &> /dev/null; do sleep 45s; done
           done
 
   setup-and-test:
@@ -353,8 +353,8 @@ jobs:
             ln -s /host /home/root/go/src/github.com/cilium/cilium
             cp -r /host/test/provision /tmp
             git config --global --add safe.directory /host
-            export CILIUM_IMAGE=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.sha }}
-            export CILIUM_DOCKER_PLUGIN_IMAGE=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docker-plugin-ci:${{ steps.vars.outputs.sha }}
+            export CILIUM_IMAGE=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.sha }}-race
+            export CILIUM_DOCKER_PLUGIN_IMAGE=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/docker-plugin-ci:${{ steps.vars.outputs.sha }}-race
             export PROVISION_EXTERNAL_WORKLOAD=false
             export VMUSER=root
             echo '127.0.0.1 localhost' >> /etc/hosts
@@ -461,7 +461,7 @@ jobs:
         with:
           provision: 'false'
           cmd: |
-            docker create --name cilium-dbg quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.sha }}
+            docker create --name cilium-dbg quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci:${{ steps.vars.outputs.sha }}-race
             docker cp cilium-dbg:/usr/bin/cilium-dbg /usr/local/bin/cilium-dbg
             docker rm cilium-dbg
             cilium-dbg metrics list -p cilium_feature -o json > '/host/${{ env.job_name }} (${{ matrix.focus }}).json'

--- a/.github/workflows/fqdn-perf.yaml
+++ b/.github/workflows/fqdn-perf.yaml
@@ -142,7 +142,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.SHA }}-RACE &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Go

--- a/.github/workflows/hubble-cli-integration-test.yaml
+++ b/.github/workflows/hubble-cli-integration-test.yaml
@@ -143,7 +143,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }}-race &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium CLI

--- a/.github/workflows/k8s-kind-network-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-e2e.yaml
@@ -176,7 +176,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }}-race &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/k8s-kind-network-policies-e2e.yaml
+++ b/.github/workflows/k8s-kind-network-policies-e2e.yaml
@@ -158,7 +158,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.sha }}-race &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Cilium

--- a/.github/workflows/scale-test-node-throughput-gce.yaml
+++ b/.github/workflows/scale-test-node-throughput-gce.yaml
@@ -91,7 +91,7 @@ jobs:
         shell: bash
         run: |
           for image in cilium-ci operator-generic-ci hubble-relay-ci ; do
-            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
+            until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ steps.vars.outputs.SHA }}-RACE &> /dev/null; do sleep 45s; done
           done
 
       - name: Install Go

--- a/cilium-dbg/Makefile
+++ b/cilium-dbg/Makefile
@@ -20,7 +20,8 @@ all: $(TARGET)
 
 $(TARGET):
 	@$(ECHO_GO)
-	$(QUIET)$(GO_BUILD) -o $@
+	# drop -race from cilium-dbg command
+	$(QUIET)$(filter-out -race,$(GO_BUILD)) -o $@
 
 clean:
 	@$(ECHO_CLEAN)

--- a/go.mod
+++ b/go.mod
@@ -76,6 +76,7 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.36.1
 	github.com/osrg/gobgp/v3 v3.37.0
+	github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus-community/pro-bing v0.7.0
@@ -262,7 +263,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
-	github.com/petermattis/goid v0.0.0-20240813172612-4fcff4a6cae7 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -48,6 +48,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg \
     ./build-gops.sh
+RUN mkdir -p /out/.config
 
 FROM ${BASE_IMAGE} AS release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
@@ -63,6 +64,8 @@ COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 COPY --chmod=777 --from=scratch / /home/gops
 ENV GOPS_CONFIG_DIR=/home/gops
 # use uid:gid for the nonroot user for compatibility with runAsNonRoot
+ENV GOPS_CONFIG_DIR=/.config
+COPY --chown=65532:65532 --from=gops /out/.config /.config
 USER 65532:65532
 ENTRYPOINT ["/usr/bin/hubble-relay"]
 CMD ["serve"]

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/cilium/ebpf"
+	"github.com/petermattis/goid"
 	"github.com/vishvananda/netlink"
 
 	"github.com/cilium/cilium/pkg/bpf"
@@ -368,9 +369,14 @@ func (l *loader) Reinitialize(ctx context.Context, lnc *datapath.LocalNodeConfig
 		{Name: []string{"kernel", "timer_migration"}, Val: "0", IgnoreErr: true},
 	}
 
+	fmt.Printf("aanm Reinitialize executed with go routine %d\n", goid.Get())
+	defer fmt.Printf("aanm Reinitialize leaving with go routine %d\n", goid.Get())
+
 	// Lock so that endpoints cannot be built while we are compile base programs.
 	l.compilationLock.Lock()
 	defer l.compilationLock.Unlock()
+
+	fmt.Printf("aanm Reinitialize executed with go routine after locking %d\n", goid.Get())
 
 	// Startup relies on not returning an error here, maybe something we
 	// can fix in the future.

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -85,6 +85,11 @@ func (o *objectCache) UpdateDatapathHash(nodeCfg *datapath.LocalNodeConfiguratio
 
 		return err
 	}
+	// Unlock all objects so that race detector doesn't complain about potential
+	// deadlocks.
+	for _, obj := range o.objects {
+		obj.Unlock()
+	}
 
 	o.baseHash = newHash
 	o.objects = make(map[string]*cachedSpec)

--- a/pkg/ebpf/map.go
+++ b/pkg/ebpf/map.go
@@ -192,10 +192,8 @@ func (m *Map) OpenOrCreate() error {
 // IterateWithCallback iterates through all the keys/values of a map, passing
 // each key/value pair to the cb callback.
 func (m *Map) IterateWithCallback(key, value any, cb IterateCallback) error {
-	if m.Map == nil {
-		if err := m.OpenOrCreate(); err != nil {
-			return err
-		}
+	if err := m.OpenOrCreate(); err != nil {
+		return err
 	}
 
 	m.lock.RLock()

--- a/vendor/github.com/sasha-s/go-deadlock/deadlock.go
+++ b/vendor/github.com/sasha-s/go-deadlock/deadlock.go
@@ -260,14 +260,16 @@ func checkDeadlock(stack []uintptr, ptr interface{}, currentID int64, ch <-chan 
 }
 
 type lockOrder struct {
-	mu    sync.Mutex
-	cur   map[interface{}]stackGID // stacktraces + gids for the locks currently taken.
-	order map[beforeAfter]ss       // expected order of locks.
+	mu          sync.Mutex
+	cur         map[interface{}]stackGID // stacktraces + gids for the locks currently taken.
+	pToStackGID map[interface{}]stackGID // stacktraces + gids for the locks currently taken.
+	order       map[beforeAfter]ss       // expected order of locks.
 }
 
 type stackGID struct {
 	stack []uintptr
 	gid   int64
+	time  time.Time
 }
 
 type beforeAfter struct {
@@ -284,15 +286,16 @@ var lo = newLockOrder()
 
 func newLockOrder() *lockOrder {
 	return &lockOrder{
-		cur:   map[interface{}]stackGID{},
-		order: map[beforeAfter]ss{},
+		pToStackGID: map[interface{}]stackGID{},
+		cur:         map[interface{}]stackGID{},
+		order:       map[beforeAfter]ss{},
 	}
 }
 
 func (l *lockOrder) postLock(stack []uintptr, p interface{}) {
 	gid := goid.Get()
 	l.mu.Lock()
-	l.cur[p] = stackGID{stack, gid}
+	l.cur[p] = stackGID{stack, gid, time.Now()}
 	l.mu.Unlock()
 }
 
@@ -302,6 +305,7 @@ func (l *lockOrder) preLock(stack []uintptr, p interface{}) {
 	}
 	gid := goid.Get()
 	l.mu.Lock()
+	l.pToStackGID[p] = stackGID{stack, gid, time.Now()}
 	for b, bs := range l.cur {
 		if b == p {
 			if bs.gid == gid {
@@ -323,14 +327,16 @@ func (l *lockOrder) preLock(stack []uintptr, p interface{}) {
 		if bs.gid != gid { // We want locks taken in the same goroutine only.
 			continue
 		}
+		// bs gid == current gid
 		if s, ok := l.order[beforeAfter{p, b}]; ok {
+			pGID := l.pToStackGID[p]
 			Opts.mu.Lock()
-			fmt.Fprintln(Opts.LogBuf, header, "Inconsistent locking. saw this ordering in one goroutine:")
-			fmt.Fprintln(Opts.LogBuf, "happened before")
+			fmt.Fprintf(Opts.LogBuf, header+"Inconsistent locking. saw this ordering in one goroutine[%d] at %s:\n", pGID.gid, pGID.time)
+			fmt.Fprintf(Opts.LogBuf, "happened before pointer %p\n", b)
 			printStack(Opts.LogBuf, s.before)
-			fmt.Fprintln(Opts.LogBuf, "happened after")
+			fmt.Fprintf(Opts.LogBuf, "happened after pointer %p\n", p)
 			printStack(Opts.LogBuf, s.after)
-			fmt.Fprintln(Opts.LogBuf, "in another goroutine: happened before")
+			fmt.Fprintf(Opts.LogBuf, "in another goroutine[%d] at %s: happened before\n", bs.gid, bs.time)
 			printStack(Opts.LogBuf, bs.stack)
 			fmt.Fprintln(Opts.LogBuf, "happened after")
 			printStack(Opts.LogBuf, stack)
@@ -363,22 +369,9 @@ func (r *rlocker) Unlock() { (*RWMutex)(r).RUnlock() }
 
 // Under lo.mu Locked.
 func (l *lockOrder) other(ptr interface{}) {
-	empty := true
-	for k := range l.cur {
-		if k == ptr {
-			continue
-		}
-		empty = false
-	}
-	if empty {
-		return
-	}
-	fmt.Fprintln(Opts.LogBuf, "Other goroutines holding locks:")
+	fmt.Fprintln(Opts.LogBuf, "All goroutines holding locks:")
 	for k, pp := range l.cur {
-		if k == ptr {
-			continue
-		}
-		fmt.Fprintf(Opts.LogBuf, "goroutine %v lock %p\n", pp.gid, k)
+		fmt.Fprintf(Opts.LogBuf, "goroutine %v lock %p caused problems? %t\n", pp.gid, k, k == ptr)
 		printStack(Opts.LogBuf, pp.stack)
 	}
 	fmt.Fprintln(Opts.LogBuf)


### PR DESCRIPTION
This commit introduces a new workflow for running the ginkgo test suite with race detection enabled. The goal is to start this effort by doing a copy and paste of the existing ginkgo workflow and modifying it as needed. In the future, effort will be put towards reducing this duplication.

Thank you to @markpash for getting this started.

Fixes: #26170

Supersedes https://github.com/cilium/cilium/pull/27797.

Here is the diff between `conformance-ginkgo-race` and `conformance-ginkgo`:

```diff
1c1
< name: Conformance Ginkgo (ci-ginkgo)
---
> name: Conformance Ginkgo Race Detection (ci-ginkgo-race)
22a23
>   pull_request: {}
171c172
<             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ needs.setup-vars.outputs.SHA }} &> /dev/null; do sleep 45s; done
---
>             until docker manifest inspect quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/$image:${{ needs.setup-vars.outputs.SHA }}-race &> /dev/null; do sleep 45s; done
385a387,389
>             # Race detection variables
>             export RACE=1
>             export LOCKDEBUG=1
393c397
<              -cilium.tag=${{ needs.setup-vars.outputs.SHA }}  \
---
>              -cilium.tag=${{ needs.setup-vars.outputs.SHA }}-race  \
395c399
<              -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }} \
---
>              -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }}-race \
397c401
<              -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }} \
---
>              -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }}-race \
409c413
<                -cilium.tag=${{ needs.setup-vars.outputs.SHA }}  \
---
>                -cilium.tag=${{ needs.setup-vars.outputs.SHA }}-race  \
411c415
<                -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }} \
---
>                -cilium.operator-tag=${{ needs.setup-vars.outputs.SHA }}-race \
413c417
<                -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }} \
---
>                -cilium.hubble-relay-tag=${{ needs.setup-vars.outputs.SHA }}-race \
```

```release-note
Add CI workflow for running ginkgo with race detection
```
