### PR TITLE
[v1.12] bpf: lxc: support Pod->Service->Pod hairpinning with endpoint routes

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -30,6 +30,9 @@ triggers:
   /ci-gke:
     workflows:
     - conformance-gke.yaml
+  /ci-ingress:
+    workflows:
+    - conformance-ingress.yaml
   /ci-l4lb:
     workflows:
     - tests-l4lb.yaml

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -1,4 +1,4 @@
-name: Conformance Ingress
+name: Conformance Ingress (ci-ingress)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1966,6 +1966,76 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	return ret;
 }
 
+static __always_inline bool
+ipv4_to_endpoint_is_hairpin_flow(struct __ctx_buff *ctx, struct iphdr *ip4)
+{
+	__be16 client_port, backend_port, service_port;
+	struct ipv4_ct_tuple tuple = {};
+	struct lb4_backend *backend;
+	__be32 pod_ip, service_ip;
+	struct ct_entry *entry;
+	struct ct_map *map;
+	int err, l4_off;
+
+	/* Extract the tuple from the packet so we can freely access addrs and ports.
+	 * All values are in network byte order.
+	 */
+	err = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
+	if (IS_ERR(err))
+		return false;
+
+	/* If the packet originates from a regular, non-loopback address, it will look
+	 * like service_ip:client_port -> pod_ip:service_port.
+	 *
+	 * In order to determine whether the packet has been hairpinned, we need to
+	 * obtain the backend (listen) port first, requiring a CT lookup with the
+	 * TUPLE_F_SERVICE flag, followed by a backend lookup. After this, the regular
+	 * CT TUPLE_F_OUT lookup can proceed.
+	 */
+	service_ip = tuple.saddr;
+	pod_ip = tuple.daddr;
+	client_port = tuple.sport;
+	service_port = tuple.dport;
+
+	tuple.daddr = service_ip;
+	tuple.saddr = pod_ip;
+	tuple.dport = client_port;
+	tuple.sport = service_port;
+
+	tuple.flags = TUPLE_F_SERVICE;
+
+	map = get_ct_map4(&tuple);
+	entry = map_lookup_elem(map, &tuple);
+	if (!entry)
+		return false;
+
+	backend = lb4_lookup_backend(ctx, entry->backend_id);
+	if (!backend)
+		return false;
+
+	backend_port = backend->port;
+
+	/* Now the backend (listen) port inside the container is known, an egress CT
+	 * lookup can be performed.
+	 */
+	tuple.daddr = IPV4_LOOPBACK;
+	tuple.saddr = pod_ip;
+	tuple.dport = backend_port;
+	tuple.sport = client_port;
+
+	tuple.flags = TUPLE_F_OUT;
+
+	map = get_ct_map4(&tuple);
+	entry = map_lookup_elem(map, &tuple);
+	if (entry)
+		/* The packet is considered hairpinned if its egress CT entry has the
+		 * loopback flag set.
+		 */
+		return entry->lb_loopback == 1;
+
+	return false;
+}
+
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_TO_ENDPOINT)
 int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 {
@@ -2013,6 +2083,23 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 	update_metrics(ctx_full_len(ctx), METRIC_INGRESS, REASON_FORWARDED);
 #endif
 	ctx_store_meta(ctx, CB_SRC_LABEL, 0);
+
+	/* Check if packet is locally hairpinned (pod reaching itself through a
+	 * service) and skip the policy check if that is the case. Otherwise, pods may
+	 * need to explicitly allow traffic to themselves in some network
+	 * configurations.
+	 */
+	if (ipv4_to_endpoint_is_hairpin_flow(ctx, ip4)) {
+		send_trace_notify4(ctx, TRACE_TO_LXC,
+				   ctx_load_meta(ctx, CB_SRC_LABEL),
+				   SECLABEL, ip4->saddr, LXC_ID,
+				   ctx->ingress_ifindex,
+				   TRACE_REASON_UNKNOWN, 0);
+
+		/* Skip policy check for hairpinned flow */
+		ret = CTX_ACT_OK;
+		goto out;
+	}
 
 	ret = ipv4_policy(ctx, 0, src_identity, &ct_status, NULL,
 			  &proxy_port, true);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -967,6 +967,16 @@ ct_recreate4:
 	 * been passed to the stack.
 	 */
 	if (is_defined(ENABLE_ROUTING) || hairpin_flow) {
+		/* Hairpin requests need to pass through the backend's to-container
+		 * path, to create a CT_INGRESS entry with .lb_loopback set. This
+		 * drives RevNAT in the backend's from-container path.
+		 *
+		 * Hairpin replies are fully RevNATed in the backend's from-container
+		 * path. Thus they don't match the CT_EGRESS entry, and we can't rely
+		 * on a CT_REPLY result that would provide bypass of ingress policy.
+		 * Thus manually skip the ingress policy path.
+		 */
+		bool bypass_ingress_policy = hairpin_flow && ct_status == CT_REPLY;
 		struct endpoint_info *ep;
 
 		/* Lookup IPv4 address, this will return a match if:
@@ -990,7 +1000,8 @@ ct_recreate4:
 			policy_clear_mark(ctx);
 			/* If the packet is from L7 LB it is coming from the host */
 			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL, ip4,
-						   ep, METRIC_EGRESS, from_l7lb, hairpin_flow);
+						   ep, METRIC_EGRESS, from_l7lb,
+						   bypass_ingress_policy);
 		}
 	}
 
@@ -1790,7 +1801,19 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, enum ct_status
 	 * define policy rules to allow pods to talk to themselves. We still
 	 * want to execute the conntrack logic so that replies can be correctly
 	 * matched.
+	 *
+	 * If ip4.saddr is IPV4_LOOPBACK, this is almost certainly a loopback
+	 * connection. Populate
+	 * - .loopback, so that policy enforcement is bypassed, and
+	 * - .rev_nat_index, so that replies can be RevNATed.
 	 */
+	if (ret == CT_NEW && ip4->saddr == IPV4_LOOPBACK &&
+	    ct_has_loopback_egress_entry4(get_ct_map4(tuple), tuple,
+					  &ct_state_new.rev_nat_index)) {
+		ct_state_new.loopback = true;
+		goto skip_policy_enforcement;
+	}
+
 	if (unlikely(ct_state->loopback))
 		goto skip_policy_enforcement;
 #endif /* ENABLE_PER_PACKET_LB && !DISABLE_LOOPBACK_LB */


### PR DESCRIPTION
- [ ] https://github.com/cilium/cilium/pull/27822 (@tklauser) (:warning: Skipped the first two commits)
- [ ] https://github.com/cilium/cilium/pull/27304 (@sayboras) (:warning: Skipped the first commit)
- [ ] https://github.com/cilium/cilium/pull/27798 (@ti-mo)
- [x] https://github.com/cilium/cilium/pull/27602 (@julianwiedmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27822 27304 27602 27798; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
make add-labels BRANCH=v1.12 ISSUES=27822,27304,27602,27798
```
