### PR TITLE
Resiliency: Add checks to ensure endpoint BPF programs remain loaded

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -162,6 +162,7 @@ cilium-agent [flags]
       --encrypt-node                                              Enables encrypting traffic from non-Cilium pods and host networking (only supported with WireGuard, beta)
       --encryption-strict-mode-allow-remote-node-identities       Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.
       --encryption-strict-mode-cidr string                        In strict-mode encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped
+      --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --endpoint-queue-size int                                   Size of EventQueue per-endpoint (default 25)
       --endpoint-status strings                                   Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
       --envoy-config-timeout duration                             Timeout duration for Envoy Config acknowledgements (default 2m0s)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -32,6 +32,7 @@ cilium-agent hive [flags]
       --enable-k8s-endpoint-slice                                 Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-l2-pod-announcements                               Enable announcing Pod IPs with Gratuitous ARP
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
+      --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
   -h, --help                                                      help for hive
       --k8s-api-server string                                     Kubernetes API server URL

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -38,6 +38,7 @@ cilium-agent hive dot-graph [flags]
       --enable-k8s-endpoint-slice                                 Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-l2-pod-announcements                               Enable announcing Pod IPs with Gratuitous ARP
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
+      --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
       --k8s-api-server string                                     Kubernetes API server URL
       --k8s-client-burst int                                      Burst value allowed for the K8s client

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1276,6 +1276,8 @@ func (d *Daemon) Close() {
 	}
 	identitymanager.RemoveAll()
 	d.cgroupManager.Close()
+
+	// Ensures all controllers are stopped!
 	d.controllers.RemoveAllAndWait()
 }
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1627,6 +1627,7 @@ var daemonCell = cell.Module(
 	// by the debuginfo API
 	cell.ProvidePrivate(daemonSettings),
 	cell.Invoke(func(promise.Promise[*Daemon]) {}), // Force instantiation.
+	endpointBPFrogWatchdogCell,
 )
 
 type daemonParams struct {

--- a/daemon/cmd/watchdogs.go
+++ b/daemon/cmd/watchdogs.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/controller"
+	"github.com/cilium/cilium/pkg/datapath/loader"
+	"github.com/cilium/cilium/pkg/endpoint"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/promise"
+)
+
+const epBPFProgWatchdog = "ep-bpf-prog-watchdog"
+
+type epBPFProgWatchdogConfig struct {
+	EndpointBPFProgWatchdogInterval time.Duration
+}
+
+func (c epBPFProgWatchdogConfig) Flags(flags *pflag.FlagSet) {
+	flags.Duration("endpoint-bpf-prog-watchdog-interval", c.EndpointBPFProgWatchdogInterval,
+		"Interval to trigger endpoint BPF programs load check watchdog")
+}
+
+type epBPFProgWatchdogParams struct {
+	cell.In
+
+	Config        epBPFProgWatchdogConfig
+	Logger        logrus.FieldLogger
+	Lifecycle     hive.Lifecycle
+	DaemonPromise promise.Promise[*Daemon]
+}
+
+var (
+	// endpointBPFrogWatchdogCell triggers a job to ensure device tc programs remain loaded.
+	endpointBPFrogWatchdogCell = cell.Module(
+		epBPFProgWatchdog,
+		"Periodically checks that endpoint BPF programs remain loaded",
+
+		cell.Config(epBPFProgWatchdogConfigDefault),
+		cell.Invoke(registerEndpointBPFProgWatchdog),
+	)
+
+	epBPFProgWatchdogConfigDefault = epBPFProgWatchdogConfig{
+		EndpointBPFProgWatchdogInterval: 30 * time.Second,
+	}
+)
+
+func registerEndpointBPFProgWatchdog(p epBPFProgWatchdogParams) {
+	if p.Config.EndpointBPFProgWatchdogInterval == 0 {
+		return
+	}
+
+	var (
+		ctx, cancel = context.WithCancel(context.Background())
+		mgr         = controller.NewManager()
+	)
+	p.Lifecycle.Append(hive.Hook{
+		OnStart: func(hive.HookContext) error {
+			mgr.UpdateController(
+				epBPFProgWatchdog,
+				controller.ControllerParams{
+					Group: controller.NewGroup(epBPFProgWatchdog),
+					DoFunc: func(ctx context.Context) error {
+						d, err := p.DaemonPromise.Await(ctx)
+						if err != nil {
+							return err
+						}
+						return d.checkEndpointBPFPrograms(ctx, p)
+					},
+					RunInterval: p.Config.EndpointBPFProgWatchdogInterval,
+					Context:     ctx,
+				},
+			)
+
+			return nil
+		},
+		OnStop: func(hive.HookContext) error {
+			cancel()
+			mgr.RemoveAllAndWait()
+			return nil
+		},
+	},
+	)
+}
+
+func (d *Daemon) checkEndpointBPFPrograms(ctx context.Context, p epBPFProgWatchdogParams) error {
+	var (
+		loaded = true
+		err    error
+		eps    = d.endpointManager.GetEndpoints()
+	)
+	for _, ep := range eps {
+		if ep.GetState() != endpoint.StateReady {
+			continue
+		}
+		loaded, err = loader.DeviceHasTCProgramLoaded(ep.HostInterface(), ep.RequireEgressProg())
+		if err != nil {
+			log.WithField(logfields.Endpoint, ep.HostInterface()).
+				WithError(err).
+				Error("Unable to assert if endpoint BPF programs need to be reloaded")
+			return err
+		}
+		// We've detected missing bpf progs for this endpoint.
+		// Break and trigger bpf progs reload.
+		if !loaded {
+			break
+		}
+	}
+	if loaded {
+		return nil
+	}
+
+	log.WithField(logfields.Count, len(eps)).
+		Warn(
+			"Detected unexpected endpoint BPF program removal. " +
+				"Consider investigating whether other software running on this machine is removing Cilium's endpoint BPF programs. " +
+				"If endpoint BPF programs are removed, the associated pods will lose connectivity and only reinstating the programs will restore connectivity.",
+		)
+	wg, err := d.TriggerReloadWithoutCompile(epBPFProgWatchdog)
+	if err != nil {
+		log.WithError(err).Error("Failed to reload Cilium endpoints BPF programs")
+	} else {
+		wg.Wait()
+	}
+
+	return err
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Resiliency: Add checks to ensure endpoints related BPF programs remain loaded
    
We've seen instance where BPF programs are deleted by third party
software (aka Ddog). When this occurrs either agents will fail to
restart or connectivity may be compromised.
    
This PR attempts to reconciliate BPF program state with their associated
endpoints by ensuring endpoints programs are reloaded when necessary.
        

Signed-off-by: Fernand Galiana <fernand.galiana@gmail.com>
