### PR TITLE
daemon: Fix boostrap restore duration metric

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1072,6 +1072,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		d.restoreCiliumHostIPs(true, router6FromK8s)
 	}
 
+	bootstrapStats.restore.Start()
 	// restore endpoints before any IPs are allocated to avoid eventual IP
 	// conflicts later on, otherwise any IP conflict will result in the
 	// endpoint not being able to be restored.


### PR DESCRIPTION
The start timestamp update for 'restoreOldEndpoints' is missed for bootstrap stats calculation.

```release-note
Fix inaccurate calculation for bootstrap stats of restore
```
