### PR TITLE
egressgw: reject config with CiliumEndpointSlice

### DIFF
--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -79,6 +79,9 @@ set to ``crd``). This is the default setting for new installations.
 Egress gateway is not compatible with the Cluster Mesh feature. The gateway selected
 by an egress gateway policy must be in the same cluster as the selected pods.
 
+Egress gateway is not compatible with the CiliumEndpointSlice feature
+(see :gh-issue:`24833` for details).
+
 Egress gateway is not supported for IPv6 traffic.
 
 Enable egress gateway

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -199,6 +199,10 @@ func NewEgressGatewayManager(p Params) (out struct {
 		return out, errors.New("egress gateway is not supported in high scale IPcache mode")
 	}
 
+	if dcfg.EnableCiliumEndpointSlice {
+		return out, errors.New("egress gateway is not supported in combination with the CiliumEndpointSlice feature")
+	}
+
 	if !dcfg.MasqueradingEnabled() || !dcfg.EnableBPFMasquerade {
 		return out, fmt.Errorf("egress gateway requires --%s=\"true\" and --%s=\"true\"", option.EnableIPv4Masquerade, option.EnableBPFMasquerade)
 	}


### PR DESCRIPTION
These two features are currently not compatible. Have the agent fatal until https://github.com/cilium/cilium/issues/24833 is resolved.