### PR TITLE
endpoint: Fix use of PolicyMapFullReconciliationInterval option

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1345,12 +1345,6 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	return err
 }
 
-const (
-	// syncPolicyMapInterval is the interval for periodic full reconciliation of
-	// the policy map to catch unexpected discrepancies with agent and kernel state.
-	syncPolicyMapInterval = 15 * time.Minute
-)
-
 func (e *Endpoint) startSyncPolicyMapController() {
 	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
 	e.controllers.CreateController(ctrlName,
@@ -1366,7 +1360,7 @@ func (e *Endpoint) startSyncPolicyMapController() {
 				defer e.unlock()
 				return e.syncPolicyMapWithDump()
 			},
-			RunInterval: syncPolicyMapInterval,
+			RunInterval: option.Config.PolicyMapFullReconciliationInterval,
 			Context:     e.aliveCtx,
 		},
 	)


### PR DESCRIPTION
The last minute change in 867e41a610 to add an option for configuring the full endpoint policy sync forgot to actually change the use-site.

Fixes: 867e41a610 ("endpoint: Only perform full synchronization periodically")