### PR TITLE
Avoid panic when counting IPsec keys

### DIFF
--- a/cilium/cmd/encrypt_status.go
+++ b/cilium/cmd/encrypt_status.go
@@ -84,6 +84,10 @@ func countUniqueIPsecKeys() int {
 		Fatalf("Cannot get xfrm state: %s", err)
 	}
 	for _, v := range xfrmStates {
+		if v.Aead == nil {
+			fmt.Printf("Warning: non-AEAD xfrm state found: %s\n", v.String())
+			continue
+		}
 		keys[string(v.Aead.Key)] = voidType
 	}
 


### PR DESCRIPTION
When executing `cilium encrypt status`, cilium-agent lists xfrm states and counts number of different AEAD keys. However, cilium-agent panics if there is any xfrm state using non-AEAD algorithm. These unexpected xfrm states could be installed by other applications.

To reproduce the panic, we can manually install one by running command:

```
ip x s a src 1.1.1.1 dst 1.1.1.2 proto esp spi 0x3 reqid 1 mode tunnel enc aes 0xf0e1d2c3b4a5f60708090a0b0c0d0e0f
```

Then `cilium encrypt status` crashes.

This patch fixes it.

```release-note
Fixes a bug causing panic when counting IPsec keys number via "cilium encrypt status".
```
