### PR TITLE
ipam: let `allocator.Dump` return map of allocated IPs per pool

### DIFF
--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -312,40 +312,46 @@ func (ipam *IPAM) ReleaseIP(ip net.IP, pool Pool) error {
 	return ipam.releaseIPLocked(ip, pool)
 }
 
-func splitIPAndPool(ip string) (string, Pool) {
-	// IPs from non-default pools are prefixed with <pool name>/
-	if i := strings.LastIndexByte(ip, '/'); i >= 0 {
-		return ip[i+1:], Pool(ip[:i])
-	}
-	return ip, PoolDefault
-}
-
 // Dump dumps the list of allocated IP addresses
 func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, status string) {
 	var st4, st6 string
+	var allocPerPool4, allocPerPool6 map[Pool]map[string]string
+
+	allocv4 = make(map[string]string)
+	allocv6 = make(map[string]string)
 
 	ipam.allocatorMutex.RLock()
 	defer ipam.allocatorMutex.RUnlock()
 
 	if ipam.IPv4Allocator != nil {
-		allocv4, st4 = ipam.IPv4Allocator.Dump()
+		allocPerPool4, st4 = ipam.IPv4Allocator.Dump()
 		st4 = "IPv4: " + st4
-		for ip := range allocv4 {
-			onlyIP, pool := splitIPAndPool(ip)
-			owner := ipam.getIPOwner(onlyIP, pool)
-			// If owner is not available, report IP but leave owner empty
-			allocv4[ip] = owner
+		for pool, alloc := range allocPerPool4 {
+			for ip := range alloc {
+				owner := ipam.getIPOwner(ip, pool)
+				ipPrefix := ""
+				if pool != PoolDefault {
+					ipPrefix = string(pool) + "/"
+				}
+				// If owner is not available, report IP but leave owner empty
+				allocv4[ipPrefix+ip] = owner
+			}
 		}
 	}
 
 	if ipam.IPv6Allocator != nil {
-		allocv6, st6 = ipam.IPv6Allocator.Dump()
+		allocPerPool6, st6 = ipam.IPv6Allocator.Dump()
 		st6 = "IPv6: " + st6
-		for ip := range allocv6 {
-			onlyIP, pool := splitIPAndPool(ip)
-			owner := ipam.getIPOwner(onlyIP, pool)
-			// If owner is not available, report IP but leave owner empty
-			allocv6[ip] = owner
+		for pool, alloc := range allocPerPool6 {
+			for ip := range alloc {
+				owner := ipam.getIPOwner(ip, pool)
+				ipPrefix := ""
+				if pool != PoolDefault {
+					ipPrefix = string(pool) + "/"
+				}
+				// If owner is not available, report IP but leave owner empty
+				allocv6[ipPrefix+ip] = owner
+			}
 		}
 	}
 

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -877,17 +877,17 @@ func (a *crdAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool) 
 }
 
 // Dump provides a status report and lists all allocated IP addresses
-func (a *crdAllocator) Dump() (map[string]string, string) {
+func (a *crdAllocator) Dump() (map[Pool]map[string]string, string) {
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
 
-	allocs := map[string]string{}
+	allocs := make(map[string]string, len(a.allocated))
 	for ip := range a.allocated {
 		allocs[ip] = ""
 	}
 
 	status := fmt.Sprintf("%d/%d allocated", len(allocs), a.store.totalPoolSize(a.family))
-	return allocs, status
+	return map[Pool]map[string]string{PoolDefault: allocs}, status
 }
 
 func (a *crdAllocator) Capacity() uint64 {

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -63,7 +63,7 @@ func (h *hostScopeAllocator) AllocateNextWithoutSyncUpstream(owner string, pool 
 	return &AllocationResult{IP: ip}, nil
 }
 
-func (h *hostScopeAllocator) Dump() (map[string]string, string) {
+func (h *hostScopeAllocator) Dump() (map[Pool]map[string]string, string) {
 	var origIP *big.Int
 	alloc := map[string]string{}
 	_, data, err := h.allocator.Snapshot()
@@ -86,7 +86,7 @@ func (h *hostScopeAllocator) Dump() (map[string]string, string) {
 	maxIPs := ip.CountIPsInCIDR(h.allocCIDR)
 	status := fmt.Sprintf("%d/%s allocated from %s", len(alloc), maxIPs.String(), h.allocCIDR.String())
 
-	return alloc, status
+	return map[Pool]map[string]string{PoolDefault: alloc}, status
 }
 
 func (h *hostScopeAllocator) Capacity() uint64 {

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -109,12 +109,15 @@ func (f fakePoolAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Po
 	return f.AllocateNext(owner, pool)
 }
 
-func (f fakePoolAllocator) Dump() (map[string]string, string) {
-	result := map[string]string{}
+func (f fakePoolAllocator) Dump() (map[Pool]map[string]string, string) {
+	result := map[Pool]map[string]string{}
 	for name, alloc := range f.pools {
 		dump, _ := alloc.Dump()
-		for k, v := range dump {
-			result[string(name)+":"+k] = v
+		if _, ok := result[name]; !ok {
+			result[name] = map[string]string{}
+		}
+		for k, v := range dump[name] {
+			result[name][k] = v
 		}
 	}
 	return result, fmt.Sprintf("%d pools", len(f.pools))

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -337,7 +337,9 @@ func Test_MultiPoolManager(t *testing.T) {
 	assert.Error(t, errors.New("all pod CIDR ranges are exhausted"), err)
 
 	ipv4Dump, _ := c.dump(IPv4)
-	assert.Len(t, ipv4Dump, numMarsIPs+1) // +1 from default pool
+	assert.Len(t, ipv4Dump, 2) // 2 pools: default + mars
+	assert.Len(t, ipv4Dump[PoolDefault], 1)
+	assert.Len(t, ipv4Dump[Pool("mars")], numMarsIPs)
 
 	// Ensure Requested numbers are bumped
 	assert.Equal(t, <-events, "upsert")
@@ -430,9 +432,13 @@ func Test_MultiPoolManager(t *testing.T) {
 	}, currentNode.Spec.IPAM.Pools.Allocated)
 
 	ipv4Dump, ipv4Summary := c.dump(IPv4)
-	assert.Equal(t, map[string]string{
-		defaultAllocation.IP.String():        "",
-		"mars/" + marsAllocation.IP.String(): "",
+	assert.Equal(t, map[Pool]map[string]string{
+		PoolDefault: {
+			defaultAllocation.IP.String(): "",
+		},
+		Pool("mars"): {
+			marsAllocation.IP.String(): "",
+		},
 	}, ipv4Dump)
 	assert.Equal(t, "2 IPAM pool(s) available", ipv4Summary)
 }

--- a/pkg/ipam/noop_allocator.go
+++ b/pkg/ipam/noop_allocator.go
@@ -35,7 +35,7 @@ func (n *noOpAllocator) AllocateNextWithoutSyncUpstream(owner string, pool Pool)
 	return nil, errNotSupported
 }
 
-func (n *noOpAllocator) Dump() (map[string]string, string) {
+func (n *noOpAllocator) Dump() (map[Pool]map[string]string, string) {
 	return nil, "delegated to plugin"
 }
 

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -68,11 +68,10 @@ type Allocator interface {
 	// upstream or fails if no more IPs are available
 	AllocateNextWithoutSyncUpstream(owner string, pool Pool) (*AllocationResult, error)
 
-	// Dump returns a map of all allocated IPs with the IP represented as
-	// key in the map. Dump must also provide a status one-liner to
-	// represent the overall status, e.g. number of IPs allocated and
-	// overall health information if available.
-	Dump() (map[string]string, string)
+	// Dump returns a map of all allocated IPs per pool with the IP represented as key in the
+	// map. Dump must also provide a status one-liner to represent the overall status, e.g.
+	// number of IPs allocated and overall health information if available.
+	Dump() (map[Pool]map[string]string, string)
 
 	// Capacity returns the total IPAM allocator capacity (not the current
 	// available).


### PR DESCRIPTION
The first commit is preparatory refactoring in unit tests to simplify the second commit. The second commit contains the actual change:

Instead of encoding the pool name in the IP string, let `Allocator.Dump` return the pool information separately, i.e. a map of allocated IPs per pool. `(*IPAM).Dump` will keep returning a map of allocated IPs with their owner in order not to change the interface towards other packages.
    
Follow-up for commit afd8e4eef3b6 ("ipam: report IP owner of non-default pool IPs in multi-pool IPAM"), as suggested by @gandro in https://github.com/cilium/cilium/pull/27968#pullrequestreview-1613446046