### PR TITLE
[v1.13] bpf: lxc: support Pod->Service->Pod hairpinning with endpoint routes

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -998,6 +998,16 @@ ct_recreate4:
 	 * been passed to the stack.
 	 */
 	if (is_defined(ENABLE_ROUTING) || hairpin_flow) {
+		/* Hairpin requests need to pass through the backend's to-container
+		 * path, to create a CT_INGRESS entry with .lb_loopback set. This
+		 * drives RevNAT in the backend's from-container path.
+		 *
+		 * Hairpin replies are fully RevNATed in the backend's from-container
+		 * path. Thus they don't match the CT_EGRESS entry, and we can't rely
+		 * on a CT_REPLY result that would provide bypass of ingress policy.
+		 * Thus manually skip the ingress policy path.
+		 */
+		bool bypass_ingress_policy = hairpin_flow && ct_status == CT_REPLY;
 		struct endpoint_info *ep;
 
 		/* Lookup IPv4 address, this will return a match if:
@@ -1020,9 +1030,10 @@ ct_recreate4:
 #endif /* ENABLE_ROUTING */
 			policy_clear_mark(ctx);
 			/* If the packet is from L7 LB it is coming from the host */
-			return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL, ip4,
-						   ep, METRIC_EGRESS, from_l7lb, hairpin_flow);
-		}
+                        return ipv4_local_delivery(ctx, ETH_HLEN, SECLABEL, ip4,
+                                                   ep, METRIC_EGRESS, from_l7lb,
+                                                   bypass_ingress_policy);
+                }
 	}
 
 #if defined(ENABLE_HOST_FIREWALL) && !defined(ENABLE_ROUTING)
@@ -1810,7 +1821,19 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label, enum ct_status
 	 * define policy rules to allow pods to talk to themselves. We still
 	 * want to execute the conntrack logic so that replies can be correctly
 	 * matched.
+	 *
+	 * If ip4.saddr is IPV4_LOOPBACK, this is almost certainly a loopback
+	 * connection. Populate
+	 * - .loopback, so that policy enforcement is bypassed, and
+	 * - .rev_nat_index, so that replies can be RevNATed.
 	 */
+	if (ret == CT_NEW && ip4->saddr == IPV4_LOOPBACK &&
+	    ct_has_loopback_egress_entry4(get_ct_map4(tuple), tuple,
+					  &ct_state_new.rev_nat_index)) {
+		ct_state_new.loopback = true;
+		goto skip_policy_enforcement;
+	}
+
 	if (unlikely(ct_state->loopback))
 		goto skip_policy_enforcement;
 #endif /* ENABLE_PER_PACKET_LB && !DISABLE_LOOPBACK_LB */

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1970,6 +1970,76 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	return ret;
 }
 
+static __always_inline bool
+ipv4_to_endpoint_is_hairpin_flow(struct __ctx_buff *ctx, struct iphdr *ip4)
+{
+	__be16 client_port, backend_port, service_port;
+	struct ipv4_ct_tuple tuple = {};
+	struct lb4_backend *backend;
+	__be32 pod_ip, service_ip;
+	struct ct_entry *entry;
+	struct ct_map *map;
+	int err, l4_off;
+
+	/* Extract the tuple from the packet so we can freely access addrs and ports.
+	 * All values are in network byte order.
+	 */
+	err = lb4_extract_tuple(ctx, ip4, ETH_HLEN, &l4_off, &tuple);
+	if (IS_ERR(err))
+		return false;
+
+	/* If the packet originates from a regular, non-loopback address, it will look
+	 * like service_ip:client_port -> pod_ip:service_port.
+	 *
+	 * In order to determine whether the packet has been hairpinned, we need to
+	 * obtain the backend (listen) port first, requiring a CT lookup with the
+	 * TUPLE_F_SERVICE flag, followed by a backend lookup. After this, the regular
+	 * CT TUPLE_F_OUT lookup can proceed.
+	 */
+	service_ip = tuple.saddr;
+	pod_ip = tuple.daddr;
+	client_port = tuple.sport;
+	service_port = tuple.dport;
+
+	tuple.daddr = service_ip;
+	tuple.saddr = pod_ip;
+	tuple.dport = client_port;
+	tuple.sport = service_port;
+
+	tuple.flags = TUPLE_F_SERVICE;
+
+	map = get_ct_map4(&tuple);
+	entry = map_lookup_elem(map, &tuple);
+	if (!entry)
+		return false;
+
+	backend = lb4_lookup_backend(ctx, entry->backend_id);
+	if (!backend)
+		return false;
+
+	backend_port = backend->port;
+
+	/* Now the backend (listen) port inside the container is known, an egress CT
+	 * lookup can be performed.
+	 */
+	tuple.daddr = IPV4_LOOPBACK;
+	tuple.saddr = pod_ip;
+	tuple.dport = backend_port;
+	tuple.sport = client_port;
+
+	tuple.flags = TUPLE_F_OUT;
+
+	map = get_ct_map4(&tuple);
+	entry = map_lookup_elem(map, &tuple);
+	if (entry)
+		/* The packet is considered hairpinned if its egress CT entry has the
+		 * loopback flag set.
+		 */
+		return entry->lb_loopback == 1;
+
+	return false;
+}
+
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV4_TO_ENDPOINT)
 int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 {
@@ -2017,6 +2087,23 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 	update_metrics(ctx_full_len(ctx), METRIC_INGRESS, REASON_FORWARDED);
 #endif
 	ctx_store_meta(ctx, CB_SRC_LABEL, 0);
+
+	/* Check if packet is locally hairpinned (pod reaching itself through a
+	 * service) and skip the policy check if that is the case. Otherwise, pods may
+	 * need to explicitly allow traffic to themselves in some network
+	 * configurations.
+	 */
+	if (ipv4_to_endpoint_is_hairpin_flow(ctx, ip4)) {
+		send_trace_notify4(ctx, TRACE_TO_LXC,
+				   ctx_load_meta(ctx, CB_SRC_LABEL),
+				   SECLABEL, ip4->saddr, LXC_ID,
+				   ctx->ingress_ifindex,
+				   TRACE_REASON_UNKNOWN, 0);
+
+		/* Skip policy check for hairpinned flow */
+		ret = CTX_ACT_OK;
+		goto out;
+	}
 
 	ret = ipv4_policy(ctx, 0, src_identity, &ct_status, NULL,
 			  &proxy_port, true);

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -536,6 +536,15 @@ static __always_inline void ct_flip_tuple_dir4(struct ipv4_ct_tuple *tuple)
 }
 
 static __always_inline void
+ipv4_ct_tuple_swap_addrs(struct ipv4_ct_tuple *tuple)
+{
+	__be32 tmp_addr = tuple->saddr;
+
+	tuple->saddr = tuple->daddr;
+	tuple->daddr = tmp_addr;
+}
+
+static __always_inline void
 __ipv4_ct_tuple_reverse(struct ipv4_ct_tuple *tuple)
 {
 	__be32 tmp_addr = tuple->saddr;
@@ -982,37 +991,6 @@ static __always_inline int ct_create4(const void *map_main,
 		return DROP_CT_CREATE_FAILED;
 	}
 
-	if (ct_state->addr && ct_state->loopback) {
-		__u8 flags = tuple->flags;
-		__be32 saddr, daddr;
-
-		saddr = tuple->saddr;
-		daddr = tuple->daddr;
-
-		/* We are looping back into the origin endpoint through a
-		 * service, set up a conntrack tuple for the reply to ensure we
-		 * do rev NAT before attempting to route the destination
-		 * address which will not point back to the right source.
-		 */
-		tuple->flags = TUPLE_F_IN;
-		if (dir == CT_INGRESS) {
-			tuple->saddr = ct_state->addr;
-			tuple->daddr = ct_state->svc_addr;
-		} else {
-			tuple->saddr = ct_state->svc_addr;
-			tuple->daddr = ct_state->addr;
-		}
-
-		if (map_update_elem(map_main, tuple, &entry, 0) < 0) {
-			send_signal_ct_fill_up(ctx, SIGNAL_PROTO_V4);
-			return DROP_CT_CREATE_FAILED;
-		}
-
-		tuple->saddr = saddr;
-		tuple->daddr = daddr;
-		tuple->flags = flags;
-	}
-
 	if (map_related != NULL) {
 		/* Create an ICMP entry to relate errors */
 		struct ipv4_ct_tuple icmp_tuple = {
@@ -1036,6 +1014,27 @@ static __always_inline int ct_create4(const void *map_main,
 	}
 	return 0;
 }
+
+#ifndef DISABLE_LOOPBACK_LB
+static __always_inline bool
+ct_has_loopback_egress_entry4(const void *map, struct ipv4_ct_tuple *tuple,
+			      __u16 *rev_nat_index)
+{
+	__u8 flags = tuple->flags;
+	struct ct_entry *entry;
+
+	tuple->flags = TUPLE_F_OUT;
+	entry = map_lookup_elem(map, tuple);
+	tuple->flags = flags;
+
+	if (entry && entry->lb_loopback) {
+		*rev_nat_index = entry->rev_nat_index;
+		return true;
+	}
+
+	return false;
+}
+#endif
 
 /* The function tries to determine whether the flow identified by the given
  * CT_INGRESS tuple belongs to a NodePort traffic (i.e., outside client => N/S

--- a/bpf/tests/hairpin_sctp_flow.c
+++ b/bpf/tests/hairpin_sctp_flow.c
@@ -41,6 +41,7 @@ struct {
 } entry_call_map __section(".maps") = {
 	.values = {
 		[0] = &cil_from_container,
+		[1] = &cil_to_container,
 	},
 };
 
@@ -203,8 +204,109 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	test_finish();
 }
 
+/* Let backend's ingress path create its CT own entry: */
+PKTGEN("tc", "hairpin_sctp_flow_2_forward_ingress_v4")
+int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
+{
+	struct pktgen builder;
+	volatile const __u8 *src = mac_one;
+	volatile const __u8 *dst = mac_two;
+	struct ethhdr *l2;
+	struct iphdr *l3;
+	struct sctphdr *l4;
+
+	/* Init packet builder */
+	pktgen__init(&builder, ctx);
+
+	/* Push ethernet header */
+	l2 = pktgen__push_ethhdr(&builder);
+	if (!l2)
+		return TEST_ERROR;
+
+	ethhdr__set_macs(l2, (__u8 *)src, (__u8 *)dst);
+
+	/* Push IPv4 header */
+	l3 = pktgen__push_default_iphdr(&builder);
+	if (!l3)
+		return TEST_ERROR;
+
+	l3->saddr = IPV4_LOOPBACK;
+	l3->daddr = v4_pod_one;
+
+	/* Push SCTP header */
+	l4 = pktgen__push_sctphdr(&builder);
+
+	if (!l4)
+		return TEST_ERROR;
+	if ((void *)l4 + sizeof(struct sctphdr) > ctx_data_end(ctx))
+		return TEST_ERROR;
+
+	l4->source = tcp_src_one;
+	l4->dest = tcp_svc_one;
+
+	/* Calc lengths, set protocol fields and calc checksums */
+	pktgen__finish(&builder);
+
+	return 0;
+}
+
+SETUP("tc", "hairpin_sctp_flow_2_forward_ingress_v4")
+int hairpin_flow_forward_ingress_setup(struct __ctx_buff *ctx)
+{
+	/* Jump into the entrypoint */
+	tail_call_static(ctx, &entry_call_map, 1);
+	/* Fail if we didn't jump */
+	return TEST_ERROR;
+}
+
+CHECK("tc", "hairpin_sctp_flow_2_forward_ingress_v4")
+int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *ctx)
+{
+	void *data;
+	void *data_end;
+	__u32 *status_code;
+	struct iphdr *l3;
+	struct sctphdr *l4;
+
+	test_init();
+
+	data = (void *)(long)ctx->data;
+	data_end = (void *)(long)ctx->data_end;
+
+	if (data + sizeof(__u32) > data_end)
+		test_fatal("status code out of bounds");
+
+	status_code = data;
+
+	assert(*status_code == TC_ACT_OK);
+
+	l3 = data + sizeof(__u32) + sizeof(struct ethhdr);
+
+	if ((void *)l3 + sizeof(struct iphdr) > data_end)
+		test_fatal("l3 out of bounds");
+
+	if (l3->saddr != IPV4_LOOPBACK)
+		test_fatal("src IP changed");
+
+	if (l3->daddr != v4_pod_one)
+		test_fatal("dest IP changed");
+
+	l4 = (void *)l3 + sizeof(struct iphdr);
+
+	if ((void *)l4 + sizeof(struct sctphdr) > data_end)
+		test_fatal("l4 out of bounds");
+
+	if (l4->source != tcp_src_one)
+		test_fatal("src SCTP port changed");
+
+	if (l4->dest != tcp_svc_one)
+		test_fatal("dst SCTP port changed");
+
+	test_finish();
+}
+
 /* Test that a packet in the reverse direction gets translated back. */
-SETUP("tc", "hairpin_sctp_flow_2_reverse_v4")
+SETUP("tc", "hairpin_sctp_flow_3_reverse_v4")
 int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 {
 	struct pktgen builder;
@@ -252,7 +354,7 @@ int hairpin_flow_rev_setup(struct __ctx_buff *ctx)
 	return TEST_ERROR;
 }
 
-CHECK("tc", "hairpin_sctp_flow_2_reverse_v4")
+CHECK("tc", "hairpin_sctp_flow_3_reverse_v4")
 int hairpin_flow_rev_check(__maybe_unused const struct __ctx_buff *ctx)
 {
 	void *data;

--- a/bpf/tests/pktgen.h
+++ b/bpf/tests/pktgen.h
@@ -76,9 +76,13 @@ static volatile const __u8 v6_node_three[] = {0xfd, 0x07, 0, 0, 0, 0, 0, 0,
 					   0, 0, 0, 0, 0, 0, 0, 3};
 
 /* Source port to be used by a client */
-#define tcp_src_one	__bpf_htons(22334)
-#define tcp_src_two	__bpf_htons(33445)
-#define tcp_src_three	__bpf_htons(44556)
+#define tcp_src_one	__bpf_htons(22330)
+#define tcp_src_two	__bpf_htons(33440)
+#define tcp_src_three	__bpf_htons(44550)
+
+#define tcp_dst_one	__bpf_htons(22331)
+#define tcp_dst_two	__bpf_htons(33441)
+#define tcp_dst_three	__bpf_htons(44551)
 
 #define tcp_svc_one	__bpf_htons(80)
 #define tcp_svc_two	__bpf_htons(443)

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -150,7 +150,7 @@ int hairpin_flow_forward_setup(struct __ctx_buff *ctx)
 	 * packet to.
 	 */
 	backend.address = v4_pod_one;
-	backend.port = tcp_svc_one;
+	backend.port = tcp_dst_one;
 	backend.proto = IPPROTO_TCP;
 	backend.flags = 0;
 	map_update_elem(&LB4_BACKEND_MAP, &lb_svc_value.backend_id, &backend, BPF_ANY);
@@ -213,7 +213,7 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	if (l4->source != tcp_src_one)
 		test_fatal("src TCP port was changed");
 
-	if (l4->dest != tcp_svc_one)
+	if (l4->dest != tcp_dst_one)
 		test_fatal("dst TCP port incorrect");
 
 	struct ipv4_ct_tuple tuple = {};
@@ -240,7 +240,7 @@ int hairpin_flow_forward_check(__maybe_unused const struct __ctx_buff *ctx)
 	tuple.saddr = IPV4_LOOPBACK;
 	tuple.sport = tcp_src_one;
 	tuple.daddr = v4_pod_one;
-	tuple.dport = tcp_svc_one;
+	tuple.dport = tcp_dst_one;
 
 	/* Addrs are stored in reverse order: */
 	ipv4_ct_tuple_swap_addrs(&tuple);
@@ -289,7 +289,7 @@ int hairpin_flow_forward_ingress_pktgen(struct __ctx_buff *ctx)
 		return TEST_ERROR;
 
 	l4->source = tcp_src_one;
-	l4->dest = tcp_svc_one;
+	l4->dest = tcp_dst_one;
 
 	data = pktgen__push_data(&builder, default_data, sizeof(default_data));
 
@@ -352,7 +352,7 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 	if (l4->source != tcp_src_one)
 		test_fatal("src TCP port changed");
 
-	if (l4->dest != tcp_svc_one)
+	if (l4->dest != tcp_dst_one)
 		test_fatal("dst TCP port changed");
 
 	struct ipv4_ct_tuple tuple = {};
@@ -364,7 +364,7 @@ int hairpin_flow_forward_ingress_check(__maybe_unused const struct __ctx_buff *c
 	tuple.saddr = IPV4_LOOPBACK;
 	tuple.sport = tcp_src_one;
 	tuple.daddr = v4_pod_one;
-	tuple.dport = tcp_svc_one;
+	tuple.dport = tcp_dst_one;
 
 	/* Addrs are stored in reverse order: */
 	ipv4_ct_tuple_swap_addrs(&tuple);
@@ -411,11 +411,10 @@ int hairpin_flow_reverse_pktgen(struct __ctx_buff *ctx)
 
 	/* Push TCP header */
 	l4 = pktgen__push_default_tcphdr(&builder);
-
 	if (!l4)
 		return TEST_ERROR;
 
-	l4->source = tcp_svc_one;
+	l4->source = tcp_dst_one;
 	l4->dest = tcp_src_one;
 	l4->ack = 1;
 


### PR DESCRIPTION
- [ ] https://github.com/cilium/cilium/pull/27798 (@ti-mo)
- [x] https://github.com/cilium/cilium/pull/27602 (@julianwiedmann)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27602 27798; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=27602,27798
```
