### PR TITLE
renovate: fix match string for go version updates in go.mod

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -494,10 +494,10 @@
     },
     {
       "fileMatch": [
-        "^go.mod$",
+        "^go\\.mod$",
       ],
       "matchStrings": [
-        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+.+go (?<currentValue>.*)"
+        "// renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\s+go (?<currentValue>.*)"
       ]
     }
   ]


### PR DESCRIPTION
There are no trailing characters before the `go` directive. Also exactly match the file name.

Fixes: 2f7e2f336597 ("go.mod, renovate: specify and update Go toolchain version")
