### PR TITLE
k8s: remove extensions/v1beta1 support

### DIFF
--- a/cilium/cmd/preflight_k8s_valid_cnp.go
+++ b/cilium/cmd/preflight_k8s_valid_cnp.go
@@ -18,7 +18,6 @@ import (
 	v2_validation "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2/validator"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/scheme"
-	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -101,20 +100,11 @@ func validateNPResources(
 	shortName string,
 ) error {
 	// Check if the crd is installed at all.
-	var err error
-	if k8sversion.Capabilities().APIExtensionsV1CRD {
-		_, err = clientset.ApiextensionsV1().CustomResourceDefinitions().Get(
-			ctx,
-			name+"."+ciliumGroup,
-			metav1.GetOptions{},
-		)
-	} else {
-		_, err = clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(
-			ctx,
-			name+"."+ciliumGroup,
-			metav1.GetOptions{},
-		)
-	}
+	_, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Get(
+		ctx,
+		name+"."+ciliumGroup,
+		metav1.GetOptions{},
+	)
 	switch {
 	case err == nil:
 	case k8sErrors.IsNotFound(err):

--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/informer"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -340,21 +339,10 @@ const (
 // client (v1 or v1beta1) in order to retrieve the CRDs in a
 // backwards-compatible way. This implements the cache.Getter interface.
 func (c *crdGetter) Get() *rest.Request {
-	var req *rest.Request
-
-	if k8sversion.Capabilities().APIExtensionsV1CRD {
-		req = c.api.ApiextensionsV1().
-			RESTClient().
-			Get().
-			Name("customresourcedefinitions")
-	} else {
-		req = c.api.ApiextensionsV1beta1().
-			RESTClient().
-			Get().
-			Name("customresourcedefinitions")
-	}
-
-	return req
+	return c.api.ApiextensionsV1().
+		RESTClient().
+		Get().
+		Name("customresourcedefinitions")
 }
 
 type crdGetter struct {


### PR DESCRIPTION
This API is no longer supported since k8s 1.16 [1] which is the minimum required k8s version for Cilium since version 1.10 [2], ref. commit 83b8f8b9d514 ("docs: bump minimal supported k8s version to 1.16").

[1] https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/
[2] https://docs.cilium.io/en/latest/network/kubernetes/compatibility/#k8scompatibility