### PR TITLE
labelsfilter: ignore StatefulSet-related labels by default for CID creation

### DIFF
--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -21,19 +21,21 @@ application.
 By default, Cilium considers all labels to be relevant for identities, with the
 following exceptions:
 
-================================== ==============================================
-Label                               Description
----------------------------------- ----------------------------------------------
-``any:!io.kubernetes``             Ignore all ``io.kubernetes`` labels
-``any:!kubernetes\.io``            Ignore all other ``kubernetes\.io`` labels
-``any:!beta.kubernetes\.io``       Ignore all ``beta\.kubernetes\.io`` labels
-``any:!k8s\.io``                   Ignore all ``k8s\.io`` labels
-``any:!pod-template-generation``   Ignore all ``pod-template-generation`` labels
-``any:!pod-template-hash``         Ignore all ``pod-template-hash`` labels
-``any:!controller-revision-hash``  Ignore all ``controller-revision-hash`` labels
-``any:!annotation.*``              Ignore all ``annotation`` labels
-``any:!etcd_node``                 Ignore all ``etcd_node`` labels
-================================== ==============================================
+============================================= =====================================================
+Label                                         Description
+--------------------------------------------- -----------------------------------------------------
+``any:!io.kubernetes``                        Ignore all ``io.kubernetes`` labels
+``any:!kubernetes\.io``                       Ignore all other ``kubernetes.io`` labels
+``any:!statefulset\.kubernetes\.io/pod-name`` Ignore ``statefulset.kubernetes.io/pod-name`` label
+``any:!apps\.kubernetes\.io/pod-index``       Ignore ``apps.kubernetes.io/pod-index`` label
+``any:!beta\.kubernetes\.io``                 Ignore all ``beta.kubernetes.io`` labels
+``any:!k8s\.io``                              Ignore all ``k8s.io`` labels
+``any:!pod-template-generation``              Ignore all ``pod-template-generation`` labels
+``any:!pod-template-hash``                    Ignore all ``pod-template-hash`` labels
+``any:!controller-revision-hash``             Ignore all ``controller-revision-hash`` labels
+``any:!annotation.*``                         Ignore all ``annotation`` labels
+``any:!etcd_node``                            Ignore all ``etcd_node`` labels
+============================================= =====================================================
 
 The above label patterns are all *exclusive label patterns*, that is to say
 they define which label keys should be ignored. These are identified by the

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -61,6 +61,16 @@ const (
 	// documentation add the label for every resource object.
 	AppKubernetes = "app.kubernetes.io"
 
+	// StatefulSetPodNameLabel is the label name which, in-tree, is used to
+	// automatically label Pods that are owned by StatefulSets with their name,
+	// so that one can attach a Service to a specific Pod in the StatefulSet.
+	StatefulSetPodNameLabel = "statefulset.kubernetes.io/pod-name"
+
+	// StatefulSetPodIndexLabel is the label name which, in-tree, is used to
+	// automatically label Pods that are owned by StatefulSets with their
+	// ordinal index.
+	StatefulSetPodIndexLabel = "apps.kubernetes.io/pod-index"
+
 	// CtrlPrefixPolicyStatus is the prefix used for the controllers set up
 	// to sync the CNP with kube-apiserver.
 	CtrlPrefixPolicyStatus = "sync-cnp-policy-status"

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -189,19 +189,21 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 	}
 
 	expressions := []string{
-		reservedLabelsPattern,                             // include all reserved labels
-		regexp.QuoteMeta(k8sConst.PodNamespaceLabel),      // include io.kubernetes.pod.namespace
-		regexp.QuoteMeta(k8sConst.PodNamespaceMetaLabels), // include all namespace labels
-		regexp.QuoteMeta(k8sConst.AppKubernetes),          // include app.kubernetes.io
-		`!io\.kubernetes`,                                 // ignore all other io.kubernetes labels
-		`!kubernetes\.io`,                                 // ignore all other kubernetes.io labels
-		`!.*beta\.kubernetes\.io`,                         // ignore all beta.kubernetes.io labels
-		`!k8s\.io`,                                        // ignore all k8s.io labels
-		`!pod-template-generation`,                        // ignore pod-template-generation
-		`!pod-template-hash`,                              // ignore pod-template-hash
-		`!controller-revision-hash`,                       // ignore controller-revision-hash
-		`!annotation.*`,                                   // ignore all annotation labels
-		`!etcd_node`,                                      // ignore etcd_node label
+		reservedLabelsPattern,                                     // include all reserved labels
+		regexp.QuoteMeta(k8sConst.PodNamespaceLabel),              // include io.kubernetes.pod.namespace
+		regexp.QuoteMeta(k8sConst.PodNamespaceMetaLabels),         // include all namespace labels
+		regexp.QuoteMeta(k8sConst.AppKubernetes),                  // include app.kubernetes.io
+		`!io\.kubernetes`,                                         // ignore all other io.kubernetes labels
+		`!kubernetes\.io`,                                         // ignore all other kubernetes.io labels
+		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodNameLabel),  // ignore statefulset.kubernetes.io/pod-name label
+		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodIndexLabel), // ignore apps.kubernetes.io/pod-index label
+		`!.*beta\.kubernetes\.io`,                                 // ignore all beta.kubernetes.io labels
+		`!k8s\.io`,                                                // ignore all k8s.io labels
+		`!pod-template-generation`,                                // ignore pod-template-generation
+		`!pod-template-hash`,                                      // ignore pod-template-hash
+		`!controller-revision-hash`,                               // ignore controller-revision-hash
+		`!annotation.*`,                                           // ignore all annotation labels
+		`!etcd_node`,                                              // ignore etcd_node label
 	}
 
 	for _, e := range expressions {

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -95,7 +95,7 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 		"io.kubernetes.container.name":                              "POD",
 		"io.kubernetes.container.restartCount":                      "0",
 		"io.kubernetes.container.terminationMessagePath":            "",
-		"io.kubernetes.pod.name":                                    "my-nginx-3800858182-07i3n",
+		"io.kubernetes.pod.name":                                    "my-nginx-0",
 		"io.kubernetes.pod.namespace":                               "default",
 		"app.kubernetes.io":                                         "my-nginx",
 		"kubernetes.io.foo":                                         "foo",
@@ -110,6 +110,8 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 		"ignorE":                                                    "foo",
 		"annotation.kubernetes.io/config.seen":                      "2017-05-30T14:22:17.691491034Z",
 		"controller-revision-hash":                                  "123456",
+		"statefulset.kubernetes.io/pod-name":                        "my-nginx-0",
+		"apps.kubernetes.io/pod-index":                              "0",
 	}
 	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)
 	allLabels["host"] = labels.NewLabel("host", "", labels.LabelSourceReserved)


### PR DESCRIPTION
Beforehand, every single Pod owned by a StatefulSet object had its own `CiliumIdentity` because each such Pod had their own unique set of label values (more about these labels can be found [here](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-name-label) and [here](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-index-label)).

In large clusters with many StatefulSet-owned Pods it is problematic, especially when the churn of such objects is high, resulting in a high churn of such CIDs that doesn't scale well. In addition, it essentially limited the number of such Pods to the theoretical number of CIDs in a cluster which is 2^16 ~ 65k.

```release-note
Ignore StatefulSet-specific labels by default for CID creation. This includes the two following labels:
* statefulset.kubernetes.io/pod-name
* apps.kubernetes.io/pod-index
```
