### PR TITLE
Operator modular metrics

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -41,6 +41,7 @@ cilium-operator-alibabacloud hive [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -41,6 +41,7 @@ cilium-operator-aws hive [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator-aws hive dot-graph [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -41,6 +41,7 @@ cilium-operator-azure hive [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator-azure hive dot-graph [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -41,6 +41,7 @@ cilium-operator-generic hive [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator-generic hive dot-graph [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -41,6 +41,7 @@ cilium-operator hive [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -46,6 +46,7 @@ cilium-operator hive dot-graph [flags]
       --operator-pprof                                       Enable serving pprof debugging API
       --operator-pprof-address string                        Address that pprof listens on (default "localhost")
       --operator-pprof-port uint16                           Port that pprof listens on (default 6061)
+      --operator-prometheus-serve-addr string                Address to serve Prometheus metrics (default ":9963")
       --skip-crd-creation                                    When true, Kubernetes Custom Resource Definitions will not be created
 ```
 

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -240,9 +240,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Duration(operatorOption.NodesGCInterval, 5*time.Minute, "GC interval for CiliumNodes")
 	option.BindEnv(vp, operatorOption.NodesGCInterval)
 
-	flags.String(operatorOption.OperatorPrometheusServeAddr, operatorOption.PrometheusServeAddr, "Address to serve Prometheus metrics")
-	option.BindEnv(vp, operatorOption.OperatorPrometheusServeAddr)
-
 	flags.Bool(operatorOption.SyncK8sServices, true, "Synchronize Kubernetes services to kvstore")
 	option.BindEnv(vp, operatorOption.SyncK8sServices)
 

--- a/operator/cmd/k8s_cep_gc.go
+++ b/operator/cmd/k8s_cep_gc.go
@@ -192,13 +192,9 @@ func doCiliumEndpointSyncGC(ctx context.Context, clientset k8sClient.Clientset, 
 }
 
 func successfulEndpointObjectGC() {
-	if operatorOption.Config.EnableMetrics {
-		metrics.EndpointGCObjects.WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
-	}
+	metrics.EndpointGCObjects.WithLabelValues(metrics.LabelValueOutcomeSuccess).Inc()
 }
 
 func failedEndpointObjectGC() {
-	if operatorOption.Config.EnableMetrics {
-		metrics.EndpointGCObjects.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
-	}
+	metrics.EndpointGCObjects.WithLabelValues(metrics.LabelValueOutcomeFail).Inc()
 }

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -137,7 +137,6 @@ var (
 		) identitygc.SharedConfig {
 			return identitygc.SharedConfig{
 				IdentityAllocationMode: daemonCfg.IdentityAllocationMode,
-				EnableMetrics:          operatorCfg.EnableMetrics,
 				K8sNamespace:           daemonCfg.CiliumNamespaceName(),
 			}
 		}),

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -218,6 +218,9 @@ func NewOperatorCmd(h *hive.Hive) *cobra.Command {
 	// case Discovery API fails.
 	h.Viper().Set(option.K8sEnableAPIDiscovery, true)
 
+	// Overwrite the metrics namespace with the one specific for the Operator
+	metrics.Namespace = metrics.CiliumOperatorNamespace
+
 	cmd.AddCommand(
 		MetricsCmd,
 		h.Command(),

--- a/operator/identitygc/cell.go
+++ b/operator/identitygc/cell.go
@@ -79,9 +79,6 @@ type SharedConfig struct {
 	// IdentityAllocationMode specifies what mode to use for identity allocation
 	IdentityAllocationMode string
 
-	// EnableMetrics enables prometheus metrics
-	EnableMetrics bool
-
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
 	K8sNamespace string

--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -154,18 +154,16 @@ func (igc *GC) gc(ctx context.Context) error {
 		}
 	}
 
-	if igc.enableMetrics {
-		if ctx.Err() == nil {
-			igc.successfulRuns++
-			metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
-		} else {
-			igc.failedRuns++
-			metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeFail).Set(float64(igc.failedRuns))
-		}
-		aliveEntries := totalEntries - deletedEntries
-		metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeAlive).Set(float64(aliveEntries))
-		metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeDeleted).Set(float64(deletedEntries))
+	if ctx.Err() == nil {
+		igc.successfulRuns++
+		metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
+	} else {
+		igc.failedRuns++
+		metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeFail).Set(float64(igc.failedRuns))
 	}
+	aliveEntries := totalEntries - deletedEntries
+	metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeAlive).Set(float64(aliveEntries))
+	metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeDeleted).Set(float64(deletedEntries))
 
 	igc.heartbeatStore.gc()
 

--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -81,7 +81,6 @@ type GC struct {
 	allocationCfg identityAllocationConfig
 	allocator     *allocator.Allocator
 
-	enableMetrics bool
 	// counters for GC failed/successful runs
 	failedRuns     int
 	successfulRuns int

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -58,7 +58,6 @@ func TestIdentitiesGC(t *testing.T) {
 		cell.Provide(func() SharedConfig {
 			return SharedConfig{
 				IdentityAllocationMode: option.IdentityAllocationModeCRD,
-				EnableMetrics:          false,
 				K8sNamespace:           "",
 			}
 		}),

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -55,10 +55,8 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 		if err != nil {
 			igc.logger.WithError(err).Warning("Unable to run security identity garbage collector")
 
-			if igc.enableMetrics {
-				igc.failedRuns++
-				metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeFail).Set(float64(igc.failedRuns))
-			}
+			igc.failedRuns++
+			metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeFail).Set(float64(igc.failedRuns))
 		} else {
 			// Best effort to run auth identity GC
 			err = igc.runAuthGC(ctx, keysToDeletePrev)
@@ -70,13 +68,11 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 
 			keysToDeletePrev = keysToDelete
 
-			if igc.enableMetrics {
-				igc.successfulRuns++
-				metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
+			igc.successfulRuns++
+			metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
 
-				metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeAlive).Set(float64(gcStats.Alive))
-				metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeDeleted).Set(float64(gcStats.Deleted))
-			}
+			metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeAlive).Set(float64(gcStats.Alive))
+			metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeDeleted).Set(float64(gcStats.Deleted))
 		}
 
 		if igc.gcInterval <= gcDuration {

--- a/operator/metrics/cell.go
+++ b/operator/metrics/cell.go
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+const (
+	// OperatorPrometheusServeAddr IP:Port on which to serve prometheus metrics
+	// (pass ":<port>" to bind on all interfaces).
+	OperatorPrometheusServeAddr = "operator-prometheus-serve-addr"
+)
+
+// Cell provides the modular metrics registry, metric HTTP server and
+// legacy metrics cell for the operator.
+var Cell = cell.Module(
+	"operator-metrics",
+	"Operator Metrics",
+
+	cell.Config(defaultConfig),
+	cell.Invoke(registerMetricsManager),
+
+	// Operator legacy metrics accessed via global variables
+	cell.Metric(newLegacyMetrics),
+)
+
+// Config contains the configuration for the operator-metrics cell.
+type Config struct {
+	OperatorPrometheusServeAddr string
+}
+
+var defaultConfig = Config{
+	// default server address for operator metrics
+	OperatorPrometheusServeAddr: ":9963",
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.String(OperatorPrometheusServeAddr, def.OperatorPrometheusServeAddr, "Address to serve Prometheus metrics")
+}
+
+// SharedConfig contains the configuration that is shared between
+// this module and others.
+// Metrics cell needs to know if GatewayAPI is enabled in order to use
+// the same Registry as controller-runtime and avoid to expose
+// multiple metrics endpoints or servers.
+type SharedConfig struct {
+	// EnableMetrics is set to true if operator metrics are enabled
+	EnableMetrics bool
+
+	// EnableGatewayAPI enables support of Gateway API
+	EnableGatewayAPI bool
+}

--- a/operator/metrics/legacy.go
+++ b/operator/metrics/legacy.go
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/cilium/cilium/api/v1/operator/models"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+// Registry is the global prometheus registry for cilium-operator metrics.
+var Registry RegisterGatherer
+
+type RegisterGatherer interface {
+	prometheus.Registerer
+	prometheus.Gatherer
+}
+
+const (
+	// LabelStatus marks the status of a resource or completed task
+	LabelStatus = "status"
+
+	// LabelOutcome indicates whether the outcome of the operation was successful or not
+	LabelOutcome = "outcome"
+
+	// LabelOpcode indicates the kind of CES metric, could be CEP insert or remove
+	LabelOpcode = "opcode"
+
+	// Label values
+
+	// LabelValueOutcomeSuccess is used as a successful outcome of an operation
+	LabelValueOutcomeSuccess = "success"
+
+	// LabelValueOutcomeFail is used as an unsuccessful outcome of an operation
+	LabelValueOutcomeFail = "fail"
+
+	// LabelValueOutcomeAlive is used as outcome of alive identity entries
+	LabelValueOutcomeAlive = "alive"
+
+	// LabelValueOutcomeDeleted is used as outcome of deleted identity entries
+	LabelValueOutcomeDeleted = "deleted"
+
+	// LabelValueCEPInsert is used to indicate the number of CEPs inserted in a CES
+	LabelValueCEPInsert = "cepinserted"
+
+	// LabelValueCEPRemove is used to indicate the number of CEPs removed from a CES
+	LabelValueCEPRemove = "cepremoved"
+)
+
+var (
+	// IdentityGCSize records the identity GC results
+	IdentityGCSize = metrics.NoOpGaugeVec
+
+	// IdentityGCRuns records how many times identity GC has run
+	IdentityGCRuns = metrics.NoOpGaugeVec
+
+	// EndpointGCObjects records the number of times endpoint objects have been
+	// garbage-collected.
+	EndpointGCObjects = metrics.NoOpCounterVec
+
+	// CiliumEndpointSliceDensity indicates the number of CEPs batched in a CES and it used to
+	// collect the number of CEPs in CES at various buckets.
+	CiliumEndpointSliceDensity = metrics.NoOpHistogram
+
+	// CiliumEndpointsChangeCount indicates the total number of CEPs changed for every CES request sent to k8s-apiserver.
+	// This metric is used to collect number of CEP changes happening at various buckets.
+	CiliumEndpointsChangeCount = metrics.NoOpObserverVec
+
+	// CiliumEndpointSliceSyncTotal indicates the total number of completed CES syncs with k8s-apiserver by success/fail outcome.
+	CiliumEndpointSliceSyncTotal = metrics.NoOpCounterVec
+
+	// CiliumEndpointSliceSyncErrors used to track the total number of errors occurred during syncing CES with k8s-apiserver.
+	// This metric is going to be deprecated in Cilium 1.14 and removed in 1.15.
+	// It is replaced by CiliumEndpointSliceSyncTotal metric.
+	CiliumEndpointSliceSyncErrors = metrics.NoOpCounter
+
+	// CiliumEndpointSliceQueueDelay measures the time spent by CES's in the workqueue. This measures time difference between
+	// CES insert in the workqueue and removal from workqueue.
+	CiliumEndpointSliceQueueDelay = metrics.NoOpHistogram
+)
+
+type legacyMetrics struct {
+	IdentityGCSize                metric.Vec[metric.Gauge]
+	IdentityGCRuns                metric.Vec[metric.Gauge]
+	EndpointGCObjects             metric.Vec[metric.Counter]
+	CiliumEndpointSliceDensity    metric.Histogram
+	CiliumEndpointsChangeCount    metric.Vec[metric.Observer]
+	CiliumEndpointSliceSyncTotal  metric.Vec[metric.Counter]
+	CiliumEndpointSliceSyncErrors metric.Counter
+	CiliumEndpointSliceQueueDelay metric.Histogram
+}
+
+func newLegacyMetrics() *legacyMetrics {
+	lm := &legacyMetrics{
+		IdentityGCSize: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "identity_gc_entries",
+			Help:      "The number of alive and deleted identities at the end of a garbage collector run",
+		}, []string{LabelStatus}),
+
+		IdentityGCRuns: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "identity_gc_runs",
+			Help:      "The number of times identity garbage collector has run",
+		}, []string{LabelOutcome}),
+
+		EndpointGCObjects: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "endpoint_gc_objects",
+			Help:      "The number of times endpoint objects have been garbage-collected",
+		}, []string{LabelOutcome}),
+
+		CiliumEndpointSliceDensity: metric.NewHistogram(metric.HistogramOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "number_of_ceps_per_ces",
+			Help:      "The number of CEPs batched in a CES",
+			Buckets:   []float64{1, 10, 25, 50, 100, 200, 500, 1000},
+		}),
+
+		CiliumEndpointsChangeCount: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "number_of_cep_changes_per_ces",
+			Help:      "The number of changed CEPs in each CES update",
+		}, []string{LabelOpcode}),
+
+		CiliumEndpointSliceSyncErrors: metric.NewCounter(metric.CounterOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "ces_sync_errors_total",
+			Help:      "Number of CES sync errors",
+		}),
+
+		CiliumEndpointSliceSyncTotal: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "ces_sync_total",
+			Help:      "The number of completed CES syncs by outcome",
+		}, []string{LabelOutcome}),
+
+		CiliumEndpointSliceQueueDelay: metric.NewHistogram(metric.HistogramOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "ces_queueing_delay_seconds",
+			Help:      "CiliumEndpointSlice queueing delay in seconds",
+			Buckets:   append(prometheus.DefBuckets, 60, 300, 900, 1800, 3600),
+		}),
+	}
+
+	IdentityGCSize = lm.IdentityGCSize
+	IdentityGCRuns = lm.IdentityGCRuns
+	EndpointGCObjects = lm.EndpointGCObjects
+	CiliumEndpointSliceDensity = lm.CiliumEndpointSliceDensity
+	CiliumEndpointsChangeCount = lm.CiliumEndpointsChangeCount
+	CiliumEndpointSliceSyncTotal = lm.CiliumEndpointSliceSyncTotal
+	CiliumEndpointSliceSyncErrors = lm.CiliumEndpointSliceSyncErrors
+	CiliumEndpointSliceQueueDelay = lm.CiliumEndpointSliceQueueDelay
+
+	return lm
+}
+
+// DumpMetrics gets the current Cilium operator metrics and dumps all into a
+// Metrics structure. If metrics cannot be retrieved, returns an error.
+func DumpMetrics() ([]*models.Metric, error) {
+	result := []*models.Metric{}
+	if Registry == nil {
+		return result, nil
+	}
+
+	currentMetrics, err := Registry.Gather()
+	if err != nil {
+		return result, err
+	}
+
+	for _, val := range currentMetrics {
+
+		metricName := val.GetName()
+		metricType := val.GetType()
+
+		for _, metricLabel := range val.Metric {
+			labelPairs := metricLabel.GetLabel()
+			labels := make(map[string]string, len(labelPairs))
+			for _, label := range labelPairs {
+				labels[label.GetName()] = label.GetValue()
+			}
+
+			var value float64
+			switch metricType {
+			case dto.MetricType_COUNTER:
+				value = metricLabel.Counter.GetValue()
+			case dto.MetricType_GAUGE:
+				value = metricLabel.GetGauge().GetValue()
+			case dto.MetricType_UNTYPED:
+				value = metricLabel.GetUntyped().GetValue()
+			case dto.MetricType_SUMMARY:
+				value = metricLabel.GetSummary().GetSampleSum()
+			case dto.MetricType_HISTOGRAM:
+				value = metricLabel.GetHistogram().GetSampleSum()
+			default:
+				continue
+			}
+
+			metric := &models.Metric{
+				Name:   metricName,
+				Labels: labels,
+				Value:  value,
+			}
+			result = append(result, metric)
+		}
+	}
+
+	return result, nil
+}

--- a/operator/metrics/metrics.go
+++ b/operator/metrics/metrics.go
@@ -4,43 +4,80 @@
 package metrics
 
 import (
-	"context"
+	"errors"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	dto "github.com/prometheus/client_model/go"
+	"github.com/sirupsen/logrus"
 	controllerRuntimeMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
-	"github.com/cilium/cilium/api/v1/operator/models"
-	operatorOption "github.com/cilium/cilium/operator/option"
-	"github.com/cilium/cilium/pkg/logging"
-	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 
-var (
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "metrics")
-)
+type params struct {
+	cell.In
 
-// Namespace is the namespace key to use for cilium operator metrics.
-const Namespace = "cilium_operator"
+	Logger     logrus.FieldLogger
+	Lifecycle  hive.Lifecycle
+	Shutdowner hive.Shutdowner
 
-type RegisterGatherer interface {
-	prometheus.Registerer
-	prometheus.Gatherer
+	Cfg       Config
+	SharedCfg SharedConfig
+
+	Metrics []metric.WithMetadata `group:"hive-metrics"`
 }
 
-var (
-	// Registry is the global prometheus registry for cilium-operator metrics.
-	Registry   RegisterGatherer
-	shutdownCh chan struct{}
-)
+type metricsManager struct {
+	logger     logrus.FieldLogger
+	shutdowner hive.Shutdowner
 
-// Register registers metrics for cilium-operator.
-func Register() {
-	log.Info("Registering Operator metrics")
+	server http.Server
 
-	if operatorOption.Config.EnableGatewayAPI {
+	metrics []metric.WithMetadata
+}
+
+func (mm *metricsManager) Start(ctx hive.HookContext) error {
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(Registry, promhttp.HandlerOpts{}))
+	mm.server.Handler = mux
+
+	go func() {
+		mm.logger.WithField("address", mm.server.Addr).Info("Starting metrics server")
+		if err := mm.server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			mm.logger.WithError(err).Error("Unable to start metrics server")
+			mm.shutdowner.Shutdown()
+		}
+	}()
+
+	return nil
+}
+
+func (mm *metricsManager) Stop(ctx hive.HookContext) error {
+	if err := mm.server.Shutdown(ctx); err != nil {
+		mm.logger.WithError(err).Error("Shutdown operator metrics server failed")
+		return err
+	}
+	return nil
+}
+
+func registerMetricsManager(p params) {
+	if !p.SharedCfg.EnableMetrics {
+		return
+	}
+
+	mm := &metricsManager{
+		logger:     p.Logger,
+		shutdowner: p.Shutdowner,
+		server:     http.Server{Addr: p.Cfg.OperatorPrometheusServeAddr},
+		metrics:    p.Metrics,
+	}
+
+	if p.SharedCfg.EnableGatewayAPI {
 		// Use the same Registry as controller-runtime, so that we don't need
 		// to expose multiple metrics endpoints or servers.
 		//
@@ -52,228 +89,11 @@ func Register() {
 		Registry = prometheus.NewPedanticRegistry()
 	}
 
-	registerMetrics()
+	Registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{Namespace: metrics.CiliumOperatorNamespace}))
 
-	m := http.NewServeMux()
-	m.Handle("/metrics", promhttp.HandlerFor(Registry, promhttp.HandlerOpts{}))
-	srv := &http.Server{
-		Addr:    operatorOption.Config.OperatorPrometheusServeAddr,
-		Handler: m,
+	for _, metric := range mm.metrics {
+		Registry.MustRegister(metric.(prometheus.Collector))
 	}
 
-	shutdownCh = make(chan struct{})
-	go func() {
-		go func() {
-			err := srv.ListenAndServe()
-			switch err {
-			case http.ErrServerClosed:
-				log.Info("Metrics server shutdown successfully")
-				return
-			default:
-				log.WithError(err).Fatal("Metrics server ListenAndServe failed")
-			}
-		}()
-
-		<-shutdownCh
-		log.Info("Received shutdown signal")
-		if err := srv.Shutdown(context.TODO()); err != nil {
-			log.WithError(err).Error("Shutdown operator metrics server failed")
-		}
-	}()
-}
-
-// Unregister shuts down the metrics server.
-func Unregister() {
-	log.Info("Shutting down metrics server")
-
-	if shutdownCh == nil {
-		return
-	}
-
-	shutdownCh <- struct{}{}
-}
-
-var (
-	// IdentityGCSize records the identity GC results
-	IdentityGCSize *prometheus.GaugeVec
-
-	// IdentityGCRuns records how many times identity GC has run
-	IdentityGCRuns *prometheus.GaugeVec
-
-	// EndpointGCObjects records the number of times endpoint objects have been
-	// garbage-collected.
-	EndpointGCObjects *prometheus.CounterVec
-
-	// CiliumEndpointSliceDensity indicates the number of CEPs batched in a CES and it used to
-	// collect the number of CEPs in CES at various buckets.
-	CiliumEndpointSliceDensity prometheus.Histogram
-
-	// CiliumEndpointsChangeCount indicates the total number of CEPs changed for every CES request sent to k8s-apiserver.
-	// This metric is used to collect number of CEP changes happening at various buckets.
-	CiliumEndpointsChangeCount *prometheus.HistogramVec
-
-	// CiliumEndpointSliceSyncTotal indicates the total number of completed CES syncs with k8s-apiserver by success/fail outcome.
-	CiliumEndpointSliceSyncTotal *prometheus.CounterVec
-
-	// CiliumEndpointSliceSyncErrors used to track the total number of errors occurred during syncing CES with k8s-apiserver.
-	// This metric is going to be deprecated in Cilium 1.14 and removed in 1.15.
-	// It is replaced by CiliumEndpointSliceSyncTotal metric.
-	CiliumEndpointSliceSyncErrors prometheus.Counter
-
-	// CiliumEndpointSliceQueueDelay measures the time spent by CES's in the workqueue. This measures time difference between
-	// CES insert in the workqueue and removal from workqueue.
-	CiliumEndpointSliceQueueDelay prometheus.Histogram
-)
-
-const (
-	// LabelStatus marks the status of a resource or completed task
-	LabelStatus = "status"
-
-	// LabelOutcome indicates whether the outcome of the operation was successful or not
-	LabelOutcome = "outcome"
-
-	// LabelOpcode indicates the kind of CES metric, could be CEP insert or remove
-	LabelOpcode = "opcode"
-
-	// Label values
-
-	// LabelValueOutcomeSuccess is used as a successful outcome of an operation
-	LabelValueOutcomeSuccess = "success"
-
-	// LabelValueOutcomeFail is used as an unsuccessful outcome of an operation
-	LabelValueOutcomeFail = "fail"
-
-	// LabelValueOutcomeAlive is used as outcome of alive identity entries
-	LabelValueOutcomeAlive = "alive"
-
-	// LabelValueOutcomeDeleted is used as outcome of deleted identity entries
-	LabelValueOutcomeDeleted = "deleted"
-
-	// LabelValueCEPInsert is used to indicate the number of CEPs inserted in a CES
-	LabelValueCEPInsert = "cepinserted"
-
-	// LabelValueCEPRemove is used to indicate the number of CEPs removed from a CES
-	LabelValueCEPRemove = "cepremoved"
-)
-
-func registerMetrics() []prometheus.Collector {
-	// Builtin process metrics
-	Registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{Namespace: Namespace}))
-
-	// Custom metrics
-	var collectors []prometheus.Collector
-
-	IdentityGCSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: Namespace,
-		Name:      "identity_gc_entries",
-		Help:      "The number of alive and deleted identities at the end of a garbage collector run",
-	}, []string{LabelStatus})
-	collectors = append(collectors, IdentityGCSize)
-
-	IdentityGCRuns = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: Namespace,
-		Name:      "identity_gc_runs",
-		Help:      "The number of times identity garbage collector has run",
-	}, []string{LabelOutcome})
-	collectors = append(collectors, IdentityGCRuns)
-
-	EndpointGCObjects = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "endpoint_gc_objects",
-		Help:      "The number of times endpoint objects have been garbage-collected",
-	}, []string{LabelOutcome})
-	collectors = append(collectors, EndpointGCObjects)
-
-	CiliumEndpointSliceDensity = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: Namespace,
-		Name:      "number_of_ceps_per_ces",
-		Help:      "The number of CEPs batched in a CES",
-		Buckets:   []float64{1, 10, 25, 50, 100, 200, 500, 1000},
-	})
-	collectors = append(collectors, CiliumEndpointSliceDensity)
-
-	CiliumEndpointsChangeCount = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: Namespace,
-		Name:      "number_of_cep_changes_per_ces",
-		Help:      "The number of changed CEPs in each CES update",
-	}, []string{LabelOpcode})
-	collectors = append(collectors, CiliumEndpointsChangeCount)
-
-	CiliumEndpointSliceSyncErrors = prometheus.NewCounter(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "ces_sync_errors_total",
-		Help:      "Number of CES sync errors",
-	})
-	collectors = append(collectors, CiliumEndpointSliceSyncErrors)
-
-	CiliumEndpointSliceSyncTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Namespace: Namespace,
-		Name:      "ces_sync_total",
-		Help:      "The number of completed CES syncs by outcome",
-	}, []string{"outcome"})
-	collectors = append(collectors, CiliumEndpointSliceSyncTotal)
-
-	CiliumEndpointSliceQueueDelay = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Namespace: Namespace,
-		Name:      "ces_queueing_delay_seconds",
-		Help:      "CiliumEndpointSlice queueing delay in seconds",
-		Buckets:   append(prometheus.DefBuckets, 60, 300, 900, 1800, 3600),
-	})
-	collectors = append(collectors, CiliumEndpointSliceQueueDelay)
-
-	Registry.MustRegister(collectors...)
-
-	return collectors
-}
-
-// DumpMetrics gets the current Cilium operator metrics and dumps all into a
-// Metrics structure. If metrics cannot be retrieved, returns an error.
-func DumpMetrics() ([]*models.Metric, error) {
-	result := []*models.Metric{}
-	if Registry == nil {
-		return result, nil
-	}
-
-	currentMetrics, err := Registry.Gather()
-	if err != nil {
-		return result, err
-	}
-
-	for _, val := range currentMetrics {
-
-		metricName := val.GetName()
-		metricType := val.GetType()
-
-		for _, metricLabel := range val.Metric {
-			labels := map[string]string{}
-			for _, label := range metricLabel.GetLabel() {
-				labels[label.GetName()] = label.GetValue()
-			}
-
-			var value float64
-			switch metricType {
-			case dto.MetricType_COUNTER:
-				value = metricLabel.Counter.GetValue()
-			case dto.MetricType_GAUGE:
-				value = metricLabel.GetGauge().GetValue()
-			case dto.MetricType_UNTYPED:
-				value = metricLabel.GetUntyped().GetValue()
-			case dto.MetricType_SUMMARY:
-				value = metricLabel.GetSummary().GetSampleSum()
-			case dto.MetricType_HISTOGRAM:
-				value = metricLabel.GetHistogram().GetSampleSum()
-			default:
-				continue
-			}
-
-			metric := &models.Metric{
-				Name:   metricName,
-				Labels: labels,
-				Value:  value,
-			}
-			result = append(result, metric)
-		}
-	}
-
-	return result, nil
+	p.Lifecycle.Append(mm)
 }

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -23,8 +23,25 @@ const (
 	// EndpointGCIntervalDefault is the default time for the CEP GC
 	EndpointGCIntervalDefault = 5 * time.Minute
 
-	// PrometheusServeAddr is the default server address for operator metrics
-	PrometheusServeAddr = ":9963"
+	// CESMaxCEPsInCESDefault is the maximum number of cilium endpoints allowed in a CES
+	CESMaxCEPsInCESDefault = 100
+
+	// CESSlicingModeDefault is default method for grouping CEP in a CES.
+	CESSlicingModeDefault = "cesSliceModeIdentity"
+
+	// CESWriteQPSLimitDefault is the default rate limit for the CES work queue.
+	CESWriteQPSLimitDefault = 10
+
+	// CESWriteQPSLimitMax is the maximum rate limit for the CES work queue.
+	// CES work queue QPS limit cannot exceed this value, regardless of other config.
+	CESWriteQPSLimitMax = 50
+
+	// CESWriteQPSBurstDefault is the default burst rate for the CES work queue.
+	CESWriteQPSBurstDefault = 20
+
+	// CESWriteQPSBurstMax is the maximum burst rate for the CES work queue.
+	// CES work queue QPS burst cannot exceed this value, regardless of other config.
+	CESWriteQPSBurstMax = 100
 
 	// CNPStatusCleanupQPSDefault is the default rate for the CNP NodeStatus updates GC.
 	CNPStatusCleanupQPSDefault = 10
@@ -83,10 +100,6 @@ const (
 
 	// NodesGCInterval is the duration for which the cilium nodes are GC.
 	NodesGCInterval = "nodes-gc-interval"
-
-	// OperatorPrometheusServeAddr IP:Port on which to serve prometheus
-	// metrics (pass ":Port" to bind on all interfaces, "" is off).
-	OperatorPrometheusServeAddr = "operator-prometheus-serve-addr"
 
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices = "synchronize-k8s-services"
@@ -334,8 +347,6 @@ type OperatorConfig struct {
 	// will simply return.
 	EndpointGCInterval time.Duration
 
-	OperatorPrometheusServeAddr string
-
 	// SyncK8sServices synchronizes k8s services into the kvstore
 	SyncK8sServices bool
 
@@ -558,7 +569,6 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.CNPStatusCleanupBurst = vp.GetInt(CNPStatusCleanupBurst)
 	c.EnableMetrics = vp.GetBool(EnableMetrics)
 	c.EndpointGCInterval = vp.GetDuration(EndpointGCInterval)
-	c.OperatorPrometheusServeAddr = vp.GetString(OperatorPrometheusServeAddr)
 	c.SyncK8sServices = vp.GetBool(SyncK8sServices)
 	c.SyncK8sNodes = vp.GetBool(SyncK8sNodes)
 	c.UnmanagedPodWatcherInterval = vp.GetInt(UnmanagedPodWatcherInterval)

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -11,7 +11,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/cilium/cilium/operator/metrics"
-	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/k8s"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	cilium_v2a1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -54,9 +53,7 @@ func newReconciler(
 
 func (r *reconciler) reconcileCES(cesName CESName) (err error) {
 	desiredCEPsNumber := r.cesManager.getCEPCountInCES(cesName)
-	if operatorOption.Config.EnableMetrics {
-		metrics.CiliumEndpointSliceDensity.Observe(float64(desiredCEPsNumber))
-	}
+	metrics.CiliumEndpointSliceDensity.Observe(float64(desiredCEPsNumber))
 	// Check the CES exists is in cesStore i.e. in api-server copy of CESs, if exist update or delete the CES.
 	cesObj, exists, err := r.cesStore.GetByKey(cesName.key())
 	if err != nil {
@@ -79,9 +76,7 @@ func (r *reconciler) reconcileCESCreate(cesName CESName) (err error) {
 		logfields.CESName: cesName.string(),
 	}).Debug("Reconciling CES Create.")
 	ceps := r.cesManager.getCEPinCES(cesName)
-	if operatorOption.Config.EnableMetrics {
-		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPInsert).Observe(float64(len(ceps)))
-	}
+	metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPInsert).Observe(float64(len(ceps)))
 	newCES := &cilium_v2a1.CiliumEndpointSlice{
 		TypeMeta: meta_v1.TypeMeta{
 			Kind:       "CiliumEndpointSlice",
@@ -170,10 +165,8 @@ func (r *reconciler) reconcileCESUpdate(cesName CESName, cesObj *cilium_v2a1.Cil
 		cesEqual = false
 	}
 
-	if operatorOption.Config.EnableMetrics {
-		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPInsert).Observe(float64(cepInserted + cepUpdated))
-		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPRemove).Observe(float64(cepRemoved))
-	}
+	metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPInsert).Observe(float64(cepInserted + cepUpdated))
+	metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPRemove).Observe(float64(cepRemoved))
 
 	if !cesEqual {
 		r.logger.WithFields(logrus.Fields{
@@ -199,9 +192,7 @@ func (r *reconciler) reconcileCESDelete(ces *cilium_v2a1.CiliumEndpointSlice) (e
 	r.logger.WithFields(logrus.Fields{
 		logfields.CESName: ces.Name,
 	}).Debug("Reconciling CES Delete.")
-	if operatorOption.Config.EnableMetrics {
-		metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPRemove).Observe(float64(len(ces.Endpoints)))
-	}
+	metrics.CiliumEndpointsChangeCount.WithLabelValues(metrics.LabelValueCEPRemove).Observe(float64(len(ces.Endpoints)))
 	if err = r.client.CiliumEndpointSlices().Delete(
 		r.context, ces.Name, meta_v1.DeleteOptions{}); err != nil && !errors.Is(err, context.Canceled) {
 		r.logger.WithError(err).WithFields(logrus.Fields{

--- a/operator/pkg/lbipam/metrics.go
+++ b/operator/pkg/lbipam/metrics.go
@@ -4,7 +4,7 @@
 package lbipam
 
 import (
-	"github.com/cilium/cilium/operator/metrics"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 )
 

--- a/pkg/ipam/allocator/alibabacloud/alibabacloud.go
+++ b/pkg/ipam/allocator/alibabacloud/alibabacloud.go
@@ -22,6 +22,7 @@ import (
 	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-allocator-alibaba-cloud")
@@ -37,7 +38,7 @@ func (a *AllocatorAlibabaCloud) Init(ctx context.Context) error {
 	var aMetrics openapi.MetricsAPI
 
 	if operatorOption.Config.EnableMetrics {
-		aMetrics = apiMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, "alibabacloud", operatorMetrics.Registry)
+		aMetrics = apiMetrics.NewPrometheusMetrics(metrics.Namespace, "alibabacloud", operatorMetrics.Registry)
 	} else {
 		aMetrics = &apiMetrics.NoOpMetrics{}
 	}
@@ -94,7 +95,7 @@ func (a *AllocatorAlibabaCloud) Start(ctx context.Context, getterUpdater ipam.Ci
 	log.Info("Starting AlibabaCloud ENI allocator...")
 
 	if operatorOption.Config.EnableMetrics {
-		iMetrics = ipamMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, operatorMetrics.Registry)
+		iMetrics = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, operatorMetrics.Registry)
 	} else {
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}

--- a/pkg/ipam/allocator/aws/aws.go
+++ b/pkg/ipam/allocator/aws/aws.go
@@ -22,6 +22,7 @@ import (
 	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -79,7 +80,7 @@ func (a *AllocatorAWS) Init(ctx context.Context) error {
 	instancesFilters := ec2shim.NewTagsFilter(operatorOption.Config.IPAMInstanceTags)
 
 	if operatorOption.Config.EnableMetrics {
-		aMetrics = apiMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, "ec2", operatorMetrics.Registry)
+		aMetrics = apiMetrics.NewPrometheusMetrics(metrics.Namespace, "ec2", operatorMetrics.Registry)
 	} else {
 		aMetrics = &apiMetrics.NoOpMetrics{}
 	}
@@ -115,7 +116,7 @@ func (a *AllocatorAWS) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 	log.Info("Starting ENI allocator...")
 
 	if operatorOption.Config.EnableMetrics {
-		iMetrics = ipamMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, operatorMetrics.Registry)
+		iMetrics = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, operatorMetrics.Registry)
 	} else {
 		iMetrics = &ipamMetrics.NoOpMetrics{}
 	}

--- a/pkg/ipam/allocator/azure/azure.go
+++ b/pkg/ipam/allocator/azure/azure.go
@@ -17,6 +17,7 @@ import (
 	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 )
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "ipam-allocator-azure")
@@ -66,8 +67,8 @@ func (*AllocatorAzure) Start(ctx context.Context, getterUpdater ipam.CiliumNodeG
 	}
 
 	if operatorOption.Config.EnableMetrics {
-		azMetrics = apiMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, "azure", operatorMetrics.Registry)
-		iMetrics = ipamMetrics.NewPrometheusMetrics(operatorMetrics.Namespace, operatorMetrics.Registry)
+		azMetrics = apiMetrics.NewPrometheusMetrics(metrics.Namespace, "azure", operatorMetrics.Registry)
+		iMetrics = ipamMetrics.NewPrometheusMetrics(metrics.Namespace, operatorMetrics.Registry)
 	} else {
 		azMetrics = &apiMetrics.NoOpMetrics{}
 		iMetrics = &ipamMetrics.NoOpMetrics{}

--- a/pkg/ipam/allocator/clusterpool/clusterpool.go
+++ b/pkg/ipam/allocator/clusterpool/clusterpool.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator"
@@ -18,6 +17,7 @@ import (
 	ipamMetrics "github.com/cilium/cilium/pkg/ipam/metrics"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/trigger"
 )
@@ -75,7 +75,7 @@ func (a *AllocatorOperator) Start(ctx context.Context, updater ipam.CiliumNodeGe
 	)
 
 	if operatorOption.Config.EnableMetrics {
-		iMetrics = ipamMetrics.NewTriggerMetrics(operatorMetrics.Namespace, "k8s_sync")
+		iMetrics = ipamMetrics.NewTriggerMetrics(metrics.Namespace, "k8s_sync")
 	} else {
 		iMetrics = &ipamMetrics.NoOpMetricsObserver{}
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -79,6 +79,9 @@ const (
 	// Cilium KVStoreMesh
 	CiliumKVStoreMeshNamespace = "cilium_kvstoremesh"
 
+	// CiliumOperatorNamespace is used to scope metrics from the Cilium Operator
+	CiliumOperatorNamespace = "cilium_operator"
+
 	// LabelError indicates the type of error (string)
 	LabelError = "error"
 


### PR DESCRIPTION
Add a cell to provide global metrics registry and prometheus metrics server for the operator hive.

This makes possible to use `cell.Metric` to export metrics in the operator cells.

Since there are parts of the operator code not yet modularized, the legacy metrics variables and the global registry are kept exported, in order to be directly used by legacy code. This approach is inspired by the agent metrics cell.

Besides, this PR fixes the operator metrics namespace, setting it early at startup, so that all the code shared between other components (e.g: the agent) will report the correct `cilium_operator` namespace when updating the metrics.

Here a query that shows both the correct namespace for all the metrics and also all the metrics registered with `cell.Metric` (like the ones in the `operator/pkg/lbipam` cell) showing up:

```
$ curl localhost:9234/v1/metrics
[
    {
        "name": "cilium_operator_ces_queueing_delay_seconds"
    },
    {
        "name": "cilium_operator_ces_sync_errors_total"
    },
    {
        "name": "cilium_operator_lbipam_conflicting_pools_total"
    },
    {
        "name": "cilium_operator_lbipam_services_matching_total"
    },
    {
        "name": "cilium_operator_lbipam_services_unsatisfied_total"
    },
    {
        "name": "cilium_operator_number_of_ceps_per_ces"
    },
    {
        "name": "cilium_operator_process_cpu_seconds_total",
        "value": 1.03
    },
    {
        "name": "cilium_operator_process_max_fds",
        "value": 1048576
    },
    {
        "name": "cilium_operator_process_open_fds",
        "value": 12
    },
    {
        "name": "cilium_operator_process_resident_memory_bytes",
        "value": 95997952
    },
    {
        "name": "cilium_operator_process_start_time_seconds",
        "value": 1694106767.7
    },
    {
        "name": "cilium_operator_process_virtual_memory_bytes",
        "value": 1351573504
    },
    {
        "name": "cilium_operator_process_virtual_memory_max_bytes",
        "value": 18446744073709552000
    }
]
```