### PR TITLE
k8s: Restrict configuring reserved:init policy via CNP

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -315,6 +315,11 @@ Annotations:
   Upgrading from Cilium 1.14.x or earlier to 1.15.y or later does not
   trigger this problem. Downgrading from Cilium 1.15.y or later to Cilium
   1.14.x or earlier may trigger this problem.
+* ``CiliumNetworkPolicy`` cannot match the ``reserved:init`` labels any more.
+  If you have ``CiliumNetworkPolicy`` resources that have a match for
+  labels ``reserved:init``, these policies must be converted to
+  ``CiliumClusterwideNetworkPolicy`` by changing the resource type for the
+  policy.
 
 .. _upgrade_cilium_cli_helm_mode:
 

--- a/examples/policies/l4/init.yaml
+++ b/examples/policies/l4/init.yaml
@@ -1,5 +1,5 @@
 apiVersion: "cilium.io/v2"
-kind: CiliumNetworkPolicy
+kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: init
 specs:

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -82,14 +82,16 @@ func getEndpointSelector(namespace string, labelSelector *slim_metav1.LabelSelec
 	// Those pods don't have any labels, so they don't have a namespace label either.
 	// Don't add a namespace label to those endpoint selectors, or we wouldn't be
 	// able to match on those pods.
-	if !matchesInit && !es.HasKey(podPrefixLbl) && !es.HasKey(podAnyPrefixLbl) {
+	if !es.HasKey(podPrefixLbl) && !es.HasKey(podAnyPrefixLbl) {
 		if namespace == "" {
 			// For a clusterwide policy if a namespace is not specified in the labels we add
 			// a selector to only match endpoints that contains a namespace label.
 			// This is to make sure that we are only allowing traffic for cilium managed k8s endpoints
 			// and even if a wildcard is provided in the selector we don't proceed with a truly
 			// empty(allow all) endpoint selector for the policy.
-			es.AddMatchExpression(podPrefixLbl, slim_metav1.LabelSelectorOpExists, []string{})
+			if !matchesInit {
+				es.AddMatchExpression(podPrefixLbl, slim_metav1.LabelSelectorOpExists, []string{})
+			}
 		} else {
 			es.AddMatch(podPrefixLbl, namespace)
 		}
@@ -301,11 +303,11 @@ func ParseToCiliumRule(namespace, name string, uid types.UID, r *api.Rule) *api.
 		// the policy is being stored, thus we add the namespace to
 		// the MatchLabels map.
 		//
-		// Policies applying on initializing pods are a special case.
-		// Those pods don't have any labels, so they don't have a namespace label either.
-		// Don't add a namespace label to those endpoint selectors, or we wouldn't be
-		// able to match on those pods.
-		if !retRule.EndpointSelector.HasKey(podInitLbl) && namespace != "" {
+		// Policies applying to all namespaces are a special case.
+		// Such policies can match on any traffic from Pods or Nodes,
+		// so it wouldn't make sense to inject a namespace match for
+		// those policies.
+		if namespace != "" {
 			userNamespace, present := r.EndpointSelector.GetMatch(podPrefixLbl)
 			if present && !namespacesAreValid(namespace, userNamespace) {
 				log.WithFields(logrus.Fields{

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -152,8 +152,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			// is for init policies.
 			name: "parse-init-policy",
 			args: args{
-				namespace: slim_metav1.NamespaceDefault,
-				uid:       uuid,
+				uid: uuid,
 				rule: &api.Rule{
 					EndpointSelector: api.NewESFromMatchRequirements(
 						map[string]string{
@@ -178,17 +177,12 @@ func Test_ParseToCiliumRule(t *testing.T) {
 				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.derived-from",
-						Value:  "CiliumNetworkPolicy",
+						Value:  "CiliumClusterwideNetworkPolicy",
 						Source: labels.LabelSourceK8s,
 					},
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "parse-init-policy",
-						Source: labels.LabelSourceK8s,
-					},
-					{
-						Key:    "io.cilium.k8s.policy.namespace",
-						Value:  "default",
 						Source: labels.LabelSourceK8s,
 					},
 					{

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator.go
@@ -6,13 +6,30 @@ package validator
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
+	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
+	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/sirupsen/logrus"
 	apiextensionsinternal "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
 
-	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/client"
+var (
+	// We can remove the check for this warning once 1.15 is the oldest supported Cilium version.
+	logInitPolicyCNP = "It seems you have a CiliumNetworkPolicy with a " +
+		"match on the 'reserved:init' labels. This label is not " +
+		"supported in CiliumNetworkPolicy any more. If you wish to " +
+		"define a policy for endpoints before they receive a full " +
+		"security identity, change the resource type for the policy " +
+		"to CiliumClusterwideNetworkPolicy."
+	errInitPolicyCNP = fmt.Errorf("CiliumNetworkPolicy incorrectly matches reserved:init label")
+	logOnce          sync.Once
 )
 
 // NPValidator is a validator structure used to validate CNP and CCNP.
@@ -96,6 +113,10 @@ func (n *NPValidator) ValidateCNP(cnp *unstructured.Unstructured) error {
 		return err
 	}
 
+	if err := checkInitLabelsPolicy(cnp); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -107,6 +128,36 @@ func (n *NPValidator) ValidateCCNP(ccnp *unstructured.Unstructured) error {
 
 	if err := detectUnknownFields(ccnp); err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func checkInitLabelsPolicy(cnp *unstructured.Unstructured) error {
+	cnpBytes, err := cnp.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	resCNP := cilium_v2.CiliumNetworkPolicy{}
+	err = json.Unmarshal(cnpBytes, &resCNP)
+	if err != nil {
+		return err
+	}
+
+	for _, spec := range append(resCNP.Specs, resCNP.Spec) {
+		if spec == nil {
+			continue
+		}
+		podInitLbl := labels.LabelSourceReservedKeyPrefix + labels.IDNameInit
+		if spec.EndpointSelector.HasKey(podInitLbl) {
+			logOnce.Do(func() {
+				log.WithFields(logrus.Fields{
+					logfields.CiliumNetworkPolicyName: cnp.GetName(),
+				}).Error(logInitPolicyCNP)
+			})
+			return errInitPolicyCNP
+		}
 	}
 
 	return nil

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
@@ -469,3 +469,32 @@ specs:
 		}
 	}
 }
+
+func (s *CNPValidationSuite) Test_GH28007(c *C) {
+	cnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: exampleapp
+  namespace: examplens
+spec:
+  egress:
+  - toEntities:
+    - world
+  endpointSelector:
+    matchExpressions:
+    - key: reserved:init
+      operator: DoesNotExist
+`)
+	jsnByte, err := yaml.YAMLToJSON(cnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCNP(&us)
+	// Err can't be nil since validation should detect the policy is not correct.
+	c.Assert(err, Equals, errInitPolicyCNP)
+}


### PR DESCRIPTION
Typically if the policy target EndpointSelector does not include a
namespace, parsing will inject the namespace to ensure that only Pods
within the same namespace can be selected. Furthermore, for peer
EndpointSelectors there is a similar behaviour where ingress or egress
is allowed only to the current namespace unless the user specifies which
namespace the peer exists in. However, these defaults did not previously
apply to policies that select the reserved:init Identity, since this
Identity is not inherently namespaced. Automatically injecting the
namespace would cause the policy to no longer match this Identity.

The reserved:init Identity was introduced in order to allow a different
policy to apply to Pods as they start up, iff the full Identity of those
workloads cannot be determined when they are first connecting to the
Cilium network (CNI ADD). In order to support this special reserved:init
Identity, various exceptions were introduced into CiliumNetworkPolicy
parser that removed the automatic insertion of namespace into the
policies when there were label matches for the reserved:init namespace.

The awkward part about this abstraction early on was that there was no
way to directly associate the reserved:init Identity to any specific
Kubernetes namespace, and yet CiliumNetworkPolicy was always inherently
tied to a specific namespace. Since the introduction of the
reserved:init Identity, CiliumClusterwideNetworkPolicy was also
introduced, which is a much better fit for the ability to select
endpoints that are not inherently namespaced. This is because CCNP is
also not restricted to any specific namespace, it applies to Endpoints
in all namespaces. This patch proposes to even extend that policy to
apply to Endpoints that are not inside a namespace, such as Endpoints
with the `reserved:init` Identity.

This patch removes support for applying network policies for the
reserved:init Identity via CiliumNetworkPolicy in favour of
CiliumClusterwideNetworkPolicy. As a benefit, this allows us to simplify
the logic that applies the namespaces into the policies and reduce the
likelihood of misconfigurations.
