### PR TITLE
Daemon: Updates Detect() Call to Return Detected Devices

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -899,7 +899,9 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	// which can be modified after the device detection.
 	var devices []string
 	if d.deviceManager != nil {
-		if _, err := d.deviceManager.Detect(params.Clientset.IsEnabled()); err != nil {
+		if detected, err := d.deviceManager.Detect(params.Clientset.IsEnabled()); err == nil {
+			devices = append(devices, detected...)
+		} else {
 			if option.Config.AreDevicesRequired() {
 				// Fail hard if devices are required to function.
 				return nil, nil, fmt.Errorf("failed to detect devices: %w", err)


### PR DESCRIPTION
Updates the call to `d.deviceManager.Detect()` so returned devices are added to the list of network device strings. This allows `DevicesChanged()` can be invoked with the discovered network devices used for constructing L2 announcement policies.

Fixes: #28009
