### PR TITLE
Fix Gateway API HttpRoute cannot strip path prefix.

### DIFF
--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -170,6 +170,19 @@ func Test_pathPrefixMutation(t *testing.T) {
 		res := pathPrefixMutation(rewrite)(route)
 		require.Equal(t, res.Route.PrefixRewrite, "/prefix")
 	})
+	t.Run("with empty prefix rewrite", func(t *testing.T) {
+		route := &envoy_config_route_v3.Route_Route{
+			Route: &envoy_config_route_v3.RouteAction{},
+		}
+		rewrite := &model.HTTPURLRewriteFilter{
+			Path: &model.StringMatch{
+				Prefix: "",
+			},
+		}
+
+		res := pathPrefixMutation(rewrite)(route)
+		require.Equal(t, res.Route.PrefixRewrite, "/")
+	})
 }
 
 func Test_requestMirrorMutation(t *testing.T) {


### PR DESCRIPTION
According to Kubernetes guidlines empty prefix should be allowed.

Fixes: #27994

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: #issue-number

```release-note
Fix Gateway API HttpRoute cannot strip path prefix.
```
