### PR TITLE
egressgw: manager: test: mark helpers with c.Helper()

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -592,6 +592,8 @@ func parseIPRule(sourceIP, destCIDR, egressIP string, ifaceIndex int) parsedIPRu
 }
 
 func assertIPRules(c *C, rules []ipRule) {
+	c.Helper()
+
 	err := tryAssertIPRules(rules)
 	c.Assert(err, IsNil)
 }
@@ -696,6 +698,8 @@ func parseEgressRule(sourceIP, destCIDR, egressIP, gatewayIP string) parsedEgres
 }
 
 func assertEgressRules(c *C, policyMap egressmap.PolicyMap, rules []egressRule) {
+	c.Helper()
+
 	err := tryAssertEgressRules(policyMap, rules)
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
in this way when a test fails we don't get the line number of the helper but rather the one of the caller