### PR TITLE
ipam/multipool: Fix comment for removeExpiration

### DIFF
--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -156,7 +156,7 @@ func (p pendingAllocationsPerOwner) startExpirationAt(now time.Time, owner strin
 	p[family] = expires
 }
 
-// startExpiration removes the expiration timer for a pending allocation, this
+// removeExpiration removes the expiration timer for a pending allocation, this
 // happens either because the timer expired, or the allocation was fulfilled
 func (p pendingAllocationsPerOwner) removeExpiration(owner string, family Family) {
 	delete(p[family], owner)


### PR DESCRIPTION
The comment for removeExpiration is still using startExpiration.  
Looks like it's just a copy-paste error.
