### PR TITLE
[1.12] test: add namespace name in pod metadata test

### DIFF
--- a/pkg/k8s/labels_test.go
+++ b/pkg/k8s/labels_test.go
@@ -19,6 +19,7 @@ import (
 func TestGetPodMetadata(t *testing.T) {
 	ns := &slim_corev1.Namespace{
 		ObjectMeta: slim_metav1.ObjectMeta{
+			Name: "default",
 			Labels: map[string]string{
 				"kubernetes.io/metadata.name": "default",
 				"namespace-level-key":         "namespace-level-value",


### PR DESCRIPTION
Recent changes added pod label namespace sanitization, this change fixes test data to adjust to that.

This is a backport of https://github.com/cilium/cilium/pull/28028