### PR TITLE
BGP CP: API Helper Functions Cleanup

### DIFF
--- a/cilium/cmd/bgp_route_get.go
+++ b/cilium/cmd/bgp_route_get.go
@@ -115,7 +115,7 @@ func parseBGPRoutesMandatoryArgs(args []string) (tableType, afi, safi string, ar
 		err = fmt.Errorf("missing AFI value (e.g. `ipv4`)")
 		return
 	}
-	if api.ToAgentAfi(args[1]) == types.AfiUnknown {
+	if types.ParseAfi(args[1]) == types.AfiUnknown {
 		err = fmt.Errorf("unknown AFI %s", args[1])
 		return
 	}
@@ -125,7 +125,7 @@ func parseBGPRoutesMandatoryArgs(args []string) (tableType, afi, safi string, ar
 		err = fmt.Errorf("missing SAFI value (e.g. `unicast`)")
 		return
 	}
-	if api.ToAgentSafi(args[2]) == types.SafiUnknown {
+	if types.ParseSafi(args[2]) == types.SafiUnknown {
 		err = fmt.Errorf("unknown SAFI %s", args[2])
 		return
 	}

--- a/pkg/bgpv1/api/conversions.go
+++ b/pkg/bgpv1/api/conversions.go
@@ -16,85 +16,18 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 )
 
-func ToAgentAfi(s string) types.Afi {
-	switch s {
-	case "ipv4":
-		return types.AfiIPv4
-	case "ipv6":
-		return types.AfiIPv6
-	case "l2vpn":
-		return types.AfiL2VPN
-	case "ls":
-		return types.AfiLS
-	case "opaque":
-		return types.AfiOpaque
-	default:
-		return types.AfiUnknown
-	}
-}
-
-func ToAgentSafi(s string) types.Safi {
-	switch s {
-	case "unicast":
-		return types.SafiUnicast
-	case "multicast":
-		return types.SafiMulticast
-	case "mpls_label":
-		return types.SafiMplsLabel
-	case "encapsulation":
-		return types.SafiEncapsulation
-	case "vpls":
-		return types.SafiVpls
-	case "evpn":
-		return types.SafiEvpn
-	case "ls":
-		return types.SafiLs
-	case "sr_policy":
-		return types.SafiSrPolicy
-	case "mup":
-		return types.SafiMup
-	case "mpls_vpn":
-		return types.SafiMplsVpn
-	case "mpls_vpn_multicast":
-		return types.SafiMplsVpnMulticast
-	case "route_target_constraints":
-		return types.SafiRouteTargetConstraints
-	case "flowspec_unicast":
-		return types.SafiFlowSpecUnicast
-	case "flowspec_vpn":
-		return types.SafiFlowSpecVpn
-	case "key_value":
-		return types.SafiKeyValue
-	default:
-		return types.SafiUnknown
-	}
-}
-
-func ToAgentTableType(s string) types.TableType {
-	switch s {
-	case "loc-rib":
-		return types.TableTypeLocRIB
-	case "adj-rib-in":
-		return types.TableTypeAdjRIBIn
-	case "adj-rib-out":
-		return types.TableTypeAdjRIBOut
-	default:
-		return types.TableTypeUnknown
-	}
-}
-
 func ToAgentGetRoutesRequest(params restapi.GetBgpRoutesParams) (*types.GetRoutesRequest, error) {
 	ret := &types.GetRoutesRequest{}
 
-	if ret.TableType = ToAgentTableType(params.TableType); ret.TableType == types.TableTypeUnknown {
+	if ret.TableType = types.ParseTableType(params.TableType); ret.TableType == types.TableTypeUnknown {
 		return nil, fmt.Errorf("unknown table type %s", params.TableType)
 	}
 
-	if ret.Family.Afi = ToAgentAfi(params.Afi); ret.Family.Afi == types.AfiUnknown {
+	if ret.Family.Afi = types.ParseAfi(params.Afi); ret.Family.Afi == types.AfiUnknown {
 		return nil, fmt.Errorf("unknown AFI %s", params.Afi)
 	}
 
-	if ret.Family.Safi = ToAgentSafi(params.Safi); ret.Family.Safi == types.SafiUnknown {
+	if ret.Family.Safi = types.ParseSafi(params.Safi); ret.Family.Safi == types.SafiUnknown {
 		return nil, fmt.Errorf("unknown SAFI %s", params.Safi)
 	}
 
@@ -126,11 +59,11 @@ func ToAPIFamily(f *types.Family) (*models.BgpFamily, error) {
 func ToAgentFamily(m *models.BgpFamily) (*types.Family, error) {
 	f := &types.Family{}
 
-	if f.Afi = ToAgentAfi(m.Afi); f.Afi == types.AfiUnknown {
+	if f.Afi = types.ParseAfi(m.Afi); f.Afi == types.AfiUnknown {
 		return nil, fmt.Errorf("unknown afi %s", m.Afi)
 	}
 
-	if f.Safi = ToAgentSafi(m.Safi); f.Safi == types.SafiUnknown {
+	if f.Safi = types.ParseSafi(m.Safi); f.Safi == types.SafiUnknown {
 		return nil, fmt.Errorf("unknown safi %s", m.Safi)
 	}
 
@@ -183,8 +116,8 @@ func ToAgentPath(m *models.BgpPath) (*types.Path, error) {
 	p.AgeNanoseconds = m.AgeNanoseconds
 	p.Best = m.Best
 
-	afi := ToAgentAfi(m.Family.Afi)
-	safi := ToAgentSafi(m.Family.Safi)
+	afi := types.ParseAfi(m.Family.Afi)
+	safi := types.ParseSafi(m.Family.Safi)
 
 	// Create empty NLRI structure. The underlying type will be set correctly by providing AFI/SAFI
 	nlri, err := bgp.NewPrefixFromRouteFamily(uint16(afi), uint8(safi))

--- a/pkg/bgpv1/types/bgp.go
+++ b/pkg/bgpv1/types/bgp.go
@@ -211,6 +211,21 @@ const (
 	TableTypeAdjRIBOut
 )
 
+// ParseTableType parses s as a routing table type. If s is unknown,
+// TableTypeUnknown is returned.
+func ParseTableType(s string) TableType {
+	switch s {
+	case "loc-rib":
+		return TableTypeLocRIB
+	case "adj-rib-in":
+		return TableTypeAdjRIBIn
+	case "adj-rib-out":
+		return TableTypeAdjRIBOut
+	default:
+		return TableTypeUnknown
+	}
+}
+
 // GetRoutesRequest contains parameters for retrieving routes from the RIB of underlying router
 type GetRoutesRequest struct {
 	// TableType specifies a table type to retrieve

--- a/pkg/bgpv1/types/state.go
+++ b/pkg/bgpv1/types/state.go
@@ -51,6 +51,8 @@ const (
 	AfiOpaque  Afi = 16397
 )
 
+// FromString assigns s to a. An error is returned if s is
+// an unknown address family indicator.
 func (a *Afi) FromString(s string) error {
 	switch s {
 	case "ipv4":
@@ -69,6 +71,7 @@ func (a *Afi) FromString(s string) error {
 	return nil
 }
 
+// String returns the stringified form of a.
 func (a Afi) String() string {
 	switch a {
 	case AfiUnknown:
@@ -86,6 +89,27 @@ func (a Afi) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+// ParseAfi parses s as an address family identifier.
+// If s is unknown, AfiUnknown is returned.
+func ParseAfi(s string) Afi {
+	var ret Afi
+	switch s {
+	case "ipv4":
+		ret = AfiIPv4
+	case "ipv6":
+		ret = AfiIPv6
+	case "l2vpn":
+		ret = AfiL2VPN
+	case "ls":
+		ret = AfiLS
+	case "opaque":
+		ret = AfiOpaque
+	default:
+		ret = AfiUnknown
+	}
+	return ret
 }
 
 // Safi is subsequent address family identifier
@@ -110,6 +134,8 @@ const (
 	SafiKeyValue               Safi = 241
 )
 
+// FromString assigns safi to s. An error is returned if safi
+// is an unknown subsequent address family indicator.
 func (s *Safi) FromString(safi string) error {
 	switch safi {
 	case "unicast":
@@ -148,6 +174,7 @@ func (s *Safi) FromString(safi string) error {
 	return nil
 }
 
+// String returns the stringified form of s.
 func (s Safi) String() string {
 	switch s {
 	case SafiUnknown:
@@ -185,4 +212,45 @@ func (s Safi) String() string {
 	default:
 		return "unknown"
 	}
+}
+
+// ParseSafi parses s as a subsequent address family identifier.
+// If s is unknown, SafiUnknown is returned.
+func ParseSafi(s string) Safi {
+	var ret Safi
+	switch s {
+	case "unicast":
+		ret = SafiUnicast
+	case "multicast":
+		ret = SafiMulticast
+	case "mpls_label":
+		ret = SafiMplsLabel
+	case "encapsulation":
+		ret = SafiEncapsulation
+	case "vpls":
+		ret = SafiVpls
+	case "evpn":
+		ret = SafiEvpn
+	case "ls":
+		ret = SafiLs
+	case "sr_policy":
+		ret = SafiSrPolicy
+	case "mup":
+		ret = SafiMup
+	case "mpls_vpn":
+		ret = SafiMplsVpn
+	case "mpls_vpn_multicast":
+		ret = SafiMplsVpnMulticast
+	case "route_target_constraints":
+		ret = SafiRouteTargetConstraints
+	case "flowspec_unicast":
+		ret = SafiFlowSpecUnicast
+	case "flowspec_vpn":
+		ret = SafiFlowSpecVpn
+	case "key_value":
+		ret = SafiKeyValue
+	default:
+		ret = SafiUnknown
+	}
+	return ret
 }


### PR DESCRIPTION
- Moves functions next to types.
- Renames functions to ParseXXX
- Adds godocs.