### PR TITLE
v1.12: k8s: Restrict configuring reserved:init policy via CNP

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -304,6 +304,15 @@ Annotations:
 
 .. _1.12_upgrade_notes:
 
+1.12.14 Upgrade Notes
+---------------------
+
+* ``CiliumNetworkPolicy`` cannot match the ``reserved:init`` labels any more.
+  If you have ``CiliumNetworkPolicy`` resources that have a match for
+  labels ``reserved:init``, these policies must be converted to
+  ``CiliumClusterwideNetworkPolicy`` by changing the resource type for the
+  policy.
+
 1.12.9+ Upgrade Notes
 ---------------------
 

--- a/examples/policies/l4/init.yaml
+++ b/examples/policies/l4/init.yaml
@@ -1,5 +1,5 @@
 apiVersion: "cilium.io/v2"
-kind: CiliumNetworkPolicy
+kind: CiliumClusterwideNetworkPolicy
 metadata:
   name: init
 specs:

--- a/pkg/k8s/apis/cilium.io/utils/utils.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils.go
@@ -82,14 +82,16 @@ func getEndpointSelector(namespace string, labelSelector *slim_metav1.LabelSelec
 	// Those pods don't have any labels, so they don't have a namespace label either.
 	// Don't add a namespace label to those endpoint selectors, or we wouldn't be
 	// able to match on those pods.
-	if !matchesInit && !es.HasKey(podPrefixLbl) && !es.HasKey(podAnyPrefixLbl) {
+	if !es.HasKey(podPrefixLbl) && !es.HasKey(podAnyPrefixLbl) {
 		if namespace == "" {
 			// For a clusterwide policy if a namespace is not specified in the labels we add
 			// a selector to only match endpoints that contains a namespace label.
 			// This is to make sure that we are only allowing traffic for cilium managed k8s endpoints
 			// and even if a wildcard is provided in the selector we don't proceed with a truly
 			// empty(allow all) endpoint selector for the policy.
-			es.AddMatchExpression(podPrefixLbl, slim_metav1.LabelSelectorOpExists, []string{})
+			if !matchesInit {
+				es.AddMatchExpression(podPrefixLbl, slim_metav1.LabelSelectorOpExists, []string{})
+			}
 		} else {
 			es.AddMatch(podPrefixLbl, namespace)
 		}
@@ -299,11 +301,11 @@ func ParseToCiliumRule(namespace, name string, uid types.UID, r *api.Rule) *api.
 		// the policy is being stored, thus we add the namespace to
 		// the MatchLabels map.
 		//
-		// Policies applying on initializing pods are a special case.
-		// Those pods don't have any labels, so they don't have a namespace label either.
-		// Don't add a namespace label to those endpoint selectors, or we wouldn't be
-		// able to match on those pods.
-		if !retRule.EndpointSelector.HasKey(podInitLbl) && namespace != "" {
+		// Policies applying to all namespaces are a special case.
+		// Such policies can match on any traffic from Pods or Nodes,
+		// so it wouldn't make sense to inject a namespace match for
+		// those policies.
+		if namespace != "" {
 			userNamespace, present := r.EndpointSelector.GetMatch(podPrefixLbl)
 			if present && !namespacesAreValid(namespace, userNamespace) {
 				log.WithFields(logrus.Fields{

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -196,6 +196,89 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			),
 		},
 		{
+			// CNP with endpoint selectors should always select the
+			// current namespace
+			name: "parse-init-policy-namespaced",
+			args: args{
+				namespace: slim_metav1.NamespaceDefault,
+				uid:       uuid,
+				rule: &api.Rule{
+					EndpointSelector: api.NewESFromMatchRequirements(
+						nil,
+						[]slim_metav1.LabelSelectorRequirement{
+							{
+								Key:      "reserved.init",
+								Operator: slim_metav1.LabelSelectorOpDoesNotExist,
+							},
+						},
+					),
+					Ingress: []api.IngressRule{
+						{
+							IngressCommonRule: api.IngressCommonRule{
+								FromEndpoints: []api.EndpointSelector{
+									{
+										LabelSelector: &slim_metav1.LabelSelector{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: api.NewRule().WithEndpointSelector(
+				api.NewESFromMatchRequirements(
+					map[string]string{
+						namespace: "default",
+					},
+					[]slim_metav1.LabelSelectorRequirement{
+						{
+							Key:      "reserved.init",
+							Operator: slim_metav1.LabelSelectorOpDoesNotExist,
+						},
+					},
+				),
+			).WithIngressRules(
+				[]api.IngressRule{
+					{
+						IngressCommonRule: api.IngressCommonRule{
+							FromEndpoints: []api.EndpointSelector{
+								api.NewESFromK8sLabelSelector(
+									labels.LabelSourceK8sKeyPrefix,
+									&slim_metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											k8sConst.PodNamespaceLabel: "default",
+										},
+									}),
+							},
+						},
+					},
+				},
+			).WithLabels(
+				labels.LabelArray{
+					{
+						Key:    "io.cilium.k8s.policy.derived-from",
+						Value:  "CiliumNetworkPolicy",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.name",
+						Value:  "parse-init-policy-namespaced",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.namespace",
+						Value:  "default",
+						Source: labels.LabelSourceK8s,
+					},
+					{
+						Key:    "io.cilium.k8s.policy.uid",
+						Value:  string(uuid),
+						Source: labels.LabelSourceK8s,
+					},
+				},
+			),
+		},
+		{
 			name: "set-any-source-for-namespace",
 			args: args{
 				namespace: slim_metav1.NamespaceDefault,

--- a/pkg/k8s/apis/cilium.io/utils/utils_test.go
+++ b/pkg/k8s/apis/cilium.io/utils/utils_test.go
@@ -154,8 +154,7 @@ func Test_ParseToCiliumRule(t *testing.T) {
 			// is for init policies.
 			name: "parse-init-policy",
 			args: args{
-				namespace: slim_metav1.NamespaceDefault,
-				uid:       uuid,
+				uid: uuid,
 				rule: &api.Rule{
 					EndpointSelector: api.NewESFromMatchRequirements(
 						map[string]string{
@@ -180,17 +179,12 @@ func Test_ParseToCiliumRule(t *testing.T) {
 				labels.LabelArray{
 					{
 						Key:    "io.cilium.k8s.policy.derived-from",
-						Value:  "CiliumNetworkPolicy",
+						Value:  "CiliumClusterwideNetworkPolicy",
 						Source: labels.LabelSourceK8s,
 					},
 					{
 						Key:    "io.cilium.k8s.policy.name",
 						Value:  "parse-init-policy",
-						Source: labels.LabelSourceK8s,
-					},
-					{
-						Key:    "io.cilium.k8s.policy.namespace",
-						Value:  "default",
 						Source: labels.LabelSourceK8s,
 					},
 					{

--- a/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/validator/validator_test.go
@@ -471,3 +471,32 @@ specs:
 		}
 	}
 }
+
+func (s *CNPValidationSuite) Test_GH28007(c *C) {
+	cnp := []byte(`apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: exampleapp
+  namespace: examplens
+spec:
+  egress:
+  - toEntities:
+    - world
+  endpointSelector:
+    matchExpressions:
+    - key: reserved:init
+      operator: DoesNotExist
+`)
+	jsnByte, err := yaml.YAMLToJSON(cnp)
+	c.Assert(err, IsNil)
+
+	us := unstructured.Unstructured{}
+	err = json.Unmarshal(jsnByte, &us)
+	c.Assert(err, IsNil)
+
+	validator, err := NewNPValidator()
+	c.Assert(err, IsNil)
+	err = validator.ValidateCNP(&us)
+	// Err can't be nil since validation should detect the policy is not correct.
+	c.Assert(err, Equals, errInitPolicyCNP)
+}


### PR DESCRIPTION
 * [ ] #28007 (@joestringer)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 28007; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
make add-labels BRANCH=v1.12 ISSUES=28007
```

