### PR TITLE
docs: Remove "by Default" suffix in cilium-agent metrics header

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -260,8 +260,8 @@ disable the following two metrics as they generate too much data:
 
 You can then configure the agent with ``--metrics="-cilium_node_connectivity_status -cilium_node_connectivity_latency_seconds"``.
 
-Exported Metrics by Default
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Exported Metrics
+^^^^^^^^^^^^^^^^
 
 Endpoint
 ~~~~~~~~


### PR DESCRIPTION
Some documentation on metrics for cilium-agent is below a header which reads "Exported Metrics by Default". This commit removes the "by Default" part of the header. This is needed because the tables shown below the header already have a 'Default' column which describes if the metric is exported by default.

```release-note
docs: Remove "by Default" suffix in cilium-agent metrics header
```
