### PR TITLE
Docs: Updates for Deprecation of CNI network-plugin Flag

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -137,20 +137,13 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
 
        .. code-block:: shell-session
 
-          minikube start --network-plugin=cni --cni=false
+          minikube start --cni=cilium
 
        .. note::
 
-          From minikube v1.12.1+, cilium networking plugin can be enabled directly with
-          ``--cni=cilium`` parameter in ``minikube start`` command. However, this may not
-          install the latest version of cilium.
-
-          MacOS M1 users using a Minikube version < v1.28.0 with ``--cni=false`` will also need to run
-          ``minikube ssh -- sudo mount bpffs -t bpf /sys/fs/bpf`` in order to mount the BPF filesystem
-          ``bpffs`` to ``/sys/fs/bpf``.
-
-          It might be necessary to add ``--host-dns-resolver=false`` if using the Virtualbox provider,
-          otherwise DNS resolution may not work after Cilium installation.
+          - This may not install the latest version of cilium.
+          - It might be necessary to add ``--host-dns-resolver=false`` if using the Virtualbox provider,
+            otherwise DNS resolution may not work after Cilium installation.
 
     .. group-tab:: Rancher Desktop
 

--- a/Documentation/network/kubernetes/requirements.rst
+++ b/Documentation/network/kubernetes/requirements.rst
@@ -38,10 +38,10 @@ Enable CNI in Kubernetes
 ========================
 
 :term:`CNI` - Container Network Interface is the plugin layer used by Kubernetes to
-delegate networking configuration. CNI must be enabled in your Kubernetes
-cluster in order to install Cilium. This is done by passing
-``--network-plugin=cni`` to kubelet on all nodes. For more information, see
-the `Kubernetes CNI network-plugins documentation <https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/>`_.
+delegate networking configuration and is enabled by default in Kubernetes 1.24 and
+later. Previously, CNI plugins were managed by the kubelet using the ``--network-plugin=cni``
+command-line parameter. For more information, see the
+`Kubernetes CNI network-plugins documentation <https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/>`_.
 
 Enable automatic node CIDR allocation (Recommended)
 ===================================================


### PR DESCRIPTION
- Updates kubelet command-line parameters in K8s requirements section.
- Updates install steps for deprecated CLI flag in minikube install section.
- Since the minikube install docs state `minikube ≥ v1.28.0`, notes specific to older minikube versions were removed.

Fixes: #26531
