### PR TITLE
cni: use case-insensitive names for CNI chaining mode

### DIFF
--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -307,7 +307,7 @@ func (c *cniConfigManager) renderCNIConf() (cniConfig []byte, err error) {
 		}
 	} else {
 		c.log.Infof("Generating CNI configuration file with mode %s", c.config.CNIChainingMode)
-		tmpl := cniConfigs[c.config.CNIChainingMode]
+		tmpl := cniConfigs[strings.ToLower(c.config.CNIChainingMode)]
 		cniConfig = []byte(c.renderCNITemplate(tmpl))
 	}
 


### PR DESCRIPTION
Allow case-insensitive names for CNI chaining mode

Upon startup, Cilium must write CNI config files for the configured chaining mode. For this purpose, it uses a package-scoped map with lowercase string keys to refer to each mode.

We have seen configurations in the wild which do not use all-lowercase names for these chaining modes. For example, in the reccomended configuration for OpenShift conformance testing we have:

    cni.chainingMode=portMap

This causes Cilium to fail on startup with:

    failed to render CNI configuration file: invalid CNI chaining mode:
    portMap

```release-note
Allow case-insensitive name for CNI chaining mode
```
