### PR TITLE
docs: Update the message of Gateway API 'Programmed'

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/troubleshooting.rst
+++ b/Documentation/network/servicemesh/gateway-api/troubleshooting.rst
@@ -45,7 +45,7 @@ Checking resources
           Reason:                Accepted
           Status:                True
           Type:                  Accepted
-          Message:               Gateway successfully configured
+          Message:               Gateway successfully reconciled
           Reason:                Programmed
           Status:                True
           Type:                  Programmed


### PR DESCRIPTION
According to the commit 8a985fa6361c ("Implement programmed flag"), update the 'Programmed' message text.

The message text "Gateway successfully configured" is for 'Ready', which was deprecated by the commit 1055d5988f32 ("Remove deprecated ready status").

<!-- Description of change -->

```release-note
docs: Update the message of Gateway API 'Programmed'
```
