### PR TITLE
docs: Update the tile for 'kubectl get' Gateway API

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/http.rst
+++ b/Documentation/network/servicemesh/gateway-api/http.rst
@@ -39,8 +39,8 @@ gateway, but it may take up to 20 minutes.
 .. code-block:: shell-session
 
     $ kubectl get gateway my-gateway
-    NAME         CLASS    ADDRESS        READY   AGE
-    my-gateway   cilium   10.100.26.37   True    2d7h
+    NAME         CLASS    ADDRESS        PROGRAMMED   AGE
+    my-gateway   cilium   10.100.26.37   True         2d7h
 
 .. Note::
 

--- a/Documentation/network/servicemesh/gateway-api/https.rst
+++ b/Documentation/network/servicemesh/gateway-api/https.rst
@@ -63,8 +63,8 @@ related HTTPRoutes.
 .. code-block:: shell-session
 
     $ kubectl get gateway tls-gateway
-    NAME          CLASS    ADDRESS         READY   AGE
-    tls-gateway   cilium   10.104.247.23   True    29s
+    NAME          CLASS    ADDRESS         PROGRAMMED   AGE
+    tls-gateway   cilium   10.104.247.23   True         29s
 
     $ kubectl get httproutes https-app-route-1 https-app-route-2
     NAME                HOSTNAMES                      AGE


### PR DESCRIPTION
The commit 1055d5988f32 ("Remove deprecated ready status") has deprecated the 'READY' column, to align with Gateway API v0.8.0.

```release-note
docs: Update the tile for 'kubectl get' Gateway API
```
