### PR TITLE
[v1.13] .github/workflows: add trigger phrase to conformance ingress workflow name

### DIFF
--- a/.github/ariane-config.yaml
+++ b/.github/ariane-config.yaml
@@ -32,9 +32,15 @@ triggers:
   /ci-external-workloads:
     workflows:
     - conformance-externalworkloads.yaml
+  /ci-gateway-api:
+    workflows:
+    - conformance-gateway-api.yaml
   /ci-gke:
     workflows:
     - conformance-gke.yaml
+  /ci-ingress:
+    workflows:
+    - conformance-ingress.yaml
   /ci-l4lb:
     workflows:
     - tests-l4lb.yaml

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -1,4 +1,4 @@
-name: Conformance Ingress
+name: Conformance Ingress (ci-ingress)
 
 # Any change in triggers needs to be reflected in the concurrency group.
 on:


### PR DESCRIPTION
Backport:

- https://github.com/cilium/cilium/pull/27304 (@sayboras)
  - Only backported first commit adding the ariane config.
- https://github.com/cilium/cilium/pull/27822 (@tklauser)
  - Only backported third commit adding the trigger phrase to the conformance ingress workflow. The first two commits don't apply to the `v1.13` branch.

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27304 27822; do contrib/backporting/set-labels.py $pr done 1.13; done
```
or with
```
make add-labels BRANCH=v1.13 ISSUES=27304,27822
```