### PR TITLE
v1.12 Backports 2023-09-12

### DIFF
--- a/Documentation/gettingstarted/egress-gateway.rst
+++ b/Documentation/gettingstarted/egress-gateway.rst
@@ -78,6 +78,12 @@ acceleration (``--bpf-lb-acceleration=native``), the user must ensure that the
 host Iptables configuration allows packets through the ``FORWARD`` chain. Full
 support will be added in an upcoming release once :gh-issue:`19717` is resolved.
 
+Cluster Mesh
+------------
+
+Egress gateway is not compatible with the Cluster Mesh feature. The gateway selected
+by an egress gateway policy must be in the same cluster as the selected pods.
+
 Enable egress gateway
 =====================
 

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -495,7 +495,7 @@ func (n *Node) GetIPv6AllocCIDRs() []*cidr.CIDR {
 	if n.IPv6AllocCIDR != nil {
 		result = append(result, n.IPv6AllocCIDR)
 	}
-	if len(n.IPv4SecondaryAllocCIDRs) > 0 {
+	if len(n.IPv6SecondaryAllocCIDRs) > 0 {
 		result = append(result, n.IPv6SecondaryAllocCIDRs...)
 	}
 	return result

--- a/pkg/node/types/node_test.go
+++ b/pkg/node/types/node_test.go
@@ -6,9 +6,11 @@
 package types
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	. "gopkg.in/check.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -239,4 +241,116 @@ func (s *NodeSuite) TestNode_ToCiliumNode(c *C) {
 			NodeIdentity: uint64(12345),
 		},
 	})
+}
+
+func TestGetIPv4AllocCIDRs(t *testing.T) {
+	var (
+		cidr1 = cidr.MustParseCIDR("1.0.0.0/24")
+		cidr2 = cidr.MustParseCIDR("2.0.0.0/24")
+		cidr3 = cidr.MustParseCIDR("3.0.0.0/24")
+	)
+
+	var tests = []struct {
+		// name of test
+		name string
+		// primary ipv4 allocation cidr
+		allocCIDR *cidr.CIDR
+		// secondary ipv4 allocation cidrs
+		secAllocCIDRs []*cidr.CIDR
+		// expected ipv4 cidrs
+		expectedCIDRs []*cidr.CIDR
+	}{
+		{
+			name:          "nil cidrs",
+			allocCIDR:     nil,
+			secAllocCIDRs: nil,
+			expectedCIDRs: make([]*cidr.CIDR, 0),
+		},
+		{
+			name:          "one primary and no secondary cidrs",
+			allocCIDR:     cidr1,
+			secAllocCIDRs: nil,
+			expectedCIDRs: []*cidr.CIDR{cidr1},
+		},
+		{
+			name:          "one primary and one secondary cidr",
+			allocCIDR:     cidr1,
+			secAllocCIDRs: []*cidr.CIDR{cidr2},
+			expectedCIDRs: []*cidr.CIDR{cidr1, cidr2},
+		},
+		{
+			name:          "one primary and multiple secondary cidrs",
+			allocCIDR:     cidr1,
+			secAllocCIDRs: []*cidr.CIDR{cidr2, cidr3},
+			expectedCIDRs: []*cidr.CIDR{cidr1, cidr2, cidr3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := Node{
+				Name:                    fmt.Sprintf("node-%s", tt.name),
+				IPv4AllocCIDR:           tt.allocCIDR,
+				IPv4SecondaryAllocCIDRs: tt.secAllocCIDRs,
+			}
+
+			actual := n.GetIPv4AllocCIDRs()
+			assert.Equal(t, actual, tt.expectedCIDRs)
+		})
+	}
+}
+
+func TestGetIPv6AllocCIDRs(t *testing.T) {
+	var (
+		cidr2001 = cidr.MustParseCIDR("2001:db8::/32")
+		cidr2002 = cidr.MustParseCIDR("2002:db8::/32")
+		cidr2003 = cidr.MustParseCIDR("2003:db8::/32")
+	)
+
+	var tests = []struct {
+		// name of test
+		name string
+		// primary ipv6 allocation cidr
+		allocCIDR *cidr.CIDR
+		// secondary ipv6 allocation cidrs
+		secAllocCIDRs []*cidr.CIDR
+		// expected ipv6 cidrs
+		expectedCIDRs []*cidr.CIDR
+	}{
+		{
+			name:          "nil cidrs",
+			allocCIDR:     nil,
+			secAllocCIDRs: nil,
+			expectedCIDRs: make([]*cidr.CIDR, 0),
+		},
+		{
+			name:          "one primary and no secondary cidrs",
+			allocCIDR:     cidr2001,
+			secAllocCIDRs: nil,
+			expectedCIDRs: []*cidr.CIDR{cidr2001},
+		},
+		{
+			name:          "one primary and one secondary cidr",
+			allocCIDR:     cidr2001,
+			secAllocCIDRs: []*cidr.CIDR{cidr2002},
+			expectedCIDRs: []*cidr.CIDR{cidr2001, cidr2002},
+		},
+		{
+			name:          "one primary and multiple secondary cidrs",
+			allocCIDR:     cidr2001,
+			secAllocCIDRs: []*cidr.CIDR{cidr2002, cidr2003},
+			expectedCIDRs: []*cidr.CIDR{cidr2001, cidr2002, cidr2003},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n := Node{
+				Name:                    fmt.Sprintf("node-%s", tt.name),
+				IPv6AllocCIDR:           tt.allocCIDR,
+				IPv6SecondaryAllocCIDRs: tt.secAllocCIDRs,
+			}
+
+			actual := n.GetIPv6AllocCIDRs()
+			assert.Equal(t, actual, tt.expectedCIDRs)
+		})
+	}
 }

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -337,7 +337,11 @@ func (s *selectorManager) Equal(b *selectorManager) bool {
 // of the selections. If the old version is returned, the user is
 // guaranteed to receive a notification including the update.
 func (s *selectorManager) GetSelections() []identity.NumericIdentity {
-	return *(*[]identity.NumericIdentity)(atomic.LoadPointer(&s.selections))
+	selections := (*[]identity.NumericIdentity)(atomic.LoadPointer(&s.selections))
+	if selections == nil {
+		return emptySelection
+	}
+	return *selections
 }
 
 // Selects return 'true' if the CachedSelector selects the given

--- a/pkg/policy/selectorcache_test.go
+++ b/pkg/policy/selectorcache_test.go
@@ -612,6 +612,21 @@ func (ds *SelectorCacheTestSuite) TestIdentityUpdatesMultipleUsers(c *C) {
 	c.Assert(len(sc.selectors), Equals, 0)
 }
 
+func (ds *SelectorCacheTestSuite) TestSelectorManagerCanGetBeforeSet(c *C) {
+	defer func() {
+		r := recover()
+		c.Assert(r, Equals, nil)
+	}()
+
+	selectorManager := selectorManager{
+		key:   "test",
+		users: make(map[CachedSelectionUser]struct{}),
+	}
+	selections := selectorManager.GetSelections()
+	c.Assert(selections, Not(Equals), nil)
+	c.Assert(len(selections), Equals, 0)
+}
+
 func testNewSelectorCache(ids cache.IdentityCache) *SelectorCache {
 	sc := NewSelectorCache(testidentity.NewMockIdentityAllocator(ids), ids)
 	sc.SetLocalIdentityNotifier(testidentity.NewDummyIdentityNotifier())


### PR DESCRIPTION
 * [ ] #27855 (@danehans)
        - :warning: Minor conflict in unit test file (missing package import in v1.12)
 * [x] #27918 (@julianwiedmann)
        - :warning: Minor conflict because the change is in a different file. Also added a title to the newly added paragraph to be consistent.
 * [x] #27805 (@learnitall)
       - :warning: Minor conflict due to different atomic pointer type in older Golang versions **Please review carefully**

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 27855 27918 27805; do contrib/backporting/set-labels.py $pr done 1.12; done
```
or with
```
make add-labels BRANCH=v1.12 ISSUES=27855,27918,27805
```
