### PR TITLE
policy/api: use netip.Addr when sanitizing CIDR rules

### DIFF
--- a/pkg/policy/api/rule_validation_test.go
+++ b/pkg/policy/api/rule_validation_test.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"fmt"
+	"testing"
 
 	. "github.com/cilium/checkmate"
 	"github.com/cilium/proxy/pkg/policy/api/kafka"
@@ -1073,4 +1074,22 @@ func (s *PolicyAPITestSuite) TestL7RuleDirectionalitySupport(c *C) {
 	err = invalidDNSRule.Sanitize()
 	c.Assert(err, Not(IsNil))
 
+}
+
+func BenchmarkCIDRSanitize(b *testing.B) {
+	cidr4 := CIDRRule{Cidr: "192.168.100.200/24"}
+	cidr6 := CIDRRule{Cidr: "2001:0db8:85a3:0000:0000:8a2e:0370:7334/128"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := cidr4.sanitize()
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = cidr6.sanitize()
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }


### PR DESCRIPTION
This conversion should bring some memory usage improvements when using CIDR rules in policies.

Before/after benchmark:

```
name            old time/op    new time/op    delta
CIDRSanitize-8     969ns ± 7%     146ns ± 5%   -84.93%  (p=0.000 n=10+10)

name            old alloc/op   new alloc/op   delta
CIDRSanitize-8      168B ± 0%        0B       -100.00%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
CIDRSanitize-8      8.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```