### PR TITLE
feat(hubble): flows per pod metric

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -10,6 +10,8 @@
 Upgrade Guide
 *************
 
+TODO: update this doc
+
 .. _upgrade_general:
 
 This upgrade guide is intended for Cilium running on Kubernetes. If you have

--- a/pkg/hubble/metrics/flows-per-pod/handler.go
+++ b/pkg/hubble/metrics/flows-per-pod/handler.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package flows_per_pod
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	flowpb "github.com/cilium/cilium/api/v1/flow"
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+)
+
+type flowsPerPodHandler struct {
+	flowsPerPod *prometheus.CounterVec
+	context     *api.ContextOptions
+}
+
+func (h *flowsPerPodHandler) Init(registry *prometheus.Registry, options api.Options) error {
+	c, err := api.ParseContextOptions(options)
+	if err != nil {
+		return err
+	}
+	h.context = c
+
+	labels := []string{"protocol", "verdict"}
+	labels = append(labels, h.context.GetLabelNames()...)
+
+	h.flowsPerPod = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: api.DefaultPrometheusNamespace,
+		Name:      "flows_per_pod_total",
+		Help:      "Total number of flows per pod",
+	}, labels)
+
+	registry.MustRegister(h.flowsPerPod)
+
+	return nil
+}
+
+func (h *flowsPerPodHandler) Status() string {
+	return h.context.Status()
+}
+
+func (h *flowsPerPodHandler) Context() *api.ContextOptions {
+	return h.context
+}
+
+func (h *flowsPerPodHandler) ListMetricVec() []*prometheus.MetricVec {
+	return []*prometheus.MetricVec{h.flowsPerPod.MetricVec}
+}
+
+func (h *flowsPerPodHandler) ProcessFlow(ctx context.Context, flow *flowpb.Flow) error {
+	labelValues, err := h.context.GetLabelValues(flow)
+	if err != nil {
+		return err
+	}
+
+	labels := []string{v1.FlowProtocol(flow), flow.GetVerdict().String()}
+	labels = append(labels, labelValues...)
+
+	h.flowsPerPod.WithLabelValues(labels...).Inc()
+
+	return nil
+}

--- a/pkg/hubble/metrics/flows-per-pod/plugin.go
+++ b/pkg/hubble/metrics/flows-per-pod/plugin.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Hubble
+
+package flows_per_pod
+
+import (
+	"github.com/cilium/cilium/pkg/hubble/metrics/api"
+)
+
+type flowsPerPodPlugin struct{}
+
+func (p *flowsPerPodPlugin) NewHandler() api.Handler {
+	return &flowsPerPodHandler{}
+}
+
+func (p *flowsPerPodPlugin) HelpText() string {
+	return `flows-per-pod - Flows per pod
+Reports metrics related to flows by pod
+
+Metrics:
+  hubble_flows_per_pod_total  Number of flows per pod
+
+Options:` +
+		api.ContextOptionsHelp
+}
+
+func init() {
+	api.DefaultRegistry().Register("flows-per-pod", &flowsPerPodPlugin{})
+}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
  - TODO
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

New counter metric in Hubble measuring flows per pod.

```release-note
New counter metric in Hubble: `flows_per_pod_total`. Labels are `protocol`, `verdict`, and context-based labels.
```
