### PR TITLE
Refactor CiliumExecContext() Retry Logic

### DIFF
--- a/test/helpers/kubectl.go
+++ b/test/helpers/kubectl.go
@@ -2911,9 +2911,15 @@ func (kub *Kubectl) CiliumExecContext(ctx context.Context, pod string, cmd strin
 	for i := 0; i < limitTimes; i++ {
 		res = execute()
 		switch res.GetExitCode() {
+		case 0:
+			// Command succeeded. Return the result.
+			return res
 		case -1, 126:
-			// Retry.
+			// The preceding comments indicate that these return codes may occur frequently.
+			// To prevent excessive log entries in the default case, we catch these errors here
+			// and retry the command without generating additional log entries.
 		default:
+			// Command failed. Log failure and retry.
 			kub.Logger().Warningf("command terminated with exit code %d on try %d", res.GetExitCode(), i)
 		}
 		time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
Previously, the CiliumExecContext() function would retry the cilium command up to 5 times (limitTimes) without verifying the success of previous executions. This pull request introduces a logic enhancement that validates the return code of each executed command and exits upon success.

Additionally, this change optimizes test execution time by reducing unnecessary retries. With a 200ms delay between retries, the overall test execution time is expected to improve by at least 200ms multiplied by the number of cilium commands and the number of cilium pods involved.

Local Ginkgo tests, specifically those focused on 'K8sDatapathBGPTests' 'K8sDatapathCustomCalls' and 'K8sDatapathLRPTests' have shown significant improvements:

Before:
`Ran 2 of 106 Specs in 233.348 seconds`

After:
`Ran 2 of 106 Specs in 168.563 seconds`

Signed-off-by: Boris Petrovic <carnerito.b@gmail.com>