### PR TITLE
bpf: lxc: fix source sec identity in hairpin trace notification

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2092,7 +2092,7 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 	 */
 	if (ipv4_to_endpoint_is_hairpin_flow(ctx, ip4)) {
 		send_trace_notify4(ctx, TRACE_TO_LXC,
-				   ctx_load_meta(ctx, CB_SRC_LABEL),
+				   src_sec_identity,
 				   SECLABEL, ip4->saddr, LXC_ID,
 				   ctx->ingress_ifindex,
 				   TRACE_REASON_UNKNOWN, 0);


### PR DESCRIPTION
CB_SRC_LABEL is cleared just a few lines above. So to get the source's actual security identity, we need to use our local variable.

Fixes: e2829a061a53 ("bpf: lxc: support Pod->Service->Pod hairpinning with endpoint routes")

```release-note
Fix the trace notification for hairpinned reply traffic, to indicate the correct security identity for the client.
```
