### PR TITLE
Backport v1.12: FQDN fixes

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -65,6 +65,7 @@ cilium-agent [flags]
       --config string                                           Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                                       Configuration directory that contains a file for each option
       --conntrack-gc-interval duration                          Overwrite the connection-tracking garbage collection interval
+      --conntrack-gc-max-interval duration                      Set the maximum interval for the connection-tracking garbage collection
       --crd-wait-timeout duration                               Cilium will exit if CRDs are not available within this duration upon startup (default 5m0s)
       --datapath-mode string                                    Datapath mode name (default "veth")
   -D, --debug                                                   Enable debugging mode

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -373,6 +373,10 @@
      - Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable.
      - bool
      - ``true``
+   * - :spelling:ignore:`conntrackGCMaxInterval`
+     - Configure the maximum frequency for the garbage collection of the connection tracking table. Only affects the automatic computation for the frequency and has no effect when 'conntrackGCInterval' is set. This can be set to more frequently clean up unused identities created from ToFQDN policies.
+     - string
+     - ``""``
    * - :spelling:ignore:`containerRuntime`
      - Configure container runtime specific integration.
      - object

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -196,6 +196,7 @@ config
 configmap
 configs
 conntrack
+conntrackGCInterval
 containerd
 contrib
 coord

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -272,6 +272,9 @@ func initializeFlags() {
 	flags.Duration(option.ConntrackGCInterval, time.Duration(0), "Overwrite the connection-tracking garbage collection interval")
 	option.BindEnv(option.ConntrackGCInterval)
 
+	flags.Duration(option.ConntrackGCMaxInterval, time.Duration(0), "Set the maximum interval for the connection-tracking garbage collection")
+	option.BindEnv(option.ConntrackGCMaxInterval)
+
 	flags.BoolP(option.DebugArg, "D", false, "Enable debugging mode")
 	option.BindEnv(option.DebugArg)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -889,6 +889,10 @@ func initializeFlags() {
 	flags.Int(option.PolicyMapEntriesName, policymap.MaxEntries, "Maximum number of entries in endpoint policy map (per endpoint)")
 	option.BindEnv(option.PolicyMapEntriesName)
 
+	flags.Duration(option.PolicyMapFullReconciliationIntervalName, 15*time.Minute, "Interval for full reconciliation of endpoint policy map")
+	option.BindEnv(option.PolicyMapFullReconciliationIntervalName)
+	flags.MarkHidden(option.PolicyMapFullReconciliationIntervalName)
+
 	flags.Int(option.SockRevNatEntriesName, option.SockRevNATMapEntriesDefault, "Maximum number of entries for the SockRevNAT BPF map")
 	option.BindEnv(option.SockRevNatEntriesName)
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -144,6 +144,7 @@ contributors across the globe, there is almost always someone available to help.
 | cni.install | bool | `true` | Install the CNI configuration and binary files into the filesystem. |
 | cni.logFile | string | `"/var/run/cilium/cilium-cni.log"` | Configure the log file for CNI logging with retention policy of 7 days. Disable CNI file logging by setting this field to empty explicitly. |
 | cni.uninstall | bool | `true` | Remove the CNI configuration and binary files on agent shutdown. Enable this if you're removing Cilium from the cluster. Disable this to prevent the CNI configuration file from being removed during agent upgrade, which can cause nodes to go unmanageable. |
+| conntrackGCMaxInterval | string | `""` | Configure the maximum frequency for the garbage collection of the connection tracking table. Only affects the automatic computation for the frequency and has no effect when 'conntrackGCInterval' is set. This can be set to more frequently clean up unused identities created from ToFQDN policies. |
 | containerRuntime | object | `{"integration":"none"}` | Configure container runtime specific integration. |
 | containerRuntime.integration | string | `"none"` | Enables specific integrations for container runtimes. Supported values: - containerd - crio - docker - none - auto (automatically detect the container runtime) |
 | customCalls | object | `{"enabled":false}` | Tail call hooks for custom eBPF programs. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -101,6 +101,10 @@ data:
   conntrack-gc-interval: {{ .Values.conntrackGCInterval | quote }}
 {{- end }}
 
+{{- if .Values.conntrackGCMaxInterval }}
+  conntrack-gc-max-interval: {{ .Values.conntrackGCMaxInterval | quote }}
+{{- end }}
+
 {{- if hasKey .Values "disableEnvoyVersionCheck" }}
   disable-envoy-version-check: {{ .Values.disableEnvoyVersionCheck | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -434,6 +434,12 @@ cni:
 # connection tracking table.
 # conntrackGCInterval: "0s"
 
+# -- (string) Configure the maximum frequency for the garbage collection of the
+# connection tracking table. Only affects the automatic computation for the frequency
+# and has no effect when 'conntrackGCInterval' is set. This can be set to more frequently
+# clean up unused identities created from ToFQDN policies.
+conntrackGCMaxInterval: ""
+
 # -- Configure container runtime specific integration.
 containerRuntime:
   # -- Enables specific integrations for container runtimes.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -431,6 +431,12 @@ cni:
 # connection tracking table.
 # conntrackGCInterval: "0s"
 
+# -- (string) Configure the maximum frequency for the garbage collection of the
+# connection tracking table. Only affects the automatic computation for the frequency
+# and has no effect when 'conntrackGCInterval' is set. This can be set to more frequently
+# clean up unused identities created from ToFQDN policies.
+conntrackGCMaxInterval: ""
+
 # -- Configure container runtime specific integration.
 containerRuntime:
   # -- Enables specific integrations for container runtimes.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -101,29 +101,29 @@ func NoopFunc(ctx context.Context) error {
 // Controllers have a name and are tied to a Manager. The manager is typically
 // bound to higher level objects such as endpoint. These higher level objects
 // can then run multiple controllers to perform async tasks such as:
-//  - Annotating k8s resources with values
-//  - Synchronizing an object with the kvstore
-//  - Any other async operation to may fail and require retries
+//   - Annotating k8s resources with values
+//   - Synchronizing an object with the kvstore
+//   - Any other async operation to may fail and require retries
 //
 // Embedding the Manager into higher level resources allows to bind controllers
 // to the lifetime of that object. Controllers also have a UUID to allow
 // correlating all log messages of a controller instance.
 //
 // Guidelines to writing controllers:
-// * Make sure that the task the controller performs is done in an atomic
-//   fashion, e.g. if a controller modifies a resource in multiple steps, an
-//   intermediate manipulation operation failing should not leave behind
-//   an inconsistent state. This can typically be achieved by locking the
-//   resource and rolling back or by using transactions.
-// * Controllers typically act on behalf of a higher level object such as an
-//   endpoint. The controller must ensure that the higher level object is
-//   properly locked when accessing any fields.
-// * Controllers run asynchronously in the background, it is the responsibility
-//   of the controller to be aware of the lifecycle of the owning higher level
-//   object. This is typically achieved by removing all controllers when the
-//   owner dies. It is the responsibility of the owner to either lock the owner
-//   in a way that will delay destruction throughout the controller run or to
-//   check for the destruction throughout the run.
+//   - Make sure that the task the controller performs is done in an atomic
+//     fashion, e.g. if a controller modifies a resource in multiple steps, an
+//     intermediate manipulation operation failing should not leave behind
+//     an inconsistent state. This can typically be achieved by locking the
+//     resource and rolling back or by using transactions.
+//   - Controllers typically act on behalf of a higher level object such as an
+//     endpoint. The controller must ensure that the higher level object is
+//     properly locked when accessing any fields.
+//   - Controllers run asynchronously in the background, it is the responsibility
+//     of the controller to be aware of the lifecycle of the owning higher level
+//     object. This is typically achieved by removing all controllers when the
+//     owner dies. It is the responsibility of the owner to either lock the owner
+//     in a way that will delay destruction throughout the controller run or to
+//     check for the destruction throughout the run.
 type Controller struct {
 	mutex             lock.RWMutex
 	name              string

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -27,8 +27,6 @@ import (
 	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
-	"github.com/cilium/cilium/pkg/identity"
-	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/loadinfo"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/bwmap"
@@ -196,24 +194,6 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	return err
 }
 
-// policyIdentitiesLabelLookup is an implementation of the policy.Identites interface.
-type policyIdentitiesLabelLookup struct {
-	*Endpoint
-}
-
-// GetLabels implements the policy.Identites interface{} method GetLabels,
-// which allows Endpoint.addNewRedirectsFromDesiredPolicy to call `l4.ToMapState`
-// with a label cache. This enables `l4.ToMapstate` to look up CIDRs associated with
-// identites to make a final determination about whether they should even be inserted into
-// an Endpoint's policy map.
-func (p *policyIdentitiesLabelLookup) GetLabels(id identity.NumericIdentity) labels.LabelArray {
-	ident := p.allocator.LookupIdentityByID(context.Background(), id)
-	if ident != nil {
-		return ident.LabelArray
-	}
-	return nil
-}
-
 // addNewRedirectsFromDesiredPolicy must be called while holding the endpoint lock for
 // writing. On success, returns nil; otherwise, returns an error indicating the
 // problem that occurred while adding an l7 redirect for the specified policy.
@@ -239,6 +219,8 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 
 	adds := make(policy.Keys)
 	old := make(policy.MapState)
+
+	selectorCache := e.desiredPolicy.SelectorCache
 
 	for _, l4 := range m {
 		// Deny policies do not support redirects
@@ -314,13 +296,12 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				direction = trafficdirection.Egress
 			}
 
-			idLookup := &policyIdentitiesLabelLookup{e}
-			keysFromFilter := l4.ToMapState(e, direction, idLookup)
+			keysFromFilter := l4.ToMapState(e, direction, selectorCache)
 			for keyFromFilter, entry := range keysFromFilter {
 				if entry.IsRedirectEntry() {
 					entry.ProxyPort = redirectPort
 				}
-				e.desiredPolicy.PolicyMapState.DenyPreferredInsertWithChanges(keyFromFilter, entry, adds, nil, old, idLookup)
+				e.desiredPolicy.PolicyMapState.DenyPreferredInsertWithChanges(keyFromFilter, entry, adds, nil, old, selectorCache)
 			}
 		}
 	}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1413,12 +1413,6 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	return err
 }
 
-const (
-	// syncPolicyMapInterval is the interval for periodic full reconciliation of
-	// the policy map to catch unexpected discrepancies with agent and kernel state.
-	syncPolicyMapInterval = 15 * time.Minute
-)
-
 func (e *Endpoint) startSyncPolicyMapController() {
 	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
 	e.controllers.CreateController(ctrlName,
@@ -1436,7 +1430,7 @@ func (e *Endpoint) startSyncPolicyMapController() {
 			StopFunc: func(ctx context.Context) error {
 				return nil
 			},
-			RunInterval: syncPolicyMapInterval,
+			RunInterval: option.Config.PolicyMapFullReconciliationInterval,
 			Context:     e.aliveCtx,
 		},
 	)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -419,9 +419,10 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
 	}
 
-	// Keep PolicyMap for this endpoint in sync with desired / realized state.
+	// Start periodic background full reconciliation of the policy map.
+	// Does nothing if it has already been started.
 	if !option.Config.DryMode {
-		e.syncPolicyMapController()
+		e.startSyncPolicyMapController()
 	}
 
 	if e.desiredPolicy != e.realizedPolicy {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -464,13 +464,24 @@ func (l Label) FormatForKVStore() []byte {
 	// kvstore.prefixMatchesKey())
 	b := make([]byte, 0, len(l.Source)+len(l.Key)+len(l.Value)+3)
 	buf := bytes.NewBuffer(b)
+	l.formatForKVStoreInto(buf)
+	return buf.Bytes()
+}
+
+// formatForKVStoreInto writes the label as a formatted string, ending in
+// a semicolon into buf.
+//
+// DO NOT BREAK THE FORMAT OF THIS. THE RETURNED STRING IS USED AS
+// PART OF THE KEY IN THE KEY-VALUE STORE.
+//
+// Non-pointer receiver allows this to be called on a value in a map.
+func (l Label) formatForKVStoreInto(buf *bytes.Buffer) {
 	buf.WriteString(l.Source)
 	buf.WriteRune(':')
 	buf.WriteString(l.Key)
 	buf.WriteRune('=')
 	buf.WriteString(l.Value)
 	buf.WriteRune(';')
-	return buf.Bytes()
 }
 
 // SortedList returns the labels as a sorted list, separated by semicolon
@@ -484,10 +495,21 @@ func (l Labels) SortedList() []byte {
 	}
 	sort.Strings(keys)
 
-	b := make([]byte, 0, len(keys)*2)
+	// Labels can have arbitrary size. However, when many CIDR identities are in
+	// the system, for example due to a FQDN policy matching S3, CIDR labels
+	// dominate in number. IPv4 CIDR labels in serialized form are max 25 bytes
+	// long. Allocate slightly more to avoid having a realloc if there's some
+	// other labels which may longer, since the cost of allocating a few bytes
+	// more is dominated by a second allocation, especially since these
+	// allocations are short-lived.
+	//
+	// cidr:123.123.123.123/32=;
+	// 0        1         2
+	// 1234567890123456789012345
+	b := make([]byte, 0, len(keys)*30)
 	buf := bytes.NewBuffer(b)
 	for _, k := range keys {
-		buf.Write(l[k].FormatForKVStore())
+		l[k].formatForKVStoreInto(buf)
 	}
 
 	return buf.Bytes()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -111,6 +111,9 @@ const (
 	// ConntrackGCInterval is the name of the ConntrackGCInterval option
 	ConntrackGCInterval = "conntrack-gc-interval"
 
+	// ConntrackGCMaxInterval is the name of the ConntrackGCMaxInterval option
+	ConntrackGCMaxInterval = "conntrack-gc-max-interval"
+
 	// DebugArg is the argument enables debugging mode
 	DebugArg = "debug"
 
@@ -1816,6 +1819,10 @@ type DaemonConfig struct {
 	// interval
 	ConntrackGCInterval time.Duration
 
+	// ConntrackGCMaxInterval if set limits the automatic GC interval calculation to
+	// the specified maximum value.
+	ConntrackGCMaxInterval time.Duration
+
 	// K8sEventHandover enables use of the kvstore to optimize Kubernetes
 	// event handling by listening for k8s events in the operator and
 	// mirroring it into the kvstore for reduced overhead in large
@@ -3143,6 +3150,7 @@ func (c *DaemonConfig) Populate() {
 	}
 
 	c.ConntrackGCInterval = viper.GetDuration(ConntrackGCInterval)
+	c.ConntrackGCMaxInterval = viper.GetDuration(ConntrackGCMaxInterval)
 
 	if m, err := command.GetStringMapStringE(viper.GetViper(), KVStoreOpt); err != nil {
 		log.Fatalf("unable to parse %s: %s", KVStoreOpt, err)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -627,6 +627,10 @@ const (
 	// PolicyMapEntriesName configures max entries for BPF policymap.
 	PolicyMapEntriesName = "bpf-policy-map-max"
 
+	// PolicyMapFullReconciliationInterval sets the interval for performing the full
+	// reconciliation of the endpoint policy map.
+	PolicyMapFullReconciliationIntervalName = "bpf-policy-map-full-reconciliation-interval"
+
 	// SockRevNatEntriesName configures max entries for BPF sock reverse nat
 	// entries.
 	SockRevNatEntriesName = "bpf-sock-rev-map-max"
@@ -1459,6 +1463,10 @@ type DaemonConfig struct {
 	// PolicyMapEntries is the maximum number of peer identities that an
 	// endpoint may allow traffic to exchange traffic with.
 	PolicyMapEntries int
+
+	// PolicyMapFullReconciliationInterval is the interval at which to perform
+	// the full reconciliation of the endpoint policy map.
+	PolicyMapFullReconciliationInterval time.Duration
 
 	// SockRevNatEntries is the maximum number of sock rev nat mappings
 	// allowed in the BPF rev nat table
@@ -3530,6 +3538,7 @@ func (c *DaemonConfig) calculateBPFMapSizes() error {
 	c.NATMapEntriesGlobal = viper.GetInt(NATMapEntriesGlobalName)
 	c.NeighMapEntriesGlobal = viper.GetInt(NeighMapEntriesGlobalName)
 	c.PolicyMapEntries = viper.GetInt(PolicyMapEntriesName)
+	c.PolicyMapFullReconciliationInterval = viper.GetDuration(PolicyMapFullReconciliationIntervalName)
 	c.SockRevNatEntries = viper.GetInt(SockRevNatEntriesName)
 	c.LBMapEntries = viper.GetInt(LBMapEntriesName)
 	c.LBServiceMapEntries = viper.GetInt(LBServiceMapMaxEntries)

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -453,7 +453,6 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 func (m MapState) clearCaches() {
 	for k, v := range m {
 		v.owners = make(map[MapStateOwner]struct{})
-		v.cachedNets = nil
 		m[k] = v
 	}
 }

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -40,6 +40,10 @@ var (
 	ep2 = testutils.NewTestEndpoint()
 )
 
+func localIdentity(n uint32) identity.NumericIdentity {
+	return identity.NumericIdentity(n) | identity.LocalIdentityFlag
+
+}
 func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
 	repo := NewPolicyRepository(nil, nil, nil)
 	cache := repo.policyCache
@@ -1206,7 +1210,7 @@ var (
 		owners:           map[MapStateOwner]struct{}{},
 	}
 
-	worldIPIdentity    = identity.NumericIdentity(16324)
+	worldIPIdentity    = localIdentity(16324)
 	worldCIDR          = api.CIDR("192.0.2.3/32")
 	lblWorldIP         = labels.ParseSelectLabelArray(fmt.Sprintf("%s:%s", labels.LabelSourceCIDR, worldCIDR))
 	ruleL3AllowWorldIP = api.NewRule().WithIngressRules([]api.IngressRule{{
@@ -1219,7 +1223,7 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	worldSubnetIdentity = identity.NumericIdentity(16325)
+	worldSubnetIdentity = localIdentity(16325)
 	worldSubnet         = api.CIDR("192.0.2.0/24")
 	worldSubnetRule     = api.CIDRRule{
 		Cidr: worldSubnet,

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -194,11 +194,11 @@ func (e *MapStateEntry) getNets(identities Identities, ident uint32) []*net.IPNe
 		}
 		return e.cachedNets
 	}
-	if identities == nil {
+	// CIDR identities have a local scope, so we can skip the rest if id is not of local scope.
+	if !id.HasLocalScope() || identities == nil {
 		return nil
 	}
 	lbls := identities.GetLabels(id)
-	nets := make([]*net.IPNet, 0, 1)
 	var (
 		maskSize         int
 		mostSpecificCidr *net.IPNet
@@ -215,10 +215,10 @@ func (e *MapStateEntry) getNets(identities Identities, ident uint32) []*net.IPNe
 		}
 	}
 	if mostSpecificCidr != nil {
-		nets = append(nets, mostSpecificCidr)
+		e.cachedNets = []*net.IPNet{mostSpecificCidr}
+		return e.cachedNets
 	}
-	e.cachedNets = nets
-	return nets
+	return nil
 }
 
 // AddDependent adds 'key' to the set of dependent keys.

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -48,7 +48,7 @@ const (
 type MapState map[Key]MapStateEntry
 
 type Identities interface {
-	GetLabels(identity.NumericIdentity) labels.LabelArray
+	GetNetsLocked(identity.NumericIdentity) []*net.IPNet
 }
 
 // Key is the userspace representation of a policy key in BPF. It is
@@ -122,9 +122,6 @@ type MapStateEntry struct {
 	// dependents contains the keys for entries create based on this entry. These entries
 	// will be deleted once all of the owners are deleted.
 	dependents Keys
-
-	// cachedNets caches the subnets (if any) associated with this MapStateEntry.
-	cachedNets []*net.IPNet
 }
 
 // NewMapStateEntry creates a map state entry. If redirect is true, the
@@ -179,46 +176,22 @@ func (e *MapStateEntry) HasDependent(key Key) bool {
 
 // getNets returns the most specific CIDR for an identity. For the "World" identity
 // it returns both IPv4 and IPv6.
-func (e *MapStateEntry) getNets(identities Identities, ident uint32) []*net.IPNet {
-	// Caching results is not dangerous in this situation as the entry
-	// is ephemerally tied to the lifecycle of the MapState object that
-	// it will be in.
-	if e.cachedNets != nil {
-		return e.cachedNets
-	}
+func getNets(identities Identities, ident uint32) []*net.IPNet {
+	// World identities are handled explicitly for two reasons:
+	// 1. 'identities' may be nil, but world identities are still expected to be considered
+	// 2. SelectorCache is not be informed of reserved/world identities in all test cases
 	id := identity.NumericIdentity(ident)
 	if id == identity.ReservedIdentityWorld {
-		e.cachedNets = []*net.IPNet{
+		return []*net.IPNet{
 			{IP: net.IPv4zero, Mask: net.CIDRMask(0, net.IPv4len*8)},
 			{IP: net.IPv6zero, Mask: net.CIDRMask(0, net.IPv6len*8)},
 		}
-		return e.cachedNets
 	}
 	// CIDR identities have a local scope, so we can skip the rest if id is not of local scope.
 	if !id.HasLocalScope() || identities == nil {
 		return nil
 	}
-	lbls := identities.GetLabels(id)
-	var (
-		maskSize         int
-		mostSpecificCidr *net.IPNet
-	)
-	for _, lbl := range lbls {
-		if lbl.Source == labels.LabelSourceCIDR {
-			_, netIP, err := net.ParseCIDR(lbl.Key)
-			if err == nil {
-				if ms, _ := netIP.Mask.Size(); ms > maskSize {
-					mostSpecificCidr = netIP
-					maskSize = ms
-				}
-			}
-		}
-	}
-	if mostSpecificCidr != nil {
-		e.cachedNets = []*net.IPNet{mostSpecificCidr}
-		return e.cachedNets
-	}
-	return nil
+	return identities.GetNetsLocked(id)
 }
 
 // AddDependent adds 'key' to the set of dependent keys.
@@ -413,18 +386,18 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, adds, de
 	}
 }
 
-// entryIdentityIsSupersetOf compares two entries and keys to see if the primary identity contains
+// identityIsSupersetOf compares two entries and keys to see if the primary identity contains
 // the compared identity. This means that either that primary identity is 0 (i.e. it is a superset
 // of every other identity), or one of the subnets of the primary identity fully contains or is
 // equal to one of the subnets in the compared identity (note:this covers cases like "reserved:world").
-func entryIdentityIsSupersetOf(primaryKey Key, primaryEntry MapStateEntry, compareKey Key, compareEntry MapStateEntry, identities Identities) bool {
+func identityIsSupersetOf(primaryIdentity, compareIdentity uint32, identities Identities) bool {
 	// If the identities are equal then neither is a superset (for the purposes of our business logic).
-	if primaryKey.Identity == compareKey.Identity {
+	if primaryIdentity == compareIdentity {
 		return false
 	}
-	return primaryKey.Identity == 0 && compareKey.Identity != 0 ||
-		ip.NetsContainsAny(primaryEntry.getNets(identities, primaryKey.Identity),
-			compareEntry.getNets(identities, compareKey.Identity))
+	return primaryIdentity == 0 && compareIdentity != 0 ||
+		ip.NetsContainsAny(getNets(identities, primaryIdentity),
+			getNets(identities, compareIdentity))
 }
 
 // protocolsMatch checks to see if two given keys match on protocol.
@@ -465,7 +438,7 @@ func (keys MapState) DenyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 				continue
 			}
 			if !v.IsDeny {
-				if entryIdentityIsSupersetOf(k, v, newKey, newEntry, identities) {
+				if identityIsSupersetOf(k.Identity, newKey.Identity, identities) {
 					if newKey.PortProtoIsBroader(k) {
 						// If this iterated-allow-entry is a superset of the new-entry
 						// and it has a more specific port-protocol than the new-entry
@@ -482,7 +455,7 @@ func (keys MapState) DenyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 						newEntry.AddDependent(newKeyCpy)
 					}
 				} else if (newKey.Identity == k.Identity ||
-					entryIdentityIsSupersetOf(newKey, newEntry, k, v, identities)) &&
+					identityIsSupersetOf(newKey.Identity, k.Identity, identities)) &&
 					(newKey.PortProtoIsBroader(k) || newKey.PortProtoIsEqual(k)) {
 					// If the new-entry is a superset (or equal) of the iterated-allow-entry and
 					// the new-entry has a broader (or equal) port-protocol then we
@@ -490,7 +463,7 @@ func (keys MapState) DenyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 					keys.deleteKeyWithChanges(k, nil, adds, deletes, old)
 				}
 			} else if (newKey.Identity == k.Identity ||
-				entryIdentityIsSupersetOf(k, v, newKey, newEntry, identities)) &&
+				identityIsSupersetOf(k.Identity, newKey.Identity, identities)) &&
 				k.DestPort == 0 && k.Nexthdr == 0 &&
 				!v.HasDependent(newKey) {
 				// If this iterated-deny-entry is a supserset (or equal) of the new-entry and
@@ -503,7 +476,7 @@ func (keys MapState) DenyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 				// but there *may* be performance tradeoffs.
 				return
 			} else if (newKey.Identity == k.Identity ||
-				entryIdentityIsSupersetOf(newKey, newEntry, k, v, identities)) &&
+				identityIsSupersetOf(newKey.Identity, k.Identity, identities)) &&
 				newKey.DestPort == 0 && newKey.Nexthdr == 0 &&
 				!newEntry.HasDependent(k) {
 				// If this iterated-deny-entry is a subset (or equal) of the new-entry and
@@ -527,7 +500,7 @@ func (keys MapState) DenyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 			}
 			// NOTE: We do not delete redundant allow entries.
 			if v.IsDeny {
-				if entryIdentityIsSupersetOf(newKey, newEntry, k, v, identities) {
+				if identityIsSupersetOf(newKey.Identity, k.Identity, identities) {
 					if k.PortProtoIsBroader(newKey) {
 						// If the new-entry is *only* superset of the iterated-deny-entry
 						// and the new-entry has a more specific port-protocol than the
@@ -546,7 +519,7 @@ func (keys MapState) DenyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 						keys[k] = v
 					}
 				} else if (k.Identity == newKey.Identity ||
-					entryIdentityIsSupersetOf(k, v, newKey, newEntry, identities)) &&
+					identityIsSupersetOf(k.Identity, newKey.Identity, identities)) &&
 					(k.PortProtoIsBroader(newKey) || k.PortProtoIsEqual(newKey)) &&
 					!v.HasDependent(newKey) {
 					// If the iterated-deny-entry is a superset (or equal) of the new-entry and has a

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -162,7 +162,9 @@ type identitySelector interface {
 type scIdentity struct {
 	NID       identity.NumericIdentity
 	lbls      labels.LabelArray
-	namespace string // value of the namespace label, or ""
+	nets      []*net.IPNet // Most specific CIDR for the identity, if any.
+	computed  bool         // nets has been computed
+	namespace string       // value of the namespace label, or ""
 }
 
 // scIdentityCache is a cache of Identities keyed by the numeric identity
@@ -172,8 +174,35 @@ func newIdentity(nid identity.NumericIdentity, lbls labels.LabelArray) scIdentit
 	return scIdentity{
 		NID:       nid,
 		lbls:      lbls,
+		nets:      getLocalScopeNets(nid, lbls),
 		namespace: lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceLabel),
+		computed:  true,
 	}
+}
+
+// getLocalScopeNets returns the most specific CIDR for a local scope identity.
+func getLocalScopeNets(id identity.NumericIdentity, lbls labels.LabelArray) []*net.IPNet {
+	if id.HasLocalScope() {
+		var (
+			maskSize         int
+			mostSpecificCidr *net.IPNet
+		)
+		for _, lbl := range lbls {
+			if lbl.Source == labels.LabelSourceCIDR {
+				_, netIP, err := net.ParseCIDR(lbl.Key)
+				if err == nil {
+					if ms, _ := netIP.Mask.Size(); ms > maskSize {
+						mostSpecificCidr = netIP
+						maskSize = ms
+					}
+				}
+			}
+		}
+		if mostSpecificCidr != nil {
+			return []*net.IPNet{mostSpecificCidr}
+		}
+	}
+	return nil
 }
 
 func getIdentityCache(ids cache.IdentityCache) scIdentityCache {
@@ -1084,10 +1113,18 @@ func (sc *SelectorCache) RemoveIdentitiesFQDNSelectors(fqdnSels []api.FQDNSelect
 	sc.releaseIdentityMappings(identitiesToRelease)
 }
 
-func (sc *SelectorCache) GetLabels(id identity.NumericIdentity) labels.LabelArray {
+// GetNetsLocked returns the most specific CIDR for an identity. For the "World" identity
+// it returns both IPv4 and IPv6.
+func (sc *SelectorCache) GetNetsLocked(id identity.NumericIdentity) []*net.IPNet {
 	ident, ok := sc.idCache[id]
 	if !ok {
-		return labels.LabelArray{}
+		return nil
 	}
-	return ident.lbls
+	if !ident.computed {
+		log.WithFields(logrus.Fields{
+			logfields.Identity: id,
+			logfields.Labels:   ident.lbls,
+		}).Warning("GetNetsLocked: Identity with missing nets!")
+	}
+	return ident.nets
 }


### PR DESCRIPTION
Backports FQDN related fixes to v1.12 that were not straightforward to backport.

- [x] https://github.com/cilium/cilium/pull/26345 (@jrajahalme)
- [x] https://github.com/cilium/cilium/pull/27670 (@jrajahalme)
- [x] https://github.com/cilium/cilium/pull/27693 (@joamaki)
- [x] https://github.com/cilium/cilium/pull/27870 (@joamaki)
- [x] https://github.com/cilium/cilium/pull/27985 (@joamaki)
- [x] https://github.com/cilium/cilium/pull/27796 (@bimmlerd)

```
for pr in 26345 27670 27693 27870 27985 27796; do contrib/backporting/set-labels.py $pr done 1.12; done
```