### PR TITLE
StateDB: split write methods from Table into RWTable

### DIFF
--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -41,7 +41,7 @@ type params struct {
 
 	Lifecycle           hive.Lifecycle
 	Logger              logrus.FieldLogger
-	L2AnnouncementTable statedb.Table[*tables.L2AnnounceEntry]
+	L2AnnouncementTable statedb.RWTable[*tables.L2AnnounceEntry]
 	StateDB             *statedb.DB
 	L2ResponderMap      l2respondermap.Map
 	NetLink             linkByNamer

--- a/pkg/datapath/l2responder/l2responder_test.go
+++ b/pkg/datapath/l2responder/l2responder_test.go
@@ -24,7 +24,7 @@ import (
 
 type fixture struct {
 	reconciler         *l2ResponderReconciler
-	proxyNeighborTable statedb.Table[*tables.L2AnnounceEntry]
+	proxyNeighborTable statedb.RWTable[*tables.L2AnnounceEntry]
 	stateDB            *statedb.DB
 	mockNetlink        *mockNeighborNetlink
 	respondermap       l2respondermap.Map
@@ -32,7 +32,7 @@ type fixture struct {
 
 func newFixture() *fixture {
 	var (
-		tbl statedb.Table[*tables.L2AnnounceEntry]
+		tbl statedb.RWTable[*tables.L2AnnounceEntry]
 		db  *statedb.DB
 		jr  job.Registry
 	)
@@ -41,7 +41,7 @@ func newFixture() *fixture {
 		statedb.Cell,
 		tables.Cell,
 		job.Cell,
-		cell.Invoke(func(d *statedb.DB, t statedb.Table[*tables.L2AnnounceEntry], j job.Registry) {
+		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], j job.Registry) {
 			db = d
 			tbl = t
 			jr = j

--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -13,8 +13,10 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/statedb"
 )
 
 // DeviceManager is a temporary compatibility bridge to keep DeviceManager uses as is and reuse its tests
@@ -23,7 +25,7 @@ import (
 // This will be refactored away in follow-up PRs that convert code over to the devices table.
 // The DirectRoutingDevice and IPv6MCastDevice would computed from the devices table as necessary.
 type DeviceManager struct {
-	params         devicesControllerParams
+	params         devicesManagerParams
 	initialDevices []string
 	hive           *hive.Hive
 }
@@ -134,9 +136,17 @@ func (dm *DeviceManager) Listen(ctx context.Context) (chan []string, error) {
 	return devs, nil
 }
 
+type devicesManagerParams struct {
+	cell.In
+
+	DB          *statedb.DB
+	DeviceTable statedb.Table[*tables.Device]
+	RouteTable  statedb.Table[*tables.Route]
+}
+
 // newDeviceManager constructs a DeviceManager that implements the old DeviceManager API.
 // Dummy dependency to *devicesController to make sure devices table is populated.
-func newDeviceManager(p devicesControllerParams, _ *devicesController) *DeviceManager {
+func newDeviceManager(p devicesManagerParams, _ *devicesController) *DeviceManager {
 	return &DeviceManager{params: p, hive: nil}
 }
 

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -40,10 +40,22 @@ var DevicesControllerCell = cell.Module(
 	"devices-controller",
 	"Synchronizes the device and route tables with the kernel",
 
+	// This controller owns the device and route tables. This gives
+	// Table[*Device] to the world and RWTable[*Device] for us.
+	// But these cells are still usable directly in tests to provide
+	// the modules under test device and route test data.
+	tables.DeviceTableCell,
+	tables.RouteTableCell,
+
 	cell.Provide(
 		newDevicesController,
 		newDeviceManager,
 	),
+
+	// Always construct the devices controller. We provide the
+	// *devicesController for DeviceManager, but once it has been removed,
+	// this can be refactored to just do an invoke to register the
+	// controller jobs.
 	cell.Invoke(func(*devicesController) {}),
 )
 

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -77,8 +77,8 @@ type devicesControllerParams struct {
 	Config      DevicesConfig
 	Log         logrus.FieldLogger
 	DB          *statedb.DB
-	DeviceTable statedb.Table[*tables.Device]
-	RouteTable  statedb.Table[*tables.Route]
+	DeviceTable statedb.RWTable[*tables.Device]
+	RouteTable  statedb.RWTable[*tables.Route]
 
 	// netlinkFuncs is optional and used by tests to verify error handling behavior.
 	NetlinkFuncs *netlinkFuncs `optional:"true"`

--- a/pkg/datapath/linux/devices_controller_test.go
+++ b/pkg/datapath/linux/devices_controller_test.go
@@ -445,7 +445,6 @@ func TestDevicesController_Restarts(t *testing.T) {
 
 	h := hive.New(
 		statedb.Cell,
-		tables.Cell,
 		DevicesControllerCell,
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Provide(func() *netlinkFuncs { return &funcs }),

--- a/pkg/datapath/tables/cells.go
+++ b/pkg/datapath/tables/cells.go
@@ -12,6 +12,4 @@ var Cell = cell.Module(
 	"Datapath state tables",
 
 	L2AnnounceTableCell,
-	DeviceTableCell,
-	RouteTableCell,
 )

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -45,7 +45,7 @@ var (
 		},
 	}
 
-	DeviceTableCell = statedb.NewTableCell[*Device](
+	DeviceTableCell = statedb.NewProtectedTableCell[*Device](
 		"devices",
 		DeviceIDIndex,
 		DeviceNameIndex,

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -41,7 +41,7 @@ var (
 		},
 	}
 
-	RouteTableCell = statedb.NewTableCell[*Route](
+	RouteTableCell = statedb.NewProtectedTableCell[*Route](
 		"routes",
 		RouteIDIndex,
 		RouteLinkIndex,

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -72,7 +72,7 @@ type l2AnnouncerParams struct {
 	Services             resource.Resource[*slim_corev1.Service]
 	L2AnnouncementPolicy resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy]
 	LocalNodeResource    daemon_k8s.LocalCiliumNodeResource
-	L2AnnounceTable      statedb.Table[*tables.L2AnnounceEntry]
+	L2AnnounceTable      statedb.RWTable[*tables.L2AnnounceEntry]
 	StateDB              *statedb.DB
 	JobRegistry          job.Registry
 }

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -45,7 +45,7 @@ type fixture struct {
 
 func newFixture() *fixture {
 	var (
-		tbl statedb.Table[*tables.L2AnnounceEntry]
+		tbl statedb.RWTable[*tables.L2AnnounceEntry]
 		db  *statedb.DB
 		jr  job.Registry
 	)
@@ -54,7 +54,7 @@ func newFixture() *fixture {
 		statedb.Cell,
 		tables.Cell,
 		job.Cell,
-		cell.Invoke(func(d *statedb.DB, t statedb.Table[*tables.L2AnnounceEntry], j job.Registry) {
+		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], j job.Registry) {
 			db = d
 			tbl = t
 			jr = j

--- a/pkg/statedb/cell.go
+++ b/pkg/statedb/cell.go
@@ -42,8 +42,9 @@ func newHiveDB(lc hive.Lifecycle, tablesIn tablesIn) (*DB, error) {
 
 type tableOut[Obj any] struct {
 	cell.Out
-	Table Table[Obj]
-	Meta  TableMeta `group:"statedb-tables"`
+	Reader Table[Obj]
+	Writer RWTable[Obj]
+	Meta   TableMeta `group:"statedb-tables"`
 }
 
 // NewTableCell creates a cell for creating and registering a statedb Table[Obj].
@@ -53,10 +54,44 @@ func NewTableCell[Obj any](
 	secondaryIndexers ...Indexer[Obj],
 ) cell.Cell {
 	return cell.Provide(func() (tableOut[Obj], error) {
-		if table, err := NewTable(tableName, primaryIndexer, secondaryIndexers...); err != nil {
+		if writer, err := NewTable(tableName, primaryIndexer, secondaryIndexers...); err != nil {
 			return tableOut[Obj]{}, err
 		} else {
-			return tableOut[Obj]{Table: table, Meta: table}, nil
+			return tableOut[Obj]{
+				Reader: writer, // RWTable[Obj] is superset of Table[Obj]
+				Writer: writer,
+				Meta:   writer}, nil
 		}
 	})
+}
+
+type tableOutProtected[Obj any] struct {
+	cell.Out
+	Reader Table[Obj]
+	Meta   TableMeta `group:"statedb-tables"`
+}
+
+// NewProtectedTableCell creates a cell for creating and registering a statedb Table[Obj]. The
+// provided RWTable[Obj] is scoped to the module and thus prevents the table from being
+// directly modified outside this module.
+func NewProtectedTableCell[Obj any](
+	tableName TableName,
+	primaryIndexer Indexer[Obj],
+	secondaryIndexers ...Indexer[Obj],
+) cell.Cell {
+	rwtable, err := NewTable(tableName, primaryIndexer, secondaryIndexers...)
+	return cell.Group(
+		// Derive Table[Obj] and TableMeta from RWTable[Obj] (they're a subset of it)
+		cell.Provide(func() (tableOutProtected[Obj], error) {
+			if err != nil {
+				return tableOutProtected[Obj]{}, err
+			}
+			return tableOutProtected[Obj]{Reader: rwtable, Meta: rwtable}, nil
+		}),
+
+		// Provide RWTable[Obj] only in the module's scope.
+		cell.ProvidePrivate(func() (RWTable[Obj], error) {
+			return rwtable, err
+		}),
+	)
 }

--- a/pkg/statedb/db_test.go
+++ b/pkg/statedb/db_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -31,6 +32,10 @@ func TestMain(m *testing.M) {
 type testObject struct {
 	ID   uint64
 	Tags []string
+}
+
+func (t testObject) String() string {
+	return fmt.Sprintf("testObject{ID: %d, Tags: %v}", t.ID, t.Tags)
 }
 
 var (
@@ -591,6 +596,90 @@ func TestDB_CommitAbort(t *testing.T) {
 	require.Equal(t, rev, newRev, "expected unchanged revision")
 	require.EqualValues(t, obj.ID, 123, "expected obj.ID to equal 123")
 	require.Nil(t, obj.Tags, "expected no tags")
+}
+
+func TestDB_CompareAndSwap_CompareAndDelete(t *testing.T) {
+	t.Parallel()
+
+	db, table, _ := newTestDB(t, tagsIndex)
+
+	// Updating a non-existing object fails and nothing is inserted.
+	wtxn := db.WriteTxn(table)
+	{
+		_, hadOld, err := table.CompareAndSwap(wtxn, 1, testObject{ID: 1})
+		require.ErrorIs(t, ErrObjectNotFound, err)
+		require.False(t, hadOld)
+
+		objs, _ := table.All(wtxn)
+		require.Len(t, Collect(objs), 0)
+
+		wtxn.Abort()
+	}
+
+	// Insert a test object and retrieve it.
+	wtxn = db.WriteTxn(table)
+	table.Insert(wtxn, testObject{ID: 1})
+	wtxn.Commit()
+
+	obj, rev1, ok := table.First(db.ReadTxn(), idIndex.Query(1))
+	require.True(t, ok)
+
+	// Updating an object with matching revision number works
+	wtxn = db.WriteTxn(table)
+	obj.Tags = []string{"updated"} // NOTE: testObject stored by value so no explicit copy needed.
+	_, hadOld, err := table.CompareAndSwap(wtxn, rev1, obj)
+	require.NoError(t, err)
+	require.True(t, hadOld)
+	wtxn.Commit()
+
+	obj, _, ok = table.First(db.ReadTxn(), idIndex.Query(1))
+	require.True(t, ok)
+	require.Len(t, obj.Tags, 1)
+	require.Equal(t, "updated", obj.Tags[0])
+
+	// Updating an object with mismatching revision number fails
+	wtxn = db.WriteTxn(table)
+	obj.Tags = []string{"mismatch"}
+	_, hadOld, err = table.CompareAndSwap(wtxn, rev1, obj)
+	require.ErrorIs(t, ErrRevisionNotEqual, err)
+	require.True(t, hadOld)
+	wtxn.Commit()
+
+	obj, _, ok = table.First(db.ReadTxn(), idIndex.Query(1))
+	require.True(t, ok)
+	require.Len(t, obj.Tags, 1)
+	require.Equal(t, "updated", obj.Tags[0])
+
+	// Deleting an object with mismatching revision number fails
+	wtxn = db.WriteTxn(table)
+	obj.Tags = []string{"mismatch"}
+	_, hadOld, err = table.CompareAndDelete(wtxn, rev1, obj)
+	require.ErrorIs(t, ErrRevisionNotEqual, err)
+	require.True(t, hadOld)
+	wtxn.Commit()
+
+	obj, rev2, ok := table.First(db.ReadTxn(), idIndex.Query(1))
+	require.True(t, ok)
+	require.Len(t, obj.Tags, 1)
+	require.Equal(t, "updated", obj.Tags[0])
+
+	// Deleting with matching revision number works
+	wtxn = db.WriteTxn(table)
+	obj.Tags = []string{"mismatch"}
+	_, hadOld, err = table.CompareAndDelete(wtxn, rev2, obj)
+	require.NoError(t, err)
+	require.True(t, hadOld)
+	wtxn.Commit()
+
+	_, _, ok = table.First(db.ReadTxn(), idIndex.Query(1))
+	require.False(t, ok)
+
+	// Deleting non-existing object yields not found
+	wtxn = db.WriteTxn(table)
+	_, hadOld, err = table.CompareAndDelete(wtxn, rev2, obj)
+	require.NoError(t, err)
+	require.False(t, hadOld)
+	wtxn.Abort()
 }
 
 func TestWriteJSON(t *testing.T) {

--- a/pkg/statedb/errors.go
+++ b/pkg/statedb/errors.go
@@ -31,6 +31,16 @@ var (
 	// table that was not locked for writing, e.g. target table not given as argument to
 	// WriteTxn().
 	ErrTableNotLockedForWriting = errors.New("not locked for writing")
+
+	// ErrRevisionNotEqual indicates that the CompareAndSwap or CompareAndDelete failed due to
+	// the object having a mismatching revision, e.g. it had been changed since the object
+	// was last read.
+	ErrRevisionNotEqual = errors.New("revision not equal")
+
+	// ErrObjectNotFound indicates that the object was not found when the operation required
+	// it to exists. This error is not returned by Insert or Delete, but may be returned by
+	// CompareAndSwap or CompareAndDelete.
+	ErrObjectNotFound = errors.New("object not found")
 )
 
 // tableError wraps an error with the table name.

--- a/pkg/statedb/example/control.go
+++ b/pkg/statedb/example/control.go
@@ -28,7 +28,7 @@ var controlCell = cell.Module(
 type controlParams struct {
 	cell.In
 
-	Backends  statedb.Table[Backend]
+	Backends  statedb.RWTable[Backend]
 	DB        *statedb.DB
 	Lifecycle hive.Lifecycle
 	Log       logrus.FieldLogger

--- a/pkg/statedb/example/reconcile.go
+++ b/pkg/statedb/example/reconcile.go
@@ -29,7 +29,7 @@ var reconcilerCell = cell.Module(
 type reconcilerParams struct {
 	cell.In
 
-	Backends  statedb.Table[Backend]
+	Backends  statedb.RWTable[Backend]
 	DB        *statedb.DB
 	Lifecycle hive.Lifecycle
 	Log       logrus.FieldLogger

--- a/pkg/statedb/fuzz_test.go
+++ b/pkg/statedb/fuzz_test.go
@@ -154,9 +154,9 @@ type actionLogEntry struct {
 	value uint64
 }
 
-type action func(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, target statedb.Table[fuzzObj])
+type action func(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, target statedb.RWTable[fuzzObj])
 
-func insertAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func insertAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	value := rand.Uint64()
 	log.log("%s: Insert %d", table.Name(), id)
@@ -164,43 +164,43 @@ func insertAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, tabl
 	actLog.append(actionLogEntry{table, actInsert, id, value})
 }
 
-func deleteAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func deleteAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	log.log("%s: Delete %d", table.Name(), id)
 	table.Delete(txn, fuzzObj{id, 0})
 	actLog.append(actionLogEntry{table, actDelete, id, 0})
 }
 
-func deleteAllAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func deleteAllAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	log.log("%s: DeleteAll", table.Name())
 	table.DeleteAll(txn)
 	actLog.append(actionLogEntry{table, actDeleteAll, 0, 0})
 }
 
-func allAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func allAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	iter, _ := table.All(txn)
 	log.log("%s: All => %d found", table.Name(), len(statedb.Collect(iter)))
 }
 
-func getAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func getAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	iter, _ := table.Get(txn, idIndex.Query(mkID()))
 	log.log("%s: Get(%d) => %d found", table.Name(), id, len(statedb.Collect(iter)))
 }
 
-func firstAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func firstAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	_, rev, ok := table.First(txn, idIndex.Query(id))
 	log.log("%s: First(%d) => rev=%d, ok=%v", table.Name(), id, rev, ok)
 }
 
-func lastAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func lastAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	_, rev, ok := table.First(txn, idIndex.Query(id))
 	log.log("%s: First(%d) => rev=%d, ok=%v", table.Name(), id, rev, ok)
 }
 
-func lowerboundAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func lowerboundAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	iter, _ := table.LowerBound(txn, idIndex.Query(id))
 	log.log("%s: LowerBound(%d) => %d found", table.Name(), id, len(statedb.Collect(iter)))
@@ -254,7 +254,7 @@ func fuzzWorker(realActionLog *realActionLog, worker int, iterations int) {
 
 		for _, target := range targets {
 			act := randomAction()
-			act(log, actLog, txn, target.(statedb.Table[fuzzObj]))
+			act(log, actLog, txn, target.(statedb.RWTable[fuzzObj]))
 			runtime.Gosched()
 		}
 		runtime.Gosched()

--- a/pkg/statedb/table.go
+++ b/pkg/statedb/table.go
@@ -17,7 +17,7 @@ func NewTable[Obj any](
 	tableName TableName,
 	primaryIndexer Indexer[Obj],
 	secondaryIndexers ...Indexer[Obj],
-) (Table[Obj], error) {
+) (RWTable[Obj], error) {
 	toAnyIndexer := func(idx Indexer[Obj]) anyIndexer {
 		return anyIndexer{
 			name: idx.indexName(),
@@ -212,3 +212,4 @@ func (t *genTable[Obj]) sortableMutex() lock.SortableMutex {
 }
 
 var _ Table[bool] = &genTable[bool]{}
+var _ RWTable[bool] = &genTable[bool]{}

--- a/pkg/statedb/types.go
+++ b/pkg/statedb/types.go
@@ -18,9 +18,10 @@ type (
 	Revision  = uint64
 )
 
+// Table provides methods for querying the contents of a table.
 type Table[Obj any] interface {
 	// TableMeta for querying table metadata that is independent of
-	// 'Obj' type. Provides the database access to table's indexers.
+	// 'Obj' type.
 	TableMeta
 
 	// Revision of the table. Constant for a read transaction, but
@@ -56,6 +57,21 @@ type Table[Obj any] interface {
 	// are not possible with a lower bound search.
 	LowerBound(ReadTxn, Query[Obj]) (iter Iterator[Obj], watch <-chan struct{})
 
+	// DeleteTracker creates a new delete tracker for the table.
+	//
+	// It starts tracking deletions performed against the table from the
+	// current revision. A WriteTxn against the target table is required to
+	// add the tracker to the table.
+	DeleteTracker(txn WriteTxn, trackerName string) (*DeleteTracker[Obj], error)
+}
+
+// RWTable provides methods for modifying the table under a write transaction
+// that targets this table.
+type RWTable[Obj any] interface {
+	// RWTable[Obj] is a superset of Table[Obj]. Queries made with a
+	// write transaction return the fresh uncommitted modifications if any.
+	Table[Obj]
+
 	// Insert an object into the table. Returns the object that was
 	// replaced if there was one. Error may be returned if the table
 	// is not locked for writing or if the write transaction has already
@@ -66,24 +82,26 @@ type Table[Obj any] interface {
 	Insert(WriteTxn, Obj) (oldObj Obj, hadOld bool, err error)
 
 	// Delete an object from the table. Returns the object that was
-	// deleted if there was one. Error may be returned if the table
-	// is not locked for writing or if the write transaction has already
-	// been committed or aborted.
+	// deleted if there was one.
 	//
 	// If the table is being tracked for deletions via DeleteTracker()
 	// the deleted object is inserted into a graveyard index and garbage
 	// collected when all delete trackers have consumed it. Each deleted
 	// object in the graveyard has unique revision allowing interleaved
 	// iteration of updates and deletions (see (*DeleteTracker[Obj]).Process).
+	//
+	// Possible errors:
+	// - ErrTableNotLockedForWriting: table was not locked for writing
+	// - ErrTransactionClosed: the write transaction already committed or aborted
 	Delete(WriteTxn, Obj) (oldObj Obj, hadOld bool, err error)
 
-	// DeleteAll deletes all objects from the table. Semantically the
-	// same as All() + Delete().
+	// DeleteAll removes all objects in the table. Semantically the same as
+	// All() + Delete(). See Delete() for more information.
+	//
+	// Possible errors:
+	// - ErrTableNotLockedForWriting: table was not locked for writing
+	// - ErrTransactionClosed: the write transaction already committed or aborted
 	DeleteAll(WriteTxn) error
-
-	// DeleteTracker creates a new delete tracker for the table
-	// starting from the given revision.
-	DeleteTracker(txn WriteTxn, trackerName string) (*DeleteTracker[Obj], error)
 }
 
 // TableMeta provides information about the table that is independent of


### PR DESCRIPTION
- Splits Table[Obj] into Table[Obj] (reader) and RWTable[Obj] (reader-writer) and adds
`NewProtectedTableCell`. This allows modules to define protected tables where outside modules can only read from the table, or write to the table only in restricted/validated ways.
- Moves RWTable[*Device] and RWTable[*Route] under the scope of the devices-controller module to protect the tables. 

Open questions:
- Is `RWTable` a good name? What about `TableWriter`? Should `Table[Obj]` be `RTable[Obj]` or `TableReader[Obj]`? WDYT?
- WriteTxn still takes a TableMeta (from `Table[Obj]`). Reasoning is that we want to be able to construct a `WriteTxn` against multiple tables (for that cross-table atomic transaction sweetness) even when `RWTable` isn't directly available (but indirect smart writers are). An alternative I see to this is some sort of `WriteTxnBuilder` pattern to allow composing together the `WriteTxn` in a controlled way, e.g. a smart writer would take `WriteTxnBuilder` and then return `(WriterHandle, WriteTxnBuilder)`. This way one explicitly asks for access to the writer methods, but I'm not sure if this boilerplate brings a lot of value. The downside of allowing `WriteTxn` with `Table[Obj]` is that arbitrary code can lock the table without intention or ability to write to it, but I would expect this to be easily catched by code review.