### PR TITLE
endpoint: correct stats for prepareBuild

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -543,8 +543,6 @@ func (e *Endpoint) regenerateBPF(regenContext *regenerationContext) (revnum uint
 	<-datapathRegenCtxt.ctCleaned
 	stats.waitingForCTClean.End(true)
 
-	stats.prepareBuild.End(true)
-
 	compilationExecuted, err = e.realizeBPFState(regenContext)
 	if err != nil {
 		return datapathRegenCtxt.epInfoCache.revision, compilationExecuted, err


### PR DESCRIPTION
Previous change relocated CT cleanup blocker, but left prepareBuild
stats calculated after that. Afterwards, some modifications also been
done for the code related to prebuild. So the stats related to prepareBuild
should be handled within runPreCompilationSteps.

Fixes: eaa486d787ef ("endpoint: Wait for CT cleanup to complete before BPF compilation")

```release-note
correct stats calculation for prepareBuild of endpoint_regeneration_time 
```
