### PR TITLE
endpoint: correct stats for total of policyregenerateion

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -214,7 +214,6 @@ func (e *Endpoint) regeneratePolicy() (*policyGenerateResult, error) {
 	stats := &policyRegenerationStatistics{}
 	stats.totalTime.Start()
 	defer func() {
-		stats.totalTime.End(err == nil)
 		e.updatePolicyRegenerationStatistics(stats, forcePolicyCompute, err)
 	}()
 


### PR DESCRIPTION
totalTime.End has been called within updatePolicyRegenerationStatistics,
remove the duplicated one in defer func.

Fixes: f048a6a88b7b ("endpoint: don't hold the endpoint lock while generating policy")

```release-note
correct stats for total time of policyregenerateion
```
