### PR TITLE
egressgw: make reconciliationEventsCount an atomic.Uint64

### DIFF
--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -163,7 +164,7 @@ type Manager struct {
 
 	// reconciliationEventsCount keeps track of how many reconciliation
 	// events have occoured
-	reconciliationEventsCount uint64
+	reconciliationEventsCount atomic.Uint64
 }
 
 type Params struct {
@@ -1028,5 +1029,5 @@ func (manager *Manager) reconcileLocked() {
 	// clear the events bitmap
 	manager.eventsBitmap = 0
 
-	manager.reconciliationEventsCount += 1
+	manager.reconciliationEventsCount.Add(1)
 }

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -228,7 +228,7 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	close(k.cacheStatus)
 	k.policies.sync(c)
 
-	reconciliationEventsCount := egressGatewayManager.reconciliationEventsCount
+	reconciliationEventsCount := egressGatewayManager.reconciliationEventsCount.Load()
 
 	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
 	egressGatewayManager.OnUpdateNode(node1)
@@ -583,8 +583,9 @@ func createTestInterface(tb testing.TB, iface string, addr string) int {
 
 func waitForReconciliationRun(tb testing.TB, egressGatewayManager *Manager, currentRun uint64) uint64 {
 	for i := 0; i < 100; i++ {
-		if egressGatewayManager.reconciliationEventsCount > currentRun {
-			return egressGatewayManager.reconciliationEventsCount
+		count := egressGatewayManager.reconciliationEventsCount.Load()
+		if count > currentRun {
+			return count
 		}
 
 		time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
as otherwise the reconciliation count logic in tests would be racy