### PR TITLE
contrib/kind: custom kind values

### DIFF
--- a/Documentation/contributing/development/dev_setup.rst
+++ b/Documentation/contributing/development/dev_setup.rst
@@ -119,7 +119,7 @@ makefile targets:
 For Linux and Mac OS
 ^^^^^^^^^^^^^^^^^^^^
 
-Makefile targets automate building Cilium images:
+Makefile targets automate building and installing Cilium images:
 
 * ``make kind-image``: Builds all Cilium images and loads them into the
   cluster.
@@ -151,6 +151,18 @@ code, in an pre-existing running Cilium container.
 
 * ``make kind-image-fast``: Builds all Cilium binaries and loads them into all
   kind clusters available in the host.
+
+Configuration for Cilium
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Makefile targets that install Cilium pass the following list of Helm
+values (YAML files) to the Cilium CLI.
+
+* ``contrib/testing/kind-common.yaml``: Shared between normal and fast installation modes.
+* ``contrib/testing/kind-values.yaml``: Used by normal installation mode.
+* ``contrib/testing/kind-fast.yaml``: Used by fast installation mode.
+* ``contrib/testing/kind-custom.yaml``: User defined custom values that are applied if
+  the file is present. The file is ignored by Git as specified in ``contrib/testing/.gitignore``.
 
 .. _configurations_for_clusters:
 

--- a/contrib/testing/.gitignore
+++ b/contrib/testing/.gitignore
@@ -1,0 +1,4 @@
+# May contain additional custom Helm values that are taken into account when
+# installing cilium via Make target `kind-install-cilium`.
+kind-custom.yaml
+


### PR DESCRIPTION
The Make targets to deploy Cilium into a kind cluster are using the following Helm values files.

* `contrib/testing/kind-common.yaml`
* `contrib/testing/kind-values.yaml`
* `contrib/testing/kind-fast.yaml`

These contain reasonable defaults. Nevertheless, it would be great to be able to define additional helm values without having to modify the existing files.

Therefore, this commit introduces the possibility to define a user-defined values file that is added to the list of helm values files.

* `contrib/testing/kind-custom.yaml`

To prevent users from committing the file, it's ignored by Git.