### PR TITLE
build: fix usage of local golangci-lint installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ govet: ## Run govet on Go source files in the repository.
 	$(QUIET) $(GO_VET) ./...
 
 golangci-lint: ## Run golangci-lint
-ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION),$(GOLANGCILINT_VERSION)))
+ifneq (,$(findstring $(GOLANGCILINT_WANT_VERSION:v%=%),$(GOLANGCILINT_VERSION)))
 	@$(ECHO_CHECK) golangci-lint $(GOLANGCI_LINT_ARGS)
 	$(QUIET) golangci-lint run $(GOLANGCI_LINT_ARGS)
 else

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -97,7 +97,7 @@ endif
 # renovate: datasource=docker depName=golangci/golangci-lint
 GOLANGCILINT_WANT_VERSION = v1.54.2
 GOLANGCILINT_IMAGE_SHA = sha256:2082f5379c48c46e447bc1b890512f3aa9339db5eeed1a483a34aae9476ba6ee
-GOLANGCILINT_VERSION = $(shell golangci-lint version 2>/dev/null)
+GOLANGCILINT_VERSION = $(shell golangci-lint version --format short 2>/dev/null)
 
 VERSION = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION)
 VERSION_MAJOR = $(shell cat $(dir $(lastword $(MAKEFILE_LIST)))/VERSION | cut -d. -f1)


### PR DESCRIPTION
The make target `make lint` should prefer the locally installed `golangci-lint` if the installed version matches the expected one. This comes with the advantage of using the local cache.

It seems that there are differences in the version representation between the upstream binaries (including the `v` prefix) and the one installed via `go install ...` (without the prefix). The current implementation doesn't support the upstream binaries with the `v` prefix - it always falls back to executing the docker version.

This commit introduces support for both formats by stripping any given `v` prefix before comparison.