### PR TITLE
fqdn proxy: fix data race by using separate sessionUDPFactories

### DIFF
--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1128,8 +1128,12 @@ func bindToAddr(address string, port uint16, handler dns.Handler, ipv4, ipv6 boo
 		if err != nil {
 			return nil, 0, fmt.Errorf("failed to listen on %s: %w", ipf.UDPAddress, err)
 		}
+		sessionUDPFactory, ferr := NewSessionUDPFactory(ipf)
+		if ferr != nil {
+			return nil, 0, fmt.Errorf("failed to create UDP session factory for %s: %w", ipf.UDPAddress, err)
+		}
 		dnsServers = append(dnsServers, &dns.Server{
-			PacketConn: udpConn, Handler: handler, SessionUDPFactory: &sessionUDPFactory{ipv4Enabled: ipf.IPv4Enabled, ipv6Enabled: ipf.IPv6Enabled},
+			PacketConn: udpConn, Handler: handler, SessionUDPFactory: sessionUDPFactory,
 			// Net & Addr are only set for logging purposes and aren't used if using ActivateAndServe.
 			Net: ipf.UDPAddress, Addr: udpConn.LocalAddr().String(),
 		})

--- a/pkg/fqdn/dnsproxy/udp.go
+++ b/pkg/fqdn/dnsproxy/udp.go
@@ -75,23 +75,11 @@ type sessionUDP struct {
 // IP(V6)_RECVORIGDSTADDR tells the kernel to pass the original destination address/port on recvmsg
 // By design, a socket of a DNS Server can only receive IPv4 or IPv6 traffic.
 func transparentSetsockopt(fd int, ipFamily ipfamily.IPFamily) error {
-	switch ipFamily {
-	case ipfamily.IPv4():
-		if err := unix.SetsockoptInt(fd, unix.SOL_IP, unix.IP_TRANSPARENT, 1); err != nil {
-			return fmt.Errorf("setsockopt(IP_TRANSPARENT) failed: %w", err)
-		}
-		if err := unix.SetsockoptInt(fd, unix.SOL_IP, unix.IP_RECVORIGDSTADDR, 1); err != nil {
-			return fmt.Errorf("setsockopt(IP_RECVORIGDSTADDR) failed: %w", err)
-		}
-	case ipfamily.IPv6():
-		if err := unix.SetsockoptInt(fd, unix.SOL_IPV6, unix.IPV6_TRANSPARENT, 1); err != nil {
-			return fmt.Errorf("setsockopt(IPV6_TRANSPARENT) failed: %w", err)
-		}
-		if err := unix.SetsockoptInt(fd, unix.SOL_IPV6, unix.IPV6_RECVORIGDSTADDR, 1); err != nil {
-			return fmt.Errorf("setsockopt(IPV6_RECVORIGDSTADDR) failed: %w", err)
-		}
-	default:
-		return fmt.Errorf("unknown ipfamily: %s", ipFamily.Name)
+	if err := unix.SetsockoptInt(fd, ipFamily.SocketOptsFamily, ipFamily.SocketOptsTransparent, 1); err != nil {
+		return fmt.Errorf("setsockopt(IP_TRANSPARENT) for %s failed: %w", ipFamily.Name, err)
+	}
+	if err := unix.SetsockoptInt(fd, ipFamily.SocketOptsFamily, ipFamily.SocketOptsRecvOrigDstAddr, 1); err != nil {
+		return fmt.Errorf("setsockopt(IP_RECVORIGDSTADDR) for %s failed: %w", ipFamily.Name, err)
 	}
 
 	return nil

--- a/pkg/fqdn/proxy/ipfamily/ipfamily.go
+++ b/pkg/fqdn/proxy/ipfamily/ipfamily.go
@@ -4,32 +4,26 @@
 package ipfamily
 
 type IPFamily struct {
-	Name        string
-	IPv4Enabled bool
-	IPv6Enabled bool
-	UDPAddress  string
-	TCPAddress  string
-	Localhost   string
+	Name       string
+	UDPAddress string
+	TCPAddress string
+	Localhost  string
 }
 
 func IPv4() IPFamily {
 	return IPFamily{
-		Name:        "ipv4",
-		IPv4Enabled: true,
-		IPv6Enabled: false,
-		UDPAddress:  "udp4",
-		TCPAddress:  "tcp4",
-		Localhost:   "127.0.0.1",
+		Name:       "ipv4",
+		UDPAddress: "udp4",
+		TCPAddress: "tcp4",
+		Localhost:  "127.0.0.1",
 	}
 }
 
 func IPv6() IPFamily {
 	return IPFamily{
-		Name:        "ipv6",
-		IPv4Enabled: false,
-		IPv6Enabled: true,
-		UDPAddress:  "udp6",
-		TCPAddress:  "tcp6",
-		Localhost:   "::1",
+		Name:       "ipv6",
+		UDPAddress: "udp6",
+		TCPAddress: "tcp6",
+		Localhost:  "::1",
 	}
 }

--- a/pkg/fqdn/proxy/ipfamily/ipfamily.go
+++ b/pkg/fqdn/proxy/ipfamily/ipfamily.go
@@ -3,11 +3,17 @@
 
 package ipfamily
 
+import "golang.org/x/sys/unix"
+
 type IPFamily struct {
 	Name       string
 	UDPAddress string
 	TCPAddress string
 	Localhost  string
+
+	SocketOptsFamily          int
+	SocketOptsTransparent     int
+	SocketOptsRecvOrigDstAddr int
 }
 
 func IPv4() IPFamily {
@@ -16,6 +22,10 @@ func IPv4() IPFamily {
 		UDPAddress: "udp4",
 		TCPAddress: "tcp4",
 		Localhost:  "127.0.0.1",
+
+		SocketOptsFamily:          unix.SOL_IP,
+		SocketOptsTransparent:     unix.IP_TRANSPARENT,
+		SocketOptsRecvOrigDstAddr: unix.IP_RECVORIGDSTADDR,
 	}
 }
 
@@ -25,5 +35,9 @@ func IPv6() IPFamily {
 		UDPAddress: "udp6",
 		TCPAddress: "tcp6",
 		Localhost:  "::1",
+
+		SocketOptsFamily:          unix.SOL_IPV6,
+		SocketOptsTransparent:     unix.IPV6_TRANSPARENT,
+		SocketOptsRecvOrigDstAddr: unix.IPV6_RECVORIGDSTADDR,
 	}
 }


### PR DESCRIPTION
PR #25309 introduced a data race by sharing the sessionUDPFactory between the DNS server instances for the different IP families (IPv4 & IPv6). This has been detected by #27979.

This commit fixes the data race by using dedicated instances of the sessionUDPFactory.

In addition the global response UDP connections (IPv4 & IPv6) variables have been replaced with fields in the `SessionUDPFactory`. This way the connections can already be setup during construction of the factory and the `sync.Once`s (global vars) can be removed.

Fixes: #28156