### PR TITLE
operator: Remove identity GC and CES controller legacy metrics

### DIFF
--- a/operator/api/metrics_test.go
+++ b/operator/api/metrics_test.go
@@ -119,12 +119,6 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 			lc.Append(hive.Hook{
 				OnStart: func(hive.HookContext) error {
 					// set values for some operator metrics
-					operatorMetrics.IdentityGCSize.
-						WithLabelValues(operatorMetrics.LabelValueOutcomeAlive).
-						Set(float64(12))
-					operatorMetrics.IdentityGCRuns.
-						WithLabelValues(operatorMetrics.LabelValueOutcomeSuccess).
-						Set(float64(15))
 					operatorMetrics.EndpointGCObjects.
 						WithLabelValues(operatorMetrics.LabelValueOutcomeSuccess).
 						Inc()
@@ -161,26 +155,6 @@ func TestMetricsHandlerWithMetrics(t *testing.T) {
 		t.Fatalf("error while unmarshaling response body: %s", err)
 	}
 
-	if err := testMetric(
-		metrics,
-		"cilium_operator_identity_gc_entries",
-		float64(12),
-		map[string]string{
-			operatorMetrics.LabelStatus: operatorMetrics.LabelValueOutcomeAlive,
-		},
-	); err != nil {
-		t.Fatalf("error while inspecting metric: %s", err)
-	}
-	if err := testMetric(
-		metrics,
-		"cilium_operator_identity_gc_runs",
-		float64(15),
-		map[string]string{
-			operatorMetrics.LabelOutcome: operatorMetrics.LabelValueOutcomeSuccess,
-		},
-	); err != nil {
-		t.Fatalf("error while inspecting metric: %s", err)
-	}
 	if err := testMetric(
 		metrics,
 		"cilium_operator_endpoint_gc_objects",

--- a/operator/identitygc/cell.go
+++ b/operator/identitygc/cell.go
@@ -43,6 +43,8 @@ var Cell = cell.Module(
 
 	// Invoke forces the instantiation of the identity gc
 	cell.Invoke(registerGC),
+
+	cell.Metric(NewMetrics),
 )
 
 // Config contains the configuration for the identity-gc.

--- a/operator/identitygc/crd_gc.go
+++ b/operator/identitygc/crd_gc.go
@@ -12,7 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorK8s "github.com/cilium/cilium/operator/k8s"
-	"github.com/cilium/cilium/operator/metrics"
 	"github.com/cilium/cilium/pkg/controller"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
@@ -156,14 +155,14 @@ func (igc *GC) gc(ctx context.Context) error {
 
 	if ctx.Err() == nil {
 		igc.successfulRuns++
-		metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
+		igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
 	} else {
 		igc.failedRuns++
-		metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeFail).Set(float64(igc.failedRuns))
+		igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeFail).Set(float64(igc.failedRuns))
 	}
 	aliveEntries := totalEntries - deletedEntries
-	metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeAlive).Set(float64(aliveEntries))
-	metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeDeleted).Set(float64(deletedEntries))
+	igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeAlive).Set(float64(aliveEntries))
+	igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeDeleted).Set(float64(deletedEntries))
 
 	igc.heartbeatStore.gc()
 

--- a/operator/identitygc/gc.go
+++ b/operator/identitygc/gc.go
@@ -42,6 +42,8 @@ type params struct {
 	Cfg         Config
 	SharedCfg   SharedConfig
 	ClusterInfo cmtypes.ClusterInfo
+
+	Metrics *Metrics
 }
 
 // GC represents the Cilium identities periodic GC.
@@ -84,6 +86,7 @@ type GC struct {
 	// counters for GC failed/successful runs
 	failedRuns     int
 	successfulRuns int
+	metrics        *Metrics
 }
 
 func registerGC(p params) {
@@ -114,6 +117,7 @@ func registerGC(p params) {
 		allocationCfg: identityAllocationConfig{
 			k8sNamespace: p.SharedCfg.K8sNamespace,
 		},
+		metrics: p.Metrics,
 	}
 	p.Lifecycle.Append(hive.Hook{
 		OnStart: func(ctx hive.HookContext) error {

--- a/operator/identitygc/gc_test.go
+++ b/operator/identitygc/gc_test.go
@@ -37,6 +37,7 @@ func TestIdentitiesGC(t *testing.T) {
 
 	hive := hive.New(
 		cell.Config(cmtypes.DefaultClusterInfo),
+		cell.Metric(NewMetrics),
 
 		// provide a fake clientset
 		k8sClient.FakeClientCell,

--- a/operator/identitygc/kvstore_gc.go
+++ b/operator/identitygc/kvstore_gc.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/cilium/cilium/operator/metrics"
 	"github.com/cilium/cilium/pkg/allocator"
 	ciliumIdentity "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
@@ -56,7 +55,7 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 			igc.logger.WithError(err).Warning("Unable to run security identity garbage collector")
 
 			igc.failedRuns++
-			metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeFail).Set(float64(igc.failedRuns))
+			igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeFail).Set(float64(igc.failedRuns))
 		} else {
 			// Best effort to run auth identity GC
 			err = igc.runAuthGC(ctx, keysToDeletePrev)
@@ -69,10 +68,10 @@ func (igc *GC) runKVStoreModeGC(ctx context.Context) error {
 			keysToDeletePrev = keysToDelete
 
 			igc.successfulRuns++
-			metrics.IdentityGCRuns.WithLabelValues(metrics.LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
+			igc.metrics.IdentityGCRuns.WithLabelValues(LabelValueOutcomeSuccess).Set(float64(igc.successfulRuns))
 
-			metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeAlive).Set(float64(gcStats.Alive))
-			metrics.IdentityGCSize.WithLabelValues(metrics.LabelValueOutcomeDeleted).Set(float64(gcStats.Deleted))
+			igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeAlive).Set(float64(gcStats.Alive))
+			igc.metrics.IdentityGCSize.WithLabelValues(LabelValueOutcomeDeleted).Set(float64(gcStats.Deleted))
 		}
 
 		if igc.gcInterval <= gcDuration {

--- a/operator/identitygc/metrics.go
+++ b/operator/identitygc/metrics.go
@@ -47,6 +47,9 @@ func NewMetrics() *Metrics {
 }
 
 type Metrics struct {
+	// IdentityGCSize records the identity GC results
 	IdentityGCSize metric.Vec[metric.Gauge]
+
+	// IdentityGCRuns records how many times identity GC has run
 	IdentityGCRuns metric.Vec[metric.Gauge]
 }

--- a/operator/identitygc/metrics.go
+++ b/operator/identitygc/metrics.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package identitygc
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	// LabelStatus marks the status of a resource or completed task
+	LabelStatus = "status"
+
+	// LabelOutcome indicates whether the outcome of the operation was successful or not
+	LabelOutcome = "outcome"
+
+	// Label values
+
+	// LabelValueOutcomeSuccess is used as a successful outcome of an operation
+	LabelValueOutcomeSuccess = "success"
+
+	// LabelValueOutcomeFail is used as an unsuccessful outcome of an operation
+	LabelValueOutcomeFail = "fail"
+
+	// LabelValueOutcomeAlive is used as outcome of alive identity entries
+	LabelValueOutcomeAlive = "alive"
+
+	// LabelValueOutcomeDeleted is used as outcome of deleted identity entries
+	LabelValueOutcomeDeleted = "deleted"
+)
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		IdentityGCSize: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "identity_gc_entries",
+			Help:      "The number of alive and deleted identities at the end of a garbage collector run",
+		}, []string{LabelStatus}),
+
+		IdentityGCRuns: metric.NewGaugeVec(metric.GaugeOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "identity_gc_runs",
+			Help:      "The number of times identity garbage collector has run",
+		}, []string{LabelOutcome}),
+	}
+}
+
+type Metrics struct {
+	IdentityGCSize metric.Vec[metric.Gauge]
+	IdentityGCRuns metric.Vec[metric.Gauge]
+}

--- a/operator/metrics/legacy.go
+++ b/operator/metrics/legacy.go
@@ -24,9 +24,6 @@ const (
 	// LabelOutcome indicates whether the outcome of the operation was successful or not
 	LabelOutcome = "outcome"
 
-	// LabelOpcode indicates the kind of CES metric, could be CEP insert or remove
-	LabelOpcode = "opcode"
-
 	// Label values
 
 	// LabelValueOutcomeSuccess is used as a successful outcome of an operation
@@ -34,47 +31,16 @@ const (
 
 	// LabelValueOutcomeFail is used as an unsuccessful outcome of an operation
 	LabelValueOutcomeFail = "fail"
-
-	// LabelValueCEPInsert is used to indicate the number of CEPs inserted in a CES
-	LabelValueCEPInsert = "cepinserted"
-
-	// LabelValueCEPRemove is used to indicate the number of CEPs removed from a CES
-	LabelValueCEPRemove = "cepremoved"
 )
 
 var (
 	// EndpointGCObjects records the number of times endpoint objects have been
 	// garbage-collected.
 	EndpointGCObjects = metrics.NoOpCounterVec
-
-	// CiliumEndpointSliceDensity indicates the number of CEPs batched in a CES and it used to
-	// collect the number of CEPs in CES at various buckets.
-	CiliumEndpointSliceDensity = metrics.NoOpHistogram
-
-	// CiliumEndpointsChangeCount indicates the total number of CEPs changed for every CES request sent to k8s-apiserver.
-	// This metric is used to collect number of CEP changes happening at various buckets.
-	CiliumEndpointsChangeCount = metrics.NoOpObserverVec
-
-	// CiliumEndpointSliceSyncTotal indicates the total number of completed CES syncs with k8s-apiserver by success/fail outcome.
-	CiliumEndpointSliceSyncTotal = metrics.NoOpCounterVec
-
-	// CiliumEndpointSliceSyncErrors used to track the total number of errors occurred during syncing CES with k8s-apiserver.
-	// This metric is going to be deprecated in Cilium 1.14 and removed in 1.15.
-	// It is replaced by CiliumEndpointSliceSyncTotal metric.
-	CiliumEndpointSliceSyncErrors = metrics.NoOpCounter
-
-	// CiliumEndpointSliceQueueDelay measures the time spent by CES's in the workqueue. This measures time difference between
-	// CES insert in the workqueue and removal from workqueue.
-	CiliumEndpointSliceQueueDelay = metrics.NoOpHistogram
 )
 
 type legacyMetrics struct {
-	EndpointGCObjects             metric.Vec[metric.Counter]
-	CiliumEndpointSliceDensity    metric.Histogram
-	CiliumEndpointsChangeCount    metric.Vec[metric.Observer]
-	CiliumEndpointSliceSyncTotal  metric.Vec[metric.Counter]
-	CiliumEndpointSliceSyncErrors metric.Counter
-	CiliumEndpointSliceQueueDelay metric.Histogram
+	EndpointGCObjects metric.Vec[metric.Counter]
 }
 
 func newLegacyMetrics() *legacyMetrics {
@@ -84,46 +50,9 @@ func newLegacyMetrics() *legacyMetrics {
 			Name:      "endpoint_gc_objects",
 			Help:      "The number of times endpoint objects have been garbage-collected",
 		}, []string{LabelOutcome}),
-
-		CiliumEndpointSliceDensity: metric.NewHistogram(metric.HistogramOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "number_of_ceps_per_ces",
-			Help:      "The number of CEPs batched in a CES",
-			Buckets:   []float64{1, 10, 25, 50, 100, 200, 500, 1000},
-		}),
-
-		CiliumEndpointsChangeCount: metric.NewHistogramVec(metric.HistogramOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "number_of_cep_changes_per_ces",
-			Help:      "The number of changed CEPs in each CES update",
-		}, []string{LabelOpcode}),
-
-		CiliumEndpointSliceSyncErrors: metric.NewCounter(metric.CounterOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "ces_sync_errors_total",
-			Help:      "Number of CES sync errors",
-		}),
-
-		CiliumEndpointSliceSyncTotal: metric.NewCounterVec(metric.CounterOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "ces_sync_total",
-			Help:      "The number of completed CES syncs by outcome",
-		}, []string{LabelOutcome}),
-
-		CiliumEndpointSliceQueueDelay: metric.NewHistogram(metric.HistogramOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "ces_queueing_delay_seconds",
-			Help:      "CiliumEndpointSlice queueing delay in seconds",
-			Buckets:   append(prometheus.DefBuckets, 60, 300, 900, 1800, 3600),
-		}),
 	}
 
 	EndpointGCObjects = lm.EndpointGCObjects
-	CiliumEndpointSliceDensity = lm.CiliumEndpointSliceDensity
-	CiliumEndpointsChangeCount = lm.CiliumEndpointsChangeCount
-	CiliumEndpointSliceSyncTotal = lm.CiliumEndpointSliceSyncTotal
-	CiliumEndpointSliceSyncErrors = lm.CiliumEndpointSliceSyncErrors
-	CiliumEndpointSliceQueueDelay = lm.CiliumEndpointSliceQueueDelay
 
 	return lm
 }

--- a/operator/metrics/legacy.go
+++ b/operator/metrics/legacy.go
@@ -21,9 +21,6 @@ type RegisterGatherer interface {
 }
 
 const (
-	// LabelStatus marks the status of a resource or completed task
-	LabelStatus = "status"
-
 	// LabelOutcome indicates whether the outcome of the operation was successful or not
 	LabelOutcome = "outcome"
 
@@ -38,12 +35,6 @@ const (
 	// LabelValueOutcomeFail is used as an unsuccessful outcome of an operation
 	LabelValueOutcomeFail = "fail"
 
-	// LabelValueOutcomeAlive is used as outcome of alive identity entries
-	LabelValueOutcomeAlive = "alive"
-
-	// LabelValueOutcomeDeleted is used as outcome of deleted identity entries
-	LabelValueOutcomeDeleted = "deleted"
-
 	// LabelValueCEPInsert is used to indicate the number of CEPs inserted in a CES
 	LabelValueCEPInsert = "cepinserted"
 
@@ -52,12 +43,6 @@ const (
 )
 
 var (
-	// IdentityGCSize records the identity GC results
-	IdentityGCSize = metrics.NoOpGaugeVec
-
-	// IdentityGCRuns records how many times identity GC has run
-	IdentityGCRuns = metrics.NoOpGaugeVec
-
 	// EndpointGCObjects records the number of times endpoint objects have been
 	// garbage-collected.
 	EndpointGCObjects = metrics.NoOpCounterVec
@@ -84,8 +69,6 @@ var (
 )
 
 type legacyMetrics struct {
-	IdentityGCSize                metric.Vec[metric.Gauge]
-	IdentityGCRuns                metric.Vec[metric.Gauge]
 	EndpointGCObjects             metric.Vec[metric.Counter]
 	CiliumEndpointSliceDensity    metric.Histogram
 	CiliumEndpointsChangeCount    metric.Vec[metric.Observer]
@@ -96,18 +79,6 @@ type legacyMetrics struct {
 
 func newLegacyMetrics() *legacyMetrics {
 	lm := &legacyMetrics{
-		IdentityGCSize: metric.NewGaugeVec(metric.GaugeOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "identity_gc_entries",
-			Help:      "The number of alive and deleted identities at the end of a garbage collector run",
-		}, []string{LabelStatus}),
-
-		IdentityGCRuns: metric.NewGaugeVec(metric.GaugeOpts{
-			Namespace: metrics.CiliumOperatorNamespace,
-			Name:      "identity_gc_runs",
-			Help:      "The number of times identity garbage collector has run",
-		}, []string{LabelOutcome}),
-
 		EndpointGCObjects: metric.NewCounterVec(metric.CounterOpts{
 			Namespace: metrics.CiliumOperatorNamespace,
 			Name:      "endpoint_gc_objects",
@@ -147,8 +118,6 @@ func newLegacyMetrics() *legacyMetrics {
 		}),
 	}
 
-	IdentityGCSize = lm.IdentityGCSize
-	IdentityGCRuns = lm.IdentityGCRuns
 	EndpointGCObjects = lm.EndpointGCObjects
 	CiliumEndpointSliceDensity = lm.CiliumEndpointSliceDensity
 	CiliumEndpointsChangeCount = lm.CiliumEndpointsChangeCount

--- a/operator/pkg/ciliumendpointslice/cell.go
+++ b/operator/pkg/ciliumendpointslice/cell.go
@@ -36,6 +36,7 @@ var Cell = cell.Module(
 	"Cilium Endpoint Slice Controller",
 	cell.Config(defaultConfig),
 	cell.Invoke(registerController),
+	cell.Metric(NewMetrics),
 )
 
 type Config struct {

--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -34,6 +34,8 @@ type params struct {
 
 	Cfg       Config
 	SharedCfg SharedConfig
+
+	Metrics *Metrics
 }
 
 type Controller struct {
@@ -69,6 +71,8 @@ type Controller struct {
 	enqueuedAtLock lock.Mutex
 
 	wp *workerpool.WorkerPool
+
+	metrics *Metrics
 }
 
 // registerController creates and initializes the CES controller
@@ -87,6 +91,7 @@ func registerController(p params) {
 		writeQPSLimit:       p.Cfg.CESWriteQPSLimit,
 		writeQPSBurst:       p.Cfg.CESWriteQPSBurst,
 		enqueuedAt:          make(map[CESName]time.Time),
+		metrics:             p.Metrics,
 	}
 
 	p.Lifecycle.Append(cesController)

--- a/operator/pkg/ciliumendpointslice/controller_test.go
+++ b/operator/pkg/ciliumendpointslice/controller_test.go
@@ -45,6 +45,7 @@ func TestRegisterController(t *testing.T) {
 				EnableCiliumEndpointSlice: true,
 			}
 		}),
+		cell.Metric(NewMetrics),
 		cell.Invoke(func(p params) error {
 			registerController(p)
 			return nil
@@ -92,6 +93,7 @@ func TestNotRegisterControllerWithCESDisabled(t *testing.T) {
 				EnableCiliumEndpointSlice: false,
 			}
 		}),
+		cell.Metric(NewMetrics),
 		cell.Invoke(func(p params) error {
 			registerController(p)
 			return nil

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -138,7 +138,7 @@ func (c *Controller) Start(ctx hive.HookContext) error {
 	} else {
 		c.manager = newCESManagerFcfs(c.maxCEPsInCES, c.logger)
 	}
-	c.reconciler = newReconciler(c.clientset.CiliumV2alpha1(), c.manager, c.logger, c.ciliumEndpoint, c.ciliumEndpointSlice, c.context)
+	c.reconciler = newReconciler(c.context, c.clientset.CiliumV2alpha1(), c.manager, c.logger, c.ciliumEndpoint, c.ciliumEndpointSlice)
 
 	c.initializeQueue()
 

--- a/operator/pkg/ciliumendpointslice/endpointslice_test.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice_test.go
@@ -69,7 +69,7 @@ func TestSyncCESsInLocalCache(t *testing.T) {
 		}),
 	)
 	hive.Start(context.Background())
-	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice)
 	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
 	cesController := &Controller{
 		logger:              log,

--- a/operator/pkg/ciliumendpointslice/metrics.go
+++ b/operator/pkg/ciliumendpointslice/metrics.go
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumendpointslice
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+const (
+	// LabelOutcome indicates whether the outcome of the operation was successful or not
+	LabelOutcome = "outcome"
+
+	// LabelOpcode indicates the kind of CES metric, could be CEP insert or remove
+	LabelOpcode = "opcode"
+
+	// Label values
+
+	// LabelValueOutcomeSuccess is used as a successful outcome of an operation
+	LabelValueOutcomeSuccess = "success"
+
+	// LabelValueOutcomeFail is used as an unsuccessful outcome of an operation
+	LabelValueOutcomeFail = "fail"
+
+	// LabelValueCEPInsert is used to indicate the number of CEPs inserted in a CES
+	LabelValueCEPInsert = "cepinserted"
+
+	// LabelValueCEPRemove is used to indicate the number of CEPs removed from a CES
+	LabelValueCEPRemove = "cepremoved"
+)
+
+func NewMetrics() *Metrics {
+	return &Metrics{
+		CiliumEndpointSliceDensity: metric.NewHistogram(metric.HistogramOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "number_of_ceps_per_ces",
+			Help:      "The number of CEPs batched in a CES",
+			Buckets:   []float64{1, 10, 25, 50, 100, 200, 500, 1000},
+		}),
+
+		CiliumEndpointsChangeCount: metric.NewHistogramVec(metric.HistogramOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "number_of_cep_changes_per_ces",
+			Help:      "The number of changed CEPs in each CES update",
+		}, []string{LabelOpcode}),
+
+		CiliumEndpointSliceSyncErrors: metric.NewCounter(metric.CounterOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "ces_sync_errors_total",
+			Help:      "Number of CES sync errors",
+		}),
+
+		CiliumEndpointSliceSyncTotal: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "ces_sync_total",
+			Help:      "The number of completed CES syncs by outcome",
+		}, []string{LabelOutcome}),
+
+		CiliumEndpointSliceQueueDelay: metric.NewHistogram(metric.HistogramOpts{
+			Namespace: metrics.CiliumOperatorNamespace,
+			Name:      "ces_queueing_delay_seconds",
+			Help:      "CiliumEndpointSlice queueing delay in seconds",
+			Buckets:   append(prometheus.DefBuckets, 60, 300, 900, 1800, 3600),
+		}),
+	}
+}
+
+type Metrics struct {
+	// CiliumEndpointSliceDensity indicates the number of CEPs batched in a CES and it used to
+	// collect the number of CEPs in CES at various buckets.
+	CiliumEndpointSliceDensity metric.Histogram
+
+	// CiliumEndpointsChangeCount indicates the total number of CEPs changed for every CES request sent to k8s-apiserver.
+	// This metric is used to collect number of CEP changes happening at various buckets.
+	CiliumEndpointsChangeCount metric.Vec[metric.Observer]
+
+	// CiliumEndpointSliceSyncTotal indicates the total number of completed CES syncs with k8s-apiserver by success/fail outcome.
+	CiliumEndpointSliceSyncTotal metric.Vec[metric.Counter]
+
+	// CiliumEndpointSliceSyncErrors used to track the total number of errors occurred during syncing CES with k8s-apiserver.
+	// This metric is going to be deprecated in Cilium 1.14 and removed in 1.15.
+	// It is replaced by CiliumEndpointSliceSyncTotal metric.
+	CiliumEndpointSliceSyncErrors metric.Counter
+
+	// CiliumEndpointSliceQueueDelay measures the time spent by CES's in the workqueue. This measures time difference between
+	// CES insert in the workqueue and removal from workqueue.
+	CiliumEndpointSliceQueueDelay metric.Histogram
+}

--- a/operator/pkg/ciliumendpointslice/reconciler.go
+++ b/operator/pkg/ciliumendpointslice/reconciler.go
@@ -32,22 +32,22 @@ type reconciler struct {
 
 // newReconciler creates and initializes a new reconciler.
 func newReconciler(
+	ctx context.Context,
 	client clientset.CiliumV2alpha1Interface,
 	cesMgr operations,
 	logger logrus.FieldLogger,
 	ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint],
 	ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
-	ctx context.Context,
 ) *reconciler {
 	cepStore, _ := ciliumEndpoint.Store(ctx)
 	cesStore, _ := ciliumEndpointSlice.Store(ctx)
 	return &reconciler{
+		context:    ctx,
 		logger:     logger,
 		client:     client,
 		cesManager: cesMgr,
 		cepStore:   cepStore,
 		cesStore:   cesStore,
-		context:    ctx,
 	}
 }
 

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -31,18 +31,26 @@ func TestReconcileCreate(t *testing.T) {
 	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var cesMetrics *Metrics
 	hive := hive.New(
 		k8sClient.FakeClientCell,
 		k8s.ResourcesCell,
-		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+		cell.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			cep resource.Resource[*cilium_v2.CiliumEndpoint],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			metrics *Metrics,
+		) error {
 			fakeClient = *c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
+			cesMetrics = metrics
 			return nil
 		}),
 	)
 	hive.Start(context.Background())
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice)
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 
 	var createdSlice *v2alpha1.CiliumEndpointSlice
@@ -81,18 +89,26 @@ func TestReconcileUpdate(t *testing.T) {
 	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var cesMetrics *Metrics
 	hive := hive.New(
 		k8sClient.FakeClientCell,
 		k8s.ResourcesCell,
-		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+		cell.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			cep resource.Resource[*cilium_v2.CiliumEndpoint],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			metrics *Metrics,
+		) error {
 			fakeClient = *c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
+			cesMetrics = metrics
 			return nil
 		}),
 	)
 	hive.Start(context.Background())
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice)
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
 
@@ -136,18 +152,26 @@ func TestReconcileDelete(t *testing.T) {
 	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var cesMetrics *Metrics
 	hive := hive.New(
 		k8sClient.FakeClientCell,
 		k8s.ResourcesCell,
-		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+		cell.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			cep resource.Resource[*cilium_v2.CiliumEndpoint],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			metrics *Metrics,
+		) error {
 			fakeClient = *c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
+			cesMetrics = metrics
 			return nil
 		}),
 	)
 	hive.Start(context.Background())
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice)
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
 
@@ -185,18 +209,26 @@ func TestReconcileNoop(t *testing.T) {
 	m := newCESManagerFcfs(2, log).(*cesManagerFcfs)
 	var ciliumEndpoint resource.Resource[*cilium_v2.CiliumEndpoint]
 	var ciliumEndpointSlice resource.Resource[*cilium_v2a1.CiliumEndpointSlice]
+	var cesMetrics *Metrics
 	hive := hive.New(
 		k8sClient.FakeClientCell,
 		k8s.ResourcesCell,
-		cell.Invoke(func(c *k8sClient.FakeClientset, cep resource.Resource[*cilium_v2.CiliumEndpoint], ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice]) error {
+		cell.Metric(NewMetrics),
+		cell.Invoke(func(
+			c *k8sClient.FakeClientset,
+			cep resource.Resource[*cilium_v2.CiliumEndpoint],
+			ces resource.Resource[*cilium_v2a1.CiliumEndpointSlice],
+			metrics *Metrics,
+		) error {
 			fakeClient = *c
 			ciliumEndpoint = cep
 			ciliumEndpointSlice = ces
+			cesMetrics = metrics
 			return nil
 		}),
 	)
 	hive.Start(context.Background())
-	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice)
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, cesMetrics)
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 
 	noRequest := true

--- a/operator/pkg/ciliumendpointslice/reconciler_test.go
+++ b/operator/pkg/ciliumendpointslice/reconciler_test.go
@@ -42,7 +42,7 @@ func TestReconcileCreate(t *testing.T) {
 		}),
 	)
 	hive.Start(context.Background())
-	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice)
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 
 	var createdSlice *v2alpha1.CiliumEndpointSlice
@@ -92,7 +92,7 @@ func TestReconcileUpdate(t *testing.T) {
 		}),
 	)
 	hive.Start(context.Background())
-	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice)
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
 
@@ -147,7 +147,7 @@ func TestReconcileDelete(t *testing.T) {
 		}),
 	)
 	hive.Start(context.Background())
-	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice)
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 	cesStore, _ := ciliumEndpointSlice.Store(context.Background())
 
@@ -196,7 +196,7 @@ func TestReconcileNoop(t *testing.T) {
 		}),
 	)
 	hive.Start(context.Background())
-	r = newReconciler(fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice, context.Background())
+	r = newReconciler(context.Background(), fakeClient.CiliumFakeClientset.CiliumV2alpha1(), m, log, ciliumEndpoint, ciliumEndpointSlice)
 	cepStore, _ := ciliumEndpoint.Store(context.Background())
 
 	noRequest := true


### PR DESCRIPTION
Update Identity GC and CES controller metrics to use modular metrics support from pkg hive.
Existing tests have been updated accordingly.

~Depends on: https://github.com/cilium/cilium/pull/28005~