### PR TITLE
Fix BPF Map Pressure for policy maps goes above 100%

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1056,7 +1056,7 @@ type policyMapPressureUpdater interface {
 }
 
 func (e *Endpoint) updatePolicyMapPressureMetric() {
-	value := float64(e.realizedPolicy.GetPolicyMap().Len()) / float64(e.policyMap.MaxEntries())
+	value := float64(e.desiredPolicy.GetPolicyMap().Len()) / float64(e.policyMap.MaxEntries())
 	e.PolicyMapPressureUpdater.Update(PolicyMapPressureEvent{value})
 }
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -528,6 +528,7 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 		status:           NewEndpointStatus(),
 		hasBPFProgram:    make(chan struct{}),
 		desiredPolicy:    policy.NewEndpointPolicy(policyGetter.GetPolicyRepository()),
+		realizedPolicy:   policy.NewEndpointPolicy(policyGetter.GetPolicyRepository()),
 		controllers:      controller.NewManager(),
 		regenFailedChan:  make(chan struct{}, 1),
 		allocator:        allocator,
@@ -540,8 +541,6 @@ func createEndpoint(owner regeneration.Owner, policyGetter policyRepoGetter, nam
 	ctx, cancel := context.WithCancel(context.Background())
 	ep.aliveCancel = cancel
 	ep.aliveCtx = ctx
-
-	ep.realizedPolicy = ep.desiredPolicy
 
 	ep.SetDefaultOpts(option.Config.Opts)
 
@@ -883,6 +882,8 @@ func FilterEPDir(dirFiles []os.DirEntry) []string {
 	return eptsID
 }
 
+// parseEndpoint parses and returns an endpoint from base64 header data retrieved
+// during endpoint restore.
 // parseEndpoint parses the given bEp which is in the form of:
 // common.CiliumCHeaderPrefix + common.Version + ":" + endpointBase64
 // Note that the parse'd endpoint's identity is only partially restored. The
@@ -912,7 +913,7 @@ func parseEndpoint(ctx context.Context, owner regeneration.Owner, policyGetter p
 	// Initialize fields to values which are non-nil that are not serialized.
 	ep.hasBPFProgram = make(chan struct{})
 	ep.desiredPolicy = policy.NewEndpointPolicy(policyGetter.GetPolicyRepository())
-	ep.realizedPolicy = ep.desiredPolicy
+	ep.realizedPolicy = policy.NewEndpointPolicy(policyGetter.GetPolicyRepository())
 	ep.controllers = controller.NewManager()
 	ep.regenFailedChan = make(chan struct{}, 1)
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -537,13 +537,6 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		e.startSyncPolicyMapController()
 	}
 
-	if e.desiredPolicy != e.realizedPolicy {
-		// Remove references to the old policy
-		e.realizedPolicy.Detach()
-		// Set realized state to desired state.
-		e.realizedPolicy = e.desiredPolicy
-	}
-
 	// Mark the endpoint to be running the policy revision it was
 	// compiled for
 	e.setPolicyRevision(revision)

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -80,6 +80,14 @@ type mapState struct {
 	denies map[Key]MapStateEntry
 }
 
+func (m MapState) DeepCopy() MapState {
+	nm := make(MapState, len(m))
+	for k, v := range m {
+		nm[k] = v.DeepCopy()
+	}
+	return nm
+}
+
 type Identities interface {
 	GetNetsLocked(identity.NumericIdentity) []*net.IPNet
 }
@@ -166,6 +174,17 @@ type MapStateEntry struct {
 	// dependents contains the keys for entries create based on this entry. These entries
 	// will be deleted once all of the owners are deleted.
 	dependents Keys
+}
+
+func (e *MapStateEntry) DeepCopy() MapStateEntry {
+	nm := *e
+	nm.DerivedFromRules = make(labels.LabelArrayList, len(e.DerivedFromRules))
+	copy(nm.DerivedFromRules, e.DerivedFromRules)
+	nm.owners = make(map[MapStateOwner]struct{}, len(e.owners))
+	nm.dependents = make(Keys, len(e.dependents))
+	maps.Copy(nm.owners, e.owners)
+	maps.Copy(nm.dependents, e.dependents)
+	return nm
 }
 
 // NewMapStateEntry creates a map state entry. If redirect is true, the

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -61,6 +61,14 @@ type EndpointPolicy struct {
 	PolicyOwner PolicyOwner
 }
 
+func (e *EndpointPolicy) DeepCopy() *EndpointPolicy {
+	return &EndpointPolicy{
+		selectorPolicy: e.selectorPolicy,
+		PolicyMapState: e.PolicyMapState.DeepCopy(),
+		PolicyOwner:    e.PolicyOwner,
+	}
+}
+
 // PolicyOwner is anything which consumes a EndpointPolicy.
 type PolicyOwner interface {
 	GetID() uint64


### PR DESCRIPTION
endpoint: fix issue where bpf_map_pressure goes above 100% for policy

Endpoints that are being created/restored would have their
realizedPolicy and desiredPolicy to point at the same object in memory.

Under normal operations, this seems to not cause much issue since
everything that is intended to be in the desired policy state should
also end up in the realized policy state.

However, in the case where the bpf policy map fills up, the realized
policy map would appear to grow above its max size as the desired map
state would still be updated.

In such a case, this was noticeable with the bpf_map_pressure metric for
policy map types going above 100%.

This can be reproduced by setting bpf.policyMapMax=256 and creating a
Pod using fqdn policy and continuously performing DNS lookups from
within the Pod to domains that return many IPs (i.e. such as AWS
domains).
Eventually the policy map should fill up, continuing doing lookups
further will lead to unexpected bpf_map_pressure metrics for policy
maps.

**Note:** Submitting #28185 as a seperate PR to make backporting easier (this change will likely need to be backported, the former will not) as a series of changes to fix the map pressure metric for policy maps.