### PR TITLE
Add proxy protocol support for ingress controller

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1944,6 +1944,10 @@
      - Default secret namespace for ingresses without .spec.tls[].secretName set.
      - string
      - ``nil``
+   * - :spelling:ignore:`ingressController.enableProxyProtocol`
+     - Enable proxy protocol for the listeners.
+     - bool
+     - ``false``
    * - :spelling:ignore:`ingressController.enabled`
      - Enable cilium ingress controller This will automatically set enable-envoy-config as well.
      - bool

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -1945,7 +1945,7 @@
      - string
      - ``nil``
    * - :spelling:ignore:`ingressController.enableProxyProtocol`
-     - Enable proxy protocol for the listeners.
+     - Enable proxy protocol for all Ingress listeners. Note that *only* Proxy protocol traffic will be accepted once this is enabled.
      - bool
      - ``false``
    * - :spelling:ignore:`ingressController.enabled`

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -536,6 +536,7 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.default | bool | `false` | Set cilium ingress controller to be the default ingress controller This will let cilium ingress controller route entries without ingress class set |
 | ingressController.defaultSecretName | string | `nil` | Default secret name for ingresses without .spec.tls[].secretName set. |
 | ingressController.defaultSecretNamespace | string | `nil` | Default secret namespace for ingresses without .spec.tls[].secretName set. |
+| ingressController.enableProxyProtocol | bool | `false` | Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled. |
 | ingressController.enabled | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
 | ingressController.enforceHttps | bool | `true` | Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. |
 | ingressController.ingressLBAnnotationPrefixes | list | `["service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate from Ingress to the Load Balancer service |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -250,6 +250,7 @@ data:
 {{- if .Values.ingressController.enabled }}
   enable-ingress-controller: "true"
   enforce-ingress-https: {{ .Values.ingressController.enforceHttps | quote }}
+  enable-ingress-proxy-protocol: {{ .Values.ingressController.enableProxyProtocol | quote }}
   enable-ingress-secrets-sync: {{ .Values.ingressController.secretsNamespace.sync | quote }}
   ingress-secrets-namespace: {{ .Values.ingressController.secretsNamespace.name | quote }}
   ingress-lb-annotation-prefixes: {{ .Values.ingressController.ingressLBAnnotationPrefixes | join " " | quote }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -721,7 +721,7 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
-  # -- Enable proxy protocol for the listeners.
+  # -- Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
   enableProxyProtocol: false
 
   # -- IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -721,6 +721,9 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
+  # -- Enable proxy protocol for the listeners.
+  enableProxyProtocol: false
+
   # -- IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate
   # from Ingress to the Load Balancer service
   ingressLBAnnotationPrefixes: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -718,7 +718,7 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
-  # -- Enable proxy protocol for the listeners.
+  # -- Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
   enableProxyProtocol: false
 
   # -- IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -718,6 +718,9 @@ ingressController:
   # Incoming traffic to http listener will return 308 http error code with respective location in header.
   enforceHttps: true
 
+  # -- Enable proxy protocol for the listeners.
+  enableProxyProtocol: false
+
   # -- IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate
   # from Ingress to the Load Balancer service
   ingressLBAnnotationPrefixes: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -715,6 +715,7 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 		ingressController, err := ingress.NewController(
 			legacy.clientset,
 			ingress.WithHTTPSEnforced(operatorOption.Config.EnforceIngressHTTPS),
+			ingress.WithProxyProtocol(operatorOption.Config.EnableIngressProxyProtocol),
 			ingress.WithSecretsSyncEnabled(operatorOption.Config.EnableIngressSecretsSync),
 			ingress.WithSecretsNamespace(operatorOption.Config.IngressSecretsNamespace),
 			ingress.WithLBAnnotationPrefixes(operatorOption.Config.IngressLBAnnotationPrefixes),

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -249,7 +249,7 @@ const (
 	// Incoming traffic to http listener will return 308 http error code with respective location in header.
 	EnforceIngressHttps = "enforce-ingress-https"
 
-	// EnableIngressProxyProtocol enable proxy protocol for the listeners.
+	// EnableIngressProxyProtocol enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
 	EnableIngressProxyProtocol = "enable-ingress-proxy-protocol"
 
 	// EnableIngressSecretsSync enables fan-in TLS secrets from multiple namespaces to singular namespace (specified

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -249,6 +249,9 @@ const (
 	// Incoming traffic to http listener will return 308 http error code with respective location in header.
 	EnforceIngressHttps = "enforce-ingress-https"
 
+	// EnableIngressProxyProtocol enable proxy protocol for the listeners.
+	EnableIngressProxyProtocol = "enable-ingress-proxy-protocol"
+
 	// EnableIngressSecretsSync enables fan-in TLS secrets from multiple namespaces to singular namespace (specified
 	// by ingress-secrets-namespace flag
 	EnableIngressSecretsSync = "enable-ingress-secrets-sync"
@@ -507,6 +510,9 @@ type OperatorConfig struct {
 	// EnforceIngressHTTPS enforces https if required
 	EnforceIngressHTTPS bool
 
+	// EnableIngressProxyProtocol uses proxy protocol in listeners
+	EnableIngressProxyProtocol bool
+
 	// EnableIngressSecretsSync enables background TLS secret sync for Ingress
 	EnableIngressSecretsSync bool
 
@@ -595,6 +601,7 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.EnableIngressController = vp.GetBool(EnableIngressController)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
 	c.EnforceIngressHTTPS = vp.GetBool(EnforceIngressHttps)
+	c.EnableIngressProxyProtocol = vp.GetBool(EnableIngressProxyProtocol)
 	c.IngressSecretsNamespace = vp.GetString(IngressSecretsNamespace)
 	c.GatewayAPISecretsNamespace = vp.GetString(GatewayAPISecretsNamespace)
 	c.ProxyIdleTimeoutSeconds = vp.GetInt(ProxyIdleTimeoutSeconds)

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -121,8 +121,8 @@ func NewController(clientset k8sClient.Clientset, options ...Option) (*Controlle
 		defaultLoadbalancerMode: opts.DefaultLoadbalancerMode,
 		defaultSecretNamespace:  opts.DefaultSecretNamespace,
 		defaultSecretName:       opts.DefaultSecretName,
-		sharedTranslator:        ingressTranslation.NewSharedIngressTranslator(opts.SharedLBServiceName, opts.CiliumNamespace, opts.SecretsNamespace, opts.EnforcedHTTPS, opts.IdleTimeoutSeconds),
-		dedicatedTranslator:     ingressTranslation.NewDedicatedIngressTranslator(opts.SecretsNamespace, opts.EnforcedHTTPS, opts.IdleTimeoutSeconds),
+		sharedTranslator:        ingressTranslation.NewSharedIngressTranslator(opts.SharedLBServiceName, opts.CiliumNamespace, opts.SecretsNamespace, opts.EnforcedHTTPS, opts.UseProxyProtocol, opts.IdleTimeoutSeconds),
+		dedicatedTranslator:     ingressTranslation.NewDedicatedIngressTranslator(opts.SecretsNamespace, opts.EnforcedHTTPS, opts.UseProxyProtocol, opts.IdleTimeoutSeconds),
 	}
 	ic.ingressStore, ic.ingressInformer = informer.NewInformer(
 		utils.ListerWatcherFromTyped[*slim_networkingv1.IngressList](clientset.Slim().NetworkingV1().Ingresses(corev1.NamespaceAll)),

--- a/operator/pkg/ingress/ingress_options.go
+++ b/operator/pkg/ingress/ingress_options.go
@@ -7,6 +7,7 @@ package ingress
 type Options struct {
 	MaxRetries              int
 	EnforcedHTTPS           bool
+	UseProxyProtocol        bool
 	EnabledSecretsSync      bool
 	SecretsNamespace        string
 	LBAnnotationPrefixes    []string
@@ -37,6 +38,14 @@ type Option func(o *Options) error
 func WithMaxRetries(maxRetries int) Option {
 	return func(o *Options) error {
 		o.MaxRetries = maxRetries
+		return nil
+	}
+}
+
+// WithProxyProtocol sets the listeners to use proxy protocol.
+func WithProxyProtocol(proxyProtocol bool) Option {
+	return func(o *Options) error {
+		o.UseProxyProtocol = proxyProtocol
 		return nil
 	}
 }

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -4,6 +4,7 @@
 package translation
 
 import (
+	"slices"
 	"sort"
 	"testing"
 
@@ -57,7 +58,13 @@ func TestNewHTTPListener(t *testing.T) {
 		require.Nil(t, err)
 
 		require.Equal(t, "dummy-name", listener.Name)
-		require.Len(t, listener.GetListenerFilters(), 2)
+
+		listenerNames := []string{}
+		for _, l := range listener.GetListenerFilters() {
+			listenerNames = append(listenerNames, l.Name)
+		}
+		slices.Sort(listenerNames)
+		require.Equal(t, []string{tlsInspectorType, proxyProtocolType}, listenerNames)
 		require.Len(t, listener.GetFilterChains(), 1)
 	})
 
@@ -136,7 +143,12 @@ func TestNewSNIListener(t *testing.T) {
 		require.Nil(t, err)
 
 		require.Equal(t, "dummy-name", listener.Name)
-		require.Len(t, listener.GetListenerFilters(), 2)
+		listenerNames := []string{}
+		for _, l := range listener.GetListenerFilters() {
+			listenerNames = append(listenerNames, l.Name)
+		}
+		slices.Sort(listenerNames)
+		require.Equal(t, []string{tlsInspectorType, proxyProtocolType}, listenerNames)
 		require.Len(t, listener.GetFilterChains(), 1)
 		require.Len(t, listener.GetFilterChains()[0].FilterChainMatch.ServerNames, 2)
 	})

--- a/operator/pkg/model/translation/envoy_listener_test.go
+++ b/operator/pkg/model/translation/envoy_listener_test.go
@@ -64,7 +64,7 @@ func TestNewHTTPListener(t *testing.T) {
 			listenerNames = append(listenerNames, l.Name)
 		}
 		slices.Sort(listenerNames)
-		require.Equal(t, []string{tlsInspectorType, proxyProtocolType}, listenerNames)
+		require.Equal(t, []string{proxyProtocolType, tlsInspectorType}, listenerNames)
 		require.Len(t, listener.GetFilterChains(), 1)
 	})
 
@@ -148,7 +148,7 @@ func TestNewSNIListener(t *testing.T) {
 			listenerNames = append(listenerNames, l.Name)
 		}
 		slices.Sort(listenerNames)
-		require.Equal(t, []string{tlsInspectorType, proxyProtocolType}, listenerNames)
+		require.Equal(t, []string{proxyProtocolType, tlsInspectorType}, listenerNames)
 		require.Len(t, listener.GetFilterChains(), 1)
 		require.Len(t, listener.GetFilterChains()[0].FilterChainMatch.ServerNames, 2)
 	})

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -56,7 +56,7 @@ func (t *translator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *co
 		return nil, nil, nil, fmt.Errorf("model source name can't be empty")
 	}
 
-	trans := translation.NewTranslator(ciliumGatewayPrefix+source.Name, source.Namespace, t.secretsNamespace, false, true, t.idleTimeoutSeconds)
+	trans := translation.NewTranslator(ciliumGatewayPrefix+source.Name, source.Namespace, t.secretsNamespace, false, false, true, t.idleTimeoutSeconds)
 	cec, _, _, err := trans.Translate(m)
 	if err != nil {
 		return nil, nil, nil, err

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -27,13 +27,15 @@ var _ translation.Translator = (*DedicatedIngressTranslator)(nil)
 type DedicatedIngressTranslator struct {
 	secretsNamespace   string
 	enforceHTTPs       bool
+	useProxyProtocol   bool
 	idleTimeoutSeconds int
 }
 
-func NewDedicatedIngressTranslator(secretsNamespace string, enforceHTTPs bool, idleTimeoutSeconds int) *DedicatedIngressTranslator {
+func NewDedicatedIngressTranslator(secretsNamespace string, enforceHTTPs bool, useProxyProtocol bool, idleTimeoutSeconds int) *DedicatedIngressTranslator {
 	return &DedicatedIngressTranslator{
 		secretsNamespace:   secretsNamespace,
 		enforceHTTPs:       enforceHTTPs,
+		useProxyProtocol:   useProxyProtocol,
 		idleTimeoutSeconds: idleTimeoutSeconds,
 	}
 }
@@ -48,7 +50,7 @@ func (d *DedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 
 	// The logic is same as what we have with default translator, but with a different model
 	// (i.e. the HTTP listeners are just belonged to one Ingress resource).
-	translator := translation.NewTranslator(name, namespace, d.secretsNamespace, d.enforceHTTPs, false, d.idleTimeoutSeconds)
+	translator := translation.NewTranslator(name, namespace, d.secretsNamespace, d.enforceHTTPs, d.useProxyProtocol, false, d.idleTimeoutSeconds)
 	cec, _, _, err := translator.Translate(m)
 	if err != nil {
 		return nil, nil, nil, err

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_test.go
@@ -170,8 +170,9 @@ func Test_getEndpointForIngress(t *testing.T) {
 
 func Test_translator_Translate(t *testing.T) {
 	type args struct {
-		m            *model.Model
-		enforceHTTPs bool
+		m                *model.Model
+		enforceHTTPs     bool
+		useProxyProtocol bool
 	}
 	tests := []struct {
 		name    string
@@ -209,6 +210,17 @@ func Test_translator_Translate(t *testing.T) {
 			},
 			want: pathRulesListenersCiliumEnvoyConfig,
 		},
+		{
+			name: "Conformance/ProxyProtocol",
+			args: args{
+				m: &model.Model{
+					HTTP: proxyProtocolListeners,
+				},
+				enforceHTTPs:     true,
+				useProxyProtocol: true,
+			},
+			want: proxyProtoListenersCiliumEnvoyConfig,
+		},
 	}
 
 	for _, tt := range tests {
@@ -216,6 +228,7 @@ func Test_translator_Translate(t *testing.T) {
 			trans := &DedicatedIngressTranslator{
 				secretsNamespace:   "cilium-secrets",
 				enforceHTTPs:       tt.args.enforceHTTPs,
+				useProxyProtocol:   tt.args.useProxyProtocol,
 				idleTimeoutSeconds: 60,
 			}
 

--- a/operator/pkg/model/translation/ingress/shared_ingress.go
+++ b/operator/pkg/model/translation/ingress/shared_ingress.go
@@ -8,6 +8,6 @@ import (
 )
 
 // NewSharedIngressTranslator returns a new translator for shared ingress mode.
-func NewSharedIngressTranslator(name, namespace, secretsNamespace string, enforceHTTPs bool, idleTimeoutSeconds int) translation.Translator {
-	return translation.NewTranslator(name, namespace, secretsNamespace, enforceHTTPs, false, idleTimeoutSeconds)
+func NewSharedIngressTranslator(name, namespace, secretsNamespace string, enforceHTTPs bool, useProxyProtocol bool, idleTimeoutSeconds int) translation.Translator {
+	return translation.NewTranslator(name, namespace, secretsNamespace, enforceHTTPs, useProxyProtocol, false, idleTimeoutSeconds)
 }

--- a/operator/pkg/model/translation/translator_test.go
+++ b/operator/pkg/model/translation/translator_test.go
@@ -4,6 +4,7 @@
 package translation
 
 import (
+	"slices"
 	"testing"
 
 	envoy_config_cluster_v3 "github.com/cilium/proxy/go/envoy/config/cluster/v3"
@@ -212,7 +213,12 @@ func TestSharedIngressTranslator_getHTTPRouteListenerProxy(t *testing.T) {
 	err := proto.Unmarshal(res[0].GetValue(), listener)
 	require.NoError(t, err)
 
-	require.Len(t, listener.ListenerFilters, 2)
+	listenerNames := []string{}
+	for _, l := range listener.ListenerFilters {
+		listenerNames = append(listenerNames, l.Name)
+	}
+	slices.Sort(listenerNames)
+	require.Equal(t, []string{tlsInspectorType, proxyProtocolType}, listenerNames)
 }
 
 func TestSharedIngressTranslator_getHTTPRouteListener(t *testing.T) {

--- a/operator/pkg/model/translation/translator_test.go
+++ b/operator/pkg/model/translation/translator_test.go
@@ -188,6 +188,33 @@ func TestSharedIngressTranslator_getServices(t *testing.T) {
 	}
 }
 
+func TestSharedIngressTranslator_getHTTPRouteListenerProxy(t *testing.T) {
+	i := &defaultTranslator{
+		name:             "cilium-ingress",
+		namespace:        "kube-system",
+		secretsNamespace: "cilium-secrets",
+		useProxyProtocol: true,
+	}
+	res := i.getHTTPRouteListener(&model.Model{
+		HTTP: []model.HTTPListener{
+			{
+				TLS: []model.TLSSecret{
+					{
+						Name:      "dummy-secret",
+						Namespace: "dummy-namespace",
+					},
+				},
+			},
+		},
+	})
+	require.Len(t, res, 1)
+	listener := &envoy_config_listener.Listener{}
+	err := proto.Unmarshal(res[0].GetValue(), listener)
+	require.NoError(t, err)
+
+	require.Len(t, listener.ListenerFilters, 2)
+}
+
 func TestSharedIngressTranslator_getHTTPRouteListener(t *testing.T) {
 	i := &defaultTranslator{
 		name:             "cilium-ingress",

--- a/operator/pkg/model/translation/translator_test.go
+++ b/operator/pkg/model/translation/translator_test.go
@@ -218,7 +218,7 @@ func TestSharedIngressTranslator_getHTTPRouteListenerProxy(t *testing.T) {
 		listenerNames = append(listenerNames, l.Name)
 	}
 	slices.Sort(listenerNames)
-	require.Equal(t, []string{tlsInspectorType, proxyProtocolType}, listenerNames)
+	require.Equal(t, []string{proxyProtocolType, tlsInspectorType}, listenerNames)
 }
 
 func TestSharedIngressTranslator_getHTTPRouteListener(t *testing.T) {


### PR DESCRIPTION
<!-- Description of change -->

Adds support for proxy protocol in listeners using https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/listener_filters/proxy_protocol

Fixes: #21438

```release-note
add Ingress controller proxy protocol support
```
