### PR TITLE
contrib: Fix remote repo detection for .git suffix

### DIFF
--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -12,7 +12,7 @@ get_remote () {
   local org=${1:-cilium}
   local repo=${2:-cilium}
   remote=$(git remote -v | \
-    grep "github.com[/:]${org}/${repo} " | \
+    grep "github.com[/:]${org}/${repo}\(\.git\)\? " | \
     head -n1 | cut -f1)
   if [ -z "$remote" ]; then
       echo "No remote git@github.com:${org}/${repo}.git or https://github.com/${org}/${repo} found" 1>&2


### PR DESCRIPTION
Michi pointed out that the previous iteration on this regex fixed
security remotes but broke remotes with a URL ending in ".git". Enhance
the regex to also solve this case.
