### PR TITLE
gha: Remove priviledged helm option in {Ingress, Gateway}

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -129,7 +129,6 @@ jobs:
             --helm-set=operator.image.tag=${SHA} \
             --helm-set=operator.image.useDigest=false \
             --helm-set kubeProxyReplacement=true \
-            --helm-set=securityContext.privileged=true \
             --helm-set=gatewayAPI.enabled=true"
 
           echo cilium_install_defaults=${CILIUM_INSTALL_DEFAULTS} >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-ingress.yaml
+++ b/.github/workflows/conformance-ingress.yaml
@@ -150,7 +150,6 @@ jobs:
             --helm-set=operator.image.suffix=-ci \
             --helm-set=operator.image.tag=${SHA} \
             --helm-set=operator.image.useDigest=false \
-            --helm-set=securityContext.privileged=true \
             --helm-set kubeProxyReplacement=${{ matrix.kube-proxy-replacement }} \
             --helm-set nodePort.enabled=${{ matrix.enable-node-port }} \
             --helm-set=ingressController.enabled=true \


### PR DESCRIPTION
Originally, this option is added for old minikube version, which requires priviledge permission to mount ebpf dir, however, we have migrated to kind + metallb in Ingress and Gateway related workflows.
