### PR TITLE
endpoint/id: use strings.IndexByte

### DIFF
--- a/pkg/endpoint/id/id.go
+++ b/pkg/endpoint/id/id.go
@@ -113,7 +113,7 @@ func NewCNIAttachmentID(containerID, containerIfName string) string {
 
 // splitID splits ID into prefix and id. No validation is performed on prefix.
 func splitID(id string) (PrefixType, string) {
-	if idx := strings.Index(id, ":"); idx > -1 {
+	if idx := strings.IndexByte(id, ':'); idx > -1 {
 		return PrefixType(id[:idx]), id[idx+1:]
 	}
 


### PR DESCRIPTION
Use `strings.IndexByte` instead of `strings.Index` to look for a single byte. This improves `BenchmarkSplitID` as follows:

```
name       old time/op    new time/op    delta
SplitID-8    62.5ns ±61%    41.1ns ± 5%  -34.14%  (p=0.000 n=10+9)
```