### PR TITLE
Use default pool when specified pool has no corresponding ip family

### DIFF
--- a/daemon/k8s/resources.go
+++ b/daemon/k8s/resources.go
@@ -62,6 +62,7 @@ var (
 			k8s.CiliumNetworkPolicyResource,
 			k8s.CiliumClusterwideNetworkPolicyResource,
 			k8s.CiliumCIDRGroupResource,
+			k8s.CiliumPodIPPoolResource,
 		),
 	)
 )
@@ -92,4 +93,5 @@ type Resources struct {
 	CiliumNetworkPolicies            resource.Resource[*cilium_api_v2.CiliumNetworkPolicy]
 	CiliumClusterwideNetworkPolicies resource.Resource[*cilium_api_v2.CiliumClusterwideNetworkPolicy]
 	CIDRGroups                       resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup]
+	CiliumPodIPPool                  resource.Resource[*cilium_api_v2alpha1.CiliumPodIPPool]
 }

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -30,12 +30,12 @@ var (
 	ErrIPv6Disabled = errors.New("IPv6 allocation disabled")
 )
 
-func (ipam *IPAM) determineIPAMPool(owner string) (Pool, error) {
+func (ipam *IPAM) determineIPAMPool(owner string, family Family) (Pool, error) {
 	if ipam.metadata == nil {
 		return PoolDefault, nil
 	}
 
-	pool, err := ipam.metadata.GetIPPoolForPod(owner)
+	pool, err := ipam.metadata.GetIPPoolForPodOnFamily(owner, family)
 	if err != nil {
 		return "", fmt.Errorf("unable to determine IPAM pool for owner %q: %w", owner, err)
 	}
@@ -152,7 +152,7 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 	}
 
 	if pool == "" {
-		pool, err = ipam.determineIPAMPool(owner)
+		pool, err = ipam.determineIPAMPool(owner, family)
 		if err != nil {
 			return
 		}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -100,6 +100,7 @@ type MtuConfiguration interface {
 
 type Metadata interface {
 	GetIPPoolForPod(owner string) (pool string, err error)
+	GetIPPoolForPodOnFamily(owner string, family Family) (pool string, err error)
 }
 
 // NewIPAM returns a new IP address manager

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -51,6 +51,10 @@ func (f fakeMetadataFunc) GetIPPoolForPod(owner string) (pool string, err error)
 	return f(owner)
 }
 
+func (f fakeMetadataFunc) GetIPPoolForPodOnFamily(owner string, family Family) (pool string, err error) {
+	return "", nil
+}
+
 type fakePoolAllocator struct {
 	pools map[Pool]Allocator
 }

--- a/pkg/ipam/metadata/cell.go
+++ b/pkg/ipam/metadata/cell.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
+	cilium_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/option"
@@ -26,8 +27,9 @@ type managerParams struct {
 	Lifecycle    hive.Lifecycle
 	DaemonConfig *option.DaemonConfig
 
-	NamespaceResource resource.Resource[*slim_core_v1.Namespace]
-	PodResource       k8s.LocalPodResource
+	NamespaceResource       resource.Resource[*slim_core_v1.Namespace]
+	PodResource             k8s.LocalPodResource
+	CiliumPodIPPoolResource resource.Resource[*cilium_v2alpha1.CiliumPodIPPool]
 }
 
 func newIPAMMetadataManager(params managerParams) *Manager {
@@ -38,6 +40,7 @@ func newIPAMMetadataManager(params managerParams) *Manager {
 	manager := &Manager{
 		namespaceResource: params.NamespaceResource,
 		podResource:       params.PodResource,
+		ipPoolResource:    params.CiliumPodIPPoolResource,
 	}
 	params.Lifecycle.Append(manager)
 


### PR DESCRIPTION
In dual-stack mode, it's necessary to allocate both IPv4 and IPv6 addresses for pods. However, custom IP pools may only focus on either IPv4 or IPv6, which can result in the custom IP pool being configured with only IPv4 or IPv6. When specifying an IP pool for a namespace or pod through annotations, this can cause pod creation to fail because the specified IP pool lacks the IPv4 or IPv6 family. This commit allows for the missing IPv4 or IPv6 to be obtained from the default pool when the specified IP pool lacks either of them. 
For example, in dual-stack mode, if a pod specifies an IP pool named “ipv4-pool" that contains only IPv4 addresses, its IPv4 address will come from "ipv4-pool",  and its IPv6 address will come from the corresponding IPv6 pod CIDRs in the default pool.