### PR TITLE
Add hubble_relay_pool_peer_connection_status metric

### DIFF
--- a/pkg/hubble/relay/pool/manager_test.go
+++ b/pkg/hubble/relay/pool/manager_test.go
@@ -7,13 +7,17 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -672,6 +676,7 @@ func TestPeerManager(t *testing.T) {
 			once = sync.Once{}
 
 			mgr, err := NewPeerManager(
+				prometheus.NewPedanticRegistry(),
 				WithPeerClientBuilder(tt.pcBuilder),
 				WithClientConnBuilder(tt.ccBuilder),
 				WithConnCheckInterval(1*time.Second),
@@ -702,6 +707,228 @@ func TestPeerManager(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPeerManager_CheckMetrics(t *testing.T) {
+	var done chan struct{}
+	var once sync.Once
+
+	tests := []struct {
+		name       string
+		pcBuilder  peerTypes.ClientBuilder
+		ccBuilder  poolTypes.ClientConnBuilder
+		wantStatus map[string]uint32
+	}{
+		{
+			name: "7 peers with all possible non-nil connectivity states",
+			pcBuilder: testutils.FakePeerClientBuilder{
+				OnClient: func() onClientFunc {
+					i := -1
+					return func(target string) (peerTypes.Client, error) {
+						return &testutils.FakePeerClient{
+							OnNotify: func(_ context.Context, _ *peerpb.NotifyRequest, _ ...grpc.CallOption) (peerpb.Peer_NotifyClient, error) {
+								cns := []*peerpb.ChangeNotification{
+									{
+										Name:    "peererino_uno",
+										Address: "192.0.1.1",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+									{
+										Name:    "peererino_dos",
+										Address: "192.0.1.2",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+									{
+										Name:    "peererino_tres",
+										Address: "192.0.1.3",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+									{
+										Name:    "peererino_cuatro",
+										Address: "192.0.1.4",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+									{
+										Name:    "peererino_cinco",
+										Address: "192.0.1.5",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+									{
+										Name:    "peererino_seis",
+										Address: "192.0.1.6",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+									{
+										Name:    "peererino_siete",
+										Address: "192.0.1.7",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+								}
+								return &testutils.FakePeerNotifyClient{
+									OnRecv: func() (*peerpb.ChangeNotification, error) {
+										i++
+										switch {
+										case i >= len(cns):
+											once.Do(func() { close(done) })
+											return nil, io.EOF
+										default:
+											return cns[i], nil
+										}
+									},
+								}, nil
+							},
+							OnClose: func() error {
+								return nil
+							},
+						}, nil
+					}
+				}(),
+			},
+			ccBuilder: FakeClientConnBuilder{
+				OnClientConn: func() onClientConnFunc {
+					var i int
+					return func(target, hostname string) (poolTypes.ClientConn, error) {
+						return testutils.FakeClientConn{
+							OnGetState: func() connectivity.State {
+								states := []connectivity.State{
+									connectivity.Idle,
+									connectivity.Ready,
+									connectivity.Connecting,
+									connectivity.TransientFailure,
+									connectivity.Shutdown,
+								}
+								resultState := states[i%len(states)]
+								i = (i + 1) % 7
+								return resultState
+							},
+							OnClose: func() error {
+								return nil
+							},
+						}, nil
+					}
+				}(),
+			},
+			wantStatus: map[string]uint32{
+				"READY":             2,
+				"CONNECTING":        1,
+				"IDLE":              2,
+				"TRANSIENT_FAILURE": 1,
+				"SHUTDOWN":          1,
+				"NIL_CONNECTION":    0,
+			},
+		},
+		{
+			name: "3 peers with nil connection",
+			pcBuilder: testutils.FakePeerClientBuilder{
+				OnClient: func() onClientFunc {
+					i := -1
+					return func(target string) (peerTypes.Client, error) {
+						return &testutils.FakePeerClient{
+							OnNotify: func(_ context.Context, _ *peerpb.NotifyRequest, _ ...grpc.CallOption) (peerpb.Peer_NotifyClient, error) {
+								cns := []*peerpb.ChangeNotification{
+									{
+										Name:    "noip_uno",
+										Address: "",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+									{
+										Name:    "noip_dos",
+										Address: "",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+									{
+										Name:    "noip_tres",
+										Address: "",
+										Type:    peerpb.ChangeNotificationType_PEER_ADDED,
+									},
+								}
+								return &testutils.FakePeerNotifyClient{
+									OnRecv: func() (*peerpb.ChangeNotification, error) {
+										i++
+										switch {
+										case i >= len(cns):
+											once.Do(func() { close(done) })
+											return nil, io.EOF
+										default:
+											return cns[i], nil
+										}
+									},
+								}, nil
+							},
+							OnClose: func() error {
+								return nil
+							},
+						}, nil
+					}
+				}(),
+			},
+			ccBuilder: FakeClientConnBuilder{},
+			wantStatus: map[string]uint32{
+				"READY":             0,
+				"CONNECTING":        0,
+				"IDLE":              0,
+				"TRANSIENT_FAILURE": 0,
+				"SHUTDOWN":          0,
+				"NIL_CONNECTION":    3,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			done = make(chan struct{})
+			once = sync.Once{}
+
+			var buf bytes.Buffer
+			formatter := &logrus.TextFormatter{
+				DisableColors:    true,
+				DisableTimestamp: true,
+			}
+			logger := logrus.New()
+			logger.SetOutput(&buf)
+			logger.SetFormatter(formatter)
+			logger.SetLevel(logrus.DebugLevel)
+
+			registry := prometheus.NewPedanticRegistry()
+			options := []Option{
+				WithPeerClientBuilder(tt.pcBuilder),
+				WithClientConnBuilder(tt.ccBuilder),
+				WithLogger(logger),
+				WithConnStatusInterval(2 * time.Second),
+				// set interval large enough not to fire in 3 seconds sleep
+				WithConnCheckInterval(20 * time.Minute),
+			}
+
+			mgr, err := NewPeerManager(registry, options...)
+			assert.NoError(t, err)
+			mgr.Start()
+			wantExp := metricTextFormatFromPeerStatusMap(tt.wantStatus)
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				err = testutil.GatherAndCompare(registry, bytes.NewBufferString(wantExp), "hubble_relay_pool_peer_connection_status")
+				assert.NoError(c, err)
+			}, time.Minute, time.Second)
+			<-done
+			mgr.Stop()
+		})
+	}
+}
+
+// metricTextFormatFromPeerStatusMap converts peer status map to the metric text format
+// expected by Prometheus testutil library
+func metricTextFormatFromPeerStatusMap(peerStatus map[string]uint32) string {
+	var buf strings.Builder
+	buf.WriteString(`# HELP hubble_relay_pool_peer_connection_status Measures the connectivity status of all peers by counting the number of peers for each given connection status.
+# TYPE hubble_relay_pool_peer_connection_status gauge
+`)
+	keys := make([]string, 0, len(peerStatus))
+	for key := range peerStatus {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
+	for _, key := range keys {
+		buf.WriteString(fmt.Sprintf("hubble_relay_pool_peer_connection_status{status=\"%s\"} %d\n", key, peerStatus[key]))
+	}
+	return buf.String()
 }
 
 type ByName []poolTypes.Peer

--- a/pkg/hubble/relay/pool/metrics.go
+++ b/pkg/hubble/relay/pool/metrics.go
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package pool
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/connectivity"
+
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+const (
+	// namespace is a namespace used in Prometheus pool metrics naming
+	namespace = "hubble_relay"
+
+	// subsystem is a subsystem used in Prometheus pool metrics naming
+	subsystem = "pool"
+
+	// nilConnectionLabelValue is a value for "status" label for PeerConnStatus
+	// metric, used for reporting peers that have nil connection
+	// (no connectivity.State applies to these peers).
+	nilConnectionLabelValue = "NIL_CONNECTION"
+)
+
+// PoolMetrics holds metrics related to the scope of this package.
+type PoolMetrics struct {
+	PeerConnStatus   *prometheus.GaugeVec
+	peerConnStatusMu lock.Mutex
+}
+
+// NewPoolMetrics creates a new PoolMetrics object.
+func NewPoolMetrics(registry prometheus.Registerer) *PoolMetrics {
+	m := &PoolMetrics{
+		PeerConnStatus: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "peer_connection_status",
+			Help:      "Measures the connectivity status of all peers by counting the number of peers for each given connection status.",
+		}, []string{"status"}),
+	}
+	registry.MustRegister(m.PeerConnStatus)
+	return m
+}
+
+// ObservePeerConnectionStatus sets the value of PeerConnStatus gauge metric family.
+// This method is thread-safe.
+func (m *PoolMetrics) ObservePeerConnectionStatus(peerConnStatus map[connectivity.State]uint32, nilConnNum uint32) {
+	// initialize map with zeros to make sure gauges are set even if caller does not pass values for every key
+	status := map[string]uint32{
+		connectivity.Idle.String():             0,
+		connectivity.Connecting.String():       0,
+		connectivity.Ready.String():            0,
+		connectivity.TransientFailure.String(): 0,
+		connectivity.Shutdown.String():         0,
+		nilConnectionLabelValue:                0,
+	}
+
+	status[nilConnectionLabelValue] = nilConnNum
+	for state, num := range peerConnStatus {
+		status[state.String()] = num
+	}
+
+	m.peerConnStatusMu.Lock()
+	for state, num := range status {
+		m.PeerConnStatus.WithLabelValues(state).Set(float64(num))
+	}
+	m.peerConnStatusMu.Unlock()
+}

--- a/pkg/hubble/relay/pool/option.go
+++ b/pkg/hubble/relay/pool/option.go
@@ -38,9 +38,10 @@ var defaultOptions = options{
 		Max:    90 * time.Minute,
 		Factor: 2.0,
 	},
-	connCheckInterval: 2 * time.Minute,
-	retryTimeout:      defaults.RetryTimeout,
-	log:               logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay"),
+	connCheckInterval:  2 * time.Minute,
+	connStatusInterval: 5 * time.Second,
+	retryTimeout:       defaults.RetryTimeout,
+	log:                logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay"),
 }
 
 // Option customizes the configuration of the Manager.
@@ -53,6 +54,7 @@ type options struct {
 	clientConnBuilder  poolTypes.ClientConnBuilder
 	backoff            BackoffDuration
 	connCheckInterval  time.Duration
+	connStatusInterval time.Duration
 	retryTimeout       time.Duration
 	log                logrus.FieldLogger
 }
@@ -96,6 +98,15 @@ func WithBackoff(b BackoffDuration) Option {
 func WithConnCheckInterval(i time.Duration) Option {
 	return func(o *options) error {
 		o.connCheckInterval = i
+		return nil
+	}
+}
+
+// WithConnStatusInterval sets the time interval between peer connection status
+// is reported through Prometheus gauge metrics.
+func WithConnStatusInterval(i time.Duration) Option {
+	return func(o *options) error {
+		o.connStatusInterval = i
 		return nil
 	}
 }

--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -86,6 +86,7 @@ func New(options ...Option) (*Server, error) {
 	}
 
 	pm, err := pool.NewPeerManager(
+		registry,
 		pool.WithPeerServiceAddress(opts.peerTarget),
 		pool.WithPeerClientBuilder(peerClientBuilder),
 		pool.WithClientConnBuilder(pool.GRPCClientConnBuilder{


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

This change adds a new gauge metric to hubble-relay measuring the connectiion status to all peers. Metric keeps track of number of peers for each possible connectiion status

The current set of metrics is not enough to accurately measure the availability of hubble-relay. They measure the status of gRPC calls, but, for instance, in case all peers are unreachable when GetFlows is called, even though gRPC call will succeed and return "OK" status, the response will come with no flows gathered, rendering it useless. This new metric is introduced to cover such cases.

Fixes #27890

```release-note
Added hubble_relay_pool_peer_connection_status metric for measuring the connection status of all peers. Metric keeps track of number of peers for each possible connectiion status.
```
