### PR TITLE
fqdn proxy: fix data race detection on TCP fqdn proxy

### DIFF
--- a/pkg/fqdn/dnsproxy/noop_sessionudpfactory.go
+++ b/pkg/fqdn/dnsproxy/noop_sessionudpfactory.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package dnsproxy
+
+import (
+	"net"
+
+	"github.com/cilium/dns"
+)
+
+type noopSessionUDPFactory struct{}
+
+var _ dns.SessionUDPFactory = &noopSessionUDPFactory{}
+
+func (*noopSessionUDPFactory) InitPool(msgSize int) {}
+
+func (*noopSessionUDPFactory) ReadRequest(conn *net.UDPConn) ([]byte, dns.SessionUDP, error) {
+	return nil, nil, nil
+}
+
+func (*noopSessionUDPFactory) ReadRequestConn(conn net.PacketConn) ([]byte, net.Addr, error) {
+	return nil, nil, nil
+}
+
+func (*noopSessionUDPFactory) SetSocketOptions(conn *net.UDPConn) error {
+	return nil
+}

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -1118,6 +1118,9 @@ func bindToAddr(address string, port uint16, handler dns.Handler, ipv4, ipv6 boo
 		}
 		dnsServers = append(dnsServers, &dns.Server{
 			Listener: tcpListener, Handler: handler,
+			// Explicitly set a noop factory to prevent data race detection when InitPool is called
+			// multiple times on the default factory even for TCP (IPv4 & IPv6).
+			SessionUDPFactory: &noopSessionUDPFactory{},
 			// Net & Addr are only set for logging purposes and aren't used if using ActivateAndServe.
 			Net: ipFamily.TCPAddress, Addr: tcpListener.Addr().String(),
 		})


### PR DESCRIPTION
PR #25309 introduced a data race by sharing the `sessionUDPFactory` between the DNS server instances for the different IP families (IPv4 & IPv6). This has been detected by #27979.

This commit fixes the issue for the TCP servers too. If not set explicitly, these are initialized with the default udp session factory to prevent nil pointer exceptions. Therefore, an explicit noop udp session factory is set.

Fixes: #28156