### PR TITLE
Make tolerations configurable in clustermesh-apiserver certgen job

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -49,6 +49,10 @@ spec:
           {{- toYaml . | nindent 10 }}
           {{- end }}
       hostNetwork: true
+      {{- with .Values.certgen.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccount: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
       serviceAccountName: {{ .Values.serviceAccounts.clustermeshcertgen.name | quote }}
       automountServiceAccountToken: {{ .Values.serviceAccounts.clustermeshcertgen.automount }}


### PR DESCRIPTION
A certgen job can be used to generate the TLS certificates required both for hubble and clustermesh. Yet, the clustermesh one lacks the possibility of configuring additional tolerations, which are instead configurable in the hubble case. This is possibly useful for instance to allow running the job on control-plane nodes. Hence, let's fix this divergence.

Related: https://github.com/cilium/cilium/issues/28167

<!-- Description of change -->

```release-note
Make tolerations configurable in clustermesh-apiserver certgen job
```
