### PR TITLE
 pkg/labels: print all leaf CIDRs, not just the last one. 

### DIFF
--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -74,10 +73,10 @@ func (s *IdentityTestSuite) TestIsReservedIdentity(c *C) {
 
 func (s *IdentityTestSuite) TestRequiresGlobalIdentity(c *C) {
 	prefix := netip.MustParsePrefix("0.0.0.0/0")
-	c.Assert(RequiresGlobalIdentity(cidr.GetCIDRLabels(prefix)), Equals, false)
+	c.Assert(RequiresGlobalIdentity(labels.GetCIDRLabels(prefix)), Equals, false)
 
 	prefix = netip.MustParsePrefix("192.168.23.0/24")
-	c.Assert(RequiresGlobalIdentity(cidr.GetCIDRLabels(prefix)), Equals, false)
+	c.Assert(RequiresGlobalIdentity(labels.GetCIDRLabels(prefix)), Equals, false)
 
 	c.Assert(RequiresGlobalIdentity(labels.NewLabelsFromModel([]string{"k8s:foo=bar"})), Equals, true)
 }
@@ -88,11 +87,11 @@ func (s *IdentityTestSuite) TestScopeForLabels(c *C) {
 		scope NumericIdentity
 	}{
 		{
-			lbls:  cidr.GetCIDRLabels(netip.MustParsePrefix("0.0.0.0/0")),
+			lbls:  labels.GetCIDRLabels(netip.MustParsePrefix("0.0.0.0/0")),
 			scope: IdentityScopeLocal,
 		},
 		{
-			lbls:  cidr.GetCIDRLabels(netip.MustParsePrefix("192.168.23.0/24")),
+			lbls:  labels.GetCIDRLabels(netip.MustParsePrefix("192.168.23.0/24")),
 			scope: IdentityScopeLocal,
 		},
 		{
@@ -294,8 +293,8 @@ func TestLookupReservedIdentityByLabels(t *testing.T) {
 		{
 			name: "cidr",
 			args: labels.Map2Labels(map[string]string{
-				labels.LabelWorld.String():              "",
-				cidr.GetCIDRLabels(cidrPrefix).String(): "",
+				labels.LabelWorld.String():                "",
+				labels.GetCIDRLabels(cidrPrefix).String(): "",
 			}, ""),
 			want: nil,
 		},

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
@@ -189,7 +188,7 @@ func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, prefixes []netip.
 
 	toDelete := make([]netip.Prefix, 0, len(prefixes))
 	for _, prefix := range prefixes {
-		lbls := cidr.GetCIDRLabels(prefix)
+		lbls := labels.GetCIDRLabels(prefix)
 		id := ipc.IdentityAllocator.LookupIdentity(ctx, lbls)
 		if id == nil {
 			log.Errorf("Unable to find identity of previously used CIDR %s", prefix.String())

--- a/pkg/ipcache/ipcache.go
+++ b/pkg/ipcache/ipcache.go
@@ -19,7 +19,6 @@ import (
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
@@ -478,7 +477,7 @@ func (ipc *IPCache) RemoveMetadata(prefix netip.Prefix, resource ipcacheTypes.Re
 func (ipc *IPCache) UpsertPrefixes(prefixes []netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID) {
 	ipc.metadata.Lock()
 	for _, p := range prefixes {
-		ipc.metadata.upsertLocked(p, src, resource, cidr.GetCIDRLabels(p))
+		ipc.metadata.upsertLocked(p, src, resource, labels.GetCIDRLabels(p))
 		ipc.metadata.enqueuePrefixUpdates(p)
 	}
 	ipc.metadata.Unlock()
@@ -499,7 +498,7 @@ func (ipc *IPCache) UpsertPrefixes(prefixes []netip.Prefix, src source.Source, r
 func (ipc *IPCache) RemovePrefixes(prefixes []netip.Prefix, src source.Source, resource ipcacheTypes.ResourceID) {
 	ipc.metadata.Lock()
 	for _, p := range prefixes {
-		ipc.metadata.remove(p, resource, cidr.GetCIDRLabels(p))
+		ipc.metadata.remove(p, resource, labels.GetCIDRLabels(p))
 		ipc.metadata.enqueuePrefixUpdates(p)
 	}
 	ipc.metadata.Unlock()

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
-	cidrlabels "github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
@@ -462,7 +461,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 	// when we remove CIDR labels for identities that should not have them.
 	if restoredIdentity.Scope() == identity.IdentityScopeRemoteNode {
 		lbls.MergeLabels(labels.LabelRemoteNode)
-		cidrLabels := cidrlabels.GetCIDRLabels(prefix)
+		cidrLabels := labels.GetCIDRLabels(prefix)
 		lbls.MergeLabels(cidrLabels)
 	}
 
@@ -470,7 +469,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 	// then merge the CIDR-label.
 	if lbls.Has(labels.LabelHost[labels.IDNameHost]) &&
 		option.Config.PolicyCIDRMatchesNodes() {
-		cidrLabels := cidrlabels.GetCIDRLabels(prefix)
+		cidrLabels := labels.GetCIDRLabels(prefix)
 		lbls.MergeLabels(cidrLabels)
 	}
 
@@ -485,7 +484,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 		// It is not allowed for nodes to have CIDR labels, unless policy-cidr-match-mode
 		// includes "nodes". Then CIDR labels are required.
 		if !option.Config.PolicyCIDRMatchesNodes() {
-			n = n.Remove(cidrlabels.GetCIDRLabels(prefix))
+			n = n.Remove(labels.GetCIDRLabels(prefix))
 		}
 		lbls = n
 	}
@@ -527,7 +526,7 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 	if !lbls.Has(labels.LabelRemoteNode[labels.IDNameRemoteNode]) &&
 		!lbls.Has(labels.LabelHealth[labels.IDNameHealth]) &&
 		!lbls.Has(labels.LabelIngress[labels.IDNameIngress]) {
-		cidrLabels := cidrlabels.GetCIDRLabels(prefix)
+		cidrLabels := labels.GetCIDRLabels(prefix)
 		lbls.MergeLabels(cidrLabels)
 	}
 

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
@@ -91,8 +90,8 @@ func TestInjectLabels(t *testing.T) {
 	option.Config.PolicyCIDRMatchMode = []string{"nodes"}
 
 	// Insert CIDR labels for the remote nodes (this is done by the node manager, but we need to test that it goes through)
-	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "node-uid-cidr", cidr.GetCIDRLabels(inClusterPrefix))
-	IPIdentityCache.metadata.upsertLocked(inClusterPrefix2, source.CustomResource, "node-uid-cidr", cidr.GetCIDRLabels(inClusterPrefix2))
+	IPIdentityCache.metadata.upsertLocked(inClusterPrefix, source.CustomResource, "node-uid-cidr", labels.GetCIDRLabels(inClusterPrefix))
+	IPIdentityCache.metadata.upsertLocked(inClusterPrefix2, source.CustomResource, "node-uid-cidr", labels.GetCIDRLabels(inClusterPrefix2))
 
 	remaining, err = IPIdentityCache.InjectLabels(ctx, []netip.Prefix{inClusterPrefix, inClusterPrefix2})
 	assert.NoError(t, err)
@@ -399,7 +398,7 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	// This is to "force" a race condition
 	resource := types.NewResourceID(
 		types.ResourceKindCNP, "default", "policy")
-	labels := cidr.GetCIDRLabels(prefix)
+	labels := labels.GetCIDRLabels(prefix)
 	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, resource, labels)
 
 	// Now, emulate policyAdd(), which calls AllocateCIDRs()

--- a/pkg/labels/cidr/doc.go
+++ b/pkg/labels/cidr/doc.go
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-// Copyright Authors of Cilium
-
-// Package cidr provides helper methods for generating labels for CIDRs which
-// are partially derived from node state.
-package cidr

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net"
+	"net/netip"
 	"slices"
 	"sort"
 	"strings"
@@ -144,26 +144,24 @@ type Labels map[string]Label
 
 // GetPrintableModel turns the Labels into a sorted list of strings
 // representing the labels, with CIDRs deduplicated (ie, only provide the most
-// specific CIDR).
+// specific CIDRs).
 func (l Labels) GetPrintableModel() (res []string) {
-	cidr := ""
-	prefixLength := 0
+	// Aggregate list of "leaf" CIDRs
+	leafCIDRs := leafCIDRList[*Label]{}
 	for _, v := range l {
+		// If this is a CIDR label, filter out non-leaf CIDRs for human consumption
 		if v.Source == LabelSourceCIDR {
-			vStr := strings.Replace(v.String(), "-", ":", -1)
-			prefix := strings.Replace(v.Key, "-", ":", -1)
-			_, ipnet, _ := net.ParseCIDR(prefix)
-			ones, _ := ipnet.Mask.Size()
-			if ones > prefixLength {
-				cidr = vStr
-				prefixLength = ones
-			}
-			continue
+			v := v
+			prefixStr := strings.Replace(v.Key, "-", ":", -1)
+			prefix, _ := netip.ParsePrefix(prefixStr)
+			leafCIDRs.insert(prefix, &v)
+		} else {
+			// not a CIDR label, no magic needed
+			res = append(res, v.String())
 		}
-		res = append(res, v.String())
 	}
-	if cidr != "" {
-		res = append(res, cidr)
+	for _, val := range leafCIDRs {
+		res = append(res, strings.Replace(val.String(), "-", ":", -1))
 	}
 
 	sort.Strings(res)

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cilium/cilium/pkg/ipcache"
 	ipcacheTypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
-	cidrlabels "github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/metrics/metric"
@@ -420,7 +419,7 @@ func (m *manager) nodeIdentityLabels(n nodeTypes.Node) (nodeLabels labels.Labels
 					if ok {
 						prefix, err := addr.Prefix(addr.BitLen())
 						if err == nil {
-							cidrLabels := cidrlabels.GetCIDRLabels(prefix)
+							cidrLabels := labels.GetCIDRLabels(prefix)
 							nodeLabels.MergeLabels(cidrLabels)
 						}
 					}
@@ -500,7 +499,7 @@ func (m *manager) NodeUpdated(n nodeTypes.Node) {
 		// Add the CIDR labels for this node, if we allow selecting nodes by CIDR
 		if option.Config.PolicyCIDRMatchesNodes() {
 			lbls = labels.NewFrom(nodeLabels)
-			lbls.MergeLabels(cidrlabels.GetCIDRLabels(prefix))
+			lbls.MergeLabels(labels.GetCIDRLabels(prefix))
 		}
 
 		// Always associate the prefix with metadata, even though this may not

--- a/pkg/policy/api/cidr.go
+++ b/pkg/policy/api/cidr.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/ip"
 	"github.com/cilium/cilium/pkg/labels"
-	cidrpkg "github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -85,7 +84,7 @@ func (s CIDRSlice) GetAsEndpointSelectors() EndpointSelectorSlice {
 		if cidr == ipv6All {
 			hasIPv6AllBeenAdded = true
 		}
-		lbl, err := cidrpkg.IPStringToLabel(string(cidr))
+		lbl, err := labels.IPStringToLabel(string(cidr))
 		if err == nil {
 			slice = append(slice, NewESFromLabels(lbl))
 		}

--- a/pkg/policy/api/cidr_test.go
+++ b/pkg/policy/api/cidr_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
-	cidrpkg "github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -26,15 +25,15 @@ func (s *PolicyAPITestSuite) TestGetAsEndpointSelectors(c *C) {
 	labelWorldIPv6 := labels.ParseSelectLabel("reserved:world-ipv6")
 	esWorldIPv6 := NewESFromLabels(labelWorldIPv6)
 
-	labelAllV4, err := cidrpkg.IPStringToLabel("0.0.0.0/0")
+	labelAllV4, err := labels.IPStringToLabel("0.0.0.0/0")
 	c.Assert(err, IsNil)
 	v4World := NewESFromLabels(labelAllV4)
 
-	labelAllV6, err := cidrpkg.IPStringToLabel("::/0")
+	labelAllV6, err := labels.IPStringToLabel("::/0")
 	c.Assert(err, IsNil)
 	v6World := NewESFromLabels(labelAllV6)
 
-	labelOtherCIDR, err := cidrpkg.IPStringToLabel("192.168.128.0/24")
+	labelOtherCIDR, err := labels.IPStringToLabel("192.168.128.0/24")
 	c.Assert(err, IsNil)
 	esOtherCIDR := NewESFromLabels(labelOtherCIDR)
 

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
-	"github.com/cilium/cilium/pkg/labels/cidr"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
@@ -1405,8 +1404,8 @@ var (
 	lblWorldIP      = labels.ParseSelectLabelArray(fmt.Sprintf("%s:%s", labels.LabelSourceCIDR, worldCIDR))
 	hostIPv4        = api.CIDR("172.19.0.1/32")
 	hostIPv6        = api.CIDR("fc00:c111::3/64")
-	lblHostIPv4CIDR = cidr.GetCIDRLabels(netip.MustParsePrefix(string(hostIPv4)))
-	lblHostIPv6CIDR = cidr.GetCIDRLabels(netip.MustParsePrefix(string(hostIPv6)))
+	lblHostIPv4CIDR = labels.GetCIDRLabels(netip.MustParsePrefix(string(hostIPv4)))
+	lblHostIPv6CIDR = labels.GetCIDRLabels(netip.MustParsePrefix(string(hostIPv6)))
 
 	ruleL3AllowWorldIP = api.NewRule().WithIngressRules([]api.IngressRule{{
 		IngressCommonRule: api.IngressCommonRule{
@@ -1423,7 +1422,7 @@ var (
 	worldSubnetRule     = api.CIDRRule{
 		Cidr: worldSubnet,
 	}
-	lblWorldSubnet   = cidr.GetCIDRLabels(netip.MustParsePrefix(string(worldSubnet)))
+	lblWorldSubnet   = labels.GetCIDRLabels(netip.MustParsePrefix(string(worldSubnet)))
 	ruleL3DenySubnet = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{{
 		IngressCommonRule: api.IngressCommonRule{
 			FromCIDRSet: api.CIDRRuleSlice{worldSubnetRule},


### PR DESCRIPTION
When printing Labels (e.g. by `cilium identity list`), CIDR labels are de-expanded to only show the relevant ones. For example, the CIDR label `1.1.1.0/24` is under-the-hood expanded to `0.0.0.0/0, 0.0.0.0/1, ..., 1.1.0.0/23, 1.1.1.0/24`. Then, when the identity is printed for human consumption, the CIDR labels are de-expanded. However, this code did not anticipate a single identity having multiple "leaf" CIDR labels.

So, change the printing logic to output all interesting CIDRs. This adds a O(N^2) check, but given that N is never over ~100, it shouldn't be an issue.

Note that this output is only for human consumption; it is not persisted or used as an API.