### PR TITLE
Fix missing NODE_ADD messages

### DIFF
--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -4030,6 +4030,12 @@ func (c *DaemonConfig) IsDualStack() bool {
 	return c.EnableIPv4 && c.EnableIPv6
 }
 
+// IsLocalRouterIP checks if provided IP address matches either LocalRouterIPv4
+// or LocalRouterIPv6
+func (c *DaemonConfig) IsLocalRouterIP(ip string) bool {
+	return ip != "" && (c.LocalRouterIPv4 == ip || c.LocalRouterIPv6 == ip)
+}
+
 // StoreViperInFile stores viper's configuration in a the given directory under
 // the file name 'viper-config.yaml'. If this file already exists, it is renamed
 // to 'viper-config-1.yaml', if 'viper-config-1.yaml' also exists,

--- a/pkg/option/fake/config.go
+++ b/pkg/option/fake/config.go
@@ -31,3 +31,9 @@ func (f *Config) EncryptionEnabled() bool {
 func (f *Config) NodeEncryptionEnabled() bool {
 	return true
 }
+
+// IsLocalRouterIP checks if provided IP address matches either LocalRouterIPv4
+// or LocalRouterIPv6
+func (f *Config) IsLocalRouterIP(ip string) bool {
+	return false
+}


### PR DESCRIPTION
When `local-router-ipv4` is set in `cilium-config` it causes all `CiliumNodes` to have `NodeCiliumInternalIP` set to the same value. When "upserting" it in the node manager it detects collision expecting to later send node_update message, but as the node is new it instead skips sending node_add message completely.

This avoids setting `dpUpdate = false` when collision is detected for IP addresses of `NodeCiliumInternalIP`.

Bug: b/284134355

```release-note
Fix missing NODE_ADD Hubble peer messages in some cases
```
