### PR TITLE
Fix the build

### DIFF
--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -25,6 +25,8 @@ import (
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2alpha1"
+	"github.com/cilium/cilium/pkg/k8s/resource"
+	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/types"
 	"github.com/cilium/cilium/pkg/option"


### PR DESCRIPTION
The main branch build is failing with these errors:

    -: # github.com/cilium/cilium/pkg/bgpv1/test
    Error: pkg/bgpv1/test/fixtures.go:120:13: undefined: resource
    Error: pkg/bgpv1/test/fixtures.go:121:9: undefined: utils
    Error: /home/runner/work/cilium/cilium/src/github.com/cilium/cilium/pkg/bgpv1/test/fixtures.go:120:13: undefined: resource
    Error: /home/runner/work/cilium/cilium/src/github.com/cilium/cilium/pkg/bgpv1/test/fixtures.go:121:9: undefined: utils
    -: # github.com/cilium/cilium/pkg/bgpv1/test [github.com/cilium/cilium/pkg/bgpv1/test.test]
    Error: pkg/bgpv1/test/fixtures.go:120:13: undefined: resource
    Error: pkg/bgpv1/test/fixtures.go:121:9: undefined: utils
    Error: /home/runner/work/cilium/cilium/src/github.com/cilium/cilium/pkg/bgpv1/test/fixtures.go:120:13: undefined: resource
    Error: /home/runner/work/cilium/cilium/src/github.com/cilium/cilium/pkg/bgpv1/test/fixtures.go:121:9: undefined: utils
    linters: 6 errors during loading

Ref: https://github.com/cilium/cilium/actions/runs/6237746960/job/16932035909