### PR TITLE
BGP CP: Replaces LocalNodeStore with Local CiliumNode

### DIFF
--- a/pkg/bgpv1/agent/routermgr.go
+++ b/pkg/bgpv1/agent/routermgr.go
@@ -10,7 +10,6 @@ import (
 	restapi "github.com/cilium/cilium/api/v1/server/restapi/bgp"
 	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/node"
 )
 
 // BGPRouterManager provides a declarative API for defining
@@ -34,7 +33,7 @@ type BGPRouterManager interface {
 	//
 	// Providing a nil policy to ConfigurePeers will withdrawal all routes
 	// and disconnect from the peers.
-	ConfigurePeers(ctx context.Context, policy *v2alpha1api.CiliumBGPPeeringPolicy, node *node.LocalNode, ciliumNode *v2api.CiliumNode) error
+	ConfigurePeers(ctx context.Context, policy *v2alpha1api.CiliumBGPPeeringPolicy, ciliumNode *v2api.CiliumNode) error
 
 	// GetPeers fetches BGP peering state from underlying routing daemon.
 	//

--- a/pkg/bgpv1/manager/pod_ip_pool_reconciler_test.go
+++ b/pkg/bgpv1/manager/pod_ip_pool_reconciler_test.go
@@ -5,7 +5,6 @@ package manager
 
 import (
 	"context"
-	"net"
 	"net/netip"
 	"testing"
 
@@ -17,9 +16,6 @@ import (
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/node"
-	"github.com/cilium/cilium/pkg/node/addressing"
-	nodeTypes "github.com/cilium/cilium/pkg/node/types"
 )
 
 func TestPodIPPoolReconciler(t *testing.T) {
@@ -234,33 +230,20 @@ func TestPodIPPoolReconciler(t *testing.T) {
 			}
 			reconciler := NewPodIPPoolReconciler(store).Reconciler.(*PodIPPoolReconciler)
 
-			node := &node.LocalNode{
-				Node: nodeTypes.Node{
-					Name: "node1",
-					IPAddresses: []nodeTypes.Address{
-						{
-							Type: addressing.NodeExternalIP,
-							IP:   net.ParseIP("127.0.0.1"),
-						},
-					},
-				},
-			}
-
-			ciliumNode := &v2api.CiliumNode{
+			node := &v2api.CiliumNode{
 				ObjectMeta: meta_v1.ObjectMeta{
-					Name:      node.Name,
+					Name:      "node1",
 					Namespace: "default",
 				},
 			}
 
 			if tt.nodeAllocs != nil {
-				ciliumNode.Spec.IPAM.Pools.Allocated = append(ciliumNode.Spec.IPAM.Pools.Allocated, tt.nodeAllocs...)
+				node.Spec.IPAM.Pools.Allocated = append(node.Spec.IPAM.Pools.Allocated, tt.nodeAllocs...)
 			}
 			err = reconciler.Reconcile(context.Background(), ReconcileParams{
 				CurrentServer: testSC,
 				DesiredConfig: testSC.Config,
-				Node:          node,
-				CiliumNode:    ciliumNode,
+				CiliumNode:    node,
 			})
 			if err != nil {
 				t.Fatalf("failed to reconcile pool cidr advertisements: %v", err)

--- a/pkg/bgpv1/manager/route_policy_reconciler.go
+++ b/pkg/bgpv1/manager/route_policy_reconciler.go
@@ -72,8 +72,8 @@ func (r *RoutePolicyReconciler) Reconcile(ctx context.Context, params ReconcileP
 	if params.CurrentServer == nil {
 		return fmt.Errorf("attempted routing policy reconciliation with nil ServerWithConfig")
 	}
-	if params.Node == nil {
-		return fmt.Errorf("attempted routing policy reconciliation with nil LocalNode")
+	if params.CiliumNode == nil {
+		return fmt.Errorf("attempted routing policy reconciliation with nil local CiliumNode")
 	}
 
 	// take currently configured policies from cache
@@ -232,10 +232,10 @@ func (r *RoutePolicyReconciler) pathAttributesToPolicy(attrs v2alpha1api.CiliumB
 			}
 		}
 	case v2alpha1api.PodCIDRSelectorName:
-		if attrs.Selector != nil && !labelSelector.Matches(labels.Set(params.Node.Labels)) {
+		if attrs.Selector != nil && !labelSelector.Matches(labels.Set(params.CiliumNode.Labels)) {
 			break
 		}
-		for _, podCIDR := range params.Node.ToCiliumNode().Spec.IPAM.PodCIDRs {
+		for _, podCIDR := range params.CiliumNode.Spec.IPAM.PodCIDRs {
 			cidr, err := netip.ParsePrefix(podCIDR)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse PodCIDR %s: %w", podCIDR, err)

--- a/pkg/bgpv1/manager/workdiff.go
+++ b/pkg/bgpv1/manager/workdiff.go
@@ -8,7 +8,6 @@ import (
 
 	v2api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1api "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/node"
 )
 
 // reconcileDiff is a helper structure which provides fields and a method set
@@ -18,9 +17,7 @@ type reconcileDiff struct {
 	// incoming CiliumBGPVirtualRouter configs mapped by their
 	// local ASN.
 	seen map[int64]*v2alpha1api.CiliumBGPVirtualRouter
-	// the Cilium node information at the time which reconciliation was triggered.
-	node *node.LocalNode
-	// The local CiliumNode node information at the time which reconciliation was triggered.
+	// The local CiliumNode information at the time which reconciliation was triggered.
 	ciliumNode *v2api.CiliumNode
 	// Local ASNs which BgpServers must be instantiated, configured,
 	// and added to the manager. Intended key for `seen` map.
@@ -36,10 +33,9 @@ type reconcileDiff struct {
 
 // newReconcileDiff constructs a new *reconcileDiff with all internal instructures
 // initialized.
-func newReconcileDiff(node *node.LocalNode, ciliumNode *v2api.CiliumNode) *reconcileDiff {
+func newReconcileDiff(ciliumNode *v2api.CiliumNode) *reconcileDiff {
 	return &reconcileDiff{
 		seen:       make(map[int64]*v2alpha1api.CiliumBGPVirtualRouter),
-		node:       node,
 		ciliumNode: ciliumNode,
 		register:   []int64{},
 		withdraw:   []int64{},

--- a/pkg/bgpv1/mock/mocks.go
+++ b/pkg/bgpv1/mock/mocks.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/node"
 
 	v1 "k8s.io/api/core/v1"
 	k8sLabels "k8s.io/apimachinery/pkg/labels"
@@ -37,15 +36,15 @@ func (m *MockNodeLister) Get(name string) (*v1.Node, error) {
 var _ agent.BGPRouterManager = (*MockBGPRouterManager)(nil)
 
 type MockBGPRouterManager struct {
-	ConfigurePeers_   func(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, node *node.LocalNode, ciliumNode *v2.CiliumNode) error
+	ConfigurePeers_   func(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, ciliumNode *v2.CiliumNode) error
 	GetPeers_         func(ctx context.Context) ([]*models.BgpPeer, error)
 	GetRoutes_        func(ctx context.Context, params restapi.GetBgpRoutesParams) ([]*models.BgpRoute, error)
 	GetRoutePolicies_ func(ctx context.Context, params restapi.GetBgpRoutePoliciesParams) ([]*models.BgpRoutePolicy, error)
 	Stop_             func()
 }
 
-func (m *MockBGPRouterManager) ConfigurePeers(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, node *node.LocalNode, ciliumNode *v2.CiliumNode) error {
-	return m.ConfigurePeers_(ctx, policy, node, ciliumNode)
+func (m *MockBGPRouterManager) ConfigurePeers(ctx context.Context, policy *v2alpha1.CiliumBGPPeeringPolicy, ciliumNode *v2.CiliumNode) error {
+	return m.ConfigurePeers_(ctx, policy, ciliumNode)
 }
 
 func (m *MockBGPRouterManager) GetPeers(ctx context.Context) ([]*models.BgpPeer, error) {

--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -11,13 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cilium/cilium/pkg/cidr"
 	ipam_option "github.com/cilium/cilium/pkg/ipam/option"
 	ipam_types "github.com/cilium/cilium/pkg/ipam/types"
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
@@ -37,9 +35,6 @@ var (
 // Test_PodCIDRAdvert validates pod IPv4/v6 subnet is advertised, withdrawn and modified on node addresses change.
 func Test_PodCIDRAdvert(t *testing.T) {
 	testutils.PrivilegedTest(t)
-
-	node.SetTestLocalNodeStore()
-	defer node.UnsetTestLocalNodeStore()
 
 	// steps define order in which test is run. Note, this is different from table tests, in which each unit is
 	// independent. In this case, tests are run sequentially and there is dependency on previous test step.
@@ -160,17 +155,20 @@ func Test_PodCIDRAdvert(t *testing.T) {
 	err = gobgpPeers[0].waitForSessionState(testCtx, []string{"ESTABLISHED"})
 	require.NoError(t, err)
 
+	tracker := fixture.fakeClientSet.CiliumFakeClientset.Tracker()
+	obj, err := tracker.Get(v2.SchemeGroupVersion.WithResource("ciliumnodes"), "", baseNode.name)
+	require.NoError(t, err)
+	node, ok := obj.(*v2.CiliumNode)
+	require.True(t, ok)
+
 	for _, step := range steps {
 		t.Run(step.description, func(t *testing.T) {
-			// update node in LocalNodeStore with new PodCIDR
+			// update CiliumNode with new PodCIDR
 			// this will trigger a reconciliation as the controller is observing
-			// the LocalNodeStore
-			fixture.nodeStore.Update(func(n *node.LocalNode) {
-				n.IPv4SecondaryAllocCIDRs = n.IPv4SecondaryAllocCIDRs[0:0]
-				for _, podCIDR := range step.podCIDRs {
-					n.IPv4SecondaryAllocCIDRs = append(n.IPv4SecondaryAllocCIDRs, cidr.MustParseCIDR(podCIDR))
-				}
-			})
+			// the local CiliumNode
+			node.Spec.IPAM.PodCIDRs = step.podCIDRs
+			err = tracker.Update(v2.SchemeGroupVersion.WithResource("ciliumnodes"), node, "")
+			require.NoError(t, err)
 
 			// validate expected result
 			receivedEvents, err := gobgpPeers[0].getRouteEvents(testCtx, len(step.expectedRouteEvents))
@@ -186,9 +184,6 @@ func Test_PodCIDRAdvert(t *testing.T) {
 func Test_PodIPPoolAdvert(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
-	node.SetTestLocalNodeStore()
-	defer node.UnsetTestLocalNodeStore()
-
 	// Steps define the order that tests are run. Note, this is different from table tests,
 	// in which each unit is independent. In this case, tests are run sequentially and there
 	// is dependency on previous test step.
@@ -196,7 +191,7 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 		name         string
 		ipPools      []ipam_types.IPAMPoolAllocation
 		poolLabels   map[string]string
-		nodePools    map[string][]string
+		nodePools    []ipam_types.IPAMPoolAllocation
 		poolSelector *slim_metav1.LabelSelector
 		expected     []routeEvent
 	}{
@@ -209,8 +204,11 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 				},
 			},
 			poolLabels: nil,
-			nodePools: map[string][]string{
-				"pool1": {"10.1.1.0/24", "10.1.2.0/24"},
+			nodePools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"10.1.1.0/24", "10.1.2.0/24"},
+				},
 			},
 			poolSelector: &slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{"no": "pool-labels"},
@@ -241,8 +239,11 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 				},
 			},
 			poolLabels: map[string]string{"label": "matched"},
-			nodePools: map[string][]string{
-				"pool1": {"11.1.1.0/24"},
+			nodePools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"11.1.1.0/24"},
+				},
 			},
 			poolSelector: &slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{"label": "matched"},
@@ -265,8 +266,11 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 				},
 			},
 			poolLabels: map[string]string{"label": "matched"},
-			nodePools: map[string][]string{
-				"pool1": {"11.2.1.0/24"},
+			nodePools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"11.2.1.0/24"},
+				},
 			},
 			poolSelector: &slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{"label": "matched"},
@@ -295,8 +299,11 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 				},
 			},
 			poolLabels: map[string]string{"label": "matched"},
-			nodePools: map[string][]string{
-				"pool1": {"2001:0:0:1234:5678::/96"},
+			nodePools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"2001:0:0:1234:5678::/96"},
+				},
 			},
 			poolSelector: &slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{"label": "matched"},
@@ -325,8 +332,11 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 				},
 			},
 			poolLabels: map[string]string{"label": "matched"},
-			nodePools: map[string][]string{
-				"pool1": {"2002:0:0:1234:5678::/96"},
+			nodePools: []ipam_types.IPAMPoolAllocation{
+				{
+					Pool:  "pool1",
+					CIDRs: []ipam_types.IPAMPodCIDR{"2002:0:0:1234:5678::/96"},
+				},
 			},
 			poolSelector: &slim_metav1.LabelSelector{
 				MatchLabels: map[string]string{"label": "matched"},
@@ -396,22 +406,15 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			// Setup the cilium node object with test case node cidrs.
-			allocs := make(map[string][]string)
-			for pool, cidrs := range step.nodePools {
-				allocs[pool] = cidrs
-			}
-			nodeObj := newCiliumNode(&ciliumNodeConfig{
-				name:   "test",
-				allocs: allocs,
-			})
+			// get the local CiliumNode
+			obj, err := tracker.Get(v2.SchemeGroupVersion.WithResource("ciliumnodes"), "", baseNode.name)
+			require.NoError(t, err)
+			node, ok := obj.(*v2.CiliumNode)
+			require.True(t, ok)
 
-			// Add or update the cilium node object in the object tracker.
-			if i == 0 {
-				err = tracker.Add(nodeObj)
-			} else {
-				err = tracker.Update(v2.SchemeGroupVersion.WithResource("ciliumnodes"), nodeObj, "")
-			}
+			// update the local CiliumNode with the test case node ipam pools
+			node.Spec.IPAM.Pools.Allocated = step.nodePools
+			err = tracker.Update(v2.SchemeGroupVersion.WithResource("ciliumnodes"), node, "")
 			require.NoError(t, err)
 
 			// Setup the bgp policy object with the test case pool selector.
@@ -434,9 +437,6 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 // Test_LBEgressAdvertisement validates Service v4 and v6 IPs is advertised, withdrawn and modified on changing policy.
 func Test_LBEgressAdvertisement(t *testing.T) {
 	testutils.PrivilegedTest(t)
-
-	node.SetTestLocalNodeStore()
-	defer node.UnsetTestLocalNodeStore()
 
 	var steps = []struct {
 		description         string
@@ -632,9 +632,6 @@ func Test_LBEgressAdvertisement(t *testing.T) {
 func Test_AdvertisedPathAttributes(t *testing.T) {
 	testutils.PrivilegedTest(t)
 
-	node.SetTestLocalNodeStore()
-	defer node.UnsetTestLocalNodeStore()
-
 	var steps = []struct {
 		description         string
 		op                  string // add or update
@@ -739,6 +736,11 @@ func Test_AdvertisedPathAttributes(t *testing.T) {
 
 	slimTracker := fixture.fakeClientSet.SlimFakeClientset.Tracker()
 	ciliumTracker := fixture.fakeClientSet.CiliumFakeClientset.Tracker()
+	obj, err := ciliumTracker.Get(v2.SchemeGroupVersion.WithResource("ciliumnodes"), "", baseNode.name)
+	require.NoError(t, err)
+
+	node, ok := obj.(*v2.CiliumNode)
+	require.True(t, ok)
 
 	for _, step := range steps {
 		t.Run(step.description, func(t *testing.T) {
@@ -749,13 +751,10 @@ func Test_AdvertisedPathAttributes(t *testing.T) {
 			require.NoError(t, err)
 
 			if step.podCIDRs != nil {
-				// update node in LocalNodeStore with new PodCIDR
-				fixture.nodeStore.Update(func(n *node.LocalNode) {
-					n.IPv4SecondaryAllocCIDRs = n.IPv4SecondaryAllocCIDRs[0:0]
-					for _, podCIDR := range step.podCIDRs {
-						n.IPv4SecondaryAllocCIDRs = append(n.IPv4SecondaryAllocCIDRs, cidr.MustParseCIDR(podCIDR))
-					}
-				})
+				// update CiliumNode with new PodCIDR
+				node.Spec.IPAM.PodCIDRs = step.podCIDRs
+				err = ciliumTracker.Update(v2.SchemeGroupVersion.WithResource("ciliumnodes"), node, "")
+				require.NoError(t, err)
 			}
 
 			if step.lbPool != nil {

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/cilium/api/v1/models"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
-	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/testutils"
 
 	"github.com/stretchr/testify/require"
@@ -42,9 +41,6 @@ type peeringState struct {
 // Topology - (BGP CP) === (2 x gobgp instances)
 func Test_NeighborAddDel(t *testing.T) {
 	testutils.PrivilegedTest(t)
-
-	node.SetTestLocalNodeStore()
-	defer node.UnsetTestLocalNodeStore()
 
 	var steps = []struct {
 		description        string
@@ -191,9 +187,6 @@ func Test_NeighborAddDel(t *testing.T) {
 // Test_NeighborGracefulRestart tests graceful restart configuration knobs with single peer.
 func Test_NeighborGracefulRestart(t *testing.T) {
 	testutils.PrivilegedTest(t)
-
-	node.SetTestLocalNodeStore()
-	defer node.UnsetTestLocalNodeStore()
 
 	var steps = []struct {
 		description       string

--- a/pkg/bgpv1/test/objects.go
+++ b/pkg/bgpv1/test/objects.go
@@ -148,13 +148,15 @@ func newIPPoolObj(conf ipPoolConfig) *v2alpha1.CiliumPodIPPool {
 
 // ciliumNodeConfig data used to create a CiliumNode resource.
 type ciliumNodeConfig struct {
-	name   string
-	allocs map[string][]string
+	name        string
+	labels      map[string]string
+	annotations map[string]string
+	ipamAllocs  map[string][]string
 }
 
 // newCiliumNode creates a CiliumNode resource based on the provided conf.
-func newCiliumNode(conf *ciliumNodeConfig) *v2.CiliumNode {
-	obj := &v2.CiliumNode{
+func newCiliumNode(conf ciliumNodeConfig) v2.CiliumNode {
+	obj := v2.CiliumNode{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              conf.name,
 			UID:               uid,
@@ -162,9 +164,17 @@ func newCiliumNode(conf *ciliumNodeConfig) *v2.CiliumNode {
 		},
 	}
 
-	if conf.allocs != nil {
+	if conf.labels != nil {
+		obj.Labels = conf.labels
+	}
+
+	if conf.annotations != nil {
+		obj.Annotations = conf.annotations
+	}
+
+	if conf.ipamAllocs != nil {
 		var allocs []ipam_types.IPAMPoolAllocation
-		for pool, cidrs := range conf.allocs {
+		for pool, cidrs := range conf.ipamAllocs {
 			poolCIDRs := []ipam_types.IPAMPodCIDR{}
 			for _, c := range cidrs {
 				poolCIDRs = append(poolCIDRs, ipam_types.IPAMPodCIDR(c))

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -4,6 +4,7 @@
 package v2
 
 import (
+	"net"
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -464,4 +465,23 @@ func (n *CiliumNode) InstanceID() (instanceID string) {
 		}
 	}
 	return
+}
+
+func (n NodeAddress) ToString() string {
+	return n.IP
+}
+
+func (n NodeAddress) AddrType() addressing.AddressType {
+	return n.Type
+}
+
+// GetIP returns one of the CiliumNode's IP addresses available with the
+// following priority:
+// - NodeInternalIP
+// - NodeExternalIP
+// - other IP address type
+// An error is returned if GetIP fails to extract an IP from the CiliumNode
+// based on the provided address family.
+func (n *CiliumNode) GetIP(ipv6 bool) net.IP {
+	return addressing.ExtractNodeIP[NodeAddress](n.Spec.Addresses, ipv6)
 }

--- a/pkg/node/addressing/addresstype.go
+++ b/pkg/node/addressing/addresstype.go
@@ -3,6 +3,10 @@
 
 package addressing
 
+import (
+	"net"
+)
+
 // AddressType represents a type of IP address for a node. They are copied
 // from k8s.io/api/core/v1/types.go to avoid pulling in a lot of Kubernetes
 // imports into this package.s
@@ -16,3 +20,46 @@ const (
 	NodeInternalDNS      AddressType = "InternalDNS"
 	NodeCiliumInternalIP AddressType = "CiliumInternalIP"
 )
+
+type Address interface {
+	AddrType() AddressType
+	ToString() string
+}
+
+// ExtractNodeIP returns one of the provided IP addresses available with the following priority:
+// - NodeInternalIP
+// - NodeExternalIP
+// - other IP address type
+// An error is returned if ExtractNodeIP fails to get an IP based on the provided address family.
+func ExtractNodeIP[T Address](addrs []T, ipv6 bool) net.IP {
+	var backupIP net.IP
+	for _, addr := range addrs {
+		parsed := net.ParseIP(addr.ToString())
+		if parsed == nil {
+			continue
+		}
+		if (ipv6 && parsed.To4() != nil) ||
+			(!ipv6 && parsed.To4() == nil) {
+			continue
+		}
+		switch addr.AddrType() {
+		// Ignore CiliumInternalIPs
+		case NodeCiliumInternalIP:
+			continue
+		// Always prefer a cluster internal IP
+		case NodeInternalIP:
+			return parsed
+		case NodeExternalIP:
+			// Fall back to external Node IP
+			// if no internal IP could be found
+			backupIP = parsed
+		default:
+			// As a last resort, if no internal or external
+			// IP was found, use any node address available
+			if backupIP == nil {
+				backupIP = parsed
+			}
+		}
+	}
+	return backupIP
+}

--- a/pkg/node/types/node.go
+++ b/pkg/node/types/node.go
@@ -287,38 +287,23 @@ type Address struct {
 	IP   net.IP
 }
 
+func (a Address) ToString() string {
+	return a.IP.String()
+}
+
+func (a Address) AddrType() addressing.AddressType {
+	return a.Type
+}
+
 // GetNodeIP returns one of the node's IP addresses available with the
 // following priority:
 // - NodeInternalIP
 // - NodeExternalIP
 // - other IP address type
+// Nil is returned if GetNodeIP fails to extract an IP from the Node based
+// on the provided address family.
 func (n *Node) GetNodeIP(ipv6 bool) net.IP {
-	var backupIP net.IP
-	for _, addr := range n.IPAddresses {
-		if (ipv6 && addr.IP.To4() != nil) ||
-			(!ipv6 && addr.IP.To4() == nil) {
-			continue
-		}
-		switch addr.Type {
-		// Ignore CiliumInternalIPs
-		case addressing.NodeCiliumInternalIP:
-			continue
-		// Always prefer a cluster internal IP
-		case addressing.NodeInternalIP:
-			return addr.IP
-		case addressing.NodeExternalIP:
-			// Fall back to external Node IP
-			// if no internal IP could be found
-			backupIP = addr.IP
-		default:
-			// As a last resort, if no internal or external
-			// IP was found, use any node address available
-			if backupIP == nil {
-				backupIP = addr.IP
-			}
-		}
-	}
-	return backupIP
+	return addressing.ExtractNodeIP[Address](n.IPAddresses, ipv6)
 }
 
 // GetExternalIP returns ExternalIP of k8s Node. If not present, then it


### PR DESCRIPTION
- Replaces the LocalNodeStore with the existing local CiliumNode throughout the BGP CP.
- Updates unit and integration tests accordingly.
- Adds the GetIP() method for returning the CiliumNode IP.

Fixes: #28237
