### PR TITLE
Add option to pass api-rate-limit via Helm values

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -40,6 +40,10 @@
      - Annotate k8s node upon initialization with Cilium's metadata.
      - bool
      - ``false``
+   * - :spelling:ignore:`apiRateLimit`
+     - The api-rate-limit option can be used to overwrite individual settings of the default configuration for rate limiting calls to the Cilium Agent API
+     - string
+     - ``nil``
    * - :spelling:ignore:`authentication.enabled`
      - Enable authentication processing and garbage collection. Note that if disabled, policy enforcement will still block requests that require authentication. But the resulting authentication requests for these requests will not be processed, therefore the requests not be allowed.
      - bool

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -60,6 +60,7 @@ contributors across the globe, there is almost always someone available to help.
 | aksbyocni.enabled | bool | `false` | Enable AKS BYOCNI integration. Note that this is incompatible with AKS clusters not created in BYOCNI mode: use Azure integration (`azure.enabled`) instead. |
 | alibabacloud.enabled | bool | `false` | Enable AlibabaCloud ENI integration |
 | annotateK8sNode | bool | `false` | Annotate k8s node upon initialization with Cilium's metadata. |
+| apiRateLimit | string | `nil` | The api-rate-limit option can be used to overwrite individual settings of the default configuration for rate limiting calls to the Cilium Agent API |
 | authentication.enabled | bool | `true` | Enable authentication processing and garbage collection. Note that if disabled, policy enforcement will still block requests that require authentication. But the resulting authentication requests for these requests will not be processed, therefore the requests not be allowed. |
 | authentication.gcInterval | string | `"5m0s"` | Interval for garbage collection of auth map entries. |
 | authentication.mutual.connectTimeout | string | `"5s"` | Timeout for connecting to the remote node TCP socket |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -964,6 +964,10 @@ data:
   limit-ipam-api-qps: {{ .Values.ipam.operator.externalAPILimitQPS | quote }}
 {{- end }}
 
+{{- if .Values.apiRateLimit }}
+  api-rate-limit: {{ .Values.apiRateLimit | quote }}
+{{- end }}
+
 {{- if .Values.enableCnpStatusUpdates }}
   disable-cnp-status-updates: "false"
 {{- else if (eq $defaultEnableCnpStatusUpdates "false") }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1572,6 +1572,9 @@ ipam:
     # @default -- `4.0`
     externalAPILimitQPS: ~
 
+# -- The api-rate-limit option can be used to overwrite individual settings of the default configuration for rate limiting calls to the Cilium Agent API
+apiRateLimit: ~
+
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:
   enabled: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1569,6 +1569,9 @@ ipam:
     # @default -- `4.0`
     externalAPILimitQPS: ~
 
+# -- The api-rate-limit option can be used to overwrite individual settings of the default configuration for rate limiting calls to the Cilium Agent API
+apiRateLimit: ~
+
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:
   enabled: false


### PR DESCRIPTION
I was looking at tweaking this values when running Cilium in OpenShift, but realized there is no option directly for it.

I know we have the https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/values.yaml.tmpl#L203-L210 option and used that for now. Interested in your thoughts about having an explicit value for setting the api rate limiter settings.

Signed-off-by: Vlad Ungureanu <vladu@ungureanuvladvictor@gmail.com>


```release-note
Add option to pass api-rate-limit via Helm values
```
