### PR TITLE
fix: Remove the latest image tag from docs as latest tag is not published

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -88,7 +88,6 @@ if not branch or branch == 'latest':
     branch = 'HEAD'
     archive_name = 'main'
     chart_release = './cilium'
-    image_tag = 'latest'
     chart_version = "--chart-directory ./install/kubernetes/cilium"
 elif branch == 'stable':
     branch = release


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

Remove the latest image tag from the docs as it does not get published. By default it will pick the version from the `VERSION` file of the github.

Fixes: #27473

