### PR TITLE
ipam/multipool: Introduce specific ip family annotations for specifying ip pools

### DIFF
--- a/pkg/annotation/k8s.go
+++ b/pkg/annotation/k8s.go
@@ -126,6 +126,14 @@ const (
 	// IPAMPoolKey is the annotation name used to store the IPAM pool name from
 	// which workloads should allocate their IP from
 	IPAMPoolKey = IPAMPrefix + "/ip-pool"
+
+	// IPAMIPv4PoolKey is the annotation name used to store the IPAM IPv4 pool name from
+	// which workloads should allocate their IP from
+	IPAMIPv4PoolKey = IPAMPrefix + "/ipv4-pool"
+
+	// IPAMIPv6PoolKey is the annotation name used to store the IPAM IPv6 pool name from
+	// which workloads should allocate their IP from
+	IPAMIPv6PoolKey = IPAMPrefix + "/ipv6-pool"
 )
 
 // Get returns the annotation value associated with the given key, or any of

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -30,12 +30,12 @@ var (
 	ErrIPv6Disabled = errors.New("IPv6 allocation disabled")
 )
 
-func (ipam *IPAM) determineIPAMPool(owner string) (Pool, error) {
+func (ipam *IPAM) determineIPAMPool(owner string, family Family) (Pool, error) {
 	if ipam.metadata == nil {
 		return PoolDefault, nil
 	}
 
-	pool, err := ipam.metadata.GetIPPoolForPod(owner)
+	pool, err := ipam.metadata.GetIPPoolForPod(owner, family)
 	if err != nil {
 		return "", fmt.Errorf("unable to determine IPAM pool for owner %q: %w", owner, err)
 	}
@@ -152,7 +152,7 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 	}
 
 	if pool == "" {
-		pool, err = ipam.determineIPAMPool(owner)
+		pool, err = ipam.determineIPAMPool(owner, family)
 		if err != nil {
 			return
 		}

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -99,7 +99,7 @@ type MtuConfiguration interface {
 }
 
 type Metadata interface {
-	GetIPPoolForPod(owner string) (pool string, err error)
+	GetIPPoolForPod(owner string, family Family) (pool string, err error)
 }
 
 // NewIPAM returns a new IP address manager

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -45,10 +45,10 @@ func (t *testConfiguration) IPAMMode() string                         { return i
 func (t *testConfiguration) SetIPv4NativeRoutingCIDR(cidr *cidr.CIDR) {}
 func (t *testConfiguration) GetIPv4NativeRoutingCIDR() *cidr.CIDR     { return nil }
 
-type fakeMetadataFunc func(owner string) (pool string, err error)
+type fakeMetadataFunc func(owner string, family Family) (pool string, err error)
 
-func (f fakeMetadataFunc) GetIPPoolForPod(owner string) (pool string, err error) {
-	return f(owner)
+func (f fakeMetadataFunc) GetIPPoolForPod(owner string, family Family) (pool string, err error) {
+	return f(owner, family)
 }
 
 type fakePoolAllocator struct {
@@ -202,7 +202,7 @@ func (s *IPAMSuite) TestIPAMMetadata(c *C) {
 	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
 	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
 
-	ipam.WithMetadata(fakeMetadataFunc(func(owner string) (pool string, err error) {
+	ipam.WithMetadata(fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
 		// use namespace to determine pool name
 		namespace, _, _ := strings.Cut(owner, "/")
 		switch namespace {
@@ -262,7 +262,7 @@ func (s *IPAMSuite) TestLegacyAllocatorIPAMMetadata(c *C) {
 	// pool
 	fakeAddressing := fake.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &mtuMock, nil)
-	ipam.WithMetadata(fakeMetadataFunc(func(owner string) (pool string, err error) {
+	ipam.WithMetadata(fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
 		return "some-pool", nil
 	}))
 


### PR DESCRIPTION
In dual-stack mode, it's necessary to allocate both IPv4 and IPv6 addresses for pods. However, custom IP pools may only focus on either IPv4 or IPv6, which can result in the custom IP pool being configured with only IPv4 or IPv6. When specifying an IP pool for a namespace or pod through annotations, this can cause pod creation to fail because the specified IP pool lacks the IPv4 or IPv6 family.

This PR introduces two IP-family specific annotations: ipam.cilium.io/ipv4-pool and ipam.cilium.io/ipv6-pool. When specifying pools for pods or namespaces, combining these annotations allows for handling more scenarios.

This PR covers the use cases mentioned here https://github.com/cilium/cilium/pull/28204#issue-1900776538 and has been implemented based on the suggestions here https://github.com/cilium/cilium/pull/28204#pullrequestreview-1631009351.