### PR TITLE
ci: update k8s versions support for v1.13

### DIFF
--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -7,7 +7,4 @@ include:
   - version: "1.26"
     location: westus
     index: 2
-  - version: "1.27"
-    location: eastasia
-    index: 3
     default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,16 +1,13 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.23"
-    zone: europe-west6-b
-    vmIndex: 1
   - version: "1.24"
     zone: us-west2-a
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.25"
     zone: asia-northeast1-c
-    vmIndex: 3
+    vmIndex: 2
   - version: "1.26"
     zone: europe-north1-b
-    vmIndex: 4
+    vmIndex: 3
     default: true


### PR DESCRIPTION
Cilium 1.13 only supports K8s up to 1.26 as per
https://docs.cilium.io/en/v1.13/network/kubernetes/compatibility/#k8scompatibility

- We remove 1.27 testing on AKS as it shouldn't have been here in the first place as per our historical policy.
- We remove 1.23 testing on GKE since it's not supported anymore.