### PR TITLE
ci: update k8s versions support for v1.14

### DIFF
--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -1,19 +1,16 @@
 # List of k8s version for GKE tests
 ---
 k8s:
-  - version: "1.23"
-    zone: europe-west6-b
-    vmIndex: 1
   - version: "1.24"
     zone: us-west2-a
-    vmIndex: 2
+    vmIndex: 1
   - version: "1.25"
     zone: asia-northeast1-c
-    vmIndex: 3
+    vmIndex: 2
   - version: "1.26"
     zone: europe-north1-b
-    vmIndex: 4
+    vmIndex: 3
   - version: "1.27"
     zone: us-east5-a
-    vmIndex: 5
+    vmIndex: 4
     default: true


### PR DESCRIPTION
We remove 1.23 testing on GKE since it's not supported anymore.