### PR TITLE
Docs: Updates L2 Announce for LB Class Support

### DIFF
--- a/Documentation/network/l2-announcements.rst
+++ b/Documentation/network/l2-announcements.rst
@@ -114,7 +114,9 @@ Service Selector
 
 The service selector is a `label selector <https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/>`__ 
 that determines which services are selected by this policy. If no service 
-selector is provided, all services are selected by the policy.
+selector is provided, all services are selected by the policy. A service must have
+`loadBalancerClass <https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class>`__
+unspecified or set to ``io.cilium/l2-announcer`` to be selected by a policy for announcement.
 
 There are a few special purpose selector fields which don't match on labels but
 instead on other metadata like ``.meta.name`` or ``.meta.namespace``.


### PR DESCRIPTION
Updates L2 announcer docs for [load balancer class](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class) support.

Fixes: #28236
