### PR TITLE
Docs: Updates BGP CP for LB Class Support

### DIFF
--- a/Documentation/network/bgp-control-plane.rst
+++ b/Documentation/network/bgp-control-plane.rst
@@ -347,7 +347,8 @@ Service announcements
 
 By default, virtual routers will not announce services. Virtual routers will announce
 the ingress IPs of any LoadBalancer services that matches the ``.serviceSelector``
-of the virtual router.
+of the virtual router and has `loadBalancerClass <https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class>`__
+unspecified or set to ``io.cilium/bgp-control-plane``.
 
 If you wish to announce ALL services within the cluster, a ``NotIn`` match expression
 with a dummy key and value can be used like:


### PR DESCRIPTION
Adds [LB class](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class) support to BGP CP docs.

Fixes: #27056

```release-note
docs: Update BGP control plane documentation with regards to LB class support and service announcements
```