### PR TITLE
gateway-api: Add conformance profile test

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -86,7 +86,11 @@ jobs:
       matrix:
         include:
         - crd-channel: experimental
+          conformance-profile: false
         - crd-channel: standard
+          conformance-profile: false
+        - crd-channel: experimental
+          conformance-profile: true
     steps:
       - name: Checkout context ref (trusted)
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
@@ -228,13 +232,38 @@ jobs:
             controllerName: io.cilium/gateway-controller
           EOF
           
-          GATEWAY_API_CONFORMANCE_TESTS=1 go test \
-            -p 4 \
-            -v ./operator/pkg/gateway-api \
-            --gateway-class cilium \
-            --supported-features "${{ steps.vars.outputs.supported_features }}" \
-            -test.run "TestConformance" \
-            -test.skip "${{ steps.vars.outputs.skipped_tests }}"
+          if [ ${{ matrix.conformance-profile }} == "true" ]; then
+            GATEWAY_API_CONFORMANCE_TESTS=1 go test \
+              -p 4 \
+              -v ./operator/pkg/gateway-api \
+              --gateway-class cilium \
+              --supported-features "${{ steps.vars.outputs.supported_features }}" \
+              --conformance-profiles HTTP,TLS \
+              --organization cilium \
+              --project cilium \
+              --url github.com/cilium/cilium \
+              --version main \
+              --contact https://github.com/cilium/community/blob/main/roles/Maintainers.md \
+              --report-output report.yaml \
+              -test.run "TestExperimentalConformance" \
+              -test.skip "${{ steps.vars.outputs.skipped_tests }}"
+          else
+            GATEWAY_API_CONFORMANCE_TESTS=1 go test \
+              -p 4 \
+              -v ./operator/pkg/gateway-api \
+              --gateway-class cilium \
+              --supported-features "${{ steps.vars.outputs.supported_features }}" \
+              -test.run "TestConformance" \
+              -test.skip "${{ steps.vars.outputs.skipped_tests }}"
+          fi
+
+      - name: Upload report artifacts
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        with:
+          name: report.yaml
+          path: operator/pkg/gateway-api/report.yaml
+          retention-days: 5
+          if-no-files-found: ignore
 
       - name: Post-test information gathering
         if: ${{ !success() && steps.install-cilium.outcome != 'skipped' }}

--- a/operator/pkg/gateway-api/experimental_conformance_test.go
+++ b/operator/pkg/gateway-api/experimental_conformance_test.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"os"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/yaml"
+
+	"sigs.k8s.io/gateway-api/apis/v1alpha2"
+	"sigs.k8s.io/gateway-api/apis/v1beta1"
+	confv1a1 "sigs.k8s.io/gateway-api/conformance/apis/v1alpha1"
+	"sigs.k8s.io/gateway-api/conformance/tests"
+	"sigs.k8s.io/gateway-api/conformance/utils/flags"
+	"sigs.k8s.io/gateway-api/conformance/utils/suite"
+
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+var (
+	cfg                  *rest.Config
+	k8sClientset         *kubernetes.Clientset
+	mgrClient            client.Client
+	supportedFeatures    sets.Set[suite.SupportedFeature]
+	exemptFeatures       sets.Set[suite.SupportedFeature]
+	namespaceLabels      map[string]string
+	namespaceAnnotations map[string]string
+	implementation       *confv1a1.Implementation
+	conformanceProfiles  sets.Set[suite.ConformanceProfileName]
+	skipTests            []string
+)
+
+func TestExperimentalConformance(t *testing.T) {
+	testutils.GatewayAPIConformanceTest(t)
+
+	var err error
+	cfg, err = config.GetConfig()
+	if err != nil {
+		t.Fatalf("Error loading Kubernetes config: %v", err)
+	}
+	mgrClient, err = client.New(cfg, client.Options{})
+	if err != nil {
+		t.Fatalf("Error initializing Kubernetes client: %v", err)
+	}
+	k8sClientset, err = kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("Error initializing Kubernetes REST client: %v", err)
+	}
+
+	_ = v1alpha2.AddToScheme(mgrClient.Scheme())
+	_ = v1beta1.AddToScheme(mgrClient.Scheme())
+
+	// standard conformance flags
+	supportedFeatures = suite.ParseSupportedFeatures(*flags.SupportedFeatures)
+	exemptFeatures = suite.ParseSupportedFeatures(*flags.ExemptFeatures)
+	skipTests = suite.ParseSkipTests(*flags.SkipTests)
+	namespaceLabels = suite.ParseKeyValuePairs(*flags.NamespaceLabels)
+	namespaceAnnotations = suite.ParseKeyValuePairs(*flags.NamespaceAnnotations)
+
+	// experimental conformance flags
+	conformanceProfiles = suite.ParseConformanceProfiles(*flags.ConformanceProfiles)
+
+	if conformanceProfiles.Len() > 0 {
+		// if some conformance profiles have been set, run the experimental conformance suite...
+		implementation, err = suite.ParseImplementation(
+			*flags.ImplementationOrganization,
+			*flags.ImplementationProject,
+			*flags.ImplementationURL,
+			*flags.ImplementationVersion,
+			*flags.ImplementationContact,
+		)
+		if err != nil {
+			t.Fatalf("Error parsing implementation's details: %v", err)
+		}
+		testExperimentalConformance(t)
+	} else {
+		// ...otherwise run the standard conformance suite.
+		t.Run("standard conformance tests", TestConformance)
+	}
+}
+
+func testExperimentalConformance(t *testing.T) {
+	t.Logf("Running experimental conformance tests with %s GatewayClass\n cleanup: %t\n debug: %t\n enable all features: %t \n supported features: [%v]\n exempt features: [%v]",
+		*flags.GatewayClassName, *flags.CleanupBaseResources, *flags.ShowDebug, *flags.EnableAllSupportedFeatures, *flags.SupportedFeatures, *flags.ExemptFeatures)
+
+	cSuite, err := suite.NewExperimentalConformanceTestSuite(
+		suite.ExperimentalConformanceOptions{
+			Options: suite.Options{
+				Client:     mgrClient,
+				RestConfig: cfg,
+				// This clientset is needed in addition to the client only because
+				// controller-runtime client doesn't support non CRUD sub-resources yet (https://github.com/kubernetes-sigs/controller-runtime/issues/452).
+				Clientset:                  k8sClientset,
+				GatewayClassName:           *flags.GatewayClassName,
+				Debug:                      *flags.ShowDebug,
+				CleanupBaseResources:       *flags.CleanupBaseResources,
+				SupportedFeatures:          supportedFeatures,
+				ExemptFeatures:             exemptFeatures,
+				EnableAllSupportedFeatures: *flags.EnableAllSupportedFeatures,
+				NamespaceLabels:            namespaceLabels,
+				NamespaceAnnotations:       namespaceAnnotations,
+				SkipTests:                  skipTests,
+			},
+			Implementation:      *implementation,
+			ConformanceProfiles: conformanceProfiles,
+		})
+	if err != nil {
+		t.Fatalf("error creating experimental conformance test suite: %v", err)
+	}
+
+	cSuite.Setup(t)
+	_ = cSuite.Run(t, tests.ConformanceTests)
+	report, err := cSuite.Report()
+	if err != nil {
+		t.Fatalf("error generating conformance profile report: %v", err)
+	}
+	_ = writeReport(t.Logf, *report, *flags.ReportOutput)
+}
+
+func writeReport(logf func(string, ...any), report confv1a1.ConformanceReport, output string) error {
+	rawReport, err := yaml.Marshal(report)
+	if err != nil {
+		return err
+	}
+
+	if output != "" {
+		if err = os.WriteFile(output, rawReport, 0644); err != nil {
+			return err
+		}
+	}
+	logf("Conformance report:\n%s", string(rawReport))
+
+	return nil
+}


### PR DESCRIPTION
### Description

This is to support the conformance profile run, so that we can just easily capture the report and submit the same to upstream repo

https://github.com/kubernetes-sigs/gateway-api/blob/main/conformance/reports/v0.7.1/cilium-cilium.yaml

### Testing

Please find below the conformance report generated as part of this run


https://github.com/cilium/cilium/suites/16825211249/artifacts/960894970

```yaml
apiVersion: gateway.networking.k8s.io/v1alpha1
date: "2023-10-03T13:08:01Z"
gatewayAPIVersion: TODO
implementation:
  contact:
  - https://github.com/cilium/community/blob/main/roles/Maintainers.md
  organization: cilium
  project: cilium
  url: github.com/cilium/cilium
  version: main
kind: ConformanceReport
profiles:
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 29
      Skipped: 0
    summary: ""
  extended:
    result: success
    statistics:
      Failed: 0
      Passed: 10
      Skipped: 0
    summary: ""
    supportedFeatures:
    - HTTPRouteMethodMatching
    - HTTPResponseHeaderModification
    - HTTPRoutePathRedirect
    - HTTPRouteQueryParamMatching
    - HTTPRouteSchemeRedirect
    - HTTPRouteRequestMirror
    - HTTPRouteHostRewrite
    - HTTPRoutePathRewrite
    - HTTPRoutePortRedirect
    - HTTPRouteRequestMultipleMirrors
  name: HTTP
- core:
    result: success
    statistics:
      Failed: 0
      Passed: 11
      Skipped: 0
    summary: ""
  name: TLS
```

