### PR TITLE
[DRAFT]: Generic reconciler

### DIFF
--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -27,6 +27,8 @@ import (
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/reconciler"
+	"github.com/cilium/cilium/pkg/reconciler/example/reconcilers"
 	wg "github.com/cilium/cilium/pkg/wireguard/agent"
 	wgTypes "github.com/cilium/cilium/pkg/wireguard/types"
 )
@@ -65,6 +67,10 @@ var Cell = cell.Module(
 	// This cell defines StateDB tables and their schemas for tables which are used to transfer information
 	// between datapath components and more high-level components.
 	tables.Cell,
+
+	// HACK HACK HACK route reconcilation.
+	reconciler.Cell, // For reconciler metrics
+	reconcilers.RoutesCell,
 
 	// Gratuitous ARP event processor emits GARP packets on k8s pod creation events.
 	garp.Cell,
@@ -133,7 +139,7 @@ func newDatapath(params datapathParams) types.Datapath {
 			return nil
 		}})
 
-	datapath := linuxdatapath.NewDatapath(datapathConfig, iptablesManager, params.WgAgent, params.NodeMap, params.ConfigWriter)
+	datapath := linuxdatapath.NewDatapath(datapathConfig, iptablesManager, params.WgAgent, params.NodeMap, params.ConfigWriter, params.Routes)
 
 	params.LC.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {
@@ -163,4 +169,6 @@ type datapathParams struct {
 	DeviceManager *linuxdatapath.DeviceManager
 
 	ConfigWriter types.ConfigWriter
+
+	Routes reconcilers.Routes
 }

--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -41,7 +41,7 @@ type params struct {
 
 	Lifecycle           hive.Lifecycle
 	Logger              logrus.FieldLogger
-	L2AnnouncementTable statedb.Table[*tables.L2AnnounceEntry]
+	L2AnnouncementTable statedb.RWTable[*tables.L2AnnounceEntry]
 	StateDB             *statedb.DB
 	L2ResponderMap      l2respondermap.Map
 	NetLink             linkByNamer

--- a/pkg/datapath/l2responder/l2responder_test.go
+++ b/pkg/datapath/l2responder/l2responder_test.go
@@ -24,7 +24,7 @@ import (
 
 type fixture struct {
 	reconciler         *l2ResponderReconciler
-	proxyNeighborTable statedb.Table[*tables.L2AnnounceEntry]
+	proxyNeighborTable statedb.RWTable[*tables.L2AnnounceEntry]
 	stateDB            *statedb.DB
 	mockNetlink        *mockNeighborNetlink
 	respondermap       l2respondermap.Map
@@ -32,7 +32,7 @@ type fixture struct {
 
 func newFixture() *fixture {
 	var (
-		tbl statedb.Table[*tables.L2AnnounceEntry]
+		tbl statedb.RWTable[*tables.L2AnnounceEntry]
 		db  *statedb.DB
 		jr  job.Registry
 	)
@@ -41,7 +41,7 @@ func newFixture() *fixture {
 		statedb.Cell,
 		tables.Cell,
 		job.Cell,
-		cell.Invoke(func(d *statedb.DB, t statedb.Table[*tables.L2AnnounceEntry], j job.Registry) {
+		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], j job.Registry) {
 			db = d
 			tbl = t
 			jr = j

--- a/pkg/datapath/linux/datapath.go
+++ b/pkg/datapath/linux/datapath.go
@@ -8,6 +8,7 @@ import (
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/maps/lbmap"
 	"github.com/cilium/cilium/pkg/maps/nodemap"
+	"github.com/cilium/cilium/pkg/reconciler/example/reconcilers"
 )
 
 // DatapathConfiguration is the static configuration of the datapath. The
@@ -32,18 +33,18 @@ type linuxDatapath struct {
 
 // NewDatapath creates a new Linux datapath
 func NewDatapath(cfg DatapathConfiguration, ruleManager datapath.IptablesManager, wgAgent datapath.WireguardAgent,
-	nodeMap nodemap.Map, writer datapath.ConfigWriter) datapath.Datapath {
+	nodeMap nodemap.Map, writer datapath.ConfigWriter, routes reconcilers.Routes) datapath.Datapath {
 	dp := &linuxDatapath{
 		ConfigWriter:    writer,
 		IptablesManager: ruleManager,
 		nodeAddressing:  NewNodeAddressing(),
 		config:          cfg,
-		loader:          loader.NewLoader(),
+		loader:          loader.NewLoader(routes),
 		wgAgent:         wgAgent,
 		lbmap:           lbmap.New(),
 	}
 
-	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, nodeMap)
+	dp.node = NewNodeHandler(cfg, dp.nodeAddressing, nodeMap, routes)
 	return dp
 }
 

--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -13,8 +13,10 @@ import (
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/statedb"
 )
 
 // DeviceManager is a temporary compatibility bridge to keep DeviceManager uses as is and reuse its tests
@@ -23,7 +25,7 @@ import (
 // This will be refactored away in follow-up PRs that convert code over to the devices table.
 // The DirectRoutingDevice and IPv6MCastDevice would computed from the devices table as necessary.
 type DeviceManager struct {
-	params         devicesControllerParams
+	params         devicesManagerParams
 	initialDevices []string
 	hive           *hive.Hive
 }
@@ -134,9 +136,17 @@ func (dm *DeviceManager) Listen(ctx context.Context) (chan []string, error) {
 	return devs, nil
 }
 
+type devicesManagerParams struct {
+	cell.In
+
+	DB          *statedb.DB
+	DeviceTable statedb.Table[*tables.Device]
+	RouteTable  statedb.Table[*tables.Route]
+}
+
 // newDeviceManager constructs a DeviceManager that implements the old DeviceManager API.
 // Dummy dependency to *devicesController to make sure devices table is populated.
-func newDeviceManager(p devicesControllerParams, _ *devicesController) *DeviceManager {
+func newDeviceManager(p devicesManagerParams, _ *devicesController) *DeviceManager {
 	return &DeviceManager{params: p, hive: nil}
 }
 

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -40,10 +40,22 @@ var DevicesControllerCell = cell.Module(
 	"devices-controller",
 	"Synchronizes the device and route tables with the kernel",
 
+	// This controller owns the device and route tables. This gives
+	// Table[*Device] to the world and RWTable[*Device] for us.
+	// But these cells are still usable directly in tests to provide
+	// the modules under test device and route test data.
+	tables.DeviceTableCell,
+	tables.RouteTableCell,
+
 	cell.Provide(
 		newDevicesController,
 		newDeviceManager,
 	),
+
+	// Always construct the devices controller. We provide the
+	// *devicesController for DeviceManager, but once it has been removed,
+	// this can be refactored to just do an invoke to register the
+	// controller jobs.
 	cell.Invoke(func(*devicesController) {}),
 )
 

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -47,6 +47,8 @@ var DevicesControllerCell = cell.Module(
 	tables.DeviceTableCell,
 	tables.RouteTableCell,
 
+	cell.Provide(newNetlinkFuncs),
+
 	cell.Provide(
 		newDevicesController,
 		newDeviceManager,
@@ -405,6 +407,8 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 					Table:     u.Table,
 					LinkIndex: index,
 					Scope:     uint8(u.Scope),
+					MTU:       u.MTU,
+					Priority:  u.Priority,
 					Dst:       ipnetToPrefix(u.Family, u.Dst),
 				}
 				r.Src, _ = netip.AddrFromSlice(u.Src)
@@ -593,6 +597,23 @@ type netlinkFuncs struct {
 	LinkList          func() ([]netlink.Link, error)
 	AddrList          func(link netlink.Link, family int) ([]netlink.Addr, error)
 	RouteListFiltered func(family int, filter *netlink.Route, filterMask uint64) ([]netlink.Route, error)
+}
+
+type netnsParams struct {
+	cell.In
+	NetNS *netns.NsHandle `optional:"true"`
+}
+
+type netlinkFuncsOut struct {
+	cell.Out
+	Funcs *netlinkFuncs `optional:"true"`
+}
+
+func newNetlinkFuncs(p netnsParams) (out netlinkFuncsOut, err error) {
+	if p.NetNS != nil {
+		out.Funcs, err = makeNetlinkFuncs(*p.NetNS)
+	}
+	return
 }
 
 func makeNetlinkFuncs(netns netns.NsHandle) (*netlinkFuncs, error) {

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -77,8 +77,8 @@ type devicesControllerParams struct {
 	Config      DevicesConfig
 	Log         logrus.FieldLogger
 	DB          *statedb.DB
-	DeviceTable statedb.Table[*tables.Device]
-	RouteTable  statedb.Table[*tables.Route]
+	DeviceTable statedb.RWTable[*tables.Device]
+	RouteTable  statedb.RWTable[*tables.Route]
 
 	// netlinkFuncs is optional and used by tests to verify error handling behavior.
 	NetlinkFuncs *netlinkFuncs `optional:"true"`

--- a/pkg/datapath/linux/devices_controller_test.go
+++ b/pkg/datapath/linux/devices_controller_test.go
@@ -445,7 +445,6 @@ func TestDevicesController_Restarts(t *testing.T) {
 
 	h := hive.New(
 		statedb.Cell,
-		tables.Cell,
 		DevicesControllerCell,
 		cell.Provide(func() DevicesConfig { return DevicesConfig{} }),
 		cell.Provide(func() *netlinkFuncs { return &funcs }),

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -473,8 +473,7 @@ func (n *linuxNodeHandler) updateNodeRoute(prefix *cidr.CIDR, addressFamilyEnabl
 	if err != nil {
 		return err
 	}
-	n.routes.InsertLegacy(nodeRoute)
-	return nil
+	return n.routes.InsertLegacy(nodeRoute)
 }
 
 func (n *linuxNodeHandler) deleteNodeRoute(prefix *cidr.CIDR, isLocalNode bool) error {
@@ -486,8 +485,7 @@ func (n *linuxNodeHandler) deleteNodeRoute(prefix *cidr.CIDR, isLocalNode bool) 
 	if err != nil {
 		return err
 	}
-	n.routes.DeleteLegacy(nodeRoute)
-	return nil
+	return n.routes.DeleteLegacy(nodeRoute)
 }
 
 func (n *linuxNodeHandler) familyEnabled(c *cidr.CIDR) bool {

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -105,17 +105,15 @@ func upsertEndpointRoute(routes reconcilers.RoutesHandle, ep datapath.Endpoint, 
 		Scope:  netlink.SCOPE_LINK,
 		Proto:  linux_defaults.RTProto,
 	}
-	routes.InsertLegacy(endpointRoute)
-	return nil
+	return routes.InsertLegacy(endpointRoute)
 }
 
 func removeEndpointRoute(routes reconcilers.RoutesHandle, ep datapath.Endpoint, ip net.IPNet) error {
-	routes.DeleteLegacy(route.Route{
+	return routes.DeleteLegacy(route.Route{
 		Prefix: ip,
 		Device: ep.InterfaceName(),
 		Scope:  netlink.SCOPE_LINK,
 	})
-	return nil
 }
 
 // We need this function when patching an object file for which symbols were

--- a/pkg/datapath/tables/cells.go
+++ b/pkg/datapath/tables/cells.go
@@ -12,6 +12,4 @@ var Cell = cell.Module(
 	"Datapath state tables",
 
 	L2AnnounceTableCell,
-	DeviceTableCell,
-	RouteTableCell,
 )

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -45,7 +45,7 @@ var (
 		},
 	}
 
-	DeviceTableCell = statedb.NewTableCell[*Device](
+	DeviceTableCell = statedb.NewProtectedTableCell[*Device](
 		"devices",
 		DeviceIDIndex,
 		DeviceNameIndex,

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -41,7 +41,7 @@ var (
 		},
 	}
 
-	RouteTableCell = statedb.NewTableCell[*Route](
+	RouteTableCell = statedb.NewProtectedTableCell[*Route](
 		"routes",
 		RouteIDIndex,
 		RouteLinkIndex,

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -56,7 +56,7 @@ type RouteID struct {
 
 func (id RouteID) Key() []byte {
 	key := append(index.Uint64(uint64(id.Table)), '+')
-	key = append(key, index.Uint64(uint64(id.Table))...)
+	key = append(key, index.Uint64(uint64(id.LinkIndex))...)
 	key = append(key, '+')
 	key = append(key, index.NetIPPrefix(id.Dst)...)
 	return key
@@ -65,11 +65,12 @@ func (id RouteID) Key() []byte {
 type Route struct {
 	Table     int
 	LinkIndex int
-
-	Scope uint8
-	Dst   netip.Prefix
-	Src   netip.Addr
-	Gw    netip.Addr
+	MTU       int
+	Scope     uint8
+	Priority  int
+	Dst       netip.Prefix
+	Src       netip.Addr
+	Gw        netip.Addr
 }
 
 func (r *Route) DeepCopy() *Route {

--- a/pkg/hive/cell/module.go
+++ b/pkg/hive/cell/module.go
@@ -13,6 +13,8 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
+type ModuleId string
+
 // Module creates a scoped set of cells with a given identifier.
 //
 // The id and title will be included in the object dump (hive.PrintObjects).
@@ -60,8 +62,17 @@ func (m *module) moduleScopedStatusReporter(p Health) HealthReporter {
 	return p.forModule(m.id)
 }
 
+func (m *module) moduleId() ModuleId {
+	return ModuleId(m.id)
+}
+
 func (m *module) Apply(c container) error {
 	scope := c.Scope(m.id)
+
+	// Provide the 'ModuleId' privately to the module.
+	if err := scope.Provide(m.moduleId, dig.Export(false)); err != nil {
+		return err
+	}
 
 	// Provide module scoped status reporter, used for reporting module level
 	// health status.

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -72,7 +72,7 @@ type l2AnnouncerParams struct {
 	Services             resource.Resource[*slim_corev1.Service]
 	L2AnnouncementPolicy resource.Resource[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy]
 	LocalNodeResource    daemon_k8s.LocalCiliumNodeResource
-	L2AnnounceTable      statedb.Table[*tables.L2AnnounceEntry]
+	L2AnnounceTable      statedb.RWTable[*tables.L2AnnounceEntry]
 	StateDB              *statedb.DB
 	JobRegistry          job.Registry
 }

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -45,7 +45,7 @@ type fixture struct {
 
 func newFixture() *fixture {
 	var (
-		tbl statedb.Table[*tables.L2AnnounceEntry]
+		tbl statedb.RWTable[*tables.L2AnnounceEntry]
 		db  *statedb.DB
 		jr  job.Registry
 	)
@@ -54,7 +54,7 @@ func newFixture() *fixture {
 		statedb.Cell,
 		tables.Cell,
 		job.Cell,
-		cell.Invoke(func(d *statedb.DB, t statedb.Table[*tables.L2AnnounceEntry], j job.Registry) {
+		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], j job.Registry) {
 			db = d
 			tbl = t
 			jr = j

--- a/pkg/reconciler/cell.go
+++ b/pkg/reconciler/cell.go
@@ -1,0 +1,10 @@
+package reconciler
+
+import "github.com/cilium/cilium/pkg/hive/cell"
+
+var Cell = cell.Module(
+	"reconciler",
+	"Generic reconciler",
+
+	cell.Metric(newMetrics),
+)

--- a/pkg/reconciler/example/iptables.go
+++ b/pkg/reconciler/example/iptables.go
@@ -55,13 +55,13 @@ type iptablesTarget struct {
 }
 
 // Delete implements reconciler.Target
-func (*iptablesTarget) Delete(_ context.Context, rule *Rule) error {
+func (*iptablesTarget) Delete(_ context.Context, txn statedb.ReadTxn, rule *Rule) error {
 	fmt.Printf(">>> iptables %s\n", strings.Join(rule.ToArgs("-D"), " "))
 	return nil
 }
 
 // Sync implements reconciler.Target
-func (*iptablesTarget) Sync(_ context.Context, _ statedb.Iterator[*Rule]) (outOfSync bool, err error) {
+func (*iptablesTarget) Sync(_ context.Context, txn statedb.ReadTxn, _ statedb.Iterator[*Rule]) (outOfSync bool, err error) {
 	// TODO:
 	// - "iptables-save" and parse? Or "-C" on each rule?
 	// - Check that cilium chains exist
@@ -70,7 +70,7 @@ func (*iptablesTarget) Sync(_ context.Context, _ statedb.Iterator[*Rule]) (outOf
 }
 
 // Update implements reconciler.Target
-func (*iptablesTarget) Update(_ context.Context, rule *Rule) error {
+func (*iptablesTarget) Update(_ context.Context, txn statedb.ReadTxn, rule *Rule) error {
 	fmt.Printf(">>> iptables %s\n", strings.Join(rule.ToArgs("-A"), " "))
 	return errors.New("oops iptables error")
 }

--- a/pkg/reconciler/example/iptables.go
+++ b/pkg/reconciler/example/iptables.go
@@ -60,19 +60,14 @@ func (*iptablesTarget) Delete(_ context.Context, txn statedb.ReadTxn, rule *Rule
 	return nil
 }
 
-// Sync implements reconciler.Target
-func (*iptablesTarget) Sync(_ context.Context, txn statedb.ReadTxn, _ statedb.Iterator[*Rule]) (outOfSync bool, err error) {
-	// TODO:
-	// - "iptables-save" and parse? Or "-C" on each rule?
-	// - Check that cilium chains exist
-	// - Find unexpected rules in cilium chains?
-	return false, nil
+// Update implements reconciler.Target
+func (*iptablesTarget) Update(_ context.Context, txn statedb.ReadTxn, rule *Rule) (bool, error) {
+	fmt.Printf(">>> iptables %s\n", strings.Join(rule.ToArgs("-A"), " "))
+	return true, errors.New("oops iptables error")
 }
 
-// Update implements reconciler.Target
-func (*iptablesTarget) Update(_ context.Context, txn statedb.ReadTxn, rule *Rule) error {
-	fmt.Printf(">>> iptables %s\n", strings.Join(rule.ToArgs("-A"), " "))
-	return errors.New("oops iptables error")
+func (*iptablesTarget) Prune(context.Context, statedb.ReadTxn, statedb.Iterator[*Rule]) error {
+	return nil
 }
 
 func (*iptablesTarget) Init(context.Context) error {

--- a/pkg/reconciler/example/iptables.go
+++ b/pkg/reconciler/example/iptables.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/netip"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/reconciler"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+var (
+	RulePrimaryIndex = statedb.Index[*Rule, *Rule]{
+		Name: "primary",
+		FromObject: func(rule *Rule) index.KeySet {
+			return index.NewKeySet(rule.PrimaryKey())
+		},
+		FromKey: (*Rule).PrimaryKey,
+		Unique:  true,
+	}
+	RuleStatusIndex = reconciler.NewStatusIndex[*Rule]()
+)
+
+var IPTablesCell = cell.Module(
+	"iptables",
+	"IPTables desired state and reconciliation",
+
+	statedb.NewTableCell[*Rule]("iptables-rules", RulePrimaryIndex, RuleStatusIndex),
+
+	cell.ProvidePrivate(
+		func() reconciler.Target[*Rule] { return &iptablesTarget{} },
+		func() reconciler.Config {
+			return reconciler.Config{
+				FullReconcilationInterval: 10 * time.Second,
+				RetryBackoffMinDuration:   time.Second,
+				RetryBackoffMaxDuration:   10 * time.Second,
+			}
+		},
+		func() statedb.Index[*Rule, reconciler.StatusKind] { return RuleStatusIndex },
+	),
+	cell.Invoke(reconciler.Register[*Rule]),
+)
+
+//
+// iptables reconciliation target
+//
+
+type iptablesTarget struct {
+}
+
+// Delete implements reconciler.Target
+func (*iptablesTarget) Delete(_ context.Context, rule *Rule) error {
+	fmt.Printf(">>> iptables %s\n", strings.Join(rule.ToArgs("-D"), " "))
+	return nil
+}
+
+// Sync implements reconciler.Target
+func (*iptablesTarget) Sync(_ context.Context, _ statedb.Iterator[*Rule]) (outOfSync bool, err error) {
+	// TODO:
+	// - "iptables-save" and parse? Or "-C" on each rule?
+	// - Check that cilium chains exist
+	// - Find unexpected rules in cilium chains?
+	return false, nil
+}
+
+// Update implements reconciler.Target
+func (*iptablesTarget) Update(_ context.Context, rule *Rule) error {
+	fmt.Printf(">>> iptables %s\n", strings.Join(rule.ToArgs("-A"), " "))
+	return errors.New("oops iptables error")
+}
+
+func (*iptablesTarget) Init(context.Context) error {
+	// TODO:
+	// - Load kernel modules.
+	// - Probe for features.
+	// - Setup cilium chains.
+	return nil
+}
+
+var _ reconciler.Target[*Rule] = &iptablesTarget{}
+
+//
+// Rule
+//
+
+type Rule struct {
+	TableChain TableChain
+	IPv6       bool
+	Comment    string
+	Args       []ToArgs
+	Jump       Jump
+	Status     reconciler.Status
+}
+
+func (rule *Rule) GetStatus() reconciler.Status { return rule.Status }
+
+func (rule *Rule) WithStatus(new reconciler.Status) *Rule {
+	ruleCopy := *rule
+	ruleCopy.Status = new
+	return &ruleCopy
+}
+
+func (rule *Rule) PrimaryKey() index.Key {
+	// TODO: This is pretty expensive. Could the "Comment" make for a reasonable
+	// key?
+	return index.String(strings.Join(rule.ToArgs("X"), " "))
+}
+
+func (rule *Rule) ToArgs(action string) []string {
+	args := []string{
+		"-t", rule.TableChain.Table,
+		action, rule.TableChain.Chain,
+		"-m", "comment", "--comment", rule.Comment,
+	}
+	for _, a := range rule.Args {
+		args = append(args, a.ToArgs()...)
+	}
+	return append(args, rule.Jump.ToArgs()...)
+}
+
+//
+// Jumps
+//
+
+type Jump struct {
+	Target string
+	Args   []string
+}
+
+func (j Jump) ToArgs() (args []string) {
+	args = append(args, "-j", j.Target)
+	return append(args, j.Args...)
+}
+
+var (
+	JumpAccept = Jump{Target: "ACCEPT", Args: nil}
+	JumpDrop   = Jump{Target: "DROP", Args: nil}
+	JumpReject = Jump{Target: "REJECT", Args: nil}
+)
+
+func JumpSnat(toSource string, randomFully bool) Jump {
+	args := []string{"--to-source", toSource}
+	if randomFully {
+		args = append(args, "--random-fully")
+	}
+	return Jump{
+		Target: "SNAT",
+		Args:   args,
+	}
+}
+
+func JumpConnMark(setXMark string, nfMask string, ctMask string, restoreMark bool) Jump {
+	panic("TBD")
+}
+
+//
+// Tables and chains
+//
+
+type TableChain struct {
+	Table, Chain string
+}
+
+var (
+	TableChainFilterInput   = TableChain{"filter", "INPUT"}
+	TableChainFilterForward = TableChain{"filter", "FORWARD"}
+	TableChainFilterOutput  = TableChain{"filter", "OUTPUT"}
+
+	TableChainNatPreRouting  = TableChain{"nat", "PREROUTING"}
+	TableChainNatInput       = TableChain{"nat", "INPUT"}
+	TableChainNatOutput      = TableChain{"nat", "OUTPUT"}
+	TableChainNatPostRouting = TableChain{"nat", "POSTROUTING"}
+
+	TableChainManglePreRouting  = TableChain{"mangle", "PREROUTING"}
+	TableChainMangleOutput      = TableChain{"mangle", "OUTPUT"}
+	TableChainMangleInput       = TableChain{"mangle", "INPUT"}
+	TableChainMangleForward     = TableChain{"mangle", "FORWARD"}
+	TableChainManglePostRouting = TableChain{"mangle", "POSTROUTING"}
+
+	TableChainRawNoTrack    = TableChain{"raw", "NOTRACK"}
+	TableChainRawPreRouting = TableChain{"raw", "PREROUTING"}
+	TableChainRawOutput     = TableChain{"raw", "OUTPUT"}
+
+	TableChainSecurityInput   = TableChain{"security", "INPUT"}
+	TableChainSecurityOutput  = TableChain{"security", "OUTPUT"}
+	TableChainSecurityForward = TableChain{"security", "FORWARD"}
+
+	TableChainFilterCiliumInput  = TableChain{"filter", "CILIUM_INPUT"}
+	TableChainFilterCiliumOutput = TableChain{"filter", "CILIUM_OUTPUT"}
+	// ...
+)
+
+//
+// Arguments
+//
+
+type ToArgs interface {
+	ToArgs() []string
+}
+
+type Mark string
+
+func (m Mark) ToArgs() []string {
+	return []string{"-m", "mark", "--mark", string(m)}
+}
+
+type NegMark string
+
+func (m NegMark) ToArgs() []string {
+	return []string{"-m", "mark", "!", "--mark", string(m)}
+}
+
+type OutDevice string
+
+func (out OutDevice) ToArgs() []string {
+	return []string{"-o", string(out)}
+}
+
+type InDevice string
+
+func (in InDevice) ToArgs() []string {
+	return []string{"-i", string(in)}
+}
+
+type Proto string
+
+func (p Proto) ToArgs() []string {
+	return []string{"-p", string(p)}
+}
+
+type NotDestination Destination
+
+func (d NotDestination) ToArgs() (args []string) {
+	args = append(args, "!")
+	return append(args, d.ToArgs()...)
+}
+
+type Destination struct {
+	IP   netip.Addr
+	Port *uint16
+}
+
+func (d Destination) ToArgs() (args []string) {
+	args = append(args, "-d", d.IP.String())
+	if d.Port != nil {
+		args = append(args,
+			"--dport",
+			strconv.FormatUint(uint64(*d.Port), 10))
+	}
+	return
+}
+
+type Source struct {
+	IP   netip.Addr
+	Port *uint16
+}
+
+func (s Source) ToArgs() (args []string) {
+	args = append(args, "-s", s.IP.String())
+	if s.Port != nil {
+		args = append(args,
+			"--sport",
+			strconv.FormatUint(uint64(*s.Port), 10))
+	}
+	return
+}
+
+type NotSource Source
+
+func (s NotSource) ToArgs() (args []string) {
+	args = append(args, "!")
+	return append(args, s.ToArgs()...)
+}
+
+type NoTrack struct{}
+
+func (NoTrack) ToArgs() []string {
+	return []string{"--notrack"}
+}
+
+type ConnTrack struct {
+	CTState string
+}
+
+func (ct ConnTrack) ToArgs() (args []string) {
+	return []string{
+		"-m", "conntrack",
+		"--ctstate", ct.CTState,
+		// TODO rest
+	}
+}

--- a/pkg/reconciler/example/main.go
+++ b/pkg/reconciler/example/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/reconciler"
+	"github.com/cilium/cilium/pkg/statedb"
+)
+
+var fakeProcPath = "/tmp/fakeproc"
+
+func main() {
+	os.MkdirAll(fakeProcPath, 0755)
+	h := hive.New(
+		statedb.Cell,
+		job.Cell,
+		reconciler.Cell,
+
+		cell.Group(
+			cell.Provide(func() *option.DaemonConfig {
+				return &option.DaemonConfig{}
+			}),
+			metrics.Cell,
+		),
+
+		Cell,
+		cell.Invoke(
+			modify,
+			healthReport,
+		),
+	)
+	h.PrintObjects()
+	h.Run()
+}
+
+func modify(db *statedb.DB, t statedb.RWTable[*SysctlSetting]) {
+	go func() {
+		for {
+			time.Sleep(500 * time.Millisecond)
+
+			n := rand.Intn(5)
+			x := rand.Intn(5)
+			key := fmt.Sprintf("foo%d", n)
+			val := fmt.Sprintf("bar%d", x)
+
+			txn := db.WriteTxn(t)
+			if x == 0 {
+				obj, _, ok := t.First(txn, SysctlKeyIndex.Query(key))
+				if ok {
+					obj = obj.WithStatus(reconciler.StatusPendingDelete())
+					t.Insert(txn, obj)
+				}
+			} else {
+				t.Insert(txn, &SysctlSetting{
+					Key: key, Value: val, status: reconciler.StatusPending(),
+				})
+			}
+			txn.Commit()
+		}
+	}()
+}
+
+func healthReport(health cell.Health) {
+	go func() {
+		for {
+			time.Sleep(time.Second)
+
+			for _, status := range health.All() {
+				fmt.Println(status.String())
+			}
+		}
+
+	}()
+
+}

--- a/pkg/reconciler/example/main.go
+++ b/pkg/reconciler/example/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/reconciler"
+	"github.com/cilium/cilium/pkg/reconciler/example/reconcilers"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -56,7 +57,7 @@ func main() {
 
 		//IPTablesCell,
 
-		RoutesCell,
+		reconcilers.RoutesCell,
 
 		cell.Invoke(
 			//modify,
@@ -108,7 +109,7 @@ func modifyIPTables(db *statedb.DB, t statedb.RWTable[*Rule]) {
 	}()
 }
 
-func modifyRoutes(r Routes, ns *netns.NsHandle) {
+func modifyRoutes(r reconcilers.Routes, ns *netns.NsHandle) {
 	nlHandle, _ := netlink.NewHandleAt(*ns)
 	loIndex := 0
 	if l, err := nlHandle.LinkByName("lo"); err == nil {
@@ -161,7 +162,7 @@ func healthReport(health cell.Health) {
 
 }
 
-func printPendingOrErrored(db *statedb.DB, t statedb.Table[*DesiredRoute]) {
+func printPendingOrErrored(db *statedb.DB, t statedb.Table[*reconcilers.DesiredRoute]) {
 	go func() {
 		for {
 			fmt.Printf("Desired routes:\n")

--- a/pkg/reconciler/example/reconcilers/route.go
+++ b/pkg/reconciler/example/reconcilers/route.go
@@ -396,7 +396,7 @@ func (t *routeTestTarget) Delete(_ context.Context, txn statedb.ReadTxn, desired
 
 // Sync implements reconciler.Target
 func (t *routeTestTarget) Sync(ctx context.Context, txn statedb.ReadTxn, iter statedb.Iterator[*DesiredRoute]) (outOfSync bool, err error) {
-	t.log.Infof("Sync\n")
+	t.log.Infof("Sync")
 
 	var errs []error
 

--- a/pkg/reconciler/example/route.go
+++ b/pkg/reconciler/example/route.go
@@ -1,0 +1,419 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/netip"
+	"time"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+	"github.com/cilium/cilium/pkg/datapath/linux/route"
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/reconciler"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+var RoutesCell = cell.Module(
+	"routes",
+	"Routing table reconciliation",
+
+	statedb.NewProtectedTableCell[*DesiredRoute](
+		"desired-routes",
+		RouteIDIndex,
+		RouteOwnerIndex,
+		RouteStatusIndex,
+	),
+
+	cell.Provide(newRoutes),
+
+	// Provide the dependencies to the reconciler.
+	cell.ProvidePrivate(
+		// Construct the route reconciliation target against the target
+		// network namespace. It uses the device and route tables to
+		// efficiently check for existence.
+		func(ns *netns.NsHandle,
+			devices statedb.Table[*tables.Device],
+			routes statedb.Table[*tables.Route],
+		) (reconciler.Target[*DesiredRoute], error) {
+			h, err := netlink.NewHandleAt(*ns)
+			if err != nil {
+				return nil, err
+			}
+			return &routeTestTarget{h, devices, routes}, nil
+		},
+		func() reconciler.Config {
+			return reconciler.Config{
+				FullReconcilationInterval: 10 * time.Second,
+				RetryBackoffMinDuration:   time.Second,
+				RetryBackoffMaxDuration:   10 * time.Second,
+			}
+		},
+
+		reconciler.New[*DesiredRoute],
+	),
+
+	// Provide a job group for this module.
+	cell.ProvidePrivate(job.Registry.NewGroup),
+	cell.Invoke(func(lc hive.Lifecycle, g job.Group) { lc.Append(g) }),
+
+	// Trigger synchronization when devices change to react to
+	// devices changing state.
+	cell.Invoke(syncOnDeviceChanges),
+)
+
+// syncOnDeviceChanges triggers full reconciliation when devices change.
+// This allows quickly reacting to flapping device state that causes routes
+// to get flushed.
+func syncOnDeviceChanges(
+	jobs job.Group,
+	db *statedb.DB,
+	devices statedb.Table[*tables.Device],
+	reconciler reconciler.Reconciler[*DesiredRoute],
+) {
+	limiter := rate.NewLimiter(30*time.Second, 2)
+	jobs.Add(job.OneShot(
+		"sync-routes-on-device-changes",
+		func(ctx context.Context) error {
+			for {
+				limiter.Wait(ctx)
+				_, watch := tables.SelectedDevices(
+					devices,
+					db.ReadTxn(),
+				)
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-watch:
+				}
+				reconciler.TriggerSync()
+			}
+		},
+	))
+}
+
+//
+// The Route API
+//
+
+type Routes struct {
+	db    *statedb.DB
+	table statedb.RWTable[*DesiredRoute]
+}
+
+type RoutesHandle struct {
+	owner string
+	r     Routes
+}
+
+func newRoutes(db *statedb.DB, table statedb.RWTable[*DesiredRoute]) Routes {
+	return Routes{db, table}
+}
+
+func (r Routes) NewHandle(name string) RoutesHandle {
+	return RoutesHandle{name, r}
+}
+
+func (h RoutesHandle) InsertLegacy(route route.Route) bool {
+	// TODO: Should we deal here with device names or indexes?
+	// Existing code mostly deals with names, so hacking this
+	// by including the name in DesiredRoute for this case
+
+	txn := h.r.db.WriteTxn(h.r.table)
+	var gw netip.Addr
+	if route.Nexthop != nil {
+		// TODO errs
+		gw, _ = ip.AddrFromIP(*route.Nexthop)
+	}
+	dstAddr, _ := ip.AddrFromIP(route.Prefix.IP)
+	dstBits, _ := route.Prefix.Mask.Size()
+	dst := netip.PrefixFrom(
+		dstAddr,
+		dstBits,
+	)
+
+	_, hadOld, _ := h.r.table.Insert(txn,
+		&DesiredRoute{
+			Owner: h.owner,
+			Route: tables.Route{
+				Table:     route.Table,
+				LinkIndex: 0,
+				MTU:       route.MTU,
+				Scope:     uint8(route.Scope),
+				Priority:  route.Priority,
+				Dst:       dst,
+				Gw:        gw,
+			},
+			OptDeviceName: route.Device,
+			Status:        reconciler.StatusPending(),
+		})
+	txn.Commit()
+
+	return hadOld
+
+}
+
+func (h RoutesHandle) Insert(route tables.Route) bool {
+	// TODO: Where would we handle the automatic "next hop" creation
+	// logic done in route_linux.go?
+
+	// TODO: How do we deal with overlapping routes coming from
+	// different handles?
+
+	txn := h.r.db.WriteTxn(h.r.table)
+	_, hadOld, _ := h.r.table.Insert(txn,
+		&DesiredRoute{
+			Owner:  h.owner,
+			Route:  route,
+			Status: reconciler.StatusPending(),
+		})
+	txn.Commit()
+	return hadOld
+}
+
+func (h RoutesHandle) Delete(route tables.Route) bool {
+	txn := h.r.db.WriteTxn(h.r.table)
+	entry, _, ok := h.r.table.First(txn,
+		RouteIDIndex.Query(
+			tables.RouteID{Table: route.Table,
+				LinkIndex: route.LinkIndex,
+				Dst:       route.Dst,
+			}))
+	if ok {
+		h.r.table.Insert(
+			txn,
+			entry.WithStatus(reconciler.StatusPendingDelete()))
+	}
+	txn.Commit()
+	return ok
+}
+
+func (h RoutesHandle) DeleteAll() {
+	txn := h.r.db.WriteTxn(h.r.table)
+	iter, _ := h.r.table.Get(txn, RouteOwnerIndex.Query(h.owner))
+	for route, _, ok := iter.Next(); ok; route, _, ok = iter.Next() {
+		h.r.table.Insert(
+			txn,
+			route.WithStatus(reconciler.StatusPendingDelete()))
+	}
+	txn.Commit()
+}
+
+func (h RoutesHandle) Wait(ctx context.Context) error {
+	// TODO: Return error(s) from status if ctx cancelled?
+	txn := h.r.db.ReadTxn()
+
+	for {
+		iter, watch := h.r.table.Get(txn, RouteOwnerIndex.Query(h.owner))
+		done := true
+		for route, _, ok := iter.Next(); ok; route, _, ok = iter.Next() {
+			if route.Status.Kind != reconciler.StatusKindDone {
+				done = false
+				break
+			}
+		}
+		if done {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-watch:
+		}
+	}
+}
+
+//
+// Route setting and indexes
+//
+
+type DesiredRoute struct {
+	Owner         string
+	Route         tables.Route
+	OptDeviceName string
+	Status        reconciler.Status
+}
+
+func (s *DesiredRoute) PrimaryKey() []byte {
+	return s.RouteID().Key()
+}
+
+func (s *DesiredRoute) RouteID() tables.RouteID {
+	return tables.RouteID{
+		Table:     s.Route.Table,
+		LinkIndex: s.Route.LinkIndex,
+		Dst:       s.Route.Dst,
+	}
+}
+
+func (s *DesiredRoute) GetStatus() reconciler.Status {
+	return s.Status
+}
+
+func (s *DesiredRoute) WithStatus(newStatus reconciler.Status) *DesiredRoute {
+	s2 := *s
+	s2.Status = newStatus
+	return &s2
+}
+
+func (d *DesiredRoute) toNetlinkRoute(linkIndex int) *netlink.Route {
+	return &netlink.Route{
+		Table:     d.Route.Table,
+		LinkIndex: linkIndex,
+		Dst:       prefixToIPNet(d.Route.Dst),
+		Src:       d.Route.Src.AsSlice(),
+		Gw:        d.Route.Gw.AsSlice(),
+		Scope:     netlink.Scope(d.Route.Scope),
+		Protocol:  linux_defaults.RTProto,
+	}
+}
+
+var (
+	RouteIDIndex = statedb.Index[*DesiredRoute, tables.RouteID]{
+		Name: "id",
+		FromObject: func(s *DesiredRoute) index.KeySet {
+			return index.NewKeySet(s.PrimaryKey())
+		},
+		FromKey: tables.RouteID.Key,
+		Unique:  true,
+	}
+	RouteOwnerIndex = statedb.Index[*DesiredRoute, string]{
+		Name: "owner",
+		FromObject: func(s *DesiredRoute) index.KeySet {
+			return index.NewKeySet(index.String(s.Owner))
+		},
+		FromKey: index.String,
+		Unique:  false,
+	}
+	RouteStatusIndex = reconciler.NewStatusIndex[*DesiredRoute]()
+)
+
+//
+// Route reconciliation target
+//
+
+type routeTestTarget struct {
+	netlinkHandle *netlink.Handle
+	devices       statedb.Table[*tables.Device]
+	routes        statedb.Table[*tables.Route]
+}
+
+func (routeTestTarget) Init(context.Context) error {
+	return nil
+}
+
+func (t *routeTestTarget) Delete(_ context.Context, txn statedb.ReadTxn, desired *DesiredRoute) error {
+	fmt.Printf("Delete: %v\n", desired)
+
+	_, _, ok := t.routes.First(txn, tables.RouteIDIndex.Query(desired.RouteID()))
+	if !ok {
+		// Route already gone.
+		return nil
+	}
+
+	linkIndex := desired.Route.LinkIndex
+
+	// TODO
+	if desired.OptDeviceName != "" {
+		dev, _, ok := t.devices.First(txn, tables.DeviceNameIndex.Query(desired.OptDeviceName))
+		if !ok {
+			return fmt.Errorf("device %q not found for route to %q", desired.OptDeviceName, desired.Route.Dst.String())
+		}
+		linkIndex = dev.Index
+	}
+
+	if err := t.netlinkHandle.RouteDel(desired.toNetlinkRoute(linkIndex)); err != nil {
+		return fmt.Errorf("failed to delete route to %q owned by %q: %w",
+			desired.Route.Dst.String(),
+			desired.Owner,
+			err)
+	}
+	return nil
+}
+
+// Sync implements reconciler.Target
+func (t *routeTestTarget) Sync(ctx context.Context, txn statedb.ReadTxn, iter statedb.Iterator[*DesiredRoute]) (outOfSync bool, err error) {
+	// TODO: Might want to trigger sync when devices change their state.
+	// (e.g. go UP from DOWN).
+	fmt.Printf("Sync\n")
+
+	var errs []error
+
+	for desired, _, ok := iter.Next(); ok; desired, _, ok = iter.Next() {
+		actual, _, ok := t.routes.First(txn, tables.RouteIDIndex.Query(desired.RouteID()))
+		if ok && *actual == desired.Route {
+			continue
+		}
+		outOfSync = true
+
+		if err := t.Update(ctx, txn, desired); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		err = errors.Join(errs...)
+	}
+
+	return
+}
+
+// Update implements reconciler.Target
+func (t *routeTestTarget) Update(_ context.Context, txn statedb.ReadTxn, desired *DesiredRoute) error {
+	fmt.Printf("Update: %v\n", desired)
+	actual, _, ok := t.routes.First(txn, tables.RouteIDIndex.Query(desired.RouteID()))
+	if ok {
+		if *actual == desired.Route {
+			// Route already exists.
+			return nil
+		}
+	}
+
+	linkIndex := desired.Route.LinkIndex
+
+	// TODO
+	if desired.OptDeviceName != "" {
+		dev, _, ok := t.devices.First(txn, tables.DeviceNameIndex.Query(desired.OptDeviceName))
+		if !ok {
+			return fmt.Errorf("device %q not found for route to %q", desired.OptDeviceName, desired.Route.Dst.String())
+		}
+		linkIndex = dev.Index
+	}
+
+	_, _, ok = t.devices.First(txn, tables.DeviceIDIndex.Query(linkIndex))
+	if !ok {
+		// TODO: we likely hit races where the device is removed but the desired
+		// routes aren't yet updated. feels safer to have spurious errors on
+		// device changes versus ignoring this completely.
+		return fmt.Errorf("device with index %d does not exist", desired.Route.LinkIndex)
+	}
+
+	if err := t.netlinkHandle.RouteReplace(desired.toNetlinkRoute(linkIndex)); err != nil {
+		return fmt.Errorf("failed to replace route to %q owned by %q: %w",
+			desired.Route.Dst.String(),
+			desired.Owner,
+			err)
+	}
+	return nil
+}
+
+func prefixToIPNet(prefix netip.Prefix) *net.IPNet {
+	if !prefix.IsValid() {
+		return nil
+	}
+	return &net.IPNet{
+		IP:   prefix.Addr().AsSlice(),
+		Mask: net.CIDRMask(prefix.Bits(), prefix.Addr().BitLen()),
+	}
+}
+
+var _ reconciler.Target[*DesiredRoute] = &routeTestTarget{}

--- a/pkg/reconciler/example/sysctl.go
+++ b/pkg/reconciler/example/sysctl.go
@@ -114,7 +114,7 @@ func (sysctlTestTarget) Init(context.Context) error {
 	return nil
 }
 
-func (t *sysctlTestTarget) Delete(_ context.Context, s *SysctlSetting) error {
+func (t *sysctlTestTarget) Delete(_ context.Context, _ statedb.ReadTxn, s *SysctlSetting) error {
 	//fmt.Printf("Delete: %s\n", s.Key)
 	if err := maybeError(); err != nil {
 		return err
@@ -125,7 +125,7 @@ func (t *sysctlTestTarget) Delete(_ context.Context, s *SysctlSetting) error {
 }
 
 // Sync implements reconciler.Target
-func (t *sysctlTestTarget) Sync(_ context.Context, iter statedb.Iterator[*SysctlSetting]) (outOfSync bool, err error) {
+func (t *sysctlTestTarget) Sync(_ context.Context, _ statedb.ReadTxn, iter statedb.Iterator[*SysctlSetting]) (outOfSync bool, err error) {
 	if err := maybeError(); err != nil {
 		return false, err
 	}
@@ -159,7 +159,7 @@ func maybeError() error {
 }
 
 // Update implements reconciler.Target
-func (t *sysctlTestTarget) Update(_ context.Context, s *SysctlSetting) error {
+func (t *sysctlTestTarget) Update(_ context.Context, _ statedb.ReadTxn, s *SysctlSetting) error {
 	//fmt.Printf("Update: %s => %s\n", s.Key, s.Value)
 	if err := maybeError(); err != nil {
 		return err

--- a/pkg/reconciler/example/sysctl.go
+++ b/pkg/reconciler/example/sysctl.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"time"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/reconciler"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+type SysctlSetting struct {
+	Key   string
+	Value string
+
+	status reconciler.Status
+}
+
+func (s *SysctlSetting) GetStatus() reconciler.Status {
+	return s.status
+}
+
+func (s *SysctlSetting) WithStatus(newStatus reconciler.Status) *SysctlSetting {
+	s2 := *s
+	s2.status = newStatus
+	return &s2
+}
+
+var (
+	SysctlKeyIndex = statedb.Index[*SysctlSetting, string]{
+		Name: "key",
+		FromObject: func(s *SysctlSetting) index.KeySet {
+			return index.NewKeySet(index.String(s.Key))
+		},
+		FromKey: index.String,
+		Unique:  true,
+	}
+	SysctlStatusIndex = reconciler.NewStatusIndex[*SysctlSetting]()
+)
+
+var Cell = cell.Module(
+	"sysctl",
+	"sysctl settings",
+
+	statedb.NewTableCell[*SysctlSetting]("sysctl", SysctlKeyIndex, SysctlStatusIndex),
+
+	cell.ProvidePrivate(
+		func() reconciler.Target[*SysctlSetting] { return &sysctlTestTarget{} },
+		func() reconciler.Config {
+			return reconciler.Config{
+				FullReconcilationInterval: 10 * time.Second,
+				RetryBackoffMinDuration:   time.Second,
+				RetryBackoffMaxDuration:   10 * time.Second,
+			}
+		},
+		func() statedb.Index[*SysctlSetting, reconciler.StatusKind] { return SysctlStatusIndex },
+
+		reconciler.New[*SysctlSetting],
+	),
+	cell.Invoke(func(reconciler.Reconciler[*SysctlSetting]) {}),
+)
+
+type sysctlTestTarget struct {
+}
+
+func fakeProcFile(s *SysctlSetting) (*os.File, error) {
+	return os.OpenFile(fakeProcPath+"/"+s.Key, os.O_RDWR|os.O_CREATE, 0644)
+}
+
+func (t *sysctlTestTarget) Delete(s *SysctlSetting) error {
+	fmt.Printf("Delete: %s\n", s.Key)
+	if err := maybeError(); err != nil {
+		return err
+	}
+
+	// Real proc of course doesn't allow delete.
+	return os.Remove(fakeProcPath + "/" + s.Key)
+}
+
+// Sync implements reconciler.Target
+func (t *sysctlTestTarget) Sync(iter statedb.Iterator[*SysctlSetting]) (outOfSync bool, err error) {
+	if err := maybeError(); err != nil {
+		return false, err
+	}
+
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		var f *os.File
+		f, err = fakeProcFile(obj)
+		if err != nil {
+			return
+		}
+
+		var oldValue []byte
+		oldValue, err = io.ReadAll(f)
+
+		if string(oldValue) != obj.Value {
+			outOfSync = true
+			f.Seek(0, 0)
+			f.Truncate(int64(len(obj.Value)))
+			f.WriteString(obj.Value)
+			f.Close()
+		}
+	}
+	return
+}
+
+func maybeError() error {
+	if rand.Intn(10) == 0 {
+		return errors.New("some error")
+	}
+	return nil
+}
+
+// Update implements reconciler.Target
+func (t *sysctlTestTarget) Update(s *SysctlSetting) error {
+	fmt.Printf("Update: %s => %s\n", s.Key, s.Value)
+	if err := maybeError(); err != nil {
+		return err
+	}
+
+	var f *os.File
+	f, err := fakeProcFile(s)
+	if err != nil {
+		return err
+	}
+	err = f.Truncate(int64(len(s.Value)))
+	if err != nil {
+		return err
+	}
+	_, err = f.WriteString(s.Value)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}
+
+var _ reconciler.Target[*SysctlSetting] = &sysctlTestTarget{}

--- a/pkg/reconciler/index.go
+++ b/pkg/reconciler/index.go
@@ -1,6 +1,8 @@
 package reconciler
 
 import (
+	"context"
+
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/statedb/index"
 )
@@ -15,5 +17,33 @@ func NewStatusIndex[Obj Reconcilable[Obj]]() statedb.Index[Obj, StatusKind] {
 			return index.String(string(k))
 		},
 		Unique: false,
+	}
+}
+
+// WaitForReconciliation blocks until all objects have been reconciled or the context
+// has cancelled.
+func WaitForReconciliation[Obj Reconcilable[Obj], Table statedb.Table[Obj]](
+	ctx context.Context,
+	db *statedb.DB,
+	table Table,
+	statusIndex statedb.Index[Obj, StatusKind],
+) error {
+	for {
+		txn := db.ReadTxn()
+
+		// See if there are any pending or error'd objects.
+		_, _, watchPending, okPending := table.FirstWatch(txn, statusIndex.Query(StatusKindPending))
+		_, _, watchError, okError := table.FirstWatch(txn, statusIndex.Query(StatusKindError))
+		if !okPending && !okError {
+			return nil
+		}
+
+		// Wait for updates before checking again.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-watchPending:
+		case <-watchError:
+		}
 	}
 }

--- a/pkg/reconciler/index.go
+++ b/pkg/reconciler/index.go
@@ -1,0 +1,19 @@
+package reconciler
+
+import (
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+)
+
+func NewStatusIndex[Obj Reconcilable[Obj]]() statedb.Index[Obj, StatusKind] {
+	return statedb.Index[Obj, StatusKind]{
+		Name: "status",
+		FromObject: func(obj Obj) index.KeySet {
+			return index.NewKeySet(index.String(string(obj.GetStatus().Kind)))
+		},
+		FromKey: func(k StatusKind) index.Key {
+			return index.String(string(k))
+		},
+		Unique: false,
+	}
+}

--- a/pkg/reconciler/metrics.go
+++ b/pkg/reconciler/metrics.go
@@ -40,7 +40,7 @@ func newMetrics() *reconcilerMetrics {
 			Namespace:  metrics.Namespace,
 			Subsystem:  "reconciler",
 			Name:       "incremental_duration_seconds",
-			Help:       "Histogram over incremental reconciliation duration",
+			Help:       "Histogram of per-operation duration during incremental reconciliation",
 		}, []string{LabelModuleId}),
 
 		IncrementalReconciliationTotalErrors: metric.NewCounterVec(metric.CounterOpts{

--- a/pkg/reconciler/metrics.go
+++ b/pkg/reconciler/metrics.go
@@ -1,0 +1,100 @@
+package reconciler
+
+import (
+	"github.com/cilium/cilium/pkg/metrics"
+	"github.com/cilium/cilium/pkg/metrics/metric"
+)
+
+type reconcilerMetrics struct {
+	IncrementalReconciliationCount         metric.Vec[metric.Counter]
+	IncrementalReconciliationDuration      metric.Vec[metric.Observer]
+	IncrementalReconciliationTotalErrors   metric.Vec[metric.Counter]
+	IncrementalReconciliationCurrentErrors metric.Vec[metric.Gauge]
+
+	FullReconciliationCount          metric.Vec[metric.Counter]
+	FullReconciliationOutOfSyncCount metric.Vec[metric.Counter]
+	FullReconciliationTotalErrors    metric.Vec[metric.Counter]
+	FullReconciliationDuration       metric.Vec[metric.Observer]
+}
+
+const LabelModuleId = "module_id"
+
+// TODO: Or would it be better if the metrics for reconciliation would be
+// instantiated by the user with a configurable prefix (versus using a global
+// set of metrics with labels)?
+
+func newMetrics() *reconcilerMetrics {
+	return &reconcilerMetrics{
+		IncrementalReconciliationCount: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_incremental_total",
+			Disabled:   false,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "incremental_total",
+			Help:       "Number of incremental reconciliations performed",
+		}, []string{LabelModuleId}),
+
+		IncrementalReconciliationDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: metrics.Namespace + "_reconciler_incremental_duration_seconds",
+			Disabled:   false,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "incremental_duration_seconds",
+			Help:       "Histogram over incremental reconciliation duration",
+		}, []string{LabelModuleId}),
+
+		IncrementalReconciliationTotalErrors: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_incremental_errors_total",
+			Disabled:   false,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "incremental_errors_total",
+			Help:       "Total number of errors encountered during incremental reconciliation",
+		}, []string{LabelModuleId}),
+
+		IncrementalReconciliationCurrentErrors: metric.NewGaugeVec(metric.GaugeOpts{
+			ConfigName: metrics.Namespace + "_reconciler_incremental_errors_current",
+			Disabled:   false,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "incremental_errors_current",
+			Help:       "The number of objects currently failing to be reconciled",
+		}, []string{LabelModuleId}),
+
+		FullReconciliationCount: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_full_total",
+			Disabled:   false,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "full_total",
+			Help:       "Number of full reconciliations performed",
+		}, []string{LabelModuleId}),
+
+		FullReconciliationOutOfSyncCount: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_full_out_of_sync_total",
+			Disabled:   false,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "full_out_of_sync_total",
+			Help:       "Number of times full reconciliation found objects to reconcile",
+		}, []string{LabelModuleId}),
+
+		FullReconciliationTotalErrors: metric.NewCounterVec(metric.CounterOpts{
+			ConfigName: metrics.Namespace + "_reconciler_full_errors_total",
+			Disabled:   false,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "full_errors_total",
+			Help:       "Total number of errors encountered during full reconciliation",
+		}, []string{LabelModuleId}),
+
+		FullReconciliationDuration: metric.NewHistogramVec(metric.HistogramOpts{
+			ConfigName: metrics.Namespace + "_reconciler_full_duration_seconds",
+			Disabled:   false,
+			Namespace:  metrics.Namespace,
+			Subsystem:  "reconciler",
+			Name:       "full_duration_seconds",
+			Help:       "Histogram over full reconciliation duration",
+		}, []string{LabelModuleId}),
+	}
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -1,0 +1,262 @@
+package reconciler
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cilium/cilium/pkg/backoff"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/statedb"
+)
+
+type params[Obj Reconcilable[Obj]] struct {
+	cell.In
+
+	Config      Config
+	Lifecycle   hive.Lifecycle
+	Log         logrus.FieldLogger
+	DB          *statedb.DB
+	Table       statedb.RWTable[Obj]
+	StatusIndex statedb.Index[Obj, StatusKind]
+	Target      Target[Obj]
+	Jobs        job.Registry
+	Metrics     *reconcilerMetrics
+	ModuleId    cell.ModuleId
+	Health      cell.HealthReporter
+}
+
+type reconciler[Obj Reconcilable[Obj]] struct {
+	params[Obj]
+
+	labels prometheus.Labels
+}
+
+func New[Obj Reconcilable[Obj]](p params[Obj]) Reconciler[Obj] {
+	r := &reconciler[Obj]{
+		params: p,
+		labels: prometheus.Labels{
+			LabelModuleId: string(p.ModuleId),
+		},
+	}
+
+	g := p.Jobs.NewGroup()
+	g.Add(job.OneShot("reconciler-loop", r.loop))
+	p.Lifecycle.Append(g)
+	return r
+}
+
+func (r *reconciler[Obj]) loop(ctx context.Context) error {
+	r.Log.Info("reconciler started")
+
+	fullReconTicker := time.NewTicker(r.Config.FullReconcilationInterval)
+	defer fullReconTicker.Stop()
+
+	backoff := backoff.Exponential{
+		Min: r.Config.RetryBackoffMinDuration,
+		Max: r.Config.RetryBackoffMaxDuration,
+	}
+	retryAttempt := 0
+	retryTimer, stopRetryTimer := inctimer.New()
+	defer stopRetryTimer()
+	var retryChan <-chan time.Time
+
+	scheduleRetry := func() {
+		retryAttempt++
+		t := backoff.Duration(retryAttempt)
+		retryChan = retryTimer.After(t)
+	}
+
+	tableWatchChan := closedWatchChannel()
+
+	revision := statedb.Revision(0)
+
+	fullReconciliation := false
+
+	for {
+
+		r.Log.Info("Waiting for trigger")
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-fullReconTicker.C:
+			fullReconciliation = true
+
+		case <-tableWatchChan:
+		case <-retryChan:
+		}
+
+		txn := r.DB.ReadTxn()
+
+		var err error
+
+		r.Log.Info("Incremental reconciliation")
+		revision, tableWatchChan, err = r.incremental(ctx, txn, revision)
+		if err != nil {
+			r.Log.WithError(err).Warn("Incremental reconcilation failed, retrying")
+			r.Health.Degraded("Incremental reconciliation failure", err)
+			scheduleRetry()
+			continue
+		}
+
+		if fullReconciliation {
+			r.Log.Info("Full reconciliation")
+
+			// Time to perform a full reconciliation. An incremental reconciliation
+			// has been performed prior to this, so the assumption is that everything
+			// is up to date (provided incremental reconciliation did not fail). We
+			// report full reconciliation disparencies as they're indicative of something
+			// interfering with Cilium operations.
+			var err error
+			revision, err = r.full(ctx, txn, revision)
+			if err != nil {
+				r.Log.WithError(err).Warn("Full reconciliation failed, retrying")
+				r.Health.Degraded("Full reconciliation failure", err)
+				scheduleRetry()
+				continue
+			}
+		}
+
+		// Clear retries after success.
+		retryChan = nil
+		retryAttempt = 0
+		stopRetryTimer()
+		fullReconciliation = false
+		r.Health.OK("Nominal")
+	}
+}
+
+func (r *reconciler[Obj]) incremental(
+	ctx context.Context,
+	txn statedb.ReadTxn,
+	lastRev statedb.Revision,
+) (statedb.Revision, <-chan struct{}, error) {
+	start := time.Now()
+
+	// In order to not lock the table while doing potentially expensive operations,
+	// we collect the reconciliation statuses for the objects and then commit them
+	// afterwards. If the object has changed in the meanwhile the status update for
+	// the old object is skipped.
+	type result struct {
+		rev    statedb.Revision
+		status Status
+	}
+	updateResults := make(map[Obj]result)
+	toBeDeleted := make(map[Obj]statedb.Revision)
+
+	// lastSuccessRev is the highest revision that was successfully reconciled
+	// without any failures prior to it. This revision will be used in the next
+	// reconciliation round.
+	lastSuccessRev := statedb.Revision(lastRev)
+	var errs []error
+
+	// Iterate in revision order through new, changed or failed objects.
+	iter, watch := r.Table.LowerBound(txn, statedb.ByRevision[Obj](lastRev+1))
+	for obj, rev, ok := iter.Next(); ok; obj, rev, ok = iter.Next() {
+		status := obj.GetStatus()
+
+		// Ignore objects that have already been marked as reconciled.
+		if status.Kind == StatusKindDone {
+			if len(errs) == 0 {
+				lastSuccessRev = rev
+			}
+			continue
+		}
+
+		var err error
+		if status.Delete {
+			err = r.Target.Delete(obj)
+			if err == nil {
+				toBeDeleted[obj] = rev
+			} else {
+				updateResults[obj] = result{rev, StatusError(true, err)}
+			}
+		} else {
+			err = r.Target.Update(obj)
+			if err == nil {
+				updateResults[obj] = result{rev, StatusDone()}
+			} else {
+				updateResults[obj] = result{rev, StatusError(false, err)}
+			}
+		}
+
+		if len(errs) == 0 && err == nil {
+			// Keep track of the last successfully processed revision so
+			// on retry we can skip everything that has already been
+			// processed.
+			lastSuccessRev = rev
+		} else if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	wtxn := r.DB.WriteTxn(r.Table)
+	defer wtxn.Commit()
+
+	// Commit status for updated objects.
+	for obj, result := range updateResults {
+		// Update the object if it is unchanged. It may happen that the object has
+		// been updated in the meanwhile, in which case we ignore the status as the
+		// update will be picked up by next reconciliation round.
+		r.Table.CompareAndSwap(wtxn, result.rev, obj.WithStatus(result.status))
+	}
+
+	// Delete the objects that had been successfully deleted from target.
+	// The object is only deleted if it has not been changed.
+	for obj, rev := range toBeDeleted {
+		r.Table.CompareAndDelete(wtxn, rev, obj)
+	}
+
+	r.Metrics.IncrementalReconciliationTotalErrors.With(r.labels).Add(float64(len(errs)))
+	r.Metrics.IncrementalReconciliationCurrentErrors.With(r.labels).Set(float64(len(errs)))
+	r.Metrics.IncrementalReconciliationCount.With(r.labels).Add(1)
+	r.Metrics.IncrementalReconciliationDuration.With(r.labels).Observe(
+		float64(time.Since(start)) / float64(time.Second),
+	)
+
+	r.Log.Infof("Incremental done (%d, %s)", lastSuccessRev, errs)
+
+	return lastSuccessRev, watch, errors.Join(errs...)
+}
+
+func (r *reconciler[Obj]) full(ctx context.Context, txn statedb.ReadTxn, lastRev statedb.Revision) (statedb.Revision, error) {
+	start := time.Now()
+
+	defer r.Metrics.FullReconciliationCount.With(r.labels).Add(1)
+
+	iter, _ := r.Table.All(txn)
+
+	outOfSync, err := r.Target.Sync(iter)
+
+	r.Metrics.FullReconciliationDuration.With(r.labels).Observe(
+		float64(time.Since(start)) / float64(time.Second),
+	)
+
+	if err != nil {
+		r.Metrics.FullReconciliationTotalErrors.With(r.labels).Add(1)
+		// Sync failed, assume no changes and keep at the last revision.
+		return lastRev, err
+	}
+
+	if outOfSync {
+		r.Metrics.FullReconciliationOutOfSyncCount.With(r.labels).Add(1)
+	}
+
+	// Sync succeeded up to latest revision. Continue incremental reconciliation from
+	// this revision.
+	return r.Table.Revision(txn), nil
+}
+
+func closedWatchChannel() <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
+}

--- a/pkg/reconciler/types.go
+++ b/pkg/reconciler/types.go
@@ -1,0 +1,110 @@
+package reconciler
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/statedb"
+)
+
+type Config struct {
+	FullReconcilationInterval time.Duration
+	RetryBackoffMinDuration   time.Duration
+	RetryBackoffMaxDuration   time.Duration
+}
+
+var DefaultConfig = Config{
+	FullReconcilationInterval: 5 * time.Minute,
+	RetryBackoffMinDuration:   50 * time.Millisecond,
+	RetryBackoffMaxDuration:   time.Minute,
+}
+
+// Reconcilable objects are Go types that carry a reconciliation status.
+// The generic reconciler uses WithStatus() to update the status of each
+// reconciled object. This status can then be used to implement waiting.
+type Reconcilable[Obj comparable] interface {
+	comparable
+
+	GetStatus() Status
+
+	// WithStatus returns a clone of the object with the specified
+	// status.
+	WithStatus(Status) Obj
+}
+
+// Target captures the effectful operations for reconciling
+// an object.
+type Target[Obj Reconcilable[Obj]] interface {
+	Update(Obj) error
+	Delete(Obj) error
+
+	// Sync performs full reconciliation.
+	// As full reconciliation is performed after incremental reconciliation,
+	// we do not expect this to actually do anything. If there is something
+	// to be reconciled the 'outOfSync' is returned as true. If these
+	// operations failed, then 'err' is also non-nil and this will be retried
+	// (after backoff).
+	Sync(statedb.Iterator[Obj]) (outOfSync bool, err error)
+}
+
+type Reconciler[Obj Reconcilable[Obj]] interface {
+	// TODO
+}
+
+type StatusKind string
+
+const (
+	StatusKindPending StatusKind = "pending"
+	StatusKindDone    StatusKind = "done"
+	StatusKindError   StatusKind = "error"
+)
+
+// Status is embedded into the reconcilable object. It allows
+// inspecting per-object reconcilation status and waiting for
+// the reconciler.
+type Status struct {
+	Kind StatusKind
+
+	// Delete is true if the object should be deleted by the reconciler.
+	// If an object is deleted outside the reconciler it will not be
+	// processed by the incremental reconciliation.
+	// We use soft deletes in order to observe and wait for deletions.
+	Delete bool
+
+	UpdatedAt time.Time
+	Error     error
+}
+
+func StatusPending() Status {
+	return Status{
+		Kind:      StatusKindPending,
+		UpdatedAt: time.Now(),
+		Delete:    false,
+		Error:     nil,
+	}
+}
+
+func StatusPendingDelete() Status {
+	return Status{
+		Kind:      StatusKindPending,
+		UpdatedAt: time.Now(),
+		Delete:    true,
+		Error:     nil,
+	}
+}
+
+func StatusDone() Status {
+	return Status{
+		Kind:      StatusKindDone,
+		UpdatedAt: time.Now(),
+		Error:     nil,
+	}
+}
+
+func StatusError(delete bool, err error) Status {
+	return Status{
+		Kind:      StatusKindError,
+		UpdatedAt: time.Now(),
+		Delete:    delete,
+		Error:     err,
+	}
+}

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/maps/recorder"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/reconciler/example/reconcilers"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
 
@@ -218,7 +219,7 @@ func (r *Recorder) orderedMaskSets() ([]*RecMask, []*RecMask) {
 
 func (r *Recorder) triggerDatapathRegenerate() error {
 	var masks4, masks6 string
-	l := loader.NewLoader()
+	l := loader.NewLoader(reconcilers.Routes{}) // FIXME this is broken
 	extraCArgs := []string{}
 	if len(r.recMask) == 0 {
 		extraCArgs = append(extraCArgs, "-Dcapture_enabled=0")

--- a/pkg/statedb/cell.go
+++ b/pkg/statedb/cell.go
@@ -42,8 +42,9 @@ func newHiveDB(lc hive.Lifecycle, tablesIn tablesIn) (*DB, error) {
 
 type tableOut[Obj any] struct {
 	cell.Out
-	Table Table[Obj]
-	Meta  TableMeta `group:"statedb-tables"`
+	Reader Table[Obj]
+	Writer RWTable[Obj]
+	Meta   TableMeta `group:"statedb-tables"`
 }
 
 // NewTableCell creates a cell for creating and registering a statedb Table[Obj].
@@ -53,10 +54,44 @@ func NewTableCell[Obj any](
 	secondaryIndexers ...Indexer[Obj],
 ) cell.Cell {
 	return cell.Provide(func() (tableOut[Obj], error) {
-		if table, err := NewTable(tableName, primaryIndexer, secondaryIndexers...); err != nil {
+		if writer, err := NewTable(tableName, primaryIndexer, secondaryIndexers...); err != nil {
 			return tableOut[Obj]{}, err
 		} else {
-			return tableOut[Obj]{Table: table, Meta: table}, nil
+			return tableOut[Obj]{
+				Reader: writer, // RWTable[Obj] is superset of Table[Obj]
+				Writer: writer,
+				Meta:   writer}, nil
 		}
 	})
+}
+
+type tableOutProtected[Obj any] struct {
+	cell.Out
+	Reader Table[Obj]
+	Meta   TableMeta `group:"statedb-tables"`
+}
+
+// NewProtectedTableCell creates a cell for creating and registering a statedb Table[Obj]. The
+// provided RWTable[Obj] is scoped to the module and thus prevents the table from being
+// directly modified outside this module.
+func NewProtectedTableCell[Obj any](
+	tableName TableName,
+	primaryIndexer Indexer[Obj],
+	secondaryIndexers ...Indexer[Obj],
+) cell.Cell {
+	rwtable, err := NewTable(tableName, primaryIndexer, secondaryIndexers...)
+	return cell.Group(
+		// Derive Table[Obj] and TableMeta from RWTable[Obj] (they're a subset of it)
+		cell.Provide(func() (tableOutProtected[Obj], error) {
+			if err != nil {
+				return tableOutProtected[Obj]{}, err
+			}
+			return tableOutProtected[Obj]{Reader: rwtable, Meta: rwtable}, nil
+		}),
+
+		// Provide RWTable[Obj] only in the module's scope.
+		cell.ProvidePrivate(func() (RWTable[Obj], error) {
+			return rwtable, err
+		}),
+	)
 }

--- a/pkg/statedb/errors.go
+++ b/pkg/statedb/errors.go
@@ -31,6 +31,16 @@ var (
 	// table that was not locked for writing, e.g. target table not given as argument to
 	// WriteTxn().
 	ErrTableNotLockedForWriting = errors.New("not locked for writing")
+
+	// ErrRevisionNotEqual indicates that the CompareAndSwap or CompareAndDelete failed due to
+	// the object having a mismatching revision, e.g. it had been changed since the object
+	// was last read.
+	ErrRevisionNotEqual = errors.New("revision not equal")
+
+	// ErrObjectNotFound indicates that the object was not found when the operation required
+	// it to exists. This error is not returned by Insert or Delete, but may be returned by
+	// CompareAndSwap or CompareAndDelete.
+	ErrObjectNotFound = errors.New("object not found")
 )
 
 // tableError wraps an error with the table name.

--- a/pkg/statedb/example/control.go
+++ b/pkg/statedb/example/control.go
@@ -28,7 +28,7 @@ var controlCell = cell.Module(
 type controlParams struct {
 	cell.In
 
-	Backends  statedb.Table[Backend]
+	Backends  statedb.RWTable[Backend]
 	DB        *statedb.DB
 	Lifecycle hive.Lifecycle
 	Log       logrus.FieldLogger

--- a/pkg/statedb/example/reconcile.go
+++ b/pkg/statedb/example/reconcile.go
@@ -29,7 +29,7 @@ var reconcilerCell = cell.Module(
 type reconcilerParams struct {
 	cell.In
 
-	Backends  statedb.Table[Backend]
+	Backends  statedb.RWTable[Backend]
 	DB        *statedb.DB
 	Lifecycle hive.Lifecycle
 	Log       logrus.FieldLogger

--- a/pkg/statedb/fuzz_test.go
+++ b/pkg/statedb/fuzz_test.go
@@ -154,9 +154,9 @@ type actionLogEntry struct {
 	value uint64
 }
 
-type action func(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, target statedb.Table[fuzzObj])
+type action func(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, target statedb.RWTable[fuzzObj])
 
-func insertAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func insertAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	value := rand.Uint64()
 	log.log("%s: Insert %d", table.Name(), id)
@@ -164,43 +164,43 @@ func insertAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, tabl
 	actLog.append(actionLogEntry{table, actInsert, id, value})
 }
 
-func deleteAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func deleteAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	log.log("%s: Delete %d", table.Name(), id)
 	table.Delete(txn, fuzzObj{id, 0})
 	actLog.append(actionLogEntry{table, actDelete, id, 0})
 }
 
-func deleteAllAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func deleteAllAction(log *debugLogger, actLog actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	log.log("%s: DeleteAll", table.Name())
 	table.DeleteAll(txn)
 	actLog.append(actionLogEntry{table, actDeleteAll, 0, 0})
 }
 
-func allAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func allAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	iter, _ := table.All(txn)
 	log.log("%s: All => %d found", table.Name(), len(statedb.Collect(iter)))
 }
 
-func getAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func getAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	iter, _ := table.Get(txn, idIndex.Query(mkID()))
 	log.log("%s: Get(%d) => %d found", table.Name(), id, len(statedb.Collect(iter)))
 }
 
-func firstAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func firstAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	_, rev, ok := table.First(txn, idIndex.Query(id))
 	log.log("%s: First(%d) => rev=%d, ok=%v", table.Name(), id, rev, ok)
 }
 
-func lastAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func lastAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	_, rev, ok := table.First(txn, idIndex.Query(id))
 	log.log("%s: First(%d) => rev=%d, ok=%v", table.Name(), id, rev, ok)
 }
 
-func lowerboundAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.Table[fuzzObj]) {
+func lowerboundAction(log *debugLogger, _ actionLog, txn statedb.WriteTxn, table statedb.RWTable[fuzzObj]) {
 	id := mkID()
 	iter, _ := table.LowerBound(txn, idIndex.Query(id))
 	log.log("%s: LowerBound(%d) => %d found", table.Name(), id, len(statedb.Collect(iter)))
@@ -254,7 +254,7 @@ func fuzzWorker(realActionLog *realActionLog, worker int, iterations int) {
 
 		for _, target := range targets {
 			act := randomAction()
-			act(log, actLog, txn, target.(statedb.Table[fuzzObj]))
+			act(log, actLog, txn, target.(statedb.RWTable[fuzzObj]))
 			runtime.Gosched()
 		}
 		runtime.Gosched()

--- a/pkg/statedb/table.go
+++ b/pkg/statedb/table.go
@@ -17,7 +17,7 @@ func NewTable[Obj any](
 	tableName TableName,
 	primaryIndexer Indexer[Obj],
 	secondaryIndexers ...Indexer[Obj],
-) (Table[Obj], error) {
+) (RWTable[Obj], error) {
 	toAnyIndexer := func(idx Indexer[Obj]) anyIndexer {
 		return anyIndexer{
 			name: idx.indexName(),
@@ -212,3 +212,4 @@ func (t *genTable[Obj]) sortableMutex() lock.SortableMutex {
 }
 
 var _ Table[bool] = &genTable[bool]{}
+var _ RWTable[bool] = &genTable[bool]{}

--- a/pkg/statedb/txn.go
+++ b/pkg/statedb/txn.go
@@ -123,25 +123,20 @@ func (txn *txn) indexWriteTxn(name TableName, index IndexName) *iradix.Txn[objec
 	return indexTreeTxn
 }
 
-func (txn *txn) newRevision(tableName TableName) (Revision, error) {
-	table, ok := txn.modifiedTables[tableName]
-	if !ok {
-		return 0, tableError(tableName, ErrTableNotLockedForWriting)
-	}
-	table.revision++
-	return table.revision, nil
-}
-
-func (txn *txn) Insert(meta TableMeta, data any) (any, bool, error) {
+func (txn *txn) Insert(meta TableMeta, guardRevision Revision, data any) (any, bool, error) {
 	if txn.rootReadTxn == nil {
 		return nil, false, ErrTransactionClosed
 	}
 
+	// Look up table and allocate a new revision.
 	tableName := meta.Name()
-	revision, err := txn.newRevision(tableName)
-	if err != nil {
-		return nil, false, err
+	table, ok := txn.modifiedTables[tableName]
+	if !ok {
+		return nil, false, tableError(tableName, ErrTableNotLockedForWriting)
 	}
+	oldRevision := table.revision
+	table.revision++
+	revision := table.revision
 
 	obj := object{
 		revision: revision,
@@ -152,6 +147,25 @@ func (txn *txn) Insert(meta TableMeta, data any) (any, bool, error) {
 	idKey := meta.primaryIndexer().fromObject(obj).First()
 	idIndexTree := txn.indexWriteTxn(tableName, meta.primaryIndexer().name)
 	oldObj, oldExists := idIndexTree.Insert(idKey, obj)
+
+	// For CompareAndSwap() validate against the given guard revision
+	if guardRevision > 0 {
+		if !oldExists {
+			// CompareAndSwap requires the object to exist. Revert
+			// the insert.
+			idIndexTree.Delete(idKey)
+			table.revision = oldRevision
+			return nil, false, ErrObjectNotFound
+		}
+		if oldObj.revision != guardRevision {
+			// Revert the change. We're assuming here that it's rarer for CompareAndSwap() to
+			// fail and thus we're optimizing to have only one lookup in the common case
+			// (versus doing a Get() and then Insert()).
+			idIndexTree.Insert(idKey, oldObj)
+			table.revision = oldRevision
+			return oldObj, true, ErrRevisionNotEqual
+		}
+	}
 
 	// Update revision index
 	revIndexTree := txn.indexWriteTxn(tableName, RevisionIndex)
@@ -235,16 +249,20 @@ func (txn *txn) addDeleteTracker(meta TableMeta, trackerName string, dt deleteTr
 
 }
 
-func (txn *txn) Delete(meta TableMeta, data any) (any, bool, error) {
+func (txn *txn) Delete(meta TableMeta, guardRevision Revision, data any) (any, bool, error) {
 	if txn.rootReadTxn == nil {
 		return nil, false, ErrTransactionClosed
 	}
 
+	// Look up table and allocate a new revision.
 	tableName := meta.Name()
-	revision, err := txn.newRevision(tableName)
-	if err != nil {
-		return nil, false, err
+	table, ok := txn.modifiedTables[tableName]
+	if !ok {
+		return nil, false, tableError(tableName, ErrTableNotLockedForWriting)
 	}
+	oldRevision := table.revision
+	table.revision++
+	revision := table.revision
 
 	// Delete from the primary index first to grab the object.
 	// We assume that "data" has only enough defined fields to
@@ -253,7 +271,17 @@ func (txn *txn) Delete(meta TableMeta, data any) (any, bool, error) {
 	idIndexTree := txn.indexWriteTxn(tableName, meta.primaryIndexer().name)
 	obj, existed := idIndexTree.Delete(idKey)
 	if !existed {
-		return nil, false, nil
+		return nil, false, ErrObjectNotFound
+	}
+
+	// For CompareAndDelete() validate against guard revision and if there's a mismatch,
+	// revert the change.
+	if guardRevision > 0 {
+		if obj.revision != guardRevision {
+			idIndexTree.Insert(idKey, obj)
+			table.revision = oldRevision
+			return obj, true, ErrRevisionNotEqual
+		}
 	}
 
 	// Update revision index.


### PR DESCRIPTION
Builds on top of https://github.com/cilium/cilium/pull/28140.

This implements a "generic reconciler" which takes the desired state as a StateDB table
and a "reconciliation target" that defines the reconciliation operations. It performs 
fast incremental reconciliation of changes and periodic full reconciliation. Metrics
and health reporting are included.

`pkg/reconciler/example` has some rough early examples for sysctl and iptables. 

By wrapping the reconciliation into a reusable generic utility we gain:
- Single well-tested implementation for mission critical code
- Uniform metrics, health and status reporting
- Significant reduction in code duplication
- The "concept" of reconciler that can be understood and inspected from outside

Summary of the API:
```
package reconciler

// Reconcilable objects carry status
type Reconcilable[Obj comparable] interface {
  comparable
  GetStatus() Status
  WithStatus(Status) Obj
}

// Reconciliation target defines the operations for reconciling a single
// object.
type Target[Obj Reconcilable[Obj]] interface {
  Init(context.Context) error
  Update(context.Context, Obj) error
  Delete(context.Context, Obj) error
  Sync(context.Context, statedb.Iterator[Obj]) (outOfSync bool, err error)
}

type params[Obj Reconcilable[Obj]] struct {
  cell.In

  // ... other dependencies ...

  // Dependencies that parametrize the reconciler for the concrete
  // use case:
  Config
  Target Target[Obj]
  StatusIndex statedb.Index[Obj, StatusKind]
}

// Register creates a reconciler and adds it to the application lifecycle.
// "cell.Invoke(reconciler.Register[MyObject])".
func Register[Obj Reconcilable[Obj]](p params[Obj]) { ... }
  
```

Usage:
```
package example

// Define the object that presents the desired state.
type MyObject struct { ... }
func (m *MyObject) GetStatus() reconciler.Status { ... }
func (m *MyObject) WithStatus(s reconciler.Status) *MyObject { /* copy and set status */ }
var statusIndex = reconciler.NewStatusIndex[*MyObject]()
var idIndex = statedb.Index[*MyObject, UUID]{...}

// Define a safe API for managing the desired state. Alternatively if it's obvious
// the RWTable[*MyObject] could be directly exposed.
// (TODO: Not sure at all if we want to call these sort of things managers)
type MyObjectManager struct {...}
func (m *MyObjectManager) Set(...) error {}
func (m *MyObjectManager) Get(...) error {}
func (m *MyObjectManager) Wait(context.Context) error { 
  // see example/sysctl.go for how we can wait for reconciliation.
}
func newMyObjectManager(db *statedb.DB, table statedb.RWTable[*MyObject) *MyObjectManager { ... }

var Cell = cell.Module(
  "my-module", 
  "There are many like it, but this one is mine",

  // Create the table for the desired state. Keep write access protected to this module.
  statedb.NewProtectedTableCell[*MyObject]("my-objects", idIndex, statusIndex),

  // Provide a public API for managing the desired state to the rest of the application.
  cell.Provide(newMyObjectManager),

  // Provide the reconciler dependencies, but scoped to just this module.
  cell.ProvidePrivate(
    func() reconciler.Target[*MyObject] { return &myObjectTarget{} },
    func() reconciler.Config { ...},
    func() statedb.Index[*MyObject, reconciler.StatusKind] { return statusIndex },
  ),

  // Create and register the reconciler to the application lifecycle. 
  cell.Invoke(reconciler.Register[*MyObject]),
)

type myObjectTarget struct { ... }
func (r *myObjectTarget) Init(context.Context) error { ... }
func (r *myObjectTarget) Update(context.Context, Obj) error { ... }
func (r *myObjectTarget) Delete(context.Context, Obj) error { ... }
func (r *myObjectTarget) Sync(context.Context, statedb.Iterator[Obj]) (outOfSync bool, err error) { .. }
```

Health reporting:
```
Status{ModuleID: iptables, Level: Degraded, Since: 3.000499163s ago, Message: Incremental reconciliation failure, Err: oops iptables error}
```

Metrics: 
```
# HELP cilium_reconciler_full_duration_seconds Histogram over full reconciliation duration
# TYPE cilium_reconciler_full_duration_seconds histogram
cilium_reconciler_full_duration_seconds_bucket{module_id="sysctl",le="0.005"} 1
# ...
cilium_reconciler_full_duration_seconds_sum{module_id="sysctl"} 6.0364e-05
cilium_reconciler_full_duration_seconds_count{module_id="sysctl"} 1
# HELP cilium_reconciler_full_total Number of full reconciliations performed
# TYPE cilium_reconciler_full_total counter
cilium_reconciler_full_total{module_id="sysctl"} 1
# HELP cilium_reconciler_incremental_duration_seconds Histogram of per-operation duration during incremental reconciliation
# TYPE cilium_reconciler_incremental_duration_seconds histogram
cilium_reconciler_incremental_duration_seconds_bucket{module_id="iptables",le="0.005"} 4
# ...
cilium_reconciler_incremental_duration_seconds_sum{module_id="iptables"} 9.6464e-05
cilium_reconciler_incremental_duration_seconds_count{module_id="iptables"} 4
cilium_reconciler_incremental_duration_seconds_bucket{module_id="sysctl",le="0.005"} 14
# ...
cilium_reconciler_incremental_duration_seconds_sum{module_id="sysctl"} 0.0009456850000000001
cilium_reconciler_incremental_duration_seconds_count{module_id="sysctl"} 14
# HELP cilium_reconciler_incremental_errors_current The number of objects currently failing to be reconciled
# TYPE cilium_reconciler_incremental_errors_current gauge
cilium_reconciler_incremental_errors_current{module_id="iptables"} 1
cilium_reconciler_incremental_errors_current{module_id="sysctl"} 0
# HELP cilium_reconciler_incremental_errors_total Total number of errors encountered during incremental reconciliation
# TYPE cilium_reconciler_incremental_errors_total counter
cilium_reconciler_incremental_errors_total{module_id="iptables"} 4
cilium_reconciler_incremental_errors_total{module_id="sysctl"} 4
# HELP cilium_reconciler_incremental_total Number of incremental reconciliations performed
# TYPE cilium_reconciler_incremental_total counter
cilium_reconciler_incremental_total{module_id="iptables"} 4
cilium_reconciler_incremental_total{module_id="sysctl"} 15
```