### PR TITLE
bpf: egressgw: allow to override external API

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1077,7 +1077,7 @@ ct_recreate4:
 		if (identity_is_cluster(*dst_sec_identity))
 			goto skip_egress_gateway;
 
-		if (egress_gw_request_needs_redirect(tuple, ct_status, &tunnel_endpoint)) {
+		if (egress_gw_request_needs_redirect_hook(tuple, ct_status, &tunnel_endpoint)) {
 			if (tunnel_endpoint == EGRESS_GATEWAY_NO_GATEWAY) {
 				/* Special case for no gateway to drop the traffic */
 				return DROP_NO_EGRESS_GATEWAY;

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -137,5 +137,25 @@ bool egress_gw_reply_needs_redirect(struct iphdr *ip4 __maybe_unused,
 #endif /* ENABLE_EGRESS_GATEWAY */
 }
 
+static __always_inline
+bool egress_gw_request_needs_redirect_hook(struct ipv4_ct_tuple *rtuple, int ct_status,
+					   __u32 *tunnel_endpoint)
+{
+	return egress_gw_request_needs_redirect(rtuple, ct_status, tunnel_endpoint);
+}
+
+static __always_inline
+bool egress_gw_snat_needed_hook(__be32 saddr, __be32 daddr, __be32 *snat_addr)
+{
+	return egress_gw_snat_needed(saddr, daddr, snat_addr);
+}
+
+static __always_inline
+bool egress_gw_reply_needs_redirect_hook(struct iphdr *ip4, __u32 *tunnel_endpoint,
+					 __u32 *dst_sec_identity)
+{
+	return egress_gw_reply_needs_redirect(ip4, tunnel_endpoint, dst_sec_identity);
+}
+
 #endif /* ENABLE_EGRESS_GATEWAY_COMMON */
 #endif /* __LIB_EGRESS_GATEWAY_H_ */

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -695,7 +695,7 @@ snat_v4_needs_masquerade(struct __ctx_buff *ctx __maybe_unused,
 	if (is_reply)
 		goto skip_egress_gateway;
 
-	if (egress_gw_snat_needed(tuple->saddr, tuple->daddr, &target->addr)) {
+	if (egress_gw_snat_needed_hook(tuple->saddr, tuple->daddr, &target->addr)) {
 		target->egress_gateway = true;
 		/* If the endpoint is local, then the connection is already tracked. */
 		if (!local_ep)

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2399,7 +2399,7 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 	 * any reply traffic for a remote pod into the tunnel (to avoid iptables
 	 * potentially dropping the packets).
 	 */
-	if (egress_gw_reply_needs_redirect(ip4, &tunnel_endpoint, &dst_sec_identity)) {
+	if (egress_gw_reply_needs_redirect_hook(ip4, &tunnel_endpoint, &dst_sec_identity)) {
 		trace->reason = TRACE_REASON_CT_REPLY;
 		goto redirect;
 	}


### PR DESCRIPTION
replace all egress_gw_foo function calls in bpf_lxc.c, lib/nodeport.h and lib/nat.h with egress_gw_foo_hook, and then point these new hooks to the existing functions to allow overriding the egressgw external API, making it easier to extend the codebase with alternative implementations.