### PR TITLE
pkg/pprof: add CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -476,6 +476,7 @@ Makefile* @cilium/build
 /pkg/policy @cilium/sig-policy
 /pkg/policy/api/ @cilium/api
 /pkg/policy/groups/aws/ @cilium/sig-policy @cilium/aws
+/pkg/pprof @cilium/sig-foundations
 /pkg/promise @cilium/sig-foundations
 /pkg/proxy/ @cilium/proxy
 /pkg/proxy/accesslog @cilium/api


### PR DESCRIPTION
The package is currently owned by tophat. Let's give it to the last team that touched it.