### PR TITLE
[v1.13] cocci: fix warnings related to const qualifiers and DROP_MISSED_TAIL_CALL 

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -71,6 +71,12 @@ jobs:
         uses: docker://cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
+        # Note: Setting COCCINELLE_HOME can be removed, here and in the
+        # messages in the .cocci files, next time we upgrade coccinelle.
+        # The issue was fixed, after v1.1.1 that we're using, in
+        # https://gitlab.inria.fr/coccinelle/coccinelle/-/commit/540888ff426e.
+        env:
+          COCCINELLE_HOME: /usr/local/lib/coccinelle
 
   set_clang_dir:
     name: Set clang directory

--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1131,7 +1131,7 @@ static __always_inline int lb4_rev_nat(struct __ctx_buff *ctx, int l3_off, int l
 }
 
 static __always_inline void
-lb4_fill_key(struct lb4_key *key, struct ipv4_ct_tuple *tuple)
+lb4_fill_key(struct lb4_key *key, const struct ipv4_ct_tuple *tuple)
 {
 	/* FIXME: set after adding support for different L4 protocols in LB */
 	key->proto = 0;

--- a/bpf/lib/nat.h
+++ b/bpf/lib/nat.h
@@ -552,7 +552,8 @@ snat_v4_rev_nat_can_skip(const struct ipv4_nat_target *target, const struct ipv4
  * - on CT_NEW (ie. the tuple is reversed)
  */
 static __always_inline __maybe_unused int
-snat_v4_create_dsr(struct ipv4_ct_tuple *tuple, __be32 to_saddr, __be16 to_sport,
+snat_v4_create_dsr(const struct ipv4_ct_tuple *tuple, __be32 to_saddr,
+		   __be16 to_sport,
 		   __s8 *ext_err)
 {
 	struct ipv4_ct_tuple tmp = *tuple;
@@ -1321,7 +1322,7 @@ snat_v6_rev_nat_can_skip(const struct ipv6_nat_target *target, const struct ipv6
 }
 
 static __always_inline __maybe_unused int
-snat_v6_create_dsr(struct ipv6_ct_tuple *tuple, union v6addr *to_saddr,
+snat_v6_create_dsr(const struct ipv6_ct_tuple *tuple, union v6addr *to_saddr,
 		   __be16 to_sport, __s8 *ext_err)
 {
 	struct ipv6_ct_tuple tmp = *tuple;

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -1028,7 +1028,7 @@ skip_service_lookup:
 			if (dsr) {
 				ctx_store_meta(ctx, CB_SRC_LABEL, src_identity);
 				ep_tail_call(ctx, CILIUM_CALL_IPV6_NODEPORT_DSR_INGRESS);
-				ret = DROP_MISSED_TAIL_CALL;
+				return DROP_MISSED_TAIL_CALL;
 			}
 
 			if (IS_ERR(ret))
@@ -2262,7 +2262,7 @@ skip_service_lookup:
 			if (dsr) {
 				ctx_store_meta(ctx, CB_SRC_LABEL, src_identity);
 				ep_tail_call(ctx, CILIUM_CALL_IPV4_NODEPORT_DSR_INGRESS);
-				ret = DROP_MISSED_TAIL_CALL;
+				return DROP_MISSED_TAIL_CALL;
 			}
 
 			if (IS_ERR(ret))

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -334,7 +334,7 @@ static __always_inline int find_dsr_v6(struct __ctx_buff *ctx, __u8 nexthdr,
 
 static __always_inline int
 nodeport_extract_dsr_v6(struct __ctx_buff *ctx, struct ipv6hdr *ip6,
-			struct ipv6_ct_tuple *tuple, int l4_off,
+			const struct ipv6_ct_tuple *tuple, int l4_off,
 			union v6addr *addr, __be16 *port, bool *dsr)
 {
 	struct dsr_opt_v6 opt __align_stack_8 = {};
@@ -1611,8 +1611,9 @@ static __always_inline int dsr_set_opt4(struct __ctx_buff *ctx,
 #endif /* DSR_ENCAP_MODE */
 
 static __always_inline int
-nodeport_extract_dsr_v4(struct __ctx_buff *ctx, struct iphdr *ip4,
-			struct ipv4_ct_tuple *tuple, int l4_off, __be32 *addr,
+nodeport_extract_dsr_v4(struct __ctx_buff *ctx, const struct iphdr *ip4,
+			const struct ipv4_ct_tuple *tuple, int l4_off,
+			__be32 *addr,
 			__be16 *port, bool *dsr)
 {
 	struct ipv4_ct_tuple tmp = *tuple;

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -158,7 +158,7 @@ static __always_inline void ctx_snat_done_set(struct __sk_buff *ctx)
 	ctx->mark |= MARK_MAGIC_SNAT_DONE;
 }
 
-static __always_inline bool ctx_snat_done(struct __sk_buff *ctx)
+static __always_inline bool ctx_snat_done(const struct __sk_buff *ctx)
 {
 	return (ctx->mark & MARK_MAGIC_SNAT_DONE) == MARK_MAGIC_SNAT_DONE;
 }

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -107,7 +107,7 @@ combine_ports(__u16 dport, __u16 sport)
  * ingress. Will modify 'tuple'!						\
  */										\
 static __always_inline int							\
-NAME(struct __ctx_buff *ctx, CT_TUPLE_TYPE * ct_tuple, __be16 proxy_port)	\
+NAME(struct __ctx_buff *ctx, const CT_TUPLE_TYPE * ct_tuple, __be16 proxy_port)	\
 {										\
 	struct bpf_sock_tuple *tuple = (struct bpf_sock_tuple *)ct_tuple;	\
 	__u8 nexthdr = ct_tuple->nexthdr;					\

--- a/bpf/tests/tc_nodeport_test.c
+++ b/bpf/tests/tc_nodeport_test.c
@@ -527,7 +527,7 @@ int tc_drop_no_backend_setup(struct __ctx_buff *ctx)
 }
 
 CHECK("tc", "tc_drop_no_backend")
-int tc_drop_no_backend_check(struct __ctx_buff *ctx)
+int tc_drop_no_backend_check(const struct __ctx_buff *ctx)
 {
 	__u32 expected_status = TC_ACT_SHOT;
 	__u32 *status_code;

--- a/bpf/tests/wildcard_lookup.c
+++ b/bpf/tests/wildcard_lookup.c
@@ -274,7 +274,7 @@ int test_v4_check(__maybe_unused struct xdp_md *ctx)
 	test_finish();
 }
 
-static inline void __setup_v6_ipcache(union v6addr *HOST_IP6)
+static inline void __setup_v6_ipcache(const union v6addr *HOST_IP6)
 {
 	struct remote_endpoint_info cache_value = {};
 	struct ipcache_key cache_key = {};

--- a/contrib/coccinelle/aligned.cocci
+++ b/contrib/coccinelle/aligned.cocci
@@ -63,7 +63,9 @@ cnt += 1
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                  \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a spatch --sp-file contrib/coccinelle/aligned.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/aligned.cocci\n
 """)

--- a/contrib/coccinelle/const.cocci
+++ b/contrib/coccinelle/const.cocci
@@ -64,7 +64,9 @@ cnt += 1
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a spatch --sp-file contrib/coccinelle/const.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/const.cocci\n
 """)

--- a/contrib/coccinelle/identity_is_node.cocci
+++ b/contrib/coccinelle/identity_is_node.cocci
@@ -60,7 +60,9 @@ if len(p2) > 0:
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                           \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a spatch --sp-file contrib/coccinelle/identity_is_node.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/identity_is_node.cocci\n
 """)

--- a/contrib/coccinelle/tail_calls.cocci
+++ b/contrib/coccinelle/tail_calls.cocci
@@ -109,5 +109,8 @@ cnt += 1
 if cnt > 0:
   print("""Unlogged tail calls found. Please fix and use the following command to check:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a make -C bpf coccicheck\n
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/tail_calls.cocci\n
 """)

--- a/contrib/coccinelle/zero_trace_reason.cocci
+++ b/contrib/coccinelle/zero_trace_reason.cocci
@@ -84,7 +84,9 @@ cnt += 1
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                           \\
-    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a spatch --sp-file contrib/coccinelle/zero_trace_reason.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/zero_trace_reason.cocci\n
 """)


### PR DESCRIPTION
The coccicheck has been silently failing for a while [1], and the CI was recently fixed for the v1.13 branch bumping the related docker image in 100b5807ec94c544126f8db674c94843b7c91a0d. Yet, the given check was not run in that PR (fixed by https://github.com/cilium/cilium/pull/28122, currently being backported), hence the warnings are only popping up in newer PRs. Hence, let's fix them.

\[1\]: 0dad1577d314 ("cocci: Fix Python path for coccilib")

<!-- Description of change -->

```release-note
cocci: fix warnings related to const qualifiers and DROP_MISSED_TAIL_CALL 
```
