### PR TITLE
docs: Remove the duplicated envoy resource list

### DIFF
--- a/Documentation/network/servicemesh/l7-traffic-management.rst
+++ b/Documentation/network/servicemesh/l7-traffic-management.rst
@@ -65,46 +65,8 @@ To see which Envoy extensions are available, please have a look at
 the `Envoy extensions configuration
 file <https://github.com/cilium/proxy/blob/main/envoy_build_config/extensions_build_config.bzl>`_.
 Only the extensions that have not been commented out with ``#`` are
-built in to the Cilium Envoy image. Currently this contains the
-following extensions:
-
-- ``envoy.access_loggers.file``
-- ``envoy.access_loggers.extension_filters.cel``
-- ``envoy.access_loggers.http_grpc``
-- ``envoy.access_loggers.tcp_grpc``
-- ``envoy.access_loggers.open_telemetry``
-- ``envoy.access_loggers.stdout``
-- ``envoy.access_loggers.stderr``
-- ``envoy.access_loggers.wasm``
-- ``envoy.clusters.dynamic_forward_proxy``
-- ``envoy.filters.http.dynamic_forward_proxy``
-- ``envoy.filters.http.ext_authz``
-- ``envoy.filters.http.jwt_authn``
-- ``envoy.filters.http.local_ratelimit``
-- ``envoy.filters.http.grpc_stats``
-- ``envoy.filters.http.grpc_web``
-- ``envoy.filters.http.oauth2``
-- ``envoy.filters.http.ratelimit``
-- ``envoy.filters.http.router``
-- ``envoy.filters.http.set_metadata``
-- ``envoy.filters.listener.tls_inspector``
-- ``envoy.filters.network.connection_limit``
-- ``envoy.filters.network.ext_authz``
-- ``envoy.filters.network.http_connection_manager``
-- ``envoy.filters.network.local_ratelimit``
-- ``envoy.filters.network.mongo_proxy``
-- ``envoy.filters.network.mysql_proxy``
-- ``envoy.filters.network.ratelimit``
-- ``envoy.filters.network.tcp_proxy``
-- ``envoy.filters.network.sni_cluster``
-- ``envoy.filters.network.sni_dynamic_forward_proxy``
-- ``envoy.stat_sinks.metrics_service``
-- ``envoy.transport_sockets.raw_buffer``
-- ``envoy.upstreams.http.http``
-- ``envoy.upstreams.http.tcp``
-
-We will evolve the list of built-in extensions based on user
-feedback.
+built in to the Cilium Envoy image. We will evolve the list of built-in
+extensions based on user feedback.
 
 Examples
 ########


### PR DESCRIPTION
This is to reduce the maintenance effort as we are already referencing to cilium/proxy repo.

Suggested-by: Anna Kapuscinska <anna@isovalent.com>
