### PR TITLE
[v1.12] cocci: backport fix about incorrect warnings and resolve warning related to a const qualifier

### DIFF
--- a/.github/workflows/lint-bpf-checks.yaml
+++ b/.github/workflows/lint-bpf-checks.yaml
@@ -68,6 +68,12 @@ jobs:
         uses: docker://cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b
         with:
           entrypoint: ./contrib/coccinelle/check-cocci.sh
+        # Note: Setting COCCINELLE_HOME can be removed, here and in the
+        # messages in the .cocci files, next time we upgrade coccinelle.
+        # The issue was fixed, after v1.1.1 that we're using, in
+        # https://gitlab.inria.fr/coccinelle/coccinelle/-/commit/540888ff426e.
+        env:
+          COCCINELLE_HOME: /usr/local/lib/coccinelle
 
   set_clang_dir:
     name: Set clang directory

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -107,7 +107,7 @@ combine_ports(__u16 dport, __u16 sport)
  * ingress. Will modify 'tuple'!						\
  */										\
 static __always_inline int							\
-NAME(struct __ctx_buff *ctx, CT_TUPLE_TYPE * ct_tuple, __be16 proxy_port)	\
+NAME(struct __ctx_buff *ctx, const CT_TUPLE_TYPE * ct_tuple, __be16 proxy_port)	\
 {										\
 	struct bpf_sock_tuple *tuple = (struct bpf_sock_tuple *)ct_tuple;	\
 	__u8 nexthdr = ct_tuple->nexthdr;					\

--- a/contrib/coccinelle/aligned.cocci
+++ b/contrib/coccinelle/aligned.cocci
@@ -63,7 +63,9 @@ cnt += 1
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                  \\
-    -it docker.io/cilium/coccicheck spatch --sp-file contrib/coccinelle/aligned.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/aligned.cocci\n
 """)

--- a/contrib/coccinelle/const.cocci
+++ b/contrib/coccinelle/const.cocci
@@ -67,7 +67,9 @@ cnt += 1
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                \\
-    -it docker.io/cilium/coccicheck spatch --sp-file contrib/coccinelle/const.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/const.cocci\n
 """)

--- a/contrib/coccinelle/identity_is_node.cocci
+++ b/contrib/coccinelle/identity_is_node.cocci
@@ -60,7 +60,9 @@ if len(p2) > 0:
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                           \\
-    -it docker.io/cilium/coccicheck spatch --sp-file contrib/coccinelle/identity_is_node.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.4@sha256:24abe3fbb8e829fa41a68a3b76cb4df84fd5a87a7d1d6254c1c1fe5effb5bd1b \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/identity_is_node.cocci\n
 """)

--- a/contrib/coccinelle/tail_calls.cocci
+++ b/contrib/coccinelle/tail_calls.cocci
@@ -109,5 +109,8 @@ cnt += 1
 if cnt > 0:
   print("""Unlogged tail calls found. Please fix and use the following command to check:
 docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
-    -it docker.io/cilium/coccicheck make -C bpf coccicheck\n
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/tail_calls.cocci\n
 """)

--- a/contrib/coccinelle/zero_trace_reason.cocci
+++ b/contrib/coccinelle/zero_trace_reason.cocci
@@ -84,7 +84,9 @@ cnt += 1
 
 if cnt > 0:
   print("""Use the following command to fix the above issues:
-docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace                           \\
-    -it docker.io/cilium/coccicheck spatch --sp-file contrib/coccinelle/zero_trace_reason.cocci \\
-    --include-headers --very-quiet --in-place bpf/\n
+docker run --rm --user 1000 --workdir /workspace -v `pwd`:/workspace \\
+    -e COCCINELLE_HOME=/usr/local/lib/coccinelle \\
+    -it docker.io/cilium/coccicheck:2.3@sha256:56c7445e3d0cc37de49750f5dfd154786082c4be6bc17683c231c0445862233a \\
+    spatch --include-headers --very-quiet --in-place bpf/ \\
+    --sp-file contrib/coccinelle/zero_trace_reason.cocci\n
 """)


### PR DESCRIPTION
This PR manually backports a coccicheck fix which can cause the emission of incorrect warning reports, and fixes a const qualifier issue that led to a failure in one of the checks. 

<!-- Description of change -->

```release-note
cocci: backport fix about incorrect warnings and resolve warning related to a const qualifier
```
