### PR TITLE
Add a new option to exclude unwanted k8s node labels from CiliumNode

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -172,6 +172,7 @@ cilium-agent [flags]
       --envoy-log string                                          Path to a separate Envoy log file, if any
       --envoy-secrets-namespace string                            EnvoySecretsNamespace is the namespace having secrets used by CEC
       --exclude-local-address strings                             Exclude CIDR from being recognized as local address
+      --exclude-node-label-patterns strings                       List of k8s node label regex patterns to be excluded from CiliumNode
       --external-envoy-proxy                                      whether the Envoy is deployed externally in form of a DaemonSet or not
       --fixed-identity-mapping map                                Key-value for the fixed identity mapping which allows to use reserved label for fixed identities, e.g. 128=kv-store,129=kube-dns
       --gateway-api-secrets-namespace string                      GatewayAPISecretsNamespace is the namespace having tls secrets used by CEC, originating from Gateway API

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -188,6 +188,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.AutoCreateCiliumNodeResource, defaults.AutoCreateCiliumNodeResource, "Automatically create CiliumNode resource for own node on startup")
 	option.BindEnv(vp, option.AutoCreateCiliumNodeResource)
 
+	flags.StringSlice(option.ExcludeNodeLabelPatterns, []string{}, "List of k8s node label regex patterns to be excluded from CiliumNode")
+	option.BindEnv(vp, option.ExcludeNodeLabelPatterns)
+
 	flags.String(option.BPFRoot, "", "Path to BPF filesystem")
 	option.BindEnv(vp, option.BPFRoot)
 

--- a/pkg/k8s/node.go
+++ b/pkg/k8s/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/cidr"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodeTypes "github.com/cilium/cilium/pkg/node/types"
@@ -134,7 +135,7 @@ func ParseNode(k8sNode *slim_corev1.Node, source source.Source) *nodeTypes.Node 
 		}
 	}
 
-	newNode.Labels = k8sNode.GetLabels()
+	newNode.Labels = labelsfilter.FilterLabelsByRegex(option.Config.ExcludeNodeLabelPatterns, k8sNode.GetLabels())
 	newNode.Annotations = make(map[string]string)
 	// Propagate only Cilium specific annotations.
 	for key, value := range k8sNode.GetAnnotations() {

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -338,3 +338,23 @@ func Filter(lbls labels.Labels) (identityLabels, informationLabels labels.Labels
 func FilterNodeLabels(lbls labels.Labels) (identityLabels, informationLabels labels.Labels) {
 	return validNodeLabelPrefixes.filterLabels(lbls)
 }
+
+func FilterLabelsByRegex(excludePatterns []*regexp.Regexp, labels map[string]string) map[string]string {
+	if len(excludePatterns) == 0 && labels != nil {
+		return labels
+	}
+	newLabels := make(map[string]string)
+	for k, v := range labels {
+		labelNeedsExclusion := false
+		for _, pattern := range excludePatterns {
+			if pattern.MatchString(k) {
+				labelNeedsExclusion = true
+				break
+			}
+		}
+		if !labelNeedsExclusion {
+			newLabels[k] = v
+		}
+	}
+	return newLabels
+}

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -4,6 +4,8 @@
 package labelsfilter
 
 import (
+	"reflect"
+	"regexp"
 	"testing"
 
 	. "github.com/cilium/checkmate"
@@ -162,4 +164,68 @@ func (s *LabelsPrefCfgSuite) TestFilterLabelsDocExample(c *C) {
 	filtered, _ = dlpcfg.filterLabels(allLabels)
 	c.Assert(len(filtered), Equals, 6)
 	c.Assert(filtered, checker.DeepEquals, wanted)
+}
+
+func TestFilterLabelsByRegex(t *testing.T) {
+	type args struct {
+		excludePatterns []*regexp.Regexp
+		labels          map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]string
+	}{
+		{
+			name: "exclude_test",
+			args: args{
+				[]*regexp.Regexp{regexp.MustCompile("foobar.*")},
+				map[string]string{
+					"topology.kubernetes.io/region": "us-east-1",
+					"foobar.com":                    "unwanted-label",
+				},
+			},
+			want: map[string]string{
+				"topology.kubernetes.io/region": "us-east-1",
+			},
+		},
+		{
+			name: "multi_exclude_test",
+			args: args{
+				[]*regexp.Regexp{
+					regexp.MustCompile("foo.*"),
+					regexp.MustCompile("bar.*"),
+				},
+				map[string]string{
+					"topology.kubernetes.io/region": "us-east-1",
+					"foo.com":                       "unwanted-label",
+					"bar.com":                       "unwanted-label",
+				},
+			},
+			want: map[string]string{
+				"topology.kubernetes.io/region": "us-east-1",
+			},
+		},
+		{
+			name: "baseline_test",
+			args: args{
+				[]*regexp.Regexp{},
+				map[string]string{
+					"topology.kubernetes.io/region": "us-east-1",
+					"foobar.com":                    "unwanted-label",
+				},
+			},
+			want: map[string]string{
+				"topology.kubernetes.io/region": "us-east-1",
+				"foobar.com":                    "unwanted-label",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FilterLabelsByRegex(tt.args.excludePatterns, tt.args.labels); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("FilterLabelsByRegex() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -14,6 +14,7 @@ import (
 	"net/netip"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -883,6 +884,10 @@ const (
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource = "auto-create-cilium-node-resource"
+
+	// ExcludeNodeLabelPatterns allows for excluding unnecessary labels from being propagated from k8s node to cilium
+	// node object. This allows for avoiding unnecessary events being broadcast to all nodes in the cluster.
+	ExcludeNodeLabelPatterns = "exclude-node-label-patterns"
 
 	// IPv4NativeRoutingCIDR describes a v4 CIDR in which pod IPs are routable
 	IPv4NativeRoutingCIDR = "ipv4-native-routing-cidr"
@@ -2091,6 +2096,10 @@ type DaemonConfig struct {
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource bool
+
+	// ExcludeNodeLabelPatterns allows for excluding unnecessary labels from being propagated from k8s node to cilium
+	// node object. This allows for avoiding unnecessary events being broadcast to all nodes in the cluster.
+	ExcludeNodeLabelPatterns []*regexp.Regexp
 
 	// IPv4NativeRoutingCIDR describes a CIDR in which pod IPs are routable
 	IPv4NativeRoutingCIDR *cidr.CIDR
@@ -3539,6 +3548,17 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.PolicyCIDRMatchMode = vp.GetStringSlice(PolicyCIDRMatchMode)
 	c.EnableNodeSelectorLabels = vp.GetBool(EnableNodeSelectorLabels)
 	c.NodeLabels = vp.GetStringSlice(NodeLabels)
+
+	// Parse node label patterns
+	nodeLabelPatterns := vp.GetStringSlice(ExcludeNodeLabelPatterns)
+	for _, pattern := range nodeLabelPatterns {
+		r, err := regexp.Compile(pattern)
+		if err != nil {
+			log.WithError(err).Errorf("Unable to compile exclude node label regex pattern %s", pattern)
+			continue
+		}
+		c.ExcludeNodeLabelPatterns = append(c.ExcludeNodeLabelPatterns, r)
+	}
 }
 
 func (c *DaemonConfig) populateDevices(vp *viper.Viper) {


### PR DESCRIPTION
Updates to CiliumNode object can trigger expensive operations like `InjectLabels()` on the ipcache subsystem. Since updates to cilium node objects are sent to all nodes in the cluster, these unwanted updates can end up wasting quite some CPU cycles.

`exclude-node-label-patterns` allows for dropping unwanted labels added by other controllers from being propagated to CiliumNode CRD and data stored in kvstore under `cilium/state/nodes/v1/*`