### PR TITLE
bgpv1: set R-bit in graceful restart

### DIFF
--- a/pkg/bgpv1/gobgp/server.go
+++ b/pkg/bgpv1/gobgp/server.go
@@ -283,6 +283,7 @@ func (g *GoBGPServer) getPeerConfig(ctx context.Context, n types.NeighborRequest
 		peer.GracefulRestart.Enabled = true
 		peer.GracefulRestart.RestartTime = uint32(*n.Neighbor.GracefulRestart.RestartTimeSeconds)
 		peer.GracefulRestart.NotificationEnabled = true
+		peer.GracefulRestart.LocalRestarting = true
 	}
 
 	for _, afiConf := range peer.AfiSafis {


### PR DESCRIPTION
Set R-bit in graceful restart negotiation to not withdraw routes by Receiving Speaker Details is in https://www.rfc-editor.org/rfc/rfc4724.html#section-4.1

Fixes: #28168

```release-note
BGPv1: Set R-bit in graceful restart capability negotiation.
```
