### PR TITLE
test: Add -bpf-test-run flag to bpf_test.go runner to filter tests.

### DIFF
--- a/test/bpf_tests/bpf_test.go
+++ b/test/bpf_tests/bpf_test.go
@@ -43,6 +43,7 @@ var (
 	testCoverageReport     = flag.String("coverage-report", "", "Specify a path for the coverage report")
 	testCoverageFormat     = flag.String("coverage-format", "html", "Specify the format of the coverage report")
 	noTestCoverage         = flag.String("no-test-coverage", "", "Don't collect coverages for the file matches to the given regex")
+	bpfTestRun             = flag.String("bpf-test-run", "", "If set only tests matching the regex will be run")
 	testInstrumentationLog = flag.String("instrumentation-log", "", "Path to a log file containing details about"+
 		" code coverage instrumentation, needed if code coverage breaks the verifier")
 
@@ -85,6 +86,17 @@ func TestBPF(t *testing.T) {
 
 		if !strings.HasSuffix(entry.Name(), ".o") {
 			continue
+		}
+
+		name := strings.TrimSuffix(entry.Name(), ".o")
+		if *bpfTestRun != "" {
+			re, err := regexp.Compile(*bpfTestRun)
+			if err != nil {
+				t.Fatalf("run regex compilation failed (%q): %v", *bpfTestRun, err)
+			}
+			if !re.MatchString(name) {
+				continue
+			}
 		}
 
 		t.Run(entry.Name(), func(t *testing.T) {


### PR DESCRIPTION
While running this test suite with a large -count value to reproduce flakes, executing each bpf test is quite slow.

This allows for filtering tests via regex, by test name (excluding the .o ext).

Example usage:

```
go test -count=1000 ./test/bpf_tests -exec sudo -bpf-test-path /home/tom/go/src/github.com/cilium/cilium/bpf/tests/ -v -bpf-test-run=ipsec_from_lxc_test -failfast
```
