### PR TITLE
loader: attach XDP programs using bpf_link

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -491,6 +491,7 @@ Makefile* @cilium/build
 /pkg/serializer @cilium/sig-agent
 /pkg/service @cilium/sig-lb
 /pkg/slices @cilium/sig-foundations
+/pkg/socketlb @cilium/loader
 /pkg/source @cilium/ipcache
 /pkg/status/ @cilium/sig-agent
 /pkg/statedb @cilium/sig-foundations

--- a/cilium-dbg/cmd/cleanup.go
+++ b/cilium-dbg/cmd/cleanup.go
@@ -254,7 +254,7 @@ func (c ciliumCleanup) cleanupFuncs() []cleanupFunc {
 		return removeNamedNetNSs(c.netNSs)
 	}
 	cleanupXDPs := func() error {
-		return removeXDPs(c.xdpLinks)
+		return removeXDPAttachments(c.xdpLinks)
 	}
 	cleanupTCFilters := func() error {
 		return removeTCFilters(c.tcFilters)
@@ -572,7 +572,7 @@ func removeTCFilters(linkAndFilters map[string][]*netlink.BpfFilter) error {
 	return nil
 }
 
-func removeXDPs(links []netlink.Link) error {
+func removeXDPAttachments(links []netlink.Link) error {
 	for _, link := range links {
 		err := netlink.LinkSetXdpFdWithFlags(link, -1, int(nl.XDP_FLAGS_DRV_MODE))
 		if err != nil {

--- a/cilium-dbg/cmd/cleanup.go
+++ b/cilium-dbg/cmd/cleanup.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netlink/nl"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/ebpf"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/common"
+	"github.com/cilium/cilium/pkg/datapath/loader"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/netns"
@@ -574,12 +574,7 @@ func removeTCFilters(linkAndFilters map[string][]*netlink.BpfFilter) error {
 
 func removeXDPAttachments(links []netlink.Link) error {
 	for _, link := range links {
-		err := netlink.LinkSetXdpFdWithFlags(link, -1, int(nl.XDP_FLAGS_DRV_MODE))
-		if err != nil {
-			return err
-		}
-		err = netlink.LinkSetXdpFdWithFlags(link, -1, int(nl.XDP_FLAGS_SKB_MODE))
-		if err != nil {
+		if err := loader.DetachXDP(link, bpf.CiliumPath(), "cil_xdp_entry"); err != nil {
 			return err
 		}
 		fmt.Printf("removed cilium xdp of %s\n", link.Attrs().Name)

--- a/pkg/bpf/bpf_linux.go
+++ b/pkg/bpf/bpf_linux.go
@@ -116,7 +116,7 @@ func OpenOrCreateMap(spec *ebpf.MapSpec, pinDir string) (*ebpf.Map, error) {
 			return nil, errors.New("cannot load unnamed map from pin")
 		}
 
-		if err := os.MkdirAll(pinDir, 0755); err != nil {
+		if err := MkdirBPF(pinDir); err != nil {
 			return nil, fmt.Errorf("creating map base pinning directory: %w", err)
 		}
 

--- a/pkg/bpf/bpffs_linux.go
+++ b/pkg/bpf/bpffs_linux.go
@@ -58,6 +58,12 @@ func CiliumPath() string {
 	return filepath.Join(bpffsRoot, "cilium")
 }
 
+// MkdirBPF wraps [os.MkdirAll] with the right permission bits for bpffs.
+// Use this for ensuring the existence of directories on bpffs.
+func MkdirBPF(path string) error {
+	return os.MkdirAll(path, 0755)
+}
+
 func tcPathFromMountInfo(name string) string {
 	readMountInfo.Do(func() {
 		mountInfos, err := mountinfo.GetMountInfo()
@@ -116,7 +122,7 @@ func mountFS(printWarning bool) error {
 	mapRootStat, err := os.Stat(bpffsRoot)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if err := os.MkdirAll(bpffsRoot, 0755); err != nil {
+			if err := MkdirBPF(bpffsRoot); err != nil {
 				return fmt.Errorf("unable to create bpf mount directory: %s", err)
 			}
 		} else {

--- a/pkg/bpf/link.go
+++ b/pkg/bpf/link.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package bpf
+
+import (
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+)
+
+// UpdateLink loads a pinned bpf_link at the given pin path and updates its
+// program.
+//
+// Returns [os.ErrNotExist] if the pin is not found.
+//
+// Updating the link can fail if it is defunct (the hook it points to no longer
+// exists).
+func UpdateLink(pin string, prog *ebpf.Program) error {
+	l, err := link.LoadPinnedLink(pin, &ebpf.LoadPinOptions{})
+	if err != nil {
+		return fmt.Errorf("opening pinned link %s: %w", pin, err)
+	}
+	defer l.Close()
+
+	if err = l.Update(prog); err != nil {
+		return fmt.Errorf("updating link %s: %w", pin, err)
+	}
+	return nil
+}
+
+// DetachLink loads and unpins a bpf_link at the given pin path.
+//
+// Returns [os.ErrNotExist] if the pin is not found.
+func UnpinLink(pin string) error {
+	l, err := link.LoadPinnedLink(pin, &ebpf.LoadPinOptions{})
+	if err != nil {
+		return fmt.Errorf("opening pinned link %s: %w", pin, err)
+	}
+	defer l.Close()
+
+	if err := l.Unpin(); err != nil {
+		return fmt.Errorf("unpinning link %s: %w", pin, err)
+	}
+	return nil
+}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/datapath/alignchecker"
 	"github.com/cilium/cilium/pkg/datapath/connector"
 	"github.com/cilium/cilium/pkg/datapath/linux/ethtool"
@@ -236,7 +237,7 @@ func (l *Loader) reinitializeOverlay(ctx context.Context, encapProto string) err
 
 func (l *Loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string) error {
 	maybeRemoveXDPLinks()
-	maybeUnloadObsoleteXDPPrograms(option.Config.GetDevices(), option.Config.XDPMode)
+	maybeUnloadObsoleteXDPPrograms(option.Config.GetDevices(), option.Config.XDPMode, bpf.CiliumPath())
 	if option.Config.XDPMode == option.XDPModeDisabled {
 		return nil
 	}

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -235,6 +235,7 @@ func (l *Loader) reinitializeOverlay(ctx context.Context, encapProto string) err
 }
 
 func (l *Loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string) error {
+	maybeRemoveXDPLinks()
 	maybeUnloadObsoleteXDPPrograms(option.Config.GetDevices(), option.Config.XDPMode)
 	if option.Config.XDPMode == option.XDPModeDisabled {
 		return nil

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -236,7 +236,6 @@ func (l *Loader) reinitializeOverlay(ctx context.Context, encapProto string) err
 }
 
 func (l *Loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string) error {
-	maybeRemoveXDPLinks()
 	maybeUnloadObsoleteXDPPrograms(option.Config.GetDevices(), option.Config.XDPMode, bpf.CiliumPath())
 	if option.Config.XDPMode == option.XDPModeDisabled {
 		return nil

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -268,14 +268,14 @@ func removeObsoleteNetdevPrograms() error {
 	}
 
 	for _, dev := range ingressDevs {
-		err = RemoveTCFilters(dev.Attrs().Name, directionToParent(dirIngress))
+		err = removeTCFilters(dev.Attrs().Name, directionToParent(dirIngress))
 		if err != nil {
 			log.WithError(err).Errorf("couldn't remove ingress tc filters from %s", dev.Attrs().Name)
 		}
 	}
 
 	for _, dev := range egressDevs {
-		err = RemoveTCFilters(dev.Attrs().Name, directionToParent(dirEgress))
+		err = removeTCFilters(dev.Attrs().Name, directionToParent(dirEgress))
 		if err != nil {
 			log.WithError(err).Errorf("couldn't remove egress tc filters from %s", dev.Attrs().Name)
 		}
@@ -377,7 +377,7 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		} else {
 			// Remove any previously attached device from egress path if BPF
 			// NodePort and host firewall are disabled.
-			err := RemoveTCFilters(device, netlink.HANDLE_MIN_EGRESS)
+			err := removeTCFilters(device, netlink.HANDLE_MIN_EGRESS)
 			if err != nil {
 				log.WithField("device", device).Error(err)
 			}
@@ -425,7 +425,7 @@ func (l *Loader) reloadDatapath(ctx context.Context, ep datapath.Endpoint, dirs 
 		if ep.RequireEgressProg() {
 			progs = append(progs, progDefinition{progName: symbolToEndpoint, direction: dirEgress})
 		} else {
-			err := RemoveTCFilters(ep.InterfaceName(), netlink.HANDLE_MIN_EGRESS)
+			err := removeTCFilters(ep.InterfaceName(), netlink.HANDLE_MIN_EGRESS)
 			if err != nil {
 				log.WithField("device", ep.InterfaceName()).Error(err)
 			}

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -128,8 +128,12 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 	// Load the CollectionSpec into the kernel, picking up any pinned maps from
 	// bpffs in the process.
 	finalize := func() {}
+	pinPath := bpf.TCGlobalsPath()
 	opts := ebpf.CollectionOptions{
-		Maps: ebpf.MapOptions{PinPath: bpf.TCGlobalsPath()},
+		Maps: ebpf.MapOptions{PinPath: pinPath},
+	}
+	if err := bpf.MkdirBPF(pinPath); err != nil {
+		return nil, fmt.Errorf("creating bpffs pin path: %w", err)
 	}
 	l.Debug("Loading Collection into kernel")
 	coll, err := bpf.LoadCollection(spec, opts)

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -227,9 +227,9 @@ func attachProgram(link netlink.Link, prog *ebpf.Program, progName string, qdisc
 	return nil
 }
 
-// RemoveTCFilters removes all tc filters from the given interface.
+// removeTCFilters removes all tc filters from the given interface.
 // Direction is passed as netlink.HANDLE_MIN_{INGRESS,EGRESS} via tcDir.
-func RemoveTCFilters(ifName string, tcDir uint32) error {
+func removeTCFilters(ifName string, tcDir uint32) error {
 	link, err := netlink.LinkByName(ifName)
 	if err != nil {
 		return err

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/defaults"
@@ -192,7 +193,7 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 
 // attachProgram attaches prog to link.
 // If xdpFlags is non-zero, attaches prog to XDP.
-func attachProgram(link netlink.Link, prog *ebpf.Program, progName string, qdiscParent uint32, xdpFlags uint32) error {
+func attachProgram(link netlink.Link, prog *ebpf.Program, progName string, qdiscParent uint32, xdpFlags link.XDPAttachFlags) error {
 	if prog == nil {
 		return errors.New("cannot attach a nil program")
 	}

--- a/pkg/datapath/loader/netlink_test.go
+++ b/pkg/datapath/loader/netlink_test.go
@@ -502,7 +502,7 @@ func TestRemoveTCPrograms(t *testing.T) {
 		err = attachProgram(dummy, prog, "test", directionToParent(dirEgress), 0)
 		require.NoError(t, err)
 
-		err = RemoveTCFilters(dummy.Attrs().Name, directionToParent(dirEgress))
+		err = removeTCFilters(dummy.Attrs().Name, directionToParent(dirEgress))
 		require.NoError(t, err)
 
 		filters, err := netlink.FilterList(dummy, directionToParent(dirEgress))

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loader
+
+import (
+	"path/filepath"
+
+	"github.com/vishvananda/netlink"
+)
+
+// bpffsDevicesDir returns the path to the 'devices' directory on bpffs, usually
+// /sys/fs/bpf/cilium/devices. It does not ensure the directory exists.
+//
+// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
+// during tests.
+func bpffsDevicesDir(base string) string {
+	return filepath.Join(base, "devices")
+}
+
+// bpffsDeviceLinksDir returns the bpffs path to the per-device links directory,
+// usually /sys/fs/bpf/cilium/devices/<device>/links. It does not ensure the
+// directory exists.
+//
+// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
+// during tests.
+func bpffsDeviceLinksDir(base string, device netlink.Link) string {
+	return filepath.Join(bpffsDevicesDir(base), device.Attrs().Name, "links")
+}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -52,7 +52,7 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode string) {
 		used := false
 		for _, xdpDev := range xdpDevs {
 			if link.Attrs().Name == xdpDev &&
-				linkxdp.Flags&xdpModeToFlag(xdpMode) != 0 {
+				linkxdp.AttachMode == xdpModeToFlag(xdpMode) {
 				// XDP mode matches; don't unload, otherwise we might introduce
 				// intermittent connectivity problems
 				used = true

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -75,26 +75,6 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode, bpffsBase string)
 	}
 }
 
-// maybeRemoveXDPLinks removes bpf_links for XDP programs.
-//
-// This is needed for the downgrade path from newer Cilium versions that attach
-// XDP using bpf_link. If this is not supported by an old version of Cilium, the
-// bpf_link needs to be removed by deleting its pin from bpffs. Then, the old
-// version will be able to attach XDP programs using the legacy netlink again.
-func maybeRemoveXDPLinks() {
-	links, err := netlink.LinkList()
-	if err != nil {
-		log.WithError(err).Warn("Failed to list links for XDP link removal")
-	}
-
-	for _, link := range links {
-		bpfLinkPath := filepath.Join(bpffsDeviceLinksDir(bpf.CiliumPath(), link), symbolFromHostNetdevXDP)
-		if err := os.Remove(bpfLinkPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			log.WithError(err).Errorf("Failed to remove link %s", bpfLinkPath)
-		}
-	}
-}
-
 // xdpCompileArgs derives compile arguments for bpf_xdp.c.
 func xdpCompileArgs(xdpDev string, extraCArgs []string) ([]string, error) {
 	link, err := netlink.LinkByName(xdpDev)

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loader
+
+import (
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/netns"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func TestMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	netnsName := "test-maybe-unload-xdp"
+	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+	require.NoError(t, err)
+	require.NotNil(t, netns0)
+	t.Cleanup(func() {
+		netns0.Close()
+		netns.RemoveNetNSWithName(netnsName)
+	})
+
+	netns0.Do(func(_ ns.NetNS) error {
+		veth0 := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+			PeerName:  "veth2",
+		}
+		err := netlink.LinkAdd(veth0)
+		require.NoError(t, err)
+
+		veth1 := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "veth1"},
+			PeerName:  "veth3",
+		}
+		err = netlink.LinkAdd(veth1)
+		require.NoError(t, err)
+
+		prog := mustXDPProgram(t)
+
+		err = attachProgram(veth0, prog, "test", 0, xdpModeToFlag(option.XDPModeLinkGeneric))
+		require.NoError(t, err)
+
+		err = attachProgram(veth1, prog, "test", 0, xdpModeToFlag(option.XDPModeLinkGeneric))
+		require.NoError(t, err)
+
+		maybeUnloadObsoleteXDPPrograms([]string{"veth0"}, option.XDPModeLinkGeneric)
+
+		v0, err := netlink.LinkByName("veth0")
+		require.NoError(t, err)
+		require.NotNil(t, v0.Attrs().Xdp)
+		require.True(t, v0.Attrs().Xdp.Attached)
+
+		v1, err := netlink.LinkByName("veth1")
+		require.NoError(t, err)
+		if v1.Attrs().Xdp != nil {
+			require.False(t, v1.Attrs().Xdp.Attached)
+		}
+
+		err = netlink.LinkDel(veth0)
+		require.NoError(t, err)
+
+		err = netlink.LinkDel(veth1)
+		require.NoError(t, err)
+
+		return nil
+	})
+}

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -4,12 +4,18 @@
 package loader
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/stretchr/testify/require"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+
+	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -28,45 +34,224 @@ func TestMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
 	})
 
 	netns0.Do(func(_ ns.NetNS) error {
+		// create netlink handle in the test netns to ensure subsequent netlink
+		// calls request data from the correct netns, even if called in a separate
+		// goroutine (require.Eventually)
+		h, err := netlink.NewHandle()
+		require.NoError(t, err)
+
 		veth0 := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
 			PeerName:  "veth2",
 		}
-		err := netlink.LinkAdd(veth0)
+		err = h.LinkAdd(veth0)
 		require.NoError(t, err)
 
 		veth1 := &netlink.Veth{
 			LinkAttrs: netlink.LinkAttrs{Name: "veth1"},
 			PeerName:  "veth3",
 		}
-		err = netlink.LinkAdd(veth1)
+		err = h.LinkAdd(veth1)
 		require.NoError(t, err)
 
 		prog := mustXDPProgram(t)
+		basePath := testutils.TempBPFFS(t)
 
-		err = attachProgram(veth0, prog, "test", 0, xdpModeToFlag(option.XDPModeLinkGeneric))
+		// need to use symbolFromHostNetdevXDP as progName here as maybeUnloadObsoleteXDPPrograms explicitly uses that name.
+		err = attachXDPProgram(veth0, prog, symbolFromHostNetdevXDP, basePath, link.XDPGenericMode)
 		require.NoError(t, err)
 
-		err = attachProgram(veth1, prog, "test", 0, xdpModeToFlag(option.XDPModeLinkGeneric))
+		err = attachXDPProgram(veth1, prog, symbolFromHostNetdevXDP, basePath, link.XDPGenericMode)
 		require.NoError(t, err)
 
-		maybeUnloadObsoleteXDPPrograms([]string{"veth0"}, option.XDPModeLinkGeneric)
+		maybeUnloadObsoleteXDPPrograms([]string{"veth0"}, option.XDPModeLinkGeneric, basePath)
 
-		v0, err := netlink.LinkByName("veth0")
+		v0, err := h.LinkByName("veth0")
 		require.NoError(t, err)
 		require.NotNil(t, v0.Attrs().Xdp)
 		require.True(t, v0.Attrs().Xdp.Attached)
 
-		v1, err := netlink.LinkByName("veth1")
-		require.NoError(t, err)
-		if v1.Attrs().Xdp != nil {
-			require.False(t, v1.Attrs().Xdp.Attached)
-		}
+		require.Eventually(t, func() bool {
+			v1, err := h.LinkByName("veth1")
+			require.NoError(t, err)
+			if v1.Attrs().Xdp != nil {
+				return v1.Attrs().Xdp.Attached == false
+			}
+			return true
+		}, 150*time.Millisecond, 15*time.Millisecond)
 
 		err = netlink.LinkDel(veth0)
 		require.NoError(t, err)
 
 		err = netlink.LinkDel(veth1)
+		require.NoError(t, err)
+
+		return nil
+	})
+}
+
+// Attach a program to a clean dummy device, no replacing necessary.
+func TestAttachXDP(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	netnsName := "test-attach-xdp"
+	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+	require.NoError(t, err)
+	require.NotNil(t, netns0)
+	t.Cleanup(func() {
+		netns0.Close()
+		netns.RemoveNetNSWithName(netnsName)
+	})
+
+	netns0.Do(func(_ ns.NetNS) error {
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+			PeerName:  "veth1",
+		}
+		err := netlink.LinkAdd(veth)
+		require.NoError(t, err)
+
+		prog := mustXDPProgram(t)
+		basePath := testutils.TempBPFFS(t)
+
+		err = attachXDPProgram(veth, prog, "test", basePath, link.XDPGenericMode)
+		require.NoError(t, err)
+
+		err = netlink.LinkDel(veth)
+		require.NoError(t, err)
+
+		return nil
+	})
+}
+
+// Replace an existing program attached using netlink attach.
+func TestAttachXDPWithPreviousAttach(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	netnsName := "test-attach-xdp-previous"
+	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+	require.NoError(t, err)
+	require.NotNil(t, netns0)
+	t.Cleanup(func() {
+		netns0.Close()
+		netns.RemoveNetNSWithName(netnsName)
+	})
+
+	netns0.Do(func(_ ns.NetNS) error {
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+			PeerName:  "veth1",
+		}
+		err := netlink.LinkAdd(veth)
+		require.NoError(t, err)
+
+		prog := mustXDPProgram(t)
+		basePath := testutils.TempBPFFS(t)
+
+		err = netlink.LinkSetXdpFdWithFlags(veth, prog.FD(), int(link.XDPGenericMode))
+		require.NoError(t, err)
+
+		err = attachXDPProgram(veth, prog, "test", basePath, link.XDPGenericMode)
+		require.NoError(t, err)
+
+		err = netlink.LinkDel(veth)
+		require.NoError(t, err)
+
+		return nil
+	})
+}
+
+// On kernels that support it, make sure an existing bpf_link can be updated.
+func TestAttachXDPWithExistingLink(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	netnsName := "test-attach-xdp-existing"
+	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+	require.NoError(t, err)
+	require.NotNil(t, netns0)
+	t.Cleanup(func() {
+		netns0.Close()
+		netns.RemoveNetNSWithName(netnsName)
+	})
+
+	netns0.Do(func(_ ns.NetNS) error {
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+			PeerName:  "veth1",
+		}
+		err := netlink.LinkAdd(veth)
+		require.NoError(t, err)
+
+		prog := mustXDPProgram(t)
+
+		// Probe XDP bpf_link support by manually attaching a Program and
+		// immediately closing the link when it succeeds.
+		l, err := link.AttachXDP(link.XDPOptions{
+			Program:   prog,
+			Interface: veth.Attrs().Index,
+			Flags:     link.XDPGenericMode,
+		})
+		if errors.Is(err, ebpf.ErrNotSupported) {
+			t.Skip("bpf_link is not supported")
+		}
+		require.NoError(t, err)
+		require.NoError(t, l.Close())
+
+		basePath := testutils.TempBPFFS(t)
+		pinDir := bpffsDeviceLinksDir(basePath, veth)
+		require.NoError(t, bpf.MkdirBPF(pinDir))
+
+		// At this point, we know bpf_link is supported, so attachXDPProgram should
+		// use it.
+		err = attachXDPProgram(veth, prog, "test", pinDir, link.XDPGenericMode)
+		require.NoError(t, err)
+
+		// Attach the same program again. This should update the existing link.
+		err = attachXDPProgram(veth, prog, "test", pinDir, link.XDPGenericMode)
+		require.NoError(t, err)
+
+		// Detach the program.
+		err = DetachXDP(veth, basePath, "test")
+		require.NoError(t, err)
+
+		err = netlink.LinkDel(veth)
+		require.NoError(t, err)
+
+		return nil
+	})
+}
+
+// Detach an XDP program that was attached using netlink.
+func TestDetachXDPWithPreviousAttach(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	netnsName := "test-detach-xdp-previous"
+	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+	require.NoError(t, err)
+	require.NotNil(t, netns0)
+	t.Cleanup(func() {
+		netns0.Close()
+		netns.RemoveNetNSWithName(netnsName)
+	})
+
+	netns0.Do(func(_ ns.NetNS) error {
+		veth := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+			PeerName:  "veth1",
+		}
+		err := netlink.LinkAdd(veth)
+		require.NoError(t, err)
+
+		prog := mustXDPProgram(t)
+		basePath := testutils.TempBPFFS(t)
+
+		err = netlink.LinkSetXdpFdWithFlags(veth, prog.FD(), int(link.XDPGenericMode))
+		require.NoError(t, err)
+
+		err = DetachXDP(veth, basePath, "test")
+		require.NoError(t, err)
+
+		err = netlink.LinkDel(veth)
 		require.NoError(t, err)
 
 		return nil


### PR DESCRIPTION
See individual commits.

The first two commits (prog removal and xdp bpf_link cleanup) will be submitted as a separate PR for backporting to 1.14 and 1.13 so these versions can handle downgrades from bpf_link-enabled Cilium agents. They were kept in this branch since future commits depended on them, and getting this broken up into smaller commits that make sense was already a challenge.

On a high level, this PR:
- attaches XDP progs using bpf_link
- adds per-device bpffs dirs, currently only for 'physical' devs, and only used for XDP links, at e.g. `/sys/fs/bpf/cilium/devices/enp5s0/links/cil_xdp_entry`
- adds a few utility functions to package bpf for working with bpffs and bpf_link pins
- refactors `attachProgram()` into `attachTCProgram()` and `attachXDPProgram()` (this was a minimal change)
- now uses ebpf-go's `link.XDPAttachFlags` as parameters instead of a simple u32
- adds netns-driven tests for attaching XDP progs to veths

This also puts us in a better position for adding tcx support during the next cycle.

Fixes: #27630