### PR TITLE
bgpv1: Adds CiliumPodIPPool Support to PathAttr Policies

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2alpha1/ciliumbgppeeringpolicies.yaml
@@ -253,10 +253,14 @@ spec:
                                     not Multi-Pool IPAM CIDRs. - For "CiliumLoadBalancerIPPool"
                                     the Selector matches CiliumLoadBalancerIPPool
                                     custom resources (path attributes apply to routes
-                                    announced for selected CiliumLoadBalancerIPPools).'
+                                    announced for selected CiliumLoadBalancerIPPools).
+                                    - For "CiliumPodIPPool" the Selector matches CiliumPodIPPool
+                                    custom resources (path attributes apply to routes
+                                    announced for allocated CIDRs of selected CiliumPodIPPools).'
                                   enum:
                                   - PodCIDR
                                   - CiliumLoadBalancerIPPool
+                                  - CiliumPodIPPool
                                   type: string
                               required:
                               - selectorType

--- a/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
+++ b/pkg/k8s/apis/cilium.io/v2alpha1/bgpp_types.go
@@ -34,6 +34,8 @@ const (
 	PodCIDRSelectorName = "PodCIDR"
 	// CiliumLoadBalancerIPPoolSelectorName defines the name for a selector matching CiliumLoadBalancerIPPool resources.
 	CiliumLoadBalancerIPPoolSelectorName = "CiliumLoadBalancerIPPool"
+	// CiliumPodIPPoolSelectorName defines the name for a selector matching CiliumPodIPPool resources.
+	CiliumPodIPPoolSelectorName = CPIPKindDefinition
 )
 
 // +genclient
@@ -138,8 +140,10 @@ type CiliumBGPPathAttributes struct {
 	//   Only affects routes of cluster scope / Kubernetes IPAM CIDRs, not Multi-Pool IPAM CIDRs.
 	// - For "CiliumLoadBalancerIPPool" the Selector matches CiliumLoadBalancerIPPool custom resources
 	//   (path attributes apply to routes announced for selected CiliumLoadBalancerIPPools).
+	// - For "CiliumPodIPPool" the Selector matches CiliumPodIPPool custom resources
+	//   (path attributes apply to routes announced for allocated CIDRs of selected CiliumPodIPPools).
 	//
-	// +kubebuilder:validation:Enum=PodCIDR;CiliumLoadBalancerIPPool
+	// +kubebuilder:validation:Enum=PodCIDR;CiliumLoadBalancerIPPool;CiliumPodIPPool
 	// +kubebuilder:validation:Required
 	SelectorType string `json:"selectorType"`
 


### PR DESCRIPTION
- Adds the CiliumPodIPPool selector type to BGP CP CiliumBGPPathAttributes API.
- Updates RoutePolicyReconciler to support CiliumPodIPPool.
- Added unit tests for the CiliumPodIPPool selector type.
- Regenerated CiliumBGPPeeringPolicy CRD.

<!-- Description of change -->

Fixes: #28296

```release-note
Adds the CiliumPodIPPool selector type to BGP CP AdvertisedPathAttributes to match CiliumPodIPPool custom resources. Path attributes apply to routes announced for selected CiliumPodIPPools.
```
