### PR TITLE
bgpv1: Adds Special Purpose Selectors to PodIPPoolSelector

### DIFF
--- a/pkg/bgpv1/manager/pod_ip_pool_reconciler_test.go
+++ b/pkg/bgpv1/manager/pod_ip_pool_reconciler_test.go
@@ -44,6 +44,13 @@ func TestPodIPPoolReconciler(t *testing.T) {
 		},
 	}
 
+	nsNameSelector := slim_metav1.LabelSelector{
+		MatchLabels: map[string]string{
+			podIPPoolNamespaceLabel: pool1.Namespace,
+			podIPPoolNameLabel:      pool1.Name,
+		},
+	}
+
 	pool2Key := resource.Key{Name: "pool-2", Namespace: "default"}
 	pool2 := &v2alpha1api.CiliumPodIPPool{
 		ObjectMeta: meta_v1.ObjectMeta{
@@ -91,6 +98,18 @@ func TestPodIPPoolReconciler(t *testing.T) {
 			poolSelector:  &blueSelector,
 			upsertedPools: []*v2alpha1api.CiliumPodIPPool{pool1},
 			updated:       map[resource.Key][]string{},
+		},
+		{
+			name: "match one ipv4 cidr from one pool using special purpose selector",
+			nodeAllocs: []ipamtypes.IPAMPoolAllocation{
+				{
+					Pool:  pool1.Name,
+					CIDRs: []ipamtypes.IPAMPodCIDR{"10.0.1.0/24"},
+				},
+			},
+			poolSelector:  &nsNameSelector,
+			upsertedPools: []*v2alpha1api.CiliumPodIPPool{pool1},
+			updated:       map[resource.Key][]string{pool1Key: {"10.0.1.0/24"}},
 		},
 		{
 			name: "match one ipv4 cidr from one pool",

--- a/pkg/bgpv1/manager/reconcile.go
+++ b/pkg/bgpv1/manager/reconcile.go
@@ -26,6 +26,11 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+const (
+	podIPPoolNameLabel      = "io.cilium.podippool.name"
+	podIPPoolNamespaceLabel = "io.cilium.podippool.namespace"
+)
+
 type ReconcileParams struct {
 	CurrentServer *ServerWithConfig
 	DesiredConfig *v2alpha1api.CiliumBGPVirtualRouter
@@ -788,5 +793,7 @@ func podIPPoolLabelSet(pool *v2alpha1api.CiliumPodIPPool) labels.Labels {
 	if poolLabels == nil {
 		poolLabels = make(map[string]string)
 	}
+	poolLabels[podIPPoolNameLabel] = pool.Name
+	poolLabels[podIPPoolNamespaceLabel] = pool.Namespace
 	return labels.Set(poolLabels)
 }


### PR DESCRIPTION
Adds the special purpose `io.cilium.podippool.namespace: <CiliumPodIPPool_NAMESPACE>` and `io.cilium.podippool.name: <CiliumPodIPPool_NAME>` selectors to PodIPPoolSelector of a CiliumBGPPeeringPolicy to select a CiliumPodIPPool by namespaced name instead of labels.

Fixes: #28313

```release-note
`io.cilium.podippool.namespace: <CiliumPodIPPool_NAMESPACE>` and `io.cilium.podippool.name: <CiliumPodIPPool_NAME>` selectors can be specified for a PodIPPoolSelector of a CiliumBGPPeeringPolicy to select a CiliumPodIPPool by namespaced name instead of labels.
```
