### PR TITLE
ci: Avoid using deprecated "tunnel" flag

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -211,7 +211,7 @@ jobs:
             --helm-set=clustermesh.useAPIServer=true \
             "
 
-          CILIUM_INSTALL_TUNNEL="--helm-set=tunnel=vxlan"
+          CILIUM_INSTALL_TUNNEL="--helm-set=tunnelProtocol=${{ matrix.tunnel }}"
           if [ "${{ matrix.tunnel }}" == "disabled" ]; then
             CILIUM_INSTALL_TUNNEL="--helm-set-string=routingMode=native \
               --helm-set=autoDirectNodeRoutes=true \

--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -124,7 +124,6 @@ jobs:
           CILIUM_INSTALL_DEFAULTS="${{ steps.default_vars.outputs.cilium_install_defaults }} \
             --helm-set=debug.verbose=envoy \
             --helm-set=hubble.relay.enabled=true \
-            --helm-set=tunnel=disabled \
             --helm-set=autoDirectNodeRoutes=true \
             --helm-set=routingMode=native \
             --helm-set=endpointRoutes.enabled=true \


### PR DESCRIPTION
The tunnel option is deprecated and will be removed in Cilium v1.15. This commit fixes the remaining uses I have found where the CI explicitly set the old `tunnel` flag.

Note that the Cilium CLI also still sets the flag some times in our CI, this is addressed by cilium/cilium-cli#1993.
