### PR TITLE
cmd: Disable local node routes when endpoint routes are enabled

### DIFF
--- a/.github/workflows/conformance-multi-pool.yaml
+++ b/.github/workflows/conformance-multi-pool.yaml
@@ -135,7 +135,6 @@ jobs:
             --helm-set=autoDirectNodeRoutes=true \
             --helm-set=routingMode=native \
             --helm-set=endpointRoutes.enabled=true \
-            --helm-set-string=extraConfig.enable-local-node-route=false \
             --helm-set=kubeProxyReplacement=strict \
             --helm-set=bpf.masquerade=true \
             --helm-set=bpf.hostLegacyRouting=true\

--- a/Documentation/network/concepts/routing.rst
+++ b/Documentation/network/concepts/routing.rst
@@ -296,8 +296,7 @@ The following configuration options must be set to run the datapath on GKE:
   * ``ipam: kubernetes``: Enable :ref:`k8s_hostscope` IPAM
   * ``routing-mode: native``: Enable native routing mode
   * ``enable-endpoint-routes: true``: Enable per-endpoint routing on the node
-  * ``enable-local-node-route: false``: Disable installation of the local node route
-
+    (automatically disables the local node route).
 * ``ipv4-native-routing-cidr: x.x.x.x/y``: Set the CIDR in which native routing
   is supported.
 

--- a/Documentation/network/kubernetes/ipam-multi-pool.rst
+++ b/Documentation/network/kubernetes/ipam-multi-pool.rst
@@ -28,7 +28,6 @@ Enable Multi-pool IPAM mode
    * ``--set autoDirectNodeRoutes=true``
    * ``--set ipv4NativeRoutingCIDR=10.0.0.0/8``
    * ``--set endpointRoutes.enabled=true``
-   * ``--set-string extraConfig.enable-local-node-route=false``
    * ``--set kubeProxyReplacement=true``
    * ``--set bpf.masquerade=true``
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -326,6 +326,8 @@ Annotations:
   specify them as parameters.
   Generate the installation script using Cilium CLI >=v0.15.8 to automatically
   include these parameters.
+* ``enable-endpoint-routes`` now automatically sets ``enable-local-node-route``
+  to false, as local node routes are redundant when per-endpoint routes are enabled.
 
 .. _upgrade_cilium_cli_helm_mode:
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1487,6 +1487,14 @@ func initEnv(vp *viper.Viper) {
 		}
 	}
 
+	if option.Config.EnableEndpointRoutes && option.Config.EnableLocalNodeRoute {
+		option.Config.EnableLocalNodeRoute = false
+		log.Debugf(
+			"Auto-set %q to `false` because it is redundant to per-endpoint routes (%s=true)",
+			option.EnableLocalNodeRoute, option.EnableEndpointRoutes,
+		)
+	}
+
 	if option.Config.IPAM == ipamOption.IPAMAzure {
 		option.Config.EgressMultiHomeIPRuleCompat = true
 		log.WithFields(logrus.Fields{

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -444,7 +444,6 @@ data:
 {{- if .Values.gke.enabled }}
   routing-mode: "native"
   enable-endpoint-routes: "true"
-  enable-local-node-route: "false"
 {{- else if .Values.aksbyocni.enabled }}
   routing-mode: "tunnel"
   tunnel-protocol: "vxlan"
@@ -512,7 +511,6 @@ data:
 {{- if .Values.azure.enabled }}
   enable-endpoint-routes: "true"
   auto-create-cilium-node-resource: "true"
-  enable-local-node-route: "false"
 {{- if .Values.azure.userAssignedIdentityID }}
   azure-user-assigned-identity-id: {{ .Values.azure.userAssignedIdentityID | quote }}
 {{- end }}


### PR DESCRIPTION
The command-line description of `enable-endpoint-routes` states: "Use per endpoint routes instead of routing via cilium_host". This description however has not been true: Even with per-endpoint routes enabled, Cilium would still install the local node route (i.e. "routing via cilium_host") unless explicitly disabled.

Not only is the local node route (which installs a single route based on the local pod CIDR) redundant to per-endpoint routes (which installs a route per endpoint), it also does not work on IPAM modes that do not have a local pod CIDR, such as ENI or Azure.

On Azure, GKE, and in the MultiPool CI, we already disabled the local node route explicitly when enabling per-endpoint routes, but in many other cases (ENI, as well as most of our CI (see
github/actions/cilium-config)) we forgot to disable local node routes explicitly when per-endpoint routes are enabled. Therefore, this commit improves UX by automatically disabling the local node route if per-endpoint routes are enabled. This approach was discussed at the Cilium Community meeting on June 7, 2023.

As an alternative to this change, we could also introduce a new tri-mode flag (i.e. "per-endpoint routes", "local node route", "none"), but such a change might introduce unnecessary churn if we decide to remove the local node routes further down the road.
