### PR TITLE
Fix IPv6 adding prefix route

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -435,6 +435,7 @@ func addHostDeviceAddr(hostDev netlink.Link, ipv4, ipv6 net.IP) error {
 				IP:   ipv6,
 				Mask: net.CIDRMask(64, 128), // corresponds to /64
 			},
+			Flags: unix.IFA_F_NOPREFIXROUTE,
 		}
 
 		if err := netlink.AddrReplace(hostDev, &addr); err != nil {


### PR DESCRIPTION
Adds flag `noprefixroute` to IPv6 address, as adding /64 route steers any cross-node pod traffic.

Fixes #28327

```release-note
Add flag `noprefixroute` to IPv6 address
```
