### PR TITLE
docs: Remove bare URLs from Flow gRPC API Reference

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -126,7 +126,7 @@ CiliumEventType from which the flow originated.
 <a name="flow-DNS"></a>
 
 ### DNS
-DNS flow. This is basically directly mapped from Cilium&#39;s [LogRecordDNS]( https://github.com/cilium/cilium/blob/04f3889d627774f79e56d14ddbc165b3169e2d01/pkg/proxy/accesslog/record.go#L264):
+DNS flow. This is basically directly mapped from Cilium&#39;s [LogRecordDNS](https://github.com/cilium/cilium/blob/04f3889d627774f79e56d14ddbc165b3169e2d01/pkg/proxy/accesslog/record.go#L264):
 
 
 | Field | Type | Label | Description |
@@ -355,6 +355,7 @@ multiple fields are set, then all fields must match for the filter to match.
 
 ### HTTP
 L7 information for HTTP flows. It corresponds to Cilium&#39;s [accesslog.LogRecordHTTP](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L206) type.
+
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -729,8 +730,7 @@ that happened before the events were captured by Hubble.
 ### TraceContext
 TraceContext contains trace context propagation data, i.e. information about a
 distributed trace.
-For more information about trace context, check the [W3C Trace Context
-specification](https://www.w3.org/TR/trace-context/).
+For more information about trace context, check the [W3C Trace Context specification](https://www.w3.org/TR/trace-context/).
 
 
 | Field | Type | Label | Description |
@@ -1166,3 +1166,4 @@ This mirrors enum xlate_point in bpf/lib/trace_sock.h
 | <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
 | <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
 | <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
+

--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -110,7 +110,7 @@
 <a name="flow-CiliumEventType"></a>
 
 ### CiliumEventType
-CiliumEventType from which the flow originated
+CiliumEventType from which the flow originated.
 
 
 | Field | Type | Label | Description |
@@ -126,8 +126,7 @@ CiliumEventType from which the flow originated
 <a name="flow-DNS"></a>
 
 ### DNS
-DNS flow. This is basically directly mapped from Cilium&#39;s LogRecordDNS:
-    https://github.com/cilium/cilium/blob/04f3889d627774f79e56d14ddbc165b3169e2d01/pkg/proxy/accesslog/record.go#L264
+DNS flow. This is basically directly mapped from Cilium&#39;s [LogRecordDNS]( https://github.com/cilium/cilium/blob/04f3889d627774f79e56d14ddbc165b3169e2d01/pkg/proxy/accesslog/record.go#L264):
 
 
 | Field | Type | Label | Description |
@@ -243,7 +242,7 @@ DNS flow. This is basically directly mapped from Cilium&#39;s LogRecordDNS:
 <a name="flow-EventTypeFilter"></a>
 
 ### EventTypeFilter
-EventTypeFilter is a filter describing a particular event type
+EventTypeFilter is a filter describing a particular event type.
 
 
 | Field | Type | Label | Description |
@@ -355,9 +354,7 @@ multiple fields are set, then all fields must match for the filter to match.
 <a name="flow-HTTP"></a>
 
 ### HTTP
-L7 information for HTTP flows. It corresponds to Cilium&#39;s accesslog.LogRecordHTTP type.
-  https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L206
-
+L7 information for HTTP flows. It corresponds to Cilium&#39;s [accesslog.LogRecordHTTP](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L206) type.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
@@ -463,8 +460,7 @@ L7 information for HTTP flows. It corresponds to Cilium&#39;s accesslog.LogRecor
 <a name="flow-Kafka"></a>
 
 ### Kafka
-L7 information for Kafka flows. It corresponds to Cilium&#39;s accesslog.LogRecordKafka type.
-  https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L229
+L7 information for Kafka flows. It corresponds to Cilium&#39;s [accesslog.LogRecordKafka](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L229) type.
 
 
 | Field | Type | Label | Description |
@@ -502,8 +498,7 @@ L7 information for Kafka flows. It corresponds to Cilium&#39;s accesslog.LogReco
 <a name="flow-Layer7"></a>
 
 ### Layer7
-Message for L7 flow, which roughly corresponds to Cilium&#39;s accesslog LogRecord:
-  https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L141
+Message for L7 flow, which roughly corresponds to Cilium&#39;s accesslog [LogRecord](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L141):
 
 
 | Field | Type | Label | Description |
@@ -732,10 +727,10 @@ that happened before the events were captured by Hubble.
 <a name="flow-TraceContext"></a>
 
 ### TraceContext
-TraceContext contains trace context propagation data, ie information about a
+TraceContext contains trace context propagation data, i.e. information about a
 distributed trace.
-For more information about trace context, check the W3C Trace Context
-specification: https://www.w3.org/TR/trace-context/
+For more information about trace context, check the [W3C Trace Context
+specification](https://www.w3.org/TR/trace-context/).
 
 
 | Field | Type | Label | Description |
@@ -800,7 +795,7 @@ TraceParent identifies the incoming request in a tracing system.
 
 ### AgentEventType
 AgentEventType is the type of agent event. These values are shared with type
-AgentNotification in pkg/monitor/api/types.go
+AgentNotification in pkg/monitor/api/types.go.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -822,7 +817,7 @@ AgentNotification in pkg/monitor/api/types.go
 <a name="flow-AuthType"></a>
 
 ### AuthType
-These types correspond to definitions in pkg/policy/l4.go
+These types correspond to definitions in pkg/policy/l4.go.
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -1051,8 +1046,7 @@ EventType are constants are based on the ones from &lt;linux/perf_event.h&gt;.
 <a name="flow-L7FlowType"></a>
 
 ### L7FlowType
-This enum corresponds to Cilium&#39;s L7 accesslog FlowType:
-  https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L26
+This enum corresponds to Cilium&#39;s L7 accesslog [FlowType](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L26):
 
 | Name | Number | Description |
 | ---- | ------ | ----------- |
@@ -1172,4 +1166,3 @@ This mirrors enum xlate_point in bpf/lib/trace_sock.h
 | <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
 | <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
 | <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
-

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -78,7 +78,7 @@ func (FlowType) EnumDescriptor() ([]byte, []int) {
 	return file_flow_flow_proto_rawDescGZIP(), []int{0}
 }
 
-// These types correspond to definitions in pkg/policy/l4.go
+// These types correspond to definitions in pkg/policy/l4.go.
 type AuthType int32
 
 const (
@@ -232,9 +232,7 @@ func (TraceObservationPoint) EnumDescriptor() ([]byte, []int) {
 	return file_flow_flow_proto_rawDescGZIP(), []int{2}
 }
 
-// This enum corresponds to Cilium's L7 accesslog FlowType:
-//
-//	https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L26
+// This enum corresponds to Cilium's L7 accesslog [FlowType](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L26):
 type L7FlowType int32
 
 const (
@@ -893,7 +891,7 @@ func (LostEventSource) EnumDescriptor() ([]byte, []int) {
 }
 
 // AgentEventType is the type of agent event. These values are shared with type
-// AgentNotification in pkg/monitor/api/types.go
+// AgentNotification in pkg/monitor/api/types.go.
 type AgentEventType int32
 
 const (
@@ -1765,9 +1763,7 @@ func (*Layer4_ICMPv6) isLayer4_Protocol() {}
 
 func (*Layer4_SCTP) isLayer4_Protocol() {}
 
-// Message for L7 flow, which roughly corresponds to Cilium's accesslog LogRecord:
-//
-//	https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L141
+// Message for L7 flow, which roughly corresponds to Cilium's accesslog [LogRecord](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L141):
 type Layer7 struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1882,10 +1878,9 @@ func (*Layer7_Http) isLayer7_Record() {}
 
 func (*Layer7_Kafka) isLayer7_Record() {}
 
-// TraceContext contains trace context propagation data, ie information about a
+// TraceContext contains trace context propagation data, i.e. information about a
 // distributed trace.
-// For more information about trace context, check the W3C Trace Context
-// specification: https://www.w3.org/TR/trace-context/
+// For more information about trace context, check the [W3C Trace Context specification](https://www.w3.org/TR/trace-context/).
 type TraceContext struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2720,7 +2715,7 @@ func (x *Policy) GetRevision() uint64 {
 	return 0
 }
 
-// EventTypeFilter is a filter describing a particular event type
+// EventTypeFilter is a filter describing a particular event type.
 type EventTypeFilter struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2790,7 +2785,7 @@ func (x *EventTypeFilter) GetSubType() int32 {
 	return 0
 }
 
-// CiliumEventType from which the flow originated
+// CiliumEventType from which the flow originated.
 type CiliumEventType struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3185,9 +3180,7 @@ func (x *FlowFilter) GetTraceId() []string {
 	return nil
 }
 
-// DNS flow. This is basically directly mapped from Cilium's LogRecordDNS:
-//
-//	https://github.com/cilium/cilium/blob/04f3889d627774f79e56d14ddbc165b3169e2d01/pkg/proxy/accesslog/record.go#L264
+// DNS flow. This is basically directly mapped from Cilium's [LogRecordDNS](https://github.com/cilium/cilium/blob/04f3889d627774f79e56d14ddbc165b3169e2d01/pkg/proxy/accesslog/record.go#L264):
 type DNS struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3361,9 +3354,7 @@ func (x *HTTPHeader) GetValue() string {
 	return ""
 }
 
-// L7 information for HTTP flows. It corresponds to Cilium's accesslog.LogRecordHTTP type.
-//
-//	https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L206
+// L7 information for HTTP flows. It corresponds to Cilium's [accesslog.LogRecordHTTP](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L206) type.
 type HTTP struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3443,9 +3434,7 @@ func (x *HTTP) GetHeaders() []*HTTPHeader {
 	return nil
 }
 
-// L7 information for Kafka flows. It corresponds to Cilium's accesslog.LogRecordKafka type.
-//
-//	https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L229
+// L7 information for Kafka flows. It corresponds to Cilium's [accesslog.LogRecordKafka](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L229) type.
 type Kafka struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -134,7 +134,7 @@ enum FlowType {
     SOCK = 3;
 }
 
-// These types correspond to definitions in pkg/policy/l4.go
+// These types correspond to definitions in pkg/policy/l4.go.
 enum AuthType {
     DISABLED = 0;
     SPIRE = 1;
@@ -194,8 +194,7 @@ message Layer4 {
     }
 }
 
-// This enum corresponds to Cilium's L7 accesslog FlowType:
-//   https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L26
+// This enum corresponds to Cilium's L7 accesslog [FlowType](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L26):
 enum L7FlowType {
     UNKNOWN_L7_TYPE = 0;
     REQUEST = 1;
@@ -203,8 +202,7 @@ enum L7FlowType {
     SAMPLE = 3;
 }
 
-// Message for L7 flow, which roughly corresponds to Cilium's accesslog LogRecord:
-//   https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L141
+// Message for L7 flow, which roughly corresponds to Cilium's accesslog [LogRecord](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L141):
 message Layer7 {
     L7FlowType type = 1;
     // Latency of the response
@@ -217,10 +215,9 @@ message Layer7 {
     }
 }
 
-// TraceContext contains trace context propagation data, ie information about a
+// TraceContext contains trace context propagation data, i.e. information about a
 // distributed trace.
-// For more information about trace context, check the W3C Trace Context
-// specification: https://www.w3.org/TR/trace-context/
+// For more information about trace context, check the [W3C Trace Context specification](https://www.w3.org/TR/trace-context/).
 message TraceContext {
     // parent identifies the incoming request in a tracing system.
     TraceParent parent = 1;
@@ -434,7 +431,7 @@ message Policy {
 	uint64 revision = 4;
 }
 
-// EventTypeFilter is a filter describing a particular event type
+// EventTypeFilter is a filter describing a particular event type.
 message EventTypeFilter {
 	// type is the primary flow type as defined by:
 	// github.com/cilium/cilium/pkg/monitor/api.MessageType*
@@ -449,7 +446,7 @@ message EventTypeFilter {
 	int32 sub_type = 3;
 }
 
-// CiliumEventType from which the flow originated
+// CiliumEventType from which the flow originated.
 message CiliumEventType {
     // type of event the flow originated from, i.e.
     // github.com/cilium/cilium/pkg/monitor/api.MessageType*
@@ -560,8 +557,7 @@ enum EventType {
     RecordLost = 2;
 }
 
-// DNS flow. This is basically directly mapped from Cilium's LogRecordDNS:
-//     https://github.com/cilium/cilium/blob/04f3889d627774f79e56d14ddbc165b3169e2d01/pkg/proxy/accesslog/record.go#L264
+// DNS flow. This is basically directly mapped from Cilium's [LogRecordDNS](https://github.com/cilium/cilium/blob/04f3889d627774f79e56d14ddbc165b3169e2d01/pkg/proxy/accesslog/record.go#L264):
 message DNS {
     // DNS name that's being looked up: e.g. "isovalent.com."
     string query = 1;
@@ -590,8 +586,7 @@ message HTTPHeader {
     string value = 2;
 }
 
-// L7 information for HTTP flows. It corresponds to Cilium's accesslog.LogRecordHTTP type.
-//   https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L206
+// L7 information for HTTP flows. It corresponds to Cilium's [accesslog.LogRecordHTTP](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L206) type. 
 message HTTP {
     uint32 code = 1;
     string method = 2;
@@ -600,8 +595,7 @@ message HTTP {
     repeated HTTPHeader headers = 5;
 }
 
-// L7 information for Kafka flows. It corresponds to Cilium's accesslog.LogRecordKafka type.
-//   https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L229
+// L7 information for Kafka flows. It corresponds to Cilium's [accesslog.LogRecordKafka](https://github.com/cilium/cilium/blob/728c79e427438ab6f8d9375b62fccd6fed4ace3a/pkg/proxy/accesslog/record.go#L229) type.
 message Kafka {
     int32 error_code = 1;
     int32 api_version = 2;
@@ -644,7 +638,7 @@ message LostEvent {
 }
 
 // AgentEventType is the type of agent event. These values are shared with type
-// AgentNotification in pkg/monitor/api/types.go
+// AgentNotification in pkg/monitor/api/types.go.
 enum AgentEventType {
     AGENT_EVENT_UNKNOWN = 0;
     // used for AGENT_EVENT_GENERIC in monitor API, but there are currently no


### PR DESCRIPTION
The **[Flow gRPC API Reference](https://docs.cilium.io/en/stable/_api/v1/flow/README/)** contains bare URLs to Cilium's source code on GitHub and the W3C Trace Context specification. This changes the non-tabled bare URLs to Markdown links for an improved reading experience. Following this change, users can click on the links and directly access a page instead of having to copy and paste URLs. This also adds punctuation in several places for consistency.

I tested these changes locally.
