### PR TITLE
Split mapstate keys into allow and deny

### DIFF
--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -373,17 +373,17 @@ func (e *Endpoint) GetPolicyModel() *models.EndpointPolicyStatus {
 
 	realizedLog := log.WithField("map-name", "realized").Logger
 	realizedIngressIdentities, realizedEgressIdentities :=
-		e.realizedPolicy.PolicyMapState.GetIdentities(realizedLog)
+		e.realizedPolicy.GetPolicyMap().GetIdentities(realizedLog)
 
 	realizedDenyIngressIdentities, realizedDenyEgressIdentities :=
-		e.realizedPolicy.PolicyMapState.GetDenyIdentities(realizedLog)
+		e.realizedPolicy.GetPolicyMap().GetDenyIdentities(realizedLog)
 
 	desiredLog := log.WithField("map-name", "desired").Logger
 	desiredIngressIdentities, desiredEgressIdentities :=
-		e.desiredPolicy.PolicyMapState.GetIdentities(desiredLog)
+		e.desiredPolicy.GetPolicyMap().GetIdentities(desiredLog)
 
 	desiredDenyIngressIdentities, desiredDenyEgressIdentities :=
-		e.desiredPolicy.PolicyMapState.GetDenyIdentities(desiredLog)
+		e.desiredPolicy.GetPolicyMap().GetDenyIdentities(desiredLog)
 
 	policyEnabled := e.policyStatus()
 

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -704,7 +704,7 @@ func (e *Endpoint) Allows(id identity.NumericIdentity) bool {
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 
-	v, ok := e.desiredPolicy.PolicyMapState[keyToLookup]
+	v, ok := e.desiredPolicy.GetPolicyMap().Get(keyToLookup)
 	return ok && !v.IsDeny
 }
 

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -80,7 +80,7 @@ func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *End
 		})
 	}
 
-	e.desiredPolicy.PolicyMapState = policy.MapState{}
+	e.desiredPolicy.SetPolicyMap(nil)
 
 	if spec.numPortsPerIdentity == 0 {
 		spec.numPortsPerIdentity = 1
@@ -93,7 +93,7 @@ func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *End
 				DestPort:         uint16(80 + n),
 				TrafficDirection: trafficdirection.Ingress.Uint8(),
 			}
-			e.desiredPolicy.PolicyMapState[key] = policy.MapStateEntry{}
+			e.desiredPolicy.GetPolicyMap().Insert(key, policy.MapStateEntry{})
 		}
 	}
 
@@ -104,7 +104,7 @@ func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *End
 				DestPort:         uint16(80 + n),
 				TrafficDirection: trafficdirection.Egress.Uint8(),
 			}
-			e.desiredPolicy.PolicyMapState[key] = policy.MapStateEntry{}
+			e.desiredPolicy.GetPolicyMap().Insert(key, policy.MapStateEntry{})
 		}
 	}
 
@@ -397,7 +397,7 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 	}
 
 	for _, tt := range tests {
-		e.desiredPolicy.PolicyMapState = policy.MapState{}
+		e.desiredPolicy.SetPolicyMap(nil)
 		for _, arg := range tt.args {
 			t := policy.Key{
 				Identity:         arg.identity,
@@ -405,7 +405,7 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 				Nexthdr:          arg.nexthdr,
 				TrafficDirection: arg.direction.Uint8(),
 			}
-			e.desiredPolicy.PolicyMapState[t] = policy.MapStateEntry{}
+			e.desiredPolicy.GetPolicyMap().Insert(t, policy.MapStateEntry{})
 		}
 		expectedIngressList := prepareExpectedList(tt.ingressResult)
 		expectedEgressList := prepareExpectedList(tt.egressResult)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -985,7 +985,7 @@ func (e *Endpoint) GetRealizedPolicyRuleLabelsForKey(key policy.Key) (
 	e.mutex.RLock()
 	defer e.mutex.RUnlock()
 
-	entry, ok := e.realizedPolicy.PolicyMapState[key]
+	entry, ok := e.realizedPolicy.GetPolicyMap().Get(key)
 	if !ok {
 		return nil, 0, false
 	}

--- a/pkg/endpoint/policy_test.go
+++ b/pkg/endpoint/policy_test.go
@@ -189,9 +189,10 @@ func TestIncrementalUpdatesDuringPolicyGeneration(t *testing.T) {
 		// while holding the endpoint lock
 		res.endpointPolicy.ConsumeMapChanges()
 		haveIDs := make(sets.Set[identity.NumericIdentity], testfactor)
-		for k := range res.endpointPolicy.PolicyMapState {
+		res.endpointPolicy.GetPolicyMap().ForEach(func(k policy.Key, _ policy.MapStateEntry) bool {
 			haveIDs.Insert(identity.NumericIdentity(k.Identity))
-		}
+			return true
+		})
 
 		// It is okay if we have *more* IDs than allocatedIDs, since we may have propagated
 		// an ID change through the policy system but not yet added to the extra list we're

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -9,7 +9,6 @@ import (
 	check "github.com/cilium/checkmate"
 	"github.com/sirupsen/logrus"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/completion"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/fqdn/restore"
@@ -184,12 +183,12 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 
 	_, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
-	v, ok := ep.desiredPolicy.PolicyMapState[policy.Key{
+	v, ok := ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
-	}]
+	})
 	c.Assert(ok, check.Equals, true)
 	c.Assert(v.ProxyPort, check.Equals, httpPort)
 
@@ -205,12 +204,12 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 
 	d, err, _, _ := ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
-	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
-	}]
+	})
 	c.Assert(ok, check.Equals, true)
 	// Check that proxyport was updated accordingly.
 	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
@@ -228,30 +227,30 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 
 	_, err, _, _ = ep.addNewRedirects(cmp)
 	c.Assert(err, check.IsNil)
-	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
-	}]
+	})
 	c.Assert(ok, check.Equals, true)
 	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
 
-	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
-	}]
+	})
 	c.Assert(ok, check.Equals, true)
 	c.Assert(v.ProxyPort, check.Equals, kafkaPort)
 
-	v, ok = ep.desiredPolicy.PolicyMapState[policy.Key{
+	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Egress.Uint8(),
-	}]
+	})
 	c.Assert(ok, check.Equals, true)
 	c.Assert(v.ProxyPort, check.Equals, httpPort)
 	pID := policy.ProxyID(ep.ID, false, u8proto.TCP.String(), uint16(80))
@@ -408,19 +407,18 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	err = ep.setDesiredPolicy(res)
 	c.Assert(err, check.IsNil)
 
-	expected := policy.MapState{
-		mapKeyAllowAllE: policy.MapStateEntry{
+	expected := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
+		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
-		mapKeyFoo: policy.MapStateEntry{
+		mapKeyFoo: {
 			IsDeny:           true,
 			DerivedFromRules: labels.LabelArrayList{lblsL3DenyFoo},
 		},
+	})
+	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
+		c.Fatal("desired policy map does not equal expected map")
 	}
-
-	equal, errStr := checker.ExportedEqual(ep.desiredPolicy.PolicyMapState, expected)
-	c.Assert(errStr, check.Equals, "")
-	c.Assert(equal, check.Equals, true)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -441,45 +439,45 @@ func (s *RedirectSuite) TestRedirectWithDeny(c *check.C) {
 	// entries and make any conclusions from it.
 	c.Assert(len(desiredRedirects), check.Equals, 1)
 
-	expected2 := policy.MapState{
-		mapKeyAllowAllE: policy.MapStateEntry{
+	expected2 := policy.NewMapState(map[policy.Key]policy.MapStateEntry{
+		mapKeyAllowAllE: {
 			DerivedFromRules: labels.LabelArrayList{AllowAnyEgressLabels},
 		},
-		mapKeyAllL7: policy.MapStateEntry{
+		mapKeyAllL7: {
 			IsDeny:           false,
 			ProxyPort:        httpPort,
 			DerivedFromRules: labels.LabelArrayList{lblsL4L7Allow},
 		},
-		mapKeyFoo: policy.MapStateEntry{
+		mapKeyFoo: {
 			IsDeny:           true,
 			DerivedFromRules: labels.LabelArrayList{lblsL3DenyFoo},
 		},
-		mapKeyFooL7: policy.MapStateEntry{
+		mapKeyFooL7: {
 			IsDeny:           true,
 			DerivedFromRules: labels.LabelArrayList{lblsL3DenyFoo},
 		},
-	}
+	})
 
 	// Redirect for the HTTP port should have been added, but there should be a deny for Foo on
 	// that port, as it is shadowed by the deny rule
-	equal, errStr = checker.ExportedEqual(ep.desiredPolicy.PolicyMapState, expected2)
-	c.Assert(errStr, check.Equals, "")
-	c.Assert(equal, check.Equals, true)
+	if !ep.desiredPolicy.GetPolicyMap().Equals(expected2) {
+		c.Fatal("desired policy map does not equal expected map")
+	}
 
 	// Keep only desired redirects
 	ep.removeOldRedirects(desiredRedirects, cmp)
 
 	// Check that the redirect is still realized
 	c.Assert(len(ep.realizedRedirects), check.Equals, 1)
-	c.Assert(len(ep.desiredPolicy.PolicyMapState), check.Equals, 4)
+	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 4)
 
 	// Pretend that something failed and revert the changes
 	revertFunc()
 
 	// Check that the state before addRedirects is restored
-	equal, errStr = checker.ExportedEqual(ep.desiredPolicy.PolicyMapState, expected)
-	c.Assert(errStr, check.Equals, "")
-	c.Assert(equal, check.Equals, true)
+	if !ep.desiredPolicy.GetPolicyMap().Equals(expected) {
+		c.Fatal("desired policy map does not equal expected map")
+	}
 	c.Assert(len(ep.realizedRedirects), check.Equals, 0)
-	c.Assert(len(ep.desiredPolicy.PolicyMapState), check.Equals, 2)
+	c.Assert(ep.desiredPolicy.GetPolicyMap().Len(), check.Equals, 2)
 }

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -431,9 +431,9 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 	// because this test suite doesn't have a notion of traffic direction, so
 	// the extra egress allow-all is technically correct, but omitted from the
 	// expected output that's asserted against for the sake of brevity.
-	delete(epp.PolicyMapState, mapKeyAllowAllE_)
+	epp.policyMapState.Delete(mapKeyAllowAllE_)
 
-	return epp.PolicyMapState, nil
+	return epp.policyMapState, nil
 }
 
 // Perm calls f with each permutation of a.
@@ -493,10 +493,10 @@ func Test_MergeL3(t *testing.T) {
 		{
 			0,
 			api.Rules{ruleL3__AllowFoo, ruleL3__AllowBar},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowBar__: mapEntryL7None_(lblsL3__AllowBar),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{},
 				identity.NumericIdentity(identityFoo): AuthTypes{},
@@ -505,10 +505,10 @@ func Test_MergeL3(t *testing.T) {
 		{
 			1,
 			api.Rules{ruleL3__AllowFoo, ruleL3L4__Allow},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{},
 				identity.NumericIdentity(identityFoo): AuthTypes{},
@@ -517,10 +517,10 @@ func Test_MergeL3(t *testing.T) {
 		{
 			2,
 			api.Rules{ruleL3__AllowFoo, ruleL3__AllowBarAuth},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}},
 				identity.NumericIdentity(identityFoo): AuthTypes{},
@@ -529,11 +529,11 @@ func Test_MergeL3(t *testing.T) {
 		{
 			3,
 			api.Rules{ruleL3__AllowFoo, ruleL3__AllowBarAuth, rule__L4__AllowAuth},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeSpire, lbls__L4__Allow),
 				mapKeyAllowFoo__: mapEntryL7None_(lblsL3__AllowFoo),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}, AuthTypeSpire: struct{}{}},
 				identity.NumericIdentity(identityFoo): AuthTypes{AuthTypeSpire: struct{}{}},
@@ -542,10 +542,10 @@ func Test_MergeL3(t *testing.T) {
 		{
 			4,
 			api.Rules{rule____AllowAll, ruleL3__AllowBarAuth},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}},
 				identity.NumericIdentity(identityFoo): AuthTypes{},
@@ -554,10 +554,10 @@ func Test_MergeL3(t *testing.T) {
 		{
 			5,
 			api.Rules{rule____AllowAllAuth, ruleL3__AllowBar},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeSpire, lbls____AllowAll),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeSpire, lblsL3__AllowBar),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeSpire: struct{}{}},
 				identity.NumericIdentity(identityFoo): AuthTypes{AuthTypeSpire: struct{}{}},
@@ -566,10 +566,10 @@ func Test_MergeL3(t *testing.T) {
 		{
 			6,
 			api.Rules{rule____AllowAllAuth, rule__L4__Allow},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeSpire, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeSpire, lbls__L4__Allow),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeSpire: struct{}{}},
 				identity.NumericIdentity(identityFoo): AuthTypes{AuthTypeSpire: struct{}{}},
@@ -578,11 +578,11 @@ func Test_MergeL3(t *testing.T) {
 		{
 			7,
 			api.Rules{rule____AllowAllAuth, ruleL3__AllowBar, rule__L4__Allow},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeSpire, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeSpire, lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeSpire, lblsL3__AllowBar),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeSpire: struct{}{}},
 				identity.NumericIdentity(identityFoo): AuthTypes{AuthTypeSpire: struct{}{}},
@@ -591,11 +591,11 @@ func Test_MergeL3(t *testing.T) {
 		{
 			8,
 			api.Rules{rule____AllowAll, ruleL3__AllowBar, rule__L4__Allow},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeDisabled, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeDisabled, lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeDisabled, lblsL3__AllowBar),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{},
 				identity.NumericIdentity(identityFoo): AuthTypes{},
@@ -604,12 +604,12 @@ func Test_MergeL3(t *testing.T) {
 		{
 			9,
 			api.Rules{rule____AllowAll, rule__L4__Allow, ruleL3__AllowBarAuth},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeDisabled, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeDisabled, lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
 				mapKeyAllowBarL4: mapEntryL7Auth_(AuthTypeAlwaysFail, lbls__L4__Allow, lblsL3__AllowBar),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}},
 				identity.NumericIdentity(identityFoo): AuthTypes{},
@@ -618,12 +618,12 @@ func Test_MergeL3(t *testing.T) {
 		{
 			10, // Same as 9, but the L3L4 entry is created by an explicit rule.
 			api.Rules{rule____AllowAll, rule__L4__Allow, ruleL3__AllowBarAuth, ruleL3L4AllowBarAuth},
-			MapState{
+			NewMapState(map[Key]MapStateEntry{
 				mapKeyAllowAll__: mapEntryL7Auth_(AuthTypeDisabled, lbls____AllowAll),
 				mapKeyAllow___L4: mapEntryL7Auth_(AuthTypeDisabled, lbls__L4__Allow),
 				mapKeyAllowBar__: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3__AllowBar),
 				mapKeyAllowBarL4: mapEntryL7Auth_(AuthTypeAlwaysFail, lblsL3L4AllowBar, lbls__L4__Allow, lblsL3__AllowBar),
-			},
+			}),
 			authResult{
 				identity.NumericIdentity(identityBar): AuthTypes{AuthTypeAlwaysFail: struct{}{}},
 				identity.NumericIdentity(identityFoo): AuthTypes{},
@@ -751,15 +751,15 @@ func parseTable(test string) generatedBPFKey {
 // The algorithm represented in this function should be the source of truth
 // of our expectations when enforcing multiple types of policies.
 func testCaseToMapState(t generatedBPFKey) MapState {
-	m := MapState{}
+	m := newMapState(nil)
 
 	if t.L3Key.L3 != nil {
 		if t.L3Key.Deny != nil && *t.L3Key.Deny {
-			m[mapKeyDeny_Foo__] = mapEntryL7Deny_()
+			m.keys[mapKeyDeny_Foo__] = mapEntryL7Deny_()
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3Key.L7 == nil || !*t.L3Key.L7 {
-				m[mapKeyAllowFoo__] = mapEntryL7None_()
+				m.keys[mapKeyAllowFoo__] = mapEntryL7None_()
 			}
 			// there's no "else" because we don't support L3L7 policies, i.e.,
 			// a L4 port needs to be specified.
@@ -767,40 +767,40 @@ func testCaseToMapState(t generatedBPFKey) MapState {
 	}
 	if t.L4Key.L3 != nil {
 		if t.L4Key.Deny != nil && *t.L4Key.Deny {
-			m[mapKeyDeny____L4] = mapEntryL7Deny_()
+			m.keys[mapKeyDeny____L4] = mapEntryL7Deny_()
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-				m[mapKeyAllow___L4] = mapEntryL7None_()
+				m.keys[mapKeyAllow___L4] = mapEntryL7None_()
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection.
-				m[mapKeyAllow___L4] = mapEntryL7Proxy()
+				m.keys[mapKeyAllow___L4] = mapEntryL7Proxy()
 			}
 		}
 	}
 	if t.L3L4Key.L3 != nil {
 		if t.L3L4Key.Deny != nil && *t.L3L4Key.Deny {
-			m[mapKeyDeny_FooL4] = mapEntryL7Deny_()
+			m.keys[mapKeyDeny_FooL4] = mapEntryL7Deny_()
 		} else {
 			// If L7 is not set or if it explicitly set but it's false
 			if t.L3L4Key.L7 == nil || !*t.L3L4Key.L7 {
-				m[mapKeyAllowFooL4] = mapEntryL7None_()
+				m.keys[mapKeyAllowFooL4] = mapEntryL7None_()
 			} else {
 				// L7 is set and it's true then we should expected a mapEntry
 				// with L7 redirection only if we haven't set it already
 				// for an existing L4-only.
 				if t.L4Key.L7 == nil || !*t.L4Key.L7 {
-					m[mapKeyAllowFooL4] = mapEntryL7Proxy()
+					m.keys[mapKeyAllowFooL4] = mapEntryL7Proxy()
 				}
 			}
 		}
 	}
 
 	// Add dependency deny-L3->deny-L3L4 if allow-L4 exists
-	denyL3, denyL3exists := m[mapKeyDeny_Foo__]
-	denyL3L4, denyL3L4exists := m[mapKeyDeny_FooL4]
-	allowL4, allowL4exists := m[mapKeyAllow___L4]
+	denyL3, denyL3exists := m.keys[mapKeyDeny_Foo__]
+	denyL3L4, denyL3L4exists := m.keys[mapKeyDeny_FooL4]
+	allowL4, allowL4exists := m.keys[mapKeyAllow___L4]
 	if allowL4exists && !allowL4.IsDeny && denyL3exists && denyL3.IsDeny && denyL3L4exists && denyL3L4.IsDeny {
 		m.AddDependent(mapKeyDeny_Foo__, mapKeyDeny_FooL4, ChangeState{})
 	}
@@ -1133,38 +1133,38 @@ func Test_MergeRules(t *testing.T) {
 		// https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw/edit?usp=sharing
 		//
 		//  Rule 0                   | Rule 1         | Rule 2         | Rule 3         | Rule 4         | Rule 5         | Rule 6         | Rule 7         | Desired BPF map state
-		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{}},
-		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)}},
-		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)}},
-		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)}},                                                     // identical L3L4 entry suppressed
-		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}}, // identical L3L4 entry suppressed
-		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)}},
-		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)}},
-		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)}},                                                                      // L3L4 entry suppressed to allow L4-only entry to redirect
-		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},                  // L3L4 entry suppressed to allow L4-only entry to redirect
-		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)}},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
-		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}}, // L3L4 entry suppressed to allow L4-only entry to redirect
-		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)}},
-		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)}},
-		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow)}},
-		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)}},
-		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)}},                                                                      // identical L3L4 entry suppressed
-		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},                  // identical L3L4 entry suppressed
-		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)}},                                                     // identical L3L4 entry suppressed
-		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}}, // identical L3L4 entry suppressed
-		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)}},                                                                      // identical L3L4 entry suppressed
-		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},                  // identical L3L4 entry suppressed
-		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)}},                                                     // identical L3L4 entry suppressed
-		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}}, // identical L3L4 entry suppressed
+		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(nil)},
+		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
+		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
+		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},
+		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // L3L4 entry suppressed to allow L4-only entry to redirect
+		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // L3L4 entry suppressed to allow L4-only entry to redirect
+		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
+		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
+		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
+		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow)})},
+		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule____NoAllow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
+		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
+		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, rule____NoAllow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                      // identical L3L4 entry suppressed
+		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                  // identical L3L4 entry suppressed
+		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3L4L7Allow, rule__L4L7Allow, ruleL3L4__Allow, rule__L4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
 	}
 
 	expectedMapState := generateMapStates()
@@ -1212,13 +1212,14 @@ func Test_MergeRules(t *testing.T) {
 			// Since this field is only used for debuggability purposes we can
 			// ignore it and test only for the MapState that we are expecting
 			// to be plumbed into the datapath.
-			for k, v := range mapstate {
+			mapstate.ForEach(func(k Key, v MapStateEntry) (cont bool) {
 				if v.DerivedFromRules == nil || len(v.DerivedFromRules) == 0 {
-					continue
+					return true
 				}
 				v.DerivedFromRules = labels.LabelArrayList(nil).Sort()
-				mapstate[k] = v
-			}
+				mapstate.Insert(k, v)
+				return true
+			})
 			if equal, err := checker.ExportedEqual(mapstate, expectedMapState[tt.test]); !equal {
 				t.Logf("Rules:\n%s\n\n", tt.rules.String())
 				t.Logf("Policy Trace: \n%s\n", logBuffer.String())
@@ -1256,38 +1257,38 @@ func Test_MergeRulesWithNamedPorts(t *testing.T) {
 		// https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw/edit?usp=sharing
 		//
 		//  Rule 0                   | Rule 1         | Rule 2         | Rule 3         | Rule 4         | Rule 5         | Rule 6         | Rule 7         | Desired BPF map state
-		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{}},
-		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)}},
-		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)}},
-		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)}},                                                     // identical L3L4 entry suppressed
-		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}}, // identical L3L4 entry suppressed
-		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)}},
-		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)}},
-		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)}},                                                                        // L3L4 entry suppressed to allow L4-only entry to redirect
-		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},                    // L3L4 entry suppressed to allow L4-only entry to redirect
-		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)}},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
-		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}}, // L3L4 entry suppressed to allow L4-only entry to redirect
-		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)}},
-		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)}},
-		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow)}},
-		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)}},
-		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, MapState{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},
-		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)}},                                                                          // identical L3L4 entry suppressed
-		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},                      // identical L3L4 entry suppressed
-		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)}},                                                       // identical L3L4 entry suppressed
-		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},   // identical L3L4 entry suppressed
-		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)}},                                                                        // identical L3L4 entry suppressed
-		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}},                    // identical L3L4 entry suppressed
-		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)}},                                                     // identical L3L4 entry suppressed
-		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, MapState{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)}}, // identical L3L4 entry suppressed
+		{0, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(nil)},
+		{1, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{2, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{3, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{4, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow)})},
+		{5, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7None_(lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{6, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{7, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
+		{8, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},
+		{9, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{10, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},
+		{11, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{12, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // L3L4 entry suppressed to allow L4-only entry to redirect
+		{13, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // L3L4 entry suppressed to allow L4-only entry to redirect
+		{14, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // L3L4 entry suppressed to allow L4-only entry to redirect
+		{15, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, rule____NoAllow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // L3L4 entry suppressed to allow L4-only entry to redirect
+		{16, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow)})},
+		{17, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{18, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{19, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{20, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow)})},
+		{21, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{22, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow)})},
+		{23, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule____NoAllow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllowFooL4: mapEntryL7Proxy(lblsL3L4L7Allow, lblsL3L4__Allow), mapKeyAllow___L4: mapEntryL7None_(lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},
+		{24, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                          // identical L3L4 entry suppressed
+		{25, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                      // identical L3L4 entry suppressed
+		{26, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                       // identical L3L4 entry suppressed
+		{27, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, rule____NoAllow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},   // identical L3L4 entry suppressed
+		{28, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow)})},                                                                        // identical L3L4 entry suppressed
+		{29, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule____NoAllow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})},                    // identical L3L4 entry suppressed
+		{30, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, rule____NoAllow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow)})},                                                     // identical L3L4 entry suppressed
+		{31, api.Rules{rule_____NoDeny, rule_____NoDeny, rule_____NoDeny, ruleL3npL4L7Allow, rule__npL4L7Allow, ruleL3npL4__Allow, rule__npL4__Allow, ruleL3____Allow}, newMapState(map[Key]MapStateEntry{mapKeyAllow___L4: mapEntryL7Proxy(lbls__L4L7Allow, lbls__L4__Allow), mapKeyAllowFoo__: mapEntryL7None_(lblsL3____Allow)})}, // identical L3L4 entry suppressed
 	}
 	for _, tt := range tests {
 		repo := newPolicyDistillery(selectorCache)
@@ -1334,8 +1335,8 @@ func Test_AllowAll(t *testing.T) {
 		rules    api.Rules
 		result   MapState
 	}{
-		{0, api.EndpointSelectorNone, api.Rules{rule____AllowAll}, MapState{mapKeyAllowAll__: mapEntryL7None_(lblsAllowAllIngress)}},
-		{1, api.WildcardEndpointSelector, api.Rules{rule____AllowAll}, MapState{mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll)}},
+		{0, api.EndpointSelectorNone, api.Rules{rule____AllowAll}, NewMapState(map[Key]MapStateEntry{mapKeyAllowAll__: mapEntryL7None_(lblsAllowAllIngress)})},
+		{1, api.WildcardEndpointSelector, api.Rules{rule____AllowAll}, NewMapState(map[Key]MapStateEntry{mapKeyAllowAll__: mapEntryL7None_(lbls____AllowAll)})},
 	}
 
 	for _, tt := range tests {
@@ -1625,21 +1626,21 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 		rules  api.Rules
 		result MapState
 	}{
-		{"deny_world_no_labels", api.Rules{ruleL3DenyWorld, ruleL3AllowWorldIP}, MapState{
+		{"deny_world_no_labels", api.Rules{ruleL3DenyWorld, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
 			mapKeyL3WorldIngress: mapEntryDeny,
 			mapKeyL3WorldEgress:  mapEntryDeny,
-		}}, {"deny_world_with_labels", api.Rules{ruleL3DenyWorldWithLabels, ruleL3AllowWorldIP}, MapState{
+		})}, {"deny_world_with_labels", api.Rules{ruleL3DenyWorldWithLabels, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
 			mapKeyL3WorldIngress: mapEntryWorldDenyWithLabels,
 			mapKeyL3WorldEgress:  mapEntryWorldDenyWithLabels,
-		}}, {"deny_one_ip_with_a_larger_subnet", api.Rules{ruleL3DenySubnet, ruleL3AllowWorldIP}, MapState{
+		})}, {"deny_one_ip_with_a_larger_subnet", api.Rules{ruleL3DenySubnet, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
 			mapKeyL3SubnetIngress: mapEntryDeny,
 			mapKeyL3SubnetEgress:  mapEntryDeny,
-		}}, {"deny_part_of_a_subnet_with_an_ip", api.Rules{ruleL3DenySmallerSubnet, ruleL3AllowLargerSubnet}, MapState{
+		})}, {"deny_part_of_a_subnet_with_an_ip", api.Rules{ruleL3DenySmallerSubnet, ruleL3AllowLargerSubnet}, newMapState(map[Key]MapStateEntry{
 			mapKeyL3SmallerSubnetIngress: mapEntryDeny,
 			mapKeyL3SmallerSubnetEgress:  mapEntryDeny,
 			mapKeyL3SubnetIngress:        mapEntryAllow,
 			mapKeyL3SubnetEgress:         mapEntryAllow,
-		}}, {"broad_deny_is_a_portproto_subset_of_a_specific_allow", api.Rules{ruleL3L4Port8080ProtoAnyDenyWorld, ruleL3AllowWorldIP}, MapState{
+		})}, {"broad_deny_is_a_portproto_subset_of_a_specific_allow", api.Rules{ruleL3L4Port8080ProtoAnyDenyWorld, ruleL3AllowWorldIP}, newMapState(map[Key]MapStateEntry{
 			mapKeyL3L4Port8080ProtoTCPWorldIngress:      mapEntryDeny,
 			mapKeyL3L4Port8080ProtoTCPWorldEgress:       mapEntryDeny,
 			mapKeyL3L4Port8080ProtoTCPWorldIPv4Ingress:  mapEntryDeny,
@@ -1660,8 +1661,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL3L4Port8080ProtoSCTPWorldIPv6Egress:  mapEntryDeny,
 			mapKeyL3SmallerSubnetIngress:                mapEntryAllow,
 			mapKeyL3SmallerSubnetEgress:                 mapEntryAllow,
-		}}, {"broad_allow_is_a_portproto_subset_of_a_specific_deny", api.Rules{ruleL3AllowWorldSubnet, ruleL3DenyWorldIP}, MapState{
-
+		})}, {"broad_allow_is_a_portproto_subset_of_a_specific_deny", api.Rules{ruleL3AllowWorldSubnet, ruleL3DenyWorldIP}, newMapState(map[Key]MapStateEntry{
 			mapKeyL3L4Port8080ProtoTCPWorldSNIngress:  mapEntryAllow,
 			mapKeyL3L4Port8080ProtoTCPWorldSNEgress:   mapEntryAllow,
 			mapKeyL3L4Port8080ProtoUDPWorldSNIngress:  mapEntryAllow,
@@ -1677,7 +1677,7 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL4Port8080ProtoUDPWorldIPEgress:   mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPIngress: mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPEgress:  mapEntryDeny,
-		}},
+		})},
 	}
 
 	for _, tt := range tests {
@@ -1724,10 +1724,10 @@ func Test_EnsureEntitiesSelectableByCIDR(t *testing.T) {
 		rules  api.Rules
 		result MapState
 	}{
-		{"host_cidr_select", api.Rules{ruleL3AllowHostEgress}, MapState{
+		{"host_cidr_select", api.Rules{ruleL3AllowHostEgress}, newMapState(map[Key]MapStateEntry{
 			mapKeyL3UnknownIngress: mapEntryL3UnknownIngress,
 			mapKeyL3HostEgress:     mapEntryAllow,
-		}},
+		})},
 	}
 
 	for _, tt := range tests {

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -40,7 +40,7 @@ func FuzzResolveEgressPolicy(f *testing.F) {
 
 func FuzzDenyPreferredInsert(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
-		keys := MapState{}
+		keys := newMapState(nil)
 		key := Key{}
 		entry := MapStateEntry{}
 		ff := fuzz.NewConsumer(data)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -552,7 +552,7 @@ func (l4Filter *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures,
 		if cs.IsWildcard() {
 			keyToAdd.Identity = 0
 			if entryCb(keyToAdd, &entry) {
-				p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 
 				if port == 0 {
 					// Allow-all
@@ -582,18 +582,18 @@ func (l4Filter *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures,
 		for _, id := range idents {
 			keyToAdd.Identity = id.Uint32()
 			if entryCb(keyToAdd, &entry) {
-				p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+				p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 				// If Cilium is in dual-stack mode then the "World" identity
 				// needs to be split into two identities to represent World
 				// IPv6 and IPv4 traffic distinctly from one another.
 				if id == identity.ReservedIdentityWorld && option.Config.IsDualStack() {
 					keyToAdd.Identity = identity.ReservedIdentityWorldIPv4.Uint32()
 					if entryCb(keyToAdd, &entry) {
-						p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+						p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 					}
 					keyToAdd.Identity = identity.ReservedIdentityWorldIPv6.Uint32()
 					if entryCb(keyToAdd, &entry) {
-						p.PolicyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
+						p.policyMapState.denyPreferredInsertWithChanges(keyToAdd, entry, p.SelectorCache, features, changes)
 					}
 				}
 			}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -72,7 +72,8 @@ type MapState interface {
 
 // mapState is a state of a policy map.
 type mapState struct {
-	keys map[Key]MapStateEntry
+	allows map[Key]MapStateEntry
+	denies map[Key]MapStateEntry
 }
 
 type Identities interface {
@@ -251,45 +252,68 @@ func NewMapState(initMap map[Key]MapStateEntry) MapState {
 }
 
 func newMapState(initMap map[Key]MapStateEntry) *mapState {
-	if initMap == nil {
-		initMap = make(map[Key]MapStateEntry)
+	m := &mapState{
+		allows: make(map[Key]MapStateEntry),
+		denies: make(map[Key]MapStateEntry),
 	}
-	return &mapState{
-		keys: initMap,
+	for k, v := range initMap {
+		m.Insert(k, v)
 	}
+	return m
 }
 
 // Get the MapStateEntry that matches the Key.
 func (ms *mapState) Get(k Key) (MapStateEntry, bool) {
-	if ms == nil || ms.keys == nil {
-		return MapStateEntry{}, false
+	v, ok := ms.denies[k]
+	if ok {
+		return v, ok
 	}
-	v, ok := ms.keys[k]
+	v, ok = ms.allows[k]
 	return v, ok
 }
 
 // Insert the Key and matcthing MapStateEntry into the
 // MapState
 func (ms *mapState) Insert(k Key, v MapStateEntry) {
-	if ms != nil && ms.keys != nil {
-		ms.keys[k] = v
+	if v.IsDeny {
+		delete(ms.allows, k)
+		ms.denies[k] = v
+	} else {
+		delete(ms.denies, k)
+		ms.allows[k] = v
 	}
 }
 
 // Delete removes the Key an related MapStateEntry.
 func (ms *mapState) Delete(k Key) {
-	if ms != nil && ms.keys != nil {
-		delete(ms.keys, k)
-	}
+	delete(ms.allows, k)
+	delete(ms.denies, k)
 }
 
 // ForEach iterates over every Key MapStateEntry and stops when the function
 // argument returns false. It returns false iff the iteration was cut short.
 func (ms *mapState) ForEach(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
-	if ms == nil || ms.keys == nil {
-		return true
+	if complete := ms.forEachAllow(f); !complete {
+		return complete
 	}
-	for k, v := range ms.keys {
+	return ms.forEachDeny(f)
+}
+
+// forEachAllow iterates over every Key MapStateEntry that isn't a deny and
+// stops when the function argument returns false
+func (ms *mapState) forEachAllow(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
+	for k, v := range ms.allows {
+		if !f(k, v) {
+			return false
+		}
+	}
+	return true
+}
+
+// forEachDeny iterates over every Key MapStateEntry that is a deny and
+// stops when the function argument returns false
+func (ms *mapState) forEachDeny(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
+	for k, v := range ms.denies {
 		if !f(k, v) {
 			return false
 		}
@@ -299,17 +323,13 @@ func (ms *mapState) ForEach(f func(Key, MapStateEntry) (cont bool)) (complete bo
 
 // Len returns the length of the map
 func (ms *mapState) Len() int {
-	return len(ms.keys)
+	return len(ms.allows) + len(ms.denies)
 }
 
 // Equals determines if this MapState is equal to the
 // argument MapState
 func (msA *mapState) Equals(msB MapState) bool {
-	if (msA == nil) != (msB == nil) {
-		return false
-	} else if msA == nil && msB == nil {
-		return true
-	} else if msA.Len() != msB.Len() {
+	if msA.Len() != msB.Len() {
 		return false
 	}
 
@@ -328,7 +348,9 @@ func (msA *mapState) Equals(msB MapState) bool {
 
 // AddDependent adds 'key' to the set of dependent keys.
 func (ms *mapState) AddDependent(owner Key, dependent Key, changes ChangeState) {
-	if e, exists := ms.keys[owner]; exists {
+	if e, exists := ms.allows[owner]; exists {
+		ms.addDependentOnEntry(owner, e, dependent, changes)
+	} else if e, exists := ms.denies[owner]; exists {
 		ms.addDependentOnEntry(owner, e, dependent, changes)
 	}
 }
@@ -340,7 +362,13 @@ func (ms *mapState) addDependentOnEntry(owner Key, e MapStateEntry, dependent Ke
 			changes.Old.Insert(owner, e)
 		}
 		e.AddDependent(dependent)
-		ms.keys[owner] = e
+		if e.IsDeny {
+			delete(ms.allows, owner)
+			ms.denies[owner] = e
+		} else {
+			delete(ms.denies, owner)
+			ms.allows[owner] = e
+		}
 	}
 }
 
@@ -348,10 +376,19 @@ func (ms *mapState) addDependentOnEntry(owner Key, e MapStateEntry, dependent Ke
 // This is called when a dependent entry is being deleted.
 // If 'old' is not nil, then old value is added there before any modifications.
 func (ms *mapState) RemoveDependent(owner Key, dependent Key, old MapState) {
-	if e, exists := ms.keys[owner]; exists {
+	if e, exists := ms.allows[owner]; exists {
 		old.InsertIfNotExists(owner, e)
 		e.RemoveDependent(dependent)
-		ms.keys[owner] = e
+		delete(ms.denies, owner)
+		ms.allows[owner] = e
+		return
+	}
+
+	if e, exists := ms.denies[owner]; exists {
+		old.InsertIfNotExists(owner, e)
+		e.RemoveDependent(dependent)
+		delete(ms.allows, owner)
+		ms.denies[owner] = e
 	}
 }
 
@@ -486,7 +523,7 @@ func (ms *mapState) denyPreferredInsert(newKey Key, newEntry MapStateEntry, iden
 // addKeyWithChanges adds a 'key' with value 'entry' to 'keys' keeping track of incremental changes in 'adds' and 'deletes', and any changed or removed old values in 'old', if not nil.
 func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes ChangeState) {
 	// Keep all owners that need this entry so that it is deleted only if all the owners delete their contribution
-	oldEntry, exists := ms.keys[key]
+	oldEntry, exists := ms.Get(key)
 	if exists {
 		// Deny entry can only be overridden by another deny entry
 		if oldEntry.IsDeny && !entry.IsDeny {
@@ -503,14 +540,14 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Chan
 		}
 
 		oldEntry.Merge(&entry)
-		ms.keys[key] = oldEntry
+		ms.Insert(key, oldEntry)
 	} else {
 		// Newly inserted entries must have their own containers, so that they
 		// remain separate when new owners/dependents are added to existing entries
 		entry.DerivedFromRules = slices.Clone(entry.DerivedFromRules)
 		entry.owners = maps.Clone(entry.owners)
 		entry.dependents = maps.Clone(entry.dependents)
-		ms.keys[key] = entry
+		ms.Insert(key, entry)
 	}
 
 	// Record an incremental Add if desired and entry is new or changed
@@ -526,7 +563,7 @@ func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Chan
 // deleteKeyWithChanges deletes a 'key' from 'keys' keeping track of incremental changes in 'adds' and 'deletes'.
 // The key is unconditionally deleted if 'cs' is nil, otherwise only the contribution of this 'cs' is removed.
 func (ms *mapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes ChangeState) {
-	if entry, exists := ms.keys[key]; exists {
+	if entry, exists := ms.Get(key); exists {
 		// Save old value before any changes, if desired
 		if changes.Old == nil {
 			changes.Old = newMapState(nil)
@@ -579,7 +616,8 @@ func (ms *mapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes C
 			}
 		}
 
-		delete(ms.keys, key)
+		delete(ms.allows, key)
+		delete(ms.denies, key)
 	}
 }
 
@@ -662,11 +700,12 @@ func protocolsMatch(a, b Key) bool {
 // denyPreferredInsertWithChanges().
 func (ms *mapState) RevertChanges(changes ChangeState) {
 	for k := range changes.Adds {
-		delete(ms.keys, k)
+		delete(ms.allows, k)
+		delete(ms.denies, k)
 	}
 	// 'old' contains all the original values of both modified and deleted entries
 	changes.Old.ForEach(func(k Key, v MapStateEntry) bool {
-		ms.keys[k] = v
+		ms.Insert(k, v)
 		return true
 	})
 }
@@ -685,15 +724,16 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 	allCpy := allKey
 	allCpy.TrafficDirection = newKey.TrafficDirection
 	// If we have a deny "all" we don't accept any kind of map entry.
-	if v, ok := ms.keys[allCpy]; ok && v.IsDeny {
+	if _, ok := ms.denies[allCpy]; ok {
 		return
 	}
 	if newEntry.IsDeny {
-		for k, v := range ms.keys {
+		bailed := false
+		ms.ForEach(func(k Key, v MapStateEntry) bool {
 			// Protocols and traffic directions that don't match ensure that the policies
 			// do not interact in anyway.
 			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
-				continue
+				return true
 			}
 			if !v.IsDeny {
 				if identityIsSupersetOf(k.Identity, newKey.Identity, identities) {
@@ -732,7 +772,8 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				//
 				// NOTE: This condition could be broader to reject more deny entries,
 				// but there *may* be performance tradeoffs.
-				return
+				bailed = true
+				return false
 			} else if (newKey.Identity == k.Identity ||
 				identityIsSupersetOf(newKey.Identity, k.Identity, identities)) &&
 				newKey.DestPort == 0 && newKey.Nexthdr == 0 &&
@@ -747,14 +788,18 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 				// but there *may* be performance tradeoffs.
 				ms.deleteKeyWithChanges(k, nil, changes)
 			}
+			return true
+		})
+		if !bailed {
+			ms.addKeyWithChanges(newKey, newEntry, changes)
 		}
-		ms.addKeyWithChanges(newKey, newEntry, changes)
 	} else {
-		for k, v := range ms.keys {
+		bailed := false
+		ms.ForEach(func(k Key, v MapStateEntry) bool {
 			// Protocols and traffic directions that don't match ensure that the policies
 			// do not interact in anyway.
 			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
-				continue
+				return true
 			}
 			// NOTE: We do not delete redundant allow entries.
 			if v.IsDeny {
@@ -782,11 +827,16 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 					// If the iterated-deny-entry is a superset (or equal) of the new-entry and has a
 					// broader (or equal) port-protocol than the new-entry then the new
 					// entry should not be inserted.
-					return
+					bailed = true
+					return false
 				}
 			}
+
+			return true
+		})
+		if !bailed {
+			ms.authPreferredInsert(newKey, newEntry, features, changes)
 		}
-		ms.authPreferredInsert(newKey, newEntry, features, changes)
 	}
 }
 
@@ -860,21 +910,22 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 			// Fill in the AuthType from more generic entries with an explicit auth type
 			maxSpecificity := 0
 			l3l4State := newMapState(nil)
-			for k, v := range ms.keys {
+
+			ms.ForEach(func(k Key, v MapStateEntry) bool {
 				// Only consider the same Traffic direction
 				if newKey.TrafficDirection != k.TrafficDirection {
-					continue
+					return true
 				}
 				// Skip deny entries, they have no effect on authentication requirements,
 				// and we should not create any new (non-deny) entries based on a combination
 				// of an existing deny and the new non-deny entry.
 				if v.IsDeny {
-					continue
+					return true
 				}
 
 				// Nothing to be done if entry has default AuthType
 				if v.hasAuthType == DefaultAuthType {
-					continue
+					return true
 				}
 
 				// Find out if 'k' is an identity-port-proto superset of 'newKey'
@@ -903,22 +954,24 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 						newKeyCpy.Nexthdr = newKey.Nexthdr
 						l3l4AuthEntry := NewMapStateEntry(k, v.DerivedFromRules, false, false, DefaultAuthType, v.AuthType)
 						l3l4AuthEntry.DerivedFromRules.MergeSorted(newEntry.DerivedFromRules)
-						l3l4State.keys[newKeyCpy] = l3l4AuthEntry
+						l3l4State.allows[newKeyCpy] = l3l4AuthEntry
 					}
 				}
-			}
+				return true
+			})
 			// Add collected L3/L4 entries if the auth type of the new entry was not
 			// overridden by a more generic entry. If it was overridden, the new L3L4
 			// entries are not needed as the L4-only entry with an overridden AuthType
 			// will be matched before the L3-only entries in the datapath.
 			if maxSpecificity == 0 {
-				for k, v := range l3l4State.keys {
+				l3l4State.ForEach(func(k Key, v MapStateEntry) bool {
 					ms.addKeyWithChanges(k, v, changes)
 					// L3-only entries can be deleted incrementally so we need to track their
 					// effects on other entries so that those effects can be reverted when the
 					// identity is removed.
 					newEntry.AddDependent(k)
-				}
+					return true
+				})
 			}
 		} else {
 			// New entry has an explicit auth type.
@@ -927,16 +980,17 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 			// entry to such entries.
 			explicitSubsetKeys := make(Keys)
 			defaultSubsetKeys := make(map[Key]int)
-			for k, v := range ms.keys {
+
+			ms.ForEach(func(k Key, v MapStateEntry) bool {
 				// Only consider the same Traffic direction
 				if newKey.TrafficDirection != k.TrafficDirection {
-					continue
+					return true
 				}
 				// Skip deny entries, they have no effect on authentication requirements,
 				// and we should not create any new (non-deny) entries based on a combination
 				// of an existing deny and the new non-deny entry.
 				if v.IsDeny {
-					continue
+					return true
 				}
 
 				// Find out if 'newKey' is a superset of 'k'
@@ -966,7 +1020,9 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 						newEntry.AddDependent(newKeyCpy)
 					}
 				}
-			}
+
+				return true
+			})
 			// Find out if this newKey is the most specific superset for all the subset keys with default auth type
 		Next:
 			for k, specificity := range defaultSubsetKeys {
@@ -978,7 +1034,7 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 				}
 				// newKey is the most specific superset with an explicit auth type,
 				// propagate auth type from newEntry to the entry of k
-				v := ms.keys[k]
+				v, _ := ms.Get(k)
 				v.AuthType = newEntry.AuthType
 				ms.addKeyWithChanges(k, v, changes) // Update the map value
 			}
@@ -996,14 +1052,19 @@ var visibilityDerivedFrom = labels.LabelArrayList{visibilityDerivedFromLabels}
 // InsertIfNotExists only inserts `key=value` if `key` does not exist in keys already
 // returns 'true' if 'key=entry' was added to 'keys'
 func (ms *mapState) InsertIfNotExists(key Key, entry MapStateEntry) bool {
-	if ms != nil && ms.keys != nil {
-		if _, exists := ms.keys[key]; !exists {
+	isDeny := entry.IsDeny
+	if ms != nil && (isDeny && ms.denies != nil || !isDeny && ms.allows != nil) {
+		m := ms.allows
+		if isDeny {
+			m = ms.denies
+		}
+		if _, exists := m[key]; !exists {
 			// new containers to keep this entry separate from the one that may remain in 'keys'
 			entry.DerivedFromRules = slices.Clone(entry.DerivedFromRules)
 			entry.owners = maps.Clone(entry.owners)
 			entry.dependents = maps.Clone(entry.dependents)
 
-			ms.keys[key] = entry
+			m[key] = entry
 			return true
 		}
 	}
@@ -1072,8 +1133,8 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 	entry := NewMapStateEntry(nil, visibilityDerivedFrom, true, false, DefaultAuthType, AuthTypeDisabled)
 	entry.ProxyPort = redirectPort
 
-	_, haveAllowAllKey := ms.keys[allowAllKey]
-	l4Only, haveL4OnlyKey := ms.keys[key]
+	_, haveAllowAllKey := ms.Get(allowAllKey)
+	l4Only, haveL4OnlyKey := ms.Get(key)
 	addL4OnlyKey := false
 	if haveL4OnlyKey && !l4Only.IsDeny && l4Only.ProxyPort == 0 {
 		// 1. Change existing L4-only ALLOW key on matching port that does not already
@@ -1097,9 +1158,9 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 	//
 	// Loop through all L3 keys in the traffic direction of the new key
 	//
-	for k, v := range ms.keys {
+	ms.ForEach(func(k Key, v MapStateEntry) bool {
 		if k.TrafficDirection != key.TrafficDirection || k.Identity == 0 {
-			continue
+			return true
 		}
 		if k.DestPort == key.DestPort && k.Nexthdr == key.Nexthdr {
 			//
@@ -1127,7 +1188,7 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 				// 4. For each L3-only ALLOW key add the corresponding L3/L4
 				//    ALLOW redirect if no L3/L4 key already exists and no
 				//    L4-only key already exists and one is not added.
-				if _, ok := ms.keys[k2]; !ok {
+				if _, ok := ms.Get(k2); !ok {
 					d2 := labels.LabelArrayList{visibilityDerivedFromLabels}
 					d2.MergeSorted(v.DerivedFromRules)
 					v2 := NewMapStateEntry(k, d2, true, false, v.hasAuthType, v.AuthType)
@@ -1145,7 +1206,7 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 				// 5. If a new L4-only key was added: For each L3-only DENY
 				//    key add the corresponding L3/L4 DENY key if no L3/L4
 				//    key already exists.
-				if _, ok := ms.keys[k2]; !ok {
+				if _, ok := ms.Get(k2); !ok {
 					v2 := NewMapStateEntry(k, v.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
 					e.PolicyDebug(logrus.Fields{
 						logfields.BPFMapKey:   k2,
@@ -1158,7 +1219,9 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 				}
 			}
 		}
-	}
+
+		return true
+	})
 }
 
 // determineAllowLocalhostIngress determines whether communication should be allowed
@@ -1176,7 +1239,7 @@ func (ms *mapState) determineAllowLocalhostIngress() {
 		ms.denyPreferredInsert(localHostKey, es, nil, allFeatures)
 		if !option.Config.EnableRemoteNodeIdentity {
 			var isHostDenied bool
-			v, ok := ms.keys[localHostKey]
+			v, ok := ms.Get(localHostKey)
 			isHostDenied = ok && v.IsDeny
 			derivedFrom := labels.LabelArrayList{
 				labels.LabelArray{
@@ -1206,7 +1269,7 @@ func (ms *mapState) allowAllIdentities(ingress, egress bool) {
 				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 			},
 		}
-		ms.keys[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled)
+		ms.allows[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled)
 	}
 	if egress {
 		keyToAdd := Key{
@@ -1220,7 +1283,7 @@ func (ms *mapState) allowAllIdentities(ingress, egress bool) {
 				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyEgress, labels.LabelSourceReserved),
 			},
 		}
-		ms.keys[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled)
+		ms.allows[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled)
 	}
 }
 
@@ -1249,7 +1312,7 @@ func (ms *mapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 		TrafficDirection: dir,
 	}
 	// Are we explicitly denying all traffic?
-	v, ok := ms.keys[anyKey]
+	v, ok := ms.Get(anyKey)
 	if ok && v.IsDeny {
 		return true
 	}
@@ -1257,7 +1320,7 @@ func (ms *mapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	// Are we explicitly denying this L4-only traffic?
 	anyKey.DestPort = port
 	anyKey.Nexthdr = proto
-	v, ok = ms.keys[anyKey]
+	v, ok = ms.Get(anyKey)
 	if ok && v.IsDeny {
 		return true
 	}
@@ -1278,9 +1341,9 @@ func (ms *mapState) GetDenyIdentities(log *logrus.Logger) (ingIdentities, egIden
 // GetIdentities returns the ingress and egress identities stored in the
 // MapState.
 func (ms *mapState) getIdentities(log *logrus.Logger, denied bool) (ingIdentities, egIdentities []int64) {
-	for policyMapKey, policyMapValue := range ms.keys {
+	ms.ForEach(func(policyMapKey Key, policyMapValue MapStateEntry) bool {
 		if denied != policyMapValue.IsDeny {
-			continue
+			return true
 		}
 		if policyMapKey.DestPort != 0 {
 			// If the port is non-zero, then the Key no longer only applies
@@ -1288,7 +1351,7 @@ func (ms *mapState) getIdentities(log *logrus.Logger, denied bool) (ingIdentitie
 			// contain sets of which identities (i.e., label-based L3 only)
 			// are allowed, so anything which contains L4-related policy should
 			// not be added to these sets.
-			continue
+			return true
 		}
 		switch trafficdirection.TrafficDirection(policyMapKey.TrafficDirection) {
 		case trafficdirection.Ingress:
@@ -1300,7 +1363,8 @@ func (ms *mapState) getIdentities(log *logrus.Logger, denied bool) (ingIdentitie
 			log.WithField(logfields.TrafficDirection, td).
 				Errorf("Unexpected traffic direction present in policy map state for endpoint")
 		}
-	}
+		return true
+	})
 	return ingIdentities, egIdentities
 }
 

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -47,8 +47,33 @@ const (
 	LabelVisibilityAnnotation   = "visibility-annotation"
 )
 
-// MapState is a state of a policy map.
-type MapState map[Key]MapStateEntry
+// MapState is a map interface for policy maps
+type MapState interface {
+	Get(Key) (MapStateEntry, bool)
+	Insert(Key, MapStateEntry)
+	Delete(Key)
+	InsertIfNotExists(Key, MapStateEntry) bool
+	// ForEach allows iteration over the MapStateEntries. It returns true iff
+	// the iteration was not stopped early by the callback.
+	ForEach(func(Key, MapStateEntry) (cont bool)) (complete bool)
+	GetIdentities(*logrus.Logger) ([]int64, []int64)
+	GetDenyIdentities(*logrus.Logger) ([]int64, []int64)
+	RevertChanges(ChangeState)
+	AddVisibilityKeys(PolicyOwner, uint16, *VisibilityMetadata, ChangeState)
+	Len() int
+	Equals(MapState) bool
+
+	allowAllIdentities(ingress, egress bool)
+	determineAllowLocalhostIngress()
+	deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool
+	denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, identities Identities, features policyFeatures, changes ChangeState)
+	deleteKeyWithChanges(key Key, owner MapStateOwner, changes ChangeState)
+}
+
+// mapState is a state of a policy map.
+type mapState struct {
+	keys map[Key]MapStateEntry
+}
 
 type Identities interface {
 	GetNetsLocked(identity.NumericIdentity) []*net.IPNet
@@ -220,32 +245,113 @@ func getNets(identities Identities, ident uint32) []*net.IPNet {
 	return identities.GetNetsLocked(id)
 }
 
+// NewMapState creates a new MapState interface
+func NewMapState(initMap map[Key]MapStateEntry) MapState {
+	return newMapState(initMap)
+}
+
+func newMapState(initMap map[Key]MapStateEntry) *mapState {
+	if initMap == nil {
+		initMap = make(map[Key]MapStateEntry)
+	}
+	return &mapState{
+		keys: initMap,
+	}
+}
+
+// Get the MapStateEntry that matches the Key.
+func (ms *mapState) Get(k Key) (MapStateEntry, bool) {
+	if ms == nil || ms.keys == nil {
+		return MapStateEntry{}, false
+	}
+	v, ok := ms.keys[k]
+	return v, ok
+}
+
+// Insert the Key and matcthing MapStateEntry into the
+// MapState
+func (ms *mapState) Insert(k Key, v MapStateEntry) {
+	if ms != nil && ms.keys != nil {
+		ms.keys[k] = v
+	}
+}
+
+// Delete removes the Key an related MapStateEntry.
+func (ms *mapState) Delete(k Key) {
+	if ms != nil && ms.keys != nil {
+		delete(ms.keys, k)
+	}
+}
+
+// ForEach iterates over every Key MapStateEntry and stops when the function
+// argument returns false. It returns false iff the iteration was cut short.
+func (ms *mapState) ForEach(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
+	if ms == nil || ms.keys == nil {
+		return true
+	}
+	for k, v := range ms.keys {
+		if !f(k, v) {
+			return false
+		}
+	}
+	return true
+}
+
+// Len returns the length of the map
+func (ms *mapState) Len() int {
+	return len(ms.keys)
+}
+
+// Equals determines if this MapState is equal to the
+// argument MapState
+func (msA *mapState) Equals(msB MapState) bool {
+	if (msA == nil) != (msB == nil) {
+		return false
+	} else if msA == nil && msB == nil {
+		return true
+	} else if msA.Len() != msB.Len() {
+		return false
+	}
+
+	return msB.ForEach(func(kA Key, vA MapStateEntry) bool {
+		if vB, ok := msB.Get(kA); ok {
+			if !(&vB).DatapathEqual(&vA) {
+				return false
+			}
+		} else {
+			return false
+		}
+
+		return true
+	})
+}
+
 // AddDependent adds 'key' to the set of dependent keys.
-func (keys MapState) AddDependent(owner Key, dependent Key, changes ChangeState) {
-	if e, exists := keys[owner]; exists {
-		keys.addDependentOnEntry(owner, e, dependent, changes)
+func (ms *mapState) AddDependent(owner Key, dependent Key, changes ChangeState) {
+	if e, exists := ms.keys[owner]; exists {
+		ms.addDependentOnEntry(owner, e, dependent, changes)
 	}
 }
 
 // addDependentOnEntry adds 'dependent' to the set of dependent keys of 'e'.
-func (keys MapState) addDependentOnEntry(owner Key, e MapStateEntry, dependent Key, changes ChangeState) {
+func (ms *mapState) addDependentOnEntry(owner Key, e MapStateEntry, dependent Key, changes ChangeState) {
 	if _, exists := e.dependents[dependent]; !exists {
 		if changes.Old != nil {
-			changes.Old[owner] = e
+			changes.Old.Insert(owner, e)
 		}
 		e.AddDependent(dependent)
-		keys[owner] = e
+		ms.keys[owner] = e
 	}
 }
 
 // RemoveDependent removes 'key' from the list of dependent keys.
 // This is called when a dependent entry is being deleted.
 // If 'old' is not nil, then old value is added there before any modifications.
-func (keys MapState) RemoveDependent(owner Key, dependent Key, old MapState) {
-	if e, exists := keys[owner]; exists {
-		old.insertIfNotExists(owner, e)
+func (ms *mapState) RemoveDependent(owner Key, dependent Key, old MapState) {
+	if e, exists := ms.keys[owner]; exists {
+		old.InsertIfNotExists(owner, e)
 		e.RemoveDependent(dependent)
-		keys[owner] = e
+		ms.keys[owner] = e
 	}
 }
 
@@ -370,17 +476,17 @@ func (e MapStateEntry) String() string {
 // in accumulating incremental changes.
 // Caller may insert the same MapStateEntry multiple times for different Keys, but all from the same
 // owner.
-func (keys MapState) denyPreferredInsert(newKey Key, newEntry MapStateEntry, identities Identities, features policyFeatures) {
+func (ms *mapState) denyPreferredInsert(newKey Key, newEntry MapStateEntry, identities Identities, features policyFeatures) {
 	// Enforce nil values from NewMapStateEntry
 	newEntry.dependents = nil
 
-	keys.denyPreferredInsertWithChanges(newKey, newEntry, identities, features, ChangeState{})
+	ms.denyPreferredInsertWithChanges(newKey, newEntry, identities, features, ChangeState{})
 }
 
 // addKeyWithChanges adds a 'key' with value 'entry' to 'keys' keeping track of incremental changes in 'adds' and 'deletes', and any changed or removed old values in 'old', if not nil.
-func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, changes ChangeState) {
+func (ms *mapState) addKeyWithChanges(key Key, entry MapStateEntry, changes ChangeState) {
 	// Keep all owners that need this entry so that it is deleted only if all the owners delete their contribution
-	oldEntry, exists := keys[key]
+	oldEntry, exists := ms.keys[key]
 	if exists {
 		// Deny entry can only be overridden by another deny entry
 		if oldEntry.IsDeny && !entry.IsDeny {
@@ -393,18 +499,18 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Cha
 
 		// Save old value before any changes, if desired
 		if changes.Old != nil {
-			changes.Old.insertIfNotExists(key, oldEntry)
+			changes.Old.InsertIfNotExists(key, oldEntry)
 		}
 
 		oldEntry.Merge(&entry)
-		keys[key] = oldEntry
+		ms.keys[key] = oldEntry
 	} else {
 		// Newly inserted entries must have their own containers, so that they
 		// remain separate when new owners/dependents are added to existing entries
 		entry.DerivedFromRules = slices.Clone(entry.DerivedFromRules)
 		entry.owners = maps.Clone(entry.owners)
 		entry.dependents = maps.Clone(entry.dependents)
-		keys[key] = entry
+		ms.keys[key] = entry
 	}
 
 	// Record an incremental Add if desired and entry is new or changed
@@ -419,10 +525,13 @@ func (keys MapState) addKeyWithChanges(key Key, entry MapStateEntry, changes Cha
 
 // deleteKeyWithChanges deletes a 'key' from 'keys' keeping track of incremental changes in 'adds' and 'deletes'.
 // The key is unconditionally deleted if 'cs' is nil, otherwise only the contribution of this 'cs' is removed.
-func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes ChangeState) {
-	if entry, exists := keys[key]; exists {
+func (ms *mapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes ChangeState) {
+	if entry, exists := ms.keys[key]; exists {
 		// Save old value before any changes, if desired
-		oldAdded := changes.Old.insertIfNotExists(key, entry)
+		if changes.Old == nil {
+			changes.Old = newMapState(nil)
+		}
+		oldAdded := changes.Old.InsertIfNotExists(key, entry)
 
 		if owner != nil {
 			// remove the contribution of the given selector only
@@ -430,7 +539,7 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes 
 				// Remove the contribution of this selector from the entry
 				delete(entry.owners, owner)
 				if ownerKey, ok := owner.(Key); ok {
-					keys.RemoveDependent(ownerKey, key, changes.Old)
+					ms.RemoveDependent(ownerKey, key, changes.Old)
 				}
 				// key is not deleted if other owners still need it
 				if len(entry.owners) > 0 {
@@ -439,7 +548,7 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes 
 			} else {
 				// 'owner' was not found, do not change anything
 				if oldAdded {
-					delete(changes.Old, key)
+					changes.Old.Delete(key)
 				}
 				return
 			}
@@ -452,7 +561,7 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes 
 			for owner := range entry.owners {
 				if owner != nil {
 					if ownerKey, ok := owner.(Key); ok {
-						keys.RemoveDependent(ownerKey, key, changes.Old)
+						ms.RemoveDependent(ownerKey, key, changes.Old)
 					}
 				}
 			}
@@ -460,7 +569,7 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes 
 
 		// Check if dependent entries need to be deleted as well
 		for k := range entry.dependents {
-			keys.deleteKeyWithChanges(k, key, changes)
+			ms.deleteKeyWithChanges(k, key, changes)
 		}
 		if changes.Deletes != nil {
 			changes.Deletes[key] = struct{}{}
@@ -470,7 +579,7 @@ func (keys MapState) deleteKeyWithChanges(key Key, owner MapStateOwner, changes 
 			}
 		}
 
-		delete(keys, key)
+		delete(ms.keys, key)
 	}
 }
 
@@ -551,35 +660,36 @@ func protocolsMatch(a, b Key) bool {
 
 // RevertChanges undoes changes to 'keys' as indicated by 'changes.adds' and 'changes.old' collected via
 // denyPreferredInsertWithChanges().
-func (keys MapState) RevertChanges(changes ChangeState) {
+func (ms *mapState) RevertChanges(changes ChangeState) {
 	for k := range changes.Adds {
-		delete(keys, k)
+		delete(ms.keys, k)
 	}
 	// 'old' contains all the original values of both modified and deleted entries
-	for k, v := range changes.Old {
-		keys[k] = v
-	}
+	changes.Old.ForEach(func(k Key, v MapStateEntry) bool {
+		ms.keys[k] = v
+		return true
+	})
 }
 
 // denyPreferredInsertWithChanges contains the most important business logic for policy insertions. It inserts
 // a key and entry into the map by giving preference to deny entries, and L3-only deny entries over L3-L4 allows.
 // Incremental changes performed are recorded in 'adds' and 'deletes', if not nil.
 // See https://docs.google.com/spreadsheets/d/1WANIoZGB48nryylQjjOw6lKjI80eVgPShrdMTMalLEw#gid=2109052536 for details
-func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, identities Identities, features policyFeatures, changes ChangeState) {
+func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStateEntry, identities Identities, features policyFeatures, changes ChangeState) {
 	// Skip deny rules processing if the policy in this direction has no deny rules
 	if !features.contains(denyRules) {
-		keys.authPreferredInsert(newKey, newEntry, features, changes)
+		ms.authPreferredInsert(newKey, newEntry, features, changes)
 		return
 	}
 
 	allCpy := allKey
 	allCpy.TrafficDirection = newKey.TrafficDirection
 	// If we have a deny "all" we don't accept any kind of map entry.
-	if v, ok := keys[allCpy]; ok && v.IsDeny {
+	if v, ok := ms.keys[allCpy]; ok && v.IsDeny {
 		return
 	}
 	if newEntry.IsDeny {
-		for k, v := range keys {
+		for k, v := range ms.keys {
 			// Protocols and traffic directions that don't match ensure that the policies
 			// do not interact in anyway.
 			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
@@ -596,7 +706,7 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 						newKeyCpy.DestPort = k.DestPort
 						newKeyCpy.Nexthdr = k.Nexthdr
 						l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
-						keys.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, changes)
+						ms.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, changes)
 						// L3-only entries can be deleted incrementally so we need to track their
 						// effects on other entries so that those effects can be reverted when the
 						// identity is removed.
@@ -608,7 +718,7 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 					// If the new-entry is a superset (or equal) of the iterated-allow-entry and
 					// the new-entry has a broader (or equal) port-protocol then we
 					// should delete the iterated-allow-entry
-					keys.deleteKeyWithChanges(k, nil, changes)
+					ms.deleteKeyWithChanges(k, nil, changes)
 				}
 			} else if (newKey.Identity == k.Identity ||
 				identityIsSupersetOf(k.Identity, newKey.Identity, identities)) &&
@@ -635,12 +745,12 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 				//
 				// NOTE: This condition could be broader to reject more deny entries,
 				// but there *may* be performance tradeoffs.
-				keys.deleteKeyWithChanges(k, nil, changes)
+				ms.deleteKeyWithChanges(k, nil, changes)
 			}
 		}
-		keys.addKeyWithChanges(newKey, newEntry, changes)
+		ms.addKeyWithChanges(newKey, newEntry, changes)
 	} else {
-		for k, v := range keys {
+		for k, v := range ms.keys {
 			// Protocols and traffic directions that don't match ensure that the policies
 			// do not interact in anyway.
 			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
@@ -659,11 +769,11 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 						denyKeyCpy.DestPort = newKey.DestPort
 						denyKeyCpy.Nexthdr = newKey.Nexthdr
 						l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
-						keys.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, changes)
+						ms.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, changes)
 						// L3-only entries can be deleted incrementally so we need to track their
 						// effects on other entries so that those effects can be reverted when the
 						// identity is removed.
-						keys.addDependentOnEntry(k, v, denyKeyCpy, changes)
+						ms.addDependentOnEntry(k, v, denyKeyCpy, changes)
 					}
 				} else if (k.Identity == newKey.Identity ||
 					identityIsSupersetOf(k.Identity, newKey.Identity, identities)) &&
@@ -676,7 +786,7 @@ func (keys MapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapStat
 				}
 			}
 		}
-		keys.authPreferredInsert(newKey, newEntry, features, changes)
+		ms.authPreferredInsert(newKey, newEntry, features, changes)
 	}
 }
 
@@ -743,14 +853,14 @@ func (k Key) IsSuperSetOf(other Key) int {
 // This function is expected to be called for a map insertion after deny
 // entry evaluation. If there is a map entry that is a superset of 'newKey'
 // which denies traffic matching 'newKey', then this function should not be called.
-func (keys MapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, features policyFeatures, changes ChangeState) {
+func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, features policyFeatures, changes ChangeState) {
 	if features.contains(authRules) {
 		if newEntry.hasAuthType == DefaultAuthType {
 			// New entry has a default auth type.
 			// Fill in the AuthType from more generic entries with an explicit auth type
 			maxSpecificity := 0
-			l3l4keys := make(MapState)
-			for k, v := range keys {
+			l3l4State := newMapState(nil)
+			for k, v := range ms.keys {
 				// Only consider the same Traffic direction
 				if newKey.TrafficDirection != k.TrafficDirection {
 					continue
@@ -793,7 +903,7 @@ func (keys MapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, fea
 						newKeyCpy.Nexthdr = newKey.Nexthdr
 						l3l4AuthEntry := NewMapStateEntry(k, v.DerivedFromRules, false, false, DefaultAuthType, v.AuthType)
 						l3l4AuthEntry.DerivedFromRules.MergeSorted(newEntry.DerivedFromRules)
-						l3l4keys[newKeyCpy] = l3l4AuthEntry
+						l3l4State.keys[newKeyCpy] = l3l4AuthEntry
 					}
 				}
 			}
@@ -802,8 +912,8 @@ func (keys MapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, fea
 			// entries are not needed as the L4-only entry with an overridden AuthType
 			// will be matched before the L3-only entries in the datapath.
 			if maxSpecificity == 0 {
-				for k, v := range l3l4keys {
-					keys.addKeyWithChanges(k, v, changes)
+				for k, v := range l3l4State.keys {
+					ms.addKeyWithChanges(k, v, changes)
 					// L3-only entries can be deleted incrementally so we need to track their
 					// effects on other entries so that those effects can be reverted when the
 					// identity is removed.
@@ -817,7 +927,7 @@ func (keys MapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, fea
 			// entry to such entries.
 			explicitSubsetKeys := make(Keys)
 			defaultSubsetKeys := make(map[Key]int)
-			for k, v := range keys {
+			for k, v := range ms.keys {
 				// Only consider the same Traffic direction
 				if newKey.TrafficDirection != k.TrafficDirection {
 					continue
@@ -849,7 +959,7 @@ func (keys MapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, fea
 						newKeyCpy.Nexthdr = k.Nexthdr
 						l3l4AuthEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, false, false, DefaultAuthType, newEntry.AuthType)
 						l3l4AuthEntry.DerivedFromRules.MergeSorted(v.DerivedFromRules)
-						keys.addKeyWithChanges(newKeyCpy, l3l4AuthEntry, changes)
+						ms.addKeyWithChanges(newKeyCpy, l3l4AuthEntry, changes)
 						// L3-only entries can be deleted incrementally so we need to track their
 						// effects on other entries so that those effects can be reverted when the
 						// identity is removed.
@@ -868,13 +978,13 @@ func (keys MapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, fea
 				}
 				// newKey is the most specific superset with an explicit auth type,
 				// propagate auth type from newEntry to the entry of k
-				v := keys[k]
+				v := ms.keys[k]
 				v.AuthType = newEntry.AuthType
-				keys.addKeyWithChanges(k, v, changes) // Update the map value
+				ms.addKeyWithChanges(k, v, changes) // Update the map value
 			}
 		}
 	}
-	keys.addKeyWithChanges(newKey, newEntry, changes)
+	ms.addKeyWithChanges(newKey, newEntry, changes)
 }
 
 var visibilityDerivedFromLabels = labels.LabelArray{
@@ -883,17 +993,17 @@ var visibilityDerivedFromLabels = labels.LabelArray{
 
 var visibilityDerivedFrom = labels.LabelArrayList{visibilityDerivedFromLabels}
 
-// insertIfNotExists only inserts `key=value` if `key` does not exist in keys already
+// InsertIfNotExists only inserts `key=value` if `key` does not exist in keys already
 // returns 'true' if 'key=entry' was added to 'keys'
-func (keys MapState) insertIfNotExists(key Key, entry MapStateEntry) bool {
-	if keys != nil {
-		if _, exists := keys[key]; !exists {
+func (ms *mapState) InsertIfNotExists(key Key, entry MapStateEntry) bool {
+	if ms != nil && ms.keys != nil {
+		if _, exists := ms.keys[key]; !exists {
 			// new containers to keep this entry separate from the one that may remain in 'keys'
 			entry.DerivedFromRules = slices.Clone(entry.DerivedFromRules)
 			entry.owners = maps.Clone(entry.owners)
 			entry.dependents = maps.Clone(entry.dependents)
 
-			keys[key] = entry
+			ms.keys[key] = entry
 			return true
 		}
 	}
@@ -944,7 +1054,7 @@ func (keys MapState) insertIfNotExists(key Key, entry MapStateEntry) bool {
 // 'adds' and 'oldValues' are updated with the changes made. 'adds' contains both the added and
 // changed keys. 'oldValues' contains the old values for changed keys. This function does not
 // delete any keys.
-func (keys MapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMeta *VisibilityMetadata, changes ChangeState) {
+func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMeta *VisibilityMetadata, changes ChangeState) {
 	direction := trafficdirection.Egress
 	if visMeta.Ingress {
 		direction = trafficdirection.Ingress
@@ -962,8 +1072,8 @@ func (keys MapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMe
 	entry := NewMapStateEntry(nil, visibilityDerivedFrom, true, false, DefaultAuthType, AuthTypeDisabled)
 	entry.ProxyPort = redirectPort
 
-	_, haveAllowAllKey := keys[allowAllKey]
-	l4Only, haveL4OnlyKey := keys[key]
+	_, haveAllowAllKey := ms.keys[allowAllKey]
+	l4Only, haveL4OnlyKey := ms.keys[key]
 	addL4OnlyKey := false
 	if haveL4OnlyKey && !l4Only.IsDeny && l4Only.ProxyPort == 0 {
 		// 1. Change existing L4-only ALLOW key on matching port that does not already
@@ -972,7 +1082,7 @@ func (keys MapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMe
 			logfields.BPFMapKey:   key,
 			logfields.BPFMapValue: entry,
 		}, "AddVisibilityKeys: Changing L4-only ALLOW key for visibility redirect")
-		keys.addKeyWithChanges(key, entry, changes)
+		ms.addKeyWithChanges(key, entry, changes)
 	}
 	if haveAllowAllKey && !haveL4OnlyKey {
 		// 2. If allow-all policy exists, add L4-only visibility redirect key if the L4-only
@@ -982,12 +1092,12 @@ func (keys MapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMe
 			logfields.BPFMapValue: entry,
 		}, "AddVisibilityKeys: Adding L4-only ALLOW key for visibility redirect")
 		addL4OnlyKey = true
-		keys.addKeyWithChanges(key, entry, changes)
+		ms.addKeyWithChanges(key, entry, changes)
 	}
 	//
 	// Loop through all L3 keys in the traffic direction of the new key
 	//
-	for k, v := range keys {
+	for k, v := range ms.keys {
 		if k.TrafficDirection != key.TrafficDirection || k.Identity == 0 {
 			continue
 		}
@@ -1004,7 +1114,7 @@ func (keys MapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMe
 					logfields.BPFMapKey:   k,
 					logfields.BPFMapValue: v,
 				}, "AddVisibilityKeys: Changing L3/L4 ALLOW key for visibility redirect")
-				keys.addKeyWithChanges(k, v, changes)
+				ms.addKeyWithChanges(k, v, changes)
 			}
 		} else if k.DestPort == 0 && k.Nexthdr == 0 {
 			//
@@ -1017,7 +1127,7 @@ func (keys MapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMe
 				// 4. For each L3-only ALLOW key add the corresponding L3/L4
 				//    ALLOW redirect if no L3/L4 key already exists and no
 				//    L4-only key already exists and one is not added.
-				if _, ok := keys[k2]; !ok {
+				if _, ok := ms.keys[k2]; !ok {
 					d2 := labels.LabelArrayList{visibilityDerivedFromLabels}
 					d2.MergeSorted(v.DerivedFromRules)
 					v2 := NewMapStateEntry(k, d2, true, false, v.hasAuthType, v.AuthType)
@@ -1026,36 +1136,36 @@ func (keys MapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMe
 						logfields.BPFMapKey:   k2,
 						logfields.BPFMapValue: v2,
 					}, "AddVisibilityKeys: Extending L3-only ALLOW key to L3/L4 key for visibility redirect")
-					keys.addKeyWithChanges(k2, v2, changes)
+					ms.addKeyWithChanges(k2, v2, changes)
 
 					// Mark the new entry as a dependent of 'v'
-					keys.addDependentOnEntry(k, v, k2, changes)
+					ms.addDependentOnEntry(k, v, k2, changes)
 				}
 			} else if addL4OnlyKey && v.IsDeny {
 				// 5. If a new L4-only key was added: For each L3-only DENY
 				//    key add the corresponding L3/L4 DENY key if no L3/L4
 				//    key already exists.
-				if _, ok := keys[k2]; !ok {
+				if _, ok := ms.keys[k2]; !ok {
 					v2 := NewMapStateEntry(k, v.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
 					e.PolicyDebug(logrus.Fields{
 						logfields.BPFMapKey:   k2,
 						logfields.BPFMapValue: v2,
 					}, "AddVisibilityKeys: Extending L3-only DENY key to L3/L4 key to deny a port with visibility annotation")
-					keys.addKeyWithChanges(k2, v2, changes)
+					ms.addKeyWithChanges(k2, v2, changes)
 
 					// Mark the new entry as a dependent of 'v'
-					keys.addDependentOnEntry(k, v, k2, changes)
+					ms.addDependentOnEntry(k, v, k2, changes)
 				}
 			}
 		}
 	}
 }
 
-// DetermineAllowLocalhostIngress determines whether communication should be allowed
+// determineAllowLocalhostIngress determines whether communication should be allowed
 // from the localhost. It inserts the Key corresponding to the localhost in
 // the desiredPolicyKeys if the localhost is allowed to communicate with the
 // endpoint. Authentication for localhost traffic is not required.
-func (keys MapState) DetermineAllowLocalhostIngress() {
+func (ms *mapState) determineAllowLocalhostIngress() {
 	if option.Config.AlwaysAllowLocalhost() {
 		derivedFrom := labels.LabelArrayList{
 			labels.LabelArray{
@@ -1063,10 +1173,10 @@ func (keys MapState) DetermineAllowLocalhostIngress() {
 			},
 		}
 		es := NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled) // Authentication never required for local host ingress
-		keys.denyPreferredInsert(localHostKey, es, nil, allFeatures)
+		ms.denyPreferredInsert(localHostKey, es, nil, allFeatures)
 		if !option.Config.EnableRemoteNodeIdentity {
 			var isHostDenied bool
-			v, ok := keys[localHostKey]
+			v, ok := ms.keys[localHostKey]
 			isHostDenied = ok && v.IsDeny
 			derivedFrom := labels.LabelArrayList{
 				labels.LabelArray{
@@ -1074,16 +1184,16 @@ func (keys MapState) DetermineAllowLocalhostIngress() {
 				},
 			}
 			es := NewMapStateEntry(nil, derivedFrom, false, isHostDenied, ExplicitAuthType, AuthTypeDisabled) // Authentication never required for remote node ingress
-			keys.denyPreferredInsert(localRemoteNodeKey, es, nil, allFeatures)
+			ms.denyPreferredInsert(localRemoteNodeKey, es, nil, allFeatures)
 		}
 	}
 }
 
-// AllowAllIdentities translates all identities in selectorCache to their
+// allowAllIdentities translates all identities in selectorCache to their
 // corresponding Keys in the specified direction (ingress, egress) which allows
 // all at L3.
 // Note that this is used when policy is not enforced, so authentication is explicitly not required.
-func (keys MapState) AllowAllIdentities(ingress, egress bool) {
+func (ms *mapState) allowAllIdentities(ingress, egress bool) {
 	if ingress {
 		keyToAdd := Key{
 			Identity:         0,
@@ -1096,7 +1206,7 @@ func (keys MapState) AllowAllIdentities(ingress, egress bool) {
 				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 			},
 		}
-		keys[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled)
+		ms.keys[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled)
 	}
 	if egress {
 		keyToAdd := Key{
@@ -1110,11 +1220,11 @@ func (keys MapState) AllowAllIdentities(ingress, egress bool) {
 				labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyEgress, labels.LabelSourceReserved),
 			},
 		}
-		keys[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled)
+		ms.keys[keyToAdd] = NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled)
 	}
 }
 
-func (keys MapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
+func (ms *mapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	port := uint16(l4.Port)
 	proto := uint8(l4.U8Proto)
 
@@ -1139,7 +1249,7 @@ func (keys MapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 		TrafficDirection: dir,
 	}
 	// Are we explicitly denying all traffic?
-	v, ok := keys[anyKey]
+	v, ok := ms.keys[anyKey]
 	if ok && v.IsDeny {
 		return true
 	}
@@ -1147,7 +1257,7 @@ func (keys MapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	// Are we explicitly denying this L4-only traffic?
 	anyKey.DestPort = port
 	anyKey.Nexthdr = proto
-	v, ok = keys[anyKey]
+	v, ok = ms.keys[anyKey]
 	if ok && v.IsDeny {
 		return true
 	}
@@ -1157,18 +1267,18 @@ func (keys MapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	return false
 }
 
-func (pms MapState) GetIdentities(log *logrus.Logger) (ingIdentities, egIdentities []int64) {
-	return pms.getIdentities(log, false)
+func (ms *mapState) GetIdentities(log *logrus.Logger) (ingIdentities, egIdentities []int64) {
+	return ms.getIdentities(log, false)
 }
 
-func (pms MapState) GetDenyIdentities(log *logrus.Logger) (ingIdentities, egIdentities []int64) {
-	return pms.getIdentities(log, true)
+func (ms *mapState) GetDenyIdentities(log *logrus.Logger) (ingIdentities, egIdentities []int64) {
+	return ms.getIdentities(log, true)
 }
 
 // GetIdentities returns the ingress and egress identities stored in the
 // MapState.
-func (pms MapState) getIdentities(log *logrus.Logger, denied bool) (ingIdentities, egIdentities []int64) {
-	for policyMapKey, policyMapValue := range pms {
+func (ms *mapState) getIdentities(log *logrus.Logger, denied bool) (ingIdentities, egIdentities []int64) {
+	for policyMapKey, policyMapValue := range ms.keys {
 		if denied != policyMapValue.IsDeny {
 			continue
 		}

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -56,6 +56,10 @@ type MapState interface {
 	// ForEach allows iteration over the MapStateEntries. It returns true iff
 	// the iteration was not stopped early by the callback.
 	ForEach(func(Key, MapStateEntry) (cont bool)) (complete bool)
+	// ForEachAllow behaves like ForEach, but only iterates MapStateEntries which are not denies.
+	ForEachAllow(func(Key, MapStateEntry) (cont bool)) (complete bool)
+	// ForEachDeny behaves like ForEach, but only iterates MapStateEntries which are denies.
+	ForEachDeny(func(Key, MapStateEntry) (cont bool)) (complete bool)
 	GetIdentities(*logrus.Logger) ([]int64, []int64)
 	GetDenyIdentities(*logrus.Logger) ([]int64, []int64)
 	RevertChanges(ChangeState)
@@ -293,15 +297,16 @@ func (ms *mapState) Delete(k Key) {
 // ForEach iterates over every Key MapStateEntry and stops when the function
 // argument returns false. It returns false iff the iteration was cut short.
 func (ms *mapState) ForEach(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
-	if complete := ms.forEachAllow(f); !complete {
+	if complete := ms.ForEachAllow(f); !complete {
 		return complete
 	}
-	return ms.forEachDeny(f)
+
+	return ms.ForEachDeny(f)
 }
 
-// forEachAllow iterates over every Key MapStateEntry that isn't a deny and
+// ForEachAllow iterates over every Key MapStateEntry that isn't a deny and
 // stops when the function argument returns false
-func (ms *mapState) forEachAllow(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
+func (ms *mapState) ForEachAllow(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
 	for k, v := range ms.allows {
 		if !f(k, v) {
 			return false
@@ -310,9 +315,9 @@ func (ms *mapState) forEachAllow(f func(Key, MapStateEntry) (cont bool)) (comple
 	return true
 }
 
-// forEachDeny iterates over every Key MapStateEntry that is a deny and
+// ForEachDeny iterates over every Key MapStateEntry that is a deny and
 // stops when the function argument returns false
-func (ms *mapState) forEachDeny(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
+func (ms *mapState) ForEachDeny(f func(Key, MapStateEntry) (cont bool)) (complete bool) {
 	for k, v := range ms.denies {
 		if !f(k, v) {
 			return false
@@ -728,39 +733,49 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 		return
 	}
 	if newEntry.IsDeny {
-		bailed := false
-		ms.ForEach(func(k Key, v MapStateEntry) bool {
+		ms.ForEachAllow(func(k Key, v MapStateEntry) bool {
 			// Protocols and traffic directions that don't match ensure that the policies
 			// do not interact in anyway.
 			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
 				return true
 			}
-			if !v.IsDeny {
-				if identityIsSupersetOf(k.Identity, newKey.Identity, identities) {
-					if newKey.PortProtoIsBroader(k) {
-						// If this iterated-allow-entry is a superset of the new-entry
-						// and it has a more specific port-protocol than the new-entry
-						// then an additional copy of the new-entry with the more
-						// specific port-protocol of the iterated-allow-entry must be inserted.
-						newKeyCpy := newKey
-						newKeyCpy.DestPort = k.DestPort
-						newKeyCpy.Nexthdr = k.Nexthdr
-						l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
-						ms.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, changes)
-						// L3-only entries can be deleted incrementally so we need to track their
-						// effects on other entries so that those effects can be reverted when the
-						// identity is removed.
-						newEntry.AddDependent(newKeyCpy)
-					}
-				} else if (newKey.Identity == k.Identity ||
-					identityIsSupersetOf(newKey.Identity, k.Identity, identities)) &&
-					(newKey.PortProtoIsBroader(k) || newKey.PortProtoIsEqual(k)) {
-					// If the new-entry is a superset (or equal) of the iterated-allow-entry and
-					// the new-entry has a broader (or equal) port-protocol then we
-					// should delete the iterated-allow-entry
-					ms.deleteKeyWithChanges(k, nil, changes)
+
+			if identityIsSupersetOf(k.Identity, newKey.Identity, identities) {
+				if newKey.PortProtoIsBroader(k) {
+					// If this iterated-allow-entry is a superset of the new-entry
+					// and it has a more specific port-protocol than the new-entry
+					// then an additional copy of the new-entry with the more
+					// specific port-protocol of the iterated-allow-entry must be inserted.
+					newKeyCpy := newKey
+					newKeyCpy.DestPort = k.DestPort
+					newKeyCpy.Nexthdr = k.Nexthdr
+					l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
+					ms.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, changes)
+					// L3-only entries can be deleted incrementally so we need to track their
+					// effects on other entries so that those effects can be reverted when the
+					// identity is removed.
+					newEntry.AddDependent(newKeyCpy)
 				}
 			} else if (newKey.Identity == k.Identity ||
+				identityIsSupersetOf(newKey.Identity, k.Identity, identities)) &&
+				(newKey.PortProtoIsBroader(k) || newKey.PortProtoIsEqual(k)) {
+				// If the new-entry is a superset (or equal) of the iterated-allow-entry and
+				// the new-entry has a broader (or equal) port-protocol then we
+				// should delete the iterated-allow-entry
+				ms.deleteKeyWithChanges(k, nil, changes)
+			}
+			return true
+		})
+
+		bailed := false
+		ms.ForEachDeny(func(k Key, v MapStateEntry) bool {
+			// Protocols and traffic directions that don't match ensure that the policies
+			// do not interact in anyway.
+			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
+				return true
+			}
+
+			if (newKey.Identity == k.Identity ||
 				identityIsSupersetOf(k.Identity, newKey.Identity, identities)) &&
 				k.DestPort == 0 && k.Nexthdr == 0 &&
 				!v.HasDependent(newKey) {
@@ -790,50 +805,50 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 			}
 			return true
 		})
+
 		if !bailed {
 			ms.addKeyWithChanges(newKey, newEntry, changes)
 		}
 	} else {
+		// NOTE: We do not delete redundant allow entries.
 		bailed := false
-		ms.ForEach(func(k Key, v MapStateEntry) bool {
+		ms.ForEachDeny(func(k Key, v MapStateEntry) bool {
 			// Protocols and traffic directions that don't match ensure that the policies
 			// do not interact in anyway.
 			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
 				return true
 			}
-			// NOTE: We do not delete redundant allow entries.
-			if v.IsDeny {
-				if identityIsSupersetOf(newKey.Identity, k.Identity, identities) {
-					if k.PortProtoIsBroader(newKey) {
-						// If the new-entry is *only* superset of the iterated-deny-entry
-						// and the new-entry has a more specific port-protocol than the
-						// iterated-deny-entry then an additional copy of the iterated-deny-entry
-						// with the more specific port-porotocol of the new-entry must
-						// be added.
-						denyKeyCpy := k
-						denyKeyCpy.DestPort = newKey.DestPort
-						denyKeyCpy.Nexthdr = newKey.Nexthdr
-						l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
-						ms.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, changes)
-						// L3-only entries can be deleted incrementally so we need to track their
-						// effects on other entries so that those effects can be reverted when the
-						// identity is removed.
-						ms.addDependentOnEntry(k, v, denyKeyCpy, changes)
-					}
-				} else if (k.Identity == newKey.Identity ||
-					identityIsSupersetOf(k.Identity, newKey.Identity, identities)) &&
-					(k.PortProtoIsBroader(newKey) || k.PortProtoIsEqual(newKey)) &&
-					!v.HasDependent(newKey) {
-					// If the iterated-deny-entry is a superset (or equal) of the new-entry and has a
-					// broader (or equal) port-protocol than the new-entry then the new
-					// entry should not be inserted.
-					bailed = true
-					return false
+			if identityIsSupersetOf(newKey.Identity, k.Identity, identities) {
+				if k.PortProtoIsBroader(newKey) {
+					// If the new-entry is *only* superset of the iterated-deny-entry
+					// and the new-entry has a more specific port-protocol than the
+					// iterated-deny-entry then an additional copy of the iterated-deny-entry
+					// with the more specific port-porotocol of the new-entry must
+					// be added.
+					denyKeyCpy := k
+					denyKeyCpy.DestPort = newKey.DestPort
+					denyKeyCpy.Nexthdr = newKey.Nexthdr
+					l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
+					ms.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, changes)
+					// L3-only entries can be deleted incrementally so we need to track their
+					// effects on other entries so that those effects can be reverted when the
+					// identity is removed.
+					ms.addDependentOnEntry(k, v, denyKeyCpy, changes)
 				}
+			} else if (k.Identity == newKey.Identity ||
+				identityIsSupersetOf(k.Identity, newKey.Identity, identities)) &&
+				(k.PortProtoIsBroader(newKey) || k.PortProtoIsEqual(newKey)) &&
+				!v.HasDependent(newKey) {
+				// If the iterated-deny-entry is a superset (or equal) of the new-entry and has a
+				// broader (or equal) port-protocol than the new-entry then the new
+				// entry should not be inserted.
+				bailed = true
+				return false
 			}
 
 			return true
 		})
+
 		if !bailed {
 			ms.authPreferredInsert(newKey, newEntry, features, changes)
 		}
@@ -911,15 +926,9 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 			maxSpecificity := 0
 			l3l4State := newMapState(nil)
 
-			ms.ForEach(func(k Key, v MapStateEntry) bool {
+			ms.ForEachAllow(func(k Key, v MapStateEntry) bool {
 				// Only consider the same Traffic direction
 				if newKey.TrafficDirection != k.TrafficDirection {
-					return true
-				}
-				// Skip deny entries, they have no effect on authentication requirements,
-				// and we should not create any new (non-deny) entries based on a combination
-				// of an existing deny and the new non-deny entry.
-				if v.IsDeny {
 					return true
 				}
 
@@ -981,15 +990,9 @@ func (ms *mapState) authPreferredInsert(newKey Key, newEntry MapStateEntry, feat
 			explicitSubsetKeys := make(Keys)
 			defaultSubsetKeys := make(map[Key]int)
 
-			ms.ForEach(func(k Key, v MapStateEntry) bool {
+			ms.ForEachAllow(func(k Key, v MapStateEntry) bool {
 				// Only consider the same Traffic direction
 				if newKey.TrafficDirection != k.TrafficDirection {
-					return true
-				}
-				// Skip deny entries, they have no effect on authentication requirements,
-				// and we should not create any new (non-deny) entries based on a combination
-				// of an existing deny and the new non-deny entry.
-				if v.IsDeny {
 					return true
 				}
 

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -143,8 +143,8 @@ func (ds *PolicyTestSuite) TestPolicyKeyTrafficDirection(c *check.C) {
 
 // validatePortProto makes sure each Key in MapState abides by the contract that protocol/nexthdr
 // can only be wildcarded if the destination port is also wildcarded.
-func (m MapState) validatePortProto(c *check.C) {
-	for k := range m {
+func (ms *mapState) validatePortProto(c *check.C) {
+	for k := range ms.keys {
 		if k.Nexthdr == 0 {
 			c.Assert(k.DestPort, check.Equals, uint16(0))
 		}
@@ -158,59 +158,59 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 	}
 	tests := []struct {
 		name                  string
-		keys, want            MapState
+		ms, want              *mapState
 		wantAdds, wantDeletes Keys
-		wantOldValues         MapState
+		wantOldValues         *mapState
 		args                  args
 	}{
 		{
 			name: "test-1 - no KV added, map should remain the same",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         0,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: 0,
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 			args: args{
 				key:   Key{},
 				entry: MapStateEntry{},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         0,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: 0,
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 			wantAdds:      Keys{},
 			wantDeletes:   Keys{},
-			wantOldValues: MapState{},
+			wantOldValues: newMapState(nil),
 		},
 		{
 			name: "test-2 - L3 allow KV should not overwrite deny entry",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         1,
@@ -224,28 +224,28 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           false,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			wantAdds: Keys{
 				Key{
 					Identity:         1,
@@ -255,22 +255,22 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 				}: struct{}{},
 			},
 			wantDeletes:   Keys{},
-			wantOldValues: MapState{},
+			wantOldValues: newMapState(nil),
 		},
 		{
 			name: "test-3 - L3-L4 allow KV should not overwrite deny entry",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         1,
@@ -284,36 +284,36 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           false,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			wantAdds:      Keys{},
 			wantDeletes:   Keys{},
-			wantOldValues: MapState{},
+			wantOldValues: newMapState(nil),
 		},
 		{
 			name: "test-4 - L3-L4 deny KV should overwrite allow entry",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         1,
@@ -327,18 +327,18 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			wantAdds: Keys{
 				Key{
 					Identity:         1,
@@ -348,63 +348,63 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 				}: struct{}{},
 			},
 			wantDeletes: Keys{},
-			wantOldValues: MapState{
-				Key{
+			wantOldValues: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 		},
 		{
 			name: "test-5 - L3 deny KV should overwrite all L3-L4 allow and L3 allow entries for the same L3",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         2,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         2,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         1,
@@ -418,38 +418,38 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				Key{
+				{
 					Identity:         2,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         2,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 			wantAdds: Keys{
 				Key{
 					Identity:         1,
@@ -466,73 +466,73 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 			},
-			wantOldValues: MapState{
-				Key{
+			wantOldValues: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 		},
 		{
 			name: "test-6 - L3 egress deny KV should not overwrite any existing ingress allow",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         2,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         2,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         1,
@@ -546,58 +546,58 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				Key{
+				{
 					Identity:         2,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         2,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 			wantAdds: Keys{
 				Key{
 					Identity:         1,
@@ -607,22 +607,22 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 				}: struct{}{},
 			},
 			wantDeletes:   Keys{},
-			wantOldValues: MapState{},
+			wantOldValues: newMapState(nil),
 		},
 		{
 			name: "test-7 - L3 ingress deny KV should not be overwritten by a L3-L4 ingress allow",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         1,
@@ -636,36 +636,36 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           false,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			wantAdds:      Keys{},
 			wantDeletes:   Keys{},
-			wantOldValues: MapState{},
+			wantOldValues: newMapState(nil),
 		},
 		{
 			name: "test-8 - L3 ingress deny KV should not be overwritten by a L3-L4-L7 ingress allow",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         1,
@@ -679,36 +679,36 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           false,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			wantAdds:      Keys{},
 			wantDeletes:   Keys{},
-			wantOldValues: MapState{},
+			wantOldValues: newMapState(nil),
 		},
 		{
 			name: "test-9 - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         1,
@@ -722,18 +722,18 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			wantAdds: Keys{
 				Key{
 					Identity:         1,
@@ -750,43 +750,43 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 			},
-			wantOldValues: MapState{
-				Key{
+			wantOldValues: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 		},
 		{
 			name: "test-10 - L3 ingress deny KV should overwrite a L3-L4-L7 ingress allow and a L3-L4 deny",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         1,
@@ -800,18 +800,18 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			wantAdds: Keys{
 				Key{
 					Identity:         1,
@@ -834,53 +834,53 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 			},
-			wantOldValues: MapState{
-				Key{
+			wantOldValues: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 		},
 		{
 			name: "test-11 - L3 ingress allow should not be allowed if there is a L3 'all' deny",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         0,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         100,
@@ -894,65 +894,65 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           false,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         0,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			wantAdds:      Keys{},
 			wantDeletes:   Keys{},
-			wantOldValues: MapState{},
+			wantOldValues: newMapState(nil),
 		}, {
 			name: "test-12 - inserting a L3 'all' deny should delete all entries for that direction",
-			keys: MapState{
-				Key{
+			ms: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         5,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         100,
 					DestPort:         5,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			args: args{
 				key: Key{
 					Identity:         0,
@@ -966,28 +966,28 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					IsDeny:           true,
 				},
 			},
-			want: MapState{
-				Key{
+			want: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         0,
 					DestPort:         0,
 					Nexthdr:          0,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        0,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-				Key{
+				{
 					Identity:         100,
 					DestPort:         5,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Egress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           true,
 				},
-			},
+			}),
 			wantAdds: Keys{
 				Key{
 					Identity:         0,
@@ -1010,51 +1010,55 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
 				}: struct{}{},
 			},
-			wantOldValues: MapState{
-				Key{
+			wantOldValues: newMapState(map[Key]MapStateEntry{
+				{
 					Identity:         1,
 					DestPort:         80,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-				Key{
+				{
 					Identity:         1,
 					DestPort:         5,
 					Nexthdr:          3,
 					TrafficDirection: trafficdirection.Ingress.Uint8(),
-				}: MapStateEntry{
+				}: {
 					ProxyPort:        8080,
 					DerivedFromRules: nil,
 					IsDeny:           false,
 				},
-			},
+			}),
 		},
 	}
 	for _, tt := range tests {
 		changes := ChangeState{
 			Adds:    make(Keys),
 			Deletes: make(Keys),
-			Old:     make(MapState),
+			Old:     newMapState(nil),
 		}
 		// copy the starging point
-		keys := make(MapState, len(tt.keys))
-		for k, v := range tt.keys {
-			keys[k] = v
+		ms := newMapState(make(map[Key]MapStateEntry, len(tt.ms.keys)))
+		for k, v := range tt.ms.keys {
+			ms.keys[k] = v
 		}
-		keys.denyPreferredInsertWithChanges(tt.args.key, tt.args.entry, nil, denyRules, changes)
-		keys.validatePortProto(c)
-		c.Assert(keys, checker.DeepEquals, tt.want, check.Commentf("%s: MapState mismatch", tt.name))
+		ms.denyPreferredInsertWithChanges(tt.args.key, tt.args.entry, nil, denyRules, changes)
+		ms.validatePortProto(c)
+		c.Assert(ms.keys, checker.DeepEquals, tt.want.keys, check.Commentf("%s: MapState mismatch", tt.name))
 		c.Assert(changes.Adds, checker.DeepEquals, tt.wantAdds, check.Commentf("%s: Adds mismatch", tt.name))
 		c.Assert(changes.Deletes, checker.DeepEquals, tt.wantDeletes, check.Commentf("%s: Deletes mismatch", tt.name))
-		c.Assert(changes.Old, checker.DeepEquals, tt.wantOldValues, check.Commentf("%s: OldValues mismatch", tt.name))
+		oldMap, ok := changes.Old.(*mapState)
+		if !ok {
+			c.Fatal("Failed to coerce \"changes.Old\" to \"*mapState\"")
+		}
+		c.Assert(oldMap.keys, checker.DeepEquals, tt.wantOldValues.keys, check.Commentf("%s: OldValues mismatch", tt.name))
 
 		// Revert changes and check that we get the original mapstate
-		keys.RevertChanges(changes)
-		c.Assert(keys, checker.DeepEquals, tt.keys, check.Commentf("%s: Revert mismatch", tt.name))
+		ms.RevertChanges(changes)
+		c.Assert(ms.keys, checker.DeepEquals, tt.ms.keys, check.Commentf("%s: Revert mismatch", tt.name))
 	}
 }
 
@@ -1151,26 +1155,26 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 	tests := []struct {
 		continued bool // Start from the end state of the previous test
 		name      string
-		setup     MapState
+		setup     *mapState
 		args      []args // changes applied, in order
 		state     MapState
 		adds      Keys
 		deletes   Keys
 	}{{
 		name: "test-1a - Adding L3-deny to an existing allow-all with L4-only allow redirect map state entries",
-		setup: MapState{
+		setup: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():   allowEntry(0),
 			HttpIngressKey(0): allowEntry(12345, nil),
-		},
+		}),
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():          allowEntry(0),
 			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
 			HttpIngressKey(0):        allowEntry(12345, nil),
 			HttpIngressKey(41):       denyEntry(0).WithOwners(testIngressKey(41, 0, 0)),
-		},
+		}),
 		adds: Keys{
 			testIngressKey(41, 0, 0): {},
 			HttpIngressKey(41):       {},
@@ -1182,14 +1186,14 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():          allowEntry(0),
 			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
 			testIngressKey(42, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(42)),
 			HttpIngressKey(0):        allowEntry(12345, nil),
 			HttpIngressKey(41):       denyEntry(0).WithOwners(testIngressKey(41, 0, 0)),
 			HttpIngressKey(42):       denyEntry(0).WithOwners(testIngressKey(42, 0, 0)),
-		},
+		}),
 		adds: Keys{
 			testIngressKey(42, 0, 0): {},
 			HttpIngressKey(42):       {},
@@ -1201,12 +1205,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: nil, deletes: []int{42}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():          allowEntry(0),
 			testIngressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(41)),
 			HttpIngressKey(0):        allowEntry(12345, nil),
 			HttpIngressKey(41):       denyEntry(0).WithOwners(testIngressKey(41, 0, 0)),
-		},
+		}),
 		adds: Keys{},
 		deletes: Keys{
 			testIngressKey(42, 0, 0): {},
@@ -1217,10 +1221,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): denyEntry(0, csFoo),
 			HttpIngressKey(43): denyEntry(0, csFoo),
-		},
+		}),
 		adds: Keys{
 			HttpIngressKey(42): {},
 			HttpIngressKey(43): {},
@@ -1232,11 +1236,11 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args: []args{
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): denyEntry(0, csFoo, csBar),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
-		},
+		}),
 		adds: Keys{
 			HttpIngressKey(44): {},
 		},
@@ -1247,11 +1251,11 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): denyEntry(0, csBar),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
@@ -1260,11 +1264,11 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): denyEntry(0, csBar),
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
@@ -1273,10 +1277,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args: []args{
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
-		},
+		}),
 		adds: Keys{},
 		deletes: Keys{
 			HttpIngressKey(42): {},
@@ -1287,29 +1291,29 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args: []args{
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(43): denyEntry(0, csFoo),
 			HttpIngressKey(44): denyEntry(0, csBar),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
 		continued: false,
 		name:      "test-3a - egress allow with deny-L3",
-		setup: MapState{
+		setup: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
-		},
+		}),
 		args: []args{
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
@@ -1319,13 +1323,13 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csBar, adds: []int{43}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{43}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
 			DNSUDPEgressKey(43):     allowEntry(0, csBar),
 			DNSTCPEgressKey(43):     allowEntry(0, csBar),
-		},
+		}),
 		adds: Keys{
 			DNSUDPEgressKey(43): {},
 			DNSTCPEgressKey(43): {},
@@ -1337,14 +1341,14 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
 			DNSUDPEgressKey(43):     allowEntry(0, csBar),
 			DNSTCPEgressKey(43):     allowEntry(0, csBar),
 			HttpEgressKey(43):       allowEntry(1, csFoo),
-		},
+		}),
 		adds: Keys{
 			HttpEgressKey(43): {},
 		},
@@ -1352,19 +1356,19 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 	}, {
 		continued: false,
 		name:      "test-4a - Add L7 skipped due to covering L3 deny",
-		setup: MapState{
+		setup: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
-		},
+		}),
 		args: []args{
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
@@ -1374,47 +1378,47 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			{cs: csFoo, adds: []int{42}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():         allowEntry(0),
 			HostIngressKey():        allowEntry(0),
 			testEgressKey(42, 0, 0): denyEntry(0, csFoo),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
 		name: "test-5 - Adding L3-deny to an existing allow-all",
-		setup: MapState{
+		setup: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey(): allowEntry(0),
-		},
+		}),
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():          allowEntry(0),
 			testIngressKey(41, 0, 0): denyEntry(0, csFoo),
-		},
+		}),
 		adds: Keys{
 			testIngressKey(41, 0, 0): {},
 		},
 		deletes: Keys{},
 	}, {
 		name: "test-6 - Multiple dependent entries",
-		setup: MapState{
+		setup: newMapState(map[Key]MapStateEntry{
 			AnyEgressKey():     allowEntry(0),
 			HttpEgressKey(0):   allowEntry(12345, nil),
 			DNSUDPEgressKey(0): allowEntry(12346, nil),
-		},
+		}),
 		args: []args{
 			{cs: csFoo, adds: []int{41}, deletes: []int{}, port: 0, proto: 0, ingress: false, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyEgressKey():          allowEntry(0),
 			testEgressKey(41, 0, 0): denyEntry(0, csFoo).WithDependents(HttpEgressKey(41), DNSUDPEgressKey(41)),
 			HttpEgressKey(0):        allowEntry(12345, nil),
 			HttpEgressKey(41):       denyEntry(0).WithOwners(testEgressKey(41, 0, 0)),
 			DNSUDPEgressKey(0):      allowEntry(12346, nil),
 			DNSUDPEgressKey(41):     denyEntry(0).WithOwners(testEgressKey(41, 0, 0)),
-		},
+		}),
 		adds: Keys{
 			testEgressKey(41, 0, 0): {},
 			HttpEgressKey(41):       {},
@@ -1427,10 +1431,8 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 		args:      []args{
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: MapState{
-			//HttpIngressKey(42): allowEntry(0, csFoo),
-		},
-		adds: Keys{
+		state: newMapState(nil),
+		adds:  Keys{
 			//HttpIngressKey(42): allowEntry(0),
 		},
 		deletes: Keys{
@@ -1439,7 +1441,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 	},
 	}
 
-	policyMapState := MapState{}
+	policyMapState := newMapState(nil)
 
 	for _, tt := range tests {
 		policyMaps := MapChanges{}
@@ -1447,7 +1449,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			if tt.setup != nil {
 				policyMapState = tt.setup
 			} else {
-				policyMapState = MapState{}
+				policyMapState = newMapState(nil)
 			}
 		}
 		for _, x := range tt.args {
@@ -1499,10 +1501,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): allowEntry(0, csFoo),
 			HttpIngressKey(43): allowEntry(0, csFoo),
-		},
+		}),
 		adds: Keys{
 			HttpIngressKey(42): {},
 			HttpIngressKey(43): {},
@@ -1514,11 +1516,11 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		args: []args{
 			{cs: csBar, adds: []int{42, 44}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): allowEntry(0, csFoo, csBar),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
-		},
+		}),
 		adds: Keys{
 			HttpIngressKey(44): {},
 		},
@@ -1529,11 +1531,11 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): allowEntry(0, csBar),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
@@ -1542,11 +1544,11 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(42): allowEntry(0, csBar),
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
@@ -1555,10 +1557,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		args: []args{
 			{cs: csBar, adds: []int{}, deletes: []int{42}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
-		},
+		}),
 		adds: Keys{},
 		deletes: Keys{
 			HttpIngressKey(42): {},
@@ -1569,10 +1571,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		args: []args{
 			{cs: csBar, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpIngressKey(43): allowEntry(0, csFoo),
 			HttpIngressKey(44): allowEntry(0, csBar),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
@@ -1584,12 +1586,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():     allowEntry(0, nil),
 			HostIngressKey():    allowEntry(0, nil),
 			DNSUDPEgressKey(42): allowEntry(0, csBar),
 			DNSTCPEgressKey(42): allowEntry(0, csBar),
-		},
+		}),
 		adds: Keys{
 			AnyIngressKey():     {},
 			HostIngressKey():    {},
@@ -1603,13 +1605,13 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		args: []args{
 			{cs: csFoo, adds: []int{43}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():     allowEntry(0, nil),
 			HostIngressKey():    allowEntry(0, nil),
 			DNSUDPEgressKey(42): allowEntry(0, csBar),
 			DNSTCPEgressKey(42): allowEntry(0, csBar),
 			HttpEgressKey(43):   allowEntry(1, csFoo),
-		},
+		}),
 		adds: Keys{
 			HttpEgressKey(43): {},
 		},
@@ -1621,7 +1623,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: MapState{},
+		state: newMapState(nil),
 		adds:  Keys{},
 		deletes: Keys{
 			// Delete of the key is recoded as the key may have existed already in the (bpf) map
@@ -1635,9 +1637,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			{cs: csFoo, adds: []int{}, deletes: []int{44}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 			{cs: csFoo, adds: []int{44}, deletes: []int{}, port: 80, proto: 6, ingress: false, redirect: true, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			HttpEgressKey(44): allowEntry(1, csFoo),
-		},
+		}),
 		adds: Keys{
 			HttpEgressKey(44): {},
 		},
@@ -1648,10 +1650,8 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 		args:      []args{
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: MapState{
-			//HttpIngressKey(42): allowEntry(0, csFoo),
-		},
-		adds: Keys{
+		state: newMapState(nil),
+		adds:  Keys{
 			//HttpIngressKey(42): allowEntry(0),
 		},
 		deletes: Keys{
@@ -1660,12 +1660,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 	},
 	}
 
-	policyMapState := MapState{}
+	policyMapState := newMapState(nil)
 
 	for _, tt := range tests {
 		policyMaps := MapChanges{}
 		if !tt.continued {
-			policyMapState = MapState{}
+			policyMapState = newMapState(nil)
 		}
 		for _, x := range tt.args {
 			dir := trafficdirection.Egress
@@ -1701,173 +1701,173 @@ func (ds *PolicyTestSuite) TestMapState_AddVisibilityKeys(c *check.C) {
 		visMeta      VisibilityMetadata
 	}
 	tests := []struct {
-		name       string
-		keys, want MapState
-		args       args
+		name     string
+		ms, want *mapState
+		args     args
 	}{
 		{
 			name: "test-1 - Add HTTP ingress visibility - allow-all",
-			keys: MapState{
+			ms: newMapState(map[Key]MapStateEntry{
 				AnyIngressKey(): allowEntry(0),
-			},
+			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{
+			want: newMapState(map[Key]MapStateEntry{
 				AnyIngressKey():   allowEntry(0),
 				HttpIngressKey(0): allowEntryD(12345, visibilityDerivedFrom, nil),
-			},
+			}),
 		},
 		{
 			name: "test-2 - Add HTTP ingress visibility - no allow-all",
-			keys: MapState{},
+			ms:   newMapState(nil),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{},
+			want: newMapState(nil),
 		},
 		{
 			name: "test-3 - Add HTTP ingress visibility - L4-allow",
-			keys: MapState{
+			ms: newMapState(map[Key]MapStateEntry{
 				HttpIngressKey(0): allowEntryD(0, labels.LabelArrayList{testLabels}),
-			},
+			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{
+			want: newMapState(map[Key]MapStateEntry{
 				HttpIngressKey(0): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels, testLabels}, nil),
-			},
+			}),
 		},
 		{
 			name: "test-4 - Add HTTP ingress visibility - L3/L4-allow",
-			keys: MapState{
+			ms: newMapState(map[Key]MapStateEntry{
 				HttpIngressKey(123): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
-			},
+			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{
+			want: newMapState(map[Key]MapStateEntry{
 				HttpIngressKey(123): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels, testLabels}, csBar),
-			},
+			}),
 		},
 		{
 			name: "test-5 - Add HTTP ingress visibility - L3-allow (host)",
-			keys: MapState{
+			ms: newMapState(map[Key]MapStateEntry{
 				HostIngressKey(): allowEntry(0),
-			},
+			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{
+			want: newMapState(map[Key]MapStateEntry{
 				HostIngressKey():  allowEntry(0).WithDependents(HttpIngressKey(1)),
 				HttpIngressKey(1): allowEntryD(12345, labels.LabelArrayList{visibilityDerivedFromLabels}).WithOwners(HostIngressKey()),
-			},
+			}),
 		},
 		{
 			name: "test-6 - Add HTTP ingress visibility - L3/L4-allow on different port",
-			keys: MapState{
+			ms: newMapState(map[Key]MapStateEntry{
 				testIngressKey(123, 88, 6): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
-			},
+			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{
+			want: newMapState(map[Key]MapStateEntry{
 				testIngressKey(123, 88, 6): allowEntryD(0, labels.LabelArrayList{testLabels}, csBar),
-			},
+			}),
 		},
 		{
 			name: "test-7 - Add HTTP ingress visibility - allow-all + L4-deny (no change)",
-			keys: MapState{
+			ms: newMapState(map[Key]MapStateEntry{
 				AnyIngressKey():   allowEntry(0),
 				HttpIngressKey(0): denyEntry(0),
-			},
+			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{
+			want: newMapState(map[Key]MapStateEntry{
 				AnyIngressKey():   allowEntry(0),
 				HttpIngressKey(0): denyEntry(0),
-			},
+			}),
 		},
 		{
 			name: "test-8 - Add HTTP ingress visibility - allow-all + L3-deny",
-			keys: MapState{
+			ms: newMapState(map[Key]MapStateEntry{
 				AnyIngressKey():           allowEntry(0),
 				testIngressKey(234, 0, 0): denyEntry(0, csFoo),
-			},
+			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{
+			want: newMapState(map[Key]MapStateEntry{
 				AnyIngressKey():           allowEntry(0),
 				testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
 				HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
 				HttpIngressKey(234):       denyEntry(0, csFoo).WithOwners(testIngressKey(234, 0, 0)),
-			},
+			}),
 		},
 		{
 			name: "test-9 - Add HTTP ingress visibility - allow-all + L3/L4-deny",
-			keys: MapState{
+			ms: newMapState(map[Key]MapStateEntry{
 				AnyIngressKey():     allowEntry(0),
 				HttpIngressKey(132): denyEntry(0, csBar),
-			},
+			}),
 			args: args{
 				redirectPort: 12345,
 				visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{
+			want: newMapState(map[Key]MapStateEntry{
 				AnyIngressKey():     allowEntry(0),
 				HttpIngressKey(132): denyEntry(0, csBar),
 				HttpIngressKey(0):   allowEntryD(12345, visibilityDerivedFrom, nil),
-			},
+			}),
 		},
 		{
 			name: "test-10 - Add HTTP egress visibility",
-			keys: MapState{
+			ms: newMapState(map[Key]MapStateEntry{
 				AnyEgressKey(): allowEntry(0),
-			},
+			}),
 			args: args{
 				redirectPort: 12346,
 				visMeta:      VisibilityMetadata{Ingress: false, Port: 80, Proto: u8proto.TCP},
 			},
-			want: MapState{
+			want: newMapState(map[Key]MapStateEntry{
 				AnyEgressKey():   allowEntry(0),
 				HttpEgressKey(0): allowEntryD(12346, visibilityDerivedFrom, nil),
-			},
+			}),
 		},
 	}
 	for _, tt := range tests {
-		old := make(MapState, len(tt.keys))
-		for k, v := range tt.keys {
-			old.insertIfNotExists(k, v)
+		old := newMapState(nil)
+		for k, v := range tt.ms.keys {
+			old.InsertIfNotExists(k, v)
 		}
 		changes := ChangeState{
 			Adds: make(Keys),
-			Old:  make(MapState),
+			Old:  newMapState(nil),
 		}
-		tt.keys.AddVisibilityKeys(DummyOwner{}, tt.args.redirectPort, &tt.args.visMeta, changes)
-		tt.keys.validatePortProto(c)
-		c.Assert(tt.keys, checker.DeepEquals, tt.want, check.Commentf(tt.name))
+		tt.ms.AddVisibilityKeys(DummyOwner{}, tt.args.redirectPort, &tt.args.visMeta, changes)
+		tt.ms.validatePortProto(c)
+		c.Assert(tt.ms.keys, checker.DeepEquals, tt.want.keys, check.Commentf(tt.name))
 		// Find new and updated entries
 		wantAdds := make(Keys)
-		wantOld := make(MapState)
-		for k, v := range old {
-			if _, ok := tt.keys[k]; !ok {
-				wantOld[k] = v
+		wantOld := newMapState(nil)
+		for k, v := range old.keys {
+			if _, ok := tt.ms.keys[k]; !ok {
+				wantOld.keys[k] = v
 			}
 		}
-		for k, v := range tt.keys {
-			if v2, ok := old[k]; ok {
+		for k, v := range tt.ms.keys {
+			if v2, ok := old.keys[k]; ok {
 				if equals, _ := checker.DeepEqual(v2, v); !equals {
-					wantOld[k] = v2
+					wantOld.keys[k] = v2
 				}
 			} else {
 				wantAdds[k] = struct{}{}
@@ -1899,7 +1899,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 	tests := []struct {
 		continued bool // Start from the end state of the previous test
 		name      string
-		setup     MapState
+		setup     *mapState
 		visArgs   []visArgs
 		visAdds   Keys
 		visOld    MapState
@@ -1909,10 +1909,10 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		deletes   Keys
 	}{{
 		name: "test-1a - Adding identity to deny with visibilty",
-		setup: MapState{
+		setup: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():           allowEntry(0),
 			testIngressKey(234, 0, 0): denyEntry(0, csFoo),
-		},
+		}),
 		visArgs: []visArgs{{
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
@@ -1921,20 +1921,20 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			HttpIngressKey(0):   {},
 			HttpIngressKey(234): {},
 		},
-		visOld: MapState{
+		visOld: newMapState(map[Key]MapStateEntry{
 			testIngressKey(234, 0, 0): denyEntry(0, csFoo),
-		},
+		}),
 		args: []args{
 			{cs: csFoo, adds: []int{235}, deletes: []int{}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():           allowEntry(0),
 			testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
 			testIngressKey(235, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
 			HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
 			HttpIngressKey(234):       denyEntry(0).WithOwners(testIngressKey(234, 0, 0)),
 			HttpIngressKey(235):       denyEntry(0).WithOwners(testIngressKey(235, 0, 0)),
-		},
+		}),
 		adds: Keys{
 			testIngressKey(235, 0, 0): {},
 			HttpIngressKey(235):       {},
@@ -1946,12 +1946,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		args: []args{
 			{cs: csFoo, adds: nil, deletes: []int{235}, port: 0, proto: 0, ingress: true, redirect: false, deny: true},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():           allowEntry(0),
 			testIngressKey(234, 0, 0): denyEntry(0, csFoo).WithDependents(HttpIngressKey(234)),
 			HttpIngressKey(0):         allowEntryD(12345, visibilityDerivedFrom, nil),
 			HttpIngressKey(234):       denyEntry(0).WithOwners(testIngressKey(234, 0, 0)),
-		},
+		}),
 		adds: Keys{},
 		deletes: Keys{
 			testIngressKey(235, 0, 0): {},
@@ -1966,12 +1966,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			testIngressKey(235, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(235)),
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
 			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
-		},
+		}),
 		adds: Keys{
 			testIngressKey(235, 0, 0): {},
 			HttpIngressKey(235):       {},
@@ -1992,14 +1992,14 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			testIngressKey(235, 0, 0): allowEntry(0, csFoo, csBar).WithDependents(HttpIngressKey(235)),
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
 			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
 			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
 			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
-		},
+		}),
 		adds: Keys{
 			testIngressKey(237, 0, 0): {},
 			HttpIngressKey(237):       {},
@@ -2017,14 +2017,14 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			testIngressKey(235, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
 			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
 			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
 			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
@@ -2037,14 +2037,14 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			testIngressKey(235, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(235)),
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(235):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(235, 0, 0)),
 			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
 			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
 			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
@@ -2057,12 +2057,12 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
 			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
 			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
-		},
+		}),
 		adds: Keys{},
 		deletes: Keys{
 			testIngressKey(235, 0, 0): {},
@@ -2078,22 +2078,22 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			redirectPort: 12345,
 			visMeta:      VisibilityMetadata{Ingress: true, Port: 80, Proto: u8proto.TCP},
 		}},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			testIngressKey(236, 0, 0): allowEntry(0, csFoo).WithDependents(HttpIngressKey(236)),
 			HttpIngressKey(236):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(236, 0, 0)),
 			testIngressKey(237, 0, 0): allowEntry(0, csBar).WithDependents(HttpIngressKey(237)),
 			HttpIngressKey(237):       allowEntryD(12345, visibilityDerivedFrom).WithOwners(testIngressKey(237, 0, 0)),
-		},
+		}),
 		adds:    Keys{},
 		deletes: Keys{},
 	}, {
 		continued: false,
 		name:      "test-3a - egress HTTP proxy (setup)",
-		setup: MapState{
+		setup: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():  allowEntry(0),
 			HostIngressKey(): allowEntry(0),
 			HttpEgressKey(0): allowEntry(0),
-		},
+		}),
 		visArgs: []visArgs{
 			{
 				redirectPort: 12345,
@@ -2111,15 +2111,15 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		visAdds: Keys{
 			HttpIngressKey(0): {},
 		},
-		visOld: MapState{
+		visOld: newMapState(map[Key]MapStateEntry{
 			// Old value for the modified entry
 			HttpEgressKey(0): allowEntry(0),
-		},
+		}),
 		args: []args{
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 17, ingress: false, redirect: false, deny: false},
 			{cs: csBar, adds: []int{42}, deletes: []int{}, port: 53, proto: 6, ingress: false, redirect: false, deny: false},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():  allowEntry(0),
 			HostIngressKey(): allowEntry(0),
 			// Entry added solely due to visibility annotation has a 'nil' owner
@@ -2128,7 +2128,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			HttpEgressKey(0):    allowEntryD(12346, visibilityDerivedFrom, nil),
 			DNSUDPEgressKey(42): allowEntryD(12347, visibilityDerivedFrom, csBar),
 			DNSTCPEgressKey(42): allowEntry(0, csBar),
-		},
+		}),
 		adds: Keys{
 			DNSUDPEgressKey(42): {},
 			DNSTCPEgressKey(42): {},
@@ -2157,7 +2157,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 				visMeta:      VisibilityMetadata{Ingress: false, Port: 53, Proto: u8proto.UDP},
 			},
 		},
-		state: MapState{
+		state: newMapState(map[Key]MapStateEntry{
 			AnyIngressKey():     allowEntry(0),
 			HostIngressKey():    allowEntry(0),
 			HttpIngressKey(0):   allowEntryD(12345, visibilityDerivedFrom).WithOwners(nil),
@@ -2166,7 +2166,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			DNSTCPEgressKey(42): allowEntry(0, csBar),
 			// Redirect entries are not modified by visibility annotations
 			HttpEgressKey(43): allowEntry(1, csFoo),
-		},
+		}),
 		adds: Keys{
 			HttpEgressKey(43): {},
 		},
@@ -2177,10 +2177,8 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		args:      []args{
 			//{cs: csFoo, adds: []int{42, 43}, deletes: []int{50}, port: 80, proto: 6, ingress: true, redirect: false, deny: false},
 		},
-		state: MapState{
-			//HttpIngressKey(42): allowEntry(0, csFoo),
-		},
-		adds: Keys{
+		state: newMapState(nil),
+		adds:  Keys{
 			//HttpIngressKey(42): {},
 		},
 		deletes: Keys{
@@ -2189,7 +2187,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 	},
 	}
 
-	policyMapState := MapState{}
+	policyMapState := newMapState(nil)
 
 	for _, tt := range tests {
 		// Allow omit empty maps
@@ -2197,7 +2195,7 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			tt.visAdds = make(Keys)
 		}
 		if tt.visOld == nil {
-			tt.visOld = make(MapState)
+			tt.visOld = newMapState(nil)
 		}
 		if tt.adds == nil {
 			tt.adds = make(Keys)
@@ -2210,13 +2208,13 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			if tt.setup != nil {
 				policyMapState = tt.setup
 			} else {
-				policyMapState = MapState{}
+				policyMapState = newMapState(nil)
 			}
 		}
 		changes := ChangeState{
 			Adds:    make(Keys),
 			Deletes: make(Keys),
-			Old:     make(MapState),
+			Old:     newMapState(nil),
 		}
 		for _, arg := range tt.visArgs {
 			policyMapState.AddVisibilityKeys(DummyOwner{}, arg.redirectPort, &arg.visMeta, changes)
@@ -2241,16 +2239,17 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 		changes = ChangeState{
 			Adds:    adds,
 			Deletes: deletes,
-			Old:     make(MapState),
+			Old:     newMapState(nil),
 		}
 
 		// Visibilty redirects need to be re-applied after consumeMapChanges()
 		for _, arg := range tt.visArgs {
 			policyMapState.AddVisibilityKeys(DummyOwner{}, arg.redirectPort, &arg.visMeta, changes)
 		}
-		for k := range changes.Old {
+		changes.Old.ForEach(func(k Key, _ MapStateEntry) bool {
 			changes.Deletes[k] = struct{}{}
-		}
+			return true
+		})
 		policyMapState.validatePortProto(c)
 		c.Assert(policyMapState, checker.DeepEquals, tt.state, check.Commentf(tt.name+" (MapState)"))
 		c.Assert(changes.Adds, checker.DeepEquals, tt.adds, check.Commentf(tt.name+" (adds)"))
@@ -2340,30 +2339,30 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithSubnets(c *check.
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
 		bKey := Key{Identity: tt.bIdentity, DestPort: tt.bPort, Nexthdr: tt.bProto}
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
-		expectedKeys := MapState{}
+		expectedKeys := newMapState(nil)
 		if tt.outcome&insertA > 0 {
-			expectedKeys[aKey] = aEntry
+			expectedKeys.keys[aKey] = aEntry
 		}
 		if tt.outcome&insertB > 0 {
-			expectedKeys[bKey] = bEntry
+			expectedKeys.keys[bKey] = bEntry
 		}
 		if tt.outcome&insertAWithBProto > 0 {
 			aKeyWithBProto := Key{Identity: tt.aIdentity, DestPort: tt.bPort, Nexthdr: tt.bProto}
 			aEntryCpy := MapStateEntry{IsDeny: tt.aIsDeny}
 			aEntryCpy.owners = map[MapStateOwner]struct{}{aKey: {}}
 			aEntry.AddDependent(aKeyWithBProto)
-			expectedKeys[aKey] = aEntry
-			expectedKeys[aKeyWithBProto] = aEntryCpy
+			expectedKeys.keys[aKey] = aEntry
+			expectedKeys.keys[aKeyWithBProto] = aEntryCpy
 		}
 		if tt.outcome&insertBWithAProto > 0 {
 			bKeyWithBProto := Key{Identity: tt.bIdentity, DestPort: tt.aPort, Nexthdr: tt.aProto}
 			bEntryCpy := MapStateEntry{IsDeny: tt.bIsDeny}
 			bEntryCpy.owners = map[MapStateOwner]struct{}{bKey: {}}
 			bEntry.AddDependent(bKeyWithBProto)
-			expectedKeys[bKey] = bEntry
-			expectedKeys[bKeyWithBProto] = bEntryCpy
+			expectedKeys.keys[bKey] = bEntry
+			expectedKeys.keys[bKeyWithBProto] = bEntryCpy
 		}
-		outcomeKeys := MapState{}
+		outcomeKeys := newMapState(nil)
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(c)
@@ -2377,10 +2376,10 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithSubnets(c *check.
 		aEntry := MapStateEntry{IsDeny: tt.aIsDeny}
 		bKey := Key{Identity: tt.bIdentity, DestPort: tt.bPort, Nexthdr: tt.bProto, TrafficDirection: 1}
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
-		expectedKeys := MapState{}
-		expectedKeys[aKey] = aEntry
-		expectedKeys[bKey] = bEntry
-		outcomeKeys := MapState{}
+		expectedKeys := newMapState(nil)
+		expectedKeys.keys[aKey] = aEntry
+		expectedKeys.keys[bKey] = bEntry
+		outcomeKeys := newMapState(nil)
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)
 		outcomeKeys.validatePortProto(c)

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -144,11 +144,12 @@ func (ds *PolicyTestSuite) TestPolicyKeyTrafficDirection(c *check.C) {
 // validatePortProto makes sure each Key in MapState abides by the contract that protocol/nexthdr
 // can only be wildcarded if the destination port is also wildcarded.
 func (ms *mapState) validatePortProto(c *check.C) {
-	for k := range ms.keys {
+	ms.ForEach(func(k Key, _ MapStateEntry) bool {
 		if k.Nexthdr == 0 {
 			c.Assert(k.DestPort, check.Equals, uint16(0))
 		}
-	}
+		return true
+	})
 }
 
 func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.C) {
@@ -1041,24 +1042,29 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithChanges(c *check.
 			Old:     newMapState(nil),
 		}
 		// copy the starging point
-		ms := newMapState(make(map[Key]MapStateEntry, len(tt.ms.keys)))
-		for k, v := range tt.ms.keys {
-			ms.keys[k] = v
-		}
+		ms := newMapState(make(map[Key]MapStateEntry, tt.ms.Len()))
+		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
+			ms.Insert(k, v)
+			return true
+		})
+
 		ms.denyPreferredInsertWithChanges(tt.args.key, tt.args.entry, nil, denyRules, changes)
 		ms.validatePortProto(c)
-		c.Assert(ms.keys, checker.DeepEquals, tt.want.keys, check.Commentf("%s: MapState mismatch", tt.name))
+		c.Assert(ms.allows, checker.DeepEquals, tt.want.allows, check.Commentf("%s: MapState mismatch allows", tt.name))
+		c.Assert(ms.denies, checker.DeepEquals, tt.want.denies, check.Commentf("%s: MapState mismatch denies", tt.name))
 		c.Assert(changes.Adds, checker.DeepEquals, tt.wantAdds, check.Commentf("%s: Adds mismatch", tt.name))
 		c.Assert(changes.Deletes, checker.DeepEquals, tt.wantDeletes, check.Commentf("%s: Deletes mismatch", tt.name))
 		oldMap, ok := changes.Old.(*mapState)
 		if !ok {
 			c.Fatal("Failed to coerce \"changes.Old\" to \"*mapState\"")
 		}
-		c.Assert(oldMap.keys, checker.DeepEquals, tt.wantOldValues.keys, check.Commentf("%s: OldValues mismatch", tt.name))
+		c.Assert(oldMap.allows, checker.DeepEquals, tt.wantOldValues.allows, check.Commentf("%s: OldValues mismatch allows", tt.name))
+		c.Assert(oldMap.denies, checker.DeepEquals, tt.wantOldValues.denies, check.Commentf("%s: OldValues mismatch denies", tt.name))
 
 		// Revert changes and check that we get the original mapstate
 		ms.RevertChanges(changes)
-		c.Assert(ms.keys, checker.DeepEquals, tt.ms.keys, check.Commentf("%s: Revert mismatch", tt.name))
+		c.Assert(ms.allows, checker.DeepEquals, tt.ms.allows, check.Commentf("%s: Revert mismatch allows", tt.name))
+		c.Assert(ms.denies, checker.DeepEquals, tt.ms.denies, check.Commentf("%s: Revert mismatch denies", tt.name))
 	}
 }
 
@@ -1846,33 +1852,38 @@ func (ds *PolicyTestSuite) TestMapState_AddVisibilityKeys(c *check.C) {
 	}
 	for _, tt := range tests {
 		old := newMapState(nil)
-		for k, v := range tt.ms.keys {
+		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
 			old.InsertIfNotExists(k, v)
-		}
+			return true
+		})
 		changes := ChangeState{
 			Adds: make(Keys),
 			Old:  newMapState(nil),
 		}
 		tt.ms.AddVisibilityKeys(DummyOwner{}, tt.args.redirectPort, &tt.args.visMeta, changes)
 		tt.ms.validatePortProto(c)
-		c.Assert(tt.ms.keys, checker.DeepEquals, tt.want.keys, check.Commentf(tt.name))
+		c.Assert(tt.ms.allows, checker.DeepEquals, tt.want.allows, check.Commentf(tt.name))
+		c.Assert(tt.ms.denies, checker.DeepEquals, tt.want.denies, check.Commentf(tt.name))
 		// Find new and updated entries
 		wantAdds := make(Keys)
 		wantOld := newMapState(nil)
-		for k, v := range old.keys {
-			if _, ok := tt.ms.keys[k]; !ok {
-				wantOld.keys[k] = v
+
+		old.ForEach(func(k Key, v MapStateEntry) bool {
+			if _, ok := tt.ms.Get(k); !ok {
+				wantOld.Insert(k, v)
 			}
-		}
-		for k, v := range tt.ms.keys {
-			if v2, ok := old.keys[k]; ok {
+			return true
+		})
+		tt.ms.ForEach(func(k Key, v MapStateEntry) bool {
+			if v2, ok := old.Get(k); ok {
 				if equals, _ := checker.DeepEqual(v2, v); !equals {
-					wantOld.keys[k] = v2
+					wantOld.Insert(k, v2)
 				}
 			} else {
 				wantAdds[k] = struct{}{}
 			}
-		}
+			return true
+		})
 		c.Assert(changes.Adds, checker.DeepEquals, wantAdds, check.Commentf(tt.name))
 		c.Assert(changes.Old, checker.DeepEquals, wantOld, check.Commentf(tt.name))
 	}
@@ -2341,26 +2352,44 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithSubnets(c *check.
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
 		expectedKeys := newMapState(nil)
 		if tt.outcome&insertA > 0 {
-			expectedKeys.keys[aKey] = aEntry
+			if tt.aIsDeny {
+				expectedKeys.denies[aKey] = aEntry
+			} else {
+				expectedKeys.allows[aKey] = aEntry
+			}
 		}
 		if tt.outcome&insertB > 0 {
-			expectedKeys.keys[bKey] = bEntry
+			if tt.bIsDeny {
+				expectedKeys.denies[bKey] = bEntry
+			} else {
+				expectedKeys.allows[bKey] = bEntry
+			}
 		}
 		if tt.outcome&insertAWithBProto > 0 {
 			aKeyWithBProto := Key{Identity: tt.aIdentity, DestPort: tt.bPort, Nexthdr: tt.bProto}
 			aEntryCpy := MapStateEntry{IsDeny: tt.aIsDeny}
 			aEntryCpy.owners = map[MapStateOwner]struct{}{aKey: {}}
 			aEntry.AddDependent(aKeyWithBProto)
-			expectedKeys.keys[aKey] = aEntry
-			expectedKeys.keys[aKeyWithBProto] = aEntryCpy
+			if tt.aIsDeny {
+				expectedKeys.denies[aKey] = aEntry
+				expectedKeys.denies[aKeyWithBProto] = aEntryCpy
+			} else {
+				expectedKeys.allows[aKey] = aEntry
+				expectedKeys.allows[aKeyWithBProto] = aEntryCpy
+			}
 		}
 		if tt.outcome&insertBWithAProto > 0 {
 			bKeyWithBProto := Key{Identity: tt.bIdentity, DestPort: tt.aPort, Nexthdr: tt.aProto}
 			bEntryCpy := MapStateEntry{IsDeny: tt.bIsDeny}
 			bEntryCpy.owners = map[MapStateOwner]struct{}{bKey: {}}
 			bEntry.AddDependent(bKeyWithBProto)
-			expectedKeys.keys[bKey] = bEntry
-			expectedKeys.keys[bKeyWithBProto] = bEntryCpy
+			if tt.bIsDeny {
+				expectedKeys.denies[bKey] = bEntry
+				expectedKeys.denies[bKeyWithBProto] = bEntryCpy
+			} else {
+				expectedKeys.allows[bKey] = bEntry
+				expectedKeys.allows[bKeyWithBProto] = bEntryCpy
+			}
 		}
 		outcomeKeys := newMapState(nil)
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
@@ -2377,8 +2406,16 @@ func (ds *PolicyTestSuite) TestMapState_denyPreferredInsertWithSubnets(c *check.
 		bKey := Key{Identity: tt.bIdentity, DestPort: tt.bPort, Nexthdr: tt.bProto, TrafficDirection: 1}
 		bEntry := MapStateEntry{IsDeny: tt.bIsDeny}
 		expectedKeys := newMapState(nil)
-		expectedKeys.keys[aKey] = aEntry
-		expectedKeys.keys[bKey] = bEntry
+		if tt.aIsDeny {
+			expectedKeys.denies[aKey] = aEntry
+		} else {
+			expectedKeys.allows[aKey] = aEntry
+		}
+		if tt.bIsDeny {
+			expectedKeys.denies[bKey] = bEntry
+		} else {
+			expectedKeys.allows[bKey] = bEntry
+		}
 		outcomeKeys := newMapState(nil)
 		outcomeKeys.denyPreferredInsert(aKey, aEntry, selectorCache, allFeatures)
 		outcomeKeys.denyPreferredInsert(bKey, bEntry, selectorCache, allFeatures)

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -44,7 +44,7 @@ type EndpointPolicy struct {
 	// referring to a shared selectorPolicy!
 	*selectorPolicy
 
-	// PolicyMapState contains the state of this policy as it relates to the
+	// policyMapState contains the state of this policy as it relates to the
 	// datapath. In the future, this will be factored out of this object to
 	// decouple the policy as it relates to the datapath vs. its userspace
 	// representation.
@@ -52,7 +52,7 @@ type EndpointPolicy struct {
 	// Proxy port 0 indicates no proxy redirection.
 	// All fields within the Key and the proxy port must be in host byte-order.
 	// Must only be accessed with PolicyOwner (aka Endpoint) lock taken.
-	PolicyMapState MapState
+	policyMapState MapState
 
 	// policyMapChanges collects pending changes to the PolicyMapState
 	policyMapChanges MapChanges
@@ -106,12 +106,12 @@ func (p *selectorPolicy) Detach() {
 func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *EndpointPolicy {
 	calculatedPolicy := &EndpointPolicy{
 		selectorPolicy: p,
-		PolicyMapState: make(MapState),
+		policyMapState: NewMapState(nil),
 		PolicyOwner:    policyOwner,
 	}
 
 	if !p.IngressPolicyEnabled || !p.EgressPolicyEnabled {
-		calculatedPolicy.PolicyMapState.AllowAllIdentities(
+		calculatedPolicy.policyMapState.allowAllIdentities(
 			!p.IngressPolicyEnabled, !p.EgressPolicyEnabled)
 	}
 
@@ -133,11 +133,28 @@ func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *En
 	p.SelectorCache.mutex.RLock()
 	calculatedPolicy.toMapState()
 	if !isHost {
-		calculatedPolicy.PolicyMapState.DetermineAllowLocalhostIngress()
+		calculatedPolicy.policyMapState.determineAllowLocalhostIngress()
 	}
 	p.SelectorCache.mutex.RUnlock()
 
 	return calculatedPolicy
+}
+
+// GetPolicyMap gets the policy map state as the interface
+// MapState
+func (p *EndpointPolicy) GetPolicyMap() MapState {
+	return p.policyMapState
+}
+
+// SetPolicyMap sets the policy map state as the interface
+// MapState. If the main argument is nil, then this method
+// will initialize a new MapState object for the caller.
+func (p *EndpointPolicy) SetPolicyMap(ms MapState) {
+	if ms == nil {
+		p.policyMapState = NewMapState(nil)
+		return
+	}
+	p.policyMapState = ms
 }
 
 // Detach removes EndpointPolicy references from selectorPolicy
@@ -180,7 +197,9 @@ func (l4policy L4DirectionPolicy) toMapState(p *EndpointPolicy) {
 				}
 			}
 			return true
-		}, ChangeState{})
+		}, ChangeState{
+			Old: newMapState(nil),
+		})
 	}
 }
 
@@ -206,7 +225,7 @@ func (l4policy L4DirectionPolicy) updateRedirects(p *EndpointPolicy, getProxyPor
 	for _, l4 := range l4policy.PortRules {
 		if l4.IsRedirect() {
 			// Check if we are denying this specific L4 first regardless the L3, if there are any deny policies
-			if l4policy.features.contains(denyRules) && p.PolicyMapState.deniesL4(p.PolicyOwner, l4) {
+			if l4policy.features.contains(denyRules) && p.policyMapState.deniesL4(p.PolicyOwner, l4) {
 				continue
 			}
 
@@ -234,7 +253,7 @@ func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
 	p.selectorPolicy.SelectorCache.mutex.Lock()
 	defer p.selectorPolicy.SelectorCache.mutex.Unlock()
 	features := p.selectorPolicy.L4Policy.Ingress.features | p.selectorPolicy.L4Policy.Egress.features
-	return p.policyMapChanges.consumeMapChanges(p.PolicyMapState, features, p.SelectorCache)
+	return p.policyMapChanges.consumeMapChanges(p.policyMapState, features, p.SelectorCache)
 }
 
 // AllowsIdentity returns whether the specified policy allows
@@ -251,7 +270,7 @@ func (p *EndpointPolicy) AllowsIdentity(identity identity.NumericIdentity) (ingr
 		ingress = true
 	} else {
 		key.TrafficDirection = trafficdirection.Ingress.Uint8()
-		if v, exists := p.PolicyMapState[key]; exists && !v.IsDeny {
+		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
 			ingress = true
 		}
 	}
@@ -260,7 +279,7 @@ func (p *EndpointPolicy) AllowsIdentity(identity identity.NumericIdentity) (ingr
 		egress = true
 	} else {
 		key.TrafficDirection = trafficdirection.Egress.Uint8()
-		if v, exists := p.PolicyMapState[key]; exists && !v.IsDeny {
+		if v, exists := p.policyMapState.Get(key); exists && !v.IsDeny {
 			egress = true
 		}
 	}
@@ -272,5 +291,6 @@ func (p *EndpointPolicy) AllowsIdentity(identity identity.NumericIdentity) (ingr
 func NewEndpointPolicy(repo *Repository) *EndpointPolicy {
 	return &EndpointPolicy{
 		selectorPolicy: newSelectorPolicy(repo.GetSelectorCache()),
+		policyMapState: NewMapState(nil),
 	}
 }

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -168,7 +168,7 @@ func (ds *PolicyTestSuite) TestL3WithIngressDenyWildcard(c *C) {
 		PolicyOwner: DummyOwner{},
 		// inherit this from the result as it is outside of the scope
 		// of this test
-		PolicyMapState: policy.PolicyMapState,
+		policyMapState: policy.policyMapState,
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -253,7 +253,7 @@ func (ds *PolicyTestSuite) TestL3WithLocalHostWildcardd(c *C) {
 		PolicyOwner: DummyOwner{},
 		// inherit this from the result as it is outside of the scope
 		// of this test
-		PolicyMapState: policy.PolicyMapState,
+		policyMapState: policy.policyMapState,
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -335,12 +335,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDenyWildcard(c *C) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		PolicyMapState: MapState{
+		policyMapState: newMapState(map[Key]MapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			{TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
 			{DestPort: 80, Nexthdr: 6}:                          rule1MapStateEntry,
-		},
+		}),
 	}
 
 	// Add new identity to test accumulation of MapChanges
@@ -478,7 +478,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 			IngressPolicyEnabled: true,
 		},
 		PolicyOwner: DummyOwner{},
-		PolicyMapState: MapState{
+		policyMapState: newMapState(map[Key]MapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
 			{TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
@@ -487,7 +487,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
-		},
+		}),
 	}
 
 	adds, deletes := policy.ConsumeMapChanges()

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -333,7 +333,7 @@ func (ds *PolicyTestSuite) TestL7WithIngressWildcard(c *C) {
 		PolicyOwner: DummyOwner{},
 		// inherit this from the result as it is outside of the scope
 		// of this test
-		PolicyMapState: policy.PolicyMapState,
+		policyMapState: policy.policyMapState,
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -430,7 +430,7 @@ func (ds *PolicyTestSuite) TestL7WithLocalHostWildcardd(c *C) {
 		PolicyOwner: DummyOwner{},
 		// inherit this from the result as it is outside of the scope
 		// of this test
-		PolicyMapState: policy.PolicyMapState,
+		policyMapState: policy.policyMapState,
 	}
 
 	// Have to remove circular reference before testing to avoid an infinite loop
@@ -512,10 +512,10 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{},
-		PolicyMapState: MapState{
+		policyMapState: newMapState(map[Key]MapStateEntry{
 			{TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
 			{DestPort: 80, Nexthdr: 6}:                          rule1MapStateEntry,
-		},
+		}),
 	}
 
 	// Add new identity to test accumulation of MapChanges
@@ -664,14 +664,14 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 			EgressPolicyEnabled:  false,
 		},
 		PolicyOwner: DummyOwner{},
-		PolicyMapState: MapState{
+		policyMapState: newMapState(map[Key]MapStateEntry{
 			{TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
 			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
 			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
 			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
-		},
+		}),
 	}
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop
@@ -703,7 +703,7 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 	type fields struct {
 		selectorPolicy *selectorPolicy
-		PolicyMapState MapState
+		PolicyMapState *mapState
 	}
 	type args struct {
 		identity identity.NumericIdentity
@@ -722,7 +722,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: false,
 					EgressPolicyEnabled:  false,
 				},
-				PolicyMapState: MapState{},
+				PolicyMapState: newMapState(nil),
 			},
 			args: args{
 				identity: 0,
@@ -737,7 +737,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: MapState{},
+				PolicyMapState: newMapState(nil),
 			},
 			args: args{
 				identity: 0,
@@ -752,14 +752,14 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: MapState{
-					Key{
+				PolicyMapState: newMapState(map[Key]MapStateEntry{
+					{
 						Identity:         0,
 						DestPort:         0,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
-					}: MapStateEntry{},
-				},
+					}: {},
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -774,14 +774,14 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: MapState{
-					Key{
+				PolicyMapState: newMapState(map[Key]MapStateEntry{
+					{
 						Identity:         0,
 						DestPort:         0,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
-					}: MapStateEntry{},
-				},
+					}: {},
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -796,14 +796,14 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: MapState{
-					Key{
+				PolicyMapState: newMapState(map[Key]MapStateEntry{
+					{
 						Identity:         0,
 						DestPort:         0,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
-					}: MapStateEntry{IsDeny: true},
-				},
+					}: {IsDeny: true},
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -818,14 +818,14 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: false,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: MapState{
-					Key{
+				PolicyMapState: newMapState(map[Key]MapStateEntry{
+					{
 						Identity:         0,
 						DestPort:         0,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
-					}: MapStateEntry{IsDeny: true},
-				},
+					}: {IsDeny: true},
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -840,14 +840,14 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  true,
 				},
-				PolicyMapState: MapState{
-					Key{
+				PolicyMapState: newMapState(map[Key]MapStateEntry{
+					{
 						Identity:         0,
 						DestPort:         0,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
-					}: MapStateEntry{IsDeny: true},
-				},
+					}: {IsDeny: true},
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -862,14 +862,14 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					IngressPolicyEnabled: true,
 					EgressPolicyEnabled:  false,
 				},
-				PolicyMapState: MapState{
-					Key{
+				PolicyMapState: newMapState(map[Key]MapStateEntry{
+					{
 						Identity:         0,
 						DestPort:         0,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
-					}: MapStateEntry{IsDeny: true},
-				},
+					}: {IsDeny: true},
+				}),
 			},
 			args: args{
 				identity: 0,
@@ -882,7 +882,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &EndpointPolicy{
 				selectorPolicy: tt.fields.selectorPolicy,
-				PolicyMapState: tt.fields.PolicyMapState,
+				policyMapState: tt.fields.PolicyMapState,
 			}
 			gotIngress, gotEgress := p.AllowsIdentity(tt.args.identity)
 			if gotIngress != tt.wantIngress {


### PR DESCRIPTION
The first commit converts the MapState type from a newtype an interface (mostly Nate's work, rebased on newer `main`)

The second commit then splits the map in the struct into two - to track allows and denies seperately. 

This allows for an optimization in the third commit: `denyPreferredInserts` for the allow case, now doesn't have to loop through all other allows (which we don't care about).

Commit msgs for convenience:

`policy: Make MapState an interface`
    
    `MapState` has many methods, some of which are public.
    In order to keep state to accomplish creating a cohesive
    map state that can keep state besides what will be put into
    an ebpf map, `MapState` can no longer be a type declaration
    for a golang map, but must be a struct that keeps state.
    
    The endpoint package must also be refactored to use `MapState`
    as an interface rather than a instantiated type of a map.

`mapstate: split allows and denies`
    
    Now that mapState is a struct, we can split the tracking of allows and
    denies. This commit should not introduce functional changes, but
    prepares us for an optimization in a later commit.
   
`mapstate: optimize denyPreferredInsert`
    
    Since the denyPreferredInsert logic cleanly splits on whether the to be
    inserted entry is a deny entry, we can avoid iterating over some
    entries: If we are inserting a deny, we are mostly interested in
    iteration over existing allows, and vice versa.
    
    In the case where we have a FQDN policy for a hostname which resolves to
    many IPs (for example with a fqdn policy covering Amazon's S3), this
    becomes a hot function (without performing a lot of useful work). The S3
    workload is expected to be heavily skewed towards allow entries for the
    many CIDR identities allocated for S3. When we insert such an entry, we
    only need to iterate deny entries, of which there are expected to be
    much fewer. Now that the tracking is split, we can employ this fact and,
    instead of iterating all entries, iterate only the deny entries.
 