### PR TITLE
Remove dependencies on linux probes for Windows builds

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,7 +19,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/api/v1/models"
-	"github.com/cilium/cilium/pkg/datapath/linux/probes"
 	"github.com/cilium/cilium/pkg/metrics/metric"
 	"github.com/cilium/cilium/pkg/promise"
 	"github.com/cilium/cilium/pkg/version"
@@ -1346,18 +1345,10 @@ func NewLegacyMetrics() *LegacyMetrics {
 
 	ifindexOpts := metric.GaugeOpts{
 		ConfigName: Namespace + "_endpoint_max_ifindex",
-		Disabled:   true,
+		Disabled:   !enableIfIndexMetric(),
 		Namespace:  Namespace,
 		Name:       "endpoint_max_ifindex",
 		Help:       "Maximum interface index observed for existing endpoints",
-	}
-	// On kernels which do not provide ifindex via the FIB, Cilium needs
-	// to store it in the CT map, with a field limit of max(uint16).
-	// The EndpointMaxIfindex metric can be used to determine if that
-	// limit is approaching. However, it should only be enabled by
-	// default if we observe that the FIB is not providing the ifindex.
-	if probes.HaveFibIfindex() != nil {
-		ifindexOpts.Disabled = false
 	}
 	lm.EndpointMaxIfindex = metric.NewGauge(ifindexOpts)
 

--- a/pkg/metrics/metrics_unix.go
+++ b/pkg/metrics/metrics_unix.go
@@ -5,7 +5,11 @@
 
 package metrics
 
-import "golang.org/x/sys/unix"
+import (
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/probes"
+)
 
 // Errno2Outcome converts a unix.Errno to LabelOutcome
 func Errno2Outcome(errno unix.Errno) string {
@@ -14,4 +18,13 @@ func Errno2Outcome(errno unix.Errno) string {
 	}
 
 	return LabelValueOutcomeSuccess
+}
+
+func enableIfIndexMetric() bool {
+	// On kernels which do not provide ifindex via the FIB, Cilium needs
+	// to store it in the CT map, with a field limit of max(uint16).
+	// The EndpointMaxIfindex metric can be used to determine if that
+	// limit is approaching. However, it should only be enabled by
+	// default if we observe that the FIB is not providing the ifindex.
+	return probes.HaveFibIfindex() != nil
 }

--- a/pkg/metrics/metrics_windows.go
+++ b/pkg/metrics/metrics_windows.go
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package metrics
+
+func enableIfIndexMetric() bool {
+	return false
+}


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.



We provide CLI binaries for Windows in `cilium/hubble` and `cilium/cilium-cli`. These repositories import parts of cilium, including the `pkg/metrics` package. So we need to make sure that `pkg/metrics` builds on Windows.


Found the issue in https://github.com/cilium/hubble/pull/1236 and https://github.com/cilium/cilium-cli/pull/1985
