### PR TITLE
backporting: Revert changes until the new workflow will be in place

### DIFF
--- a/contrib/backporting/set-labels.py
+++ b/contrib/backporting/set-labels.py
@@ -19,12 +19,15 @@ except ImportError:
 
 parser = argparse.ArgumentParser()
 parser.add_argument('pr_number', type=int)
+actions = ["pending", "done"]
+parser.add_argument('action', type=str, choices=actions)
 parser.add_argument('version', type=str, default="1.0", nargs='?')
 
 args = parser.parse_args()
 
 token = os.environ["GITHUB_TOKEN"]
 pr_number = args.pr_number
+action = args.action
 version = args.version
 
 g = Github(token)
@@ -35,19 +38,47 @@ old_label_len = len(pr_labels)
 
 cilium_labels = cilium.get_labels()
 
+# After the introduction of the "Update labels of backported PRs" GH
+# workflow and all the workflows in the stable branches that calls it,
+# there is no need to use this script to update the backported PRs label.
+# Specifically, this script shouldn't be used with the `action` parameter
+# set to `done` anymore.
+# However, since there might still be in-flight backporting PRs relying on
+# the old backporting workflow (based on this script to update the labels),
+# we leave the code here.
+#
+# This can be updated once all the new workflows will be in place and the
+# "old" backport PRs will have their labels updated.
+
 print("Setting labels for PR {}... ".format(pr_number), end="")
-pr_labels = [l for l in pr_labels
-                if l.name != "needs-backport/"+version]
-if old_label_len - 1 != len(pr_labels):
-    print("needs-backport/"+version+" label not found in PR, exiting")
-    sys.exit(1)
+if action == "pending":
+    pr_labels = [l for l in pr_labels
+                 if l.name != "needs-backport/"+version]
+    if old_label_len - 1 != len(pr_labels):
+        print("needs-backport/"+version+" label not found in PR, exiting")
+        sys.exit(1)
 
-pr_labels.append(
-    [l for l in cilium_labels if l.name == "backport-pending/"+version][0])
+    pr_labels.append(
+        [l for l in cilium_labels if l.name == "backport-pending/"+version][0])
 
-if old_label_len != len(pr_labels):
-    print("error adding backport-pending/"+version+" label to PR, exiting")
-    sys.exit(2)
-pr.set_labels(*pr_labels)
+    if old_label_len != len(pr_labels):
+        print("error adding backport-pending/"+version+" label to PR, exiting")
+        sys.exit(2)
+    pr.set_labels(*pr_labels)
+
+if action == "done":
+    pr_labels = [l for l in pr_labels
+                 if l.name != "backport-pending/"+version]
+    if old_label_len - 1 != len(pr_labels):
+        print("backport-pending/"+version+" label not found in PR, exiting")
+        sys.exit(1)
+
+    pr_labels.append(
+        [l for l in cilium_labels if l.name == "backport-done/"+version][0])
+
+    if old_label_len != len(pr_labels):
+        print("error adding backport-done/"+version+" label to PR, exiting")
+        sys.exit(2)
+    pr.set_labels(*pr_labels)
 
 print("✓")


### PR DESCRIPTION
The new GH workflow "Update labels of backported PRs", called from each stable branch, updates each `backport-pending` PRs to mark them as `backport-done` when the related backport is merged. So, there should be no need to use the contrib/backporting/set-labels.py to do that anymore.

However, there are still some in-flight backport PRs that rely on the script to do that manually.  Thus, this commit reverts the changes in 2966b03469 to restore the old script code.

Once all the new GH workflows will be in place for the stable branches and the backport PRs will be created following the new format documented in the backporting docs, the script may be updated.

Fixes: 2966b03469 ("backporting: Update docs after introduction of Label Updater")
