### PR TITLE
contrib: Fix missing function in post-release.sh

### DIFF
--- a/contrib/backporting/common.sh
+++ b/contrib/backporting/common.sh
@@ -82,3 +82,15 @@ get_branch_from_version() {
     fi
     echo "$branch"
 }
+
+# $1 - VERSION
+version_is_prerelease() {
+    case "$1" in
+        *pre*|*rc*|*snapshot*)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}

--- a/contrib/release/start-release.sh
+++ b/contrib/release/start-release.sh
@@ -22,18 +22,6 @@ usage() {
     logecho "--help     Print this help message"
 }
 
-# $1 - VERSION
-version_is_prerelease() {
-    case "$1" in
-        *pre*|*rc*|*snapshot*)
-            return 0
-            ;;
-        *)
-            return 1
-            ;;
-    esac
-}
-
 handle_args() {
     if [ "$#" -gt 3 ]; then
         usage 2>&1


### PR DESCRIPTION
Commit 4afed72cde71 ("contrib: Move github release to post-release")
introduced a usage of version_is_prerelease() in post-release.sh, but
this was defined in start-release.sh so the function couldn't be found.
Move it to common.sh so it can be reused across scripts.

Fixes: 4afed72cde71 ("contrib: Move github release to post-release")
Related: https://github.com/cilium/cilium/pull/27861
Fixes: https://github.com/cilium/cilium/issues/28338
