### PR TITLE
labels/cidr: Fix slice preallocation size

### DIFF
--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -87,7 +87,7 @@ func IPStringToLabel(ip string) (labels.Label, error) {
 // The identity reserved:world is always added as it includes any CIDR.
 func GetCIDRLabels(prefix netip.Prefix) labels.Labels {
 	ones := prefix.Bits()
-	result := make([]string, 0, ones+1)
+	result := make([]string, 0, ones+2)
 
 	// If ones is zero, then it's the default CIDR prefix /0 which should
 	// just be regarded as reserved:world. In all other cases, we need


### PR DESCRIPTION
The number of CIDR labels returned from GetCIDRLabels are equal to the sum of:

- ones+1 labels coming from the prefixes generated in the loop
- an additional one for the reserved "world" label

To improve performance, we should then allocate a slice of size ones+2.

benchstat analysis confirms this reporting 1 allocation less for each operation, except for the "0.0.0.0/0" corner case.

```
name                             old time/op    new time/op    delta
GetCIDRLabels/0.0.0.0/0-8           306ns ±36%     299ns ±32%     ~     (p=0.251 n=20+20)
GetCIDRLabels/10.16.0.0/16-8       4.42µs ± 5%    4.17µs ± 3%   -5.65%  (p=0.000 n=19+19)
GetCIDRLabels/192.0.2.3/32-8       8.43µs ± 5%    8.02µs ± 5%   -4.88%  (p=0.000 n=20+20)
GetCIDRLabels/192.0.2.3/24-8       6.79µs ± 5%    6.49µs ± 5%   -4.41%  (p=0.000 n=20+20)
GetCIDRLabels/192.0.2.0/24-8       6.78µs ± 4%    6.46µs ± 4%   -4.68%  (p=0.000 n=19+20)
GetCIDRLabels/::/0-8                329ns ± 2%     338ns ± 3%   +2.54%  (p=0.000 n=19+20)
GetCIDRLabels/fdff::ff/128-8       53.6µs ± 4%    52.1µs ± 6%   -2.66%  (p=0.000 n=19+17)
GetCIDRLabels/f00d:42::ff/128-8    56.8µs ± 4%    55.1µs ± 2%   -3.04%  (p=0.000 n=20+18)
GetCIDRLabels/f00d:42::ff/96-8     42.4µs ± 3%    40.8µs ± 6%   -3.82%  (p=0.000 n=20+20)

name                             old alloc/op   new alloc/op   delta
GetCIDRLabels/0.0.0.0/0-8            640B ± 0%      656B ± 0%   +2.50%  (p=0.000 n=20+20)
GetCIDRLabels/10.16.0.0/16-8       3.75kB ± 0%    3.17kB ± 0%  -15.37%  (p=0.000 n=18+20)
GetCIDRLabels/192.0.2.3/32-8       8.03kB ± 0%    6.88kB ± 0%  -14.34%  (p=0.000 n=16+20)
GetCIDRLabels/192.0.2.3/24-8       7.21kB ± 0%    6.32kB ± 0%  -12.42%  (p=0.000 n=20+19)
GetCIDRLabels/192.0.2.0/24-8       7.21kB ± 0%    6.32kB ± 0%  -12.42%  (p=0.000 n=19+20)
GetCIDRLabels/::/0-8                 640B ± 0%      656B ± 0%   +2.50%  (p=0.000 n=20+20)
GetCIDRLabels/fdff::ff/128-8       30.8kB ± 0%    25.9kB ± 0%  -15.80%  (p=0.000 n=20+19)
GetCIDRLabels/f00d:42::ff/128-8    33.7kB ± 0%    28.8kB ± 0%  -14.45%  (p=0.000 n=19+20)
GetCIDRLabels/f00d:42::ff/96-8     28.3kB ± 0%    25.1kB ± 0%  -11.31%  (p=0.000 n=20+20)

name                             old allocs/op  new allocs/op  delta
GetCIDRLabels/0.0.0.0/0-8            3.00 ± 0%      3.00 ± 0%     ~     (all equal)
GetCIDRLabels/10.16.0.0/16-8         38.0 ± 0%      37.0 ± 0%   -2.63%  (p=0.000 n=20+20)
GetCIDRLabels/192.0.2.3/32-8         70.0 ± 0%      69.0 ± 0%   -1.43%  (p=0.000 n=20+20)
GetCIDRLabels/192.0.2.3/24-8         54.0 ± 0%      53.0 ± 0%   -1.85%  (p=0.000 n=20+20)
GetCIDRLabels/192.0.2.0/24-8         54.0 ± 0%      53.0 ± 0%   -1.85%  (p=0.000 n=20+20)
GetCIDRLabels/::/0-8                 3.00 ± 0%      3.00 ± 0%     ~     (all equal)
GetCIDRLabels/fdff::ff/128-8          450 ± 0%       449 ± 0%   -0.22%  (p=0.000 n=20+20)
GetCIDRLabels/f00d:42::ff/128-8       450 ± 0%       449 ± 0%   -0.22%  (p=0.000 n=20+20)
GetCIDRLabels/f00d:42::ff/96-8        296 ± 0%       295 ± 0%   -0.34%  (p=0.000 n=20+20)
```
