### PR TITLE
Makefile: fix 'fast' make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -575,18 +575,13 @@ endif
 .PHONY: kind-install-cilium-fast
 kind-install-cilium-fast: kind-ready ## Install a local Cilium version into the cluster.
 	@echo "  INSTALL cilium"
-	# cilium-cli doesn't support idempotent installs, so we uninstall and
-	# reinstall here. https://github.com/cilium/cilium-cli/issues/205
-	-@$(CILIUM_CLI) uninstall >/dev/null 2>&1 || true
-
-	# cilium-cli's --wait flag doesn't work, so we just force it to run
-	# in the background instead and wait for the resources to be available.
-	# https://github.com/cilium/cilium-cli/issues/1070
-	$(CILIUM_CLI) install \
-		--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
-		$(KIND_VALUES_FAST_FILES) \
-		--version= \
-		>/dev/null 2>&1 &
+	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
+		$(CILIUM_CLI) --context=kind-$$cluster_name uninstall >/dev/null 2>&1 || true; \
+		$(CILIUM_CLI) install --context=kind-$$cluster_name \
+			--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \
+			$(KIND_VALUES_FAST_FILES) \
+			--version= >/dev/null 2>&1 & \
+	done
 
 .PHONY: build-cli
 build-cli: ## Build cilium cli binary

--- a/Makefile
+++ b/Makefile
@@ -608,7 +608,7 @@ build-clustermesh-apiserver: ## Build cilium clustermesh-apiserver binary
 kind-image-fast-agent: kind-ready build-cli build-agent ## Build cilium cli and daemon binaries. Copy the bins and bpf files to kind nodes.
 	$(eval dst:=/cilium-binaries)
 	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
-		for node_name in $(shell kind get nodes -n "${cluster_name}"); do \
+		for node_name in $$(kind get nodes -n "$$cluster_name"); do \
 			docker exec -ti $${node_name} mkdir -p "${dst}"; \
 			\
 			docker exec -ti $${node_name} rm -rf "${dst}/var/lib/cilium"; \
@@ -632,7 +632,7 @@ kind-image-fast-agent: kind-ready build-cli build-agent ## Build cilium cli and 
 kind-image-fast-operator: kind-ready build-operator ## Build cilium operator binary and copy it to all kind nodes.
 	$(eval dst:=/cilium-binaries)
 	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
-		for node_name in $(shell kind get nodes -n "${cluster_name}"); do \
+		for node_name in $$(kind get nodes -n "$$cluster_name"); do \
 			docker exec -ti $${node_name} mkdir -p "${dst}"; \
 			\
 			docker exec -ti $${node_name} rm -f "${dst}/cilium-operator-generic"; \
@@ -647,7 +647,7 @@ kind-image-fast-operator: kind-ready build-operator ## Build cilium operator bin
 kind-image-fast-clustermesh-apiserver: kind-ready build-clustermesh-apiserver ## Build clustermesh-apiserver binary and copy it to all kind nodes.
 	$(eval dst:=/cilium-binaries)
 	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
-		for node_name in $(shell kind get nodes -n "${cluster_name}"); do \
+		for node_name in $$(kind get nodes -n "$$cluster_name"); do \
 			docker exec -ti $${node_name} mkdir -p "${dst}"; \
 			\
 			docker exec -ti $${node_name} rm -f "${dst}/clustermesh-apiserver"; \


### PR DESCRIPTION
These targets failed to select the nodes of a kind cluster. This change selects the right variables that are used to check for the cluster nodes.

Fixes 5f88bbffeb50 ("docs: Add Makefile and documentation for "fast" development targets")