### PR TITLE
Metrics associated with a deleted node should not be reported

### DIFF
--- a/pkg/metrics/interfaces.go
+++ b/pkg/metrics/interfaces.go
@@ -24,13 +24,14 @@ var (
 	NoOpMetric    prometheus.Metric    = &mockMetric{}
 	NoOpCollector prometheus.Collector = &collector{}
 
-	NoOpCounter     metricpkg.Counter                 = &counter{NoOpMetric, NoOpCollector}
-	NoOpCounterVec  metricpkg.Vec[metricpkg.Counter]  = &counterVec{NoOpCollector}
-	NoOpObserver    metricpkg.Observer                = &observer{}
-	NoOpHistogram   metricpkg.Histogram               = &histogram{NoOpCollector}
-	NoOpObserverVec metricpkg.Vec[metricpkg.Observer] = &observerVec{NoOpCollector}
-	NoOpGauge       metricpkg.Gauge                   = &gauge{NoOpMetric, NoOpCollector}
-	NoOpGaugeVec    metricpkg.Vec[metricpkg.Gauge]    = &gaugeVec{NoOpCollector}
+	NoOpCounter           metricpkg.Counter                       = &counter{NoOpMetric, NoOpCollector}
+	NoOpCounterVec        metricpkg.Vec[metricpkg.Counter]        = &counterVec{NoOpCollector}
+	NoOpObserver          metricpkg.Observer                      = &observer{}
+	NoOpHistogram         metricpkg.Histogram                     = &histogram{NoOpCollector}
+	NoOpObserverVec       metricpkg.Vec[metricpkg.Observer]       = &observerVec{NoOpCollector}
+	NoOpGauge             metricpkg.Gauge                         = &gauge{NoOpMetric, NoOpCollector}
+	NoOpGaugeVec          metricpkg.Vec[metricpkg.Gauge]          = &gaugeVec{NoOpCollector}
+	NoOpGaugeDeletableVec metricpkg.DeletableVec[metricpkg.Gauge] = &gaugeDeletableVec{gaugeVec{NoOpCollector}}
 )
 
 // Metric
@@ -155,6 +156,24 @@ func (g *gauge) SetEnabled(bool)      {}
 func (g *gauge) Opts() metricpkg.Opts { return metricpkg.Opts{} }
 
 // GaugeVec
+
+type gaugeDeletableVec struct {
+	gaugeVec
+}
+
+func (*gaugeDeletableVec) Delete(ll prometheus.Labels) bool {
+	return false
+}
+
+func (*gaugeDeletableVec) DeleteLabelValues(lvs ...string) bool {
+	return false
+}
+
+func (*gaugeDeletableVec) DeletePartialMatch(labels prometheus.Labels) int {
+	return 0
+}
+
+func (*gaugeDeletableVec) Reset() {}
 
 type gaugeVec struct {
 	prometheus.Collector

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -254,11 +254,11 @@ var (
 
 	// NodeConnectivityStatus is the connectivity status between local node to
 	// other node intra or inter cluster.
-	NodeConnectivityStatus = NoOpGaugeVec
+	NodeConnectivityStatus = NoOpGaugeDeletableVec
 
 	// NodeConnectivityLatency is the connectivity latency between local node to
 	// other node intra or inter cluster.
-	NodeConnectivityLatency = NoOpGaugeVec
+	NodeConnectivityLatency = NoOpGaugeDeletableVec
 
 	// Endpoint
 
@@ -639,8 +639,8 @@ var (
 type LegacyMetrics struct {
 	BootstrapTimes                   metric.Vec[metric.Observer]
 	APIInteractions                  metric.Vec[metric.Observer]
-	NodeConnectivityStatus           metric.Vec[metric.Gauge]
-	NodeConnectivityLatency          metric.Vec[metric.Gauge]
+	NodeConnectivityStatus           metric.DeletableVec[metric.Gauge]
+	NodeConnectivityLatency          metric.DeletableVec[metric.Gauge]
 	Endpoint                         metric.GaugeFunc
 	EndpointMaxIfindex               metric.Gauge
 	EndpointRegenerationTotal        metric.Vec[metric.Counter]

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cilium/workerpool"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 
@@ -182,6 +183,31 @@ type nodeMetrics struct {
 	// metricDatapathValidations is the prometheus metric to track the
 	// number of datapath node validation calls
 	DatapathValidations metric.Counter
+}
+
+// ProcessNodeDeletion upon node deletion ensures metrics associated
+// with the deleted node are no longer reported.
+// Notably for metrics node connectivity status and latency metrics
+func (*nodeMetrics) ProcessNodeDeletion(clusterName, nodeName string) {
+	// Removes all connectivity status associated with the deleted node.
+	_ = metrics.NodeConnectivityStatus.DeletePartialMatch(prometheus.Labels{
+		metrics.LabelSourceCluster:  clusterName,
+		metrics.LabelSourceNodeName: nodeName,
+	})
+	_ = metrics.NodeConnectivityStatus.DeletePartialMatch(prometheus.Labels{
+		metrics.LabelTargetCluster:  clusterName,
+		metrics.LabelTargetNodeName: nodeName,
+	})
+
+	// Removes all connectivity latency associated with the deleted node.
+	_ = metrics.NodeConnectivityLatency.DeletePartialMatch(prometheus.Labels{
+		metrics.LabelSourceCluster:  clusterName,
+		metrics.LabelSourceNodeName: nodeName,
+	})
+	_ = metrics.NodeConnectivityLatency.DeletePartialMatch(prometheus.Labels{
+		metrics.LabelTargetCluster:  clusterName,
+		metrics.LabelTargetNodeName: nodeName,
+	})
 }
 
 func NewNodeMetrics() *nodeMetrics {
@@ -688,6 +714,7 @@ func (m *manager) NodeDeleted(n nodeTypes.Node) {
 	m.removeNodeFromIPCache(entry.node, resource, nil, nil, nil)
 
 	m.metrics.NumNodes.Dec()
+	m.metrics.ProcessNodeDeletion(n.Cluster, n.Name)
 
 	entry.mutex.Lock()
 	delete(m.nodes, nodeIdentifier)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

When a node is deleted from a cluster, metrics associated with that node are still being exported to prometheus. 
Short of restarting the agent, we want to dynamically delete these metrics when a node is removed from the cluster.

This PR ensures node_connectivity_status and node_connectivity_latency no longer report metrics for nodes that are no longer present on the cluster.

Fixes: #issue-number

```release-note
Cilium now properly deletes stale (deleted) nodes from the node_connectivity_status and node_connectivity_latency_seconds metrics, reducing metric cardinality.
```
