### PR TITLE
docs: Update Kubernetes Gateway-API version to v0.8.1

### DIFF
--- a/Documentation/network/servicemesh/gateway-api/gateway-api.rst
+++ b/Documentation/network/servicemesh/gateway-api/gateway-api.rst
@@ -23,7 +23,7 @@ See the `Gateway API site <https://gateway-api.sigs.k8s.io/>`__ for more details
 Cilium Gateway API Support
 ##########################
 
-Cilium supports Gateway API v0.7.1 for below resources, all the Core conformance
+Cilium supports Gateway API v0.8.1 for below resources, all the Core conformance
 tests are passed.
 
 - `GatewayClass <https://gateway-api.sigs.k8s.io/api-types/gatewayclass/>`_
@@ -49,7 +49,7 @@ Cilium's Gateway API features:
    splitting
    header
 
-More examples can be found in the `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v0.7.1/examples/standard>`_.
+More examples can be found in the `upstream repository <https://github.com/kubernetes-sigs/gateway-api/tree/v0.8.1/examples/standard>`_.
 
 Troubleshooting
 ###############


### PR DESCRIPTION
Synchronize the Cilium Gateway API version support description to align with the commit d4d7ff4282a2 ("gateway-api: Bump the version to v0.8.1").
