### PR TITLE
bpf: lxc: remove stale ENABLE_IDENTITY_MARK ifdefs

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -663,9 +663,7 @@ pass_to_stack:
 		ret = set_ipsec_encrypt_mark(ctx, encrypt_key, tunnel_endpoint);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
-#  ifdef ENABLE_IDENTITY_MARK
 		set_identity_meta(ctx, SECLABEL_IPV6);
-#  endif /* ENABLE_IDENTITY_MARK */
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* TUNNEL_MODE */
@@ -1205,9 +1203,7 @@ pass_to_stack:
 		ret = set_ipsec_encrypt_mark(ctx, encrypt_key, tunnel_endpoint);
 		if (unlikely(ret != CTX_ACT_OK))
 			return ret;
-#  ifdef ENABLE_IDENTITY_MARK
 		set_identity_meta(ctx, SECLABEL_IPV4);
-#  endif
 	} else
 # endif /* ENABLE_IPSEC */
 #endif /* TUNNEL_MODE */


### PR DESCRIPTION
4de20fc2027a ("bpf: Pass security ID via skb->cb from lxc to host") switched these parts from using set_identity_mark() to set_identity_meta(). Thus we no longer have to respect the opt-in that controls whether the skb mark may be used to store the identity.