### PR TITLE
Do not hardcode the AWS VPC CNI plugin version in the conformance-aws-cni GHA workflow

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -211,10 +211,6 @@ jobs:
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
 
-      - name: Update AWS VPC CNI plugin
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.11/config/master/aws-k8s-cni.yaml
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash


### PR DESCRIPTION
Currently, we are installing a fixed version of the AWS VPC CNI plugin
version (i.e., v1.11) regardless of the Kubernetes version. Yet, this
means that in certain cases we upgrade it, while in others we downgrade,
it, introducing unnecessary churn.

Let's instead use the default one that gets installed with the given
k8s version. Specifically, for the k8s versions currently tested:

* k8s: v1.23 - AWS VPC CNI: v1.10.4-eksbuild.1
* k8s: v1.24 - AWS VPC CNI: v1.11.4-eksbuild.1
* k8s: v1.25 - AWS VPC CNI: v1.12.2-eksbuild.1
* k8s: v1.26 - AWS VPC CNI: v1.12.5-eksbuild.2
* k8s: v1.27 - AWS VPC CNI: v1.12.6-eksbuild.2

Retrieved through:

```bash
for MINOR in $(seq 23 27)
do
    echo -n "k8s: v1.$MINOR - AWS VPC CNI: "
    aws eks describe-addon-versions --addon-name vpc-cni \
      --kubernetes-version 1.$MINOR --output yaml | \
      yq '.addons[].addonVersions[] | select(.compatibilities[].defaultVersion == true) | .addonVersion';
done
```

Link to successful run: https://github.com/cilium/cilium/actions/runs/6403302318
