### PR TITLE
devices: Remove logging and report reason in device struct

### DIFF
--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -53,19 +53,37 @@ var (
 	)
 )
 
-// Device is a local network device along with addresses associated with it.
-type Device struct {
-	Index        int              // positive integer that starts at one, zero is never used
-	MTU          int              // maximum transmission unit
-	Name         string           // e.g., "en0", "lo0", "eth0.100"
-	HardwareAddr net.HardwareAddr // IEEE MAC-48, EUI-48 and EUI-64 form
-	Flags        net.Flags        // e.g. net.FlagUp, net.eFlagLoopback, net.FlagMulticast
+// HardwareAddr is the physical address for a network device.
+// Defined here instead of using net.Hardwareaddr for proper
+// JSON marshalling.
+type HardwareAddr []byte
 
-	Selected    bool            // If true this device can be used by Cilium
-	Addrs       []DeviceAddress // Addresses assigned to the device
-	RawFlags    uint32          // Raw interface flags
-	Type        string          // Device type, e.g. "veth" etc.
-	MasterIndex int             // Index of the master device (e.g. bridge or bonding device)
+func (a HardwareAddr) String() string {
+	return net.HardwareAddr([]byte(a)).String()
+}
+
+func (a HardwareAddr) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + a.String() + "\""), nil
+}
+
+// Device is a local network device along with addresses associated with it.
+//
+// The devices that are selected are the external facing native devices that
+// Cilium will use with features such as load-balancing, host firewall and routing.
+// For the selection logic applied see 'pkg/datapath/linux/devices_controller.go'.
+type Device struct {
+	Index        int             // positive integer that starts at one, zero is never used
+	MTU          int             // maximum transmission unit
+	Name         string          // e.g., "en0", "lo0", "eth0.100"
+	HardwareAddr HardwareAddr    // IEEE MAC-48, EUI-48 and EUI-64 form
+	Flags        net.Flags       // e.g. net.FlagUp, net.eFlagLoopback, net.FlagMulticast
+	Addrs        []DeviceAddress // Addresses assigned to the device
+	RawFlags     uint32          // Raw interface flags
+	Type         string          // Device type, e.g. "veth" etc.
+	MasterIndex  int             // Index of the master device (e.g. bridge or bonding device)
+
+	Selected          bool   // True if this is an external facing device
+	NotSelectedReason string // Reason why this device was not selected
 }
 
 func (d *Device) DeepCopy() *Device {
@@ -92,8 +110,8 @@ func (d *DeviceAddress) AsIP() net.IP {
 	return d.Addr.AsSlice()
 }
 
-// SelectedDevices returns the network devices selected for
-// Cilium use.
+// SelectedDevices returns the external facing network devices to use for
+// load-balancing, host firewall and routing.
 //
 // The invalidated channel is closed when devices have changed and
 // should be requeried with a new transaction.


### PR DESCRIPTION
With runtime device detection we may see a lot of churn in devices, addresses and routes which can lead to a lot of log spam from the devices controller.

Since the reason why a certain device is not selected for use in the datapath is important when debugging we don't want to just remove logging and call it a day, so instead this patch moves the information into a field in the Device struct that can be then inspected with "ciliumctl statedb dump" and which is included in sysdumps:

```
  {"Index":7,"MTU":1500,"Name":"br0","HardwareAddr":"86:ab:d8:9b:f9:33",
   "Flags":19,"Addrs":[{"Addr":"192.168.5.1","Scope":0}],"RawFlags":69699,
   "Type":"bridge","MasterIndex":0,
   "Selected":false,
   "NotSelectedReason":"bridge-like device, use --devices to override"}
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Also included is a fix to the "HardwareAddr" marshalling which now shows up as expected in JSON instead of as: "HardwareAddr":"vpVG/hUg".
