### PR TITLE
CODEOWNERS: assign .github/actions to github-sec and ci-structure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -226,6 +226,7 @@
 /.devcontainer @cilium/contributing
 /.gitattributes @cilium/tophat
 /.github/ @cilium/contributing
+/.github/actions/ @cilium/github-sec @cilium/ci-structure
 /.github/workflows/ @cilium/github-sec @cilium/ci-structure
 /.github/workflows/*datapath*.yaml @cilium/sig-datapath @cilium/github-sec @cilium/ci-structure
 /.gitignore @cilium/tophat


### PR DESCRIPTION
similarly to what we are already doing with .github/workflows