### PR TITLE
datapath: Pin CT tail call buffers

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -133,6 +133,7 @@ struct {
 	__type(key, __u32);
 	__type(value, struct ct_buffer6);
 	__uint(max_entries, 1);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } CT_TAIL_CALL_BUFFER6 __section_maps_btf;
 
 static __always_inline int
@@ -519,6 +520,7 @@ struct {
 	__type(key, __u32);
 	__type(value, struct ct_buffer4);
 	__uint(max_entries, 1);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } CT_TAIL_CALL_BUFFER4 __section_maps_btf;
 
 static __always_inline int

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -360,6 +360,7 @@ struct {
 	__type(key, __u32);
 	__type(value, struct ct_buffer6);
 	__uint(max_entries, 1);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } CT_TAIL_CALL_BUFFER6 __section_maps_btf;
 
 /* Handle egress IPv6 traffic from a container after service translation has been done
@@ -765,6 +766,7 @@ struct {
 	__type(key, __u32);
 	__type(value, struct ct_buffer4);
 	__uint(max_entries, 1);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
 } CT_TAIL_CALL_BUFFER4 __section_maps_btf;
 
 /* Handle egress IPv4 traffic from a container after service translation has been done

--- a/bpf/lib/conntrack.h
+++ b/bpf/lib/conntrack.h
@@ -36,6 +36,7 @@ enum ct_entry_type {
 };
 
 #ifdef ENABLE_IPV4
+/* NOTE: Do not modify the struct until #20691. */
 struct ct_buffer4 {
 	struct ipv4_ct_tuple tuple;
 	struct ct_state ct_state;
@@ -46,6 +47,7 @@ struct ct_buffer4 {
 #endif
 
 #ifdef ENABLE_IPV6
+/* NOTE: Do not modify the struct until #20691. */
 struct ct_buffer6 {
 	struct ipv6_ct_tuple tuple;
 	struct ct_state ct_state;

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -238,8 +238,6 @@ func (h *HeaderfileWriter) WriteNodeConfig(w io.Writer, cfg *datapath.LocalNodeC
 	cDefinesMap["CT_CLOSE_TIMEOUT"] = fmt.Sprintf("%d", int64(option.Config.CTMapEntriesTimeoutFIN.Seconds()))
 	cDefinesMap["CT_REPORT_INTERVAL"] = fmt.Sprintf("%d", int64(option.Config.MonitorAggregationInterval.Seconds()))
 	cDefinesMap["CT_REPORT_FLAGS"] = fmt.Sprintf("%#04x", int64(option.Config.MonitorAggregationFlags))
-	cDefinesMap["CT_TAIL_CALL_BUFFER4"] = "cilium_tail_call_buffer4"
-	cDefinesMap["CT_TAIL_CALL_BUFFER6"] = "cilium_tail_call_buffer6"
 	cDefinesMap["PER_CLUSTER_CT_TCP4"] = "cilium_per_cluster_ct_tcp4"
 	cDefinesMap["PER_CLUSTER_CT_TCP6"] = "cilium_per_cluster_ct_tcp6"
 	cDefinesMap["PER_CLUSTER_CT_ANY4"] = "cilium_per_cluster_ct_any4"
@@ -1057,6 +1055,10 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 	if e.IsHost() {
 		callsMapName = callsmap.HostMapName
 	}
+
+	fmt.Fprintf(fw, "#define CT_TAIL_CALL_BUFFER4 %s\n", bpf.LocalMapName(ctmap.MapNameCTTailCallBuffer4, epID))
+	fmt.Fprintf(fw, "#define CT_TAIL_CALL_BUFFER6 %s\n", bpf.LocalMapName(ctmap.MapNameCTTailCallBuffer6, epID))
+
 	fmt.Fprintf(fw, "#define CALLS_MAP %s\n", bpf.LocalMapName(callsMapName, epID))
 	if option.Config.EnableCustomCalls && !e.IsHost() {
 		fmt.Fprintf(fw, "#define CUSTOM_CALLS_MAP %s\n", bpf.LocalMapName(callsmap.CustomCallsMapName, epID))

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -36,6 +36,8 @@ var (
 		policymap.MapName,
 		callsmap.MapName,
 		callsmap.CustomCallsMapName,
+		ctmap.MapNameCTTailCallBuffer4,
+		ctmap.MapNameCTTailCallBuffer6,
 	}
 	elfCtMapPrefixes = []string{
 		ctmap.MapNameTCP4,
@@ -155,6 +157,14 @@ func elfMapSubstitutions(ep datapath.Endpoint) map[string]string {
 			(!option.Config.EnableCustomCalls || ep.IsHost()) {
 			continue
 		}
+
+		if name == ctmap.MapNameCTTailCallBuffer4 && !option.Config.EnableIPv4 {
+			continue
+		}
+		if name == ctmap.MapNameCTTailCallBuffer6 && !option.Config.EnableIPv6 {
+			continue
+		}
+
 		templateStr := bpf.LocalMapName(name, templateLxcID)
 		desiredStr := bpf.LocalMapName(name, epID)
 		result[templateStr] = desiredStr

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -71,6 +71,16 @@ func (e *Endpoint) customCallsMapPath() string {
 	return e.owner.Datapath().Loader().CustomCallsMapPath(e.ID)
 }
 
+// ctTailCallBufferMapPath returns the path to cilium CT buffer map.
+func (e *Endpoint) ctTailCallBufferMapPath(ipv6 bool) string {
+	prefix := ctmap.MapNameCTTailCallBuffer4
+	if ipv6 {
+		prefix = ctmap.MapNameCTTailCallBuffer6
+	}
+
+	return bpf.LocalMapPath(prefix, e.ID)
+}
+
 // writeInformationalComments writes annotations to the specified writer,
 // including a base64 encoding of the endpoint object, and human-readable
 // strings describing the configuration of the datapath.
@@ -904,8 +914,10 @@ func (e *Endpoint) deleteMaps() []error {
 	var errors []error
 
 	maps := map[string]string{
-		"policy": e.policyMapPath(),
-		"calls":  e.callsMapPath(),
+		"policy":     e.policyMapPath(),
+		"calls":      e.callsMapPath(),
+		"ct_buffer4": e.ctTailCallBufferMapPath(false),
+		"ct_buffer6": e.ctTailCallBufferMapPath(true),
 	}
 	if !e.isHost {
 		maps["custom"] = e.customCallsMapPath()

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -64,10 +64,12 @@ const (
 	MapNameTCP4Global = MapNameTCP4 + "global"
 
 	// Map names for "any" protocols indicate CT for non-TCP protocols.
-	MapNameAny6       = MapNamePrefix + "_any6_"
-	MapNameAny4       = MapNamePrefix + "_any4_"
-	MapNameAny6Global = MapNameAny6 + "global"
-	MapNameAny4Global = MapNameAny4 + "global"
+	MapNameAny6              = MapNamePrefix + "_any6_"
+	MapNameAny4              = MapNamePrefix + "_any4_"
+	MapNameAny6Global        = MapNameAny6 + "global"
+	MapNameAny4Global        = MapNameAny4 + "global"
+	MapNameCTTailCallBuffer4 = "cilium_ct_buffer4_"
+	MapNameCTTailCallBuffer6 = "cilium_ct_buffer6_"
 
 	mapNumEntriesLocal = 64000
 


### PR DESCRIPTION
This commit pins the per-endpoint CT tail call buffer maps, so that they can be preserved during an endpoint regeneration (e.g., when cilium-agent restarts).

Previously, the buffers were recreated during the regeneration. The problem with this is that the TAIL_CT_LOOKUP* stores a CT lookup value in the buffer map, then does the tail call to a next program which retrieves the value from the map. As we don't atomically swap the whole prog map, it is possible that the next program is a new program with the new buffer map. So in this case, the CT lookup value cannot be restored, and the packet is dropped. This behavior was observed in the test
failures \[1\].

The proper fix is to always atomically swap the whole tail call (aka the prog map), and it is documented in \[2\]. Until \[2\] has been fixed, let's pin the buffer maps.

\[1\]: https://github.com/cilium/cilium/issues/28088
\[2\]: https://github.com/cilium/cilium/issues/20691

Fix #28088 