### PR TITLE
Backport v1.13: FQDN fixes

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -825,6 +825,10 @@ func initializeFlags() {
 	flags.Int(option.PolicyMapEntriesName, policymap.MaxEntries, "Maximum number of entries in endpoint policy map (per endpoint)")
 	option.BindEnv(Vp, option.PolicyMapEntriesName)
 
+	flags.Duration(option.PolicyMapFullReconciliationIntervalName, 15*time.Minute, "Interval for full reconciliation of endpoint policy map")
+	option.BindEnv(Vp, option.PolicyMapFullReconciliationIntervalName)
+	flags.MarkHidden(option.PolicyMapFullReconciliationIntervalName)
+
 	flags.Int(option.SockRevNatEntriesName, option.SockRevNATMapEntriesDefault, "Maximum number of entries for the SockRevNAT BPF map")
 	option.BindEnv(Vp, option.SockRevNatEntriesName)
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -31,6 +31,37 @@ func (b *ControllerSuite) TestUpdateRemoveController(c *C) {
 	c.Assert(mngr.RemoveController("not-exist"), Not(IsNil))
 }
 
+func (b *ControllerSuite) TestCreateController(c *C) {
+	var iterations uint32
+	mngr := NewManager()
+	created := mngr.CreateController("test", ControllerParams{
+		DoFunc: func(ctx context.Context) error {
+			atomic.AddUint32(&iterations, 1)
+			return nil
+		},
+		StopFunc: func(ctx context.Context) error {
+			return nil
+		},
+	})
+	c.Assert(created, Equals, true)
+
+	// Second creation is a no-op.
+	created = mngr.CreateController("test", ControllerParams{
+		DoFunc: func(ctx context.Context) error {
+			atomic.AddUint32(&iterations, 1)
+			return nil
+		},
+		StopFunc: func(ctx context.Context) error {
+			return nil
+		},
+	})
+	c.Assert(created, Equals, false)
+
+	c.Assert(mngr.RemoveControllerAndWait("test"), IsNil)
+
+	c.Assert(atomic.LoadUint32(&iterations), Equals, uint32(1))
+}
+
 func (b *ControllerSuite) TestStopFunc(c *C) {
 	stopFuncRan := false
 	waitChan := make(chan struct{})

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1417,12 +1417,6 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	return err
 }
 
-const (
-	// syncPolicyMapInterval is the interval for periodic full reconciliation of
-	// the policy map to catch unexpected discrepancies with agent and kernel state.
-	syncPolicyMapInterval = 15 * time.Minute
-)
-
 func (e *Endpoint) startSyncPolicyMapController() {
 	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
 	e.controllers.CreateController(ctrlName,
@@ -1440,7 +1434,7 @@ func (e *Endpoint) startSyncPolicyMapController() {
 			StopFunc: func(ctx context.Context) error {
 				return nil
 			},
-			RunInterval: syncPolicyMapInterval,
+			RunInterval: option.Config.PolicyMapFullReconciliationInterval,
 			Context:     e.aliveCtx,
 		},
 	)

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1349,18 +1349,24 @@ func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 	return currentMap, err
 }
 
-// syncPolicyMapWithDump attempts to synchronize the PolicyMap for this endpoint to
-// contain the set of PolicyKeys represented by the endpoint's desiredMapState.
-// It checks the current contents of the endpoint's PolicyMap and deletes any
-// PolicyKeys that are not present in the endpoint's desiredMapState. It then
-// adds any keys that are not present in the map. When a key from desiredMapState
-// is inserted successfully to the endpoint's BPF PolicyMap, it is added to the
-// endpoint's realizedMapState field. Returns an error if the endpoint's BPF
-// PolicyMap is unable to be dumped, or any update operation to the map fails.
+// syncPolicyMapWithDump is invoked periodically to perform a full reconciliation
+// of the endpoint's PolicyMap against the BPF maps to catch cases where either
+// due to kernel issue or user intervention the agent's view of the PolicyMap
+// state has diverged from the kernel. A warning is logged if this method finds
+// such an discrepancy.
+//
+// Returns an error if the endpoint's BPF PolicyMap is unable to be dumped,
+// or any update operation to the map fails.
 // Must be called with e.mutex Lock()ed.
 func (e *Endpoint) syncPolicyMapWithDump() error {
 	if e.policyMap == nil {
 		return fmt.Errorf("not syncing PolicyMap state for endpoint because PolicyMap is nil")
+	}
+
+	// Endpoint not yet fully initialized or currently regenerating. Skip the check
+	// this round.
+	if e.getState() != StateReady {
+		return nil
 	}
 
 	// Apply pending policy map changes first so that desired map is up-to-date before
@@ -1411,11 +1417,17 @@ func (e *Endpoint) syncPolicyMapWithDump() error {
 	return err
 }
 
-func (e *Endpoint) syncPolicyMapController() {
+const (
+	// syncPolicyMapInterval is the interval for periodic full reconciliation of
+	// the policy map to catch unexpected discrepancies with agent and kernel state.
+	syncPolicyMapInterval = 15 * time.Minute
+)
+
+func (e *Endpoint) startSyncPolicyMapController() {
 	ctrlName := fmt.Sprintf("sync-policymap-%d", e.ID)
-	e.controllers.UpdateController(ctrlName,
+	e.controllers.CreateController(ctrlName,
 		controller.ControllerParams{
-			DoFunc: func(ctx context.Context) (reterr error) {
+			DoFunc: func(ctx context.Context) error {
 				// Failure to lock is not an error, it means
 				// that the endpoint was disconnected and we
 				// should exit gracefully.
@@ -1425,7 +1437,10 @@ func (e *Endpoint) syncPolicyMapController() {
 				defer e.unlock()
 				return e.syncPolicyMapWithDump()
 			},
-			RunInterval: 1 * time.Minute,
+			StopFunc: func(ctx context.Context) error {
+				return nil
+			},
+			RunInterval: syncPolicyMapInterval,
 			Context:     e.aliveCtx,
 		},
 	)

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -511,9 +511,10 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
 	}
 
-	// Keep PolicyMap for this endpoint in sync with desired / realized state.
+	// Start periodic background full reconciliation of the policy map.
+	// Does nothing if it has already been started.
 	if !option.Config.DryMode {
-		e.syncPolicyMapController()
+		e.startSyncPolicyMapController()
 	}
 
 	if e.desiredPolicy != e.realizedPolicy {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -462,13 +462,24 @@ func (l Label) FormatForKVStore() []byte {
 	// kvstore.prefixMatchesKey())
 	b := make([]byte, 0, len(l.Source)+len(l.Key)+len(l.Value)+3)
 	buf := bytes.NewBuffer(b)
+	l.formatForKVStoreInto(buf)
+	return buf.Bytes()
+}
+
+// formatForKVStoreInto writes the label as a formatted string, ending in
+// a semicolon into buf.
+//
+// DO NOT BREAK THE FORMAT OF THIS. THE RETURNED STRING IS USED AS
+// PART OF THE KEY IN THE KEY-VALUE STORE.
+//
+// Non-pointer receiver allows this to be called on a value in a map.
+func (l Label) formatForKVStoreInto(buf *bytes.Buffer) {
 	buf.WriteString(l.Source)
 	buf.WriteRune(':')
 	buf.WriteString(l.Key)
 	buf.WriteRune('=')
 	buf.WriteString(l.Value)
 	buf.WriteRune(';')
-	return buf.Bytes()
 }
 
 // SortedList returns the labels as a sorted list, separated by semicolon
@@ -482,10 +493,21 @@ func (l Labels) SortedList() []byte {
 	}
 	sort.Strings(keys)
 
-	b := make([]byte, 0, len(keys)*2)
+	// Labels can have arbitrary size. However, when many CIDR identities are in
+	// the system, for example due to a FQDN policy matching S3, CIDR labels
+	// dominate in number. IPv4 CIDR labels in serialized form are max 25 bytes
+	// long. Allocate slightly more to avoid having a realloc if there's some
+	// other labels which may longer, since the cost of allocating a few bytes
+	// more is dominated by a second allocation, especially since these
+	// allocations are short-lived.
+	//
+	// cidr:123.123.123.123/32=;
+	// 0        1         2
+	// 1234567890123456789012345
+	b := make([]byte, 0, len(keys)*30)
 	buf := bytes.NewBuffer(b)
 	for _, k := range keys {
-		buf.Write(l[k].FormatForKVStore())
+		l[k].formatForKVStoreInto(buf)
 	}
 
 	return buf.Bytes()

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -634,6 +634,10 @@ const (
 	// PolicyMapEntriesName configures max entries for BPF policymap.
 	PolicyMapEntriesName = "bpf-policy-map-max"
 
+	// PolicyMapFullReconciliationInterval sets the interval for performing the full
+	// reconciliation of the endpoint policy map.
+	PolicyMapFullReconciliationIntervalName = "bpf-policy-map-full-reconciliation-interval"
+
 	// SockRevNatEntriesName configures max entries for BPF sock reverse nat
 	// entries.
 	SockRevNatEntriesName = "bpf-sock-rev-map-max"
@@ -1481,6 +1485,10 @@ type DaemonConfig struct {
 	// PolicyMapEntries is the maximum number of peer identities that an
 	// endpoint may allow traffic to exchange traffic with.
 	PolicyMapEntries int
+
+	// PolicyMapFullReconciliationInterval is the interval at which to perform
+	// the full reconciliation of the endpoint policy map.
+	PolicyMapFullReconciliationInterval time.Duration
 
 	// SockRevNatEntries is the maximum number of sock rev nat mappings
 	// allowed in the BPF rev nat table
@@ -3621,6 +3629,7 @@ func (c *DaemonConfig) calculateBPFMapSizes(vp *viper.Viper) error {
 	c.NATMapEntriesGlobal = vp.GetInt(NATMapEntriesGlobalName)
 	c.NeighMapEntriesGlobal = vp.GetInt(NeighMapEntriesGlobalName)
 	c.PolicyMapEntries = vp.GetInt(PolicyMapEntriesName)
+	c.PolicyMapFullReconciliationInterval = vp.GetDuration(PolicyMapFullReconciliationIntervalName)
 	c.SockRevNatEntries = vp.GetInt(SockRevNatEntriesName)
 	c.LBMapEntries = vp.GetInt(LBMapEntriesName)
 	c.LBServiceMapEntries = vp.GetInt(LBServiceMapMaxEntries)

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -38,6 +38,10 @@ var (
 	ep2 = testutils.NewTestEndpoint()
 )
 
+func localIdentity(n uint32) identity.NumericIdentity {
+	return identity.NumericIdentity(n) | identity.LocalIdentityFlag
+
+}
 func (s *DistilleryTestSuite) TestCacheManagement(c *C) {
 	repo := NewPolicyRepository(nil, nil, nil)
 	cache := repo.policyCache
@@ -1196,7 +1200,7 @@ var (
 		owners:           map[MapStateOwner]struct{}{},
 	}
 
-	worldIPIdentity    = identity.NumericIdentity(16324)
+	worldIPIdentity    = localIdentity(16324)
 	worldCIDR          = api.CIDR("192.0.2.3/32")
 	lblWorldIP         = labels.ParseSelectLabelArray(fmt.Sprintf("%s:%s", labels.LabelSourceCIDR, worldCIDR))
 	ruleL3AllowWorldIP = api.NewRule().WithIngressRules([]api.IngressRule{{
@@ -1209,7 +1213,7 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	worldSubnetIdentity = identity.NumericIdentity(16325)
+	worldSubnetIdentity = localIdentity(16325)
 	worldSubnet         = api.CIDR("192.0.2.0/24")
 	worldSubnetRule     = api.CIDRRule{
 		Cidr: worldSubnet,

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -451,7 +451,6 @@ func (d *policyDistillery) distillPolicy(owner PolicyOwner, epLabels labels.Labe
 func (m MapState) clearCaches() {
 	for k, v := range m {
 		v.owners = make(map[MapStateOwner]struct{})
-		v.cachedNets = nil
 		m[k] = v
 	}
 }

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -198,11 +198,11 @@ func (e *MapStateEntry) getNets(identities Identities, ident uint32) []*net.IPNe
 		}
 		return e.cachedNets
 	}
-	if identities == nil {
+	// CIDR identities have a local scope, so we can skip the rest if id is not of local scope.
+	if !id.HasLocalScope() || identities == nil {
 		return nil
 	}
 	lbls := identities.GetLabels(id)
-	nets := make([]*net.IPNet, 0, 1)
 	var (
 		maskSize         int
 		mostSpecificCidr *net.IPNet
@@ -219,10 +219,10 @@ func (e *MapStateEntry) getNets(identities Identities, ident uint32) []*net.IPNe
 		}
 	}
 	if mostSpecificCidr != nil {
-		nets = append(nets, mostSpecificCidr)
+		e.cachedNets = []*net.IPNet{mostSpecificCidr}
+		return e.cachedNets
 	}
-	e.cachedNets = nets
-	return nets
+	return nil
 }
 
 // AddDependent adds 'key' to the set of dependent keys.

--- a/pkg/policy/selectorcache.go
+++ b/pkg/policy/selectorcache.go
@@ -162,7 +162,9 @@ type identitySelector interface {
 type scIdentity struct {
 	NID       identity.NumericIdentity
 	lbls      labels.LabelArray
-	namespace string // value of the namespace label, or ""
+	nets      []*net.IPNet // Most specific CIDR for the identity, if any.
+	computed  bool         // nets has been computed
+	namespace string       // value of the namespace label, or ""
 }
 
 // scIdentityCache is a cache of Identities keyed by the numeric identity
@@ -172,8 +174,35 @@ func newIdentity(nid identity.NumericIdentity, lbls labels.LabelArray) scIdentit
 	return scIdentity{
 		NID:       nid,
 		lbls:      lbls,
+		nets:      getLocalScopeNets(nid, lbls),
 		namespace: lbls.Get(labels.LabelSourceK8sKeyPrefix + k8sConst.PodNamespaceLabel),
+		computed:  true,
 	}
+}
+
+// getLocalScopeNets returns the most specific CIDR for a local scope identity.
+func getLocalScopeNets(id identity.NumericIdentity, lbls labels.LabelArray) []*net.IPNet {
+	if id.HasLocalScope() {
+		var (
+			maskSize         int
+			mostSpecificCidr *net.IPNet
+		)
+		for _, lbl := range lbls {
+			if lbl.Source == labels.LabelSourceCIDR {
+				_, netIP, err := net.ParseCIDR(lbl.Key)
+				if err == nil {
+					if ms, _ := netIP.Mask.Size(); ms > maskSize {
+						mostSpecificCidr = netIP
+						maskSize = ms
+					}
+				}
+			}
+		}
+		if mostSpecificCidr != nil {
+			return []*net.IPNet{mostSpecificCidr}
+		}
+	}
+	return nil
 }
 
 func getIdentityCache(ids cache.IdentityCache) scIdentityCache {
@@ -1084,10 +1113,18 @@ func (sc *SelectorCache) RemoveIdentitiesFQDNSelectors(fqdnSels []api.FQDNSelect
 	sc.releaseIdentityMappings(identitiesToRelease)
 }
 
-func (sc *SelectorCache) GetLabels(id identity.NumericIdentity) labels.LabelArray {
+// GetNetsLocked returns the most specific CIDR for an identity. For the "World" identity
+// it returns both IPv4 and IPv6.
+func (sc *SelectorCache) GetNetsLocked(id identity.NumericIdentity) []*net.IPNet {
 	ident, ok := sc.idCache[id]
 	if !ok {
-		return labels.LabelArray{}
+		return nil
 	}
-	return ident.lbls
+	if !ident.computed {
+		log.WithFields(logrus.Fields{
+			logfields.Identity: id,
+			logfields.Labels:   ident.lbls,
+		}).Warning("GetNetsLocked: Identity with missing nets!")
+	}
+	return ident.nets
 }


### PR DESCRIPTION
Backports FQDN related fixes to v1.13 that were not straightforward to backport.

- [x] https://github.com/cilium/cilium/pull/26345 (@jrajahalme)
- [x] https://github.com/cilium/cilium/pull/27670 (@jrajahalme)
- [x] https://github.com/cilium/cilium/pull/27693 (@joamaki)
- [x] https://github.com/cilium/cilium/pull/27985 (@joamaki)
- [x] https://github.com/cilium/cilium/pull/27796 (@bimmlerd)

```
for pr in 26345 27670 27693 27985 27796; do contrib/backporting/set-labels.py $pr done 1.12; done
```