### PR TITLE
Remove daemon health from being reported via the CLI

### DIFF
--- a/daemon/cmd/vitals.go
+++ b/daemon/cmd/vitals.go
@@ -14,6 +14,12 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 )
 
+// moduleExcludes tracks modules that should be excluded from the health report.
+var moduleExcludes = map[string]struct{}{
+	// daemon currently does not rollup status and hence reports default health aka unknown.
+	"daemon": {},
+}
+
 type getHealth struct {
 	daemon *Daemon
 }
@@ -33,6 +39,9 @@ func (d *Daemon) getHealthReport() models.ModulesHealth {
 	mm := d.healthProvider.All()
 	rr := make([]*models.ModuleHealth, 0, len(mm))
 	for _, m := range mm {
+		if _, ok := moduleExcludes[m.ModuleID]; ok {
+			continue
+		}
 		rr = append(rr, toModuleHealth(m))
 	}
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

The daemon module currently does not support health rollups and hence reports the default status aka Unknown.
This is less than ideal and may yields to confusion. This PR removes daemon health from being reported via the cilium health command.

Fixes: #issue-number

Signed-off-by: Fernand Galiana <fernand.galiana@isovalent.com>