### PR TITLE
ipcache: Fix incorrect source for kube-apiserver in tests

### DIFF
--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -616,7 +616,7 @@ func setupTest(t *testing.T) (cleanup func()) {
 		DatapathHandler:   &mockTriggerer{},
 	})
 
-	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.CustomResource, "kube-uid", labels.LabelKubeAPIServer)
+	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.KubeAPIServer, "kube-uid", labels.LabelKubeAPIServer)
 	IPIdentityCache.metadata.upsertLocked(worldPrefix, source.Local, "host-uid", labels.LabelHost)
 
 	return func() {


### PR DESCRIPTION
This should not have been set to CustomResource.

This commit has no functional impact; it's just to prevent potential
confusion for readers in the future.

Signed-off-by: Chris Tarazi <chris@isovalent.com>
