### PR TITLE
.github/actions/helm-default: use the derived SHA as image tag

### DIFF
--- a/.github/actions/helm-default/action.yaml
+++ b/.github/actions/helm-default/action.yaml
@@ -27,19 +27,19 @@ runs:
         CILIUM_INSTALL_DEFAULTS="--chart-directory=install/kubernetes/cilium \
           --helm-set=image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/cilium-ci \
           --helm-set=image.useDigest=false \
-          --helm-set=image.tag=${{ inputs.image-tag }} \
+          --helm-set=image.tag=${SHA} \
           --helm-set=operator.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/operator \
           --helm-set=operator.image.suffix=-ci \
-          --helm-set=operator.image.tag=${{ inputs.image-tag }} \
+          --helm-set=operator.image.tag=${SHA} \
           --helm-set=operator.image.useDigest=false \
           --helm-set=clustermesh.apiserver.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
-          --helm-set=clustermesh.apiserver.image.tag=${{ inputs.image-tag }} \
+          --helm-set=clustermesh.apiserver.image.tag=${SHA} \
           --helm-set=clustermesh.apiserver.image.useDigest=false \
           --helm-set=clustermesh.apiserver.kvstoremesh.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/clustermesh-apiserver-ci \
-          --helm-set=clustermesh.apiserver.kvstoremesh.image.tag=${{ inputs.image-tag }} \
+          --helm-set=clustermesh.apiserver.kvstoremesh.image.tag=${SHA} \
           --helm-set=clustermesh.apiserver.kvstoremesh.image.useDigest=false \
           --helm-set=hubble.relay.image.repository=quay.io/${{ env.QUAY_ORGANIZATION_DEV }}/hubble-relay-ci \
-          --helm-set=hubble.relay.image.tag=${{ inputs.image-tag }} \
+          --helm-set=hubble.relay.image.tag=${SHA} \
           --helm-set=hubble.relay.image.useDigest=false \
           --helm-set=debug.enabled=true \
           --helm-set=bpf.monitorAggregation=none"


### PR DESCRIPTION
This commit ensures that the correct image tag, derived from the GitHub SHA, is used in the Helm chart when workflows are triggered by events other than 'workflow_dispatch' or 'pull_request'

Fixes: 4498ec908b02 (".github: re-use common helm values from a single action")

Reported-by: Marco Iorio <marco.iorio@isovalent.com