### PR TITLE
[v1.13] ipcache: aggregate labels from all IPs with local host identity

### DIFF
--- a/pkg/identity/reserved.go
+++ b/pkg/identity/reserved.go
@@ -17,25 +17,30 @@ var (
 )
 
 // AddReservedIdentity adds the reserved numeric identity with the respective
-// label into the map of reserved identity cache.
-func AddReservedIdentity(ni NumericIdentity, lbl string) {
+// label into the map of reserved identity cache, and returns the resulting Identity.
+// This identity must not be mutated!
+func AddReservedIdentity(ni NumericIdentity, lbl string) *Identity {
 	identity := NewIdentity(ni, labels.Labels{lbl: labels.NewLabel(lbl, "", labels.LabelSourceReserved)})
 	cacheMU.Lock()
 	reservedIdentityCache[ni] = identity
 	cacheMU.Unlock()
+	return identity
 }
 
 // AddReservedIdentityWithLabels is the same as AddReservedIdentity but accepts
-// multiple labels.
-func AddReservedIdentityWithLabels(ni NumericIdentity, lbls labels.Labels) {
+// multiple labels. Returns the resulting Identity.
+// This identity must not be mutated!
+func AddReservedIdentityWithLabels(ni NumericIdentity, lbls labels.Labels) *Identity {
 	identity := NewIdentity(ni, lbls)
 	cacheMU.Lock()
 	reservedIdentityCache[ni] = identity
 	cacheMU.Unlock()
+	return identity
 }
 
 // LookupReservedIdentity looks up a reserved identity by its NumericIdentity
 // and returns it if found. Returns nil if not found.
+// This identity must not be mutated!
 func LookupReservedIdentity(ni NumericIdentity) *Identity {
 	cacheMU.RLock()
 	defer cacheMU.RUnlock()
@@ -43,7 +48,9 @@ func LookupReservedIdentity(ni NumericIdentity) *Identity {
 }
 
 func init() {
-	iterateReservedIdentityLabels(AddReservedIdentityWithLabels)
+	iterateReservedIdentityLabels(func(ni NumericIdentity, lbls labels.Labels) {
+		AddReservedIdentityWithLabels(ni, lbls)
+	})
 }
 
 // IterateReservedIdentities iterates over all reserved identities and

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/checker"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/types"
@@ -32,6 +33,7 @@ type IPCacheTestSuite struct {
 var (
 	_               = Suite(&IPCacheTestSuite{})
 	IPIdentityCache *IPCache
+	PolicyHandler   *mockUpdater
 )
 
 func Test(t *testing.T) {
@@ -41,10 +43,13 @@ func Test(t *testing.T) {
 func (s *IPCacheTestSuite) SetUpTest(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	allocator := testidentity.NewMockIdentityAllocator(nil)
+	PolicyHandler = &mockUpdater{
+		identities: make(map[identityPkg.NumericIdentity]labels.LabelArray),
+	}
 	IPIdentityCache = NewIPCache(&Configuration{
 		Context:           ctx,
 		IdentityAllocator: allocator,
-		PolicyHandler:     &mockUpdater{},
+		PolicyHandler:     PolicyHandler,
 		DatapathHandler:   &mockTriggerer{},
 	})
 

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -77,12 +77,22 @@ type metadata struct {
 	// generate updates into the ipcache, policy engine and datapath.
 	queuedChangesMU lock.Mutex
 	queuedPrefixes  map[netip.Prefix]struct{}
+
+	// reservedHostLock protects the localHostLabels map. Holders must
+	// always take the metadata read lock first.
+	reservedHostLock lock.Mutex
+
+	// reservedHostLabels collects all labels that apply to the host identity.
+	// see updateLocalHostLabels() for more info.
+	reservedHostLabels map[netip.Prefix]labels.Labels
 }
 
 func newMetadata() *metadata {
 	return &metadata{
 		m:              make(map[netip.Prefix]prefixInfo),
 		queuedPrefixes: make(map[netip.Prefix]struct{}),
+
+		reservedHostLabels: make(map[netip.Prefix]labels.Labels),
 	}
 }
 
@@ -186,6 +196,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 	for i, prefix := range modifiedPrefixes {
 		id, entryExists := ipc.LookupByIP(prefix.String())
 		prefixInfo := ipc.metadata.getLocked(prefix)
+		var newID *identity.Identity
 		if prefixInfo == nil {
 			if !entryExists {
 				// Already deleted, no new metadata to associate
@@ -193,7 +204,6 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			} // else continue below to remove the old entry
 		} else {
 			oldIDs[prefix] = id
-			var newID *identity.Identity
 
 			// Insert to propagate the updated set of labels after removal.
 			newID, _, err = ipc.injectLabels(ctx, prefix, prefixInfo.ToLabels())
@@ -255,6 +265,25 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 				previouslyAllocatedIdentities[prefix] = id
 			}
 		}
+
+		// The reserved:host identity is special: the numeric ID is fixed,
+		// and the set of labels is mutable. Thus, whenever it changes,
+		// we must always update the SelectorCache (normally, this is elided
+		// when no changes are present).
+		if newID != nil && newID.ID == identity.ReservedIdentityHost {
+			idsToAdd[newID.ID] = newID.Labels.LabelArray()
+		}
+
+		// Again, more reserved:host bookkeeping: if this prefix is no longer ID 1 (because
+		// it is being deleted or changing IDs), we need to recompute the labels
+		// for reserved:host and push that to the SelectorCache
+		if entryExists && id.ID == identity.ReservedIdentityHost &&
+			(newID == nil || newID.ID != identity.ReservedIdentityHost) {
+
+			i := ipc.updateReservedHostLabels(prefix, nil)
+			idsToAdd[i.ID] = i.Labels.LabelArray()
+		}
+
 	}
 	// Don't hold lock while calling UpdateIdentities, as it will otherwise run into a deadlock
 	ipc.metadata.RUnlock()
@@ -399,8 +428,12 @@ func (ipc *IPCache) injectLabels(ctx context.Context, prefix netip.Prefix, lbls 
 		// for itself). For all other identities, we avoid modifying
 		// the labels at runtime and instead opt to allocate new
 		// identities below.
-		identity.AddReservedIdentityWithLabels(identity.ReservedIdentityHost, lbls)
-		return identity.LookupReservedIdentity(identity.ReservedIdentityHost), false, nil
+		//
+		// As an extra gotcha, we need need to merge all labels for all IPs
+		// that resolve to the reserved:host identity, otherwise we can
+		// flap identities labels depending on which prefix writes first. See GH-28259.
+		i := ipc.updateReservedHostLabels(prefix, lbls)
+		return i, false, nil
 	}
 
 	// If no other labels are associated with this IP, we assume that it's
@@ -437,6 +470,37 @@ func (ipc *IPCache) injectLabelsForCIDR(ctx context.Context, prefix netip.Prefix
 	)
 
 	return ipc.allocate(ctx, prefix, allLbls, identity.InvalidIdentity)
+}
+
+// updateReservedHostLabels adds or removes labels that apply to the local host.
+// The `reserved:host` identity is special: the numeric identity is fixed
+// and the set of labels is mutable. (The datapath requires this.) So,
+// we need to determine all prefixes that have the `reserved:host` label and
+// capture their labels. Then, we must aggregate *all* labels from all prefixes and
+// update the labels that correspond to the `reserved:host` identity.
+//
+// This could be termed a meta-ipcache. The ipcache metadata layer aggregates
+// an arbitrary set of resources and labels to a prefix. Here, we are aggregating an arbitrary
+// set of prefixes and labels to an identity.
+func (ipc *IPCache) updateReservedHostLabels(prefix netip.Prefix, lbls labels.Labels) *identity.Identity {
+	ipc.metadata.reservedHostLock.Lock()
+	defer ipc.metadata.reservedHostLock.Unlock()
+	if lbls == nil {
+		delete(ipc.metadata.reservedHostLabels, prefix)
+	} else {
+		ipc.metadata.reservedHostLabels[prefix] = lbls
+	}
+
+	// aggregate all labels and update static identity
+	newLabels := labels.Labels{}
+	newLabels.MergeLabels(labels.LabelHost)
+	for _, l := range ipc.metadata.reservedHostLabels {
+		newLabels.MergeLabels(l)
+	}
+
+	log.WithField(logfields.Labels, newLabels).Debug("Merged labels for reserved:host identity")
+
+	return identity.AddReservedIdentityWithLabels(identity.ReservedIdentityHost, newLabels)
 }
 
 // RemoveLabelsExcluded removes the given labels from all IPs inside the IDMD


### PR DESCRIPTION
- [ ] #28332 -- ipcache: aggregate labels from all IPs with local host identity

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 28332; do contrib/backporting/set-labels.py $pr done 1.13; done
```