### PR TITLE
[v1.14] ipcache: fix flapping labels in SelectorCache when reserved:host identity has multiple IPs

### DIFF
--- a/pkg/identity/reserved.go
+++ b/pkg/identity/reserved.go
@@ -17,25 +17,30 @@ var (
 )
 
 // AddReservedIdentity adds the reserved numeric identity with the respective
-// label into the map of reserved identity cache.
-func AddReservedIdentity(ni NumericIdentity, lbl string) {
+// label into the map of reserved identity cache, and returns the resulting Identity.
+// This identity must not be mutated!
+func AddReservedIdentity(ni NumericIdentity, lbl string) *Identity {
 	identity := NewIdentity(ni, labels.Labels{lbl: labels.NewLabel(lbl, "", labels.LabelSourceReserved)})
 	cacheMU.Lock()
 	reservedIdentityCache[ni] = identity
 	cacheMU.Unlock()
+	return identity
 }
 
 // AddReservedIdentityWithLabels is the same as AddReservedIdentity but accepts
-// multiple labels.
-func AddReservedIdentityWithLabels(ni NumericIdentity, lbls labels.Labels) {
+// multiple labels. Returns the resulting Identity.
+// This identity must not be mutated!
+func AddReservedIdentityWithLabels(ni NumericIdentity, lbls labels.Labels) *Identity {
 	identity := NewIdentity(ni, lbls)
 	cacheMU.Lock()
 	reservedIdentityCache[ni] = identity
 	cacheMU.Unlock()
+	return identity
 }
 
 // LookupReservedIdentity looks up a reserved identity by its NumericIdentity
 // and returns it if found. Returns nil if not found.
+// This identity must not be mutated!
 func LookupReservedIdentity(ni NumericIdentity) *Identity {
 	cacheMU.RLock()
 	defer cacheMU.RUnlock()
@@ -43,7 +48,9 @@ func LookupReservedIdentity(ni NumericIdentity) *Identity {
 }
 
 func init() {
-	iterateReservedIdentityLabels(AddReservedIdentityWithLabels)
+	iterateReservedIdentityLabels(func(ni NumericIdentity, lbls labels.Labels) {
+		AddReservedIdentityWithLabels(ni, lbls)
+	})
 }
 
 // IterateReservedIdentities iterates over all reserved identities and

--- a/pkg/ipcache/ipcache_test.go
+++ b/pkg/ipcache/ipcache_test.go
@@ -20,6 +20,7 @@ import (
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	identityPkg "github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache/types/fake"
+	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/source"
 	testidentity "github.com/cilium/cilium/pkg/testutils/identity"
 	"github.com/cilium/cilium/pkg/types"
@@ -34,6 +35,7 @@ type IPCacheTestSuite struct {
 var (
 	_               = Suite(&IPCacheTestSuite{})
 	IPIdentityCache *IPCache
+	PolicyHandler   *mockUpdater
 )
 
 func Test(t *testing.T) {
@@ -43,10 +45,13 @@ func Test(t *testing.T) {
 func (s *IPCacheTestSuite) SetUpTest(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	allocator := testidentity.NewMockIdentityAllocator(nil)
+	PolicyHandler = &mockUpdater{
+		identities: make(map[identityPkg.NumericIdentity]labels.LabelArray),
+	}
 	IPIdentityCache = NewIPCache(&Configuration{
 		Context:           ctx,
 		IdentityAllocator: allocator,
-		PolicyHandler:     &mockUpdater{},
+		PolicyHandler:     PolicyHandler,
 		DatapathHandler:   &mockTriggerer{},
 		NodeIDHandler:     &fake.FakeNodeIDHandler{},
 	})


### PR DESCRIPTION
- [ ] #28332 -- ipcache: fix flapping labels in SelectorCache when reserved:host identity has multiple IPs

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 28332; do contrib/backporting/set-labels.py $pr done 1.14; done
```