### PR TITLE
Add error metrics for data synchronization to kvstore

### DIFF
--- a/Documentation/observability/metrics.rst
+++ b/Documentation/observability/metrics.rst
@@ -515,6 +515,7 @@ Name                                     Labels                                 
 ``kvstore_operations_duration_seconds``  ``action``, ``kind``, ``outcome``, ``scope`` Enabled    Duration of kvstore operation
 ``kvstore_events_queue_seconds``         ``action``, ``scope``                        Enabled    Seconds waited before a received event was queued
 ``kvstore_quorum_errors_total``          ``error``                                    Enabled    Number of quorum errors
+``kvstore_sync_errors_total``            ``scope``, ``source_cluster``                Enabled    Number of times synchronization to the kvstore failed
 ``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Enabled    Number of elements queued for synchronization in the kvstore
 ``kvstore_initial_sync_completed``       ``scope``, ``source_cluster``, ``action``    Enabled    Whether the initial synchronization from/to the kvstore has completed
 ======================================== ============================================ ========== ========================================================
@@ -1029,6 +1030,7 @@ Name                                     Labels                                 
 ``kvstore_operations_duration_seconds``  ``action``, ``kind``, ``outcome``, ``scope`` Duration of kvstore operation
 ``kvstore_events_queue_seconds``         ``action``, ``scope``                        Seconds waited before a received event was queued
 ``kvstore_quorum_errors_total``          ``error``                                    Number of quorum errors
+``kvstore_sync_errors_total``            ``scope``, ``source_cluster``                Number of times synchronization to the kvstore failed
 ``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Number of elements queued for synchronization in the kvstore
 ``kvstore_initial_sync_completed``       ``scope``, ``source_cluster``, ``action``    Whether the initial synchronization from/to the kvstore has completed
 ======================================== ============================================ ========================================================
@@ -1103,6 +1105,7 @@ Name                                     Labels                                 
 ``kvstore_operations_duration_seconds``  ``action``, ``kind``, ``outcome``, ``scope`` Duration of kvstore operation
 ``kvstore_events_queue_seconds``         ``action``, ``scope``                        Seconds waited before a received event was queued
 ``kvstore_quorum_errors_total``          ``error``                                    Number of quorum errors
+``kvstore_sync_errors_total``            ``scope``, ``source_cluster``                Number of times synchronization to the kvstore failed
 ``kvstore_sync_queue_size``              ``scope``, ``source_cluster``                Number of elements queued for synchronization in the kvstore
 ``kvstore_initial_sync_completed``       ``scope``, ``source_cluster``, ``action``    Whether the initial synchronization from/to the kvstore has completed
 ======================================== ============================================ ========================================================

--- a/pkg/kvstore/store/metrics.go
+++ b/pkg/kvstore/store/metrics.go
@@ -10,25 +10,29 @@ import (
 
 type Metrics struct {
 	KVStoreSyncQueueSize        metric.Vec[metric.Gauge]
+	KVStoreSyncErrors           metric.Vec[metric.Counter]
 	KVStoreInitialSyncCompleted metric.Vec[metric.Gauge]
 }
 
 func MetricsProvider() *Metrics {
 	return &Metrics{
 		KVStoreSyncQueueSize: metric.NewGaugeVec(metric.GaugeOpts{
-			ConfigName: metrics.Namespace + "_" + metrics.SubsystemKVStore + "_sync_queue_size",
-			Namespace:  metrics.Namespace,
-			Subsystem:  metrics.SubsystemKVStore,
-			Name:       "sync_queue_size",
-			Help:       "Number of elements queued for synchronization in the kvstore",
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.SubsystemKVStore,
+			Name:      "sync_queue_size",
+			Help:      "Number of elements queued for synchronization in the kvstore",
 		}, []string{metrics.LabelScope, metrics.LabelSourceCluster}),
-
+		KVStoreSyncErrors: metric.NewCounterVec(metric.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.SubsystemKVStore,
+			Name:      "sync_errors_total",
+			Help:      "Number of times synchronization to the kvstore failed",
+		}, []string{metrics.LabelScope, metrics.LabelSourceCluster}),
 		KVStoreInitialSyncCompleted: metric.NewGaugeVec(metric.GaugeOpts{
-			ConfigName: metrics.Namespace + "_" + metrics.SubsystemKVStore + "_initial_sync_completed",
-			Namespace:  metrics.Namespace,
-			Subsystem:  metrics.SubsystemKVStore,
-			Name:       "initial_sync_completed",
-			Help:       "Whether the initial synchronization from/to the kvstore has completed",
+			Namespace: metrics.Namespace,
+			Subsystem: metrics.SubsystemKVStore,
+			Name:      "initial_sync_completed",
+			Help:      "Whether the initial synchronization from/to the kvstore has completed",
 		}, []string{metrics.LabelScope, metrics.LabelSourceCluster, metrics.LabelAction}),
 	}
 }

--- a/pkg/kvstore/store/syncstore.go
+++ b/pkg/kvstore/store/syncstore.go
@@ -75,6 +75,7 @@ type wqSyncStore struct {
 
 	log          *logrus.Entry
 	queuedMetric prometheus.Gauge
+	errorsMetric prometheus.Counter
 	syncedMetric prometheus.Gauge
 }
 
@@ -134,6 +135,7 @@ func newWorkqueueSyncStore(clusterName string, backend SyncStoreBackend, prefix 
 	wss.log = wss.log.WithField(logfields.ClusterName, wss.source)
 	wss.workqueue = workqueue.NewRateLimitingQueue(wss.limiter)
 	wss.queuedMetric = m.KVStoreSyncQueueSize.WithLabelValues(kvstore.GetScopeFromKey(prefix), wss.source)
+	wss.errorsMetric = m.KVStoreSyncErrors.WithLabelValues(kvstore.GetScopeFromKey(prefix), wss.source)
 	wss.syncedMetric = m.KVStoreInitialSyncCompleted.WithLabelValues(kvstore.GetScopeFromKey(prefix), wss.source, "write")
 	return wss
 }
@@ -236,6 +238,7 @@ func (wss *wqSyncStore) processNextItem(ctx context.Context) bool {
 	// Run the handler, passing it the key to be processed as parameter.
 	if err := wss.handle(ctx, key); err != nil {
 		// Put the item back on the workqueue to handle any transient errors.
+		wss.errorsMetric.Inc()
 		wss.workqueue.AddRateLimited(key)
 		return true
 	}

--- a/pkg/kvstore/store/syncstore_test.go
+++ b/pkg/kvstore/store/syncstore_test.go
@@ -429,6 +429,8 @@ func TestWorkqueueSyncStoreMetrics(t *testing.T) {
 	store.DeleteKey(ctx, NewKVPair("key1", ""))
 	require.Equal(t, float64(2), testutil.ToFloat64(me.KVStoreSyncQueueSize.WithLabelValues("nodes/v1", "foo")))
 
+	// For now, we don't have synchronization errors.
+	require.Equal(t, float64(0), testutil.ToFloat64(me.KVStoreSyncErrors.WithLabelValues("nodes/v1", "foo")))
 	backend.errorsOnUpdate["cilium/state/nodes/v1/key3"] = 1
 	require.Equal(t, NewKVPair("cilium/state/nodes/v1/key2", "value2"), eventually(backend.updated))
 	require.Equal(t, NewKVPair("cilium/state/nodes/v1/key3", "value3"), eventually(backend.updated))
@@ -441,6 +443,7 @@ func TestWorkqueueSyncStoreMetrics(t *testing.T) {
 			testutil.ToFloat64(me.KVStoreInitialSyncCompleted.WithLabelValues("nodes/v1", "foo", "write")))
 	})
 
+	require.Equal(t, float64(1), testutil.ToFloat64(me.KVStoreSyncErrors.WithLabelValues("nodes/v1", "foo")))
 	// The store should not yet be synced, as the synced entry has not yet been written to the kvstore.
 	require.Equal(t, metrics.BoolToFloat64(false),
 		testutil.ToFloat64(me.KVStoreInitialSyncCompleted.WithLabelValues("nodes/v1", "foo", "write")))


### PR DESCRIPTION
Add error metrics for data synchronization to kvstore

```release-note
Added cilium_kvstoremesh_kvstore_sync_errors_counter, cilium_clustermesh_apiserver_kvstore_sync_errors_counter and kvstore_sync_errors_counter metrics that capture data synchronization errors to kvstore.
```
