### PR TITLE
bgpv1,ci: Fix BGP component tests reusing the same VirtualRouter config

### DIFF
--- a/pkg/bgpv1/test/adverts_test.go
+++ b/pkg/bgpv1/test/adverts_test.go
@@ -142,7 +142,7 @@ func Test_PodCIDRAdvert(t *testing.T) {
 	defer testDone()
 
 	// setup topology
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, fixtureConf)
+	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()
@@ -347,7 +347,7 @@ func Test_PodIPPoolAdvert(t *testing.T) {
 	defer testDone()
 
 	// setup topology
-	cfg := fixtureConf
+	cfg := newFixtureConf()
 	cfg.ipam = ipam_option.IPAMMultiPool
 	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, cfg)
 	require.NoError(t, err)
@@ -570,7 +570,7 @@ func Test_LBEgressAdvertisement(t *testing.T) {
 	defer testDone()
 
 	// setup topology
-	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, fixtureConf)
+	gobgpPeers, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpPeers, 1)
 	defer cleanup()

--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -70,13 +70,6 @@ var (
 			},
 		},
 	}
-
-	// Daemon start config
-	fixtureConf = fixtureConfig{
-		policy:    newPolicyObj(baseBGPPolicy),
-		ipam:      ipamOption.IPAMKubernetes,
-		bgpEnable: true,
-	}
 )
 
 // fixture is test harness
@@ -94,6 +87,21 @@ type fixtureConfig struct {
 	policy    cilium_api_v2alpha1.CiliumBGPPeeringPolicy
 	ipam      string
 	bgpEnable bool
+}
+
+func newFixtureConf() fixtureConfig {
+	policyCfg := policyConfig{
+		nodeSelector: baseBGPPolicy.nodeSelector,
+	}
+	// deepcopy the VirtualRouters as the tests modify them
+	for _, vr := range baseBGPPolicy.virtualRouters {
+		policyCfg.virtualRouters = append(policyCfg.virtualRouters, *vr.DeepCopy())
+	}
+	return fixtureConfig{
+		policy:    newPolicyObj(policyCfg),
+		ipam:      ipamOption.IPAMKubernetes,
+		bgpEnable: true,
+	}
 }
 
 func newFixture(conf fixtureConfig) *fixture {
@@ -168,8 +176,7 @@ func newFixture(conf fixtureConfig) *fixture {
 }
 
 func setupSingleNeighbor(ctx context.Context, f *fixture) error {
-	bgpPolicy := baseBGPPolicy
-	bgpPolicy.virtualRouters[0] = cilium_api_v2alpha1.CiliumBGPVirtualRouter{
+	f.config.policy.Spec.VirtualRouters[0] = cilium_api_v2alpha1.CiliumBGPVirtualRouter{
 		LocalASN:      int64(ciliumASN),
 		ExportPodCIDR: pointer.Bool(true),
 		Neighbors: []cilium_api_v2alpha1.CiliumBGPNeighbor{
@@ -179,9 +186,8 @@ func setupSingleNeighbor(ctx context.Context, f *fixture) error {
 			},
 		},
 	}
-	policyObj := newPolicyObj(bgpPolicy)
 
-	_, err := f.policyClient.Update(ctx, &policyObj, meta_v1.UpdateOptions{})
+	_, err := f.policyClient.Update(ctx, &f.config.policy, meta_v1.UpdateOptions{})
 	return err
 }
 

--- a/pkg/bgpv1/test/neighbor_test.go
+++ b/pkg/bgpv1/test/neighbor_test.go
@@ -127,7 +127,7 @@ func Test_NeighborAddDel(t *testing.T) {
 	defer testDone()
 
 	// test setup, we configure two gobgp instances here.
-	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf, gobgpConf2}, fixtureConf)
+	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf, gobgpConf2}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpInstances, 2)
 	defer cleanup()
@@ -272,7 +272,7 @@ func Test_NeighborGracefulRestart(t *testing.T) {
 	defer testDone()
 
 	// test setup, we configure single gobgp instance here.
-	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, fixtureConf)
+	gobgpInstances, fixture, cleanup, err := setup(testCtx, []gobgpConfig{gobgpConf}, newFixtureConf())
 	require.NoError(t, err)
 	require.Len(t, gobgpInstances, 1)
 	defer cleanup()


### PR DESCRIPTION
As some of the BGP component tests mutate the `CiliumBGPVirtualRouter` config, we need to make sure that mutated config is not used by the subsequent tests. That was the case before this fix, as multiple tests are using the same `baseBGPPolicy` variable. Now each test creates a deep copy of the virtual routers  from the base config, which are fine to mutate within the test.

This change also ensures that `fixture.config.policy` always contains the most up-to-date policy, as it is used to update the policy in some tests. This could lead to incorrect updates of the `CiliumBGPVirtualRouter` config.

This can potentially fix the flake described in issue https://github.com/cilium/cilium/issues/28415, although I'm not sure, as I can not reproduce that issue locally. I have found this problem when developing a new BGP component test where the symptoms were similar.