### PR TITLE
docs: add documentation for policy-cidr-match-mode=nodes

### DIFF
--- a/Documentation/internals/security-identities.rst
+++ b/Documentation/internals/security-identities.rst
@@ -23,6 +23,7 @@ Security identities span over several ranges, depending on the context:
 1) Cluster-local
 2) ClusterMesh
 3) Identities generated from CIDR-based policies
+4) Identities generated for remote nodes (optional)
 
 Cluster-local identities (1) range from ``1`` to ``2^16 - 1``. The lowest
 values, from ``1`` to ``255``, correspond to the reserved identity range.  See
@@ -42,8 +43,14 @@ their effective range ``1 | (1 << 24)`` to ``16777215 | (1 << 24)`` or from
 generated is local to each node. In other words, the identity may not be the
 same for the same CIDR policy across two nodes.
 
-CIDR identities are never used for traffic between Cilium-managed nodes, so
-they do not need to fit inside of a VXLAN or Geneve virtual network field.
+Remote-node identities (4) are also local to each node. Functionally, they
+work much the same as CIDR identities: they are local to each node, potentially
+differing across nodes on the cluster. They are only used when the option
+``policy-cidr-match-mode`` includes ``nodes``.
+
+Node-local identities (CIDR or remote-node) are never used for traffic
+between Cilium-managed nodes, so they do not need to fit inside of a
+VXLAN or Geneve virtual network field.
 Non-CIDR identities are limited to 24 bits so that they will fit in these
 fields on the wire, but since CIDR identities will not be encoded in these
 packets, they can start with a higher value. Hence, the minimum value for a
@@ -53,8 +60,9 @@ Overall, the following represents the different ranges:
 
 ::
 
-   0x00000001 - 0x000000FF (1           to 2^8  - 1)        => reserved identities
-   0x00000100 - 0x0000FFFF (2^8         to 2^16 - 1)        => cluster-local identities
-   0x00010000 - 0x00FFFFFF (2^16        to 2^24 - 1)        => identities for remote clusters
-   0x01000000 - 0x0100FFFF (2^24        to 2^24 + 2^16 - 1) => identities for CIDRs (node-local)
-   0x01010000 - 0xFFFFFFFF (2^24 + 2^16 to 2^32 - 1)        => reserved for future use
+   0x00000001 - 0x000000FF (1           to 2^8  - 1       ) => reserved identities
+   0x00000100 - 0x0000FFFF (2^8         to 2^16 - 1       ) => cluster-local identities
+   0x00010000 - 0x00FFFFFF (2^16        to 2^24 - 1       ) => identities for remote clusters
+   0x01000000 - 0x01FFFFFF (2^24        to 2^25 - 1       ) => identities for CIDRs (node-local)
+   0x02000000 - 0x02FFFFFF (2^25        to 2^25 + 2^24 - 1) => identities for remote nodes (local)
+   0x01010000 - 0xFFFFFFFF (2^25 + 2^24 to 2^32 - 1       ) => reserved for future use

--- a/Documentation/network/kubernetes/policy.rst
+++ b/Documentation/network/kubernetes/policy.rst
@@ -55,6 +55,9 @@ Known missing features for Kubernetes Network Policy:
 | Port ranges (endPort)         | :gh-issue:`16622` |
 +-------------------------------+-------------------+
 
+As of v1.15, ``ipBlock`` can now optionally select :ref:`node IPs <cidr_select_nodes>`. Previously,
+nodes were excluded from ``ipBlock``; see :gh-issue:`20550`.
+
 .. _CiliumNetworkPolicy:
 
 CiliumNetworkPolicy

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -448,6 +448,7 @@ will apply to traffic where one side of the connection is:
 * A network endpoint outside the cluster
 * The host network namespace where the pod is running.
 * Within the cluster prefix but the IP's networking is not provided by Cilium.
+* (:ref:`optional <cidr_select_nodes>`) Node IPs within the cluster
 
 Conversely, CIDR rules do not apply to traffic where both sides of the
 connection are either managed by Cilium or use an IP belonging to a node in the
@@ -502,6 +503,30 @@ but not CIDR prefix ``10.96.0.0/12``
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/l3/cidr/cidr.json
+
+.. _cidr_select_nodes:
+
+Selecting nodes with CIDR / ipBlock
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. include:: ../../beta.rst
+
+By default, CIDR-based selectors do not match in-cluster entities (pods or nodes).
+Optionally, you can direct the policy engine to select nodes by CIDR / ipBlock.
+This requires you to configure Cilium with ``--policy-cidr-match-mode=nodes`` or
+the equivalent Helm value ``policyCIDRMatchMode: nodes``. It is safe to toggle this
+option on a running cluster, and toggling the option affects neither upgrades nor downgrades.
+
+When ``--policy-cidr-match-mode=nodes`` is specified, every agent allocates a
+distinct local :ref:`security identity <arch_id_security>` for all other nodes.
+This slightly increases memory usage -- approximately 1MB for every 1000 nodes
+in the cluster.
+
+This is particularly relevant to self-hosted clusters -- that is, clusters where
+the apiserver is hosted on in-cluster nodes. Because CIDR-based selectors ignore
+nodes by default, you must ordinarily use the ``kube-apiserver`` :ref:`entity <Entities based>`
+as part of a CiliumNetworkPolicy. Setting ``--policy-cidr-match-mode=nodes`` permits
+selecting the apiserver via an ``ipBlock`` peer in a KubernetesNetworkPolicy.
 
 .. _DNS based:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -372,6 +372,7 @@ internalTrafficPolicy
 intra
 io
 ip
+ipBlock
 ipam
 ipcache
 ipmasq


### PR DESCRIPTION
This feature, added in #27464, allows for CIDR / ipBlock selectors to reference nodes within the cluster. Previously, nodes were only selectable via an entity selector.

This adds some basic documentation to the feature.