### PR TITLE
Print full labelset for all identities in 'cilium ip list' output

### DIFF
--- a/cilium-dbg/cmd/ip_list.go
+++ b/cilium-dbg/cmd/ip_list.go
@@ -91,11 +91,13 @@ func printEntry(w *tabwriter.Writer, entry *models.IPListEntry) {
 			params := ipApi.NewGetIdentityIDParams().WithID(identity).WithTimeout(api.ClientTimeout)
 			id, err := client.Policy.GetIdentityID(params)
 			if err != nil {
-				Fatalf("Cannot get identity for given ID %s: %s\n", id, err)
-			}
-			lbls := labels.NewLabelsFromModel(id.Payload.Labels)
-			for _, lbl := range lbls {
-				identities = append(identities, lbl.String())
+				fmt.Fprintf(os.Stderr, "Cannot get identity for ID %s: %s\n", ni.StringID(), err)
+				identities = append(identities, identity)
+			} else {
+				lbls := labels.NewLabelsFromModel(id.Payload.Labels)
+				for _, lbl := range lbls {
+					identities = append(identities, lbl.String())
+				}
 			}
 		}
 	}

--- a/cilium-dbg/cmd/ip_list.go
+++ b/cilium-dbg/cmd/ip_list.go
@@ -94,10 +94,8 @@ func printEntry(w *tabwriter.Writer, entry *models.IPListEntry) {
 				fmt.Fprintf(os.Stderr, "Cannot get identity for ID %s: %s\n", ni.StringID(), err)
 				identities = append(identities, identity)
 			} else {
-				lbls := labels.NewLabelsFromModel(id.Payload.Labels)
-				for _, lbl := range lbls {
-					identities = append(identities, lbl.String())
-				}
+				lbls := labels.NewLabelsFromModel(id.Payload.Labels).GetPrintableModel()
+				identities = append(identities, lbls...)
 			}
 		}
 	}

--- a/cilium-dbg/cmd/ip_list.go
+++ b/cilium-dbg/cmd/ip_list.go
@@ -90,23 +90,23 @@ func printEntry(w *tabwriter.Writer, entry *models.IPListEntry) {
 
 	ni := identity.NumericIdentity(*entry.Identity)
 	identityNumeric := ni.StringID()
-	var identities []string
+	var labels []string
 	if numeric {
-		identities = append(identities, identityNumeric)
+		labels = append(labels, identityNumeric)
 	} else {
-		identities = append(identities, getLabels(ni)...)
+		labels = append(labels, getLabels(ni)...)
 	}
 	first := true
-	for _, identity := range identities {
+	for _, lbl := range labels {
 		if first {
 			if verbose {
-				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", *entry.Cidr, identity, src, entry.HostIP, entry.EncryptKey)
+				fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\n", *entry.Cidr, lbl, src, entry.HostIP, entry.EncryptKey)
 			} else {
-				fmt.Fprintf(w, "%s\t%s\t%s\n", *entry.Cidr, identity, src)
+				fmt.Fprintf(w, "%s\t%s\t%s\n", *entry.Cidr, lbl, src)
 			}
 			first = false
 		} else {
-			fmt.Fprintf(w, "\t%s\t\n", identity)
+			fmt.Fprintf(w, "\t%s\t\n", lbl)
 		}
 	}
 }


### PR DESCRIPTION
The host identity can have multiple labels that are not hardcoded directly from
the number, so we should just always fetch the full labelset from the agent for
all identities to ensure that the CLI prints what the agent knows. No need for
special cases for reserved identities.

Technically this bug goes way back and impacts any version since the kube-apiserver
entity policy feature has existed, but it's a minor bug so I'm only proposing this
for 1.14 at this time.
