### PR TITLE
bpf: clean up some drop notifications

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1243,7 +1243,7 @@ handle_srv6(struct __ctx_buff *ctx)
 __section_entry
 int cil_from_netdev(struct __ctx_buff *ctx)
 {
-	__u32 __maybe_unused src_id = 0;
+	__u32 src_id = 0;
 
 #ifdef ENABLE_NODEPORT_ACCELERATION
 	__u32 flags = ctx_get_xfer(ctx, XFER_FLAGS);
@@ -1280,8 +1280,8 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 #ifdef ENABLE_HIGH_SCALE_IPCACHE
 	ret = decapsulate_overlay(ctx, &src_id);
 	if (IS_ERR(ret))
-		return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP,
-				       METRIC_INGRESS);
+		goto drop_err;
+
 	if (ret == CTX_ACT_REDIRECT)
 		return ret;
 #endif /* ENABLE_HIGH_SCALE_IPCACHE */
@@ -1289,7 +1289,7 @@ int cil_from_netdev(struct __ctx_buff *ctx)
 	return handle_netdev(ctx, false);
 
 drop_err:
-	return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP, METRIC_INGRESS);
+	return send_drop_notify_error(ctx, src_id, ret, CTX_ACT_DROP, METRIC_INGRESS);
 }
 
 /*

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -62,8 +62,7 @@ static __always_inline bool allow_vlan(__u32 __maybe_unused ifindex, __u32 __may
 }
 
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
-static __always_inline int rewrite_dmac_to_host(struct __ctx_buff *ctx,
-						__u32 src_sec_identity)
+static __always_inline int rewrite_dmac_to_host(struct __ctx_buff *ctx)
 {
 	/* When attached to cilium_host, we rewrite the DMAC to the mac of
 	 * cilium_host (peer) to ensure the packet is being considered to be
@@ -73,8 +72,7 @@ static __always_inline int rewrite_dmac_to_host(struct __ctx_buff *ctx,
 
 	/* Rewrite to destination MAC of cilium_net (remote peer) */
 	if (eth_store_daddr(ctx, (__u8 *) &cilium_net_mac.addr, 0) < 0)
-		return send_drop_notify_error(ctx, src_sec_identity, DROP_WRITE_ERROR,
-					      CTX_ACT_OK, METRIC_INGRESS);
+		return DROP_WRITE_ERROR;
 
 	return CTX_ACT_OK;
 }
@@ -293,8 +291,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		/* If we are attached to cilium_host at egress, this will
 		 * rewrite the destination MAC address to the MAC of cilium_net.
 		 */
-		ret = rewrite_dmac_to_host(ctx, secctx);
-		/* DIRECT PACKET READ INVALID */
+		ret = rewrite_dmac_to_host(ctx);
 		if (IS_ERR(ret))
 			return ret;
 
@@ -672,8 +669,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		/* If we are attached to cilium_host at egress, this will
 		 * rewrite the destination MAC address to the MAC of cilium_net.
 		 */
-		ret = rewrite_dmac_to_host(ctx, secctx);
-		/* DIRECT PACKET READ INVALID */
+		ret = rewrite_dmac_to_host(ctx);
 		if (IS_ERR(ret))
 			return ret;
 

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -79,7 +79,7 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip __maybe_un
 /* encap_and_redirect_with_nodeid returns CTX_ACT_OK after ctx meta-data is
  * set. Caller should pass the ctx to the stack at this point. Otherwise
  * returns CTX_ACT_REDIRECT on successful redirect to tunnel device.
- * On error returns CTX_ACT_DROP or DROP_WRITE_ERROR.
+ * On error returns a DROP_* reason.
  */
 static __always_inline int
 encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
@@ -137,8 +137,8 @@ __encap_and_redirect_lxc(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
  * the IP stack.
  *
  * Returns CTX_ACT_OK when ctx needs to be handed to IP stack (eg. for IPSec
- * handling), CTX_ACT_DROP, DROP_NO_TUNNEL_ENDPOINT or DROP_WRITE_ERROR on error,
- * and finally on successful redirect returns CTX_ACT_REDIRECT.
+ * handling), a DROP_* reason on error, and finally on successful redirect returns
+ * CTX_ACT_REDIRECT.
  */
 static __always_inline int
 encap_and_redirect_lxc(struct __ctx_buff *ctx,


### PR DESCRIPTION
Consolidate a few drop notifications, to have more consistency and allow for easier reading.

Also update the code documentation for two encap helpers to clarify that they no longer return `CTX_ACT_DROP`.
