### PR TITLE
ci-e2e: add job testing node cidr feature

### DIFF
--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -210,6 +210,15 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
 
+          - name: '13'
+            # renovate: datasource=docker depName=quay.io/lvh-images/kind
+            kernel: '6.0-20230928.053816'
+            kube-proxy: 'none'
+            kpr: 'true'
+            tunnel: 'vxlan'
+            misc: 'cidr-match-mode=nodes'
+
+
     timeout-minutes: 60
     steps:
       - name: Checkout context ref (trusted)
@@ -248,6 +257,7 @@ jobs:
           encryption-node: ${{ matrix.encryption-node }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
+          misc: ${{ matrix.misc }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.


### PR DESCRIPTION
Add a job that sets policy-cidr-match-mode=nodes.