### PR TITLE
v1.14 Backports 2023-10-06

### DIFF
--- a/.github/workflows/conformance-aws-cni.yaml
+++ b/.github/workflows/conformance-aws-cni.yaml
@@ -210,10 +210,6 @@ jobs:
           owner: "${{ steps.vars.outputs.owner }}"
           version: ${{ matrix.version }}
 
-      - name: Update AWS VPC CNI plugin
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.11/config/master/aws-k8s-cni.yaml
-
       - name: Wait for images to be available
         timeout-minutes: 30
         shell: bash

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -58,7 +58,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Build HTML
-        uses: docker://quay.io/cilium/docs-builder:9eb38bbec80e56a8a498b0cac42456e42cfe7f04@sha256:9936a2f648cb25cad6cf1fe5772ad1a5800d0033eb88b0dce77ad70a083661d9
+        uses: docker://quay.io/cilium/docs-builder:b4742c730ff6b05c0b6b3e3383a264bf706aef5e@sha256:28e22c2f0c747216a5216304855be244f44d8d2752c6f810d0da1918712c5f61
         with:
           entrypoint: ./Documentation/check-build.sh
           args: html

--- a/Documentation/operations/system_requirements.rst
+++ b/Documentation/operations/system_requirements.rst
@@ -461,6 +461,17 @@ filesystem to be automatically mounted when the node boots.
 If you are using systemd to manage the kubelet, see the section
 :ref:`bpffs_systemd`.
 
+Routing Tables
+==============
+
+When running in :ref:`ipam_eni` IPAM mode, Cilium will install per-ENI routing
+tables for each ENI that is used by Cilium for pod IP allocation.
+These routing tables are added to the host network namespace and must not be
+otherwise used by the system.
+The index of those per-ENI routing tables is computed as
+``10 + <eni-interface-index>``. The base offset of 10 is chosen as it is highly
+unlikely to collide with the main routing table which is between 253-255.
+
 Privileges
 ==========
 

--- a/Documentation/requirements.txt
+++ b/Documentation/requirements.txt
@@ -3,7 +3,7 @@ Sphinx==7.1.2
 sphinx-autobuild==2021.3.14
 
 # Custom theme, forked from Read the Docs
-sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@acee8d9964f6eeee042e8f4301508970784fe659
+sphinx-rtd-theme-cilium @ git+https://github.com/cilium/sphinx_rtd_theme.git@84a34e7f301e9bfed5330da9acdb65d62020af4d
 # We use semver to parse Cilium's version in the config file
 semver==3.0.1
 # Sphinx extensions

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -47,6 +47,7 @@ Dockerfile
 Dockerfiles
 Donenfeld
 Elasticsearch
+ENI
 FIt
 Facebook
 Fastabend

--- a/Makefile
+++ b/Makefile
@@ -594,7 +594,7 @@ kind-image-fast: ## Build cilium, operator, clustermesh-apiserver and mount them
 	$(MAKE) -C clustermesh-apiserver
 
 	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
-	    for node_name in $(shell kind get nodes -n "${cluster_name}"); do \
+	    for node_name in $$(kind get nodes -n "$$cluster_name"); do \
 			docker exec -ti $${node_name} mkdir -p "${dst}"; \
 			\
 			docker exec -ti $${node_name} rm -rf "${dst}/var/lib/cilium"; \
@@ -610,9 +610,31 @@ kind-image-fast: ## Build cilium, operator, clustermesh-apiserver and mount them
 			docker cp "./daemon/cilium-agent" $${node_name}:"${dst}"; \
 			docker exec -ti $${node_name} chmod +x "${dst}/cilium-agent"; \
 			\
+			kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l k8s-app=cilium --force; \
+		done; \
+	done
+
+.PHONY: kind-image-fast-operator
+kind-image-fast-operator: kind-ready build-operator ## Build cilium operator binary and copy it to all kind nodes.
+	$(eval dst:=/cilium-binaries)
+	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
+		for node_name in $$(kind get nodes -n "$$cluster_name"); do \
+			docker exec -ti $${node_name} mkdir -p "${dst}"; \
+			\
 			docker exec -ti $${node_name} rm -f "${dst}/cilium-operator-generic"; \
 			docker cp "./operator/cilium-operator-generic" $${node_name}:"${dst}"; \
 			docker exec -ti $${node_name} chmod +x "${dst}/cilium-operator-generic"; \
+			\
+			kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l name=cilium-operator --force; \
+		done; \
+	done
+
+.PHONY: kind-image-fast-clustermesh-apiserver
+kind-image-fast-clustermesh-apiserver: kind-ready build-clustermesh-apiserver ## Build clustermesh-apiserver binary and copy it to all kind nodes.
+	$(eval dst:=/cilium-binaries)
+	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
+		for node_name in $$(kind get nodes -n "$$cluster_name"); do \
+			docker exec -ti $${node_name} mkdir -p "${dst}"; \
 			\
 			docker exec -ti $${node_name} rm -f "${dst}/clustermesh-apiserver"; \
 			docker cp "./clustermesh-apiserver/clustermesh-apiserver" $${node_name}:"${dst}"; \

--- a/pkg/auth/authmap.go
+++ b/pkg/auth/authmap.go
@@ -18,6 +18,7 @@ type authMap interface {
 	DeleteIf(predicate func(key authKey, info authInfo) bool) error
 	Get(key authKey) (authInfo, error)
 	All() (map[authKey]authInfo, error)
+	MaxEntries() uint32
 }
 
 type authMapCacher interface {

--- a/pkg/auth/authmap_writer.go
+++ b/pkg/auth/authmap_writer.go
@@ -105,3 +105,7 @@ func (r *authMapWriter) DeleteIf(predicate func(key authKey, info authInfo) bool
 
 	return nil
 }
+
+func (r *authMapWriter) MaxEntries() uint32 {
+	return r.authMap.MaxEntries()
+}

--- a/pkg/auth/manager_test.go
+++ b/pkg/auth/manager_test.go
@@ -287,6 +287,10 @@ func (r *fakeAuthMap) Update(key authKey, info authInfo) error {
 	return nil
 }
 
+func (r *fakeAuthMap) MaxEntries() uint32 {
+	return 1 << 8
+}
+
 func assertErrorString(errString string) assert.ErrorAssertionFunc {
 	return func(t assert.TestingT, err error, msgAndArgs ...interface{}) bool {
 		return assert.EqualError(t, err, errString, msgAndArgs)

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -323,12 +323,12 @@ func ipSecReplaceStateIn(localIP, remoteIP net.IP, zeroMark bool) (uint8, error)
 	if !zeroMark {
 		state.OutputMark = &netlink.XfrmMark{
 			Value: linux_defaults.RouteMarkDecrypt,
-			Mask:  linux_defaults.RouteMarkMask,
+			Mask:  linux_defaults.OutputMarkMask,
 		}
 	} else {
 		state.OutputMark = &netlink.XfrmMark{
 			Value: 0,
-			Mask:  linux_defaults.RouteMarkMask,
+			Mask:  linux_defaults.OutputMarkMask,
 		}
 	}
 
@@ -347,7 +347,7 @@ func ipSecReplaceStateOut(localIP, remoteIP net.IP, nodeID uint16) (uint8, error
 	state.Mark = generateEncryptMark(key.Spi, nodeID)
 	state.OutputMark = &netlink.XfrmMark{
 		Value: linux_defaults.RouteMarkEncrypt,
-		Mask:  linux_defaults.RouteMarkMask,
+		Mask:  linux_defaults.OutputMarkMask,
 	}
 	return key.Spi, xfrmStateReplace(state)
 }

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -43,6 +43,10 @@ const (
 	// RouteMarkMask is the mask required for the route mark value
 	RouteMarkMask = 0xF00
 
+	// OutputMarkMask is the mask to use in output-mark of XFRM states. It is
+	// used to clear the node ID and the SPI from the packet mark.
+	OutputMarkMask = 0xFFFFFF00
+
 	// RouteMarkToProxy is the default route mark to use to indicate
 	// datapath needs to send the packet to the proxy.
 	//

--- a/pkg/maps/authmap/auth_map.go
+++ b/pkg/maps/authmap/auth_map.go
@@ -35,6 +35,9 @@ type Map interface {
 	// IterateWithCallback iterates through all the keys/values of an auth map,
 	// passing each key/value pair to the cb callback.
 	IterateWithCallback(cb IterateCallback) error
+
+	// MaxEntries returns the maximum number of entries the auth map can hold.
+	MaxEntries() uint32
 }
 
 type authMap struct {
@@ -111,6 +114,10 @@ func (m *authMap) IterateWithCallback(cb IterateCallback) error {
 			cb(key, value)
 		},
 	)
+}
+
+func (m *authMap) MaxEntries() uint32 {
+	return m.bpfMap.MaxEntries()
 }
 
 // AuthKey implements the bpf.MapKey interface.

--- a/pkg/maps/authmap/fake/auth_map.go
+++ b/pkg/maps/authmap/fake/auth_map.go
@@ -47,3 +47,7 @@ func (f fakeAuthMap) IterateWithCallback(cb authmap.IterateCallback) error {
 	}
 	return nil
 }
+
+func (f fakeAuthMap) MaxEntries() uint32 {
+	return 1 << 8
+}


### PR DESCRIPTION
 * [ ] ~#27323 (@michaelasp)~
    * :warning: conflict with test files 
    * dropped this one as we might need https://github.com/cilium/cilium/pull/24677 (cc @joamaki, who is PR author and next week backporter)
 * [x] #28358 (@gandro)
 * [x] #28258 (@pchaigno)
 * [x] #28357 (@sayboras)
 * [x] #28380 (@aanm)
 * [x] #28392 (@giorio94)
 * [x] #28294 (@nxy7)
 * [ ] ~#28388 (@haiyuewa)~
 * [ ] #28403 (@raphink)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
for pr in 28358 28258 28357 28380 28392 28294 28403; do contrib/backporting/set-labels.py $pr done 1.14; done
```
or with
```
make add-labels BRANCH=v1.14 ISSUES=28358,28258,28357,28380,28392,28294,28403
```
