### PR TITLE
docs: remove annotations-based l7 visibility

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -328,6 +328,9 @@ Annotations:
   include these parameters.
 * ``enable-endpoint-routes`` now automatically sets ``enable-local-node-route``
   to false, as local node routes are redundant when per-endpoint routes are enabled.
+* L7 visibility using Pod annotations (``policy.cilium.io/proxy-visibility``) is
+  no longer supported. 
+  We recommend users to switch to L7 policies instead (see :ref:`proxy_visibility`).
 
 .. _upgrade_cilium_cli_helm_mode:
 

--- a/Documentation/security/network/proxy/index.rst
+++ b/Documentation/security/network/proxy/index.rst
@@ -4,6 +4,8 @@
     Please use the official rendered version released here:
     https://docs.cilium.io
 
+.. _proxy_injection:
+
 ***************
 Proxy Injection
 ***************

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -531,7 +531,7 @@ a single egress rule.
 .. note:: The DNS Proxy is provided in each Cilium agent.
    As a result, DNS requests targeted by policies depend on the availability
    of the Cilium agent pod.
-   This includes DNS policies as well as :ref:`proxy_visibility` annotations.
+   This includes DNS policies (:ref:`proxy_visibility`).
 
 ``toFQDNs`` egress rules cannot contain any other L3 rules, such as
 ``toEndpoints`` (under `Endpoints Based`_) and ``toCIDRs`` (under `CIDR Based`_).
@@ -827,11 +827,10 @@ latter rule will have no effect.
 .. note:: Layer 7 rules are not currently supported in `HostPolicies`, i.e.,
           policies that use :ref:`NodeSelector`.
 
-.. note:: Layer 7 policies --and pod annotations-- result in traffic being
-   proxied through an Envoy instance provided in each Cilium agent pod.
-   As a result, L7 traffic targeted by policies depend on the availability
-   of the Cilium agent pod.
-   This includes L7 policies as well as :ref:`proxy_visibility` annotations.
+.. note:: Layer 7 policies will proxy traffic through an Envoy instance provided 
+          in each Cilium agent pod. As a result, L7 traffic targeted by policies 
+          depend on the availability of the Cilium agent pod. This includes L7 
+          policies (:ref:`proxy_visibility`).
 
 HTTP
 ----

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -726,6 +726,7 @@ webhook
 webhooks
 webservice
 whitespace
+wildcarded
 workqueue
 www
 xDS


### PR DESCRIPTION
L7-based annotations have had little adoption and are causing a [lot of bugs](https://github.com/cilium/cilium/issues?q=is%3Aissue+proxy-visibility). This change is to move them to the background in the docs and bring forward the more standard way of enabling L7 visibility (CNP)