### PR TITLE
daemon: Skip Ingress Endpoint on BPF watchdog

### DIFF
--- a/daemon/cmd/watchdogs.go
+++ b/daemon/cmd/watchdogs.go
@@ -102,6 +102,10 @@ func (d *Daemon) checkEndpointBPFPrograms(ctx context.Context, p epBPFProgWatchd
 		if ep.GetState() != endpoint.StateReady {
 			continue
 		}
+		if !ep.HasBPFPolicyMap() {
+			// Skip Endpoints without BPF datapath
+			continue
+		}
 		loaded, err = loader.DeviceHasTCProgramLoaded(ep.HostInterface(), ep.RequireEgressProg())
 		if err != nil {
 			log.WithField(logfields.Endpoint, ep.HostInterface()).


### PR DESCRIPTION
Skip endpoints without BPF datapath (currently only the Ingress Endpoint) when checking for Endpoint's bpf programs in `checkEndpointBPFPrograms()`. This helps avoid errors like this:

level=error msg="Unable to assert if endpoint BPF programs need to be reloaded" endpoint= error="unable to find endpoint link by name: Link not found" subsys=daemon

Fixes: #28126
