### PR TITLE
labels/cidr: Memoize labels for already seen prefixes

### DIFF
--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
@@ -18,7 +19,7 @@ import (
 //
 // For IPv6 addresses, it converts ":" into "-" as EndpointSelectors don't
 // support colons inside the name section of a label.
-func maskedIPToLabelString(ip netip.Addr, prefix int) string {
+func maskedIPToLabel(ip netip.Addr, prefix int) labels.Label {
 	ipStr := ip.String()
 	ipNoColons := strings.Replace(ipStr, ":", "-", -1)
 
@@ -35,28 +36,24 @@ func maskedIPToLabelString(ip netip.Addr, prefix int) string {
 	}
 	var str strings.Builder
 	str.Grow(
-		len(labels.LabelSourceCIDR) +
-			len(preZero) +
+		len(preZero) +
 			len(ipNoColons) +
 			len(postZero) +
 			2 /*len of prefix*/ +
-			2, /* ':' '/' */
+			1, /* '/' */
 	)
-	str.WriteString(labels.LabelSourceCIDR)
-	str.WriteRune(':')
 	str.WriteString(preZero)
 	str.WriteString(ipNoColons)
 	str.WriteString(postZero)
 	str.WriteRune('/')
 	str.WriteString(strconv.Itoa(prefix))
-	return str.String()
+	return labels.Label{Key: str.String(), Source: labels.LabelSourceCIDR}
 }
 
 // IPStringToLabel parses a string and returns it as a CIDR label.
 //
 // If ip is not a valid IP address or CIDR Prefix, returns an error.
 func IPStringToLabel(ip string) (labels.Label, error) {
-	var lblString string
 	// factored out of netip.ParsePrefix to avoid allocating an empty netip.Prefix in case it's
 	// an IP and not a CIDR.
 	i := strings.LastIndexByte(ip, '/')
@@ -65,15 +62,14 @@ func IPStringToLabel(ip string) (labels.Label, error) {
 		if err != nil {
 			return labels.Label{}, fmt.Errorf("%q is not an IP address: %w", ip, err)
 		}
-		lblString = maskedIPToLabelString(parsedIP, parsedIP.BitLen())
+		return maskedIPToLabel(parsedIP, parsedIP.BitLen()), nil
 	} else {
 		parsedPrefix, err := netip.ParsePrefix(ip)
 		if err != nil {
 			return labels.Label{}, fmt.Errorf("%q is not a CIDR: %w", ip, err)
 		}
-		lblString = maskedIPToLabelString(parsedPrefix.Masked().Addr(), parsedPrefix.Bits())
+		return maskedIPToLabel(parsedPrefix.Masked().Addr(), parsedPrefix.Bits()), nil
 	}
-	return labels.ParseLabel(lblString), nil
 }
 
 // GetCIDRLabels turns a CIDR into a set of labels representing the cidr itself
@@ -86,31 +82,93 @@ func IPStringToLabel(ip string) (labels.Label, error) {
 //
 // The identity reserved:world is always added as it includes any CIDR.
 func GetCIDRLabels(prefix netip.Prefix) labels.Labels {
+	addr := prefix.Addr()
 	ones := prefix.Bits()
-	result := make([]string, 0, ones+2)
+	lbls := make(labels.Labels, 1 /* this CIDR */ +ones /* the prefixes */ +1 /*world label*/)
 
 	// If ones is zero, then it's the default CIDR prefix /0 which should
 	// just be regarded as reserved:world. In all other cases, we need
 	// to generate the set of prefixes starting from the /0 up to the
 	// specified prefix length.
-	if ones > 0 {
-		ip := prefix.Addr()
-		for i := 0; i <= ones; i++ {
-			p := netip.PrefixFrom(ip, i)
-			label := maskedIPToLabelString(p.Masked().Addr(), i)
-			result = append(result, label)
-		}
+	if ones == 0 {
+		addWorldLabel(addr, lbls)
+		return lbls
 	}
 
-	if option.Config.IsDualStack() {
-		if prefix.Addr().Is4() {
-			result = append(result, labels.LabelSourceReserved+":"+labels.IDNameWorldIPv4)
+	cache := cidrLabelsCache.Get().(map[netip.Prefix][]labels.Label)
+	computeCIDRLabels(
+		cache,
+		lbls,
+		nil, // avoid allocating space for the intermediate results until we need it
+		addr,
+		ones,
+		0,
+	)
+	cidrLabelsCache.Put(cache)
+	addWorldLabel(addr, lbls)
+
+	return lbls
+}
+
+// cidrLabelsCache stores the partial computations for CIDR labels.
+// This both avoids repeatedly computing the prefixes and makes sure the
+// CIDR strings are reused to reduce memory usage.
+// Stored in a sync.Pool to allow GC to garbage collect the cache if needed.
+// With lots of contention, multiple cache maps might exist.
+//
+// Stores e.g. for prefix "10.0.0.0/8" the labels ["10.0.0.0/8", ..., "0.0.0.0/0"].
+var cidrLabelsCache = sync.Pool{
+	New: func() any { return make(map[netip.Prefix][]labels.Label) },
+}
+
+func addWorldLabel(addr netip.Addr, lbls labels.Labels) {
+	switch {
+	case !option.Config.IsDualStack():
+		lbls[worldLabelNonDualStack.Key] = worldLabelNonDualStack
+	case addr.Is4():
+		lbls[worldLabelV4.Key] = worldLabelV4
+	default:
+		lbls[worldLabelV6.Key] = worldLabelV6
+	}
+}
+
+var (
+	worldLabelNonDualStack = labels.Label{Key: labels.IDNameWorld, Source: labels.LabelSourceReserved}
+	worldLabelV4           = labels.Label{Source: labels.LabelSourceReserved, Key: labels.IDNameWorldIPv4}
+	worldLabelV6           = labels.Label{Source: labels.LabelSourceReserved, Key: labels.IDNameWorldIPv6}
+)
+
+func computeCIDRLabels(cache map[netip.Prefix][]labels.Label, lbls labels.Labels, results []labels.Label, addr netip.Addr, ones, i int) []labels.Label {
+	if i > ones {
+		return results
+	}
+
+	prefix := netip.PrefixFrom(addr, i)
+
+	if cachedLbls, ok := cache[prefix]; ok {
+		for _, lbl := range cachedLbls {
+			lbls[lbl.Key] = lbl
+		}
+		if results == nil {
+			return cachedLbls
 		} else {
-			result = append(result, labels.LabelSourceReserved+":"+labels.IDNameWorldIPv6)
+			return append(results, cachedLbls...)
 		}
-	} else {
-		result = append(result, labels.LabelSourceReserved+":"+labels.IDNameWorld)
 	}
 
-	return labels.NewLabelsFromModel(result)
+	// Compute the label for this prefix (e.g. "cidr:10.0.0.0/8")
+	prefixLabel := maskedIPToLabel(prefix.Masked().Addr(), i)
+	lbls[prefixLabel.Key] = prefixLabel
+
+	// Keep computing the rest (e.g. "cidr:10.0.0.0/7", ...).
+	results = computeCIDRLabels(
+		cache,
+		lbls,
+		append(results, prefixLabel),
+		addr, ones, i+1,
+	)
+	// Cache the resulting labels derived from this prefix, e.g. /8, /7, ...
+	cache[prefix] = results[i:]
+
+	return results
 }

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -4,8 +4,11 @@
 package cidr
 
 import (
+	"math/rand"
 	"net/netip"
 	"runtime"
+	"strconv"
+	"sync"
 	"testing"
 
 	. "github.com/cilium/checkmate"
@@ -314,6 +317,43 @@ func BenchmarkLabels_SortedListCIDRIDs(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = lbls.SortedList()
+	}
+}
+
+func BenchmarkGetCIDRLabelsConcurrent(b *testing.B) {
+	prefixes := make([]netip.Prefix, 0, 16)
+	octets := [4]byte{0, 0, 1, 1}
+	for i := 0; i < 16; i++ {
+		octets[0], octets[1] = byte(rand.Intn(256)), byte(rand.Intn(256))
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom4(octets), 32))
+	}
+
+	for _, goroutines := range []int{1, 2, 4, 16, 32, 48} {
+		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				start := make(chan struct{})
+				var wg sync.WaitGroup
+
+				wg.Add(goroutines)
+				for j := 0; j < goroutines; j++ {
+					go func() {
+						defer wg.Done()
+
+						<-start
+
+						for k := 0; k < 64; k++ {
+							_ = GetCIDRLabels(prefixes[rand.Intn(len(prefixes))])
+						}
+					}()
+				}
+
+				b.StartTimer()
+				close(start)
+				wg.Wait()
+			}
+		})
 	}
 }
 

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -5,6 +5,7 @@ package cidr
 
 import (
 	"net/netip"
+	"runtime"
 	"testing"
 
 	. "github.com/cilium/checkmate"
@@ -314,6 +315,87 @@ func BenchmarkLabels_SortedListCIDRIDs(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = lbls.SortedList()
 	}
+}
+
+// BenchmarkCIDRLabelsCacheHeapUsageIPv4 should be run with -benchtime=1x
+func BenchmarkCIDRLabelsCacheHeapUsageIPv4(b *testing.B) {
+	b.Skip()
+
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+
+	// be sure to fill the cache
+	prefixes := make([]netip.Prefix, 0, 256*256)
+	octets := [4]byte{0, 0, 1, 1}
+	for i := 0; i < 256*256; i++ {
+		octets[0], octets[1] = byte(i/256), byte(i%256)
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom4(octets), 32))
+	}
+
+	var m1, m2 runtime.MemStats
+	// One GC does not give precise results,
+	// because concurrent sweep may be still in progress.
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, cidr := range prefixes {
+			_ = GetCIDRLabels(cidr)
+		}
+	}
+	b.StopTimer()
+
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+
+	usage := m2.HeapAlloc - m1.HeapAlloc
+	b.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
+}
+
+// BenchmarkCIDRLabelsCacheHeapUsageIPv6 should be run with -benchtime=1x
+func BenchmarkCIDRLabelsCacheHeapUsageIPv6(b *testing.B) {
+	b.Skip()
+
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+
+	// be sure to fill the cache
+	prefixes := make([]netip.Prefix, 0, 256*256)
+	octets := [16]byte{
+		0x00, 0x00, 0x00, 0xd8, 0x33, 0x33, 0x44, 0x44,
+		0x55, 0x55, 0x66, 0x66, 0x77, 0x77, 0x88, 0x88,
+	}
+	for i := 0; i < 256*256; i++ {
+		octets[15], octets[14] = byte(i/256), byte(i%256)
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom16(octets), 128))
+	}
+
+	var m1, m2 runtime.MemStats
+	// One GC does not give precise results,
+	// because concurrent sweep may be still in progress.
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, cidr := range prefixes {
+			_ = GetCIDRLabels(cidr)
+		}
+	}
+	b.StopTimer()
+
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+
+	usage := m2.HeapAlloc - m1.HeapAlloc
+	b.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
 }
 
 func BenchmarkIPStringToLabel(b *testing.B) {

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/cilium/checkmate"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
@@ -276,6 +277,9 @@ func (s *CIDRLabelsSuite) TestIPStringToLabel(c *C) {
 }
 
 func BenchmarkGetCIDRLabels(b *testing.B) {
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+
 	for _, cidr := range []netip.Prefix{
 		netip.MustParsePrefix("0.0.0.0/0"),
 		netip.MustParsePrefix("10.16.0.0/16"),
@@ -300,6 +304,9 @@ func BenchmarkGetCIDRLabels(b *testing.B) {
 // without causing an import cycle. We want to benchmark this specific case, as
 // it is excercised by toFQDN policies.
 func BenchmarkLabels_SortedListCIDRIDs(b *testing.B) {
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+
 	lbls := GetCIDRLabels(netip.MustParsePrefix("123.123.123.123/32"))
 
 	b.ReportAllocs()

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -409,6 +409,15 @@ func NewLabelsFromModel(base []string) Labels {
 	return lbls
 }
 
+// FromSlice creates labels from a slice of labels.
+func FromSlice(labels []Label) Labels {
+	lbls := make(Labels, len(labels))
+	for _, lbl := range labels {
+		lbls[lbl.Key] = lbl
+	}
+	return lbls
+}
+
 // NewLabelsFromSortedList returns labels based on the output of SortedList()
 func NewLabelsFromSortedList(list string) Labels {
 	return NewLabelsFromModel(strings.Split(list, ";"))


### PR DESCRIPTION
GetCIDRLabels turns a CIDR into a set of labels representing the cidr itself and all broader CIDRS which include the specified CIDR in them.

In case of ToFQDNs policies matching many names that maps to many IPs with very short TTLs, this function can easily become a hot path.

To improve performance, the PR adds a LRU cache to memoize intermediate results.

See individual commit messages for further details.