### PR TITLE
bpf: overlay: fix missing DBG_DECAP for Inter-Cluster-SNAT

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -79,11 +79,15 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 			*identity = info->sec_identity;
 			key.tunnel_id = get_tunnel_id(info->sec_identity);
 		}
+
+		cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, 0);
 	} else {
 		key_size = TUNNEL_KEY_WITHOUT_SRC_IP;
 		if (unlikely(ctx_get_tunnel_key(ctx, &key, key_size, 0) < 0))
 			return DROP_NO_TUNNEL_KEY;
 		*identity = get_id_from_tunnel_id(key.tunnel_id, ctx_get_protocol(ctx));
+
+		cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
 
 		/* Any node encapsulating will map any HOST_ID source to be
 		 * presented as REMOTE_NODE_ID, therefore any attempt to signal
@@ -99,8 +103,6 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 		if (info && identity_is_remote_node(*identity))
 			*identity = info->sec_identity;
 	}
-
-	cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
 
 #ifdef ENABLE_IPSEC
 	if (!decrypted) {
@@ -316,6 +318,8 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 			*identity = info->sec_identity;
 			key.tunnel_id = get_tunnel_id(info->sec_identity);
 		}
+
+		cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, 0);
 	} else {
 #ifdef ENABLE_HIGH_SCALE_IPCACHE
 		key.tunnel_id = get_tunnel_id(*identity);
@@ -325,6 +329,8 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 			return DROP_NO_TUNNEL_KEY;
 		*identity = get_id_from_tunnel_id(key.tunnel_id, ctx_get_protocol(ctx));
 #endif /* ENABLE_HIGH_SCALE_IPCACHE */
+
+		cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
 
 		if (*identity == HOST_ID)
 			return DROP_INVALID_IDENTITY;
@@ -369,8 +375,6 @@ skip_vtep:
 		if (info && identity_is_remote_node(*identity))
 			*identity = info->sec_identity;
 	}
-
-	cilium_dbg(ctx, DBG_DECAP, key.tunnel_id, key.tunnel_label);
 
 #ifdef ENABLE_IPSEC
 	if (!decrypted) {


### PR DESCRIPTION
For Inter-Cluster-SNAT traffic we tail-call in handle_ipv4() before even reaching the DBG_DECAP message.

Pull up the cilium_dbg() call a bit so that it also applies to inter-cluster-SNAT traffic. While at it also clarify which parameters are relevant for the path that handles decrypted packets.