### PR TITLE
ENI: fix calculateExcessIPs excessive calculate of excess ip

### DIFF
--- a/pkg/aws/eni/node_manager_test.go
+++ b/pkg/aws/eni/node_manager_test.go
@@ -437,7 +437,7 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(node.Stats().UsedIPs, check.Equals, 10)
 
 	// Trigger resync manually, excess IPs should be released
-	// 10 used + 3 pre-allocate + 2 max-above-watermark => 15
+	// 10 used + 2 pre-allocate + 3 max-above-watermark => 15
 	node = mngr.Get("node3")
 	eniNode, castOK := node.Ops().(*Node)
 	c.Assert(castOK, check.Equals, true)
@@ -470,7 +470,7 @@ func (e *ENISuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node3")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 15)
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 13)
 	c.Assert(node.Stats().UsedIPs, check.Equals, 10)
 }
 

--- a/pkg/ipam/node.go
+++ b/pkg/ipam/node.go
@@ -335,6 +335,12 @@ func calculateExcessIPs(availableIPs, usedIPs, preAllocate, minAllocate, maxAbov
 		if availableIPs <= (minAllocate + maxAboveWatermark) {
 			return 0
 		}
+
+		// if usedIPs+preAllocate not over minAllocate + maxAboveWatermark, only care
+		// the ips out of minAllocate + maxAboveWatermark
+		if (usedIPs + preAllocate) <= (minAllocate + maxAboveWatermark) {
+			return availableIPs - minAllocate - maxAboveWatermark
+		}
 	}
 
 	// Once above the minimum allocation level, calculate based on

--- a/pkg/ipam/node_manager_test.go
+++ b/pkg/ipam/node_manager_test.go
@@ -502,7 +502,7 @@ func (e *IPAMSuite) TestNodeManagerReleaseAddress(c *check.C) {
 	c.Assert(testutils.WaitUntil(func() bool { return reachedAddressesNeeded(mngr, "node3", 0) }, 5*time.Second), check.IsNil)
 	node = mngr.Get("node3")
 	c.Assert(node, check.Not(check.IsNil))
-	c.Assert(node.Stats().AvailableIPs, check.Equals, 18)
+	c.Assert(node.Stats().AvailableIPs, check.Equals, 19)
 	c.Assert(node.Stats().UsedIPs, check.Equals, 10)
 }
 

--- a/pkg/ipam/node_test.go
+++ b/pkg/ipam/node_test.go
@@ -39,7 +39,7 @@ var neededDef = []testNeededDef{
 var excessDef = []testExcessDef{
 	{0, 0, 0, 16, 0, 0},
 	{15, 0, 8, 16, 8, 0},
-	{17, 0, 8, 16, 0, 9}, // 17 used, 8 pre-allocate, 16 min-allocate => 1 excess
+	{17, 0, 8, 16, 0, 1}, // 17 used, 8 pre-allocate, 16 min-allocate => 1 excess
 	{20, 0, 8, 16, 4, 0}, // 20 used, 8 pre-allocate, 16 min-allocate, 4 max-above-watermark => 0 excess
 	{21, 0, 8, 0, 4, 9},  // 21 used, 8 pre-allocate, 4 max-above-watermark => 9 excess
 	{20, 0, 8, 20, 8, 0},


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->
If usedIPs+preAllocate not over minAllocate + maxAboveWatermark and availableIPs over minAllocate + maxAboveWatermark, only care  IPs out of minAllocate + maxAboveWatermark calculateExcessIPs.

Fixes: #27970

```release-note
ENI: fix calculateExcessIPs excessive calculate of excess ip
```
