### PR TITLE
[DRAFT] Improve efficiency of applying policy map changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -393,6 +393,7 @@ Makefile* @cilium/build
 /pkg/bpf/ @cilium/loader
 /pkg/byteorder/ @cilium/sig-datapath @cilium/api
 /pkg/cgroups/ @cilium/sig-datapath
+/pkg/channels/ @cilium/sig-foundations
 /pkg/checker/ @cilium/ci-structure
 /pkg/cleanup/ @cilium/sig-agent
 /pkg/client @cilium/api

--- a/pkg/channels/doc.go
+++ b/pkg/channels/doc.go
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+/*
+Package channels provides common utilities related to channels.
+*/
+package channels

--- a/pkg/channels/done.go
+++ b/pkg/channels/done.go
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package channels
+
+type DoneChan = <-chan struct{}
+
+var ClosedDoneChan DoneChan
+
+func init() {
+	ch := make(chan struct{})
+	close(ch)
+	ClosedDoneChan = ch
+}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -227,6 +227,11 @@ type Endpoint struct {
 	// PolicyMapPressureUpdater updates the policymap pressure metric.
 	PolicyMapPressureUpdater policyMapPressureUpdater
 
+	// policyMapLastFullReconciliation is the timestamp of the last full
+	// policy map reconciliation, e.g. full comparison of the desired
+	// policy map state against the BPF map state.
+	policyMapLastFullReconciliation time.Time
+
 	// Options determine the datapath configuration of the endpoint.
 	Options *option.IntOptions
 

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -531,10 +531,9 @@ func (e *Endpoint) updateRealizedState(stats *regenerationStatistics, origDir st
 		return fmt.Errorf("error synchronizing endpoint BPF program directories: %s", err)
 	}
 
-	// Start periodic background full reconciliation of the policy map.
-	// Does nothing if it has already been started.
+	// Trigger reconciliation of the policy map.
 	if !option.Config.DryMode {
-		e.startSyncPolicyMapController()
+		e.updateSyncPolicyMapController()
 	}
 
 	if e.desiredPolicy != e.realizedPolicy {

--- a/pkg/endpointmanager/cell.go
+++ b/pkg/endpointmanager/cell.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/hive"
@@ -136,11 +137,11 @@ type EndpointManager interface {
 	// Unsubscribe from endpoint events.
 	Unsubscribe(s Subscriber)
 
-	// UpdatePolicyMaps returns a WaitGroup which is signaled upon once all endpoints
+	// UpdatePolicyMaps returns a channel which is closed once all endpoints
 	// have had their PolicyMaps updated against the Endpoint's desired policy state.
 	//
-	// Endpoints will wait on the 'notifyWg' parameter before updating policy maps.
-	UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) *sync.WaitGroup
+	// Will wait on the 'notifyWg' parameter before updating policy maps.
+	UpdatePolicyMaps(ctx context.Context, notifyWg *sync.WaitGroup) channels.DoneChan
 
 	// RegenerateAllEndpoints calls a setState for each endpoint and
 	// regenerates if state transaction is valid. During this process, the endpoint

--- a/pkg/fqdn/config.go
+++ b/pkg/fqdn/config.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"net"
 	"net/netip"
-	"sync"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/api"
 )
@@ -25,5 +25,5 @@ type Config struct {
 
 	// UpdateSelectors is a callback to update the mapping of FQDNSelector to
 	// sets of IPs.
-	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[netip.Prefix]*identity.Identity, error)
+	UpdateSelectors func(ctx context.Context, selectorsWithIPs map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (channels.DoneChan, []*identity.Identity, map[netip.Prefix]*identity.Identity, error)
 }

--- a/pkg/fqdn/name_manager_test.go
+++ b/pkg/fqdn/name_manager_test.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"net"
 	"net/netip"
-	"sync"
 	"time"
 
 	. "github.com/cilium/checkmate"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/fqdn/dns"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/policy/api"
@@ -30,11 +30,11 @@ func (ds *FQDNTestSuite) TestNameManagerCIDRGeneration(c *C) {
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[netip.Prefix]*identity.Identity, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (channels.DoneChan, []*identity.Identity, map[netip.Prefix]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}, nil, nil, nil
+				return channels.ClosedDoneChan, nil, nil, nil
 			},
 		})
 	)
@@ -76,11 +76,11 @@ func (ds *FQDNTestSuite) TestNameManagerMultiIPUpdate(c *C) {
 			MinTTL: 1,
 			Cache:  NewDNSCache(0),
 
-			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (*sync.WaitGroup, []*identity.Identity, map[netip.Prefix]*identity.Identity, error) {
+			UpdateSelectors: func(ctx context.Context, selectorIPMapping map[api.FQDNSelector][]net.IP, selectorsWithoutIPs []api.FQDNSelector) (<-chan struct{}, []*identity.Identity, map[netip.Prefix]*identity.Identity, error) {
 				for k, v := range selectorIPMapping {
 					selIPMap[k] = v
 				}
-				return &sync.WaitGroup{}, nil, nil, nil
+				return channels.ClosedDoneChan, nil, nil, nil
 			},
 		})
 	)

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -429,8 +429,7 @@ func (ipc *IPCache) UpdatePolicyMaps(ctx context.Context, addedIdentities, delet
 	if addedIdentities != nil {
 		ipc.PolicyHandler.UpdateIdentities(addedIdentities, nil, &wg)
 	}
-	policyImplementedWG := ipc.DatapathHandler.UpdatePolicyMaps(ctx, &wg)
-	policyImplementedWG.Wait()
+	<-ipc.DatapathHandler.UpdatePolicyMaps(ctx, &wg)
 }
 
 // resolveIdentity will either return a previously-allocated identity for the

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/ipcache/types"
@@ -729,6 +730,6 @@ func (m *mockUpdater) UpdateIdentities(added, deleted cache.IdentityCache, _ *sy
 
 type mockTriggerer struct{}
 
-func (m *mockTriggerer) UpdatePolicyMaps(ctx context.Context, wg *sync.WaitGroup) *sync.WaitGroup {
-	return wg
+func (m *mockTriggerer) UpdatePolicyMaps(ctx context.Context, wg *sync.WaitGroup) channels.DoneChan {
+	return channels.ClosedDoneChan
 }

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cilium/cilium/pkg/channels"
 	"github.com/cilium/cilium/pkg/identity/cache"
 )
 
@@ -28,7 +29,7 @@ type PolicyHandler interface {
 // Wait on the returned sync.WaitGroup to ensure that the operation is complete
 // before updating the datapath's IPCache maps.
 type DatapathHandler interface {
-	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
+	UpdatePolicyMaps(context.Context, *sync.WaitGroup) channels.DoneChan
 }
 
 // ResourceID identifies a unique copy of a resource that provides a source for

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -133,7 +133,6 @@ type endpointManager interface {
 	GetHostEndpoint() *endpoint.Endpoint
 	GetEndpointsByPodName(string) []*endpoint.Endpoint
 	WaitForEndpointsAtPolicyRev(ctx context.Context, rev uint64) error
-	UpdatePolicyMaps(context.Context, *sync.WaitGroup) *sync.WaitGroup
 }
 
 type nodeDiscoverManager interface {


### PR DESCRIPTION
This moves the incremental policy map change applying into the "sync-policy-map" controller instead of performing the applying of the changes directly. `EndpointManager.UpdatePolicyMaps` is refactored to trigger the controller of each endpoint and then to wait for reconciliation to finish. Semantics with regards to when e.g. `UpdatePolicyMaps` returns are unchanged, e.g. a failed reconciliation attempt does not block. Compared to prior a failed incremental policy map update is now retried by the controller.

This will reduce the amount of overhead in processing of ToFQDN policies in relation to a DNS request/response. Prior to this each DNS response would have triggered call to `EndpointManager.UpdatePolicyMaps` which in turn spawned a goroutine per endpoint to apply the changes. With high rate of DNS requests this may lead to lots of endpoint lock contention and context switching overhead due to queueing of calls to `ApplyPolicyMaps` that are unnecessary since a prior call likely had already applied the pending changes.