### PR TITLE
v1.14: avoid relying on golang.org/exp/slices.SortFunc

### DIFF
--- a/pkg/hive/cell/health.go
+++ b/pkg/hive/cell/health.go
@@ -6,13 +6,13 @@ package cell
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync/atomic"
 	"time"
 
 	"github.com/cilium/cilium/pkg/lock"
 
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 // Level denotes what kind an update is.
@@ -191,8 +191,8 @@ func (p *healthProvider) All() []Status {
 	p.mu.RLock()
 	all := maps.Values(p.moduleStatuses)
 	p.mu.RUnlock()
-	slices.SortFunc(all, func(a, b Status) bool {
-		return a.ModuleID < b.ModuleID
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].ModuleID < all[j].ModuleID
 	})
 	return all
 }

--- a/pkg/hubble/observer/namespace_manager.go
+++ b/pkg/hubble/observer/namespace_manager.go
@@ -5,9 +5,8 @@ package observer
 
 import (
 	"context"
+	"sort"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
 	"github.com/cilium/cilium/pkg/lock"
@@ -76,7 +75,9 @@ func (m *namespaceManager) GetNamespaces() []*observerpb.Namespace {
 	}
 	m.mu.RUnlock()
 
-	slices.SortFunc(namespaces, func(a, b *observerpb.Namespace) bool {
+	sort.Slice(namespaces, func(i, j int) bool {
+		a := namespaces[i]
+		b := namespaces[j]
 		if a.Cluster != b.Cluster {
 			return a.Cluster < b.Cluster
 		}

--- a/pkg/ipcache/types.go
+++ b/pkg/ipcache/types.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
 	"github.com/cilium/cilium/pkg/labels"
@@ -137,7 +136,9 @@ func (s PrefixInfo) isValid() bool {
 
 func (s PrefixInfo) sortedBySourceThenResourceID() []ipcachetypes.ResourceID {
 	resourceIDs := maps.Keys(s)
-	slices.SortFunc(resourceIDs, func(a, b ipcachetypes.ResourceID) bool {
+	sort.Slice(resourceIDs, func(i, j int) bool {
+		a := resourceIDs[i]
+		b := resourceIDs[j]
 		if s[a].source != s[b].source {
 			return !source.AllowOverwrite(s[a].source, s[b].source)
 		}


### PR DESCRIPTION
The signature of `slices.SortFunc` has changed recently, breaking builds for projects that vendor Cilium 1.14 and a newer version of `golang.org/x/exp` with the signature change.

Due to the way dependencies work, it's unfortunately not always possible to downgrade `golang.org/x/exp` to a previous version.

The patch is based on the patch that has been applied to the main branch to allow upgrading `golang.org/x/exp` but without actually bumping the dependency.

ref: 036f1dc0eeefc407492c8230831a90156ecb9b6b
