### PR TITLE
clustermesh-apiserver: extract external workloads in a separate cell

### DIFF
--- a/clustermesh-apiserver/k8s/resources.go
+++ b/clustermesh-apiserver/k8s/resources.go
@@ -29,6 +29,7 @@ var (
 			k8s.CiliumNodeResource,
 			k8s.CiliumIdentityResource,
 			k8s.CiliumSlimEndpointResource,
+			k8s.CiliumExternalWorkloads,
 		),
 	)
 )

--- a/pkg/k8s/resource_ctors.go
+++ b/pkg/k8s/resource_ctors.go
@@ -299,3 +299,14 @@ func CiliumSlimEndpointResource(lc hive.Lifecycle, cs client.Clientset, opts ...
 		}, TransformToCiliumEndpoint),
 	), nil
 }
+
+func CiliumExternalWorkloads(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*cilium_api_v2.CiliumExternalWorkload], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*cilium_api_v2.CiliumExternalWorkloadList](cs.CiliumV2().CiliumExternalWorkloads()),
+		opts...,
+	)
+	return resource.New[*cilium_api_v2.CiliumExternalWorkload](lc, lw, resource.WithMetric("CiliumExternalWorkloads")), nil
+}


### PR DESCRIPTION
Refactor the initialization of the external workloads logic into a separate cell. A few of the existing parameters are dropped, as they were never explicitly configured, and more in detail:

* --identity-allocation-mode: the clustermesh-apiserver is expected to be used only when Cilium is configured in CRD mode, while kvstore mode is not supported; the same also applies to the current implementation of external workloads;
* --allocator-list-timeout: it has been hard-coded to the default value for the sake of simplicity;
* --enable-well-known-identities: not applicable to the external workloads from the clustermesh-apiserver perspective, and thus not necessary.

For https://github.com/cilium/cilium/pull/27888.
