### PR TITLE
helm: don't expose kvstoremesh metrics if not enabled

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/metrics-service.yaml
@@ -1,6 +1,7 @@
+{{- $kvstoreMetricsEnabled := and .Values.clustermesh.apiserver.kvstoremesh.enabled .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled -}}
 {{- if and
   (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer)
-  (or .Values.clustermesh.apiserver.metrics.enabled .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled .Values.clustermesh.apiserver.metrics.etcd.enabled) }}
+  (or .Values.clustermesh.apiserver.metrics.enabled $kvstoreMetricsEnabled .Values.clustermesh.apiserver.metrics.etcd.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,7 +26,7 @@ spec:
     protocol: TCP
     targetPort: apiserv-metrics
   {{- end }}
-  {{- if .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled }}
+  {{- if $kvstoreMetricsEnabled }}
   - name: kvmesh-metrics
     port: {{ .Values.clustermesh.apiserver.metrics.kvstoremesh.port }}
     protocol: TCP

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/servicemonitor.yaml
@@ -1,6 +1,7 @@
+{{- $kvstoreMetricsEnabled := and .Values.clustermesh.apiserver.kvstoremesh.enabled .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled -}}
 {{- if and
   (or .Values.externalWorkloads.enabled .Values.clustermesh.useAPIServer)
-  (or .Values.clustermesh.apiserver.metrics.enabled .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled .Values.clustermesh.apiserver.metrics.etcd.enabled)
+  (or .Values.clustermesh.apiserver.metrics.enabled $kvstoreMetricsEnabled .Values.clustermesh.apiserver.metrics.etcd.enabled)
   .Values.clustermesh.apiserver.metrics.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -45,7 +46,7 @@ spec:
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
-  {{- if .Values.clustermesh.apiserver.metrics.kvstoremesh.enabled }}
+  {{- if $kvstoreMetricsEnabled }}
   - port: kvmesh-metrics
     interval: {{ .Values.clustermesh.apiserver.metrics.serviceMonitor.kvstoremesh.interval | quote }}
     honorLabels: true


### PR DESCRIPTION
Currently, the kvstoremesh metrics entry inside the dedicated Service and ServiceMonitor is always inserted if the corresponding setting is enabled (true by default), regardless of whether kvstoremesh is actually enabled or not. Yet, this would create problems when Prometheus attempts to scrape it, as the target port would be closed. Hence, let's update the helm chart so that these entries are inserted only if kvstoremesh is enabled.

<!-- Description of change -->

Fixes: #issue-number

```release-note
Fix issue causing KVStoreMesh metrics to be included in the dedicated Service/ServiceMonitor when KVStoreMesh is disabled 
```
