### PR TITLE
bgpv1,ci: Add Test_AdvertisedPathAttributes into BGP component tests

### DIFF
--- a/pkg/bgpv1/test/fixtures.go
+++ b/pkg/bgpv1/test/fixtures.go
@@ -141,6 +141,9 @@ func newFixture(conf fixtureConfig) *fixture {
 		// endpoints
 		cell.Provide(k8sPkg.EndpointsResource),
 
+		// CiliumLoadBalancerIPPool
+		cell.Provide(k8sPkg.LBIPPoolsResource),
+
 		// cilium node
 		cell.Provide(func(lc hive.Lifecycle, c k8sClient.Clientset) daemon_k8s.LocalCiliumNodeResource {
 			store := resource.New[*cilium_api_v2.CiliumNode](
@@ -192,14 +195,14 @@ func newFixture(conf fixtureConfig) *fixture {
 	return f
 }
 
-func setupSingleNeighbor(ctx context.Context, f *fixture) error {
+func setupSingleNeighbor(ctx context.Context, f *fixture, peerASN uint32) error {
 	f.config.policy.Spec.VirtualRouters[0] = cilium_api_v2alpha1.CiliumBGPVirtualRouter{
 		LocalASN:      int64(ciliumASN),
 		ExportPodCIDR: pointer.Bool(true),
 		Neighbors: []cilium_api_v2alpha1.CiliumBGPNeighbor{
 			{
 				PeerAddress: dummies[instance1Link].ipv4.String(),
-				PeerASN:     int64(gobgpASN),
+				PeerASN:     int64(peerASN),
 			},
 		},
 	}

--- a/pkg/bgpv1/test/gobgp.go
+++ b/pkg/bgpv1/test/gobgp.go
@@ -11,6 +11,7 @@ import (
 
 	gobgpapi "github.com/osrg/gobgp/v3/api"
 	"github.com/osrg/gobgp/v3/pkg/apiutil"
+	"github.com/osrg/gobgp/v3/pkg/packet/bgp"
 	gobgpb "github.com/osrg/gobgp/v3/pkg/packet/bgp"
 	"github.com/osrg/gobgp/v3/pkg/server"
 )
@@ -31,6 +32,11 @@ var (
 		Asn:        gobgpASN2,
 		RouterId:   dummies[instance1Link].ipv4.Addr().String(),
 		ListenPort: gobgpListenPort2,
+	}
+	gobgpGlobalIBGP = &gobgpapi.Global{
+		Asn:        ciliumASN, // iBGP
+		RouterId:   dummies[instance1Link].ipv4.Addr().String(),
+		ListenPort: gobgpListenPort,
 	}
 
 	gbgpNeighConf = &gobgpapi.Peer{
@@ -125,6 +131,12 @@ var (
 			gbgpNeighConfPassword,
 		},
 	}
+	gobgpConfIBGP = gobgpConfig{
+		global: gobgpGlobalIBGP,
+		neighbors: []*gobgpapi.Peer{
+			gbgpNeighConf,
+		},
+	}
 )
 
 // gobgpConfig used for starting gobgp instance
@@ -135,10 +147,11 @@ type gobgpConfig struct {
 
 // routeEvent contains information about new event in routing table of gobgp
 type routeEvent struct {
-	sourceASN   uint32
-	prefix      string
-	prefixLen   uint8
-	isWithdrawn bool
+	sourceASN           uint32
+	prefix              string
+	prefixLen           uint8
+	isWithdrawn         bool
+	extraPathAttributes []bgp.PathAttributeInterface // non-standard path attributes (other than Origin / ASPath / NextHop / MpReachNLRI)
 }
 
 // peerEvent contains information about peer state change of gobgp
@@ -164,7 +177,7 @@ func startGoBGP(ctx context.Context, conf gobgpConfig) (g *goBGP, err error) {
 	g = &goBGP{
 		context: ctx,
 		server: server.NewBgpServer(server.LoggerOption(gobgp.NewServerLogger(log, gobgp.LogParams{
-			AS:        gobgpASN,
+			AS:        conf.global.Asn,
 			Component: "tests.BGP",
 			SubSys:    "basic",
 		}))),
@@ -262,12 +275,19 @@ func (g *goBGP) readEvents() {
 					continue
 				}
 
+				pattrs, err := apiutil.UnmarshalPathAttributes(p.Pattrs)
+				if err != nil {
+					log.Errorf("failed to unmarshal path attributes %v: %v", p, err)
+					continue
+				}
+
 				select {
 				case g.routeNotif <- routeEvent{
-					sourceASN:   p.SourceAsn,
-					prefix:      prefix,
-					prefixLen:   length,
-					isWithdrawn: p.IsWithdraw,
+					sourceASN:           p.SourceAsn,
+					prefix:              prefix,
+					prefixLen:           length,
+					isWithdrawn:         p.IsWithdraw,
+					extraPathAttributes: g.filterStandardPathAttributes(pattrs),
 				}:
 				case <-g.context.Done():
 					return
@@ -326,4 +346,24 @@ func (g *goBGP) getRouteEvents(ctx context.Context, numExpectedEvents int) ([]ro
 	}
 
 	return receivedEvents, nil
+}
+
+// filterStandardPathAttributes filters standard path attributes (usually present on all routes) from the
+// provided list of the path attributes.
+func (g *goBGP) filterStandardPathAttributes(attrs []bgp.PathAttributeInterface) []bgp.PathAttributeInterface {
+	var res []bgp.PathAttributeInterface
+	for _, a := range attrs {
+		switch a.(type) {
+		case *bgp.PathAttributeOrigin:
+			continue
+		case *bgp.PathAttributeAsPath:
+			continue
+		case *bgp.PathAttributeNextHop:
+			continue
+		case *bgp.PathAttributeMpReachNLRI:
+			continue
+		}
+		res = append(res, a)
+	}
+	return res
 }

--- a/pkg/bgpv1/test/objects.go
+++ b/pkg/bgpv1/test/objects.go
@@ -76,6 +76,32 @@ func newLBServiceObj(conf lbSrvConfig) slim_core_v1.Service {
 	return srvObj
 }
 
+// lbSrvConfig contains lb service configuration data
+type lbPoolConfig struct {
+	name   string
+	labels map[string]string
+	cidrs  []string
+}
+
+// newLBPoolObj creates CiliumLoadBalancerIPPool object based on lbSrvConfig
+func newLBPoolObj(conf lbPoolConfig) v2alpha1.CiliumLoadBalancerIPPool {
+	obj := v2alpha1.CiliumLoadBalancerIPPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              conf.name,
+			UID:               uid,
+			CreationTimestamp: metav1.Now(),
+			Labels:            make(map[string]string),
+		},
+	}
+	if conf.labels != nil {
+		obj.Labels = conf.labels
+	}
+	for _, cidr := range conf.cidrs {
+		obj.Spec.Cidrs = append(obj.Spec.Cidrs, v2alpha1.CiliumLoadBalancerIPPoolCIDRBlock{Cidr: v2alpha1.IPv4orIPv6CIDR(cidr)})
+	}
+	return obj
+}
+
 // ipPoolConfig data used to create a CiliumPodIPPool resource.
 type ipPoolConfig struct {
 	name   string


### PR DESCRIPTION
Adds a new BGP component test which tests the `AdvertisedPathAttributes` options of the `CiliumBGPPeeringPolicy` CRD. As iBGP peering is needed to test Local Preference, it modifies the test framework to allow it.
