### PR TITLE
gateway-api: De-flake HTTPRouteRequestMultipleMirrors test

### DIFF
--- a/.github/workflows/conformance-gateway-api.yaml
+++ b/.github/workflows/conformance-gateway-api.yaml
@@ -118,8 +118,7 @@ jobs:
         run: |
           echo sha=${{ steps.default_vars.outputs.sha }} >> $GITHUB_OUTPUT
           
-          # Enable HTTPRouteRequestMultipleMirrors again once https://github.com/cilium/cilium/issues/28374 is fixed
-          SUPPORTED_FEATURES="ReferenceGrant,HTTPRoute,TLSRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,GatewayClassObservedGenerationBump,HTTPRouteHostRewrite,HTTPRoutePathRewrite,HTTPRouteSchemeRedirect,HTTPRoutePathRedirect,HTTPRoutePortRedirect,HTTPRouteRequestMirror"
+          SUPPORTED_FEATURES="ReferenceGrant,HTTPRoute,TLSRoute,HTTPRouteQueryParamMatching,HTTPRouteMethodMatching,GatewayClassObservedGenerationBump,HTTPRouteHostRewrite,HTTPRoutePathRewrite,HTTPRouteSchemeRedirect,HTTPRoutePathRedirect,HTTPRoutePortRedirect,HTTPRouteRequestMirror,HTTPRouteRequestMultipleMirrors"
           if [ ${{ matrix.crd-channel }} == "experimental" ]; then
             SUPPORTED_FEATURES+=",HTTPResponseHeaderModification,RouteDestinationPortMatching"
           fi

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -12,6 +12,7 @@ import (
 	envoy_config_core_v3 "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
 	envoy_type_matcher_v3 "github.com/cilium/proxy/go/envoy/type/matcher/v3"
+	envoy_type_v3 "github.com/cilium/proxy/go/envoy/type/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -319,6 +320,11 @@ func requestMirrorMutation(mirrors []*model.HTTPRequestMirror) routeActionMutati
 			}
 			action = append(action, &envoy_config_route_v3.RouteAction_RequestMirrorPolicy{
 				Cluster: fmt.Sprintf("%s/%s:%s", m.Backend.Namespace, m.Backend.Name, m.Backend.Port.GetPort()),
+				RuntimeFraction: &envoy_config_core_v3.RuntimeFractionalPercent{
+					DefaultValue: &envoy_type_v3.FractionalPercent{
+						Numerator: 100,
+					},
+				},
 			})
 		}
 		route.Route.RequestMirrorPolicies = action

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -253,6 +253,8 @@ func Test_requestMirrorMutation(t *testing.T) {
 		res := requestMirrorMutation(mirror)(route)
 		require.Len(t, res.Route.RequestMirrorPolicies, 2)
 		require.Equal(t, res.Route.RequestMirrorPolicies[0].Cluster, "default/dummy-service:8080")
+		require.Equal(t, res.Route.RequestMirrorPolicies[0].RuntimeFraction.DefaultValue.Numerator, uint32(100))
 		require.Equal(t, res.Route.RequestMirrorPolicies[1].Cluster, "default/another-dummy-service:8080")
+		require.Equal(t, res.Route.RequestMirrorPolicies[1].RuntimeFraction.DefaultValue.Numerator, uint32(100))
 	})
 }


### PR DESCRIPTION
This commit is to add the runtime fraction value to ensure the request is mirrored to all downstream clusters.

Fixes: #28374 