### PR TITLE
ci: Preprocess PR body in update label workflow

### DIFF
--- a/.github/workflows/update-label-backport-pr.yaml
+++ b/.github/workflows/update-label-backport-pr.yaml
@@ -22,12 +22,26 @@
         runs-on: ubuntu-latest
         permissions:
           pull-requests: write # Adding and removing labels
+        env:
+          body: ${{ inputs.pr-body }}
         steps:
-          - name: Update labels in backported PRs
+          - name: Pre-process PR body
+            id: pre-process
+            uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 #v6.4.1
+            with:
+              script: |
+                const { body } = process.env
+                return body.replace(/\'/g, '')
+                  .replace(/"/g, '')
+                  .replace(/`/g, '')
+                  .replace(/$/g, '')
+              result-encoding: string
+
+          - name: Update labels
             env:
               GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
             run: |
-              echo '${{ inputs.pr-body }}' | sed -En "/upstream-prs/ { n; p }" | cut -d ';' -f 1 | grep -Eo '[0-9]+' | while read -r pr; do
+              echo "${{steps.pre-process.outputs.result}}" | sed -En "/upstream-prs/ { n; p }" | cut -d ';' -f 1 | grep -Eo '[0-9]+' | while read -r pr; do
                 echo "Removing label backport-pending/${{ inputs.branch }} from pr #${pr}."
                 gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --remove-label backport-pending/"${{ inputs.branch }}"
                 echo "Adding label backport-done/${{ inputs.branch }} to pr #${pr}."


### PR DESCRIPTION
The update-label-backport-pr workflow cannot handle characters like single quote and double quotes in the body of the PR passed as input.

An example of a PR body containing single quotes is https://github.com/cilium/cilium/pull/28435 Calling the workflow with that PR as input led to this failure:

```
Run echo '- [x] #28417 -- bpf: don't sign-extend IPv6 address components (@ti-mo)
  echo '- [x] #28417 -- bpf: don't sign-extend IPv6 address components (@ti-mo)

  Once this PR is merged, you can update the PR labels via:
  ```upstream-prs
  $ for pr in 28417; do contrib/backporting/set-labels.py $pr done 1.14; done
  ```' | sed -En "/upstream-prs/ { n; p }" | cut -d ';' -f 1 | grep -Eo '[0-9]+' | while read -r pr; do
    echo "Removing label backport-pending/1.14 from pr #${pr}."
    gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --remove-label backport-pending/"1.14"
    echo "Adding label backport-done/1.14 to pr #${pr}."
    gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --add-label backport-done/"1.14"
  done
  shell: /usr/bin/bash -e {0}
  env:
    GITHUB_TOKEN: ***
/home/runner/work/_temp/f513ca6f-a4be-4c83-b2fa-7c179befdf5f.sh: line 1: syntax error near unexpected token `('
```

This is due to the single quote in the word "don't" contained in the backported PR title.

To fix the issue an initial step to preprocess the body is added. The step will remove single quotes, double quotes, backtick and dollar signs before parsing the input to get the list of backported PRs.

Fixes: https://github.com/cilium/cilium/issues/28448
