### PR TITLE
egressgw: Switch from net to netip

### DIFF
--- a/cilium-dbg/cmd/bpf_egress_list.go
+++ b/cilium-dbg/cmd/bpf_egress_list.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net"
+	"net/netip"
 	"os"
 	"text/tabwriter"
 
@@ -53,8 +53,8 @@ var bpfEgressListCmd = &cobra.Command{
 			bpfEgressList = append(bpfEgressList, egressPolicy{
 				SourceIP:  key.GetSourceIP().String(),
 				DestCIDR:  key.GetDestCIDR().String(),
-				EgressIP:  val.GetEgressIP().String(),
-				GatewayIP: mapGatewayIP(val.GetGatewayIP()),
+				EgressIP:  val.GetEgressAddr().String(),
+				GatewayIP: mapGatewayIP(val.GetGatewayAddr()),
 			})
 		}
 
@@ -79,11 +79,11 @@ var bpfEgressListCmd = &cobra.Command{
 
 // This function attempt to translate gatewayIP to special values if they exist
 // or return the IP as a string otherwise.
-func mapGatewayIP(ip net.IP) string {
-	if ip.Equal(egressgateway.GatewayNotFoundIPv4) {
+func mapGatewayIP(ip netip.Addr) string {
+	if ip == egressgateway.GatewayNotFoundIPv4 {
 		return "Not Found"
 	}
-	if ip.Equal(egressgateway.ExcludedCIDRIPv4) {
+	if ip == egressgateway.ExcludedCIDRIPv4 {
 		return "Excluded CIDR"
 	}
 	return ip.String()

--- a/pkg/egressgateway/endpoint.go
+++ b/pkg/egressgateway/endpoint.go
@@ -5,7 +5,7 @@ package egressgateway
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -21,14 +21,14 @@ type endpointMetadata struct {
 	// Endpoint ID
 	id endpointID
 	// ips are endpoint's unique IPs
-	ips []net.IP
+	ips []netip.Addr
 }
 
 // endpointID includes endpoint name and namespace
 type endpointID = types.NamespacedName
 
 func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels labels.Labels) (*endpointMetadata, error) {
-	var ipv4s []net.IP
+	var addrs []netip.Addr
 	id := types.NamespacedName{
 		Name:      endpoint.GetName(),
 		Namespace: endpoint.GetNamespace(),
@@ -44,7 +44,11 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels label
 
 	for _, pair := range endpoint.Networking.Addressing {
 		if pair.IPV4 != "" {
-			ipv4s = append(ipv4s, net.ParseIP(pair.IPV4).To4())
+			addr, err := netip.ParseAddr(pair.IPV4)
+			if err != nil || !addr.Is4() {
+				continue
+			}
+			addrs = append(addrs, addr)
 		}
 	}
 
@@ -53,7 +57,7 @@ func getEndpointMetadata(endpoint *k8sTypes.CiliumEndpoint, identityLabels label
 	}
 
 	data := &endpointMetadata{
-		ips:    ipv4s,
+		ips:    addrs,
 		labels: identityLabels.K8sStringMap(),
 		id:     id,
 	}

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"sort"
 	"strings"
 	"sync"
@@ -42,10 +42,10 @@ var (
 	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "egressgateway")
 	// GatewayNotFoundIPv4 is a special IP value used as gatewayIP in the BPF policy
 	// map to indicate no gateway was found for the given policy
-	GatewayNotFoundIPv4 = net.ParseIP("0.0.0.0")
+	GatewayNotFoundIPv4 = netip.IPv4Unspecified()
 	// ExcludedCIDRIPv4 is a special IP value used as gatewayIP in the BPF policy map
 	// to indicate the entry is for an excluded CIDR and should skip egress gateway
-	ExcludedCIDRIPv4 = net.ParseIP("0.0.0.1")
+	ExcludedCIDRIPv4 = netip.MustParseAddr("0.0.0.1")
 )
 
 // Cell provides a [Manager] for consumption with hive.
@@ -586,11 +586,11 @@ func (manager *Manager) updatePoliciesBySourceIP() {
 //
 // This method returns true whenever the f callback matches one of the endpoint
 // and CIDR tuples (i.e. whenever one callback invocation returns true)
-func (manager *Manager) policyMatches(sourceIP net.IP, f func(net.IP, *net.IPNet, bool, *gatewayConfig) bool) bool {
+func (manager *Manager) policyMatches(sourceIP netip.Addr, f func(netip.Addr, netip.Prefix, bool, *gatewayConfig) bool) bool {
 	for _, policy := range manager.policyConfigsBySourceIP[sourceIP.String()] {
 		for _, ep := range policy.matchedEndpoints {
 			for _, endpointIP := range ep.ips {
-				if !endpointIP.Equal(sourceIP) {
+				if endpointIP != sourceIP {
 					continue
 				}
 
@@ -627,8 +627,8 @@ func (manager *Manager) addMissingEgressRules() {
 			egressPolicies[*key] = *val
 		})
 
-	addEgressRule := func(endpointIP net.IP, dstCIDR *net.IPNet, excludedCIDR bool, gwc *gatewayConfig) {
-		policyKey := egressmap.NewEgressPolicyKey4(endpointIP, dstCIDR.IP, dstCIDR.Mask)
+	addEgressRule := func(endpointIP netip.Addr, dstCIDR netip.Prefix, excludedCIDR bool, gwc *gatewayConfig) {
+		policyKey := egressmap.NewEgressPolicyKey4(endpointIP, dstCIDR)
 		policyVal, policyPresent := egressPolicies[policyKey]
 
 		gatewayIP := gwc.gatewayIP
@@ -636,18 +636,18 @@ func (manager *Manager) addMissingEgressRules() {
 			gatewayIP = ExcludedCIDRIPv4
 		}
 
-		if policyPresent && policyVal.Match(gwc.egressIP.IP, gatewayIP) {
+		if policyPresent && policyVal.Match(gwc.egressIP, gatewayIP) {
 			return
 		}
 
 		logger := log.WithFields(logrus.Fields{
 			logfields.SourceIP:        endpointIP,
 			logfields.DestinationCIDR: dstCIDR.String(),
-			logfields.EgressIP:        gwc.egressIP.IP,
+			logfields.EgressIP:        gwc.egressIP,
 			logfields.GatewayIP:       gatewayIP,
 		})
 
-		if err := manager.policyMap.Update(endpointIP, *dstCIDR, gwc.egressIP.IP, gatewayIP); err != nil {
+		if err := manager.policyMap.Update(endpointIP, dstCIDR, gwc.egressIP, gatewayIP); err != nil {
 			logger.WithError(err).Error("Error applying egress gateway policy")
 		} else {
 			logger.Debug("Egress gateway policy applied")
@@ -670,27 +670,27 @@ func (manager *Manager) removeUnusedEgressRules() {
 
 nextPolicyKey:
 	for policyKey, policyVal := range egressPolicies {
-		matchPolicy := func(endpointIP net.IP, dstCIDR *net.IPNet, excludedCIDR bool, gwc *gatewayConfig) bool {
+		matchPolicy := func(endpointIP netip.Addr, dstCIDR netip.Prefix, excludedCIDR bool, gwc *gatewayConfig) bool {
 			gatewayIP := gwc.gatewayIP
 			if excludedCIDR {
 				gatewayIP = ExcludedCIDRIPv4
 			}
 
-			return policyKey.Match(endpointIP, dstCIDR) && policyVal.Match(gwc.egressIP.IP, gatewayIP)
+			return policyKey.Match(endpointIP, dstCIDR) && policyVal.Match(gwc.egressIP, gatewayIP)
 		}
 
-		if manager.policyMatches(policyKey.SourceIP.IP(), matchPolicy) {
+		if manager.policyMatches(policyKey.GetSourceIP(), matchPolicy) {
 			continue nextPolicyKey
 		}
 
 		logger := log.WithFields(logrus.Fields{
 			logfields.SourceIP:        policyKey.GetSourceIP(),
 			logfields.DestinationCIDR: policyKey.GetDestCIDR().String(),
-			logfields.EgressIP:        policyVal.GetEgressIP(),
-			logfields.GatewayIP:       policyVal.GetGatewayIP(),
+			logfields.EgressIP:        policyVal.GetEgressAddr(),
+			logfields.GatewayIP:       policyVal.GetGatewayAddr(),
 		})
 
-		if err := manager.policyMap.Delete(policyKey.GetSourceIP(), *policyKey.GetDestCIDR()); err != nil {
+		if err := manager.policyMap.Delete(policyKey.GetSourceIP(), policyKey.GetDestCIDR()); err != nil {
 			logger.WithError(err).Error("Error removing egress gateway policy")
 		} else {
 			logger.Debug("Egress gateway policy removed")

--- a/pkg/types/ipv4.go
+++ b/pkg/types/ipv4.go
@@ -31,3 +31,15 @@ func (v4 IPv4) String() string {
 func (v4 *IPv4) DeepCopyInto(out *IPv4) {
 	copy(out[:], v4[:])
 }
+
+// FromAddr will populate the receiver with the specified address if and only
+// if the provided address is a valid IPv4 address. Any other address,
+// including the "invalid ip" value netip.Addr{} will zero the receiver.
+func (v4 *IPv4) FromAddr(addr netip.Addr) {
+	if addr.Is4() {
+		a := IPv4(addr.As4())
+		copy(v4[:], a[:])
+	} else {
+		clear(v4[:])
+	}
+}


### PR DESCRIPTION
Modernize this section of the codebase by switching over to newer
addressing types provided by recent Go standard libraries.

Related: #24246
