### PR TITLE
hive: ModuleID and FullModuleID, use full ID in module health

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -223,7 +223,6 @@ type Daemon struct {
 	settings cellSettings
 	// enable modules health support
 	healthProvider cell.Health
-	healthReporter cell.HealthReporter
 }
 
 func (d *Daemon) initDNSProxyContext(size int) {
@@ -529,7 +528,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		authManager:          params.AuthManager,
 		settings:             params.Settings,
 		healthProvider:       params.HealthProvider,
-		healthReporter:       params.HealthReporter,
 	}
 
 	d.configModifyQueue = eventqueue.NewEventQueueBuffered("config-modify-queue", ConfigModifyQueueSize)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1665,7 +1665,6 @@ type daemonParams struct {
 	AuthManager          *auth.AuthManager
 	Settings             cellSettings
 	HealthProvider       cell.Health
-	HealthReporter       cell.HealthReporter
 	DeviceManager        *linuxdatapath.DeviceManager `optional:"true"`
 	// Grab the GC object so that we can start the CT/NAT map garbage collection.
 	// This is currently necessary because these maps have not yet been modularized,

--- a/daemon/cmd/vitals.go
+++ b/daemon/cmd/vitals.go
@@ -17,7 +17,7 @@ import (
 // moduleExcludes tracks modules that should be excluded from the health report.
 var moduleExcludes = map[string]struct{}{
 	// daemon currently does not rollup status and hence reports default health aka unknown.
-	"daemon": {},
+	"agent.daemon": {},
 }
 
 type getHealth struct {
@@ -39,7 +39,7 @@ func (d *Daemon) getHealthReport() models.ModulesHealth {
 	mm := d.healthProvider.All()
 	rr := make([]*models.ModuleHealth, 0, len(mm))
 	for _, m := range mm {
-		if _, ok := moduleExcludes[m.ModuleID]; ok {
+		if _, ok := moduleExcludes[m.FullModuleID.String()]; ok {
 			continue
 		}
 		rr = append(rr, toModuleHealth(m))
@@ -52,7 +52,7 @@ func (d *Daemon) getHealthReport() models.ModulesHealth {
 
 func toModuleHealth(m cell.Status) *models.ModuleHealth {
 	return &models.ModuleHealth{
-		ModuleID:    m.ModuleID,
+		ModuleID:    m.FullModuleID.String(),
 		Message:     m.Message,
 		Level:       string(m.Level),
 		LastOk:      toAgeHuman(m.LastOK),

--- a/daemon/cmd/vitals.go
+++ b/daemon/cmd/vitals.go
@@ -14,12 +14,6 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 )
 
-// moduleExcludes tracks modules that should be excluded from the health report.
-var moduleExcludes = map[string]struct{}{
-	// daemon currently does not rollup status and hence reports default health aka unknown.
-	"agent.daemon": {},
-}
-
 type getHealth struct {
 	daemon *Daemon
 }
@@ -39,9 +33,6 @@ func (d *Daemon) getHealthReport() models.ModulesHealth {
 	mm := d.healthProvider.All()
 	rr := make([]*models.ModuleHealth, 0, len(mm))
 	for _, m := range mm {
-		if _, ok := moduleExcludes[m.FullModuleID.String()]; ok {
-			continue
-		}
 		rr = append(rr, toModuleHealth(m))
 	}
 

--- a/daemon/cmd/vitals_test.go
+++ b/daemon/cmd/vitals_test.go
@@ -28,9 +28,9 @@ func TestVitalsToModuleHealth(t *testing.T) {
 		"happy": {
 			s: cell.Status{
 				Update: cell.Update{
-					ModuleID: "fred",
-					Message:  "blee",
-					Err:      fmt.Errorf("zorg"),
+					FullModuleID: []string{"fred"},
+					Message:      "blee",
+					Err:          fmt.Errorf("zorg"),
 				},
 				Stopped: true,
 				Final:   "fred",

--- a/pkg/hive/cell/health.go
+++ b/pkg/hive/cell/health.go
@@ -64,13 +64,13 @@ type Health interface {
 
 	// Get returns a copy of a modules status, by module ID.
 	// This includes unknown status for modules that have not reported a status yet.
-	Get(string) *Status
+	Get(FullModuleID) *Status
 
 	// Stop stops the health provider from processing updates.
 	Stop(context.Context) error
 
 	// forModule creates a moduleID scoped reporter handle.
-	forModule(string) HealthReporter
+	forModule(FullModuleID) HealthReporter
 
 	// processed returns the number of updates processed.
 	processed() uint64
@@ -79,9 +79,9 @@ type Health interface {
 // Update is an event that denotes the change of a modules health state.
 type Update struct {
 	Level
-	ModuleID string
-	Message  string
-	Err      error
+	FullModuleID FullModuleID
+	Message      string
+	Err          error
 }
 
 // Status is a modules last health state, including the last update.
@@ -108,7 +108,7 @@ func (s *Status) String() string {
 		sinceLast = time.Since(s.LastUpdated).String() + " ago"
 	}
 	return fmt.Sprintf("Status{ModuleID: %s, Level: %s, Since: %s, Message: %s, Err: %v}",
-		s.ModuleID, s.Level, sinceLast, s.Message, s.Err)
+		s.FullModuleID, s.Level, sinceLast, s.Message, s.Err)
 }
 
 // NewHealthProvider starts and returns a health status which processes
@@ -131,7 +131,7 @@ func (p *healthProvider) process(u Update) {
 		defer p.mu.Unlock()
 
 		t := time.Now()
-		prev := p.moduleStatuses[u.ModuleID]
+		prev := p.moduleStatuses[u.FullModuleID.String()]
 
 		if !p.running {
 			return prev
@@ -150,13 +150,13 @@ func (p *healthProvider) process(u Update) {
 			ns.Stopped = true
 			ns.Final = u.Message
 		}
-		p.moduleStatuses[u.ModuleID] = ns
+		p.moduleStatuses[u.FullModuleID.String()] = ns
 		log.WithField("status", ns.String()).Debug("Processed new health status")
 		return prev
 	}()
 	p.numProcessed.Add(1)
 	if prev.Stopped {
-		log.Warnf("module %q reported health status after being Stopped", u.ModuleID)
+		log.Warnf("module %q reported health status after being Stopped", u.FullModuleID)
 	}
 }
 
@@ -171,12 +171,12 @@ func (p *healthProvider) Stop(ctx context.Context) error {
 
 // forModule returns a module scoped status reporter handle for emitting status updates.
 // This is used to automatically provide declared modules with a status reported.
-func (p *healthProvider) forModule(moduleID string) HealthReporter {
+func (p *healthProvider) forModule(moduleID FullModuleID) HealthReporter {
 	p.mu.Lock()
-	p.moduleStatuses[moduleID] = Status{Update: Update{
-		ModuleID: moduleID,
-		Level:    StatusUnknown,
-		Message:  "No status reported yet"},
+	p.moduleStatuses[moduleID.String()] = Status{Update: Update{
+		FullModuleID: moduleID,
+		Level:        StatusUnknown,
+		Message:      "No status reported yet"},
 	}
 	p.mu.Unlock()
 
@@ -192,16 +192,16 @@ func (p *healthProvider) All() []Status {
 	all := maps.Values(p.moduleStatuses)
 	p.mu.RUnlock()
 	sort.Slice(all, func(i, j int) bool {
-		return all[i].ModuleID < all[j].ModuleID
+		return all[i].FullModuleID.String() < all[j].FullModuleID.String()
 	})
 	return all
 }
 
 // Get returns the latest status for a module, by module ID.
-func (p *healthProvider) Get(moduleID string) *Status {
+func (p *healthProvider) Get(moduleID FullModuleID) *Status {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	s, ok := p.moduleStatuses[moduleID]
+	s, ok := p.moduleStatuses[moduleID.String()]
 	if ok {
 		return &s
 	}
@@ -219,22 +219,22 @@ type healthProvider struct {
 
 // reporter is a handle for emitting status updates.
 type reporter struct {
-	moduleID string
+	moduleID FullModuleID
 	process  func(Update)
 }
 
 // Degraded reports a degraded status update, should be used when a module encounters a
 // a state that is not fully reconciled.
 func (r *reporter) Degraded(reason string, err error) {
-	r.process(Update{ModuleID: r.moduleID, Level: StatusDegraded, Message: reason, Err: err})
+	r.process(Update{FullModuleID: r.moduleID, Level: StatusDegraded, Message: reason, Err: err})
 }
 
 // Stopped reports that a module has stopped, further updates will not be processed.
 func (r *reporter) Stopped(reason string) {
-	r.process(Update{ModuleID: r.moduleID, Level: StatusStopped, Message: reason})
+	r.process(Update{FullModuleID: r.moduleID, Level: StatusStopped, Message: reason})
 }
 
 // OK reports that a module is in a healthy state.
 func (r *reporter) OK(status string) {
-	r.process(Update{ModuleID: r.moduleID, Level: StatusOK, Message: status})
+	r.process(Update{FullModuleID: r.moduleID, Level: StatusOK, Message: status})
 }

--- a/pkg/hive/cell/health_test.go
+++ b/pkg/hive/cell/health_test.go
@@ -17,7 +17,7 @@ import (
 func TestStatusProvider(t *testing.T) {
 	assert := assert.New(t)
 	sp := NewHealthProvider()
-	reporter := sp.forModule("module000")
+	reporter := sp.forModule([]string{"module000"})
 	reporter.OK("OK")
 	reporter.Degraded("bad", fmt.Errorf("zzz"))
 	reporter.Stopped("meh")
@@ -25,7 +25,7 @@ func TestStatusProvider(t *testing.T) {
 	defer cancel()
 	assert.NoError(sp.Stop(ctx))
 	assert.Equal(sp.processed(), uint64(3))
-	assert.Equal(StatusDegraded, sp.Get("module000").Level)
+	assert.Equal(StatusDegraded, sp.Get([]string{"module000"}).Level)
 	reporter.OK("")
 }
 
@@ -37,7 +37,7 @@ func TestHealthReporter(t *testing.T) {
 	s := NewHealthProvider()
 	wg := &sync.WaitGroup{}
 	for i := 0; i < m; i++ {
-		reporter := s.forModule(fmt.Sprintf("module-%d", i))
+		reporter := s.forModule([]string{fmt.Sprintf("module-%d", i)})
 		wg.Add(1)
 		go func(hr HealthReporter) {
 			for j := 1; j <= u; j++ {
@@ -68,10 +68,10 @@ func TestStatusString(t *testing.T) {
 	assert := assert.New(t)
 	s := Status{
 		Update: Update{
-			Level:    StatusUnknown,
-			ModuleID: "m-000",
-			Err:      nil,
-			Message:  "something happened",
+			Level:        StatusUnknown,
+			FullModuleID: []string{"m-000"},
+			Err:          nil,
+			Message:      "something happened",
 		},
 	}
 	assert.Equal("Status{ModuleID: m-000, Level: Unknown, Since: never, Message: something happened, Err: <nil>}",

--- a/pkg/hive/hive.go
+++ b/pkg/hive/hive.go
@@ -146,21 +146,23 @@ func (h *Hive) Viper() *viper.Viper {
 type defaults struct {
 	dig.Out
 
-	Flags       *pflag.FlagSet
-	Lifecycle   Lifecycle
-	Logger      logrus.FieldLogger
-	Shutdowner  Shutdowner
-	InvokerList cell.InvokerList
+	Flags             *pflag.FlagSet
+	Lifecycle         Lifecycle
+	Logger            logrus.FieldLogger
+	Shutdowner        Shutdowner
+	InvokerList       cell.InvokerList
+	EmptyFullModuleID cell.FullModuleID
 }
 
 func (h *Hive) provideDefaults() error {
 	return h.container.Provide(func() defaults {
 		return defaults{
-			Flags:       h.flags,
-			Lifecycle:   h.lifecycle,
-			Logger:      log,
-			Shutdowner:  h,
-			InvokerList: h,
+			Flags:             h.flags,
+			Lifecycle:         h.lifecycle,
+			Logger:            log,
+			Shutdowner:        h,
+			InvokerList:       h,
+			EmptyFullModuleID: nil,
 		}
 	})
 }

--- a/pkg/hive/hive_test.go
+++ b/pkg/hive/hive_test.go
@@ -287,15 +287,18 @@ func TestProvideHealthReporter(t *testing.T) {
 	var all []cell.Status
 	h := hive.New(
 		testCell,
-		testCell2,
-		unknown,
+		cell.Module(
+			"wrap", "Wraps test modules",
+			testCell2,
+			unknown,
+		),
 		cell.Invoke(func(lc hive.Lifecycle, shutdowner hive.Shutdowner, hr cell.Health) {
 			lc.Append(hive.Hook{
 				OnStop: func(hive.HookContext) error {
 					all = hr.All()
-					s1 = hr.Get("test")
-					s2 = hr.Get("test2")
-					s3 = hr.Get("unknown")
+					s1 = hr.Get([]string{"test"})
+					s2 = hr.Get([]string{"wrap", "test2"})
+					s3 = hr.Get([]string{"wrap", "unknown"})
 					return nil
 				}})
 		}),
@@ -304,11 +307,11 @@ func TestProvideHealthReporter(t *testing.T) {
 	assert.NoError(t, h.Run(), "expected Run to succeed")
 	assert.Len(t, all, 3, "expected two health reports")
 	assert.Equal(t, s1.Level, cell.StatusOK)
-	assert.Equal(t, s1.ModuleID, "test")
+	assert.Equal(t, s1.FullModuleID.String(), "test")
 	assert.Equal(t, s1.Err, nil)
 	assert.True(t, s1.Stopped)
 	assert.Equal(t, s2.Level, cell.StatusDegraded)
-	assert.Equal(t, s2.ModuleID, "test2")
+	assert.Equal(t, s2.FullModuleID.String(), "wrap.test2")
 	assert.Equal(t, s2.Err, fmt.Errorf("someerr"))
 	assert.Equal(t, s3.Level, cell.StatusUnknown)
 }


### PR DESCRIPTION
First patch adds ModuleID and FullModuleID types:

```
    
      cell.Module(
        "outer",
        "Outer",
    
        cell.Module(
          "inner",
          "Inner",
    
          cell.Invoke(id cell.ModuleID, fullID cell.FullModuleID) {
            // id == "inner"
            // fullID == "outer.inner"
          },
        ),
      )
```

Second switches health reporter to use full module id:

```
      Modules Health:
        Module                            Status   Message                      Last Updated
        agent.controlplane.node-manager   OK       Node validation successful             4s
```

Final patch removes the unnecessary module exclusion from health REST API handler and
instead drops the unused HealthReporter dependency from daemon.