### PR TITLE
added a missing note for getting started kind cluster

### DIFF
--- a/Documentation/gettingstarted/k8s-install-default.rst
+++ b/Documentation/gettingstarted/k8s-install-default.rst
@@ -129,6 +129,13 @@ to create a Kubernetes cluster locally or using a managed Kubernetes service:
           curl -LO \ |SCM_WEB|\/Documentation/installation/kind-config.yaml
           kind create cluster --config=kind-config.yaml
 
+       .. note::
+
+         Cilium may fail to deploy due to too many open files in one or more
+         of the agent pods. If you notice this error, you can increase the
+         ``inotify`` resource limits on your host machine (see
+         `Pod errors due to "too many open files" <https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files>`__).
+
     .. group-tab:: minikube
 
        Install minikube ≥ v1.28.0 as per minikube documentation:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
with installing cilium on kind cluster we need to increase the host computer's fs limits
Refer: https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files

![image](https://github.com/cilium/cilium/assets/65275144/76ad3290-c921-4cab-8914-f2df456fb4f3)


Fixes: #issue-number

```release-note
Add link to getting started guide for kind cluster for common "too many files" issue
```
