### PR TITLE
egressgw: doc fixes for install-egress-gateway-routes removal

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -860,10 +860,10 @@
      - The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information.
      - string
      - ``"100ms"``
-   * - :spelling:ignore:`egressGateway`
+   * - :spelling:ignore:`egressGateway.enabled`
      - Enables egress gateway to redirect and SNAT the traffic that leaves the cluster.
-     - object
-     - ``{"enabled":false,"installRoutes":false,"reconciliationTriggerInterval":"1s"}``
+     - bool
+     - ``false``
    * - :spelling:ignore:`egressGateway.installRoutes`
      - Deprecated without a replacement necessary.
      - bool

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -865,7 +865,7 @@
      - object
      - ``{"enabled":false,"installRoutes":false,"reconciliationTriggerInterval":"1s"}``
    * - :spelling:ignore:`egressGateway.installRoutes`
-     - Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface
+     - Deprecated without a replacement necessary.
      - bool
      - ``false``
    * - :spelling:ignore:`egressGateway.reconciliationTriggerInterval`

--- a/Documentation/network/egress-gateway.rst
+++ b/Documentation/network/egress-gateway.rst
@@ -118,35 +118,6 @@ Rollout both the agent pods and the operator pods to make the changes effective:
     $ kubectl rollout restart ds cilium -n kube-system
     $ kubectl rollout restart deploy cilium-operator -n kube-system
 
-Compatibility with cloud environments
--------------------------------------
-
-EKS's ENI mode
-~~~~~~~~~~~~~~
-
-Based on the specific configuration of the cloud provider and network interfaces
-it is possible that traffic leaves a node from the wrong interface. This happens in
-particular on EKS in ENI mode.
-
-To work around this issue, Cilium can be instructed to install the necessary IP
-rules and routes to route traffic through the appropriate network-facing
-interface as follows:
-
-.. tabs::
-    .. group-tab:: Helm
-
-        .. parsed-literal::
-
-            $ helm upgrade cilium |CHART_RELEASE| \\
-            [..] \\
-            --set egressGateway.installRoutes=true
-
-    .. group-tab:: ConfigMap
-
-        .. code-block:: yaml
-
-            install-egress-gateway-routes: true
-
 Writing egress gateway policies
 ===============================
 

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -353,6 +353,10 @@ Removed Options
   The functionality to dynamically allocate Pod CIDRs is now provided by the more
   flexible ``multi-pool`` IPAM mode.
 
+* The ``install-egress-gateway-routes`` flag has been deprecated because the
+  datapath has been improved to not require any additional routes in
+  ENI environments.
+
 Helm Options
 ~~~~~~~~~~~~
 
@@ -367,6 +371,9 @@ Helm Options
 * Prometheus metrics for cilium-operator and clustermesh's kvstore are now enabled by default.
   If you want to disable these prometheus metrics, set ``operator.prometheus.enabled=false``
   and ``clustermesh.apiserver.metrics.etcd.enabled=false`` respectively.
+
+* ``egressGateway.installRoutes`` has been deprecated because the setting is no
+  longer necessary.
 
 Added Metrics
 ~~~~~~~~~~~~~

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -266,7 +266,7 @@ contributors across the globe, there is almost always someone available to help.
 | dnsProxy.proxyPort | int | `0` | Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port. |
 | dnsProxy.proxyResponseMaxDelay | string | `"100ms"` | The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. |
 | egressGateway | object | `{"enabled":false,"installRoutes":false,"reconciliationTriggerInterval":"1s"}` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
-| egressGateway.installRoutes | bool | `false` | Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface |
+| egressGateway.installRoutes | bool | `false` | Deprecated without a replacement necessary. |
 | egressGateway.reconciliationTriggerInterval | string | `"1s"` | Time between triggers of egress gateway state reconciliations |
 | enableCiliumEndpointSlice | bool | `false` | Enable CiliumEndpointSlice feature. |
 | enableCnpStatusUpdates | bool | `false` | Whether to enable CNP status updates. |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -265,7 +265,7 @@ contributors across the globe, there is almost always someone available to help.
 | dnsProxy.preCache | string | `""` | DNS cache data at this path is preloaded on agent startup. |
 | dnsProxy.proxyPort | int | `0` | Global port on which the in-agent DNS proxy should listen. Default 0 is a OS-assigned port. |
 | dnsProxy.proxyResponseMaxDelay | string | `"100ms"` | The maximum time the DNS proxy holds an allowed DNS response before sending it along. Responses are sent as soon as the datapath is updated with the new IP information. |
-| egressGateway | object | `{"enabled":false,"installRoutes":false,"reconciliationTriggerInterval":"1s"}` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
+| egressGateway.enabled | bool | `false` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
 | egressGateway.installRoutes | bool | `false` | Deprecated without a replacement necessary. |
 | egressGateway.reconciliationTriggerInterval | string | `"1s"` | Time between triggers of egress gateway state reconciliations |
 | enableCiliumEndpointSlice | bool | `false` | Enable CiliumEndpointSlice feature. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1705,9 +1705,9 @@ enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
 
-# -- Enables egress gateway to redirect and SNAT the traffic that leaves the
-# cluster.
 egressGateway:
+  # -- Enables egress gateway to redirect and SNAT the traffic that leaves the
+  # cluster.
   enabled: false
   # -- Deprecated without a replacement necessary.
   installRoutes: false

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1709,8 +1709,7 @@ enableIPv6BIGTCP: false
 # cluster.
 egressGateway:
   enabled: false
-  # -- Install egress gateway IP rules and routes in order to properly steer
-  # egress gateway traffic to the correct ENI interface
+  # -- Deprecated without a replacement necessary.
   installRoutes: false
   # -- Time between triggers of egress gateway state reconciliations
   reconciliationTriggerInterval: 1s

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1702,9 +1702,9 @@ enableIPv4BIGTCP: false
 # -- Enables IPv6 BIG TCP support which increases maximum IPv6 GSO/GRO limits for nodes and pods
 enableIPv6BIGTCP: false
 
-# -- Enables egress gateway to redirect and SNAT the traffic that leaves the
-# cluster.
 egressGateway:
+  # -- Enables egress gateway to redirect and SNAT the traffic that leaves the
+  # cluster.
   enabled: false
   # -- Deprecated without a replacement necessary.
   installRoutes: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1706,8 +1706,7 @@ enableIPv6BIGTCP: false
 # cluster.
 egressGateway:
   enabled: false
-  # -- Install egress gateway IP rules and routes in order to properly steer
-  # egress gateway traffic to the correct ENI interface
+  # -- Deprecated without a replacement necessary.
   installRoutes: false
   # -- Time between triggers of egress gateway state reconciliations
   reconciliationTriggerInterval: 1s


### PR DESCRIPTION
egressgw: document deprecation of install-egress-gateway-routes

    Fixes: 334fdbcc62 ("egressgw: mark --install-egress-gateway-routes as
    deprecated") Signed-off-by: Lorenz Bauer <lmb@isovalent.com>

egressgw: fix helm documentation

    Adding a documentation comment to a node in the YAML will force it to appear
    in the generated README. This leads to the awkward "{...}" object for the
    egressGateway key. Move the documentation to egressGateway.enabled instead.

    See https://github.com/norwoodj/helm-docs#valuesyaml-metadata for details on
    how documentation is generated.

    Signed-off-by: Lorenz Bauer <lmb@isovalent.com>
