### PR TITLE
Fix kind targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -563,7 +563,7 @@ kind-install-cilium-clustermesh: kind-clustermesh-ready ## Install a local Ciliu
 	$(CILIUM_CLI) clustermesh status --context kind-clustermesh1 --wait
 	$(CILIUM_CLI) clustermesh status --context kind-clustermesh2 --wait
 
-KIND_CLUSTER_NAME ?= kind
+KIND_CLUSTER_NAME ?= $(shell kind get clusters -q | head -n1)
 
 .PHONY: kind-ready
 kind-ready:

--- a/Makefile
+++ b/Makefile
@@ -621,19 +621,19 @@ kind-install-cilium-fast: kind-ready ## Install a local Cilium version into the 
 
 .PHONY: build-cli
 build-cli: ## Build cilium cli binary
-	$(QUIET)$(MAKE) -C cilium-dbg
+	$(QUIET)$(MAKE) -C cilium-dbg GOOS=linux
 
 .PHONY: build-agent
 build-agent: ## Build cilium daemon binary
-	$(QUIET)$(MAKE) -C daemon
+	$(QUIET)$(MAKE) -C daemon GOOS=linux
 
 .PHONY: build-operator
 build-operator: ## Build cilium operator binary
-	$(QUIET)$(MAKE) -C operator cilium-operator-generic
+	$(QUIET)$(MAKE) -C operator cilium-operator-generic GOOS=linux
 
 .PHONY: build-clustermesh-apiserver
 build-clustermesh-apiserver: ## Build cilium clustermesh-apiserver binary
-	$(QUIET)$(MAKE) -C clustermesh-apiserver
+	$(QUIET)$(MAKE) -C clustermesh-apiserver  GOOS=linux
 
 .PHONY: kind-image-fast-agent
 kind-image-fast-agent: kind-ready build-cli build-agent ## Build cilium cli and daemon binaries. Copy the bins and bpf files to kind nodes.

--- a/Makefile
+++ b/Makefile
@@ -567,9 +567,8 @@ KIND_CLUSTER_NAME ?= kind
 
 .PHONY: kind-ready
 kind-ready:
-	@$(ECHO_CHECK) kind is ready...
-	@kind get clusters 2>&1 | grep "$(KIND_CLUSTER_NAME)" \
-		&& exit 0 || exit 1
+	@$(ECHO_CHECK) kind-ready
+	@if [ -n "$(shell kind get clusters -q)" ]; then echo "kind is ready"; else echo "kind not ready"; exit 1; fi
 
 $(eval $(call KIND_ENV,kind-build-image-agent))
 kind-build-image-agent: ## Build cilium-dev docker image


### PR DESCRIPTION
Fixes a few issues brought up in slack: https://cilium.slack.com/archives/C2B917YHE/p1697062058979519

- Fix `kind-ready` when dealing with clusters that are not named `kind`, fixing the `fast` variant of the kind targets.
- Do not assume a cluster is named `kind` in the non-fast kind targets, instead pick the first KIND cluster, unless overriden
- Fix kind fast targets for MacOS by setting `GOOS=linux`, since binaries need to be built for Linux to run within KIND (and agent only builds for GOOS=linux).