### PR TITLE
test: Ignore waitqueue.waitingLoop goroutine leak

### DIFF
--- a/clustermesh-apiserver/users_mgmt_test.go
+++ b/clustermesh-apiserver/users_mgmt_test.go
@@ -54,6 +54,9 @@ func TestMain(m *testing.M) {
 		// To ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go
 		// init function
 		goleak.IgnoreTopFunction("time.Sleep"),
+		// Delaying workqueues used by resource.Resource[T].Events leaks this waitingLoop goroutine.
+		// It does stop when shutting down but is not guaranteed to before we actually exit.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop"),
 	)
 }
 

--- a/operator/pkg/lbipam/lbipam_test.go
+++ b/operator/pkg/lbipam/lbipam_test.go
@@ -25,6 +25,9 @@ func TestMain(m *testing.M) {
 		// To ignore goroutine started from sigs.k8s.io/controller-runtime/pkg/log.go
 		// init function
 		goleak.IgnoreTopFunction("time.Sleep"),
+		// Delaying workqueues used by resource.Resource[T].Events leaks this waitingLoop goroutine.
+		// It does stop when shutting down but is not guaranteed to before we actually exit.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop"),
 	)
 }
 

--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -41,7 +41,12 @@ func TestMain(m *testing.M) {
 		// missing Event.Done() calls.
 		runtime.GC()
 	}
-	goleak.VerifyTestMain(m, goleak.Cleanup(cleanup))
+	goleak.VerifyTestMain(m,
+		goleak.Cleanup(cleanup),
+		// Delaying workqueues used by resource.Resource[T].Events leaks this waitingLoop goroutine.
+		// It does stop when shutting down but is not guaranteed to before we actually exit.
+		goleak.IgnoreTopFunction("k8s.io/client-go/util/workqueue.(*delayingType).waitingLoop"),
+	)
 }
 
 func testStore(t *testing.T, node *corev1.Node, store resource.Store[*corev1.Node]) {


### PR DESCRIPTION
We use goleak in certain tests to ensure we do not leak goroutines which might cause unexpected behavior during tests or shutdown in production.

Normally we expect our own goroutines to leak, but since we started using the delayed workqueue, we also leak the waitqueue.waitingLoop. This goroutine does get a shutdown signal when hive stops, but it isn't guaranteed to have exited before hive does so it sometimes triggers in CI.

This PR adds and exception to all goleak invocation that use resource.Resource[T] to ignore the waitqueue.waitingLoop goroutine.

Fixes: #28477

```release-note
Add workqueue.(delayingType).waitingLoop to goleak exception list
```
