### PR TITLE
Ensure IPsec packets go through the right path when applying L7 policies

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -368,7 +368,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 	}
 #endif
 
-	if (!info || info->sec_identity == WORLD_ID) {
+	if (!info || (!from_proxy && info->sec_identity == WORLD_ID)) {
 		/* See IPv4 comment. */
 		return DROP_UNROUTABLE;
 	}
@@ -798,7 +798,7 @@ skip_vtep:
 	}
 #endif
 
-	if (!info || info->sec_identity == WORLD_ID) {
+	if (!info || (!from_proxy && info->sec_identity == WORLD_ID)) {
 		/* We have received a packet for which no ipcache entry exists,
 		 * we do not know what to do with this packet, drop it.
 		 *
@@ -807,6 +807,10 @@ skip_vtep:
 		 * entry. Therefore we need to test for WORLD_ID. It is clearly
 		 * wrong to route a ctx to cilium_host for which we don't know
 		 * anything about it as otherwise we'll run into a routing loop.
+		 *
+		 * Note that we do not drop packets from proxy even if they are
+		 * going to WORLD_ID. This is to ensure N/S + L7 connectivity
+		 * and avoid https://github.com/cilium/cilium/issues/21954.
 		 */
 		return DROP_UNROUTABLE;
 	}

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -30,6 +30,7 @@ PROXY_RULE=${23}
 FILTER_PRIO=${24}
 DEFAULT_RTPROTO=${25}
 LOCAL_RULE_PRIO=${26}
+ENCRYPTION=${27}
 
 # If the value below is changed, be sure to update bugtool/cmd/configuration.go
 # as well when dumping the routing table in bugtool. See GH-5828.
@@ -120,7 +121,7 @@ function setup_proxy_rules()
 			if [ -z "$(ip -4 rule list $to_proxy_rulespec)" ]; then
 				ip -4 rule add $to_proxy_rulespec
 			fi
-			if [ "$ENDPOINT_ROUTES" = "true" ]; then
+			if [ "$ENDPOINT_ROUTES" = "true" ] && [ "$ENCRYPTION" != "true" ]; then
 				if [ ! -z "$(ip -4 rule list $from_ingress_rulespec)" ]; then
 					ip -4 rule delete $from_ingress_rulespec
 				fi
@@ -134,7 +135,7 @@ function setup_proxy_rules()
 		# Traffic to the host proxy is local
 		ip route replace table $TO_PROXY_RT_TABLE local 0.0.0.0/0 dev lo proto $DEFAULT_RTPROTO
 		# Traffic from ingress proxy goes to Cilium address space via the cilium host device
-		if [ "$ENDPOINT_ROUTES" = "true" ]; then
+                if [ "$ENDPOINT_ROUTES" = "true" ] && [ "$ENCRYPTION" != "true" ]; then
 			ip route delete table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1 2>/dev/null || true
 			ip route delete table $PROXY_RT_TABLE default via $IP4_HOST 2>/dev/null || true
 		else
@@ -151,7 +152,7 @@ function setup_proxy_rules()
 			if [ -z "$(ip -6 rule list $to_proxy_rulespec)" ]; then
 				ip -6 rule add $to_proxy_rulespec
 			fi
-			if [ "$ENDPOINT_ROUTES" = "true" ]; then
+                        if [ "$ENDPOINT_ROUTES" = "true" ] && [ "$ENCRYPTION" != "true" ]; then
 				if [ ! -z "$(ip -6 rule list $from_ingress_rulespec)" ]; then
 					ip -6 rule delete $from_ingress_rulespec
 				fi
@@ -167,7 +168,7 @@ function setup_proxy_rules()
 			# Traffic to the host proxy is local
 			ip -6 route replace table $TO_PROXY_RT_TABLE local ::/0 dev lo proto $DEFAULT_RTPROTO
 			# Traffic from ingress proxy goes to Cilium address space via the cilium host device
-			if [ "$ENDPOINT_ROUTES" = "true" ]; then
+                        if [ "$ENDPOINT_ROUTES" = "true" ] && [ "$ENCRYPTION" != "true" ]; then
 				ip -6 route delete table $PROXY_RT_TABLE ${IP6_LLADDR}/128 dev $HOST_DEV1 2>/dev/null || true
 				ip -6 route delete table $PROXY_RT_TABLE default via $IP6_LLADDR dev $HOST_DEV1 2>/dev/null || true
 			else

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -139,17 +139,29 @@ function setup_proxy_rules()
 			if [ -z "$(ip -6 rule list $to_proxy_rulespec)" ]; then
 				ip -6 rule add $to_proxy_rulespec
 			fi
-
-			ip -6 rule delete $from_ingress_rulespec || true
+			if [ "$ENDPOINT_ROUTES" = "true" ]; then
+				if [ ! -z "$(ip -6 rule list $from_ingress_rulespec)" ]; then
+					ip -6 rule delete $from_ingress_rulespec
+				fi
+			else
+				if [ -z "$(ip -6 rule list $from_ingress_rulespec)" ]; then
+					ip -6 rule add $from_ingress_rulespec
+				fi
+			fi
 		fi
 
 		IP6_LLADDR=$(ip -6 addr show dev $HOST_DEV2 | grep inet6 | head -1 | awk '{print $2}' | awk -F'/' '{print $1}')
 		if [ -n "$IP6_LLADDR" ]; then
 			# Traffic to the host proxy is local
 			ip -6 route replace table $TO_PROXY_RT_TABLE local ::/0 dev lo proto $DEFAULT_RTPROTO
-			# The $PROXY_RT_TABLE is no longer in use, so delete it
-			ip -6 route delete table $PROXY_RT_TABLE ${IP6_LLADDR}/128 dev $HOST_DEV1 2>/dev/null || true
-			ip -6 route delete table $PROXY_RT_TABLE default via $IP6_LLADDR dev $HOST_DEV1 2>/dev/null || true
+			# Traffic from ingress proxy goes to Cilium address space via the cilium host device
+			if [ "$ENDPOINT_ROUTES" = "true" ]; then
+				ip -6 route delete table $PROXY_RT_TABLE ${IP6_LLADDR}/128 dev $HOST_DEV1 2>/dev/null || true
+				ip -6 route delete table $PROXY_RT_TABLE default via $IP6_LLADDR dev $HOST_DEV1 2>/dev/null || true
+			else
+				ip -6 route replace table $PROXY_RT_TABLE ${IP6_LLADDR}/128 dev $HOST_DEV1
+				ip -6 route replace table $PROXY_RT_TABLE default via $IP6_LLADDR dev $HOST_DEV1
+			fi
 		fi
 	else
 		ip -6 rule del $to_proxy_rulespec 2> /dev/null || true

--- a/bpf/init.sh
+++ b/bpf/init.sh
@@ -105,7 +105,8 @@ function move_local_rules()
 
 function setup_proxy_rules()
 {
-	# TODO(brb): remove $PROXY_RT_TABLE -related code in v1.15
+	# Any packet from an ingress proxy uses a separate routing table that routes
+	# the packet back to the cilium host device.
 	from_ingress_rulespec="fwmark 0xA00/0xF00 pref 10 lookup $PROXY_RT_TABLE proto $DEFAULT_RTPROTO"
 
 	# Any packet to an ingress or egress proxy uses a separate routing table
@@ -119,16 +120,27 @@ function setup_proxy_rules()
 			if [ -z "$(ip -4 rule list $to_proxy_rulespec)" ]; then
 				ip -4 rule add $to_proxy_rulespec
 			fi
-
-			ip -4 rule delete $from_ingress_rulespec || true
+			if [ "$ENDPOINT_ROUTES" = "true" ]; then
+				if [ ! -z "$(ip -4 rule list $from_ingress_rulespec)" ]; then
+					ip -4 rule delete $from_ingress_rulespec
+				fi
+			else
+				if [ -z "$(ip -4 rule list $from_ingress_rulespec)" ]; then
+					ip -4 rule add $from_ingress_rulespec
+				fi
+			fi
 		fi
 
 		# Traffic to the host proxy is local
 		ip route replace table $TO_PROXY_RT_TABLE local 0.0.0.0/0 dev lo proto $DEFAULT_RTPROTO
-
-		# The $PROXY_RT_TABLE is no longer in use, so delete it
-		ip route delete table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1 2>/dev/null || true
-		ip route delete table $PROXY_RT_TABLE default via $IP4_HOST 2>/dev/null || true
+		# Traffic from ingress proxy goes to Cilium address space via the cilium host device
+		if [ "$ENDPOINT_ROUTES" = "true" ]; then
+			ip route delete table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1 2>/dev/null || true
+			ip route delete table $PROXY_RT_TABLE default via $IP4_HOST 2>/dev/null || true
+		else
+			ip route replace table $PROXY_RT_TABLE $IP4_HOST/32 dev $HOST_DEV1
+			ip route replace table $PROXY_RT_TABLE default via $IP4_HOST
+		fi
 	else
 		ip -4 rule del $to_proxy_rulespec 2> /dev/null || true
 		ip -4 rule del $from_ingress_rulespec 2> /dev/null || true

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -745,8 +745,8 @@ static __always_inline __u32 or_encrypt_key(__u8 key)
  * cilium_host @egress
  *   bpf_host -> bpf_lxc
  */
-#define TC_INDEX_F_SKIP_INGRESS_PROXY	1
-#define TC_INDEX_F_SKIP_EGRESS_PROXY	2
+#define TC_INDEX_F_FROM_INGRESS_PROXY	1
+#define TC_INDEX_F_FROM_EGRESS_PROXY	2
 #define TC_INDEX_F_SKIP_NODEPORT	4
 #define TC_INDEX_F_SKIP_RECIRCULATION	8
 #define TC_INDEX_F_SKIP_HOST_FIREWALL	16

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -83,9 +83,16 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip __maybe_un
  */
 static __always_inline int
 encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __be32 tunnel_endpoint,
+			       __u8 encrypt_key __maybe_unused,
 			       __u32 seclabel, __u32 dstid,
 			       const struct trace_ctx *trace)
 {
+#ifdef ENABLE_IPSEC
+	if (encrypt_key)
+		return set_ipsec_encrypt(ctx, encrypt_key, tunnel_endpoint,
+					 seclabel);
+#endif
+
 	return __encap_and_redirect_with_nodeid(ctx, 0, tunnel_endpoint,
 						seclabel, dstid, NOT_VTEP_DST,
 						trace);

--- a/bpf/lib/proxy.h
+++ b/bpf/lib/proxy.h
@@ -368,11 +368,11 @@ static __always_inline bool tc_index_skip_ingress_proxy(struct __ctx_buff *ctx)
 {
 	volatile __u32 tc_index = ctx->tc_index;
 #ifdef DEBUG
-	if (tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY)
+	if (tc_index & TC_INDEX_F_FROM_INGRESS_PROXY)
 		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
 #endif
 
-	return tc_index & TC_INDEX_F_SKIP_INGRESS_PROXY;
+	return tc_index & TC_INDEX_F_FROM_INGRESS_PROXY;
 }
 
 /**
@@ -382,10 +382,10 @@ static __always_inline bool tc_index_skip_egress_proxy(struct __ctx_buff *ctx)
 {
 	volatile __u32 tc_index = ctx->tc_index;
 #ifdef DEBUG
-	if (tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY)
+	if (tc_index & TC_INDEX_F_FROM_EGRESS_PROXY)
 		cilium_dbg(ctx, DBG_SKIP_PROXY, tc_index, 0);
 #endif
 
-	return tc_index & TC_INDEX_F_SKIP_EGRESS_PROXY;
+	return tc_index & TC_INDEX_F_FROM_EGRESS_PROXY;
 }
 #endif /* __LIB_PROXY_H_ */

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -64,6 +64,7 @@ const (
 	initTCFilterPriority
 	initDefaultRTProto
 	initLocalRulePriority
+	initEncryption
 	initArgMax
 )
 
@@ -466,6 +467,12 @@ func (l *Loader) Reinitialize(ctx context.Context, o datapath.BaseProgramOwner, 
 	args[initTCFilterPriority] = "<nil>"
 	args[initDefaultRTProto] = strconv.Itoa(linux_defaults.RTProto)
 	args[initLocalRulePriority] = strconv.Itoa(linux_defaults.RulePriorityLocalLookup)
+
+	if option.Config.EnableIPSec || option.Config.EnableWireguard {
+		args[initEncryption] = "true"
+	} else {
+		args[initEncryption] = "false"
+	}
 
 	// "Legacy" datapath inizialization with the init.sh script
 	// TODO(mrostecki): Rewrite the whole init.sh in Go, step by step.


### PR DESCRIPTION
See commit message.

```release-note
Ensure IPsec packets go through the right path when applying L7 policies
```
