### PR TITLE
Documentation: Consistently use --set for cilium install

### DIFF
--- a/Documentation/contributing/development/bgp_cplane.rst
+++ b/Documentation/contributing/development/bgp_cplane.rst
@@ -57,7 +57,7 @@ Install Cilium on the lab with your favorite way. The following example assumes 
 .. code-block:: shell-session
 
    $ KIND_CLUSTER_NAME=bgp-cplane-dev-v4 make kind-image
-   $ cilium install --chart-directory install/kubernetes/cilium -f contrib/containerlab/bgp-cplane-dev-v4/values.yaml --helm-set image.override="localhost:5000/cilium/cilium-dev:local" --helm-set image.pullPolicy=Never --helm-set operator.image.override="localhost:5000/cilium/operator-generic:local" --helm-set operator.image.pullPolicy=Never
+   $ cilium install --chart-directory install/kubernetes/cilium -f contrib/containerlab/bgp-cplane-dev-v4/values.yaml --set image.override="localhost:5000/cilium/cilium-dev:local" --set image.pullPolicy=Never --set operator.image.override="localhost:5000/cilium/operator-generic:local" --set operator.image.pullPolicy=Never
 
 Peering with Router
 -------------------

--- a/Documentation/contributing/testing/e2e.rst
+++ b/Documentation/contributing/testing/e2e.rst
@@ -70,11 +70,11 @@ You can install Cilium with the following command:
 
     $ cilium install --wait \
         --chart-directory=$GOPATH/src/github.com/cilium/cilium/install/kubernetes/cilium \
-        --helm-set=image.override=localhost:5000/cilium/cilium-dev:local \
-        --helm-set=image.pullPolicy=Never \
-        --helm-set=operator.image.override=localhost:5000/cilium/operator-generic:local \
-        --helm-set=operator.image.pullPolicy=Never \
-        --helm-set-string=tunnel=vxlan \
+        --set image.override=localhost:5000/cilium/cilium-dev:local \
+        --set image.pullPolicy=Never \
+        --set operator.image.override=localhost:5000/cilium/operator-generic:local \
+        --set operator.image.pullPolicy=Never \
+        --set tunnel=vxlan \
         --nodes-without-cilium=kind-worker3
     ...
     ⌛ Waiting for Cilium to be installed and ready...
@@ -156,7 +156,7 @@ Finally, you can SSH into the VM to start a K8s cluster, install Cilium, and fin
     # ./cilium install --wait \
         --chart-directory=../cilium/install/kubernetes/cilium \
         --version=v1.13.2 \
-        --helm-set-string=tunnel=vxlan \
+        --set tunnel=vxlan \
         --nodes-without-cilium=kind-worker3
     # ./cilium connectivity test
     ...

--- a/Documentation/network/servicemesh/installation.rst
+++ b/Documentation/network/servicemesh/installation.rst
@@ -30,7 +30,7 @@ Installation
             $ helm upgrade cilium |CHART_RELEASE| \\
                 --namespace kube-system \\
                 --reuse-values \\
-                --set-string extraConfig.enable-envoy-config=true
+                --set envoyConfig.enabled=true
             $ kubectl -n kube-system rollout restart deployment/cilium-operator
             $ kubectl -n kube-system rollout restart ds/cilium
 
@@ -76,7 +76,7 @@ Installation
 
             $ cilium install |CHART_VERSION| \
                 --set kubeProxyReplacement=true \
-                --set-string extraConfig.enable-envoy-config=true
+                --set envoyConfig.enabled=true
 
         Additionally, the proxy load-balancing feature can be configured with the ``loadBalancer.l7.backend=envoy`` flag.
 
@@ -84,7 +84,7 @@ Installation
 
             $ cilium install |CHART_VERSION| \
                 --set kubeProxyReplacement=true \
-                --set-string extraConfig.enable-envoy-config=true \
+                --set envoyConfig.enabled=true \
                 --set loadBalancer.l7.backend=envoy
 
         Next you can check the status of the Cilium agent and operator:

--- a/Documentation/network/servicemesh/mutual-authentication/installation.rst
+++ b/Documentation/network/servicemesh/mutual-authentication/installation.rst
@@ -28,8 +28,8 @@ Installation
         .. code-block:: shell-session
 
             $ cilium install \
-                --helm-set authentication.mutual.spire.enabled=true \
-                --helm-set authentication.mutual.spire.install.enabled=true
+                --set authentication.mutual.spire.enabled=true \
+                --set authentication.mutual.spire.install.enabled=true
 
         Next, you can check the status of the Cilium agent and operator:
 


### PR DESCRIPTION
- Replace --helm-set with --set since --helm-set is deprecated.
- Don't use --set-string unless it's necessary.
- Use envoyConfig.enabled to set enable-envoy-config to true in cilium-config ConfigMap instead of using extraConfig.

Ref: https://github.com/cilium/cilium-cli/issues/2030