### PR TITLE
checkpatch: Fix on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -872,3 +872,6 @@ force :;
 CILIUM_BUILDER_IMAGE=$(shell cat images/cilium/Dockerfile | grep "ARG CILIUM_BUILDER_IMAGE=" | cut -d"=" -f2)
 run_bpf_tests:
 	docker run -v $$(pwd):/src --privileged -w /src -e RUN_WITH_SUDO=false $(CILIUM_BUILDER_IMAGE) "make" "-C" "test/" "run_bpf_tests"
+
+checkpatch:
+	$(MAKE) -C bpf checkpatch

--- a/bpf/Makefile.bpf
+++ b/bpf/Makefile.bpf
@@ -57,7 +57,19 @@ force:
 # TODO: revert addition of ignore MACRO_ARG_REUSE below once cilium-checkpatch
 # image is updated to ignore it.
 #
-CHECKPATCH_IMAGE := quay.io/cilium/cilium-checkpatch:a8f73eced11c29d8c5003ba75071fb9ff91251e4@sha256:9fba31c924b0e675ee45dada3788ded045cd63c979fae3cddcb08636ed2e00da
+CHECKPATCH_IMAGE = quay.io/cilium/cilium-checkpatch:a8f73eced11c29d8c5003ba75071fb9ff91251e4@sha256:9fba31c924b0e675ee45dada3788ded045cd63c979fae3cddcb08636ed2e00da
+#
+# Docker on macOS handles file permissions differently, do not map uid:gid on Darwin
+#	
+# Use the new multiarch image only on macOS, as it introduces a checkpatch.pl permissions
+# issue if run as non-root user.
+#
+CONTAINER_USER=
+ifeq ("$(shell uname -o)","Darwin")
+	CHECKPATCH_IMAGE = quay.io/cilium/cilium-checkpatch:d434038978e00477b48d696c02e3ba75c7753a4c@sha256:6f3d127c608d138e4725315508b88b1126f60e5d88f9cb0d570ed4e2edb10b77
+else
+	CONTAINER_USER=--user "$(shell id -u):$(shell id -g)"
+endif
 ifneq ($(CHECKPATCH_DEBUG),)
   # Run script with "bash -x"
   CHECKPATCH_IMAGE_AND_ENTRY := \
@@ -72,7 +84,7 @@ checkpatch:
 	$(QUIET) $(CONTAINER_ENGINE) container run --rm \
 		--workdir /workspace \
 		--volume $(CURDIR)/..:/workspace \
-		--user "$(shell id -u):$(shell id -g)" \
+		$(CONTAINER_USER) \
 		-e GITHUB_REF=$(GITHUB_REF) -e GITHUB_REPOSITORY=$(GITHUB_REPOSITORY) \
 		$(CHECKPATCH_IMAGE_AND_ENTRY) $(CHECKPATCH_ARGS)
 


### PR DESCRIPTION
Bump checkpatch to a multiarch image and remove user:group mapping on macOS to allow it to run properly.

The old image is retained on non-macOS as it introduces the problem (2 below) when run as non-root user.

Add a top level make target for convenience.

Docker desktop on macOS maps user id:gruop on file operations transparently, so that container can run as "root" without having root privileges on the host. This causes two problems when user and group are mapped to be the same in the container as they are in the host:

1. git does not work:

	fatal: detected dubious ownership in repository at '/workspace'
	To add an exception for this directory, call:

		git config --global --add safe.directory /workspace

2. checkpatch.pl can not be run:

	/checkpatch/checkpatch.sh: line 282: /checkpatch/checkpatch.pl: Permission denied

Both of these problems are resolved, if the '--user' parameter is omitted on macOS.
