### PR TITLE
make: add "run-builder" target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -872,3 +872,6 @@ force :;
 CILIUM_BUILDER_IMAGE=$(shell cat images/cilium/Dockerfile | grep "ARG CILIUM_BUILDER_IMAGE=" | cut -d"=" -f2)
 run_bpf_tests:
 	docker run -v $$(pwd):/src --privileged -w /src -e RUN_WITH_SUDO=false $(CILIUM_BUILDER_IMAGE) "make" "-C" "test/" "run_bpf_tests"
+
+run-builder:
+	docker run -it --rm -v $$(pwd):/go/src/github.com/cilium/cilium $(CILIUM_BUILDER_IMAGE) bash


### PR DESCRIPTION
Add make target for running bash in the cilium builder container.  This provides quick access for the correct build environment, with the correct go version for example. If backported to releases, this makes it easy to to work with go vendoring with different releases, which each require a different Go version to be able to run 'go mod' commands.
