### PR TITLE
resource: Fix flaky TestResource_RepeatedDelete

### DIFF
--- a/pkg/k8s/resource/resource_test.go
+++ b/pkg/k8s/resource/resource_test.go
@@ -246,6 +246,29 @@ func TestResource_WithFakeClient(t *testing.T) {
 	}
 }
 
+type createsAndDeletesListerWatcher struct {
+	events chan watch.Event
+}
+
+func (lw *createsAndDeletesListerWatcher) ResultChan() <-chan watch.Event {
+	return lw.events
+}
+
+func (lw *createsAndDeletesListerWatcher) Stop() {
+	close(lw.events)
+}
+
+func (*createsAndDeletesListerWatcher) List(options metav1.ListOptions) (k8sRuntime.Object, error) {
+	return &corev1.NodeList{}, nil
+}
+
+func (lw *createsAndDeletesListerWatcher) Watch(options metav1.ListOptions) (watch.Interface, error) {
+	return lw, nil
+}
+
+var _ cache.ListerWatcher = &createsAndDeletesListerWatcher{}
+var _ watch.Interface = &createsAndDeletesListerWatcher{}
+
 func TestResource_RepeatedDelete(t *testing.T) {
 	var (
 		nodeName = "some-node"
@@ -259,9 +282,9 @@ func TestResource_RepeatedDelete(t *testing.T) {
 			},
 		}
 
-		nodes          resource.Resource[*corev1.Node]
-		fakeClient, cs = k8sClient.NewFakeClientset()
+		nodes resource.Resource[*corev1.Node]
 
+		lw     = createsAndDeletesListerWatcher{events: make(chan watch.Event, 100)}
 		events <-chan resource.Event[*corev1.Node]
 	)
 
@@ -269,8 +292,11 @@ func TestResource_RepeatedDelete(t *testing.T) {
 	defer cancel()
 
 	hive := hive.New(
-		cell.Provide(func() k8sClient.Clientset { return cs }),
-		nodesResource,
+		cell.Provide(
+			func(lc hive.Lifecycle) resource.Resource[*corev1.Node] {
+				return resource.New[*corev1.Node](lc, &lw)
+			}),
+
 		cell.Invoke(func(r resource.Resource[*corev1.Node]) {
 			nodes = r
 
@@ -298,24 +324,29 @@ func TestResource_RepeatedDelete(t *testing.T) {
 		for i := 0; i < 1000; i++ {
 			node.ObjectMeta.ResourceVersion = fmt.Sprintf("%d", i)
 
-			fakeClient.KubernetesFakeClientset.Tracker().Create(
-				corev1.SchemeGroupVersion.WithResource("nodes"),
-				node.DeepCopy(), "")
+			lw.events <- watch.Event{
+				Type:   watch.Added,
+				Object: node.DeepCopy(),
+			}
 
+			// Sleep tiny amount to force a context switch
 			time.Sleep(time.Microsecond)
 
-			fakeClient.KubernetesFakeClientset.Tracker().Delete(
-				corev1.SchemeGroupVersion.WithResource("nodes"),
-				"", "some-node")
+			lw.events <- watch.Event{
+				Type:   watch.Deleted,
+				Object: node.DeepCopy(),
+			}
 
+			// Sleep tiny amount to force a context switch
 			time.Sleep(time.Microsecond)
 		}
 
 		// Create final copy of the object to mark the end of the test.
 		node.ObjectMeta.ResourceVersion = finalVersion
-		fakeClient.KubernetesFakeClientset.Tracker().Create(
-			corev1.SchemeGroupVersion.WithResource("nodes"),
-			node.DeepCopy(), "")
+		lw.events <- watch.Event{
+			Type:   watch.Added,
+			Object: node.DeepCopy(),
+		}
 	}()
 
 	var (


### PR DESCRIPTION
The fake K8s client checks if the events channel becomes full and panics if it does. Fix this by using a hand-rolled ListerWatcher to have full control over the events channel.

Fixes: #28575
Fixes: a7f1eeffc1c6 ("resource: Fix double upserts on subscribe and retrying of delete events")
