### PR TITLE
hubble/relay: Remove ReportOffline and refactor PeerManager

### DIFF
--- a/pkg/hubble/peer/types/peer.go
+++ b/pkg/hubble/peer/types/peer.go
@@ -98,3 +98,13 @@ func FromChangeNotification(cn *peerpb.ChangeNotification) *Peer {
 func (p Peer) String() string {
 	return p.Name
 }
+
+// Equal reports whether the Peer is equal to the provided Peer
+func (p Peer) Equal(o Peer) bool {
+	addrEq := (p.Address == nil && o.Address == nil) ||
+		(p.Address.String() == o.Address.String() && p.Address.Network() == o.Address.Network())
+	return p.Name == o.Name &&
+		p.TLSEnabled == o.TLSEnabled &&
+		p.TLSServerName == o.TLSServerName &&
+		addrEq
+}

--- a/pkg/hubble/relay/observer/observer.go
+++ b/pkg/hubble/relay/observer/observer.go
@@ -25,11 +25,9 @@ func isAvailable(conn poolTypes.ClientConn) bool {
 	if conn == nil {
 		return false
 	}
-	switch conn.GetState() {
-	case connectivity.Ready, connectivity.Idle:
-		return true
-	}
-	return false
+	state := conn.GetState()
+	return state != connectivity.TransientFailure &&
+		state != connectivity.Shutdown
 }
 
 func retrieveFlowsFromPeer(

--- a/pkg/hubble/relay/observer/server_test.go
+++ b/pkg/hubble/relay/observer/server_test.go
@@ -49,7 +49,7 @@ func TestGetFlows(t *testing.T) {
 	done := make(chan struct{})
 	tests := []struct {
 		name   string
-		plr    PeerListReporter
+		plr    PeerLister
 		ocb    observerClientBuilder
 		req    *observerpb.GetFlowsRequest
 		stream observerpb.Observer_GetFlowsServer
@@ -57,7 +57,7 @@ func TestGetFlows(t *testing.T) {
 	}{
 		{
 			name: "Observe 0 flows from 1 peer without address",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -69,7 +69,6 @@ func TestGetFlows(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(name string) {},
 			},
 			ocb: fakeObserverClientBuilder{},
 			req: &observerpb.GetFlowsRequest{Number: 0},
@@ -105,7 +104,7 @@ func TestGetFlows(t *testing.T) {
 			},
 		}, {
 			name: "Observe 4 flows from 2 online peers",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -199,7 +198,7 @@ func TestGetFlows(t *testing.T) {
 			},
 		}, {
 			name: "Observe 2 flows from 1 online peer and none from 1 unavailable peer",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -231,7 +230,6 @@ func TestGetFlows(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(name string) {},
 			},
 			ocb: fakeObserverClientBuilder{
 				onObserverClient: func(p *poolTypes.Peer) observerpb.ObserverClient {
@@ -349,14 +347,14 @@ func TestGetNodes(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		plr  PeerListReporter
+		plr  PeerLister
 		ocb  observerClientBuilder
 		req  *observerpb.GetNodesRequest
 		want want
 	}{
 		{
 			name: "1 peer without address",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -368,7 +366,6 @@ func TestGetNodes(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(_ string) {},
 			},
 			ocb: fakeObserverClientBuilder{},
 			want: want{
@@ -392,7 +389,7 @@ func TestGetNodes(t *testing.T) {
 			},
 		}, {
 			name: "2 connected peers",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -488,7 +485,7 @@ func TestGetNodes(t *testing.T) {
 			},
 		}, {
 			name: "2 connected peers with TLS",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -588,7 +585,7 @@ func TestGetNodes(t *testing.T) {
 			},
 		}, {
 			name: "1 connected peer, 1 unreachable peer",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -620,7 +617,6 @@ func TestGetNodes(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(_ string) {},
 			},
 			ocb: fakeObserverClientBuilder{
 				onObserverClient: func(p *poolTypes.Peer) observerpb.ObserverClient {
@@ -677,7 +673,7 @@ func TestGetNodes(t *testing.T) {
 			},
 		}, {
 			name: "1 connected peer, 1 unreachable peer, 1 peer with error",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -722,7 +718,6 @@ func TestGetNodes(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(_ string) {},
 			},
 			ocb: fakeObserverClientBuilder{
 				onObserverClient: func(p *poolTypes.Peer) observerpb.ObserverClient {
@@ -828,14 +823,14 @@ func TestGetNamespaces(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		plr  PeerListReporter
+		plr  PeerLister
 		ocb  observerClientBuilder
 		req  *observerpb.GetNamespacesRequest
 		want want
 	}{
 		{
 			name: "get no namespaces from 1 peer without address",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -847,7 +842,6 @@ func TestGetNamespaces(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(name string) {},
 			},
 			ocb: fakeObserverClientBuilder{
 				onObserverClient: func(p *poolTypes.Peer) observerpb.ObserverClient {
@@ -869,7 +863,7 @@ func TestGetNamespaces(t *testing.T) {
 		},
 		{
 			name: "2 connected peer, 1 unreachable peer",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -916,7 +910,6 @@ func TestGetNamespaces(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(_ string) {},
 			},
 			ocb: fakeObserverClientBuilder{
 				onObserverClient: func(p *poolTypes.Peer) observerpb.ObserverClient {
@@ -1033,14 +1026,14 @@ func TestServerStatus(t *testing.T) {
 	}
 	tests := []struct {
 		name string
-		plr  PeerListReporter
+		plr  PeerLister
 		ocb  observerClientBuilder
 		req  *observerpb.ServerStatusRequest
 		want want
 	}{
 		{
 			name: "1 peer without address",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -1052,7 +1045,6 @@ func TestServerStatus(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(_ string) {},
 			},
 			ocb: fakeObserverClientBuilder{},
 			want: want{
@@ -1073,7 +1065,7 @@ func TestServerStatus(t *testing.T) {
 			},
 		}, {
 			name: "2 connected peers",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -1148,7 +1140,7 @@ func TestServerStatus(t *testing.T) {
 			},
 		}, {
 			name: "1 connected peer, 1 unreachable peer",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -1180,7 +1172,6 @@ func TestServerStatus(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(_ string) {},
 			},
 			ocb: fakeObserverClientBuilder{
 				onObserverClient: func(p *poolTypes.Peer) observerpb.ObserverClient {
@@ -1220,7 +1211,7 @@ func TestServerStatus(t *testing.T) {
 			},
 		}, {
 			name: "2 unreachable peers",
-			plr: &testutils.FakePeerListReporter{
+			plr: &testutils.FakePeerLister{
 				OnList: func() []poolTypes.Peer {
 					return []poolTypes.Peer{
 						{
@@ -1252,7 +1243,6 @@ func TestServerStatus(t *testing.T) {
 						},
 					}
 				},
-				OnReportOffline: func(_ string) {},
 			},
 			ocb: fakeObserverClientBuilder{
 				onObserverClient: func(p *poolTypes.Peer) observerpb.ObserverClient {

--- a/pkg/hubble/relay/pool/manager.go
+++ b/pkg/hubble/relay/pool/manager.go
@@ -223,6 +223,7 @@ func (m *PeerManager) List() []poolTypes.Peer {
 	peers := make([]poolTypes.Peer, 0, len(m.peers))
 	for _, v := range m.peers {
 		// note: there shouldn't be null entries in the map
+		v.mu.Lock()
 		peers = append(peers, poolTypes.Peer{
 			Peer: peerTypes.Peer{
 				Name:          v.Name,
@@ -232,6 +233,7 @@ func (m *PeerManager) List() []poolTypes.Peer {
 			},
 			Conn: v.conn,
 		})
+		v.mu.Unlock()
 	}
 	return peers
 }

--- a/pkg/hubble/relay/pool/manager_test.go
+++ b/pkg/hubble/relay/pool/manager_test.go
@@ -317,10 +317,10 @@ func TestPeerManager(t *testing.T) {
 				OnClientConn: func(target, hostname string) (poolTypes.ClientConn, error) {
 					return testutils.FakeClientConn{
 						OnGetState: func() connectivity.State {
+							once.Do(func() { close(done) })
 							return connectivity.TransientFailure
 						},
 						OnClose: func() error {
-							once.Do(func() { close(done) })
 							return nil
 						},
 					}, nil

--- a/pkg/hubble/relay/server/server_test.go
+++ b/pkg/hubble/relay/server/server_test.go
@@ -216,7 +216,7 @@ func benchmarkRelayGetFlows(b *testing.B, withFieldMask bool) {
 			grpc.WithReturnConnectionError(),
 		},
 	}
-	plr := &testutils.FakePeerListReporter{
+	plr := &testutils.FakePeerLister{
 		OnList: func() []poolTypes.Peer {
 			ret := make([]poolTypes.Peer, len(peers))
 			for i := range peers {

--- a/pkg/hubble/testutils/fake.go
+++ b/pkg/hubble/testutils/fake.go
@@ -201,28 +201,18 @@ func (b FakePeerClientBuilder) Client(target string) (peerTypes.Client, error) {
 	panic("OnClient not set")
 }
 
-// FakePeerListReporter is used for unit tests and implements the
+// FakePeerLister is used for unit tests and implements the
 // relay/observer.PeerListReporter interface.
-type FakePeerListReporter struct {
-	OnList          func() []poolTypes.Peer
-	OnReportOffline func(name string)
+type FakePeerLister struct {
+	OnList func() []poolTypes.Peer
 }
 
 // List implements relay/observer.PeerListReporter.List.
-func (r *FakePeerListReporter) List() []poolTypes.Peer {
+func (r *FakePeerLister) List() []poolTypes.Peer {
 	if r.OnList != nil {
 		return r.OnList()
 	}
 	panic("OnList not set")
-}
-
-// ReportOffline implements relay/observer.PeerListReporter.ReportOffline.
-func (r *FakePeerListReporter) ReportOffline(name string) {
-	if r.OnReportOffline != nil {
-		r.OnReportOffline(name)
-		return
-	}
-	panic("OnReportOffline not set")
 }
 
 // FakeClientConn is used for unit tests and implements the


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.


This commit removes the `ReportOffline` method as the gRPC library is already able to notice broken connections and will try to reconnect on its own and uses exponential backoff to try again. While the `ReportOffline` feature might have speed up re-connection time in some cases, it potentially leaked goroutines, tried to reconnect far too often ignoring any backoff, and can result in unexpected interactions with the gRPC library.

The goroutine leak could be triggered by making more than one request every 5 seconds, when at least one peer is inaccessible. We spawned a goroutine for every request that will try and reconnect to the peer. However, we only closed a goroutine whenever a dial times out, which is every 5 second. So if the rate of request is higher than one request every 5 second, we slowly build up goroutines.

At the same time this change fixes two different issues:

* Whenever the relay reconnected to the peer service, it leaked all exiting connections, as it didn't close exiting connections when adding peers with the same name. We fix this by treating `update` and `add` notifications the same.
* There was a minor data race as `List` did not lock the peer when copying the connection (which might be updated by `connect` or `disconnect`)

