### PR TITLE
gateway-api: fix empty URI when removing path prefix

### DIFF
--- a/operator/pkg/model/ingestion/gateway.go
+++ b/operator/pkg/model/ingestion/gateway.go
@@ -4,6 +4,8 @@
 package ingestion
 
 import (
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -273,7 +275,8 @@ func toHTTPRewriteFilter(rewrite *gatewayv1beta1.HTTPURLRewriteFilter) *model.HT
 		case gatewayv1beta1.PrefixMatchHTTPPathModifier:
 			if rewrite.Path.ReplacePrefixMatch != nil {
 				path = &model.StringMatch{
-					Prefix: *rewrite.Path.ReplacePrefixMatch,
+					// a trailing `/` is ignored
+					Prefix: strings.TrimSuffix(*rewrite.Path.ReplacePrefixMatch, "/"),
 				}
 			}
 		}

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -6,6 +6,7 @@ package translation
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -281,9 +282,10 @@ func pathPrefixMutation(rewrite *model.HTTPURLRewriteFilter, httpRoute *model.HT
 
 			route.Route.RegexRewrite = &envoy_type_matcher_v3.RegexMatchAndSubstitute{
 				Pattern: &envoy_type_matcher_v3.RegexMatcher{
-					Regex: "^" + httpRoute.PathMatch.Prefix,
+					Regex: fmt.Sprintf(`^%s(/?)(.*)`, regexp.QuoteMeta(httpRoute.PathMatch.Prefix)),
 				},
-				Substitution: "",
+				// hold `/` in case the entire path is removed
+				Substitution: `/\2`,
 			}
 
 		} else {

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -4,6 +4,8 @@
 package translation
 
 import (
+	"fmt"
+	"regexp"
 	"sort"
 	"testing"
 
@@ -187,9 +189,9 @@ func Test_pathPrefixMutation(t *testing.T) {
 		res := pathPrefixMutation(rewrite, &httpRoute)(route)
 		require.EqualValues(t, &envoy_type_matcher_v3.RegexMatchAndSubstitute{
 			Pattern: &envoy_type_matcher_v3.RegexMatcher{
-				Regex: "^" + httpRoute.PathMatch.Prefix,
+				Regex: fmt.Sprintf(`^%s(/?)(.*)`, regexp.QuoteMeta(httpRoute.PathMatch.Prefix)),
 			},
-			Substitution: "",
+			Substitution: `/\2`,
 		}, res.Route.RegexRewrite)
 	})
 	t.Run("with slash prefix rewrite", func(t *testing.T) {
@@ -207,9 +209,9 @@ func Test_pathPrefixMutation(t *testing.T) {
 		res := pathPrefixMutation(rewrite, &httpRoute)(route)
 		require.EqualValues(t, &envoy_type_matcher_v3.RegexMatchAndSubstitute{
 			Pattern: &envoy_type_matcher_v3.RegexMatcher{
-				Regex: "^" + httpRoute.PathMatch.Prefix,
+				Regex: fmt.Sprintf(`^%s(/?)(.*)`, regexp.QuoteMeta(httpRoute.PathMatch.Prefix)),
 			},
-			Substitution: "",
+			Substitution: `/\2`,
 		}, res.Route.RegexRewrite)
 	})
 }


### PR DESCRIPTION
https://github.com/cilium/cilium/blob/2f8bd31d490b9439ea21d5ffdff1b9902611de24/operator/pkg/model/translation/envoy_virtual_host.go#L282-L287

The current implementation does not handle the case where the entire path is removed. In this case we must set the URI to `/`. Please see https://www.rfc-editor.org/rfc/rfc9112.html#section-3.2.1-2.
> If the target URI's path component is empty, the client __MUST__ send "/" as the path within the origin-form of request-target.

If I have a `RegexRewrite` like:
```yaml
regexRewrite:
  pattern:
    regex: ^/foo
  substitution: ""
```
I will get 502 when accessing `/foo`