### PR TITLE
bpf: overlay: clean up extraction of source identity

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -551,12 +551,11 @@ int cil_from_overlay(struct __ctx_buff *ctx)
  * 1. ESP packets coming from overlay (encrypted and not marked)
  * 2. Non-ESP packets coming from overlay (plain and not marked)
  * 3. Non-ESP packets coming from stack re-inserted by xfrm (plain
- *    and marked with MARK_MAGIC_DECRYPT and has an identity as
- *    well, IPSec mode only)
+ *    and marked with MARK_MAGIC_DECRYPT. Only in IPSec mode.)
  *
  * 1. will be traced with TRACE_REASON_ENCRYPTED
  * 2. will be traced without TRACE_REASON_ENCRYPTED
- * 3. will be traced without TRACE_REASON_ENCRYPTED, and with identity
+ * 3. will be traced without TRACE_REASON_ENCRYPTED
  *
  * Note that 1. contains the ESP packets someone else generated.
  * In that case, we trace it as "encrypted", but it doesn't mean

--- a/bpf/lib/high_scale_ipcache.h
+++ b/bpf/lib/high_scale_ipcache.h
@@ -125,7 +125,6 @@ decapsulate_overlay(struct __ctx_buff *ctx, __u32 *src_id)
 	}
 
 	*src_id = tunnel_vni_to_sec_identity(*src_id);
-	*src_id = get_id_from_tunnel_id(*src_id, proto);
 	ctx_store_meta(ctx, CB_SRC_LABEL, *src_id);
 
 	if (ctx_adjust_hroom(ctx, -shrink, BPF_ADJ_ROOM_MAC, ctx_adjust_hroom_flags()))


### PR DESCRIPTION
This PR removes some clunkiness in `from-overlay`'s approach to handling the source identity, in particular when combined with `ENABLE_NODEPORT`.

Ideally we would also lift the ipcache lookup into earlier stages of the `from-overlay` program, but that's a future item.