### PR TITLE
datapath: Introduce fake datapath cell

### DIFF
--- a/daemon/cmd/daemon_test.go
+++ b/daemon/cmd/daemon_test.go
@@ -19,7 +19,6 @@ import (
 	fakecni "github.com/cilium/cilium/daemon/cmd/cni/fake"
 	"github.com/cilium/cilium/pkg/controller"
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
-	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/envoy"
@@ -33,12 +32,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore/store"
 	"github.com/cilium/cilium/pkg/labelsfilter"
 	"github.com/cilium/cilium/pkg/lock"
-	"github.com/cilium/cilium/pkg/maps/authmap"
-	fakeauthmap "github.com/cilium/cilium/pkg/maps/authmap/fake"
 	ctmapgc "github.com/cilium/cilium/pkg/maps/ctmap/gc"
-	"github.com/cilium/cilium/pkg/maps/egressmap"
-	"github.com/cilium/cilium/pkg/maps/signalmap"
-	fakesignalmap "github.com/cilium/cilium/pkg/maps/signalmap/fake"
 	"github.com/cilium/cilium/pkg/metrics"
 	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
@@ -158,19 +152,14 @@ func (ds *DaemonSuite) SetUpTest(c *C) {
 				cs.Disable()
 				return cs
 			},
-			func() datapath.Datapath { return fakeDatapath.NewDatapath() },
-			func(dp datapath.Datapath) datapath.NodeIDHandler { return dp.NodeIDs() },
 			func() *option.DaemonConfig { return option.Config },
 			func() cnicell.CNIConfigManager { return &fakecni.FakeCNIConfigManager{} },
-			func() signalmap.Map { return fakesignalmap.NewFakeSignalMap([][]byte{}, time.Second) },
-			func() authmap.Map { return fakeauthmap.NewFakeAuthMap() },
-			func() egressmap.PolicyMap { return nil },
 			func() ctmapgc.Enabler { return ctmapgc.NewFake() },
 		),
+		fakeDatapath.Cell,
 		monitorAgent.Cell,
 		ControlPlane,
 		statedb.Cell,
-		tables.Cell,
 		job.Cell,
 		metrics.Cell,
 		store.Cell,

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -33,6 +33,9 @@ import (
 
 // Datapath provides the privileged operations to apply control-plane
 // decision to the kernel.
+//
+// For integration testing a fake counterpart of this module is defined
+// in pkg/datapath/fake/cells.go.
 var Cell = cell.Module(
 	"datapath",
 	"Datapath",

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package fake
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/maps/authmap"
+	"github.com/cilium/cilium/pkg/maps/egressmap"
+	"github.com/cilium/cilium/pkg/maps/signalmap"
+
+	fakeauthmap "github.com/cilium/cilium/pkg/maps/authmap/fake"
+	fakesignalmap "github.com/cilium/cilium/pkg/maps/signalmap/fake"
+)
+
+// Cell provides a fake version of the datapath cell.
+//
+// Used in integration tests such as test/controlplane.
+var Cell = cell.Module(
+	"fake-datapath",
+	"Fake Datapath",
+
+	cell.Provide(
+		func() (*FakeDatapath, types.Datapath, types.NodeIDHandler) {
+			dp := NewDatapath()
+			return dp, dp, dp.NodeIDs()
+		},
+
+		func() signalmap.Map { return fakesignalmap.NewFakeSignalMap([][]byte{}, time.Second) },
+		func() authmap.Map { return fakeauthmap.NewFakeAuthMap() },
+		func() egressmap.PolicyMap { return nil },
+	),
+
+	// This cell defines StateDB tables and their schemas for tables which are used to transfer information
+	// between datapath components and more high-level components.
+	tables.Cell,
+)

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -98,9 +98,6 @@ func (cpt *ControlPlaneTest) SetupEnvironment() *ControlPlaneTest {
 	// Configure k8s and perform capability detection with the fake client.
 	version.Update(cpt.clients, true)
 
-	datapath := fakeDatapath.NewDatapath()
-	cpt.Datapath = datapath
-
 	cpt.tempDir = setupTestDirectories()
 
 	return cpt
@@ -120,7 +117,7 @@ func (cpt *ControlPlaneTest) StartAgent(modConfig func(*agentOption.DaemonConfig
 		t: cpt.t,
 	}
 
-	cpt.agentHandle.setupCiliumAgentHive(cpt.clients, cpt.Datapath, cell.Group(extraCells...))
+	cpt.agentHandle.setupCiliumAgentHive(cpt.clients, cell.Group(extraCells...))
 
 	mockCmd := &cobra.Command{}
 	cpt.agentHandle.hive.RegisterFlags(mockCmd.Flags())
@@ -133,6 +130,7 @@ func (cpt *ControlPlaneTest) StartAgent(modConfig func(*agentOption.DaemonConfig
 		cpt.t.Fatalf("Failed to start cilium agent: %s", err)
 	}
 	cpt.agentHandle.d = daemon
+	cpt.Datapath = cpt.agentHandle.dp
 
 	return cpt
 }


### PR DESCRIPTION
As more of the datapath code is modularized into cells, the fakes needed to be enumerated in big integration tests (daemon/cmd/daemon_test.go and test/controlplane) are starting to become too numerous. To combat this, add fake.Cell as a counterpart for the real datapath cell.

The gc.Enabler is for now left in there due to import cycle.

This PR is preparation for modularization of further components under pkg/datapath and pkg/maps.