### PR TITLE
[WIP] Add WireGuard node-to-node strict mode

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -161,7 +161,8 @@ cilium-agent [flags]
       --encrypt-interface string                                  Transparent encryption interface
       --encrypt-node                                              Enables encrypting traffic from non-Cilium pods and host networking (only supported with WireGuard, beta)
       --encryption-strict-mode-allow-remote-node-identities       Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.
-      --encryption-strict-mode-cidr string                        In strict-mode encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped
+      --encryption-strict-mode-node-cidrs strings                 In strict-mode encryption, all unencrypted traffic coming from one of those CIDRs and going one of those CIDRs will be dropped
+      --encryption-strict-mode-pod-cidrs strings                  In strict-mode encryption, all unencrypted traffic coming from one of those CIDRs and going one of those CIDRs will be dropped
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --endpoint-queue-size int                                   Size of EventQueue per-endpoint (default 25)
       --endpoint-status strings                                   Enable additional CiliumEndpoint status features (controllers,health,log,policy,state)
@@ -326,6 +327,5 @@ cilium-agent [flags]
 
 ### SEE ALSO
 
-* [cilium-agent completion](cilium-agent_completion.md)	 - Generate the autocompletion script for the specified shell
-* [cilium-agent hive](cilium-agent_hive.md)	 - Inspect the hive
-
+* [cilium-agent completion](cilium-agent_completion.md)  - Generate the autocompletion script for the specified shell
+* [cilium-agent hive](cilium-agent_hive.md)  - Inspect the hive

--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -969,21 +969,25 @@
      - string
      - ``"cilium-ipsec-keys"``
    * - :spelling:ignore:`encryption.strictMode`
-     - Configure the WireGuard Pod2Pod strict mode.
+     - Configure the WireGuard strict mode.
      - object
-     - ``{"allowRemoteNodeIdentities":false,"cidr":"","enabled":false}``
+     - ``{"allowRemoteNodeIdentities":true,"enabled":false,"nodeCIDRList":[],"podCIDRList":[]}``
    * - :spelling:ignore:`encryption.strictMode.allowRemoteNodeIdentities`
-     - Allow dynamic lookup of remote node identities. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.
+     - Allow dynamic lookup of remote node identities. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap. This is also required when control-plane nodes are exempted from node-to-node encryption.
      - bool
-     - ``false``
-   * - :spelling:ignore:`encryption.strictMode.cidr`
-     - CIDR for the WireGuard Pod2Pod strict mode.
-     - string
-     - ``""``
+     - ``true``
    * - :spelling:ignore:`encryption.strictMode.enabled`
-     - Enable WireGuard Pod2Pod strict mode.
+     - Enable WireGuard strict mode.
      - bool
      - ``false``
+   * - :spelling:ignore:`encryption.strictMode.nodeCIDRList`
+     - nodeCIDRList for the WireGuard strict mode.
+     - list
+     - ``[]``
+   * - :spelling:ignore:`encryption.strictMode.podCIDRList`
+     - podCIDRList for the WireGuard strict mode.
+     - list
+     - ``[]``
    * - :spelling:ignore:`encryption.type`
      - Encryption method. Can be either ipsec or wireguard.
      - string

--- a/bpf/bpf_alignchecker.c
+++ b/bpf/bpf_alignchecker.c
@@ -85,3 +85,4 @@ add_type(struct tunnel_key);
 add_type(struct tunnel_value);
 add_type(struct auth_key);
 add_type(struct auth_info);
+add_type(struct strict_mode_policy);

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1433,11 +1433,11 @@ skip_host_firewall:
 	 * packet to check if the packet's original destination is allowed to
 	 * be sent unencrypted.
 	 */
-#if !defined(TUNNEL_MODE) && defined(ENCRYPTION_STRICT_MODE)
+#if defined(ENCRYPTION_STRICT_MODE) && (!defined(TUNNEL_MODE) || defined(ENABLE_NODE_ENCRYPTION))
 	if (!strict_allow(ctx))
 		return send_drop_notify_error(ctx, 0, DROP_UNENCRYPTED_TRAFFIC,
 					      CTX_ACT_DROP, METRIC_EGRESS);
-#endif /* !TUNNEL_MODE && ENCRYPTION_STRICT_MODE */
+#endif /* ENCRYPTION_STRICT_MODE && (!TUNNEL_MODE || ENABLE_NODE_ENCRYPTION) */
 #endif /* ENABLE_WIREGUARD */
 
 #ifdef ENABLE_SRV6

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -662,11 +662,11 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	 * packets against the CIDRs before encapsulation. If the packet is not
 	 * encrypted, we drop it.
 	 */
-	#if defined(TUNNEL_MODE) && defined(ENCRYPTION_STRICT_MODE)
+#if !defined(ENABLE_NODE_ENCRYPTION) && defined(TUNNEL_MODE) && defined(ENCRYPTION_STRICT_MODE)
 	if (!strict_allow(ctx))
 		return send_drop_notify_error(ctx, 0, DROP_UNENCRYPTED_TRAFFIC,
 					      CTX_ACT_DROP, METRIC_EGRESS);
-	#endif
+#endif
 
 #ifdef ENABLE_BANDWIDTH_MANAGER
 	/* In tunneling mode, we should do this as close as possible to the

--- a/bpf/lib/maps.h
+++ b/bpf/lib/maps.h
@@ -183,6 +183,22 @@ struct {
 	__uint(max_entries, 1);
 } ENCRYPT_MAP __section_maps_btf;
 
+struct strict_mode_policy {
+	__u8	allow;
+	__u8	pad1;
+	__be16	port1;
+	__be16	port2;
+};
+
+struct {
+	__uint(type, BPF_MAP_TYPE_LPM_TRIE);
+	__type(key, struct ipcache_key);
+	__type(value, struct strict_mode_policy);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, STRICT_MAP_SIZE);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
+} STRICT_MODE_MAP __section_maps_btf;
+
 struct node_key {
 	__u16 pad1;
 	__u8 pad2;

--- a/bpf/node_config.h
+++ b/bpf/node_config.h
@@ -148,6 +148,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define AUTH_MAP test_cilium_auth
 #define CONFIG_MAP test_cilium_runtime_config
 #define IPCACHE_MAP test_cilium_ipcache
+#define STRICT_MODE_MAP test_cilium_strict_mode_map
 #define NODE_MAP test_cilium_node_map
 #define ENCRYPT_MAP test_cilium_encrypt_state
 #define L2_RESPONDER_MAP4 test_cilium_l2_responder_v4
@@ -186,6 +187,7 @@ DEFINE_IPV6(HOST_IP, 0xbe, 0xef, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, 0x0, 0xa, 0x
 #define POLICY_MAP_SIZE 16384
 #define AUTH_MAP_SIZE 512000
 #define CONFIG_MAP_SIZE 256
+#define STRICT_MAP_SIZE 5
 #define IPCACHE_MAP_SIZE 512000
 #define NODE_MAP_SIZE 16384
 #define EGRESS_POLICY_MAP_SIZE 16384

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -464,6 +464,10 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		return nil, nil, fmt.Errorf("unable to setup encryption: %s", err)
 	}
 
+	if err := setupStrictModeMap(); err != nil {
+		return nil, nil, fmt.Errorf("unable to setup strict map: %s", err)
+	}
+
 	var mtuConfig mtu.Configuration
 	externalIP := node.GetIPv4()
 	if externalIP == nil {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -391,8 +391,11 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.EnableEncryptionStrictMode, false, "Enable encryption strict mode")
 	option.BindEnv(vp, option.EnableEncryptionStrictMode)
 
-	flags.String(option.EncryptionStrictModeCIDR, "", "In strict-mode encryption, all unencrypted traffic coming from this CIDR and going to this same CIDR will be dropped")
-	option.BindEnv(vp, option.EncryptionStrictModeCIDR)
+	flags.StringSlice(option.EncryptionStrictModeNodeCIDRs, []string{}, "In strict-mode encryption, all unencrypted traffic coming from one of those CIDRs and going one of those CIDRs will be dropped")
+	option.BindEnv(vp, option.EncryptionStrictModeNodeCIDRs)
+
+	flags.StringSlice(option.EncryptionStrictModePodCIDRs, []string{}, "In strict-mode encryption, all unencrypted traffic coming from one of those CIDRs and going one of those CIDRs will be dropped")
+	option.BindEnv(vp, option.EncryptionStrictModePodCIDRs)
 
 	flags.Bool(option.EncryptionStrictModeAllowRemoteNodeIdentities, false, "Allows unencrypted traffic from pods to remote node identities within the strict mode CIDR. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.")
 	option.BindEnv(vp, option.EncryptionStrictModeAllowRemoteNodeIdentities)

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
+	k8sLabels "k8s.io/apimachinery/pkg/labels"
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/controller"
@@ -40,6 +41,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/neighborsmap"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/maps/srv6map"
+	"github.com/cilium/cilium/pkg/maps/strictmap"
 	"github.com/cilium/cilium/pkg/maps/tunnel"
 	"github.com/cilium/cilium/pkg/maps/vtep"
 	"github.com/cilium/cilium/pkg/maps/worldcidrsmap"
@@ -524,6 +526,54 @@ func setupIPSec() (int, uint8, error) {
 	}
 	node.SetIPsecKeyIdentity(spi)
 	return authKeySize, spi, nil
+}
+
+func setupStrictModeMap() error {
+	if err := strictmap.Create(); err != nil {
+		return fmt.Errorf("initializing strict mode map: %w", err)
+	}
+
+	strictCIDRs := append(option.Config.EncryptionStrictModeNodeCIDRs, option.Config.EncryptionStrictModePodCIDRs...)
+	for _, cidr := range strictCIDRs {
+
+		ipv4Interface, ok := netip.AddrFromSlice(node.GetIPv4().To4())
+		if !ok {
+			return fmt.Errorf("unable to parse node IPv4 address %s", node.GetIPv4())
+		}
+		if cidr.Contains(ipv4Interface) && !option.Config.NodeEncryptionEnabled() {
+			if !option.Config.EncryptionStrictModeAllowRemoteNodeIdentities {
+				return fmt.Errorf(`encryption strict mode is enabled but the node's IPv4 address is within the strict CIDR range.
+				This will cause the node to drop all traffic.
+				Please either disable encryption or set --encryption-strict-mode-allow-dynamic-lookup=true`)
+			}
+		}
+
+		if err := strictmap.UpdateContext(cidr, 0, 0, 0, 0); err != nil {
+			return fmt.Errorf("updating strict mode map: %w", err)
+		}
+	}
+
+	// Add the default match to the trie map.
+	// If this prefix is matched, then the packet is allowed to pass unencrypted as indicated by the "1" as a value.
+	if err := strictmap.UpdateContext(netip.MustParsePrefix("0.0.0.0/0"), 0, 1, 0, 0); err != nil {
+		return fmt.Errorf("updating strict mode map: %w", err)
+	}
+
+	// Allow etcd ports only on control plane nodes
+	sel, err := k8sLabels.Parse("node-role.kubernetes.io/control-plane")
+	if err != nil {
+		return fmt.Errorf("unable to parse control plane label selector: %w", err)
+	}
+
+	if sel.Matches(k8sLabels.Set(node.GetLabels())) {
+		for _, nodeCIDR := range option.Config.EncryptionStrictModeNodeCIDRs {
+			if err := strictmap.UpdateContext(nodeCIDR, 0, 0, 2379, 2380); err != nil {
+				return fmt.Errorf("updating strict mode map: %w", err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func setupVTEPMapping() error {

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -292,10 +292,11 @@ contributors across the globe, there is almost always someone available to help.
 | encryption.mountPath | string | `"/etc/ipsec"` | Deprecated in favor of encryption.ipsec.mountPath. To be removed in 1.15. Path to mount the secret inside the Cilium pod. This option is only effective when encryption.type is set to ipsec. |
 | encryption.nodeEncryption | bool | `false` | Enable encryption for pure node to node traffic. This option is only effective when encryption.type is set to "wireguard". |
 | encryption.secretName | string | `"cilium-ipsec-keys"` | Deprecated in favor of encryption.ipsec.secretName. To be removed in 1.15. Name of the Kubernetes secret containing the encryption keys. This option is only effective when encryption.type is set to ipsec. |
-| encryption.strictMode | object | `{"allowRemoteNodeIdentities":false,"cidr":"","enabled":false}` | Configure the WireGuard Pod2Pod strict mode. |
-| encryption.strictMode.allowRemoteNodeIdentities | bool | `false` | Allow dynamic lookup of remote node identities. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap. |
-| encryption.strictMode.cidr | string | `""` | CIDR for the WireGuard Pod2Pod strict mode. |
-| encryption.strictMode.enabled | bool | `false` | Enable WireGuard Pod2Pod strict mode. |
+| encryption.strictMode | object | `{"allowRemoteNodeIdentities":true,"enabled":false,"nodeCIDRList":[],"podCIDRList":[]}` | Configure the WireGuard strict mode. |
+| encryption.strictMode.allowRemoteNodeIdentities | bool | `true` | Allow dynamic lookup of remote node identities. This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap. This is also required when control-plane nodes are exempted from node-to-node encryption. |
+| encryption.strictMode.enabled | bool | `false` | Enable WireGuard strict mode. |
+| encryption.strictMode.nodeCIDRList | list | `[]` | nodeCIDRList for the WireGuard strict mode. |
+| encryption.strictMode.podCIDRList | list | `[]` | podCIDRList for the WireGuard strict mode. |
 | encryption.type | string | `"ipsec"` | Encryption method. Can be either ipsec or wireguard. |
 | encryption.wireguard.persistentKeepalive | string | `"0s"` | Controls Wireguard PersistentKeepalive option. Set 0s to disable. |
 | encryption.wireguard.userspaceFallback | bool | `false` | Enables the fallback to the user-space implementation. |

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -606,7 +606,9 @@ data:
 {{- if .Values.encryption.strictMode.enabled }}
   enable-encryption-strict-mode: {{ .Values.encryption.strictMode.enabled | quote }}
 
-  encryption-strict-mode-cidr: {{ .Values.encryption.strictMode.cidr | quote }}
+  encryption-strict-mode-node-cidrs: {{ .Values.encryption.strictMode.nodeCIDRList | join " " | quote }}
+
+  encryption-strict-mode-pod-cidrs: {{ .Values.encryption.strictMode.podCIDRList | join " " | quote }}
 
   encryption-strict-mode-allow-remote-node-identities: {{ .Values.encryption.strictMode.allowRemoteNodeIdentities | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -800,17 +800,21 @@ encryption:
   # This option is only effective when encryption.type is set to "wireguard".
   nodeEncryption: false
 
-  # -- Configure the WireGuard Pod2Pod strict mode.
+  # -- Configure the WireGuard strict mode.
   strictMode:
-    # -- Enable WireGuard Pod2Pod strict mode.
+    # -- Enable WireGuard strict mode.
     enabled: false
 
-    # -- CIDR for the WireGuard Pod2Pod strict mode.
-    cidr: ""
+    # -- podCIDRList for the WireGuard strict mode.
+    podCIDRList: []
+
+    # -- nodeCIDRList for the WireGuard strict mode.
+    nodeCIDRList: []
 
     # -- Allow dynamic lookup of remote node identities.
     # This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.
-    allowRemoteNodeIdentities: false
+    # This is also required when control-plane nodes are exempted from node-to-node encryption.
+    allowRemoteNodeIdentities: true
 
   ipsec:
     # -- Name of the key file inside the Kubernetes secret configured via secretName.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -797,17 +797,21 @@ encryption:
   # This option is only effective when encryption.type is set to "wireguard".
   nodeEncryption: false
 
-  # -- Configure the WireGuard Pod2Pod strict mode.
+  # -- Configure the WireGuard strict mode.
   strictMode:
-    # -- Enable WireGuard Pod2Pod strict mode.
+    # -- Enable WireGuard strict mode.
     enabled: false
 
-    # -- CIDR for the WireGuard Pod2Pod strict mode.
-    cidr: ""
+    # -- podCIDRList for the WireGuard strict mode.
+    podCIDRList: []
+
+    # -- nodeCIDRList for the WireGuard strict mode.
+    nodeCIDRList: []
 
     # -- Allow dynamic lookup of remote node identities.
     # This is required when tunneling is used or direct routing is used and the node CIDR and pod CIDR overlap.
-    allowRemoteNodeIdentities: false
+    # This is also required when control-plane nodes are exempted from node-to-node encryption.
+    allowRemoteNodeIdentities: true
 
   ipsec:
     # -- Name of the key file inside the Kubernetes secret configured via secretName.

--- a/pkg/datapath/loader/cache.go
+++ b/pkg/datapath/loader/cache.go
@@ -51,6 +51,7 @@ var ignoredELFPrefixes = []string{
 	"cilium_runtime_config",      // Global
 	"cilium_signals",             // Global
 	"cilium_snat",                // All SNAT maps
+	"cilium_strict",              // Global
 	"cilium_tail_call_buffer",    // Global
 	"cilium_tunnel",              // Global
 	"cilium_ipv4_frag_datagrams", // Global

--- a/pkg/maps/strictmap/doc.go
+++ b/pkg/maps/strictmap/doc.go
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+// +groupName=maps
+package strictmap

--- a/pkg/maps/strictmap/strict.go
+++ b/pkg/maps/strictmap/strict.go
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package strictmap
+
+import (
+	"fmt"
+	"net"
+	"net/netip"
+	"sync"
+	"unsafe"
+
+	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/byteorder"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/ebpf"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/types"
+)
+
+const (
+	// MaxEntries is the maximum number of keys that can be present in the
+	// StrictModeMap.
+	MaxEntries = 5
+
+	// Name is the canonical name for the StrictModeMap on the filesystem.
+	Name = "cilium_strict"
+)
+
+// key implements the bpf.MapKey interface.
+//
+// Must be in sync with struct ipcache_key in <bpf/lib/maps.h>
+type key struct {
+	Prefixlen uint32 `align:"lpm_key"`
+	Pad1      uint16 `align:"pad1"`
+	ClusterID uint8  `align:"cluster_id"`
+	Family    uint8  `align:"family"`
+	// represents both IPv6 and IPv4 (in the lowest four bytes)
+	IP types.IPv6 `align:"$union0"`
+}
+
+type value struct {
+	Allow uint8  `align:"allow"`
+	Pad1  uint8  `align:"pad1"`
+	Port1 uint16 `align:"port1"`
+	Port2 uint16 `align:"port2"`
+}
+
+const (
+	sizeofStrictKey = int(unsafe.Sizeof(key{}))
+	sizeofPrefixlen = int(unsafe.Sizeof(key{}.Prefixlen))
+	sizeofIP        = int(unsafe.Sizeof(key{}.IP))
+
+	staticPrefixBits = uint32(sizeofStrictKey-sizeofPrefixlen-sizeofIP) * 8
+)
+
+func (k key) String() string {
+	var (
+		addr netip.Addr
+		ok   bool
+	)
+
+	switch k.Family {
+	case bpf.EndpointKeyIPv4:
+		addr, ok = netip.AddrFromSlice(k.IP[:net.IPv4len])
+		if !ok {
+			return "<unknown>"
+		}
+	case bpf.EndpointKeyIPv6:
+		addr = netip.AddrFrom16(k.IP)
+	default:
+		return "<unknown>"
+	}
+
+	prefixLen := int(k.Prefixlen - staticPrefixBits)
+	clusterID := uint32(k.ClusterID)
+
+	return cmtypes.PrefixClusterFrom(addr, prefixLen, cmtypes.WithClusterID(clusterID)).String()
+}
+
+func (k *key) New() bpf.MapKey { return &key{} }
+
+// getPrefixLen determines the length that should be set inside the Key so that
+// the lookup prefix is correct in the BPF map key. The specified 'prefixBits'
+// indicates the number of bits in the IP that must match to match the entry in
+// the BPF StrictModeMap.
+func getPrefixLen(ipPrefixBits int) uint32 {
+	return staticPrefixBits + uint32(ipPrefixBits)
+}
+
+// newKey returns an Key based on the provided CIDR and ClusterID.
+// The address family is automatically detected
+func newKey(ip netip.Prefix, clusterID uint8) (*key, error) {
+	result := key{}
+
+	ones := ip.Bits()
+	if ones == -1 {
+		return nil, fmt.Errorf("invalid IP address: %s", ip)
+	}
+
+	if ip.Addr().Is4() {
+		ipv4 := ip.Addr().As4()
+		result.Family = bpf.EndpointKeyIPv4
+		copy(result.IP[:], ipv4[:])
+	} else if ip.Addr().Is6() {
+		ipv6 := ip.Addr().As16()
+		result.Family = bpf.EndpointKeyIPv6
+		copy(result.IP[:], ipv6[:])
+	} else {
+		return nil, fmt.Errorf("invalid IP address: %s", ip)
+	}
+
+	result.Prefixlen = getPrefixLen(ones)
+	result.ClusterID = clusterID
+
+	return &result, nil
+}
+
+func (v *value) String() string {
+	return fmt.Sprintf("allowed=%d, AllowPorts=%d,%d", v.Allow, byteorder.NetworkToHost16(v.Port1), byteorder.NetworkToHost16(v.Port2))
+}
+
+func (v *value) New() bpf.MapValue { return &value{} }
+
+var (
+	// The StrictModeMap is a mapping of all CIDRs in the cluster to whether
+	// strict encryption should be enforced.
+	// It is a singleton; there is only one such map per agent.
+	strict *bpf.Map
+	once   = &sync.Once{}
+)
+
+// Create will create a strict map
+func Create() error {
+	once.Do(func() {
+		strict = bpf.NewMap(
+			Name,
+			ebpf.LPMTrie,
+			&key{},
+			&value{},
+			MaxEntries,
+			bpf.BPF_F_NO_PREALLOC,
+		).WithCache().
+			WithEvents(option.Config.GetEventBufferConfig(Name))
+	})
+
+	return strict.OpenOrCreate()
+}
+
+// UpdateContext updates the encrypt state with ctxID to use the new keyID
+func UpdateContext(ip netip.Prefix, clusterID uint8, allow uint8, port1 uint16, port2 uint16) error {
+	k, err := newKey(ip, clusterID)
+	if err != nil {
+		return err
+	}
+
+	v := &value{
+		Allow: allow,
+		Port1: byteorder.HostToNetwork16(port1),
+		Port2: byteorder.HostToNetwork16(port2),
+	}
+
+	return strict.Update(k, v)
+}


### PR DESCRIPTION
This PR is for demonstration only and should not be merged. It's purpose is to serve to show a potential implementation of a WireGuard node-to-node strict mode.

I also have downstream patches to add tests in the cilium-cli repository. But since the original pod-to-pod strict mode test are currently on hold there. The node-to-node strict mode tests build on top of the pod-to-pod strict mode tests.


<!-- Description of change -->
* Add a eBPF map to track CIDRs which should or shoudn't be encrypted. 
* We differentiate between nodeCIDRs and podCIDRs to be able to allowlist certain ports (currently hard-coded) such as etcd.
* For the eBPF map key we repurpose the struct of the IPCache.  


```release-note
<!-- Enter the release note text here if needed or remove this section! -->
```
