### PR TITLE
helm: Correct command for initContainer config

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -412,7 +412,7 @@ spec:
         image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
-        - cilium
+        - cilium-dbg
         - build-config
         {{- if (not (kindIs "invalid" .Values.daemon.configSources)) }}
         - "--source={{.Values.daemon.configSources}}"


### PR DESCRIPTION
This is to fix the below issue:

```shell
  Warning  Failed     8m3s (x5 over 9m31s)    kubelet            Error: failed to start container "config": Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "cilium": executable file not found in $PATH: unknown
````

Relates: #28085
