### PR TITLE
chore: Use slices package from Go std lib

### DIFF
--- a/operator/pkg/lbipam/lbipam.go
+++ b/operator/pkg/lbipam/lbipam.go
@@ -10,12 +10,12 @@ import (
 	"fmt"
 	"net"
 	"runtime/pprof"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"

--- a/operator/pkg/lbipam/range_store.go
+++ b/operator/pkg/lbipam/range_store.go
@@ -7,8 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/cilium/cilium/pkg/ipam/service/ipallocator"
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"

--- a/operator/pkg/lbipam/service_store.go
+++ b/operator/pkg/lbipam/service_store.go
@@ -5,9 +5,9 @@ package lbipam
 
 import (
 	"net"
+	"slices"
 
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"

--- a/pkg/bgpv1/manager/manager.go
+++ b/pkg/bgpv1/manager/manager.go
@@ -6,6 +6,7 @@ package manager
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/cilium/cilium/api/v1/models"
@@ -22,7 +23,6 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 )
 
 var (

--- a/pkg/bgpv1/manager/pod_ip_pool_reconciler.go
+++ b/pkg/bgpv1/manager/pod_ip_pool_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"slices"
 
 	"github.com/cilium/cilium/pkg/bgpv1/types"
 	"github.com/cilium/cilium/pkg/hive/cell"
@@ -16,7 +17,6 @@ import (
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 )
 
 type PodIPPoolReconcilerOut struct {

--- a/pkg/bgpv1/manager/reconcile.go
+++ b/pkg/bgpv1/manager/reconcile.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/netip"
+	"slices"
 
 	"github.com/cilium/cilium/pkg/bgpv1/agent"
 	"github.com/cilium/cilium/pkg/bgpv1/types"
@@ -24,7 +25,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/pkg/clustermesh/common/config.go
+++ b/pkg/clustermesh/common/config.go
@@ -8,11 +8,11 @@ import (
 	"errors"
 	"os"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 )
 
 // clusterLifecycle is the interface to implement in order to receive cluster

--- a/pkg/datapath/linux/devices.go
+++ b/pkg/datapath/linux/devices.go
@@ -7,9 +7,8 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strings"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/hive"

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"slices"
 	"strings"
 	"time"
 
@@ -17,7 +18,6 @@ import (
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netlink/nl"
 	"github.com/vishvananda/netns"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
 	"k8s.io/apimachinery/pkg/util/sets"
 

--- a/pkg/datapath/linux/devices_test.go
+++ b/pkg/datapath/linux/devices_test.go
@@ -9,13 +9,13 @@ import (
 	"context"
 	"net"
 	"runtime"
+	"slices"
 	"sort"
 	"time"
 
 	. "github.com/cilium/checkmate"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
-	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
 
 	"github.com/cilium/cilium/pkg/checker"

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -6,8 +6,7 @@ package tables
 import (
 	"net"
 	"net/netip"
-
-	"golang.org/x/exp/slices"
+	"slices"
 
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/statedb/index"

--- a/pkg/datapath/tables/l2_announce.go
+++ b/pkg/datapath/tables/l2_announce.go
@@ -5,12 +5,11 @@ package tables
 
 import (
 	"net/netip"
+	"slices"
 
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/statedb/index"
-
-	"golang.org/x/exp/slices"
 )
 
 type L2AnnounceKey struct {

--- a/pkg/ipam/allocator/multipool/pool_allocator.go
+++ b/pkg/ipam/allocator/multipool/pool_allocator.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"math/big"
 	"net/netip"
+	"slices"
 	"sort"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/ipam"
 	"github.com/cilium/cilium/pkg/ipam/allocator/clusterpool/cidralloc"

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"sort"
 	"strconv"
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	agentK8s "github.com/cilium/cilium/daemon/k8s"

--- a/pkg/k8s/service_cache.go
+++ b/pkg/k8s/service_cache.go
@@ -5,10 +5,10 @@ package k8s
 
 import (
 	"net"
+	"slices"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 	core_v1 "k8s.io/api/core/v1"
 
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -12,6 +12,7 @@ import (
 	"net/netip"
 	"regexp"
 	"runtime/pprof"
+	"slices"
 	"strings"
 	"time"
 
@@ -35,7 +36,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -6,6 +6,7 @@ package l2announcer
 import (
 	"context"
 	"net/netip"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -27,7 +28,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/goleak"
-	"golang.org/x/exp/slices"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"

--- a/pkg/lock/sortable_mutex_test.go
+++ b/pkg/lock/sortable_mutex_test.go
@@ -5,12 +5,12 @@ package lock
 
 import (
 	"math/rand"
+	"slices"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 )
 
 func TestSortableMutex(t *testing.T) {

--- a/pkg/node/local_node_store_test.go
+++ b/pkg/node/local_node_store_test.go
@@ -5,11 +5,10 @@ package node_test
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"

--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -11,10 +11,11 @@ import (
 	"net/netip"
 	"time"
 
+	"slices"
+
 	"github.com/cilium/workerpool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/backoff"
 	"github.com/cilium/cilium/pkg/controller"

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -6,11 +6,11 @@ package policy
 import (
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ip"

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -4,10 +4,10 @@
 package slices
 
 import (
+	"slices"
 	"sort"
 
 	"golang.org/x/exp/constraints"
-	"golang.org/x/exp/slices"
 )
 
 // Unique deduplicates the elements in the input slice, preserving their ordering and

--- a/pkg/statedb/fuzz_test.go
+++ b/pkg/statedb/fuzz_test.go
@@ -11,11 +11,11 @@ import (
 	"math/rand"
 	"os"
 	"runtime"
+	"slices"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/slices"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/lock"

--- a/test/controlplane/services/helpers/lbmap_validation.go
+++ b/test/controlplane/services/helpers/lbmap_validation.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -15,7 +16,6 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	fakeDatapath "github.com/cilium/cilium/pkg/datapath/fake"
 	lb "github.com/cilium/cilium/pkg/loadbalancer"


### PR DESCRIPTION
Go 1.21 promoted the slices package from the experimental repository ("golang.org/x/exp/slices") to the standard library. The commit updates the import paths in the entire codebase.

See https://go.dev/doc/go1.21#slices for more info about slices package in Go 1.21
