### PR TITLE
ipam/multipool: Identity allocation via etcd is now supported

### DIFF
--- a/Documentation/network/concepts/ipam/multi-pool.rst
+++ b/Documentation/network/concepts/ipam/multi-pool.rst
@@ -160,4 +160,3 @@ Multi-Pool IPAM mode:
      ``ip-masq-agent`` feature.
    - Announcing PodCIDRs by way of the built-in :ref:`bgp` mode is not yet
      supported.  Use ``auto-direct-node-routes`` instead.
-   - KVstore-based identity allocation mode is currently not supported (:gh-issue:`26621`)

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1514,9 +1514,6 @@ func initEnv(vp *viper.Viper) {
 		if option.Config.EnableIPSec {
 			log.Fatalf("Cannot specify IPAM mode %s with %s.", option.Config.IPAM, option.EnableIPSecName)
 		}
-		if option.Config.IdentityAllocationMode != option.IdentityAllocationModeCRD {
-			log.Fatalf("IPAM mode %s does not support %s=%s", option.Config.IPAM, option.IdentityAllocationMode, option.Config.IdentityAllocationMode)
-		}
 	}
 
 	if option.Config.InstallNoConntrackIptRules {


### PR DESCRIPTION
Now that cilium/cilium#26962 has been merged, the multipool allocator can now receive local CiliumNode updates in kvstore-mode too.

Fixes: #26621

Tested-by: Ondrej Blazek <ondrej.blazek@firma.seznam.cz> @oblazek (thank you!)