### PR TITLE
ipcache: fix releasing node CIDRs after restoration

### DIFF
--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -191,10 +191,26 @@ func (ipc *IPCache) releaseCIDRIdentities(ctx context.Context, prefixes []netip.
 	for _, prefix := range prefixes {
 		lbls := cidr.GetCIDRLabels(prefix)
 		id := ipc.IdentityAllocator.LookupIdentity(ctx, lbls)
+		if id == nil && option.Config.PolicyCIDRMatchesNodes() {
+			// Hack for node-cidr feature.
+			// We need to look up, exactly, the labels created during AllocateCIDRs(). Which we don't actually
+			// know, since it might be a "normal" CIDR identity *or* a remote-node identity.
+			//
+			// So, if we don't find an identity for the CIDR label-set, and the node-cidr feature is enabled, then try
+			// again with the set of labels for nodes.
+			//
+			// This can go away when CIDR identity restoration transitions to the UpsertLabels() api.
+			lbls.MergeLabels(labels.LabelRemoteNode)
+			lbls = lbls.Remove(labels.LabelWorld)
+			lbls = lbls.Remove(labels.LabelWorldIPv4)
+			lbls = lbls.Remove(labels.LabelWorldIPv6)
+			id = ipc.IdentityAllocator.LookupIdentity(ctx, lbls)
+		}
 		if id == nil {
 			log.Errorf("Unable to find identity of previously used CIDR %s", prefix.String())
 			continue
 		}
+
 		released, err := ipc.IdentityAllocator.Release(ctx, id, false)
 		if err != nil {
 			log.WithFields(logrus.Fields{


### PR DESCRIPTION
This fixes a bug where node CIDR identities were not cleaned up after restoration. Specifically, the set of labels used for allocation vs. the set of labels released may not be the same.

This is made more awkward by the fact that we don't actually *know* the set of labels that were allocated -- only the CIDRs. This means we have to go and recreate them. So, we guess. However, now that CIDR identities can be either global *or* remote-node, we need to update our guess.

So, try and release CIDR identiites as usual, but if the node-cidr feature is enabled, and the first guess is incorrect, also try in the node-cidr style.

Fixes: 02406f2c