### PR TITLE
Some small fixes to make kind-fast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -660,9 +660,8 @@ kind-image-fast-agent: kind-ready build-cli build-agent ## Build cilium cli and 
 			docker exec -ti $${node_name} rm -f "${dst}/cilium-agent"; \
 			docker cp "./daemon/cilium-agent" $${node_name}:"${dst}"; \
 			docker exec -ti $${node_name} chmod +x "${dst}/cilium-agent"; \
-			\
-			kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l k8s-app=cilium --force; \
 		done; \
+		kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l k8s-app=cilium --force; \
 	done
 
 .PHONY: kind-image-fast-operator
@@ -675,9 +674,8 @@ kind-image-fast-operator: kind-ready build-operator ## Build cilium operator bin
 			docker exec -ti $${node_name} rm -f "${dst}/cilium-operator-generic"; \
 			docker cp "./operator/cilium-operator-generic" $${node_name}:"${dst}"; \
 			docker exec -ti $${node_name} chmod +x "${dst}/cilium-operator-generic"; \
-			\
-			kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l name=cilium-operator --force; \
 		done; \
+	kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l name=cilium-operator --force; \
 	done
 
 .PHONY: kind-image-fast-clustermesh-apiserver
@@ -690,9 +688,8 @@ kind-image-fast-clustermesh-apiserver: kind-ready build-clustermesh-apiserver ##
 			docker exec -ti $${node_name} rm -f "${dst}/clustermesh-apiserver"; \
 			docker cp "./clustermesh-apiserver/clustermesh-apiserver" $${node_name}:"${dst}"; \
 			docker exec -ti $${node_name} chmod +x "${dst}/clustermesh-apiserver"; \
-			\
-			kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l k8s-app=clustermesh-apiserver --force; \
 		done; \
+	kubectl --context=kind-$${cluster_name} delete pods -n kube-system -l k8s-app=clustermesh-apiserver --force; \
 	done
 
 .PHONY: kind-image-fast

--- a/Makefile
+++ b/Makefile
@@ -617,7 +617,9 @@ endif
 .PHONY: kind-install-cilium-fast
 kind-install-cilium-fast: kind-ready ## Install a local Cilium version into the cluster.
 	@echo "  INSTALL cilium"
+	docker pull quay.io/cilium/cilium-ci:latest
 	for cluster_name in $${KIND_CLUSTERS:-$(shell kind get clusters)}; do \
+		kind load docker-image --name $$cluster_name quay.io/cilium/cilium-ci:latest; \
 		$(CILIUM_CLI) --context=kind-$$cluster_name uninstall >/dev/null 2>&1 || true; \
 		$(CILIUM_CLI) install --context=kind-$$cluster_name \
 			--chart-directory=$(ROOT_DIR)/install/kubernetes/cilium \

--- a/contrib/testing/kind-fast.yaml
+++ b/contrib/testing/kind-fast.yaml
@@ -30,6 +30,8 @@ operator:
       path: /cilium-binaries/cilium-operator-generic
       type: File
     name: cilium-operator-binary
+  image:
+    pullPolicy: IfNotPresent
 clustermesh:
   apiserver:
     extraVolumeMounts:
@@ -41,3 +43,7 @@ clustermesh:
           path: /cilium-binaries/clustermesh-apiserver
           type: File
         name: clustermesh-apiserver-binary
+    image:
+      pullPolicy: IfNotPresent
+image:
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
Two fixes:

1. Stop unnecessarily deleting agent pods. There was a bug where *all* agent pods were deleted for all nodes, rather than once per rollout
2. Stop unnecessarily pulling the base image. Images with the `:latest` tag have an ImagePullPolicy defaulted to `Always`, which is a waste of bandwidth and time.