### PR TITLE
Fix IPv6 cilium_host address assignment

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -430,7 +430,7 @@ func addHostDeviceAddr(hostDev netlink.Link, ipv4, ipv6 net.IP) error {
 		addr := netlink.Addr{
 			IPNet: &net.IPNet{
 				IP:   ipv6,
-				Mask: net.CIDRMask(64, 128), // corresponds to /64
+				Mask: net.CIDRMask(128, 128), // corresponds to /128
 			},
 		}
 


### PR DESCRIPTION
Fixes #28327

This patch stops adding /64 route to the cilium_net iface, which brought all the traffic to local node. When using something like /128 per node and having pods within the same /64 as the node meant that no cross-node traffic from pods worked.

```release-note
Don't bind a /64 address to cilium_host to avoid misrouting cross-node traffic
```
