### PR TITLE
fixed cilium-operator delete CEC cilium-ingress when other ingressclass resources are created

### DIFF
--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -654,6 +654,10 @@ func (ic *Controller) isEffectiveLoadbalancerModeDedicated(ing *slim_networkingv
 }
 
 func (ic *Controller) garbageCollectOwnedResources(ing *slim_networkingv1.Ingress) error {
+	// When the Ingress is in shared mode, shared resources cannot be deleted.
+	if !ic.isEffectiveLoadbalancerModeDedicated(ing) {
+		return nil
+	}
 	cec, svc, ep, err := ic.regenerate(ing, false)
 	if err != nil {
 		return err


### PR DESCRIPTION

<!-- Description of change -->

Fixes: #28289

When the `ingress controller` is in `shared` mode,  we create an ingress resources with an ingressclass does not belong to cilium, the ciliumEnvoyConfig resource in kube-system called cilium-ingress is deleted making all ingress routing by cilium fail.



```release-note
fixed cilium-operator delete CEC cilium-ingress when other ingressclass resources are created
```
