### PR TITLE
cmd: Display decryption interfaces in encrypt status

### DIFF
--- a/Documentation/security/network/encryption-ipsec.rst
+++ b/Documentation/security/network/encryption-ipsec.rst
@@ -205,6 +205,7 @@ Troubleshooting
 
        $ cilium-dbg encrypt status
        Encryption: IPsec
+       Decryption interface(s): eth0, eth1, eth2
        Keys in use: 1
        Max Seq. Number: 0x1e3/0xffffffff
        Errors: 0
@@ -212,7 +213,9 @@ Troubleshooting
    If the error counter is non-zero, additional information will be displayed
    with the specific errors the kernel encountered. If the sequence number
    reaches its maximum value, it will also result in errors. The number of
-   keys in use should be 2 during a key rotation and always 1 otherwise.
+   keys in use should be 2 during a key rotation and always 1 otherwise. The
+   list of decryption interfaces should have all native devices that may
+   receive pod traffic (for example, ENI interfaces).
 
  * All XFRM errors correspond to a packet drop in the kernel. Except for
    ``XfrmFwdHdrError`` and ``XfrmInError``, all XFRM errors indicate a bug in


### PR DESCRIPTION
This commit adds a new line to cilium encrypt status, with the list of interfaces on which decryption can happen:

    $ ks exec ds/cilium -c cilium-agent -- cilium encrypt status
    Encryption: IPsec
    Decryption interface(s): eth0, eth1, eth2
    Keys in use: 1
    Max Seq. Number: 0x6e/0xffffffff
    Errors: 0

This can be useful to check that Cilium is attached to all the interfaces it should be attached to (all those that can receive remote pod traffic).

```release-note
Display interfaces used for IPsec decryption in `cilium encrypt status`.
```
