### PR TITLE
gateway-api: watch ownerreference to enable stricter reconcilation

### DIFF
--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -22,6 +22,7 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/cilium/cilium/operator/pkg/gateway-api/helpers"
+	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -78,6 +79,10 @@ func (r *gatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// Watch related namespace in allowed namespaces
 		Watches(&corev1.Namespace{},
 			r.enqueueRequestForAllowedNamespace()).
+		// Watch created and owned resources
+		Owns(&ciliumv2.CiliumEnvoyConfig{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.Endpoints{}).
 		Complete(r)
 }
 

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -69,6 +69,7 @@ func (t *translator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *co
 			Kind:       source.Kind,
 			Name:       source.Name,
 			UID:        types.UID(source.UID),
+			Controller: model.AddressOf(true),
 		},
 	}
 	return cec, getService(source, ports), getEndpoints(*source), err
@@ -100,6 +101,7 @@ func getService(resource *model.FullyQualifiedResource, allPorts []uint32) *core
 					Kind:       resource.Kind,
 					Name:       resource.Name,
 					UID:        types.UID(resource.UID),
+					Controller: model.AddressOf(true),
 				},
 			},
 		},
@@ -122,6 +124,7 @@ func getEndpoints(resource model.FullyQualifiedResource) *corev1.Endpoints {
 					Kind:       resource.Kind,
 					Name:       resource.Name,
 					UID:        types.UID(resource.UID),
+					Controller: model.AddressOf(true),
 				},
 			},
 		},
@@ -131,7 +134,7 @@ func getEndpoints(resource model.FullyQualifiedResource) *corev1.Endpoints {
 				// to the lb map when the service has no backends.
 				// Related github issue https://github.com/cilium/cilium/issues/19262
 				Addresses: []corev1.EndpointAddress{{IP: "192.192.192.192"}}, // dummy
-				Ports:     []corev1.EndpointPort{{Port: 9999}},               //dummy
+				Ports:     []corev1.EndpointPort{{Port: 9999}},               // dummy
 			},
 		},
 	}

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -28,14 +28,20 @@ import (
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 )
 
-var backendV1XDSResource = toAny(toEnvoyCluster("gateway-conformance-infra", "infra-backend-v1", "8080"))
-var routeActionBackendV1 = toRouteAction("gateway-conformance-infra", "infra-backend-v1", "8080")
+var (
+	backendV1XDSResource = toAny(toEnvoyCluster("gateway-conformance-infra", "infra-backend-v1", "8080"))
+	routeActionBackendV1 = toRouteAction("gateway-conformance-infra", "infra-backend-v1", "8080")
+)
 
-var backendV2XDSResource = toAny(toEnvoyCluster("gateway-conformance-infra", "infra-backend-v2", "8080"))
-var routeActionBackendV2 = toRouteAction("gateway-conformance-infra", "infra-backend-v2", "8080")
+var (
+	backendV2XDSResource = toAny(toEnvoyCluster("gateway-conformance-infra", "infra-backend-v2", "8080"))
+	routeActionBackendV2 = toRouteAction("gateway-conformance-infra", "infra-backend-v2", "8080")
+)
 
-var backendV3XDSResource = toAny(toEnvoyCluster("gateway-conformance-infra", "infra-backend-v3", "8080"))
-var routeActionBackendV3 = toRouteAction("gateway-conformance-infra", "infra-backend-v3", "8080")
+var (
+	backendV3XDSResource = toAny(toEnvoyCluster("gateway-conformance-infra", "infra-backend-v3", "8080"))
+	routeActionBackendV3 = toRouteAction("gateway-conformance-infra", "infra-backend-v3", "8080")
+)
 
 var httpInsecureListenerXDSResource = toAny(&envoy_config_listener.Listener{
 	Name: "listener",
@@ -163,6 +169,7 @@ var basicHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "my-gateway",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -250,6 +257,7 @@ var basicTLSListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "my-gateway",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -383,6 +391,7 @@ var simpleSameNamespaceHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var simpleSameNamespaceHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -392,6 +401,7 @@ var simpleSameNamespaceHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyCon
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -465,6 +475,7 @@ var crossNamespaceHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var crossNamespaceHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-backend-namespaces",
@@ -474,6 +485,7 @@ var crossNamespaceHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "backend-namespaces",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -560,6 +572,7 @@ var exactPathMatchingHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var exactPathMatchingHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -569,6 +582,7 @@ var exactPathMatchingHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfi
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -776,6 +790,7 @@ var headerMatchingHTTPCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -1066,6 +1081,7 @@ var hostnameIntersectionHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var hostnameIntersectionHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-httproute-hostname-intersection",
@@ -1075,6 +1091,7 @@ var hostnameIntersectionHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyCo
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "httproute-hostname-intersection",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -1253,7 +1270,8 @@ var listenerHostnameMatchingHTTPListeners = []model.HTTPListener{
 		Sources: []model.FullyQualifiedResource{
 			{
 				Name:      "httproute-listener-hostname-matching",
-				Namespace: "gateway-conformance-infra"},
+				Namespace: "gateway-conformance-infra",
+			},
 		},
 		Port:     80,
 		Hostname: "*.bar.com",
@@ -1308,6 +1326,7 @@ var listenerHostNameMatchingCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Name:       "httproute-listener-hostname-matching",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -1457,6 +1476,7 @@ var matchingAcrossHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var matchingAcrossHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -1466,6 +1486,7 @@ var matchingAcrossHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -1628,6 +1649,7 @@ var matchingHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var matchingHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -1637,6 +1659,7 @@ var matchingHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -1809,6 +1832,7 @@ var queryParamMatchingHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var queryParamMatchingHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -1818,6 +1842,7 @@ var queryParamMatchingHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConf
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -1998,6 +2023,7 @@ var methodMatchingHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var methodMatchingHTTPListenersHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -2007,6 +2033,7 @@ var methodMatchingHTTPListenersHTTPListenersCiliumEnvoyConfig = &ciliumv2.Cilium
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -2232,6 +2259,7 @@ var requestHeaderModifierHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var requestHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -2241,6 +2269,7 @@ var requestHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyC
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -2450,6 +2479,7 @@ var requestRedirectHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var requestRedirectHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -2459,6 +2489,7 @@ var requestRedirectHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -2692,6 +2723,7 @@ var responseHeaderModifierHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var responseHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -2701,6 +2733,7 @@ var responseHeaderModifierHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoy
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -2928,6 +2961,7 @@ var rewriteHostHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var rewriteHostHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -2937,6 +2971,7 @@ var rewriteHostHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -3143,6 +3178,7 @@ var rewritePathHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -3152,6 +3188,7 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},
@@ -3359,6 +3396,7 @@ var mirrorHTTPListeners = []model.HTTPListener{
 		},
 	},
 }
+
 var mirrorHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "cilium-gateway-same-namespace",
@@ -3368,6 +3406,7 @@ var mirrorHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
 				Kind:       "Gateway",
 				Name:       "same-namespace",
+				Controller: model.AddressOf(true),
 			},
 		},
 	},


### PR DESCRIPTION
Currently, manually deleted Services, Endpoints & CiliumEnvoyConfigs that belong to a Gateway resource aren't immediately reconciled and recreated.

This commit sets the ownerreference (controller) on these resources and adds an owning watch in the respective controller. This triggers an immediate re-creation of the deleted resources.
