### PR TITLE
ipsec: Improve logging

### DIFF
--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -204,7 +204,7 @@ func xfrmStateReplace(new *netlink.XfrmState) error {
 		logfields.SourceIP:         new.Src,
 		logfields.DestinationIP:    new.Dst,
 		logfields.TrafficDirection: getDirFromXfrmMark(new.Mark),
-		logfields.NodeID:           getNodeIDFromXfrmMark(new.Mark),
+		logfields.NodeID:           getNodeIDAsHexFromXfrmMark(new.Mark),
 	})
 
 	// Check if the XFRM state already exists
@@ -307,7 +307,7 @@ func xfrmDeleteConflictingState(states []netlink.XfrmState, new *netlink.XfrmSta
 				logfields.SourceIP:         s.Src,
 				logfields.DestinationIP:    s.Dst,
 				logfields.TrafficDirection: getDirFromXfrmMark(s.Mark),
-				logfields.NodeID:           getNodeIDFromXfrmMark(s.Mark),
+				logfields.NodeID:           getNodeIDAsHexFromXfrmMark(s.Mark),
 			}).Info("Removed a conflicting XFRM state")
 		}
 	}
@@ -495,7 +495,7 @@ func deprioritizeOldOutPolicy(family int) {
 					logfields.SourceCIDR:       p.Src,
 					logfields.DestinationCIDR:  p.Dst,
 					logfields.TrafficDirection: getDirFromXfrmMark(p.Mark),
-					logfields.NodeID:           getNodeIDFromXfrmMark(p.Mark),
+					logfields.NodeID:           getNodeIDAsHexFromXfrmMark(p.Mark),
 				}).Error("Failed to deprioritize old XFRM policy")
 			}
 		}
@@ -526,6 +526,10 @@ func getNodeIDFromXfrmMark(mark *netlink.XfrmMark) uint16 {
 		return 0
 	}
 	return uint16(mark.Value >> 16)
+}
+
+func getNodeIDAsHexFromXfrmMark(mark *netlink.XfrmMark) string {
+	return fmt.Sprintf("0x%x", getNodeIDFromXfrmMark(mark))
 }
 
 func getDirFromXfrmMark(mark *netlink.XfrmMark) dir {
@@ -1123,7 +1127,7 @@ func deleteStaleXfrmPolicies(reclaimTimestamp time.Time) error {
 			logfields.SourceIP:         p.Src,
 			logfields.DestinationIP:    p.Dst,
 			logfields.TrafficDirection: getDirFromXfrmMark(p.Mark),
-			logfields.NodeID:           getNodeIDFromXfrmMark(p.Mark),
+			logfields.NodeID:           getNodeIDAsHexFromXfrmMark(p.Mark),
 		})
 		scopedLog.Info("Deleting stale XFRM policy")
 		if err := netlink.XfrmPolicyDel(&p); err != nil {

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -67,6 +67,14 @@ const (
 	oldXFRMOutPolicyPriority = 50
 )
 
+type dir string
+
+const (
+	dirUnspec  dir = "unspecified"
+	dirIngress dir = "ingress"
+	dirEgress  dir = "egress"
+)
+
 type ipSecKey struct {
 	Spi   uint8
 	ReqID int
@@ -512,6 +520,18 @@ func getNodeIDFromXfrmMark(mark *netlink.XfrmMark) uint16 {
 		return 0
 	}
 	return uint16(mark.Value >> 16)
+}
+
+func getDirFromXfrmMark(mark *netlink.XfrmMark) dir {
+	switch {
+	case mark == nil:
+		return dirUnspec
+	case mark.Value&linux_defaults.RouteMarkDecrypt != 0:
+		return dirIngress
+	case mark.Value&linux_defaults.RouteMarkEncrypt != 0:
+		return dirEgress
+	}
+	return dirUnspec
 }
 
 func generateEncryptMark(spi uint8, nodeID uint16) *netlink.XfrmMark {

--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -550,7 +550,7 @@ func upsertIPsecLog(err error, spec string, loc, rem *net.IPNet, spi uint8, node
 		logfields.SPI:      spi,
 		logfields.LocalIP:  loc,
 		logfields.RemoteIP: rem,
-		logfields.NodeID:   nodeID,
+		logfields.NodeID:   fmt.Sprintf("0x%x", nodeID),
 	})
 	if err != nil {
 		scopedLog.WithError(err).Error("IPsec enable failed")

--- a/pkg/logging/logfields/logfields.go
+++ b/pkg/logging/logfields/logfields.go
@@ -658,6 +658,10 @@ const (
 
 	DestinationIP = "destinationIP"
 
+	LocalIP = "localIP"
+
+	RemoteIP = "remoteIP"
+
 	SourceCIDR = "sourceCIDR"
 
 	// DestinationCIDR is a destination CIDR


### PR DESCRIPTION
See commits for details.

```release-note
Fix IPsec error logs to always have all information needed to identify the XFRM configuration on which the error happened.
```