### PR TITLE
statedb: Fix watch channel returned by LowerBound

### DIFF
--- a/pkg/statedb/table.go
+++ b/pkg/statedb/table.go
@@ -136,7 +136,7 @@ func (t *genTable[Obj]) LowerBound(txn ReadTxn, q Query[Obj]) (Iterator[Obj], <-
 	// Since LowerBound query may be invalidated by changes in another branch
 	// of the tree, we cannot just simply watch the node we seeked to. Instead
 	// we watch the whole table for changes.
-	watch, _, _ := root.GetWatch([]byte(t.table))
+	watch, _, _ := root.GetWatch(nil)
 	iter := root.Iterator()
 	iter.SeekLowerBound(q.key)
 	return &iterator[Obj]{iter}, watch


### PR DESCRIPTION
The LowerBound should return the root node's watch channel, e.g. by doing a 'GetWatch(nil)'. The code used the table as the key instead, likely due to a leftover from a refactoring. In practice this still mostly did the right thing, albeit with a useless lookup. Only if the index would've had a key matching the table name would a wrong watch channel have been returned.

Fixes: 23b0492f30 ("statedb2: StateDB v2.0 with per-table locks and deletion tracking")