### PR TITLE
labels/cidr: On the fly char replacement for IPv6

### DIFF
--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -24,30 +24,36 @@ import (
 // support colons inside the name section of a label.
 func maskedIPToLabel(ip netip.Addr, prefix int) labels.Label {
 	ipStr := ip.String()
-	ipNoColons := strings.Replace(ipStr, ":", "-", -1)
 
-	// EndpointSelector keys can't start or end with a "-", so insert a
-	// zero at the start or end if it would otherwise have a "-" at that
-	// position.
-	preZero := ""
-	postZero := ""
-	if ipNoColons[0] == '-' {
-		preZero = "0"
-	}
-	if ipNoColons[len(ipNoColons)-1] == '-' {
-		postZero = "0"
-	}
 	var str strings.Builder
 	str.Grow(
-		len(preZero) +
-			len(ipNoColons) +
-			len(postZero) +
+		1 /* preZero */ +
+			len(ipStr) +
+			1 /* postZero */ +
 			2 /*len of prefix*/ +
 			1, /* '/' */
 	)
-	str.WriteString(preZero)
-	str.WriteString(ipNoColons)
-	str.WriteString(postZero)
+
+	for i := 0; i < len(ipStr); i++ {
+		if ipStr[i] == ':' {
+			// EndpointSelector keys can't start or end with a "-", so insert a
+			// zero at the start or end if it would otherwise have a "-" at that
+			// position.
+			if i == 0 {
+				str.WriteByte('0')
+				str.WriteByte('-')
+				continue
+			}
+			if i == len(ipStr)-1 {
+				str.WriteByte('-')
+				str.WriteByte('0')
+				continue
+			}
+			str.WriteByte('-')
+		} else {
+			str.WriteByte(ipStr[i])
+		}
+	}
 	str.WriteRune('/')
 	str.WriteString(strconv.Itoa(prefix))
 	return labels.Label{Key: str.String(), Source: labels.LabelSourceCIDR}


### PR DESCRIPTION
Suggested by @squeed [here](https://github.com/cilium/cilium/pull/28465#discussion_r1361842591)

```
When generating labels for IPv6 addresses, ':' characters need to be
replaced with '-'. Also, a leading or trailing '0' is added to avoid
labels starting or ending with '-'.  To avoid the allocation of an
additional string, replace the character on the fly while accumulating
the label key in the strings.Builder.

IPStringToLabel/0.0.0.0/0-8           104ns ±11%      94ns ± 4%  -10.25%  (p=0.008 n=5+5)
IPStringToLabel/192.0.2.3-8           146ns ± 3%     128ns ±27%     ~     (p=0.841 n=5+5)
IPStringToLabel/192.0.2.3/32-8        175ns ±11%     190ns ± 8%     ~     (p=0.056 n=5+5)
IPStringToLabel/192.0.2.3/24-8        176ns ±12%     167ns ± 7%     ~     (p=0.095 n=5+5)
IPStringToLabel/192.0.2.0/24-8        169ns ± 2%     162ns ± 1%   -4.08%  (p=0.008 n=5+5)
IPStringToLabel/::/0-8                309ns ± 2%     232ns ±11%  -24.91%  (p=0.008 n=5+5)
IPStringToLabel/fdff::ff-8            412ns ± 1%     264ns ± 1%  -35.90%  (p=0.008 n=5+5)
IPStringToLabel/f00d:42::ff/128-8     469ns ± 2%     305ns ± 1%  -34.96%  (p=0.016 n=5+4)
IPStringToLabel/f00d:42::ff/96-8      405ns ±11%     293ns ± 7%  -27.58%  (p=0.008 n=5+5)

name                               old alloc/op   new alloc/op   delta
IPStringToLabel/0.0.0.0/0-8           24.0B ± 0%     24.0B ± 0%     ~     (all equal)
IPStringToLabel/192.0.2.3-8           32.0B ± 0%     32.0B ± 0%     ~     (all equal)
IPStringToLabel/192.0.2.3/32-8        32.0B ± 0%     32.0B ± 0%     ~     (all equal)
IPStringToLabel/192.0.2.3/24-8        32.0B ± 0%     32.0B ± 0%     ~     (all equal)
IPStringToLabel/192.0.2.0/24-8        32.0B ± 0%     32.0B ± 0%     ~     (all equal)
IPStringToLabel/::/0-8                16.0B ± 0%     16.0B ± 0%     ~     (all equal)
IPStringToLabel/fdff::ff-8            56.0B ± 0%     32.0B ± 0%  -42.86%  (p=0.008 n=5+5)
IPStringToLabel/f00d:42::ff/128-8     80.0B ± 0%     32.0B ± 0%  -60.00%  (p=0.008 n=5+5)
IPStringToLabel/f00d:42::ff/96-8      48.0B ± 0%     32.0B ± 0%  -33.33%  (p=0.008 n=5+5)

name                               old allocs/op  new allocs/op  delta
IPStringToLabel/0.0.0.0/0-8            2.00 ± 0%      2.00 ± 0%     ~     (all equal)
IPStringToLabel/192.0.2.3-8            2.00 ± 0%      2.00 ± 0%     ~     (all equal)
IPStringToLabel/192.0.2.3/32-8         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
IPStringToLabel/192.0.2.3/24-8         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
IPStringToLabel/192.0.2.0/24-8         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
IPStringToLabel/::/0-8                 3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
IPStringToLabel/fdff::ff-8             5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.008 n=5+5)
IPStringToLabel/f00d:42::ff/128-8      5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.008 n=5+5)
IPStringToLabel/f00d:42::ff/96-8       3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.008 n=5+5)
```

~Depends on https://github.com/cilium/cilium/pull/28465~
