### PR TITLE
labels: Use slices.Sort instead of sort.Strings

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"slices"
 	"sort"
 	"strings"
 )
@@ -512,7 +513,7 @@ func (l Labels) SortedList() []byte {
 	for k := range l {
 		keys = append(keys, k)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 
 	// Labels can have arbitrary size. However, when many CIDR identities are in
 	// the system, for example due to a FQDN policy matching S3, CIDR labels


### PR DESCRIPTION
As suggested by package "sort" documentation (https://pkg.go.dev/sort#Strings), `slices.Sort` should be preferred to `sort.Strings` since it runs faster.

Comparison between `sort.Strings` ("old") and `slices.Sort` ("new"):

```
name                        old time/op    new time/op    delta
pkg:github.com/cilium/cilium/pkg/labels goos:linux goarch:amd64
Labels_SortedList-8            787ns ± 4%     736ns ±12%   -6.42%  (p=0.014 n=7+8)
pkg:github.com/cilium/cilium/pkg/labels/cidr goos:linux goarch:amd64
Labels_SortedListCIDRIDs-8    5.22µs ± 8%    4.67µs ± 4%  -10.63%  (p=0.000 n=10+10)

name                        old alloc/op   new alloc/op   delta
pkg:github.com/cilium/cilium/pkg/labels goos:linux goarch:amd64
Labels_SortedList-8             360B ± 0%      336B ± 0%   -6.67%  (p=0.000 n=10+10)
pkg:github.com/cilium/cilium/pkg/labels/cidr goos:linux goarch:amd64
Labels_SortedListCIDRIDs-8    1.62kB ± 0%    1.60kB ± 0%   -1.48%  (p=0.000 n=10+10)

name                        old allocs/op  new allocs/op  delta
pkg:github.com/cilium/cilium/pkg/labels goos:linux goarch:amd64
Labels_SortedList-8             3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
pkg:github.com/cilium/cilium/pkg/labels/cidr goos:linux goarch:amd64
Labels_SortedListCIDRIDs-8      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
```
