### PR TITLE
endpoint: fix policy drops on first regeneration

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -405,6 +405,7 @@ func (e *Endpoint) regenerate(ctx *regenerationContext) (retErr error) {
 	// the state remains unchanged
 	//
 	// GH-5350: Remove this special case to require checking for StateWaitingForIdentity
+	ctx.datapathRegenerationContext.initialState = e.getState()
 	if e.getState() != StateWaitingForIdentity &&
 		!e.BuilderSetStateLocked(StateRegenerating, "Regenerating endpoint: "+ctx.Reason) {
 		if debugLogsEnabled {

--- a/pkg/endpoint/regenerationcontext.go
+++ b/pkg/endpoint/regenerationcontext.go
@@ -63,6 +63,7 @@ type datapathRegenerationContext struct {
 	currentDir         string
 	nextDir            string
 	regenerationLevel  regeneration.DatapathRegenerationLevel
+	initialState       State
 
 	finalizeList revert.FinalizeList
 	revertStack  revert.RevertStack

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -357,7 +357,7 @@ func TestInjectExisting(t *testing.T) {
 	IPIdentityCache.UpsertLabels(prefix, labels.LabelKubeAPIServer, source.KubeAPIServer, resource)
 
 	// Need to wait for the label injector to finish; easiest just to remove it
-	IPIdentityCache.controllers.RemoveControllerAndWait(LabelInjectorName)
+	IPIdentityCache.ShutdownLabelInjection()
 
 	// Ensure the source is now correctly understood in the ipcache
 	id, ok = IPIdentityCache.LookupByIP(prefix.String())
@@ -413,9 +413,9 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	identityReferences++
 	for i := 0; i < 2; i++ {
 		IPIdentityCache.UpsertLabels(prefix, labels, source.CustomResource, resource)
-		// Need to wait for the label injector to finish; easiest just to remove it
-		IPIdentityCache.controllers.RemoveControllerAndWait(LabelInjectorName)
 	}
+	// Need to wait for the label injector to finish; easiest just to remove it
+	IPIdentityCache.ShutdownLabelInjection()
 
 	// Ensure the source is now correctly understood in the ipcache
 	id, ok = IPIdentityCache.LookupByIP(prefix.String())
@@ -447,7 +447,7 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 
 	// Remove the identity allocation via newer APIs
 	IPIdentityCache.RemoveLabels(prefix, labels, resource)
-	IPIdentityCache.controllers.RemoveControllerAndWait(LabelInjectorName)
+	IPIdentityCache.ShutdownLabelInjection()
 	identityReferences--
 	assert.Equal(t, identityReferences, 0)
 


### PR DESCRIPTION
There are two small changes in this PR.

The first blocks endpoint regeneration until the ipcache has written at least once. This is an unlikely race, but important to make explicit.

The second commit fixes a source of policy drops on initial regeneration. Because an un-regenerated endpoint references an old ipcache (because the map is referenced by file descriptor), IPs still have "old" identities until a new BPF program is applied.

However, the endpoint's policy map is synchronized *before* the new bpf program is created. That means that if any IPs have changed identities after restart, the policy map will reference the new IP, but the endpoint's ipcache provides the old identity, leading to a policy drop.

The solution is to defer removing stale entries until after the endpoint has been regenerated for the first time. Fortunately the code already has two calls to `ep.syncPolicyMap()`. We just need to wire up the bits to keep stale entries as applicable.

Fixes: #28645
Related: #3897 

```release-note
Fixes a bug where polices that allow access to the kubernetes apiserver may experience brief interruptions on agent restart
```
