### PR TITLE
maps: Consider actual passed time for GC interval calculation

### DIFF
--- a/pkg/maps/ctmap/ctmap_test.go
+++ b/pkg/maps/ctmap/ctmap_test.go
@@ -46,21 +46,21 @@ func (t *CTMapTestSuite) TestCalculateInterval(c *C) {
 
 func (t *CTMapTestSuite) TestGetInterval(c *C) {
 	cachedGCInterval = time.Minute
-	c.Assert(GetInterval(0.1), Equals, time.Minute)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, time.Minute)
 
 	// Setting ConntrackGCInterval overrides the calculation
 	oldInterval := option.Config.ConntrackGCInterval
 	option.Config.ConntrackGCInterval = 10 * time.Second
-	c.Assert(GetInterval(0.1), Equals, 10*time.Second)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, 10*time.Second)
 	option.Config.ConntrackGCInterval = oldInterval
-	c.Assert(GetInterval(0.1), Equals, time.Minute)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, time.Minute)
 
 	// Setting ConntrackGCMaxInterval limits the maximum interval
 	oldMaxInterval := option.Config.ConntrackGCMaxInterval
 	option.Config.ConntrackGCMaxInterval = 20 * time.Second
-	c.Assert(GetInterval(0.1), Equals, 20*time.Second)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, 20*time.Second)
 	option.Config.ConntrackGCMaxInterval = oldMaxInterval
-	c.Assert(GetInterval(0.1), Equals, time.Minute)
+	c.Assert(GetInterval(cachedGCInterval, 0.1), Equals, time.Minute)
 
 	cachedGCInterval = time.Duration(0)
 }


### PR DESCRIPTION
When GetInterval calculates the new GC interval, it uses the result of the previous calculation as a pivot point. However, if GC was triggered by a signal, smaller time interval has passed, therefore, expectations on the delete ratio should be lower. Adjust the delete ratio proportionally to avoid increasing the interval uncontrollably when multiple signals arrive over a short period of time.

Ref: #27405

```release-note
Fix GC interval calculation by taking into account the actual time passed between GC runs.
```
