### PR TITLE
don't remove neighbor link state file if migrateOnly

### DIFF
--- a/pkg/datapath/linux/node.go
+++ b/pkg/datapath/linux/node.go
@@ -2109,7 +2109,7 @@ func (n *linuxNodeHandler) NodeCleanNeighbors(migrateOnly bool) {
 	// up all neighbors.
 	successClean := true
 	defer func() {
-		if successClean {
+		if successClean && !migrateOnly {
 			os.Remove(filepath.Join(option.Config.StateDir, neighFileName))
 		}
 	}()


### PR DESCRIPTION
NodeCleanNeighbors is also called when enable-l2-neigh-discovery with migrateOnly==false. In that case, all existing arp entries can still be removed because neighLastPingByNextHop is still empty (https://github.com/cilium/cilium/blob/main/pkg/datapath/linux/node.go#L2013). The neighbor link state file then is removed https://github.com/cilium/cilium/blob/main/pkg/datapath/linux/node.go#L2113

The file is only resotred again when next time
NodeConfigurationChanged() is called.

This can break arp entry cleanup when next time cilium is started without enable-l2-neigh-discovery