### PR TITLE
operator: Fix logic used to sync Cilium's IngressClass on startup

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -713,7 +713,9 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 
 	if operatorOption.Config.EnableIngressController {
 		ingressController, err := ingress.NewController(
+			legacy.ctx,
 			legacy.clientset,
+			legacy.resources.IngressClasses,
 			ingress.WithHTTPSEnforced(operatorOption.Config.EnforceIngressHTTPS),
 			ingress.WithSecretsSyncEnabled(operatorOption.Config.EnableIngressSecretsSync),
 			ingress.WithSecretsNamespace(operatorOption.Config.IngressSecretsNamespace),
@@ -729,7 +731,7 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 			log.WithError(err).WithField(logfields.LogSubsys, ingress.Subsys).Fatal(
 				"Failed to start ingress controller")
 		}
-		go ingressController.Run()
+		go ingressController.Run(legacy.ctx)
 	}
 
 	if operatorOption.Config.EnableGatewayAPI {

--- a/operator/k8s/resource_ctors.go
+++ b/operator/k8s/resource_ctors.go
@@ -16,6 +16,7 @@ import (
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
+	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
 	"github.com/cilium/cilium/pkg/k8s/utils"
 )
 
@@ -56,4 +57,14 @@ func CiliumEndpointSliceResource(lc hive.Lifecycle, cs client.Clientset, opts ..
 		opts...,
 	)
 	return resource.New[*cilium_api_v2alpha1.CiliumEndpointSlice](lc, lw, resource.WithMetric("CiliumEndpointSlice")), nil
+}
+
+func IngressClassResource(lc hive.Lifecycle, cs client.Clientset, opts ...func(*metav1.ListOptions)) (resource.Resource[*slim_networkingv1.IngressClass], error) {
+	if !cs.IsEnabled() {
+		return nil, nil
+	}
+	lw := utils.ListerWatcherWithModifiers(
+		utils.ListerWatcherFromTyped[*slim_networkingv1.IngressClassList](cs.Slim().NetworkingV1().IngressClasses()), opts...,
+	)
+	return resource.New[*slim_networkingv1.IngressClass](lc, lw, resource.WithMetric("IngressClass")), nil
 }

--- a/operator/k8s/resources.go
+++ b/operator/k8s/resources.go
@@ -10,6 +10,7 @@ import (
 	cilium_api_v2alpha1 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2alpha1"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
+	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
 )
 
 const (
@@ -37,6 +38,7 @@ var (
 			CiliumEndpointSliceResource,
 			k8s.CiliumNodeResource,
 			k8s.PodResource,
+			IngressClassResource,
 		),
 	)
 )
@@ -54,4 +56,5 @@ type Resources struct {
 	CiliumEndpointSlices resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice]
 	CiliumNodes          resource.Resource[*cilium_api_v2.CiliumNode]
 	Pods                 resource.Resource[*slim_corev1.Pod]
+	IngressClasses       resource.Resource[*slim_networkingv1.IngressClass]
 }

--- a/operator/pkg/ingress/ingress_class.go
+++ b/operator/pkg/ingress/ingress_class.go
@@ -4,172 +4,196 @@
 package ingress
 
 import (
-	"fmt"
+	"context"
+	"strconv"
+	"sync/atomic"
 
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
-	"github.com/cilium/cilium/pkg/k8s"
-	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	"github.com/cilium/cilium/pkg/k8s/informer"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
-	"github.com/cilium/cilium/pkg/k8s/utils"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
-type ingressClassAddedEvent struct {
-	ingressClass *slim_networkingv1.IngressClass
+// isIngressClassMarkedDefault determines if the given IngressClass has an annotation marking it as the
+// default IngressClass for the cluster.
+// If the annotation's value fails to parse, then an error is returned to signal that processing the
+// IngressClass should be retried at a later point in time.
+// There are four possible cases:
+// 1. Annotation is set to "true": we are the default IngressClass.
+// 2. Annotation is set to "false", a non-bool value, or is missing: we are not the default IngressClass.
+func isIngressClassMarkedDefault(obj *slim_networkingv1.IngressClass) (bool, error) {
+	var err error
+
+	// If the annotation is not set, or set to an improper value,
+	// we should not be the default ingress class.
+	isDefault := false
+
+	if val, ok := obj.GetAnnotations()[slim_networkingv1.AnnotationIsDefaultIngressClass]; ok {
+		isDefault, err = strconv.ParseBool(val)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to parse annotation value for %q", slim_networkingv1.AnnotationIsDefaultIngressClass)
+
+			return false, err
+		}
+	}
+
+	return isDefault, nil
 }
 
-type ingressClassUpdatedEvent struct {
-	oldIngressClass *slim_networkingv1.IngressClass
-	newIngressClass *slim_networkingv1.IngressClass
+// isIngressClassCilium returns true if the given IngressClass resource has the same name as
+// the constant 'ciliumIngressClassName'.
+func isIngressClassCilium(obj *slim_networkingv1.IngressClass) bool {
+	return obj.GetName() == ciliumIngressClassName
 }
 
-type ingressClassDeletedEvent struct {
-	ingressClass *slim_networkingv1.IngressClass
-}
-
-type ingressClassManager struct {
-	informer cache.Controller
-	store    cache.Store
-
-	queue      workqueue.RateLimitingInterface
-	maxRetries int
-
-	ingressQueue workqueue.RateLimitingInterface
-}
-
-// type used to signal changes to the ingress controller queue
 type ciliumIngressClassUpdatedEvent struct {
-	ingressClass *slim_networkingv1.IngressClass
+	isDefault bool
+	changed   bool
 }
 
 type ciliumIngressClassDeletedEvent struct {
-	ingressClass *slim_networkingv1.IngressClass
+	wasDefault bool
 }
 
-func newIngressClassManager(clientset k8sClient.Clientset, ingressQueue workqueue.RateLimitingInterface, maxRetries int) (*ingressClassManager, error) {
+type ingressClassManager struct {
+	isDefaultIngressClass atomic.Bool
+	synced                atomic.Bool
+	queue                 workqueue.RateLimitingInterface
+	ingressClassEvents    <-chan resource.Event[*slim_networkingv1.IngressClass]
+}
+
+// newIngressClassManager creates a new ingressClassManager.
+func newIngressClassManager(
+	ctx context.Context,
+	queue workqueue.RateLimitingInterface,
+	ingressClasses resource.Resource[*slim_networkingv1.IngressClass],
+) *ingressClassManager {
 	manager := &ingressClassManager{
-		queue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
-		ingressQueue: ingressQueue,
-		maxRetries:   maxRetries,
+		isDefaultIngressClass: atomic.Bool{},
+		synced:                atomic.Bool{},
+		ingressClassEvents:    ingressClasses.Events(ctx),
+		queue:                 queue,
 	}
 
-	manager.store, manager.informer = informer.NewInformer(
-		utils.ListerWatcherFromTyped[*slim_networkingv1.IngressClassList](clientset.Slim().NetworkingV1().IngressClasses()),
-		&slim_networkingv1.IngressClass{},
-		0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc:    manager.handleAddIngressClass,
-			UpdateFunc: manager.handleUpdateIngressClass,
-			DeleteFunc: manager.handleDeleteIngressClass,
+	manager.isDefaultIngressClass.Store(false)
+	manager.synced.Store(false)
+
+	return manager
+}
+
+func (i *ingressClassManager) IsDefault() bool {
+	return i.isDefaultIngressClass.Load()
+}
+
+// WaitForSync blocks until a Sync event is received from the IngressClasses Resource.
+// If a Sync event has already been received, this method immediately returns.
+func (i *ingressClassManager) WaitForSync(ctx context.Context) error {
+	if i.synced.Load() {
+		return nil
+	}
+
+	// This function will only return "false" if ctx.Done() is closed.
+	// Instead of returning a bool, this method returns an error, which will
+	// be easier for callers to handle.
+	success := cache.WaitForNamedCacheSync(
+		"ingressClassManager", ctx.Done(),
+		func() bool {
+			return i.synced.Load()
 		},
-		nil,
 	)
 
-	go manager.informer.Run(wait.NeverStop)
-	if !cache.WaitForCacheSync(wait.NeverStop, manager.informer.HasSynced) {
-		return manager, fmt.Errorf("unable to sync service")
+	if success {
+		return nil
 	}
-	log.WithField("existing-ingressclasses", manager.store.ListKeys()).Debug("ingress classes synced")
-	return manager, nil
+
+	return ctx.Err()
 }
 
-// Run kicks off the control loop
-func (i *ingressClassManager) Run() {
-	for i.processEvent() {
-	}
-}
+// Run kicks off the the main control loop for the ingressClassManager.
+// The ingressClassManager will start processing IngressClass events and signaling updates by
+// sending events on the queue that was provided during construction.
+// This method returns when the given context is cancelled or when then IngressClasses
+// resource given during construction is stopped.
+func (i *ingressClassManager) Run(ctx context.Context) error {
+	log.Debug("Starting ingressClassManager")
 
-func (i *ingressClassManager) handleAddIngressClass(obj interface{}) {
-	if ic := k8s.CastInformerEvent[slim_networkingv1.IngressClass](obj); ic != nil {
-		i.queue.Add(ingressClassAddedEvent{ingressClass: ic})
-	}
-}
-
-func (i *ingressClassManager) handleUpdateIngressClass(oldObj, newObj interface{}) {
-	oldIngressClass := k8s.CastInformerEvent[slim_networkingv1.IngressClass](oldObj)
-	if oldIngressClass == nil {
-		return
-	}
-	newIngressClass := k8s.CastInformerEvent[slim_networkingv1.IngressClass](newObj)
-	if newIngressClass == nil {
-		return
-	}
-	if oldIngressClass.DeepEqual(newIngressClass) {
-		return
-	}
-	i.queue.Add(ingressClassUpdatedEvent{oldIngressClass: oldIngressClass, newIngressClass: newIngressClass})
-}
-
-func (i *ingressClassManager) handleDeleteIngressClass(obj interface{}) {
-	if ic := k8s.CastInformerEvent[slim_networkingv1.IngressClass](obj); ic != nil {
-		i.queue.Add(ingressClassDeletedEvent{ingressClass: ic})
-	}
-}
-
-func (i *ingressClassManager) processEvent() bool {
-	event, shutdown := i.queue.Get()
-	if shutdown {
-		return false
-	}
-	defer i.queue.Done(event)
-	err := i.handleEvent(event)
-	if err == nil {
-		i.queue.Forget(event)
-	} else if i.queue.NumRequeues(event) < i.maxRetries {
-		i.queue.AddRateLimited(event)
-	} else {
-		log.Errorf("failed to process event: %s", event)
-		i.queue.Forget(event)
-	}
-	return true
-}
-
-func (i *ingressClassManager) handleEvent(event interface{}) error {
 	var err error
-	switch ev := event.(type) {
-	case ingressClassAddedEvent:
-		log.WithField(logfields.IngressClass, ev.ingressClass.Name).Debug("Handling ingress class added event")
-		err = i.handleIngressClassAddedEvent(ev)
-	case ingressClassUpdatedEvent:
-		log.WithField(logfields.IngressClass, ev.newIngressClass.Name).Debug("Handling ingress class updated event")
-		err = i.handleIngressClassUpdatedEvent(ev)
-	case ingressClassDeletedEvent:
-		log.WithField(logfields.IngressClass, ev.ingressClass.Name).Debug("Handling ingress class deleted event")
-		err = i.handleIngressClassDeletedEvent(ev)
-	default:
-		err = fmt.Errorf("received an unknown event: %s", ev)
+
+	for {
+		select {
+		case event, ok := <-i.ingressClassEvents:
+			if !ok {
+				return nil
+			}
+
+			err = nil
+
+			switch event.Kind {
+			case resource.Sync:
+				err = i.handleSyncEvent()
+			case resource.Upsert:
+				err = i.handleUpsertEvent(event)
+			case resource.Delete:
+				err = i.handleDeleteEvent(event)
+			}
+
+			event.Done(err)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
+}
+
+// handleSyncEvent handles a Sync event for the events of an IngressClasses Resource.
+func (i *ingressClassManager) handleSyncEvent() error {
+	log.Debug("Handling IngressClass Sync event")
+	i.synced.Store(true)
+
+	return nil
+}
+
+// handleUpsertEvent handles an Upsert event for an IngressClass resource.
+// If the IngressClass has a name that is not the Cilium IngressClass name, it will be ignored.
+// If an error is returned, then the IngressClass contained in the event should be retried at a later
+// point in time.
+func (i *ingressClassManager) handleUpsertEvent(event resource.Event[*slim_networkingv1.IngressClass]) error {
+	log.WithField(logfields.IngressClass, event.Object).Warn("Handling IngressClass Upsert event")
+
+	if event.Object == nil || !isIngressClassCilium(event.Object) {
+		return nil
+	}
+
+	// Even if an error occurs due to a bad annotation value, we still need to perform an update to
+	// signal that we are no longer the default ingress class.
+	isDefault, err := isIngressClassMarkedDefault(event.Object)
+	old := i.isDefaultIngressClass.Swap(isDefault)
+
+	i.queue.Add(ciliumIngressClassUpdatedEvent{
+		isDefault: isDefault,
+		changed:   !(old == isDefault),
+	})
+
 	return err
 }
 
-func (i *ingressClassManager) handleIngressClassAddedEvent(event ingressClassAddedEvent) error {
-	log.WithField(logfields.IngressClass, event.ingressClass).Debug("Handling ingress class add")
-	i.notify(event.ingressClass)
-	return nil
-}
+// handleDeleteEvent handles a Delete event for an IngressClass resource.
+// If the IngressClass has a name that is not the Cilium IngressClass name, it will be ignored.
+// If an error is returned, then the IngressClass contained in the event should be retried at a later
+// point in time.
+func (i *ingressClassManager) handleDeleteEvent(event resource.Event[*slim_networkingv1.IngressClass]) error {
+	log.WithField(logfields.IngressClass, event.Object).Debug("Handling IngressClass Delete event")
 
-func (i *ingressClassManager) handleIngressClassUpdatedEvent(event ingressClassUpdatedEvent) error {
-	log.WithField("old", event.oldIngressClass).WithField("new", event.newIngressClass).Debug("Handling ingress class update")
-	i.notify(event.newIngressClass)
-	return nil
-}
-
-func (i *ingressClassManager) handleIngressClassDeletedEvent(event ingressClassDeletedEvent) error {
-	log.WithField(logfields.IngressClass, event.ingressClass).Debug("Handling ingress class delete")
-
-	if event.ingressClass.GetName() == ciliumIngressClassName {
-		i.ingressQueue.Add(ciliumIngressClassDeletedEvent(event))
+	if event.Object == nil || !isIngressClassCilium(event.Object) {
+		return nil
 	}
-	return nil
-}
 
-// notify informs parent ingress about change in our ingress class configuration
-func (i *ingressClassManager) notify(ic *slim_networkingv1.IngressClass) {
-	if ic.GetName() == ciliumIngressClassName {
-		i.ingressQueue.Add(ciliumIngressClassUpdatedEvent{ingressClass: ic})
-	}
+	old := i.isDefaultIngressClass.Swap(false)
+
+	i.queue.Add(ciliumIngressClassDeletedEvent{
+		wasDefault: old,
+	})
+
+	return nil
 }

--- a/operator/pkg/ingress/ingress_class_test.go
+++ b/operator/pkg/ingress/ingress_class_test.go
@@ -4,96 +4,557 @@
 package ingress
 
 import (
+	"context"
+	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
 
+	"github.com/cilium/cilium/operator/k8s"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
 	slim_metav1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
 )
 
+func Test_ingressClassSyncCanExit(t *testing.T) {
+	_, cs := k8sClient.NewFakeClientset()
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	var ingressClasses resource.Resource[*slim_networkingv1.IngressClass]
+
+	h := hive.New(
+		cell.Provide(func() k8sClient.Clientset { return cs }),
+		cell.Provide(k8s.IngressClassResource),
+		cell.Invoke(func(r resource.Resource[*slim_networkingv1.IngressClass]) {
+			ingressClasses = r
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := h.Start(ctx); err != nil {
+		t.Fatalf("hive.start failed: %s", err)
+	}
+
+	i := newIngressClassManager(ctx, queue, ingressClasses)
+
+	// Start the ingressClassManager
+	go i.Run(ctx)
+
+	// Wait for an initial sync.
+	if err := i.WaitForSync(ctx); err != nil {
+		t.Fatalf("unexpected error while doing initial sync: %s", err)
+	}
+	assert.True(t, i.synced.Load())
+
+	// This second sync should not block.
+	if err := i.WaitForSync(ctx); err != nil {
+		t.Fatalf("unexpected error while doing second sync: %s", err)
+	}
+
+	// Try exiting a sync using context
+	testCtx, testCancel := context.WithCancel(ctx)
+	testCancel()
+	i.synced.Store(false)
+
+	if err := i.WaitForSync(testCtx); err == nil {
+		t.Fatalf("unexpected nil error while doing forced block sync: %s", err)
+	} else if !errors.Is(err, context.Canceled) {
+		t.Fatalf("unexpected error while doing forced block sync, wanted context.Canceled: %s", err)
+	}
+
+	assert.Nil(t, h.Stop(ctx))
+}
+
+func Test_ingressClassIgnoresNonCilium(t *testing.T) {
+	_, cs := k8sClient.NewFakeClientset()
+	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+	var ingressClasses resource.Resource[*slim_networkingv1.IngressClass]
+
+	h := hive.New(
+		cell.Provide(func() k8sClient.Clientset { return cs }),
+		cell.Provide(k8s.IngressClassResource),
+		cell.Invoke(func(r resource.Resource[*slim_networkingv1.IngressClass]) {
+			ingressClasses = r
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := h.Start(ctx); err != nil {
+		t.Fatalf("hive.start failed: %s", err)
+	}
+
+	i := newIngressClassManager(ctx, queue, ingressClasses)
+
+	nonCiliumIngressClass := &slim_networkingv1.IngressClass{
+		ObjectMeta: slim_metav1.ObjectMeta{
+			Name:            "my-name-is-not-cilium",
+			ResourceVersion: "0",
+		},
+	}
+
+	err := i.handleDeleteEvent(
+		resource.Event[*slim_networkingv1.IngressClass]{
+			Kind:   resource.Delete,
+			Object: nonCiliumIngressClass,
+			Done:   func(_ error) {},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error handling delete event for non-cilium IngressClass: %s", err)
+	}
+
+	assert.Equal(t, 0, queue.Len())
+
+	err = i.handleUpsertEvent(
+		resource.Event[*slim_networkingv1.IngressClass]{
+			Kind:   resource.Upsert,
+			Object: nonCiliumIngressClass,
+			Done:   func(_ error) {},
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error handling upsert event for non-cilium IngressClass: %s", err)
+	}
+
+	assert.Equal(t, 0, queue.Len())
+
+	assert.Nil(t, h.Stop(ctx))
+}
+
 func Test_ingressClassHandleEvent(t *testing.T) {
+	type testCase struct {
+		desc                 string
+		class                *slim_networkingv1.IngressClass
+		classMod             func(i slim_networkingv1.IngressClass) slim_networkingv1.IngressClass
+		doDelete             bool
+		defaultAtStart       bool
+		defaultAfterMod      bool
+		expectedStartEvent   interface{}
+		expectedModEvent     interface{}
+		expectedRestoreEvent interface{}
+	}
 
-	t.Run("unknown event", func(t *testing.T) {
-		i := ingressClassManager{
-			ingressQueue: newQueue(),
-		}
-		err := i.handleEvent(ingressAddedEvent{})
-		require.Error(t, err)
-	})
-
-	t.Run("delete ingressClass", func(t *testing.T) {
-		i := ingressClassManager{
-			ingressQueue: newQueue(),
-		}
-		err := i.handleEvent(ingressClassDeletedEvent{ingressClass: &slim_networkingv1.IngressClass{
-			ObjectMeta: slim_metav1.ObjectMeta{
-				Name: ciliumIngressClassName,
-			},
-		}})
-		require.NoError(t, err)
-		require.Equal(t, 1, i.ingressQueue.Len())
-	})
-
-	t.Run("add ingressClass", func(t *testing.T) {
-		t.Run("no ops if name is not us", func(t *testing.T) {
-			i := ingressClassManager{
-				ingressQueue: newQueue(),
-			}
-			err := i.handleEvent(ingressClassAddedEvent{ingressClass: &slim_networkingv1.IngressClass{}})
-			require.NoError(t, err)
-			require.Empty(t, i.ingressQueue.Len())
-		})
-
-		t.Run("with correct name", func(t *testing.T) {
-			i := ingressClassManager{
-				ingressQueue: newQueue(),
-			}
-			err := i.handleEvent(ingressClassAddedEvent{ingressClass: &slim_networkingv1.IngressClass{
+	cases := []testCase{
+		{
+			desc: "become default, false to true",
+			class: &slim_networkingv1.IngressClass{
 				ObjectMeta: slim_metav1.ObjectMeta{
-					Name: ciliumIngressClassName,
-				},
-			}})
-			require.NoError(t, err)
-			require.Equal(t, 1, i.ingressQueue.Len())
-		})
-	})
-
-	t.Run("update ingressClass", func(t *testing.T) {
-		t.Run("no ops if not ours", func(t *testing.T) {
-			i := ingressClassManager{
-				ingressQueue: newQueue(),
-			}
-			err := i.handleEvent(ingressClassUpdatedEvent{
-				oldIngressClass: &slim_networkingv1.IngressClass{},
-				newIngressClass: &slim_networkingv1.IngressClass{},
-			})
-			require.NoError(t, err)
-			require.Empty(t, i.ingressQueue.Len())
-		})
-
-		t.Run("with change in annotations on correct name", func(t *testing.T) {
-			i := ingressClassManager{
-				ingressQueue: newQueue(),
-			}
-
-			err := i.handleEvent(ingressClassUpdatedEvent{
-				oldIngressClass: &slim_networkingv1.IngressClass{
-					ObjectMeta: slim_metav1.ObjectMeta{
-						Name: ciliumIngressClassName,
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						slim_networkingv1.AnnotationIsDefaultIngressClass: "false",
+						"test": "false-to-true",
 					},
 				},
-				newIngressClass: &slim_networkingv1.IngressClass{
-					ObjectMeta: slim_metav1.ObjectMeta{
-						Name: ciliumIngressClassName,
-						Annotations: map[string]string{
-							slim_networkingv1.AnnotationIsDefaultIngressClass: "true",
-						},
+			},
+			classMod: func(i slim_networkingv1.IngressClass) slim_networkingv1.IngressClass {
+				i.ObjectMeta.Annotations[slim_networkingv1.AnnotationIsDefaultIngressClass] = "true"
+				return i
+			},
+			defaultAtStart:  false,
+			defaultAfterMod: true,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   false,
+			},
+			expectedModEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   true,
+			},
+		},
+		{
+			desc: "become default, none to true",
+			class: &slim_networkingv1.IngressClass{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						"test": "none-to-true",
 					},
 				},
-			})
-			require.NoError(t, err)
-			require.Equal(t, 1, i.ingressQueue.Len())
+			},
+			classMod: func(i slim_networkingv1.IngressClass) slim_networkingv1.IngressClass {
+				i.ObjectMeta.Annotations[slim_networkingv1.AnnotationIsDefaultIngressClass] = "true"
+
+				return i
+			},
+			defaultAtStart:  false,
+			defaultAfterMod: true,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   false,
+			},
+			expectedModEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   true,
+			},
+		},
+		{
+			desc: "stay default",
+			class: &slim_networkingv1.IngressClass{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						slim_networkingv1.AnnotationIsDefaultIngressClass: "true",
+						"test": "stay-default",
+					},
+				},
+			},
+			classMod: func(i slim_networkingv1.IngressClass) slim_networkingv1.IngressClass {
+				return i
+			},
+			defaultAtStart:  true,
+			defaultAfterMod: true,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+			expectedModEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   false,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   false,
+			},
+		},
+		{
+			desc: "become non-default, true to false",
+			class: &slim_networkingv1.IngressClass{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						slim_networkingv1.AnnotationIsDefaultIngressClass: "true",
+						"test": "true-to-false",
+					},
+				},
+			},
+			classMod: func(i slim_networkingv1.IngressClass) slim_networkingv1.IngressClass {
+				i.ObjectMeta.Annotations[slim_networkingv1.AnnotationIsDefaultIngressClass] = "false"
+
+				return i
+			},
+			defaultAtStart:  true,
+			defaultAfterMod: false,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+			expectedModEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   true,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+		},
+		{
+			desc: "become non-default, true to none",
+			class: &slim_networkingv1.IngressClass{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						slim_networkingv1.AnnotationIsDefaultIngressClass: "true",
+						"test": "true-to-none",
+					},
+				},
+			},
+			classMod: func(i slim_networkingv1.IngressClass) slim_networkingv1.IngressClass {
+				delete(i.ObjectMeta.Annotations, slim_networkingv1.AnnotationIsDefaultIngressClass)
+
+				return i
+			},
+			defaultAtStart:  true,
+			defaultAfterMod: false,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+			expectedModEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   true,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+		},
+		{
+			desc: "stay non-default",
+			class: &slim_networkingv1.IngressClass{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						slim_networkingv1.AnnotationIsDefaultIngressClass: "false",
+						"test": "stay-non-default",
+					},
+				},
+			},
+			classMod: func(i slim_networkingv1.IngressClass) slim_networkingv1.IngressClass {
+				return i
+			},
+			defaultAtStart:  false,
+			defaultAfterMod: false,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   false,
+			},
+			expectedModEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   false,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   false,
+			},
+		},
+		{
+			desc: "delete default",
+			class: &slim_networkingv1.IngressClass{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						slim_networkingv1.AnnotationIsDefaultIngressClass: "true",
+						"test": "delete-default",
+					},
+				},
+			},
+			doDelete:       true,
+			defaultAtStart: true,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+			expectedModEvent: ciliumIngressClassDeletedEvent{
+				wasDefault: true,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+		},
+		{
+			desc: "delete non-default",
+			class: &slim_networkingv1.IngressClass{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						slim_networkingv1.AnnotationIsDefaultIngressClass: "false",
+						"test": "delete-non-default",
+					},
+				},
+			},
+			doDelete:       true,
+			defaultAtStart: false,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   false,
+			},
+			expectedModEvent: ciliumIngressClassDeletedEvent{
+				wasDefault: false,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   false,
+			},
+		},
+		{
+			desc: "fix bad annotation value",
+			class: &slim_networkingv1.IngressClass{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						"test": "fix-bad-annotation",
+						slim_networkingv1.AnnotationIsDefaultIngressClass: "notabool",
+					},
+				},
+			},
+			classMod: func(i slim_networkingv1.IngressClass) slim_networkingv1.IngressClass {
+				i.ObjectMeta.Annotations[slim_networkingv1.AnnotationIsDefaultIngressClass] = "true"
+				return i
+			},
+			defaultAtStart:  false,
+			defaultAfterMod: true,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   false,
+			},
+			expectedModEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   true,
+			},
+		},
+		{
+			desc: "apply bad annotation value",
+			class: &slim_networkingv1.IngressClass{
+				ObjectMeta: slim_metav1.ObjectMeta{
+					Name:            ciliumIngressClassName,
+					ResourceVersion: "0",
+					Annotations: map[string]string{
+						"test": "apply-bad-annotation",
+						slim_networkingv1.AnnotationIsDefaultIngressClass: "true",
+					},
+				},
+			},
+			classMod: func(i slim_networkingv1.IngressClass) slim_networkingv1.IngressClass {
+				i.ObjectMeta.Annotations[slim_networkingv1.AnnotationIsDefaultIngressClass] = "notabool"
+				return i
+			},
+			defaultAtStart:  true,
+			defaultAfterMod: false,
+			expectedStartEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+			expectedModEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: false,
+				changed:   true,
+			},
+			expectedRestoreEvent: ciliumIngressClassUpdatedEvent{
+				isDefault: true,
+				changed:   true,
+			},
+		},
+	}
+
+	handleEventExpectation := func(
+		t *testing.T, expectedEvent interface{}, queue workqueue.RateLimitingInterface,
+	) {
+		e, _ := queue.Get()
+		log.WithField("queue-event", e).Warn("Got event from test queue")
+
+		switch receivedEvent := e.(type) {
+		case ciliumIngressClassUpdatedEvent:
+			switch expectedEvent := expectedEvent.(type) {
+			case ciliumIngressClassUpdatedEvent:
+				assert.Equal(t, expectedEvent.isDefault, receivedEvent.isDefault)
+				assert.Equal(t, expectedEvent.changed, receivedEvent.changed)
+			default:
+				t.Fatalf("expected ciliumIngressClassUpdatedEvent, got %+v", receivedEvent)
+			}
+		case ciliumIngressClassDeletedEvent:
+			switch expectedEvent := expectedEvent.(type) {
+			case ciliumIngressClassDeletedEvent:
+				assert.Equal(t, expectedEvent.wasDefault, receivedEvent.wasDefault)
+			default:
+				t.Fatalf("expected ciliumIngressClassDeletedEvent, got %+v", receivedEvent)
+			}
+		default:
+			t.Fatalf("unknown event: %+v", receivedEvent)
+		}
+
+		queue.Forget(e)
+		queue.Done(e)
+	}
+
+	runTestCase := func(t *testing.T, c testCase) {
+		fakeClient, cs := k8sClient.NewFakeClientset()
+		ingressClassesClient := cs.Slim().NetworkingV1().IngressClasses()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
+
+		var ingressClasses resource.Resource[*slim_networkingv1.IngressClass]
+
+		// Create the first IngressClass
+		// Do this first to avoid a race condition
+		fakeClient.SlimFakeClientset.Tracker().Create(
+			slim_networkingv1.SchemeGroupVersion.WithResource("ingressclasses"), c.class, "",
+		)
+
+		h := hive.New(
+			cell.Provide(func() k8sClient.Clientset { return cs }),
+			cell.Provide(k8s.IngressClassResource),
+			cell.Invoke(func(r resource.Resource[*slim_networkingv1.IngressClass]) {
+				ingressClasses = r
+			}),
+		)
+
+		if err := h.Start(ctx); err != nil {
+			t.Fatalf("hive.start failed: %s", err)
+		}
+
+		i := newIngressClassManager(ctx, queue, ingressClasses)
+
+		// Start the class manager
+		go i.Run(ctx)
+
+		if err := i.WaitForSync(ctx); err != nil {
+			t.Fatalf("unexpected error while running WaitForSync: %s", err)
+		}
+
+		// Handle our initial expectations before modifications
+		handleEventExpectation(t, c.expectedStartEvent, queue)
+		assert.Equal(t, c.defaultAtStart, i.IsDefault())
+
+		// Now adjust the IngressClass based on the test case
+		if c.classMod != nil {
+			newClass := c.classMod(*c.class.DeepCopy())
+			ingressClassesClient.Update(ctx, &newClass, v1.UpdateOptions{})
+		}
+
+		if c.doDelete {
+			ingressClassesClient.Delete(ctx, c.class.Name, v1.DeleteOptions{})
+		}
+
+		handleEventExpectation(t, c.expectedModEvent, queue)
+
+		if c.doDelete {
+			assert.False(t, i.IsDefault())
+		} else {
+			assert.Equal(t, c.defaultAfterMod, i.IsDefault())
+		}
+
+		// Restore the original Ingress Class
+		if c.classMod != nil {
+			ingressClassesClient.Update(ctx, c.class, v1.UpdateOptions{})
+		}
+
+		if c.doDelete {
+			ingressClassesClient.Create(ctx, c.class, v1.CreateOptions{})
+		}
+
+		handleEventExpectation(t, c.expectedRestoreEvent, queue)
+		assert.Equal(t, c.defaultAtStart, i.IsDefault())
+
+		assert.Nil(t, h.Stop(ctx))
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			runTestCase(t, c)
 		})
-	})
+	}
 }

--- a/operator/pkg/ingress/logfields.go
+++ b/operator/pkg/ingress/logfields.go
@@ -9,5 +9,6 @@ import (
 )
 
 const Subsys = "ingress-controller"
+const CiliumIngressClassIsDefault = "cilium-is-default"
 
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, Subsys)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

Please see the commit for more details. The TL;DR here is that the Ingress Controller in the Cilium Operator will always assume that Cilium is the non-default IngressClass on startup. This is because the Ingress Controller processes events from its Ingress resource Informer before processing events from its IngressClass Informer (which is a part of the `ingressClassManager`).

This bug may cause two full reconciliations of Ingress resources on the startup of the operator: one after the Ingress resource Informer is synced, and one after the ingress controller learns Cilium should act as the default IngressClass in the cluster.

```release-note
Fix incorrect logic used by the Ingress Controller to sync Cilium's IngressClass on startup.
```
