### PR TITLE
.github: bump k8s version from v1.28.0 -> v1.28.2.

### DIFF
--- a/.github/kind-config.yaml.tmpl
+++ b/.github/kind-config.yaml.tmpl
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:${K8S_VERSION}
+    image: quay.io/cilium/kindest-node:${K8S_VERSION}
     kubeadmConfigPatches:
       # To make sure that there is no taint for master node.
       # Otherwise additional worker node might be required for conformance testing.
@@ -12,7 +12,7 @@ nodes:
         nodeRegistration:
           taints: []
   - role: worker
-    image: kindest/node:${K8S_VERSION}
+    image: quay.io/cilium/kindest-node:${K8S_VERSION}
 networking:
   disableDefaultCNI: true
   ipFamily: ${IPFAMILY}

--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -53,8 +53,8 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.20.0
-  # renovate: datasource=docker depName=kindest/node
-  k8s_version: v1.28.0
+  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
+  k8s_version: v1.28.2
   # renovate: datasource=github-releases depName=cilium/cilium-cli
   cilium_cli_version: v0.15.11
   cilium_cli_ci_version:

--- a/.github/workflows/conformance-k8s-kind-network-policies.yaml
+++ b/.github/workflows/conformance-k8s-kind-network-policies.yaml
@@ -28,8 +28,8 @@ env:
   cilium_cli_version: v0.15.11
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=kindest/node
-  k8s_version: v1.28.0
+  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
+  k8s_version: v1.28.2
 
 jobs:
   kubernetes-e2e-net-conformance:
@@ -82,7 +82,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image kindest/node:${{ env.k8s_version }}  \
+            --image quay.io/cilium/kindest-node:${{ env.k8s_version }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4

--- a/.github/workflows/conformance-k8s-kind.yaml
+++ b/.github/workflows/conformance-k8s-kind.yaml
@@ -28,8 +28,8 @@ env:
   cilium_cli_version: v0.15.11
   cilium_cli_ci_version:
   CILIUM_CLI_MODE: helm
-  # renovate: datasource=docker depName=kindest/node
-  k8s_version: v1.28.0
+  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
+  k8s_version: v1.28.2
 
 jobs:
   kubernetes-e2e:
@@ -82,7 +82,7 @@ jobs:
         run: |
           cat <<EOF | /usr/local/bin/kind create cluster \
             --name ${{ env.cluster_name}}           \
-            --image kindest/node:${{ env.k8s_version }}  \
+            --image quay.io/cilium/kindest-node:${{ env.k8s_version }}  \
             -v7 --wait 1m --retain --config=-
           kind: Cluster
           apiVersion: kind.x-k8s.io/v1alpha4

--- a/.github/workflows/tests-clustermesh-upgrade.yaml
+++ b/.github/workflows/tests-clustermesh-upgrade.yaml
@@ -53,8 +53,8 @@ concurrency:
 env:
   # renovate: datasource=github-releases depName=kubernetes-sigs/kind
   kind_version: v0.20.0
-  # renovate: datasource=docker depName=kindest/node
-  k8s_version: v1.28.0
+  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
+  k8s_version: v1.28.2
   # renovate: datasource=github-releases depName=cilium/cilium-cli
   cilium_cli_version: v0.15.11
   cilium_cli_ci_version:

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -55,6 +55,8 @@ env:
   cilium_cli_version: v0.15.11
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+  # renovate: datasource=docker depName=quay.io/cilium/kindest-node
+  k8s_version: v1.28.2
 
 jobs:
   commit-status-start:
@@ -209,7 +211,7 @@ jobs:
             if [ "${{ matrix.ipv6 }}" == "false" ]; then
               IP_FAM="ipv4"
             fi
-            ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
+            IMAGE=quay.io/cilium/kindest-node:${k8s_version} ./contrib/scripts/kind.sh "" 3 "" "" "${{ matrix.kube-proxy }}" \$IP_FAM
 
             kubectl patch node kind-worker3 --type=json -p='[{"op":"add","path":"/metadata/labels/cilium.io~1no-schedule","value":"true"}]'
             kubectl create -n kube-system secret generic cilium-ipsec-keys \


### PR DESCRIPTION
K8s v1.28.0 causes the following regression: https://github.com/cilium/cilium/issues/27982.

Most noticeably, this has been causing k8s conformance test failures.

