### PR TITLE
bpf: let set_identity_mark() also set MARK_MAGIC_IDENTITY

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -674,7 +674,6 @@ pass_to_stack:
 		 * source identity can still be derived even if SNAT is
 		 * performed by a component such as portmap.
 		 */
-		ctx->mark |= MARK_MAGIC_IDENTITY;
 		set_identity_mark(ctx, SECLABEL_IPV6);
 #endif
 	}
@@ -1214,7 +1213,6 @@ pass_to_stack:
 		 * source identity can still be derived even if SNAT is
 		 * performed by a component such as portmap.
 		 */
-		ctx->mark |= MARK_MAGIC_IDENTITY;
 		set_identity_mark(ctx, SECLABEL_IPV4);
 #endif
 	}

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -87,7 +87,6 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 
 #if defined(USE_BPF_PROG_FOR_INGRESS_POLICY) && \
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
-	ctx->mark |= MARK_MAGIC_IDENTITY;
 	set_identity_mark(ctx, seclabel);
 
 # if defined(IS_BPF_OVERLAY) && !defined(ENABLE_NODEPORT)

--- a/bpf/lib/overloadable_skb.h
+++ b/bpf/lib/overloadable_skb.h
@@ -43,6 +43,7 @@ get_epid(const struct __sk_buff *ctx)
 static __always_inline __maybe_unused void
 set_identity_mark(struct __sk_buff *ctx, __u32 identity)
 {
+	ctx->mark |= MARK_MAGIC_IDENTITY;
 	ctx->mark = ctx->mark & MARK_MAGIC_KEY_MASK;
 	ctx->mark |= ((identity & 0xFFFF) << 16) | ((identity & 0xFF0000) >> 16);
 }


### PR DESCRIPTION
Setting MARK_MAGIC_IDENTITY is really a property of the identity encoding, hide this detail from the users.

No functional change.