### PR TITLE
Best effort for xdp

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -2191,7 +2191,11 @@
    * - :spelling:ignore:`loadBalancer`
      - Configure service load balancing
      - object
-     - ``{"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}``
+     - ``{"acceleration":"disabled","l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}``
+   * - :spelling:ignore:`loadBalancer.acceleration`
+     - acceleration is the option to accelerate service handling via XDP Applicable values can be: disabled (do not use XDP), native (XDP BPF program is run directly out of the networking driver's early receive path), or best-effort (use native mode XDP acceleration on devices that support it).
+     - string
+     - ``"disabled"``
    * - :spelling:ignore:`loadBalancer.l7`
      - L7 LoadBalancer
      - object

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -676,8 +676,10 @@ In case of a multi-device environment, where Cilium's device auto-detection sele
 more than a single device to expose NodePort or a user specifies multiple devices
 with ``devices``, the XDP acceleration is enabled on all devices. This means that
 each underlying device's driver must have native XDP support on all Cilium managed
-nodes. In addition, for performance reasons we recommend kernel >= 5.5 for
-the multi-device XDP acceleration.
+nodes. If you have an environment where some devices support XDP but others do not
+you can have XDP enabled on the supported devices by setting
+``loadBalancer.acceleration`` to ``best-effort``. In addition, for performance
+reasons we recommend kernel >= 5.5 for the multi-device XDP acceleration.
 
 A list of drivers supporting XDP can be found in :ref:`the XDP documentation<xdp_drivers>`.
 

--- a/api/v1/models/kube_proxy_replacement.go
+++ b/api/v1/models/kube_proxy_replacement.go
@@ -1134,7 +1134,7 @@ func (m *KubeProxyReplacementFeaturesNat46X64Service) UnmarshalBinary(b []byte) 
 type KubeProxyReplacementFeaturesNodePort struct {
 
 	// acceleration
-	// Enum: [None Native Generic]
+	// Enum: [None Native Generic Best-Effort]
 	Acceleration string `json:"acceleration,omitempty"`
 
 	// algorithm
@@ -1184,7 +1184,7 @@ var kubeProxyReplacementFeaturesNodePortTypeAccelerationPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["None","Native","Generic"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["None","Native","Generic","Best-Effort"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -1202,6 +1202,9 @@ const (
 
 	// KubeProxyReplacementFeaturesNodePortAccelerationGeneric captures enum value "Generic"
 	KubeProxyReplacementFeaturesNodePortAccelerationGeneric string = "Generic"
+
+	// KubeProxyReplacementFeaturesNodePortAccelerationBestDashEffort captures enum value "Best-Effort"
+	KubeProxyReplacementFeaturesNodePortAccelerationBestDashEffort string = "Best-Effort"
 )
 
 // prop value enum

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -2387,6 +2387,7 @@ definitions:
                 - None
                 - Native
                 - Generic
+                - Best-Effort
               portMin:
                 type: integer
               portMax:

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -3699,7 +3699,8 @@ func init() {
                   "enum": [
                     "None",
                     "Native",
-                    "Generic"
+                    "Generic",
+                    "Best-Effort"
                   ]
                 },
                 "algorithm": {
@@ -9382,7 +9383,8 @@ func init() {
                   "enum": [
                     "None",
                     "Native",
-                    "Generic"
+                    "Generic",
+                    "Best-Effort"
                   ]
                 },
                 "algorithm": {
@@ -9564,7 +9566,8 @@ func init() {
               "enum": [
                 "None",
                 "Native",
-                "Generic"
+                "Generic",
+                "Best-Effort"
               ]
             },
             "algorithm": {
@@ -9733,7 +9736,8 @@ func init() {
           "enum": [
             "None",
             "Native",
-            "Generic"
+            "Generic",
+            "Best-Effort"
           ]
         },
         "algorithm": {

--- a/daemon/cmd/kube_proxy_replacement.go
+++ b/daemon/cmd/kube_proxy_replacement.go
@@ -170,7 +170,8 @@ func initKubeProxyReplacementOptions() error {
 
 		if option.Config.NodePortAcceleration != option.NodePortAccelerationDisabled &&
 			option.Config.NodePortAcceleration != option.NodePortAccelerationGeneric &&
-			option.Config.NodePortAcceleration != option.NodePortAccelerationNative {
+			option.Config.NodePortAcceleration != option.NodePortAccelerationNative &&
+			option.Config.NodePortAcceleration != option.NodePortAccelerationBestEffort {
 			return fmt.Errorf("Invalid value for --%s: %s", option.NodePortAcceleration, option.Config.NodePortAcceleration)
 		}
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -597,7 +597,8 @@ contributors across the globe, there is almost always someone available to help.
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
-| loadBalancer | object | `{"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
+| loadBalancer | object | `{"acceleration":"disabled","l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
+| loadBalancer.acceleration | string | `"disabled"` | acceleration is the option to accelerate service handling via XDP Applicable values can be: disabled (do not use XDP), native (XDP BPF program is run directly out of the networking driver's early receive path), or best-effort (use native mode XDP acceleration on devices that support it). |
 | loadBalancer.l7 | object | `{"algorithm":"round_robin","backend":"disabled","ports":[]}` | L7 LoadBalancer |
 | loadBalancer.l7.algorithm | string | `"round_robin"` | Default LB algorithm The default LB algorithm to be used for services, which can be overridden by the service annotation (e.g. service.cilium.io/lb-l7-algorithm) Applicable values: round_robin, least_request, random |
 | loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. service.cilium.io/lb-l7, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration.  Applicable values:   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.   - disabled: Disable L7 load balancing by way of service annotation. |

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1837,8 +1837,11 @@ loadBalancer:
   # mode: snat
 
   # -- acceleration is the option to accelerate service handling via XDP
-  # e.g. native, disabled
-  # acceleration: disabled
+  # Applicable values can be: disabled (do not use XDP), native (XDP BPF
+  # program is run directly out of the networking driver's early receive
+  # path), or best-effort (use native mode XDP acceleration on devices
+  # that support it).
+  acceleration: disabled
 
   # -- dsrDispatch configures whether IP option or IPIP encapsulation is
   # used to pass a service IP and port to remote backend

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1834,8 +1834,11 @@ loadBalancer:
   # mode: snat
 
   # -- acceleration is the option to accelerate service handling via XDP
-  # e.g. native, disabled
-  # acceleration: disabled
+  # Applicable values can be: disabled (do not use XDP), native (XDP BPF
+  # program is run directly out of the networking driver's early receive
+  # path), or best-effort (use native mode XDP acceleration on devices
+  # that support it).
+  acceleration: disabled
 
   # -- dsrDispatch configures whether IP option or IPIP encapsulation is
   # used to pass a service IP and port to remote backend

--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -248,8 +248,13 @@ func (l *Loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string)
 		if dev == wgTypes.IfaceName {
 			continue
 		}
+
 		if err := compileAndLoadXDPProg(ctx, dev, option.Config.XDPMode, extraCArgs); err != nil {
-			return err
+			if option.Config.NodePortAcceleration == option.XDPModeBestEffort {
+				log.WithError(err).WithField(logfields.Device, dev).Info("Failed to attach XDP program, ignoring due to best-effort mode")
+			} else {
+				return fmt.Errorf("attaching XDP program to interface %s: %w", dev, err)
+			}
 		}
 	}
 	return nil

--- a/pkg/datapath/loader/link.go
+++ b/pkg/datapath/loader/link.go
@@ -11,7 +11,7 @@ import (
 
 func SetXDPMode(mode string) error {
 	switch mode {
-	case option.XDPModeNative:
+	case option.XDPModeNative, option.XDPModeBestEffort:
 		if option.Config.XDPMode == option.XDPModeLinkNone ||
 			option.Config.XDPMode == option.XDPModeLinkDriver {
 			option.Config.XDPMode = option.XDPModeLinkDriver

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -226,7 +226,7 @@ func attachTCProgram(link netlink.Link, prog *ebpf.Program, progName string, qdi
 	}
 
 	if err := netlink.FilterReplace(filter); err != nil {
-		return fmt.Errorf("replacing tc filter: %w", err)
+		return fmt.Errorf("replacing tc filter for interface %s: %w", link.Attrs().Name, err)
 	}
 
 	return nil

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -27,7 +27,7 @@ import (
 
 func xdpModeToFlag(xdpMode string) link.XDPAttachFlags {
 	switch xdpMode {
-	case option.XDPModeNative, option.XDPModeLinkDriver:
+	case option.XDPModeNative, option.XDPModeLinkDriver, option.XDPModeBestEffort:
 		return link.XDPDriverMode
 	case option.XDPModeGeneric, option.XDPModeLinkGeneric:
 		return link.XDPGenericMode

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -260,7 +260,7 @@ const (
 	NodePortAlg = "node-port-algorithm"
 
 	// NodePortAcceleration indicates whether NodePort should be accelerated
-	// via XDP ("none", "generic" or "native")
+	// via XDP ("none", "generic", "native", or "best-effort")
 	NodePortAcceleration = "node-port-acceleration"
 
 	// Alias to NodePortMode
@@ -874,6 +874,9 @@ const (
 	// XDPModeNative for loading progs with XDPModeLinkDriver
 	XDPModeNative = "native"
 
+	// XDPModeBestEffort for loading progs with XDPModeLinkDriver
+	XDPModeBestEffort = "best-effort"
+
 	// XDPModeGeneric for loading progs with XDPModeLinkGeneric
 	XDPModeGeneric = "testing-only"
 
@@ -1344,6 +1347,9 @@ const (
 
 	// NodePortAccelerationNative means we accelerate NodePort via native XDP in the driver (preferred)
 	NodePortAccelerationNative = XDPModeNative
+
+	// NodePortAccelerationBestEffort means we accelerate NodePort via native XDP in the driver (preferred), but will skip devices without driver support
+	NodePortAccelerationBestEffort = XDPModeBestEffort
 
 	// KubeProxyReplacementPartial specifies to enable only selected kube-proxy
 	// replacement features (might panic)
@@ -2047,7 +2053,7 @@ type DaemonConfig struct {
 	MaglevHashSeed string
 
 	// NodePortAcceleration indicates whether NodePort should be accelerated
-	// via XDP ("none", "generic" or "native")
+	// via XDP ("none", "generic", "native", or "best-effort")
 	NodePortAcceleration string
 
 	// NodePortBindProtection rejects bind requests to NodePort service ports


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [?] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [?] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

This allows a user to specify a new mode, `best-effort` when enabling XDP. We need this ability since we are running physical hosts where the primary NICs do support XDP, but have additional `vlan` devices that _do not_ have XDP support in the driver.

More background can be found in #24768, but to summarize we have 1 physical device (ens785np0) per host and due to network design we need an additional `vlan` type interface (`vlan3`). Regrettably the `vlan` driver in the kernel does not support XDP. When enabling XDP without this change Cilium enters a crashloop with this error:

```
level=fatal msg="Failed to compile XDP program" error="program cil_xdp_entry: attaching XDP program to interface vlan3: operation not supported" subsys=datapath-loader
```

With this change applied and by setting `loadBalancer.acceleration` to `best-effort` in our values.yaml file we get the following log output with XDP enabled only on devices that support it:

```
level=info msg="attaching XDP program to interface vlan3 failed. Ignoring" subsys=datapath-loader
```

```
$ sudo bpftool net
xdp:
ens785np0(2) driver id 28652

tc:
ens785np0(2) clsact/ingress cil_from_netdev-ens785np0 id 28699
ens785np0(2) clsact/egress cil_to_netdev-ens785np0 id 28721
vlan3(4) clsact/ingress cil_from_netdev-vlan3 id 28731
vlan3(4) clsact/egress cil_to_netdev-vlan3 id 28739
cilium_net(5) clsact/ingress cil_to_host-cilium_net id 28692
cilium_host(6) clsact/ingress cil_to_host-cilium_host id 28674
cilium_host(6) clsact/egress cil_from_host-cilium_host id 28686
cilium_vxlan(7) clsact/ingress cil_from_overlay-cilium_vxlan id 28663
cilium_vxlan(7) clsact/egress cil_to_overlay-cilium_vxlan id 28664
lxc_health(11) clsact/ingress cil_from_container-lxc_health id 28708

flow_dissector:
```

I initially created https://github.com/cilium/cilium/pull/25870 and it was indicated in [this comment thread](https://github.com/cilium/cilium/pull/25870#discussion_r1313247066) that swallowing these errors if set to "best-effort" would be an acceptable solution.

Any and all feedback would be very welcome!

Fixes: #24768

```release-note
Adds "best-effort" mode for XDP to skip interfaces without driver support
```

