### PR TITLE
bpf: fine-tune a few L3 header validations

### DIFF
--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1392,24 +1392,19 @@ out:
 
 #ifdef ENABLE_IPV6
 static __always_inline int
-ipv6_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
+ipv6_policy(struct __ctx_buff *ctx, struct ipv6hdr *ip6, int ifindex, __u32 src_label,
 	    struct ipv6_ct_tuple *tuple_out, __s8 *ext_err, __u16 *proxy_port)
 {
 	struct ct_state *ct_state, ct_state_new = {};
 	struct ipv6_ct_tuple *tuple;
 	int ret, verdict, l4_off, zero = 0;
 	struct ct_buffer6 *ct_buffer;
-	void *data, *data_end;
-	struct ipv6hdr *ip6;
 	bool skip_ingress_proxy = false;
 	struct trace_ctx trace;
 	union v6addr orig_sip;
 	__u8 policy_match_type = POLICY_MATCH_NONE;
 	__u8 audited = 0;
 	__u8 auth_type = 0;
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip6))
-		return DROP_INVALID;
 
 	policy_clear_mark(ctx);
 
@@ -1550,13 +1545,21 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	__u32 src_label = ctx_load_meta(ctx, CB_SRC_LABEL);
 	bool from_host = ctx_load_meta(ctx, CB_FROM_HOST);
 	bool proxy_redirect __maybe_unused = false;
+	void *data, *data_end;
 	__u16 proxy_port = 0;
+	struct ipv6hdr *ip6;
 	__s8 ext_err = 0;
 
 	ctx_store_meta(ctx, CB_SRC_LABEL, 0);
 	ctx_store_meta(ctx, CB_FROM_HOST, 0);
 
-	ret = ipv6_policy(ctx, ifindex, src_label, &tuple, &ext_err, &proxy_port);
+	if (!revalidate_data(ctx, &data, &data_end, &ip6)) {
+		ret = DROP_INVALID;
+		goto drop_err;
+	}
+
+	ret = ipv6_policy(ctx, ip6, ifindex, src_label, &tuple, &ext_err,
+			  &proxy_port);
 	switch (ret) {
 	case POLICY_ACT_PROXY_REDIRECT:
 		ret = ctx_redirect_to_proxy6(ctx, &tuple, proxy_port, from_host);
@@ -1576,8 +1579,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 	}
 
 	if (IS_ERR(ret))
-		return send_drop_notify_ext(ctx, src_label, SECLABEL_IPV6, LXC_ID,
-					ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
+		goto drop_err;
 
 	/* Store meta: essential for proxy ingress, see bpf_host.c */
 	ctx_store_meta(ctx, CB_PROXY_MAGIC, ctx->mark);
@@ -1597,6 +1599,10 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 #endif
 
 	return ret;
+
+drop_err:
+	return send_drop_notify_ext(ctx, src_label, SECLABEL_IPV6, LXC_ID,
+				    ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
 }
 
 __section_tail(CILIUM_MAP_CALLS, CILIUM_CALL_IPV6_TO_ENDPOINT)
@@ -1653,7 +1659,8 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 #endif
 	ctx_store_meta(ctx, CB_SRC_LABEL, 0);
 
-	ret = ipv6_policy(ctx, 0, src_sec_identity, NULL, &ext_err, &proxy_port);
+	ret = ipv6_policy(ctx, ip6, 0, src_sec_identity, NULL, &ext_err,
+			  &proxy_port);
 	switch (ret) {
 	case POLICY_ACT_PROXY_REDIRECT:
 		ret = ctx_redirect_to_proxy_hairpin_ipv6(ctx, proxy_port);
@@ -1702,14 +1709,12 @@ TAIL_CT_LOOKUP6(CILIUM_CALL_IPV6_CT_INGRESS, tail_ipv6_ct_ingress, CT_INGRESS,
 
 #ifdef ENABLE_IPV4
 static __always_inline int
-ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
+ipv4_policy(struct __ctx_buff *ctx, struct iphdr *ip4, int ifindex, __u32 src_label,
 	    struct ipv4_ct_tuple *tuple_out, __s8 *ext_err, __u16 *proxy_port,
 	    bool from_tunnel)
 {
 	struct ct_state *ct_state, ct_state_new = {};
 	struct ipv4_ct_tuple *tuple;
-	void *data, *data_end;
-	struct iphdr *ip4;
 	bool skip_ingress_proxy = false;
 	bool is_untracked_fragment = false;
 	struct ct_buffer4 *ct_buffer;
@@ -1720,9 +1725,6 @@ ipv4_policy(struct __ctx_buff *ctx, int ifindex, __u32 src_label,
 	__u8 audited = 0;
 	__u8 auth_type = 0;
 	__u32 zero = 0;
-
-	if (!revalidate_data(ctx, &data, &data_end, &ip4))
-		return DROP_INVALID;
 
 	policy_clear_mark(ctx);
 
@@ -1902,7 +1904,9 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	bool from_host = ctx_load_meta(ctx, CB_FROM_HOST);
 	bool from_tunnel = ctx_load_meta(ctx, CB_FROM_TUNNEL);
 	bool proxy_redirect __maybe_unused = false;
+	void *data, *data_end;
 	__u16 proxy_port = 0;
+	struct iphdr *ip4;
 	__s8 ext_err = 0;
 
 	ctx_store_meta(ctx, CB_SRC_LABEL, 0);
@@ -1910,8 +1914,13 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	ctx_store_meta(ctx, CB_FROM_HOST, 0);
 	ctx_store_meta(ctx, CB_FROM_TUNNEL, 0);
 
-	ret = ipv4_policy(ctx, ifindex, src_label, &tuple, &ext_err, &proxy_port,
-			  from_tunnel);
+	if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
+		ret = DROP_INVALID;
+		goto drop_err;
+	}
+
+	ret = ipv4_policy(ctx, ip4, ifindex, src_label, &tuple, &ext_err,
+			  &proxy_port, from_tunnel);
 	switch (ret) {
 	case POLICY_ACT_PROXY_REDIRECT:
 		ret = ctx_redirect_to_proxy4(ctx, &tuple, proxy_port, from_host);
@@ -1938,8 +1947,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 	}
 
 	if (IS_ERR(ret))
-		return send_drop_notify_ext(ctx, src_label, SECLABEL_IPV4, LXC_ID,
-					ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
+		goto drop_err;
 
 	/* Store meta: essential for proxy ingress, see bpf_host.c */
 	ctx_store_meta(ctx, CB_PROXY_MAGIC, ctx->mark);
@@ -1959,6 +1967,10 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 #endif
 
 	return ret;
+
+drop_err:
+	return send_drop_notify_ext(ctx, src_label, SECLABEL_IPV4, LXC_ID,
+				    ret, ext_err, CTX_ACT_DROP, METRIC_INGRESS);
 }
 
 static __always_inline bool
@@ -2097,8 +2109,8 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 		goto out;
 	}
 
-	ret = ipv4_policy(ctx, 0, src_sec_identity, NULL, &ext_err, &proxy_port,
-			  false);
+	ret = ipv4_policy(ctx, ip4, 0, src_sec_identity, NULL, &ext_err,
+			  &proxy_port, false);
 	switch (ret) {
 	case POLICY_ACT_PROXY_REDIRECT:
 		ret = ctx_redirect_to_proxy_hairpin_ipv4(ctx, proxy_port);

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -2113,7 +2113,12 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 			  &proxy_port, false);
 	switch (ret) {
 	case POLICY_ACT_PROXY_REDIRECT:
-		ret = ctx_redirect_to_proxy_hairpin_ipv4(ctx, proxy_port);
+		if (!revalidate_data(ctx, &data, &data_end, &ip4)) {
+			ret = DROP_INVALID;
+			goto out;
+		}
+
+		ret = ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4, proxy_port);
 		proxy_redirect = true;
 		break;
 	case CTX_ACT_OK:

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -2789,7 +2789,7 @@ static __always_inline int nodeport_lb4(struct __ctx_buff *ctx,
 			send_trace_notify(ctx, TRACE_TO_PROXY, src_sec_identity, 0,
 					  bpf_ntohs((__u16)svc->l7_lb_proxy_port), 0,
 					  TRACE_REASON_POLICY, monitor);
-			return ctx_redirect_to_proxy_hairpin_ipv4(ctx,
+			return ctx_redirect_to_proxy_hairpin_ipv4(ctx, ip4,
 								  (__be16)svc->l7_lb_proxy_port);
 		}
 #endif

--- a/bpf/lib/proxy_hairpin.h
+++ b/bpf/lib/proxy_hairpin.h
@@ -15,12 +15,17 @@
 #include "l4.h"
 
 #if defined(HOST_IFINDEX_MAC) && defined(HOST_IFINDEX)
-/**
- * ctx_redirect_to_proxy_hairpin redirects to the proxy by hairpining the
- * packet out the incoming interface
+
+/** Redirect to the proxy by hairpinning the packet out the incoming
+ *  interface.
+ *
+ * @arg ctx		Packet
+ * @arg ip4		Pointer to IPv4 header. NULL for IPv6 packet.
+ * @arg proxy_port	Proxy port
  */
 static __always_inline int
-ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port, const bool is_ipv6)
+ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, struct iphdr *ip4,
+			      __be16 proxy_port)
 {
 #if defined(ENABLE_IPV4) || defined(ENABLE_IPV6)
 	union macaddr host_mac = HOST_IFINDEX_MAC;
@@ -32,19 +37,13 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port, const b
 		       MARK_MAGIC_TO_PROXY | (proxy_port << 16));
 	bpf_barrier(); /* verifier workaround */
 
-	if (is_ipv6) {
+	if (!ip4) {
 #ifdef ENABLE_IPV6
 		ret = ipv6_l3(ctx, ETH_HLEN, (__u8 *)&router_mac, (__u8 *)&host_mac,
 			      METRIC_EGRESS);
 #endif
 	} else {
 #ifdef ENABLE_IPV4
-		void *data, *data_end;
-		struct iphdr *ip4;
-
-		if (!revalidate_data(ctx, &data, &data_end, &ip4))
-			return DROP_INVALID;
-
 		ret = ipv4_l3(ctx, ETH_HLEN, (__u8 *)&router_mac, (__u8 *)&host_mac,
 			      ip4);
 #endif
@@ -64,9 +63,10 @@ ctx_redirect_to_proxy_hairpin(struct __ctx_buff *ctx, __be16 proxy_port, const b
 
 #ifdef ENABLE_IPV4
 static __always_inline int
-ctx_redirect_to_proxy_hairpin_ipv4(struct __ctx_buff *ctx, __be16 proxy_port)
+ctx_redirect_to_proxy_hairpin_ipv4(struct __ctx_buff *ctx, struct iphdr *ip4,
+				   __be16 proxy_port)
 {
-	return ctx_redirect_to_proxy_hairpin(ctx, proxy_port, false);
+	return ctx_redirect_to_proxy_hairpin(ctx, ip4, proxy_port);
 }
 #endif
 
@@ -74,7 +74,7 @@ ctx_redirect_to_proxy_hairpin_ipv4(struct __ctx_buff *ctx, __be16 proxy_port)
 static __always_inline int
 ctx_redirect_to_proxy_hairpin_ipv6(struct __ctx_buff *ctx, __be16 proxy_port)
 {
-	return ctx_redirect_to_proxy_hairpin(ctx, proxy_port, true);
+	return ctx_redirect_to_proxy_hairpin(ctx, NULL, proxy_port);
 }
 #endif
 


### PR DESCRIPTION
Lift two `revalidate_data()` users out of their current location, so that callers can pass a L3 header if already available.
