### PR TITLE
ipcache: move CIDR restoration to asynchronous APIs

### DIFF
--- a/daemon/cmd/ipcache.go
+++ b/daemon/cmd/ipcache.go
@@ -4,15 +4,33 @@
 package cmd
 
 import (
+	"fmt"
 	"net"
+	"net/netip"
+	"os"
 
 	"github.com/go-openapi/runtime/middleware"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/policy"
 	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/bpf"
 	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/ipcache"
+	ipcachetypes "github.com/cilium/cilium/pkg/ipcache/types"
+	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+	ipcachemap "github.com/cilium/cilium/pkg/maps/ipcache"
+	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/source"
+)
+
+var (
+	// the ipcache resource id (just a constant string) used for restored CIDRs
+	restoredCIDRResource = ipcachetypes.NewResourceID(ipcachetypes.ResourceKindDaemon, "", "restored")
+	ingressResource      = ipcachetypes.NewResourceID(ipcachetypes.ResourceKindDaemon, "", "ingress")
 )
 
 func getIPHandler(d *Daemon, params GetIPParams) middleware.Responder {
@@ -86,4 +104,146 @@ func containsSubnet(outer, inner net.IPNet) bool {
 	innerOnes, innerBits := inner.Mask.Size()
 
 	return outerBits == innerBits && outerOnes <= innerOnes && outer.Contains(inner.IP)
+}
+
+// restoreIPCache dumps the existing (old) bpf ipcache, adding relevant information
+// back in to the ipcache / identity allocator.
+//
+// The goal of this logic is to ensure, as much as possible, that local identities (i.e. CIDR)
+// get the same numeric identity upon agent restart.
+//
+// For all local (cidr / remote-node) identities found, this adds a placeholder entry in the
+// ipcache metadata layer requesting the previous numeric identity. When the agent initializes
+// and the ipcache finally recreates the bpf map, this placeholder entry ensures the prefixes
+// exist and have the same identity as before.
+//
+// After a grace period, the placeholder metadata is removed and any prefixes not referenced
+// by other subsystems will be deallocated, see releaseRestoredCIDRs().
+// (Aside: prefix references mostly come from network policies, either directly through CIDR
+// selectors or via ToFQDN rules.)
+//
+// For ingress IPs, it will add those to the ipcache and configure the local node
+// accordingly.
+//
+// This *must* be called before initMaps(), which will hide the "old" ipcache.
+func (d *Daemon) restoreIPCache() error {
+	ingressIPs := make([]netip.Prefix, 0, 2)
+	// need to preserve this so we can remove it later.
+	d.restoredCIDRs = map[netip.Prefix]identity.NumericIdentity{}
+
+	// Dump the bpf ipcache, recording any prefixes with local or ingress
+	// numeric identities.
+	err := ipcachemap.IPCacheMap().DumpWithCallback(func(key bpf.MapKey, value bpf.MapValue) {
+		k := key.(*ipcachemap.Key)
+		v := value.(*ipcachemap.RemoteEndpointInfo)
+		nid := identity.NumericIdentity(v.SecurityIdentity)
+
+		if isLocalIdentity(nid) {
+			d.restoredCIDRs[k.Prefix()] = nid
+		} else if nid == identity.ReservedIdentityIngress && v.TunnelEndpoint.IsZero() {
+			ingressIPs = append(ingressIPs, k.Prefix())
+		}
+	})
+	// dumpwithcallback() leaves the ipcache map open, must close before opened for
+	// parallel mode in daemon.initmaps()
+	ipcachemap.IPCacheMap().Close()
+
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("error dumping ipcache: %w", err)
+	}
+
+	// Now that the map is dumped,
+	// - upsert relevant metadata in to the ipcache
+	// - withhold all existing CIDR identities
+	// - add Ingress IPs to local Node.
+	metaUpdates := make([]ipcache.MU, 0, len(ingressIPs)+len(d.restoredCIDRs))
+	nidsToWithhold := make([]identity.NumericIdentity, 0, len(d.restoredCIDRs))
+
+	for prefix, nid := range d.restoredCIDRs {
+		nidsToWithhold = append(nidsToWithhold, nid)
+		metaUpdates = append(metaUpdates, ipcache.MU{
+			Prefix:   prefix,
+			Source:   source.Restored,
+			Resource: restoredCIDRResource,
+			Metadata: []ipcache.IPMetadata{ipcachetypes.RequestedIdentity(nid)},
+		})
+	}
+	for _, prefix := range ingressIPs {
+		metaUpdates = append(metaUpdates, ipcache.MU{
+			Prefix:   prefix,
+			Source:   source.Restored,
+			Resource: ingressResource,
+			Metadata: []ipcache.IPMetadata{labels.LabelIngress},
+		})
+
+		// Set any restored ingress IPs back on the LocalNode object
+		d.nodeLocalStore.Update(func(n *node.LocalNode) {
+			addr := prefix.Addr()
+			if addr.Is4() {
+				n.IPv4IngressIP = addr.AsSlice()
+			} else {
+				n.IPv6IngressIP = addr.AsSlice()
+			}
+		})
+	}
+	if len(ingressIPs) > 0 {
+		log.WithField(logfields.Ingress, ingressIPs).Info("Restored ingress IPs")
+	}
+
+	// Insert the batched changes in to the ipcache.
+	// Even though the ipcache map hasn't been initialized yet, this is
+	// safe to do so, because the ipcache's apply controller is currently
+	// paused.
+	d.ipcache.IdentityAllocator.WithholdLocalIdentities(nidsToWithhold)
+	d.ipcache.UpsertMetadataBatch(metaUpdates...)
+
+	return nil
+}
+
+// releaseRestoredCIDRS removes the placeholder metadata that was inserted
+// in to the ipcache when local identities were restored.
+// Any identities actually in use will still exist after this.
+//
+// This should be called after a grace period (default 10 minutes, set
+// by --identity-restore-grace-period).
+// This grace period is needed when running on an external workload
+// where policy synchronization is not done via k8s. Also in k8s
+// case it is prudent to allow concurrent endpoint regenerations to
+// (re-)allocate the restored identities before we release them.
+//
+// Any CIDRs still in use after the grace period will have other sources
+// of metadata in the ipcache, and thus will remain. CIDRs for which
+// restoration was the only source of metadata will be deallocated.
+func (d *Daemon) releaseRestoredCIDRs() {
+	defer func() {
+		// release the memory held by restored CIDRs
+		d.restoredCIDRs = nil
+	}()
+	if len(d.restoredCIDRs) == 0 {
+		return
+	}
+
+	log.WithField(logfields.Count, len(d.restoredCIDRs)).Info("Removing identity reservations for restored CIDR identities")
+	updates := make([]ipcache.MU, 0, len(d.restoredCIDRs))
+	nids := make([]identity.NumericIdentity, 0, len(d.restoredCIDRs))
+	for prefix, nid := range d.restoredCIDRs {
+		nids = append(nids, nid)
+		updates = append(updates, ipcache.MU{
+			Prefix:   prefix,
+			Resource: restoredCIDRResource,
+			Metadata: []ipcache.IPMetadata{ipcachetypes.RequestedIdentity(0)},
+		})
+	}
+
+	d.ipcache.RemoveMetadataBatch(updates...)
+	d.ipcache.IdentityAllocator.UnwithholdLocalIdentities(nids)
+}
+
+func isLocalIdentity(nid identity.NumericIdentity) bool {
+	scope := nid.Scope()
+	return scope == identity.IdentityScopeLocal ||
+		(scope == identity.IdentityScopeRemoteNode && option.Config.PolicyCIDRMatchesNodes())
 }

--- a/pkg/identity/cache/allocator.go
+++ b/pkg/identity/cache/allocator.go
@@ -135,6 +135,15 @@ type IdentityAllocator interface {
 	// ReleaseCIDRIdentitiesByID() is a wrapper for ReleaseSlice() that
 	// also handles ipcache entries.
 	ReleaseCIDRIdentitiesByID(context.Context, []identity.NumericIdentity)
+
+	// WithholdLocalIdentities holds a set of numeric identities out of the local
+	// allocation pool(s). Once withheld, a numeric identity can only be used
+	// when explicitly requested via AllocateIdentity(..., oldNID).
+	WithholdLocalIdentities(nids []identity.NumericIdentity)
+
+	// UnwithholdLocalIdentities removes numeric identities from the withheld set,
+	// freeing them for general allocation.
+	UnwithholdLocalIdentities(nids []identity.NumericIdentity)
 }
 
 // InitIdentityAllocator creates the global identity allocator. Only the first
@@ -392,6 +401,25 @@ func (m *CachingIdentityAllocator) AllocateIdentity(ctx context.Context, lbls la
 	}
 
 	return identity.NewIdentity(identity.NumericIdentity(idp), lbls), isNew, nil
+}
+
+func (m *CachingIdentityAllocator) WithholdLocalIdentities(nids []identity.NumericIdentity) {
+	log.WithField(logfields.Identity, nids).Debug("Withholding numeric identities for later restoration")
+
+	// The allocators will return any identities that are not in-scope.
+	nids = m.localIdentities.withhold(nids)
+	nids = m.localNodeIdentities.withhold(nids)
+	if len(nids) > 0 {
+		log.WithField(logfields.Identity, nids).Error("Attempt to restore invalid numeric identities.")
+	}
+}
+
+func (m *CachingIdentityAllocator) UnwithholdLocalIdentities(nids []identity.NumericIdentity) {
+	log.WithField(logfields.Identity, nids).Debug("Unwithholding numeric identities")
+
+	// The allocators will ignore any identities that are not in-scope.
+	m.localIdentities.unwithhold(nids)
+	m.localNodeIdentities.unwithhold(nids)
 }
 
 // Release is the reverse operation of AllocateIdentity() and releases the

--- a/pkg/identity/cache/local.go
+++ b/pkg/identity/cache/local.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 type localIdentityCache struct {
@@ -24,6 +25,15 @@ type localIdentityCache struct {
 	minID               identity.NumericIdentity
 	maxID               identity.NumericIdentity
 	events              allocator.AllocatorEventSendChan
+
+	// withheldIdentities is a set of identities that should be considered unavailable for allocation,
+	// but not yet allocated.
+	// They are used during agent restart, where local identities are restored to prevent unnecessary
+	// ID flapping on restart.
+	//
+	// If an old nID is passed to lookupOrCreate(), then it is allowed to use a withhend entry here. Otherwise
+	// it must allocate a new ID not in this set.
+	withheldIdentities map[identity.NumericIdentity]struct{}
 }
 
 func newLocalIdentityCache(scope, minID, maxID identity.NumericIdentity, events allocator.AllocatorEventSendChan) *localIdentityCache {
@@ -35,6 +45,7 @@ func newLocalIdentityCache(scope, minID, maxID identity.NumericIdentity, events 
 		minID:               minID,
 		maxID:               maxID,
 		events:              events,
+		withheldIdentities:  map[identity.NumericIdentity]struct{}{},
 	}
 }
 
@@ -57,18 +68,32 @@ func (l *localIdentityCache) getNextFreeNumericIdentity(idCandidate identity.Num
 			// let nextNumericIdentity be, allocated identities will be skipped anyway
 			log.Debugf("Reallocated restored local identity: %d", idCandidate)
 			return idCandidate, nil
+		} else {
+			log.WithField(logfields.Identity, idCandidate).Debug("Requested local identity not available to allocate")
 		}
 	}
 	firstID := l.nextNumericIdentity
 	for {
 		idCandidate = l.nextNumericIdentity | l.scope
-		if _, taken := l.identitiesByID[idCandidate]; !taken {
+		_, taken := l.identitiesByID[idCandidate]
+		_, withheld := l.withheldIdentities[idCandidate]
+		if !taken && !withheld {
 			l.bumpNextNumericIdentity()
 			return idCandidate, nil
 		}
 
 		l.bumpNextNumericIdentity()
 		if l.nextNumericIdentity == firstID {
+			// Desperation: no local identities left (unlikely). If there are withheld
+			// but not-taken identities, claim one of them.
+			for withheldID := range l.withheldIdentities {
+				if _, taken := l.identitiesByID[withheldID]; !taken {
+					delete(l.withheldIdentities, withheldID)
+					log.WithField(logfields.Identity, withheldID).Warn("Local identity allocator full; claiming first withheld identity. This may cause momentary policy drops")
+					return withheldID, nil
+				}
+			}
+
 			return 0, fmt.Errorf("out of local identity space")
 		}
 	}
@@ -153,6 +178,40 @@ func (l *localIdentityCache) release(id *identity.Identity) bool {
 	}
 
 	return false
+}
+
+// withhold marks the nids as unavailable. Any out-of-scope identities are returned.
+func (l *localIdentityCache) withhold(nids []identity.NumericIdentity) []identity.NumericIdentity {
+	if len(nids) == 0 {
+		return nil
+	}
+
+	unused := make([]identity.NumericIdentity, 0, len(nids))
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	for _, nid := range nids {
+		if nid.Scope() != l.scope {
+			unused = append(unused, nid)
+			continue
+		}
+		l.withheldIdentities[nid] = struct{}{}
+	}
+
+	return unused
+}
+
+func (l *localIdentityCache) unwithhold(nids []identity.NumericIdentity) {
+	if len(nids) == 0 {
+		return
+	}
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	for _, nid := range nids {
+		if nid.Scope() != l.scope {
+			continue
+		}
+		delete(l.withheldIdentities, nid)
+	}
 }
 
 // lookup searches for a local identity matching the given labels and returns

--- a/pkg/identity/cache/local_test.go
+++ b/pkg/identity/cache/local_test.go
@@ -5,8 +5,11 @@ package cache
 
 import (
 	"fmt"
+	"net/netip"
+	"testing"
 
 	. "github.com/cilium/checkmate"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/identity"
@@ -93,4 +96,65 @@ func (s *IdentityCacheTestSuite) TestLocalIdentityCache(c *C) {
 	c.Assert(isNew, Equals, true)
 	// the selected numeric identity must be the one released before
 	c.Assert(id.ID, Equals, randomID)
+}
+
+func TestOldNID(t *testing.T) {
+	minID, maxID := identity.NumericIdentity(1), identity.NumericIdentity(10)
+	scope := identity.NumericIdentity(0x42_00_00_00)
+	c := newLocalIdentityCache(scope, minID, maxID, nil)
+
+	// Request identity, it should work
+	l := labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.1/32"))
+	id, _, _ := c.lookupOrCreate(l, scope)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, scope, id.ID)
+
+	// Re-request identity, it should not
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.2/32"))
+	id, _, _ = c.lookupOrCreate(l, scope)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, scope+1, id.ID)
+
+	// Withhold the next identity, it should be skipped
+	c.withhold([]identity.NumericIdentity{scope + 2})
+
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.3/32"))
+	id, _, _ = c.lookupOrCreate(l, 0)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, scope+3, id.ID)
+
+	// Request a withheld identity, it should succeed
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.4/32"))
+	id2, _, _ := c.lookupOrCreate(l, scope+2)
+	assert.NotNil(t, id2)
+	assert.EqualValues(t, scope+2, id2.ID)
+
+	// Request a withheld and allocated identity, it should be ignored
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.5/32"))
+	id, _, _ = c.lookupOrCreate(l, scope+2)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, scope+4, id.ID)
+
+	// Unwithhold and release an identity, requesting should now succeed
+	c.unwithhold([]identity.NumericIdentity{scope + 2})
+	c.release(id2)
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.6/32"))
+	id, _, _ = c.lookupOrCreate(l, scope+2)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, scope+2, id.ID)
+
+	// Request an identity out of scope, it should not be honored
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.7/32"))
+	id, _, _ = c.lookupOrCreate(l, scope-2)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, scope+5, id.ID)
+
+	// Withhold all identities; allocator should fall back to a (random) withheld identity
+	c.withhold([]identity.NumericIdentity{scope + 6, scope + 7, scope + 8, scope + 9, scope + 10})
+
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.8/32"))
+	id, _, _ = c.lookupOrCreate(l, scope-2)
+	assert.NotNil(t, id)
+	// actual value is random, just need it to succeed
+	assert.True(t, id.ID >= scope+6 && id.ID <= scope+10, "%d <= %d <= %d", scope+6, id.ID, scope+10)
 }

--- a/pkg/ipcache/cidr.go
+++ b/pkg/ipcache/cidr.go
@@ -61,6 +61,8 @@ func (ipc *IPCache) AllocateCIDRs(
 		oldNID := identity.InvalidIdentity
 		if oldNIDs != nil && len(oldNIDs) > i {
 			oldNID = oldNIDs[i]
+		} else {
+			oldNID = info.RequestedIdentity().ID()
 		}
 		id, isNew, err := ipc.resolveIdentity(allocateCtx, prefix, info, oldNID)
 		if err != nil {

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -223,7 +223,7 @@ func (ipc *IPCache) InjectLabels(ctx context.Context, modifiedPrefixes []netip.P
 			} // else continue below to remove the old entry
 		} else {
 			// Insert to propagate the updated set of labels after removal.
-			newID, _, err = ipc.resolveIdentity(ctx, prefix, prefixInfo, identity.InvalidIdentity)
+			newID, _, err = ipc.resolveIdentity(ctx, prefix, prefixInfo, prefixInfo.RequestedIdentity().ID())
 			if err != nil {
 				// NOTE: This may fail during a 2nd or later
 				// iteration of the loop. To handle this, break

--- a/pkg/ipcache/metadata.go
+++ b/pkg/ipcache/metadata.go
@@ -455,16 +455,6 @@ func (ipc *IPCache) resolveIdentity(ctx context.Context, prefix netip.Prefix, in
 
 	lbls := info.ToLabels()
 
-	// If we are restoring an identity in the remote-node identity scope, we need to
-	// unconditionally add remote-node and cidr labels back. We do not need to check
-	// if CIDR selection for nodes is enabled here, as we explicitly check further down
-	// when we remove CIDR labels for identities that should not have them.
-	if restoredIdentity.Scope() == identity.IdentityScopeRemoteNode {
-		lbls.MergeLabels(labels.LabelRemoteNode)
-		cidrLabels := labels.GetCIDRLabels(prefix)
-		lbls.MergeLabels(cidrLabels)
-	}
-
 	// If we are restoring a host identity and policy-cidr-match-mode includes "nodes"
 	// then merge the CIDR-label.
 	if lbls.Has(labels.LabelHost[labels.IDNameHost]) &&

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -318,28 +318,30 @@ func TestUpdateLocalNode(t *testing.T) {
 }
 
 // TestInjectExisting tests "upgrading" an existing identity to the apiserver.
-// This is a common occurrence on startup - and this tests ensures we don't
-// regress the known issue in GH-24502
+// This is possible if a CIDR policy references a given IP, which is then
+// upgraded to the apiserver.
+//
+// This was intended to ensure we don't regress on GH-24502, but that is moot
+// now that identity restoration happens using the asynch apis.
 func TestInjectExisting(t *testing.T) {
 	cancel := setupTest(t)
 	defer cancel()
 
-	// mimic the "restore cidr" logic from daemon.go
-	// for every ip -> identity mapping in the bpf ipcache
-	// - allocate that identity
-	// - insert the cidr=>identity mapping back in to the go ipcache
-	identities := make(map[netip.Prefix]*identity.Identity)
+	// mimic fqdn policy:
+	// - identitiesForFQDNSelectorIPs calls AllocateCIDRsForIPs()
+	// - notifyOnDNSMsg calls UpsertGeneratedIdentities())
+	newlyAllocatedIdentities := make(map[netip.Prefix]*identity.Identity)
 	prefix := netip.MustParsePrefix("172.19.0.5/32")
-	oldID := identity.NumericIdentity(16777219)
-	_, err := IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, []identity.NumericIdentity{oldID}, identities)
+	_, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{prefix.Addr().AsSlice()}, newlyAllocatedIdentities)
 	assert.NoError(t, err)
 
-	IPIdentityCache.UpsertGeneratedIdentities(identities, nil)
+	IPIdentityCache.UpsertGeneratedIdentities(newlyAllocatedIdentities, nil)
 
 	// sanity check: ensure the cidr is correctly in the ipcache
+	wantID := identity.IdentityScopeLocal
 	id, ok := IPIdentityCache.LookupByIP(prefix.String())
 	assert.True(t, ok)
-	assert.Equal(t, int32(16777219), int32(id.ID))
+	assert.Equal(t, wantID, id.ID)
 
 	// Simulate the first half of UpsertLabels -- insert the labels only in to the metadata cache
 	// This is to "force" a race condition
@@ -347,27 +349,30 @@ func TestInjectExisting(t *testing.T) {
 		types.ResourceKindEndpoint, "default", "kubernetes")
 	IPIdentityCache.metadata.upsertLocked(prefix, source.KubeAPIServer, resource, labels.LabelKubeAPIServer)
 
-	// Now, emulate policyAdd(), which calls AllocateCIDRs()
-	_, err = IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, []identity.NumericIdentity{oldID}, nil)
+	// Now, emulate a ToServices policy, which calls AllocateCIDRs
+	_, err = IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, nil, nil)
 	assert.NoError(t, err)
 
-	// Now, trigger label injection
-	// This will allocate a new ID for the same /32 since the labels have changed
-	IPIdentityCache.UpsertLabels(prefix, labels.LabelKubeAPIServer, source.KubeAPIServer, resource)
-
-	// Need to wait for the label injector to finish; easiest just to remove it
-	IPIdentityCache.controllers.RemoveControllerAndWait(LabelInjectorName)
+	// Now, the second half of UpsertLabels -- identity injection
+	remaining, err := IPIdentityCache.InjectLabels(context.Background(), []netip.Prefix{prefix})
+	assert.NoError(t, err)
+	assert.Len(t, remaining, 0)
 
 	// Ensure the source is now correctly understood in the ipcache
 	id, ok = IPIdentityCache.LookupByIP(prefix.String())
 	assert.True(t, ok)
 	assert.Equal(t, source.KubeAPIServer, id.Source)
+
+	// Ensure the SelectorCache has the correct labels
+	selectorID := PolicyHandler.identities[id.ID]
+	assert.NotNil(t, selectorID)
+	assert.True(t, selectorID.Contains(labels.LabelKubeAPIServer.LabelArray()))
 }
 
 // TestInjectWithLegacyAPIOverlap tests that a previously allocated identity
 // will continue to be used in the ipcache even if other users of newer APIs
 // also use the API, and that reference counting is properly balanced for this
-// pattern.This is a common occurrence on startup - and this tests ensures we
+// pattern. This is a common occurrence on startup - and this tests ensures we
 // don't regress the known issue in GH-24502
 //
 // This differs from TestInjectExisting() by reusing the same identity, and by
@@ -376,23 +381,23 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	cancel := setupTest(t)
 	defer cancel()
 
-	// mimic the "restore cidr" logic from daemon.go
-	// for every ip -> identity mapping in the bpf ipcache
-	// - allocate that identity
-	// - insert the cidr=>identity mapping back in to the go ipcache
-	identities := make(map[netip.Prefix]*identity.Identity)
+	// mimic fqdn policy:
+	// - identitiesForFQDNSelectorIPs calls AllocateCIDRsForIPs()
+	// - notifyOnDNSMsg calls UpsertGeneratedIdentities())
+	newlyAllocatedIdentities := make(map[netip.Prefix]*identity.Identity)
 	prefix := netip.MustParsePrefix("172.19.0.5/32")
-	oldID := identity.NumericIdentity(16777219)
-	_, err := IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, []identity.NumericIdentity{oldID}, identities)
+	_, err := IPIdentityCache.AllocateCIDRsForIPs([]net.IP{prefix.Addr().AsSlice()}, newlyAllocatedIdentities)
 	assert.NoError(t, err)
 	identityReferences := 1
 
-	IPIdentityCache.UpsertGeneratedIdentities(identities, nil)
+	wantID := newlyAllocatedIdentities[prefix].ID
+
+	IPIdentityCache.UpsertGeneratedIdentities(newlyAllocatedIdentities, nil)
 
 	// sanity check: ensure the cidr is correctly in the ipcache
 	id, ok := IPIdentityCache.LookupByIP(prefix.String())
 	assert.True(t, ok)
-	assert.Equal(t, int32(16777219), int32(id.ID))
+	assert.Equal(t, wantID, id.ID)
 
 	// Simulate the first half of UpsertLabels -- insert the labels only in to the metadata cache
 	// This is to "force" a race condition
@@ -401,8 +406,8 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	labels := labels.GetCIDRLabels(prefix)
 	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, resource, labels)
 
-	// Now, emulate policyAdd(), which calls AllocateCIDRs()
-	_, err = IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, []identity.NumericIdentity{oldID}, nil)
+	// Now, emulate a ToServices policy, which calls AllocateCIDRs
+	_, err = IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, nil, nil)
 	assert.NoError(t, err)
 	identityReferences++
 
@@ -435,7 +440,7 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	// sanity check: ensure the cidr is correctly in the ipcache
 	id, ok = IPIdentityCache.LookupByIP(prefix.String())
 	assert.True(t, ok)
-	assert.Equal(t, oldID.Uint32(), id.ID.Uint32())
+	assert.Equal(t, wantID, id.ID)
 
 	// Check that the corresponding identity in the identity allocator
 	// is still allocated, which implies that it's reference counted

--- a/pkg/ipcache/metadata_test.go
+++ b/pkg/ipcache/metadata_test.go
@@ -350,7 +350,7 @@ func TestInjectExisting(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(prefix, source.KubeAPIServer, resource, labels.LabelKubeAPIServer)
 
 	// Now, emulate a ToServices policy, which calls AllocateCIDRs
-	_, err = IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, nil, nil)
+	_, err = IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, nil)
 	assert.NoError(t, err)
 
 	// Now, the second half of UpsertLabels -- identity injection
@@ -407,7 +407,7 @@ func TestInjectWithLegacyAPIOverlap(t *testing.T) {
 	IPIdentityCache.metadata.upsertLocked(prefix, source.CustomResource, resource, labels)
 
 	// Now, emulate a ToServices policy, which calls AllocateCIDRs
-	_, err = IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, nil, nil)
+	_, err = IPIdentityCache.AllocateCIDRs([]netip.Prefix{prefix}, nil)
 	assert.NoError(t, err)
 	identityReferences++
 

--- a/pkg/ipcache/types/types.go
+++ b/pkg/ipcache/types/types.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 )
 
@@ -86,4 +87,23 @@ func (e EncryptKey) Uint8() uint8 {
 
 func (e EncryptKey) String() string {
 	return strconv.Itoa(int(e))
+}
+
+// RequestedIdentity is a desired numeric identity for the prefix. When the
+// prefix is next injected, this numeric ID will be requested from the local
+// allocator. If the allocator can accommodate that request, it will do so.
+// In order for this to be useful, the prefix must not already have an identity
+// (or its set of labels must have changed), and that numeric identity must
+// be free.
+// Thus, the numeric ID should have already been held-aside in the allocator
+// using WithholdLocalIdentities(). That will ensure the numeric ID remains free
+// for the prefix to request.
+type RequestedIdentity identity.NumericIdentity
+
+func (id RequestedIdentity) IsValid() bool {
+	return id != 0
+}
+
+func (id RequestedIdentity) ID() identity.NumericIdentity {
+	return identity.NumericIdentity(id)
 }

--- a/pkg/k8s/watchers/watcher.go
+++ b/pkg/k8s/watchers/watcher.go
@@ -198,7 +198,7 @@ type cgroupManager interface {
 }
 
 type ipcacheManager interface {
-	AllocateCIDRs(prefixes []netip.Prefix, oldNIDs []identity.NumericIdentity, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error)
+	AllocateCIDRs(prefixes []netip.Prefix, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error)
 	ReleaseCIDRIdentitiesByCIDR(prefixes []netip.Prefix)
 
 	// GH-21142: Re-evaluate the need for these APIs
@@ -673,7 +673,7 @@ func (k *K8sWatcher) k8sServiceHandler() {
 			} else if result.NumToServicesRules > 0 {
 				// Only trigger policy updates if ToServices rules are in effect
 				k.ipcache.ReleaseCIDRIdentitiesByCIDR(result.PrefixesToRelease)
-				_, err := k.ipcache.AllocateCIDRs(result.PrefixesToAdd, nil, nil)
+				_, err := k.ipcache.AllocateCIDRs(result.PrefixesToAdd, nil)
 				if err != nil {
 					scopedLog.WithError(err).
 						Error("Unabled to allocate ipcache CIDR for toService rule")

--- a/pkg/testutils/identity/allocator_test.go
+++ b/pkg/testutils/identity/allocator_test.go
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package testidentity
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/labels"
+)
+
+func TestOldNID(t *testing.T) {
+	a := NewMockIdentityAllocator(nil)
+	ctx := context.Background()
+
+	// Request identity, it should work
+	l := labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.1/32"))
+	id, _, _ := a.AllocateIdentity(ctx, l, false, 16777216)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, 16777216, id.ID)
+
+	// Re-request identity, it should not
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.2/32"))
+	id, _, _ = a.AllocateIdentity(ctx, l, false, 16777216)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, 16777217, id.ID)
+
+	// Withhold the next identity, it should be skipped
+	a.WithholdLocalIdentities([]identity.NumericIdentity{16777218})
+
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.3/32"))
+	id, _, _ = a.AllocateIdentity(ctx, l, false, 0)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, 16777219, id.ID)
+
+	// Request a withheld identity, it should succeed
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.4/32"))
+	id, _, _ = a.AllocateIdentity(ctx, l, false, 16777218)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, 16777218, id.ID)
+
+	// Request a withheld and allocated identity, it should be ignored
+	l = labels.GetCIDRLabels(netip.MustParsePrefix("1.1.1.5/32"))
+	id, _, _ = a.AllocateIdentity(ctx, l, false, 16777218)
+	assert.NotNil(t, id)
+	assert.EqualValues(t, 16777220, id.ID)
+}

--- a/pkg/testutils/ipcache/ipcache.go
+++ b/pkg/testutils/ipcache/ipcache.go
@@ -23,7 +23,7 @@ func (m *MockIPCache) GetNamedPorts() types.NamedPortMultiMap {
 
 func (m *MockIPCache) AddListener(listener ipcache.IPIdentityMappingListener) {}
 
-func (m *MockIPCache) AllocateCIDRs(prefixes []netip.Prefix, oldNIDs []identity.NumericIdentity, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
+func (m *MockIPCache) AllocateCIDRs(prefixes []netip.Prefix, newlyAllocatedIdentities map[netip.Prefix]*identity.Identity) ([]*identity.Identity, error) {
 	return nil, nil
 }
 

--- a/test/k8s/manifests/cnp-to-cidr-oneoneoneone.yaml
+++ b/test/k8s/manifests/cnp-to-cidr-oneoneoneone.yaml
@@ -1,0 +1,12 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "to-cidr-oneoneoneone"
+spec:
+  endpointSelector:
+    matchLabels: {}
+  egress:
+    - toCIDR:
+      - 1.1.1.1/32
+      - 2.2.2.2/32
+      - 3.3.3.3/32


### PR DESCRIPTION
This PR contains a key insight: we don't need to insert restored CIDRs directly in to the ipcache. Rather, we just need to ensure their identities are not used by any other prefixes.

This PR accomplishes this by adding a new identity reservation mechanism in to the local allocator. It then plumbs up the ability to request a reserved (i.e. restored) identity when inserting in to the ipcache. The primary benefit of this approach is that we don't have to try and back-fill labels based on a dump of the ipcache. Rather, we just reserve already-existing numeric identities and let all the usual ipcache writers do their thing. When the initial k8s sync is finished and ipcache writing is allowed, then all the restored identities *should* have the exact same labels they had before agent restart - and all without any fancy logic!

This PR has one significant immediate benefit: the `reserved:kube-apiserver` label no longer flaps on restart :tada: .

The previous flow:
1. Dump the ipcache, listing (prefix -> id) pairs.
2. Upsert that prefix -> id directly in the ipcache, guessing at the set of labels `(cidr:xxxx, ... reserved:world)`. At this point, a numeric ID that previously had the kube-apiserver label has now lost it.
3. Perform a k8s sync, adding the `reserved:kube-apiserver` label back to the IP.
4. Do an `ipcache.UpsertLabels()`, which causes the kube-apiserver cidr to allocate a new numeric ID. This is because the set of labels allocated for the cidr didn't include the kube-apiserver label.

The new flow:
1. Dump the ipcache, reserving all IDs from allocation
2. Upsert the prefix in to the ipcache metadata layer, tagging it as having a restored identity.
3. Perform a k8s sync, adding in all relevant metadata / labels
4. Do an `ipcache.UpsertLabels()`, which will allocate an identity with the same set of labels as before, *and* use the previous numeric ID for that prefix.

As a bonus, we can remove the special hack for re-creating node-cidr labels. That was added in `resolveIdentity()` but it really didn't belong there.

If we decide this is the right way forward, outstanding items are:
- [ ] Add test that ensures identities remain constant after restarts
- [ ] Clean up code comments
- [ ] Test extensively with FQDN policies