### PR TITLE
install: Remove AWS-CONNMARK-CHAIN iptable rules

### DIFF
--- a/install/kubernetes/cilium/files/agent/poststart-eni.bash
+++ b/install/kubernetes/cilium/files/agent/poststart-eni.bash
@@ -14,6 +14,6 @@ set -o nounset
 if [[ "$(iptables-save | grep -c AWS-SNAT-CHAIN)" != "0" ]];
 then
     echo 'Deleting iptables rules created by the AWS CNI VPC plugin'
-    iptables-save | grep -v AWS-SNAT-CHAIN | iptables-restore
+    iptables-save | grep -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore
 fi
 echo 'Done!'


### PR DESCRIPTION
We were missing some AWS-specific iptable rules that need to be deleted when running in ENI mode.

related: #25804 

```release-note
Remove AWS-CONNMARK-CHAIN iptable rules when running in ENI mode.
```