### PR TITLE
hive/jobs: Add health reporting to jobs

### DIFF
--- a/Documentation/contributing/development/hive.rst
+++ b/Documentation/contributing/development/hive.rst
@@ -965,145 +965,23 @@ Job groups
 
 The `job package <https://pkg.go.dev/github.com/cilium/cilium/pkg/hive/job>`_ contains logic that 
 makes it easy to manage units of work that the package refers to as "jobs". These jobs are 
-scheduled as part of a job group. These jobs themselves come in several varieties.
+scheduled as part of a job group.
 
 Every job is a callback function provided by the user with additional logic which
 differs slightly for each job type. The jobs and groups manage a lot of the boilerplate
 surrounding lifecycle management. The callbacks are called from the job to perform the actual
 work.
 
-Consider the following example:
+These jobs themselves come in several varieties. The ``OneShot`` job invokes its callback just once.
+This job type can be used for initialization after cell startup, routines that run for the full lifecycle
+of the cell, or for any other task you would normally use a plain goroutine for.
 
-.. code-block:: go
+The ``Timer`` job invokes its callback periodically. This job type can be used for periodic tasks
+such as synchronization or garbage collection. Timer jobs can also be externally triggered in
+addition to the periodic invocations.
 
-    package job_example
+The ``Observer`` job invokes its callback for every message sent on a ``stream.Observable``. This job
+type can be used to react to a data stream or events created by other cells.
 
-    import (
-        "context"
-        "fmt"
-        "math/rand"
-        "runtime/pprof"
-        "time"
+Please take a look at ``pkg/hive/examples/jobs.go`` for an example of how to use the job package.
 
-        "github.com/cilium/cilium/pkg/hive"
-        "github.com/cilium/cilium/pkg/hive/cell"
-        "github.com/cilium/cilium/pkg/hive/job"
-        "github.com/cilium/cilium/pkg/stream"
-        "github.com/sirupsen/logrus"
-        "k8s.io/client-go/util/workqueue"
-    )
-
-    var Cell = cell.Provide(newExampleCell)
-
-    type exampleCell struct {
-        jobGroup job.Group
-        workChan chan struct{}
-        trigger  job.Trigger
-        logger   logrus.FieldLogger
-    }
-
-    func newExampleCell(
-        lifecycle hive.Lifecycle, 
-        logger logrus.FieldLogger, 
-        registry job.Registry,
-    ) *exampleCell {
-        ex := exampleCell{
-            jobGroup: registry.NewGroup(
-                job.WithLogger(logger),
-                job.WithPprofLabels(pprof.Labels("cell", "example")),
-            ),
-            workChan: make(chan struct{}, 3),
-            trigger:  job.NewTrigger(),
-            logger:   logger,
-        }
-
-        ex.jobGroup.Add(
-            job.OneShot(
-                "sync-on-startup",
-                ex.sync,
-                job.WithRetry(3, workqueue.DefaultControllerRateLimiter()),
-                job.WithShutdown(), // if the retries fail, shutdown the hive
-            ),
-            job.OneShot("daemon", ex.daemon),
-            job.Timer("timer", ex.timer, 5*time.Second, job.WithTrigger(ex.trigger)),
-            job.Observer("observer", ex.observer, stream.FromChannel(ex.workChan)),
-        )
-
-        lifecycle.Append(ex.jobGroup)
-
-        return &ex
-    }
-
-    func (ex *exampleCell) sync(ctx context.Context) error {
-        for i := 0; i < 3; i++ {
-            if err := ex.doSomeWork(); err != nil {
-                return fmt.Errorf("doSomeWork: %w", err)
-            }
-        }
-
-        return nil
-    }
-
-    func (ex *exampleCell) daemon(ctx context.Context) error {
-        for {
-            randomTimeout := time.NewTimer(time.Duration(rand.Intn(3000)) * time.Millisecond)
-            select {
-            case <-ctx.Done():
-                return nil
-
-            case <-randomTimeout.C:
-                ex.doSomeWork()
-            }
-        }
-    }
-
-    func (ex *exampleCell) timer(ctx context.Context) error {
-        if err := ex.doSomeWork(); err != nil {
-            return fmt.Errorf("doSomeWork: %w", err)
-        }
-
-        return nil
-    }
-
-    func (ex *exampleCell) Trigger() {
-        ex.trigger.Trigger()
-    }
-
-    func (ex *exampleCell) observer(ctx context.Context, event struct{}) error {
-        ex.logger.Info("Observed event")
-        return nil
-    }
-
-    func (ex *exampleCell) HeavyLifting() {
-        ex.jobGroup.Add(job.OneShot("long-running-job", func(ctx context.Context) error {
-            for i := 0; i < 1_000_000; i++ {
-                // Do some heavy lifting
-            }
-            return nil
-        }))
-    }
-
-    func (ex *exampleCell) doSomeWork() error {
-        ex.workChan <- struct{}{}
-        return nil
-    }
-
-
-The preceding example shows a number of use cases in one cell. The cell starts by requesting the job.Registry
-by way of the constructor. The registry can create job groups; in most cases, one is enough.
-You can add jobs in the constructor to this group. Any jobs added in the constructor are queued
-until the lifecycle of the cell starts. The group is added to the lifecycle and manages jobs 
-internally. You can also add jobs at runtime, which can be handy for dynamic workloads while still
-guaranteeing a clean shutdown.
-
-A job group cancels the context to all jobs when the lifecycle ends. Any job callbacks are 
-expected to exit as soon as the ``ctx`` is "Done". The group makes sure that all
-jobs are properly shut down before the cell stops. Callbacks that do not stop within a reasonable 
-amount of time may cause the hive to perform a hard shutdown.
-
-There are 3 job types: one-shot jobs, timer jobs, and observer jobs. One-shot jobs run a limited 
-number of times: use them for brief jobs, or for jobs that span the entire lifecycle.
-Once the callback exits without error, it is never called again. Optionally, a one-shot job can include retry
-logic and/or trigger hive shutdown if it fails. Timers are called on a specified interval but they
-can also be externally triggered. Lastly, observer jobs are invoked for every event
-on a ``stream.Observable``.

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -56,7 +56,6 @@ JUnit
 Jakub
 Jenkinsfiles
 Jesper
-jobLabel
 KV
 KVstore
 Kata
@@ -322,6 +321,7 @@ gluecon
 gobpf
 golang
 gops
+goroutine
 goroutines
 grafana
 graphviz
@@ -387,6 +387,7 @@ jitter
 jle
 jlt
 jne
+jobLabel
 jq
 js
 jset

--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -35,6 +35,7 @@ type LBIPAMParams struct {
 	LC          hive.Lifecycle
 	Shutdowner  hive.Shutdowner
 	JobRegistry job.Registry
+	Scope       cell.Scope
 
 	Clientset    k8sClient.Clientset
 	PoolResource resource.Resource[*cilium_api_v2alpha1.CiliumLoadBalancerIPPool]

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -75,6 +75,7 @@ type authManagerParams struct {
 	Logger      logrus.FieldLogger
 	Lifecycle   hive.Lifecycle
 	JobRegistry job.Registry
+	Scope       cell.Scope
 
 	Config       config
 	AuthMap      authmap.Map
@@ -119,6 +120,7 @@ func registerAuthManager(params authManagerParams) (*AuthManager, error) {
 	})
 
 	jobGroup := params.JobRegistry.NewGroup(
+		params.Scope,
 		job.WithLogger(params.Logger),
 		job.WithPprofLabels(pprof.Labels("cell", "auth")),
 	)

--- a/pkg/datapath/agentliveness/agent_liveness.go
+++ b/pkg/datapath/agentliveness/agent_liveness.go
@@ -45,13 +45,14 @@ func newAgentLivenessUpdater(
 	logger logrus.FieldLogger,
 	lifecycle hive.Lifecycle,
 	jobRegistry job.Registry,
+	scope cell.Scope,
 	configMap configmap.Map,
 	agentLivenessConfig agentLivenessConfig,
 ) {
 	// Discard even debug logs since this particular job is very noisy
 	log := logrus.New()
 	log.Out = io.Discard
-	group := jobRegistry.NewGroup(job.WithLogger(log))
+	group := jobRegistry.NewGroup(scope, job.WithLogger(log))
 
 	group.Add(job.Timer("agent-liveness-updater", func(_ context.Context) error {
 		mtime, err := bpf.GetMtime()

--- a/pkg/datapath/l2responder/l2responder.go
+++ b/pkg/datapath/l2responder/l2responder.go
@@ -46,6 +46,7 @@ type params struct {
 	L2ResponderMap      l2respondermap.Map
 	NetLink             linkByNamer
 	JobRegistry         job.Registry
+	Scope               cell.Scope
 }
 
 type linkByNamer interface {
@@ -66,6 +67,7 @@ func NewL2ResponderReconciler(params params) *l2ResponderReconciler {
 	}
 
 	group := params.JobRegistry.NewGroup(
+		params.Scope,
 		job.WithLogger(params.Logger),
 		job.WithPprofLabels(pprof.Labels("cell", "l2-responder-reconciler")),
 	)
@@ -75,7 +77,7 @@ func NewL2ResponderReconciler(params params) *l2ResponderReconciler {
 	return &reconciler
 }
 
-func (p *l2ResponderReconciler) run(ctx context.Context) error {
+func (p *l2ResponderReconciler) run(ctx context.Context, health cell.HealthReporter) error {
 	log := p.params.Logger
 
 	// This timer triggers full reconciliation once in a while, in case partial reconciliation

--- a/pkg/hive/example/jobs.go
+++ b/pkg/hive/example/jobs.go
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"runtime/pprof"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/stream"
+)
+
+// This example shows a number of use cases in one cell. The cell starts by requesting the job.Registry
+// by way of the constructor. The registry can create job groups; in most cases, one is enough.
+// You can add jobs in the constructor to this group. Any jobs added in the constructor are queued
+// until the lifecycle of the cell starts. The group is added to the lifecycle and manages jobs
+// internally. You can also add jobs at runtime, which can be handy for dynamic workloads while still
+// guaranteeing a clean shutdown.
+
+// A job group cancels the context to all jobs when the lifecycle ends. Any job callbacks are
+// expected to exit as soon as the ``ctx`` is "Done". The group makes sure that all
+// jobs are properly shut down before the cell stops. Callbacks that do not stop within a reasonable
+// amount of time may cause the hive to perform a hard shutdown.
+
+// There are 3 job types: one-shot jobs, timer jobs, and observer jobs. One-shot jobs run a limited
+// number of times: use them for brief jobs, or for jobs that span the entire lifecycle.
+// Once the callback exits without error, it is never called again. Optionally, a one-shot job can include retry
+// logic and/or trigger hive shutdown if it fails. Timers are called on a specified interval but they
+// can also be externally triggered. Lastly, observer jobs are invoked for every event
+// on a ``stream.Observable``.
+
+var jobsCell = cell.Provide(newExampleCell)
+
+type exampleCell struct {
+	jobGroup job.Group
+	workChan chan struct{}
+	trigger  job.Trigger
+	logger   logrus.FieldLogger
+}
+
+func newExampleCell(
+	lifecycle hive.Lifecycle,
+	logger logrus.FieldLogger,
+	registry job.Registry,
+	scope cell.Scope,
+) *exampleCell {
+	ex := exampleCell{
+		jobGroup: registry.NewGroup(
+			scope,
+			job.WithLogger(logger),
+			job.WithPprofLabels(pprof.Labels("cell", "example")),
+		),
+		workChan: make(chan struct{}, 3),
+		trigger:  job.NewTrigger(),
+		logger:   logger,
+	}
+
+	ex.jobGroup.Add(
+		job.OneShot(
+			"sync-on-startup",
+			ex.sync,
+			job.WithRetry(3, workqueue.DefaultControllerRateLimiter()),
+			job.WithShutdown(), // if the retries fail, shutdown the hive
+		),
+		job.OneShot("daemon", ex.daemon),
+		job.Timer("timer", ex.timer, 5*time.Second, job.WithTrigger(ex.trigger)),
+		job.Observer("observer", ex.observer, stream.FromChannel(ex.workChan)),
+	)
+
+	lifecycle.Append(ex.jobGroup)
+
+	return &ex
+}
+
+func (ex *exampleCell) sync(ctx context.Context, health cell.HealthReporter) error {
+	for i := 0; i < 3; i++ {
+		if err := ex.doSomeWork(); err != nil {
+			return fmt.Errorf("doSomeWork: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (ex *exampleCell) daemon(ctx context.Context, health cell.HealthReporter) error {
+	for {
+		randomTimeout := time.NewTimer(time.Duration(rand.Intn(3000)) * time.Millisecond)
+		select {
+		case <-ctx.Done():
+			return nil
+
+		case <-randomTimeout.C:
+			ex.doSomeWork()
+		}
+	}
+}
+
+func (ex *exampleCell) timer(ctx context.Context) error {
+	if err := ex.doSomeWork(); err != nil {
+		return fmt.Errorf("doSomeWork: %w", err)
+	}
+
+	return nil
+}
+
+func (ex *exampleCell) Trigger() {
+	ex.trigger.Trigger()
+}
+
+func (ex *exampleCell) observer(ctx context.Context, event struct{}) error {
+	ex.logger.Info("Observed event")
+	return nil
+}
+
+func (ex *exampleCell) HeavyLifting() {
+	ex.jobGroup.Add(job.OneShot("long-running-job", func(ctx context.Context, health cell.HealthReporter) error {
+		for i := 0; i < 1_000_000; i++ {
+			// Do some heavy lifting
+		}
+		return nil
+	}))
+}
+
+func (ex *exampleCell) doSomeWork() error {
+	ex.workChan <- struct{}{}
+	return nil
+}

--- a/pkg/hive/example/main.go
+++ b/pkg/hive/example/main.go
@@ -20,6 +20,7 @@ var (
 		helloHandlerCell,   // Handler for /hello
 		eventsHandlerCell,  // Handler for /events
 		exampleMetricsCell, // Register the metrics
+		jobsCell,           // Examples of jobs
 
 		// Constructors are lazy and only invoked if they are a dependency
 		// to an "invoke" function or an indirect dependency of a constructor

--- a/pkg/l2announcer/l2announcer.go
+++ b/pkg/l2announcer/l2announcer.go
@@ -75,6 +75,7 @@ type l2AnnouncerParams struct {
 	L2AnnounceTable      statedb.RWTable[*tables.L2AnnounceEntry]
 	StateDB              *statedb.DB
 	JobRegistry          job.Registry
+	Scope                cell.Scope
 }
 
 // L2Announcer takes all L2 announcement policies and filters down to those that match the labels of the local node. It
@@ -88,7 +89,8 @@ type L2Announcer struct {
 	policyStore resource.Store[*cilium_api_v2alpha1.CiliumL2AnnouncementPolicy]
 	localNode   *v2.CiliumNode
 
-	jobgroup job.Group
+	jobgroup    job.Group
+	scopedGroup job.ScopedGroup
 
 	leaderChannel     chan leaderElectionEvent
 	devicesUpdatedSig chan struct{}
@@ -108,6 +110,7 @@ func NewL2Announcer(params l2AnnouncerParams) *L2Announcer {
 	announcer := &L2Announcer{
 		params: params,
 		jobgroup: params.JobRegistry.NewGroup(
+			params.Scope,
 			job.WithLogger(params.Logger),
 			job.WithPprofLabels(pprof.Labels("cell", "l2-announcer")),
 		),
@@ -122,6 +125,8 @@ func NewL2Announcer(params l2AnnouncerParams) *L2Announcer {
 		return announcer
 	}
 
+	announcer.scopedGroup = announcer.jobgroup.Scoped("leader-election")
+
 	params.Lifecycle.Append(announcer.jobgroup)
 
 	if !params.DaemonConfig.EnableL2Announcements {
@@ -132,7 +137,9 @@ func NewL2Announcer(params l2AnnouncerParams) *L2Announcer {
 	}
 
 	announcer.jobgroup.Add(job.OneShot("l2-announcer run", announcer.run))
-	announcer.jobgroup.Add(job.Timer("l2-announcer lease-gc", announcer.leaseGC, time.Minute))
+	announcer.jobgroup.Add(job.Timer("l2-announcer lease-gc", func(ctx context.Context) error {
+		return announcer.leaseGC(ctx, nil)
+	}, time.Minute))
 
 	return announcer
 }
@@ -148,7 +155,7 @@ func (l2a *L2Announcer) DevicesChanged(devices []string) {
 	}
 }
 
-func (l2a *L2Announcer) run(ctx context.Context) error {
+func (l2a *L2Announcer) run(ctx context.Context, health cell.HealthReporter) error {
 	var err error
 	l2a.svcStore, err = l2a.params.Services.Store(ctx)
 	if err != nil {
@@ -233,7 +240,7 @@ loop:
 
 // Called periodically to garbage collect any leases which are no longer held by any agent.
 // This is needed since agents do not track leases for services that we no longer select.
-func (l2a *L2Announcer) leaseGC(ctx context.Context) error {
+func (l2a *L2Announcer) leaseGC(ctx context.Context, health cell.HealthReporter) error {
 	leaseClient := l2a.params.Clientset.CoordinationV1().Leases(l2a.leaseNamespace())
 	list, err := leaseClient.List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -703,7 +710,7 @@ func (l2a *L2Announcer) addSelectedService(svc *slim_corev1.Service, byPolicies 
 	l2a.selectedServices[serviceKey(svc)] = ss
 
 	// kick off leader election job
-	l2a.jobgroup.Add(job.OneShot(
+	l2a.scopedGroup.Add(job.OneShot(
 		fmt.Sprintf("leader-election/%s/%s", svc.Namespace, svc.Name),
 		ss.serviceLeaderElection),
 	)
@@ -1046,7 +1053,7 @@ type selectedService struct {
 	done   chan struct{}
 }
 
-func (ss *selectedService) serviceLeaderElection(ctx context.Context) error {
+func (ss *selectedService) serviceLeaderElection(ctx context.Context, health cell.HealthReporter) error {
 	defer close(ss.done)
 
 	ss.ctx, ss.cancel = context.WithCancel(ctx)

--- a/pkg/l2announcer/l2announcer_test.go
+++ b/pkg/l2announcer/l2announcer_test.go
@@ -48,17 +48,19 @@ func newFixture() *fixture {
 		tbl statedb.RWTable[*tables.L2AnnounceEntry]
 		db  *statedb.DB
 		jr  job.Registry
+		sk  cell.Scope
 	)
 
 	hive.New(
 		statedb.Cell,
 		tables.Cell,
 		job.Cell,
-		cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], j job.Registry) {
+		cell.Module("test", "test", cell.Invoke(func(d *statedb.DB, t statedb.RWTable[*tables.L2AnnounceEntry], s cell.Scope, j job.Registry) {
 			db = d
 			tbl = t
 			jr = j
-		}),
+			sk = s
+		})),
 	).Populate()
 
 	fakeSvcStore := &fakeStore[*slim_corev1.Service]{}
@@ -86,7 +88,8 @@ func newFixture() *fixture {
 	announcer := NewL2Announcer(params)
 	announcer.policyStore = fakePolicyStore
 	announcer.svcStore = fakeSvcStore
-	announcer.jobgroup = jr.NewGroup()
+	announcer.jobgroup = jr.NewGroup(sk)
+	announcer.scopedGroup = announcer.jobgroup.Scoped("leader-election")
 	announcer.jobgroup.Start(context.Background())
 
 	return &fixture{

--- a/pkg/statedb/example/control.go
+++ b/pkg/statedb/example/control.go
@@ -33,10 +33,11 @@ type controlParams struct {
 	Lifecycle hive.Lifecycle
 	Log       logrus.FieldLogger
 	Registry  job.Registry
+	Scope     cell.Scope
 }
 
 func registerControl(p controlParams) {
-	g := p.Registry.NewGroup()
+	g := p.Registry.NewGroup(p.Scope)
 	c := &control{p}
 	g.Add(job.OneShot("control-loop", c.controlLoop))
 	p.Lifecycle.Append(g)
@@ -46,7 +47,7 @@ type control struct {
 	controlParams
 }
 
-func (c *control) controlLoop(ctx context.Context) error {
+func (c *control) controlLoop(ctx context.Context, health cell.HealthReporter) error {
 	tick := time.NewTicker(100 * time.Millisecond)
 	defer tick.Stop()
 	for {

--- a/pkg/statedb/example/main.go
+++ b/pkg/statedb/example/main.go
@@ -43,8 +43,8 @@ func main() {
 	}
 }
 
-func reportHealth(health cell.Health, log logrus.FieldLogger, jobs job.Registry, lc hive.Lifecycle) {
-	g := jobs.NewGroup()
+func reportHealth(health cell.Health, log logrus.FieldLogger, scope cell.Scope, jobs job.Registry, lc hive.Lifecycle) {
+	g := jobs.NewGroup(scope)
 	reportHealth := func(ctx context.Context) error {
 		for _, status := range health.All() {
 			log.Info(status.String())

--- a/pkg/statedb/example/reconcile.go
+++ b/pkg/statedb/example/reconcile.go
@@ -34,11 +34,12 @@ type reconcilerParams struct {
 	Lifecycle hive.Lifecycle
 	Log       logrus.FieldLogger
 	Registry  job.Registry
+	Scope     cell.Scope
 	Reporter  cell.HealthReporter
 }
 
 func registerReconciler(p reconcilerParams) {
-	g := p.Registry.NewGroup()
+	g := p.Registry.NewGroup(p.Scope)
 	r := &reconciler{
 		reconcilerParams: p,
 		handle:           &backendsHandle{backends: sets.New[BackendID]()},
@@ -53,7 +54,7 @@ type reconciler struct {
 	handle *backendsHandle
 }
 
-func (r *reconciler) reconcileLoop(ctx context.Context) error {
+func (r *reconciler) reconcileLoop(ctx context.Context, health cell.HealthReporter) error {
 	defer r.Reporter.Stopped("Stopped")
 
 	wtxn := r.DB.WriteTxn(r.Backends)


### PR DESCRIPTION
Jobs now report their health to the modular health reporter. Job groups now require a `cell.Scope` during creation which is provided by a `cell.Module` wrapping the cell in which the job group is created.

When jobs are added to the job group, each job will get a health reporter under the given scope, so directly under the module scope.

One shot jobs are marked OK (running) once started unless they return an error. The callback signature has changed and one shot jobs now are provided the `cell.HealthReporter` so long running jobs can report their health without exiting.

Timer jobs are initially marked OK (Primed). After each invocation the job reports OK ({time spent}) unless an error was returned.

Observer jobs are also initially marked OK (Primed). They report OK ({time spent}) [{events processed}] after a event, but at most once every ten seconds to avoid spamming the health reporter.

To facilitate the pattern where jobs are spawned dynamically such as for each selected service in the case of L2 announcements, scoped groups were added. A scoped group can be created with `Group.Scoped(name)`, any jobs added to this scoped group will be added to a sub-scope with the given name.

Example output:
```
# cilium status --verbose
[...]
Modules Health:
  Module                    Status   Message   Last Updated
  agent.controlplane.auth   OK              3m28s
  
   observer-job-auth request-authentication OK Primed        1h0m0.000164074s ago (x1)
   observer-job-auth gc-identity-events     OK Primed        1h0m0.000162725s ago (x1)
   timer-job-auth gc-cleanup                OK OK (31.919µs) 1h0m0.000137548s ago (x1)
  agent.controlplane.daemon             Unknown   No status reported yet            n/a
  agent.controlplane.endpoint-manager   OK                  3s
  
   cilium-endpoint-470 (kube-system/coredns-5d78c9869d-2jrz6)
    cep-k8s-sync        OK sync-to-k8s-ciliumendpoint (470) 1h3m20.874172654s ago (x382)
    datapath-regenerate OK Endpoint regeneration successful 1h3m20.826398573s ago (x2)
    policy map sync     OK sync-policymap-470               1h3m16.678519928s ago (x5)
   cilium-endpoint-1263 (kube-system/coredns-5d78c9869d-mxnfp)
               cep-k8s-sync        OK          sync-to-k8s-ciliumendpoint (1263) 1h3m20.87392989s ago  (x382)
               datapath-regenerate OK          Endpoint regeneration successful  1h3m20.822672251s ago (x2)
               policy map sync     OK          sync-policymap-1263               1h3m16.670332097s ago (x5)
   endpoint-gc OK                  endpoint-gc 1h3m25.058578593s ago             (x13)
   cilium-endpoint-3145 (/)
    policy map sync     OK sync-policymap-3145              1h3m20.730445585s ago (x5)
    datapath-regenerate OK Endpoint regeneration successful 1h3m22.972805065s ago (x4)
   cilium-endpoint-302 (/)
    policy map sync     OK sync-policymap-302               1h3m16.676547083s ago (x5)
    datapath-regenerate OK Endpoint regeneration successful 1h3m21.916903513s ago (x2)
   cilium-endpoint-1188 (local-path-storage/local-path-provisioner-6bc4bddd6b-c9gfj)
    cep-k8s-sync        OK sync-to-k8s-ciliumendpoint (1188) 1h3m20.87430288s ago  (x382)
    datapath-regenerate OK Endpoint regeneration successful  1h3m20.863074528s ago (x2)
    policy map sync     OK sync-policymap-1188               1h3m16.648360935s ago (x5)
  agent.controlplane.l2-announcer   OK            28s
  
   leader-election
                                   job-leader-election/kube-system/kube-dns    OK              Running              59m58.136220986s ago (x1)
                                   job-leader-election/default/kubernetes      OK              Running              59m58.136271731s ago (x1)
                                   job-leader-election/kube-system/hubble-peer OK              Running              59m58.136250023s ago (x1)
   job-l2-announcer run            OK                                          Running         1h3m0.002508311s ago (x1)
   timer-job-l2-announcer lease-gc OK                                          OK (1.930675ms) 1h3m0.002484125s ago (x1)
  agent.controlplane.node-manager   OK            56s
  
   background-sync OK Node validation successful 1h2m31.411019841s ago (x58)
  agent.datapath.agent-liveness-updater   OK             0s
  
   timer-job-agent-liveness-updater OK OK (31.58µs) 1h3m26.000438231s ago (x1)
  agent.datapath.l2-responder   OK            63m
  
   job-l2-responder-reconciler OK Running 136.135µs ago (x1)
```

```release-note
Jobs now report health
```
