### PR TITLE
Avoid requiring the latest Go toolchain patch version to build

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -120,6 +120,28 @@
       ]
     },
     {
+      // Avoid updating patch releases of golang in go.mod
+      "enabled": "false",
+      "matchFiles": [
+        "go.mod",
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      matchBaseBranches: [
+        "main",
+        "v1.14",
+        "v1.13",
+        "v1.12"
+      ]
+    },
+    {
       // Do not allow any updates into stable branches.
       "enabled": false,
       "groupName": "all go dependencies stable",

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/cilium/cilium
 
 // renovate: datasource=golang-version depName=go
-go 1.21.3
+go 1.21.0
 
 require (
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24


### PR DESCRIPTION
Forcing developers to change their local toolchain within patch releases
introduces more problems than it's worth. Remove the automatic go.mod
update and don't require newer patch releases of the latest Go version.

Related: https://github.com/cilium/cilium/pull/27820
Related: https://github.com/golang/go/issues/63522
