### PR TITLE
Enhance supported patterns to include ** matching multilevel of subdomains

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -302,6 +302,23 @@ Annotations:
 
 .. _current_release_required_changes:
 
+.. _1.16_upgrade_notes:
+
+1.16 Upgrade Notes
+------------------
+* The ** in matchpattern allows a short notation of multilevel subdomains,
+  eg. ``**.cilium.io`` matches ``a.cilium.io``, ``a.b.cilium.io``, ``a.b.c.cilium.io``, etc.
+
+  This feature can break current configuration if a double asterisk was used 
+  inside of FQDN, eg. ``cil**.io``. Before this enhancement two or more directly 
+  adjacent asterisks meant the same - a single asterisk, eg. ``cil**.io == cil*.io``
+  The correct usage of the asterisk before this enhancement should be a single 
+  presence between other characters, eg. ``c*m.io``, ``*.cil*.io``.
+  With this enhancement the correct usage of the single asterisk does not change
+  A double asterisk must be at the beginning of the FQDN string only, eg. ``**.cilium.io``
+  The single and double asterisk can be present in the same FQDN if they are 
+  separated by a dot directly or indirectly, ``eg. **.*lium.io``, ``**.cili*.io``.
+
 .. _1.15_upgrade_notes:
 
 1.15 Upgrade Notes

--- a/Documentation/security/policy/language.rst
+++ b/Documentation/security/policy/language.rst
@@ -588,6 +588,23 @@ IPs to be allowed are selected via:
   * ``*`` alone matches all names, and inserts all cached DNS IPs into this
     rule.
 
+  ``**`` is allowed at the beginning of a domain as a wildcard with a number of convenience behaviors:
+
+  * ``**`` within a domain allows 0 or more valid DNS subdomains and characters, including
+    ``.`` separator. ``**.cilium.io`` will match ``sub1.cilium.io`` as well as  ``sub2.sub1.cilium.io``.
+  * ``**`` alone matches all names, and inserts all cached DNS IPs into this rule.
+
+   ``*`` and ``**`` interactions:
+
+  * Before this enhancement two or more directly adjacent asterisks meant the same - a single asterisk, eg. ``cil**.io == cil*.io``.
+  * The correct usage of the asterisk before this enhancement should be a single presence between other characters, eg. ``c*m.io``, ``*.cil*.io``.
+  * With this enhancement the correct usage of the single asterisk does not change.
+  * A double asterisk must be at the beginning of the FQDN string only, eg. ``**.cilium.io``.
+  * The single and double asterisk can be present in the same FQDN if they are separated by a dot directly or indirectly, eg. ``**.*lium.io``, ``**.cili*.io``.
+
+
+.. note::   This feature can break current configuration if a double asterisk was used inside of FQDN, eg. cil**.io.
+
 The example below allows all DNS traffic on port 53 to the DNS service and
 intercepts it via the `DNS Proxy`_. If using a non-standard DNS port for
 a DNS application behind a Kubernetes service, the port must match the backend
@@ -611,6 +628,38 @@ Example
 .. only:: epub or latex
 
         .. literalinclude:: ../../../examples/policies/l3/fqdn/fqdn.json
+
+
+Another example is related to ``**``.
+So far subdomains required a definition of all subdomains by adding a chain of ``*.``.
+
+Example:
+
+.. only:: html
+
+   .. tabs::
+      .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../../examples/policies/l3/fqdn/fqdn-cascade.yaml
+
+With the ``**`` feature enhancement with the policy can be delivered in a concise form.
+
+.. only:: html
+
+   .. tabs::
+      .. group-tab:: k8s YAML
+
+        .. literalinclude:: ../../../examples/policies/l3/fqdn/fqdn-short.yaml
+
+``*`` and ``**`` wildcards as described above should be used with caution, 
+as they could allow outward traffic from a Cilium cluster to unexpected destinations; 
+the ``**`` and the chain of ``*.`` wildcards in particular could have far-reaching
+effects. Before implementing policies which use such wildcards, users should 
+evaluate their own threat model and the likelihood of a target domain or 
+sub-domain being configured or hijacked to exfiltrate information from the Cilium 
+deployment. In situations where users do not use security measures like 
+authentication codes to protect their DNS entries or do not have full control 
+of the target domain or sub-domain, usage of such wildcards is generally discouraged.
 
 
 Managing Short-Lived Connections & Maximum IPs per FQDN/endpoint

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -293,6 +293,7 @@ etcd
 eth
 ethernet
 ethtool
+exfiltrate
 extTrafficPolicy
 extern
 externalIPs

--- a/examples/policies/l3/fqdn/fqdn-cascade.yaml
+++ b/examples/policies/l3/fqdn/fqdn-cascade.yaml
@@ -1,0 +1,36 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "to-fqdn-cascade"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: test-app
+  egress:
+    - toEndpoints:
+      - matchLabels:
+          "k8s:io.kubernetes.pod.namespace": kube-system
+          "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+           - port: "53"
+             protocol: ANY
+          rules:
+            dns:
+              - matchPattern: '*.cluster.local'
+              - matchPattern: '*.*.cluster.local'
+              - matchPattern: '*.*.*.cluster.local'
+              - matchPattern: '*.*.*.*.cluster.local'
+              - matchPattern: '*.*.*.*.*.cluster.local'
+              - matchPattern: '*.*.*.*.*.*.cluster.local'
+              - matchPattern: '*.*.*.*.*.*.*.cluster.local'
+              - matchPattern: '*.*.*.*.*.*.*.*.cluster.local'
+    - toFQDNs:
+        - matchPattern: '*.cilium.io'
+        - matchPattern: '*.*.cilium.io'
+        - matchPattern: '*.*.*.cilium.io'
+        - matchPattern: '*.*.*.*.cilium.io'
+        - matchPattern: '*.*.*.*.*.cilium.io'
+        - matchPattern: '*.*.*.*.*.*.cilium.io'
+        - matchPattern: '*.*.*.*.*.*.*.cilium.io'
+        - matchPattern: '*.*.*.*.*.*.*.*.cilium.io'

--- a/examples/policies/l3/fqdn/fqdn-short.yaml
+++ b/examples/policies/l3/fqdn/fqdn-short.yaml
@@ -1,0 +1,22 @@
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  name: "to-fqdn-short"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: test-app
+  egress:
+    - toEndpoints:
+      - matchLabels:
+          "k8s:io.kubernetes.pod.namespace": kube-system
+          "k8s:k8s-app": kube-dns
+      toPorts:
+        - ports:
+           - port: "53"
+             protocol: ANY
+          rules:
+            dns:
+              - matchPattern: '**.cluster.local'
+    - toFQDNs:
+        - matchPattern: '**.cilium.io'

--- a/pkg/policy/api/fqdn.go
+++ b/pkg/policy/api/fqdn.go
@@ -30,7 +30,8 @@ var (
 	// in the MatchPattern field in the FQDNSelector. This should be kept in-sync
 	// with the marker comment for validation. There's no way to use a Golang
 	// variable in the marker comment, so it's left up to the developer.
-	FQDNMatchPatternRegexString = `^([-a-zA-Z0-9_*]+[.]?)+$`
+	//FQDNMatchPatternRegexString = `^([-a-zA-Z0-9_*]+[.]?)+$`
+	FQDNMatchPatternRegexString = `^(\**.)?([*]?[-a-zA-Z0-9_]+([*]?[.]?)+)+$`
 )
 
 type FQDNSelector struct {


### PR DESCRIPTION
Adding ** to match substrings as a prefix including subdomains.


<!-- Description of change -->
```
So far subdomains required a definition of all subdomains by adding a chain of star and dot.

Example:
rules:
  dns:
    - matchPattern: '*.cluster.local'
    - matchPattern: '*.*.cluster.local'
    - matchPattern: '*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.internal'
    - matchPattern: '*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.*.*.*.internal'
    - matchPattern: '*.*.*.*.*.*.*.*.*.internal'
    - matchPattern: '*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.*.*.*.internal.cloudapp.net'
    - matchPattern: '*.*.*.*.*.*.*.*.internal.cloudapp.net'

A feature enhancement introduces wildcards where ** would represent 1 or more DNS subdomains. That would allow them to compress the above policy to:

rules:
  dns:
    - matchPattern: '**.cluster.local'
    - matchPattern: '**.internal'
    - matchPattern: '**.internal.cloudapp.net'

Th code modification does not change the old behaviour if someone wants to list subdomains explicitly.

For example the policy:
apiVersion: cilium.io/v2
kind: CiliumNetworkPolicy
metadata:
  name: fqdn-policy
spec:
  endpointSelector: {}
  egress:
    - toFQDNs:
      - matchPattern: "*pl"
      - matchPattern: "*.io"
      - matchPattern: "**com"
      - matchPattern: "**.amazonaws.com"
    - toPorts:
      - ports:
         - port: "53"
           protocol: UDP
        rules:
          dns:
            - matchPattern: "*"
         
produces the following result:
Forbids domain.pl as expected by the old behaviour.
Allows cilium.io as expected by the old behaviour.
Allows google.com as expected by a new behaviour.
Allows elasticbeanstalk-eu-west-1-123456789000.s3-eu-west-1.amazonaws.com as expected by a new behaviour.
```
Release note:
```release-note
Enhance supported patterns to include ** matching multilevel of subdomains.

Instead of the rules with listed subdomains:

rules:
  dns:
    - matchPattern: '*.cluster.local'
    - matchPattern: '*.*.cluster.local'
    - matchPattern: '*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.*.cluster.local'
    - matchPattern: '*.*.*.*.*.*.*.*.cluster.local'

the following policy can be used:

rules:
  dns:
    - matchPattern: '**.cluster.local'
 
```
Signed-off-by: Piotr Jablonski <piotr.jablonski@isovalent.com>

Fixes: https://github.com/cilium/cilium/issues/22081