### PR TITLE
operator: Simplify duplicated code in Ingress Controller

### DIFF
--- a/operator/pkg/ingress/ingress_dedicated.go
+++ b/operator/pkg/ingress/ingress_dedicated.go
@@ -7,12 +7,9 @@ import (
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	ciliumv2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
-	slim_networkingv1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/networking/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
@@ -76,116 +73,5 @@ func (ic *Controller) createEndpoints(endpoints *corev1.Endpoints) error {
 	}
 
 	log.WithField(logfields.Endpoint, key).Debug("Created Endpoints for Ingress")
-	return nil
-}
-
-func (ic *Controller) deleteResources(ing *slim_networkingv1.Ingress) error {
-	cec, svc, ep, err := ic.regenerate(ing, false)
-	if err != nil {
-		log.WithError(err).Warn("Failed to generate resources")
-		return err
-	}
-
-	if err = ic.deleteCiliumEnvoyConfig(cec); err != nil {
-		log.WithError(err).Warn("Failed to delete CiliumEnvoyConfig")
-		return err
-	}
-
-	if err = ic.deleteService(svc); err != nil {
-		log.WithError(err).Warn("Failed to delete load balancer")
-		return err
-	}
-
-	if err = ic.deleteEndpoint(ep); err != nil {
-		log.WithError(err).Warn("Failed to delete endpoints")
-		return err
-	}
-	return nil
-}
-
-func (ic *Controller) deleteCiliumEnvoyConfig(cec *ciliumv2.CiliumEnvoyConfig) error {
-	if cec == nil {
-		return nil
-	}
-	// check if the CiliumEnvoyConfig resource exists.
-	key, err := cache.MetaNamespaceKeyFunc(cec)
-	if err != nil {
-		return err
-	}
-	_, exists, err := ic.envoyConfigManager.getByKey(key)
-	if err != nil {
-		log.WithError(err).Warn("CiliumEnvoyConfig lookup failed")
-		return err
-	}
-
-	scopedLog := log.WithField(logfields.CiliumEnvoyConfigName, cec.GetName())
-	if !exists {
-		scopedLog.Debug("CiliumEnvoyConfig already deleted. Continuing...")
-		return nil
-	}
-	err = ic.clientset.CiliumV2().CiliumEnvoyConfigs(cec.GetNamespace()).Delete(context.Background(), cec.GetName(), metav1.DeleteOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		scopedLog.Error("Failed to delete CiliumEnvoyConfig for ingress")
-		return err
-	}
-	scopedLog.Debug("Deleted CiliumEnvoyConfig")
-	return nil
-}
-
-func (ic *Controller) deleteService(svc *corev1.Service) error {
-	if svc == nil {
-		return nil
-	}
-	// check if the Service resource exists.
-	key, err := cache.MetaNamespaceKeyFunc(svc)
-	if err != nil {
-		return err
-	}
-	_, exists, err := ic.serviceManager.getByKey(key)
-	if err != nil {
-		log.WithError(err).Warn("Service lookup failed")
-		return err
-	}
-
-	scopedLog := log.WithField(logfields.CiliumEnvoyConfigName, svc.GetName())
-	if !exists {
-		scopedLog.Debug("Service already deleted. Continuing...")
-		return nil
-	}
-	err = ic.clientset.CoreV1().Services(svc.GetNamespace()).Delete(context.Background(), svc.GetName(), metav1.DeleteOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		scopedLog.Error("Failed to delete service for ingress")
-		return err
-	}
-	scopedLog.Debug("Deleted service")
-	return nil
-}
-
-func (ic *Controller) deleteEndpoint(ep *corev1.Endpoints) error {
-	if ep == nil {
-		return nil
-	}
-	// check if the Endpoint resource exists.
-	key, err := cache.MetaNamespaceKeyFunc(ep)
-	if err != nil {
-		return err
-	}
-	_, exists, err := ic.serviceManager.getByKey(key)
-	if err != nil {
-		log.WithError(err).Warn("Endpoint lookup failed")
-		return err
-	}
-
-	scopedLog := log.WithField(logfields.CiliumEnvoyConfigName, ep.GetName())
-	if !exists {
-		scopedLog.Debug("Endpoint already deleted. Continuing...")
-		return nil
-	}
-	err = ic.clientset.CoreV1().Endpoints(ep.GetNamespace()).Delete(context.Background(), ep.GetName(), metav1.DeleteOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		scopedLog.Error("Failed to delete endpoint for ingress")
-		return err
-	}
-	scopedLog.Debug("Deleted endpoint")
 	return nil
 }


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [X] Thanks for contributing!

The ingress controller has two places where logic for deleting existing resources lives: ingress_dedicated.go#deleteResources and ingress.go#garbageCollectOwnedResources. The function garbageCollectOwnedResources uses a generic function named deleteObjectIfExists to remove resources, whereas deleteResources uses specific functions per resource type, resulting in lots of duplicated code.

https://github.com/cilium/cilium/pull/28638 introduces a fix for a bug related to garbageCollectOwnedResources, which would also fix the bug causing https://github.com/cilium/cilium/issues/28691. By removing deleteResources and using garbageCollectOwnedResources throughout the ingress controller, https://github.com/cilium/cilium/issues/28691 will be resolved.

Fixes: #28691

Requires: https://github.com/cilium/cilium/pull/28638

```release-note
Simplify duplicated code in Ingress Controller for deleting resources
```
