### PR TITLE
helm: almost always try to delete aws iptables

### DIFF
--- a/install/kubernetes/cilium/files/agent/poststart-eni.bash
+++ b/install/kubernetes/cilium/files/agent/poststart-eni.bash
@@ -11,7 +11,7 @@ set -o nounset
 # dependencies on anything that is part of the startup script
 # itself, and can be safely run multiple times per node (e.g. in
 # case of a restart).
-if [[ "$(iptables-save | grep -c AWS-SNAT-CHAIN)" != "0" ]];
+if [[ "$(iptables-save | grep -c 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN')" != "0" ]];
 then
     echo 'Deleting iptables rules created by the AWS CNI VPC plugin'
     iptables-save | grep -v 'AWS-SNAT-CHAIN|AWS-CONNMARK-CHAIN' | iptables-restore

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -213,7 +213,7 @@ spec:
         {{- end }}
         {{- if .Values.cni.install }}
         lifecycle:
-          {{- if .Values.eni.enabled }}
+          {{- if ne .Values.cni.chainingMode "aws-cni" }}
           postStart:
             exec:
               command:


### PR DESCRIPTION
Fixes: #25804

This change causes Cilium DaemonSet postStart hook to always delete AWS
iptable rules unless `cni.chainingMode` is set to `aws-cni`.

This will result in the postStart hook being a noop in all non-AWS
deployments. Unfortunately there is no way for helm chart to know
whether it is running on AWS not in ENI mode.

This approach will make sure that we are deleting AWS-specific iptables
rules that cause issues while not requiring us to introduce new
configuration flags for users.

The PR also includes a change in poststart script that makes sure that we delete proper rules.

Credit for figuring out additional scenarios in which we need to delete these rules goes to @squeed and @rabbagliettiandrea


```release-note
helm: delete AWS iptables in all deployments aside from AWS CNI chaining environments 
```