### PR TITLE
Remove non fatal errors from SPIRE client in operator

### DIFF
--- a/operator/auth/spire/client.go
+++ b/operator/auth/spire/client.go
@@ -135,7 +135,7 @@ func (c *Client) onStart(_ hive.HookContext) error {
 				c.entry = entryv1.NewEntryClient(conn)
 				break
 			}
-			c.log.WithError(err).Errorf("Unable to connect to SPIRE server, attempt %d", attempts+1)
+			c.log.WithError(err).Warnf("Unable to connect to SPIRE server, attempt %d", attempts+1)
 			time.Sleep(backoffTime.Duration(attempts))
 		}
 		c.log.Info("Initialized SPIRE client")
@@ -159,7 +159,7 @@ func (c *Client) connect(ctx context.Context) (*grpc.ClientConn, error) {
 	source, err := workloadapi.NewX509Source(timeoutCtx,
 		workloadapi.WithClientOptions(
 			workloadapi.WithAddr(fmt.Sprintf("unix://%s", c.cfg.SpireAgentSocketPath)),
-			workloadapi.WithLogger(c.log),
+			workloadapi.WithLogger(newSpiffeLogWrapper(c.log)),
 		),
 	)
 	if err != nil {

--- a/operator/auth/spire/log_wrapper.go
+++ b/operator/auth/spire/log_wrapper.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package spire
+
+import "github.com/sirupsen/logrus"
+
+// spiffeLogWrapper is a log wrapper for the SPIRE client logs
+// the log levels of this library do not match those from Cilium
+// this will be used to convert the log levels.
+type spiffeLogWrapper struct {
+	log logrus.FieldLogger
+}
+
+// newSpiffeLogWrapper returns a new spiffeLogWrapper
+func newSpiffeLogWrapper(log logrus.FieldLogger) *spiffeLogWrapper {
+	return &spiffeLogWrapper{
+		log: log,
+	}
+}
+
+// Debugf logs a debug message
+func (l *spiffeLogWrapper) Debugf(format string, args ...interface{}) {
+	l.log.Debugf(format, args...)
+}
+
+// Infof logs an info message
+func (l *spiffeLogWrapper) Infof(format string, args ...interface{}) {
+	l.log.Infof(format, args...)
+}
+
+// Warnf logs a warning message
+func (l *spiffeLogWrapper) Warnf(format string, args ...interface{}) {
+	l.log.Warnf(format, args...)
+}
+
+// Errorf logs an error message downgraded to a warning as in our case
+// a connection error on startups is expected on initial start of the oprator
+// while the SPIRE server is still starting up. Any errors given by spire will
+// result in an error passed back to the function caller which then is logged
+// as an error.
+func (l *spiffeLogWrapper) Errorf(format string, args ...interface{}) {
+	l.log.Warnf(format, args...)
+}


### PR DESCRIPTION
This removed level=error errors from the spire-client system in the operator. As it is expected to fail on initial startup of SPIRE to have connection issues Cilium will retry.

Some errors also came from the SPIFFE library itself which is why a wrapper to log them as warnings instead was added.

Fixes: https://github.com/cilium/cilium/issues/27842

```release-note
Remove non fatal errors from SPIRE client in the operator
```
