### PR TITLE
helm: Configure conditional to use hasKey to enable boolean usage

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -560,8 +560,8 @@ data:
 {{- if hasKey .Values "egressMasqueradeInterfaces" }}
   egress-masquerade-interfaces: {{ .Values.egressMasqueradeInterfaces }}
 {{- end }}
-{{- if and .Values.ipMasqAgent .Values.ipMasqAgent.enabled }}
-  enable-ip-masq-agent: "true"
+{{- if hasKey .Values.ipMasqAgent "enabled" }}
+  enable-ip-masq-agent: {{ .Values.ipMasqAgent.enabled | quote }}
 {{- end }}
 
 {{- if .Values.encryption.enabled }}
@@ -656,7 +656,7 @@ data:
   enable-nat46x64-gateway: {{ .Values.nat46x64Gateway.enabled | quote }}
 {{- end }}
 
-{{- if and .Values.hostFirewall .Values.hostFirewall.enabled }}
+{{- if hasKey .Values.hostFirewall "enabled" }}
   enable-host-firewall: {{ .Values.hostFirewall.enabled | quote }}
 {{- end}}
 
@@ -784,10 +784,10 @@ data:
 {{- if .Values.endpointStatus.enabled }}
   endpoint-status: {{ required "endpointStatus.status required: policy, health, controllers, log and / or state. For 2 or more options use a space: \"policy health\"" .Values.endpointStatus.status | quote }}
 {{- end }}
-{{- if and .Values.endpointRoutes .Values.endpointRoutes.enabled }}
+{{- if hasKey .Values.endpointRoutes "enabled" }}
   enable-endpoint-routes: {{ .Values.endpointRoutes.enabled | quote }}
 {{- end }}
-{{- if and .Values.k8sNetworkPolicy .Values.k8sNetworkPolicy.enabled }}
+{{- if hasKey .Values.k8sNetworkPolicy "enabled" }}
   enable-k8s-networkpolicy: {{ .Values.k8sNetworkPolicy.enabled | quote }}
 {{- end }}
 {{- if .Values.cni.configMap }}
@@ -1030,7 +1030,7 @@ data:
   k8s-service-proxy-name: {{ .Values.k8s.serviceProxyName | quote }}
 {{- end }}
 
-{{- if and .Values.customCalls .Values.customCalls.enabled }}
+{{- if hasKey .Values.customCalls "enabled" }}
   # Enable tail call hooks for custom eBPF programs.
   enable-custom-calls: {{ .Values.customCalls.enabled | quote }}
 {{- end }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
Requiring a string yields poor user experience. As is used elsewhere, change conditional to use hasKey to parse value as a boolean, rather than a string.

Fixes: #28381

```release-note
Make use of hasKey in cilium-configmap.yaml to enable proper use of booleans in values.yaml
```