### PR TITLE
policy: Fix Unspecified Protocol Type

### DIFF
--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -23,6 +23,11 @@ const (
 	PortProtocolAny = "0/ANY"
 )
 
+// IsAny returns true if an L4Proto represents ANY protocol
+func (l4 L4Proto) IsAny() bool {
+	return l4 == ProtoAny || string(l4) == ""
+}
+
 // PortProtocol specifies an L4 port with an optional transport protocol
 type PortProtocol struct {
 	// Port is an L4 port number. For now the string will be strictly
@@ -56,7 +61,7 @@ func (p PortProtocol) Covers(other PortProtocol) bool {
 		return false
 	}
 	if p.Protocol != other.Protocol {
-		return p.Protocol == "" || p.Protocol == ProtoAny
+		return p.Protocol.IsAny()
 	}
 	return true
 }

--- a/pkg/policy/rule.go
+++ b/pkg/policy/rule.go
@@ -433,13 +433,7 @@ func mergeIngress(policyCtx PolicyContext, ctx *SearchContext, fromEndpoints api
 		}
 
 		for _, p := range r.GetPortProtocols() {
-			if p.Protocol != api.ProtoAny {
-				cnt, err := mergeIngressPortProto(policyCtx, ctx, fromEndpoints, auth, hostWildcardL7, r, p, p.Protocol, ruleLabels, resMap)
-				if err != nil {
-					return err
-				}
-				found += cnt
-			} else {
+			if p.Protocol.IsAny() {
 				cnt, err := mergeIngressPortProto(policyCtx, ctx, fromEndpoints, auth, hostWildcardL7, r, p, api.ProtoTCP, ruleLabels, resMap)
 				if err != nil {
 					return err
@@ -453,6 +447,12 @@ func mergeIngress(policyCtx PolicyContext, ctx *SearchContext, fromEndpoints api
 				found += cnt
 
 				cnt, err = mergeIngressPortProto(policyCtx, ctx, fromEndpoints, auth, hostWildcardL7, r, p, api.ProtoSCTP, ruleLabels, resMap)
+				if err != nil {
+					return err
+				}
+				found += cnt
+			} else {
+				cnt, err := mergeIngressPortProto(policyCtx, ctx, fromEndpoints, auth, hostWildcardL7, r, p, p.Protocol, ruleLabels, resMap)
 				if err != nil {
 					return err
 				}
@@ -652,13 +652,7 @@ func mergeEgress(policyCtx PolicyContext, ctx *SearchContext, toEndpoints api.En
 		}
 
 		for _, p := range r.GetPortProtocols() {
-			if p.Protocol != api.ProtoAny {
-				cnt, err := mergeEgressPortProto(policyCtx, ctx, toEndpoints, auth, r, p, p.Protocol, ruleLabels, resMap, fqdns)
-				if err != nil {
-					return err
-				}
-				found += cnt
-			} else {
+			if p.Protocol.IsAny() {
 				cnt, err := mergeEgressPortProto(policyCtx, ctx, toEndpoints, auth, r, p, api.ProtoTCP, ruleLabels, resMap, fqdns)
 				if err != nil {
 					return err
@@ -672,6 +666,12 @@ func mergeEgress(policyCtx PolicyContext, ctx *SearchContext, toEndpoints api.En
 				found += cnt
 
 				cnt, err = mergeEgressPortProto(policyCtx, ctx, toEndpoints, auth, r, p, api.ProtoSCTP, ruleLabels, resMap, fqdns)
+				if err != nil {
+					return err
+				}
+				found += cnt
+			} else {
+				cnt, err := mergeEgressPortProto(policyCtx, ctx, toEndpoints, auth, r, p, p.Protocol, ruleLabels, resMap, fqdns)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
According to the policy API documentation, if a
protocol is not specified in a PortProtocol type its protocol is supposed to be presumed as "ANY". The
policy package inconsistently enforces this logic. As a result, empty Protocol fields are validated as "ANY", but in the actual rule logic that splits
the "ANY" protocol into the supported protocol
types, the comparison was made only to the actual
"ANY" protocol constant. This is fixed with the
L4Proto method `IsAny` that does both the constant and empty string comparison.


Fixes: #28136

```release-note
policy: Fixed a bug that incorrectly omitted port-protocol policy rules that omitted the "protocol" field. An omitted "protocol" field now, correctly, is the same as using the "ANY" protocol.
```
