### PR TITLE
k8s: Invalidate Policies that Support "EndPort"

### DIFF
--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -251,6 +251,26 @@ func ParseNetworkPolicy(np *slim_networkingv1.NetworkPolicy) (api.Rules, error) 
 	return api.Rules{rule}, nil
 }
 
+// NetworkPolicyHasEndPort returns true if the network policy has an
+// EndPort.
+func NetworkPolicyHasEndPort(np *slim_networkingv1.NetworkPolicy) bool {
+	for _, iRule := range np.Spec.Ingress {
+		for _, port := range iRule.Ports {
+			if port.EndPort != nil && *port.EndPort > 0 {
+				return true
+			}
+		}
+	}
+	for _, eRule := range np.Spec.Egress {
+		for _, port := range eRule.Ports {
+			if port.EndPort != nil && *port.EndPort > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func parsePodSelector(podSelectorIn *slim_metav1.LabelSelector, namespace string) *slim_metav1.LabelSelector {
 	podSelector := &slim_metav1.LabelSelector{
 		MatchLabels: make(map[string]slim_metav1.MatchLabelsValue, len(podSelectorIn.MatchLabels)),

--- a/pkg/k8s/watchers/network_policy.go
+++ b/pkg/k8s/watchers/network_policy.go
@@ -79,6 +79,10 @@ func (k *K8sWatcher) addK8sNetworkPolicyV1(k8sNP *slim_networkingv1.NetworkPolic
 	}
 	scopedLog = scopedLog.WithField(logfields.K8sNetworkPolicyName, k8sNP.ObjectMeta.Name)
 
+	if k8s.NetworkPolicyHasEndPort(k8sNP) {
+		scopedLog.Warning("EndPort in kubernetes NetworkPolicy is not supported")
+	}
+
 	opts := policy.AddOptions{
 		Replace: true,
 		Source:  source.Kubernetes,


### PR DESCRIPTION
Cilium does not currently support port ranges in
network policies.


```release-note
policy: Cilium will not process or enforce network policies with port ranges or Kubernetes network policies that use "EndPort".
```
