### PR TITLE
bpf: ensure inner-map flags are updated on map create

### DIFF
--- a/pkg/bpf/map_linux.go
+++ b/pkg/bpf/map_linux.go
@@ -495,6 +495,10 @@ func (m *Map) openOrCreate(pin bool) error {
 
 	m.spec.Flags |= GetPreAllocateMapFlags(m.spec.Type)
 
+	if m.spec.InnerMap != nil {
+		m.spec.InnerMap.Flags |= GetPreAllocateMapFlags(m.spec.InnerMap.Type)
+	}
+
 	if pin {
 		m.spec.Pinning = ebpf.PinByName
 	}


### PR DESCRIPTION
Fixes an issue experienced when creating nested eBPFs map.

In this commit the OpenOrCreate function is updated to also set flags appropriately for the inner map.

The failure to do this may lead to a meta data check in the kernel failing when inserting an inner map created with the OpenOrCreate function into an outer map.

This may occur when you define a nested map with an inner map spec which did not take the conditional flag setting, which occurs in OpenOrCreate, into account.

```release-note
bpf: fixes an issue where inserting inner maps into an outer may fail with EINVAL due to flags mismatch 
```
