### PR TITLE
CFP: mac spoofing protection #27955

### DIFF
--- a/api/v1/models/endpoint_datapath_configuration.go
+++ b/api/v1/models/endpoint_datapath_configuration.go
@@ -24,6 +24,10 @@ type EndpointDatapathConfiguration struct {
 	//
 	DisableSipVerification bool `json:"disable-sip-verification,omitempty"`
 
+	// Disable source MAC verification for the endpoint.
+	//
+	DisableSmacVerification bool `json:"disable-smac-verification,omitempty"`
+
 	// Indicates that IPAM is done external to Cilium. This will prevent the IP from being released and re-allocation of the IP address is skipped on restore.
 	//
 	ExternalIpam bool `json:"external-ipam,omitempty"`

--- a/api/v1/openapi.yaml
+++ b/api/v1/openapi.yaml
@@ -1509,6 +1509,10 @@ definitions:
         description: >
           Disable source IP verification for the endpoint.
         type: boolean
+      disable-smac-verification:
+        description: >
+          Disable source MAC verification for the endpoint.
+        type: boolean
   EndpointStatus:
     description: The current state and configuration of the endpoint, its policy & datapath, and subcomponents
     type: object

--- a/api/v1/server/embedded_spec.go
+++ b/api/v1/server/embedded_spec.go
@@ -2817,6 +2817,10 @@ func init() {
           "description": "Disable source IP verification for the endpoint.\n",
           "type": "boolean"
         },
+        "disable-smac-verification": {
+          "description": "Disable source MAC verification for the endpoint.\n",
+          "type": "boolean"
+        },
         "external-ipam": {
           "description": "Indicates that IPAM is done external to Cilium. This will prevent the IP from being released and re-allocation of the IP address is skipped on restore.\n",
           "type": "boolean"
@@ -8343,6 +8347,10 @@ func init() {
       "properties": {
         "disable-sip-verification": {
           "description": "Disable source IP verification for the endpoint.\n",
+          "type": "boolean"
+        },
+        "disable-smac-verification": {
+          "description": "Disable source MAC verification for the endpoint.\n",
           "type": "boolean"
         },
         "external-ipam": {

--- a/bpf/ep_config.h
+++ b/bpf/ep_config.h
@@ -10,6 +10,11 @@
 #ifndef ___EP_CONFIG____
 #define ___EP_CONFIG____
 
+#ifndef LXC_MAC
+DEFINE_MAC(LXC_MAC, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff);
+#define LXC_MAC fetch_mac(LXC_MAC)
+#endif /* LXC_MAC */
+
 DEFINE_IPV6(LXC_IP, 0xbe, 0xef, 0, 0, 0, 0, 0, 0x1, 0, 0, 0, 0x1, 0x01, 0x65, 0x82, 0xbc);
 
 #ifndef LXC_IPV4

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -569,7 +569,7 @@ enum {
  * These are shared with pkg/monitor/api/drop.go and api/v1/flow/flow.proto.
  * When modifying any of the below, those files should also be updated.
  */
-#define DROP_UNUSED1		-130 /* unused */
+#define DROP_INVALID_SMAC	-130
 #define DROP_UNUSED2		-131 /* unused */
 #define DROP_INVALID_SIP	-132
 #define DROP_POLICY		-133

--- a/bpf/lib/lxc.h
+++ b/bpf/lib/lxc.h
@@ -57,4 +57,23 @@ int is_valid_lxc_src_ipv4(struct iphdr *ip4 __maybe_unused)
 }
 #endif /* ENABLE_SIP_VERIFICATION */
 
+#ifdef ENABLE_SMAC_VERIFICATION
+static __always_inline
+int is_valid_lxc_src_mac(struct __ctx_buff *ctx)
+{
+	union macaddr lxc_mac = LXC_MAC;
+	void *data = ctx_data(ctx), *data_end = ctx_data_end(ctx);
+	struct ethhdr *eth = data;
+	union macaddr *smac = NULL;
+	if (data + 12 > data_end)
+		return 1;
+	smac = (union macaddr *) &eth->h_source;
+	return !eth_addrcmp(smac, &lxc_mac);
+}
+#else /* ENABLE_SMAC_VERIFICATION */
+static __always_inline
+int is_valid_lxc_src_mac(struct __ctx_buff *ctx __maybe_unused) {
+	return 1;
+}
+#endif /* ENABLE_SMAC_VERIFICATION */
 #endif /* __LIB_LXC_H_ */

--- a/bpf/tests/config_replacement.h
+++ b/bpf/tests/config_replacement.h
@@ -93,6 +93,12 @@
 #define NODE_MAC { { NODE_MAC_1, NODE_MAC_2 } }
 #endif
 
+#ifndef LXC_MAC
+#define LXC_MAC_1 (0xEF) << 24 | (0xBE) << 16 | (0xAD) << 8 | (0xDE)
+#define LXC_MAC_2 (0xEF) << 8 | (0xDE)
+#define LXC_MAC { { LXC_MAC_1, LXC_MAC_2 } }
+#endif
+
 #ifndef ROUTER_IP
 #define ROUTER_IP_1 bpf_htonl((0xbe) << 24 | (0xef) << 16 | (0) << 8 | (0))
 #define ROUTER_IP_2 bpf_htonl((0) << 24 | (0) << 16 | (0) << 8 | (0x01))

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -1329,6 +1329,7 @@ func initEnv(vp *viper.Viper) {
 	option.Config.Opts.SetBool(option.ConntrackLocal, false)
 	option.Config.Opts.SetBool(option.PolicyAuditMode, option.Config.PolicyAuditMode)
 	option.Config.Opts.SetBool(option.SourceIPVerification, true)
+	option.Config.Opts.SetBool(option.SourceMACVerification, true)
 
 	monitorAggregationLevel, err := option.ParseMonitorAggregationLevel(option.Config.MonitorAggregation)
 	if err != nil {

--- a/pkg/datapath/linux/config/config.go
+++ b/pkg/datapath/linux/config/config.go
@@ -1040,6 +1040,7 @@ func (h *HeaderfileWriter) writeStaticData(fw io.Writer, e datapath.EndpointConf
 
 		fmt.Fprint(fw, defineIPv4("LXC_IPV4", e.IPv4Address().AsSlice()))
 		fmt.Fprint(fw, defineUint16("LXC_ID", uint16(e.GetID())))
+		fmt.Fprint(fw, defineMAC("LXC_MAC", e.LXCMac()))
 	}
 
 	fmt.Fprint(fw, defineMAC("NODE_MAC", e.GetNodeMAC()))

--- a/pkg/datapath/loader/template.go
+++ b/pkg/datapath/loader/template.go
@@ -104,6 +104,12 @@ func (t *templateCfg) GetNodeMAC() mac.MAC {
 	return templateMAC
 }
 
+// LXCMac returns a well-known dummy MAC address which may be later
+// substituted in the ELF.
+func (t *templateCfg) LXCMac() mac.MAC {
+	return templateMAC
+}
+
 // IPv4Address always returns an IP in the documentation prefix (RFC5737) as
 // a nonsense address that should typically not be routable.
 func (t *templateCfg) IPv4Address() netip.Addr {
@@ -257,6 +263,9 @@ func elfVariableSubstitutions(ep datapath.Endpoint) map[string]uint64 {
 		result["SECCTX_FROM_IPCACHE"] = uint64(SecctxFromIpcacheDisabled)
 	} else {
 		result["LXC_ID"] = uint64(ep.GetID())
+		lxcMAC := ep.LXCMac()
+		result["LXC_MAC_1"] = uint64(sliceToBe32(lxcMAC[0:4]))
+		result["LXC_MAC_2"] = uint64(sliceToBe16(lxcMAC[4:6]))
 	}
 
 	// Contrary to IPV4_MASQUERADE, we cannot use a simple #define and

--- a/pkg/datapath/types/config.go
+++ b/pkg/datapath/types/config.go
@@ -46,6 +46,7 @@ type LoadTimeConfiguration interface {
 	IPv4Address() netip.Addr
 	IPv6Address() netip.Addr
 	GetNodeMAC() mac.MAC
+	LXCMac() mac.MAC
 }
 
 // CompileTimeConfiguration provides datapath implementations a clean interface

--- a/pkg/endpoint/api.go
+++ b/pkg/endpoint/api.go
@@ -127,6 +127,9 @@ func NewEndpointFromChangeModel(ctx context.Context, owner regeneration.Owner, p
 		if ep.DatapathConfiguration.DisableSipVerification {
 			ep.updateAndOverrideEndpointOptions(option.OptionMap{option.SourceIPVerification: option.OptionDisabled})
 		}
+		if ep.DatapathConfiguration.DisableSmacVerification {
+			ep.updateAndOverrideEndpointOptions(option.OptionMap{option.SourceMACVerification: option.OptionDisabled})
+		}
 	}
 
 	if base.Labels != nil {

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -261,6 +261,16 @@ func (s *EndpointSuite) TestEndpointDatapathOptions(c *C) {
 	c.Assert(e.Options.GetValue(option.SourceIPVerification), Equals, option.OptionDisabled)
 }
 
+func (s *EndpointSuite) TestEndpointDatapathOptions(c *C) {
+	e, err := NewEndpointFromChangeModel(context.TODO(), s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, s.mgr, &models.EndpointChangeRequest{
+		DatapathConfiguration: &models.EndpointDatapathConfiguration{
+			DisableSmacVerification: true,
+		},
+	})
+	c.Assert(err, IsNil)
+	c.Assert(e.Options.GetValue(option.SourceMACVerification), Equals, option.OptionDisabled)
+}
+
 func (s *EndpointSuite) TestEndpointUpdateLabels(c *C) {
 	e := NewEndpointWithState(s, s, testipcache.NewMockIPCache(), &FakeEndpointProxy{}, testidentity.NewMockIdentityAllocator(nil), 100, StateWaitingForIdentity)
 

--- a/pkg/option/daemon.go
+++ b/pkg/option/daemon.go
@@ -15,17 +15,18 @@ var (
 	}
 
 	DaemonMutableOptionLibrary = OptionLibrary{
-		ConntrackAccounting:  &specConntrackAccounting,
-		ConntrackLocal:       &specConntrackLocal,
-		Debug:                &specDebug,
-		DebugLB:              &specDebugLB,
-		DebugPolicy:          &specDebugPolicy,
-		DropNotify:           &specDropNotify,
-		TraceNotify:          &specTraceNotify,
-		PolicyVerdictNotify:  &specPolicyVerdictNotify,
-		PolicyAuditMode:      &specPolicyAuditMode,
-		MonitorAggregation:   &specMonitorAggregation,
-		SourceIPVerification: &specSourceIPVerification,
+		ConntrackAccounting:   &specConntrackAccounting,
+		ConntrackLocal:        &specConntrackLocal,
+		Debug:                 &specDebug,
+		DebugLB:               &specDebugLB,
+		DebugPolicy:           &specDebugPolicy,
+		DropNotify:            &specDropNotify,
+		TraceNotify:           &specTraceNotify,
+		PolicyVerdictNotify:   &specPolicyVerdictNotify,
+		PolicyAuditMode:       &specPolicyAuditMode,
+		MonitorAggregation:    &specMonitorAggregation,
+		SourceIPVerification:  &specSourceIPVerification,
+		SourceMACVerification: &specSourceMACVerification,
 	}
 )
 

--- a/pkg/option/endpoint.go
+++ b/pkg/option/endpoint.go
@@ -5,17 +5,18 @@ package option
 
 var (
 	endpointMutableOptionLibrary = OptionLibrary{
-		ConntrackAccounting:  &specConntrackAccounting,
-		ConntrackLocal:       &specConntrackLocal,
-		Debug:                &specDebug,
-		DebugLB:              &specDebugLB,
-		DebugPolicy:          &specDebugPolicy,
-		DropNotify:           &specDropNotify,
-		TraceNotify:          &specTraceNotify,
-		PolicyVerdictNotify:  &specPolicyVerdictNotify,
-		PolicyAuditMode:      &specPolicyAuditMode,
-		MonitorAggregation:   &specMonitorAggregation,
-		SourceIPVerification: &specSourceIPVerification,
+		ConntrackAccounting:   &specConntrackAccounting,
+		ConntrackLocal:        &specConntrackLocal,
+		Debug:                 &specDebug,
+		DebugLB:               &specDebugLB,
+		DebugPolicy:           &specDebugPolicy,
+		DropNotify:            &specDropNotify,
+		TraceNotify:           &specTraceNotify,
+		PolicyVerdictNotify:   &specPolicyVerdictNotify,
+		PolicyAuditMode:       &specPolicyAuditMode,
+		MonitorAggregation:    &specMonitorAggregation,
+		SourceIPVerification:  &specSourceIPVerification,
+		SourceMACVerification: &specSourceMACVerification,
 	}
 )
 

--- a/pkg/option/runtime_options.go
+++ b/pkg/option/runtime_options.go
@@ -4,22 +4,23 @@
 package option
 
 const (
-	PolicyTracing        = "PolicyTracing"
-	ConntrackAccounting  = "ConntrackAccounting"
-	ConntrackLocal       = "ConntrackLocal"
-	Debug                = "Debug"
-	DebugLB              = "DebugLB"
-	DebugPolicy          = "DebugPolicy"
-	DropNotify           = "DropNotification"
-	TraceNotify          = "TraceNotification"
-	TraceSockNotify      = "TraceSockNotification"
-	PolicyVerdictNotify  = "PolicyVerdictNotification"
-	PolicyAuditMode      = "PolicyAuditMode"
-	MonitorAggregation   = "MonitorAggregationLevel"
-	SourceIPVerification = "SourceIPVerification"
-	AlwaysEnforce        = "always"
-	NeverEnforce         = "never"
-	DefaultEnforcement   = "default"
+	PolicyTracing         = "PolicyTracing"
+	ConntrackAccounting   = "ConntrackAccounting"
+	ConntrackLocal        = "ConntrackLocal"
+	Debug                 = "Debug"
+	DebugLB               = "DebugLB"
+	DebugPolicy           = "DebugPolicy"
+	DropNotify            = "DropNotification"
+	TraceNotify           = "TraceNotification"
+	TraceSockNotify       = "TraceSockNotification"
+	PolicyVerdictNotify   = "PolicyVerdictNotification"
+	PolicyAuditMode       = "PolicyAuditMode"
+	MonitorAggregation    = "MonitorAggregationLevel"
+	SourceIPVerification  = "SourceIPVerification"
+	SourceMACVerification = "SourceMACVerification"
+	AlwaysEnforce         = "always"
+	NeverEnforce          = "never"
+	DefaultEnforcement    = "default"
 )
 
 var (
@@ -81,5 +82,10 @@ var (
 	specSourceIPVerification = Option{
 		Define:      "ENABLE_SIP_VERIFICATION",
 		Description: "Enable the check of the source IP on pod egress",
+	}
+
+	specSourceMACVerification = Option{
+		Define:      "ENABLE_SMAC_VERIFICATION",
+		Description: "Enable the check of the source MAC on pod egress",
 	}
 )

--- a/pkg/testutils/endpoint.go
+++ b/pkg/testutils/endpoint.go
@@ -24,6 +24,7 @@ type TestEndpoint struct {
 	Identity *identity.Identity
 	Opts     *option.IntOptions
 	MAC      mac.MAC
+	LXCMAC   mac.MAC
 	IPv6     netip.Addr
 	isHost   bool
 }
@@ -35,6 +36,7 @@ func NewTestEndpoint() TestEndpoint {
 		Id:       42,
 		Identity: defaultIdentity,
 		MAC:      mac.MAC([]byte{0x02, 0x00, 0x60, 0x0D, 0xF0, 0x0D}),
+		LXCMAC:   mac.MAC([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}),
 		Opts:     opts,
 	}
 }
@@ -64,6 +66,7 @@ func (e *TestEndpoint) GetIdentity() identity.NumericIdentity       { return e.I
 func (e *TestEndpoint) GetIdentityLocked() identity.NumericIdentity { return e.Identity.ID }
 func (e *TestEndpoint) GetSecurityIdentity() *identity.Identity     { return e.Identity }
 func (e *TestEndpoint) GetNodeMAC() mac.MAC                         { return e.MAC }
+func (e *TestEndpoint) LXCMac() mac.MAC                             { return e.LXCMAC }
 func (e *TestEndpoint) GetOptions() *option.IntOptions              { return e.Opts }
 func (e *TestEndpoint) IsHost() bool                                { return e.isHost }
 


### PR DESCRIPTION
1. add feature flag for mac spoof check
2. expose pod-side veth mac to bpf code with new macro LXC_MAC
3. check source mac address for the traffic in from-container
4. check arp response in from-container
5. introduce new drop reason DROP_INVALID_SRC_MAC
