### PR TITLE
bpf: ipv4: refactor L4 port extraction for fragmented packets

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -1194,14 +1194,8 @@ lb4_extract_tuple(struct __ctx_buff *ctx, struct iphdr *ip4, int l3_off, int *l4
 #ifdef ENABLE_SCTP
 	case IPPROTO_SCTP:
 #endif  /* ENABLE_SCTP */
-#ifdef ENABLE_IPV4_FRAGMENTS
-		ret = ipv4_handle_fragmentation(ctx, ip4, *l4_off,
-						CT_EGRESS,
-						(struct ipv4_frag_l4ports *)&tuple->dport,
-						NULL);
-#else
-		ret = l4_load_ports(ctx, *l4_off, &tuple->dport);
-#endif
+		ret = ipv4_load_l4_ports(ctx, ip4, *l4_off, CT_EGRESS,
+					 &tuple->dport, NULL);
 
 		if (IS_ERR(ret))
 			return ret;


### PR DESCRIPTION
Untangle the fragmentation helper from `conntrack.h`, and allow callers to pass a validated L3 header (inspired by https://github.com/cilium/cilium/pull/25340#discussion_r1342580917).
