### PR TITLE
daemon,pkg/service: Use hive cell infra for pkg/service

### DIFF
--- a/daemon/cmd/cells.go
+++ b/daemon/cmd/cells.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/cilium/pkg/proxy"
+	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/signal"
 	"github.com/cilium/cilium/pkg/statedb"
 )
@@ -147,6 +148,10 @@ var (
 
 		// daemonCell wraps the legacy daemon initialization and provides Promise[*Daemon].
 		daemonCell,
+
+		// Service is a datapath service handler. Its main responsibility is to reflect
+		// service-related changes into BPF maps used by datapath BPF programs.
+		service.Cell,
 
 		// Proxy provides the proxy port allocation and related datapath coordination and
 		// makes different L7 proxies (Envoy, DNS proxy) usable to Cilium endpoints through

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -115,7 +115,7 @@ type Daemon struct {
 	clientset        k8sClient.Clientset
 	buildEndpointSem *semaphore.Weighted
 	l7Proxy          *proxy.Proxy
-	svc              *service.Service
+	svc              service.ServiceManager
 	rec              *recorder.Recorder
 	policy           *policy.Repository
 	policyUpdater    *policy.Updater
@@ -525,6 +525,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 		clustermesh:          params.ClusterMesh,
 		monitorAgent:         params.MonitorAgent,
 		l2announcer:          params.L2Announcer,
+		svc:                  params.ServiceManager,
 		l7Proxy:              params.L7Proxy,
 		authManager:          params.AuthManager,
 		settings:             params.Settings,
@@ -603,8 +604,6 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 	}
 
 	d.endpointManager = params.EndpointManager
-
-	d.svc = service.NewService(&d, d.l7Proxy, d.datapath.LBMap())
 
 	d.redirectPolicyManager = redirectpolicy.NewRedirectPolicyManager(d.svc, params.Resources.LocalPods)
 	if option.Config.BGPAnnounceLBIP || option.Config.BGPAnnouncePodCIDR {

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -91,6 +91,7 @@ import (
 	"github.com/cilium/cilium/pkg/proxy"
 	"github.com/cilium/cilium/pkg/rate"
 	"github.com/cilium/cilium/pkg/resiliency"
+	"github.com/cilium/cilium/pkg/service"
 	"github.com/cilium/cilium/pkg/statedb"
 	"github.com/cilium/cilium/pkg/sysctl"
 	"github.com/cilium/cilium/pkg/version"
@@ -1662,6 +1663,7 @@ type daemonParams struct {
 	ClusterMesh          *clustermesh.ClusterMesh
 	MonitorAgent         monitorAgent.Agent
 	L2Announcer          *l2announcer.L2Announcer
+	ServiceManager       service.ServiceManager
 	L7Proxy              *proxy.Proxy
 	DB                   *statedb.DB
 	APILimiterSet        *rate.APILimiterSet

--- a/daemon/cmd/loadbalancer.go
+++ b/daemon/cmd/loadbalancer.go
@@ -165,7 +165,7 @@ func getServiceHandler(d *Daemon, params GetServiceParams) middleware.Responder 
 	return NewGetServiceOK().WithPayload(list)
 }
 
-func getServiceList(svc *service.Service) []*models.Service {
+func getServiceList(svc service.ServiceManager) []*models.Service {
 	svcs := svc.GetDeepCopyServices()
 	list := make([]*models.Service, 0, len(svcs))
 	for _, v := range svcs {

--- a/pkg/endpointmanager/endpointsynchronizer.go
+++ b/pkg/endpointmanager/endpointsynchronizer.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package watchers
+package endpointmanager
 
 import (
 	"context"

--- a/pkg/endpointmanager/endpointsynchronizer_test.go
+++ b/pkg/endpointmanager/endpointsynchronizer_test.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package watchers
+package endpointmanager
 
 import (
 	"fmt"

--- a/pkg/endpointmanager/manager.go
+++ b/pkg/endpointmanager/manager.go
@@ -91,13 +91,6 @@ type endpointManager struct {
 	policyMapPressure *policyMapPressure
 }
 
-// EndpointResourceSynchronizer is an interface which synchronizes CiliumEndpoint
-// resources with Kubernetes.
-type EndpointResourceSynchronizer interface {
-	RunK8sCiliumEndpointSync(ep *endpoint.Endpoint, conf endpoint.EndpointStatusConfiguration, hr cell.HealthReporter)
-	DeleteK8sCiliumEndpointSync(e *endpoint.Endpoint)
-}
-
 // endpointDeleteFunc is used to abstract away concrete Endpoint Delete
 // functionality from endpoint management for testing purposes.
 type endpointDeleteFunc func(*endpoint.Endpoint, endpoint.DeleteConfig) []error

--- a/pkg/service/cell.go
+++ b/pkg/service/cell.go
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	monitorAgent "github.com/cilium/cilium/pkg/monitor/agent"
+	"github.com/cilium/cilium/pkg/proxy"
+)
+
+// Cell provides access to the Service Manager.
+var Cell = cell.Module(
+	"service-manager",
+	"Service Manager",
+
+	cell.Provide(newServiceManager),
+)
+
+type serviceManagerParams struct {
+	cell.In
+
+	L7Proxy      *proxy.Proxy
+	Datapath     types.Datapath
+	MonitorAgent monitorAgent.Agent
+}
+
+func newServiceManager(params serviceManagerParams) ServiceManager {
+	return NewService(params.MonitorAgent, params.L7Proxy, params.Datapath.LBMap())
+}

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package service
+
+import (
+	"time"
+
+	"github.com/cilium/cilium/pkg/datapath/types"
+	"github.com/cilium/cilium/pkg/k8s"
+	lb "github.com/cilium/cilium/pkg/loadbalancer"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+// ServiceManager provides an interface for service related operations.
+// It is implemented by service handler which main responsibility is to reflect
+// service-related changes into BPF maps used by datapath BPF programs.
+type ServiceManager interface {
+	// DeleteService removes the given service.
+	DeleteService(frontend lb.L3n4Addr) (bool, error)
+
+	// DeleteServiceByID removes a service identified by the given ID.
+	DeleteServiceByID(id lb.ServiceID) (bool, error)
+
+	// GetCurrentTs retrieves the current timestamp.
+	GetCurrentTs() time.Time
+
+	// GetDeepCopyServices returns a deep-copy of all installed services.
+	GetDeepCopyServices() []*lb.SVC
+
+	// GetDeepCopyServiceByFrontend returns a deep-copy of the service that matches the Frontend address.
+	GetDeepCopyServiceByFrontend(frontend lb.L3n4Addr) (*lb.SVC, bool)
+
+	// GetDeepCopyServiceByID returns a deep-copy of a service identified with the given ID.
+	GetDeepCopyServiceByID(id lb.ServiceID) (*lb.SVC, bool)
+
+	// GetLastUpdatedTs retrieves the last updated timestamp.
+	GetLastUpdatedTs() time.Time
+
+	// GetServiceNameByAddr looks up service by IP/port. Hubble uses this function
+	// to annotate flows with service information.
+	GetServiceNameByAddr(addr lb.L3n4Addr) (string, string, bool)
+
+	// InitMaps opens or creates BPF maps used by services.
+	InitMaps(ipv6, ipv4, sockMaps, restore bool) error
+
+	// RegisterL7LBService makes the given service to be locally forwarded to th given proxy port.
+	RegisterL7LBService(serviceName, resourceName lb.ServiceName, ports []string, proxyPort uint16) error
+
+	// RegisterL7LBServiceBackendSync synchronizes the backends of a service to Envoy.
+	RegisterL7LBServiceBackendSync(serviceName, resourceName lb.ServiceName, ports []string) error
+
+	// RemoveL7LBService removes a service from L7 load balancing.
+	RemoveL7LBService(serviceName, resourceName lb.ServiceName) error
+
+	// RestoreServices restores services from BPF maps.
+	RestoreServices() error
+
+	// SyncServicesOnDeviceChange finds and adds missing load-balancing entries for new devices.
+	SyncServicesOnDeviceChange(nodeAddressing types.NodeAddressing)
+
+	// SyncWithK8sFinished removes services which we haven't heard about during
+	// a sync period of cilium-agent's k8s service cache.
+	SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.StoppableWaitGroup) bool) error
+
+	// UpdateBackendsState updates all the service(s) with the updated state of
+	// the given backends. It also persists the updated backend states to the BPF maps.
+	UpdateBackendsState(backends []*lb.Backend) error
+
+	// UpsertService inserts or updates the given service.
+	UpsertService(*lb.SVC) (bool, lb.ID, error)
+}


### PR DESCRIPTION
This PR uses hive cell infra for wiring the `pkg/service` in the Daemon. This allows for easier injection of the `pkg/service` dependency in other modules in the future. 

Also defines the `ServiceManager` interface for the `pkg/service.Service`, to allow for easier mocking of this dependency.

As it was necessary to avoid an import cycle, this also moves `endpointsynchronizer` from `pkg/k8s/watchers` to `pkg/endpointmanager` so that `endpointmanager` does not need to import the top-level `pkg/k8s/watchers`.