### PR TITLE
Fix CRI-O get script location

### DIFF
--- a/contrib/vagrant/scripts/03-install-kubernetes-worker.sh
+++ b/contrib/vagrant/scripts/03-install-kubernetes-worker.sh
@@ -16,7 +16,7 @@ k8s_cache_dir="${cache_dir}/k8s/${k8s_version}"
 certs_dir="${dir}/certs"
 
 function install_crio() {
-   curl https://raw.githubusercontent.com/cri-o/cri-o/main/scripts/get | bash -s -- -t a68a72071e5004be78fe2b1b98cb3bfa0e51b74b
+   curl https://raw.githubusercontent.com/cri-o/packaging/main/get | bash -s -- -t a68a72071e5004be78fe2b1b98cb3bfa0e51b74b
 }
 
 function install_containerd() {


### PR DESCRIPTION
The script has been moved to another repository, which is now fixed.

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

```release-note
None
```
