### PR TITLE
Always migrate cilium_calls_* during ELF load

### DIFF
--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -71,7 +71,7 @@ type progDefinition struct {
 // For example, this is the case with from-netdev and to-netdev. If eth0:to-netdev
 // gets its program and maps replaced and unpinned, its eth0:from-netdev counterpart
 // will miss tail calls (and drop packets) until it has been replaced as well.
-func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDefinition, xdpMode string) (func(), error) {
+func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDefinition, xdpMode string) (_ func(), err error) {
 	// Avoid unnecessarily loading a prog.
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -96,6 +96,33 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 		if spec.Programs[prog.progName] == nil {
 			return nil, fmt.Errorf("no program %s found in eBPF ELF", prog.progName)
 		}
+	}
+
+	// Unconditionally repin cilium_calls_* maps to prevent them from being
+	// repopulated by the loader.
+	for key, ms := range spec.Maps {
+		if !strings.HasPrefix(ms.Name, "cilium_calls_") {
+			continue
+		}
+
+		if err := bpf.RepinMap(bpf.TCGlobalsPath(), key, ms); err != nil {
+			return nil, fmt.Errorf("repinning map %s: %w", key, err)
+		}
+
+		defer func() {
+			revert := false
+			// This captures named return variable err.
+			if err != nil {
+				revert = true
+			}
+
+			if err := bpf.FinalizeMap(bpf.TCGlobalsPath(), key, revert); err != nil {
+				l.WithError(err).Error("Could not finalize map")
+			}
+		}()
+
+		// Only one cilium_calls_* per collection, we can stop here.
+		break
 	}
 
 	// Load the CollectionSpec into the kernel, picking up any pinned maps from


### PR DESCRIPTION
Note: this is obviously a hack. There's a long-standing issue with Cilium's
loader infrastructure where program arrays like cilium_calls_* are reused if
the map's properties in the ELF are compatible with the pinned version present
on the system. This has been the case since the early iproute2 days, and
ebpf-go has the same behaviour by default. This is unsound, but doesn't always
cause issues in practice.

However, as Cilium's eBPF code base grew, along with its contributor base, and
increasing code churn and the need to backport fixes, this method started
falling apart. Pinned tail call maps are actively used for handling traffic,
and should be considered fixed, as they are an integral part of the program's
control flow. When another BPF object needs to be attached to a kernel hook,
it's incorrect to replace entries in an existing program array used by a prior
version of the BPF object, since logic in some tail calls may have been enabled
or disabled in the new one, or may have been removed altogether.

A prog array's contents cannot be replaced atomically, meaning that while the
prog array is being repopulated by a new ELF, a packet may be processed by a
chain of programs that are partially old and partially new. This is bad.

This patch fixes the specific case of cilium_calls_*, since it's the only
prog array across all ELFs that consistently acts as the central tail call map.
The main motivation for this approach is backportability as far back as 1.12,
since we're seeing increased connectivity interruptions (leading to test flakes)
during up/downgrades and restarts in that branch. This is caused by other
backports creating code churn, as well as the stark difference in the contents
of tail calls between major Cilium versions.

This code will be replaced by a 'commit' system that does away with the re-
pinning behaviour and keeps new map fd's in memory; only committing them to
bpffs when the necessary endpoint prog(s) were successfully replaced.

Fixes: https://github.com/cilium/cilium/issues/20691

```release-note
Always replace the cilium_call_* tail call map during upgrade/restart to avoid "Missed tail call" errors
```
