### PR TITLE
[WIP] feat: support k8s multiple apiservers

### DIFF
--- a/contrib/testing/kind-values.yaml
+++ b/contrib/testing/kind-values.yaml
@@ -6,3 +6,7 @@ operator:
     override: "localhost:5000/cilium/operator-generic:local"
     pullPolicy: Never
     suffix: ""
+k8s:
+  apiServerURLs: https://172.21.1.3:6443,https://172.21.0.4:6443,https://172.21.1.5:6443
+kubeProxyReplacement: true
+

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -786,6 +786,9 @@ data:
 {{- if hasKey .Values.k8s "requireIPv6PodCIDR" }}
   k8s-require-ipv6-pod-cidr: {{ .Values.k8s.requireIPv6PodCIDR | quote }}
 {{- end }}
+{{- if hasKey .Values.k8s "apiServerURLs" }}
+  k8s-api-server-urls: {{ .Values.k8s.apiServerURLs | quote }}
+{{- end }}
 {{- if .Values.endpointStatus.enabled }}
   endpoint-status: {{ required "endpointStatus.status required: policy, health, controllers, log and / or state. For 2 or more options use a space: \"policy health\"" .Values.endpointStatus.status | quote }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1624,6 +1624,10 @@ k8s: {}
   # -- requireIPv6PodCIDR enables waiting for Kubernetes to provide the PodCIDR
   # range via the Kubernetes node resource
   # requireIPv6PodCIDR: false
+  
+  # -- A space separated list of Kubernetes API server URLs to use with the client.
+  # For example "https://192.168.0.1:6443 https://192.168.0.2:6443"
+  # apiServerURLs: ""
 
 # -- Keep the deprecated selector labels when deploying Cilium DaemonSet.
 keepDeprecatedLabels: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -1621,6 +1621,10 @@ k8s: {}
   # -- requireIPv6PodCIDR enables waiting for Kubernetes to provide the PodCIDR
   # range via the Kubernetes node resource
   # requireIPv6PodCIDR: false
+  
+  # -- A space separated list of Kubernetes API server URLs to use with the client.
+  # For example "https://192.168.0.1:6443 https://192.168.0.2:6443"
+  # apiServerURLs: ""
 
 # -- Keep the deprecated selector labels when deploying Cilium DaemonSet.
 keepDeprecatedLabels: false

--- a/pkg/k8s/client/cell.go
+++ b/pkg/k8s/client/cell.go
@@ -122,6 +122,12 @@ func newClientset(lc hive.Lifecycle, log logrus.FieldLogger, cfg Config) (Client
 		return &compositeClientset{disabled: true}, nil
 	}
 
+
+	if cfg.K8sAPIServer != "" &&
+		!strings.HasPrefix(cfg.K8sAPIServer, "http") {
+		cfg.K8sAPIServer = "http://" + cfg.K8sAPIServer // default to HTTP
+	}
+
 	apiServerURLs := []string{}
 
 	for _, apiServerURL := range cfg.K8sAPIServerURLs {

--- a/pkg/k8s/client/config.go
+++ b/pkg/k8s/client/config.go
@@ -18,6 +18,9 @@ type Config struct {
 	// operates with CNI-compatible orchestrators other than Kubernetes. Default to true.
 	EnableK8s bool
 
+	// K8sAPIServerURLs is the list of API server instances
+	K8sAPIServerURLs []string
+
 	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
 	K8sAPIServer string
 
@@ -40,6 +43,7 @@ type Config struct {
 var defaultConfig = Config{
 	EnableK8s:             true,
 	K8sAPIServer:          "",
+	K8sAPIServerURLs:      []string{},
 	K8sKubeConfigPath:     "",
 	K8sClientQPS:          defaults.K8sClientQPSLimit,
 	K8sClientBurst:        defaults.K8sClientBurst,
@@ -50,6 +54,7 @@ var defaultConfig = Config{
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.Bool(option.EnableK8s, def.EnableK8s, "Enable the k8s clientset")
 	flags.String(option.K8sAPIServer, def.K8sAPIServer, "Kubernetes API server URL")
+	flags.StringSlice(option.K8sAPIServerURLs, def.K8sAPIServerURLs, "Kubernetes API server URLs")
 	flags.String(option.K8sKubeConfigPath, def.K8sKubeConfigPath, "Absolute path of the kubernetes kubeconfig file")
 	flags.Float32(option.K8sClientQPSLimit, def.K8sClientQPS, "Queries per second limit for the K8s client")
 	flags.Int(option.K8sClientBurst, def.K8sClientBurst, "Burst value allowed for the K8s client")

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -209,6 +209,9 @@ const (
 	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
 	K8sAPIServer = "k8s-api-server"
 
+	// K8sAPIServer is the kubernetes api address server (for https use --k8s-kubeconfig-path instead)
+	K8sAPIServerURLs = "k8s-api-server-urls"
+
 	// K8sKubeConfigPath is the absolute path of the kubernetes kubeconfig file
 	K8sKubeConfigPath = "k8s-kubeconfig-path"
 


### PR DESCRIPTION
PSA: This is a Draft PR to keep track of progress and get early comments.
 
This PR is a continuation of https://github.com/cilium/cilium/pull/20090/.

With the upstream changes since that PR was worked on, this PR had to do things slightly different.

Short explanation:

The config used for the Kubernetes client is wrapped in a Roundtripper that rotates the Host based on a list passed through the config field `k8s-api-server-urls`. While establishing the initial connection, it rotates through the APIServerURLs one by one until it manages to establish connection.

Features missing:
* Always rotate URL if the client fails to connect for X time, not only during startUp.
* When initial connection has been established, replace the apiserver urls passed through config with the endpoints of the `kubernetes` service.