### PR TITLE
Improve CLI user experience for "kubectl get ciliumendpoints"

### DIFF
--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumendpoints.yaml
@@ -21,25 +21,24 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: Cilium endpoint id
-      jsonPath: .status.id
-      name: Endpoint ID
-      type: integer
-    - description: Cilium identity id
+    - description: Security Identity
       jsonPath: .status.identity.id
-      name: Identity ID
+      name: Security Identity
       type: integer
     - description: Ingress enforcement in the endpoint
       jsonPath: .status.policy.ingress.state
       name: Ingress Enforcement
+      priority: 1
       type: string
     - description: Egress enforcement in the endpoint
       jsonPath: .status.policy.egress.state
       name: Egress Enforcement
+      priority: 1
       type: string
     - description: Status of visibility policy in the endpoint
       jsonPath: .status.visibility-policy-status
       name: Visibility Policy
+      priority: 1
       type: string
     - description: Endpoint current state
       jsonPath: .status.state

--- a/pkg/k8s/apis/cilium.io/v2/types.go
+++ b/pkg/k8s/apis/cilium.io/v2/types.go
@@ -21,11 +21,10 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=false
 // +kubebuilder:resource:categories={cilium},singular="ciliumendpoint",path="ciliumendpoints",scope="Namespaced",shortName={cep,ciliumep}
-// +kubebuilder:printcolumn:JSONPath=".status.id",description="Cilium endpoint id",name="Endpoint ID",type=integer
-// +kubebuilder:printcolumn:JSONPath=".status.identity.id",description="Cilium identity id",name="Identity ID",type=integer
-// +kubebuilder:printcolumn:JSONPath=".status.policy.ingress.state",description="Ingress enforcement in the endpoint",name="Ingress Enforcement",type=string
-// +kubebuilder:printcolumn:JSONPath=".status.policy.egress.state",description="Egress enforcement in the endpoint",name="Egress Enforcement",type=string
-// +kubebuilder:printcolumn:JSONPath=".status.visibility-policy-status",description="Status of visibility policy in the endpoint",name="Visibility Policy",type=string
+// +kubebuilder:printcolumn:JSONPath=".status.identity.id",description="Security Identity",name="Security Identity",type=integer
+// +kubebuilder:printcolumn:JSONPath=".status.policy.ingress.state",description="Ingress enforcement in the endpoint",name="Ingress Enforcement",type=string,priority=1
+// +kubebuilder:printcolumn:JSONPath=".status.policy.egress.state",description="Egress enforcement in the endpoint",name="Egress Enforcement",type=string,priority=1
+// +kubebuilder:printcolumn:JSONPath=".status.visibility-policy-status",description="Status of visibility policy in the endpoint",name="Visibility Policy",type=string,priority=1
 // +kubebuilder:printcolumn:JSONPath=".status.state",description="Endpoint current state",name="Endpoint State",type=string
 // +kubebuilder:printcolumn:JSONPath=".status.networking.addressing[0].ipv4",description="Endpoint IPv4 address",name="IPv4",type=string
 // +kubebuilder:printcolumn:JSONPath=".status.networking.addressing[0].ipv6",description="Endpoint IPv6 address",name="IPv6",type=string


### PR DESCRIPTION
Fix the empty columns by adding priority fields to columns that may be empty.

Fixes: #27459 

```release-note
Hide empty columns by default in "kubectl get ciliumendpoints" output
```
