### PR TITLE
services: don't wait for clustermesh to delete local stale backends

### DIFF
--- a/daemon/cmd/state.go
+++ b/daemon/cmd/state.go
@@ -14,10 +14,12 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/cilium/cilium/pkg/controller"
 	"github.com/cilium/cilium/pkg/endpoint"
 	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/k8s/watchers/resources"
 	"github.com/cilium/cilium/pkg/labels"
@@ -452,32 +454,49 @@ func (d *Daemon) initRestore(restoredEndpoints *endpointRestoreState, endpointsR
 
 		go func() {
 			if d.clientset.IsEnabled() {
+				// Configure the controller which removes any leftover Kubernetes
+				// services that may have been deleted while Cilium was not
+				// running. Once this controller succeeds, because it has no
+				// RunInterval specified, it will not run again unless updated
+				// elsewhere. This means that if, for instance, a user manually
+				// adds a service via the CLI into the BPF maps, it will
+				// not be cleaned up by the daemon until it restarts.
+				syncServices := func(localOnly bool) {
+					d.controllers.UpdateController(
+						"sync-lb-maps-with-k8s-services",
+						controller.ControllerParams{
+							Group: syncLBMapsControllerGroup,
+							DoFunc: func(ctx context.Context) error {
+								var localServices sets.Set[k8s.ServiceID]
+								if localOnly {
+									localServices = d.k8sWatcher.K8sSvcCache.LocalServices()
+								}
+
+								return d.svc.SyncWithK8sFinished(d.k8sWatcher.K8sSvcCache.EnsureService, localOnly, localServices)
+							},
+							Context: d.ctx,
+						},
+					)
+				}
+
 				// Also wait for all shared services to be synchronized with the
 				// datapath before proceeding.
 				if d.clustermesh != nil {
+					// Do a first pass synchronizing only the services which are not
+					// marked as global, so that we can drop their stale backends
+					// without needing to wait for full clustermesh synchronization.
+					syncServices(true /* only local services */)
+
 					err := d.clustermesh.ServicesSynced(d.ctx)
 					if err != nil {
 						log.WithError(err).Fatal("timeout while waiting for all clusters to be locally synchronized")
 					}
 					log.Debug("all clusters have been correctly synchronized locally")
 				}
-				// Start controller which removes any leftover Kubernetes
-				// services that may have been deleted while Cilium was not
-				// running. Once this controller succeeds, because it has no
-				// RunInterval specified, it will not run again unless updated
-				// elsewhere. This means that if, for instance, a user manually
-				// adds a service via the CLI into the BPF maps, that it will
-				// not be cleaned up by the daemon until it restarts.
-				controller.NewManager().UpdateController(
-					"sync-lb-maps-with-k8s-services",
-					controller.ControllerParams{
-						Group: syncLBMapsControllerGroup,
-						DoFunc: func(ctx context.Context) error {
-							return d.svc.SyncWithK8sFinished(d.k8sWatcher.K8sSvcCache.EnsureService)
-						},
-						Context: d.ctx,
-					},
-				)
+
+				// Now that possible global services have also been synchronized, let's
+				// do a final pass to remove the remaining stale services and backends.
+				syncServices(false /* all services */)
 			}
 		}()
 	} else {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1218,7 +1218,12 @@ func (s *Service) restoreAndDeleteOrphanSourceRanges() error {
 //
 // The removal is based on an assumption that during the sync period
 // UpsertService() is going to be called for each alive service.
-func (s *Service) SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.StoppableWaitGroup) bool) error {
+//
+// The localOnly flag allows to perform a two pass removal, handling local
+// services first, and processing global ones only after full synchronization
+// with all remote clusters.
+func (s *Service) SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.StoppableWaitGroup) bool, localOnly bool,
+	localServices sets.Set[k8s.ServiceID]) error {
 	servicesWithStaleBackends := sets.New[lb.ServiceName]()
 
 	// We need to trigger the stale services refresh while not holding the
@@ -1243,6 +1248,17 @@ func (s *Service) SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.Stoppabl
 	defer s.Unlock()
 
 	for _, svc := range s.svcByHash {
+		svcID := k8s.ServiceID{
+			Cluster:   svc.svcName.Cluster,
+			Namespace: svc.svcName.Namespace,
+			Name:      svc.svcName.Name,
+		}
+
+		// Skip processing global services when the localOnly flag is set.
+		if localOnly && !localServices.Has(svcID) {
+			continue
+		}
+
 		if svc.restoredFromDatapath {
 			log.WithFields(logrus.Fields{
 				logfields.ServiceID: svc.frontend.ID,
@@ -1264,6 +1280,12 @@ func (s *Service) SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.Stoppabl
 		}
 
 		svc.restoredBackendHashes = nil
+	}
+
+	if localOnly {
+		// Wait for full clustermesh synchronization before finalizing the
+		// removal of orphan backends and affinity matches.
+		return nil
 	}
 
 	// Remove no longer existing affinity matches

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -1219,31 +1219,14 @@ func (s *Service) restoreAndDeleteOrphanSourceRanges() error {
 // The removal is based on an assumption that during the sync period
 // UpsertService() is going to be called for each alive service.
 //
+// Additionally, it returns a list of services which are associated with
+// stale backends, and which shall be refreshed. Stale services shall be
+// refreshed regardless of whether an error is also returned or not.
+//
 // The localOnly flag allows to perform a two pass removal, handling local
 // services first, and processing global ones only after full synchronization
 // with all remote clusters.
-func (s *Service) SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.StoppableWaitGroup) bool, localOnly bool,
-	localServices sets.Set[k8s.ServiceID]) error {
-	servicesWithStaleBackends := sets.New[lb.ServiceName]()
-
-	// We need to trigger the stale services refresh while not holding the
-	// lock, to ensure that the generated events can be processed, and to
-	// prevent a possible deadlock in case the events channel is already full.
-	defer func() {
-		swg := lock.NewStoppableWaitGroup()
-
-		for svc := range servicesWithStaleBackends {
-			ensurer(k8s.ServiceID{
-				Cluster:   svc.Cluster,
-				Namespace: svc.Namespace,
-				Name:      svc.Name,
-			}, swg)
-		}
-
-		swg.Stop()
-		swg.Wait()
-	}()
-
+func (s *Service) SyncWithK8sFinished(localOnly bool, localServices sets.Set[k8s.ServiceID]) (stale []k8s.ServiceID, err error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -1266,11 +1249,11 @@ func (s *Service) SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.Stoppabl
 				Warn("Deleting no longer present service")
 
 			if err := s.deleteServiceLocked(svc); err != nil {
-				return fmt.Errorf("Unable to remove service %+v: %s", svc, err)
+				return stale, fmt.Errorf("Unable to remove service %+v: %s", svc, err)
 			}
 		} else if svc.restoredBackendHashes.Len() > 0 {
 			// The service is still associated with stale backends
-			servicesWithStaleBackends.Insert(svc.svcName)
+			stale = append(stale, svcID)
 			log.WithFields(logrus.Fields{
 				logfields.ServiceID:      svc.frontend.ID,
 				logfields.ServiceName:    svc.svcName.String(),
@@ -1285,13 +1268,13 @@ func (s *Service) SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.Stoppabl
 	if localOnly {
 		// Wait for full clustermesh synchronization before finalizing the
 		// removal of orphan backends and affinity matches.
-		return nil
+		return stale, nil
 	}
 
 	// Remove no longer existing affinity matches
 	if option.Config.EnableSessionAffinity {
 		if err := s.deleteOrphanAffinityMatchesLocked(); err != nil {
-			return err
+			return stale, err
 		}
 	}
 
@@ -1301,7 +1284,7 @@ func (s *Service) SyncWithK8sFinished(ensurer func(k8s.ServiceID, *lock.Stoppabl
 
 	}
 
-	return nil
+	return stale, nil
 }
 
 func (s *Service) createSVCInfoIfNotExist(p *lb.SVC) (*svcInfo, bool, bool,


### PR DESCRIPTION
fe4dda76dd6a ("services: prevent temporary connectivity loss on agent restart") modified the handling of restored backends to prevent possibly causing temporary connectivity disruption on agent restart if a service is either associated with multiple endpointslices (e.g., it has more than 100 backends, or is dual stack) or has backends spanning across multiple clusters (i.e., it is a global service). At a high level, we now keep a list of restored backends, which continue being merged with the ones we received an update for, until the bootstrap phase completes. At that point, we trigger an update for each service still associated with stale backends, so that they can be removed.

One drawback associated with this approach, though, is that when clustermesh is enabled we currently wait for full synchronization from all remote clusters before triggering the removal of stale backends, regardless of whether the given service is global (i.e., possibly includes also remote backends) or not. One specific example in which such behavior is problematic relates to the clustermesh-apiserver. Indeed, if it gets restarted at the same time of the agents (e.g., during an upgrade), the associated service might end up including both the address of the previous pod (which is now stale) and that of the new one, which is correct. When kvstoremesh is enabled, local agents connect to it through that service. In this case, there's a circular dependency: the agent may pick the stale backend, and the connection to etcd fails, which in turn prevents the synchronization from being started, and eventually complete to trigger the removal of the stale backend. Although this dependency eventually resolves as a different backend is picked by the service load-balancing algorithm, unnecessary delay is introduced (the same could also happen for remote agents connecting through a NodePort if KPR is enabled).

To remove this dependency, let's perform a two-pass cleanup of stale backends: the first one as soon as we synchronize with Kubernetes, targeting non-global services only; the second triggered by full clustermesh synchronization, covering all remaining ones. Hence, non-global services can be fully functional also before the completion of the full clustermesh synchronization. It is worth mentioning that this fix applies to all non-global services, which can now converge faster also in case of large clustermeshes.

Marking for backport to v1.14, as the mentioned issue was observed in CI, and caused increased flakiness.

<!-- Description of change -->

```release-note
Improve deletion of stale backends associated with non-global services, without waiting for full Cluster Mesh synchronization 
```
