### PR TITLE
Modularize iptables manager

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -37,6 +37,7 @@ cilium-agent hive [flags]
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
   -h, --help                                                      help for hive
+      --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --k8s-api-server string                                     Kubernetes API server URL
       --k8s-client-burst int                                      Burst value allowed for the K8s client
       --k8s-client-qps float32                                    Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -23,6 +23,7 @@ cilium-agent hive [flags]
       --cni-exclusive                                             Whether to remove other CNI configurations
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
@@ -38,6 +39,7 @@ cilium-agent hive [flags]
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
   -h, --help                                                      help for hive
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
+      --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server string                                     Kubernetes API server URL
       --k8s-client-burst int                                      Burst value allowed for the K8s client
       --k8s-client-qps float32                                    Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -29,6 +29,7 @@ cilium-agent hive dot-graph [flags]
       --cni-exclusive                                             Whether to remove other CNI configurations
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
+      --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.
       --egress-gateway-policy-map-max int                         Maximum number of entries in egress gateway policy map (default 16384)
       --egress-gateway-reconciliation-trigger-interval duration   Time between triggers of egress gateway state reconciliations (default 1s)
       --enable-cilium-api-server-access strings                   List of cilium API APIs which are administratively enabled. Supports '*'. (default [*])
@@ -43,6 +44,7 @@ cilium-agent hive dot-graph [flags]
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
       --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
+      --iptables-random-fully                                     Set iptables flag random-fully on masquerading rules
       --k8s-api-server string                                     Kubernetes API server URL
       --k8s-client-burst int                                      Burst value allowed for the K8s client
       --k8s-client-qps float32                                    Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -42,6 +42,7 @@ cilium-agent hive dot-graph [flags]
       --enable-monitor                                            Enable the monitor unix domain socket server (default true)
       --endpoint-bpf-prog-watchdog-interval duration              Interval to trigger endpoint BPF programs load check watchdog (default 30s)
       --gops-port uint16                                          Port for gops server to listen on (default 9890)
+      --iptables-lock-timeout duration                            Time to pass to each iptables invocation to wait for xtables lock acquisition (default 5s)
       --k8s-api-server string                                     Kubernetes API server URL
       --k8s-client-burst int                                      Burst value allowed for the K8s client
       --k8s-client-qps float32                                    Queries per second limit for the K8s client

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -718,9 +718,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.InstallIptRules)
 	option.BindEnv(vp, option.InstallIptRules)
 
-	flags.Duration(option.IPTablesLockTimeout, 5*time.Second, "Time to pass to each iptables invocation to wait for xtables lock acquisition")
-	option.BindEnv(vp, option.IPTablesLockTimeout)
-
 	flags.Bool(option.IPTablesRandomFully, false, "Set iptables flag random-fully on masquerading rules")
 	option.BindEnv(vp, option.IPTablesRandomFully)
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -718,9 +718,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.MarkHidden(option.InstallIptRules)
 	option.BindEnv(vp, option.InstallIptRules)
 
-	flags.Bool(option.IPTablesRandomFully, false, "Set iptables flag random-fully on masquerading rules")
-	option.BindEnv(vp, option.IPTablesRandomFully)
-
 	flags.Int(option.MaxCtrlIntervalName, 0, "Maximum interval (in seconds) between controller runs. Zero is no limit.")
 	flags.MarkHidden(option.MaxCtrlIntervalName)
 	option.BindEnv(vp, option.MaxCtrlIntervalName)
@@ -1014,9 +1011,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.StringSlice(option.HubbleRedactHttpHeadersDeny, []string{}, "HTTP headers to redact from flows")
 	option.BindEnv(vp, option.HubbleRedactHttpHeadersDeny)
-
-	flags.StringSlice(option.DisableIptablesFeederRules, []string{}, "Chains to ignore when installing feeder rules.")
-	option.BindEnv(vp, option.DisableIptablesFeederRules)
 
 	flags.Bool(option.EnableIPv4FragmentsTrackingName, defaults.EnableIPv4FragmentsTracking, "Enable IPv4 fragments tracking for L4-based lookups")
 	option.BindEnv(vp, option.EnableIPv4FragmentsTrackingName)

--- a/daemon/cmd/status_test.go
+++ b/daemon/cmd/status_test.go
@@ -36,7 +36,7 @@ func (g *GetNodesSuite) SetUpTest(c *C) {
 
 func (g *GetNodesSuite) SetUpSuite(c *C) {
 	var err error
-	nm, err = manager.New(&fakeConfig.Config{}, nil, manager.NewNodeMetrics(), cell.TestScope())
+	nm, err = manager.New(&fakeConfig.Config{}, nil, nil, manager.NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, IsNil)
 }
 

--- a/pkg/datapath/cells.go
+++ b/pkg/datapath/cells.go
@@ -131,7 +131,7 @@ func newDatapath(params datapathParams) types.Datapath {
 		ProcFs:     option.Config.ProcFs,
 	}
 
-	iptablesManager := &iptables.IptablesManager{}
+	iptablesManager := &iptables.Manager{}
 
 	params.LC.Append(hive.Hook{
 		OnStart: func(hive.HookContext) error {

--- a/pkg/datapath/fake/cells.go
+++ b/pkg/datapath/fake/cells.go
@@ -4,6 +4,7 @@
 package fake
 
 import (
+	"github.com/cilium/cilium/pkg/datapath/iptables"
 	"github.com/cilium/cilium/pkg/datapath/linux/bigtcp"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	"github.com/cilium/cilium/pkg/datapath/types"
@@ -34,6 +35,7 @@ var Cell = cell.Module(
 		func() authmap.Map { return fakeauthmap.NewFakeAuthMap() },
 		func() egressmap.PolicyMap { return nil },
 		func() *bigtcp.Configuration { return &bigtcp.Configuration{} },
+		func() *iptables.Manager { return &iptables.Manager{} },
 	),
 
 	// This cell defines StateDB tables and their schemas for tables which are used to transfer information

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package iptables
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+var Cell = cell.Module(
+	"iptables",
+	"Handle iptables-related configuration for Cilium",
+
+	cell.Config(defaultConfig),
+	cell.ProvidePrivate(func(
+		cfg *option.DaemonConfig,
+	) SharedConfig {
+		return SharedConfig{
+			EnableIPv4:             cfg.EnableIPv4,
+			EnableIPv6:             cfg.EnableIPv6,
+			RoutingMode:            cfg.RoutingMode,
+			EnableXTSocketFallback: cfg.EnableXTSocketFallback,
+			EnableBPFTProxy:        cfg.EnableBPFTProxy,
+		}
+	}),
+	cell.Provide(newIptablesManager),
+)
+
+type Config struct {
+	// IPTablesLockTimeout defines the "-w" iptables option when the
+	// iptables CLI is directly invoked from the Cilium agent.
+	IPTablesLockTimeout time.Duration
+}
+
+var defaultConfig = Config{
+	IPTablesLockTimeout: 5 * time.Second,
+}
+
+func (def Config) Flags(flags *pflag.FlagSet) {
+	flags.Duration("iptables-lock-timeout", def.IPTablesLockTimeout, "Time to pass to each iptables invocation to wait for xtables lock acquisition")
+}
+
+type SharedConfig struct {
+	EnableIPv4             bool
+	EnableIPv6             bool
+	RoutingMode            string
+	EnableXTSocketFallback bool
+	EnableBPFTProxy        bool
+}

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -6,6 +6,7 @@ package iptables
 import (
 	"github.com/spf13/pflag"
 
+	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/time"
@@ -20,11 +21,23 @@ var Cell = cell.Module(
 		cfg *option.DaemonConfig,
 	) SharedConfig {
 		return SharedConfig{
-			EnableIPv4:             cfg.EnableIPv4,
-			EnableIPv6:             cfg.EnableIPv6,
-			RoutingMode:            cfg.RoutingMode,
-			EnableXTSocketFallback: cfg.EnableXTSocketFallback,
-			EnableBPFTProxy:        cfg.EnableBPFTProxy,
+			TunnelingEnabled:                cfg.TunnelingEnabled(),
+			NodeIpsetNeeded:                 cfg.NodeIpsetNeeded(),
+			Devices:                         cfg.GetDevices(),
+			IptablesMasqueradingIPv4Enabled: cfg.IptablesMasqueradingIPv4Enabled(),
+			IptablesMasqueradingIPv6Enabled: cfg.IptablesMasqueradingIPv6Enabled(),
+			IPv4NativeRoutingCIDR:           cfg.GetIPv4NativeRoutingCIDR(),
+
+			EnableIPv4:                  cfg.EnableIPv4,
+			EnableIPv6:                  cfg.EnableIPv6,
+			EnableXTSocketFallback:      cfg.EnableXTSocketFallback,
+			EnableBPFTProxy:             cfg.EnableBPFTProxy,
+			InstallNoConntrackIptRules:  cfg.InstallNoConntrackIptRules,
+			EnableEndpointRoutes:        cfg.EnableEndpointRoutes,
+			IPAM:                        cfg.IPAM,
+			EnableIPSec:                 cfg.EnableIPSec,
+			MasqueradeInterfaces:        cfg.MasqueradeInterfaces,
+			EnableMasqueradeRouteSource: cfg.EnableMasqueradeRouteSource,
 		}
 	}),
 	cell.Provide(newIptablesManager),
@@ -34,6 +47,14 @@ type Config struct {
 	// IPTablesLockTimeout defines the "-w" iptables option when the
 	// iptables CLI is directly invoked from the Cilium agent.
 	IPTablesLockTimeout time.Duration
+
+	// DisableIptablesFeederRules specifies which chains will be excluded
+	// when installing the feeder rules
+	DisableIptablesFeederRules []string
+
+	// IPTablesRandomFully defines the "--random-fully" iptables option when the
+	// iptables CLI is directly invoked from the Cilium agent.
+	IPTablesRandomFully bool
 }
 
 var defaultConfig = Config{
@@ -42,12 +63,26 @@ var defaultConfig = Config{
 
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.Duration("iptables-lock-timeout", def.IPTablesLockTimeout, "Time to pass to each iptables invocation to wait for xtables lock acquisition")
+	flags.StringSlice("disable-iptables-feeder-rules", def.DisableIptablesFeederRules, "Chains to ignore when installing feeder rules.")
+	flags.Bool("iptables-random-fully", def.IPTablesRandomFully, "Set iptables flag random-fully on masquerading rules")
 }
 
 type SharedConfig struct {
-	EnableIPv4             bool
-	EnableIPv6             bool
-	RoutingMode            string
-	EnableXTSocketFallback bool
-	EnableBPFTProxy        bool
+	TunnelingEnabled                bool
+	NodeIpsetNeeded                 bool
+	Devices                         []string
+	IptablesMasqueradingIPv4Enabled bool
+	IptablesMasqueradingIPv6Enabled bool
+	IPv4NativeRoutingCIDR           *cidr.CIDR
+
+	EnableIPv4                  bool
+	EnableIPv6                  bool
+	EnableXTSocketFallback      bool
+	EnableBPFTProxy             bool
+	InstallNoConntrackIptRules  bool
+	EnableEndpointRoutes        bool
+	IPAM                        string
+	EnableIPSec                 bool
+	MasqueradeInterfaces        []string
+	EnableMasqueradeRouteSource bool
 }

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -1181,7 +1181,7 @@ func (m *Manager) installForwardChainRulesIpX(prog iptablesInterface, ifName, lo
 // AddToNodeIpset adds an IP address to the ipset for cluster nodes. It creates
 // the ipset if it doesn't already exist and doesn't error if either the ipset
 // or the IP already exist.
-func AddToNodeIpset(nodeIP net.IP) {
+func (m *Manager) AddToNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
 	ciliumNodeIpset := ciliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {
@@ -1198,7 +1198,7 @@ func AddToNodeIpset(nodeIP net.IP) {
 }
 
 // RemoveFromBodeIpset removes an IP address from the ipset for cluster nodes.
-func RemoveFromNodeIpset(nodeIP net.IP) {
+func (m *Manager) RemoveFromNodeIpset(nodeIP net.IP) {
 	scopedLog := log.WithField(logfields.IPAddr, nodeIP.String())
 	ciliumNodeIpset := ciliumNodeIpsetV4
 	if ip.IsIPv6(nodeIP) {

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -86,7 +86,7 @@ func (ipt *mockIptables) checkExpectations() error {
 	return nil
 }
 
-var mockManager = &IptablesManager{
+var mockManager = &Manager{
 	haveIp6tables:        false,
 	haveSocketMatch:      true,
 	haveBPFSocketAssign:  false,

--- a/pkg/datapath/iptables/sysctl_darwin.go
+++ b/pkg/datapath/iptables/sysctl_darwin.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package datapath
+package iptables
 
 // enableIPForwarding on OS X and Darwin is not doing anything. It just exists
 // to make compilation possible.

--- a/pkg/datapath/iptables/sysctl_linux.go
+++ b/pkg/datapath/iptables/sysctl_linux.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package datapath
+package iptables
 
 import (
 	"github.com/cilium/cilium/pkg/option"

--- a/pkg/datapath/iptables/sysctl_linux_test.go
+++ b/pkg/datapath/iptables/sysctl_linux_test.go
@@ -3,7 +3,7 @@
 
 //go:build linux
 
-package datapath
+package iptables
 
 import (
 	"github.com/cilium/cilium/pkg/testutils"

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -127,6 +127,15 @@ func (i *ipcacheMock) RemoveIdentityOverride(prefix netip.Prefix, identityLabels
 	i.Delete(prefix.String(), source.CustomResource)
 }
 
+type ipsetMock struct{}
+
+func newIPSetMock() *ipsetMock {
+	return &ipsetMock{}
+}
+
+func (i *ipsetMock) AddToNodeIpset(nodeIP net.IP)      {}
+func (i *ipsetMock) RemoveFromNodeIpset(nodeIP net.IP) {}
+
 type signalNodeHandler struct {
 	EnableNodeAddEvent                    bool
 	NodeAddEvent                          chan nodeTypes.Node
@@ -207,7 +216,7 @@ func (s *managerTestSuite) TestNodeLifecycle(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	mngr.Subscribe(dp)
 	c.Assert(err, check.IsNil)
 
@@ -279,7 +288,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -361,7 +370,7 @@ func (s *managerTestSuite) TestMultipleSources(c *check.C) {
 func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -382,7 +391,7 @@ func (s *managerTestSuite) BenchmarkUpdateAndDeleteCycle(c *check.C) {
 func (s *managerTestSuite) TestClusterSizeDependantInterval(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := fake.NewNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -414,7 +423,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 	signalNodeHandler := newSignalNodeHandler()
 	signalNodeHandler.EnableNodeValidateImplementationEvent = true
 	ipcacheMock := newIPcacheMock()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	mngr.Subscribe(signalNodeHandler)
 	c.Assert(err, check.IsNil)
 	defer mngr.Stop(context.TODO())
@@ -458,7 +467,7 @@ func (s *managerTestSuite) TestBackgroundSync(c *check.C) {
 func (s *managerTestSuite) TestIpcache(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -506,7 +515,7 @@ func (s *managerTestSuite) TestIpcache(c *check.C) {
 func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -582,7 +591,7 @@ func (s *managerTestSuite) TestIpcacheHealthIP(c *check.C) {
 func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{RemoteNodeIdentity: true}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{RemoteNodeIdentity: true}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -658,7 +667,7 @@ func (s *managerTestSuite) TestRemoteNodeIdentities(c *check.C) {
 func (s *managerTestSuite) TestNodeEncryption(c *check.C) {
 	ipcacheMock := newIPcacheMock()
 	dp := newSignalNodeHandler()
-	mngr, err := New(&configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{NodeEncryption: true, Encryption: true}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -753,7 +762,7 @@ func (s *managerTestSuite) TestNode(c *check.C) {
 	dp.EnableNodeAddEvent = true
 	dp.EnableNodeUpdateEvent = true
 	dp.EnableNodeDeleteEvent = true
-	mngr, err := New(&configMock{}, ipcacheMock, NewNodeMetrics(), cell.TestScope())
+	mngr, err := New(&configMock{}, ipcacheMock, newIPSetMock(), NewNodeMetrics(), cell.TestScope())
 	c.Assert(err, check.IsNil)
 	mngr.Subscribe(dp)
 	defer mngr.Stop(context.TODO())
@@ -849,7 +858,7 @@ func TestNodeManagerEmitStatus(t *testing.T) {
 
 	baseBackgroundSyncInterval = 1 * time.Millisecond
 	hp := cell.NewHealthProvider()
-	m, err := New(&configMock{}, newIPcacheMock(), NewNodeMetrics(), cell.TestScopeFromProvider(cell.FullModuleID{"test"}, hp))
+	m, err := New(&configMock{}, newIPcacheMock(), newIPSetMock(), NewNodeMetrics(), cell.TestScopeFromProvider(cell.FullModuleID{"test"}, hp))
 	assert.NoError(err)
 
 	m.nodes[nodeTypes.Identity{

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -400,9 +400,6 @@ const (
 	// to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = "install-no-conntrack-iptables-rules"
 
-	// IPTablesRandomFully sets iptables flag random-fully on masquerading rules
-	IPTablesRandomFully = "iptables-random-fully"
-
 	// IPv6NodeAddr is the IPv6 address of node
 	IPv6NodeAddr = "ipv6-node"
 
@@ -1053,10 +1050,6 @@ const (
 	// HubbleRedactHttpHeadersDeny controls which http headers will be redacted from flows
 	HubbleRedactHttpHeadersDeny = "hubble-redact-http-headers-deny"
 
-	// DisableIptablesFeederRules specifies which chains will be excluded
-	// when installing the feeder rules
-	DisableIptablesFeederRules = "disable-iptables-feeder-rules"
-
 	// K8sHeartbeatTimeout configures the timeout for apiserver heartbeat
 	K8sHeartbeatTimeout = "k8s-heartbeat-timeout"
 
@@ -1678,10 +1671,6 @@ type DaemonConfig struct {
 	// PrependIptablesChains is the name of the option to enable prepending
 	// iptables chains instead of appending
 	PrependIptablesChains bool
-
-	// IPTablesRandomFully defines the "--random-fully" iptables option when the
-	// iptables CLI is directly invoked from the Cilium agent.
-	IPTablesRandomFully bool
 
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
@@ -2314,10 +2303,6 @@ type DaemonConfig struct {
 	// EndpointStatus enables population of information in the
 	// CiliumEndpoint.Status resource
 	EndpointStatus map[string]struct{}
-
-	// DisableIptablesFeederRules specifies which chains will be excluded
-	// when installing the feeder rules
-	DisableIptablesFeederRules []string
 
 	// EnableIPv4FragmentsTracking enables IPv4 fragments tracking for
 	// L4-based lookups. Needs LRU map support.
@@ -3194,7 +3179,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnvoyConfigTimeout = vp.GetDuration(EnvoyConfigTimeout)
 	c.IPMasqAgentConfigPath = vp.GetString(IPMasqAgentConfigPath)
 	c.InstallIptRules = vp.GetBool(InstallIptRules)
-	c.IPTablesRandomFully = vp.GetBool(IPTablesRandomFully)
 	c.IPSecKeyFile = vp.GetString(IPSecKeyFileName)
 	c.IPsecKeyRotationDuration = vp.GetDuration(IPsecKeyRotationDuration)
 	c.EnableIPsecKeyWatcher = vp.GetBool(EnableIPsecKeyWatcher)
@@ -3616,8 +3600,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.HubbleRedactKafkaApiKey = vp.GetBool(HubbleRedactKafkaApiKey)
 	c.HubbleRedactHttpHeadersAllow = vp.GetStringSlice(HubbleRedactHttpHeadersAllow)
 	c.HubbleRedactHttpHeadersDeny = vp.GetStringSlice(HubbleRedactHttpHeadersDeny)
-
-	c.DisableIptablesFeederRules = vp.GetStringSlice(DisableIptablesFeederRules)
 
 	// Hidden options
 	c.CompilerFlags = vp.GetStringSlice(CompilerFlags)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -400,8 +400,6 @@ const (
 	// to skip netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = "install-no-conntrack-iptables-rules"
 
-	IPTablesLockTimeout = "iptables-lock-timeout"
-
 	// IPTablesRandomFully sets iptables flag random-fully on masquerading rules
 	IPTablesRandomFully = "iptables-random-fully"
 
@@ -1680,10 +1678,6 @@ type DaemonConfig struct {
 	// PrependIptablesChains is the name of the option to enable prepending
 	// iptables chains instead of appending
 	PrependIptablesChains bool
-
-	// IPTablesLockTimeout defines the "-w" iptables option when the
-	// iptables CLI is directly invoked from the Cilium agent.
-	IPTablesLockTimeout time.Duration
 
 	// IPTablesRandomFully defines the "--random-fully" iptables option when the
 	// iptables CLI is directly invoked from the Cilium agent.
@@ -3200,7 +3194,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.EnvoyConfigTimeout = vp.GetDuration(EnvoyConfigTimeout)
 	c.IPMasqAgentConfigPath = vp.GetString(IPMasqAgentConfigPath)
 	c.InstallIptRules = vp.GetBool(InstallIptRules)
-	c.IPTablesLockTimeout = vp.GetDuration(IPTablesLockTimeout)
 	c.IPTablesRandomFully = vp.GetBool(IPTablesRandomFully)
 	c.IPSecKeyFile = vp.GetString(IPSecKeyFileName)
 	c.IPsecKeyRotationDuration = vp.GetDuration(IPsecKeyRotationDuration)


### PR DESCRIPTION
Modularize the iptables configuration manager in a cell.
Direct dependency to the DaemonConfig global object is avoided through a SharedConfig privately provided to the cell. This config gets the values from all the referenced DaemonConfig helpers at startup, in order to be used by the new cell.

Also, cells depending on iptables (like the node manager one) now takes a reference to it through dependency injection instead of directly calling side effectful exported functions.

~Depends on https://github.com/cilium/cilium/pull/28713~
