### PR TITLE
report endpoint ID on endpoint BPF program

### DIFF
--- a/daemon/cmd/watchdogs.go
+++ b/daemon/cmd/watchdogs.go
@@ -109,6 +109,7 @@ func (d *Daemon) checkEndpointBPFPrograms(ctx context.Context, p epBPFProgWatchd
 		loaded, err = loader.DeviceHasTCProgramLoaded(ep.HostInterface(), ep.RequireEgressProg())
 		if err != nil {
 			log.WithField(logfields.Endpoint, ep.HostInterface()).
+				WithField(logfields.EndpointID, ep.ID).
 				WithError(err).
 				Error("Unable to assert if endpoint BPF programs need to be reloaded")
 			return err


### PR DESCRIPTION
Presenting only the endpoint interface name into the logs might not be enough to understand which endpoint has the problem. Thus, we should print the endpoint ID well.

Fixes: d93659c058bf ("Resiliency: Checks endpoints BPF programs remain loaded")