### PR TITLE
Add ssl-passthrough implementation support

### DIFF
--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -107,6 +107,21 @@ Supported Ingress Annotations
      - | Enable websocket passthrough support.
        | Applicable values are ``enabled`` and ``disabled``.
      - ``disabled``
+   * - ``ingress.cilium.io/ssl-passthrough``
+     - | Enable SSL Passthrough mode for this Ingress.
+       | Applicable values are ``enabled`` and ``disabled``,
+       | although boolean-style values will also be
+       | accepted.
+       | Note that some conditions apply to SSL
+       | Passthrough Ingresses, due to how
+       | TLS Passthrough works:
+       | * A ``host`` field must be set in the Ingress
+       | * Default backends are ignored
+       | * Rules with paths other than ``/`` are ignored
+       | If all the rules in an Ingress are ignored for
+       | these reasons, no Envoy config will be generated
+       | and the Ingress will have no effect.
+     - ``disabled``
 
 Additionally, cloud-provider specific annotations for the LoadBalancer service
 are supported.

--- a/Documentation/network/servicemesh/ingress.rst
+++ b/Documentation/network/servicemesh/ingress.rst
@@ -107,12 +107,13 @@ Supported Ingress Annotations
      - | Enable websocket passthrough support.
        | Applicable values are ``enabled`` and ``disabled``.
      - ``disabled``
-   * - ``ingress.cilium.io/ssl-passthrough``
-     - | Enable SSL Passthrough mode for this Ingress.
+   * - ``ingress.cilium.io/tls-passthrough``
+     - | Enable TLS Passthrough mode for this Ingress.
        | Applicable values are ``enabled`` and ``disabled``,
        | although boolean-style values will also be
        | accepted.
-       | Note that some conditions apply to SSL
+       |
+       | Note that some conditions apply to TLS
        | Passthrough Ingresses, due to how
        | TLS Passthrough works:
        | * A ``host`` field must be set in the Ingress
@@ -121,6 +122,10 @@ Supported Ingress Annotations
        | If all the rules in an Ingress are ignored for
        | these reasons, no Envoy config will be generated
        | and the Ingress will have no effect.
+       |
+       | Note that this annotation is analogous to
+       | the ``ssl-passthrough`` on other Ingress
+       | controllers.
      - ``disabled``
 
 Additionally, cloud-provider specific annotations for the LoadBalancer service

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -162,11 +162,16 @@ func GetAnnotationWebsocketEnabled(ingress *slim_networkingv1.Ingress) int64 {
 	return 0
 }
 
-func GetAnnotationSSLPassthrough(ingress *slim_networkingv1.Ingress) bool {
+func GetAnnotationSSLPassthroughEnabled(ingress *slim_networkingv1.Ingress) bool {
 	val, exists := annotation.Get(ingress, SSLPassthroughAnnotation, SSLPassthroughAnnotationAlias)
 	if !exists {
 		return false
 	}
+
+	if val == enabled {
+		return true
+	}
+
 	boolVal, err := strconv.ParseBool(val)
 	if err != nil {
 		return false

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -16,6 +16,7 @@ const (
 	ServiceTypeAnnotation      = annotation.IngressPrefix + "/service-type"
 	InsecureNodePortAnnotation = annotation.IngressPrefix + "/insecure-node-port"
 	SecureNodePortAnnotation   = annotation.IngressPrefix + "/secure-node-port"
+	SSLPassthroughAnnotation   = annotation.IngressPrefix + "/ssl-passthrough"
 
 	TCPKeepAliveEnabledAnnotation          = annotation.IngressPrefix + "/tcp-keep-alive"
 	TCPKeepAliveIdleAnnotation             = annotation.IngressPrefix + "/tcp-keep-alive-idle"
@@ -27,6 +28,7 @@ const (
 	ServiceTypeAnnotationAlias      = annotation.Prefix + ".ingress" + "/service-type"
 	InsecureNodePortAnnotationAlias = annotation.Prefix + ".ingress" + "/insecure-node-port"
 	SecureNodePortAnnotationAlias   = annotation.Prefix + ".ingress" + "/secure-node-port"
+	SSLPassthroughAnnotationAlias   = annotation.Prefix + ".ingress" + "/ssl-passthrough"
 
 	TCPKeepAliveEnabledAnnotationAlias          = annotation.Prefix + "/tcp-keep-alive"
 	TCPKeepAliveIdleAnnotationAlias             = annotation.Prefix + "/tcp-keep-alive-idle"
@@ -158,4 +160,17 @@ func GetAnnotationWebsocketEnabled(ingress *slim_networkingv1.Ingress) int64 {
 		return 1
 	}
 	return 0
+}
+
+func GetAnnotationSSLPassthrough(ingress *slim_networkingv1.Ingress) bool {
+	val, exists := annotation.Get(ingress, SSLPassthroughAnnotation, SSLPassthroughAnnotationAlias)
+	if !exists {
+		return false
+	}
+	boolVal, err := strconv.ParseBool(val)
+	if err != nil {
+		return false
+	}
+
+	return boolVal
 }

--- a/operator/pkg/ingress/annotations/annotations.go
+++ b/operator/pkg/ingress/annotations/annotations.go
@@ -16,7 +16,7 @@ const (
 	ServiceTypeAnnotation      = annotation.IngressPrefix + "/service-type"
 	InsecureNodePortAnnotation = annotation.IngressPrefix + "/insecure-node-port"
 	SecureNodePortAnnotation   = annotation.IngressPrefix + "/secure-node-port"
-	SSLPassthroughAnnotation   = annotation.IngressPrefix + "/ssl-passthrough"
+	TLSPassthroughAnnotation   = annotation.IngressPrefix + "/tls-passthrough"
 
 	TCPKeepAliveEnabledAnnotation          = annotation.IngressPrefix + "/tcp-keep-alive"
 	TCPKeepAliveIdleAnnotation             = annotation.IngressPrefix + "/tcp-keep-alive-idle"
@@ -28,7 +28,7 @@ const (
 	ServiceTypeAnnotationAlias      = annotation.Prefix + ".ingress" + "/service-type"
 	InsecureNodePortAnnotationAlias = annotation.Prefix + ".ingress" + "/insecure-node-port"
 	SecureNodePortAnnotationAlias   = annotation.Prefix + ".ingress" + "/secure-node-port"
-	SSLPassthroughAnnotationAlias   = annotation.Prefix + ".ingress" + "/ssl-passthrough"
+	TLSPassthroughAnnotationAlias   = annotation.Prefix + ".ingress" + "/tls-passthrough"
 
 	TCPKeepAliveEnabledAnnotationAlias          = annotation.Prefix + "/tcp-keep-alive"
 	TCPKeepAliveIdleAnnotationAlias             = annotation.Prefix + "/tcp-keep-alive-idle"
@@ -162,8 +162,8 @@ func GetAnnotationWebsocketEnabled(ingress *slim_networkingv1.Ingress) int64 {
 	return 0
 }
 
-func GetAnnotationSSLPassthroughEnabled(ingress *slim_networkingv1.Ingress) bool {
-	val, exists := annotation.Get(ingress, SSLPassthroughAnnotation, SSLPassthroughAnnotationAlias)
+func GetAnnotationTLSPassthroughEnabled(ingress *slim_networkingv1.Ingress) bool {
+	val, exists := annotation.Get(ingress, TLSPassthroughAnnotation, TLSPassthroughAnnotationAlias)
 	if !exists {
 		return false
 	}

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -182,6 +182,73 @@ func TestGetAnnotationInsecureNodePort(t *testing.T) {
 	}
 }
 
+func TestGetAnnotationSSLPassthrough(t *testing.T) {
+	type args struct {
+		ingress *slim_networkingv1.Ingress
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "no SSL Passthrough port annotation",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{},
+			},
+			want: false,
+		},
+		{
+			name: "SSL Passthrough annotation present and true",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/ssl-passthrough": "true",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "SSL Passthrough annotation present and false",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/ssl-passthrough": "false",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "SSL Passthrough annotation present and invalid",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/ssl-passthrough": "invalid",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetAnnotationSSLPassthrough(tt.args.ingress)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func uint32p(u uint32) *uint32 {
 	return &u
 }

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -204,7 +204,7 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 				ingress: &slim_networkingv1.Ingress{
 					ObjectMeta: slim_metav1.ObjectMeta{
 						Annotations: map[string]string{
-							"ingress.cilium.io/ssl-passthrough": "enabled",
+							"ingress.cilium.io/tls-passthrough": "enabled",
 						},
 					},
 				},
@@ -217,7 +217,7 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 				ingress: &slim_networkingv1.Ingress{
 					ObjectMeta: slim_metav1.ObjectMeta{
 						Annotations: map[string]string{
-							"ingress.cilium.io/ssl-passthrough": "disabled",
+							"ingress.cilium.io/tls-passthrough": "disabled",
 						},
 					},
 				},
@@ -230,7 +230,7 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 				ingress: &slim_networkingv1.Ingress{
 					ObjectMeta: slim_metav1.ObjectMeta{
 						Annotations: map[string]string{
-							"ingress.cilium.io/ssl-passthrough": "true",
+							"ingress.cilium.io/tls-passthrough": "true",
 						},
 					},
 				},
@@ -243,7 +243,7 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 				ingress: &slim_networkingv1.Ingress{
 					ObjectMeta: slim_metav1.ObjectMeta{
 						Annotations: map[string]string{
-							"ingress.cilium.io/ssl-passthrough": "false",
+							"ingress.cilium.io/tls-passthrough": "false",
 						},
 					},
 				},
@@ -256,7 +256,7 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 				ingress: &slim_networkingv1.Ingress{
 					ObjectMeta: slim_metav1.ObjectMeta{
 						Annotations: map[string]string{
-							"ingress.cilium.io/ssl-passthrough": "invalid",
+							"ingress.cilium.io/tls-passthrough": "invalid",
 						},
 					},
 				},
@@ -266,7 +266,7 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetAnnotationSSLPassthroughEnabled(tt.args.ingress)
+			got := GetAnnotationTLSPassthroughEnabled(tt.args.ingress)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)

--- a/operator/pkg/ingress/annotations/annotations_test.go
+++ b/operator/pkg/ingress/annotations/annotations_test.go
@@ -199,6 +199,32 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "SSL Passthrough annotation present and enabled",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/ssl-passthrough": "enabled",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "SSL Passthrough annotation present and disabled",
+			args: args{
+				ingress: &slim_networkingv1.Ingress{
+					ObjectMeta: slim_metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"ingress.cilium.io/ssl-passthrough": "disabled",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "SSL Passthrough annotation present and true",
 			args: args{
 				ingress: &slim_networkingv1.Ingress{
@@ -240,7 +266,7 @@ func TestGetAnnotationSSLPassthrough(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetAnnotationSSLPassthrough(tt.args.ingress)
+			got := GetAnnotationSSLPassthroughEnabled(tt.args.ingress)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetAnnotationSecureNodePort() got = %v, want %v", got, tt.want)

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -596,7 +596,7 @@ func (ic *Controller) regenerate(ing *slim_networkingv1.Ingress, forceShared boo
 	if !forceShared && ic.isEffectiveLoadbalancerModeDedicated(ing) {
 		loadbalancerMode = "dedicated"
 		translator = ic.dedicatedTranslator
-		if annotations.GetAnnotationSSLPassthrough(ing) {
+		if annotations.GetAnnotationSSLPassthroughEnabled(ing) {
 			m.TLS = append(m.TLS, ingestion.IngressPassthrough(*ing, ic.defaultSecretNamespace, ic.defaultSecretName)...)
 		} else {
 			m.HTTP = append(m.HTTP, ingestion.Ingress(*ing, ic.defaultSecretNamespace, ic.defaultSecretName)...)
@@ -610,7 +610,7 @@ func (ic *Controller) regenerate(ing *slim_networkingv1.Ingress, forceShared boo
 				ing.GetDeletionTimestamp() != nil {
 				continue
 			}
-			if annotations.GetAnnotationSSLPassthrough(item) {
+			if annotations.GetAnnotationSSLPassthroughEnabled(item) {
 				m.TLS = append(m.TLS, ingestion.IngressPassthrough(*item, ic.defaultSecretNamespace, ic.defaultSecretName)...)
 			} else {
 				m.HTTP = append(m.HTTP, ingestion.Ingress(*item, ic.defaultSecretNamespace, ic.defaultSecretName)...)

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -601,6 +601,8 @@ func (ic *Controller) regenerate(ing *slim_networkingv1.Ingress, forceShared boo
 				ing.GetDeletionTimestamp() != nil {
 				continue
 			}
+			// Move this to an if that checks if this is a passthrough Ingress
+			// This means we'll need an IngressPassthrough function probably.
 			m.HTTP = append(m.HTTP, ingestion.Ingress(*item, ic.defaultSecretNamespace, ic.defaultSecretName)...)
 		}
 	}

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -588,11 +588,20 @@ func (ic *Controller) regenerate(ing *slim_networkingv1.Ingress, forceShared boo
 		logfields.Ingress:      ing.GetName(),
 	})
 
+	// Used for logging the effective LB mode for this Ingress.
+	var loadbalancerMode string = "shared"
+
 	var translator translation.Translator
 	m := &model.Model{}
 	if !forceShared && ic.isEffectiveLoadbalancerModeDedicated(ing) {
+		loadbalancerMode = "dedicated"
 		translator = ic.dedicatedTranslator
-		m.HTTP = ingestion.Ingress(*ing, ic.defaultSecretNamespace, ic.defaultSecretName)
+		if annotations.GetAnnotationSSLPassthrough(ing) {
+			m.TLS = append(m.TLS, ingestion.IngressPassthrough(*ing, ic.defaultSecretNamespace, ic.defaultSecretName)...)
+		} else {
+			m.HTTP = append(m.HTTP, ingestion.Ingress(*ing, ic.defaultSecretNamespace, ic.defaultSecretName)...)
+		}
+
 	} else {
 		translator = ic.sharedTranslator
 		for _, k := range ic.ingressStore.ListKeys() {
@@ -601,15 +610,18 @@ func (ic *Controller) regenerate(ing *slim_networkingv1.Ingress, forceShared boo
 				ing.GetDeletionTimestamp() != nil {
 				continue
 			}
-			// Move this to an if that checks if this is a passthrough Ingress
-			// This means we'll need an IngressPassthrough function probably.
-			m.HTTP = append(m.HTTP, ingestion.Ingress(*item, ic.defaultSecretNamespace, ic.defaultSecretName)...)
+			if annotations.GetAnnotationSSLPassthrough(item) {
+				m.TLS = append(m.TLS, ingestion.IngressPassthrough(*item, ic.defaultSecretNamespace, ic.defaultSecretName)...)
+			} else {
+				m.HTTP = append(m.HTTP, ingestion.Ingress(*item, ic.defaultSecretNamespace, ic.defaultSecretName)...)
+			}
 		}
 	}
 
 	scopedLog.WithFields(logrus.Fields{
 		"forcedShared": forceShared,
 		"model":        m,
+		"loadbalancer": loadbalancerMode,
 	}).Debug("Generated model for ingress")
 	cec, svc, ep, err := translator.Translate(m)
 	// Propagate Ingress annotation if required. This is applicable only for dedicated LB mode.
@@ -630,6 +642,7 @@ func (ic *Controller) regenerate(ing *slim_networkingv1.Ingress, forceShared boo
 		"ciliumEnvoyConfig": cec,
 		"service":           svc,
 		logfields.Endpoint:  ep,
+		"loadbalancer":      loadbalancerMode,
 	}).Debugf("Translated resources for ingress")
 	return cec, svc, ep, err
 }

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -596,7 +596,7 @@ func (ic *Controller) regenerate(ing *slim_networkingv1.Ingress, forceShared boo
 	if !forceShared && ic.isEffectiveLoadbalancerModeDedicated(ing) {
 		loadbalancerMode = "dedicated"
 		translator = ic.dedicatedTranslator
-		if annotations.GetAnnotationSSLPassthroughEnabled(ing) {
+		if annotations.GetAnnotationTLSPassthroughEnabled(ing) {
 			m.TLS = append(m.TLS, ingestion.IngressPassthrough(*ing, ic.defaultSecretNamespace, ic.defaultSecretName)...)
 		} else {
 			m.HTTP = append(m.HTTP, ingestion.Ingress(*ing, ic.defaultSecretNamespace, ic.defaultSecretName)...)
@@ -610,7 +610,7 @@ func (ic *Controller) regenerate(ing *slim_networkingv1.Ingress, forceShared boo
 				ing.GetDeletionTimestamp() != nil {
 				continue
 			}
-			if annotations.GetAnnotationSSLPassthroughEnabled(item) {
+			if annotations.GetAnnotationTLSPassthroughEnabled(item) {
 				m.TLS = append(m.TLS, ingestion.IngressPassthrough(*item, ic.defaultSecretNamespace, ic.defaultSecretName)...)
 			} else {
 				m.HTTP = append(m.HTTP, ingestion.Ingress(*item, ic.defaultSecretNamespace, ic.defaultSecretName)...)

--- a/operator/pkg/model/ingestion/ingress.go
+++ b/operator/pkg/model/ingestion/ingress.go
@@ -207,7 +207,7 @@ func Ingress(ing slim_networkingv1.Ingress, defaultSecretNamespace, defaultSecre
 
 }
 
-// IngressPassthrough translates an Ingress resource with the ssl-passthrough annotation to a TLSListener.
+// IngressPassthrough translates an Ingress resource with the tls-passthrough annotation to a TLSListener.
 // This function does not check IngressClass (via field or annotation).
 // It's expected that only relevant Ingresses will have this function called on them.
 //

--- a/operator/pkg/model/ingestion/ingress.go
+++ b/operator/pkg/model/ingestion/ingress.go
@@ -207,14 +207,15 @@ func Ingress(ing slim_networkingv1.Ingress, defaultSecretNamespace, defaultSecre
 
 }
 
-// Ingress translates an Ingress resource with the ssl-passhthrough annotation to a TLSListener.
+// IngressPassthrough translates an Ingress resource with the ssl-passthrough annotation to a TLSListener.
 // This function does not check IngressClass (via field or annotation).
 // It's expected that only relevant Ingresses will have this function called on them.
 //
-// Ingress objects with SSL Passthrough enabled must:
+// Ingress objects with SSL Passthrough enabled have the following properties:
 //
-// * have a host set
-// * only use the '/' path.
+// * must have a host set
+// * rules with paths other than '/' are ignored
+// * default backends are ignored
 func IngressPassthrough(ing slim_networkingv1.Ingress, defaultSecretNamespace, defaultSecretName string) []model.TLSListener {
 
 	// First, we make a map of TLSListeners, with the hostname

--- a/operator/pkg/model/ingestion/ingress_test.go
+++ b/operator/pkg/model/ingestion/ingress_test.go
@@ -1424,7 +1424,7 @@ var sslPassthru = slim_networkingv1.Ingress{
 		Name:      "sslpassthru-ingress",
 		Namespace: "dummy-namespace",
 		Annotations: map[string]string{
-			"ingress.cilium.io/ssl-passthrough": "true",
+			"ingress.cilium.io/tls-passthrough": "true",
 		},
 	},
 	Spec: slim_networkingv1.IngressSpec{
@@ -1483,7 +1483,7 @@ var sslPassthruNoHost = slim_networkingv1.Ingress{
 		Name:      "sslpassthru-ingress",
 		Namespace: "dummy-namespace",
 		Annotations: map[string]string{
-			"ingress.cilium.io/ssl-passthrough": "true",
+			"ingress.cilium.io/tls-passthrough": "true",
 		},
 	},
 	Spec: slim_networkingv1.IngressSpec{
@@ -1519,7 +1519,7 @@ var sslPassthruNoRule = slim_networkingv1.Ingress{
 		Name:      "sslpassthru-ingress",
 		Namespace: "dummy-namespace",
 		Annotations: map[string]string{
-			"ingress.cilium.io/ssl-passthrough": "true",
+			"ingress.cilium.io/tls-passthrough": "true",
 		},
 	},
 	Spec: slim_networkingv1.IngressSpec{
@@ -1539,7 +1539,7 @@ var sslPassthruExtraPath = slim_networkingv1.Ingress{
 		Name:      "sslpassthru-ingress",
 		Namespace: "dummy-namespace",
 		Annotations: map[string]string{
-			"ingress.cilium.io/ssl-passthrough": "true",
+			"ingress.cilium.io/tls-passthrough": "true",
 		},
 	},
 	Spec: slim_networkingv1.IngressSpec{
@@ -1579,7 +1579,7 @@ var sslPassthruNodePort = slim_networkingv1.Ingress{
 			"ingress.cilium.io/service-type":       "NodePort",
 			"ingress.cilium.io/insecure-node-port": "30000",
 			"ingress.cilium.io/secure-node-port":   "30001",
-			"ingress.cilium.io/ssl-passthrough":    "true",
+			"ingress.cilium.io/tls-passthrough":    "true",
 		},
 	},
 	Spec: slim_networkingv1.IngressSpec{
@@ -1643,7 +1643,7 @@ var sslPassthruMultiplePaths = slim_networkingv1.Ingress{
 		Name:      "sslpassthru-ingress",
 		Namespace: "dummy-namespace",
 		Annotations: map[string]string{
-			"ingress.cilium.io/ssl-passthrough": "true",
+			"ingress.cilium.io/tls-passthrough": "true",
 		},
 	},
 	Spec: slim_networkingv1.IngressSpec{
@@ -1714,7 +1714,7 @@ var sslPassthruDefaultBackend = slim_networkingv1.Ingress{
 		Name:      "sslpassthru-ingress",
 		Namespace: "dummy-namespace",
 		Annotations: map[string]string{
-			"ingress.cilium.io/ssl-passthrough": "true",
+			"ingress.cilium.io/tls-passthrough": "true",
 		},
 	},
 	Spec: slim_networkingv1.IngressSpec{

--- a/operator/pkg/model/translation/ingress/dedicated_ingress.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress.go
@@ -49,17 +49,20 @@ func (d *DedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	var namespace string
 	var sourceResource model.FullyQualifiedResource
 	var modelService *model.Service
+	var cecName string
 
-	if len(m.TLS) > 0 {
+	if len(m.HTTP) == 0 {
 		name = fmt.Sprintf("%s-%s", ciliumIngressPrefix, m.TLS[0].Sources[0].Name)
 		namespace = m.TLS[0].Sources[0].Namespace
 		sourceResource = m.TLS[0].Sources[0]
 		modelService = m.TLS[0].Service
+		cecName = fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, namespace, m.TLS[0].Sources[0].Name)
 	} else {
 		name = fmt.Sprintf("%s-%s", ciliumIngressPrefix, m.HTTP[0].Sources[0].Name)
 		namespace = m.HTTP[0].Sources[0].Namespace
 		sourceResource = m.HTTP[0].Sources[0]
 		modelService = m.HTTP[0].Service
+		cecName = fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, namespace, m.HTTP[0].Sources[0].Name)
 	}
 
 	// The logic is same as what we have with default translator, but with a different model
@@ -71,7 +74,7 @@ func (d *DedicatedIngressTranslator) Translate(m *model.Model) (*ciliumv2.Cilium
 	}
 
 	// Set the name to avoid any breaking change during upgrade.
-	cec.Name = fmt.Sprintf("%s-%s-%s", ciliumIngressPrefix, namespace, name)
+	cec.Name = cecName
 	return cec, getService(sourceResource, modelService), getEndpoints(sourceResource), err
 }
 


### PR DESCRIPTION
This PR adds a new `ingress.cilium.io/ssl-passthrough` annotation for Ingress objects, and support for handling them, along with some tests to cover this, and associated docs.

Updates #20960

```release-note
Added new `ingress.cilium.io/ssl-passthrough` annotation for Ingress objects
```
