### PR TITLE
Minor helm improvements concerning clustermesh

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -735,7 +735,7 @@ spec:
       tolerations:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
-      {{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.config.enabled (not .Values.clustermesh.apiserver.kvstoremesh.enabled) }}
+      {{- if and .Values.clustermesh.config.enabled (not (and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled )) }}
       hostAliases:
       {{- range $cluster := .Values.clustermesh.config.clusters }}
       {{- range $ip := $cluster.ips }}

--- a/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-config/clustermesh-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.clustermesh.useAPIServer .Values.clustermesh.config.enabled }}
+{{- if .Values.clustermesh.config.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -10,7 +10,8 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 data:
-  {{- $override := ternary (printf "https://clustermesh-apiserver.%s.svc:2379" .Release.Namespace) "" $.Values.clustermesh.apiserver.kvstoremesh.enabled }}
+  {{- $kvstoremesh := and .Values.clustermesh.useAPIServer .Values.clustermesh.apiserver.kvstoremesh.enabled }}
+  {{- $override := ternary (printf "https://clustermesh-apiserver.%s.svc:2379" .Release.Namespace) "" $kvstoremesh }}
   {{- range .Values.clustermesh.config.clusters }}
   {{ .name }}: {{ include "clustermesh-config-generate-etcd-cfg" (list . $.Values.clustermesh.config.domain $override) | b64enc }}
   {{- /* The parenthesis around .tls are required, since it can be null: https://stackoverflow.com/a/68807258 */}}

--- a/install/kubernetes/cilium/templates/validate.yaml
+++ b/install/kubernetes/cilium/templates/validate.yaml
@@ -78,3 +78,21 @@
     {{ fail "if Cilium Endpoint Slice is enabled (.Values.enableCiliumEndpointSlice=true), it requires .Values.disableEndpointCRD=false" }}
   {{- end }}
 {{- end }}
+
+{{/* validate clustermesh-apiserver */}}
+{{- if .Values.clustermesh.useAPIServer }}
+  {{- if ne .Values.identityAllocationMode "crd" }}
+    {{ fail (printf "The clustermesh-apiserver cannot be enabled in combination with .Values.identityAllocationMode=%s. To establish a Cluster Mesh, directly configure the parameters to access the remote kvstore through .Values.clustermesh.config" .Values.identityAllocationMode ) }}
+  {{- end }}
+  {{- if .Values.disableEndpointCRD }}
+    {{ fail "The clustermesh-apiserver cannot be enabled in combination with .Values.disableEndpointCRD=true" }}
+  {{- end }}
+{{- end }}
+{{- if .Values.externalWorkloads.enabled }}
+  {{- if ne .Values.identityAllocationMode "crd" }}
+    {{ fail (printf "External workloads support cannot be enabled in combination with .Values.identityAllocationMode=%s" .Values.identityAllocationMode ) }}
+  {{- end }}
+  {{- if .Values.disableEndpointCRD }}
+    {{ fail "External workloads support cannot be enabled in combination with .Values.disableEndpointCRD=true" }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
* Add validation to explicit clustermesh-apiserver incompatibilities with Cilium running in kvstore mode
* Allow to create the clustermesh configuration also when clustermesh-apiserver is disabled

<!-- Description of change -->

```release-note
Improve helm validation for clustermesh, and allow creating the clustermesh configuration also in kvstore mode
```
