### PR TITLE
Improve Hubble Relay Kubernetes Readiness/Liveness check

### DIFF
--- a/hubble-relay/cmd/serve/serve.go
+++ b/hubble-relay/cmd/serve/serve.go
@@ -34,6 +34,7 @@ const (
 	keyDialTimeout             = "dial-timeout"
 	keyRetryTimeout            = "retry-timeout"
 	keyListenAddress           = "listen-address"
+	keyHealthListenAddress     = "health-listen-address"
 	keyMetricsListenAddress    = "metrics-listen-address"
 	keyPeerService             = "peer-service"
 	keySortBufferMaxLen        = "sort-buffer-len-max"
@@ -95,6 +96,10 @@ func New(vp *viper.Viper) *cobra.Command {
 		keyListenAddress,
 		defaults.ListenAddress,
 		"Address on which to listen")
+	flags.String(
+		keyHealthListenAddress,
+		defaults.HealthListenAddress,
+		"Address on which to listen for the gRPC health service")
 	flags.String(
 		keyMetricsListenAddress,
 		"",
@@ -191,6 +196,7 @@ func runServe(vp *viper.Viper) error {
 		server.WithDialTimeout(vp.GetDuration(keyDialTimeout)),
 		server.WithPeerTarget(vp.GetString(keyPeerService)),
 		server.WithListenAddress(vp.GetString(keyListenAddress)),
+		server.WithHealthListenAddress(vp.GetString(keyHealthListenAddress)),
 		server.WithRetryTimeout(vp.GetDuration(keyRetryTimeout)),
 		server.WithSortBufferMaxLen(vp.GetInt(keySortBufferMaxLen)),
 		server.WithSortBufferDrainTimeout(vp.GetDuration(keySortBufferDrainTimeout)),

--- a/images/hubble-relay/Dockerfile
+++ b/images/hubble-relay/Dockerfile
@@ -12,6 +12,7 @@
 # https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub
 ARG BASE_IMAGE=gcr.io/distroless/static-debian11:nonroot@sha256:91ca4720011393f4d4cab3a01fa5814ee2714b7d40e6c74f2505f74168398ca9
 ARG GOLANG_IMAGE=docker.io/library/golang:1.21.4@sha256:81cd210ae58a6529d832af2892db822b30d84f817a671b8e1c15cff0b271a3db
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:c43357ef8317d6dc42f71a046c9adfc756e98b35@sha256:914163868d208197babf623174b13e767cfee67f00036804fb5f9550e34a0a6c
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
@@ -49,6 +50,14 @@ RUN apt-get update && apt-get install -y binutils-aarch64-linux-gnu binutils-x86
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     ./build-gops.sh
 
+#
+# gRPC health probes
+#
+FROM --platform=${BUILDPLATFORM} ${CILIUM_BUILDER_IMAGE} as grpc_health_probe
+ARG BUILDPLATFORM
+COPY images/hubble-relay/download-grpc-health-probe.sh /tmp/download-grpc-health-probe.sh
+RUN /tmp/download-grpc-health-probe.sh
+
 FROM ${BASE_IMAGE} as release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
@@ -56,6 +65,7 @@ ARG TARGETOS
 ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=gops /out/${TARGETOS}/${TARGETARCH}/bin/gops /bin/gops
+COPY --from=grpc_health_probe /out/${TARGETOS}/${TARGETARCH}/bin/grpc_health_probe /bin/grpc_health_probe
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/hubble-relay /usr/bin/hubble-relay
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all
 # use uid:gid for the nonroot user for compatibility with runAsNonRoot

--- a/images/hubble-relay/download-grpc-health-probe.sh
+++ b/images/hubble-relay/download-grpc-health-probe.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright Authors of Cilium
+# SPDX-License-Identifier: Apache-2.0
+
+set -o xtrace
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# renovate: datasource=github-release-attachments depName=grpc-ecosystem/grpc-health-probe
+grpc_health_probe_version="v0.4.21"
+
+declare -A grpc_health_probe_sha256
+# renovate: datasource=github-release-attachments depName=grpc-ecosystem/grpc-health-probe digestVersion=v0.4.21
+grpc_health_probe_sha256[amd64]="dbf3d1ea952ffe6dac5405b6d4cc0e630476272ef17ece02e020c55430f471ce"
+# renovate: datasource=github-release-attachments depName=grpc-ecosystem/grpc-health-probe digestVersion=v0.4.21
+grpc_health_probe_sha256[arm64]="815247e7038e92e82194bba2cd1588f7704754d1a9ea982121e734f358e37c99"
+
+for arch in amd64 arm64 ; do
+  curl --fail --show-error --silent --location "https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${grpc_health_probe_version}/grpc_health_probe-linux-${arch}" --output "/tmp/grpc_health_probe-${arch}"
+  printf "%s %s" "${grpc_health_probe_sha256[${arch}]}" "/tmp/grpc_health_probe-${arch}" | sha256sum -c
+  mkdir -p "/out/linux/${arch}/bin"
+  cp /tmp/grpc_health_probe-${arch} /out/linux/${arch}/bin/grpc_health_probe
+  chmod +x /out/linux/${arch}/bin/grpc_health_probe
+done
+
+x86_64-linux-gnu-strip /out/linux/amd64/bin/grpc_health_probe
+aarch64-linux-gnu-strip /out/linux/arm64/bin/grpc_health_probe

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -71,11 +71,26 @@ spec:
               protocol: TCP
             {{- end }}
           readinessProbe:
-            tcpSocket:
-              port: grpc
+            {{- include "hubble-relay.probe" . | nindent 12 }}
+            {{- if semverCompare "<1.20-0" .Capabilities.KubeVersion.Version }}
+            # Starting from Kubernetes 1.20, we are using startupProbe instead
+            # of this field.
+            initialDelaySeconds: 5
+            {{- end }}
           livenessProbe:
-            tcpSocket:
-              port: grpc
+            {{- include "hubble-relay.probe" . | nindent 12 }}
+            {{- if semverCompare "<1.20-0" .Capabilities.KubeVersion.Version }}
+            # Starting from Kubernetes 1.20, we are using startupProbe instead
+            # of this field.
+            initialDelaySeconds: 60
+            {{- end }}
+          {{- if semverCompare ">=1.20-0" .Capabilities.KubeVersion.Version }}
+          startupProbe:
+            # give the relay one minute to start up
+            {{- include "hubble-relay.probe" . | nindent 12 }}
+            failureThreshold: 20
+            periodSeconds: 3
+          {{- end }}
           {{- with .Values.hubble.relay.extraEnv }}
           env:
             {{- toYaml . | trim | nindent 12 }}
@@ -163,4 +178,18 @@ spec:
                   path: server.key
           {{- end }}
       {{- end }}
+{{- end }}
+
+{{- define "hubble-relay.probe" }}
+{{- /* This distinction can be removed once we drop support for k8s 1.23 */}}
+{{- if semverCompare ">=1.24-0" .Capabilities.KubeVersion.Version -}}
+grpc:
+  port: 4222
+{{- else }}
+exec:
+  command:
+  - grpc_health_probe
+  - -addr=localhost:4222
+{{- end }}
+timeoutSeconds: 3
 {{- end }}

--- a/pkg/hubble/relay/defaults/defaults.go
+++ b/pkg/hubble/relay/defaults/defaults.go
@@ -17,6 +17,8 @@ const (
 	// DialTimeout is the timeout that is used when establishing a new
 	// connection.
 	DialTimeout = 5 * time.Second
+	// HealthCheckInterval is the time interval between health checks.
+	HealthCheckInterval = 5 * time.Second
 	// GopsPort is the default port for gops to listen on.
 	GopsPort = 9893
 	// PprofAddress is the default port for pprof to listen on.
@@ -45,4 +47,8 @@ var (
 	// ListenAddress is the address on which the Hubble Relay server listens
 	// for incoming gRPC requests.
 	ListenAddress = fmt.Sprintf(":%d", hubbledefaults.RelayPort)
+
+	// HealthListenAddress is the address on which the Hubble Relay gRPC health
+	// server listens on
+	HealthListenAddress = fmt.Sprintf(":%d", 4222)
 )

--- a/pkg/hubble/relay/server/health.go
+++ b/pkg/hubble/relay/server/health.go
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package server
+
+import (
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/relay/pool"
+	"github.com/cilium/cilium/pkg/inctimer"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+type peerStatusReporter interface {
+	Status() pool.Status
+}
+type healthServer struct {
+	svc *health.Server
+	pm  peerStatusReporter
+
+	probeInterval time.Duration
+	stopChan      chan struct{}
+}
+
+// newHealthServer creates a new health server that monitors health
+// using the provided status reporter
+func newHealthServer(pm peerStatusReporter, probeInterval time.Duration) *healthServer {
+	svc := health.NewServer()
+	svc.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+	svc.SetServingStatus(v1.ObserverServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+	hs := &healthServer{
+		svc:           svc,
+		pm:            pm,
+		probeInterval: probeInterval,
+		stopChan:      make(chan struct{}),
+	}
+	return hs
+}
+
+// start starts the health server.
+func (hs healthServer) start() {
+	check := func() {
+		st := hs.pm.Status()
+		if st.PeerServiceConnected && st.AvailablePeers > 0 {
+			hs.svc.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+			hs.svc.SetServingStatus(v1.ObserverServiceName, healthpb.HealthCheckResponse_SERVING)
+		} else {
+			hs.svc.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+			hs.svc.SetServingStatus(v1.ObserverServiceName, healthpb.HealthCheckResponse_NOT_SERVING)
+		}
+	}
+	go func() {
+		connTimer, connTimerDone := inctimer.New()
+		defer connTimerDone()
+		check()
+		for {
+			select {
+			case <-hs.stopChan:
+				return
+			case <-connTimer.After(hs.probeInterval):
+				check()
+			}
+		}
+	}()
+}
+
+// stop stops the health server.
+func (hs healthServer) stop() {
+	close(hs.stopChan)
+}

--- a/pkg/hubble/relay/server/health_test.go
+++ b/pkg/hubble/relay/server/health_test.go
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/cilium/cilium/pkg/hubble/relay/pool"
+	"github.com/cilium/cilium/pkg/lock"
+)
+
+func TestHealthServer(t *testing.T) {
+
+	fpr := &fakePeerStatusReporter{}
+	hs := newHealthServer(fpr, 10*time.Millisecond)
+
+	hs.start()
+	t.Run("initially unavailable", func(t *testing.T) {
+		eventuallServingStatus(t, hs.svc, healthpb.HealthCheckResponse_NOT_SERVING)
+	})
+	t.Run("updated available", func(t *testing.T) {
+		fpr.setStatus(pool.Status{
+			PeerServiceConnected: true,
+			AvailablePeers:       3,
+		})
+		eventuallServingStatus(t, hs.svc, healthpb.HealthCheckResponse_SERVING)
+	})
+	t.Run("updated if no available peers", func(t *testing.T) {
+		fpr.setStatus(pool.Status{
+			PeerServiceConnected: true,
+			AvailablePeers:       0,
+		})
+		eventuallServingStatus(t, hs.svc, healthpb.HealthCheckResponse_NOT_SERVING)
+	})
+	t.Run("updated if peers back", func(t *testing.T) {
+		fpr.setStatus(pool.Status{
+			PeerServiceConnected: true,
+			AvailablePeers:       6,
+		})
+		eventuallServingStatus(t, hs.svc, healthpb.HealthCheckResponse_SERVING)
+	})
+	t.Run("updated if peer service unavailable", func(t *testing.T) {
+		fpr.setStatus(pool.Status{
+			PeerServiceConnected: false,
+			AvailablePeers:       6,
+		})
+		eventuallServingStatus(t, hs.svc, healthpb.HealthCheckResponse_NOT_SERVING)
+	})
+	hs.stop()
+}
+
+func eventuallServingStatus(t *testing.T, svc healthpb.HealthServer, status healthpb.HealthCheckResponse_ServingStatus) {
+	t.Helper()
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		res, err := svc.Check(context.TODO(), &healthpb.HealthCheckRequest{
+			Service: "",
+		})
+		assert.NoError(c, err)
+		assert.Equal(c, status, res.Status)
+
+		res, err = svc.Check(context.TODO(), &healthpb.HealthCheckRequest{
+			Service: v1.ObserverServiceName,
+		})
+		assert.NoError(c, err)
+		assert.Equal(c, status, res.Status)
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+type fakePeerStatusReporter struct {
+	mu lock.Mutex
+
+	status pool.Status
+}
+
+func (f *fakePeerStatusReporter) setStatus(stat pool.Status) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.status = stat
+}
+
+// Status implements peerStatusReporter.
+func (f *fakePeerStatusReporter) Status() pool.Status {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.status
+}

--- a/pkg/hubble/relay/server/option.go
+++ b/pkg/hubble/relay/server/option.go
@@ -28,6 +28,7 @@ type options struct {
 	dialTimeout            time.Duration
 	retryTimeout           time.Duration
 	listenAddress          string
+	healthListenAddress    string
 	metricsListenAddress   string
 	log                    logrus.FieldLogger
 	serverTLSConfig        certloader.ServerConfigBuilder
@@ -43,11 +44,12 @@ type options struct {
 
 // defaultOptions is the reference point for default values.
 var defaultOptions = options{
-	peerTarget:    defaults.PeerTarget,
-	dialTimeout:   defaults.DialTimeout,
-	retryTimeout:  defaults.RetryTimeout,
-	listenAddress: defaults.ListenAddress,
-	log:           logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay"),
+	peerTarget:          defaults.PeerTarget,
+	dialTimeout:         defaults.DialTimeout,
+	retryTimeout:        defaults.RetryTimeout,
+	listenAddress:       defaults.ListenAddress,
+	healthListenAddress: defaults.HealthListenAddress,
+	log:                 logging.DefaultLogger.WithField(logfields.LogSubsys, "hubble-relay"),
 }
 
 // DefaultOptions to include in the server. Other packages may extend this
@@ -79,6 +81,14 @@ func WithDialTimeout(t time.Duration) Option {
 func WithRetryTimeout(t time.Duration) Option {
 	return func(o *options) error {
 		o.retryTimeout = t
+		return nil
+	}
+}
+
+// WithHealthListenAddress sets the listen address for the hubble-relay gRPC health server.
+func WithHealthListenAddress(a string) Option {
+	return func(o *options) error {
+		o.healthListenAddress = a
 		return nil
 	}
 }

--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -4,6 +4,7 @@
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -190,6 +191,10 @@ func (s *Server) Stop() {
 	s.opts.log.Info("Stopping server...")
 	close(s.stop)
 	s.server.Stop()
+	err := s.metricsServer.Shutdown(context.Background())
+	if err != nil {
+		s.opts.log.WithError(err).Info("Failed to gracefully stop metrics server")
+	}
 	s.pm.Stop()
 	s.opts.log.Info("Server stopped")
 }

--- a/pkg/hubble/relay/server/server.go
+++ b/pkg/hubble/relay/server/server.go
@@ -19,12 +19,10 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 
 	observerpb "github.com/cilium/cilium/api/v1/observer"
-	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/cilium/pkg/hubble/peer"
 	peerTypes "github.com/cilium/cilium/pkg/hubble/peer/types"
 	"github.com/cilium/cilium/pkg/hubble/relay/defaults"
@@ -51,12 +49,13 @@ func init() {
 // Server is a proxy that connects to a running instance of hubble gRPC server
 // via unix domain socket.
 type Server struct {
-	server        *grpc.Server
-	pm            *pool.PeerManager
-	healthServer  *health.Server
-	metricsServer *http.Server
-	opts          options
-	stop          chan struct{}
+	server           *grpc.Server
+	grpcHealthServer *grpc.Server
+	pm               *pool.PeerManager
+	healthServer     *healthServer
+	metricsServer    *http.Server
+	opts             options
+	stop             chan struct{}
 }
 
 // New creates a new Server.
@@ -122,16 +121,18 @@ func New(options ...Option) (*Server, error) {
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
 	}
 	grpcServer := grpc.NewServer(serverOpts...)
+	grpcHealthServer := grpc.NewServer()
 
 	observerOptions := copyObserverOptionsWithLogger(opts.log, opts.observerOptions)
 	observerSrv, err := observer.NewServer(pm, observerOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create observer server: %v", err)
 	}
-	healthSrv := health.NewServer()
+	healthSrv := newHealthServer(pm, defaults.HealthCheckInterval)
 
 	observerpb.RegisterObserverServer(grpcServer, observerSrv)
-	healthpb.RegisterHealthServer(grpcServer, healthSrv)
+	healthpb.RegisterHealthServer(grpcServer, healthSrv.svc)
+	healthpb.RegisterHealthServer(grpcHealthServer, healthSrv.svc)
 	reflection.Register(grpcServer)
 
 	if opts.grpcMetrics != nil {
@@ -150,12 +151,13 @@ func New(options ...Option) (*Server, error) {
 	}
 
 	return &Server{
-		pm:            pm,
-		stop:          make(chan struct{}),
-		server:        grpcServer,
-		metricsServer: metricsServer,
-		healthServer:  healthSrv,
-		opts:          opts,
+		pm:               pm,
+		stop:             make(chan struct{}),
+		server:           grpcServer,
+		grpcHealthServer: grpcHealthServer,
+		metricsServer:    metricsServer,
+		healthServer:     healthSrv,
+		opts:             opts,
 	}, nil
 }
 
@@ -174,13 +176,21 @@ func (s *Server) Serve() error {
 	eg.Go(func() error {
 		s.opts.log.WithField("options", fmt.Sprintf("%+v", s.opts)).Info("Starting gRPC server...")
 		s.pm.Start()
+		s.healthServer.start()
 		socket, err := net.Listen("tcp", s.opts.listenAddress)
 		if err != nil {
 			return fmt.Errorf("failed to listen on tcp socket %s: %v", s.opts.listenAddress, err)
 		}
-
-		s.healthServer.SetServingStatus(v1.ObserverServiceName, healthpb.HealthCheckResponse_SERVING)
 		return s.server.Serve(socket)
+	})
+
+	eg.Go(func() error {
+		s.opts.log.WithField("addr", s.opts.healthListenAddress).Info("Starting gRPC health server...")
+		socket, err := net.Listen("tcp", s.opts.healthListenAddress)
+		if err != nil {
+			return fmt.Errorf("failed to listen on %s: %v", s.opts.healthListenAddress, err)
+		}
+		return s.grpcHealthServer.Serve(socket)
 	})
 
 	return eg.Wait()
@@ -196,6 +206,7 @@ func (s *Server) Stop() {
 		s.opts.log.WithError(err).Info("Failed to gracefully stop metrics server")
 	}
 	s.pm.Stop()
+	s.healthServer.stop()
 	s.opts.log.Info("Server stopped")
 }
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.


This commit improves the exiting Hubble Relay Readiness and liveness checks by using the gRPC Health Checking Protocol.

To do that we add the [grpc_health_probe](https://github.com/grpc-ecosystem/grpc-health-probe) binary to the hubble relay container image and use `exec probes`. We can't use the built-in gRPC health checking as it doesn't yet support TLS and because we still support k8s versions before v1.23.

We also update the the existing gRPC health server to check connectivity to the peer service and hubble backends. The health server is only  serving, if the peer service and at least one hubble observe service is available.

This PR also contains a relatively unrelated fix for graceful shutdown of hubble relay. It simplified the tests, but I can also split it into two PRs if requested

closes #23542