### PR TITLE
Test both VXLAN and GENEVE tunneling as part of the Conformance Cluster Mesh workflow

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -145,7 +145,7 @@ jobs:
             cm-auth-mode-2: 'cluster'
 
           - name: '7'
-            tunnel: 'vxlan'
+            tunnel: 'geneve'
             ipfamily: 'ipv4'
             encryption: 'wireguard'
             kube-proxy: 'iptables'


### PR DESCRIPTION
Switch some of the matrix entries currently configuring vxlan tunneling to geneve, so that we appropriately cover both protocols in combination with clustermesh.

<!-- Description of change -->

```release-note
Test both VXLAN and GENEVE tunneling as part of the Conformance Cluster Mesh workflow
```
