### PR TITLE
daemon: Uniquely identify daemon ipcache upserts

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -703,7 +703,7 @@ func newDaemon(ctx context.Context, cleaner *daemonCleanup, params *daemonParams
 			ingressIP,
 			labels.LabelIngress,
 			source.Restored,
-			ipcachetypes.NewResourceID(ipcachetypes.ResourceKindDaemon, "", ""),
+			ipcachetypes.NewResourceID(ipcachetypes.ResourceKindDaemon, "", "ingress"),
 		)
 	}
 	if len(oldIngressIPs) > 0 {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -256,7 +256,7 @@ func (d *Daemon) syncHostIPs() error {
 		return err
 	}
 
-	daemonResourceID := ipcachetypes.NewResourceID(ipcachetypes.ResourceKindDaemon, "", "")
+	daemonResourceID := ipcachetypes.NewResourceID(ipcachetypes.ResourceKindDaemon, "", "reserved")
 	for _, ipIDLblsPair := range specialIdentities {
 		isHost := ipIDLblsPair.ID == identity.ReservedIdentityHost
 		if isHost {


### PR DESCRIPTION
Each callpath from the daemon should use a unique resource ID to ensure
that only code corresponding to that specific callpath will add/remove
entries with the same resourceID. This can prevent bugs where either:
- The same resource gets overwritten by another caller, or
- Identities get prematurely released because the daemon thinks that the
  last remaining user for the identity has been removed.

This doesn't look like a bug yet, because the IPs for ingress and
reserved ipcache entries are disjoint sets today. However, this could
cause problems with new PRs that are out for review.

cc @christarazi (touches code you had added)

Fixes: 9ad27a8d20cc ("daemon: Convert host IP sync to async ipcache API")
Fixes: 745cd32ce1aa ("dameon: Convert ingress restoration code to async ipcache API")
