### PR TITLE
Add link to contributor ladder

### DIFF
--- a/Documentation/contributing/development/contributing_guide.rst
+++ b/Documentation/contributing/development/contributing_guide.rst
@@ -402,3 +402,17 @@ Cilium follows the real names policy described in the CNCF `DCO Guidelines v1.0
 
     Your real name should not be an anonymous id or false name that
     misrepresents who you are.
+
+.. _contributor_ladder:
+
+Contributor Ladder
+~~~~~~~~~~~~~~~~~~
+
+To help contributors grow in both privileges and responsibilities for the
+project, Cilium also has a `contributor ladder 
+<https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md>`_.
+The ladder lays out how contributors can go from community contributor
+to a committer and what is expected for each level. Community members
+generally start at the first levels of the "ladder" and advance up it as
+their involvement in the project grows. Our contributors are happy to 
+help you advance along the contributor ladder.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,9 @@
 
 See [Governance](Documentation/community/governance/commit_access.rst) for
 governance, commit, and vote guidelines as well as committer responsibilities.
-Everybody listed is a committer as per governance definition.
+Everybody listed is a committer as per governance definition. See the 
+[Contributor Ladder](https://github.com/cilium/community/blob/main/CONTRIBUTOR-LADDER.md)
+to learn how to level up through the project.
 
 ## Cilium Committers
 


### PR DESCRIPTION
Add a link from the maintainers doc to the contributor ladder will help people understand how to grow in the project towards becoming a maintainer

```release-note
Add link in maintainers.md and contributing guide to contributor ladder
```
