### PR TITLE
daemon: Simplify `cilium_host` IP restoration

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -326,6 +326,7 @@ func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 		if isRestoredIP(a) {
 			continue
 		}
+		log.WithField(logfields.IPAddr, a.IP).Debug("Removing stale router IP from cilium_host device")
 		if e := netlink.AddrDel(l, &a); e != nil {
 			err = errors.Join(err, resiliency.Retryable(fmt.Errorf("failed to remove IP %s: %w", a.IP, e)))
 		}

--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -331,9 +331,9 @@ func (d *Daemon) restoreCiliumHostIPs(ipv6 bool, fromK8s, fromFS net.IP) (restor
 // then it attempts to clear all IPs from the interface.
 func removeOldRouterState(ipv6 bool, restoredIP net.IP) error {
 	l, err := netlink.LinkByName(defaults.HostDevice)
-	if errors.As(err, &netlink.LinkNotFoundError{}) && restoredIP == nil {
-		// There's no old state remove as the host device doesn't exist and
-		// there's no restored IP anyway.
+	if errors.As(err, &netlink.LinkNotFoundError{}) {
+		// There's no old state remove as the host device doesn't exist.
+		// This is always the case when the agent is started for the first time.
 		return nil
 	}
 	if err != nil {

--- a/daemon/cmd/datapath.go
+++ b/daemon/cmd/datapath.go
@@ -54,18 +54,6 @@ func (d *Daemon) LocalConfig() *datapath.LocalNodeConfiguration {
 	return &d.nodeDiscovery.LocalConfig
 }
 
-func deleteHostDevice() {
-	link, err := netlink.LinkByName(defaults.HostDevice)
-	if err != nil {
-		log.WithError(err).Warningf("Unable to lookup host device %s. No old cilium_host interface exists", defaults.HostDevice)
-		return
-	}
-
-	if err := netlink.LinkDel(link); err != nil {
-		log.WithError(err).Errorf("Unable to delete host device %s to change allocation CIDR", defaults.HostDevice)
-	}
-}
-
 // listFilterIfs returns a map of interfaces based on the given filter.
 // The filter should take a link and, if found, return the index of that
 // interface, if not found return -1.

--- a/daemon/cmd/ipam_test.go
+++ b/daemon/cmd/ipam_test.go
@@ -4,7 +4,16 @@
 package cmd
 
 import (
+	"fmt"
+	"net"
 	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/ipam"
+	"github.com/cilium/cilium/pkg/logging"
 )
 
 func TestCoalesceCIDRs(t *testing.T) {
@@ -63,4 +72,66 @@ func TestCoalesceCIDRs(t *testing.T) {
 	if len(newCIDR) != len(expectedCIDR) || newCIDR[0] != expectedCIDR[0] {
 		t.Errorf("got %v, want %v\n", newCIDR, expectedCIDR)
 	}
+}
+
+type mockAllocateIP func(ip net.IP, owner string, pool ipam.Pool) (*ipam.AllocationResult, error)
+
+func (m mockAllocateIP) AllocateIPWithoutSyncUpstream(ip net.IP, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+	return m(ip, owner, pool)
+}
+
+func TestDaemon_reallocateDatapathIPs(t *testing.T) {
+	level := logging.GetLevel(logging.DefaultLogger)
+	logging.SetLogLevel(logrus.FatalLevel)
+	logging.AddHooks()
+	t.Cleanup(func() {
+		logging.SetLogLevel(level)
+	})
+
+	allocCIDR := cidr.MustParseCIDR("10.20.30.0/24")
+	alloc := mockAllocateIP(func(ip net.IP, owner string, pool ipam.Pool) (*ipam.AllocationResult, error) {
+		if !allocCIDR.Contains(ip) {
+			return nil, fmt.Errorf("cannot allocate IP %s", ip)
+		}
+		return &ipam.AllocationResult{IP: ip}, nil
+	})
+
+	fromFS := net.ParseIP("10.20.30.42")
+	fromK8s := net.ParseIP("10.20.30.41")
+
+	invalidFromFS := net.ParseIP("172.16.0.42")
+	invalidFromK8s := net.ParseIP("172.16.0.41")
+
+	// no restoration needed
+	result := reallocateDatapathIPs(alloc, nil, nil)
+	assert.Nil(t, result)
+
+	// fromK8s if fromFS is not available
+	result = reallocateDatapathIPs(alloc, fromK8s, nil)
+	assert.NotNil(t, result)
+	assert.Equal(t, result.IP, fromK8s)
+
+	// fromFS if fromK8s is not available
+	result = reallocateDatapathIPs(alloc, nil, fromFS)
+	assert.NotNil(t, result)
+	assert.Equal(t, result.IP, fromFS)
+
+	// fromFS should be preferred
+	result = reallocateDatapathIPs(alloc, fromK8s, fromFS)
+	assert.NotNil(t, result)
+	assert.Equal(t, result.IP, fromFS)
+
+	// reject restoration if the IP is not in the allocation CIDR
+	result = reallocateDatapathIPs(alloc, invalidFromFS, invalidFromK8s)
+	assert.Nil(t, result)
+
+	// fromFS with invalid fromK8s
+	result = reallocateDatapathIPs(alloc, invalidFromK8s, fromFS)
+	assert.NotNil(t, result)
+	assert.Equal(t, result.IP, fromFS)
+
+	// fromFS with invalid fromK8s
+	result = reallocateDatapathIPs(alloc, fromK8s, invalidFromFS)
+	assert.NotNil(t, result)
+	assert.Equal(t, result.IP, fromK8s)
 }

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 
-	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/lock"
 )
@@ -119,22 +118,6 @@ func (ipam *IPAM) DebugStatus() string {
 	str := spew.Sdump(ipam)
 	ipam.allocatorMutex.RUnlock()
 	return str
-}
-
-// GetVpcCIDRs returns all the CIDRs associated with the VPC this node belongs to.
-// This works only cloud provider IPAM modes and returns nil for other modes.
-// sharedNodeStore must be initialized before calling this method.
-func (ipam *IPAM) GetVpcCIDRs() (vpcCIDRs []*cidr.CIDR) {
-	sharedNodeStore.mutex.RLock()
-	defer sharedNodeStore.mutex.RUnlock()
-	primary, secondary := deriveVpcCIDRs(sharedNodeStore.ownNode)
-	if primary == nil {
-		return nil
-	}
-	if secondary == nil {
-		return []*cidr.CIDR{primary}
-	}
-	return append(secondary, primary)
 }
 
 // Pool is the the IP pool from which to allocate.

--- a/pkg/node/address_test.go
+++ b/pkg/node/address_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/cilium/pkg/checker"
-	"github.com/cilium/cilium/pkg/cidr"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -27,93 +26,6 @@ type NodeSuite struct{}
 var _ = Suite(&NodeSuite{})
 
 func (s *NodeSuite) TearDownTest(c *C) {
-}
-
-// This also provides cover for RestoreHostIPs.
-func (s *NodeSuite) Test_chooseHostIPsToRestore(c *C) {
-	tests := []struct {
-		name            string
-		ipv6            bool
-		fromK8s, fromFS net.IP
-		cidr            *cidr.CIDR
-		expect          net.IP
-		err             error
-	}{
-		{
-			name:    "restore IP from fs (both provided)",
-			ipv6:    false,
-			fromK8s: net.ParseIP("192.0.2.127"),
-			fromFS:  net.ParseIP("192.0.2.255"),
-			cidr:    cidr.MustParseCIDR("192.0.2.0/24"),
-			expect:  net.ParseIP("192.0.2.255"),
-			err:     errMismatch,
-		},
-		{
-			name:   "restore IP from fs",
-			ipv6:   false,
-			fromFS: net.ParseIP("192.0.2.255"),
-			cidr:   cidr.MustParseCIDR("192.0.2.0/24"),
-			expect: net.ParseIP("192.0.2.255"),
-			err:    nil,
-		},
-		{
-			name:    "restore IP from k8s",
-			ipv6:    false,
-			fromK8s: net.ParseIP("192.0.2.127"),
-			cidr:    cidr.MustParseCIDR("192.0.2.0/24"),
-			expect:  net.ParseIP("192.0.2.127"),
-			err:     nil,
-		},
-		{
-			name:    "IP not part of CIDR",
-			ipv6:    false,
-			fromK8s: net.ParseIP("192.0.2.127"),
-			cidr:    cidr.MustParseCIDR("192.1.2.0/24"),
-			expect:  net.ParseIP("192.0.2.127"),
-			err:     errDoesNotBelong,
-		},
-		{
-			name: "no IPs to restore",
-			ipv6: false,
-			err:  nil,
-		},
-		{
-			name:    "restore IP from fs (both provided)",
-			ipv6:    true,
-			fromK8s: net.ParseIP("ff02::127"),
-			fromFS:  net.ParseIP("ff02::255"),
-			cidr:    cidr.MustParseCIDR("ff02::/64"),
-			expect:  net.ParseIP("ff02::255"),
-			err:     errMismatch,
-		},
-		{
-			name:   "restore IP from fs",
-			ipv6:   true,
-			fromFS: net.ParseIP("ff02::255"),
-			cidr:   cidr.MustParseCIDR("ff02::/64"),
-			expect: net.ParseIP("ff02::255"),
-			err:    nil,
-		},
-		{
-			name:    "restore IP from k8s",
-			ipv6:    true,
-			fromK8s: net.ParseIP("ff02::127"),
-			cidr:    cidr.MustParseCIDR("ff02::/64"),
-			expect:  net.ParseIP("ff02::127"),
-			err:     nil,
-		},
-		{
-			name: "no IPs to restore",
-			ipv6: true,
-			err:  nil,
-		},
-	}
-	for _, tt := range tests {
-		c.Log("Test: " + tt.name)
-		got, err := chooseHostIPsToRestore(tt.ipv6, tt.fromK8s, tt.fromFS, []*cidr.CIDR{tt.cidr})
-		c.Assert(err, checker.DeepEquals, tt.err)
-		c.Assert(got, checker.DeepEquals, tt.expect)
-	}
 }
 
 func (s *NodeSuite) Test_getCiliumHostIPsFromFile(c *C) {


### PR DESCRIPTION
Before this PR, the `cilium_host` (aka router) IP restoration was done in two steps:

The first step collected previous IPs from the filesystem and Kubernetes and attempted to guess which one might still be valid in the new IPAM configuration. This validation was done using either the Pod CIDR, the VPC CIDR, or the native routing CIDR.

In a second step, the IP was then actually re-allocated via the IPAM subsystem. That second step could however still fail - just because an IP is part of the VPC CIDR or native routing CIDR does not mean it actually still assigned to the node.

This PR attempts to simplify the logic: Instead of trying to guess if the restore IP(s) could be allocated using IPAM, we just try to allocate them. If the allocation fails, we still have a fall back logic, and the old IP address(es) are still removed from the `cilium_host` interface. This way, the old CIDR check becomes obsolete, as we now use the IPAM subsystem as the source of truth if an IP can be restored or not.

This also fixes a bug where Multi-Pool IPAM always reallocated the router IP, because it did not implement the CIDR check in the first step.

**Review per commit.**

Fixes: #28743 