### PR TITLE
pkg/proxy/logger: switch to netip.Addr

### DIFF
--- a/daemon/cmd/fqdn_test.go
+++ b/daemon/cmd/fqdn_test.go
@@ -144,7 +144,7 @@ func (ds *DaemonFQDNSuite) SetUpTest(c *C) {
 
 type dummyInfoRegistry struct{}
 
-func (*dummyInfoRegistry) FillEndpointInfo(info *accesslog.EndpointInfo, ip net.IP, id identity.NumericIdentity) {
+func (*dummyInfoRegistry) FillEndpointInfo(info *accesslog.EndpointInfo, addr netip.Addr, id identity.NumericIdentity) {
 }
 
 // makeIPs generates count sequential IPv4 IPs

--- a/pkg/fqdn/dnsproxy/proxy.go
+++ b/pkg/fqdn/dnsproxy/proxy.go
@@ -852,9 +852,9 @@ func (p *DNSProxy) ServeDNS(w dns.ResponseWriter, request *dns.Msg) {
 		return
 	}
 
-	targetServerID := identity.GetWorldIdentityFromIP(targetServerIP)
 	// Ignore invalid IP - getter will handle invalid value.
 	targetServerAddr, _ := ippkg.AddrFromIP(targetServerIP)
+	targetServerID := identity.GetWorldIdentityFromIP(targetServerAddr)
 	if serverSecID, exists := p.LookupSecIDByIP(targetServerAddr); !exists {
 		scopedLog.WithField("server", targetServerAddrStr).Debug("cannot find server ip in ipcache, defaulting to WORLD")
 	} else {

--- a/pkg/identity/numericidentity.go
+++ b/pkg/identity/numericidentity.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"net"
+	"net/netip"
 	"sort"
 	"strconv"
 	"unsafe"
@@ -595,9 +595,9 @@ func GetAllReservedIdentities() []NumericIdentity {
 // GetWorldIdentityFromIP gets the correct world identity based
 // on the IP address version. If Cilium is not in dual-stack mode
 // then ReservedIdentityWorld will always be returned.
-func GetWorldIdentityFromIP(ip net.IP) NumericIdentity {
+func GetWorldIdentityFromIP(addr netip.Addr) NumericIdentity {
 	if option.Config.IsDualStack() {
-		if ip.To4() == nil {
+		if addr.Is6() {
 			return ReservedIdentityWorldIPv6
 		}
 		return ReservedIdentityWorldIPv4

--- a/pkg/proxy/logger/endpoint/epinfo.go
+++ b/pkg/proxy/logger/endpoint/epinfo.go
@@ -70,7 +70,7 @@ func (r *endpointInfoRegistry) FillEndpointInfo(info *accesslog.EndpointInfo, ad
 		}
 		// Default to WORLD if still unknown
 		if id == 0 {
-			id = identity.GetWorldIdentityFromIP(addr.AsSlice())
+			id = identity.GetWorldIdentityFromIP(addr)
 		}
 	}
 	info.Identity = uint64(id)


### PR DESCRIPTION
Modernize the package by switching to the `netip.Addr` type provided [since Go 1.18](https://tip.golang.org/doc/go1.18#netip).

Towards #24246