### PR TITLE
clustermesh: remove unnecessary fields from log messages

### DIFF
--- a/pkg/clustermesh/common/clustermesh.go
+++ b/pkg/clustermesh/common/clustermesh.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/lock"
+	"github.com/cilium/cilium/pkg/logging/logfields"
 )
 
 const (
@@ -121,6 +122,8 @@ func (cm *ClusterMesh) newRemoteCluster(name, path string) *remoteCluster {
 		changed:     make(chan bool, configNotificationsChannelSize),
 		controllers: controller.NewManager(),
 
+		logger: log.WithField(logfields.ClusterName, name),
+
 		metricLastFailureTimestamp: cm.conf.Metrics.LastFailureTimestamp.WithLabelValues(cm.conf.ClusterInfo.Name, cm.conf.NodeName, name),
 		metricReadinessStatus:      cm.conf.Metrics.ReadinessStatus.WithLabelValues(cm.conf.ClusterInfo.Name, cm.conf.NodeName, name),
 		metricTotalFailures:        cm.conf.Metrics.TotalFailures.WithLabelValues(cm.conf.ClusterInfo.Name, cm.conf.NodeName, name),
@@ -147,8 +150,6 @@ func (cm *ClusterMesh) add(name, path string) {
 
 	cm.conf.Metrics.TotalRemoteClusters.WithLabelValues(cm.conf.ClusterInfo.Name, cm.conf.NodeName).Set(float64(len(cm.clusters)))
 	cm.mutex.Unlock()
-
-	log.WithField(fieldClusterName, name).Debug("Remote cluster configuration added")
 
 	if inserted {
 		cluster.onInsert()

--- a/pkg/clustermesh/common/logfields.go
+++ b/pkg/clustermesh/common/logfields.go
@@ -11,10 +11,8 @@ import (
 var log = logging.DefaultLogger.WithField(logfields.LogSubsys, "clustermesh")
 
 const (
-	fieldClusterName   = "clusterName"
-	fieldConfig        = "config"
-	fieldConfigDir     = "configDir"
-	fieldEvent         = "event"
-	fieldKVStoreStatus = "kvstoreStatus"
-	fieldKVStoreErr    = "kvstoreErr"
+	fieldClusterName = "clusterName"
+	fieldConfig      = "config"
+	fieldConfigDir   = "configDir"
+	fieldEvent       = "event"
 )

--- a/pkg/k8s/service.go
+++ b/pkg/k8s/service.go
@@ -689,7 +689,7 @@ type ServiceIPGetter interface {
 // from the given ServiceIPGetter, if the address used to dial is a k8s
 // service. If verboseLogs is set, a log message is output when the
 // address to service IP translation fails.
-func CreateCustomDialer(b ServiceIPGetter, log *logrus.Entry, verboseLogs bool) func(ctx context.Context, addr string) (conn net.Conn, e error) {
+func CreateCustomDialer(b ServiceIPGetter, log logrus.FieldLogger, verboseLogs bool) func(ctx context.Context, addr string) (conn net.Conn, e error) {
 	return func(ctx context.Context, s string) (conn net.Conn, e error) {
 		// If the service is available, do the service translation to
 		// the service IP. Otherwise dial with the original service


### PR DESCRIPTION
Currently, all clustermesh-related log messages include the name of the cluster, the configuration file and the status of the kvstore connection as characterizing fields. Yet, the path to the configuration file looks redundant, as it depends on the cluster name. The same applies to the connection status (and possible errors), which is already reported when appropriate. Hence, let's drop them to make the messages easier to understand. While being at it, let's also avoid creating a separate logger object every time, to reduce the number of unnecessary allocations.

Additionally, let's also drop a redundant log message, as an analogous one is also printed by the caller.

Example logs before the change:

```
level=debug msg="Starting config directory watcher" configDir=/var/lib/cilium/clustermesh/ subsys=clustermesh
level=debug msg="Added or updated cluster configuration" clusterName=clustermesh2 config=/var/lib/cilium/clustermesh/clustermesh2 subsys=clustermesh
level=debug msg="Remote cluster configuration added" clusterName=clustermesh2 subsys=clustermesh
level=info msg="New remote cluster configuration" clusterName=clustermesh2 config=/var/lib/cilium/clustermesh/clustermesh2 kvstoreErr="<nil>" kvstoreStatus= subsys=clustermesh
level=debug msg="Waiting for connection to be established" clusterName=clustermesh2 config=/var/lib/cilium/clustermesh/clustermesh2 kvstoreErr="<nil>" kvstoreStatus= subsys=clustermesh
level=info msg="Connection to remote cluster established" clusterName=clustermesh2 config=/var/lib/cilium/clustermesh/clustermesh2 kvstoreErr="<nil>" kvstoreStatus="Waiting for initial connection to be established" subsys=clustermesh
level=debug msg="Retrieving cluster configuration from remote kvstore" clusterName=clustermesh2 config=/var/lib/cilium/clustermesh/clustermesh2 kvstoreErr="<nil>" kvstoreStatus="Waiting for initial connection to be established" subsys=clustermesh
level=info msg="Found remote cluster configuration" clusterName=clustermesh2 config=/var/lib/cilium/clustermesh/clustermesh2 kvstoreErr="<nil>" kvstoreStatus="Waiting for initial connection to be established" subsys=clustermesh
level=warning msg="Error observed on etcd connection, reconnecting etcd" clusterName=clustermesh2 config=/var/lib/cilium/clustermesh/clustermesh2 error="not able to connect to any etcd endpoints" kvstoreErr="not able to connect to any etcd endpoints" kvstoreStatus="not able to connect to any etcd endpoints" subsys=clustermesh
```

Example logs after the change:

```
level=debug msg="Starting config directory watcher" configDir=/var/lib/cilium/clustermesh/ subsys=clustermesh
level=debug msg="Added or updated cluster configuration" clusterName=clustermesh2 config=/var/lib/cilium/clustermesh/clustermesh2 subsys=clustermesh
level=info msg="New remote cluster configuration" clusterName=clustermesh2 subsys=clustermesh
level=debug msg="Waiting for connection to be established" clusterName=clustermesh2 subsys=clustermesh
level=info msg="Connection to remote cluster established" clusterName=clustermesh2 subsys=clustermesh
level=debug msg="Retrieving cluster configuration from remote kvstore" clusterName=clustermesh2 subsys=clustermesh
level=info msg="Found remote cluster configuration" clusterName=clustermesh2 subsys=clustermesh
level=warning msg="Error observed on etcd connection, reconnecting etcd" clusterName=clustermesh2 error="not able to connect to any etcd endpoints" subsys=clustermesh
```

<!-- Description of change -->

```release-note
Improve readability of clustermesh-related log messages
```
