### PR TITLE
proxy: allow to provide fixed port for DNS proxy via cell

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -119,7 +119,15 @@ type Proxy struct {
 	dnsIntegration   *dnsProxyIntegration
 }
 
-func createProxy(minPort uint16, maxPort uint16, datapathUpdater DatapathUpdater, envoyIntegration *envoyProxyIntegration, dnsIntegration *dnsProxyIntegration, xdsServer envoy.XDSServer) *Proxy {
+func createProxy(
+	minPort uint16,
+	maxPort uint16,
+	dnsProxyPort uint16,
+	datapathUpdater DatapathUpdater,
+	envoyIntegration *envoyProxyIntegration,
+	dnsIntegration *dnsProxyIntegration,
+	xdsServer envoy.XDSServer,
+) *Proxy {
 	return &Proxy{
 		XDSServer:        xdsServer,
 		rangeMin:         minPort,
@@ -127,13 +135,13 @@ func createProxy(minPort uint16, maxPort uint16, datapathUpdater DatapathUpdater
 		redirects:        make(map[string]*Redirect),
 		datapathUpdater:  datapathUpdater,
 		allocatedPorts:   make(map[uint16]bool),
-		proxyPorts:       defaultProxyPortMap(),
+		proxyPorts:       defaultProxyPortMap(dnsProxyPort),
 		envoyIntegration: envoyIntegration,
 		dnsIntegration:   dnsIntegration,
 	}
 }
 
-func defaultProxyPortMap() map[string]*ProxyPort {
+func defaultProxyPortMap(dnsProxyPort uint16) map[string]*ProxyPort {
 	return map[string]*ProxyPort{
 		"cilium-http-egress": {
 			proxyType: types.ProxyTypeHTTP,
@@ -149,6 +157,7 @@ func defaultProxyPortMap() map[string]*ProxyPort {
 			proxyType: types.ProxyTypeDNS,
 			ingress:   false,
 			localOnly: true,
+			proxyPort: dnsProxyPort,
 		},
 		"cilium-proxylib-egress": {
 			proxyType: types.ProxyTypeAny,

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -42,7 +42,7 @@ func (s *ProxySuite) TestPortAllocator(c *C) {
 	err := os.MkdirAll(socketDir, 0700)
 	c.Assert(err, IsNil)
 
-	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil, nil)
+	p := createProxy(10000, 20000, 0, mockDatapathUpdater, nil, nil, nil)
 
 	port, err := p.AllocateProxyPort("listener1", false, true)
 	c.Assert(err, IsNil)
@@ -210,7 +210,7 @@ func (s *ProxySuite) TestCreateOrUpdateRedirectMissingListener(c *C) {
 	err := os.MkdirAll(socketDir, 0700)
 	c.Assert(err, IsNil)
 
-	p := createProxy(10000, 20000, mockDatapathUpdater, nil, nil, nil)
+	p := createProxy(10000, 20000, 0, mockDatapathUpdater, nil, nil, nil)
 
 	ep := &endpointtest.ProxyUpdaterMock{
 		Id:       1000,


### PR DESCRIPTION
By default, the value will still be 0 and thus a random port will be allocated. While at it, also provide the port range as configureable parameters.