### PR TITLE
Fix CIDR labels computation

### DIFF
--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -133,7 +133,7 @@ var (
 	mu lock.Mutex
 )
 
-const cidrLabelsCacheMaxSize = 16384
+const cidrLabelsCacheMaxSize = 8192
 
 func addWorldLabel(addr netip.Addr, lbls Labels) {
 	switch {

--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -114,7 +114,6 @@ func GetCIDRLabels(prefix netip.Prefix) Labels {
 		nil, // avoid allocating space for the intermediate results until we need it
 		addr,
 		ones,
-		0,
 	)
 	addWorldLabel(addr, lbls)
 
@@ -155,12 +154,12 @@ var (
 	worldLabelV6           = Label{Source: LabelSourceReserved, Key: IDNameWorldIPv6}
 )
 
-func computeCIDRLabels(cache *simplelru.LRU[netip.Prefix, []Label], lbls Labels, results []Label, addr netip.Addr, ones, i int) []Label {
-	if i > ones {
+func computeCIDRLabels(cache *simplelru.LRU[netip.Prefix, []Label], lbls Labels, results []Label, addr netip.Addr, ones int) []Label {
+	if ones < 0 {
 		return results
 	}
 
-	prefix := netip.PrefixFrom(addr, i)
+	prefix, _ := addr.Prefix(ones)
 
 	mu.Lock()
 	cachedLbls, ok := cache.Get(prefix)
@@ -177,7 +176,7 @@ func computeCIDRLabels(cache *simplelru.LRU[netip.Prefix, []Label], lbls Labels,
 	}
 
 	// Compute the label for this prefix (e.g. "cidr:10.0.0.0/8")
-	prefixLabel := maskedIPToLabel(prefix.Masked().Addr(), i)
+	prefixLabel := maskedIPToLabel(prefix.Addr(), ones)
 	lbls[prefixLabel.Key] = prefixLabel
 
 	// Keep computing the rest (e.g. "cidr:10.0.0.0/7", ...).
@@ -185,12 +184,12 @@ func computeCIDRLabels(cache *simplelru.LRU[netip.Prefix, []Label], lbls Labels,
 		cache,
 		lbls,
 		append(results, prefixLabel),
-		addr, ones, i+1,
+		prefix.Addr(), ones-1,
 	)
 
 	// Cache the resulting labels derived from this prefix, e.g. /8, /7, ...
 	mu.Lock()
-	cache.Add(prefix, results[i:])
+	cache.Add(prefix, results[len(results)-ones-1:])
 	mu.Unlock()
 
 	return results

--- a/pkg/labels/cidr_test.go
+++ b/pkg/labels/cidr_test.go
@@ -11,11 +11,9 @@ import (
 	"sync"
 	"testing"
 
-	. "github.com/cilium/checkmate"
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/option"
 )
 
@@ -427,7 +425,7 @@ func TestCIDRLabelsCache(t *testing.T) {
 	forward()
 }
 
-func (s *LabelsSuite) TestIPStringToLabel(c *C) {
+func TestIPStringToLabel(t *testing.T) {
 	for _, tc := range []struct {
 		ip      string
 		label   string
@@ -480,10 +478,10 @@ func (s *LabelsSuite) TestIPStringToLabel(c *C) {
 	} {
 		lbl, err := IPStringToLabel(tc.ip)
 		if !tc.wantErr {
-			c.Assert(err, IsNil)
-			c.Assert(lbl.String(), checker.DeepEquals, tc.label)
+			assert.NoError(t, err)
+			assert.Equal(t, lbl.String(), tc.label)
 		} else {
-			c.Assert(err, Not(IsNil))
+			assert.Error(t, err)
 		}
 	}
 }

--- a/pkg/labels/cidr_test.go
+++ b/pkg/labels/cidr_test.go
@@ -486,6 +486,91 @@ func TestIPStringToLabel(t *testing.T) {
 	}
 }
 
+func TestCIDRLabelsCacheHeapUsageIPv4(t *testing.T) {
+	t.Skip()
+
+	// save global config and restore it at the end of the test
+	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4, option.Config.EnableIPv6 = enableIPv4, enableIPv6
+	})
+
+	option.Config.EnableIPv4, option.Config.EnableIPv6 = true, false
+
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
+
+	// be sure to fill the cache
+	prefixes := make([]netip.Prefix, 0, 256*256)
+	octets := [4]byte{0, 0, 1, 1}
+	for i := 0; i < 256*256; i++ {
+		octets[0], octets[1] = byte(i/256), byte(i%256)
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom4(octets), 32))
+	}
+
+	var m1, m2 runtime.MemStats
+	// One GC does not give precise results,
+	// because concurrent sweep may be still in progress.
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+
+	for _, cidr := range prefixes {
+		_ = GetCIDRLabels(cidr)
+	}
+
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+
+	usage := m2.HeapAlloc - m1.HeapAlloc
+	t.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
+}
+
+func TestCIDRLabelsCacheHeapUsageIPv6(t *testing.T) {
+	t.Skip()
+
+	// save global config and restore it at the end of the test
+	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4, option.Config.EnableIPv6 = enableIPv4, enableIPv6
+	})
+
+	option.Config.EnableIPv4, option.Config.EnableIPv6 = true, true
+
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
+
+	// be sure to fill the cache
+	prefixes := make([]netip.Prefix, 0, 256*256)
+	octets := [16]byte{
+		0x00, 0x00, 0x00, 0xd8, 0x33, 0x33, 0x44, 0x44,
+		0x55, 0x55, 0x66, 0x66, 0x77, 0x77, 0x88, 0x88,
+	}
+	for i := 0; i < 256*256; i++ {
+		octets[15], octets[14] = byte(i/256), byte(i%256)
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom16(octets), 128))
+	}
+
+	var m1, m2 runtime.MemStats
+	// One GC does not give precise results,
+	// because concurrent sweep may be still in progress.
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+
+	for _, cidr := range prefixes {
+		_ = GetCIDRLabels(cidr)
+	}
+
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+
+	usage := m2.HeapAlloc - m1.HeapAlloc
+	t.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
+}
+
 func BenchmarkGetCIDRLabels(b *testing.B) {
 	// clear the cache
 	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
@@ -560,87 +645,6 @@ func BenchmarkGetCIDRLabelsConcurrent(b *testing.B) {
 			}
 		})
 	}
-}
-
-// BenchmarkCIDRLabelsCacheHeapUsageIPv4 should be run with -benchtime=1x
-func BenchmarkCIDRLabelsCacheHeapUsageIPv4(b *testing.B) {
-	b.Skip()
-
-	// clear the cache
-	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-
-	// be sure to fill the cache
-	prefixes := make([]netip.Prefix, 0, 256*256)
-	octets := [4]byte{0, 0, 1, 1}
-	for i := 0; i < 256*256; i++ {
-		octets[0], octets[1] = byte(i/256), byte(i%256)
-		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom4(octets), 32))
-	}
-
-	var m1, m2 runtime.MemStats
-	// One GC does not give precise results,
-	// because concurrent sweep may be still in progress.
-	runtime.GC()
-	runtime.GC()
-	runtime.ReadMemStats(&m1)
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		for _, cidr := range prefixes {
-			_ = GetCIDRLabels(cidr)
-		}
-	}
-	b.StopTimer()
-
-	runtime.GC()
-	runtime.GC()
-	runtime.ReadMemStats(&m2)
-
-	usage := m2.HeapAlloc - m1.HeapAlloc
-	b.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
-}
-
-// BenchmarkCIDRLabelsCacheHeapUsageIPv6 should be run with -benchtime=1x
-func BenchmarkCIDRLabelsCacheHeapUsageIPv6(b *testing.B) {
-	b.Skip()
-
-	// clear the cache
-	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
-
-	// be sure to fill the cache
-	prefixes := make([]netip.Prefix, 0, 256*256)
-	octets := [16]byte{
-		0x00, 0x00, 0x00, 0xd8, 0x33, 0x33, 0x44, 0x44,
-		0x55, 0x55, 0x66, 0x66, 0x77, 0x77, 0x88, 0x88,
-	}
-	for i := 0; i < 256*256; i++ {
-		octets[15], octets[14] = byte(i/256), byte(i%256)
-		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom16(octets), 128))
-	}
-
-	var m1, m2 runtime.MemStats
-	// One GC does not give precise results,
-	// because concurrent sweep may be still in progress.
-	runtime.GC()
-	runtime.GC()
-	runtime.ReadMemStats(&m1)
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		for _, cidr := range prefixes {
-			_ = GetCIDRLabels(cidr)
-		}
-	}
-	b.StopTimer()
-
-	runtime.GC()
-	runtime.GC()
-	runtime.ReadMemStats(&m2)
-
-	usage := m2.HeapAlloc - m1.HeapAlloc
-	b.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
 }
 
 func BenchmarkIPStringToLabel(b *testing.B) {

--- a/pkg/labels/cidr_test.go
+++ b/pkg/labels/cidr_test.go
@@ -19,195 +19,412 @@ import (
 	"github.com/cilium/cilium/pkg/option"
 )
 
-// TestGetCIDRLabels checks that GetCIDRLabels returns a sane set of labels for
-// given CIDRs.
-func (s *LabelsSuite) TestGetCIDRLabels(c *C) {
-	option.Config.EnableIPv6 = false
-	prefix := netip.MustParsePrefix("192.0.2.3/32")
-	expected := ParseLabelArray(
-		"cidr:0.0.0.0/0",
-		"cidr:128.0.0.0/1",
-		"cidr:192.0.0.0/8",
-		"cidr:192.0.2.0/24",
-		"cidr:192.0.2.3/32",
-		"reserved:world",
-	)
+func TestGetCIDRLabels(t *testing.T) {
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
 
-	lbls := GetCIDRLabels(prefix)
-	lblArray := lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
-	// IPs should be masked as the labels are generated
-	c.Assert(lblArray.Has("cidr:192.0.2.3/24"), Equals, false)
+	// save global config and restore it at the end of the test
+	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4, option.Config.EnableIPv6 = enableIPv4, enableIPv6
+	})
 
-	prefix = netip.MustParsePrefix("192.0.2.0/24")
-	expected = ParseLabelArray(
-		"cidr:0.0.0.0/0",
-		"cidr:192.0.2.0/24",
-		"reserved:world",
-	)
+	for _, tc := range []struct {
+		name       string
+		enableIPv4 bool
+		enableIPv6 bool
+		prefix     netip.Prefix
+		expected   LabelArray
+	}{
+		{
+			name:       "IPv4 /32 prefix",
+			enableIPv4: true,
+			enableIPv6: false,
+			prefix:     netip.MustParsePrefix("192.0.2.3/32"),
+			expected: ParseLabelArray(
+				"cidr:0.0.0.0/0",
+				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
+				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
+				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
+				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
+				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
+				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
+				"cidr:192.0.2.0/25", "cidr:192.0.2.0/26", "cidr:192.0.2.0/27", "cidr:192.0.2.0/28",
+				"cidr:192.0.2.0/29", "cidr:192.0.2.0/30", "cidr:192.0.2.2/31", "cidr:192.0.2.3/32",
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv4 /24 prefix",
+			enableIPv4: true,
+			enableIPv6: false,
+			prefix:     netip.MustParsePrefix("192.0.2.0/24"),
+			expected: ParseLabelArray(
+				"cidr:0.0.0.0/0",
+				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
+				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
+				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
+				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
+				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
+				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv4 /16 prefix",
+			enableIPv4: true,
+			enableIPv6: false,
+			prefix:     netip.MustParsePrefix("10.0.0.0/16"),
+			expected: ParseLabelArray(
+				"cidr:0.0.0.0/0",
+				"cidr:0.0.0.0/1", "cidr:0.0.0.0/2", "cidr:0.0.0.0/3", "cidr:0.0.0.0/4",
+				"cidr:8.0.0.0/5", "cidr:8.0.0.0/6", "cidr:10.0.0.0/7", "cidr:10.0.0.0/8",
+				"cidr:10.0.0.0/9", "cidr:10.0.0.0/10", "cidr:10.0.0.0/11", "cidr:10.0.0.0/12",
+				"cidr:10.0.0.0/13", "cidr:10.0.0.0/14", "cidr:10.0.0.0/15", "cidr:10.0.0.0/16",
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv4 zero length prefix",
+			enableIPv4: true,
+			enableIPv6: false,
+			prefix:     netip.MustParsePrefix("0.0.0.0/0"),
+			expected: ParseLabelArray(
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv6 /112 prefix",
+			enableIPv4: false,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("2001:db8:cafe::cab:4:b0b:0/112"),
+			expected: ParseLabelArray(
+				// Note that we convert the colons in IPv6 addresses into dashes when
+				// translating into labels, because endpointSelectors don't support
+				// colons.
+				"cidr:0--0/0",
+				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
+				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
+				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
+				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
+				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
+				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
+				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
+				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
+				"cidr:2001-db8-8000--0/33", "cidr:2001-db8-c000--0/34", "cidr:2001-db8-c000--0/35", "cidr:2001-db8-c000--0/36",
+				"cidr:2001-db8-c800--0/37", "cidr:2001-db8-c800--0/38", "cidr:2001-db8-ca00--0/39", "cidr:2001-db8-ca00--0/40",
+				"cidr:2001-db8-ca80--0/41", "cidr:2001-db8-cac0--0/42", "cidr:2001-db8-cae0--0/43", "cidr:2001-db8-caf0--0/44",
+				"cidr:2001-db8-caf8--0/45", "cidr:2001-db8-cafc--0/46", "cidr:2001-db8-cafe--0/47", "cidr:2001-db8-cafe--0/48",
+				"cidr:2001-db8-cafe--0/49", "cidr:2001-db8-cafe--0/50", "cidr:2001-db8-cafe--0/51", "cidr:2001-db8-cafe--0/52",
+				"cidr:2001-db8-cafe--0/53", "cidr:2001-db8-cafe--0/54", "cidr:2001-db8-cafe--0/55", "cidr:2001-db8-cafe--0/56",
+				"cidr:2001-db8-cafe--0/57", "cidr:2001-db8-cafe--0/58", "cidr:2001-db8-cafe--0/59", "cidr:2001-db8-cafe--0/60",
+				"cidr:2001-db8-cafe--0/61", "cidr:2001-db8-cafe--0/62", "cidr:2001-db8-cafe--0/63", "cidr:2001-db8-cafe--0/64",
+				"cidr:2001-db8-cafe--0/65", "cidr:2001-db8-cafe--0/66", "cidr:2001-db8-cafe--0/67", "cidr:2001-db8-cafe--0/68",
+				"cidr:2001-db8-cafe-0-800--0/69", "cidr:2001-db8-cafe-0-c00--0/70", "cidr:2001-db8-cafe-0-c00--0/71", "cidr:2001-db8-cafe-0-c00--0/72",
+				"cidr:2001-db8-cafe-0-c80--0/73", "cidr:2001-db8-cafe-0-c80--0/74", "cidr:2001-db8-cafe-0-ca0--0/75", "cidr:2001-db8-cafe-0-ca0--0/76",
+				"cidr:2001-db8-cafe-0-ca8--0/77", "cidr:2001-db8-cafe-0-ca8--0/78", "cidr:2001-db8-cafe-0-caa--0/79", "cidr:2001-db8-cafe-0-cab--0/80",
+				"cidr:2001-db8-cafe-0-cab--0/81", "cidr:2001-db8-cafe-0-cab--0/82", "cidr:2001-db8-cafe-0-cab--0/83", "cidr:2001-db8-cafe-0-cab--0/84",
+				"cidr:2001-db8-cafe-0-cab--0/85", "cidr:2001-db8-cafe-0-cab--0/86", "cidr:2001-db8-cafe-0-cab--0/87", "cidr:2001-db8-cafe-0-cab--0/88",
+				"cidr:2001-db8-cafe-0-cab--0/89", "cidr:2001-db8-cafe-0-cab--0/90", "cidr:2001-db8-cafe-0-cab--0/91", "cidr:2001-db8-cafe-0-cab--0/92",
+				"cidr:2001-db8-cafe-0-cab--0/93", "cidr:2001-db8-cafe-0-cab-4--0/94", "cidr:2001-db8-cafe-0-cab-4--0/95", "cidr:2001-db8-cafe-0-cab-4--0/96",
+				"cidr:2001-db8-cafe-0-cab-4--0/97", "cidr:2001-db8-cafe-0-cab-4--0/98", "cidr:2001-db8-cafe-0-cab-4--0/99", "cidr:2001-db8-cafe-0-cab-4--0/100",
+				"cidr:2001-db8-cafe-0-cab-4-800-0/101", "cidr:2001-db8-cafe-0-cab-4-800-0/102", "cidr:2001-db8-cafe-0-cab-4-a00-0/103", "cidr:2001-db8-cafe-0-cab-4-b00-0/104",
+				"cidr:2001-db8-cafe-0-cab-4-b00-0/105", "cidr:2001-db8-cafe-0-cab-4-b00-0/106", "cidr:2001-db8-cafe-0-cab-4-b00-0/107", "cidr:2001-db8-cafe-0-cab-4-b00-0/108",
+				"cidr:2001-db8-cafe-0-cab-4-b08-0/109", "cidr:2001-db8-cafe-0-cab-4-b08-0/110", "cidr:2001-db8-cafe-0-cab-4-b0a-0/111", "cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv6 /128 prefix",
+			enableIPv4: false,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("2001:DB8::1/128"),
+			expected: ParseLabelArray(
+				"cidr:0--0/0",
+				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
+				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
+				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
+				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
+				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
+				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
+				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
+				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
+				"cidr:2001-db8--0/33", "cidr:2001-db8--0/34", "cidr:2001-db8--0/35", "cidr:2001-db8--0/36",
+				"cidr:2001-db8--0/37", "cidr:2001-db8--0/38", "cidr:2001-db8--0/39", "cidr:2001-db8--0/40",
+				"cidr:2001-db8--0/41", "cidr:2001-db8--0/42", "cidr:2001-db8--0/43", "cidr:2001-db8--0/44",
+				"cidr:2001-db8--0/45", "cidr:2001-db8--0/46", "cidr:2001-db8--0/47", "cidr:2001-db8--0/48",
+				"cidr:2001-db8--0/49", "cidr:2001-db8--0/50", "cidr:2001-db8--0/51", "cidr:2001-db8--0/52",
+				"cidr:2001-db8--0/53", "cidr:2001-db8--0/54", "cidr:2001-db8--0/55", "cidr:2001-db8--0/56",
+				"cidr:2001-db8--0/57", "cidr:2001-db8--0/58", "cidr:2001-db8--0/59", "cidr:2001-db8--0/60",
+				"cidr:2001-db8--0/61", "cidr:2001-db8--0/62", "cidr:2001-db8--0/63", "cidr:2001-db8--0/64",
+				"cidr:2001-db8--0/65", "cidr:2001-db8--0/66", "cidr:2001-db8--0/67", "cidr:2001-db8--0/68",
+				"cidr:2001-db8--0/69", "cidr:2001-db8--0/70", "cidr:2001-db8--0/71", "cidr:2001-db8--0/72",
+				"cidr:2001-db8--0/73", "cidr:2001-db8--0/74", "cidr:2001-db8--0/75", "cidr:2001-db8--0/76",
+				"cidr:2001-db8--0/77", "cidr:2001-db8--0/78", "cidr:2001-db8--0/79", "cidr:2001-db8--0/80",
+				"cidr:2001-db8--0/81", "cidr:2001-db8--0/82", "cidr:2001-db8--0/83", "cidr:2001-db8--0/84",
+				"cidr:2001-db8--0/85", "cidr:2001-db8--0/86", "cidr:2001-db8--0/87", "cidr:2001-db8--0/88",
+				"cidr:2001-db8--0/89", "cidr:2001-db8--0/90", "cidr:2001-db8--0/91", "cidr:2001-db8--0/92",
+				"cidr:2001-db8--0/93", "cidr:2001-db8--0/94", "cidr:2001-db8--0/95", "cidr:2001-db8--0/96",
+				"cidr:2001-db8--0/97", "cidr:2001-db8--0/98", "cidr:2001-db8--0/99", "cidr:2001-db8--0/100",
+				"cidr:2001-db8--0/101", "cidr:2001-db8--0/102", "cidr:2001-db8--0/103", "cidr:2001-db8--0/104",
+				"cidr:2001-db8--0/105", "cidr:2001-db8--0/106", "cidr:2001-db8--0/107", "cidr:2001-db8--0/108",
+				"cidr:2001-db8--0/109", "cidr:2001-db8--0/110", "cidr:2001-db8--0/111", "cidr:2001-db8--0/112",
+				"cidr:2001-db8--0/113", "cidr:2001-db8--0/114", "cidr:2001-db8--0/115", "cidr:2001-db8--0/116",
+				"cidr:2001-db8--0/117", "cidr:2001-db8--0/118", "cidr:2001-db8--0/119", "cidr:2001-db8--0/120",
+				"cidr:2001-db8--0/121", "cidr:2001-db8--0/122", "cidr:2001-db8--0/123", "cidr:2001-db8--0/124",
+				"cidr:2001-db8--0/125", "cidr:2001-db8--0/126", "cidr:2001-db8--0/127", "cidr:2001-db8--1/128",
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv4 /32 prefix in dual stack mode",
+			enableIPv4: true,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("192.0.2.3/32"),
+			expected: ParseLabelArray(
+				"cidr:0.0.0.0/0",
+				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
+				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
+				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
+				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
+				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
+				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
+				"cidr:192.0.2.0/25", "cidr:192.0.2.0/26", "cidr:192.0.2.0/27", "cidr:192.0.2.0/28",
+				"cidr:192.0.2.0/29", "cidr:192.0.2.0/30", "cidr:192.0.2.2/31", "cidr:192.0.2.3/32",
+				"reserved:world-ipv4",
+			),
+		},
+		{
+			name:       "IPv4 /24 prefix in dual stack mode",
+			enableIPv4: true,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("192.0.2.0/24"),
+			expected: ParseLabelArray(
+				"cidr:0.0.0.0/0",
+				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
+				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
+				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
+				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
+				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
+				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
+				"reserved:world-ipv4",
+			),
+		},
+		{
+			name:       "IPv4 /16 prefix in dual stack mode",
+			enableIPv4: true,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("10.0.0.0/16"),
+			expected: ParseLabelArray(
+				"cidr:0.0.0.0/0",
+				"cidr:0.0.0.0/1", "cidr:0.0.0.0/2", "cidr:0.0.0.0/3", "cidr:0.0.0.0/4",
+				"cidr:8.0.0.0/5", "cidr:8.0.0.0/6", "cidr:10.0.0.0/7", "cidr:10.0.0.0/8",
+				"cidr:10.0.0.0/9", "cidr:10.0.0.0/10", "cidr:10.0.0.0/11", "cidr:10.0.0.0/12",
+				"cidr:10.0.0.0/13", "cidr:10.0.0.0/14", "cidr:10.0.0.0/15", "cidr:10.0.0.0/16",
+				"reserved:world-ipv4",
+			),
+		},
+		{
+			name:       "IPv4 zero length prefix in dual stack mode",
+			enableIPv4: true,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("0.0.0.0/0"),
+			expected: ParseLabelArray(
+				"reserved:world-ipv4",
+			),
+		},
+		{
+			name:       "IPv6 /112 prefix in dual stack mode",
+			enableIPv4: true,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("2001:db8:cafe::cab:4:b0b:0/112"),
+			expected: ParseLabelArray(
+				"cidr:0--0/0",
+				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
+				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
+				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
+				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
+				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
+				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
+				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
+				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
+				"cidr:2001-db8-8000--0/33", "cidr:2001-db8-c000--0/34", "cidr:2001-db8-c000--0/35", "cidr:2001-db8-c000--0/36",
+				"cidr:2001-db8-c800--0/37", "cidr:2001-db8-c800--0/38", "cidr:2001-db8-ca00--0/39", "cidr:2001-db8-ca00--0/40",
+				"cidr:2001-db8-ca80--0/41", "cidr:2001-db8-cac0--0/42", "cidr:2001-db8-cae0--0/43", "cidr:2001-db8-caf0--0/44",
+				"cidr:2001-db8-caf8--0/45", "cidr:2001-db8-cafc--0/46", "cidr:2001-db8-cafe--0/47", "cidr:2001-db8-cafe--0/48",
+				"cidr:2001-db8-cafe--0/49", "cidr:2001-db8-cafe--0/50", "cidr:2001-db8-cafe--0/51", "cidr:2001-db8-cafe--0/52",
+				"cidr:2001-db8-cafe--0/53", "cidr:2001-db8-cafe--0/54", "cidr:2001-db8-cafe--0/55", "cidr:2001-db8-cafe--0/56",
+				"cidr:2001-db8-cafe--0/57", "cidr:2001-db8-cafe--0/58", "cidr:2001-db8-cafe--0/59", "cidr:2001-db8-cafe--0/60",
+				"cidr:2001-db8-cafe--0/61", "cidr:2001-db8-cafe--0/62", "cidr:2001-db8-cafe--0/63", "cidr:2001-db8-cafe--0/64",
+				"cidr:2001-db8-cafe--0/65", "cidr:2001-db8-cafe--0/66", "cidr:2001-db8-cafe--0/67", "cidr:2001-db8-cafe--0/68",
+				"cidr:2001-db8-cafe-0-800--0/69", "cidr:2001-db8-cafe-0-c00--0/70", "cidr:2001-db8-cafe-0-c00--0/71", "cidr:2001-db8-cafe-0-c00--0/72",
+				"cidr:2001-db8-cafe-0-c80--0/73", "cidr:2001-db8-cafe-0-c80--0/74", "cidr:2001-db8-cafe-0-ca0--0/75", "cidr:2001-db8-cafe-0-ca0--0/76",
+				"cidr:2001-db8-cafe-0-ca8--0/77", "cidr:2001-db8-cafe-0-ca8--0/78", "cidr:2001-db8-cafe-0-caa--0/79", "cidr:2001-db8-cafe-0-cab--0/80",
+				"cidr:2001-db8-cafe-0-cab--0/81", "cidr:2001-db8-cafe-0-cab--0/82", "cidr:2001-db8-cafe-0-cab--0/83", "cidr:2001-db8-cafe-0-cab--0/84",
+				"cidr:2001-db8-cafe-0-cab--0/85", "cidr:2001-db8-cafe-0-cab--0/86", "cidr:2001-db8-cafe-0-cab--0/87", "cidr:2001-db8-cafe-0-cab--0/88",
+				"cidr:2001-db8-cafe-0-cab--0/89", "cidr:2001-db8-cafe-0-cab--0/90", "cidr:2001-db8-cafe-0-cab--0/91", "cidr:2001-db8-cafe-0-cab--0/92",
+				"cidr:2001-db8-cafe-0-cab--0/93", "cidr:2001-db8-cafe-0-cab-4--0/94", "cidr:2001-db8-cafe-0-cab-4--0/95", "cidr:2001-db8-cafe-0-cab-4--0/96",
+				"cidr:2001-db8-cafe-0-cab-4--0/97", "cidr:2001-db8-cafe-0-cab-4--0/98", "cidr:2001-db8-cafe-0-cab-4--0/99", "cidr:2001-db8-cafe-0-cab-4--0/100",
+				"cidr:2001-db8-cafe-0-cab-4-800-0/101", "cidr:2001-db8-cafe-0-cab-4-800-0/102", "cidr:2001-db8-cafe-0-cab-4-a00-0/103", "cidr:2001-db8-cafe-0-cab-4-b00-0/104",
+				"cidr:2001-db8-cafe-0-cab-4-b00-0/105", "cidr:2001-db8-cafe-0-cab-4-b00-0/106", "cidr:2001-db8-cafe-0-cab-4-b00-0/107", "cidr:2001-db8-cafe-0-cab-4-b00-0/108",
+				"cidr:2001-db8-cafe-0-cab-4-b08-0/109", "cidr:2001-db8-cafe-0-cab-4-b08-0/110", "cidr:2001-db8-cafe-0-cab-4-b0a-0/111", "cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
+				"reserved:world-ipv6",
+			),
+		},
+		{
+			name:       "IPv6 /128 prefix in dual stack mode",
+			enableIPv4: true,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("2001:DB8::1/128"),
+			expected: ParseLabelArray(
+				"cidr:0--0/0",
+				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
+				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
+				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
+				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
+				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
+				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
+				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
+				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
+				"cidr:2001-db8--0/33", "cidr:2001-db8--0/34", "cidr:2001-db8--0/35", "cidr:2001-db8--0/36",
+				"cidr:2001-db8--0/37", "cidr:2001-db8--0/38", "cidr:2001-db8--0/39", "cidr:2001-db8--0/40",
+				"cidr:2001-db8--0/41", "cidr:2001-db8--0/42", "cidr:2001-db8--0/43", "cidr:2001-db8--0/44",
+				"cidr:2001-db8--0/45", "cidr:2001-db8--0/46", "cidr:2001-db8--0/47", "cidr:2001-db8--0/48",
+				"cidr:2001-db8--0/49", "cidr:2001-db8--0/50", "cidr:2001-db8--0/51", "cidr:2001-db8--0/52",
+				"cidr:2001-db8--0/53", "cidr:2001-db8--0/54", "cidr:2001-db8--0/55", "cidr:2001-db8--0/56",
+				"cidr:2001-db8--0/57", "cidr:2001-db8--0/58", "cidr:2001-db8--0/59", "cidr:2001-db8--0/60",
+				"cidr:2001-db8--0/61", "cidr:2001-db8--0/62", "cidr:2001-db8--0/63", "cidr:2001-db8--0/64",
+				"cidr:2001-db8--0/65", "cidr:2001-db8--0/66", "cidr:2001-db8--0/67", "cidr:2001-db8--0/68",
+				"cidr:2001-db8--0/69", "cidr:2001-db8--0/70", "cidr:2001-db8--0/71", "cidr:2001-db8--0/72",
+				"cidr:2001-db8--0/73", "cidr:2001-db8--0/74", "cidr:2001-db8--0/75", "cidr:2001-db8--0/76",
+				"cidr:2001-db8--0/77", "cidr:2001-db8--0/78", "cidr:2001-db8--0/79", "cidr:2001-db8--0/80",
+				"cidr:2001-db8--0/81", "cidr:2001-db8--0/82", "cidr:2001-db8--0/83", "cidr:2001-db8--0/84",
+				"cidr:2001-db8--0/85", "cidr:2001-db8--0/86", "cidr:2001-db8--0/87", "cidr:2001-db8--0/88",
+				"cidr:2001-db8--0/89", "cidr:2001-db8--0/90", "cidr:2001-db8--0/91", "cidr:2001-db8--0/92",
+				"cidr:2001-db8--0/93", "cidr:2001-db8--0/94", "cidr:2001-db8--0/95", "cidr:2001-db8--0/96",
+				"cidr:2001-db8--0/97", "cidr:2001-db8--0/98", "cidr:2001-db8--0/99", "cidr:2001-db8--0/100",
+				"cidr:2001-db8--0/101", "cidr:2001-db8--0/102", "cidr:2001-db8--0/103", "cidr:2001-db8--0/104",
+				"cidr:2001-db8--0/105", "cidr:2001-db8--0/106", "cidr:2001-db8--0/107", "cidr:2001-db8--0/108",
+				"cidr:2001-db8--0/109", "cidr:2001-db8--0/110", "cidr:2001-db8--0/111", "cidr:2001-db8--0/112",
+				"cidr:2001-db8--0/113", "cidr:2001-db8--0/114", "cidr:2001-db8--0/115", "cidr:2001-db8--0/116",
+				"cidr:2001-db8--0/117", "cidr:2001-db8--0/118", "cidr:2001-db8--0/119", "cidr:2001-db8--0/120",
+				"cidr:2001-db8--0/121", "cidr:2001-db8--0/122", "cidr:2001-db8--0/123", "cidr:2001-db8--0/124",
+				"cidr:2001-db8--0/125", "cidr:2001-db8--0/126", "cidr:2001-db8--0/127", "cidr:2001-db8--1/128",
+				"reserved:world-ipv6",
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			option.Config.EnableIPv4 = tc.enableIPv4
+			option.Config.EnableIPv6 = tc.enableIPv6
 
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
-	// CIDRs that are covered by the prefix should not be in the labels
-	c.Assert(lblArray.Has("cidr.192.0.2.3/32"), Equals, false)
+			lbls := GetCIDRLabels(tc.prefix)
+			lblArray := lbls.LabelArray()
+			assert.ElementsMatch(t, lblArray, tc.expected)
 
-	// Zero-length prefix / default route should become reserved:world.
-	prefix = netip.MustParsePrefix("0.0.0.0/0")
-	expected = ParseLabelArray(
-		"reserved:world",
-	)
+			// compute labels twice to verify the caching behavior
 
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
-	c.Assert(lblArray.Has("cidr.0.0.0.0/0"), Equals, false)
-
-	// Note that we convert the colons in IPv6 addresses into dashes when
-	// translating into labels, because endpointSelectors don't support
-	// colons.
-	option.Config.EnableIPv6 = true
-	option.Config.EnableIPv4 = false
-	prefix = netip.MustParsePrefix("2001:DB8::1/128")
-	expected = ParseLabelArray(
-		"cidr:0--0/0",
-		"cidr:2000--0/3",
-		"cidr:2001--0/16",
-		"cidr:2001-d00--0/24",
-		"cidr:2001-db8--0/32",
-		"cidr:2001-db8--1/128",
-		"reserved:world",
-	)
-
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
-	// IPs should be masked as the labels are generated
-	c.Assert(lblArray.Has("cidr.2001-db8--1/24"), Equals, false)
-	option.Config.EnableIPv4 = true
+			lbls = GetCIDRLabels(tc.prefix)
+			lblArray = lbls.LabelArray()
+			assert.ElementsMatch(t, lblArray, tc.expected)
+		})
+	}
 }
 
-// TestGetCIDRLabelsDualStack checks that GetCIDRLabels returns a sane set of labels for
-// given CIDRs in dual stack mode.
-func (s *LabelsSuite) TestGetCIDRLabelsDualStack(c *C) {
-	prefix := netip.MustParsePrefix("192.0.2.3/32")
-	expected := ParseLabelArray(
+func TestCIDRLabelsCache(t *testing.T) {
+	// save global config and restore it at the end of the test
+	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4, option.Config.EnableIPv6 = enableIPv4, enableIPv6
+	})
+
+	prefixes := []netip.Prefix{
+		netip.MustParsePrefix("87.151.93.239/32"), netip.MustParsePrefix("87.151.93.238/31"),
+		netip.MustParsePrefix("87.151.93.236/30"), netip.MustParsePrefix("87.151.93.232/29"),
+		netip.MustParsePrefix("87.151.93.224/28"), netip.MustParsePrefix("87.151.93.224/27"),
+		netip.MustParsePrefix("87.151.93.192/26"), netip.MustParsePrefix("87.151.93.128/25"),
+		netip.MustParsePrefix("87.151.93.0/24"), netip.MustParsePrefix("87.151.92.0/23"),
+		netip.MustParsePrefix("87.151.92.0/22"), netip.MustParsePrefix("87.151.88.0/21"),
+		netip.MustParsePrefix("87.151.80.0/20"), netip.MustParsePrefix("87.151.64.0/19"),
+		netip.MustParsePrefix("87.151.64.0/18"), netip.MustParsePrefix("87.151.0.0/17"),
+		netip.MustParsePrefix("87.151.0.0/16"), netip.MustParsePrefix("87.150.0.0/15"),
+		netip.MustParsePrefix("87.148.0.0/14"), netip.MustParsePrefix("87.144.0.0/13"),
+		netip.MustParsePrefix("87.144.0.0/12"), netip.MustParsePrefix("87.128.0.0/11"),
+		netip.MustParsePrefix("87.128.0.0/10"), netip.MustParsePrefix("87.128.0.0/9"),
+		netip.MustParsePrefix("87.0.0.0/8"), netip.MustParsePrefix("86.0.0.0/7"),
+		netip.MustParsePrefix("84.0.0.0/6"), netip.MustParsePrefix("80.0.0.0/5"),
+		netip.MustParsePrefix("80.0.0.0/4"), netip.MustParsePrefix("64.0.0.0/3"),
+		netip.MustParsePrefix("64.0.0.0/2"), netip.MustParsePrefix("0.0.0.0/1"),
+		netip.MustParsePrefix("0.0.0.0/0"),
+	}
+	cidrLabels := []string{
 		"cidr:0.0.0.0/0",
-		"cidr:128.0.0.0/1",
-		"cidr:192.0.0.0/8",
-		"cidr:192.0.2.0/24",
-		"cidr:192.0.2.3/32",
-		"reserved:world-ipv4",
-	)
+		"cidr:0.0.0.0/1", "cidr:64.0.0.0/2", "cidr:64.0.0.0/3", "cidr:80.0.0.0/4",
+		"cidr:80.0.0.0/5", "cidr:84.0.0.0/6", "cidr:86.0.0.0/7", "cidr:87.0.0.0/8",
+		"cidr:87.128.0.0/9", "cidr:87.128.0.0/10", "cidr:87.128.0.0/11", "cidr:87.144.0.0/12",
+		"cidr:87.144.0.0/13", "cidr:87.148.0.0/14", "cidr:87.150.0.0/15", "cidr:87.151.0.0/16",
+		"cidr:87.151.0.0/17", "cidr:87.151.64.0/18", "cidr:87.151.64.0/19", "cidr:87.151.80.0/20",
+		"cidr:87.151.88.0/21", "cidr:87.151.92.0/22", "cidr:87.151.92.0/23", "cidr:87.151.93.0/24",
+		"cidr:87.151.93.128/25", "cidr:87.151.93.192/26", "cidr:87.151.93.224/27", "cidr:87.151.93.224/28",
+		"cidr:87.151.93.232/29", "cidr:87.151.93.236/30", "cidr:87.151.93.238/31", "cidr:87.151.93.239/32",
+	}
 
-	lbls := GetCIDRLabels(prefix)
-	lblArray := lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
-	// IPs should be masked as the labels are generated
-	c.Assert(lblArray.Has("cidr:192.0.2.3/24"), Equals, false)
+	// check all the labels computing them from the largest CIDR to the smaller ones.
+	forward := func() {
+		for i := 0; i < len(prefixes); i++ {
+			lbls := GetCIDRLabels(prefixes[i])
+			lblArray := lbls.LabelArray()
 
-	prefix = netip.MustParsePrefix("192.0.2.0/24")
-	expected = ParseLabelArray(
-		"cidr:0.0.0.0/0",
-		"cidr:192.0.2.0/24",
-		"reserved:world-ipv4",
-	)
+			var expectedLblArray LabelArray
+			if prefixes[i] == prefixes[len(prefixes)-1] { // default route "0.0.0.0/0" should become "reserved:world"
+				expectedLblArray = ParseLabelArray("reserved:world")
+			} else {
+				expectedLbls := make([]string, len(cidrLabels)-i)
+				copy(expectedLbls, cidrLabels[:len(cidrLabels)-i])
+				expectedLblArray = ParseLabelArray(append(expectedLbls, "reserved:world")...)
+			}
 
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
-	// CIDRs that are covered by the prefix should not be in the labels
-	c.Assert(lblArray.Has("cidr.192.0.2.3/32"), Equals, false)
+			assert.ElementsMatch(t, lblArray, expectedLblArray)
+		}
+	}
+	// check all the labels computing them from the smallest CIDR to the larger ones.
+	backward := func() {
+		for i := 0; i < len(prefixes); i++ {
+			lbls := GetCIDRLabels(prefixes[i])
+			lblArray := lbls.LabelArray()
 
-	// Zero-length prefix / default route should become reserved:world.
-	prefix = netip.MustParsePrefix("0.0.0.0/0")
-	expected = ParseLabelArray(
-		"reserved:world-ipv4",
-	)
+			var expectedLblArray LabelArray
+			if prefixes[i] == prefixes[len(prefixes)-1] { // default route "0.0.0.0/0" should become "reserved:world"
+				expectedLblArray = ParseLabelArray("reserved:world")
+			} else {
+				expectedLbls := make([]string, len(cidrLabels)-i)
+				copy(expectedLbls, cidrLabels[:len(cidrLabels)-i])
+				expectedLblArray = ParseLabelArray(append(expectedLbls, "reserved:world")...)
+			}
 
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
-	c.Assert(lblArray.Has("cidr.0.0.0.0/0"), Equals, false)
+			assert.ElementsMatch(t, lblArray, expectedLblArray)
+		}
+	}
 
-	// Note that we convert the colons in IPv6 addresses into dashes when
-	// translating into labels, because endpointSelectors don't support
-	// colons.
-	prefix = netip.MustParsePrefix("2001:DB8::1/128")
-	expected = ParseLabelArray(
-		"cidr:0--0/0",
-		"cidr:2000--0/3",
-		"cidr:2001--0/16",
-		"cidr:2001-d00--0/24",
-		"cidr:2001-db8--0/32",
-		"cidr:2001-db8--1/128",
-		"reserved:world-ipv6",
-	)
+	option.Config.EnableIPv4, option.Config.EnableIPv6 = true, false
 
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
-	// IPs should be masked as the labels are generated
-	c.Assert(lblArray.Has("cidr.2001-db8--1/24"), Equals, false)
-}
+	// First, compute all the labels starting from the largest CIDR to the smaller ones.
+	// This will warm up the LRU cache. Then, do it the other way around to verify that
+	// the cache has been populated correctly and results are consistent.
 
-// TestGetCIDRLabelsInCluster checks that the cluster label is properly added
-// when getting labels for CIDRs that are equal to or within the cluster range.
-func (s *LabelsSuite) TestGetCIDRLabelsInCluster(c *C) {
-	option.Config.EnableIPv6 = false
-	prefix := netip.MustParsePrefix("10.0.0.0/16")
-	expected := ParseLabelArray(
-		"cidr:0.0.0.0/0",
-		"cidr:10.0.0.0/16",
-		"reserved:world",
-	)
-	lbls := GetCIDRLabels(prefix)
-	lblArray := lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
 
-	option.Config.EnableIPv6 = true
-	option.Config.EnableIPv4 = false
-	// This case is firmly within the cluster range
-	prefix = netip.MustParsePrefix("2001:db8:cafe::cab:4:b0b:0/112")
-	expected = ParseLabelArray(
-		"cidr:0--0/0",
-		"cidr:2001-db8-cafe--0/64",
-		"cidr:2001-db8-cafe-0-cab-4--0/96",
-		"cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
-		"reserved:world",
-	)
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
-	option.Config.EnableIPv4 = true
-}
+	forward()
+	backward()
 
-// TestGetCIDRLabelsInClusterDualStack checks that the cluster label is properly added
-// when getting labels for CIDRs that are equal to or within the cluster range in dual
-// stack mode.
-func (s *LabelsSuite) TestGetCIDRLabelsInClusterDualStack(c *C) {
-	prefix := netip.MustParsePrefix("10.0.0.0/16")
-	expected := ParseLabelArray(
-		"cidr:0.0.0.0/0",
-		"cidr:10.0.0.0/16",
-		"reserved:world-ipv4",
-	)
-	lbls := GetCIDRLabels(prefix)
-	lblArray := lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
+	// Now, verify that the cache is populated correctly doing the opposite.
 
-	// This case is firmly within the cluster range
-	prefix = netip.MustParsePrefix("2001:db8:cafe::cab:4:b0b:0/112")
-	expected = ParseLabelArray(
-		"cidr:0--0/0",
-		"cidr:2001-db8-cafe--0/64",
-		"cidr:2001-db8-cafe-0-cab-4--0/96",
-		"cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
-		"reserved:world-ipv6",
-	)
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, LabelArray{})
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []Label](cidrLabelsCacheMaxSize, nil)
+
+	backward()
+	forward()
 }
 
 func (s *LabelsSuite) TestIPStringToLabel(c *C) {


### PR DESCRIPTION
The previous version of the GetCIDRLabels implementation was computing the set of labels for a CIDR incorrectly in case of a cache hit: https://github.com/cilium/cilium/pull/28465#issuecomment-1777517198

Also, netip.PrefixFrom(...) does not mask the internally stored address, thus lowering the cache hit ratio even if two different CIDRs, used as keys in the LRU cache, are equal in terms of "masked address". (e.g: "1.1.1.1/16" and "1.1.0.0/16").
So, netip.Addr.Prefix(...) is used instead.

After the fix, the performance are roughly equal (but with an increased chance of having a cache hit). To keep the maximum heap usage reasonably low, the cache size is now halved.

Also, the tests are refactored to increase the coverage (checking the labels computation both in case of cache miss and in case of a cache hit).

Finally, the only remaining test using the deprecated checker package is migrated to the testing package from the standard Go library.

Read each commit message for further details and performance comparison.

cc @odinuge @sjdot
