### PR TITLE
bugtool: Collect XFRM error counters twice

### DIFF
--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -81,6 +81,10 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 	var commands []string
 	// Not expecting all of the commands to be available
 	commands = []string{
+		// We want to collect this twice: at the very beginning and at the
+		// very end of the bugtool collection, to see if the counters are
+		// increasing.
+		"cat /proc/net/xfrm_stat",
 		// Host and misc
 		"ps auxfw",
 		"hostname",
@@ -214,6 +218,15 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		commands = append(commands, tcCommands...)
 	}
 
+	// We want to collect this twice: at the very beginning and at the
+	// very end of the bugtool collection, to see if the counters are
+	// increasing.
+	// The commands end up being the names of the files where their output
+	// is stored, so we can't have the two commands be the exact same or the
+	// second would overwrite. To avoid that, we use the -u flag in this second
+	// command; that flag is documented as being ignored.
+	commands = append(commands, "cat -u /proc/net/xfrm_stat")
+
 	return k8sCommands(commands, k8sPods)
 }
 
@@ -269,7 +282,6 @@ func tcInterfaceCommands() ([]string, error) {
 
 func catCommands() []string {
 	files := []string{
-		"/proc/net/xfrm_stat",
 		"/proc/sys/net/core/bpf_jit_enable",
 		"/proc/kallsyms",
 		"/etc/resolv.conf",


### PR DESCRIPTION
This pull request changes the bugtool report to collect the XFRM error counters (i.e., `/proc/net/xfrm_stat`) twice instead of only once. We will collect at the beginning and end of the bugtool collection. In that way, there will be around 5-6 seconds between the two collections and we may see if any counter is currently increasing.

    $ diff cilium-bugtool-cilium-7d54p-20231025-115151/cmd/cat*--proc-net-xfrm_stat.md
    5c5
    < XfrmInStateProtoError   	4
    ---
    > XfrmInStateProtoError   	6

In this example, we can easily see that the `XfrmInStateProtoError` is increasing. That suggests a key rotation issue is currently ongoing (cf. IPsec troubleshooting docs).

I tried other approaches to collect over a longer timespan. That may allow us to see slower increases. They all end up being more complex or messier (we'd need to collect at beginning and end of the sysdump instead). In the end, considering this is already a fallback plan for when customers don't collect Prometheus metrics, I think the current, simpler approach is good enough.

Fixes: https://github.com/cilium/cilium/issues/16538.