### PR TITLE
makefile: fix 'make kind' for mac

### DIFF
--- a/contrib/scripts/kind.sh
+++ b/contrib/scripts/kind.sh
@@ -211,7 +211,7 @@ fi
 # This is required because in case of BPF Host Routing we bypass iptables thus
 # breaking DNS. See https://github.com/cilium/cilium/issues/23330
 # 2) Enable the log plugin to log all DNS queries for debugging.
-NewCoreFile=$(kubectl get cm -n kube-system coredns -o jsonpath='{.data.Corefile}' | "${SED}" 's,forward . /etc/resolv.conf,forward . 8.8.8.8,' | "${SED}" 's/loadbalance/loadbalance\n    log/' | "${SED}" -z 's/\n/\\n/g')
+NewCoreFile=$(kubectl get cm -n kube-system coredns -o jsonpath='{.data.Corefile}' | "${SED}" 's,forward . /etc/resolv.conf,forward . 8.8.8.8,' | "${SED}" 's/loadbalance/loadbalance\n    log/' | awk ' { printf "%s\\n", $0 } ')
 kubectl patch configmap/coredns -n kube-system --type merge -p '{"data":{"Corefile": "'"$NewCoreFile"'"}}'
 
 set +e


### PR DESCRIPTION
'sed -z' is only available for GNU sed and not the pre-installed version on MacOS. Changing to 'awk' as it accomplishes the same desired output and the specified command works on all popular awk distributions.