### PR TITLE
operator: introduce Ingress cell

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md.orig
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md.orig
@@ -37,18 +37,24 @@ cilium-operator-alibabacloud [flags]
   -D, --debug                                                Enable debugging mode
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
+<<<<<<< HEAD
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+=======
       --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
       --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
       --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
+>>>>>>> fb402a5e63 (operator: introduce Ingress cell)
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-metrics                                       Enable Prometheus metrics
-      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+<<<<<<< HEAD
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
+=======
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
+>>>>>>> fb402a5e63 (operator: introduce Ingress cell)
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for cilium-operator-alibabacloud
       --identity-allocation-mode string                      Method to use for identity allocation (default "kvstore")

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -20,9 +20,13 @@ cilium-operator-alibabacloud hive [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive
@@ -30,6 +34,12 @@ cilium-operator-alibabacloud hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -26,15 +26,25 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -42,12 +42,16 @@ cilium-operator-aws [flags]
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-metrics                                       Enable Prometheus metrics
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
       --eni-gc-tags map                                      Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
       --eni-tags map                                         ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
@@ -60,8 +64,13 @@ cilium-operator-aws [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-lb-annotation-prefixes strings               Annotation prefixes for propagating from Ingress to the Load Balancer service (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "eni")
       --k8s-api-server string                                Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -20,9 +20,13 @@ cilium-operator-aws hive [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive
@@ -30,6 +34,12 @@ cilium-operator-aws hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -26,15 +26,25 @@ cilium-operator-aws hive dot-graph [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -41,12 +41,16 @@ cilium-operator-azure [flags]
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-metrics                                       Enable Prometheus metrics
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for cilium-operator-azure
@@ -55,8 +59,13 @@ cilium-operator-azure [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-lb-annotation-prefixes strings               Annotation prefixes for propagating from Ingress to the Load Balancer service (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "azure")
       --k8s-api-server string                                Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -20,9 +20,13 @@ cilium-operator-azure hive [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive
@@ -30,6 +34,12 @@ cilium-operator-azure hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -26,15 +26,25 @@ cilium-operator-azure hive dot-graph [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -37,12 +37,16 @@ cilium-operator-generic [flags]
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-metrics                                       Enable Prometheus metrics
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for cilium-operator-generic
@@ -51,8 +55,13 @@ cilium-operator-generic [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-lb-annotation-prefixes strings               Annotation prefixes for propagating from Ingress to the Load Balancer service (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                                Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -20,9 +20,13 @@ cilium-operator-generic hive [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive
@@ -30,6 +34,12 @@ cilium-operator-generic hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -26,15 +26,25 @@ cilium-operator-generic hive dot-graph [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -47,12 +47,16 @@ cilium-operator [flags]
       --enable-cilium-endpoint-slice                         If set to true, the CiliumEndpointSlice feature is enabled. If any CiliumEndpoints resources are created, updated, or deleted in the cluster, all those changes are broadcast as CiliumEndpointSlice updates to all of the Cilium agents.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-ipv4                                          Enable IPv4 support (default true)
       --enable-ipv6                                          Enable IPv6 support (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
       --enable-metrics                                       Enable Prometheus metrics
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --eni-gc-interval duration                             Interval for garbage collection of unattached ENIs. Set to 0 to disable (default 5m0s)
       --eni-gc-tags map                                      Additional tags attached to ENIs created by Cilium. Dangling ENIs with this tag will be garbage collected
       --eni-tags map                                         ENI tags in the form of k1=v1 (multiple k/v pairs can be passed by repeating the CLI flag)
@@ -65,8 +69,13 @@ cilium-operator [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
       --ingress-default-xff-num-trusted-hops uint32          The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.
-      --ingress-lb-annotation-prefixes strings               Annotation prefixes for propagating from Ingress to the Load Balancer service (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --instance-tags-filter map                             EC2 Instance tags in the form of k1=v1,k2=v2 (multiple k/v pairs can also be passed by repeating the CLI flag
       --ipam string                                          Backend to use for IPAM (default "cluster-pool")
       --k8s-api-server string                                Kubernetes API server URL

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -20,9 +20,13 @@ cilium-operator hive [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
   -h, --help                                                 help for hive
@@ -30,6 +34,12 @@ cilium-operator hive [flags]
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -26,15 +26,25 @@ cilium-operator hive dot-graph [flags]
       --controller-group-metrics strings                     List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --enable-cilium-operator-server-access strings         List of cilium operator APIs which are administratively enabled. Supports '*'. (default [*])
       --enable-gateway-api-secrets-sync                      Enables fan-in TLS secrets sync from multiple namespaces to singular namespace (specified by gateway-api-secrets-namespace flag) (default true)
+      --enable-ingress-controller                            Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.
+      --enable-ingress-proxy-protocol                        Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
+      --enable-ingress-secrets-sync                          Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag) (default true)
       --enable-k8s                                           Enable the k8s clientset (default true)
       --enable-k8s-api-discovery                             Enable discovery of Kubernetes API groups and resources with the discovery API
       --enable-k8s-endpoint-slice                            Enables k8s EndpointSlice feature in Cilium if the k8s cluster supports it (default true)
+      --enforce-ingress-https                                Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. (default true)
       --gateway-api-secrets-namespace string                 Namespace having tls secrets used by CEC for Gateway API (default "cilium-secrets")
       --gops-port uint16                                     Port for gops server to listen on (default 9891)
       --identity-gc-interval duration                        GC interval for security identities (default 15m0s)
       --identity-gc-rate-interval duration                   Interval used for rate limiting the GC of security identities (default 1m0s)
       --identity-gc-rate-limit int                           Maximum number of security identities that will be deleted within the identity-gc-rate-interval (default 2500)
       --identity-heartbeat-timeout duration                  Timeout after which identity expires on lack of heartbeat (default 30m0s)
+      --ingress-default-lb-mode string                       Default loadbalancer mode for Ingress. Applicable values: dedicated, shared (default "dedicated")
+      --ingress-default-secret-name string                   Default secret name for Ingress.
+      --ingress-default-secret-namespace string              Default secret namespace for Ingress.
+      --ingress-lb-annotation-prefixes strings               Annotations which are needed to propagate from Ingress to the Load Balancer. (default [service.beta.kubernetes.io,service.kubernetes.io,cloud.google.com])
+      --ingress-secrets-namespace string                     Namespace having tls secrets used by Ingress and CEC. (default "cilium-secrets")
+      --ingress-shared-lb-service-name string                Name of shared LB service name for Ingress. (default "cilium-ingress")
       --k8s-api-server string                                Kubernetes API server URL
       --k8s-client-burst int                                 Burst value allowed for the K8s client
       --k8s-client-qps float32                               Queries per second limit for the K8s client

--- a/operator/cmd/flags.go
+++ b/operator/cmd/flags.go
@@ -289,9 +289,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(operatorOption.SetCiliumIsUpCondition, true, "Set CiliumIsUp Node condition to mark a Kubernetes Node that a Cilium pod is up and running in that node")
 	option.BindEnv(vp, operatorOption.SetCiliumIsUpCondition)
 
-	flags.StringSlice(operatorOption.IngressLBAnnotationPrefixes, operatorOption.IngressLBAnnotationsDefault, "Annotation prefixes for propagating from Ingress to the Load Balancer service")
-	option.BindEnv(vp, operatorOption.IngressLBAnnotationPrefixes)
-
 	flags.Uint32(operatorOption.IngressDefaultXffNumTrustedHops, 0, "The number of additional ingress proxy hops from the right side of the HTTP header to trust when determining the origin client's IP address.")
 	option.BindEnv(vp, operatorOption.IngressDefaultXffNumTrustedHops)
 

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -204,6 +204,9 @@ var (
 
 			// Cilium Gateway API controller that manages the Gateway API related CRDs.
 			gatewayapi.Cell,
+
+			// Cilium Ingress controller that manages the Kubernetes Ingress related CRDs.
+			ingress.Cell,
 		),
 	)
 
@@ -710,30 +713,6 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 			log.WithError(err).WithField(logfields.LogSubsys, "CCNPWatcher").Fatal(
 				"Cannot connect to Kubernetes apiserver ")
 		}
-	}
-
-	if operatorOption.Config.EnableIngressController {
-		ingressController, err := ingress.NewController(
-			legacy.ctx,
-			legacy.clientset,
-			legacy.resources.IngressClasses,
-			ingress.WithHTTPSEnforced(operatorOption.Config.EnforceIngressHTTPS),
-			ingress.WithProxyProtocol(operatorOption.Config.EnableIngressProxyProtocol),
-			ingress.WithSecretsSyncEnabled(operatorOption.Config.EnableIngressSecretsSync),
-			ingress.WithSecretsNamespace(operatorOption.Config.IngressSecretsNamespace),
-			ingress.WithLBAnnotationPrefixes(operatorOption.Config.IngressLBAnnotationPrefixes),
-			ingress.WithCiliumNamespace(operatorOption.Config.CiliumK8sNamespace),
-			ingress.WithSharedLBServiceName(operatorOption.Config.IngressSharedLBServiceName),
-			ingress.WithDefaultLoadbalancerMode(operatorOption.Config.IngressDefaultLoadbalancerMode),
-			ingress.WithDefaultSecretNamespace(operatorOption.Config.IngressDefaultSecretNamespace),
-			ingress.WithDefaultSecretName(operatorOption.Config.IngressDefaultSecretName),
-			ingress.WithIdleTimeoutSeconds(operatorOption.Config.ProxyIdleTimeoutSeconds),
-		)
-		if err != nil {
-			log.WithError(err).WithField(logfields.LogSubsys, ingress.Subsys).Fatal(
-				"Failed to start ingress controller")
-		}
-		go ingressController.Run(legacy.ctx)
 	}
 
 	if operatorOption.Config.LoadBalancerL7 == "envoy" {

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -241,24 +241,6 @@ const (
 	// LoadBalancerL7Algorithm is a default LB algorithm for services that do not specify related annotation
 	LoadBalancerL7Algorithm = "loadbalancer-l7-algorithm"
 
-	// EnableIngressController enables cilium ingress controller
-	// This must be enabled along with enable-envoy-config in cilium agent.
-	EnableIngressController = "enable-ingress-controller"
-
-	// EnforceIngressHttps enforces https for host having matching TLS host in Ingress.
-	// Incoming traffic to http listener will return 308 http error code with respective location in header.
-	EnforceIngressHttps = "enforce-ingress-https"
-
-	// EnableIngressProxyProtocol enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.
-	EnableIngressProxyProtocol = "enable-ingress-proxy-protocol"
-
-	// EnableIngressSecretsSync enables fan-in TLS secrets from multiple namespaces to singular namespace (specified
-	// by ingress-secrets-namespace flag
-	EnableIngressSecretsSync = "enable-ingress-secrets-sync"
-
-	// IngressSecretsNamespace is the namespace having tls secrets used by Ingress and CEC.
-	IngressSecretsNamespace = "ingress-secrets-namespace"
-
 	// ProxyIdleTimeoutSeconds is the idle timeout for proxy connections to upstream clusters
 	ProxyIdleTimeoutSeconds = "proxy-idle-timeout-seconds"
 
@@ -284,23 +266,6 @@ const (
 	// SetCiliumIsUpCondition sets the CiliumIsUp node condition in Kubernetes
 	// nodes.
 	SetCiliumIsUpCondition = "set-cilium-is-up-condition"
-
-	// IngressLBAnnotationPrefixes are the annotations which are needed to propagate
-	// from Ingress to the Load Balancer
-	IngressLBAnnotationPrefixes = "ingress-lb-annotation-prefixes"
-
-	// IngressSharedLBServiceName is the name of shared LB service name for Ingress.
-	IngressSharedLBServiceName = "ingress-shared-lb-service-name"
-
-	// IngressDefaultLoadbalancerMode is the default loadbalancer mode for Ingress.
-	// Applicable values: dedicated, shared
-	IngressDefaultLoadbalancerMode = "ingress-default-lb-mode"
-
-	// IngressDefaultSecretNamespace is the default secret namespace for Ingress.
-	IngressDefaultSecretNamespace = "ingress-default-secret-namespace"
-
-	// IngressDefaultSecretName is the default secret name for Ingress.
-	IngressDefaultSecretName = "ingress-default-secret-name"
 
 	// IngressDefaultXffNumTrustedHops is the default XffNumTrustedHops value for Ingress.
 	IngressDefaultXffNumTrustedHops = "ingress-default-xff-num-trusted-hops"
@@ -494,23 +459,8 @@ type OperatorConfig struct {
 	// LoadBalancerL7Algorithm is a default LB algorithm for services that do not specify related annotation
 	LoadBalancerL7Algorithm string
 
-	// EnableIngressController enables cilium ingress controller
-	EnableIngressController bool
-
 	// EnableGatewayAPI enables support of Gateway API
 	EnableGatewayAPI bool
-
-	// EnforceIngressHTTPS enforces https if required
-	EnforceIngressHTTPS bool
-
-	// EnableIngressProxyProtocol uses proxy protocol in listeners
-	EnableIngressProxyProtocol bool
-
-	// EnableIngressSecretsSync enables background TLS secret sync for Ingress
-	EnableIngressSecretsSync bool
-
-	// IngressSecretsNamespace is the namespace having tls secrets used by CEC for Ingress.
-	IngressSecretsNamespace string
 
 	// ProxyIdleTimeoutSeconds is the idle timeout for the proxy to upstream cluster
 	ProxyIdleTimeoutSeconds int
@@ -534,26 +484,9 @@ type OperatorConfig struct {
 	// nodes.
 	SetCiliumIsUpCondition bool
 
-	// IngressLBAnnotationPrefixes IngressLBAnnotations are the annotation prefixes,
-	// which are used to filter annotations to propagate from Ingress to the Load Balancer
-	IngressLBAnnotationPrefixes []string
-
-	// IngressSharedLBServiceName is the name of shared LB service name for Ingress.
-	IngressSharedLBServiceName string
-
-	// IngressDefaultLoadbalancerMode is the default loadbalancer mode for Ingress.
-	// Applicable values: dedicated, shared
-	IngressDefaultLoadbalancerMode string
-
-	// IngressDefaultLSecretNamespace is the default secret namespace for Ingress.
-	IngressDefaultSecretNamespace string
-
-	// IngressDefaultLSecretName is the default secret name for Ingress.
-	IngressDefaultSecretName string
-
 	// IngressProxyXffNumTrustedHops The number of additional ingress proxy hops from the right side of the
 	// HTTP header to trust when determining the origin client's IP address.
-	//The default is zero if this option is not specified.
+	// The default is zero if this option is not specified.
 	IngressProxyXffNumTrustedHops uint32
 
 	// PodRestartSelector specify the labels contained in the pod that needs to be restarted before the node can be de-stained
@@ -585,25 +518,15 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.LoadBalancerL7 = vp.GetString(LoadBalancerL7)
 	c.LoadBalancerL7Ports = vp.GetStringSlice(LoadBalancerL7Ports)
 	c.LoadBalancerL7Algorithm = vp.GetString(LoadBalancerL7Algorithm)
-	c.EnableIngressController = vp.GetBool(EnableIngressController)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
-	c.EnforceIngressHTTPS = vp.GetBool(EnforceIngressHttps)
-	c.EnableIngressProxyProtocol = vp.GetBool(EnableIngressProxyProtocol)
-	c.IngressSecretsNamespace = vp.GetString(IngressSecretsNamespace)
 	c.ProxyIdleTimeoutSeconds = vp.GetInt(ProxyIdleTimeoutSeconds)
 	if c.ProxyIdleTimeoutSeconds == 0 {
 		c.ProxyIdleTimeoutSeconds = DefaultProxyIdleTimeoutSeconds
 	}
-	c.EnableIngressSecretsSync = vp.GetBool(EnableIngressSecretsSync)
 	c.CiliumPodLabels = vp.GetString(CiliumPodLabels)
 	c.RemoveCiliumNodeTaints = vp.GetBool(RemoveCiliumNodeTaints)
 	c.SetCiliumNodeTaints = vp.GetBool(SetCiliumNodeTaints)
 	c.SetCiliumIsUpCondition = vp.GetBool(SetCiliumIsUpCondition)
-	c.IngressLBAnnotationPrefixes = vp.GetStringSlice(IngressLBAnnotationPrefixes)
-	c.IngressSharedLBServiceName = vp.GetString(IngressSharedLBServiceName)
-	c.IngressDefaultLoadbalancerMode = vp.GetString(IngressDefaultLoadbalancerMode)
-	c.IngressDefaultSecretNamespace = vp.GetString(IngressDefaultSecretNamespace)
-	c.IngressDefaultSecretName = vp.GetString(IngressDefaultSecretName)
 	c.IngressProxyXffNumTrustedHops = vp.GetUint32(IngressDefaultXffNumTrustedHops)
 	c.PodRestartSelector = vp.GetString(PodRestartSelector)
 

--- a/operator/pkg/ingress/cell.go
+++ b/operator/pkg/ingress/cell.go
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/pflag"
+
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+)
+
+// Cell manages the Kubernetes Ingress related controllers.
+var Cell = cell.Module(
+	"ingress",
+	"Manages the Kubernetes Ingress controllers",
+
+	cell.Config(ingressConfig{
+		EnableIngressController:     false,
+		EnforceIngressHTTPS:         true,
+		EnableIngressProxyProtocol:  false,
+		EnableIngressSecretsSync:    true,
+		IngressSecretsNamespace:     "cilium-secrets",
+		IngressLBAnnotationPrefixes: []string{"service.beta.kubernetes.io", "service.kubernetes.io", "cloud.google.com"},
+		IngressSharedLBServiceName:  "cilium-ingress",
+		IngressDefaultLBMode:        "dedicated",
+	}),
+	cell.Invoke(registerController),
+)
+
+type ingressConfig struct {
+	EnableIngressController       bool
+	EnforceIngressHTTPS           bool
+	EnableIngressProxyProtocol    bool
+	EnableIngressSecretsSync      bool
+	IngressSecretsNamespace       string
+	IngressLBAnnotationPrefixes   []string
+	IngressSharedLBServiceName    string
+	IngressDefaultLBMode          string
+	IngressDefaultSecretNamespace string
+	IngressDefaultSecretName      string
+}
+
+func (r ingressConfig) Flags(flags *pflag.FlagSet) {
+	flags.Bool("enable-ingress-controller", r.EnableIngressController, "Enables cilium ingress controller. This must be enabled along with enable-envoy-config in cilium agent.")
+	flags.Bool("enforce-ingress-https", r.EnforceIngressHTTPS, "Enforces https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header.")
+	flags.Bool("enable-ingress-proxy-protocol", r.EnableIngressProxyProtocol, "Enable proxy protocol for all Ingress listeners. Note that _only_ Proxy protocol traffic will be accepted once this is enabled.")
+	flags.Bool("enable-ingress-secrets-sync", r.EnableIngressSecretsSync, "Enables fan-in TLS secrets from multiple namespaces to singular namespace (specified by ingress-secrets-namespace flag)")
+	flags.String("ingress-secrets-namespace", r.IngressSecretsNamespace, "Namespace having tls secrets used by Ingress and CEC.")
+	flags.StringSlice("ingress-lb-annotation-prefixes", r.IngressLBAnnotationPrefixes, "Annotations which are needed to propagate from Ingress to the Load Balancer.")
+	flags.String("ingress-shared-lb-service-name", r.IngressSharedLBServiceName, "Name of shared LB service name for Ingress.")
+	flags.String("ingress-default-lb-mode", r.IngressDefaultLBMode, "Default loadbalancer mode for Ingress. Applicable values: dedicated, shared")
+	flags.String("ingress-default-secret-namespace", r.IngressDefaultSecretNamespace, "Default secret namespace for Ingress.")
+	flags.String("ingress-default-secret-name", r.IngressDefaultSecretName, "Default secret name for Ingress.")
+}
+
+func registerController(lc hive.Lifecycle, clientset k8sClient.Clientset, resources operatorK8s.Resources, config ingressConfig) error {
+	if !config.EnableIngressController {
+		return nil
+	}
+
+	ingressController, err := NewController(
+		clientset,
+		resources.IngressClasses,
+		WithCiliumNamespace(operatorOption.Config.CiliumK8sNamespace),
+		WithHTTPSEnforced(config.EnforceIngressHTTPS),
+		WithProxyProtocol(config.EnableIngressProxyProtocol),
+		WithSecretsSyncEnabled(config.EnableIngressSecretsSync),
+		WithSecretsNamespace(config.IngressSecretsNamespace),
+		WithLBAnnotationPrefixes(config.IngressLBAnnotationPrefixes),
+		WithSharedLBServiceName(config.IngressSharedLBServiceName),
+		WithDefaultLoadbalancerMode(config.IngressDefaultLBMode),
+		WithDefaultSecretNamespace(config.IngressDefaultSecretNamespace),
+		WithDefaultSecretName(config.IngressDefaultSecretName),
+		WithIdleTimeoutSeconds(operatorOption.Config.ProxyIdleTimeoutSeconds),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create ingress controller: %w", err)
+	}
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	lc.Append(hive.Hook{
+		OnStart: func(_ hive.HookContext) error {
+			go ingressController.Run(ctx)
+			return nil
+		},
+		OnStop: func(hive.HookContext) error {
+			cancelCtx()
+			return nil
+		},
+	})
+
+	return nil
+}

--- a/operator/pkg/ingress/endpoint.go
+++ b/operator/pkg/ingress/endpoint.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -22,7 +21,7 @@ type endpointManager struct {
 	maxRetries int
 }
 
-func newEndpointManager(clientset k8sClient.Clientset, maxRetries int) (*endpointManager, error) {
+func newEndpointManager(clientset k8sClient.Clientset, maxRetries int) *endpointManager {
 	manager := &endpointManager{
 		maxRetries: maxRetries,
 	}
@@ -40,11 +39,7 @@ func newEndpointManager(clientset k8sClient.Clientset, maxRetries int) (*endpoin
 		nil,
 	)
 
-	go manager.informer.Run(wait.NeverStop)
-	if !cache.WaitForCacheSync(wait.NeverStop, manager.informer.HasSynced) {
-		return manager, fmt.Errorf("unable to sync ingress endpoint")
-	}
-	return manager, nil
+	return manager
 }
 
 // getByKey is a wrapper of Store.GetByKey but with concrete Endpoint object

--- a/operator/pkg/ingress/envoy_config.go
+++ b/operator/pkg/ingress/envoy_config.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
@@ -22,7 +21,7 @@ type envoyConfigManager struct {
 	maxRetries int
 }
 
-func newEnvoyConfigManager(clientset k8sClient.Clientset, maxRetries int) (*envoyConfigManager, error) {
+func newEnvoyConfigManager(clientset k8sClient.Clientset, maxRetries int) *envoyConfigManager {
 	manager := &envoyConfigManager{
 		maxRetries: maxRetries,
 	}
@@ -36,11 +35,7 @@ func newEnvoyConfigManager(clientset k8sClient.Clientset, maxRetries int) (*envo
 		nil,
 	)
 
-	go manager.informer.Run(wait.NeverStop)
-	if !cache.WaitForCacheSync(wait.NeverStop, manager.informer.HasSynced) {
-		return manager, fmt.Errorf("unable to sync envoy configs")
-	}
-	return manager, nil
+	return manager
 }
 
 // getByKey is a wrapper of Store.GetByKey but with concrete Endpoint object

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -161,46 +161,46 @@ func NewController(
 		nil,
 	)
 
-	ingressClassManager := newIngressClassManager(ic.queue, ingressClasses)
-	ic.ingressClassManager = ingressClassManager
-
-	serviceManager, err := newServiceManager(clientset, ic.queue, opts.MaxRetries)
-	if err != nil {
-		return nil, err
-	}
-	ic.serviceManager = serviceManager
-
-	endpointManager, err := newEndpointManager(clientset, opts.MaxRetries)
-	if err != nil {
-		return nil, err
-	}
-	ic.endpointManager = endpointManager
-
-	envoyConfigManager, err := newEnvoyConfigManager(clientset, opts.MaxRetries)
-	if err != nil {
-		return nil, err
-	}
-	ic.envoyConfigManager = envoyConfigManager
+	ic.ingressClassManager = newIngressClassManager(ic.queue, ingressClasses)
+	ic.serviceManager = newServiceManager(clientset, ic.queue, opts.MaxRetries)
+	ic.endpointManager = newEndpointManager(clientset, opts.MaxRetries)
+	ic.envoyConfigManager = newEnvoyConfigManager(clientset, opts.MaxRetries)
 
 	ic.secretManager = newNoOpsSecretManager()
 	if ic.enabledSecretsSync {
-		secretManager, err := newSyncSecretsManager(clientset, opts.SecretsNamespace, opts.MaxRetries, ic.defaultSecretNamespace, ic.defaultSecretName)
-		if err != nil {
-			return nil, err
-		}
-		ic.secretManager = secretManager
+		ic.secretManager = newSyncSecretsManager(clientset, opts.SecretsNamespace, opts.MaxRetries, ic.defaultSecretNamespace, ic.defaultSecretName)
 	}
 	ic.sharedLBStatus = ic.retrieveSharedLBServiceStatus()
 
 	return ic, nil
 }
 
-// Run kicks off the controlled loop
+// Run starts the informers and kicks off the controlled loop
 func (ic *Controller) Run(ctx context.Context) error {
 	defer ic.queue.ShutDown()
 
-	go ic.ingressClassManager.Run(ctx)
+	go ic.serviceManager.informer.Run(wait.NeverStop)
+	if !cache.WaitForCacheSync(wait.NeverStop, ic.serviceManager.informer.HasSynced) {
+		return fmt.Errorf("unable to sync service")
+	}
+	log.WithField("existing-services", ic.serviceManager.store.ListKeys()).Debug("services synced")
 
+	go ic.endpointManager.informer.Run(wait.NeverStop)
+	if !cache.WaitForCacheSync(wait.NeverStop, ic.endpointManager.informer.HasSynced) {
+		return fmt.Errorf("unable to sync ingress endpoint")
+	}
+
+	go ic.envoyConfigManager.informer.Run(wait.NeverStop)
+	if !cache.WaitForCacheSync(wait.NeverStop, ic.envoyConfigManager.informer.HasSynced) {
+		return fmt.Errorf("unable to sync envoy configs")
+	}
+
+	go ic.secretManager.RunInformer(wait.NeverStop)
+	if !ic.secretManager.WaitForCacheSync() {
+		return fmt.Errorf("unable to sync secrets")
+	}
+
+	go ic.ingressClassManager.Run(ctx)
 	// This should only return an error if the context is canceled.
 	if err := ic.ingressClassManager.WaitForSync(ctx); err != nil {
 		return err

--- a/operator/pkg/ingress/ingress.go
+++ b/operator/pkg/ingress/ingress.go
@@ -101,7 +101,6 @@ type Controller struct {
 
 // NewController returns a controller for ingress objects having ingressClassName as cilium
 func NewController(
-	ctx context.Context,
 	clientset k8sClient.Clientset,
 	ingressClasses resource.Resource[*slim_networkingv1.IngressClass],
 	options ...Option,
@@ -162,7 +161,7 @@ func NewController(
 		nil,
 	)
 
-	ingressClassManager := newIngressClassManager(ctx, ic.queue, ingressClasses)
+	ingressClassManager := newIngressClassManager(ic.queue, ingressClasses)
 	ic.ingressClassManager = ingressClassManager
 
 	serviceManager, err := newServiceManager(clientset, ic.queue, opts.MaxRetries)

--- a/operator/pkg/ingress/ingress_class_test.go
+++ b/operator/pkg/ingress/ingress_class_test.go
@@ -42,7 +42,7 @@ func Test_ingressClassSyncCanExit(t *testing.T) {
 		t.Fatalf("hive.start failed: %s", err)
 	}
 
-	i := newIngressClassManager(ctx, queue, ingressClasses)
+	i := newIngressClassManager(queue, ingressClasses)
 
 	// Start the ingressClassManager
 	go i.Run(ctx)
@@ -93,7 +93,7 @@ func Test_ingressClassIgnoresNonCilium(t *testing.T) {
 		t.Fatalf("hive.start failed: %s", err)
 	}
 
-	i := newIngressClassManager(ctx, queue, ingressClasses)
+	i := newIngressClassManager(queue, ingressClasses)
 
 	nonCiliumIngressClass := &slim_networkingv1.IngressClass{
 		ObjectMeta: slim_metav1.ObjectMeta{
@@ -506,7 +506,7 @@ func Test_ingressClassHandleEvent(t *testing.T) {
 			t.Fatalf("hive.start failed: %s", err)
 		}
 
-		i := newIngressClassManager(ctx, queue, ingressClasses)
+		i := newIngressClassManager(queue, ingressClasses)
 
 		// Start the class manager
 		go i.Run(ctx)

--- a/operator/pkg/ingress/service.go
+++ b/operator/pkg/ingress/service.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -43,7 +42,7 @@ type serviceManager struct {
 	ingressQueue workqueue.RateLimitingInterface
 }
 
-func newServiceManager(clientset k8sClient.Clientset, ingressQueue workqueue.RateLimitingInterface, maxRetries int) (*serviceManager, error) {
+func newServiceManager(clientset k8sClient.Clientset, ingressQueue workqueue.RateLimitingInterface, maxRetries int) *serviceManager {
 	manager := &serviceManager{
 		queue:        workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		ingressQueue: ingressQueue,
@@ -66,12 +65,7 @@ func newServiceManager(clientset k8sClient.Clientset, ingressQueue workqueue.Rat
 		nil,
 	)
 
-	go manager.informer.Run(wait.NeverStop)
-	if !cache.WaitForCacheSync(wait.NeverStop, manager.informer.HasSynced) {
-		return manager, fmt.Errorf("unable to sync service")
-	}
-	log.WithField("existing-services", manager.store.ListKeys()).Debug("services synced")
-	return manager, nil
+	return manager
 }
 
 // Run kicks off the control loop


### PR DESCRIPTION
This commit moves the Ingress controller registration from the legacyOnLeader cell into its own cell.

In addition, the corresponding config properties have been moved into its own config struct `ingressConfig` where possible.