### PR TITLE
ipsec: Improve `encrypt flush` command

### DIFF
--- a/Documentation/cmdref/cilium-dbg_encrypt_flush.md
+++ b/Documentation/cmdref/cilium-dbg_encrypt_flush.md
@@ -15,6 +15,7 @@ cilium-dbg encrypt flush [flags]
 ### Options
 
 ```
+  -f, --force           Skip confirmation
   -h, --help            help for flush
   -o, --output string   json| yaml| jsonpath='{}'
 ```

--- a/Documentation/cmdref/cilium-dbg_encrypt_flush.md
+++ b/Documentation/cmdref/cilium-dbg_encrypt_flush.md
@@ -15,10 +15,11 @@ cilium-dbg encrypt flush [flags]
 ### Options
 
 ```
-  -f, --force           Skip confirmation
-  -h, --help            help for flush
-  -o, --output string   json| yaml| jsonpath='{}'
-      --spi uint8       Only delete states and policies with this SPI
+  -f, --force            Skip confirmation
+  -h, --help             help for flush
+      --node-id string   Only delete states and policies with this node ID. Decimal or hexadecimal (0x) format. If multiple filters are used, they all apply
+  -o, --output string    json| yaml| jsonpath='{}'
+      --spi uint8        Only delete states and policies with this SPI. If multiple filters are used, they all apply
 ```
 
 ### Options inherited from parent commands

--- a/Documentation/cmdref/cilium-dbg_encrypt_flush.md
+++ b/Documentation/cmdref/cilium-dbg_encrypt_flush.md
@@ -18,6 +18,7 @@ cilium-dbg encrypt flush [flags]
   -f, --force           Skip confirmation
   -h, --help            help for flush
   -o, --output string   json| yaml| jsonpath='{}'
+      --spi uint8       Only delete states and policies with this SPI
 ```
 
 ### Options inherited from parent commands

--- a/cilium-dbg/cmd/encrypt_flush.go
+++ b/cilium-dbg/cmd/encrypt_flush.go
@@ -11,6 +11,12 @@ import (
 
 	"github.com/cilium/cilium/pkg/command"
 	"github.com/cilium/cilium/pkg/common"
+	"github.com/cilium/cilium/pkg/common/ipsec"
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
+)
+
+const (
+	spiFlagName = "spi"
 )
 
 var encryptFlushCmd = &cobra.Command{
@@ -23,7 +29,73 @@ var encryptFlushCmd = &cobra.Command{
 	},
 }
 
+var (
+	spiToFilter uint8
+)
+
 func runXFRMFlush() {
+	if spiToFilter == 0 {
+		flushEverything()
+		return
+	}
+
+	if spiToFilter > linux_defaults.IPsecMaxKeyVersion {
+		Fatalf("Given SPI is too big")
+	}
+
+	states, err := netlink.XfrmStateList(netlink.FAMILY_ALL)
+	if err != nil {
+		Fatalf("Failed to retrieve XFRM states: %s", err)
+	}
+	policies, err := netlink.XfrmPolicyList(netlink.FAMILY_ALL)
+	if err != nil {
+		Fatalf("Failed to retrieve XFRM policies: %s", err)
+	}
+	nbStates := len(states)
+	nbPolicies := len(policies)
+
+	policies, states = filterXFRMBySPI(policies, states)
+	if len(policies) == nbPolicies || len(states) == nbStates {
+		confirmationMsg := "Running this command will delete all XFRM state and/or policies. " +
+			"It will lead to transient connectivity disruption and plain-text pod-to-pod traffic."
+		if !confirmXFRMCleanup(confirmationMsg) {
+			return
+		}
+	}
+
+	for _, state := range states {
+		if err := netlink.XfrmStateDel(&state); err != nil {
+			Fatalf("Stopped XFRM states deletion due to error: %s", err)
+		}
+	}
+	fmt.Printf("Deleted %d XFRM states.\n", len(states))
+	for _, pol := range policies {
+		if err := netlink.XfrmPolicyDel(&pol); err != nil {
+			Fatalf("Stopped XFRM policies deletion due to error: %s", err)
+		}
+	}
+	fmt.Printf("Deleted %d XFRM policies.\n", len(policies))
+}
+
+func filterXFRMBySPI(policies []netlink.XfrmPolicy, states []netlink.XfrmState) ([]netlink.XfrmPolicy, []netlink.XfrmState) {
+	policiesToDel := []netlink.XfrmPolicy{}
+	for _, pol := range policies {
+		if ipsec.GetSPIFromXfrmPolicy(&pol) == spiToFilter {
+			policiesToDel = append(policiesToDel, pol)
+		}
+	}
+
+	statesToDel := []netlink.XfrmState{}
+	for _, state := range states {
+		if state.Spi == int(spiToFilter) {
+			statesToDel = append(statesToDel, state)
+		}
+	}
+
+	return policiesToDel, statesToDel
+}
+
+func flushEverything() {
 	confirmationMsg := "Flushing all XFRM states and policies can lead to transient " +
 		"connectivity interruption and plain-text pod-to-pod traffic."
 	if !confirmXFRMCleanup(confirmationMsg) {
@@ -46,6 +118,7 @@ func confirmXFRMCleanup(msg string) bool {
 
 func init() {
 	encryptFlushCmd.Flags().BoolVarP(&force, forceFlagName, "f", false, "Skip confirmation")
+	encryptFlushCmd.Flags().Uint8Var(&spiToFilter, spiFlagName, 0, "Only delete states and policies with this SPI")
 	CncryptCmd.AddCommand(encryptFlushCmd)
 	command.AddOutputOption(encryptFlushCmd)
 }

--- a/cilium-dbg/cmd/encrypt_flush_test.go
+++ b/cilium-dbg/cmd/encrypt_flush_test.go
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package cmd
+
+import (
+	"net"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
+
+func TestFilterXFRMs(t *testing.T) {
+	policies := []netlink.XfrmPolicy{
+		{Ifid: 1, Proto: netlink.XFRM_PROTO_ESP, Dst: &net.IPNet{IP: net.ParseIP("192.168.1.0"), Mask: net.CIDRMask(24, 32)}},
+		{Ifid: 2, Proto: netlink.XFRM_PROTO_AH, Dst: &net.IPNet{IP: net.ParseIP("192.168.1.0"), Mask: net.CIDRMask(24, 32)}},
+		{Ifid: 3, Proto: netlink.XFRM_PROTO_ESP, Dst: &net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(16, 32)}},
+		{Ifid: 4, Proto: netlink.XFRM_PROTO_AH, Dst: &net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(16, 32)}},
+	}
+	states := []netlink.XfrmState{
+		{Ifid: 1, Proto: netlink.XFRM_PROTO_ESP, Dst: net.ParseIP("192.168.1.0")},
+		{Ifid: 2, Proto: netlink.XFRM_PROTO_AH, Dst: net.ParseIP("192.168.1.0")},
+		{Ifid: 3, Proto: netlink.XFRM_PROTO_ESP, Dst: net.ParseIP("10.0.0.0")},
+		{Ifid: 4, Proto: netlink.XFRM_PROTO_AH, Dst: net.ParseIP("10.0.0.0")},
+	}
+	filterDstPolicy := func(pol netlink.XfrmPolicy) bool {
+		return pol.Dst.IP.String() == "192.168.1.0"
+	}
+	filterDstState := func(state netlink.XfrmState) bool {
+		return state.Dst.String() == "192.168.1.0"
+	}
+	filterProtoPolicy := func(pol netlink.XfrmPolicy) bool {
+		return pol.Proto == netlink.XFRM_PROTO_ESP
+	}
+	filterProtoState := func(state netlink.XfrmState) bool {
+		return state.Proto == netlink.XFRM_PROTO_ESP
+	}
+
+	// Test that single call to filterXFRMs provides the expected results.
+	resPolicies, resStates := filterXFRMs(policies, states, filterDstPolicy, filterDstState)
+	if len(resPolicies) != 2 {
+		t.Errorf("Expected two policies to be filtered, but got %d", len(resPolicies))
+	}
+	if len(resStates) != 2 {
+		t.Errorf("Expected two states to be filtered, but got %d", len(resStates))
+	}
+	if resPolicies[0].Ifid != 1 || resPolicies[1].Ifid != 2 {
+		t.Errorf("Expected policies with Ifids 1 and 2 to be filtered, but got policies with Ifids %d and %d", resPolicies[0].Ifid, resPolicies[1].Ifid)
+	}
+	if resStates[0].Ifid != 1 || resStates[1].Ifid != 2 {
+		t.Errorf("Expected state with Ifids 1 and 2 to be filtered, but got states with Ifids %d and %d", resStates[0].Ifid, resStates[1].Ifid)
+	}
+
+	// Test that chained calls to filterXFRMs also provide the expected results.
+	resPolicies, resStates = filterXFRMs(resPolicies, resStates, filterProtoPolicy, filterProtoState)
+	if len(resPolicies) != 1 {
+		t.Errorf("Expected one policy to be filtered, but got %d", len(resPolicies))
+	}
+	if len(resStates) != 1 {
+		t.Errorf("Expected one state to be filtered, but got %d", len(resStates))
+	}
+	if resPolicies[0].Ifid != 1 {
+		t.Errorf("Expected policies with Ifid 1 to be filtered, but got policies with Ifid %d", resPolicies[0].Ifid)
+	}
+	if resStates[0].Ifid != 1 {
+		t.Errorf("Expected state with Ifid 1 to be filtered, but got states with Ifid %d", resStates[0].Ifid)
+	}
+}

--- a/cilium-dbg/cmd/encrypt_flush_test.go
+++ b/cilium-dbg/cmd/encrypt_flush_test.go
@@ -66,3 +66,37 @@ func TestFilterXFRMs(t *testing.T) {
 		t.Errorf("Expected state with Ifid 1 to be filtered, but got states with Ifid %d", resStates[0].Ifid)
 	}
 }
+
+func TestParseNodeID(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected uint16
+		err      bool
+	}{
+		{"0x0", 0, true},
+		{"42", 42, false},
+		{"0x1a", 26, false},
+		{"65535", 65535, false},
+		{"70000", 0, true}, // Too big for uint16
+		{"invalid", 0, true},
+		{"0xinvalid", 0, true},
+		{"0xdeadbeef", 0, true}, // Too big for uint16
+	}
+
+	for _, test := range tests {
+		result, err := parseNodeID(test.input)
+		if test.err {
+			if err == nil {
+				t.Errorf("Expected error for input %s, but got nil", test.input)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected error for input %s: %v", test.input, err)
+			}
+
+			if result != test.expected {
+				t.Errorf("For input %s, expected %d, but got %d", test.input, test.expected, result)
+			}
+		}
+	}
+}

--- a/pkg/common/ipsec/utils.go
+++ b/pkg/common/ipsec/utils.go
@@ -73,3 +73,10 @@ func GetSPIFromXfrmPolicy(policy *netlink.XfrmPolicy) uint8 {
 func ipSecXfrmMarkGetSPI(markValue uint32) uint8 {
 	return uint8(markValue >> linux_defaults.IPsecXFRMMarkSPIShift & 0xF)
 }
+
+func GetNodeIDFromXfrmMark(mark *netlink.XfrmMark) uint16 {
+	if mark == nil {
+		return 0
+	}
+	return uint16(mark.Value >> 16)
+}

--- a/pkg/common/ipsec/utils.go
+++ b/pkg/common/ipsec/utils.go
@@ -5,6 +5,8 @@ package ipsec
 
 import (
 	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 )
 
 const (
@@ -57,4 +59,17 @@ func CountXfrmPoliciesByDir(states []netlink.XfrmPolicy) (int, int, int) {
 		}
 	}
 	return nbXfrmIn, nbXfrmOut, nbXfrmFwd
+}
+
+func GetSPIFromXfrmPolicy(policy *netlink.XfrmPolicy) uint8 {
+	if policy.Mark == nil {
+		return 0
+	}
+
+	return ipSecXfrmMarkGetSPI(policy.Mark.Value)
+}
+
+// ipSecXfrmMarkGetSPI extracts from a XfrmMark value the encoded SPI
+func ipSecXfrmMarkGetSPI(markValue uint32) uint8 {
+	return uint8(markValue >> linux_defaults.IPsecXFRMMarkSPIShift & 0xF)
 }

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/common/ipsec"
 	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -58,10 +59,6 @@ const (
 	offsetEncKey   = 4
 	offsetIP       = 5
 	maxOffset      = offsetIP
-
-	// ipSecXfrmMarkSPIShift defines how many bits the SPI is shifted when
-	// encoded in a XfrmMark
-	ipSecXfrmMarkSPIShift = 12
 
 	defaultDropPriority      = 100
 	oldXFRMOutPolicyPriority = 50
@@ -505,20 +502,7 @@ func deprioritizeOldOutPolicy(family int) {
 // ipSecXfrmMarkSetSPI takes a XfrmMark base value, an SPI, returns the mark
 // value with the SPI value encoded in it
 func ipSecXfrmMarkSetSPI(markValue uint32, spi uint8) uint32 {
-	return markValue | (uint32(spi) << ipSecXfrmMarkSPIShift)
-}
-
-// ipSecXfrmMarkGetSPI extracts from a XfrmMark value the encoded SPI
-func ipSecXfrmMarkGetSPI(markValue uint32) uint8 {
-	return uint8(markValue >> ipSecXfrmMarkSPIShift & 0xF)
-}
-
-func getSPIFromXfrmPolicy(policy *netlink.XfrmPolicy) uint8 {
-	if policy.Mark == nil {
-		return 0
-	}
-
-	return ipSecXfrmMarkGetSPI(policy.Mark.Value)
+	return markValue | (uint32(spi) << linux_defaults.IPsecXFRMMarkSPIShift)
 }
 
 func getNodeIDFromXfrmMark(mark *netlink.XfrmMark) uint16 {
@@ -1108,7 +1092,7 @@ func deleteStaleXfrmPolicies(reclaimTimestamp time.Time) error {
 
 	errs := resiliency.NewErrorSet("failed to delete stale xfrm policies", len(xfrmPolicyList))
 	for _, p := range xfrmPolicyList {
-		policySPI := getSPIFromXfrmPolicy(&p)
+		policySPI := ipsec.GetSPIFromXfrmPolicy(&p)
 		if !ipSecSPICanBeReclaimed(policySPI, reclaimTimestamp) {
 			continue
 		}

--- a/pkg/datapath/linux/ipsec/ipsec_linux.go
+++ b/pkg/datapath/linux/ipsec/ipsec_linux.go
@@ -505,15 +505,8 @@ func ipSecXfrmMarkSetSPI(markValue uint32, spi uint8) uint32 {
 	return markValue | (uint32(spi) << linux_defaults.IPsecXFRMMarkSPIShift)
 }
 
-func getNodeIDFromXfrmMark(mark *netlink.XfrmMark) uint16 {
-	if mark == nil {
-		return 0
-	}
-	return uint16(mark.Value >> 16)
-}
-
 func getNodeIDAsHexFromXfrmMark(mark *netlink.XfrmMark) string {
-	return fmt.Sprintf("0x%x", getNodeIDFromXfrmMark(mark))
+	return fmt.Sprintf("0x%x", ipsec.GetNodeIDFromXfrmMark(mark))
 }
 
 func getDirFromXfrmMark(mark *netlink.XfrmMark) dir {
@@ -578,7 +571,7 @@ func ipsecDeleteXfrmState(nodeID uint16) error {
 
 	errs := resiliency.NewErrorSet(fmt.Sprintf("failed to delete node (%d) xfrm states", nodeID), len(xfrmStateList))
 	for _, s := range xfrmStateList {
-		if matchesOnNodeID(s.Mark) && getNodeIDFromXfrmMark(s.Mark) == nodeID {
+		if matchesOnNodeID(s.Mark) && ipsec.GetNodeIDFromXfrmMark(s.Mark) == nodeID {
 			if err := netlink.XfrmStateDel(&s); err != nil {
 				errs.Add(fmt.Errorf("failed to delete xfrm state (%s): %w", s.String(), err))
 			}
@@ -600,7 +593,7 @@ func ipsecDeleteXfrmPolicy(nodeID uint16) error {
 	}
 	errs := resiliency.NewErrorSet("failed to delete xfrm policies", len(xfrmPolicyList))
 	for _, p := range xfrmPolicyList {
-		if matchesOnNodeID(p.Mark) && getNodeIDFromXfrmMark(p.Mark) == nodeID {
+		if matchesOnNodeID(p.Mark) && ipsec.GetNodeIDFromXfrmMark(p.Mark) == nodeID {
 			if err := netlink.XfrmPolicyDel(&p); err != nil {
 				errs.Add(fmt.Errorf("unable to delete xfrm policy %s: %w", p.String(), err))
 			}

--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -122,4 +122,8 @@ const (
 
 	// IPsecFwdPriority is the priority of the fwd rules placed by IPsec
 	IPsecFwdPriority = 0x0B9F
+
+	// IPsecXFRMMarkSPIShift defines how many bits the SPI is shifted when
+	// encoded in a XfrmMark
+	IPsecXFRMMarkSPIShift = 12
 )


### PR DESCRIPTION
Add `--spi` and `--node-id` filters to the `cilium-dbg encrypt flush` command. This can be useful to clean leftover, stale XFRM configs during development or sometimes as a quick remediation for certain bugs.