### PR TITLE
Update cilium status command module health output

### DIFF
--- a/daemon/cmd/vitals.go
+++ b/daemon/cmd/vitals.go
@@ -7,13 +7,12 @@ import (
 	"net/http"
 
 	"github.com/go-openapi/runtime/middleware"
-	"k8s.io/apimachinery/pkg/util/duration"
 
 	"github.com/cilium/cilium/api/v1/models"
 	. "github.com/cilium/cilium/api/v1/server/restapi/daemon"
 	"github.com/cilium/cilium/pkg/api"
+	"github.com/cilium/cilium/pkg/health/client"
 	"github.com/cilium/cilium/pkg/hive/cell"
-	"github.com/cilium/cilium/pkg/time"
 )
 
 type getHealth struct {
@@ -59,15 +58,7 @@ func toModuleHealth(m cell.Status) (*models.ModuleHealth, error) {
 		ModuleID:    m.FullModuleID.String(),
 		Message:     string(d),
 		Level:       string(m.Level()),
-		LastOk:      toAgeHuman(m.LastOK),
-		LastUpdated: toAgeHuman(m.LastUpdated),
+		LastOk:      client.ToAgeHuman(m.LastOK),
+		LastUpdated: client.ToAgeHuman(m.LastUpdated),
 	}, nil
-}
-
-func toAgeHuman(t time.Time) string {
-	if t.IsZero() {
-		return "n/a"
-	}
-
-	return duration.HumanDuration(time.Since(t))
 }

--- a/daemon/cmd/vitals_test.go
+++ b/daemon/cmd/vitals_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/cilium/cilium/api/v1/models"
+	"github.com/cilium/cilium/pkg/health/client"
 	"github.com/cilium/cilium/pkg/hive/cell"
 )
 
@@ -62,7 +63,7 @@ func TestVitalsToAgeHuman(t *testing.T) {
 
 	for k := range uu {
 		u := uu[k]
-		assert.Equal(t, u.e, toAgeHuman(u.t))
+		assert.Equal(t, u.e, client.ToAgeHuman(u.t))
 	}
 }
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -1405,7 +1405,7 @@ func (e *Endpoint) startSyncPolicyMapController() {
 	e.controllers.CreateController(ctrlName,
 		controller.ControllerParams{
 			Group:          syncPolicymapControllerGroup,
-			HealthReporter: e.GetReporter("policy map sync"),
+			HealthReporter: e.GetReporter("policymap-sync"),
 			DoFunc: func(ctx context.Context) error {
 				// that the endpoint was disconnected and we
 				// should exit gracefully.

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -710,7 +710,7 @@ func (e *Endpoint) Regenerate(regenMetadata *regeneration.ExternalRegenerationMe
 				e.getLogger().WithError(regenError).Error("endpoint regeneration failed")
 				hr.Degraded("Endpoint regeneration failed", regenError)
 			}
-			hr.OK(("Endpoint regeneration successful"))
+			hr.OK("Endpoint regeneration successful")
 		} else {
 			// This may be unnecessary(?) since 'closing' of the results
 			// channel means that event has been cancelled?

--- a/pkg/health/client/modules.go
+++ b/pkg/health/client/modules.go
@@ -7,9 +7,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/duration"
 
 	"github.com/cilium/cilium/api/v1/client/daemon"
 	"github.com/cilium/cilium/pkg/hive/cell"
+)
+
+const (
+	noPod    = "(/)"
+	rootNode = "agent"
+	noErr    = "<nil>"
 )
 
 // ModulesHealth represent hive modules health API.
@@ -32,17 +42,16 @@ func GetAndFormatModulesHealth(w io.Writer, clt ModulesHealth, verbose bool) {
 		return
 	}
 	if verbose {
-		fmt.Fprintln(w)
+		r := newRoot(rootNode)
 		for _, m := range resp.Payload.Modules {
-			n := &cell.StatusNode{}
-			if err := json.Unmarshal([]byte(m.Message), n); err != nil {
-				panic(err)
-			}
 			if m.Level == string(cell.StatusUnknown) {
 				continue
 			}
-			fmt.Fprintf(w, "%s", n.StringIndent(2))
+			if err := buildTree(r, m.Message); err != nil {
+				fmt.Fprintf(w, "Modules Health rendering failed: %s\n", err)
+			}
 		}
+		fmt.Fprintln(w, "\n"+r.String())
 		return
 	}
 	tally := make(map[cell.Level]int, 4)
@@ -59,4 +68,52 @@ func GetAndFormatModulesHealth(w io.Writer, clt ModulesHealth, verbose bool) {
 		cell.StatusUnknown,
 		tally[cell.StatusUnknown],
 	)
+}
+
+func buildTree(n *node, raw string) error {
+	var sn cell.StatusNode
+	if err := json.Unmarshal([]byte(raw), &sn); err != nil {
+		return err
+	}
+	build(n, &sn)
+	return nil
+}
+
+func ensurePath(n *node, pp []string) *node {
+	current := n
+	for _, p := range pp {
+		if v := current.find(p); v != nil {
+			current = v
+			continue
+		}
+		current = current.addBranch(strings.Replace(p, noPod, "", 1))
+	}
+
+	return current
+}
+
+func build(n *node, sn *cell.StatusNode) {
+	meta := fmt.Sprintf("[%s] %s", strings.ToUpper(string(sn.LastLevel)), sn.Message)
+	if sn.Error != "" {
+		meta += " -- " + sn.Error
+	}
+	meta += fmt.Sprintf(" (%s, x%d)", ToAgeHuman(sn.UpdateTimestamp), sn.Count)
+	pp := strings.Split(sn.Name, ".")
+	current := ensurePath(n, pp)
+	if len(sn.SubStatuses) == 0 {
+		current.meta = meta
+		return
+	}
+	for _, s := range sn.SubStatuses {
+		build(current, s)
+	}
+}
+
+// ToAgeHuman converts time to duration.
+func ToAgeHuman(t time.Time) string {
+	if t.IsZero() {
+		return "n/a"
+	}
+
+	return duration.HumanDuration(time.Since(t))
 }

--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -5,6 +5,7 @@ package client_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -34,9 +35,15 @@ func TestGetAndFormatModulesHealth(t *testing.T) {
 		},
 		"happy-verbose": {
 			h: newTestMHappy(),
-			e: "Modules Health:\n" +
-				"  m1 OK status nominal 2s ago (x0)\n" +
-				"  m2 Degraded doh 20s ago (x0)",
+			e: `Modules Health:
+agent
+├── m1                                                      [OK] status nominal (2s, x0)
+└── a
+    └── b
+        └── c
+            ├── fred                                        [OK] yo (20s, x1)
+            │   └── blee                                    [OK] doh (20s, x1)
+            └── dork                                        [DEGRADED] bozo -- BOOM! (20s, x1)`,
 			v: true,
 		},
 	}
@@ -70,26 +77,79 @@ func newTestMHappy() *testMHappy {
 }
 
 func (m *testMHappy) GetHealth(params *daemon.GetHealthParams, opts ...daemon.ClientOption) (*daemon.GetHealthOK, error) {
-	t := time.Now().Add(-1 * time.Second * 2).Format(time.RFC3339)
-	t2 := time.Now().Add(-1 * time.Second * 20).Format(time.RFC3339)
+	t1, t2 := time.Now().Add(-1*time.Second*2), time.Now().Add(-1*time.Second*20)
 	return &daemon.GetHealthOK{
 		Payload: &models.ModulesHealth{
 			Modules: []*models.ModuleHealth{
 				{
 					ModuleID:    "m1",
 					Level:       string(cell.StatusOK),
-					Message:     fmt.Sprintf("{\"name\": \"m1\", \"level\":\"OK\",\"message\":\"status nominal\", \"timestamp\": %q}", t),
+					Message:     makeSimpleMsg(t1),
 					LastOk:      "3s",
 					LastUpdated: "2s",
 				},
 				{
-					ModuleID:    "m2",
+					ModuleID:    "a.b.c",
 					Level:       string(cell.StatusDegraded),
-					Message:     fmt.Sprintf("{\"name\": \"m2\", \"level\":\"Degraded\",\"message\":\"doh\", \"timestamp\": %q}", t2),
+					Message:     makeComplexMsg(t2),
 					LastOk:      "5m30s",
 					LastUpdated: "20s",
 				},
 			},
 		},
 	}, nil
+}
+
+func makeSimpleMsg(t time.Time) string {
+	s := cell.StatusNode{
+		Name:            "m1",
+		LastLevel:       cell.StatusOK,
+		UpdateTimestamp: t,
+		Message:         "status nominal",
+	}
+
+	bb, _ := json.Marshal(s)
+	return string(bb)
+}
+
+func makeComplexMsg(t time.Time) string {
+	s := cell.StatusNode{
+		Name:      "a.b.c",
+		LastLevel: cell.StatusOK,
+		Count:     1,
+		SubStatuses: []*cell.StatusNode{
+			{
+				Name:      "fred",
+				LastLevel: cell.StatusOK,
+				Count:     1,
+				SubStatuses: []*cell.StatusNode{
+					{
+						Name:            "blee",
+						LastLevel:       cell.StatusOK,
+						Message:         "doh",
+						UpdateTimestamp: t,
+						Count:           1,
+					},
+					{
+						Name:            "fred",
+						LastLevel:       cell.StatusOK,
+						Message:         "yo",
+						UpdateTimestamp: t,
+						Count:           1,
+					},
+				},
+			},
+			{
+				Name:            "dork",
+				LastLevel:       cell.StatusDegraded,
+				Message:         "bozo",
+				Count:           1,
+				Error:           fmt.Errorf("BOOM!").Error(),
+				UpdateTimestamp: t,
+			},
+		},
+	}
+
+	bb, _ := json.Marshal(s)
+	return string(bb)
 }

--- a/pkg/health/client/tree.go
+++ b/pkg/health/client/tree.go
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+const (
+	indentSize              = 3
+	leafMaxWidth            = 40
+	link         decoration = "│"
+	mid          decoration = "├──"
+	end          decoration = "└──"
+)
+
+type decoration string
+
+func newRoot(r string) *node {
+	return &node{val: r}
+}
+
+type node struct {
+	val, meta string
+	parent    *node
+	nodes     []*node
+}
+
+func (n *node) addNode(v string) *node {
+	return n.addNodeWithMeta(v, "")
+}
+
+func (n *node) addNodeWithMeta(v, m string) *node {
+	node := node{
+		parent: n,
+		val:    v,
+		meta:   m,
+	}
+	n.nodes = append(n.nodes, &node)
+
+	return &node
+}
+
+func (n *node) addBranch(v string) *node {
+	return n.addBranchWithMeta(v, "")
+}
+
+func (n *node) addBranchWithMeta(v, m string) *node {
+	b := node{
+		parent: n,
+		meta:   m,
+		val:    v,
+	}
+	n.nodes = append(n.nodes, &b)
+
+	return &b
+}
+
+func (n *node) find(val string) *node {
+	if n.val == val {
+		return n
+	}
+	for _, node := range n.nodes {
+		if node.val == val {
+			return node
+		}
+		if v := node.find(val); v != nil {
+			return v
+		}
+	}
+
+	return nil
+}
+
+func (n *node) asBytes() []byte {
+	w := new(bytes.Buffer)
+	level := 0
+	var levelsEnded []int
+	if n.parent == nil {
+		w.WriteString(n.val)
+		if n.meta != "" {
+			w.WriteString(" " + n.meta)
+		}
+		fmt.Fprintln(w)
+	} else {
+		edge := mid
+		if len(n.nodes) == 0 {
+			edge = end
+			levelsEnded = append(levelsEnded, level)
+		}
+		dumpVals(w, 0, levelsEnded, edge, n)
+	}
+	if len(n.nodes) > 0 {
+		dumpNodes(w, level, levelsEnded, n.nodes)
+	}
+
+	return w.Bytes()
+}
+
+func (n *node) String() string {
+	return string(n.asBytes())
+}
+
+func (n *node) lastNode() *node {
+	c := len(n.nodes)
+	if c == 0 {
+		return nil
+	}
+
+	return n.nodes[c-1]
+}
+
+func dumpNodes(w io.Writer, level int, levelsEnded []int, nodes []*node) {
+	for i, node := range nodes {
+		edge := mid
+		if i == len(nodes)-1 {
+			levelsEnded = append(levelsEnded, level)
+			edge = end
+		}
+		dumpVals(w, level, levelsEnded, edge, node)
+		if len(node.nodes) > 0 {
+			dumpNodes(w, level+1, levelsEnded, node.nodes)
+		}
+	}
+}
+
+func dumpVals(w io.Writer, level int, levelsEnded []int, edge decoration, node *node) {
+	for i := 0; i < level; i++ {
+		if isEnded(levelsEnded, i) {
+			fmt.Fprint(w, strings.Repeat(" ", indentSize+1))
+			continue
+		}
+		fmt.Fprintf(w, "%s%s", link, strings.Repeat(" ", indentSize))
+	}
+
+	val := dumpVal(level, node)
+	if node.meta != "" {
+		c := 4 - level
+		fmt.Fprintf(w, "%s %-"+strconv.Itoa(leafMaxWidth+c*2)+"s%s%s\n", edge, val, strings.Repeat("  ", c), node.meta)
+		return
+	}
+	fmt.Fprintf(w, "%s %s\n", edge, val)
+}
+
+func isEnded(levelsEnded []int, level int) bool {
+	for _, l := range levelsEnded {
+		if l == level {
+			return true
+		}
+	}
+
+	return false
+}
+
+func dumpVal(level int, node *node) string {
+	lines := strings.Split(node.val, "\n")
+	if len(lines) < 2 {
+		return node.val
+	}
+
+	pad := indent(level, node)
+	for i := 1; i < len(lines); i++ {
+		lines[i] = fmt.Sprintf("%s%s", pad, lines[i])
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func indent(level int, node *node) string {
+	links := make([]string, level+1)
+	for node.parent != nil {
+		if isLast(node) {
+			links[level] = strings.Repeat(" ", indentSize+1)
+		} else {
+			links[level] = fmt.Sprintf("%s%s", link, strings.Repeat(" ", indentSize))
+		}
+		level--
+		node = node.parent
+	}
+
+	return strings.Join(links, "")
+}
+
+func isLast(n *node) bool {
+	return n == n.parent.lastNode()
+}

--- a/pkg/health/client/tree_test.go
+++ b/pkg/health/client/tree_test.go
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTreeAddNode(t *testing.T) {
+	r := newRoot("fred")
+	r.addNode("a")
+	b := r.addBranch("b")
+	b.addNode("b1")
+	r.addNode("c")
+	r.addNodeWithMeta("d", "blee")
+
+	assert.Equal(t, "fred\n├── a\n├── b\n│   └── b1\n├── c\n└── d                                                       blee\n", r.String())
+}
+
+func TestTreeAddBranch(t *testing.T) {
+	r := newRoot("fred")
+	r.addBranch("a")
+	b := r.addBranch("b")
+	b1 := b.addBranch("b1")
+	b1.addNode("b1_1")
+	r.addBranch("c")
+	r.addBranchWithMeta("d", "blee")
+
+	assert.Equal(t, "fred\n├── a\n├── b\n│   └── b1\n│       └── b1_1\n├── c\n└── d                                                       blee\n", r.String())
+}
+
+func TestTreeFind(t *testing.T) {
+	r := newRoot("fred")
+	r.addBranch("a")
+	b := r.addBranch("b")
+	b1 := b.addBranch("b1")
+	b11 := b1.addNode("b1_1")
+	c := r.addNode("c")
+	r.addBranchWithMeta("d", "blee")
+
+	uu := map[string]struct {
+		v string
+		e *node
+	}{
+		"none": {
+			v: "bozo",
+		},
+		"leaf": {
+			v: "b1_1",
+			e: b11,
+		},
+		"node": {
+			v: "c",
+			e: c,
+		},
+		"branch": {
+			v: "b1",
+			e: b1,
+		},
+	}
+	for k := range uu {
+		u := uu[k]
+		t.Run(k, func(t *testing.T) {
+			assert.Equal(t, u.e, r.find(u.v))
+		})
+	}
+}

--- a/pkg/hive/cell/structured.go
+++ b/pkg/hive/cell/structured.go
@@ -416,6 +416,7 @@ type StatusNode struct {
 	UpdateTimestamp time.Time     `json:"timestamp"`
 	Count           int           `json:"count"`
 	SubStatuses     []*StatusNode `json:"sub_statuses,omitempty"`
+	Error           string        `json:"error,omitempty"`
 }
 
 var _ Update = (*StatusNode)(nil)
@@ -475,6 +476,9 @@ func (s *subreporterBase) getStatusTreeLocked(nid string) *StatusNode {
 			Name:            rn.name,
 			UpdateTimestamp: rn.Timestamp,
 			Count:           rn.count,
+		}
+		if err := rn.Error; err != nil {
+			n.Error = err.Error()
 		}
 		allok := true
 		childIDs := maps.Keys(children)


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

To date, we render modules health information as tabular data. As modules health instrumentation grows this rendering makes it hard for users to grok the output. This PR proposes changing the rendering of modular health using a tree like structure to give users a better line of sight to gain an understanding of the agent modules health state.

Fixes: #issue-number

```release-note
Changed cilium status CLI output to render the modules health section as a tree structure vs tabular data.
```

Signed-off-by: Fernand Galiana <fernand.galiana@gmail.com> 
