### PR TITLE
dev-doctor command version strings should be array.

### DIFF
--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -213,7 +213,7 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 		&binaryCheck{
 			name:          "kubectl",
 			ifNotFound:    checkWarning,
-			versionArgs:   []string{"version --output=yaml"},
+			versionArgs:   []string{"version", "--output=yaml", "--client=true"},
 			versionRegexp: regexp.MustCompile(`gitVersion: v(\d+\.\d+\.\d+)`),
 			minVersion:    &semver.Version{Major: 1, Minor: 14, Patch: 0},
 			hint:          "See https://kubernetes.io/docs/tasks/tools/#kubectl.",
@@ -221,7 +221,7 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 		&binaryCheck{
 			name:          "cilium",
 			ifNotFound:    checkWarning,
-			versionArgs:   []string{"version --client"},
+			versionArgs:   []string{"version", "--client"},
 			versionRegexp: regexp.MustCompile(`cilium-cli: v(\d+\.\d+\.\d+)`),
 			hint:          "See https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-the-cilium-cli.",
 		},


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

This addresses a couple of things.

1. `make dev-doctor` command version strings need to be array, instead it will return EXIT_FAILURE via `exec.Command`. (this was generated with https://github.com/cilium/cilium/pull/28269, we missed testing `make dev-doctor`.)
2. adding `--client=true` for `kubectl` command. instead of this option, kubectl will try to call kubernetes api server to query server version as well. it is likely that k8s api server is not running at this moment, it returns EXIT_FAILURE.

```bash
root@429a95defccf:/go/src/github.com/cilium/cilium# kubectl version --output=yaml
clientVersion:
  buildDate: "2023-10-18T11:42:52Z"
  compiler: gc
  gitCommit: a8a1abc25cad87333840cd7d54be2efaf31a3177
  gitTreeState: clean
  gitVersion: v1.28.3
  goVersion: go1.20.10
  major: "1"
  minor: "28"
  platform: linux/amd64
kustomizeVersion: v5.0.4-0.20230601165947-6ce0bf390ce3

The connection to the server localhost:8080 was refused - did you specify the right host or port?
```

we do not need to access server to ask the version, so it should be `--client=true` specified instead.

```bash
root@429a95defccf:/go/src/github.com/cilium/cilium# kubectl version --output=yaml --client=true
clientVersion:
  buildDate: "2023-10-18T11:42:52Z"
  compiler: gc
  gitCommit: a8a1abc25cad87333840cd7d54be2efaf31a3177
  gitTreeState: clean
  gitVersion: v1.28.3
  goVersion: go1.20.10
  major: "1"
  minor: "28"
  platform: linux/amd64
kustomizeVersion: v5.0.4-0.20230601165947-6ce0bf390ce3
```
