### PR TITLE
bpf: s/ipcache_lookup*()/lookup_ip*_remote_endpoint()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -331,7 +331,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		return CTX_ACT_OK;
 
 	dst = (union v6addr *) &ip6->daddr;
-	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN, 0);
+	info = lookup_ip6_remote_endpoint(dst, 0);
 
 #ifdef TUNNEL_MODE
 	if (info != NULL && info->tunnel_endpoint != 0) {
@@ -739,7 +739,7 @@ handle_ipv4_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 skip_vtep:
 #endif
 
-	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
+	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 
 #ifdef TUNNEL_MODE
 	if (info != NULL && info->tunnel_endpoint != 0) {

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -70,8 +70,7 @@ static __always_inline int handle_ipv6(struct __ctx_buff *ctx,
 	/* Lookup the source in the ipcache. After decryption this will be the
 	 * inner source IP to get the source security identity.
 	 */
-	info = ipcache_lookup6(&IPCACHE_MAP, (union v6addr *)&ip6->saddr,
-			       V6_CACHE_KEY_LEN, 0);
+	info = lookup_ip6_remote_endpoint((union v6addr *)&ip6->saddr, 0);
 
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
 	if (decrypted) {
@@ -309,7 +308,7 @@ static __always_inline int handle_ipv4(struct __ctx_buff *ctx,
 	/* Lookup the source in the ipcache. After decryption this will be the
 	 * inner source IP to get the source security identity.
 	 */
-	info = ipcache_lookup4(&IPCACHE_MAP, ip4->saddr, V4_CACHE_KEY_LEN, 0);
+	info = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 
 	decrypted = ((ctx->mark & MARK_MAGIC_HOST_MASK) == MARK_MAGIC_DECRYPT);
 	/* If packets are decrypted the key has already been pushed into metadata. */

--- a/bpf/bpf_sock.c
+++ b/bpf/bpf_sock.c
@@ -164,8 +164,7 @@ sock4_skip_xlate(struct lb4_service *svc, __be32 address)
 	    (lb4_svc_is_hostport(svc) && !is_v4_loopback(address))) {
 		struct remote_endpoint_info *info;
 
-		info = ipcache_lookup4(&IPCACHE_MAP, address,
-				       V4_CACHE_KEY_LEN, 0);
+		info = lookup_ip4_remote_endpoint(address, 0);
 		if (!info || info->sec_identity != HOST_ID)
 			return true;
 	}
@@ -195,7 +194,7 @@ sock4_wildcard_lookup(struct lb4_key *key __maybe_unused,
 	if (in_hostns && is_v4_loopback(key->address))
 		goto wildcard_lookup;
 
-	info = ipcache_lookup4(&IPCACHE_MAP, key->address, V4_CACHE_KEY_LEN, 0);
+	info = lookup_ip4_remote_endpoint(key->address, 0);
 	if (info && (info->sec_identity == HOST_ID ||
 		     (include_remote_hosts && identity_is_remote_node(info->sec_identity))))
 		goto wildcard_lookup;
@@ -728,8 +727,7 @@ sock6_skip_xlate(struct lb6_service *svc, const union v6addr *address)
 	    (lb6_svc_is_hostport(svc) && !is_v6_loopback(address))) {
 		struct remote_endpoint_info *info;
 
-		info = ipcache_lookup6(&IPCACHE_MAP, address,
-				       V6_CACHE_KEY_LEN, 0);
+		info = lookup_ip6_remote_endpoint(address, 0);
 		if (!info || info->sec_identity != HOST_ID)
 			return true;
 	}
@@ -759,7 +757,7 @@ sock6_wildcard_lookup(struct lb6_key *key __maybe_unused,
 	if (in_hostns && is_v6_loopback(&key->address))
 		goto wildcard_lookup;
 
-	info = ipcache_lookup6(&IPCACHE_MAP, &key->address, V6_CACHE_KEY_LEN, 0);
+	info = lookup_ip6_remote_endpoint(&key->address, 0);
 	if (info && (info->sec_identity == HOST_ID ||
 		     (include_remote_hosts && identity_is_remote_node(info->sec_identity))))
 		goto wildcard_lookup;

--- a/bpf/lib/egress_gateway.h
+++ b/bpf/lib/egress_gateway.h
@@ -145,7 +145,7 @@ bool egress_gw_reply_needs_redirect(struct iphdr *ip4 __maybe_unused,
 	    egress_policy->gateway_ip == EGRESS_GATEWAY_EXCLUDED_CIDR)
 		return false;
 
-	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
+	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 	if (!info || info->tunnel_endpoint == 0)
 		return false;
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -379,7 +379,7 @@ static __always_inline int encap_geneve_dsr_opt6(struct __ctx_buff *ctx,
 	build_bug_on((sizeof(gopt) % 4) != 0);
 
 	dst = (union v6addr *)&ip6->daddr;
-	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN, 0);
+	info = lookup_ip6_remote_endpoint(dst, 0);
 	if (!info || info->tunnel_endpoint == 0)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
@@ -968,7 +968,7 @@ nodeport_rev_dnat_ingress_ipv6(struct __ctx_buff *ctx, struct trace_ctx *trace,
 			union v6addr *dst = (union v6addr *)&ip6->daddr;
 			struct remote_endpoint_info *info;
 
-			info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN, 0);
+			info = lookup_ip6_remote_endpoint(dst, 0);
 			if (info && info->tunnel_endpoint) {
 				tunnel_endpoint = info->tunnel_endpoint;
 				dst_sec_identity = info->sec_identity;
@@ -1179,7 +1179,7 @@ int tail_nodeport_nat_egress_ipv6(struct __ctx_buff *ctx)
 
 #ifdef TUNNEL_MODE
 	dst = (union v6addr *)&ip6->daddr;
-	info = ipcache_lookup6(&IPCACHE_MAP, dst, V6_CACHE_KEY_LEN, 0);
+	info = lookup_ip6_remote_endpoint(dst, 0);
 	if (info && info->tunnel_endpoint != 0) {
 		tunnel_endpoint = info->tunnel_endpoint;
 		dst_sec_identity = info->sec_identity;
@@ -1879,7 +1879,7 @@ static __always_inline int encap_geneve_dsr_opt4(struct __ctx_buff *ctx, int l3_
 	tunnel_endpoint = ip4->daddr;
 	dst_sec_identity = 0;
 #else
-	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
+	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 	if (!info || info->tunnel_endpoint == 0)
 		return DROP_NO_TUNNEL_ENDPOINT;
 
@@ -2440,7 +2440,7 @@ nodeport_rev_dnat_ingress_ipv4(struct __ctx_buff *ctx, struct trace_ctx *trace,
 		{
 			struct remote_endpoint_info *info;
 
-			info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
+			info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 			if (info && info->tunnel_endpoint) {
 				tunnel_endpoint = info->tunnel_endpoint;
 				dst_sec_identity = info->sec_identity;
@@ -2654,7 +2654,7 @@ int tail_nodeport_nat_egress_ipv4(struct __ctx_buff *ctx)
 	has_l4_header = ipv4_has_l4_header(ip4);
 
 #ifdef TUNNEL_MODE
-	info = ipcache_lookup4(&IPCACHE_MAP, ip4->daddr, V4_CACHE_KEY_LEN, 0);
+	info = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 	if (info && info->tunnel_endpoint != 0) {
 		tunnel_endpoint = info->tunnel_endpoint;
 		dst_sec_identity = info->sec_identity;

--- a/bpf/tests/wildcard_lookup.c
+++ b/bpf/tests/wildcard_lookup.c
@@ -119,7 +119,7 @@ int test_v4_check(__maybe_unused struct xdp_md *ctx)
 	test_init();
 
 	TEST("setup", {
-		info = ipcache_lookup4(&IPCACHE_MAP, bpf_htonl(HOST_IP), V4_CACHE_KEY_LEN, 0);
+		info = lookup_ip4_remote_endpoint(bpf_htonl(HOST_IP), 0);
 		assert(info);
 	});
 
@@ -337,7 +337,7 @@ int test_v6_check(__maybe_unused struct xdp_md *ctx)
 	test_init();
 
 	TEST("setup", {
-		info = ipcache_lookup6(&IPCACHE_MAP, &HOST_IP6, V6_CACHE_KEY_LEN, 0);
+		info = lookup_ip6_remote_endpoint(&HOST_IP6, 0);
 		assert(info);
 	});
 


### PR DESCRIPTION
Consistently use the wrappers to hide some verbose parameters.