### PR TITLE
gh/workflows: Dump Cilium LB node logs in case of failure

### DIFF
--- a/.github/workflows/tests-l4lb.yaml
+++ b/.github/workflows/tests-l4lb.yaml
@@ -123,17 +123,10 @@ jobs:
         run: |
           cd ${{ github.workspace }}/test/nat46x64 && sudo ./test.sh ${{ env.QUAY_ORGANIZATION_DEV }} ${{ steps.vars.outputs.sha }}
 
-      - name: Fetch cilium-sysdump
+      - name: Fetch Cilium Standalone LB logs
         if: ${{ !success() && steps.lb-test.outcome != 'skipped' }}
         run: |
-          sudo cilium sysdump --output-filename cilium-sysdump-out
-
-      - name: Upload cilium-sysdump
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
-        if: ${{ !success() }}
-        with:
-          name: cilium-sysdump-out.zip
-          path: cilium-sysdump-out.zip
+          docker exec -t lb-node docker logs cilium-lb
 
   commit-status-final:
     if: ${{ always() }}


### PR DESCRIPTION
The Cilium standalone LB does not run as a K8s pod, so the regular Cilium's sysdump collection does not work. Instead, just show docker container logs of the LB.

An artificial failure - https://github.com/cilium/cilium/actions/runs/6652618203/job/18076964584.

Suggested-by: Sebastian Wicki <sebastian@isovalent.com>