### PR TITLE
Test upgrade/downgrade to patch release for IPsec

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -75,8 +75,11 @@ jobs:
       fail-fast: false
       max-parallel: 16
       matrix:
+        config: ['5.4', '5.10', 'bpf-next']
+        mode: ['minor', 'patch']
         include:
-          - name: '1'
+          # Define three config sets
+          - config: '5.4'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.4-20231026.065108'
             kube-proxy: 'iptables'
@@ -84,7 +87,7 @@ jobs:
             tunnel: 'disabled'
             encryption: 'ipsec'
 
-          - name: '2'
+          - config: '5.10'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: '5.10-20231026.065108'
             kube-proxy: 'iptables'
@@ -93,7 +96,7 @@ jobs:
             encryption: 'ipsec'
             endpoint-routes: 'true'
 
-          - name: '3'
+          - config: 'bpf-next'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
             kernel: 'bpf-next-20231030.012704'
             kube-proxy: 'iptables'
@@ -101,6 +104,31 @@ jobs:
             tunnel: 'vxlan'
             encryption: 'ipsec'
             endpoint-routes: 'true'
+
+          # Add names to matrix combinations of {config, mode}
+          - config: '5.4'
+            mode: 'minor'
+            name: '1'
+
+          - config: '5.10'
+            mode: 'minor'
+            name: '2'
+
+          - config: 'bpf-next'
+            mode: 'minor'
+            name: '3'
+
+          - config: '5.4'
+            mode: 'patch'
+            name: '4'
+
+          - config: '5.10'
+            mode: 'patch'
+            name: '5'
+
+          - config: 'bpf-next'
+            mode: 'patch'
+            name: '6'
 
     timeout-minutes: 60
     steps:
@@ -122,14 +150,32 @@ jobs:
             SHA="${{ github.sha }}"
           fi
           echo sha=${SHA} >> $GITHUB_OUTPUT
-          CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh)
+          if [ "${{ matrix.mode }}" = "minor" ]; then
+            CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh)
+            IMAGE_TAG=${CILIUM_DOWNGRADE_VERSION}
+          else
+            # Upgrade from / downgrade to patch release.
+            # In some cases we expect to fail to get the version number, do not
+            # fail the workflow in such case. This includes:
+            # - on main branch where we don't have preceeding patch releases
+            # - on stable branches on top of release preparation commits, where
+            #   we bump the patch version number to 90 and we can't easily
+            #   derive the number of the previous patch release version from
+            #   that.
+            CILIUM_DOWNGRADE_VERSION=$(contrib/scripts/print-downgrade-version.sh patch || true)
+            # Pass an empty tag to the cilium-config action to fall back to the
+            # default release image, without crafting an image path with the
+            # "-ci" suffix
+            IMAGE_TAG=''
+          fi
           echo downgrade_version=${CILIUM_DOWNGRADE_VERSION} >> $GITHUB_OUTPUT
+          echo image_tag=${IMAGE_TAG} >> $GITHUB_OUTPUT
 
       - name: Derive stable Cilium installation config
         id: cilium-stable-config
         uses: ./.github/actions/cilium-config
         with:
-          image-tag: ${{ steps.vars.outputs.downgrade_version }}
+          image-tag: ${{ steps.vars.outputs.image_tag }}
           chart-dir: './cilium-${{ steps.vars.outputs.downgrade_version }}/install/kubernetes/cilium/'
           tunnel: ${{ matrix.tunnel }}
           endpoint-routes: ${{ matrix.endpoint-routes }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -173,6 +173,7 @@ jobs:
 
       - name: Derive stable Cilium installation config
         id: cilium-stable-config
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: ./.github/actions/cilium-config
         with:
           image-tag: ${{ steps.vars.outputs.image_tag }}
@@ -192,6 +193,7 @@ jobs:
 
       - name: Derive newest Cilium installation config
         id: cilium-newest-config
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: ./.github/actions/cilium-config
         with:
           image-tag: ${{ steps.vars.outputs.sha }}
@@ -212,12 +214,14 @@ jobs:
       # Warning: since this is a privileged workflow, subsequent workflow job
       # steps must take care not to execute untrusted code.
       - name: Checkout pull request branch (NOT TRUSTED)
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ steps.vars.outputs.sha }}
           persist-credentials: false
 
       - name: Checkout ${{ steps.vars.outputs.downgrade_version }} branch to get the Helm chart
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           path: cilium-${{ steps.vars.outputs.downgrade_version }}
@@ -225,6 +229,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Cilium CLI-cli
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: cilium/cilium-cli@446392499db483906bcc3ade85f023912a79e5ee # v0.15.14
         with:
           release-version: ${{ env.CILIUM_CLI_VERSION }}
@@ -233,6 +238,7 @@ jobs:
           binary-dir: ./
 
       - name: Provision LVH VMs
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
           test-name: ipsec-upgrade
@@ -246,6 +252,7 @@ jobs:
             git config --global --add safe.directory /host
 
       - name: Setup K8s cluster (${{ matrix.name }})
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
           provision: 'false'
@@ -273,6 +280,7 @@ jobs:
           done
 
       - name: Install Cilium ${{ steps.vars.outputs.downgrade_version }} (${{ matrix.name }})
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
           provision: 'false'
@@ -288,6 +296,7 @@ jobs:
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
       - name: Start conn-disrupt-test
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
           provision: 'false'
@@ -300,6 +309,7 @@ jobs:
             ./cilium-cli connectivity test --include-conn-disrupt-test --conn-disrupt-test-setup
 
       - name: Upgrade Cilium & Test (${{ matrix.name }})
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: cilium/cilium/.github/actions/conn-disrupt-test@93f26fd0af7f5bd5832e08b10785ec53d4252b1c
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
@@ -314,6 +324,7 @@ jobs:
             kubectl -n kube-system exec daemonset/cilium -- cilium-dbg status
 
       - name: Downgrade Cilium to ${{ steps.vars.outputs.downgrade_version }} & Test (${{ matrix.name }})
+        if: ${{ steps.vars.outputs.downgrade_version != '' }}
         uses: cilium/cilium/.github/actions/conn-disrupt-test@93f26fd0af7f5bd5832e08b10785ec53d4252b1c
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
@@ -331,7 +342,7 @@ jobs:
             kubectl -n kube-system exec daemonset/cilium -- cilium status
 
       - name: Fetch artifacts
-        if: ${{ !success() }}
+        if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
           provision: 'false'
@@ -345,7 +356,7 @@ jobs:
             head -n -0 /proc/buddyinfo /proc/pagetypeinfo
 
       - name: Upload artifacts
-        if: ${{ !success() }}
+        if: ${{ steps.vars.outputs.downgrade_version != '' && !success() }}
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: cilium-sysdumps
@@ -353,7 +364,7 @@ jobs:
           retention-days: 5
 
       - name: Upload JUnits [junit]
-        if: ${{ always() }}
+        if: ${{ steps.vars.outputs.downgrade_version != '' && always() }}
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: cilium-junits
@@ -361,7 +372,7 @@ jobs:
           retention-days: 2
 
       - name: Publish Test Results As GitHub Summary
-        if: ${{ always() }}
+        if: ${{ steps.vars.outputs.downgrade_version != '' && always() }}
         uses: aanm/junit2md@332ebf0fddd34e91b03a832cfafaa826306558f9 # v0.0.3
         with:
           junit-directory: "cilium-junits"

--- a/contrib/scripts/print-downgrade-version.sh
+++ b/contrib/scripts/print-downgrade-version.sh
@@ -1,15 +1,38 @@
 #!/usr/bin/env bash
 #
-# A utility script to print the branch name of the previous stable release.
+# A utility script to print the branch name of the previous stable or patch
+# release.
+
+set -o errexit
+set -o nounset
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-VERSION="$(cat "$SCRIPT_DIR/../../VERSION")"
-if [[ $VERSION =~ ([0-9^]+)\.([0-9^]+)\..* ]] ; then
+VERSION=${VERSION-"$(cat "$SCRIPT_DIR/../../VERSION")"}
+if [[ $VERSION =~ ([0-9^]+)\.([0-9^]+)\.([0-9^]+).* ]] ; then
     major=${BASH_REMATCH[1]}
     minor=${BASH_REMATCH[2]}
+    patch=${BASH_REMATCH[3]}
+else
+  >&2 echo "ERROR: failed to parse version '$VERSION'"
+  exit 1
+fi
+
+if [[ ${1-} == "patch" ]] ; then
+    # If user passed "patch" as first argument, print the latest patch version
+    case ${patch} in
+        0|90)
+            # Patch release number 90 is used for preparing releases.
+            >&2 echo "ERROR: failed to deduce patch release previous to version '$VERSION'"
+            exit 1
+            ;;
+        *)
+            ((patch--))
+            echo "v${major}.${minor}.${patch}${TAG_SUFFIX:-}"
+            ;;
+    esac
+else
+    # Else print the previous stable version by decrementing the minor version
+    # and trimming the patch version.
     ((minor--))
     echo "v${major}.${minor}${BRANCH_SUFFIX:-}"
-else
-  echo "ERROR: failed to parse version '$VERSION'"
-  exit 1
 fi


### PR DESCRIPTION
- contrib/scripts: Support patch releases in print-downgrade-version.sh
- ci/ipsec: Add upgrade/downgrade tests for patch releases
- ci/ipsec: Skip upgrade/downgrade test to patch release on main branch

Related to
- #14882

Corresponding backport PRs:
- https://github.com/cilium/cilium/pull/28876
- https://github.com/cilium/cilium/pull/29003
- https://github.com/cilium/cilium/pull/29005