### PR TITLE
Config option to set the default IP Pool

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -213,6 +213,7 @@ cilium-agent [flags]
       --ip-masq-agent-config-path string                          ip-masq-agent configuration file path (default "/etc/config/ip-masq-agent")
       --ipam string                                               Backend to use for IPAM (default "cluster-pool")
       --ipam-cilium-node-update-rate duration                     Maximum rate at which the CiliumNode custom resource is updated (default 15s)
+      --ipam-default-ip-pool string                               Name of the default IP Pool when using multi-pool (default "default")
       --ipam-multi-pool-pre-allocation map                        Defines the minimum number of IPs a node should pre-allocate from each pool (default default=8)
       --ipsec-key-file string                                     Path to IPSec key file
       --ipsec-key-rotation-duration duration                      Maximum duration of the IPsec key rotation. The previous key will be removed after that delay. (default 5m0s)

--- a/cilium-health/launch/endpoint.go
+++ b/cilium-health/launch/endpoint.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cilium/cilium/pkg/endpoint/regeneration"
 	"github.com/cilium/cilium/pkg/health/probe"
 	"github.com/cilium/cilium/pkg/identity/cache"
+	"github.com/cilium/cilium/pkg/ipam"
 	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/ipcache"
 	"github.com/cilium/cilium/pkg/labels"
@@ -245,13 +246,13 @@ func LaunchAsEndpoint(baseCtx context.Context,
 
 	if healthIPv6 := node.GetEndpointHealthIPv6(); healthIPv6 != nil {
 		info.Addressing.IPV6 = healthIPv6.String()
-		info.Addressing.IPV6PoolName = ipamOption.PoolDefault
+		info.Addressing.IPV6PoolName = ipam.PoolDefault().String()
 		ip6Address = &net.IPNet{IP: healthIPv6, Mask: defaults.ContainerIPv6Mask}
 		healthIP = healthIPv6
 	}
 	if healthIPv4 := node.GetEndpointHealthIPv4(); healthIPv4 != nil {
 		info.Addressing.IPV4 = healthIPv4.String()
-		info.Addressing.IPV4PoolName = ipamOption.PoolDefault
+		info.Addressing.IPV4PoolName = ipam.PoolDefault().String()
 		ip4Address = &net.IPNet{IP: healthIPv4, Mask: defaults.ContainerIPv4Mask}
 		healthIP = healthIPv4
 	}

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -297,9 +297,13 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 
 	flags.Var(option.NewNamedMapOptions(option.IPAMMultiPoolPreAllocation, &option.Config.IPAMMultiPoolPreAllocation, nil),
 		option.IPAMMultiPoolPreAllocation,
-		fmt.Sprintf("Defines the minimum number of IPs a node should pre-allocate from each pool (default %s)", defaults.IPAMMultiPoolPreAllocation))
-	vp.SetDefault(option.IPAMMultiPoolPreAllocation, defaults.IPAMMultiPoolPreAllocation)
+		fmt.Sprintf("Defines the minimum number of IPs a node should pre-allocate from each pool (default %s=8)", defaults.IPAMDefaultIPPool))
+	vp.SetDefault(option.IPAMMultiPoolPreAllocation, "")
 	option.BindEnv(vp, option.IPAMMultiPoolPreAllocation)
+
+	flags.String(option.IPAMDefaultIPPool, defaults.IPAMDefaultIPPool, "Name of the default IP Pool when using multi-pool")
+	vp.SetDefault(option.IPAMDefaultIPPool, defaults.IPAMDefaultIPPool)
+	option.BindEnv(vp, option.IPAMDefaultIPPool)
 
 	flags.StringSlice(option.ExcludeLocalAddress, []string{}, "Exclude CIDR from being recognized as local address")
 	option.BindEnv(vp, option.ExcludeLocalAddress)

--- a/daemon/cmd/endpoint_test.go
+++ b/daemon/cmd/endpoint_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func getEPTemplate(c *C, d *Daemon) *models.EndpointChangeRequest {
-	ip4, ip6, err := d.ipam.AllocateNext("", "test", ipam.PoolDefault)
+	ip4, ip6, err := d.ipam.AllocateNext("", "test", ipam.PoolDefault())
 	c.Assert(err, Equals, nil)
 	c.Assert(ip4, Not(IsNil))
 	c.Assert(ip6, Not(IsNil))

--- a/daemon/cmd/ipam.go
+++ b/daemon/cmd/ipam.go
@@ -194,7 +194,7 @@ func coalesceCIDRs(rCIDRs []string) (result []string) {
 
 func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerIP net.IP, err error) {
 	// Avoid allocating external IP
-	d.ipam.ExcludeIP(family.PrimaryExternal(), "node-ip", ipam.PoolDefault)
+	d.ipam.ExcludeIP(family.PrimaryExternal(), "node-ip", ipam.PoolDefault())
 
 	// (Re-)allocate the router IP. If not possible, allocate a fresh IP.
 	// In that case, removal and re-creation of the cilium_host is
@@ -203,7 +203,7 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerI
 	var result *ipam.AllocationResult
 	routerIP = family.Router()
 	if routerIP != nil {
-		result, err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, "router", ipam.PoolDefault)
+		result, err = d.ipam.AllocateIPWithoutSyncUpstream(routerIP, "router", ipam.PoolDefault())
 		if err != nil {
 			log.Warn("Router IP could not be re-allocated. Need to re-allocate. This will cause brief network disruption")
 
@@ -218,7 +218,7 @@ func (d *Daemon) allocateDatapathIPs(family types.NodeAddressingFamily) (routerI
 
 	if routerIP == nil {
 		family := ipam.DeriveFamily(family.PrimaryExternal())
-		result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(family, "router", ipam.PoolDefault)
+		result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(family, "router", ipam.PoolDefault())
 		if err != nil {
 			err = fmt.Errorf("Unable to allocate router IP for family %s: %s", family, err)
 			return
@@ -255,7 +255,7 @@ func (d *Daemon) allocateHealthIPs() error {
 	bootstrapStats.healthCheck.Start()
 	if option.Config.EnableHealthChecking && option.Config.EnableEndpointHealthChecking {
 		if option.Config.EnableIPv4 {
-			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "health", ipam.PoolDefault)
+			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "health", ipam.PoolDefault())
 			if err != nil {
 				return fmt.Errorf("unable to allocate health IPs: %s, see https://cilium.link/ipam-range-full", err)
 			}
@@ -283,10 +283,10 @@ func (d *Daemon) allocateHealthIPs() error {
 		}
 
 		if option.Config.EnableIPv6 {
-			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "health", ipam.PoolDefault)
+			result, err := d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "health", ipam.PoolDefault())
 			if err != nil {
 				if healthIPv4 := node.GetEndpointHealthIPv4(); healthIPv4 != nil {
-					d.ipam.ReleaseIP(healthIPv4, ipam.PoolDefault)
+					d.ipam.ReleaseIP(healthIPv4, ipam.PoolDefault())
 					node.SetEndpointHealthIPv4(nil)
 				}
 				return fmt.Errorf("unable to allocate health IPs: %s, see https://cilium.link/ipam-range-full", err)
@@ -318,7 +318,7 @@ func (d *Daemon) allocateIngressIPs() error {
 			// Reallocate the same address as before, if possible
 			ingressIPv4 := node.GetIngressIPv4()
 			if ingressIPv4 != nil {
-				result, err = d.ipam.AllocateIPWithoutSyncUpstream(ingressIPv4, "ingress", ipam.PoolDefault)
+				result, err = d.ipam.AllocateIPWithoutSyncUpstream(ingressIPv4, "ingress", ipam.PoolDefault())
 				if err != nil {
 					log.WithError(err).WithField(logfields.SourceIP, ingressIPv4).Warn("unable to re-allocate ingress IPv4.")
 					result = nil
@@ -328,7 +328,7 @@ func (d *Daemon) allocateIngressIPs() error {
 			// Allocate a fresh IP if not restored, or the reallocation of the restored
 			// IP failed
 			if result == nil {
-				result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "ingress", ipam.PoolDefault)
+				result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv4, "ingress", ipam.PoolDefault())
 				if err != nil {
 					return fmt.Errorf("unable to allocate ingress IPs: %s, see https://cilium.link/ipam-range-full", err)
 				}
@@ -371,7 +371,7 @@ func (d *Daemon) allocateIngressIPs() error {
 			// Reallocate the same address as before, if possible
 			ingressIPv6 := node.GetIngressIPv6()
 			if ingressIPv6 != nil {
-				result, err = d.ipam.AllocateIPWithoutSyncUpstream(ingressIPv6, "ingress", ipam.PoolDefault)
+				result, err = d.ipam.AllocateIPWithoutSyncUpstream(ingressIPv6, "ingress", ipam.PoolDefault())
 				if err != nil {
 					log.WithError(err).WithField(logfields.SourceIP, ingressIPv6).Warn("unable to re-allocate ingress IPv6.")
 					result = nil
@@ -381,10 +381,10 @@ func (d *Daemon) allocateIngressIPs() error {
 			// Allocate a fresh IP if not restored, or the reallocation of the restored
 			// IP failed
 			if result == nil {
-				result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "ingress", ipam.PoolDefault)
+				result, err = d.ipam.AllocateNextFamilyWithoutSyncUpstream(ipam.IPv6, "ingress", ipam.PoolDefault())
 				if err != nil {
 					if ingressIPv4 := node.GetIngressIPv4(); ingressIPv4 != nil {
-						d.ipam.ReleaseIP(ingressIPv4, ipam.PoolDefault)
+						d.ipam.ReleaseIP(ingressIPv4, ipam.PoolDefault())
 						node.SetIngressIPv4(nil)
 					}
 					return fmt.Errorf("unable to allocate ingress IPs: %s, see https://cilium.link/ipam-range-full", err)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -380,9 +380,8 @@ const (
 	// CiliumNode.Spec.IPAM.PreAllocate if no value is set
 	IPAMPreAllocation = 8
 
-	// IPAMMultiPoolPreAllocation is the default value for multi-pool IPAM
-	// pre-allocations
-	IPAMMultiPoolPreAllocation = "default=8"
+	// IPAMDefaultIPPool is the default value for the multi-pool default pool name.
+	IPAMDefaultIPPool = "default"
 
 	// ENIFirstInterfaceIndex is the default value for
 	// CiliumNode.Spec.ENI.FirstInterfaceIndex if no value is set.

--- a/pkg/ipam/allocator.go
+++ b/pkg/ipam/allocator.go
@@ -32,7 +32,7 @@ var (
 
 func (ipam *IPAM) determineIPAMPool(owner string, family Family) (Pool, error) {
 	if ipam.metadata == nil {
-		return PoolDefault, nil
+		return PoolDefault(), nil
 	}
 
 	pool, err := ipam.metadata.GetIPPoolForPod(owner, family)
@@ -117,7 +117,7 @@ func (ipam *IPAM) allocateIP(ip net.IP, owner string, pool Pool, needSyncUpstrea
 	// If the allocator did not populate the pool, we assume it does not
 	// support IPAM pools and assign the default pool instead
 	if result.IPPoolName == "" {
-		result.IPPoolName = PoolDefault
+		result.IPPoolName = PoolDefault()
 	}
 
 	log.WithFields(logrus.Fields{
@@ -171,7 +171,7 @@ func (ipam *IPAM) allocateNextFamily(family Family, owner string, pool Pool, nee
 		// If the allocator did not populate the pool, we assume it does not
 		// support IPAM pools and assign the default pool instead
 		if result.IPPoolName == "" {
-			result.IPPoolName = PoolDefault
+			result.IPPoolName = PoolDefault()
 		}
 
 		if _, ok := ipam.isIPExcluded(result.IP, pool); !ok {
@@ -330,7 +330,7 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 			for ip := range alloc {
 				owner := ipam.getIPOwner(ip, pool)
 				ipPrefix := ""
-				if pool != PoolDefault {
+				if pool != PoolDefault() {
 					ipPrefix = string(pool) + "/"
 				}
 				// If owner is not available, report IP but leave owner empty
@@ -346,7 +346,7 @@ func (ipam *IPAM) Dump() (allocv4 map[string]string, allocv6 map[string]string, 
 			for ip := range alloc {
 				owner := ipam.getIPOwner(ip, pool)
 				ipPrefix := ""
-				if pool != PoolDefault {
+				if pool != PoolDefault() {
 					ipPrefix = string(pool) + "/"
 				}
 				// If owner is not available, report IP but leave owner empty

--- a/pkg/ipam/allocator_test.go
+++ b/pkg/ipam/allocator_test.go
@@ -63,62 +63,62 @@ func (s *IPAMSuite) TestExpirationTimer(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
-	err := ipam.AllocateIP(ip, "foo", PoolDefault)
+	err := ipam.AllocateIP(ip, "foo", PoolDefault())
 	c.Assert(err, IsNil)
 
-	uuid, err := ipam.StartExpirationTimer(ip, PoolDefault, timeout)
+	uuid, err := ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Not(Equals), "")
 	// must fail, already registered
-	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault, timeout)
+	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
 	c.Assert(err, Not(IsNil))
 	c.Assert(uuid, Equals, "")
 	// must fail, already in use
-	err = ipam.AllocateIP(ip, "foo", PoolDefault)
+	err = ipam.AllocateIP(ip, "foo", PoolDefault())
 	c.Assert(err, Not(IsNil))
 	// Let expiration timer expire
 	time.Sleep(2 * timeout)
 	// Must succeed, IP must be released again
-	err = ipam.AllocateIP(ip, "foo", PoolDefault)
+	err = ipam.AllocateIP(ip, "foo", PoolDefault())
 	c.Assert(err, IsNil)
 	// register new expiration timer
-	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault, timeout)
+	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Not(Equals), "")
 	// attempt to stop with an invalid uuid, must fail
-	err = ipam.StopExpirationTimer(ip, PoolDefault, "unknown-uuid")
+	err = ipam.StopExpirationTimer(ip, PoolDefault(), "unknown-uuid")
 	c.Assert(err, Not(IsNil))
 	// stop expiration with valid uuid
-	err = ipam.StopExpirationTimer(ip, PoolDefault, uuid)
+	err = ipam.StopExpirationTimer(ip, PoolDefault(), uuid)
 	c.Assert(err, IsNil)
 	// Let expiration timer expire
 	time.Sleep(2 * timeout)
 	// must fail as IP is properly in use now
-	err = ipam.AllocateIP(ip, "foo", PoolDefault)
+	err = ipam.AllocateIP(ip, "foo", PoolDefault())
 	c.Assert(err, Not(IsNil))
 	// release IP for real
-	err = ipam.ReleaseIP(ip, PoolDefault)
+	err = ipam.ReleaseIP(ip, PoolDefault())
 	c.Assert(err, IsNil)
 
 	// allocate IP again
-	err = ipam.AllocateIP(ip, "foo", PoolDefault)
+	err = ipam.AllocateIP(ip, "foo", PoolDefault())
 	c.Assert(err, IsNil)
 	// register expiration timer
-	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault, timeout)
+	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Not(Equals), "")
 	// release IP, must also stop expiration timer
-	err = ipam.ReleaseIP(ip, PoolDefault)
+	err = ipam.ReleaseIP(ip, PoolDefault())
 	c.Assert(err, IsNil)
 	// allocate same IP again
-	err = ipam.AllocateIP(ip, "foo", PoolDefault)
+	err = ipam.AllocateIP(ip, "foo", PoolDefault())
 	c.Assert(err, IsNil)
 	// register expiration timer must succeed even though stop was never called
-	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault, timeout)
+	uuid, err = ipam.StartExpirationTimer(ip, PoolDefault(), timeout)
 	c.Assert(err, IsNil)
 	c.Assert(uuid, Not(Equals), "")
 	// release IP
-	err = ipam.ReleaseIP(ip, PoolDefault)
+	err = ipam.ReleaseIP(ip, PoolDefault())
 	c.Assert(err, IsNil)
 }
 
@@ -128,47 +128,47 @@ func (s *IPAMSuite) TestAllocateNextWithExpiration(c *C) {
 	fakeAddressing := fake.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
 
-	ipv4, ipv6, err := ipam.AllocateNextWithExpiration("", "foo", PoolDefault, timeout)
+	ipv4, ipv6, err := ipam.AllocateNextWithExpiration("", "foo", PoolDefault(), timeout)
 	c.Assert(err, IsNil)
 
 	// IPv4 address must be in use
-	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault)
+	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
 	c.Assert(err, Not(IsNil))
 	// IPv6 address must be in use
-	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault)
+	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
 	c.Assert(err, Not(IsNil))
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be available again
-	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault)
+	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
 	c.Assert(err, IsNil)
 	// IPv6 address must be available again
-	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault)
+	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
 	c.Assert(err, IsNil)
 	// Release IPs
-	err = ipam.ReleaseIP(ipv4.IP, PoolDefault)
+	err = ipam.ReleaseIP(ipv4.IP, PoolDefault())
 	c.Assert(err, IsNil)
-	err = ipam.ReleaseIP(ipv6.IP, PoolDefault)
+	err = ipam.ReleaseIP(ipv6.IP, PoolDefault())
 	c.Assert(err, IsNil)
 
 	// Allocate IPs again and test stopping the expiration timer
-	ipv4, ipv6, err = ipam.AllocateNextWithExpiration("", "foo", PoolDefault, timeout)
+	ipv4, ipv6, err = ipam.AllocateNextWithExpiration("", "foo", PoolDefault(), timeout)
 	c.Assert(err, IsNil)
 
 	// Stop expiration timer for IPv4 address
-	err = ipam.StopExpirationTimer(ipv4.IP, PoolDefault, ipv4.ExpirationUUID)
+	err = ipam.StopExpirationTimer(ipv4.IP, PoolDefault(), ipv4.ExpirationUUID)
 	c.Assert(err, IsNil)
 
 	// Let expiration timer expire
 	time.Sleep(time.Second)
 	// IPv4 address must be in use
-	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault)
+	err = ipam.AllocateIP(ipv4.IP, "foo", PoolDefault())
 	c.Assert(err, Not(IsNil))
 	// IPv6 address must be available again
-	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault)
+	err = ipam.AllocateIP(ipv6.IP, "foo", PoolDefault())
 	c.Assert(err, IsNil)
 	// Release IPv4 address
-	err = ipam.ReleaseIP(ipv4.IP, PoolDefault)
+	err = ipam.ReleaseIP(ipv4.IP, PoolDefault())
 	c.Assert(err, IsNil)
 }

--- a/pkg/ipam/crd.go
+++ b/pkg/ipam/crd.go
@@ -887,7 +887,7 @@ func (a *crdAllocator) Dump() (map[Pool]map[string]string, string) {
 	}
 
 	status := fmt.Sprintf("%d/%d allocated", len(allocs), a.store.totalPoolSize(a.family))
-	return map[Pool]map[string]string{PoolDefault: allocs}, status
+	return map[Pool]map[string]string{PoolDefault(): allocs}, status
 }
 
 func (a *crdAllocator) Capacity() uint64 {

--- a/pkg/ipam/crd_test.go
+++ b/pkg/ipam/crd_test.go
@@ -106,7 +106,7 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 	// Allocate the first 3 IPs
 	for i := 1; i <= 3; i++ {
 		epipv4 := netip.MustParseAddr(fmt.Sprintf("1.1.1.%d", i))
-		_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), fmt.Sprintf("test%d", i), PoolDefault)
+		_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), fmt.Sprintf("test%d", i), PoolDefault())
 		c.Assert(err, IsNil)
 	}
 
@@ -114,7 +114,7 @@ func (s *IPAMSuite) TestMarkForReleaseNoAllocate(c *C) {
 	cn.Status.IPAM.ReleaseIPs["1.1.1.4"] = ipamOption.IPAMMarkForRelease
 	// Attempts to allocate 1.1.1.4 should fail, since it's already marked for release
 	epipv4 := netip.MustParseAddr("1.1.1.4")
-	_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), "test", PoolDefault)
+	_, err := ipam.IPv4Allocator.Allocate(epipv4.AsSlice(), "test", PoolDefault())
 	c.Assert(err, NotNil)
 	// Call agent's CRD update function. status for 1.1.1.4 should change from marked for release to ready for release
 	sharedNodeStore.updateLocalNodeResource(cn)

--- a/pkg/ipam/hostscope.go
+++ b/pkg/ipam/hostscope.go
@@ -86,7 +86,7 @@ func (h *hostScopeAllocator) Dump() (map[Pool]map[string]string, string) {
 	maxIPs := ip.CountIPsInCIDR(h.allocCIDR)
 	status := fmt.Sprintf("%d/%s allocated from %s", len(alloc), maxIPs.String(), h.allocCIDR.String())
 
-	return map[Pool]map[string]string{PoolDefault: alloc}, status
+	return map[Pool]map[string]string{PoolDefault(): alloc}, status
 }
 
 func (h *hostScopeAllocator) Capacity() uint64 {

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 var (
@@ -210,7 +211,12 @@ func (ipam *IPAM) isIPExcluded(ip net.IP, pool Pool) (string, bool) {
 // PoolOrDefault returns the default pool if no pool is specified.
 func PoolOrDefault(pool string) Pool {
 	if pool == "" {
-		return PoolDefault
+		return PoolDefault()
 	}
 	return Pool(pool)
+}
+
+// PoolDefault returns the default pool
+func PoolDefault() Pool {
+	return Pool(option.Config.IPAMDefaultIPPool)
 }

--- a/pkg/ipam/ipam_test.go
+++ b/pkg/ipam/ipam_test.go
@@ -142,11 +142,11 @@ func (s *IPAMSuite) TestLock(c *C) {
 	ipv6 = ipv6.Next()
 
 	// Forcefully release possible allocated IPs
-	ipam.IPv4Allocator.Release(ipv4.AsSlice(), PoolDefault)
-	ipam.IPv6Allocator.Release(ipv6.AsSlice(), PoolDefault)
+	ipam.IPv4Allocator.Release(ipv4.AsSlice(), PoolDefault())
+	ipam.IPv6Allocator.Release(ipv6.AsSlice(), PoolDefault())
 
 	// Let's allocate the IP first so we can see the tests failing
-	result, err := ipam.IPv4Allocator.Allocate(ipv4.AsSlice(), "test", PoolDefault)
+	result, err := ipam.IPv4Allocator.Allocate(ipv4.AsSlice(), "test", PoolDefault())
 	c.Assert(err, IsNil)
 	c.Assert(result.IP, checker.DeepEquals, net.IP(ipv4.AsSlice()))
 }
@@ -158,22 +158,22 @@ func (s *IPAMSuite) TestExcludeIP(c *C) {
 	ipv4 := fakeIPv4AllocCIDRIP(fakeAddressing)
 	ipv4 = ipv4.Next()
 
-	ipam.ExcludeIP(ipv4.AsSlice(), "test-foo", PoolDefault)
-	err := ipam.AllocateIP(ipv4.AsSlice(), "test-bar", PoolDefault)
+	ipam.ExcludeIP(ipv4.AsSlice(), "test-foo", PoolDefault())
+	err := ipam.AllocateIP(ipv4.AsSlice(), "test-bar", PoolDefault())
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, ".* owned by test-foo")
-	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault)
+	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault())
 	c.Assert(err, IsNil)
 
 	ipv6 := fakeIPv6AllocCIDRIP(fakeAddressing)
 	ipv6 = ipv6.Next()
 
-	ipam.ExcludeIP(ipv6.AsSlice(), "test-foo", PoolDefault)
-	err = ipam.AllocateIP(ipv6.AsSlice(), "test-bar", PoolDefault)
+	ipam.ExcludeIP(ipv6.AsSlice(), "test-foo", PoolDefault())
+	err = ipam.AllocateIP(ipv6.AsSlice(), "test-bar", PoolDefault())
 	c.Assert(err, Not(IsNil))
 	c.Assert(err, ErrorMatches, ".* owned by test-foo")
-	ipam.ReleaseIP(ipv6.AsSlice(), PoolDefault)
-	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault)
+	ipam.ReleaseIP(ipv6.AsSlice(), PoolDefault())
+	err = ipam.ReleaseIP(ipv4.AsSlice(), PoolDefault())
 	c.Assert(err, IsNil)
 }
 
@@ -196,11 +196,11 @@ func (s *IPAMSuite) TestIPAMMetadata(c *C) {
 		"special": "fe00:100::/80",
 	})
 
-	// Without metadata, should always return PoolDefault
+	// Without metadata, should always return PoolDefault()
 	resIPv4, resIPv6, err := ipam.AllocateNext("", "test/some-pod", "")
 	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
 
 	ipam.WithMetadata(fakeMetadataFunc(func(owner string, family Family) (pool string, err error) {
 		// use namespace to determine pool name
@@ -213,7 +213,7 @@ func (s *IPAMSuite) TestIPAMMetadata(c *C) {
 		case "error":
 			return "", fmt.Errorf("unable to determine pool for %s", owner)
 		default:
-			return PoolDefault.String(), nil
+			return PoolDefault().String(), nil
 		}
 	}))
 
@@ -247,8 +247,8 @@ func (s *IPAMSuite) TestIPAMMetadata(c *C) {
 	// Checks if fallback to default works
 	resIPv4, resIPv6, err = ipam.AllocateNext("", "other/special-pod", "")
 	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
 
 	// Checks if metadata errors are propagated
 	_, _, err = ipam.AllocateNext("", "error/special-value", "")
@@ -258,7 +258,7 @@ func (s *IPAMSuite) TestIPAMMetadata(c *C) {
 func (s *IPAMSuite) TestLegacyAllocatorIPAMMetadata(c *C) {
 	// This test uses a regular hostScope allocator which does not support
 	// IPAM pools. We assert that in this scenario, the pool returned in the
-	// AllocationResult is always set to PoolDefault, regardless of the requested
+	// AllocationResult is always set to PoolDefault(), regardless of the requested
 	// pool
 	fakeAddressing := fake.NewNodeAddressing()
 	ipam := NewIPAM(fakeAddressing, &testConfiguration{}, &ownerMock{}, &ownerMock{}, &resourceMock{}, &mtuMock, nil)
@@ -276,29 +276,29 @@ func (s *IPAMSuite) TestLegacyAllocatorIPAMMetadata(c *C) {
 	ipv4 = ipv4.Next()
 	resIPv4, err := ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "override")
 	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
 
 	// AllocateIP with default pool
 	ipv4 = ipv4.Next()
 	resIPv4, err = ipam.AllocateIPWithoutSyncUpstream(ipv4.AsSlice(), "default/specific-ip", "default")
 	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
 
 	// AllocateNext with empty pool
 	resIPv4, resIPv6, err := ipam.AllocateNext("", "test/some-pod", "")
 	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
 
 	// AllocateNext with specific pool
 	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/some-other-pod", "override")
 	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
 
 	// AllocateNext with default pool
 	resIPv4, resIPv6, err = ipam.AllocateNext("", "test/some-other-pod", "default")
 	c.Assert(err, IsNil)
-	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault)
-	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault)
+	c.Assert(resIPv4.IPPoolName, Equals, PoolDefault())
+	c.Assert(resIPv6.IPPoolName, Equals, PoolDefault())
 }

--- a/pkg/ipam/metadata/manager.go
+++ b/pkg/ipam/metadata/manager.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/ipam"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/logging"
@@ -128,7 +127,7 @@ func (m *Manager) GetIPPoolForPod(owner string, family ipam.Family) (pool string
 	if !ok {
 		log.WithField("owner", owner).
 			Debug("IPAM metadata request for invalid pod name, falling back to default pool")
-		return ipamOption.PoolDefault, nil
+		return ipam.PoolDefault().String(), nil
 	}
 
 	// Check annotation on pod
@@ -157,5 +156,5 @@ func (m *Manager) GetIPPoolForPod(owner string, family ipam.Family) (pool string
 	}
 
 	// Fallback to default pool
-	return ipamOption.PoolDefault, nil
+	return ipam.PoolDefault().String(), nil
 }

--- a/pkg/ipam/metadata/manager_test.go
+++ b/pkg/ipam/metadata/manager_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/annotation"
 	"github.com/cilium/cilium/pkg/ipam"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_core_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_meta_v1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/apis/meta/v1"
@@ -139,19 +138,19 @@ func TestManager_GetIPPoolForPod(t *testing.T) {
 			name:     "no annotations",
 			owner:    "default/client",
 			ipfamily: ipam.IPv4,
-			wantPool: ipamOption.PoolDefault,
+			wantPool: ipam.PoolDefault().String(),
 		},
 		{
 			name:     "not a pod name",
 			owner:    "router",
 			ipfamily: ipam.IPv4,
-			wantPool: ipamOption.PoolDefault,
+			wantPool: ipam.PoolDefault().String(),
 		},
 		{
 			name:     "also not a pod name (due to underline)",
 			owner:    "default/xwing_net2",
 			ipfamily: ipam.IPv4,
-			wantPool: ipamOption.PoolDefault,
+			wantPool: ipam.PoolDefault().String(),
 		},
 		{
 			name:     "pod annotation",
@@ -169,7 +168,7 @@ func TestManager_GetIPPoolForPod(t *testing.T) {
 			name:     "pod annotation only ipv4 pool request ipv6",
 			owner:    "default/custom-workload2",
 			ipfamily: ipam.IPv6,
-			wantPool: ipamOption.PoolDefault,
+			wantPool: ipam.PoolDefault().String(),
 		},
 		{
 			name:     "pod annotation ipv4 and custom pool request ipv4",

--- a/pkg/ipam/multipool.go
+++ b/pkg/ipam/multipool.go
@@ -586,7 +586,7 @@ func (m *multiPoolManager) dump(family Family) (allocated map[Pool]map[string]st
 		}
 
 		if poolName == "" {
-			poolName = PoolDefault
+			poolName = PoolDefault()
 		}
 
 		if _, ok := allocated[poolName]; !ok {

--- a/pkg/ipam/multipool_test.go
+++ b/pkg/ipam/multipool_test.go
@@ -287,7 +287,7 @@ func Test_MultiPoolManager(t *testing.T) {
 
 	ipv4Dump, _ := c.dump(IPv4)
 	assert.Len(t, ipv4Dump, 2) // 2 pools: default + mars
-	assert.Len(t, ipv4Dump[PoolDefault], 1)
+	assert.Len(t, ipv4Dump[PoolDefault()], 1)
 	assert.Len(t, ipv4Dump[Pool("mars")], numMarsIPs)
 
 	// Ensure Requested numbers are bumped
@@ -382,7 +382,7 @@ func Test_MultiPoolManager(t *testing.T) {
 
 	ipv4Dump, ipv4Summary := c.dump(IPv4)
 	assert.Equal(t, map[Pool]map[string]string{
-		PoolDefault: {
+		PoolDefault(): {
 			defaultAllocation.IP.String(): "",
 		},
 		Pool("mars"): {

--- a/pkg/ipam/option/option.go
+++ b/pkg/ipam/option/option.go
@@ -46,6 +46,3 @@ const (
 // prefixes. Every /28 prefix contains 16 IP addresses.
 // See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-prefix-eni.html#ec2-prefix-basics for more details
 const ENIPDBlockSizeIPv4 = 16
-
-// PoolDefault is the default IP pool from which to allocate.
-const PoolDefault = "default"

--- a/pkg/ipam/types.go
+++ b/pkg/ipam/types.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cilium/cilium/pkg/cidr"
 	"github.com/cilium/cilium/pkg/datapath/types"
-	ipamOption "github.com/cilium/cilium/pkg/ipam/option"
 	"github.com/cilium/cilium/pkg/lock"
 )
 
@@ -144,7 +143,3 @@ type Pool string
 func (p Pool) String() string {
 	return string(p)
 }
-
-const (
-	PoolDefault Pool = ipamOption.PoolDefault
-)

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -878,6 +878,9 @@ const (
 	// IPAMMultiPoolPreAllocation defines the pre-allocation value for each IPAM pool
 	IPAMMultiPoolPreAllocation = "ipam-multi-pool-pre-allocation"
 
+	// IPAMDefaultIPPool defines the default IP Pool when using multi-pool
+	IPAMDefaultIPPool = "ipam-default-ip-pool"
+
 	// XDPModeNative for loading progs with XDPModeLinkDriver
 	XDPModeNative = "native"
 
@@ -2162,7 +2165,8 @@ type DaemonConfig struct {
 
 	// IPAMMultiPoolPreAllocation defines the pre-allocation value for each IPAM pool
 	IPAMMultiPoolPreAllocation map[string]string
-
+	// IPAMDefaultIPPool the default IP Pool when using multi-pool
+	IPAMDefaultIPPool string
 	// AutoCreateCiliumNodeResource enables automatic creation of a
 	// CiliumNode resource for the local node
 	AutoCreateCiliumNodeResource bool
@@ -2492,6 +2496,7 @@ var (
 		Monitor:                         &models.MonitorStatus{Cpus: int64(runtime.NumCPU()), Npages: 64, Pagesize: int64(os.Getpagesize()), Lost: 0, Unknown: 0},
 		IPv6ClusterAllocCIDR:            defaults.IPv6ClusterAllocCIDR,
 		IPv6ClusterAllocCIDRBase:        defaults.IPv6ClusterAllocCIDRBase,
+		IPAMDefaultIPPool:               defaults.IPAMDefaultIPPool,
 		EnableHostIPRestore:             defaults.EnableHostIPRestore,
 		EnableHealthChecking:            defaults.EnableHealthChecking,
 		EnableEndpointHealthChecking:    defaults.EnableEndpointHealthChecking,
@@ -3153,6 +3158,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.IdentityChangeGracePeriod = vp.GetDuration(IdentityChangeGracePeriod)
 	c.IdentityRestoreGracePeriod = vp.GetDuration(IdentityRestoreGracePeriod)
 	c.IPAM = vp.GetString(IPAM)
+	c.IPAMDefaultIPPool = vp.GetString(IPAMDefaultIPPool)
 	c.IPv4Range = vp.GetString(IPv4Range)
 	c.IPv4NodeAddr = vp.GetString(IPv4NodeAddr)
 	c.IPv4ServiceRange = vp.GetString(IPv4ServiceRange)
@@ -3546,7 +3552,10 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	} else {
 		c.IPAMMultiPoolPreAllocation = m
 	}
-
+	if len(c.IPAMMultiPoolPreAllocation) == 0 {
+		// Default to the same value as IPAMDefaultIPPool
+		c.IPAMMultiPoolPreAllocation = map[string]string{c.IPAMDefaultIPPool: "8"}
+	}
 	c.KubeProxyReplacementHealthzBindAddr = vp.GetString(KubeProxyReplacementHealthzBindAddr)
 
 	// Hubble options.


### PR DESCRIPTION
Config option to customize the default IP Pool when using MultiPool

Fixes: #27131

Please ensure your pull request adheres to the following guidelines:

<!-- Description of change -->

Fixes: #issue-number

```release-note
 Config option to customize the default IP Pool when using MultiPool
```
