### PR TITLE
chore: Use slices package from Go std lib

### DIFF
--- a/pkg/hive/cell/module.go
+++ b/pkg/hive/cell/module.go
@@ -6,11 +6,11 @@ package cell
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 	"go.uber.org/dig"
-	"golang.org/x/exp/slices"
 
 	"github.com/cilium/cilium/pkg/hive/cell/lifecycle"
 	"github.com/cilium/cilium/pkg/logging/logfields"

--- a/pkg/ipalloc/ipalloc.go
+++ b/pkg/ipalloc/ipalloc.go
@@ -10,11 +10,10 @@ import (
 	"fmt"
 	"math/big"
 	"net/netip"
+	"slices"
 	"strings"
 
 	"github.com/cilium/cilium/pkg/lock"
-
-	"golang.org/x/exp/slices"
 )
 
 // Allocator allocates IP addresses, `T` is the type of value associated with the IP.


### PR DESCRIPTION
Follow up to https://github.com/cilium/cilium/pull/28614 / 93012fa1263111528d50c261b9f1ae48503eba99 to fix up a couple `golang.org/x/exp/slices` imports that merged after the above.

Go 1.21 promoted the slices package from the experimental repository ("golang.org/x/exp/slices") to the standard library. The commit updates the import paths in the entire codebase.

See https://go.dev/doc/go1.21#slices for more info about slices package in Go 1.21
