### PR TITLE
[v1.13] Always migrate cilium_calls_* during ELF load

### DIFF
--- a/pkg/bpf/bpffs_migrate.go
+++ b/pkg/bpf/bpffs_migrate.go
@@ -6,7 +6,9 @@ package bpf
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/cilium/ebpf"
 	"github.com/sirupsen/logrus"
@@ -39,7 +41,7 @@ func StartBPFFSMigration(bpffsPath string, coll *ebpf.CollectionSpec) error {
 
 		// Re-pin the map with ':pending' suffix if incoming spec differs from
 		// the currently-pinned map.
-		if err := repinMap(bpffsPath, name, spec); err != nil {
+		if err := RepinMap(bpffsPath, name, spec); err != nil {
 			return err
 		}
 	}
@@ -67,7 +69,7 @@ func FinalizeBPFFSMigration(bpffsPath string, coll *ebpf.CollectionSpec, revert 
 			continue
 		}
 
-		if err := finalizeMap(bpffsPath, name, revert); err != nil {
+		if err := FinalizeMap(bpffsPath, name, revert); err != nil {
 			return err
 		}
 	}
@@ -75,10 +77,10 @@ func FinalizeBPFFSMigration(bpffsPath string, coll *ebpf.CollectionSpec, revert 
 	return nil
 }
 
-// repinMap opens a map from bpffs by its pin in '<bpffs>/tc/globals/',
+// RepinMap opens a map from bpffs by its pin in '<bpffs>/tc/globals/',
 // compares its properties against the incoming spec and re-pins it to
 // ':pending' if any of its properties differ.
-func repinMap(bpffsPath string, name string, spec *ebpf.MapSpec) error {
+func RepinMap(bpffsPath string, name string, spec *ebpf.MapSpec) error {
 	file := filepath.Join(bpffsPath, name)
 	pinned, err := ebpf.LoadPinnedMap(file, nil)
 
@@ -90,21 +92,40 @@ func repinMap(bpffsPath string, name string, spec *ebpf.MapSpec) error {
 	if err != nil {
 		return fmt.Errorf("map not found at path %s: %v", name, err)
 	}
+	defer pinned.Close()
 
 	if pinned.Type() == spec.Type &&
 		pinned.KeySize() == spec.KeySize &&
 		pinned.ValueSize() == spec.ValueSize &&
 		pinned.Flags() == spec.Flags &&
 		pinned.MaxEntries() == spec.MaxEntries {
-		return nil
+		// cilium_calls_xdp is shared between XDP interfaces and should only be
+		// migrated if the existing map is incompatible.
+		if spec.Name == "cilium_calls_xdp" {
+			return nil
+		}
+		// Maps prefixed with cilium_calls_ should never be reused by subsequent ELF
+		// loads and should be migrated unconditionally.
+		if !strings.HasPrefix(spec.Name, "cilium_calls_") {
+			return nil
+		}
 	}
 
 	dest := file + bpffsPending
 
-	log.WithFields(logrus.Fields{logfields.BPFMapName: name, logfields.BPFMapPath: file}).
-		Infof("New version of map has different properties, re-pinning with '%s' suffix", bpffsPending)
+	log.WithFields(logrus.Fields{
+		logfields.BPFMapName: name,
+		logfields.BPFMapPath: file,
+	}).Infof("Re-pinning map with '%s' suffix", bpffsPending)
 
-	// Atomically re-pin the map to the its new path.
+	if err := os.Remove(dest); err == nil {
+		log.WithFields(logrus.Fields{
+			logfields.BPFMapName: name,
+			logfields.BPFMapPath: dest,
+		}).Warn("Removed pending pinned map, did the agent die unexpectedly?")
+	}
+
+	// Atomically re-pin the map to its new path.
 	if err := pinned.Pin(dest); err != nil {
 		return err
 	}
@@ -112,11 +133,11 @@ func repinMap(bpffsPath string, name string, spec *ebpf.MapSpec) error {
 	return nil
 }
 
-// finalizeMap opens the ':pending' Map pin of the given named Map from bpffs.
-// If the given map is not found in bppffs, returns nil.
+// FinalizeMap opens the ':pending' Map pin of the given named Map from bpffs.
+// If the given map is not found in bpffs, returns nil.
 // If revert is true, the map will be re-pinned back to its initial locations.
 // If revert is false, the map will be unpinned.
-func finalizeMap(bpffsPath, name string, revert bool) error {
+func FinalizeMap(bpffsPath, name string, revert bool) error {
 	// Attempt to open a 'pending' Map pin.
 	file := filepath.Join(bpffsPath, name+bpffsPending)
 	pending, err := ebpf.LoadPinnedMap(file, nil)
@@ -135,6 +156,13 @@ func finalizeMap(bpffsPath, name string, revert bool) error {
 		dest := filepath.Join(bpffsPath, name)
 		log.WithFields(logrus.Fields{logfields.BPFMapPath: dest, logfields.BPFMapName: name}).
 			Infof("Repinning without '%s' suffix after failed migration", bpffsPending)
+
+		if err := os.Remove(dest); err == nil {
+			log.WithFields(logrus.Fields{
+				logfields.BPFMapName: name,
+				logfields.BPFMapPath: dest,
+			}).Warn("Removed new pinned map after failed migration")
+		}
 
 		// Atomically re-pin the map to its original path.
 		if err := pending.Pin(dest); err != nil {

--- a/pkg/datapath/loader/loader.go
+++ b/pkg/datapath/loader/loader.go
@@ -185,45 +185,73 @@ func patchHostNetdevDatapath(ep datapath.Endpoint, objPath, dstPath, ifName stri
 	return hostObj.Write(dstPath, opts, strings)
 }
 
-// reloadHostDatapath loads bpf_host programs attached to the host device
-// (usually cilium_host) and the native devices if any. To that end, it
-// uses a single object file, pointed to by objPath, compiled for the host
-// device and patches it with values for native devices if needed.
-// Symbols in objPath have already been substituted with the appropriate values
-// for the host device. Thus, when packing the object file again for the native
-// devices, we don't need to substitute most values (see
-// nullifyStringSubstitutions above).
-// reloadHostDatapath skips native devices that do not exist just before
-// loading. If loading+attaching fails later on however, reloadHostDatapath
-// will return with an error. Failing to load or to attach the host device
-// always results in reloadHostDatapath returning with an error.
+// reloadHostDatapath (re)attaches BPF programs to:
+// - cilium_host: ingress and egress
+// - cilium_net: ingress
+// - native devices: ingress and (optionally) egress if certain features require it
 func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, objPath string) error {
-	nbInterfaces := len(option.Config.GetDevices()) + 2
-	symbols := make([]string, 2, nbInterfaces)
-	directions := make([]string, 2, nbInterfaces)
-	objPaths := make([]string, 2, nbInterfaces)
-	interfaceNames := make([]string, 2, nbInterfaces)
-	symbols[0], symbols[1] = symbolToHostEp, symbolFromHostEp
-	directions[0], directions[1] = dirIngress, dirEgress
-	objPaths[0], objPaths[1] = objPath, objPath
-	interfaceNames[0], interfaceNames[1] = ep.InterfaceName(), ep.InterfaceName()
+	// Warning: here be dragons. There used to be a single loop over
+	// interfaces+objs+progs here from the iproute2 days, but this was never
+	// correct to begin with. Tail call maps were always reused when possible,
+	// causing control flow to transition through invalid states as new tail calls
+	// were sequentially upserted into the array.
+	//
+	// Take care not to call replaceDatapath() twice for a single ELF/interface.
+	// Map migration should only be run once per ELF, otherwise cilium_calls_*
+	// created by prior loads will be unpinned, causing them to be emptied,
+	// missing all tail calls.
 
+	// Replace programs on cilium_host.
+	progs := []progDefinition{
+		{progName: symbolToHostEp, direction: dirIngress},
+		{progName: symbolFromHostEp, direction: dirEgress},
+	}
+	finalize, err := replaceDatapath(ctx, ep.InterfaceName(), objPath, progs, "")
+	if err != nil {
+		scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
+			logfields.Path: objPath,
+			logfields.Veth: ep.InterfaceName(),
+		})
+		// Don't log an error here if the context was canceled or timed out;
+		// this log message should only represent failures with respect to
+		// loading the program.
+		if ctx.Err() == nil {
+			scopedLog.WithError(err).Warningf("JoinEP: Failed to load program for %s", ep.InterfaceName())
+		}
+		return err
+	}
+	// Defer map removal until all interfaces' progs have been replaced.
+	defer finalize()
+
+	// Replace program on cilium_net.
 	if _, err := netlink.LinkByName(defaults.SecondHostDevice); err != nil {
 		log.WithError(err).WithField("device", defaults.SecondHostDevice).Error("Link does not exist")
 		return err
-	} else {
-		interfaceNames = append(interfaceNames, defaults.SecondHostDevice)
-		symbols = append(symbols, symbolToHostEp)
-		directions = append(directions, dirIngress)
-		secondDevObjPath := path.Join(ep.StateDir(), hostEndpointPrefix+"_"+defaults.SecondHostDevice+".o")
-		if err := patchHostNetdevDatapath(ep, objPath, secondDevObjPath, defaults.SecondHostDevice, nil); err != nil {
-			return err
-		}
-		objPaths = append(objPaths, secondDevObjPath)
 	}
 
-	bpfMasqIPv4Addrs := node.GetMasqIPv4AddrsWithDevices()
+	secondDevObjPath := path.Join(ep.StateDir(), hostEndpointPrefix+"_"+defaults.SecondHostDevice+".o")
+	if err := patchHostNetdevDatapath(ep, objPath, secondDevObjPath, defaults.SecondHostDevice, nil); err != nil {
+		return err
+	}
 
+	progs = []progDefinition{
+		{progName: symbolToHostEp, direction: dirIngress},
+	}
+
+	finalize, err = replaceDatapath(ctx, defaults.SecondHostDevice, secondDevObjPath, progs, "")
+	if err != nil {
+		scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
+			logfields.Path: objPath,
+			logfields.Veth: defaults.SecondHostDevice,
+		})
+		if ctx.Err() == nil {
+			scopedLog.WithError(err).Warningf("JoinEP: Failed to load program for %s", defaults.SecondHostDevice)
+		}
+		return err
+	}
+	defer finalize()
+
+	// Replace programs on physical devices.
 	for _, device := range option.Config.GetDevices() {
 		if _, err := netlink.LinkByName(device); err != nil {
 			log.WithError(err).WithField("device", device).Warn("Link does not exist")
@@ -231,19 +259,16 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 		}
 
 		netdevObjPath := path.Join(ep.StateDir(), hostEndpointNetdevPrefix+device+".o")
-		if err := patchHostNetdevDatapath(ep, objPath, netdevObjPath, device, bpfMasqIPv4Addrs); err != nil {
+		if err := patchHostNetdevDatapath(ep, objPath, netdevObjPath, device, node.GetMasqIPv4AddrsWithDevices()); err != nil {
 			return err
 		}
-		objPaths = append(objPaths, netdevObjPath)
 
-		interfaceNames = append(interfaceNames, device)
-		symbols = append(symbols, symbolFromHostNetdevEp)
-		directions = append(directions, dirIngress)
+		progs := []progDefinition{
+			{progName: symbolFromHostNetdevEp, direction: dirIngress},
+		}
+
 		if option.Config.AreDevicesRequired() {
-			interfaceNames = append(interfaceNames, device)
-			symbols = append(symbols, symbolToHostNetdevEp)
-			directions = append(directions, dirEgress)
-			objPaths = append(objPaths, netdevObjPath)
+			progs = append(progs, progDefinition{symbolToHostNetdevEp, dirEgress})
 		} else {
 			// Remove any previously attached device from egress path if BPF
 			// NodePort and host firewall are disabled.
@@ -252,26 +277,18 @@ func (l *Loader) reloadHostDatapath(ctx context.Context, ep datapath.Endpoint, o
 				log.WithField("device", device).Error(err)
 			}
 		}
-	}
 
-	for i, interfaceName := range interfaceNames {
-		symbol := symbols[i]
-		progs := []progDefinition{{progName: symbol, direction: directions[i]}}
-		finalize, err := replaceDatapath(ctx, interfaceName, objPaths[i], progs, "")
+		finalize, err := replaceDatapath(ctx, device, netdevObjPath, progs, "")
 		if err != nil {
 			scopedLog := ep.Logger(Subsystem).WithFields(logrus.Fields{
 				logfields.Path: objPath,
-				logfields.Veth: interfaceName,
+				logfields.Veth: device,
 			})
-			// Don't log an error here if the context was canceled or timed out;
-			// this log message should only represent failures with respect to
-			// loading the program.
 			if ctx.Err() == nil {
-				scopedLog.WithError(err).Warningf("JoinEP: Failed to load program for host endpoint (%s)", symbol)
+				scopedLog.WithError(err).Warningf("JoinEP: Failed to load program for physical device %s", device)
 			}
 			return err
 		}
-		// Defer map removal until all interfaces' progs have been replaced.
 		defer finalize()
 	}
 

--- a/pkg/datapath/loader/netlink.go
+++ b/pkg/datapath/loader/netlink.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/vishvananda/netlink"
@@ -75,7 +76,7 @@ type progDefinition struct {
 // For example, this is the case with from-netdev and to-netdev. If eth0:to-netdev
 // gets its program and maps replaced and unpinned, its eth0:from-netdev counterpart
 // will miss tail calls (and drop packets) until it has been replaced as well.
-func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDefinition, xdpMode string) (func(), error) {
+func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDefinition, xdpMode string) (_ func(), err error) {
 	// Avoid unnecessarily loading a prog.
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -100,6 +101,33 @@ func replaceDatapath(ctx context.Context, ifName, objPath string, progs []progDe
 		if spec.Programs[prog.progName] == nil {
 			return nil, fmt.Errorf("no program %s found in eBPF ELF", prog.progName)
 		}
+	}
+
+	// Unconditionally repin cilium_calls_* maps to prevent them from being
+	// repopulated by the loader.
+	for key, ms := range spec.Maps {
+		if !strings.HasPrefix(ms.Name, "cilium_calls_") {
+			continue
+		}
+
+		if err := bpf.RepinMap(bpf.MapPrefixPath(), key, ms); err != nil {
+			return nil, fmt.Errorf("repinning map %s: %w", key, err)
+		}
+
+		defer func() {
+			revert := false
+			// This captures named return variable err.
+			if err != nil {
+				revert = true
+			}
+
+			if err := bpf.FinalizeMap(bpf.MapPrefixPath(), key, revert); err != nil {
+				l.WithError(err).Error("Could not finalize map")
+			}
+		}()
+
+		// Only one cilium_calls_* per collection, we can stop here.
+		break
 	}
 
 	// Load the CollectionSpec into the kernel, picking up any pinned maps from


### PR DESCRIPTION
Manual backport of https://github.com/cilium/cilium/pull/28740.

Added a bit to init.sh since iproute2 is still used for loading some of the host datapath here.