### PR TITLE
makefile: fix kubectl and cilium check for make dev-doctor

### DIFF
--- a/tools/dev-doctor/rootcmd.go
+++ b/tools/dev-doctor/rootcmd.go
@@ -213,7 +213,7 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 		&binaryCheck{
 			name:          "kubectl",
 			ifNotFound:    checkWarning,
-			versionArgs:   []string{"version --output=yaml"},
+			versionArgs:   []string{"version", "--output=yaml"},
 			versionRegexp: regexp.MustCompile(`gitVersion: v(\d+\.\d+\.\d+)`),
 			minVersion:    &semver.Version{Major: 1, Minor: 14, Patch: 0},
 			hint:          "See https://kubernetes.io/docs/tasks/tools/#kubectl.",
@@ -221,7 +221,7 @@ func rootCmdRun(cmd *cobra.Command, args []string) {
 		&binaryCheck{
 			name:          "cilium",
 			ifNotFound:    checkWarning,
-			versionArgs:   []string{"version --client"},
+			versionArgs:   []string{"version", "--client"},
 			versionRegexp: regexp.MustCompile(`cilium-cli: v(\d+\.\d+\.\d+)`),
 			hint:          "See https://docs.cilium.io/en/stable/gettingstarted/k8s-install-default/#install-the-cilium-cli.",
 		},


### PR DESCRIPTION
An error occurs when running `make dev-doctor` for `kubectl` and `cilium` due to improper argument handling.

Before PR:
```shell
$ make dev-doctor
[...]
failed    kubectl         exit status 1
failed    cilium          exit status 1
[...]
$ echo $?
2
```

After PR:
```shell
$ make dev-doctor
[...]
ok        kubectl         found /opt/homebrew/bin/kubectl, version 1.28.3
ok        cilium          found /usr/local/bin/cilium, version 0.15.11
[...]
$ echo $?
0
```