### PR TITLE
example/connectivity-check: fix port conflict, capture termination log

### DIFF
--- a/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-hostport.yaml
@@ -25,6 +25,7 @@ spec:
         - containerPort: 8080
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -82,6 +83,7 @@ spec:
           hostPort: 40000
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -133,10 +135,11 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "31000"
+          value: "21000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -148,7 +151,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -160,7 +163,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -204,6 +207,7 @@ spec:
           hostPort: 40001
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -255,10 +259,11 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "31002"
+          value: "21002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -270,7 +275,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31002
+            - localhost:21002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -282,7 +287,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31002
+            - localhost:21002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -325,6 +330,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -381,6 +387,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -437,6 +444,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -483,6 +491,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -539,6 +548,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -595,6 +605,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -625,6 +636,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -674,6 +686,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -704,6 +717,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -753,6 +767,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -783,6 +798,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -832,6 +848,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -862,6 +879,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -911,6 +929,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -941,6 +960,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -990,6 +1010,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -1020,6 +1041,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1069,6 +1091,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1135,6 +1158,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1201,6 +1225,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1268,6 +1293,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1335,6 +1361,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1401,6 +1428,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1467,6 +1495,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1533,6 +1562,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:

--- a/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-internal.yaml
@@ -25,6 +25,7 @@ spec:
         - containerPort: 8080
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -82,6 +83,7 @@ spec:
           hostPort: 40000
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -133,10 +135,11 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "31000"
+          value: "21000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -148,7 +151,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -160,7 +163,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -203,6 +206,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -259,6 +263,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -305,6 +310,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -361,6 +367,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -427,6 +434,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -493,6 +501,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -560,6 +569,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -627,6 +637,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -693,6 +704,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:

--- a/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-proxy.yaml
@@ -26,6 +26,7 @@ spec:
           hostPort: 40001
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -77,10 +78,11 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "31002"
+          value: "21002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -92,7 +94,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31002
+            - localhost:21002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -104,7 +106,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31002
+            - localhost:21002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -147,6 +149,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -177,6 +180,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -226,6 +230,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -256,6 +261,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -305,6 +311,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -335,6 +342,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -384,6 +392,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -414,6 +423,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -463,6 +473,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -493,6 +504,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -542,6 +554,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -572,6 +585,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -893,6 +907,7 @@ spec:
         - containerPort: 8080
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -970,6 +985,7 @@ spec:
           hostPort: 40000
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1042,10 +1058,11 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "31000"
+          value: "21000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1057,7 +1074,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1069,7 +1086,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -1133,6 +1150,7 @@ spec:
           hostPort: 40001
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1229,10 +1247,11 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "31002"
+          value: "21002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1244,7 +1263,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31002
+            - localhost:21002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1256,7 +1275,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31002
+            - localhost:21002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-quarantine.yaml
@@ -25,6 +25,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -55,6 +56,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -104,6 +106,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -134,6 +137,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -183,6 +187,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -213,6 +218,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -262,6 +268,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -292,6 +299,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -341,6 +349,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -371,6 +380,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -420,6 +430,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           exec:
             command:
@@ -450,6 +461,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -677,6 +689,7 @@ spec:
         - containerPort: 8080
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -754,6 +767,7 @@ spec:
           hostPort: 40000
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -826,10 +840,11 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "31000"
+          value: "21000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -841,7 +856,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -853,7 +868,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -917,6 +932,7 @@ spec:
           hostPort: 40001
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1013,10 +1029,11 @@ spec:
       - name: echo-c-host-container
         env:
         - name: PORT
-          value: "31002"
+          value: "21002"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -1028,7 +1045,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31002
+            - localhost:21002
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -1040,7 +1057,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31002
+            - localhost:21002
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check-single-node.yaml
@@ -25,6 +25,7 @@ spec:
         - containerPort: 8080
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -82,6 +83,7 @@ spec:
           hostPort: 40000
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -133,10 +135,11 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "31000"
+          value: "21000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -148,7 +151,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -160,7 +163,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -203,6 +206,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -259,6 +263,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -315,6 +320,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -361,6 +367,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -417,6 +424,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -473,6 +481,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:

--- a/examples/kubernetes/connectivity-check/connectivity-check.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-check.yaml
@@ -25,6 +25,7 @@ spec:
         - containerPort: 8080
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -82,6 +83,7 @@ spec:
           hostPort: 40000
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -133,10 +135,11 @@ spec:
       - name: echo-b-host-container
         env:
         - name: PORT
-          value: "31000"
+          value: "21000"
         ports: []
         image: quay.io/cilium/json-mock:v1.3.2@sha256:bc6c46c74efadb135bc996c2467cece6989302371ef4e3f068361460abaf39be
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -148,7 +151,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
         livenessProbe:
           timeoutSeconds: 7
           exec:
@@ -160,7 +163,7 @@ spec:
             - "5"
             - -o
             - /dev/null
-            - localhost:31000
+            - localhost:21000
       affinity:
         podAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -203,6 +206,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -259,6 +263,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -315,6 +320,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -361,6 +367,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -417,6 +424,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -473,6 +481,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -539,6 +548,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -605,6 +615,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -672,6 +683,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -739,6 +751,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:
@@ -805,6 +818,7 @@ spec:
         - /bin/ash
         - -c
         - sleep 1000000000
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:

--- a/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
+++ b/examples/kubernetes/connectivity-check/connectivity-debug-tools.yaml
@@ -26,6 +26,7 @@ spec:
         - -c
         - while true; do dig +noall +question +answer +timeout=1 +tries=1 www.google.com
           && sleep 1 ; done
+        terminationMessagePolicy: FallbackToLogsOnError
         readinessProbe:
           timeoutSeconds: 7
           exec:

--- a/examples/kubernetes/connectivity-check/echo-servers.cue
+++ b/examples/kubernetes/connectivity-check/echo-servers.cue
@@ -33,7 +33,7 @@ deployment: "echo-b": _echoDeployment & {
 }
 // Expose hostport by deploying a host pod and adding a headless service with no port.
 deployment: "echo-b-host": _echoDeploymentWithHostPort & {
-	_serverPort: "31000"
+	_serverPort: "21000"
 	_affinity:   "echo-b"
 
 	metadata: labels: component: "services-check"
@@ -72,7 +72,7 @@ ingressCNP: "echo-c": ingressL7Policy & {}
 // Expose hostport by deploying a host pod and adding a headless service with no port.
 // No ingress policy will apply in this case.
 deployment: "echo-c-host": _echoDeploymentWithHostPort & {
-	_serverPort: "31002"
+	_serverPort: "21002"
 	_affinity:   "echo-c"
 	metadata: labels: component: "proxy-check"
 }

--- a/examples/kubernetes/connectivity-check/resources.cue
+++ b/examples/kubernetes/connectivity-check/resources.cue
@@ -36,6 +36,7 @@ _spec: {
 		ports: [...{
 			_expose: *false | true
 		}]
+		terminationMessagePolicy: "FallbackToLogsOnError"
 	}
 
 	if len(_allowProbe) == 0 {


### PR DESCRIPTION
It was discovered that these containers listen in the NodePort range by default, opening them up to random flakes if there's a NodePort service that happens to be there.

So, move the listening port out of that range.

Also, add a reasonable TerminationMessagePolicy so we can capture error status on exit.

Fixes: #28832