### PR TITLE
operator: introduce cec l7 envoy loadbalancing cell

### DIFF
--- a/Documentation/cmdref/cilium-operator-alibabacloud.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud.md
@@ -79,6 +79,8 @@ cilium-operator-alibabacloud [flags]
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive.md
@@ -46,6 +46,8 @@ cilium-operator-alibabacloud hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-alibabacloud_hive_dot-graph.md
@@ -51,6 +51,8 @@ cilium-operator-alibabacloud hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/Documentation/cmdref/cilium-operator-aws.md
+++ b/Documentation/cmdref/cilium-operator-aws.md
@@ -87,6 +87,8 @@ cilium-operator-aws [flags]
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).

--- a/Documentation/cmdref/cilium-operator-aws_hive.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive.md
@@ -46,6 +46,8 @@ cilium-operator-aws hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-aws_hive_dot-graph.md
@@ -51,6 +51,8 @@ cilium-operator-aws hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/Documentation/cmdref/cilium-operator-azure.md
+++ b/Documentation/cmdref/cilium-operator-azure.md
@@ -82,6 +82,8 @@ cilium-operator-azure [flags]
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).

--- a/Documentation/cmdref/cilium-operator-azure_hive.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive.md
@@ -46,6 +46,8 @@ cilium-operator-azure hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-azure_hive_dot-graph.md
@@ -51,6 +51,8 @@ cilium-operator-azure hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/Documentation/cmdref/cilium-operator-generic.md
+++ b/Documentation/cmdref/cilium-operator-generic.md
@@ -78,6 +78,8 @@ cilium-operator-generic [flags]
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).

--- a/Documentation/cmdref/cilium-operator-generic_hive.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive.md
@@ -46,6 +46,8 @@ cilium-operator-generic hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator-generic_hive_dot-graph.md
@@ -51,6 +51,8 @@ cilium-operator-generic hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/Documentation/cmdref/cilium-operator.md
+++ b/Documentation/cmdref/cilium-operator.md
@@ -92,6 +92,8 @@ cilium-operator [flags]
       --leader-election-retry-period duration                Duration that LeaderElector clients should wait between retries of the actions (default 2s)
       --limit-ipam-api-burst int                             Upper burst limit when accessing external APIs (default 20)
       --limit-ipam-api-qps float                             Queries per second limit when accessing external IPAM APIs (default 4)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --log-driver strings                                   Logging endpoints to use for example syslog
       --log-opt map                                          Log driver options for cilium-operator, configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).

--- a/Documentation/cmdref/cilium-operator_hive.md
+++ b/Documentation/cmdref/cilium-operator_hive.md
@@ -46,6 +46,8 @@ cilium-operator hive [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/Documentation/cmdref/cilium-operator_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-operator_hive_dot-graph.md
@@ -51,6 +51,8 @@ cilium-operator hive dot-graph [flags]
       --k8s-heartbeat-timeout duration                       Configures the timeout for api-server heartbeat, set to 0 to disable (default 30s)
       --k8s-kubeconfig-path string                           Absolute path of the kubernetes kubeconfig file
       --k8s-service-proxy-name string                        Value of K8s service-proxy-name label for which Cilium handles the services (empty = all services without service.kubernetes.io/service-proxy-name label)
+      --loadbalancer-l7-algorithm string                     Default LB algorithm for services that do not specify related annotation (default "round_robin")
+      --loadbalancer-l7-ports strings                        List of service ports that will be automatically redirected to backend.
       --mesh-auth-mutual-enabled                             The flag to enable mutual authentication for the SPIRE server (beta).
       --mesh-auth-spiffe-trust-domain string                 The trust domain for the SPIFFE identity. (default "spiffe.cilium")
       --mesh-auth-spire-agent-socket string                  The path for the SPIRE admin agent Unix socket. (default "/run/spire/sockets/agent/agent.sock")

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -32,6 +32,7 @@ import (
 	operatorMetrics "github.com/cilium/cilium/operator/metrics"
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/operator/pkg/ciliumendpointslice"
+	"github.com/cilium/cilium/operator/pkg/ciliumenvoyconfig"
 	gatewayapi "github.com/cilium/cilium/operator/pkg/gateway-api"
 	"github.com/cilium/cilium/operator/pkg/ingress"
 	"github.com/cilium/cilium/operator/pkg/lbipam"
@@ -207,6 +208,9 @@ var (
 
 			// Cilium Ingress controller that manages the Kubernetes Ingress related CRDs.
 			ingress.Cell,
+
+			// Cilium L7 LoadBalancing with Envoy.
+			ciliumenvoyconfig.Cell,
 		),
 	)
 
@@ -713,15 +717,6 @@ func (legacy *legacyOnLeader) onStart(_ hive.HookContext) error {
 			log.WithError(err).WithField(logfields.LogSubsys, "CCNPWatcher").Fatal(
 				"Cannot connect to Kubernetes apiserver ")
 		}
-	}
-
-	if operatorOption.Config.LoadBalancerL7 == "envoy" {
-		log.Info("Starting Envoy load balancer controller")
-		operatorWatchers.StartCECController(legacy.ctx, legacy.clientset, legacy.resources.Services,
-			operatorOption.Config.LoadBalancerL7Ports,
-			operatorOption.Config.LoadBalancerL7Algorithm,
-			operatorOption.Config.ProxyIdleTimeoutSeconds,
-		)
 	}
 
 	log.Info("Initialization complete")

--- a/operator/option/config.go
+++ b/operator/option/config.go
@@ -235,12 +235,6 @@ const (
 	// LoadBalancerL7 enables loadbalancer capabilities for services via envoy proxy
 	LoadBalancerL7 = "loadbalancer-l7"
 
-	// LoadBalancerL7Ports is a list of service ports that will be automatically redirected to backend.
-	LoadBalancerL7Ports = "loadbalancer-l7-ports"
-
-	// LoadBalancerL7Algorithm is a default LB algorithm for services that do not specify related annotation
-	LoadBalancerL7Algorithm = "loadbalancer-l7-algorithm"
-
 	// ProxyIdleTimeoutSeconds is the idle timeout for proxy connections to upstream clusters
 	ProxyIdleTimeoutSeconds = "proxy-idle-timeout-seconds"
 
@@ -453,12 +447,6 @@ type OperatorConfig struct {
 	// LoadBalancerL7 enables loadbalancer capabilities for services.
 	LoadBalancerL7 string
 
-	// EnvoyLoadBalancerPorts is a list of service ports that will be automatically redirected to Envoy
-	LoadBalancerL7Ports []string
-
-	// LoadBalancerL7Algorithm is a default LB algorithm for services that do not specify related annotation
-	LoadBalancerL7Algorithm string
-
 	// EnableGatewayAPI enables support of Gateway API
 	EnableGatewayAPI bool
 
@@ -516,8 +504,6 @@ func (c *OperatorConfig) Populate(vp *viper.Viper) {
 	c.BGPAnnounceLBIP = vp.GetBool(BGPAnnounceLBIP)
 	c.BGPConfigPath = vp.GetString(BGPConfigPath)
 	c.LoadBalancerL7 = vp.GetString(LoadBalancerL7)
-	c.LoadBalancerL7Ports = vp.GetStringSlice(LoadBalancerL7Ports)
-	c.LoadBalancerL7Algorithm = vp.GetString(LoadBalancerL7Algorithm)
 	c.EnableGatewayAPI = vp.GetBool(EnableGatewayAPI)
 	c.ProxyIdleTimeoutSeconds = vp.GetInt(ProxyIdleTimeoutSeconds)
 	if c.ProxyIdleTimeoutSeconds == 0 {

--- a/operator/pkg/ciliumenvoyconfig/cell.go
+++ b/operator/pkg/ciliumenvoyconfig/cell.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package ciliumenvoyconfig
+
+import (
+	"context"
+
+	"github.com/spf13/pflag"
+
+	operatorK8s "github.com/cilium/cilium/operator/k8s"
+	operatorOption "github.com/cilium/cilium/operator/option"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+)
+
+// Cell manages the CiliumEnvoyConfig related controllers.
+var Cell = cell.Module(
+	"ciliumenvoyconfig",
+	"Manages the CiliumEnvoyConfig controllers",
+
+	cell.Config(l7LoadBalancerConfig{
+		LoadBalancerL7Ports:     []string{},
+		LoadBalancerL7Algorithm: "round_robin",
+	}),
+	cell.Invoke(registerL7LoadBalancingController),
+)
+
+type l7LoadBalancerConfig struct {
+	LoadBalancerL7Ports     []string
+	LoadBalancerL7Algorithm string
+}
+
+func (r l7LoadBalancerConfig) Flags(flags *pflag.FlagSet) {
+	flags.StringSlice("loadbalancer-l7-ports", r.LoadBalancerL7Ports, "List of service ports that will be automatically redirected to backend.")
+	flags.String("loadbalancer-l7-algorithm", r.LoadBalancerL7Algorithm, "Default LB algorithm for services that do not specify related annotation")
+}
+
+func registerL7LoadBalancingController(lc hive.Lifecycle, clientset k8sClient.Clientset, resources operatorK8s.Resources, config l7LoadBalancerConfig) error {
+	if operatorOption.Config.LoadBalancerL7 != "envoy" {
+		return nil
+	}
+
+	ctx, cancelCtx := context.WithCancel(context.Background())
+
+	lc.Append(hive.Hook{
+		OnStart: func(_ hive.HookContext) error {
+			log.Info("Starting Envoy load balancer controller")
+			StartCECController(ctx, clientset, resources.Services,
+				config.LoadBalancerL7Ports,
+				config.LoadBalancerL7Algorithm,
+				operatorOption.Config.ProxyIdleTimeoutSeconds,
+			)
+			return nil
+		},
+		OnStop: func(hive.HookContext) error {
+			cancelCtx()
+			return nil
+		},
+	})
+
+	return nil
+}

--- a/operator/pkg/ciliumenvoyconfig/envoy_config.go
+++ b/operator/pkg/ciliumenvoyconfig/envoy_config.go
@@ -33,19 +33,12 @@ import (
 )
 
 type envoyConfigManager struct {
-	client             client.Clientset
-	informer           cache.Controller
-	store              cache.Store
-	maxRetries         int
-	idleTimeoutSeconds int
+	informer cache.Controller
+	store    cache.Store
 }
 
-func newEnvoyConfigManager(ctx context.Context, client client.Clientset, maxRetries int, idleTimeoutSeconds int) (*envoyConfigManager, error) {
-	manager := &envoyConfigManager{
-		client:             client,
-		maxRetries:         maxRetries,
-		idleTimeoutSeconds: idleTimeoutSeconds,
-	}
+func newEnvoyConfigManager(ctx context.Context, client client.Clientset) (*envoyConfigManager, error) {
+	manager := &envoyConfigManager{}
 
 	manager.store, manager.informer = informer.NewInformer(
 		utils.ListerWatcherFromTyped[*ciliumv2.CiliumEnvoyConfigList](client.CiliumV2().CiliumEnvoyConfigs(corev1.NamespaceAll)),
@@ -166,7 +159,7 @@ func (m *Manager) getClusterResources(svc *slim_corev1.Service) ([]ciliumv2.XDSR
 		},
 	}
 
-	var mutatorFuncs = []clusterMutator{
+	mutatorFuncs := []clusterMutator{
 		lbModeClusterMutator(svc),
 	}
 	for _, fn := range mutatorFuncs {
@@ -193,7 +186,7 @@ func (m *Manager) getRouteConfigurationResource(svc *slim_corev1.Service) (ciliu
 		VirtualHosts: []*envoy_config_route_v3.VirtualHost{m.getVirtualHost(svc)},
 	}
 
-	var mutatorFuncs = []routeConfigMutator{}
+	mutatorFuncs := []routeConfigMutator{}
 	for _, fn := range mutatorFuncs {
 		routeConfig = fn(routeConfig)
 	}
@@ -245,7 +238,7 @@ func (m *Manager) getListenerResource(svc *slim_corev1.Service) (ciliumv2.XDSRes
 		},
 	}
 
-	var mutatorFuncs = []listenerMutator{}
+	mutatorFuncs := []listenerMutator{}
 	for _, fn := range mutatorFuncs {
 		listener = fn(listener)
 	}
@@ -282,7 +275,7 @@ func (m *Manager) getConnectionManager(svc *slim_corev1.Service) (ciliumv2.XDSRe
 		},
 	}
 
-	var mutatorFuncs = []httpConnectionManagerMutator{
+	mutatorFuncs := []httpConnectionManagerMutator{
 		grpcHttpConnectionManagerMutator(svc),
 	}
 	for _, fn := range mutatorFuncs {
@@ -323,7 +316,7 @@ func (m *Manager) getVirtualHost(svc *slim_corev1.Service) *envoy_config_route_v
 		},
 	}
 
-	var routeMutatorFuncs = []routeMutator{}
+	routeMutatorFuncs := []routeMutator{}
 	for _, fn := range routeMutatorFuncs {
 		route = fn(route)
 	}
@@ -334,7 +327,7 @@ func (m *Manager) getVirtualHost(svc *slim_corev1.Service) *envoy_config_route_v
 		Routes:  []*envoy_config_route_v3.Route{route},
 	}
 
-	var mutatorFuncs = []virtualHostMutator{}
+	mutatorFuncs := []virtualHostMutator{}
 	for _, fn := range mutatorFuncs {
 		virtualHost = fn(virtualHost)
 	}

--- a/operator/pkg/ciliumenvoyconfig/manager.go
+++ b/operator/pkg/ciliumenvoyconfig/manager.go
@@ -40,8 +40,8 @@ type Manager struct {
 	algorithm    string
 }
 
-// New returns a new Manager for CiliumEnvoyConfig
-func New(ctx context.Context, client client.Clientset, indexer cache.Store, ports []string, algorithm string, idleTimeoutSeconds int) (*Manager, error) {
+// newManager returns a new Manager for CiliumEnvoyConfig
+func newManager(ctx context.Context, client client.Clientset, indexer cache.Store, ports []string, algorithm string, idleTimeoutSeconds int) (*Manager, error) {
 	manager := &Manager{
 		queue:              workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 		client:             client,

--- a/operator/pkg/ciliumenvoyconfig/manager.go
+++ b/operator/pkg/ciliumenvoyconfig/manager.go
@@ -52,7 +52,7 @@ func newManager(ctx context.Context, client client.Clientset, indexer cache.Stor
 		algorithm:          algorithm,
 	}
 
-	envoyConfigManager, err := newEnvoyConfigManager(ctx, client, manager.maxRetries, manager.idleTimeoutSeconds)
+	envoyConfigManager, err := newEnvoyConfigManager(ctx, client)
 	if err != nil {
 		return nil, err
 	}

--- a/operator/pkg/ciliumenvoyconfig/watcher.go
+++ b/operator/pkg/ciliumenvoyconfig/watcher.go
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Authors of Cilium
 
-package watchers
+package ciliumenvoyconfig
 
 import (
 	"context"
 
-	"github.com/cilium/cilium/operator/pkg/ciliumenvoyconfig"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -22,7 +21,7 @@ func StartCECController(ctx context.Context, clientset k8sClient.Clientset, serv
 			log.WithError(err).Fatal("Failed to retrieve service store")
 		}
 
-		m, err := ciliumenvoyconfig.New(ctx, clientset, store.CacheStore(), ports, defaultAlgorithm, idleTimeoutSeconds)
+		m, err := newManager(ctx, clientset, store.CacheStore(), ports, defaultAlgorithm, idleTimeoutSeconds)
 		if err != nil {
 			log.WithError(err).Fatal("Error creating CiliumEnvoyConfiguration manager")
 		}


### PR DESCRIPTION
This commit moves the L7 loadbalancing registration from the `legacyOnLeader` cell into its own cell.

In addition, the corresponding config properties have been moved into its own config struct where possible.