### PR TITLE
ci: use pull request target branch in image builds

### DIFF
--- a/.github/workflows/build-images-base.yaml
+++ b/.github/workflows/build-images-base.yaml
@@ -28,10 +28,10 @@ jobs:
     environment: release-base-images
     runs-on: ubuntu-22.04
     steps:
-      - name: Checkout default branch (trusted)
+      - name: Checkout pull request target branch (trusted)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.ref }}
           persist-credentials: false
 
       - name: Set Environment Variables

--- a/.github/workflows/build-images-ci.yaml
+++ b/.github/workflows/build-images-ci.yaml
@@ -68,10 +68,10 @@ jobs:
             dockerfile: ./images/cilium-docker-plugin/Dockerfile
 
     steps:
-      - name: Checkout default branch (trusted)
+      - name: Checkout pull request target branch (trusted)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.ref }}
           persist-credentials: false
 
       - name: Set Environment Variables

--- a/.github/workflows/build-images-docs-builder.yaml
+++ b/.github/workflows/build-images-docs-builder.yaml
@@ -29,10 +29,10 @@ jobs:
       tag: ${{ steps.docs-builder-tag.outputs.tag }}
       digest: ${{ steps.docker-build-docs-builder.outputs.digest }}
     steps:
-      - name: Checkout default branch (trusted)
+      - name: Checkout pull request target branch (trusted)
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          ref: ${{ github.ref }}
           persist-credentials: false
 
       - name: Set environment variables


### PR DESCRIPTION
Image builds are currently all retrieving the environment variables defined in `.github/actions/set-env-variables` from the default branch, however in some cases it is desirable to be able to configure different variables in different stable branches.

We thus switch to using the environment variables defined in the pull request target branch via `github.ref` [1], since it is a source we can trust for `pull_request_target` event. For `push` and `workflow_run` events, this will have no security impact as we still trust the sources:

- Only contributors with write access to the repository can trigger builds on `push`, and in `github.ref` can thus only point to code we trust.
- `workflow_run` uses the default branch as `github.ref` anyway.

[1]: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target