### PR TITLE
pkg/k8s: do not perform an early return on ipcache errors

### DIFF
--- a/pkg/k8s/watchers/pod.go
+++ b/pkg/k8s/watchers/pod.go
@@ -334,11 +334,11 @@ func (k *K8sWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) error
 
 	oldPodIPs := k8sUtils.ValidIPs(oldK8sPod.Status)
 	newPodIPs := k8sUtils.ValidIPs(newK8sPod.Status)
-	err = k.updatePodHostData(oldK8sPod, newK8sPod, oldPodIPs, newPodIPs)
-
-	if err != nil {
-		logger.WithError(err).Warning("Unable to update ipcache map entry on pod update")
-		return err
+	if len(oldPodIPs) != 0 || len(newPodIPs) != 0 {
+		err = k.updatePodHostData(oldK8sPod, newK8sPod, oldPodIPs, newPodIPs)
+		if err != nil {
+			logger.WithError(err).Warning("Unable to update ipcache map entry on pod update")
+		}
 	}
 
 	// Check annotation updates.
@@ -386,6 +386,12 @@ func (k *K8sWatcher) updateK8sPodV1(oldK8sPod, newK8sPod *slim_corev1.Pod) error
 
 	// Nothing changed.
 	if !annotationsChanged && !labelsChanged {
+		log.WithFields(logrus.Fields{
+			"old-labels":      oldK8sPod.GetObjectMeta().GetLabels(),
+			"old-annotations": oldK8sPod.GetObjectMeta().GetAnnotations(),
+			"new-labels":      newK8sPod.GetObjectMeta().GetLabels(),
+			"new-annotations": newK8sPod.GetObjectMeta().GetAnnotations(),
+		}).Debugf("Pod does not have any annotations nor labels changed")
 		return err
 	}
 


### PR DESCRIPTION
Although ipcache might return an error, we should not perform an early
return in the event handling of the pod event because some other
components that are unrelated to ipcache might depend on this specific
event per perform correctly. Instead we will log the ipcache error and
let the execution of the method to continue.

The pod might, for example, be in a "Pending" state which has its
status IP addresses not set but might be able to change labels in the
meanwhile which Cilium should react upon those changes which are not
related with ipcache.

```release-note
Improved event handling for pod events by removing an unnecessary early return, allowing unrelated components to execute correctly, while enhancing ipcache error logging.
```
