### PR TITLE
helm: add annotation to keep cilium-ca secret

### DIFF
--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -116,6 +116,9 @@ from one cluster to another:
   kubectl --context=$CLUSTER1 get secret -n kube-system cilium-ca -o yaml | \
     kubectl --context $CLUSTER2 create -f -
 
+  # Annotate the secret so that it isn't removed by Helm
+  kubectl --context=$CLUSTER2 annotate secret -n kube-system cilium-ca helm.sh/resource-policy=keep
+
 .. _enable_clustermesh:
 
 Enable Cluster Mesh

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -328,6 +328,10 @@ Annotations:
   include these parameters.
 * ``enable-endpoint-routes`` now automatically sets ``enable-local-node-route``
   to false, as local node routes are redundant when per-endpoint routes are enabled.
+* The Helm chart now unmanages the ``cilium-ca`` secret, rather than deleting it,
+  upon uninstall and changes to Helm values. This allows for additional
+  workflows where the CA cert has been copied to this location from an existing
+  cluster and is then used with the ``certgen`` utility.
 
 .. _upgrade_cilium_cli_helm_mode:
 

--- a/Documentation/spelling_wordlist.txt
+++ b/Documentation/spelling_wordlist.txt
@@ -691,6 +691,7 @@ uninline
 unix
 unlabel
 unmanaged
+unmanages
 unmigrated
 unsettable
 untriaged

--- a/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
+++ b/install/kubernetes/cilium/templates/cilium-ca-secret.yaml
@@ -11,6 +11,12 @@ kind: Secret
 metadata:
   name: {{ .commonCASecretName }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    # If the tls.auto.method is changed from "helm" to "cronJob" then we want
+    # to keep this CA, so that it can be used by certgen's --ca-reuse-secret
+    # flag. Keeping this CA secret also required in the case that it has been
+    # manually copied from another cluster between runs of Helm.
+    "helm.sh/resource-policy": keep
 data:
   ca.crt: {{ .commonCA.Cert | b64enc }}
   ca.key: {{ .commonCA.Key  | b64enc }}


### PR DESCRIPTION
Depending on the Helm values provided, the cilium-ca secret might be generated and managed by Helm, before later being unmanaged and intended for use with a cilium/certgen CronJob.

In the Cluster Mesh documentation, the user is instructed to copy the cilium-ca secret from one cluster to another in-between runs of Helm:

https://docs.cilium.io/en/stable/network/clustermesh/clustermesh/#shared-certificate-authority

In this case, if the Helm values result in both:

* The cilium-ca secret becoming unmanaged
* The cilium/certgen CronJob being created

Then Helm will, in a single operation, delete the `cilium-ca` secret which was just copied manually by the user, and then generate a new CA indirectly via the CronJob.

Given the CronJob's use of `--ca-reuse-secret` (see [_job_spec.tpl](https://github.com/cilium/cilium/blob/main/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl)), it should be possible to make this configuration change, and use the CA cert which had been copied to the cluster.

This annotation instructs Helm to not delete the CA cert in such cases.

This has been tested in both the case when the secret has been manually overwritten and in the case when it hasn't.

```release-note
helm: keep the cilium-ca secret in all cases
```
