### PR TITLE
agent: Add subscribe package

### DIFF
--- a/pkg/subscribe/subscribe.go
+++ b/pkg/subscribe/subscribe.go
@@ -1,0 +1,52 @@
+package subscribe
+
+import (
+	"context"
+
+	"github.com/cilium/cilium/pkg/stream"
+)
+
+// Subscription provide an interface to send and subscribe to events of type T.
+//
+// Subscriber can cancel their passed context to stop receiving events.
+// Send is used to send events to all subscribers.
+// Complete denotes the end of subscription to all subscribers.
+type Subscription[T any] interface {
+	Subscribe(ctx context.Context) Subscriber[T]
+	Send(ev T)
+	Complete()
+}
+
+func InitSubscription[T any]() Subscription[T] {
+	m := manager[T]{}
+	m.observe, m.emit, m.complete = stream.Multicast[T]()
+
+	return &m
+}
+
+type Subscriber[T any] struct {
+	events <-chan T
+}
+
+type manager[T any] struct {
+	subscribers []Subscriber[T]
+	emit        func(T)
+	complete    func(err error)
+	observe     stream.Observable[T]
+}
+
+func (m *manager[T]) Subscribe(ctx context.Context) Subscriber[T] {
+	ch := stream.ToChannel(ctx, m.observe, stream.WithBufferSize(10))
+	sub := Subscriber[T]{events: ch}
+	m.subscribers = append(m.subscribers, sub)
+
+	return sub
+}
+
+func (m *manager[T]) Send(ev T) {
+	m.emit(ev)
+}
+
+func (m *manager[T]) Complete() {
+	m.complete(nil)
+}

--- a/pkg/subscribe/subscribe_test.go
+++ b/pkg/subscribe/subscribe_test.go
@@ -1,0 +1,74 @@
+package subscribe
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubscription(t *testing.T) {
+	subscription := InitSubscription[int]()
+	ctx := context.Background()
+
+	sub1 := subscription.Subscribe(ctx)
+	sub2 := subscription.Subscribe(ctx)
+
+	subscription.Send(10)
+
+	assert.Equal(t, <-sub1.events, 10)
+	assert.Equal(t, <-sub2.events, 10)
+}
+
+func TestSubscriptionCtxDone(t *testing.T) {
+	subscription := InitSubscription[int]()
+	ctx1 := context.Background()
+	ctx2 := context.Background()
+
+	sub1 := subscription.Subscribe(ctx1)
+	sub2 := subscription.Subscribe(ctx2)
+
+	subscription.Send(10)
+
+	assert.Equal(t, <-sub1.events, 10)
+	assert.Equal(t, <-sub2.events, 10)
+
+	ctx1.Done()
+	subscription.Send(20)
+
+	select {
+	case <-sub1.events:
+	default:
+		t.Error("Channel is not closed")
+	}
+	assert.Equal(t, <-sub2.events, 20)
+}
+
+func TestSubscriptionComplete(t *testing.T) {
+	subscription := InitSubscription[int]()
+	ctx1 := context.Background()
+	ctx2 := context.Background()
+
+	sub1 := subscription.Subscribe(ctx1)
+	sub2 := subscription.Subscribe(ctx2)
+
+	subscription.Send(10)
+
+	assert.Equal(t, <-sub1.events, 10)
+	assert.Equal(t, <-sub2.events, 10)
+
+	subscription.Complete()
+
+	// Fixme: Need a better way to close.
+	time.Sleep(2 * time.Second)
+	select {
+	case v := <-sub1.events:
+		fmt.Println(v)
+	// case v := <-sub2.events:
+	// 	fmt.Println(v)
+	default:
+		t.Error("Channel is not closed")
+	}
+}


### PR DESCRIPTION
The package wraps functionality to send and subscribe to events using the internal streams API.

The streams.Multicast offers the functionality to stream events, but in a more generic way. The new subscribe package exposes regular subscribe API, so that users don't have to know the internals of the streams package in order to provide the subscription functionality.

Signed-off-by: Aditi Ghag <aditi@cilium.io>
