### PR TITLE
The cilium-operator pod is scheduled to another node

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2436,8 +2436,8 @@ operator:
 
   # -- Node tolerations for cilium-operator scheduling to nodes with taints
   # ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
-  tolerations:
-  - operator: Exists
+  tolerations: []
+ 
     # - key: "key"
     #   operator: "Equal|Exists"
     #   value: "value"


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!


I recreated the particular issue on my local machine and replicated the above problem. For `cilium-operator` the tolerations field was set to `- operator: Exists` for which reason the pods were scheduling again and again into tainted system. I think changing `tolerations` field  for `cilium-operator` will fix the issue.

Fixes: #28549

```release-note
Changed to tolerances on the operator to allow nodes to drain
```
