### PR TITLE
ctmap: add GC support for DSR NAT entries with nodeport-backed CT entry

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -280,7 +280,7 @@ func newMap(mapName string, m mapType) *Map {
 	return result
 }
 
-func purgeCtEntry6(m *Map, key CtKey, natMap *nat.Map) error {
+func purgeCtEntry6(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 	err := m.Delete(key)
 	if err != nil || natMap == nil {
 		return err
@@ -289,8 +289,10 @@ func purgeCtEntry6(m *Map, key CtKey, natMap *nat.Map) error {
 	t := key.GetTupleKey()
 
 	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
-		// To delete NAT entries created by DSR
-		nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
+		if entry.isDsrEntry() {
+			// To delete NAT entries created by DSR
+			nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
+		}
 	} else {
 		nat.DeleteMapping6(natMap, t.(*tuple.TupleKey6Global))
 	}
@@ -348,7 +350,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry6(m, currentKey6Global, natMap)
+				err := purgeCtEntry6(m, currentKey6Global, entry, natMap)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey6Global.String()).Error("Unable to delete CT entry")
 				} else {
@@ -368,7 +370,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry6(m, currentKey6, natMap)
+				err := purgeCtEntry6(m, currentKey6, entry, natMap)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey6.String()).Error("Unable to delete CT entry")
 				} else {
@@ -389,7 +391,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 	return stats
 }
 
-func purgeCtEntry4(m *Map, key CtKey, natMap *nat.Map) error {
+func purgeCtEntry4(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 	err := m.Delete(key)
 	if err != nil || natMap == nil {
 		return err
@@ -398,8 +400,10 @@ func purgeCtEntry4(m *Map, key CtKey, natMap *nat.Map) error {
 	t := key.GetTupleKey()
 
 	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
-		// To delete NAT entries created by DSR
-		nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
+		if entry.isDsrEntry() {
+			// To delete NAT entries created by DSR
+			nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
+		}
 	} else {
 		nat.DeleteMapping4(natMap, t.(*tuple.TupleKey4Global))
 	}
@@ -456,7 +460,7 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry4(m, currentKey4Global, natMap)
+				err := purgeCtEntry4(m, currentKey4Global, entry, natMap)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey4Global.String()).Error("Unable to delete CT entry")
 				} else {
@@ -476,7 +480,7 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry4(m, currentKey4, natMap)
+				err := purgeCtEntry4(m, currentKey4, entry, natMap)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey4.String()).Error("Unable to delete CT entry")
 				} else {

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -282,10 +282,20 @@ func newMap(mapName string, m mapType) *Map {
 
 func purgeCtEntry6(m *Map, key CtKey, natMap *nat.Map) error {
 	err := m.Delete(key)
-	if err == nil && natMap != nil {
-		natMap.DeleteMapping(key.GetTupleKey())
+	if err != nil || natMap == nil {
+		return err
 	}
-	return err
+
+	t := key.GetTupleKey()
+
+	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
+		// To delete NAT entries created by DSR
+		nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
+	} else {
+		nat.DeleteMapping6(natMap, t.(*tuple.TupleKey6Global))
+	}
+
+	return nil
 }
 
 // doGC6 iterates through a CTv6 map and drops entries based on the given
@@ -381,10 +391,20 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 
 func purgeCtEntry4(m *Map, key CtKey, natMap *nat.Map) error {
 	err := m.Delete(key)
-	if err == nil && natMap != nil {
-		natMap.DeleteMapping(key.GetTupleKey())
+	if err != nil || natMap == nil {
+		return err
 	}
-	return err
+
+	t := key.GetTupleKey()
+
+	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
+		// To delete NAT entries created by DSR
+		nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
+	} else {
+		nat.DeleteMapping4(natMap, t.(*tuple.TupleKey4Global))
+	}
+
+	return nil
 }
 
 // doGC4 iterates through a CTv4 map and drops entries based on the given

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -290,9 +290,13 @@ func purgeCtEntry6(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 
 	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
 		if entry.isDsrEntry() {
-			// To delete NAT entries created by DSR
+			// To delete NAT entries created by legacy DSR
 			nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
 		}
+	} else if t.GetFlags()&tuple.TUPLE_F_OUT == tuple.TUPLE_F_OUT &&
+		entry.isDsrEntry() {
+		// To delete NAT entries created by DSR
+		nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
 	} else {
 		nat.DeleteMapping6(natMap, t.(*tuple.TupleKey6Global))
 	}
@@ -401,9 +405,13 @@ func purgeCtEntry4(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 
 	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
 		if entry.isDsrEntry() {
-			// To delete NAT entries created by DSR
+			// To delete NAT entries created by legacy DSR
 			nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
 		}
+	} else if t.GetFlags()&tuple.TUPLE_F_OUT == tuple.TUPLE_F_OUT &&
+		entry.isDsrEntry() {
+		// To delete NAT entries created by DSR
+		nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
 	} else {
 		nat.DeleteMapping4(natMap, t.(*tuple.TupleKey4Global))
 	}

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -535,8 +535,10 @@ func GC(m *Map, filter *GCFilter) int {
 // PurgeOrphanNATEntries removes orphan SNAT entries. We call an SNAT entry
 // orphan if it does not have a corresponding CT entry.
 //
-// This can happen when the CT entry is removed by the LRU eviction which
-// happens when the CT map becomes full.
+// Typically NAT entries should get removed along with their owning CT entry,
+// as part of purgeCtEntry*(). But stale NAT entries can get left behind if the
+// CT entry disappears for other reasons - for instance by LRU eviction, or
+// when the datapath re-purposes the CT entry.
 //
 // PurgeOrphanNATEntries() is triggered by the datapath via the GC signaling
 // mechanism. When the datapath SNAT fails to find free mapping after

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -46,7 +46,7 @@ func (k *CTMapPrivilegedTestSuite) Benchmark_MapUpdate(c *C) {
 			DestPort:   0,
 			SourcePort: 0,
 			NextHeader: u8proto.TCP,
-			Flags:      0,
+			Flags:      tuple.TUPLE_F_OUT,
 		},
 	}
 	value := &CtEntry{
@@ -55,7 +55,7 @@ func (k *CTMapPrivilegedTestSuite) Benchmark_MapUpdate(c *C) {
 		TxPackets:        4,
 		TxBytes:          216,
 		Lifetime:         37459,
-		Flags:            0x0011,
+		Flags:            SeenNonSyn | RxClosing,
 		RevNAT:           0,
 		TxFlagsSeen:      0x02,
 		RxFlagsSeen:      0x14,
@@ -142,7 +142,7 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 				DestPort:   0,
 				SourcePort: 0x3195,
 				NextHeader: u8proto.ICMP,
-				Flags:      0,
+				Flags:      tuple.TUPLE_F_OUT,
 			},
 		},
 	}
@@ -162,7 +162,7 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 				SourcePort: 0,
 				DestPort:   0x3195,
 				NextHeader: u8proto.ICMP,
-				Flags:      1,
+				Flags:      tuple.TUPLE_F_IN,
 			},
 		},
 	}

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -569,6 +569,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		TxPackets: 1,
 		TxBytes:   216,
 		Lifetime:  37459,
+		Flags:     DSR,
 	}
 	err = ctMapTCP.Map.Update(ctKey, ctVal)
 	c.Assert(err, IsNil)
@@ -642,6 +643,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		TxPackets: 1,
 		TxBytes:   216,
 		Lifetime:  37459,
+		Flags:     DSR,
 	}
 	err = ctMapTCP.Map.Update(ctKey, ctVal)
 	c.Assert(err, IsNil)

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -310,6 +310,95 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcTcp(c *C) {
 	c.Assert(len(buf), Equals, 0)
 }
 
+// TestCtGcDsr tests whether DSR NAT entries are removed upon a removal of
+// their CT entry (== CT_EGRESS).
+func (k *CTMapPrivilegedTestSuite) TestCtGcDsr(c *C) {
+	// Init maps
+	natMap := nat.NewMap("cilium_nat_any4_test", nat.IPv4, 1000)
+	err := natMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer natMap.Map.Unpin()
+
+	ctMapName := MapNameTCP4Global + "_test"
+	mapInfo[mapTypeIPv4TCPGlobal] = mapAttributes{
+		natMap: natMap, natMapLock: mapInfo[mapTypeIPv4TCPGlobal].natMapLock,
+	}
+
+	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
+	err = ctMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer ctMap.Map.Unpin()
+
+	// Create the following entries and check that they get GC-ed:
+	//	- CT:	TCP OUT 1.1.1.1:1111 -> 192.168.61.11:8080 <..>
+	//	- NAT: 	TCP OUT 192.168.61.11:8080 -> 1.1.1.1:1111 XLATE_SRC 2.2.2.2:80
+
+	ctKey := &CtKey4Global{
+		tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: types.IPv4{192, 168, 61, 11},
+				DestAddr:   types.IPv4{1, 1, 1, 1},
+				SourcePort: 0x5704,
+				DestPort:   0x901f,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	ctVal := &CtEntry{
+		TxPackets: 1,
+		TxBytes:   216,
+		Lifetime:  37459,
+		Flags:     DSR,
+	}
+	err = ctMap.Map.Update(ctKey, ctVal)
+	c.Assert(err, IsNil)
+
+	natKey := &nat.NatKey4{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				DestAddr:   types.IPv4{1, 1, 1, 1},
+				SourceAddr: types.IPv4{192, 168, 61, 11},
+				DestPort:   0x5704,
+				SourcePort: 0x901f,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	natVal := &nat.NatEntry4{
+		Created: 37400,
+		Addr:    types.IPv4{2, 2, 2, 2},
+		Port:    0x50,
+	}
+	err = natMap.Map.Update(natKey, natVal)
+	c.Assert(err, IsNil)
+
+	buf := make(map[string][]string)
+	err = ctMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 1)
+
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 1)
+
+	// GC and check whether NAT entry has been collected
+	filter := &GCFilter{
+		RemoveExpired: true,
+		Time:          39000,
+	}
+	stats := doGC4(ctMap, filter)
+	c.Assert(stats.aliveEntries, Equals, uint32(0))
+	c.Assert(stats.deleted, Equals, uint32(1))
+
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+}
+
 // TestCtGcLegacyDsr tests whether DSR NAT entries are removed upon a removal of
 // their legacy CT entry (== CT_INGRESS).
 // See https://github.com/cilium/cilium/pull/22978 for details.

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -566,6 +566,10 @@ const (
 	MaxFlags
 )
 
+func (c *CtEntry) isDsrEntry() bool {
+	return c.Flags&DSR != 0
+}
+
 func (c *CtEntry) flagsString() string {
 	var sb strings.Builder
 

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -194,7 +194,7 @@ func (m *Map) Flush() int {
 	return int(doFlush6(m).deleted)
 }
 
-func deleteMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
+func DeleteMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 	key := NatKey4{
 		TupleKey4Global: *ctKey,
 	}
@@ -218,7 +218,7 @@ func deleteMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 	return nil
 }
 
-func deleteMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
+func DeleteMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 	key := NatKey6{
 		TupleKey6Global: *ctKey,
 	}
@@ -243,7 +243,7 @@ func deleteMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 }
 
 // Expects ingress tuple
-func deleteSwappedMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
+func DeleteSwappedMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 	key := NatKey4{TupleKey4Global: *ctKey}
 	// Because of #5848, we need to reverse only ports
 	port := key.SourcePort
@@ -256,7 +256,7 @@ func deleteSwappedMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 }
 
 // Expects ingress tuple
-func deleteSwappedMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
+func DeleteSwappedMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 	key := NatKey6{TupleKey6Global: *ctKey}
 	// Because of #5848, we need to reverse only ports
 	port := key.SourcePort
@@ -266,22 +266,6 @@ func deleteSwappedMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 	m.SilentDelete(&key)
 
 	return nil
-}
-
-// DeleteMapping removes a NAT mapping from the global NAT table.
-func (m *Map) DeleteMapping(key tuple.TupleKey) error {
-	if key.GetFlags()&tuple.TUPLE_F_IN != 0 {
-		if m.family == IPv4 {
-			// To delete NAT entries created by DSR
-			return deleteSwappedMapping4(m, key.(*tuple.TupleKey4Global))
-		}
-		return deleteSwappedMapping6(m, key.(*tuple.TupleKey6Global))
-	}
-
-	if m.family == IPv4 {
-		return deleteMapping4(m, key.(*tuple.TupleKey4Global))
-	}
-	return deleteMapping6(m, key.(*tuple.TupleKey6Global))
 }
 
 // GlobalMaps returns all global NAT maps.


### PR DESCRIPTION
https://github.com/cilium/cilium/pull/22978 changed the way how backend nodes manage the NAT entry for a DSR connection. Previously such a NAT entry's lifetime would be controlled by a `CT_INGRESS` CT entry created by `bpf_lxc`.
With the changes in the referenced PR, we are now using a `CT_EGRESS` CT entry instead gets created by the nodeport ingress path.

The PR added GC support for such NAT entries in `PurgeOrphanNATEntries()`. But it missed also adding such support to the GC code that runs when a specific CT entry is removed.

Add this support now, along with some cleanups & additional tests.


```release-note
When the CT entry for a DSR connection is garbage-collected, the corresponding SNAT entry is now also removed.
```
