### PR TITLE
helm: expose env to value file for hubble-ui backend.

### DIFF
--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -97,18 +97,9 @@ spec:
         - name: EVENTS_SERVER_PORT
           value: "8090"
         {{- if .Values.hubble.relay.tls.server.enabled }}
-        - name: FLOWS_API_ADDR
-          value: "hubble-relay:443"
-        - name: TLS_TO_RELAY_ENABLED
-          value: "true"
-        - name: TLS_RELAY_SERVER_NAME
-          value: ui.hubble-relay.cilium.io
-        - name: TLS_RELAY_CA_CERT_FILES
-          value: /var/lib/hubble-ui/certs/hubble-relay-ca.crt
-        - name: TLS_RELAY_CLIENT_CERT_FILE
-          value: /var/lib/hubble-ui/certs/client.crt
-        - name: TLS_RELAY_CLIENT_KEY_FILE
-          value: /var/lib/hubble-ui/certs/client.key
+        {{- with .Values.hubble.ui.backend.env }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
         {{- else }}
         - name: FLOWS_API_ADDR
           value: "hubble-relay:80"

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1438,6 +1438,21 @@ hubble:
       # -- Hubble-ui backend security context.
       securityContext: {}
 
+      # -- hubble-ui backend environment.
+      env:
+        - name: FLOWS_API_ADDR
+          value: "hubble-relay:443"
+        - name: TLS_TO_RELAY_ENABLED
+          value: "true"
+        - name: TLS_RELAY_SERVER_NAME
+          value: ui.hubble-relay.cilium.io
+        - name: TLS_RELAY_CA_CERT_FILES
+          value: /var/lib/hubble-ui/certs/hubble-relay-ca.crt
+        - name: TLS_RELAY_CLIENT_CERT_FILE
+          value: /var/lib/hubble-ui/certs/client.crt
+        - name: TLS_RELAY_CLIENT_KEY_FILE
+          value: /var/lib/hubble-ui/certs/client.key
+
       # -- Additional hubble-ui backend environment variables.
       extraEnv: []
 


### PR DESCRIPTION
Environment for hubble-ui backend are different on different cloud provider.

For GKE, they are using DPv2(google customized cilium).
https://cloud.google.com/kubernetes-engine/docs/how-to/configure-dpv2-observability#hubble-ui-standard

The environment are different on GKE.

Signed-off-by: canuxcheng@gmail.com

Fixes: #28826 