### PR TITLE
ctmap: limit NAT purging to expected CT tuple types

### DIFF
--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -287,18 +287,22 @@ func purgeCtEntry6(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 	}
 
 	t := key.GetTupleKey()
+	tupleType := t.GetFlags()
 
-	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
-		if entry.isDsrEntry() {
-			// To delete NAT entries created by legacy DSR
-			nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
-		}
-	} else if t.GetFlags()&tuple.TUPLE_F_OUT == tuple.TUPLE_F_OUT &&
-		entry.isDsrEntry() {
-		// To delete NAT entries created by DSR
+	if tupleType == tuple.TUPLE_F_IN && entry.isDsrEntry() {
+		// To delete NAT entries created by legacy DSR
 		nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
-	} else {
-		nat.DeleteMapping6(natMap, t.(*tuple.TupleKey6Global))
+	}
+
+	if tupleType == tuple.TUPLE_F_OUT {
+		if entry.isDsrEntry() {
+			// To delete NAT entries created by DSR
+			nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
+		} else {
+			// To delete NAT entries created for SNAT
+			nat.DeleteMapping6(natMap, t.(*tuple.TupleKey6Global))
+
+		}
 	}
 
 	return nil
@@ -402,18 +406,21 @@ func purgeCtEntry4(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 	}
 
 	t := key.GetTupleKey()
+	tupleType := t.GetFlags()
 
-	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
-		if entry.isDsrEntry() {
-			// To delete NAT entries created by legacy DSR
-			nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
-		}
-	} else if t.GetFlags()&tuple.TUPLE_F_OUT == tuple.TUPLE_F_OUT &&
-		entry.isDsrEntry() {
-		// To delete NAT entries created by DSR
+	if tupleType == tuple.TUPLE_F_IN && entry.isDsrEntry() {
+		// To delete NAT entries created by legacy DSR
 		nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
-	} else {
-		nat.DeleteMapping4(natMap, t.(*tuple.TupleKey4Global))
+	}
+
+	if tupleType == tuple.TUPLE_F_OUT {
+		if entry.isDsrEntry() {
+			// To delete NAT entries created by DSR
+			nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
+		} else {
+			// To delete NAT entries created for SNAT
+			nat.DeleteMapping4(natMap, t.(*tuple.TupleKey4Global))
+		}
 	}
 
 	return nil


### PR DESCRIPTION
There is only a limited number of CT tuple types that potentially have NAT
entries associated with them:
1. DSR, for CT_EGRESS entries with `dsr` flag set
2. legacy DSR, for CT_INGRESS entries with `dsr` flag set
3. SNAT (eg. Masquerading), for CT_EGRESS entries. We don't need to
consider TUPLE_F_RELATED here, as the SNAT code doesn't support any of
the ICMP types where ct_extract_ports*() would set TUPLE_F_RELATED. So
it will also never create NAT entries for such CT entries.

When we don't match any of these types, avoid falling through to
nat.DeleteMapping*(). In particular this means we're no longer trying to
apply NAT purging when GC removes a "related" ICMP entry or a CT_SERVICE
entry.
