### PR TITLE
v1.13 Backports 2023-10-30

### DIFF
--- a/.github/workflows/conformance-clustermesh.yaml
+++ b/.github/workflows/conformance-clustermesh.yaml
@@ -125,7 +125,7 @@ jobs:
             kube-proxy: 'none'
   
           - name: '7'
-            tunnel: 'vxlan'
+            tunnel: 'geneve'
             ipfamily: 'ipv4'
             encryption: 'wireguard'
             kube-proxy: 'iptables'

--- a/bugtool/cmd/configuration.go
+++ b/bugtool/cmd/configuration.go
@@ -81,6 +81,10 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 	var commands []string
 	// Not expecting all of the commands to be available
 	commands = []string{
+		// We want to collect this twice: at the very beginning and at the
+		// very end of the bugtool collection, to see if the counters are
+		// increasing.
+		"cat /proc/net/xfrm_stat",
 		// Host and misc
 		"ps auxfw",
 		"hostname",
@@ -213,6 +217,15 @@ func defaultCommands(confDir string, cmdDir string, k8sPods []string) []string {
 		commands = append(commands, tcCommands...)
 	}
 
+	// We want to collect this twice: at the very beginning and at the
+	// very end of the bugtool collection, to see if the counters are
+	// increasing.
+	// The commands end up being the names of the files where their output
+	// is stored, so we can't have the two commands be the exact same or the
+	// second would overwrite. To avoid that, we use the -u flag in this second
+	// command; that flag is documented as being ignored.
+	commands = append(commands, "cat -u /proc/net/xfrm_stat")
+
 	return k8sCommands(commands, k8sPods)
 }
 
@@ -268,7 +281,6 @@ func tcInterfaceCommands() ([]string, error) {
 
 func catCommands() []string {
 	files := []string{
-		"/proc/net/xfrm_stat",
 		"/proc/sys/net/core/bpf_jit_enable",
 		"/proc/kallsyms",
 		"/etc/resolv.conf",

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/hashicorp/consul/api v1.18.0
 	github.com/hashicorp/go-immutable-radix v1.3.1
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.4
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/kevinburke/ssh_config v1.2.0
 	github.com/kr/pretty v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -547,6 +547,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.4 h1:7GHuZcgid37q8o5i3QI9KMT4nCWQQ3Kx3Ov6bb9MfK0=
+github.com/hashicorp/golang-lru/v2 v2.0.4/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -808,13 +808,25 @@ func (s *XDSServer) DeleteEnvoyResources(ctx context.Context, resources Resource
 
 func (s *XDSServer) UpsertEnvoyEndpoints(serviceName lb.ServiceName, backendMap map[string][]*lb.Backend) error {
 	var resources Resources
-	lbEndpoints := []*envoy_config_endpoint.LbEndpoint{}
+
+	resources.Endpoints = getEndpointsForLBBackends(serviceName, backendMap)
+
+	// Using context.TODO() is fine as we do not upsert listener resources here - the
+	// context ends up being used only if listener(s) are included in 'resources'.
+	return s.UpsertEnvoyResources(context.TODO(), resources, nil)
+}
+
+func getEndpointsForLBBackends(serviceName lb.ServiceName, backendMap map[string][]*lb.Backend) []*envoy_config_endpoint.ClusterLoadAssignment {
+	var endpoints []*envoy_config_endpoint.ClusterLoadAssignment
+
 	for port, bes := range backendMap {
+		var lbEndpoints []*envoy_config_endpoint.LbEndpoint
 		for _, be := range bes {
 			if be.Protocol != lb.TCP {
 				// Only TCP services supported with Envoy for now
 				continue
 			}
+
 			lbEndpoints = append(lbEndpoints, &envoy_config_endpoint.LbEndpoint{
 				HostIdentifier: &envoy_config_endpoint.LbEndpoint_Endpoint{
 					Endpoint: &envoy_config_endpoint.Endpoint{
@@ -832,6 +844,7 @@ func (s *XDSServer) UpsertEnvoyEndpoints(serviceName lb.ServiceName, backendMap 
 				},
 			})
 		}
+
 		endpoint := &envoy_config_endpoint.ClusterLoadAssignment{
 			ClusterName: fmt.Sprintf("%s:%s", serviceName.String(), port),
 			Endpoints: []*envoy_config_endpoint.LocalityLbEndpoints{
@@ -840,12 +853,12 @@ func (s *XDSServer) UpsertEnvoyEndpoints(serviceName lb.ServiceName, backendMap 
 				},
 			},
 		}
-		resources.Endpoints = append(resources.Endpoints, endpoint)
+		endpoints = append(endpoints, endpoint)
 
 		// for backward compatibility, if any port is allowed, publish one more
 		// endpoint having cluster name as service name.
 		if port == anyPort {
-			resources.Endpoints = append(resources.Endpoints, &envoy_config_endpoint.ClusterLoadAssignment{
+			endpoints = append(endpoints, &envoy_config_endpoint.ClusterLoadAssignment{
 				ClusterName: serviceName.String(),
 				Endpoints: []*envoy_config_endpoint.LocalityLbEndpoints{
 					{
@@ -855,9 +868,8 @@ func (s *XDSServer) UpsertEnvoyEndpoints(serviceName lb.ServiceName, backendMap 
 			})
 		}
 	}
-	// Using context.TODO() is fine as we do not upsert listener resources here - the
-	// context ends up being used only if listener(s) are included in 'resources'.
-	return s.UpsertEnvoyResources(context.TODO(), resources, nil)
+
+	return endpoints
 }
 
 func fillInTlsContextXDS(cecNamespace string, cecName string, tls *envoy_config_tls.CommonTlsContext) bool {

--- a/pkg/envoy/ciliumenvoyconfig_test.go
+++ b/pkg/envoy/ciliumenvoyconfig_test.go
@@ -7,18 +7,25 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/netip"
+	"testing"
 
 	cilium "github.com/cilium/proxy/go/cilium/api"
 	envoy_config_cluster "github.com/cilium/proxy/go/envoy/config/cluster/v3"
 	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
+	endpointv3 "github.com/cilium/proxy/go/envoy/config/endpoint/v3"
 	envoy_config_listener "github.com/cilium/proxy/go/envoy/config/listener/v3"
 	envoy_config_http "github.com/cilium/proxy/go/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_config_tcp "github.com/cilium/proxy/go/envoy/extensions/filters/network/tcp_proxy/v3"
 	envoy_config_tls "github.com/cilium/proxy/go/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/yaml"
 
 	"github.com/cilium/cilium/pkg/bpf"
+	"github.com/cilium/cilium/pkg/clustermesh/types"
 	cilium_v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 
 	. "gopkg.in/check.v1"
 )
@@ -882,4 +889,48 @@ func (s *JSONSuite) TestListenersAddedOrDeleted(c *C) {
 	c.Assert(res, Equals, true)
 	res = new.ListenersAddedOrDeleted(&old)
 	c.Assert(res, Equals, true)
+}
+
+func TestGetEndpointsForLBBackends(t *testing.T) {
+	testAddr, err := netip.ParseAddr("192.128.1.1")
+	require.NoError(t, err)
+
+	serviceName := loadbalancer.ServiceName{
+		Namespace: "test-ns",
+		Name:      "test-name",
+	}
+	backends := map[string][]*loadbalancer.Backend{
+		"12000": {
+			{
+				L3n4Addr: *loadbalancer.NewL3n4Addr(loadbalancer.TCP, types.AddrClusterFrom(testAddr, 0), 12000, 3),
+			},
+		},
+		"13000": {
+			{
+				L3n4Addr: *loadbalancer.NewL3n4Addr(loadbalancer.TCP, types.AddrClusterFrom(testAddr, 0), 13000, 3),
+			},
+		},
+		"*": {
+			{
+				L3n4Addr: *loadbalancer.NewL3n4Addr(loadbalancer.TCP, types.AddrClusterFrom(testAddr, 0), 15000, 3),
+			},
+		},
+	}
+
+	endpoints := getEndpointsForLBBackends(serviceName, backends)
+	assert.Len(t, endpoints, 4)
+
+	var allClusterNames []string
+	for _, ep := range endpoints {
+		allClusterNames = append(allClusterNames, ep.GetClusterName())
+
+		assert.Len(t, ep.GetEndpoints(), 1)
+		assert.Len(t, ep.GetEndpoints()[0].GetLbEndpoints(), 1)
+		assert.Equal(t, ep.GetEndpoints()[0].GetLbEndpoints()[0].GetHostIdentifier().(*endpointv3.LbEndpoint_Endpoint).Endpoint.Address.GetAddress().(*envoy_config_core.Address_SocketAddress).SocketAddress.Address, "192.128.1.1")
+	}
+
+	assert.Contains(t, allClusterNames, "test-ns/test-name:12000")
+	assert.Contains(t, allClusterNames, "test-ns/test-name:13000")
+	assert.Contains(t, allClusterNames, "test-ns/test-name:*")
+	assert.Contains(t, allClusterNames, "test-ns/test-name")
 }

--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -127,7 +127,7 @@ var (
 	mu lock.Mutex
 )
 
-const cidrLabelsCacheMaxSize = 16384
+const cidrLabelsCacheMaxSize = 8192
 
 var (
 	once sync.Once

--- a/pkg/labels/cidr/cidr.go
+++ b/pkg/labels/cidr/cidr.go
@@ -10,7 +10,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/hashicorp/golang-lru/v2/simplelru"
+
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/lock"
 )
 
 // maskedIPToLabelString is the base method for serializing an IP + prefix into
@@ -81,6 +84,11 @@ func IPStringToLabel(ip string) (labels.Label, error) {
 //
 // The identity reserved:world is always added as it includes any CIDR.
 func GetCIDRLabels(prefix netip.Prefix) labels.Labels {
+	once.Do(func() {
+		// simplelru.NewLRU fails only when given a negative size, so we can skip the error check
+		cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+	})
+
 	addr := prefix.Addr()
 	ones := prefix.Bits()
 	lbls := make(labels.Labels, 1 /* this CIDR */ +ones /* the prefixes */ +1 /*world label*/)
@@ -94,42 +102,51 @@ func GetCIDRLabels(prefix netip.Prefix) labels.Labels {
 		return lbls
 	}
 
-	cache := cidrLabelsCache.Get().(map[netip.Prefix][]labels.Label)
 	computeCIDRLabels(
-		cache,
+		cidrLabelsCache,
 		lbls,
 		nil, // avoid allocating space for the intermediate results until we need it
 		addr,
 		ones,
 		0,
 	)
-	cidrLabelsCache.Put(cache)
 	lbls[worldLabel.Key] = worldLabel
 
 	return lbls
 }
 
-// cidrLabelsCache stores the partial computations for CIDR labels.
-// This both avoids repeatedly computing the prefixes and makes sure the
-// CIDR strings are reused to reduce memory usage.
-// Stored in a sync.Pool to allow GC to garbage collect the cache if needed.
-// With lots of contention, multiple cache maps might exist.
-//
-// Stores e.g. for prefix "10.0.0.0/8" the labels ["10.0.0.0/8", ..., "0.0.0.0/0"].
-var cidrLabelsCache = sync.Pool{
-	New: func() any { return make(map[netip.Prefix][]labels.Label) },
-}
+var (
+	// cidrLabelsCache stores the partial computations for CIDR labels.
+	// This both avoids repeatedly computing the prefixes and makes sure the
+	// CIDR strings are reused to reduce memory usage.
+	// Stored in a lru map to limit memory usage.
+	//
+	// Stores e.g. for prefix "10.0.0.0/8" the labels ["10.0.0.0/8", ..., "0.0.0.0/0"].
+	cidrLabelsCache *simplelru.LRU[netip.Prefix, []labels.Label]
 
-var worldLabel = labels.Label{Key: labels.IDNameWorld, Source: labels.LabelSourceReserved}
+	// mutex to serialize concurrent accesses to the cidrLabelsCache.
+	mu lock.Mutex
+)
 
-func computeCIDRLabels(cache map[netip.Prefix][]labels.Label, lbls labels.Labels, results []labels.Label, addr netip.Addr, ones, i int) []labels.Label {
+const cidrLabelsCacheMaxSize = 16384
+
+var (
+	once sync.Once
+
+	worldLabel = labels.Label{Key: labels.IDNameWorld, Source: labels.LabelSourceReserved}
+)
+
+func computeCIDRLabels(cache *simplelru.LRU[netip.Prefix, []labels.Label], lbls labels.Labels, results []labels.Label, addr netip.Addr, ones, i int) []labels.Label {
 	if i > ones {
 		return results
 	}
 
 	prefix := netip.PrefixFrom(addr, i)
 
-	if cachedLbls, ok := cache[prefix]; ok {
+	mu.Lock()
+	cachedLbls, ok := cache.Get(prefix)
+	mu.Unlock()
+	if ok {
 		for _, lbl := range cachedLbls {
 			lbls[lbl.Key] = lbl
 		}
@@ -151,8 +168,11 @@ func computeCIDRLabels(cache map[netip.Prefix][]labels.Label, lbls labels.Labels
 		append(results, prefixLabel),
 		addr, ones, i+1,
 	)
+
 	// Cache the resulting labels derived from this prefix, e.g. /8, /7, ...
-	cache[prefix] = results[i:]
+	mu.Lock()
+	cache.Add(prefix, results[i:])
+	mu.Unlock()
 
 	return results
 }

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -13,21 +13,10 @@ import (
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
 	"github.com/stretchr/testify/assert"
-	. "gopkg.in/check.v1"
 
-	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 )
-
-// Hook up gocheck into the "go test" runner.
-func Test(t *testing.T) {
-	TestingT(t)
-}
-
-type CIDRLabelsSuite struct{}
-
-var _ = Suite(&CIDRLabelsSuite{})
 
 func TestGetCIDRLabels(t *testing.T) {
 	// clear the cache
@@ -300,7 +289,7 @@ func TestCIDRLabelsCache(t *testing.T) {
 	forward()
 }
 
-func (s *CIDRLabelsSuite) TestIPStringToLabel(c *C) {
+func TestIPStringToLabel(t *testing.T) {
 	for _, tc := range []struct {
 		ip      string
 		label   string
@@ -353,10 +342,10 @@ func (s *CIDRLabelsSuite) TestIPStringToLabel(c *C) {
 	} {
 		lbl, err := IPStringToLabel(tc.ip)
 		if !tc.wantErr {
-			c.Assert(err, IsNil)
-			c.Assert(lbl.String(), checker.DeepEquals, tc.label)
+			assert.NoError(t, err)
+			assert.Equal(t, lbl.String(), tc.label)
 		} else {
-			c.Assert(err, Not(IsNil))
+			assert.Error(t, err)
 		}
 	}
 }

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 	"testing"
 
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/checker"
@@ -175,6 +176,9 @@ func (s *CIDRLabelsSuite) TestIPStringToLabel(c *C) {
 }
 
 func BenchmarkGetCIDRLabels(b *testing.B) {
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+
 	for _, cidr := range []netip.Prefix{
 		netip.MustParsePrefix("0.0.0.0/0"),
 		netip.MustParsePrefix("10.16.0.0/16"),

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -4,8 +4,11 @@
 package cidr
 
 import (
+	"math/rand"
 	"net/netip"
 	"runtime"
+	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
@@ -195,6 +198,43 @@ func BenchmarkGetCIDRLabels(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
 				_ = GetCIDRLabels(cidr)
+			}
+		})
+	}
+}
+
+func BenchmarkGetCIDRLabelsConcurrent(b *testing.B) {
+	prefixes := make([]netip.Prefix, 0, 16)
+	octets := [4]byte{0, 0, 1, 1}
+	for i := 0; i < 16; i++ {
+		octets[0], octets[1] = byte(rand.Intn(256)), byte(rand.Intn(256))
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom4(octets), 32))
+	}
+
+	for _, goroutines := range []int{1, 2, 4, 16, 32, 48} {
+		b.Run(strconv.Itoa(goroutines), func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				start := make(chan struct{})
+				var wg sync.WaitGroup
+
+				wg.Add(goroutines)
+				for j := 0; j < goroutines; j++ {
+					go func() {
+						defer wg.Done()
+
+						<-start
+
+						for k := 0; k < 64; k++ {
+							_ = GetCIDRLabels(prefixes[rand.Intn(len(prefixes))])
+						}
+					}()
+				}
+
+				b.StartTimer()
+				close(start)
+				wg.Wait()
 			}
 		})
 	}

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -12,10 +12,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
+	"github.com/stretchr/testify/assert"
 	. "gopkg.in/check.v1"
 
 	"github.com/cilium/cilium/pkg/checker"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/option"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -27,95 +29,275 @@ type CIDRLabelsSuite struct{}
 
 var _ = Suite(&CIDRLabelsSuite{})
 
-// TestGetCIDRLabels checks that GetCIDRLabels returns a sane set of labels for
-// given CIDRs.
-func (s *CIDRLabelsSuite) TestGetCIDRLabels(c *C) {
-	prefix := netip.MustParsePrefix("192.0.2.3/32")
-	expected := labels.ParseLabelArray(
-		"cidr:0.0.0.0/0",
-		"cidr:128.0.0.0/1",
-		"cidr:192.0.0.0/8",
-		"cidr:192.0.2.0/24",
-		"cidr:192.0.2.3/32",
-		"reserved:world",
-	)
+func TestGetCIDRLabels(t *testing.T) {
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
 
-	lbls := GetCIDRLabels(prefix)
-	lblArray := lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, labels.LabelArray{})
-	// IPs should be masked as the labels are generated
-	c.Assert(lblArray.Has("cidr:192.0.2.3/24"), Equals, false)
+	// save global config and restore it at the end of the test
+	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4, option.Config.EnableIPv6 = enableIPv4, enableIPv6
+	})
 
-	prefix = netip.MustParsePrefix("192.0.2.0/24")
-	expected = labels.ParseLabelArray(
-		"cidr:0.0.0.0/0",
-		"cidr:192.0.2.0/24",
-		"reserved:world",
-	)
+	for _, tc := range []struct {
+		name       string
+		enableIPv4 bool
+		enableIPv6 bool
+		prefix     netip.Prefix
+		expected   labels.LabelArray
+	}{
+		{
+			name:       "IPv4 /32 prefix",
+			enableIPv4: true,
+			enableIPv6: false,
+			prefix:     netip.MustParsePrefix("192.0.2.3/32"),
+			expected: labels.ParseLabelArray(
+				"cidr:0.0.0.0/0",
+				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
+				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
+				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
+				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
+				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
+				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
+				"cidr:192.0.2.0/25", "cidr:192.0.2.0/26", "cidr:192.0.2.0/27", "cidr:192.0.2.0/28",
+				"cidr:192.0.2.0/29", "cidr:192.0.2.0/30", "cidr:192.0.2.2/31", "cidr:192.0.2.3/32",
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv4 /24 prefix",
+			enableIPv4: true,
+			enableIPv6: false,
+			prefix:     netip.MustParsePrefix("192.0.2.0/24"),
+			expected: labels.ParseLabelArray(
+				"cidr:0.0.0.0/0",
+				"cidr:128.0.0.0/1", "cidr:192.0.0.0/2", "cidr:192.0.0.0/3", "cidr:192.0.0.0/4",
+				"cidr:192.0.0.0/5", "cidr:192.0.0.0/6", "cidr:192.0.0.0/7", "cidr:192.0.0.0/8",
+				"cidr:192.0.0.0/9", "cidr:192.0.0.0/10", "cidr:192.0.0.0/11", "cidr:192.0.0.0/12",
+				"cidr:192.0.0.0/13", "cidr:192.0.0.0/14", "cidr:192.0.0.0/15", "cidr:192.0.0.0/16",
+				"cidr:192.0.0.0/17", "cidr:192.0.0.0/18", "cidr:192.0.0.0/19", "cidr:192.0.0.0/20",
+				"cidr:192.0.0.0/21", "cidr:192.0.0.0/22", "cidr:192.0.2.0/23", "cidr:192.0.2.0/24",
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv4 /16 prefix",
+			enableIPv4: true,
+			enableIPv6: false,
+			prefix:     netip.MustParsePrefix("10.0.0.0/16"),
+			expected: labels.ParseLabelArray(
+				"cidr:0.0.0.0/0",
+				"cidr:0.0.0.0/1", "cidr:0.0.0.0/2", "cidr:0.0.0.0/3", "cidr:0.0.0.0/4",
+				"cidr:8.0.0.0/5", "cidr:8.0.0.0/6", "cidr:10.0.0.0/7", "cidr:10.0.0.0/8",
+				"cidr:10.0.0.0/9", "cidr:10.0.0.0/10", "cidr:10.0.0.0/11", "cidr:10.0.0.0/12",
+				"cidr:10.0.0.0/13", "cidr:10.0.0.0/14", "cidr:10.0.0.0/15", "cidr:10.0.0.0/16",
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv4 zero length prefix",
+			enableIPv4: true,
+			enableIPv6: false,
+			prefix:     netip.MustParsePrefix("0.0.0.0/0"),
+			expected: labels.ParseLabelArray(
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv6 /112 prefix",
+			enableIPv4: false,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("2001:db8:cafe::cab:4:b0b:0/112"),
+			expected: labels.ParseLabelArray(
+				// Note that we convert the colons in IPv6 addresses into dashes when
+				// translating into labels, because endpointSelectors don't support
+				// colons.
+				"cidr:0--0/0",
+				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
+				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
+				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
+				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
+				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
+				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
+				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
+				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
+				"cidr:2001-db8-8000--0/33", "cidr:2001-db8-c000--0/34", "cidr:2001-db8-c000--0/35", "cidr:2001-db8-c000--0/36",
+				"cidr:2001-db8-c800--0/37", "cidr:2001-db8-c800--0/38", "cidr:2001-db8-ca00--0/39", "cidr:2001-db8-ca00--0/40",
+				"cidr:2001-db8-ca80--0/41", "cidr:2001-db8-cac0--0/42", "cidr:2001-db8-cae0--0/43", "cidr:2001-db8-caf0--0/44",
+				"cidr:2001-db8-caf8--0/45", "cidr:2001-db8-cafc--0/46", "cidr:2001-db8-cafe--0/47", "cidr:2001-db8-cafe--0/48",
+				"cidr:2001-db8-cafe--0/49", "cidr:2001-db8-cafe--0/50", "cidr:2001-db8-cafe--0/51", "cidr:2001-db8-cafe--0/52",
+				"cidr:2001-db8-cafe--0/53", "cidr:2001-db8-cafe--0/54", "cidr:2001-db8-cafe--0/55", "cidr:2001-db8-cafe--0/56",
+				"cidr:2001-db8-cafe--0/57", "cidr:2001-db8-cafe--0/58", "cidr:2001-db8-cafe--0/59", "cidr:2001-db8-cafe--0/60",
+				"cidr:2001-db8-cafe--0/61", "cidr:2001-db8-cafe--0/62", "cidr:2001-db8-cafe--0/63", "cidr:2001-db8-cafe--0/64",
+				"cidr:2001-db8-cafe--0/65", "cidr:2001-db8-cafe--0/66", "cidr:2001-db8-cafe--0/67", "cidr:2001-db8-cafe--0/68",
+				"cidr:2001-db8-cafe-0-800--0/69", "cidr:2001-db8-cafe-0-c00--0/70", "cidr:2001-db8-cafe-0-c00--0/71", "cidr:2001-db8-cafe-0-c00--0/72",
+				"cidr:2001-db8-cafe-0-c80--0/73", "cidr:2001-db8-cafe-0-c80--0/74", "cidr:2001-db8-cafe-0-ca0--0/75", "cidr:2001-db8-cafe-0-ca0--0/76",
+				"cidr:2001-db8-cafe-0-ca8--0/77", "cidr:2001-db8-cafe-0-ca8--0/78", "cidr:2001-db8-cafe-0-caa--0/79", "cidr:2001-db8-cafe-0-cab--0/80",
+				"cidr:2001-db8-cafe-0-cab--0/81", "cidr:2001-db8-cafe-0-cab--0/82", "cidr:2001-db8-cafe-0-cab--0/83", "cidr:2001-db8-cafe-0-cab--0/84",
+				"cidr:2001-db8-cafe-0-cab--0/85", "cidr:2001-db8-cafe-0-cab--0/86", "cidr:2001-db8-cafe-0-cab--0/87", "cidr:2001-db8-cafe-0-cab--0/88",
+				"cidr:2001-db8-cafe-0-cab--0/89", "cidr:2001-db8-cafe-0-cab--0/90", "cidr:2001-db8-cafe-0-cab--0/91", "cidr:2001-db8-cafe-0-cab--0/92",
+				"cidr:2001-db8-cafe-0-cab--0/93", "cidr:2001-db8-cafe-0-cab-4--0/94", "cidr:2001-db8-cafe-0-cab-4--0/95", "cidr:2001-db8-cafe-0-cab-4--0/96",
+				"cidr:2001-db8-cafe-0-cab-4--0/97", "cidr:2001-db8-cafe-0-cab-4--0/98", "cidr:2001-db8-cafe-0-cab-4--0/99", "cidr:2001-db8-cafe-0-cab-4--0/100",
+				"cidr:2001-db8-cafe-0-cab-4-800-0/101", "cidr:2001-db8-cafe-0-cab-4-800-0/102", "cidr:2001-db8-cafe-0-cab-4-a00-0/103", "cidr:2001-db8-cafe-0-cab-4-b00-0/104",
+				"cidr:2001-db8-cafe-0-cab-4-b00-0/105", "cidr:2001-db8-cafe-0-cab-4-b00-0/106", "cidr:2001-db8-cafe-0-cab-4-b00-0/107", "cidr:2001-db8-cafe-0-cab-4-b00-0/108",
+				"cidr:2001-db8-cafe-0-cab-4-b08-0/109", "cidr:2001-db8-cafe-0-cab-4-b08-0/110", "cidr:2001-db8-cafe-0-cab-4-b0a-0/111", "cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
+				"reserved:world",
+			),
+		},
+		{
+			name:       "IPv6 /128 prefix",
+			enableIPv4: false,
+			enableIPv6: true,
+			prefix:     netip.MustParsePrefix("2001:DB8::1/128"),
+			expected: labels.ParseLabelArray(
+				"cidr:0--0/0",
+				"cidr:0--0/1", "cidr:0--0/2", "cidr:2000--0/3", "cidr:2000--0/4",
+				"cidr:2000--0/5", "cidr:2000--0/6", "cidr:2000--0/7", "cidr:2000--0/8",
+				"cidr:2000--0/9", "cidr:2000--0/10", "cidr:2000--0/11", "cidr:2000--0/12",
+				"cidr:2000--0/13", "cidr:2000--0/14", "cidr:2000--0/15", "cidr:2001--0/16",
+				"cidr:2001--0/17", "cidr:2001--0/18", "cidr:2001--0/19", "cidr:2001--0/20",
+				"cidr:2001-800--0/21", "cidr:2001-c00--0/22", "cidr:2001-c00--0/23", "cidr:2001-d00--0/24",
+				"cidr:2001-d80--0/25", "cidr:2001-d80--0/26", "cidr:2001-da0--0/27", "cidr:2001-db0--0/28",
+				"cidr:2001-db8--0/29", "cidr:2001-db8--0/30", "cidr:2001-db8--0/31", "cidr:2001-db8--0/32",
+				"cidr:2001-db8--0/33", "cidr:2001-db8--0/34", "cidr:2001-db8--0/35", "cidr:2001-db8--0/36",
+				"cidr:2001-db8--0/37", "cidr:2001-db8--0/38", "cidr:2001-db8--0/39", "cidr:2001-db8--0/40",
+				"cidr:2001-db8--0/41", "cidr:2001-db8--0/42", "cidr:2001-db8--0/43", "cidr:2001-db8--0/44",
+				"cidr:2001-db8--0/45", "cidr:2001-db8--0/46", "cidr:2001-db8--0/47", "cidr:2001-db8--0/48",
+				"cidr:2001-db8--0/49", "cidr:2001-db8--0/50", "cidr:2001-db8--0/51", "cidr:2001-db8--0/52",
+				"cidr:2001-db8--0/53", "cidr:2001-db8--0/54", "cidr:2001-db8--0/55", "cidr:2001-db8--0/56",
+				"cidr:2001-db8--0/57", "cidr:2001-db8--0/58", "cidr:2001-db8--0/59", "cidr:2001-db8--0/60",
+				"cidr:2001-db8--0/61", "cidr:2001-db8--0/62", "cidr:2001-db8--0/63", "cidr:2001-db8--0/64",
+				"cidr:2001-db8--0/65", "cidr:2001-db8--0/66", "cidr:2001-db8--0/67", "cidr:2001-db8--0/68",
+				"cidr:2001-db8--0/69", "cidr:2001-db8--0/70", "cidr:2001-db8--0/71", "cidr:2001-db8--0/72",
+				"cidr:2001-db8--0/73", "cidr:2001-db8--0/74", "cidr:2001-db8--0/75", "cidr:2001-db8--0/76",
+				"cidr:2001-db8--0/77", "cidr:2001-db8--0/78", "cidr:2001-db8--0/79", "cidr:2001-db8--0/80",
+				"cidr:2001-db8--0/81", "cidr:2001-db8--0/82", "cidr:2001-db8--0/83", "cidr:2001-db8--0/84",
+				"cidr:2001-db8--0/85", "cidr:2001-db8--0/86", "cidr:2001-db8--0/87", "cidr:2001-db8--0/88",
+				"cidr:2001-db8--0/89", "cidr:2001-db8--0/90", "cidr:2001-db8--0/91", "cidr:2001-db8--0/92",
+				"cidr:2001-db8--0/93", "cidr:2001-db8--0/94", "cidr:2001-db8--0/95", "cidr:2001-db8--0/96",
+				"cidr:2001-db8--0/97", "cidr:2001-db8--0/98", "cidr:2001-db8--0/99", "cidr:2001-db8--0/100",
+				"cidr:2001-db8--0/101", "cidr:2001-db8--0/102", "cidr:2001-db8--0/103", "cidr:2001-db8--0/104",
+				"cidr:2001-db8--0/105", "cidr:2001-db8--0/106", "cidr:2001-db8--0/107", "cidr:2001-db8--0/108",
+				"cidr:2001-db8--0/109", "cidr:2001-db8--0/110", "cidr:2001-db8--0/111", "cidr:2001-db8--0/112",
+				"cidr:2001-db8--0/113", "cidr:2001-db8--0/114", "cidr:2001-db8--0/115", "cidr:2001-db8--0/116",
+				"cidr:2001-db8--0/117", "cidr:2001-db8--0/118", "cidr:2001-db8--0/119", "cidr:2001-db8--0/120",
+				"cidr:2001-db8--0/121", "cidr:2001-db8--0/122", "cidr:2001-db8--0/123", "cidr:2001-db8--0/124",
+				"cidr:2001-db8--0/125", "cidr:2001-db8--0/126", "cidr:2001-db8--0/127", "cidr:2001-db8--1/128",
+				"reserved:world",
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			option.Config.EnableIPv4 = tc.enableIPv4
+			option.Config.EnableIPv6 = tc.enableIPv6
 
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, labels.LabelArray{})
-	// CIDRs that are covered by the prefix should not be in the labels
-	c.Assert(lblArray.Has("cidr.192.0.2.3/32"), Equals, false)
+			lbls := GetCIDRLabels(tc.prefix)
+			lblArray := lbls.LabelArray()
+			assert.ElementsMatch(t, lblArray, tc.expected)
 
-	// Zero-length prefix / default route should become reserved:world.
-	prefix = netip.MustParsePrefix("0.0.0.0/0")
-	expected = labels.ParseLabelArray(
-		"reserved:world",
-	)
+			// compute labels twice to verify the caching behavior
 
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, labels.LabelArray{})
-	c.Assert(lblArray.Has("cidr.0.0.0.0/0"), Equals, false)
-
-	// Note that we convert the colons in IPv6 addresses into dashes when
-	// translating into labels, because endpointSelectors don't support
-	// colons.
-	prefix = netip.MustParsePrefix("2001:DB8::1/128")
-	expected = labels.ParseLabelArray(
-		"cidr:0--0/0",
-		"cidr:2000--0/3",
-		"cidr:2001--0/16",
-		"cidr:2001-d00--0/24",
-		"cidr:2001-db8--0/32",
-		"cidr:2001-db8--1/128",
-		"reserved:world",
-	)
-
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, labels.LabelArray{})
-	// IPs should be masked as the labels are generated
-	c.Assert(lblArray.Has("cidr.2001-db8--1/24"), Equals, false)
+			lbls = GetCIDRLabels(tc.prefix)
+			lblArray = lbls.LabelArray()
+			assert.ElementsMatch(t, lblArray, tc.expected)
+		})
+	}
 }
 
-// TestGetCIDRLabelsInCluster checks that the cluster label is properly added
-// when getting labels for CIDRs that are equal to or within the cluster range.
-func (s *CIDRLabelsSuite) TestGetCIDRLabelsInCluster(c *C) {
-	prefix := netip.MustParsePrefix("10.0.0.0/16")
-	expected := labels.ParseLabelArray(
-		"cidr:0.0.0.0/0",
-		"cidr:10.0.0.0/16",
-		"reserved:world",
-	)
-	lbls := GetCIDRLabels(prefix)
-	lblArray := lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, labels.LabelArray{})
+func TestCIDRLabelsCache(t *testing.T) {
+	// save global config and restore it at the end of the test
+	enableIPv4, enableIPv6 := option.Config.EnableIPv4, option.Config.EnableIPv6
+	t.Cleanup(func() {
+		option.Config.EnableIPv4, option.Config.EnableIPv6 = enableIPv4, enableIPv6
+	})
 
-	// This case is firmly within the cluster range
-	prefix = netip.MustParsePrefix("2001:db8:cafe::cab:4:b0b:0/112")
-	expected = labels.ParseLabelArray(
-		"cidr:0--0/0",
-		"cidr:2001-db8-cafe--0/64",
-		"cidr:2001-db8-cafe-0-cab-4--0/96",
-		"cidr:2001-db8-cafe-0-cab-4-b0b-0/112",
-		"reserved:world",
-	)
-	lbls = GetCIDRLabels(prefix)
-	lblArray = lbls.LabelArray()
-	c.Assert(lblArray.Lacks(expected), checker.DeepEquals, labels.LabelArray{})
+	prefixes := []netip.Prefix{
+		netip.MustParsePrefix("87.151.93.239/32"), netip.MustParsePrefix("87.151.93.238/31"),
+		netip.MustParsePrefix("87.151.93.236/30"), netip.MustParsePrefix("87.151.93.232/29"),
+		netip.MustParsePrefix("87.151.93.224/28"), netip.MustParsePrefix("87.151.93.224/27"),
+		netip.MustParsePrefix("87.151.93.192/26"), netip.MustParsePrefix("87.151.93.128/25"),
+		netip.MustParsePrefix("87.151.93.0/24"), netip.MustParsePrefix("87.151.92.0/23"),
+		netip.MustParsePrefix("87.151.92.0/22"), netip.MustParsePrefix("87.151.88.0/21"),
+		netip.MustParsePrefix("87.151.80.0/20"), netip.MustParsePrefix("87.151.64.0/19"),
+		netip.MustParsePrefix("87.151.64.0/18"), netip.MustParsePrefix("87.151.0.0/17"),
+		netip.MustParsePrefix("87.151.0.0/16"), netip.MustParsePrefix("87.150.0.0/15"),
+		netip.MustParsePrefix("87.148.0.0/14"), netip.MustParsePrefix("87.144.0.0/13"),
+		netip.MustParsePrefix("87.144.0.0/12"), netip.MustParsePrefix("87.128.0.0/11"),
+		netip.MustParsePrefix("87.128.0.0/10"), netip.MustParsePrefix("87.128.0.0/9"),
+		netip.MustParsePrefix("87.0.0.0/8"), netip.MustParsePrefix("86.0.0.0/7"),
+		netip.MustParsePrefix("84.0.0.0/6"), netip.MustParsePrefix("80.0.0.0/5"),
+		netip.MustParsePrefix("80.0.0.0/4"), netip.MustParsePrefix("64.0.0.0/3"),
+		netip.MustParsePrefix("64.0.0.0/2"), netip.MustParsePrefix("0.0.0.0/1"),
+		netip.MustParsePrefix("0.0.0.0/0"),
+	}
+	cidrLabels := []string{
+		"cidr:0.0.0.0/0",
+		"cidr:0.0.0.0/1", "cidr:64.0.0.0/2", "cidr:64.0.0.0/3", "cidr:80.0.0.0/4",
+		"cidr:80.0.0.0/5", "cidr:84.0.0.0/6", "cidr:86.0.0.0/7", "cidr:87.0.0.0/8",
+		"cidr:87.128.0.0/9", "cidr:87.128.0.0/10", "cidr:87.128.0.0/11", "cidr:87.144.0.0/12",
+		"cidr:87.144.0.0/13", "cidr:87.148.0.0/14", "cidr:87.150.0.0/15", "cidr:87.151.0.0/16",
+		"cidr:87.151.0.0/17", "cidr:87.151.64.0/18", "cidr:87.151.64.0/19", "cidr:87.151.80.0/20",
+		"cidr:87.151.88.0/21", "cidr:87.151.92.0/22", "cidr:87.151.92.0/23", "cidr:87.151.93.0/24",
+		"cidr:87.151.93.128/25", "cidr:87.151.93.192/26", "cidr:87.151.93.224/27", "cidr:87.151.93.224/28",
+		"cidr:87.151.93.232/29", "cidr:87.151.93.236/30", "cidr:87.151.93.238/31", "cidr:87.151.93.239/32",
+	}
+
+	// check all the labels computing them from the largest CIDR to the smaller ones.
+	forward := func() {
+		for i := 0; i < len(prefixes); i++ {
+			lbls := GetCIDRLabels(prefixes[i])
+			lblArray := lbls.LabelArray()
+
+			var expectedLblArray labels.LabelArray
+			if prefixes[i] == prefixes[len(prefixes)-1] { // default route "0.0.0.0/0" should become "reserved:world"
+				expectedLblArray = labels.ParseLabelArray("reserved:world")
+			} else {
+				expectedLbls := make([]string, len(cidrLabels)-i)
+				copy(expectedLbls, cidrLabels[:len(cidrLabels)-i])
+				expectedLblArray = labels.ParseLabelArray(append(expectedLbls, "reserved:world")...)
+			}
+
+			assert.ElementsMatch(t, lblArray, expectedLblArray)
+		}
+	}
+	// check all the labels computing them from the smallest CIDR to the larger ones.
+	backward := func() {
+		for i := 0; i < len(prefixes); i++ {
+			lbls := GetCIDRLabels(prefixes[i])
+			lblArray := lbls.LabelArray()
+
+			var expectedLblArray labels.LabelArray
+			if prefixes[i] == prefixes[len(prefixes)-1] { // default route "0.0.0.0/0" should become "reserved:world"
+				expectedLblArray = labels.ParseLabelArray("reserved:world")
+			} else {
+				expectedLbls := make([]string, len(cidrLabels)-i)
+				copy(expectedLbls, cidrLabels[:len(cidrLabels)-i])
+				expectedLblArray = labels.ParseLabelArray(append(expectedLbls, "reserved:world")...)
+			}
+
+			assert.ElementsMatch(t, lblArray, expectedLblArray)
+		}
+	}
+
+	option.Config.EnableIPv4, option.Config.EnableIPv6 = true, false
+
+	// First, compute all the labels starting from the largest CIDR to the smaller ones.
+	// This will warm up the LRU cache. Then, do it the other way around to verify that
+	// the cache has been populated correctly and results are consistent.
+
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+
+	forward()
+	backward()
+
+	// Now, verify that the cache is populated correctly doing the opposite.
+
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+
+	backward()
+	forward()
 }
 
 func (s *CIDRLabelsSuite) TestIPStringToLabel(c *C) {

--- a/pkg/labels/cidr/cidr_test.go
+++ b/pkg/labels/cidr/cidr_test.go
@@ -5,6 +5,7 @@ package cidr
 
 import (
 	"net/netip"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/golang-lru/v2/simplelru"
@@ -197,6 +198,87 @@ func BenchmarkGetCIDRLabels(b *testing.B) {
 			}
 		})
 	}
+}
+
+// BenchmarkCIDRLabelsCacheHeapUsageIPv4 should be run with -benchtime=1x
+func BenchmarkCIDRLabelsCacheHeapUsageIPv4(b *testing.B) {
+	b.Skip()
+
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+
+	// be sure to fill the cache
+	prefixes := make([]netip.Prefix, 0, 256*256)
+	octets := [4]byte{0, 0, 1, 1}
+	for i := 0; i < 256*256; i++ {
+		octets[0], octets[1] = byte(i/256), byte(i%256)
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom4(octets), 32))
+	}
+
+	var m1, m2 runtime.MemStats
+	// One GC does not give precise results,
+	// because concurrent sweep may be still in progress.
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, cidr := range prefixes {
+			_ = GetCIDRLabels(cidr)
+		}
+	}
+	b.StopTimer()
+
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+
+	usage := m2.HeapAlloc - m1.HeapAlloc
+	b.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
+}
+
+// BenchmarkCIDRLabelsCacheHeapUsageIPv6 should be run with -benchtime=1x
+func BenchmarkCIDRLabelsCacheHeapUsageIPv6(b *testing.B) {
+	b.Skip()
+
+	// clear the cache
+	cidrLabelsCache, _ = simplelru.NewLRU[netip.Prefix, []labels.Label](cidrLabelsCacheMaxSize, nil)
+
+	// be sure to fill the cache
+	prefixes := make([]netip.Prefix, 0, 256*256)
+	octets := [16]byte{
+		0x00, 0x00, 0x00, 0xd8, 0x33, 0x33, 0x44, 0x44,
+		0x55, 0x55, 0x66, 0x66, 0x77, 0x77, 0x88, 0x88,
+	}
+	for i := 0; i < 256*256; i++ {
+		octets[15], octets[14] = byte(i/256), byte(i%256)
+		prefixes = append(prefixes, netip.PrefixFrom(netip.AddrFrom16(octets), 128))
+	}
+
+	var m1, m2 runtime.MemStats
+	// One GC does not give precise results,
+	// because concurrent sweep may be still in progress.
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m1)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, cidr := range prefixes {
+			_ = GetCIDRLabels(cidr)
+		}
+	}
+	b.StopTimer()
+
+	runtime.GC()
+	runtime.GC()
+	runtime.ReadMemStats(&m2)
+
+	usage := m2.HeapAlloc - m1.HeapAlloc
+	b.Logf("Memoization map heap usage: %.2f KiB", float64(usage)/1024)
 }
 
 func BenchmarkIPStringToLabel(b *testing.B) {

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -395,6 +395,15 @@ func NewLabelsFromModel(base []string) Labels {
 	return lbls
 }
 
+// FromSlice creates labels from a slice of labels.
+func FromSlice(labels []Label) Labels {
+	lbls := make(Labels, len(labels))
+	for _, lbl := range labels {
+		lbls[lbl.Key] = lbl
+	}
+	return lbls
+}
+
 // NewLabelsFromSortedList returns labels based on the output of SortedList()
 func NewLabelsFromSortedList(list string) Labels {
 	return NewLabelsFromModel(strings.Split(list, ";"))

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -354,9 +354,13 @@ func purgeCtEntry6(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 
 	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
 		if entry.isDsrEntry() {
-			// To delete NAT entries created by DSR
+			// To delete NAT entries created by legacy DSR
 			nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
 		}
+	} else if t.GetFlags()&tuple.TUPLE_F_OUT == tuple.TUPLE_F_OUT &&
+		entry.isDsrEntry() {
+		// To delete NAT entries created by DSR
+		nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
 	} else {
 		nat.DeleteMapping6(natMap, t.(*tuple.TupleKey6Global))
 	}
@@ -451,9 +455,13 @@ func purgeCtEntry4(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 
 	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
 		if entry.isDsrEntry() {
-			// To delete NAT entries created by DSR
+			// To delete NAT entries created by legacy DSR
 			nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
 		}
+	} else if t.GetFlags()&tuple.TUPLE_F_OUT == tuple.TUPLE_F_OUT &&
+		entry.isDsrEntry() {
+		// To delete NAT entries created by DSR
+		nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
 	} else {
 		nat.DeleteMapping4(natMap, t.(*tuple.TupleKey4Global))
 	}

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -571,8 +571,10 @@ func GC(m *Map, filter *GCFilter) int {
 // PurgeOrphanNATEntries removes orphan SNAT entries. We call an SNAT entry
 // orphan if it does not have a corresponding CT entry.
 //
-// This can happen when the CT entry is removed by the LRU eviction which
-// happens when the CT map becomes full.
+// Typically NAT entries should get removed along with their owning CT entry,
+// as part of purgeCtEntry*(). But stale NAT entries can get left behind if the
+// CT entry disappears for other reasons - for instance by LRU eviction, or
+// when the datapath re-purposes the CT entry.
 //
 // PurgeOrphanNATEntries() is triggered by the datapath via the GC signaling
 // mechanism. When the datapath SNAT fails to find free mapping after

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -346,10 +346,20 @@ func newMap(mapName string, m mapType) *Map {
 
 func purgeCtEntry6(m *Map, key CtKey, natMap *nat.Map) error {
 	err := m.Delete(key)
-	if err == nil && natMap != nil {
-		natMap.DeleteMapping(key.GetTupleKey())
+	if err != nil || natMap == nil {
+		return err
 	}
-	return err
+
+	t := key.GetTupleKey()
+
+	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
+		// To delete NAT entries created by DSR
+		nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
+	} else {
+		nat.DeleteMapping6(natMap, t.(*tuple.TupleKey6Global))
+	}
+
+	return nil
 }
 
 // doGC6 iterates through a CTv6 map and drops entries based on the given
@@ -431,10 +441,20 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 
 func purgeCtEntry4(m *Map, key CtKey, natMap *nat.Map) error {
 	err := m.Delete(key)
-	if err == nil && natMap != nil {
-		natMap.DeleteMapping(key.GetTupleKey())
+	if err != nil || natMap == nil {
+		return err
 	}
-	return err
+
+	t := key.GetTupleKey()
+
+	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
+		// To delete NAT entries created by DSR
+		nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
+	} else {
+		nat.DeleteMapping4(natMap, t.(*tuple.TupleKey4Global))
+	}
+
+	return nil
 }
 
 // doGC4 iterates through a CTv4 map and drops entries based on the given

--- a/pkg/maps/ctmap/ctmap.go
+++ b/pkg/maps/ctmap/ctmap.go
@@ -344,7 +344,7 @@ func newMap(mapName string, m mapType) *Map {
 	return result
 }
 
-func purgeCtEntry6(m *Map, key CtKey, natMap *nat.Map) error {
+func purgeCtEntry6(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 	err := m.Delete(key)
 	if err != nil || natMap == nil {
 		return err
@@ -353,8 +353,10 @@ func purgeCtEntry6(m *Map, key CtKey, natMap *nat.Map) error {
 	t := key.GetTupleKey()
 
 	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
-		// To delete NAT entries created by DSR
-		nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
+		if entry.isDsrEntry() {
+			// To delete NAT entries created by DSR
+			nat.DeleteSwappedMapping6(natMap, t.(*tuple.TupleKey6Global))
+		}
 	} else {
 		nat.DeleteMapping6(natMap, t.(*tuple.TupleKey6Global))
 	}
@@ -398,7 +400,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry6(m, currentKey6Global, natMap)
+				err := purgeCtEntry6(m, currentKey6Global, entry, natMap)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey6Global.String()).Error("Unable to delete CT entry")
 				} else {
@@ -418,7 +420,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry6(m, currentKey6, natMap)
+				err := purgeCtEntry6(m, currentKey6, entry, natMap)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey6.String()).Error("Unable to delete CT entry")
 				} else {
@@ -439,7 +441,7 @@ func doGC6(m *Map, filter *GCFilter) gcStats {
 	return stats
 }
 
-func purgeCtEntry4(m *Map, key CtKey, natMap *nat.Map) error {
+func purgeCtEntry4(m *Map, key CtKey, entry *CtEntry, natMap *nat.Map) error {
 	err := m.Delete(key)
 	if err != nil || natMap == nil {
 		return err
@@ -448,8 +450,10 @@ func purgeCtEntry4(m *Map, key CtKey, natMap *nat.Map) error {
 	t := key.GetTupleKey()
 
 	if t.GetFlags()&tuple.TUPLE_F_IN != 0 {
-		// To delete NAT entries created by DSR
-		nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
+		if entry.isDsrEntry() {
+			// To delete NAT entries created by DSR
+			nat.DeleteSwappedMapping4(natMap, t.(*tuple.TupleKey4Global))
+		}
 	} else {
 		nat.DeleteMapping4(natMap, t.(*tuple.TupleKey4Global))
 	}
@@ -492,7 +496,7 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry4(m, currentKey4Global, natMap)
+				err := purgeCtEntry4(m, currentKey4Global, entry, natMap)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey4Global.String()).Error("Unable to delete CT entry")
 				} else {
@@ -512,7 +516,7 @@ func doGC4(m *Map, filter *GCFilter) gcStats {
 
 			switch action {
 			case deleteEntry:
-				err := purgeCtEntry4(m, currentKey4, natMap)
+				err := purgeCtEntry4(m, currentKey4, entry, natMap)
 				if err != nil {
 					log.WithError(err).WithField(logfields.Key, currentKey4.String()).Error("Unable to delete CT entry")
 				} else {

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -579,6 +579,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		TxPackets: 1,
 		TxBytes:   216,
 		Lifetime:  37459,
+		Flags:     DSR,
 	}
 	err = bpf.UpdateElement(ctMapTCP.Map.GetFd(), ctMapTCP.Map.Name(), unsafe.Pointer(ctKey),
 		unsafe.Pointer(ctVal), 0)
@@ -654,6 +655,7 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 		TxPackets: 1,
 		TxBytes:   216,
 		Lifetime:  37459,
+		Flags:     DSR,
 	}
 	err = bpf.UpdateElement(ctMapTCP.Map.GetFd(), ctMapTCP.Map.Name(), unsafe.Pointer(ctKey),
 		unsafe.Pointer(ctVal), 0)

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -49,7 +49,7 @@ func (k *CTMapPrivilegedTestSuite) Benchmark_MapUpdate(c *C) {
 			DestPort:   0,
 			SourcePort: 0,
 			NextHeader: u8proto.TCP,
-			Flags:      0,
+			Flags:      tuple.TUPLE_F_OUT,
 		},
 	}
 	value := &CtEntry{
@@ -58,7 +58,7 @@ func (k *CTMapPrivilegedTestSuite) Benchmark_MapUpdate(c *C) {
 		TxPackets:        4,
 		TxBytes:          216,
 		Lifetime:         37459,
-		Flags:            0x0011,
+		Flags:            SeenNonSyn | RxClosing,
 		RevNAT:           0,
 		TxFlagsSeen:      0x02,
 		RxFlagsSeen:      0x14,
@@ -146,7 +146,7 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 				DestPort:   0,
 				SourcePort: 0x3195,
 				NextHeader: u8proto.ICMP,
-				Flags:      0,
+				Flags:      tuple.TUPLE_F_OUT,
 			},
 		},
 	}
@@ -167,7 +167,7 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 				SourcePort: 0,
 				DestPort:   0x3195,
 				NextHeader: u8proto.ICMP,
-				Flags:      1,
+				Flags:      tuple.TUPLE_F_IN,
 			},
 		},
 	}

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -316,6 +316,96 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcTcp(c *C) {
 	c.Assert(len(buf), Equals, 0)
 }
 
+// TestCtGcLegacyDsr tests whether DSR NAT entries are removed upon a removal of
+// their legacy CT entry (== CT_INGRESS).
+// See https://github.com/cilium/cilium/pull/22978 for details.
+func (k *CTMapPrivilegedTestSuite) TestCtGcLegacyDsr(c *C) {
+	// Init maps
+	natMap := nat.NewMap("cilium_nat_any4_test", true, 1000)
+	_, err := natMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer natMap.Map.Unpin()
+
+	ctMapName := MapNameTCP4Global + "_test"
+	setupMapInfo(mapTypeIPv4TCPGlobal, ctMapName,
+		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
+		100, natMap)
+
+	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
+	_, err = ctMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer ctMap.Map.Unpin()
+
+	// Create the following entries and check that they get GC-ed:
+	//	- CT:	TCP IN 1.1.1.1:1111 -> 192.168.61.11:8080 <..>
+	//	- NAT: 	TCP OUT 192.168.61.11:8080 -> 1.1.1.1:1111 XLATE_SRC 2.2.2.2:80
+
+	ctKey := &CtKey4Global{
+		tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: types.IPv4{192, 168, 61, 11},
+				DestAddr:   types.IPv4{1, 1, 1, 1},
+				SourcePort: 0x5704,
+				DestPort:   0x901f,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_IN,
+			},
+		},
+	}
+	ctVal := &CtEntry{
+		TxPackets: 1,
+		TxBytes:   216,
+		Lifetime:  37459,
+		Flags:     DSR,
+	}
+	err = ctMap.Map.Update(ctKey, ctVal)
+	c.Assert(err, IsNil)
+
+	natKey := &nat.NatKey4{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				DestAddr:   types.IPv4{1, 1, 1, 1},
+				SourceAddr: types.IPv4{192, 168, 61, 11},
+				DestPort:   0x5704,
+				SourcePort: 0x901f,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	natVal := &nat.NatEntry4{
+		Created: 37400,
+		Addr:    types.IPv4{2, 2, 2, 2},
+		Port:    0x50,
+	}
+	err = natMap.Map.Update(natKey, natVal)
+	c.Assert(err, IsNil)
+
+	buf := make(map[string][]string)
+	err = ctMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 1)
+
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 1)
+
+	// GC and check whether NAT entry has been collected
+	filter := &GCFilter{
+		RemoveExpired: true,
+		Time:          39000,
+	}
+	stats := doGC4(ctMap, filter)
+	c.Assert(stats.aliveEntries, Equals, uint32(0))
+	c.Assert(stats.deleted, Equals, uint32(1))
+
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+}
+
 // TestOrphanNat checks whether dangling NAT entries are GC'd (GH#12686)
 func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	// Init maps

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -316,6 +316,95 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcTcp(c *C) {
 	c.Assert(len(buf), Equals, 0)
 }
 
+// TestCtGcDsr tests whether DSR NAT entries are removed upon a removal of
+// their CT entry (== CT_EGRESS).
+func (k *CTMapPrivilegedTestSuite) TestCtGcDsr(c *C) {
+	// Init maps
+	natMap := nat.NewMap("cilium_nat_any4_test", true, 1000)
+	_, err := natMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer natMap.Map.Unpin()
+
+	ctMapName := MapNameTCP4Global + "_test"
+	setupMapInfo(mapTypeIPv4TCPGlobal, ctMapName,
+		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
+		100, natMap)
+
+	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
+	_, err = ctMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer ctMap.Map.Unpin()
+
+	// Create the following entries and check that they get GC-ed:
+	//	- CT:	TCP OUT 1.1.1.1:1111 -> 192.168.61.11:8080 <..>
+	//	- NAT: 	TCP OUT 192.168.61.11:8080 -> 1.1.1.1:1111 XLATE_SRC 2.2.2.2:80
+
+	ctKey := &CtKey4Global{
+		tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: types.IPv4{192, 168, 61, 11},
+				DestAddr:   types.IPv4{1, 1, 1, 1},
+				SourcePort: 0x5704,
+				DestPort:   0x901f,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	ctVal := &CtEntry{
+		TxPackets: 1,
+		TxBytes:   216,
+		Lifetime:  37459,
+		Flags:     DSR,
+	}
+	err = ctMap.Map.Update(ctKey, ctVal)
+	c.Assert(err, IsNil)
+
+	natKey := &nat.NatKey4{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				DestAddr:   types.IPv4{1, 1, 1, 1},
+				SourceAddr: types.IPv4{192, 168, 61, 11},
+				DestPort:   0x5704,
+				SourcePort: 0x901f,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	natVal := &nat.NatEntry4{
+		Created: 37400,
+		Addr:    types.IPv4{2, 2, 2, 2},
+		Port:    0x50,
+	}
+	err = natMap.Map.Update(natKey, natVal)
+	c.Assert(err, IsNil)
+
+	buf := make(map[string][]string)
+	err = ctMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 1)
+
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 1)
+
+	// GC and check whether NAT entry has been collected
+	filter := &GCFilter{
+		RemoveExpired: true,
+		Time:          39000,
+	}
+	stats := doGC4(ctMap, filter)
+	c.Assert(stats.aliveEntries, Equals, uint32(0))
+	c.Assert(stats.deleted, Equals, uint32(1))
+
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+}
+
 // TestCtGcLegacyDsr tests whether DSR NAT entries are removed upon a removal of
 // their legacy CT entry (== CT_INGRESS).
 // See https://github.com/cilium/cilium/pull/22978 for details.

--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -206,6 +206,116 @@ func (k *CTMapPrivilegedTestSuite) TestCtGcIcmp(c *C) {
 	c.Assert(len(buf), Equals, 0)
 }
 
+// TestCtGcTcp tests whether TCP SNAT entries are removed upon a removal of
+// their CT entry.
+func (k *CTMapPrivilegedTestSuite) TestCtGcTcp(c *C) {
+	// Init maps
+	natMap := nat.NewMap("cilium_nat_any4_test", true, 1000)
+	_, err := natMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer natMap.Map.Unpin()
+
+	ctMapName := MapNameTCP4Global + "_test"
+	setupMapInfo(mapTypeIPv4TCPGlobal, ctMapName,
+		&CtKey4Global{}, int(unsafe.Sizeof(CtKey4Global{})),
+		100, natMap)
+
+	ctMap := newMap(ctMapName, mapTypeIPv4TCPGlobal)
+	_, err = ctMap.OpenOrCreate()
+	c.Assert(err, IsNil)
+	defer ctMap.Map.Unpin()
+
+	// Create the following entries and check that they get GC-ed:
+	//	- CT:	TCP OUT 192.168.61.11:38193 -> 192.168.61.12:80 <..>
+	//	- NAT: 	TCP OUT 192.168.61.11:38193 -> 192.168.61.12:80 XLATE_SRC 192.168.61.11:38194
+	//		TCP IN 192.168.61.12:80 -> 192.168.61.11:38194 XLATE_DST 192.168.61.11:38193
+
+	ctKey := &CtKey4Global{
+		tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: types.IPv4{192, 168, 61, 12},
+				DestAddr:   types.IPv4{192, 168, 61, 11},
+				SourcePort: 0x3195,
+				DestPort:   0x50,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	ctVal := &CtEntry{
+		TxPackets: 1,
+		TxBytes:   216,
+		Lifetime:  37459,
+	}
+	err = ctMap.Map.Update(ctKey, ctVal)
+	c.Assert(err, IsNil)
+
+	natKey := &nat.NatKey4{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				DestAddr:   types.IPv4{192, 168, 61, 12},
+				SourceAddr: types.IPv4{192, 168, 61, 11},
+				DestPort:   0x50,
+				SourcePort: 0x3195,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_OUT,
+			},
+		},
+	}
+	natVal := &nat.NatEntry4{
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{192, 168, 61, 11},
+		Port:    0x3295,
+	}
+	err = natMap.Map.Update(natKey, natVal)
+	c.Assert(err, IsNil)
+	natKey = &nat.NatKey4{
+		TupleKey4Global: tuple.TupleKey4Global{
+			TupleKey4: tuple.TupleKey4{
+				SourceAddr: types.IPv4{192, 168, 61, 12},
+				DestAddr:   types.IPv4{192, 168, 61, 11},
+				SourcePort: 0x50,
+				DestPort:   0x3295,
+				NextHeader: u8proto.TCP,
+				Flags:      tuple.TUPLE_F_IN,
+			},
+		},
+	}
+	natVal = &nat.NatEntry4{
+		Created: 37400,
+		NeedsCT: 1,
+		Addr:    types.IPv4{192, 168, 61, 11},
+		Port:    0x3195,
+	}
+	err = natMap.Map.Update(natKey, natVal)
+	c.Assert(err, IsNil)
+
+	buf := make(map[string][]string)
+	err = ctMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 1)
+
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 2)
+
+	// GC and check whether NAT entries have been collected
+	filter := &GCFilter{
+		RemoveExpired: true,
+		Time:          39000,
+	}
+	stats := doGC4(ctMap, filter)
+	c.Assert(stats.aliveEntries, Equals, uint32(0))
+	c.Assert(stats.deleted, Equals, uint32(1))
+
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+}
+
 // TestOrphanNat checks whether dangling NAT entries are GC'd (GH#12686)
 func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	// Init maps

--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -524,6 +524,10 @@ const (
 	MaxFlags
 )
 
+func (c *CtEntry) isDsrEntry() bool {
+	return c.Flags&DSR != 0
+}
+
 func (c *CtEntry) flagsString() string {
 	var sb strings.Builder
 

--- a/pkg/maps/nat/nat.go
+++ b/pkg/maps/nat/nat.go
@@ -198,7 +198,7 @@ func (m *Map) Flush() int {
 	return int(doFlush6(m).deleted)
 }
 
-func deleteMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
+func DeleteMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 	key := NatKey4{
 		TupleKey4Global: *ctKey,
 	}
@@ -222,7 +222,7 @@ func deleteMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 	return nil
 }
 
-func deleteMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
+func DeleteMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 	key := NatKey6{
 		TupleKey6Global: *ctKey,
 	}
@@ -247,7 +247,7 @@ func deleteMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 }
 
 // Expects ingress tuple
-func deleteSwappedMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
+func DeleteSwappedMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 	key := NatKey4{TupleKey4Global: *ctKey}
 	// Because of #5848, we need to reverse only ports
 	port := key.SourcePort
@@ -260,7 +260,7 @@ func deleteSwappedMapping4(m *Map, ctKey *tuple.TupleKey4Global) error {
 }
 
 // Expects ingress tuple
-func deleteSwappedMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
+func DeleteSwappedMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 	key := NatKey6{TupleKey6Global: *ctKey}
 	// Because of #5848, we need to reverse only ports
 	port := key.SourcePort
@@ -270,22 +270,6 @@ func deleteSwappedMapping6(m *Map, ctKey *tuple.TupleKey6Global) error {
 	m.SilentDelete(&key)
 
 	return nil
-}
-
-// DeleteMapping removes a NAT mapping from the global NAT table.
-func (m *Map) DeleteMapping(key tuple.TupleKey) error {
-	if key.GetFlags()&tuple.TUPLE_F_IN != 0 {
-		if m.v4 {
-			// To delete NAT entries created by DSR
-			return deleteSwappedMapping4(m, key.(*tuple.TupleKey4Global))
-		}
-		return deleteSwappedMapping6(m, key.(*tuple.TupleKey6Global))
-	}
-
-	if m.v4 {
-		return deleteMapping4(m, key.(*tuple.TupleKey4Global))
-	}
-	return deleteMapping6(m, key.(*tuple.TupleKey6Global))
 }
 
 // GlobalMaps returns all global NAT maps.

--- a/vendor/github.com/hashicorp/golang-lru/v2/LICENSE
+++ b/vendor/github.com/hashicorp/golang-lru/v2/LICENSE
@@ -1,0 +1,364 @@
+Copyright (c) 2014 HashiCorp, Inc.
+
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/hashicorp/golang-lru/v2/simplelru/LICENSE_list
+++ b/vendor/github.com/hashicorp/golang-lru/v2/simplelru/LICENSE_list
@@ -1,0 +1,29 @@
+This license applies to simplelru/list.go
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/hashicorp/golang-lru/v2/simplelru/list.go
+++ b/vendor/github.com/hashicorp/golang-lru/v2/simplelru/list.go
@@ -1,0 +1,128 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE_list file.
+
+package simplelru
+
+// entry is an LRU entry
+type entry[K comparable, V any] struct {
+	// Next and previous pointers in the doubly-linked list of elements.
+	// To simplify the implementation, internally a list l is implemented
+	// as a ring, such that &l.root is both the next element of the last
+	// list element (l.Back()) and the previous element of the first list
+	// element (l.Front()).
+	next, prev *entry[K, V]
+
+	// The list to which this element belongs.
+	list *lruList[K, V]
+
+	// The LRU key of this element.
+	key K
+
+	// The value stored with this element.
+	value V
+}
+
+// prevEntry returns the previous list element or nil.
+func (e *entry[K, V]) prevEntry() *entry[K, V] {
+	if p := e.prev; e.list != nil && p != &e.list.root {
+		return p
+	}
+	return nil
+}
+
+// lruList represents a doubly linked list.
+// The zero value for lruList is an empty list ready to use.
+type lruList[K comparable, V any] struct {
+	root entry[K, V] // sentinel list element, only &root, root.prev, and root.next are used
+	len  int         // current list length excluding (this) sentinel element
+}
+
+// init initializes or clears list l.
+func (l *lruList[K, V]) init() *lruList[K, V] {
+	l.root.next = &l.root
+	l.root.prev = &l.root
+	l.len = 0
+	return l
+}
+
+// newList returns an initialized list.
+func newList[K comparable, V any]() *lruList[K, V] { return new(lruList[K, V]).init() }
+
+// length returns the number of elements of list l.
+// The complexity is O(1).
+func (l *lruList[K, V]) length() int { return l.len }
+
+// back returns the last element of list l or nil if the list is empty.
+func (l *lruList[K, V]) back() *entry[K, V] {
+	if l.len == 0 {
+		return nil
+	}
+	return l.root.prev
+}
+
+// lazyInit lazily initializes a zero List value.
+func (l *lruList[K, V]) lazyInit() {
+	if l.root.next == nil {
+		l.init()
+	}
+}
+
+// insert inserts e after at, increments l.len, and returns e.
+func (l *lruList[K, V]) insert(e, at *entry[K, V]) *entry[K, V] {
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+	e.list = l
+	l.len++
+	return e
+}
+
+// insertValue is a convenience wrapper for insert(&Element{Value: v}, at).
+func (l *lruList[K, V]) insertValue(k K, v V, at *entry[K, V]) *entry[K, V] {
+	return l.insert(&entry[K, V]{value: v, key: k}, at)
+}
+
+// remove removes e from its list, decrements l.len
+func (l *lruList[K, V]) remove(e *entry[K, V]) V {
+	e.prev.next = e.next
+	e.next.prev = e.prev
+	e.next = nil // avoid memory leaks
+	e.prev = nil // avoid memory leaks
+	e.list = nil
+	l.len--
+
+	return e.value
+}
+
+// move moves e to next to at.
+func (l *lruList[K, V]) move(e, at *entry[K, V]) {
+	if e == at {
+		return
+	}
+	e.prev.next = e.next
+	e.next.prev = e.prev
+
+	e.prev = at
+	e.next = at.next
+	e.prev.next = e
+	e.next.prev = e
+}
+
+// pushFront inserts a new element e with value v at the front of list l and returns e.
+func (l *lruList[K, V]) pushFront(k K, v V) *entry[K, V] {
+	l.lazyInit()
+	return l.insertValue(k, v, &l.root)
+}
+
+// moveToFront moves element e to the front of list l.
+// If e is not an element of l, the list is not modified.
+// The element must not be nil.
+func (l *lruList[K, V]) moveToFront(e *entry[K, V]) {
+	if e.list != l || l.root.next == e {
+		return
+	}
+	// see comment in List.Remove about initialization of l
+	l.move(e, &l.root)
+}

--- a/vendor/github.com/hashicorp/golang-lru/v2/simplelru/lru.go
+++ b/vendor/github.com/hashicorp/golang-lru/v2/simplelru/lru.go
@@ -1,0 +1,178 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package simplelru
+
+import (
+	"errors"
+)
+
+// EvictCallback is used to get a callback when a cache entry is evicted
+type EvictCallback[K comparable, V any] func(key K, value V)
+
+// LRU implements a non-thread safe fixed size LRU cache
+type LRU[K comparable, V any] struct {
+	size      int
+	evictList *lruList[K, V]
+	items     map[K]*entry[K, V]
+	onEvict   EvictCallback[K, V]
+}
+
+// NewLRU constructs an LRU of the given size
+func NewLRU[K comparable, V any](size int, onEvict EvictCallback[K, V]) (*LRU[K, V], error) {
+	if size <= 0 {
+		return nil, errors.New("must provide a positive size")
+	}
+
+	c := &LRU[K, V]{
+		size:      size,
+		evictList: newList[K, V](),
+		items:     make(map[K]*entry[K, V]),
+		onEvict:   onEvict,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache.
+func (c *LRU[K, V]) Purge() {
+	for k, v := range c.items {
+		if c.onEvict != nil {
+			c.onEvict(k, v.value)
+		}
+		delete(c.items, k)
+	}
+	c.evictList.init()
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *LRU[K, V]) Add(key K, value V) (evicted bool) {
+	// Check for existing item
+	if ent, ok := c.items[key]; ok {
+		c.evictList.moveToFront(ent)
+		if c.onEvict != nil {
+			c.onEvict(key, ent.value)
+		}
+		ent.value = value
+		return false
+	}
+
+	// Add new item
+	ent := c.evictList.pushFront(key, value)
+	c.items[key] = ent
+
+	evict := c.evictList.length() > c.size
+	// Verify size not exceeded
+	if evict {
+		c.removeOldest()
+	}
+	return evict
+}
+
+// Get looks up a key's value from the cache.
+func (c *LRU[K, V]) Get(key K) (value V, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		c.evictList.moveToFront(ent)
+		return ent.value, true
+	}
+	return
+}
+
+// Contains checks if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *LRU[K, V]) Contains(key K) (ok bool) {
+	_, ok = c.items[key]
+	return ok
+}
+
+// Peek returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *LRU[K, V]) Peek(key K) (value V, ok bool) {
+	var ent *entry[K, V]
+	if ent, ok = c.items[key]; ok {
+		return ent.value, true
+	}
+	return
+}
+
+// Remove removes the provided key from the cache, returning if the
+// key was contained.
+func (c *LRU[K, V]) Remove(key K) (present bool) {
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+		return true
+	}
+	return false
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *LRU[K, V]) RemoveOldest() (key K, value V, ok bool) {
+	if ent := c.evictList.back(); ent != nil {
+		c.removeElement(ent)
+		return ent.key, ent.value, true
+	}
+	return
+}
+
+// GetOldest returns the oldest entry
+func (c *LRU[K, V]) GetOldest() (key K, value V, ok bool) {
+	if ent := c.evictList.back(); ent != nil {
+		return ent.key, ent.value, true
+	}
+	return
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *LRU[K, V]) Keys() []K {
+	keys := make([]K, c.evictList.length())
+	i := 0
+	for ent := c.evictList.back(); ent != nil; ent = ent.prevEntry() {
+		keys[i] = ent.key
+		i++
+	}
+	return keys
+}
+
+// Values returns a slice of the values in the cache, from oldest to newest.
+func (c *LRU[K, V]) Values() []V {
+	values := make([]V, len(c.items))
+	i := 0
+	for ent := c.evictList.back(); ent != nil; ent = ent.prevEntry() {
+		values[i] = ent.value
+		i++
+	}
+	return values
+}
+
+// Len returns the number of items in the cache.
+func (c *LRU[K, V]) Len() int {
+	return c.evictList.length()
+}
+
+// Resize changes the cache size.
+func (c *LRU[K, V]) Resize(size int) (evicted int) {
+	diff := c.Len() - size
+	if diff < 0 {
+		diff = 0
+	}
+	for i := 0; i < diff; i++ {
+		c.removeOldest()
+	}
+	c.size = size
+	return diff
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *LRU[K, V]) removeOldest() {
+	if ent := c.evictList.back(); ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *LRU[K, V]) removeElement(e *entry[K, V]) {
+	c.evictList.remove(e)
+	delete(c.items, e.key)
+	if c.onEvict != nil {
+		c.onEvict(e.key, e.value)
+	}
+}

--- a/vendor/github.com/hashicorp/golang-lru/v2/simplelru/lru_interface.go
+++ b/vendor/github.com/hashicorp/golang-lru/v2/simplelru/lru_interface.go
@@ -1,0 +1,46 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package simplelru provides simple LRU implementation based on build-in container/list.
+package simplelru
+
+// LRUCache is the interface for simple LRU cache.
+type LRUCache[K comparable, V any] interface {
+	// Adds a value to the cache, returns true if an eviction occurred and
+	// updates the "recently used"-ness of the key.
+	Add(key K, value V) bool
+
+	// Returns key's value from the cache and
+	// updates the "recently used"-ness of the key. #value, isFound
+	Get(key K) (value V, ok bool)
+
+	// Checks if a key exists in cache without updating the recent-ness.
+	Contains(key K) (ok bool)
+
+	// Returns key's value without updating the "recently used"-ness of the key.
+	Peek(key K) (value V, ok bool)
+
+	// Removes a key from the cache.
+	Remove(key K) bool
+
+	// Removes the oldest entry from cache.
+	RemoveOldest() (K, V, bool)
+
+	// Returns the oldest entry from the cache. #key, value, isFound
+	GetOldest() (K, V, bool)
+
+	// Returns a slice of the keys in the cache, from oldest to newest.
+	Keys() []K
+
+	// Values returns a slice of the values in the cache, from oldest to newest.
+	Values() []V
+
+	// Returns the number of items in the cache.
+	Len() int
+
+	// Clears all cache entries.
+	Purge()
+
+	// Resizes cache, returning number evicted
+	Resize(int) int
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -718,6 +718,9 @@ github.com/hashicorp/go-rootcerts
 ## explicit; go 1.12
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
+# github.com/hashicorp/golang-lru/v2 v2.0.4
+## explicit; go 1.18
+github.com/hashicorp/golang-lru/v2/simplelru
 # github.com/hashicorp/hcl v1.0.0
 ## explicit
 github.com/hashicorp/hcl


### PR DESCRIPTION
 * [x] #28465 (@pippolo84)
  - :warning: conflicts due to `cidr.go` moved in main branch
 * [x] #27923 (@mhofstetter)
 * [x] #28767 (@giorio94)
 * [x] #28790 (@pchaigno)
 * [x] #28788 (@pippolo84)
  - :warning: conflicts due to `cidr.go` moved in main branch
 * [x] #28857 (@julianwiedmann)
  - :warning: minor conflicts due to `nat.IPv4` constant missing and different return types for `natMap.OpenOrCreate` used in tests

Once this PR is merged, a GitHub action will update the labels of these PRs:
```upstream-prs
 28465 27923 28767 28790 28788 28857
```
