### PR TITLE
policy: Add Port Range Mapping

### DIFF
--- a/cilium-dbg/cmd/helpers.go
+++ b/cilium-dbg/cmd/helpers.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -346,15 +347,15 @@ func updatePolicyKey(pa *PolicyUpdateArgs, add bool) {
 				err       error
 			)
 			if pa.isDeny {
-				err = policyMap.Deny(pa.label, pa.port, u8p, pa.trafficDirection)
+				err = policyMap.Deny(pa.label, pa.port, policyapi.FullPortMask, u8p, pa.trafficDirection)
 			} else {
-				err = policyMap.Allow(pa.label, pa.port, u8p, pa.trafficDirection, authType, proxyPort)
+				err = policyMap.Allow(pa.label, pa.port, policyapi.FullPortMask, u8p, pa.trafficDirection, authType, proxyPort)
 			}
 			if err != nil {
 				Fatalf("Cannot add policy key '%s': %s\n", entry, err)
 			}
 		} else {
-			if err := policyMap.Delete(pa.label, pa.port, u8p, pa.trafficDirection); err != nil {
+			if err := policyMap.Delete(pa.label, pa.port, policyapi.FullPortMask, u8p, pa.trafficDirection); err != nil {
 				Fatalf("Cannot delete policy key '%s': %s\n", entry, err)
 			}
 		}

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -245,7 +245,7 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				// Update the endpoint API model to report that Cilium manages a
 				// redirect for that port.
 				e.proxyStatisticsMutex.Lock()
-				proxyStats := e.getProxyStatisticsLocked(proxyID, string(l4.L7Parser), uint16(l4.Port), l4.Ingress)
+				proxyStats := e.getProxyStatisticsLocked(proxyID, string(l4.L7Parser), l4.Port, l4.Ingress)
 				proxyStats.AllocatedProxyPort = int64(redirectPort)
 				e.proxyStatisticsMutex.Unlock()
 

--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/maps/policymap"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/revert"
 	"github.com/cilium/cilium/pkg/time"
 	"github.com/cilium/cilium/pkg/version"
@@ -1062,7 +1063,7 @@ func (e *Endpoint) updatePolicyMapPressureMetric() {
 
 func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.NewKey(keyToDelete.Identity, keyToDelete.DestPort,
+	policymapKey := policymap.NewKey(keyToDelete.Identity, keyToDelete.DestPort, keyToDelete.PortMask,
 		keyToDelete.Nexthdr, keyToDelete.TrafficDirection)
 
 	// Do not error out if the map entry was already deleted from the bpf map.
@@ -1096,7 +1097,7 @@ func (e *Endpoint) deletePolicyKey(keyToDelete policy.Key, incremental bool) boo
 
 func (e *Endpoint) addPolicyKey(keyToAdd policy.Key, entry policy.MapStateEntry, incremental bool) bool {
 	// Convert from policy.Key to policymap.Key
-	policymapKey := policymap.NewKey(keyToAdd.Identity, keyToAdd.DestPort,
+	policymapKey := policymap.NewKey(keyToAdd.Identity, keyToAdd.DestPort, keyToAdd.PortMask,
 		keyToAdd.Nexthdr, keyToAdd.TrafficDirection)
 
 	var err error
@@ -1310,6 +1311,7 @@ func (e *Endpoint) dumpPolicyMapToMapState() (policy.MapState, error) {
 		policyKey := policy.Key{
 			Identity:         policymapKey.Identity,
 			DestPort:         policymapKey.GetDestPort(),
+			PortMask:         policyapi.FullPortMask,
 			Nexthdr:          policymapKey.Nexthdr,
 			TrafficDirection: policymapKey.TrafficDirection,
 		}

--- a/pkg/endpoint/endpoint.go
+++ b/pkg/endpoint/endpoint.go
@@ -54,6 +54,7 @@ import (
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/proxy/accesslog"
 	"github.com/cilium/cilium/pkg/time"
@@ -751,6 +752,7 @@ func (e *Endpoint) Allows(id identity.NumericIdentity) bool {
 
 	keyToLookup := policy.Key{
 		Identity:         uint32(id),
+		PortMask:         policyapi.FullPortMask,
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 

--- a/pkg/endpoint/endpoint_status_test.go
+++ b/pkg/endpoint/endpoint_status_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/policy"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	testipcache "github.com/cilium/cilium/pkg/testutils/ipcache"
 )
@@ -91,6 +92,7 @@ func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *End
 			key := policy.Key{
 				Identity:         uint32(i),
 				DestPort:         uint16(80 + n),
+				PortMask:         policyapi.FullPortMask,
 				TrafficDirection: trafficdirection.Ingress.Uint8(),
 			}
 			e.desiredPolicy.GetPolicyMap().Insert(key, policy.MapStateEntry{})
@@ -102,6 +104,7 @@ func (s *EndpointSuite) newEndpoint(c *check.C, spec endpointGeneratorSpec) *End
 			key := policy.Key{
 				Identity:         uint32(i + 30000),
 				DestPort:         uint16(80 + n),
+				PortMask:         policyapi.FullPortMask,
 				TrafficDirection: trafficdirection.Egress.Uint8(),
 			}
 			e.desiredPolicy.GetPolicyMap().Insert(key, policy.MapStateEntry{})
@@ -402,6 +405,7 @@ func (s *EndpointSuite) TestgetEndpointPolicyMapState(c *check.C) {
 			t := policy.Key{
 				Identity:         arg.identity,
 				DestPort:         arg.destPort,
+				PortMask:         policyapi.FullPortMask,
 				Nexthdr:          arg.nexthdr,
 				TrafficDirection: arg.direction.Uint8(),
 			}

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -89,6 +89,8 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 }
 
 // proxyID returns a unique string to identify a proxy mapping.
+// For port ranges the proxy is identified by the first port in
+// the range, as overlapping proxy port ranges are not supported.
 // Must be called with e.mutex held.
 func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
 	port := l4.Port

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -91,7 +91,7 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 // proxyID returns a unique string to identify a proxy mapping.
 // Must be called with e.mutex held.
 func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
-	port := uint16(l4.Port)
+	port := l4.Port
 	if port == 0 && l4.PortName != "" {
 		port = e.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 		if port == 0 {

--- a/pkg/endpoint/redirect_test.go
+++ b/pkg/endpoint/redirect_test.go
@@ -186,6 +186,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	v, ok := ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
@@ -207,6 +208,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
@@ -230,6 +232,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
@@ -239,6 +242,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	})
@@ -248,6 +252,7 @@ func (s *RedirectSuite) TestAddVisibilityRedirects(c *check.C) {
 	v, ok = ep.desiredPolicy.GetPolicyMap().Get(policy.Key{
 		Identity:         0,
 		DestPort:         uint16(80),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Egress.Uint8(),
 	})
@@ -332,10 +337,10 @@ var (
 
 	dirIngress      = trafficdirection.Ingress.Uint8()
 	dirEgress       = trafficdirection.Egress.Uint8()
-	mapKeyAllL7     = policy.Key{Identity: 0, DestPort: 80, Nexthdr: 6, TrafficDirection: dirIngress}
-	mapKeyFoo       = policy.Key{Identity: identityFoo, DestPort: 0, Nexthdr: 0, TrafficDirection: dirIngress}
-	mapKeyFooL7     = policy.Key{Identity: identityFoo, DestPort: 80, Nexthdr: 6, TrafficDirection: dirIngress}
-	mapKeyAllowAllE = policy.Key{Identity: 0, DestPort: 0, Nexthdr: 0, TrafficDirection: dirEgress}
+	mapKeyAllL7     = policy.Key{Identity: 0, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6, TrafficDirection: dirIngress}
+	mapKeyFoo       = policy.Key{Identity: identityFoo, DestPort: 0, PortMask: api.FullPortMask, Nexthdr: 0, TrafficDirection: dirIngress}
+	mapKeyFooL7     = policy.Key{Identity: identityFoo, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6, TrafficDirection: dirIngress}
+	mapKeyAllowAllE = policy.Key{Identity: 0, DestPort: 0, PortMask: api.FullPortMask, Nexthdr: 0, TrafficDirection: dirEgress}
 )
 
 // combineL4L7 returns a new PortRule that refers to the specified l4 ports and

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1479,7 +1479,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 		if port == 0 && l4.PortName != "" {
 			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 			if port == 0 {
-				continue
+				continue // Skip if a named port can not be resolved (yet)
 			}
 		}
 
@@ -1556,8 +1556,11 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 			continue
 		}
 
+		// NPDS supports port ranges, but range overlaps in the policy are NOT allowed.
+		// Envoy will reject a policy if any overlaps exist.
 		PerPortPolicies = append(PerPortPolicies, &cilium.PortNetworkPolicy{
 			Port:     uint32(port),
+			EndPort:  uint32(l4.EndPort),
 			Protocol: protocol,
 			Rules:    SortPortNetworkPolicyRules(rules),
 		})

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -1475,7 +1475,7 @@ func getDirectionNetworkPolicy(ep endpoint.EndpointUpdater, l4Policy policy.L4Po
 			continue
 		}
 
-		port := uint16(l4.Port)
+		port := l4.Port
 		if port == 0 && l4.PortName != "" {
 			port = ep.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 			if port == 0 {

--- a/pkg/hubble/parser/threefour/parser_test.go
+++ b/pkg/hubble/parser/threefour/parser_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cilium/cilium/pkg/monitor"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -386,6 +387,7 @@ func TestDecodePolicyVerdictNotify(t *testing.T) {
 	policyKey := policy.Key{
 		Identity:         uint32(remoteID),
 		DestPort:         uint16(dstPort),
+		PortMask:         policyapi.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Egress.Uint8(),
 	}
@@ -557,6 +559,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	policyKey := policy.Key{
 		Identity:         remoteID,
 		DestPort:         0,
+		PortMask:         policyapi.FullPortMask,
 		Nexthdr:          0,
 		TrafficDirection: trafficdirection.Egress.Uint8(),
 	}
@@ -696,6 +699,7 @@ func TestDecodeTrafficDirection(t *testing.T) {
 	assert.Equal(t, true, ok)
 	lbls, rev, ok := ep.GetRealizedPolicyRuleLabelsForKey(policy.Key{
 		Identity:         f.GetDestination().GetIdentity(),
+		PortMask:         policyapi.FullPortMask,
 		TrafficDirection: directionFromProto(f.GetTrafficDirection()).Uint8(),
 	})
 	assert.Equal(t, true, ok)

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumclusterwidenetworkpolicies.yaml
@@ -458,15 +458,10 @@ spec:
                                 an optional transport protocol
                               properties:
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
-                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  description: Port can be an L4 port number, or a
+                                    range in the form "1024-2048", or a name in the
+                                    form of "http" or "http-8080".
+                                  pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
                                   description: "Protocol is the L4 protocol. If omitted
@@ -1200,15 +1195,10 @@ spec:
                                 an optional transport protocol
                               properties:
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
-                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  description: Port can be an L4 port number, or a
+                                    range in the form "1024-2048", or a name in the
+                                    form of "http" or "http-8080".
+                                  pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
                                   description: "Protocol is the L4 protocol. If omitted
@@ -1827,15 +1817,10 @@ spec:
                                 an optional transport protocol
                               properties:
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
-                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  description: Port can be an L4 port number, or a
+                                    range in the form "1024-2048", or a name in the
+                                    form of "http" or "http-8080".
+                                  pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
                                   description: "Protocol is the L4 protocol. If omitted
@@ -2452,15 +2437,10 @@ spec:
                                 an optional transport protocol
                               properties:
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
-                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  description: Port can be an L4 port number, or a
+                                    range in the form "1024-2048", or a name in the
+                                    form of "http" or "http-8080".
+                                  pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
                                   description: "Protocol is the L4 protocol. If omitted
@@ -2992,15 +2972,10 @@ spec:
                                   an optional transport protocol
                                 properties:
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
-                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    description: Port can be an L4 port number, or
+                                      a range in the form "1024-2048", or a name in
+                                      the form of "http" or "http-8080".
+                                    pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
                                     description: "Protocol is the L4 protocol. If
@@ -3746,15 +3721,10 @@ spec:
                                   an optional transport protocol
                                 properties:
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
-                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    description: Port can be an L4 port number, or
+                                      a range in the form "1024-2048", or a name in
+                                      the form of "http" or "http-8080".
+                                    pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
                                     description: "Protocol is the L4 protocol. If
@@ -4382,15 +4352,10 @@ spec:
                                   an optional transport protocol
                                 properties:
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
-                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    description: Port can be an L4 port number, or
+                                      a range in the form "1024-2048", or a name in
+                                      the form of "http" or "http-8080".
+                                    pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
                                     description: "Protocol is the L4 protocol. If
@@ -5017,15 +4982,10 @@ spec:
                                   an optional transport protocol
                                 properties:
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
-                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    description: Port can be an L4 port number, or
+                                      a range in the form "1024-2048", or a name in
+                                      the form of "http" or "http-8080".
+                                    pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
                                     description: "Protocol is the L4 protocol. If

--- a/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
+++ b/pkg/k8s/apis/cilium.io/client/crds/v2/ciliumnetworkpolicies.yaml
@@ -462,15 +462,10 @@ spec:
                                 an optional transport protocol
                               properties:
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
-                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  description: Port can be an L4 port number, or a
+                                    range in the form "1024-2048", or a name in the
+                                    form of "http" or "http-8080".
+                                  pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
                                   description: "Protocol is the L4 protocol. If omitted
@@ -1204,15 +1199,10 @@ spec:
                                 an optional transport protocol
                               properties:
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
-                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  description: Port can be an L4 port number, or a
+                                    range in the form "1024-2048", or a name in the
+                                    form of "http" or "http-8080".
+                                  pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
                                   description: "Protocol is the L4 protocol. If omitted
@@ -1831,15 +1821,10 @@ spec:
                                 an optional transport protocol
                               properties:
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
-                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  description: Port can be an L4 port number, or a
+                                    range in the form "1024-2048", or a name in the
+                                    form of "http" or "http-8080".
+                                  pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
                                   description: "Protocol is the L4 protocol. If omitted
@@ -2456,15 +2441,10 @@ spec:
                                 an optional transport protocol
                               properties:
                                 port:
-                                  description: Port is an L4 port number. For now
-                                    the string will be strictly parsed as a single
-                                    uint16. In the future, this field may support
-                                    ranges in the form "1024-2048 Port can also be
-                                    a port name, which must contain at least one [a-z],
-                                    and may also contain [0-9] and '-' anywhere except
-                                    adjacent to another '-' or in the beginning or
-                                    the end.
-                                  pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                  description: Port can be an L4 port number, or a
+                                    range in the form "1024-2048", or a name in the
+                                    form of "http" or "http-8080".
+                                  pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                   type: string
                                 protocol:
                                   description: "Protocol is the L4 protocol. If omitted
@@ -2996,15 +2976,10 @@ spec:
                                   an optional transport protocol
                                 properties:
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
-                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    description: Port can be an L4 port number, or
+                                      a range in the form "1024-2048", or a name in
+                                      the form of "http" or "http-8080".
+                                    pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
                                     description: "Protocol is the L4 protocol. If
@@ -3750,15 +3725,10 @@ spec:
                                   an optional transport protocol
                                 properties:
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
-                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    description: Port can be an L4 port number, or
+                                      a range in the form "1024-2048", or a name in
+                                      the form of "http" or "http-8080".
+                                    pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
                                     description: "Protocol is the L4 protocol. If
@@ -4386,15 +4356,10 @@ spec:
                                   an optional transport protocol
                                 properties:
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
-                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    description: Port can be an L4 port number, or
+                                      a range in the form "1024-2048", or a name in
+                                      the form of "http" or "http-8080".
+                                    pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
                                     description: "Protocol is the L4 protocol. If
@@ -5021,15 +4986,10 @@ spec:
                                   an optional transport protocol
                                 properties:
                                   port:
-                                    description: Port is an L4 port number. For now
-                                      the string will be strictly parsed as a single
-                                      uint16. In the future, this field may support
-                                      ranges in the form "1024-2048 Port can also
-                                      be a port name, which must contain at least
-                                      one [a-z], and may also contain [0-9] and '-'
-                                      anywhere except adjacent to another '-' or in
-                                      the beginning or the end.
-                                    pattern: ^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
+                                    description: Port can be an L4 port number, or
+                                      a range in the form "1024-2048", or a name in
+                                      the form of "http" or "http-8080".
+                                    pattern: ^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$
                                     type: string
                                   protocol:
                                     description: "Protocol is the L4 protocol. If

--- a/pkg/k8s/network_policy.go
+++ b/pkg/k8s/network_policy.go
@@ -5,6 +5,7 @@ package k8s
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/cilium/cilium/pkg/annotation"
 	k8sConst "github.com/cilium/cilium/pkg/k8s/apis/cilium.io"
@@ -299,6 +300,9 @@ func parsePorts(ports []slim_networkingv1.NetworkPolicyPort) []api.PortRule {
 		portStr := "0"
 		if port.Port != nil {
 			portStr = port.Port.String()
+		}
+		if port.EndPort != nil {
+			portStr += "-" + strconv.FormatInt(int64(*port.EndPort), 10)
 		}
 
 		portRule := api.PortRule{

--- a/pkg/maps/policymap/policymap_privileged_test.go
+++ b/pkg/maps/policymap/policymap_privileged_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/checker"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/testutils"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -68,7 +69,7 @@ func (pm *PolicyMapPrivilegedTestSuite) TearDownTest(c *C) {
 func (pm *PolicyMapPrivilegedTestSuite) TestPolicyMapDumpToSlice(c *C) {
 	c.Assert(testMap, NotNil)
 
-	fooEntry := newKey(1, 1, 1, 1)
+	fooEntry := newKey(1, 1, policyapi.FullPortMask, 1, 1)
 	err := testMap.AllowKey(fooEntry, 0, 0)
 	c.Assert(err, IsNil)
 
@@ -79,7 +80,7 @@ func (pm *PolicyMapPrivilegedTestSuite) TestPolicyMapDumpToSlice(c *C) {
 	c.Assert(dump[0].Key, checker.DeepEquals, fooEntry)
 
 	// Special case: allow-all entry
-	barEntry := newKey(0, 0, 0, 0)
+	barEntry := newKey(0, 0, policyapi.FullPortMask, 0, 0)
 	err = testMap.AllowKey(barEntry, 0, 0)
 	c.Assert(err, IsNil)
 
@@ -89,7 +90,7 @@ func (pm *PolicyMapPrivilegedTestSuite) TestPolicyMapDumpToSlice(c *C) {
 }
 
 func (pm *PolicyMapPrivilegedTestSuite) TestDeleteNonexistentKey(c *C) {
-	key := newKey(27, 80, u8proto.TCP, trafficdirection.Ingress)
+	key := newKey(27, 80, policyapi.FullPortMask, u8proto.TCP, trafficdirection.Ingress)
 	err := testMap.Map.Delete(&key)
 	c.Assert(err, Not(IsNil))
 	var errno unix.Errno
@@ -100,7 +101,7 @@ func (pm *PolicyMapPrivilegedTestSuite) TestDeleteNonexistentKey(c *C) {
 func (pm *PolicyMapPrivilegedTestSuite) TestDenyPolicyMapDumpToSlice(c *C) {
 	c.Assert(testMap, NotNil)
 
-	fooKey := newKey(1, 1, 1, 1)
+	fooKey := newKey(1, 1, policyapi.FullPortMask, 1, 1)
 	fooEntry := newDenyEntry(fooKey)
 	err := testMap.DenyKey(fooKey)
 	c.Assert(err, IsNil)
@@ -113,7 +114,7 @@ func (pm *PolicyMapPrivilegedTestSuite) TestDenyPolicyMapDumpToSlice(c *C) {
 	c.Assert(dump[0].PolicyEntry, checker.DeepEquals, fooEntry)
 
 	// Special case: deny-all entry
-	barKey := newKey(0, 0, 0, 0)
+	barKey := newKey(0, 0, policyapi.FullPortMask, 0, 0)
 	err = testMap.DenyKey(barKey)
 	c.Assert(err, IsNil)
 

--- a/pkg/maps/policymap/policymap_test.go
+++ b/pkg/maps/policymap/policymap_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/cilium/checkmate"
 
 	"github.com/cilium/cilium/pkg/byteorder"
+	policyapi "github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -273,7 +274,7 @@ func (pm *PolicyMapTestSuite) TestPolicyMapWildcarding(c *C) {
 		}
 
 		// Get key
-		key := newKey(uint32(tt.args.id), uint16(tt.args.dport), u8proto.U8proto(tt.args.proto),
+		key := newKey(uint32(tt.args.id), uint16(tt.args.dport), policyapi.FullPortMask, u8proto.U8proto(tt.args.proto),
 			trafficdirection.TrafficDirection(tt.args.trafficDirection))
 
 		// Compure entry & validate key and entry

--- a/pkg/policy/api/l4.go
+++ b/pkg/policy/api/l4.go
@@ -21,6 +21,9 @@ const (
 	ProtoAny    L4Proto = "ANY"
 
 	PortProtocolAny = "0/ANY"
+
+	// FullPortMask is the mask to select only one port.
+	FullPortMask uint16 = 0xffff
 )
 
 // IsAny returns true if an L4Proto represents ANY protocol
@@ -30,14 +33,10 @@ func (l4 L4Proto) IsAny() bool {
 
 // PortProtocol specifies an L4 port with an optional transport protocol
 type PortProtocol struct {
-	// Port is an L4 port number. For now the string will be strictly
-	// parsed as a single uint16. In the future, this field may support
-	// ranges in the form "1024-2048
-	// Port can also be a port name, which must contain at least one [a-z],
-	// and may also contain [0-9] and '-' anywhere except adjacent to another
-	// '-' or in the beginning or the end.
+	// Port can be an L4 port number, or a range in the form "1024-2048",
+	// or a name in the form of "http" or "http-8080".
 	//
-	// +kubebuilder:validation:Pattern=`^(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$`
+	// +kubebuilder:validation:Pattern=`^((6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4})(-(6553[0-5]|655[0-2][0-9]|65[0-4][0-9]{2}|6[0-4][0-9]{3}|[1-5][0-9]{4}|[0-9]{1,4}))?)|([a-zA-Z0-9]-?)*[a-zA-Z](-?[a-zA-Z0-9])*$`
 	Port string `json:"port"`
 
 	// Protocol is the L4 protocol. If omitted or empty, any protocol

--- a/pkg/policy/correlation/correlation.go
+++ b/pkg/policy/correlation/correlation.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/source"
 	"github.com/cilium/cilium/pkg/u8proto"
@@ -51,6 +52,7 @@ func CorrelatePolicy(endpointGetter getters.EndpointGetter, f *flowpb.Flow) {
 	derivedFrom, rev, ok := lookupPolicyForKey(epInfo, policy.Key{
 		Identity:         uint32(remoteIdentity),
 		DestPort:         dport,
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(proto),
 		TrafficDirection: uint8(direction),
 	})
@@ -119,6 +121,7 @@ func lookupPolicyForKey(ep v1.EndpointInfo, key policy.Key) (derivedFrom labels.
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(policy.Key{
 			Identity:         key.Identity,
 			DestPort:         0,
+			PortMask:         api.FullPortMask,
 			Nexthdr:          0,
 			TrafficDirection: key.TrafficDirection,
 		})
@@ -129,6 +132,7 @@ func lookupPolicyForKey(ep v1.EndpointInfo, key policy.Key) (derivedFrom labels.
 		derivedFrom, rev, ok = ep.GetRealizedPolicyRuleLabelsForKey(policy.Key{
 			Identity:         0,
 			DestPort:         0,
+			PortMask:         api.FullPortMask,
 			Nexthdr:          0,
 			TrafficDirection: key.TrafficDirection,
 		})

--- a/pkg/policy/correlation/correlation_test.go
+++ b/pkg/policy/correlation/correlation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 	monitorAPI "github.com/cilium/cilium/pkg/monitor/api"
 	"github.com/cilium/cilium/pkg/policy"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -60,6 +61,7 @@ func TestCorrelatePolicy(t *testing.T) {
 	policyKey := policy.Key{
 		Identity:         uint32(remoteID),
 		DestPort:         uint16(dstPort),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Egress.Uint8(),
 	}
@@ -120,6 +122,7 @@ func TestCorrelatePolicy(t *testing.T) {
 	policyKey = policy.Key{
 		Identity:         uint32(localID),
 		DestPort:         uint16(dstPort),
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(u8proto.TCP),
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}

--- a/pkg/policy/distillery_test.go
+++ b/pkg/policy/distillery_test.go
@@ -353,16 +353,16 @@ var (
 	dirIngress = trafficdirection.Ingress.Uint8()
 	dirEgress  = trafficdirection.Egress.Uint8()
 	// Desired map keys for L3, L3-dependent L4, L4
-	mapKeyAllowFoo__ = Key{identityFoo, 0, 0, dirIngress}
-	mapKeyAllowBar__ = Key{identityBar, 0, 0, dirIngress}
-	mapKeyAllowBarL4 = Key{identityBar, 80, 6, dirIngress}
-	mapKeyAllowFooL4 = Key{identityFoo, 80, 6, dirIngress}
+	mapKeyAllowFoo__ = Key{identityFoo, 0, api.FullPortMask, 0, dirIngress}
+	mapKeyAllowBar__ = Key{identityBar, 0, api.FullPortMask, 0, dirIngress}
+	mapKeyAllowBarL4 = Key{identityBar, 80, api.FullPortMask, 6, dirIngress}
+	mapKeyAllowFooL4 = Key{identityFoo, 80, api.FullPortMask, 6, dirIngress}
 	mapKeyDeny_Foo__ = mapKeyAllowFoo__
 	mapKeyDeny_FooL4 = mapKeyAllowFooL4
-	mapKeyAllow___L4 = Key{0, 80, 6, dirIngress}
+	mapKeyAllow___L4 = Key{0, 80, api.FullPortMask, 6, dirIngress}
 	mapKeyDeny____L4 = mapKeyAllow___L4
-	mapKeyAllowAll__ = Key{0, 0, 0, dirIngress}
-	mapKeyAllowAllE_ = Key{0, 0, 0, dirEgress}
+	mapKeyAllowAll__ = Key{0, 0, api.FullPortMask, 0, dirIngress}
+	mapKeyAllowAllE_ = Key{0, 0, api.FullPortMask, 0, dirEgress}
 	// Desired map entries for no L7 redirect / redirect to Proxy
 	mapEntryL7None_ = func(lbls ...labels.LabelArray) MapStateEntry {
 		return NewMapStateEntry(nil, labels.LabelArrayList(lbls).Sort(), false, false, DefaultAuthType, AuthTypeDisabled).WithOwners()
@@ -1378,8 +1378,8 @@ var (
 	worldReservedID           = identity.ReservedIdentityWorld.Uint32()
 	worldReservedIPv4ID       = identity.ReservedIdentityWorldIPv4.Uint32()
 	worldReservedIPv6ID       = identity.ReservedIdentityWorldIPv6.Uint32()
-	mapKeyL3WorldIngress      = Key{worldReservedID, 0, 0, trafficdirection.Ingress.Uint8()}
-	mapKeyL3WorldEgress       = Key{worldReservedID, 0, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL3WorldIngress      = Key{worldReservedID, 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL3WorldEgress       = Key{worldReservedID, 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
 	mapEntryDeny              = MapStateEntry{
 		ProxyPort:        0,
 		DerivedFromRules: labels.LabelArrayList{nil},
@@ -1432,8 +1432,8 @@ var (
 			ToCIDRSet: api.CIDRRuleSlice{worldSubnetRule},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL3SubnetIngress = Key{worldSubnetIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8()}
-	mapKeyL3SubnetEgress  = Key{worldSubnetIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL3SubnetIngress = Key{worldSubnetIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL3SubnetEgress  = Key{worldSubnetIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
 
 	ruleL3DenySmallerSubnet = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{{
 		IngressCommonRule: api.IngressCommonRule{
@@ -1455,8 +1455,8 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	mapKeyL3SmallerSubnetIngress = Key{worldIPIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8()}
-	mapKeyL3SmallerSubnetEgress  = Key{worldIPIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL3SmallerSubnetIngress = Key{worldIPIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL3SmallerSubnetEgress  = Key{worldIPIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
 
 	ruleL3AllowHostEgress = api.NewRule().WithEgressRules([]api.EgressRule{{
 		EgressCommonRule: api.EgressCommonRule{
@@ -1464,14 +1464,14 @@ var (
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
 
-	mapKeyL3UnknownIngress = Key{identity.IdentityUnknown.Uint32(), 0, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL3UnknownIngress = Key{identity.IdentityUnknown.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
 	derivedFrom            = labels.LabelArrayList{
 		labels.LabelArray{
 			labels.NewLabel(LabelKeyPolicyDerivedFrom, LabelAllowAnyIngress, labels.LabelSourceReserved),
 		},
 	}
 	mapEntryL3UnknownIngress = NewMapStateEntry(nil, derivedFrom, false, false, ExplicitAuthType, AuthTypeDisabled)
-	mapKeyL3HostEgress       = Key{identity.ReservedIdentityHost.Uint32(), 0, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL3HostEgress       = Key{identity.ReservedIdentityHost.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
 
 	ruleL3L4Port8080ProtoAnyDenyWorld = api.NewRule().WithIngressDenyRules([]api.IngressDenyRule{
 		{
@@ -1506,31 +1506,31 @@ var (
 			},
 		},
 	}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL3L4Port8080ProtoTCPWorldIngress      = Key{worldReservedID, 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldEgress       = Key{worldReservedID, 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldIPv4Ingress  = Key{worldReservedIPv4ID, 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldIPv4Egress   = Key{worldReservedIPv4ID, 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldIPv6Ingress  = Key{worldReservedIPv6ID, 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldIPv6Egress   = Key{worldReservedIPv6ID, 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIngress      = Key{worldReservedID, 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldEgress       = Key{worldReservedID, 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIPv4Ingress  = Key{worldReservedIPv4ID, 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIPv4Egress   = Key{worldReservedIPv4ID, 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIPv6Ingress  = Key{worldReservedIPv6ID, 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldIPv6Egress   = Key{worldReservedIPv6ID, 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIngress     = Key{worldReservedID, 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldEgress      = Key{worldReservedID, 8080, 132, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIPv4Ingress = Key{worldReservedIPv4ID, 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIPv4Egress  = Key{worldReservedIPv4ID, 8080, 132, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIPv6Ingress = Key{worldReservedIPv6ID, 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldIPv6Egress  = Key{worldReservedIPv6ID, 8080, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIngress      = Key{worldReservedID, 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldEgress       = Key{worldReservedID, 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIPv4Ingress  = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIPv4Egress   = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIPv6Ingress  = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldIPv6Egress   = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIngress      = Key{worldReservedID, 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldEgress       = Key{worldReservedID, 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIPv4Ingress  = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIPv4Egress   = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIPv6Ingress  = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldIPv6Egress   = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIngress     = Key{worldReservedID, 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldEgress      = Key{worldReservedID, 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIPv4Ingress = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIPv4Egress  = Key{worldReservedIPv4ID, 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIPv6Ingress = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldIPv6Egress  = Key{worldReservedIPv6ID, 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
 
-	mapKeyL3L4Port8080ProtoTCPWorldSNIngress  = Key{worldSubnetIdentity.Uint32(), 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoTCPWorldSNEgress   = Key{worldSubnetIdentity.Uint32(), 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldSNIngress  = Key{worldSubnetIdentity.Uint32(), 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoUDPWorldSNEgress   = Key{worldSubnetIdentity.Uint32(), 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldSNIngress = Key{worldSubnetIdentity.Uint32(), 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL3L4Port8080ProtoSCTPWorldSNEgress  = Key{worldSubnetIdentity.Uint32(), 8080, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldSNIngress  = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoTCPWorldSNEgress   = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldSNIngress  = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoUDPWorldSNEgress   = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldSNIngress = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8080ProtoSCTPWorldSNEgress  = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
 
 	ruleL3AllowWorldSubnet = api.NewRule().WithIngressRules([]api.IngressRule{{
 		ToPorts: api.PortRules{
@@ -1571,14 +1571,14 @@ var (
 			ToCIDR: api.CIDRSlice{worldCIDR},
 		},
 	}}).WithEndpointSelector(api.WildcardEndpointSelector)
-	mapKeyL4Port8080ProtoAnyWorldIPIngress       = Key{worldIPIdentity.Uint32(), 0, 0, trafficdirection.Ingress.Uint8()}
-	mapKeyL4Port8080ProtoAnyWorldIPEgress        = Key{worldIPIdentity.Uint32(), 0, 0, trafficdirection.Egress.Uint8()}
-	mapKeyL4Port8080ProtoTCPWorldIPIngress       = Key{worldIPIdentity.Uint32(), 8080, 6, trafficdirection.Ingress.Uint8()}
-	mapKeyL4Port8080ProtoTCPWorldIPEgress        = Key{worldIPIdentity.Uint32(), 8080, 6, trafficdirection.Egress.Uint8()}
-	mapKeyL4Port8080ProtoUDPWorldIPIngress       = Key{worldIPIdentity.Uint32(), 8080, 17, trafficdirection.Ingress.Uint8()}
-	mapKeyL4Port8080ProtoUDPWorldIPEgress        = Key{worldIPIdentity.Uint32(), 8080, 17, trafficdirection.Egress.Uint8()}
-	mapKeyL4Port8080ProtoSCTPWorldIPIngress      = Key{worldIPIdentity.Uint32(), 8080, 132, trafficdirection.Ingress.Uint8()}
-	mapKeyL4Port8080ProtoSCTPWorldIPEgress       = Key{worldIPIdentity.Uint32(), 8080, 132, trafficdirection.Egress.Uint8()}
+	mapKeyL4Port8080ProtoAnyWorldIPIngress       = Key{worldIPIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Ingress.Uint8()}
+	mapKeyL4Port8080ProtoAnyWorldIPEgress        = Key{worldIPIdentity.Uint32(), 0, api.FullPortMask, 0, trafficdirection.Egress.Uint8()}
+	mapKeyL4Port8080ProtoTCPWorldIPIngress       = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL4Port8080ProtoTCPWorldIPEgress        = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Egress.Uint8()}
+	mapKeyL4Port8080ProtoUDPWorldIPIngress       = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 17, trafficdirection.Ingress.Uint8()}
+	mapKeyL4Port8080ProtoUDPWorldIPEgress        = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 17, trafficdirection.Egress.Uint8()}
+	mapKeyL4Port8080ProtoSCTPWorldIPIngress      = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 132, trafficdirection.Ingress.Uint8()}
+	mapKeyL4Port8080ProtoSCTPWorldIPEgress       = Key{worldIPIdentity.Uint32(), 8080, api.FullPortMask, 132, trafficdirection.Egress.Uint8()}
 	mapEntryL4SubnetPort8080ProtoAnyIngressAllow = MapStateEntry{
 		ProxyPort:        0,
 		IsDeny:           true,
@@ -1601,6 +1601,48 @@ var (
 			mapKeyL4Port8080ProtoSCTPWorldIPEgress: struct{}{},
 		},
 	}
+
+	ruleL3AllowWorldSubnetNamedPort = api.NewRule().WithIngressRules([]api.IngressRule{{
+		ToPorts: api.PortRules{
+			api.PortRule{
+				Ports: []api.PortProtocol{
+					{
+						Port:     "http-8080",
+						Protocol: api.ProtoTCP,
+					},
+				},
+			},
+		},
+		IngressCommonRule: api.IngressCommonRule{
+			FromCIDR: api.CIDRSlice{worldSubnet},
+		},
+	}})
+	mapKeyL3L4NamedPort8080ProtoTCPWorldSubNetIngress = Key{worldSubnetIdentity.Uint32(), 8080, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+
+	ruleL3AllowWorldSubnetPortRange = api.NewRule().WithIngressRules([]api.IngressRule{{
+		ToPorts: api.PortRules{
+			api.PortRule{
+				Ports: []api.PortProtocol{
+					{
+						Port:     "64-127",
+						Protocol: api.ProtoAny,
+					},
+					{
+						Port:     "5-10",
+						Protocol: api.ProtoAny,
+					},
+				},
+			},
+		},
+		IngressCommonRule: api.IngressCommonRule{
+			FromCIDR: api.CIDRSlice{worldSubnet},
+		},
+	}})
+	mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress = Key{worldSubnetIdentity.Uint32(), 64, 0xffc0, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port5ProtoTCPWorldSubNetIngress       = Key{worldSubnetIdentity.Uint32(), 5, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port6To7ProtoTCPWorldSubNetIngress    = Key{worldSubnetIdentity.Uint32(), 6, 0xfffe, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port8To9ProtoTCPWorldSubNetIngress    = Key{worldSubnetIdentity.Uint32(), 8, 0xfffe, 6, trafficdirection.Ingress.Uint8()}
+	mapKeyL3L4Port10ProtoTCPWorldSubNetIngress      = Key{worldSubnetIdentity.Uint32(), 10, api.FullPortMask, 6, trafficdirection.Ingress.Uint8()}
 )
 
 func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
@@ -1676,6 +1718,14 @@ func Test_EnsureDeniesPrecedeAllows(t *testing.T) {
 			mapKeyL4Port8080ProtoUDPWorldIPEgress:   mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPIngress: mapEntryDeny,
 			mapKeyL4Port8080ProtoSCTPWorldIPEgress:  mapEntryDeny,
+		})}, {"named_port_world_subnet", api.Rules{ruleL3AllowWorldSubnetNamedPort}, newMapState(map[Key]MapStateEntry{
+			mapKeyL3L4NamedPort8080ProtoTCPWorldSubNetIngress: mapEntryAllow,
+		})}, {"port_range_world_subnet", api.Rules{ruleL3AllowWorldSubnetPortRange}, newMapState(map[Key]MapStateEntry{
+			mapKeyL3L4Port64To127ProtoTCPWorldSubNetIngress: mapEntryAllow,
+			mapKeyL3L4Port5ProtoTCPWorldSubNetIngress:       mapEntryAllow,
+			mapKeyL3L4Port6To7ProtoTCPWorldSubNetIngress:    mapEntryAllow,
+			mapKeyL3L4Port8To9ProtoTCPWorldSubNetIngress:    mapEntryAllow,
+			mapKeyL3L4Port10ProtoTCPWorldSubNetIngress:      mapEntryAllow,
 		})},
 	}
 

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -41,7 +41,7 @@ func FuzzResolveEgressPolicy(f *testing.F) {
 func FuzzDenyPreferredInsert(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		keys := newMapState(nil)
-		key := Key{}
+		key := Key{PortMask: api.FullPortMask}
 		entry := MapStateEntry{}
 		ff := fuzz.NewConsumer(data)
 		ff.GenerateStruct(&keys)

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -396,7 +396,7 @@ func (a L7ParserType) Merge(b L7ParserType) (L7ParserType, error) {
 type L4Filter struct {
 	// Port is the destination port to allow. Port 0 indicates that all traffic
 	// is allowed at L4.
-	Port     int    `json:"port"`
+	Port     uint16 `json:"port"`
 	PortName string `json:"port-name,omitempty"`
 	// Protocol is the L4 protocol to allow or NONE
 	Protocol api.L4Proto `json:"protocol"`
@@ -461,7 +461,7 @@ func (l4 *L4Filter) GetIngress() bool {
 
 // GetPort returns the port at which the L4Filter applies as a uint16.
 func (l4 *L4Filter) GetPort() uint16 {
-	return uint16(l4.Port)
+	return l4.Port
 }
 
 // GetListener returns the optional listener name.
@@ -489,7 +489,7 @@ type ChangeState struct {
 // Keys and old values of any added or deleted entries are added to 'changes'.
 // The implementation of 'identities' is also in a locked state.
 func (l4Filter *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, entryCb entryCallback, changes ChangeState) {
-	port := uint16(l4Filter.Port)
+	port := l4Filter.Port
 	proto := uint8(l4Filter.U8Proto)
 
 	direction := trafficdirection.Egress
@@ -744,8 +744,8 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints api.EndpointSelectorS
 	u8p, _ := u8proto.ParseProtocol(string(protocol))
 
 	l4 := &L4Filter{
-		Port:                int(p),   // 0 for L3-only rules and named ports
-		PortName:            portName, // non-"" for named ports
+		Port:                uint16(p), // 0 for L3-only rules and named ports
+		PortName:            portName,  // non-"" for named ports
 		Protocol:            protocol,
 		U8Proto:             u8p,
 		PerSelectorPolicies: make(L7DataMap),

--- a/pkg/policy/l4_filter_deny_test.go
+++ b/pkg/policy/l4_filter_deny_test.go
@@ -94,7 +94,7 @@ func (ds *PolicyTestSuite) TestMergeDenyAllL3(c *C) {
 
 	filter, ok := l4IngressDenyPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(filter.SelectsAllEndpoints(), Equals, true)
@@ -141,7 +141,7 @@ func (ds *PolicyTestSuite) TestMergeDenyAllL3(c *C) {
 
 	filter, ok = l4IngressDenyPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(filter.SelectsAllEndpoints(), Equals, true)

--- a/pkg/policy/l4_filter_test.go
+++ b/pkg/policy/l4_filter_test.go
@@ -175,7 +175,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(filter.SelectsAllEndpoints(), Equals, true)
@@ -222,7 +222,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndAllowAllL7(c *C) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(filter.SelectsAllEndpoints(), Equals, true)
@@ -348,7 +348,7 @@ func (ds *PolicyTestSuite) TestMergeAllowAllL3AndShadowedL7(c *C) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(filter.SelectsAllEndpoints(), Equals, true)

--- a/pkg/policy/l4_test.go
+++ b/pkg/policy/l4_test.go
@@ -327,6 +327,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 
 	expectedEgress := []string{`{
   "port": 8080,
+  "endPort": 0,
   "protocol": "TCP"
 }`}
 	sort.StringSlice(expectedEgress).Sort()
@@ -341,6 +342,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 
 	expectedIngress := []string{`{
   "port": 80,
+  "endPort": 0,
   "protocol": "TCP",
   "l7-rules": [
     {
@@ -357,6 +359,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 }`,
 		`{
   "port": 9090,
+  "endPort": 0,
   "protocol": "TCP",
   "l7-rules": [
     {
@@ -378,6 +381,7 @@ func (s *PolicyTestSuite) TestJSONMarshal(c *C) {
 }`,
 		`{
   "port": 8080,
+  "endPort": 0,
   "protocol": "TCP",
   "l7-rules": [
     {

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cilium/cilium/pkg/lock"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
@@ -25,16 +26,19 @@ var (
 	// localHostKey represents an ingress L3 allow from the local host.
 	localHostKey = Key{
 		Identity:         identity.ReservedIdentityHost.Uint32(),
+		PortMask:         api.FullPortMask,
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 	// localRemoteNodeKey represents an ingress L3 allow from remote nodes.
 	localRemoteNodeKey = Key{
 		Identity:         identity.ReservedIdentityRemoteNode.Uint32(),
+		PortMask:         api.FullPortMask,
 		TrafficDirection: trafficdirection.Ingress.Uint8(),
 	}
 	// allKey represents a key for unknown traffic, i.e., all traffic.
 	allKey = Key{
 		Identity: identity.IdentityUnknown.Uint32(),
+		PortMask: api.FullPortMask,
 	}
 )
 
@@ -93,6 +97,12 @@ type Key struct {
 	// DestPort is the port at L4 to / from which traffic is allowed, in
 	// host-byte order.
 	DestPort uint16
+	// PortMask is the mask that should be applied to the DestPort to
+	// define a range of ports that the policy-rule should be applied to.
+	// For example:
+	// range 2-3 would be DestPort:2 and PortMask:0xfffe
+	// range 32768-49151 would be DestPort:32768 and PortMask:0xc000
+	PortMask uint16
 	// NextHdr is the protocol which is allowed.
 	Nexthdr uint8
 	// TrafficDirection indicates in which direction Identity is allowed
@@ -102,8 +112,12 @@ type Key struct {
 
 // String returns a string representation of the Key
 func (k Key) String() string {
+	dPort := strconv.FormatUint(uint64(k.DestPort), 10)
+	if k.DestPort != 0 && k.PortMask != api.FullPortMask {
+		dPort += "-" + strconv.FormatUint(uint64(k.DestPort+(^k.PortMask)), 10)
+	}
 	return "Identity=" + strconv.FormatUint(uint64(k.Identity), 10) +
-		",DestPort=" + strconv.FormatUint(uint64(k.DestPort), 10) +
+		",DestPort=" + dPort +
 		",Nexthdr=" + strconv.FormatUint(uint64(k.Nexthdr), 10) +
 		",TrafficDirection=" + strconv.FormatUint(uint64(k.TrafficDirection), 10)
 }
@@ -130,7 +144,9 @@ func (k Key) PortProtoIsBroader(c Key) bool {
 // PortProtoIsEqual returns true if the port-protocols of the
 // two keys are exactly equal.
 func (k Key) PortProtoIsEqual(c Key) bool {
-	return k.DestPort == c.DestPort && k.Nexthdr == c.Nexthdr
+	return k.DestPort == c.DestPort &&
+		k.PortMask == c.PortMask &&
+		k.Nexthdr == c.Nexthdr
 }
 
 type Keys map[Key]struct{}
@@ -739,7 +755,6 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 			if newKey.TrafficDirection != k.TrafficDirection || !protocolsMatch(newKey, k) {
 				return true
 			}
-
 			if identityIsSupersetOf(k.Identity, newKey.Identity, identities) {
 				if newKey.PortProtoIsBroader(k) {
 					// If this iterated-allow-entry is a superset of the new-entry
@@ -748,6 +763,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 					// specific port-protocol of the iterated-allow-entry must be inserted.
 					newKeyCpy := newKey
 					newKeyCpy.DestPort = k.DestPort
+					newKeyCpy.PortMask = k.PortMask
 					newKeyCpy.Nexthdr = k.Nexthdr
 					l3l4DenyEntry := NewMapStateEntry(newKey, newEntry.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
 					ms.addKeyWithChanges(newKeyCpy, l3l4DenyEntry, changes)
@@ -827,6 +843,7 @@ func (ms *mapState) denyPreferredInsertWithChanges(newKey Key, newEntry MapState
 					// be added.
 					denyKeyCpy := k
 					denyKeyCpy.DestPort = newKey.DestPort
+					denyKeyCpy.PortMask = newKey.PortMask
 					denyKeyCpy.Nexthdr = newKey.Nexthdr
 					l3l4DenyEntry := NewMapStateEntry(k, v.DerivedFromRules, false, true, DefaultAuthType, AuthTypeDisabled)
 					ms.addKeyWithChanges(denyKeyCpy, l3l4DenyEntry, changes)
@@ -1126,9 +1143,11 @@ func (ms *mapState) AddVisibilityKeys(e PolicyOwner, redirectPort uint16, visMet
 
 	allowAllKey := Key{
 		TrafficDirection: direction.Uint8(),
+		PortMask:         api.FullPortMask,
 	}
 	key := Key{
 		DestPort:         visMeta.Port,
+		PortMask:         api.FullPortMask,
 		Nexthdr:          uint8(visMeta.Proto),
 		TrafficDirection: direction.Uint8(),
 	}
@@ -1264,6 +1283,7 @@ func (ms *mapState) allowAllIdentities(ingress, egress bool) {
 		keyToAdd := Key{
 			Identity:         0,
 			DestPort:         0,
+			PortMask:         api.FullPortMask,
 			Nexthdr:          0,
 			TrafficDirection: trafficdirection.Ingress.Uint8(),
 		}
@@ -1278,6 +1298,7 @@ func (ms *mapState) allowAllIdentities(ingress, egress bool) {
 		keyToAdd := Key{
 			Identity:         0,
 			DestPort:         0,
+			PortMask:         api.FullPortMask,
 			Nexthdr:          0,
 			TrafficDirection: trafficdirection.Egress.Uint8(),
 		}
@@ -1311,6 +1332,7 @@ func (ms *mapState) deniesL4(policyOwner PolicyOwner, l4 *L4Filter) bool {
 	anyKey := Key{
 		Identity:         0,
 		DestPort:         0,
+		PortMask:         api.FullPortMask,
 		Nexthdr:          0,
 		TrafficDirection: dir,
 	}
@@ -1398,6 +1420,7 @@ func (mc *MapChanges) AccumulateMapChanges(cs CachedSelector, adds, deletes []id
 		Identity: 0,
 		// NOTE: Port is in host byte-order!
 		DestPort:         port,
+		PortMask:         api.FullPortMask,
 		Nexthdr:          proto,
 		TrafficDirection: direction.Uint8(),
 	}

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 	"github.com/cilium/cilium/pkg/u8proto"
 )
@@ -24,68 +25,68 @@ func Test_IsSuperSetOf(t *testing.T) {
 		subSet   Key
 		res      int
 	}{
-		{Key{}, Key{}, 0},
-		{Key{0, 0, 0, 0}, Key{42, 0, 6, 0}, 1},
-		{Key{0, 0, 0, 0}, Key{42, 80, 6, 0}, 1},
-		{Key{0, 0, 0, 0}, Key{42, 0, 0, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{42, 0, 6, 0}, 2},
-		{Key{0, 0, 6, 0}, Key{42, 80, 6, 0}, 2},
-		{Key{0, 80, 6, 0}, Key{42, 80, 6, 0}, 3},
-		{Key{0, 80, 6, 0}, Key{42, 80, 17, 0}, 0},  // proto is different
-		{Key{2, 80, 6, 0}, Key{42, 80, 6, 0}, 0},   // id is different
-		{Key{0, 8080, 6, 0}, Key{42, 80, 6, 0}, 0}, // port is different
-		{Key{42, 0, 0, 0}, Key{42, 0, 0, 0}, 0},    // same key
-		{Key{42, 0, 0, 0}, Key{42, 0, 6, 0}, 4},
-		{Key{42, 0, 0, 0}, Key{42, 80, 6, 0}, 4},
-		{Key{42, 0, 0, 0}, Key{42, 0, 17, 0}, 4},
-		{Key{42, 0, 0, 0}, Key{42, 80, 17, 0}, 4},
-		{Key{42, 0, 6, 0}, Key{42, 0, 6, 0}, 0}, // same key
-		{Key{42, 0, 6, 0}, Key{42, 80, 6, 0}, 5},
-		{Key{42, 0, 6, 0}, Key{42, 8080, 6, 0}, 5},
-		{Key{42, 80, 6, 0}, Key{42, 80, 6, 0}, 0},    // same key
-		{Key{42, 80, 6, 0}, Key{42, 8080, 6, 0}, 0},  // different port
-		{Key{42, 80, 6, 0}, Key{42, 80, 17, 0}, 0},   // different proto
-		{Key{42, 80, 6, 0}, Key{42, 8080, 17, 0}, 0}, // different port and proto
+		{Key{PortMask: api.FullPortMask}, Key{PortMask: api.FullPortMask}, 0},
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 3},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 0},  // proto is different
+		{Key{2, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0},   // id is different
+		{Key{0, 8080, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0}, // port is different
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},    // same key
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 17, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0}, // same key
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 5},
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 8080, api.FullPortMask, 6, 0}, 5},
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0},    // same key
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 8080, api.FullPortMask, 6, 0}, 0},  // different port
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 17, 0}, 0},   // different proto
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 8080, api.FullPortMask, 17, 0}, 0}, // different port and proto
 
 		// increasing specificity for a L3/L4 key
-		{Key{0, 0, 0, 0}, Key{42, 80, 6, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{42, 80, 6, 0}, 2},
-		{Key{0, 80, 6, 0}, Key{42, 80, 6, 0}, 3},
-		{Key{42, 0, 0, 0}, Key{42, 80, 6, 0}, 4},
-		{Key{42, 0, 6, 0}, Key{42, 80, 6, 0}, 5},
-		{Key{42, 80, 6, 0}, Key{42, 80, 6, 0}, 0}, // same key
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 3},
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 5},
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 80, api.FullPortMask, 6, 0}, 0}, // same key
 
 		// increasing specificity for a L3-only key
-		{Key{0, 0, 0, 0}, Key{42, 0, 0, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{42, 0, 0, 0}, 0},   // not a superset
-		{Key{0, 80, 6, 0}, Key{42, 0, 0, 0}, 0},  // not a superset
-		{Key{42, 0, 0, 0}, Key{42, 0, 0, 0}, 0},  // same key
-		{Key{42, 0, 6, 0}, Key{42, 0, 0, 0}, 0},  // not a superset
-		{Key{42, 80, 6, 0}, Key{42, 0, 0, 0}, 0}, // not a superset
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},   // not a superset
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},  // not a superset
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},  // same key
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0},  // not a superset
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 0, 0}, 0}, // not a superset
 
 		// increasing specificity for a L3/proto key
-		{Key{0, 0, 0, 0}, Key{42, 0, 6, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{42, 0, 6, 0}, 2},
-		{Key{0, 80, 6, 0}, Key{42, 0, 6, 0}, 0}, // not a superset
-		{Key{42, 0, 0, 0}, Key{42, 0, 6, 0}, 4},
-		{Key{42, 0, 6, 0}, Key{42, 0, 6, 0}, 0},  // same key
-		{Key{42, 80, 6, 0}, Key{42, 0, 6, 0}, 0}, // not a superset
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0}, // not a superset
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 4},
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0},  // same key
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{42, 0, api.FullPortMask, 6, 0}, 0}, // not a superset
 
 		// increasing specificity for a proto-only key
-		{Key{0, 0, 0, 0}, Key{0, 0, 6, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{0, 0, 6, 0}, 0},   // same key
-		{Key{0, 80, 6, 0}, Key{0, 0, 6, 0}, 0},  // not a superset
-		{Key{42, 0, 0, 0}, Key{0, 0, 6, 0}, 0},  // not a superset
-		{Key{42, 0, 6, 0}, Key{0, 0, 6, 0}, 0},  // not a superset
-		{Key{42, 80, 6, 0}, Key{0, 0, 6, 0}, 0}, // not a superset
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},   // same key
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{0, 0, api.FullPortMask, 6, 0}, 0}, // not a superset
 
 		// increasing specificity for a L4-only key
-		{Key{0, 0, 0, 0}, Key{0, 80, 6, 0}, 1},
-		{Key{0, 0, 6, 0}, Key{0, 80, 6, 0}, 2},
-		{Key{0, 80, 6, 0}, Key{0, 80, 6, 0}, 0},  // same key
-		{Key{42, 0, 0, 0}, Key{0, 80, 6, 0}, 0},  // not a superset
-		{Key{42, 0, 6, 0}, Key{0, 80, 6, 0}, 0},  // not a superset
-		{Key{42, 80, 6, 0}, Key{0, 80, 6, 0}, 0}, // not a superset
+		{Key{0, 0, api.FullPortMask, 0, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 1},
+		{Key{0, 0, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 2},
+		{Key{0, 80, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},  // same key
+		{Key{42, 0, api.FullPortMask, 0, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 0, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0},  // not a superset
+		{Key{42, 80, api.FullPortMask, 6, 0}, Key{0, 80, api.FullPortMask, 6, 0}, 0}, // not a superset
 
 	}
 	for i, tt := range tests {
@@ -1073,6 +1074,7 @@ func testKey(id int, port uint16, proto uint8, direction trafficdirection.Traffi
 		Identity:         uint32(id),
 		DestPort:         port,
 		Nexthdr:          proto,
+		PortMask:         api.FullPortMask,
 		TrafficDirection: direction.Uint8(),
 	}
 }

--- a/pkg/policy/portrange.go
+++ b/pkg/policy/portrange.go
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+)
+
+// MaskedPort is a port with a wild card mask value
+type MaskedPort struct {
+	port uint16
+	mask uint16
+}
+
+func (m MaskedPort) String() string {
+	return fmt.Sprintf("{port: 0x%x, mask: 0x%x}", m.port, m.mask)
+}
+
+// maskedPort returns a new MaskedPort where 'wildcardBits' lowest bits are wildcarded.
+func maskedPort(port uint16, wildcardBits int) MaskedPort {
+	mask := uint16(math.MaxUint16) << wildcardBits
+	return MaskedPort{port & mask, mask}
+}
+
+// PortRangeToMaskedPorts returns a slice of masked ports for the given port range.
+// If the end port is equal to or less than the the start port than the start port is returned,
+// as a fully masked port.
+// Ports are not returned in any particular order, so testing code needs to sort them
+// for consistency.
+func PortRangeToMaskedPorts(start uint16, end uint16) (ports []MaskedPort) {
+	if end <= start {
+		return []MaskedPort{{start, 0xffff}}
+	}
+	// Find the number of common leading bits. The first uncommon bit will be 0 for the start
+	// and 1 for the end.
+	commonBits := bits.LeadingZeros16(start ^ end)
+
+	// Cover the case where all the bits after the common bits are zeros on start and ones on
+	// end. In this case the range can be represented by a single masked port instead of two
+	// that would be produced below.
+	// For example, if the range is from 16-31 (0b10000 - 0b11111), then we return 0b1xxxx
+	// instead of 0b10xxx and 0b11xxx that would be produced when approaching the middle from
+	// the two sides.
+	//
+	// This also covers the trivial case where all the bits are in common (i.e., start == end).
+	mask := uint16(math.MaxUint16) >> commonBits
+	if start&mask == 0 && ^end&mask == 0 {
+		return append(ports, maskedPort(start, 16-commonBits))
+	}
+
+	// Find the "middle point" toward which the masked ports approach from both sides.
+	// This "middle point" is the highest bit that differs between the range start and end.
+	middleBit := 16 - 1 - commonBits
+	middle := uint16(1 << middleBit)
+
+	// Wildcard the trailing zeroes to the right of the middle bit of the range start.
+	// This covers the values immediately following the port range start, including the start itself.
+	// The middle bit is added to avoid counting zeroes past it.
+	bit := bits.TrailingZeros16(start | middle)
+	ports = append(ports, maskedPort(start, bit))
+
+	// Find all 0-bits between the trailing zeroes and the middle bit and add MaskedPorts where
+	// each found 0-bit is set and the lower bits are wildcarded. This covers the range from the
+	// start to the middle not covered by the trailing zeroes above.
+	// The current 'bit' is skipped since we know it is 1.
+	for bit++; bit < middleBit; bit++ {
+		if start&(1<<bit) == 0 {
+			// Adding 1<<bit will set the bit since we know it is not set
+			ports = append(ports, maskedPort(start+1<<bit, bit))
+		}
+	}
+
+	// Wildcard the trailing ones to the right of the middle bit of the range end.
+	// This covers the values immediately preceding and including the range end.
+	// The middle bit is added to avoid counting ones past it.
+	bit = bits.TrailingZeros16(^end | middle)
+	ports = append(ports, maskedPort(end, bit))
+
+	// Find all 1-bits between the trailing ones and the middle bit and add MaskedPorts where
+	// each found 1-bit is cleared and the lower bits are wildcarded. This covers the range from
+	// the end to the middle not covered by the trailing ones above.
+	// The current 'bit' is skipped since we know it is 0.
+	for bit++; bit < middleBit; bit++ {
+		if end&(1<<bit) != 0 {
+			// Subtracting 1<<bit will clear the bit since we know it is set
+			ports = append(ports, maskedPort(end-1<<bit, bit))
+		}
+	}
+
+	return ports
+}

--- a/pkg/policy/portrange_test.go
+++ b/pkg/policy/portrange_test.go
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package policy
+
+import (
+	"sort"
+
+	. "github.com/cilium/checkmate"
+
+	"github.com/cilium/cilium/pkg/checker"
+)
+
+// maskedPorts have to be sorted for this check
+func validateMaskedPorts(c *C, maskedPorts []MaskedPort, start, end uint16) {
+	c.Assert(maskedPorts, NotNil)
+	c.Assert(len(maskedPorts), Not(Equals), 0)
+	// validate that range elements are continuous and non-overlapping
+	first := maskedPorts[0].port
+	last := first + ^maskedPorts[0].mask
+	for i := 1; i < len(maskedPorts); i++ {
+		c.Assert(maskedPorts[i].port, Equals, last+1)
+		last = maskedPorts[i].port + ^maskedPorts[i].mask
+	}
+	// Check that the computed range matches the given range
+	c.Assert(first, Equals, start)
+	c.Assert(last, Equals, end)
+}
+
+func (ds *PolicyTestSuite) TestPortRange(c *C) {
+	type testCase struct {
+		start, end uint16
+		expected   []MaskedPort
+	}
+
+	testCases := []testCase{
+		// worst case test
+		{
+			start: 1,
+			end:   65534,
+			expected: []MaskedPort{
+				{port: 0x1, mask: 0xffff},    // 1
+				{port: 0x2, mask: 0xfffe},    // 2-3
+				{port: 0x4, mask: 0xfffc},    // 4-7
+				{port: 0x8, mask: 0xfff8},    // 8-15
+				{port: 0x10, mask: 0xfff0},   // 16-31
+				{port: 0x20, mask: 0xffe0},   // 32-63
+				{port: 0x40, mask: 0xffc0},   // 64-127
+				{port: 0x80, mask: 0xff80},   // 128-255
+				{port: 0x100, mask: 0xff00},  // 256-511
+				{port: 0x200, mask: 0xfe00},  // 512-1023
+				{port: 0x400, mask: 0xfc00},  // 1024-2047
+				{port: 0x800, mask: 0xf800},  // 2048-4095
+				{port: 0x1000, mask: 0xf000}, // 4096-8191
+				{port: 0x2000, mask: 0xe000}, // 8192-16383
+				{port: 0x4000, mask: 0xc000}, // 16384-32767
+				{port: 0x8000, mask: 0xc000}, // 32768-49151
+				{port: 0xc000, mask: 0xe000}, // 49152-57343
+				{port: 0xe000, mask: 0xf000}, // 57344-61439
+				{port: 0xf000, mask: 0xf800}, // 61440-63487
+				{port: 0xf800, mask: 0xfc00}, // 63488-64511
+				{port: 0xfc00, mask: 0xfe00}, // 64512-65023
+				{port: 0xfe00, mask: 0xff00}, // 65024-65279
+				{port: 0xff00, mask: 0xff80}, // 65280-65407
+				{port: 0xff80, mask: 0xffc0}, // 65408-65471
+				{port: 0xffc0, mask: 0xffe0}, // 65472-65503
+				{port: 0xffe0, mask: 0xfff0}, // 65504-65519
+				{port: 0xfff0, mask: 0xfff8}, // 65520-65527
+				{port: 0xfff8, mask: 0xfffc}, // 65528-65531
+				{port: 0xfffc, mask: 0xfffe}, // 65532-65533
+				{port: 0xfffe, mask: 0xffff}, // 65534
+			},
+		},
+		{
+			start: 1,
+			end:   1023,
+			expected: []MaskedPort{
+				{port: 0x1, mask: 0xffff},   // 1
+				{port: 0x2, mask: 0xfffe},   // 2-3
+				{port: 0x4, mask: 0xfffc},   // 4-7
+				{port: 0x8, mask: 0xfff8},   // 8-15
+				{port: 0x10, mask: 0xfff0},  // 16-31
+				{port: 0x20, mask: 0xffe0},  // 32-63
+				{port: 0x40, mask: 0xffc0},  // 64-127
+				{port: 0x80, mask: 0xff80},  // 128-255
+				{port: 0x100, mask: 0xff00}, // 256-511
+				{port: 0x200, mask: 0xfe00}, // 512-1023
+			},
+		},
+		{
+			start: 0,
+			end:   1023,
+			expected: []MaskedPort{
+				{port: 0, mask: 0xfc00}, // 0-1023
+			},
+		},
+		// A typical large case test
+		{
+			start: 1024,
+			end:   65535,
+			expected: []MaskedPort{
+				{port: 0x400, mask: 0xfc00},  // 1024-2047
+				{port: 0x800, mask: 0xf800},  // 2048-4095
+				{port: 0x1000, mask: 0xf000}, // 4096-8191
+				{port: 0x2000, mask: 0xe000}, // 8192-16383
+				{port: 0x4000, mask: 0xc000}, // 16384-32767
+				{port: 0x8000, mask: 0x8000}, // 32768-65535
+			},
+		},
+		// Another typical large case test
+		{
+			start: 10000,
+			end:   20000,
+			expected: []MaskedPort{
+				{port: 0x2710, mask: 0xfff0}, // 10000 - 10015
+				{port: 0x2720, mask: 0xffe0}, // 10016 - 10047
+				{port: 0x2740, mask: 0xffc0}, // 10048 - 10111
+				{port: 0x2780, mask: 0xff80}, // 10112 - 10239
+				{port: 0x2800, mask: 0xf800}, // 10240 - 12287
+				{port: 0x3000, mask: 0xf000}, // 12288 - 16383
+				{port: 0x4000, mask: 0xf800}, // 16384 - 18431
+				{port: 0x4800, mask: 0xfc00}, // 18432 - 19455
+				{port: 0x4c00, mask: 0xfe00}, // 19456 - 19967
+				{port: 0x4e00, mask: 0xffe0}, // 19968 - 19999
+				{port: 0x4e20, mask: 0xffff}, // 20000
+			},
+		},
+		{
+			start: 1000,
+			end:   1999,
+			expected: []MaskedPort{
+				{port: 0x3e8, mask: 0xfff8},
+				{port: 0x3f0, mask: 0xfff0},
+				{port: 0x400, mask: 0xfe00},
+				{port: 0x600, mask: 0xff00},
+				{port: 0x700, mask: 0xff80},
+				{port: 0x780, mask: 0xffc0},
+				{port: 0x7c0, mask: 0xfff0},
+			},
+		},
+		{
+			start: 0,
+			end:   1,
+			expected: []MaskedPort{
+				{port: 0, mask: 0xfffe}, // 0-1
+			},
+		},
+		{
+			start: 16,
+			end:   31,
+			expected: []MaskedPort{
+				{port: 0x10, mask: 0xfff0}, // 16-31
+			},
+		},
+		{
+			start: 0xff00, // 65280
+			end:   0xffff, // 65535
+			expected: []MaskedPort{
+				{port: 0xff00, mask: 0xff00}, // 65280-65535
+			},
+		},
+		{
+			start: 0,
+			end:   0xffff,
+			expected: []MaskedPort{
+				{port: 0x0, mask: 0x0000}, // 0-0xffff
+			},
+		},
+		{
+			start: 1,
+			end:   7,
+			expected: []MaskedPort{
+				{port: 0x1, mask: 0xffff}, // 1
+				{port: 0x2, mask: 0xfffe}, // 2-3
+				{port: 0x4, mask: 0xfffc}, // 4-7
+			},
+		},
+		{
+			start: 0,
+			end:   7,
+			expected: []MaskedPort{
+				{port: 0x0, mask: 0xfff8}, // 0-7
+			},
+		},
+		{
+			start: 5,
+			end:   10,
+			expected: []MaskedPort{
+				{0b0000000000000101, 0b1111111111111111}, // 5
+				{0b0000000000000110, 0b1111111111111110}, // 6-7
+				{0b0000000000001000, 0b1111111111111110}, // 8-9
+				{0b0000000000001010, 0b1111111111111111}, // 10
+			},
+		},
+		{
+			start: 0,
+			end:   16,
+			expected: []MaskedPort{
+				{0b0000000000000000, 0b1111111111110000}, // 0xxxx
+				{0b0000000000010000, 0b1111111111111111}, // 10000
+			},
+		},
+		{
+			start: 0b0000000000010000, // 16
+			end:   0b0000000110000111, // 391
+			expected: []MaskedPort{
+				{0b0000000000010000, 0b1111111111110000}, // 00001xxxx, 16-31
+				{0b0000000000100000, 0b1111111111100000}, // 0001xxxxx, 32-63
+				{0b0000000001000000, 0b1111111111000000}, // 001xxxxxx, 64-127
+				{0b0000000010000000, 0b1111111110000000}, // 01xxxxxxx, 128-255
+				{0b0000000100000000, 0b1111111110000000}, // 01xxxxxxx, 256-383
+				{0b0000000110000000, 0b1111111111111000}, // 10000000x, 384-391
+			},
+		},
+		{
+			start: 22,
+			end:   23,
+			expected: []MaskedPort{
+				{0b0000000000010110, 0b1111111111111110}, // 22-23
+			},
+		},
+		{
+			start: 23,
+			end:   24,
+			expected: []MaskedPort{
+				{0b0000000000010111, 0b1111111111111111}, // 23
+				{0b0000000000011000, 0b1111111111111111}, // 24
+			},
+		},
+		{
+			start: 0,
+			end:   0x7fff,
+			expected: []MaskedPort{
+				{port: 0x0, mask: 0x8000}, // 0-0x7fff
+			},
+		},
+		{
+			start: 256,
+			end:   256,
+			expected: []MaskedPort{
+				{port: 0x100, mask: 0xffff},
+			},
+		},
+		{
+			start: 65535,
+			end:   65535,
+			expected: []MaskedPort{
+				{port: 65535, mask: 0xffff},
+			},
+		},
+		{
+			start: 32767,
+			end:   32768,
+			expected: []MaskedPort{
+				{port: 0x7fff, mask: 0xffff},
+				{port: 0x8000, mask: 0xffff},
+			},
+		},
+		{
+			start: 0b0101010101010101, // 0x5555
+			end:   0b0101010111010101, // 0x55d5
+			expected: []MaskedPort{
+				{port: 0b0101010101010101, mask: 0b1111111111111111},
+				{port: 0b0101010101010110, mask: 0b1111111111111110},
+				{port: 0b0101010101011000, mask: 0b1111111111111000},
+				{port: 0b0101010101100000, mask: 0b1111111111100000},
+				{port: 0b0101010110000000, mask: 0b1111111111000000},
+				{port: 0b0101010111000000, mask: 0b1111111111110000},
+				{port: 0b0101010111010000, mask: 0b1111111111111100},
+				{port: 0b0101010111010100, mask: 0b1111111111111110},
+			},
+		},
+		// This is valid, as "0" defines no range.
+		{
+			start: 65535,
+			end:   0,
+			expected: []MaskedPort{
+				{port: 0xffff, mask: 0xffff}, // 65535
+			},
+		},
+		// These remaining tests are testing invalid cases where start > end.
+		// For now, these cases return the start port with a full mask,
+		// indicating that only the start port should be part of the range.
+		// This is technically correct for the case of end port being "0",
+		// and ambiguous when the port
+		{
+			start: 65535,
+			end:   1,
+			expected: []MaskedPort{
+				{port: 0xffff, mask: 0xffff}, // 65535
+			},
+		},
+		{
+			start: 65530,
+			end:   5,
+			expected: []MaskedPort{
+				{port: 0xfffa, mask: 0xffff}, // 65530
+			},
+		},
+		{
+			start: 10,
+			end:   5,
+			expected: []MaskedPort{
+				{port: 0xa, mask: 0xffff}, // 10
+			},
+		},
+	}
+
+	for i := 0; i < len(testCases); i++ {
+		test := &testCases[i]
+		maskedPorts := PortRangeToMaskedPorts(test.start, test.end)
+		// Sort the returned slice so that PortRangeToMaskedPorts() can return masked ports
+		// in any order that is convenient for it.
+		sort.Slice(maskedPorts, func(i, j int) bool {
+			return maskedPorts[i].port < maskedPorts[j].port
+		})
+		c.Logf("TestPortRange test case: 0x%x-0x%x (%d-%d)", test.start, test.end, test.start, test.end)
+		c.Assert(maskedPorts, checker.Equals, test.expected)
+		// Validate when given a proper range
+		if test.start <= test.end {
+			// Validation checks that the masked ports form a continuous range
+			validateMaskedPorts(c, maskedPorts, test.start, test.end)
+		}
+	}
+}

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/cilium/cilium/pkg/identity"
+	"github.com/cilium/cilium/pkg/policy/api"
 	"github.com/cilium/cilium/pkg/policy/trafficdirection"
 )
 
@@ -265,6 +266,7 @@ func (p *EndpointPolicy) ConsumeMapChanges() (adds, deletes Keys) {
 func (p *EndpointPolicy) AllowsIdentity(identity identity.NumericIdentity) (ingress, egress bool) {
 	key := Key{
 		Identity: uint32(identity),
+		PortMask: api.FullPortMask,
 	}
 
 	if !p.IngressPolicyEnabled {

--- a/pkg/policy/resolve_deny_test.go
+++ b/pkg/policy/resolve_deny_test.go
@@ -338,8 +338,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDenyWildcard(c *C) {
 		policyMapState: newMapState(map[Key]MapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
-			{TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
-			{DestPort: 80, Nexthdr: 6}:                          rule1MapStateEntry,
+			{PortMask: api.FullPortMask, TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
+			{DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                          rule1MapStateEntry,
 		}),
 	}
 
@@ -481,12 +481,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 		policyMapState: newMapState(map[Key]MapStateEntry{
 			// Although we have calculated deny policies, the overall policy
 			// will still allow egress to world.
-			{TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
-			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
+			{PortMask: api.FullPortMask, TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
+			{PortMask: api.FullPortMask, Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{PortMask: api.FullPortMask, Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{PortMask: api.FullPortMask, Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{PortMask: api.FullPortMask, Identity: 192, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
+			{PortMask: api.FullPortMask, Identity: 194, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry,
 		}),
 	}
 
@@ -494,11 +494,11 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressDeny(c *C) {
 	// maps on the policy got cleared
 
 	c.Assert(adds, checker.Equals, Keys{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: {},
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 192, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
+		{Identity: 194, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
 	})
 	c.Assert(deletes, checker.Equals, Keys{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 193, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
 	})
 
 	// Have to remove circular reference before testing for Equality to avoid an infinite loop

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -517,8 +517,8 @@ func (ds *PolicyTestSuite) TestMapStateWithIngressWildcard(c *C) {
 		},
 		PolicyOwner: DummyOwner{},
 		policyMapState: newMapState(map[Key]MapStateEntry{
-			{TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
-			{DestPort: 80, Nexthdr: 6}:                          rule1MapStateEntry,
+			{PortMask: api.FullPortMask, TrafficDirection: trafficdirection.Egress.Uint8()}: allowEgressMapStateEntry,
+			{DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                          rule1MapStateEntry,
 		}),
 	}
 
@@ -669,12 +669,12 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 		},
 		PolicyOwner: DummyOwner{},
 		policyMapState: newMapState(map[Key]MapStateEntry{
-			{TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
-			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
-			{Identity: 192, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
-			{Identity: 194, DestPort: 80, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
+			{PortMask: api.FullPortMask, TrafficDirection: trafficdirection.Egress.Uint8()}:                              allowEgressMapStateEntry,
+			{Identity: uint32(identity.ReservedIdentityWorld), DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:     rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv4), DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{Identity: uint32(identity.ReservedIdentityWorldIPv6), DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: rule1MapStateEntry.WithOwners(cachedSelectorWorld),
+			{Identity: 192, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
+			{Identity: 194, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}:                                        rule1MapStateEntry.WithAuthType(AuthTypeDisabled),
 		}),
 	}
 
@@ -690,11 +690,11 @@ func (ds *PolicyTestSuite) TestMapStateWithIngress(c *C) {
 	c.Assert(policy.policyMapChanges.changes, IsNil)
 
 	c.Assert(adds, checker.Equals, Keys{
-		{Identity: 192, DestPort: 80, Nexthdr: 6}: {},
-		{Identity: 194, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 192, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
+		{Identity: 194, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
 	})
 	c.Assert(deletes, checker.Equals, Keys{
-		{Identity: 193, DestPort: 80, Nexthdr: 6}: {},
+		{Identity: 193, DestPort: 80, PortMask: api.FullPortMask, Nexthdr: 6}: {},
 	})
 
 	// Assign an empty mutex so that checker.Equal does not complain about the
@@ -760,6 +760,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
 					}: {},
@@ -782,6 +783,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
 					}: {},
@@ -804,6 +806,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
 					}: {IsDeny: true},
@@ -826,6 +829,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Ingress.Uint8(),
 					}: {IsDeny: true},
@@ -848,6 +852,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
 					}: {IsDeny: true},
@@ -870,6 +875,7 @@ func TestEndpointPolicy_AllowsIdentity(t *testing.T) {
 					{
 						Identity:         0,
 						DestPort:         0,
+						PortMask:         api.FullPortMask,
 						Nexthdr:          0,
 						TrafficDirection: trafficdirection.Egress.Uint8(),
 					}: {IsDeny: true},

--- a/pkg/policy/rule_test.go
+++ b/pkg/policy/rule_test.go
@@ -1785,7 +1785,7 @@ func (ds *PolicyTestSuite) TestIngressL4AllowAll(c *C) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(len(filter.PerSelectorPolicies), Equals, 1)
@@ -1830,7 +1830,7 @@ func (ds *PolicyTestSuite) TestIngressL4AllowAllNamedPort(c *C) {
 
 	filter, ok := l4IngressPolicy["port-80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 0)
+	c.Assert(filter.Port, Equals, uint16(0))
 	c.Assert(filter.PortName, Equals, "port-80")
 	c.Assert(filter.Ingress, Equals, true)
 
@@ -1902,7 +1902,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowAll(c *C) {
 
 	filter, ok := l4EgressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, false)
 
 	c.Assert(len(filter.PerSelectorPolicies), Equals, 1)
@@ -1958,7 +1958,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowWorld(c *C) {
 
 	filter, ok := l4EgressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, false)
 
 	c.Assert(len(filter.PerSelectorPolicies), Equals, 1)
@@ -2013,7 +2013,7 @@ func (ds *PolicyTestSuite) TestEgressL4AllowAllEntity(c *C) {
 
 	filter, ok := l4EgressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, false)
 
 	c.Assert(len(filter.PerSelectorPolicies), Equals, 1)
@@ -2188,7 +2188,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(len(filter.PerSelectorPolicies), Equals, 2)
@@ -2215,7 +2215,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	filterL7, ok := l4IngressPolicy["7000/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filterL7.Port, Equals, 7000)
+	c.Assert(filterL7.Port, Equals, uint16(7000))
 	c.Assert(filterL7.Ingress, Equals, true)
 
 	c.Assert(len(filterL7.PerSelectorPolicies), Equals, 1)
@@ -2295,7 +2295,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(len(filter.PerSelectorPolicies), Equals, 2)
@@ -2306,7 +2306,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	filterL7, ok = l4IngressPolicy["7000/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filterL7.Port, Equals, 7000)
+	c.Assert(filterL7.Port, Equals, uint16(7000))
 	c.Assert(filterL7.Ingress, Equals, true)
 
 	c.Assert(len(filterL7.PerSelectorPolicies), Equals, 1)
@@ -2360,7 +2360,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
@@ -2414,7 +2414,7 @@ func (ds *PolicyTestSuite) TestL4WildcardMerge(c *C) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)
@@ -2473,7 +2473,7 @@ func (ds *PolicyTestSuite) TestL3L4L7Merge(c *C) {
 
 	filter, ok := l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(len(filter.PerSelectorPolicies), Equals, 2)
@@ -2542,7 +2542,7 @@ func (ds *PolicyTestSuite) TestL3L4L7Merge(c *C) {
 
 	filter, ok = l4IngressPolicy["80/TCP"]
 	c.Assert(ok, Equals, true)
-	c.Assert(filter.Port, Equals, 80)
+	c.Assert(filter.Port, Equals, uint16(80))
 	c.Assert(filter.Ingress, Equals, true)
 
 	c.Assert(filter.L7Parser, Equals, ParserTypeHTTP)


### PR DESCRIPTION
1.  Add utility function PortRangeToMaskedPorts() to convert a port range to
    a set of masked ports (prefixes). This function determines the "midpoint"
    as the highest bit that differs between the start and end ports, and then
    adds masked ports approaching this midpoint both from the start and end.

2. Change L4Filter.Port to uint16 to avoid unnecessary conversions.

3. Enable Port ranges
    - Add CRD/API support for Endport.
    - Pass Endport to Enovy.
    - Add PortMask to MapKey structure, make "0xffff" a default value.
    - Use PortRangeToMaskedPorts when creating keys for toMapState in L4 policies.
    - Update maps/policy to account for mask.
    - Add mapstate tests for port ranges.



Fixes: #16622

```release-note
policy: Add support for port ranges in network policies.
```
