### PR TITLE
bpf: lb: fix missing drop reason in reverse_map_l4_port()

### DIFF
--- a/bpf/lib/lb.h
+++ b/bpf/lib/lb.h
@@ -379,9 +379,8 @@ static __always_inline int reverse_map_l4_port(struct __ctx_buff *ctx, __u8 next
 			int ret;
 
 			/* Port offsets for UDP and TCP are the same */
-			ret = l4_load_port(ctx, l4_off + TCP_SPORT_OFF, &old_port);
-			if (IS_ERR(ret))
-				return ret;
+			if (l4_load_port(ctx, l4_off + TCP_SPORT_OFF, &old_port) < 0)
+				return DROP_INVALID;
 
 			if (port != old_port) {
 #ifdef ENABLE_SCTP


### PR DESCRIPTION
l4_load_port() is just a thin wrapper around ctx_load_bytes(), which returns raw kernel errnos. Translate these to a Cilium-internal drop reason before returning to the caller.