### PR TITLE
datapath: Few minor improvements to DevicesController

### DIFF
--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -406,13 +406,13 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 					continue
 				}
 				addr := deviceAddressFromAddrUpdate(u)
+				i := slices.Index(d.Addrs, addr)
 				if u.NewAddr {
-					d.Addrs = append(d.Addrs, addr)
-				} else {
-					i := slices.Index(d.Addrs, addr)
-					if i >= 0 {
-						d.Addrs = slices.Delete(d.Addrs, i, i+1)
+					if i < 0 {
+						d.Addrs = append(d.Addrs, addr)
 					}
+				} else if i >= 0 {
+					d.Addrs = slices.Delete(d.Addrs, i, i+1)
 				}
 				deviceUpdated = true
 			case netlink.RouteUpdate:

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -44,7 +44,7 @@ var (
 		},
 	}
 
-	DeviceTableCell = statedb.NewProtectedTableCell[*Device](
+	DeviceTableCell = statedb.NewPrivateRWTableCell[*Device](
 		"devices",
 		DeviceIDIndex,
 		DeviceNameIndex,

--- a/pkg/datapath/tables/route.go
+++ b/pkg/datapath/tables/route.go
@@ -41,7 +41,7 @@ var (
 		},
 	}
 
-	RouteTableCell = statedb.NewProtectedTableCell[*Route](
+	RouteTableCell = statedb.NewPrivateRWTableCell[*Route](
 		"routes",
 		RouteIDIndex,
 		RouteLinkIndex,

--- a/pkg/statedb/cell.go
+++ b/pkg/statedb/cell.go
@@ -95,3 +95,28 @@ func NewProtectedTableCell[Obj any](
 		}),
 	)
 }
+
+type tableOutMeta[Obj any] struct {
+	cell.Out
+	Meta TableMeta `group:"statedb-tables"`
+}
+
+func NewPrivateRWTableCell[Obj any](
+	tableName TableName,
+	primaryIndexer Indexer[Obj],
+	secondaryIndexers ...Indexer[Obj],
+) cell.Cell {
+	rwtable, err := NewTable(tableName, primaryIndexer, secondaryIndexers...)
+	return cell.Group(
+		cell.Provide(func() (tableOutMeta[Obj], error) {
+			if err != nil {
+				return tableOutMeta[Obj]{}, err
+			}
+			return tableOutMeta[Obj]{Meta: rwtable}, nil
+		}),
+		// Provide RWTable[Obj] only in the module's scope.
+		cell.ProvidePrivate(func() (RWTable[Obj], error) {
+			return rwtable, err
+		}),
+	)
+}


### PR DESCRIPTION
This pulls out couple improvemenst from https://github.com/cilium/cilium/pull/28712 to its own PR:

`statedb: Add NewPrivateRWTableCell`: Add ability for a constructor to provide the `Table[T]` and thus allow populating a table before readers can access it.

`datapath: Ensure device and route tables are populated before readers`: Make sure DevicesController has initially populated the devices table before anything reads it. Note that this was not a bug earlier as we didn't use `Table[*Device]` directly but rather via `option.Config.GetDevices` which came from `DeviceManager` wrapper around `DevicesController` and that did enforce the ordering.

`datapath/devices: Flush routes on device delete`: Fix cleaning of route entries when device is deleted. Surprisingly Linux doesn't send netlink notifications for each deleted route when link is removed. This was not a big issue yet as routes were only used to figure out if a 'veth' device should be selected based on if it had a default route or not.

`datapath/devices: Avoid adding duplicate address`: As DevicesController needs to populate the devices table before readers see it, it needs to do a Subscribe and List. This leads to a race where one might see an address both in listing and as an update. Fix this by not adding the address twice. (I did also think about using a `sets.Set` for addresses, but I prefer that they're in a slice and in a stable order. Happy to reconsider though). 
