### PR TITLE
clustermesh install documentation: missing step

### DIFF
--- a/Documentation/network/clustermesh/clustermesh.rst
+++ b/Documentation/network/clustermesh/clustermesh.rst
@@ -86,6 +86,8 @@ same as you typically pass to ``kubectl --context``.
 Specify the Cluster Name and ID
 ===============================
 
+Cilium needs to be installed onto each cluster.
+
 Each cluster must be assigned a unique human-readable name as well as a numeric
 cluster ID (1-255). It is best to assign both these attributes at installation
 time of Cilium:
@@ -93,6 +95,15 @@ time of Cilium:
  * ConfigMap options ``cluster-name`` and ``cluster-id``
  * Helm options ``cluster.name`` and ``cluster.id``
  * Cilium CLI install options ``--set cluster.name`` and ``--set cluster.id``
+
+Review :ref:`k8s_install_quick` for more details and use cases.
+
+Example install using the Cilium CLI:
+
+.. code-block:: shell-session
+
+  cilium install --set cluster.name=$CLUSTER1 --set cluster.id=1 --context $CLUSTER1
+  cilium install --set cluster.name=$CLUSTER2 --set cluster.id=2 --context $CLUSTER2
 
 .. important::
 


### PR DESCRIPTION
As I normally follow along with documentation, I usually look at the code blocks to see which steps I need to execute.

I was starting from scratch, following the docs, and never saw a *cilium install* step. When I got to the *cilium clustermesh enable* step I got an error, because I hadn't installed Cilium into the cluster yet.

This patch simply points out that Cilium needs to be installed on each cluster, and it gives a code block, with a copy/paste example.

Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!
