### PR TITLE
install: Allow cilium-agent to get resource "configmaps"

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/clusterrole.yaml
@@ -37,6 +37,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - configmaps
   verbs:
   - get
   - list

--- a/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/clusterrole.yaml
@@ -37,6 +37,7 @@ rules:
   - pods
   - endpoints
   - nodes
+  - configmaps
   verbs:
   - get
   - list


### PR DESCRIPTION
Add "configmaps" in the clusterrole for cilium-agent to solve the following errors when running "cilium install --chart-directory ./install/kubernetes/cilium ..." to install cilium on kind.

```
failed to start: failed to resolve configurations: failed to read config source config-map:kube-system/cilium-config: failed to retrieve ConfigMap kube-system/cilium-config: configmaps "cilium-config" is forbidden: User "system:serviceaccount:kube-system:cilium" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
```
