### PR TITLE
dnsproxy: convert LookupEndpointByIP to use netip.Addr

### DIFF
--- a/daemon/cmd/fqdn.go
+++ b/daemon/cmd/fqdn.go
@@ -425,14 +425,10 @@ func (d *Daemon) updateSelectors(ctx context.Context, selectorWithIPsToUpdate ma
 }
 
 // lookupEPByIP returns the endpoint that this IP belongs to
-func (d *Daemon) lookupEPByIP(endpointIP net.IP) (endpoint *endpoint.Endpoint, err error) {
-	endpointAddr, ok := ippkg.AddrFromIP(endpointIP)
-	if !ok {
-		return nil, fmt.Errorf("invalid IP %s for endpoint lookup", endpointIP)
-	}
+func (d *Daemon) lookupEPByIP(endpointAddr netip.Addr) (endpoint *endpoint.Endpoint, err error) {
 	e := d.endpointManager.LookupIP(endpointAddr)
 	if e == nil {
-		return nil, fmt.Errorf("Cannot find endpoint with IP %s", endpointIP.String())
+		return nil, fmt.Errorf("cannot find endpoint with IP %s", endpointAddr)
 	}
 
 	return e, nil

--- a/pkg/fqdn/dnsproxy/proxy_test.go
+++ b/pkg/fqdn/dnsproxy/proxy_test.go
@@ -195,7 +195,7 @@ func (s *DNSProxyTestSuite) SetUpTest(c *C) {
 
 	proxy, err := StartDNSProxy("", 0, true, 1000, // any address, any port, enable compression, max 1000 restore IPs
 		// LookupEPByIP
-		func(ip net.IP) (*endpoint.Endpoint, error) {
+		func(ip netip.Addr) (*endpoint.Endpoint, error) {
 			if s.restoring {
 				return nil, fmt.Errorf("No EPs available when restoring")
 			}


### PR DESCRIPTION
Modernize the package by switching to the netip.Addr type provided since Go 1.18.

This simplifies the code and avoids some conversions from/to string.

Towards #24246