### PR TITLE
k8s ingress & gateway api: fix unintentional deletion of shared envoy cluster resource

### DIFF
--- a/operator/pkg/model/translation/envoy_cluster.go
+++ b/operator/pkg/model/translation/envoy_cluster.go
@@ -118,21 +118,10 @@ func WithProtocol(protocolVersion HTTPVersionType) ClusterMutator {
 	}
 }
 
-// NewHTTPClusterWithDefaults same as NewHTTPCluster but has default mutation functions applied.
-func NewHTTPClusterWithDefaults(name string, mutationFunc ...ClusterMutator) (ciliumv2.XDSResource, error) {
-	fns := append(mutationFunc,
-		WithConnectionTimeout(5),
-		WithIdleTimeout(60),
-		WithClusterLbPolicy(int32(envoy_config_cluster_v3.Cluster_ROUND_ROBIN)),
-		WithOutlierDetection(true),
-	)
-	return NewHTTPCluster(name, fns...)
-}
-
 // NewHTTPCluster creates a new Envoy cluster.
-func NewHTTPCluster(name string, mutationFunc ...ClusterMutator) (ciliumv2.XDSResource, error) {
+func NewHTTPCluster(clusterName string, clusterServiceName string, mutationFunc ...ClusterMutator) (ciliumv2.XDSResource, error) {
 	cluster := &envoy_config_cluster_v3.Cluster{
-		Name: name,
+		Name: clusterName,
 		TypedExtensionProtocolOptions: map[string]*anypb.Any{
 			httpProtocolOptionsType: toAny(&envoy_upstreams_http_v3.HttpProtocolOptions{
 				UpstreamProtocolOptions: &envoy_upstreams_http_v3.HttpProtocolOptions_UseDownstreamProtocolConfig{
@@ -144,6 +133,9 @@ func NewHTTPCluster(name string, mutationFunc ...ClusterMutator) (ciliumv2.XDSRe
 		},
 		ClusterDiscoveryType: &envoy_config_cluster_v3.Cluster_Type{
 			Type: envoy_config_cluster_v3.Cluster_EDS,
+		},
+		EdsClusterConfig: &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
+			ServiceName: clusterServiceName,
 		},
 	}
 
@@ -167,21 +159,24 @@ func NewHTTPCluster(name string, mutationFunc ...ClusterMutator) (ciliumv2.XDSRe
 
 // NewTCPClusterWithDefaults same as NewTCPCluster but has default mutation functions applied.
 // currently this is only used for TLSRoutes to create a passthrough proxy
-func NewTCPClusterWithDefaults(name string, mutationFunc ...ClusterMutator) (ciliumv2.XDSResource, error) {
+func NewTCPClusterWithDefaults(clusterName string, clusterServiceName string, mutationFunc ...ClusterMutator) (ciliumv2.XDSResource, error) {
 	fns := append(mutationFunc,
 		WithConnectionTimeout(5),
 		WithClusterLbPolicy(int32(envoy_config_cluster_v3.Cluster_ROUND_ROBIN)),
 		WithOutlierDetection(true),
 	)
-	return NewTCPCluster(name, fns...)
+	return NewTCPCluster(clusterName, clusterServiceName, fns...)
 }
 
 // NewTCPCluster creates a new Envoy cluster.
-func NewTCPCluster(name string, mutationFunc ...ClusterMutator) (ciliumv2.XDSResource, error) {
+func NewTCPCluster(clusterName string, clusterServiceName string, mutationFunc ...ClusterMutator) (ciliumv2.XDSResource, error) {
 	cluster := &envoy_config_cluster_v3.Cluster{
-		Name: name,
+		Name: clusterName,
 		ClusterDiscoveryType: &envoy_config_cluster_v3.Cluster_Type{
 			Type: envoy_config_cluster_v3.Cluster_EDS,
+		},
+		EdsClusterConfig: &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
+			ServiceName: clusterServiceName,
 		},
 	}
 

--- a/operator/pkg/model/translation/envoy_cluster_test.go
+++ b/operator/pkg/model/translation/envoy_cluster_test.go
@@ -68,7 +68,7 @@ func TestWithConnectionTimeout(t *testing.T) {
 }
 
 func TestNewHTTPCluster(t *testing.T) {
-	res, err := NewHTTPCluster("dummy-name")
+	res, err := NewHTTPCluster("dummy-name", "dummy-name")
 	require.Nil(t, err)
 
 	cluster := &envoy_config_cluster_v3.Cluster{}
@@ -82,7 +82,7 @@ func TestNewHTTPCluster(t *testing.T) {
 }
 
 func TestNewTCPCluster(t *testing.T) {
-	res, err := NewHTTPCluster("dummy-name")
+	res, err := NewHTTPCluster("dummy-name", "dummy-name")
 	require.Nil(t, err)
 
 	cluster := &envoy_config_cluster_v3.Cluster{}

--- a/operator/pkg/model/translation/envoy_listener.go
+++ b/operator/pkg/model/translation/envoy_listener.go
@@ -207,7 +207,7 @@ func NewSNIListenerWithDefaults(name string, backendsForHost map[string][]string
 func NewSNIListener(name string, backendsForHost map[string][]string, mutatorFunc ...ListenerMutator) (ciliumv2.XDSResource, error) {
 	var filterChains []*envoy_config_listener.FilterChain
 
-	for backed, hostNames := range backendsForHost {
+	for backend, hostNames := range backendsForHost {
 		filterChains = append(filterChains, &envoy_config_listener.FilterChain{
 			FilterChainMatch: toFilterChainMatch(hostNames),
 			Filters: []*envoy_config_listener.Filter{
@@ -215,9 +215,9 @@ func NewSNIListener(name string, backendsForHost map[string][]string, mutatorFun
 					Name: tcpProxyType,
 					ConfigType: &envoy_config_listener.Filter_TypedConfig{
 						TypedConfig: toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{
-							StatPrefix: backed,
+							StatPrefix: backend,
 							ClusterSpecifier: &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
-								Cluster: backed,
+								Cluster: backend,
 							},
 						}),
 					},

--- a/operator/pkg/model/translation/envoy_virtual_host.go
+++ b/operator/pkg/model/translation/envoy_virtual_host.go
@@ -279,7 +279,6 @@ func pathPrefixMutation(rewrite *model.HTTPURLRewriteFilter, httpRoute *model.HT
 		// Refer to: https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.HTTPPathModifier
 		// ReplacePrefix is allowed to be empty.
 		if len(rewrite.Path.Prefix) == 0 || rewrite.Path.Prefix == "/" {
-
 			route.Route.RegexRewrite = &envoy_type_matcher_v3.RegexMatchAndSubstitute{
 				Pattern: &envoy_type_matcher_v3.RegexMatcher{
 					Regex: fmt.Sprintf(`^%s(/?)(.*)`, regexp.QuoteMeta(httpRoute.PathMatch.Prefix)),
@@ -287,7 +286,6 @@ func pathPrefixMutation(rewrite *model.HTTPURLRewriteFilter, httpRoute *model.HT
 				// hold `/` in case the entire path is removed
 				Substitution: `/\2`,
 			}
-
 		} else {
 			route.Route.PrefixRewrite = rewrite.Path.Prefix
 		}
@@ -321,7 +319,7 @@ func requestMirrorMutation(mirrors []*model.HTTPRequestMirror) routeActionMutati
 				continue
 			}
 			action = append(action, &envoy_config_route_v3.RouteAction_RequestMirrorPolicy{
-				Cluster: fmt.Sprintf("%s/%s:%s", m.Backend.Namespace, m.Backend.Name, m.Backend.Port.GetPort()),
+				Cluster: fmt.Sprintf("%s:%s:%s", m.Backend.Namespace, m.Backend.Name, m.Backend.Port.GetPort()),
 				RuntimeFraction: &envoy_config_core_v3.RuntimeFractionalPercent{
 					DefaultValue: &envoy_type_v3.FractionalPercent{
 						Numerator: 100,
@@ -337,7 +335,7 @@ func requestMirrorMutation(mirrors []*model.HTTPRequestMirror) routeActionMutati
 func getRouteAction(route *model.HTTPRoute, backends []model.Backend, rewrite *model.HTTPURLRewriteFilter, mirrors []*model.HTTPRequestMirror) *envoy_config_route_v3.Route_Route {
 	var routeAction *envoy_config_route_v3.Route_Route
 
-	var mutators = []routeActionMutation{
+	mutators := []routeActionMutation{
 		hostRewriteMutation(rewrite),
 		pathPrefixMutation(rewrite, route),
 		pathFullReplaceMutation(rewrite),
@@ -348,7 +346,7 @@ func getRouteAction(route *model.HTTPRoute, backends []model.Backend, rewrite *m
 		r := &envoy_config_route_v3.Route_Route{
 			Route: &envoy_config_route_v3.RouteAction{
 				ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-					Cluster: fmt.Sprintf("%s/%s:%s", backends[0].Namespace, backends[0].Name, backends[0].Port.GetPort()),
+					Cluster: getClusterName(backends[0].Namespace, backends[0].Name, backends[0].Port.GetPort()),
 				},
 			},
 		}
@@ -366,7 +364,7 @@ func getRouteAction(route *model.HTTPRoute, backends []model.Backend, rewrite *m
 			weight = *be.Weight
 		}
 		weightedClusters = append(weightedClusters, &envoy_config_route_v3.WeightedCluster_ClusterWeight{
-			Name:   fmt.Sprintf("%s/%s:%s", be.Namespace, be.Name, be.Port.GetPort()),
+			Name:   getClusterName(be.Namespace, be.Name, be.Port.GetPort()),
 			Weight: wrapperspb.UInt32(uint32(weight)),
 		})
 	}

--- a/operator/pkg/model/translation/envoy_virtual_host_test.go
+++ b/operator/pkg/model/translation/envoy_virtual_host_test.go
@@ -254,9 +254,9 @@ func Test_requestMirrorMutation(t *testing.T) {
 
 		res := requestMirrorMutation(mirror)(route)
 		require.Len(t, res.Route.RequestMirrorPolicies, 2)
-		require.Equal(t, res.Route.RequestMirrorPolicies[0].Cluster, "default/dummy-service:8080")
+		require.Equal(t, res.Route.RequestMirrorPolicies[0].Cluster, "default:dummy-service:8080")
 		require.Equal(t, res.Route.RequestMirrorPolicies[0].RuntimeFraction.DefaultValue.Numerator, uint32(100))
-		require.Equal(t, res.Route.RequestMirrorPolicies[1].Cluster, "default/another-dummy-service:8080")
+		require.Equal(t, res.Route.RequestMirrorPolicies[1].Cluster, "default:another-dummy-service:8080")
 		require.Equal(t, res.Route.RequestMirrorPolicies[1].RuntimeFraction.DefaultValue.Numerator, uint32(100))
 	})
 }

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -306,9 +306,9 @@ var basicTLSListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 								Name: "envoy.filters.network.tcp_proxy",
 								ConfigType: &envoy_config_listener.Filter_TypedConfig{
 									TypedConfig: toAny(&envoy_extensions_filters_network_tcp_v3.TcpProxy{
-										StatPrefix: "default/my-service:8080",
+										StatPrefix: "default:my-service:8080",
 										ClusterSpecifier: &envoy_extensions_filters_network_tcp_v3.TcpProxy_Cluster{
-											Cluster: "default/my-service:8080",
+											Cluster: "default:my-service:8080",
 										},
 									}),
 								},
@@ -365,7 +365,10 @@ var basicTLSListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 			},
 			{
 				Any: toAny(&envoy_config_cluster_v3.Cluster{
-					Name: "default/my-service:8080",
+					Name: "default:my-service:8080",
+					EdsClusterConfig: &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
+						ServiceName: "default/my-service:8080",
+					},
 					ClusterDiscoveryType: &envoy_config_cluster_v3.Cluster_Type{
 						Type: envoy_config_cluster_v3.Cluster_EDS,
 					},
@@ -3030,7 +3033,7 @@ var rewriteHostHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 									Action: &envoy_config_route_v3.Route_Route{
 										Route: &envoy_config_route_v3.RouteAction{
 											ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-												Cluster: fmt.Sprintf("%s/%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
+												Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
 											},
 											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
 												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
@@ -3050,7 +3053,7 @@ var rewriteHostHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 									Action: &envoy_config_route_v3.Route_Route{
 										Route: &envoy_config_route_v3.RouteAction{
 											ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-												Cluster: fmt.Sprintf("%s/%s:%s", "gateway-conformance-infra", "infra-backend-v2", "8080"),
+												Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v2", "8080"),
 											},
 											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
 												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
@@ -3242,7 +3245,7 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 									Action: &envoy_config_route_v3.Route_Route{
 										Route: &envoy_config_route_v3.RouteAction{
 											ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-												Cluster: fmt.Sprintf("%s/%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
+												Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
 											},
 											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
 												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
@@ -3284,7 +3287,7 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 									Action: &envoy_config_route_v3.Route_Route{
 										Route: &envoy_config_route_v3.RouteAction{
 											ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-												Cluster: fmt.Sprintf("%s/%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
+												Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
 											},
 											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
 												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
@@ -3331,7 +3334,7 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 									Action: &envoy_config_route_v3.Route_Route{
 										Route: &envoy_config_route_v3.RouteAction{
 											ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-												Cluster: fmt.Sprintf("%s/%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
+												Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
 											},
 											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
 												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
@@ -3349,7 +3352,7 @@ var rewritePathHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 									Action: &envoy_config_route_v3.Route_Route{
 										Route: &envoy_config_route_v3.RouteAction{
 											ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-												Cluster: fmt.Sprintf("%s/%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
+												Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
 											},
 											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
 												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
@@ -3465,14 +3468,14 @@ var mirrorHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 									Action: &envoy_config_route_v3.Route_Route{
 										Route: &envoy_config_route_v3.RouteAction{
 											ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-												Cluster: fmt.Sprintf("%s/%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
+												Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v1", "8080"),
 											},
 											MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
 												MaxStreamDuration: &durationpb.Duration{Seconds: 0},
 											},
 											RequestMirrorPolicies: []*envoy_config_route_v3.RouteAction_RequestMirrorPolicy{
 												{
-													Cluster: fmt.Sprintf("%s/%s:%s", "gateway-conformance-infra", "infra-backend-v2", "8080"),
+													Cluster: fmt.Sprintf("%s:%s:%s", "gateway-conformance-infra", "infra-backend-v2", "8080"),
 													RuntimeFraction: &envoy_config_core_v3.RuntimeFractionalPercent{
 														DefaultValue: &envoy_type_v3.FractionalPercent{
 															Numerator: 100,
@@ -3496,7 +3499,10 @@ var mirrorHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 
 func toEnvoyCluster(namespace, name, port string) *envoy_config_cluster_v3.Cluster {
 	return &envoy_config_cluster_v3.Cluster{
-		Name: fmt.Sprintf("%s/%s:%s", namespace, name, port),
+		Name: fmt.Sprintf("%s:%s:%s", namespace, name, port),
+		EdsClusterConfig: &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
+			ServiceName: fmt.Sprintf("%s/%s:%s", namespace, name, port),
+		},
 		TypedExtensionProtocolOptions: map[string]*anypb.Any{
 			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": toAny(&envoy_upstreams_http_v3.HttpProtocolOptions{
 				CommonHttpProtocolOptions: &envoy_config_core_v3.HttpProtocolOptions{
@@ -3524,7 +3530,7 @@ func toRouteAction(namespace, name, port string) *envoy_config_route_v3.Route_Ro
 	return &envoy_config_route_v3.Route_Route{
 		Route: &envoy_config_route_v3.RouteAction{
 			ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-				Cluster: fmt.Sprintf("%s/%s:%s", namespace, name, port),
+				Cluster: fmt.Sprintf("%s:%s:%s", namespace, name, port),
 			},
 			MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
 				MaxStreamDuration: &durationpb.Duration{Seconds: 0},

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -71,7 +71,10 @@ var socketOptions = []*envoy_config_core_v3.SocketOption{
 
 func toEnvoyCluster(namespace, name, port string) *envoy_config_cluster_v3.Cluster {
 	return &envoy_config_cluster_v3.Cluster{
-		Name: fmt.Sprintf("%s/%s:%s", namespace, name, port),
+		Name: fmt.Sprintf("%s:%s:%s", namespace, name, port),
+		EdsClusterConfig: &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
+			ServiceName: fmt.Sprintf("%s/%s:%s", namespace, name, port),
+		},
 		TypedExtensionProtocolOptions: map[string]*anypb.Any{
 			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": toAny(&envoy_upstreams_http_v3.HttpProtocolOptions{
 				CommonHttpProtocolOptions: &envoy_config_core_v3.HttpProtocolOptions{
@@ -99,7 +102,7 @@ func toRouteAction(namespace, name, port string) *envoy_config_route_v3.Route_Ro
 	return &envoy_config_route_v3.Route_Route{
 		Route: &envoy_config_route_v3.RouteAction{
 			ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
-				Cluster: fmt.Sprintf("%s/%s:%s", namespace, name, port),
+				Cluster: fmt.Sprintf("%s:%s:%s", namespace, name, port),
 			},
 			MaxStreamDuration: &envoy_config_route_v3.RouteAction_MaxStreamDuration{
 				MaxStreamDuration: &durationpb.Duration{Seconds: 0},
@@ -548,8 +551,8 @@ var hostRulesListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 										},
 									},
 									Action: toWeightedClusterRouteAction([]string{
-										"random-namespace/foo-bar-com:http",
-										"random-namespace/foo-bar-com:http",
+										"random-namespace:foo-bar-com:http",
+										"random-namespace:foo-bar-com:http",
 									}),
 								},
 							},

--- a/operator/pkg/model/translation/translator_test.go
+++ b/operator/pkg/model/translation/translator_test.go
@@ -295,7 +295,7 @@ func TestSharedIngressTranslator_getClusters(t *testing.T) {
 				m: defaultBackendModel,
 			},
 			expected: []string{
-				"random-namespace/default-backend:8080",
+				"random-namespace:default-backend:8080",
 			},
 		},
 		{
@@ -304,8 +304,8 @@ func TestSharedIngressTranslator_getClusters(t *testing.T) {
 				m: hostRulesModel,
 			},
 			expected: []string{
-				"random-namespace/foo-bar-com:http",
-				"random-namespace/wildcard-foo-com:8080",
+				"random-namespace:foo-bar-com:http",
+				"random-namespace:wildcard-foo-com:8080",
 			},
 		},
 		{
@@ -314,12 +314,12 @@ func TestSharedIngressTranslator_getClusters(t *testing.T) {
 				m: pathRulesModel,
 			},
 			expected: []string{
-				"random-namespace/aaa-prefix:8080",
-				"random-namespace/aaa-slash-bbb-prefix:8080",
-				"random-namespace/aaa-slash-bbb-slash-prefix:8080",
-				"random-namespace/foo-exact:8080",
-				"random-namespace/foo-prefix:8080",
-				"random-namespace/foo-slash-exact:8080",
+				"random-namespace:aaa-prefix:8080",
+				"random-namespace:aaa-slash-bbb-prefix:8080",
+				"random-namespace:aaa-slash-bbb-slash-prefix:8080",
+				"random-namespace:foo-exact:8080",
+				"random-namespace:foo-prefix:8080",
+				"random-namespace:foo-slash-exact:8080",
 			},
 		},
 		{
@@ -328,9 +328,9 @@ func TestSharedIngressTranslator_getClusters(t *testing.T) {
 				m: complexIngressModel,
 			},
 			expected: []string{
-				"dummy-namespace/another-dummy-backend:8081",
-				"dummy-namespace/default-backend:8080",
-				"dummy-namespace/dummy-backend:8080",
+				"dummy-namespace:another-dummy-backend:8081",
+				"dummy-namespace:default-backend:8080",
+				"dummy-namespace:dummy-backend:8080",
 			},
 		},
 	}


### PR DESCRIPTION
Currently, the Envoy `Cluster` resources in the `CiliumEnvoyConfig` aren't qualified with the namespace and name of the `CiliumEnvoyConfig` itself.

This leads to issues when updating a `CiliumEnvoyConfig` due to changes in the K8s Ingress & Gateway API resources. If multiple resources are referencing the same K8s Service, the Cluster resource gets deleted if one of these K8s Ingress or Gateway resources gets deleted - and therefore breaks the other resources.

With this PR, the name of the Cluster resource and their references gets qualified like the rest of the resources. For the EDS lookup of the endpoint addresses, the field `service_name` of the Cluster is used. (Currently an implicit 1:1 mapping of the names -> clusters name is used for the lookup)

See Envoy Docs for further information about the property `service_name`: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-edsclusterconfig