### PR TITLE
labelsfilter: ignore Job completion index label by default for CID creation

### DIFF
--- a/Documentation/operations/performance/scalability/identity-relevant-labels.rst
+++ b/Documentation/operations/performance/scalability/identity-relevant-labels.rst
@@ -21,21 +21,22 @@ application.
 By default, Cilium considers all labels to be relevant for identities, with the
 following exceptions:
 
-============================================= =====================================================
-Label                                         Description
---------------------------------------------- -----------------------------------------------------
-``any:!io.kubernetes``                        Ignore all ``io.kubernetes`` labels
-``any:!kubernetes\.io``                       Ignore all other ``kubernetes.io`` labels
-``any:!statefulset\.kubernetes\.io/pod-name`` Ignore ``statefulset.kubernetes.io/pod-name`` label
-``any:!apps\.kubernetes\.io/pod-index``       Ignore ``apps.kubernetes.io/pod-index`` label
-``any:!beta\.kubernetes\.io``                 Ignore all ``beta.kubernetes.io`` labels
-``any:!k8s\.io``                              Ignore all ``k8s.io`` labels
-``any:!pod-template-generation``              Ignore all ``pod-template-generation`` labels
-``any:!pod-template-hash``                    Ignore all ``pod-template-hash`` labels
-``any:!controller-revision-hash``             Ignore all ``controller-revision-hash`` labels
-``any:!annotation.*``                         Ignore all ``annotation`` labels
-``any:!etcd_node``                            Ignore all ``etcd_node`` labels
-============================================= =====================================================
+=================================================== =========================================================
+Label                                               Description
+--------------------------------------------------- ---------------------------------------------------------
+``any:!io.kubernetes``                              Ignore all ``io.kubernetes`` labels
+``any:!kubernetes\.io``                             Ignore all other ``kubernetes.io`` labels
+``any:!statefulset\.kubernetes\.io/pod-name``       Ignore ``statefulset.kubernetes.io/pod-name`` label
+``any:!apps\.kubernetes\.io/pod-index``             Ignore ``apps.kubernetes.io/pod-index`` label
+``any:!batch\.kubernetes\.io/job-completion-index`` Ignore ``batch.kubernetes.io/job-completion-index`` label
+``any:!beta\.kubernetes\.io``                       Ignore all ``beta.kubernetes.io`` labels
+``any:!k8s\.io``                                    Ignore all ``k8s.io`` labels
+``any:!pod-template-generation``                    Ignore all ``pod-template-generation`` labels
+``any:!pod-template-hash``                          Ignore all ``pod-template-hash`` labels
+``any:!controller-revision-hash``                   Ignore all ``controller-revision-hash`` labels
+``any:!annotation.*``                               Ignore all ``annotation`` labels
+``any:!etcd_node``                                  Ignore all ``etcd_node`` labels
+=================================================== =========================================================
 
 The above label patterns are all *exclusive label patterns*, that is to say
 they define which label keys should be ignored. These are identified by the

--- a/pkg/k8s/apis/cilium.io/const.go
+++ b/pkg/k8s/apis/cilium.io/const.go
@@ -71,6 +71,11 @@ const (
 	// ordinal index.
 	StatefulSetPodIndexLabel = "apps.kubernetes.io/pod-index"
 
+	// IndexedJobCompletionIndexLabel is the label name which, in-tree, is used
+	// to automatically label Pods that are owned by Indexed Jobs with their
+	// completion index.
+	IndexedJobCompletionIndexLabel = "batch.kubernetes.io/job-completion-index"
+
 	// CtrlPrefixPolicyStatus is the prefix used for the controllers set up
 	// to sync the CNP with kube-apiserver.
 	CtrlPrefixPolicyStatus = "sync-cnp-policy-status"

--- a/pkg/labelsfilter/filter.go
+++ b/pkg/labelsfilter/filter.go
@@ -189,21 +189,22 @@ func defaultLabelPrefixCfg() *labelPrefixCfg {
 	}
 
 	expressions := []string{
-		reservedLabelsPattern,                                     // include all reserved labels
-		regexp.QuoteMeta(k8sConst.PodNamespaceLabel),              // include io.kubernetes.pod.namespace
-		regexp.QuoteMeta(k8sConst.PodNamespaceMetaLabels),         // include all namespace labels
-		regexp.QuoteMeta(k8sConst.AppKubernetes),                  // include app.kubernetes.io
-		`!io\.kubernetes`,                                         // ignore all other io.kubernetes labels
-		`!kubernetes\.io`,                                         // ignore all other kubernetes.io labels
-		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodNameLabel),  // ignore statefulset.kubernetes.io/pod-name label
-		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodIndexLabel), // ignore apps.kubernetes.io/pod-index label
-		`!.*beta\.kubernetes\.io`,                                 // ignore all beta.kubernetes.io labels
-		`!k8s\.io`,                                                // ignore all k8s.io labels
-		`!pod-template-generation`,                                // ignore pod-template-generation
-		`!pod-template-hash`,                                      // ignore pod-template-hash
-		`!controller-revision-hash`,                               // ignore controller-revision-hash
-		`!annotation.*`,                                           // ignore all annotation labels
-		`!etcd_node`,                                              // ignore etcd_node label
+		reservedLabelsPattern,                                           // include all reserved labels
+		regexp.QuoteMeta(k8sConst.PodNamespaceLabel),                    // include io.kubernetes.pod.namespace
+		regexp.QuoteMeta(k8sConst.PodNamespaceMetaLabels),               // include all namespace labels
+		regexp.QuoteMeta(k8sConst.AppKubernetes),                        // include app.kubernetes.io
+		`!io\.kubernetes`,                                               // ignore all other io.kubernetes labels
+		`!kubernetes\.io`,                                               // ignore all other kubernetes.io labels
+		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodNameLabel),        // ignore statefulset.kubernetes.io/pod-name label
+		"!" + regexp.QuoteMeta(k8sConst.StatefulSetPodIndexLabel),       // ignore apps.kubernetes.io/pod-index label
+		"!" + regexp.QuoteMeta(k8sConst.IndexedJobCompletionIndexLabel), // ignore batch.kubernetes.io/job-completion-index label
+		`!.*beta\.kubernetes\.io`,                                       // ignore all beta.kubernetes.io labels
+		`!k8s\.io`,                                                      // ignore all k8s.io labels
+		`!pod-template-generation`,                                      // ignore pod-template-generation
+		`!pod-template-hash`,                                            // ignore pod-template-hash
+		`!controller-revision-hash`,                                     // ignore controller-revision-hash
+		`!annotation.*`,                                                 // ignore all annotation labels
+		`!etcd_node`,                                                    // ignore etcd_node label
 	}
 
 	for _, e := range expressions {

--- a/pkg/labelsfilter/filter_test.go
+++ b/pkg/labelsfilter/filter_test.go
@@ -111,6 +111,7 @@ func (s *LabelsPrefCfgSuite) TestDefaultFilterLabels(c *C) {
 		"annotation.kubernetes.io/config.seen":                      "2017-05-30T14:22:17.691491034Z",
 		"controller-revision-hash":                                  "123456",
 		"statefulset.kubernetes.io/pod-name":                        "my-nginx-0",
+		"batch.kubernetes.io/job-completion-index":                  "42",
 		"apps.kubernetes.io/pod-index":                              "0",
 	}
 	allLabels := labels.Map2Labels(allNormalLabels, labels.LabelSourceContainer)


### PR DESCRIPTION
This prevents creating a CiliumIdentity object per Pod that is owned by an Indexed Job. This was especially costly in clusters with large quantities of Indexed Job-controlled Pods and basically limited the number of such Pods in a single cluster to a theoretical max number of CID objects (2^16 ~ 65k).

This is a follow-up to https://github.com/cilium/cilium/pull/28003 after the relevant [change](https://github.com/kubernetes/kubernetes/pull/118883) in the upstream K8s 1.28+.

```release-note
Ignore Indexed Job-specific label by default for CID creation `batch.kubernetes.io/job-completion-index`.
```
