### PR TITLE
Docs: Updates BGP CP Developer Docs

### DIFF
--- a/contrib/containerlab/bgp-cplane-dev-dual/values.yaml
+++ b/contrib/containerlab/bgp-cplane-dev-dual/values.yaml
@@ -1,4 +1,4 @@
-tunnel: disabled
+routingMode: native
 
 ipv6:
   enabled: true

--- a/contrib/containerlab/bgp-cplane-dev-v4/values.yaml
+++ b/contrib/containerlab/bgp-cplane-dev-v4/values.yaml
@@ -1,4 +1,4 @@
-tunnel: disabled
+routingMode: native
 
 bgpControlPlane:
   enabled: true

--- a/contrib/containerlab/bgp-cplane-dev-v6/values.yaml
+++ b/contrib/containerlab/bgp-cplane-dev-v6/values.yaml
@@ -1,4 +1,4 @@
-tunnel: disabled
+routingMode: native
 
 ipv4:
   enabled: false


### PR DESCRIPTION
Removes the deprecated `tunnel` Helm value in favor of `routingMode` in relevant files.

Fixes: #28907
