### PR TITLE
ctmap: improve dump of CT_SERVICE entries

### DIFF
--- a/pkg/maps/ctmap/types.go
+++ b/pkg/maps/ctmap/types.go
@@ -264,7 +264,12 @@ func (k *CtKey4) Dump(sb *strings.Builder, reverse bool) bool {
 		addrDest = k.DestAddr.String()
 	}
 
-	if k.Flags&TUPLE_F_IN != 0 {
+	if k.Flags&TUPLE_F_SERVICE != 0 {
+		sb.WriteString(fmt.Sprintf("%s SVC %s %d:%d ",
+			k.NextHeader.String(), k.DestAddr.String(), k.DestPort,
+			k.SourcePort),
+		)
+	} else if k.Flags&TUPLE_F_IN != 0 {
 		sb.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.SourcePort,
 			k.DestPort),
@@ -278,10 +283,6 @@ func (k *CtKey4) Dump(sb *strings.Builder, reverse bool) bool {
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
 		sb.WriteString("related ")
-	}
-
-	if k.Flags&TUPLE_F_SERVICE != 0 {
-		sb.WriteString("service ")
 	}
 
 	return true
@@ -346,7 +347,12 @@ func (k *CtKey4Global) Dump(sb *strings.Builder, reverse bool) bool {
 		addrDest = k.DestAddr.String()
 	}
 
-	if k.Flags&TUPLE_F_IN != 0 {
+	if k.Flags&TUPLE_F_SERVICE != 0 {
+		sb.WriteString(fmt.Sprintf("%s SVC %s:%d -> %s:%d ",
+			k.NextHeader.String(), k.SourceAddr.String(), k.DestPort,
+			k.DestAddr.String(), k.SourcePort),
+		)
+	} else if k.Flags&TUPLE_F_IN != 0 {
 		sb.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
@@ -360,10 +366,6 @@ func (k *CtKey4Global) Dump(sb *strings.Builder, reverse bool) bool {
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
 		sb.WriteString("related ")
-	}
-
-	if k.Flags&TUPLE_F_SERVICE != 0 {
-		sb.WriteString("service ")
 	}
 
 	return true
@@ -419,7 +421,12 @@ func (k *CtKey6) Dump(sb *strings.Builder, reverse bool) bool {
 		addrDest = k.DestAddr.String()
 	}
 
-	if k.Flags&TUPLE_F_IN != 0 {
+	if k.Flags&TUPLE_F_SERVICE != 0 {
+		sb.WriteString(fmt.Sprintf("%s SVC %s %d:%d ",
+			k.NextHeader.String(), k.DestAddr.String(), k.DestPort,
+			k.SourcePort),
+		)
+	} else if k.Flags&TUPLE_F_IN != 0 {
 		sb.WriteString(fmt.Sprintf("%s IN %s %d:%d ",
 			k.NextHeader.String(), addrDest, k.SourcePort,
 			k.DestPort),
@@ -433,10 +440,6 @@ func (k *CtKey6) Dump(sb *strings.Builder, reverse bool) bool {
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
 		sb.WriteString("related ")
-	}
-
-	if k.Flags&TUPLE_F_SERVICE != 0 {
-		sb.WriteString("service ")
 	}
 
 	return true
@@ -504,7 +507,12 @@ func (k *CtKey6Global) Dump(sb *strings.Builder, reverse bool) bool {
 		addrDest = k.DestAddr.String()
 	}
 
-	if k.Flags&TUPLE_F_IN != 0 {
+	if k.Flags&TUPLE_F_SERVICE != 0 {
+		sb.WriteString(fmt.Sprintf("%s SVC %s:%d -> %s:%d ",
+			k.NextHeader.String(), k.SourceAddr.String(), k.DestPort,
+			k.DestAddr.String(), k.SourcePort),
+		)
+	} else if k.Flags&TUPLE_F_IN != 0 {
 		sb.WriteString(fmt.Sprintf("%s IN %s:%d -> %s:%d ",
 			k.NextHeader.String(), addrSource, k.SourcePort,
 			addrDest, k.DestPort),
@@ -518,10 +526,6 @@ func (k *CtKey6Global) Dump(sb *strings.Builder, reverse bool) bool {
 
 	if k.Flags&TUPLE_F_RELATED != 0 {
 		sb.WriteString("related ")
-	}
-
-	if k.Flags&TUPLE_F_SERVICE != 0 {
-		sb.WriteString("service ")
 	}
 
 	return true


### PR DESCRIPTION
The CT tuple (== key) for CT entries is typically stored in "reply" layout
- .saddr/.daddr match a reply packet,
- .sport/.dport are in reverse order of a reply packet

The exception is CT_SERVICE entries, where the CT tuple is stored in "forward" layout
- .saddr/.daddr match a forward packet,
- .sport/.dport are in reverse order of a forward packet

ctmap's .Dump() implementations didn't consider this, so when dumping a CT map the CT_SERVICE entries would be printed in opposite direction. Fix up the formatting, and also print CT_SERVICE entries as dedicated type ("TCP SVC") instead of aliasing with "TCP OUT" entries.

```
before:
---
TCP OUT 10.96.0.1:443 -> 10.244.0.113:46298 service expires=153061 RxPackets=0 RxBytes=1 RxFlagsSeen=0x00 LastRxReport=0 TxPackets=0 TxBytes=0 TxFlagsSeen=0x1a LastTxReport=145061 Flags=0x0010 [ SeenNonSyn ] RevNAT=1 SourceSecurityID=0 IfIndex=0
TCP OUT 10.96.0.1:443 -> 10.244.0.161:59970 service expires=153062 RxPackets=0 RxBytes=1 RxFlagsSeen=0x00 LastRxReport=0 TxPackets=0 TxBytes=0 TxFlagsSeen=0x1a LastTxReport=145061 Flags=0x0010 [ SeenNonSyn ] RevNAT=1 SourceSecurityID=0 IfIndex=0
TCP OUT 10.96.0.1:443 -> 10.244.0.87:49382 service expires=153062 RxPackets=0 RxBytes=1 RxFlagsSeen=0x00 LastRxReport=0 TxPackets=0 TxBytes=0 TxFlagsSeen=0x1a LastTxReport=145061 Flags=0x0010 [ SeenNonSyn ] RevNAT=1 SourceSecurityID=0 IfIndex=0

after:
---
TCP SVC 10.244.0.113:46298 -> 10.96.0.1:443 expires=155382 RxPackets=0 RxBytes=1 RxFlagsSeen=0x00 LastRxReport=0 TxPackets=0 TxBytes=0 TxFlagsSeen=0x1a LastTxReport=147382 Flags=0x0010 [ SeenNonSyn ] RevNAT=1 SourceSecurityID=0 IfIndex=0
TCP SVC 10.244.0.161:59970 -> 10.96.0.1:443 expires=155376 RxPackets=0 RxBytes=1 RxFlagsSeen=0x00 LastRxReport=0 TxPackets=0 TxBytes=0 TxFlagsSeen=0x1a LastTxReport=147376 Flags=0x0010 [ SeenNonSyn ] RevNAT=1 SourceSecurityID=0 IfIndex=0
TCP SVC 10.244.0.87:49382 -> 10.96.0.1:443 expires=155365 RxPackets=0 RxBytes=1 RxFlagsSeen=0x00 LastRxReport=0 TxPackets=0 TxBytes=0 TxFlagsSeen=0x1a LastTxReport=147361 Flags=0x0010 [ SeenNonSyn ] RevNAT=1 SourceSecurityID=0 IfIndex=0
```

```release-note
Conntrack entries for Service connections are now printed in the canonical "source -> destination" format when using the "bpf ct list" command.
```
