### PR TITLE
bpf: tunnel-related cleanups in to-container path

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -321,7 +321,7 @@ handle_ipv6_cont(struct __ctx_buff *ctx, __u32 secctx, const bool from_host,
 		}
 #endif
 		return ipv6_local_delivery(ctx, l3_off, secctx, ep,
-					   METRIC_INGRESS, from_host);
+					   METRIC_INGRESS, from_host, false);
 	}
 
 	/* Below remainder is only relevant when traffic is pushed via cilium_host.

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1617,7 +1617,7 @@ int tail_ipv6_policy(struct __ctx_buff *ctx)
 #endif /* !ENABLE_ROUTING && !ENABLE_NODEPORT */
 
 		if (ifindex)
-			ret = redirect_ep(ctx, ifindex, from_host);
+			ret = redirect_ep(ctx, ifindex, from_host, from_tunnel);
 		break;
 	default:
 		break;
@@ -1988,7 +1988,7 @@ int tail_ipv4_policy(struct __ctx_buff *ctx)
 #endif /* !ENABLE_ROUTING && !ENABLE_NODEPORT */
 
 		if (ifindex)
-			ret = redirect_ep(ctx, ifindex, from_host);
+			ret = redirect_ep(ctx, ifindex, from_host, from_tunnel);
 		break;
 	default:
 		break;

--- a/bpf/bpf_lxc.c
+++ b/bpf/bpf_lxc.c
@@ -1708,10 +1708,6 @@ int tail_ipv6_to_endpoint(struct __ctx_buff *ctx)
 		proxy_redirect = true;
 		break;
 	case CTX_ACT_OK:
-#if !defined(ENABLE_ROUTING) && defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
-		/* See comment in IPv4 path. */
-		ctx_change_type(ctx, PACKET_HOST);
-#endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
 		break;
 	default:
 		break;
@@ -2166,17 +2162,6 @@ int tail_ipv4_to_endpoint(struct __ctx_buff *ctx)
 		proxy_redirect = true;
 		break;
 	case CTX_ACT_OK:
-#if !defined(ENABLE_ROUTING) && defined(TUNNEL_MODE) && !defined(ENABLE_NODEPORT)
-		/* In tunneling mode, we execute this code to send the packet from
-		 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
-		 * redirect() because that would bypass conntrack and the reverse DNAT.
-		 * Thus, we send packets to the stack, but since they have the wrong
-		 * Ethernet addresses, we need to mark them as PACKET_HOST or the kernel
-		 * will drop them.
-		 * See #14646 for details.
-		 */
-		ctx_change_type(ctx, PACKET_HOST);
-#endif /* !ENABLE_ROUTING && TUNNEL_MODE && !ENABLE_NODEPORT */
 		break;
 	default:
 		break;

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -121,7 +121,7 @@ not_esp:
 	ep = lookup_ip6_endpoint(ip6);
 	if (ep && !(ep->flags & ENDPOINT_F_HOST))
 		return ipv6_local_delivery(ctx, l3_off, *identity, ep,
-					   METRIC_INGRESS, false);
+					   METRIC_INGRESS, false, true);
 
 	/* A packet entering the node from the tunnel and not going to a local
 	 * endpoint has to be going to the local host.

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -103,7 +103,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 	}
 # endif /* !ENABLE_NODEPORT */
 
-	return redirect_ep(ctx, ep->ifindex, from_host);
+	return redirect_ep(ctx, ep->ifindex, from_host, from_tunnel);
 #else
 # ifndef DISABLE_LOOPBACK_LB
 	/* Skip ingress policy enforcement for hairpin traffic. As the hairpin
@@ -112,7 +112,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 	 * enforcement, and directly redirect it to the endpoint.
 	 */
 	if (unlikely(hairpin_flow))
-		return redirect_ep(ctx, ep->ifindex, from_host);
+		return redirect_ep(ctx, ep->ifindex, from_host, from_tunnel);
 # endif /* DISABLE_LOOPBACK_LB */
 
 	/* Jumps to destination pod's BPF program to enforce ingress policies. */

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -134,7 +134,8 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_off,
 					       __u32 seclabel,
 					       const struct endpoint_info *ep,
-					       __u8 direction, bool from_host)
+					       __u8 direction, bool from_host,
+					       bool from_tunnel)
 {
 	mac_t router_mac = ep->node_mac;
 	mac_t lxc_mac = ep->mac;
@@ -147,7 +148,7 @@ static __always_inline int ipv6_local_delivery(struct __ctx_buff *ctx, int l3_of
 		return ret;
 
 	return l3_local_delivery(ctx, seclabel, ep, direction, from_host, false,
-				 false, 0);
+				 from_tunnel, 0);
 }
 #endif /* ENABLE_IPV6 */
 

--- a/bpf/lib/l3.h
+++ b/bpf/lib/l3.h
@@ -89,7 +89,7 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 	!defined(FORCE_LOCAL_POLICY_EVAL_AT_SOURCE)
 	set_identity_mark(ctx, seclabel);
 
-# if defined(IS_BPF_OVERLAY) && !defined(ENABLE_NODEPORT)
+# if !defined(ENABLE_NODEPORT)
 	/* In tunneling mode, we execute this code to send the packet from
 	 * cilium_vxlan to lxc*. If we're using kube-proxy, we don't want to use
 	 * redirect() because that would bypass conntrack and the reverse DNAT.
@@ -97,11 +97,13 @@ l3_local_delivery(struct __ctx_buff *ctx, __u32 seclabel,
 	 * Ethernet addresses, we need to mark them as PACKET_HOST or the kernel
 	 * will drop them.
 	 */
-	ctx_change_type(ctx, PACKET_HOST);
-	return CTX_ACT_OK;
-# else
+	if (from_tunnel) {
+		ctx_change_type(ctx, PACKET_HOST);
+		return CTX_ACT_OK;
+	}
+# endif /* !ENABLE_NODEPORT */
+
 	return redirect_ep(ctx, ep->ifindex, from_host);
-# endif /* IS_BPF_OVERLAY && !ENABLE_NODEPORT */
 #else
 # ifndef DISABLE_LOOPBACK_LB
 	/* Skip ingress policy enforcement for hairpin traffic. As the hairpin


### PR DESCRIPTION
We've accumulated a bunch of special handling and kube-proxy workaround related to tunnel traffic. With the recent introduction of a `from_tunnel` parameter for bpx_lxc's ingress tail-call, it's now easier to fine-tune these code paths and reduce their scope.