### PR TITLE
Hubble: add option to filter for pods and services in any namespace

### DIFF
--- a/api/v1/flow/README.md
+++ b/api/v1/flow/README.md
@@ -316,7 +316,7 @@ multiple fields are set, then all fields must match for the filter to match.
 | ----- | ---- | ----- | ----------- |
 | uuid | [string](#string) | repeated | uuid filters by a list of flow uuids. |
 | source_ip | [string](#string) | repeated | source_ip filters by a list of source ips. Each of the source ips can be specified as an exact match (e.g. &#34;1.1.1.1&#34;) or as a CIDR range (e.g. &#34;1.1.1.0/24&#34;). |
-| source_pod | [string](#string) | repeated | source_pod filters by a list of source pod name prefixes, optionally within a given namespace (e.g. &#34;xwing&#34;, &#34;kube-system/coredns-&#34;). The pod name can be omitted to only filter by namespace (e.g. &#34;kube-system/&#34;) |
+| source_pod | [string](#string) | repeated | source_pod filters by a list of source pod name prefixes, optionally within a given namespace (e.g. &#34;xwing&#34;, &#34;kube-system/coredns-&#34;). The pod name can be omitted to only filter by namespace (e.g. &#34;kube-system/&#34;) or the namespace can be omitted to filter for pods in any namespace (e.g. &#34;/xwing&#34;) |
 | source_fqdn | [string](#string) | repeated | source_fqdn filters by a list of source fully qualified domain names |
 | source_label | [string](#string) | repeated | source_labels filters on a list of source label selectors. Selectors support the full Kubernetes label selector syntax. |
 | source_service | [string](#string) | repeated | source_service filters on a list of source service names. This field supports the same syntax as the source_pod field. |

--- a/api/v1/flow/flow.pb.go
+++ b/api/v1/flow/flow.pb.go
@@ -2866,7 +2866,8 @@ type FlowFilter struct {
 	// source_pod filters by a list of source pod name prefixes, optionally
 	// within a given namespace (e.g. "xwing", "kube-system/coredns-").
 	// The pod name can be omitted to only filter by namespace
-	// (e.g. "kube-system/")
+	// (e.g. "kube-system/") or the namespace can be omitted to filter for
+	// pods in any namespace (e.g. "/xwing")
 	SourcePod []string `protobuf:"bytes,2,rep,name=source_pod,json=sourcePod,proto3" json:"source_pod,omitempty"`
 	// source_fqdn filters by a list of source fully qualified domain names
 	SourceFqdn []string `protobuf:"bytes,7,rep,name=source_fqdn,json=sourceFqdn,proto3" json:"source_fqdn,omitempty"`

--- a/api/v1/flow/flow.proto
+++ b/api/v1/flow/flow.proto
@@ -471,7 +471,8 @@ message FlowFilter {
     // source_pod filters by a list of source pod name prefixes, optionally
     // within a given namespace (e.g. "xwing", "kube-system/coredns-").
     // The pod name can be omitted to only filter by namespace
-    // (e.g. "kube-system/")
+    // (e.g. "kube-system/") or the namespace can be omitted to filter for
+    // pods in any namespace (e.g. "/xwing")
     repeated string source_pod = 2;
     // source_fqdn filters by a list of source fully qualified domain names
     repeated string source_fqdn = 7;

--- a/pkg/hubble/filters/k8s.go
+++ b/pkg/hubble/filters/k8s.go
@@ -37,10 +37,10 @@ func filterByNamespacedName(names []string, getName func(*v1.Event) (ns, name st
 	type nameFilter struct{ ns, prefix string }
 	nameFilters := make([]nameFilter, 0, len(names))
 	for _, name := range names {
-		ns, prefix := k8s.ParseNamespaceName(name)
-		if ns == "" && prefix == "" {
-			return nil, fmt.Errorf("invalid filter, must be [namespace/][<name>], got %q", name)
+		if name == "" {
+			return nil, fmt.Errorf("invalid filter, name must not be empty")
 		}
+		ns, prefix := k8s.ParseNamespaceName(name)
 		nameFilters = append(nameFilters, nameFilter{ns, prefix})
 	}
 
@@ -51,7 +51,7 @@ func filterByNamespacedName(names []string, getName func(*v1.Event) (ns, name st
 		}
 
 		for _, f := range nameFilters {
-			if (f.prefix == "" || strings.HasPrefix(eventName, f.prefix)) && f.ns == eventNs {
+			if (f.prefix == "" || strings.HasPrefix(eventName, f.prefix)) && (f.ns == "" || f.ns == eventNs) {
 				return true
 			}
 		}

--- a/pkg/hubble/filters/k8s_test.go
+++ b/pkg/hubble/filters/k8s_test.go
@@ -233,6 +233,49 @@ func TestPodFilter(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "all namespaces",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{SourcePod: []string{"/xwing"}},
+					{DestinationPod: []string{"/xwing"}},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{
+						Source:      &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
+						Destination: &flowpb.Endpoint{Namespace: "kube-system", PodName: "kube-proxy"},
+					}},
+					{Event: &flowpb.Flow{
+						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
+					}},
+					{Event: &flowpb.Flow{
+						Source:      &flowpb.Endpoint{Namespace: "kube-system", PodName: "coredns"},
+						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					}},
+					{Event: &flowpb.Flow{
+						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "xwing"},
+					}},
+					{Event: &flowpb.Flow{
+						Source:      &flowpb.Endpoint{Namespace: "hoth", PodName: "tiefighter"},
+						Destination: &flowpb.Endpoint{Namespace: "endor", PodName: "xwing"},
+					}},
+					{Event: &flowpb.Flow{
+						Source:      &flowpb.Endpoint{Namespace: "default", PodName: "tiefighter"},
+						Destination: &flowpb.Endpoint{Namespace: "default", PodName: "ywing"},
+					}},
+				},
+			},
+			want: []bool{
+				false,
+				false,
+				true,
+				true,
+				true,
+				false,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -299,6 +342,28 @@ func TestServiceFilter(t *testing.T) {
 				true,
 				true,
 				false,
+			},
+		},
+		{
+			name: "any namespace",
+			args: args{
+				f: []*flowpb.FlowFilter{
+					{DestinationService: []string{"/kube-"}},
+				},
+				ev: []*v1.Event{
+					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "default", Name: "xwing"}}},
+					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "default", Name: "deathstar"}}},
+					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "kube-system", Name: "kube-dns"}}},
+					{Event: &flowpb.Flow{SourceService: &flowpb.Service{Namespace: "kube-system", Name: "deathstar"}}},
+					{Event: &flowpb.Flow{DestinationService: &flowpb.Service{Namespace: "monitoring", Name: "kube-prometheus"}}},
+				},
+			},
+			want: []bool{
+				false,
+				false,
+				true,
+				false,
+				true,
 			},
 		},
 	}


### PR DESCRIPTION

Please ensure your pull request adheres to the following guidelines:


- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.


We now allow service and pod filters in the form of `/foo`, which will filter for any service/pod starting with `foo` in any namespace.

Related to: https://github.com/cilium/hubble/issues/359

