### PR TITLE
helm & ingress/l7-lb: fix hive config properties of type stringslice

### DIFF
--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -335,6 +335,10 @@ Annotations:
   The existing Gateway API resources will continue to work as usual, however, it is
   better to migrate your resources from v1beta1 to v1 for GatewayClass, Gateway and
   HTTPRoute resources.
+* Cilium Operator config flag ``ingress-lb-annotation-prefixes`` is now parsed as
+  comma-separated list of prefixes (no longer space-separated).
+* Cilium Operator config flag ``loadbalancer-l7-ports`` is now parsed as
+  comma-separated list of ports (no longer space-separated).
 
 .. _upgrade_cilium_cli_helm_mode:
 

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -253,7 +253,7 @@ data:
   enable-ingress-proxy-protocol: {{ .Values.ingressController.enableProxyProtocol | quote }}
   enable-ingress-secrets-sync: {{ .Values.ingressController.secretsNamespace.sync | quote }}
   ingress-secrets-namespace: {{ .Values.ingressController.secretsNamespace.name | quote }}
-  ingress-lb-annotation-prefixes: {{ .Values.ingressController.ingressLBAnnotationPrefixes | join " " | quote }}
+  ingress-lb-annotation-prefixes: {{ .Values.ingressController.ingressLBAnnotationPrefixes | join "," | quote }}
   ingress-default-lb-mode: {{ .Values.ingressController.loadbalancerMode }}
   ingress-shared-lb-service-name: {{ .Values.ingressController.service.name }}
   {{- if and .Values.ingressController.defaultSecretNamespace .Values.ingressController.defaultSecretName }}
@@ -271,7 +271,7 @@ data:
 {{- if hasKey .Values "loadBalancer" }}
 {{- if eq .Values.loadBalancer.l7.backend "envoy" }}
   loadbalancer-l7: "envoy"
-  loadbalancer-l7-ports: {{ .Values.loadBalancer.l7.ports | join " " | quote }}
+  loadbalancer-l7-ports: {{ .Values.loadBalancer.l7.ports | join "," | quote }}
   loadbalancer-l7-algorithm: {{ .Values.loadBalancer.l7.algorithm | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Hive config flags of type `StringSlice` are no longer split by space. Instead, they are split by comma. This leads to issues for config values that have been lately migrated to a Hive cell and didn't change this in the Helm files.

Therefore, this commit changes the affected config values to pass them as a comma-separated string.

* `ingressController.ingressLBAnnotationPrefixes` -> `ingress-lb-annotation-prefixies`
* `loadBalancer.l7.ports` -> `loadbalancer-l7-ports`

Fixes: #28794, #28835

Thanks @giorio94 for catching this!
