### PR TITLE
ci: Bump timeout on ci-runtime privileged worksflow

### DIFF
--- a/.github/workflows/conformance-runtime.yaml
+++ b/.github/workflows/conformance-runtime.yaml
@@ -369,7 +369,7 @@ jobs:
 
       - name: Runtime privileged tests
         if: ${{ matrix.focus == 'privileged' }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         uses: cilium/little-vm-helper@908ab1ff8a596a03cd5221a1f8602dc44c3f906d # v0.0.12
         with:
           provision: 'false'


### PR DESCRIPTION
Bump timeout from 20 to 30 minutes due to repeated workflow cancellations due to timeout on otherwise successful workflow runs.
