### PR TITLE
[v1.13] Author Backport of 28382 (Metrics associated with a deleted node should not be reported) 

### DIFF
--- a/pkg/metrics/interfaces.go
+++ b/pkg/metrics/interfaces.go
@@ -27,8 +27,17 @@ type CounterVec interface {
 }
 
 type GaugeVec interface {
+	deletableVec
+
 	WithLabelValues(lvls ...string) prometheus.Gauge
 	prometheus.Collector
+}
+
+type deletableVec interface {
+	Delete(ll prometheus.Labels) bool
+	DeleteLabelValues(lvs ...string) bool
+	DeletePartialMatch(labels prometheus.Labels) int
+	Reset()
 }
 
 var (
@@ -130,6 +139,16 @@ type gaugeVec struct {
 	prometheus.Collector
 }
 
+func (*gaugeVec) Delete(ll prometheus.Labels) bool {
+	return false
+}
+func (*gaugeVec) DeleteLabelValues(lvs ...string) bool {
+	return false
+}
+func (*gaugeVec) DeletePartialMatch(labels prometheus.Labels) int {
+	return 0
+}
+func (*gaugeVec) Reset() {}
 func (gv *gaugeVec) WithLabelValues(lvls ...string) prometheus.Gauge {
 	return NoOpGauge
 }


### PR DESCRIPTION
- [ ] #28382 -- Metrics associated with a deleted node should not be reported (@derailed)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 28382; do contrib/backporting/set-labels.py $pr done 1.13; done
```