### PR TITLE
bpf: use eth_store_proto()

### DIFF
--- a/bpf/lib/egress_policies.h
+++ b/bpf/lib/egress_policies.h
@@ -222,8 +222,7 @@ srv6_decapsulation(struct __ctx_buff *ctx)
 parse_outer_ipv4: __maybe_unused;
 		if (ctx_change_proto(ctx, new_proto, 0) < 0)
 			return DROP_WRITE_ERROR;
-		if (ctx_store_bytes(ctx, offsetof(struct ethhdr, h_proto),
-				    &new_proto, sizeof(new_proto), 0) < 0)
+		if (eth_store_proto(ctx, new_proto, 0) < 0)
 			return DROP_WRITE_ERROR;
 		/* ctx_change_proto above shrinks the packet from IPv6 header
 		 * length to IPv4 header length. It removes that space from the
@@ -334,8 +333,7 @@ srv6_handling4(struct __ctx_buff *ctx, union v6addr *src_sid,
 	 */
 	if (ctx_change_proto(ctx, outer_proto, 0) < 0)
 		return DROP_WRITE_ERROR;
-	if (ctx_store_bytes(ctx, offsetof(struct ethhdr, h_proto),
-			    &outer_proto, sizeof(outer_proto), 0) < 0)
+	if (eth_store_proto(ctx, outer_proto, 0) < 0)
 		return DROP_WRITE_ERROR;
 	/* ctx_change_proto above grows the packet from IPv4 header
 	 * length to IPv6 header length. It adds the additional space

--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -110,9 +110,9 @@ static __always_inline int eth_store_daddr(struct __ctx_buff *ctx,
 }
 
 static __always_inline int eth_store_proto(struct __ctx_buff *ctx,
-					   const __u16 proto, int off)
+					   const __be16 proto, int l2_off)
 {
-	return ctx_store_bytes(ctx, off + ETH_ALEN + ETH_ALEN,
+	return ctx_store_bytes(ctx, l2_off + offsetof(struct ethhdr, h_proto),
 			       &proto, sizeof(proto), 0);
 }
 

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -663,7 +663,7 @@ static __always_inline int dsr_reply_icmp6(struct __ctx_buff *ctx,
 		goto drop_err;
 	if (eth_store_saddr(ctx, dmac.addr, 0) < 0)
 		goto drop_err;
-	if (ctx_store_bytes(ctx, ETH_ALEN * 2, &type, sizeof(type), 0) < 0)
+	if (eth_store_proto(ctx, type, 0) < 0)
 		goto drop_err;
 	if (ctx_store_bytes(ctx, off, &ip, sizeof(ip), 0) < 0)
 		goto drop_err;
@@ -2196,7 +2196,7 @@ static __always_inline int dsr_reply_icmp4(struct __ctx_buff *ctx,
 		goto drop_err;
 	if (eth_store_saddr(ctx, dmac.addr, 0) < 0)
 		goto drop_err;
-	if (ctx_store_bytes(ctx, ETH_ALEN * 2, &type, sizeof(type), 0) < 0)
+	if (eth_store_proto(ctx, type, 0) < 0)
 		goto drop_err;
 	if (ctx_store_bytes(ctx, off, &ip, sizeof(ip), 0) < 0)
 		goto drop_err;


### PR DESCRIPTION
Clean up some open-coded occurences to improve readability. While at it also polish the helper a tiny bit.

For the users in nat_46x64.h also use the existing `protocol` variable to keep ctx_change_proto() and eth_store_proto() in sync.