### PR TITLE
Add protoc-gen-gotag plugin to builder image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Cilium",
-  "image": "quay.io/cilium/cilium-builder:c43357ef8317d6dc42f71a046c9adfc756e98b35@sha256:914163868d208197babf623174b13e767cfee67f00036804fb5f9550e34a0a6c",
+  "image": "quay.io/cilium/cilium-builder:08a20c35699d88e4844faa026481a39ca038e548@sha256:f49d9020ff1b7d650056dee4cc16cb3b94b33a12d8b6c3562443cc15a61cc817",
   "workspaceFolder": "/go/src/github.com/cilium/cilium",
   "workspaceMount": "source=${localWorkspaceFolder},target=/go/src/github.com/cilium/cilium,type=bind",
   "features": {

--- a/api/v1/Makefile
+++ b/api/v1/Makefile
@@ -3,7 +3,7 @@
 include ../../Makefile.defs
 
 # Update this via images/scripts/update-cilium-builder-image.sh
-CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:c43357ef8317d6dc42f71a046c9adfc756e98b35@sha256:914163868d208197babf623174b13e767cfee67f00036804fb5f9550e34a0a6c
+CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:08a20c35699d88e4844faa026481a39ca038e548@sha256:f49d9020ff1b7d650056dee4cc16cb3b94b33a12d8b6c3562443cc15a61cc817
 
 .PHONY: proto
 proto:

--- a/images/builder/install-protoplugins.sh
+++ b/images/builder/install-protoplugins.sh
@@ -13,3 +13,4 @@ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@8ba23be9613c672d40ae261
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
 go install github.com/mitchellh/protoc-gen-go-json@49905733154f04e47d685de62c2cc2b72613b69e
 go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@v1.5.1
+go install github.com/srikrsna/protoc-gen-gotag@v0.6.2

--- a/images/cilium/Dockerfile
+++ b/images/cilium/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright Authors of Cilium
 # SPDX-License-Identifier: Apache-2.0
 
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:c43357ef8317d6dc42f71a046c9adfc756e98b35@sha256:914163868d208197babf623174b13e767cfee67f00036804fb5f9550e34a0a6c
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:08a20c35699d88e4844faa026481a39ca038e548@sha256:f49d9020ff1b7d650056dee4cc16cb3b94b33a12d8b6c3562443cc15a61cc817
 ARG CILIUM_RUNTIME_IMAGE=quay.io/cilium/cilium-runtime:f15b7a816a75363f8f3130aaaafb570f3bc88f77@sha256:c18977fde2465ffd381efc76357bb87d6f7a1d027af37a38b90862ca6432ab86
 
 # cilium-envoy from github.com/cilium/proxy

--- a/images/operator/Dockerfile
+++ b/images/operator/Dockerfile
@@ -4,7 +4,7 @@
 ARG BASE_IMAGE=scratch
 ARG GOLANG_IMAGE=docker.io/library/golang:1.21.4@sha256:81cd210ae58a6529d832af2892db822b30d84f817a671b8e1c15cff0b271a3db
 ARG ALPINE_IMAGE=docker.io/library/alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
-ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:c43357ef8317d6dc42f71a046c9adfc756e98b35@sha256:914163868d208197babf623174b13e767cfee67f00036804fb5f9550e34a0a6c
+ARG CILIUM_BUILDER_IMAGE=quay.io/cilium/cilium-builder:08a20c35699d88e4844faa026481a39ca038e548@sha256:f49d9020ff1b7d650056dee4cc16cb3b94b33a12d8b6c3562443cc15a61cc817
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with

--- a/test/k8s/manifests/demo-customcalls.yaml
+++ b/test/k8s/manifests/demo-customcalls.yaml
@@ -99,7 +99,7 @@ metadata:
 spec:
   containers:
   - name: cilium-builder
-    image: quay.io/cilium/cilium-builder:c43357ef8317d6dc42f71a046c9adfc756e98b35@sha256:914163868d208197babf623174b13e767cfee67f00036804fb5f9550e34a0a6c
+    image: quay.io/cilium/cilium-builder:08a20c35699d88e4844faa026481a39ca038e548@sha256:f49d9020ff1b7d650056dee4cc16cb3b94b33a12d8b6c3562443cc15a61cc817
     workingDir: /cilium
     command: ["/bin/sh", "-c"]
     args:


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.

Adds a protoc-gen-gotag plugin to generate yaml annotations in the generated proto as discussed in https://github.com/cilium/cilium/pull/28873#discussion_r1377689955

cc: @chancez @glibsm 

```release-note
Adds a protoc-gen-gotag plugin
```
