### PR TITLE
ci: Remove useless quotes in update label workflow

### DIFF
--- a/.github/workflows/update-label-backport-pr.yaml
+++ b/.github/workflows/update-label-backport-pr.yaml
@@ -43,7 +43,7 @@
             run: |
               echo "${{steps.pre-process.outputs.result}}" | sed -En "/upstream-prs/ { n; p }" | cut -d ';' -f 1 | grep -Eo '[0-9]+' | while read -r pr; do
                 echo "Removing label backport-pending/${{ inputs.branch }} from pr #${pr}."
-                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --remove-label backport-pending/"${{ inputs.branch }}"
+                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --remove-label backport-pending/${{ inputs.branch }}
                 echo "Adding label backport-done/${{ inputs.branch }} to pr #${pr}."
-                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --add-label backport-done/"${{ inputs.branch }}"
+                gh pr edit ${pr} --repo "${GITHUB_REPOSITORY}" --add-label backport-done/${{ inputs.branch }}
               done


### PR DESCRIPTION
Quotes are not needed for GHA variables, so let's remove them.
