### PR TITLE
fix: Adding the fatal error for ipv6 cilium config on a single stack node

### DIFF
--- a/daemon/k8s/init.go
+++ b/daemon/k8s/init.go
@@ -128,6 +128,16 @@ func WaitForNodeInformation(ctx context.Context, log logrus.FieldLogger, localNo
 			logfields.K8sNodeIP:        k8sNodeIP,
 		}).Info("Received own node information from API server")
 
+		// If the host does not have an IPv6 address, return an error
+		if option.Config.EnableIPv6 && nodeIP6 == nil {
+			log.WithFields(logrus.Fields{
+				logfields.NodeName:         n.Name,
+				logfields.IPAddr + ".ipv4": nodeIP4,
+				logfields.IPAddr + ".ipv6": nodeIP6,
+			}).Error("No IPv6 support on node as ipv6 address is nil")
+			return fmt.Errorf("node %s does not have an IPv6 address", n.Name)
+		}
+
 		useNodeCIDR(n)
 		restoreRouterHostIPs(n, log)
 	} else {


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [ ] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

Cilium pods on a single  stack cluster were failing when ipv6 was enabled. The expectation is that ipv4 should be working even if there are error in ipv6.

Fixes: #28909 