### PR TITLE
startup: improve speed of syncing CRDs

### DIFF
--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -172,7 +172,7 @@ func SyncCRDs(ctx context.Context, clientset client.Clientset, crdNames []string
 
 	log.Info("Waiting until all Cilium CRDs are available")
 
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(50 * time.Millisecond)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

Currently, startup is blocked waiting for CRDs to sync by a minimum of 1s. This very frequently is ready before 1s, but we only poll every 1s so we always pay the cost.

This drops the interval down to 50ms. This should have ~no cost, but improve startup speed by up to 950ms for all users.
```release-note
init: Poll CRD synchronization times have been lowered from 1 second to 50ms.
```
