### PR TITLE
proxy: define and use well known datapath constants

### DIFF
--- a/pkg/datapath/linux/linux_defaults/linux_defaults.go
+++ b/pkg/datapath/linux/linux_defaults/linux_defaults.go
@@ -19,6 +19,9 @@ const (
 	// RouteTableVtep is the default table ID to use for VTEP routing rules
 	RouteTableVtep = 202
 
+	// RouteTableProxy is the default table ID to use for proxy routing rules.
+	RouteTableProxy = 2004
+
 	// RouteTableInterfacesOffset is the offset for the per-ENI routing tables.
 	// Each ENI interface will have its own table starting with this offset. It
 	// is 10 because it is highly unlikely to collide with the main routing

--- a/pkg/fqdn/dnsproxy/udp.go
+++ b/pkg/fqdn/dnsproxy/udp.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/net/ipv6"
 	"golang.org/x/sys/unix"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/fqdn/proxy/ipfamily"
 	"github.com/cilium/cilium/pkg/option"
 )
@@ -124,7 +125,7 @@ func listenConfig(mark int, ipFamily ipfamily.IPFamily) *net.ListenConfig {
 
 func bindResponseUDPConnection(ipFamily ipfamily.IPFamily) (*net.IPConn, error) {
 	// Mark outgoing packets as proxy egress return traffic (0x0b00)
-	conn, err := listenConfig(0xb00, ipFamily).ListenPacket(context.Background(), "ip:udp", ipFamily.Localhost)
+	conn, err := listenConfig(linux_defaults.MagicMarkEgress, ipFamily).ListenPacket(context.Background(), "ip:udp", ipFamily.Localhost)
 	if err != nil {
 		return nil, fmt.Errorf("failed to bind UDP for address %s: %w", ipFamily.Localhost, err)
 	}

--- a/pkg/proxy/routes_test.go
+++ b/pkg/proxy/routes_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/vishvananda/netlink"
 
+	"github.com/cilium/cilium/pkg/datapath/linux/linux_defaults"
 	"github.com/cilium/cilium/pkg/datapath/linux/route"
 	"github.com/cilium/cilium/pkg/netns"
 	"github.com/cilium/cilium/pkg/testutils"
@@ -37,7 +38,7 @@ func TestRoutes(t *testing.T) {
 
 			// List the proxy routing table, expect a single entry.
 			rt, err := netlink.RouteListFiltered(netlink.FAMILY_V4,
-				&netlink.Route{Table: proxyRoutingTable}, netlink.RT_FILTER_TABLE)
+				&netlink.Route{Table: linux_defaults.RouteTableProxy}, netlink.RT_FILTER_TABLE)
 			assert.NoError(t, err)
 			assert.Len(t, rt, 1)
 
@@ -53,7 +54,7 @@ func TestRoutes(t *testing.T) {
 
 			// List the proxy routing table, expect it to be empty.
 			rt, err = netlink.RouteListFiltered(netlink.FAMILY_V4,
-				&netlink.Route{Table: proxyRoutingTable}, netlink.RT_FILTER_TABLE)
+				&netlink.Route{Table: linux_defaults.RouteTableProxy}, netlink.RT_FILTER_TABLE)
 			assert.NoError(t, err)
 			assert.Len(t, rt, 0)
 
@@ -80,7 +81,7 @@ func TestRoutes(t *testing.T) {
 
 			// List the proxy routing table, expect a single entry.
 			rt, err := netlink.RouteListFiltered(netlink.FAMILY_V6,
-				&netlink.Route{Table: proxyRoutingTable}, netlink.RT_FILTER_TABLE)
+				&netlink.Route{Table: linux_defaults.RouteTableProxy}, netlink.RT_FILTER_TABLE)
 			assert.NoError(t, err)
 			assert.Len(t, rt, 1)
 
@@ -96,7 +97,7 @@ func TestRoutes(t *testing.T) {
 
 			// List the proxy routing table, expect it to be empty.
 			rt, err = netlink.RouteListFiltered(netlink.FAMILY_V6,
-				&netlink.Route{Table: proxyRoutingTable}, netlink.RT_FILTER_TABLE)
+				&netlink.Route{Table: linux_defaults.RouteTableProxy}, netlink.RT_FILTER_TABLE)
 			assert.NoError(t, err)
 			assert.Len(t, rt, 0)
 


### PR DESCRIPTION
Use datapath specific constants (packet marks and routing table IDs) defined in the well-known and documented datapath linux_defaults package rather than defining them locally.