### PR TITLE
fix: use listener port if backendRef didn't provide port

### DIFF
--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -184,6 +184,15 @@ func Test_translator_Translate(t *testing.T) {
 			},
 			want: mirrorHTTPListenersCiliumEnvoyConfig,
 		},
+		{
+			name: "Conformance/HTTPRouteWithBackendRefPortUnset",
+			args: args{
+				m: &model.Model{
+					HTTP: unsetBackendPortHTTPListeners,
+				},
+			},
+			want: unsetBackendPortHTTPListenersCiliumEnvoyConfig,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/operator/pkg/model/translation/translator.go
+++ b/operator/pkg/model/translation/translator.go
@@ -337,11 +337,18 @@ func getNamespaceNamePortsMap(m *model.Model) map[string]map[string][]string {
 	namespaceNamePortMap := map[string]map[string][]string{}
 	for _, l := range m.HTTP {
 		for _, r := range l.Routes {
-			for _, be := range r.Backends {
+			for bIdx, be := range r.Backends {
 				namePortMap, exist := namespaceNamePortMap[be.Namespace]
 				if exist {
 					namePortMap[be.Name] = slices.SortedUnique(append(namePortMap[be.Name], be.Port.GetPort()))
 				} else {
+					if be.Port == nil {
+						be.Port = &model.BackendPort{
+							Port: l.Port,
+						}
+						r.Backends[bIdx] = be
+					}
+
 					namePortMap = map[string][]string{
 						be.Name: {be.Port.GetPort()},
 					}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: #28716 

The reason why fallback to listener port if backendRef didn't provide port is based on the existing comment on `BackendPort` model.
https://github.com/cilium/cilium/blob/f8c96d65632ec2ea521768f67457a00dae40646c/operator/pkg/model/model.go#L343-L345