### PR TITLE
Add table for node addresses

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -281,6 +281,7 @@ cilium-agent [flags]
       --node-encryption-opt-out-labels string                     Label selector for nodes which will opt-out of node-to-node encryption (default "node-role.kubernetes.io/control-plane")
       --node-port-bind-protection                                 Reject application bind(2) requests to service ports in the NodePort range (default true)
       --node-port-range strings                                   Set the min/max NodePort port range (default [30000,32767])
+      --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --policy-audit-mode                                         Enable policy audit (non-drop) mode
       --policy-cidr-match-mode strings                            The entities that can be selected by CIDR policy. Supported values: 'nodes'
       --policy-queue-size int                                     Size of queues for policy-related events (default 100)

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -54,6 +54,7 @@ cilium-agent hive [flags]
       --mesh-auth-spire-admin-socket string                       The path for the SPIRE admin agent Unix socket.
       --metrics strings                                           Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo, -metric_bar to disable metric_bar)
       --monitor-queue-size int                                    Size of the event queue when reading monitor events
+      --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --pprof                                                     Enable serving pprof debugging API
       --pprof-address string                                      Address that pprof listens on (default "localhost")
       --pprof-port uint16                                         Port that pprof listens on (default 6060)

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -59,6 +59,7 @@ cilium-agent hive dot-graph [flags]
       --mesh-auth-spire-admin-socket string                       The path for the SPIRE admin agent Unix socket.
       --metrics strings                                           Metrics that should be enabled or disabled from the default metric list. (+metric_foo to enable metric_foo, -metric_bar to disable metric_bar)
       --monitor-queue-size int                                    Size of the event queue when reading monitor events
+      --nodeport-addresses strings                                A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.
       --pprof                                                     Enable serving pprof debugging API
       --pprof-address string                                      Address that pprof listens on (default "localhost")
       --pprof-port uint16                                         Port that pprof listens on (default 6060)

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -398,7 +398,10 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 			d = d.DeepCopy()
 		}
 		deviceDeleted := false
-		deviceUpdated := false // Set to true if the batch contained an address or link update.
+
+		// Set to true if the device was modified. This is done to avoid unnecessary
+		// modifications to the device that would wake up watchers.
+		deviceUpdated := false
 
 		for _, u := range updates {
 			switch u := u.(type) {
@@ -458,6 +461,18 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 			}
 		}
 
+		// Recheck the viability of the device after the updates have been applied.
+		// Since route changes may cause device to be selected (e.g. veth device that
+		// has default route), always recheck viability if device is not selected.
+		if deviceUpdated || !d.Selected {
+			oldSelected := d.Selected
+			oldReason := d.NotSelectedReason
+			d.Selected, d.NotSelectedReason = dc.isSelectedDevice(d, txn)
+			if d.Selected != oldSelected || d.NotSelectedReason != oldReason {
+				deviceUpdated = true
+			}
+		}
+
 		if deviceDeleted {
 			// Remove the deleted device.
 			dc.params.DeviceTable.Delete(txn, d)
@@ -469,9 +484,6 @@ func (dc *devicesController) processBatch(txn statedb.WriteTxn, batch map[int][]
 				dc.params.RouteTable.Delete(txn, r)
 			}
 		} else if deviceUpdated {
-			// Recheck the viability of the device after the updates have been applied.
-			d.Selected, d.NotSelectedReason = dc.isSelectedDevice(d, txn)
-
 			// Create or update the device.
 			_, _, err := dc.params.DeviceTable.Insert(txn, d)
 			if err != nil {

--- a/pkg/datapath/linux/devices_controller.go
+++ b/pkg/datapath/linux/devices_controller.go
@@ -362,7 +362,8 @@ func (dc *devicesController) processUpdates(
 
 func deviceAddressFromAddrUpdate(upd netlink.AddrUpdate) tables.DeviceAddress {
 	return tables.DeviceAddress{
-		Addr: ip.MustAddrFromIP(upd.LinkAddress.IP),
+		Addr:      ip.MustAddrFromIP(upd.LinkAddress.IP),
+		Secondary: upd.Flags&unix.IFA_F_SECONDARY != 0,
 
 		// ifaddrmsg.ifa_scope is uint8, vishvananda/netlink has wrong type
 		Scope: uint8(upd.Scope),

--- a/pkg/datapath/tables/cells.go
+++ b/pkg/datapath/tables/cells.go
@@ -12,4 +12,5 @@ var Cell = cell.Module(
 	"Datapath state tables",
 
 	L2AnnounceTableCell,
+	NodeAddressCell,
 )

--- a/pkg/datapath/tables/device.go
+++ b/pkg/datapath/tables/device.go
@@ -101,8 +101,9 @@ func (d *Device) HasIP(ip net.IP) bool {
 }
 
 type DeviceAddress struct {
-	Addr  netip.Addr
-	Scope uint8 // Routing table scope
+	Addr      netip.Addr
+	Secondary bool
+	Scope     uint8 // Address scope, e.g. unix.RT_SCOPE_LINK, unix.RT_SCOPE_HOST etc.
 }
 
 func (d *DeviceAddress) AsIP() net.IP {

--- a/pkg/datapath/tables/node_address.go
+++ b/pkg/datapath/tables/node_address.go
@@ -1,0 +1,369 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/cilium/cilium/pkg/cidr"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/rate"
+	"github.com/cilium/cilium/pkg/statedb"
+	"github.com/cilium/cilium/pkg/statedb/index"
+	"github.com/cilium/cilium/pkg/time"
+)
+
+// NodeAddress is an IP address assigned to a network interface on a Cilium node
+// that is considered a "host" IP address.
+type NodeAddress struct {
+	Addr netip.Addr
+
+	// NodePort is true if this address is to be used for NodePort.
+	// If --nodeport-addresses is set, then all addresses on native
+	// devices that are contained within the specified CIDRs are chosen.
+	// If it is not set, then only the primary IPv4 and/or IPv6 address
+	// of each native device is used.
+	NodePort bool
+
+	// Primary is true if this is the primary IPv4 or IPv6 address of this device.
+	// This is mainly used to pick the address for BPF masquerading.
+	Primary bool
+
+	// DeviceName is the name of the network device from which this address
+	// is derived from.
+	DeviceName string
+}
+
+func (n *NodeAddress) IP() net.IP {
+	return n.Addr.AsSlice()
+}
+
+func (n *NodeAddress) String() string {
+	return fmt.Sprintf("%s (%s)", n.Addr, n.DeviceName)
+}
+
+type NodeAddressConfig struct {
+	NodePortAddresses []*cidr.CIDR `mapstructure:"nodeport-addresses"`
+}
+
+var (
+	// NodeAddressIndex is the primary index for node addresses:
+	//
+	//   var nodeAddresses Table[NodeAddress]
+	//   nodeAddresses.First(txn, NodeAddressIndex.Query(netip.MustParseAddr("1.2.3.4")))
+	NodeAddressIndex = statedb.Index[NodeAddress, netip.Addr]{
+		Name: "id",
+		FromObject: func(a NodeAddress) index.KeySet {
+			return index.NewKeySet(index.NetIPAddr(a.Addr))
+		},
+		FromKey: func(addr netip.Addr) []byte {
+			return index.NetIPAddr(addr)
+		},
+		Unique: true,
+	}
+
+	NodeAddressDeviceNameIndex = statedb.Index[NodeAddress, string]{
+		Name: "name",
+		FromObject: func(a NodeAddress) index.KeySet {
+			return index.NewKeySet(index.String(a.DeviceName))
+		},
+		FromKey: index.String,
+		Unique:  false,
+	}
+
+	NodeAddressTableName statedb.TableName = "node-addresses"
+
+	// NodeAddressCell provides Table[NodeAddress] and a background controller
+	// that derives the node addresses from the low-level Table[*Device].
+	//
+	// The Table[NodeAddress] contains the actual assigned addresses on the node,
+	// but not for example external Kubernetes node addresses that may be merely
+	// NATd to a private address. Those can be queried through [node.LocalNodeStore].
+	NodeAddressCell = cell.Module(
+		"node-address",
+		"Table of node addresses derived from system network devices",
+
+		statedb.NewPrivateRWTableCell[NodeAddress](NodeAddressTableName, NodeAddressIndex, NodeAddressDeviceNameIndex),
+		cell.Provide(
+			newNodeAddressTable,
+			newAddressScopeMax,
+		),
+		cell.Config(NodeAddressConfig{}),
+	)
+
+	// NodeAddressTestTableCell provides Table[NodeAddress] and RWTable[NodeAddress]
+	// for use in tests of modules that depend on node addresses.
+	NodeAddressTestTableCell = statedb.NewTableCell[NodeAddress](
+		NodeAddressTableName,
+		NodeAddressIndex,
+	)
+)
+
+const (
+	nodeAddressControllerMinInterval = 100 * time.Millisecond
+)
+
+// AddressScopeMax sets the maximum scope an IP address can have. A scope
+// is defined in rtnetlink(7) as the distance to the destination where a
+// lower number signifies a wider scope with RT_SCOPE_UNIVERSE (0) being
+// the widest. Definitions in Go are in unix package, e.g.
+// unix.RT_SCOPE_UNIVERSE and so on.
+//
+// This defaults to RT_SCOPE_LINK-1 (defaults.AddressScopeMax) and can be
+// set by the user with --local-max-addr-scope.
+type AddressScopeMax uint8
+
+func newAddressScopeMax(cfg NodeAddressConfig, daemonCfg *option.DaemonConfig) (AddressScopeMax, error) {
+	return AddressScopeMax(daemonCfg.AddressScopeMax), nil
+}
+
+func (cfg NodeAddressConfig) getNets() []*net.IPNet {
+	nets := make([]*net.IPNet, len(cfg.NodePortAddresses))
+	for i, cidr := range cfg.NodePortAddresses {
+		nets[i] = cidr.IPNet
+	}
+	return nets
+}
+
+func (NodeAddressConfig) Flags(flags *pflag.FlagSet) {
+	flags.StringSlice(
+		"nodeport-addresses",
+		nil,
+		"A whitelist of CIDRs to limit which IPs are used for NodePort. If not set, primary IPv4 and/or IPv6 address of each native device is used.")
+}
+
+type nodeAddressControllerParams struct {
+	cell.In
+
+	HealthScope     cell.Scope
+	Log             logrus.FieldLogger
+	Config          NodeAddressConfig
+	Lifecycle       hive.Lifecycle
+	Jobs            job.Registry
+	DB              *statedb.DB
+	Devices         statedb.Table[*Device]
+	NodeAddresses   statedb.RWTable[NodeAddress]
+	AddressScopeMax AddressScopeMax
+}
+
+type nodeAddressController struct {
+	nodeAddressControllerParams
+
+	tracker *statedb.DeleteTracker[*Device]
+}
+
+// newNodeAddressTable constructs the node address controller & registers its
+// lifecycle hooks and then provides Table[NodeAddress] to the application.
+// This enforces proper ordering, e.g. controller is started before anything
+// that depends on Table[NodeAddress] and allows it to populate it before
+// it is accessed.
+func newNodeAddressTable(p nodeAddressControllerParams) (tbl statedb.Table[NodeAddress], err error) {
+	n := nodeAddressController{nodeAddressControllerParams: p}
+	n.register()
+	return n.NodeAddresses, nil
+}
+
+func (n *nodeAddressController) register() {
+	g := n.Jobs.NewGroup(n.HealthScope)
+	g.Add(job.OneShot("node-address-update", n.run))
+
+	n.Lifecycle.Append(
+		hive.Hook{
+			OnStart: func(ctx hive.HookContext) error {
+				txn := n.DB.WriteTxn(n.NodeAddresses, n.Devices /* for delete tracker */)
+				defer txn.Abort()
+
+				// Start tracking deletions of devices.
+				var err error
+				n.tracker, err = n.Devices.DeleteTracker(txn, "node-addresses")
+				if err != nil {
+					return fmt.Errorf("DeleteTracker: %w", err)
+				}
+
+				// Do an immediate update to populate the table before it is read from.
+				devices, _ := n.Devices.All(txn)
+				for dev, _, ok := devices.Next(); ok; dev, _, ok = devices.Next() {
+					n.update(txn, nil, n.getAddressesFromDevice(dev), nil)
+				}
+				txn.Commit()
+
+				// Start the job in the background to incremental refresh
+				// the node addresses.
+				return g.Start(ctx)
+			},
+			OnStop: g.Stop,
+		})
+
+}
+
+func (n *nodeAddressController) run(ctx context.Context, reporter cell.HealthReporter) error {
+	defer n.tracker.Close()
+
+	limiter := rate.NewLimiter(nodeAddressControllerMinInterval, 1)
+	revision := statedb.Revision(0)
+	for {
+		txn := n.DB.WriteTxn(n.NodeAddresses)
+		process := func(dev *Device, deleted bool, rev statedb.Revision) error {
+			addrIter, _ := n.NodeAddresses.Get(txn, NodeAddressDeviceNameIndex.Query(dev.Name))
+			existing := statedb.CollectSet[NodeAddress](addrIter)
+			var new sets.Set[NodeAddress]
+			if !deleted {
+				new = n.getAddressesFromDevice(dev)
+			}
+			n.update(txn, existing, new, reporter)
+			return nil
+		}
+		var watch <-chan struct{}
+		revision, watch, _ = n.tracker.Process(txn, revision, process)
+		txn.Commit()
+
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-watch:
+		}
+		if err := limiter.Wait(ctx); err != nil {
+			return err
+		}
+	}
+}
+
+func (n *nodeAddressController) update(txn statedb.WriteTxn, existing, new sets.Set[NodeAddress], reporter cell.HealthReporter) {
+	updated := false
+
+	// Insert new addresses that did not exist.
+	for addr := range new {
+		if !existing.Has(addr) {
+			updated = true
+			n.NodeAddresses.Insert(txn, addr)
+		}
+	}
+
+	// Remove addresses that were not part of the new set.
+	for addr := range existing {
+		if !new.Has(addr) {
+			updated = true
+			n.NodeAddresses.Delete(txn, addr)
+		}
+	}
+
+	if updated {
+		addrs := showAddresses(new)
+		n.Log.WithField("node-addresses", addrs).Info("Node addresses updated")
+		if reporter != nil {
+			reporter.OK(addrs)
+		}
+	}
+}
+
+func (n *nodeAddressController) getAddressesFromDevice(dev *Device) (addrs sets.Set[NodeAddress]) {
+	addrs = sets.New[NodeAddress]()
+
+	if dev.Flags&net.FlagUp == 0 {
+		return
+	}
+
+	// Skip obviously uninteresting devices.
+	// We include the HostDevice as its IP addresses are consider node addresses
+	// and added to e.g. ipcache as HOST_IDs.
+	if dev.Name != defaults.HostDevice {
+		for _, prefix := range defaults.ExcludedDevicePrefixes {
+			if strings.HasPrefix(dev.Name, prefix) {
+				return
+			}
+		}
+	}
+
+	// ipv4Found and ipv6Found are set to true when the primary address is picked.
+	// Used to implement 'NodePort' and 'Primary' flags.
+	ipv4Found, ipv6Found := false, false
+
+	for _, addr := range sortedAddresses(dev.Addrs) {
+		// We keep the scope-based address filtering as was introduced
+		// in 080857bdedca67d58ec39f8f96c5f38b22f6dc0b.
+		if addr.Scope > uint8(n.AddressScopeMax) || addr.Addr.IsLoopback() {
+			continue
+		}
+
+		// Figure out if the address is usable for NodePort.
+		nodePort := false
+		primary := false
+		if dev.Selected && len(n.Config.NodePortAddresses) == 0 {
+			// The user has not specified IP ranges to filter on IPs on which to serve NodePort.
+			// Thus the default behavior is to use the primary IPv4 and IPv6 addresses of each
+			// device.
+			if addr.Addr.Is4() && !ipv4Found {
+				ipv4Found = true
+				nodePort = true
+				primary = true
+			}
+			if addr.Addr.Is6() && !ipv6Found {
+				ipv6Found = true
+				nodePort = true
+				primary = true
+			}
+		} else if ip.NetsContainsAny(n.Config.getNets(), []*net.IPNet{ip.IPToPrefix(addr.AsIP())}) {
+			// User specified --nodeport-addresses and this address was within the range.
+			nodePort = true
+			if addr.Addr.Is4() && !ipv4Found {
+				primary = true
+				ipv4Found = true
+			} else if addr.Addr.Is6() && !ipv6Found {
+				primary = true
+				ipv6Found = true
+			}
+		}
+
+		addrs.Insert(NodeAddress{
+			Addr:       addr.Addr,
+			Primary:    primary,
+			NodePort:   nodePort,
+			DeviceName: dev.Name,
+		})
+	}
+	return
+}
+
+// showAddresses formats a Set[NodeAddress] as "1.2.3.4 (eth0), fe80::1 (eth1)"
+func showAddresses(addrs sets.Set[NodeAddress]) string {
+	ss := make([]string, 0, len(addrs))
+	for addr := range addrs {
+		ss = append(ss, addr.String())
+	}
+	sort.Strings(ss)
+	return strings.Join(ss, ", ")
+}
+
+// sortedAddresses returns a copy of the addresses, sorted by primary (e.g. !iIFA_F_SECONDARY) and then by
+// address scope.
+func sortedAddresses(addrs []DeviceAddress) []DeviceAddress {
+	addrs = slices.Clone(addrs)
+
+	sort.SliceStable(addrs, func(i, j int) bool {
+		switch {
+		case !addrs[i].Secondary && addrs[j].Secondary:
+			return true
+		case addrs[i].Secondary && !addrs[j].Secondary:
+			return false
+		default:
+			return addrs[i].Scope < addrs[j].Scope
+		}
+	})
+	return addrs
+}

--- a/pkg/datapath/tables/node_address_test.go
+++ b/pkg/datapath/tables/node_address_test.go
@@ -1,0 +1,463 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package tables_test
+
+import (
+	"context"
+	"math/rand"
+	"net"
+	"net/netip"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+
+	"github.com/cilium/cilium/pkg/datapath/tables"
+	"github.com/cilium/cilium/pkg/defaults"
+	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/hive/cell"
+	"github.com/cilium/cilium/pkg/hive/job"
+	"github.com/cilium/cilium/pkg/ip"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/statedb"
+)
+
+func TestNodeAddressConfig(t *testing.T) {
+	var cfg tables.NodeAddressConfig
+	newHive := func() *hive.Hive {
+		return hive.New(
+			cell.Config(tables.NodeAddressConfig{}),
+			cell.Invoke(func(c tables.NodeAddressConfig) { cfg = c }),
+		)
+	}
+	testCases := [][]string{
+		nil,                         // Empty
+		{"1.2.3.0/24"},              // IPv4
+		{"1.2.0.0/16", "fe80::/64"}, // IPv4 & IPv6
+	}
+
+	for _, testCase := range testCases {
+		flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+		h := newHive()
+		h.RegisterFlags(flags)
+		flags.Set("nodeport-addresses", strings.Join(testCase, ","))
+		if assert.NoError(t, h.Start(context.TODO()), "Start") {
+			assert.NoError(t, h.Stop(context.TODO()), "Stop")
+			require.Len(t, cfg.NodePortAddresses, len(testCase))
+			for i := range testCase {
+				assert.Equal(t, testCase[i], cfg.NodePortAddresses[i].String())
+			}
+		}
+	}
+}
+
+var ciliumHostIP = net.ParseIP("9.9.9.9")
+
+var nodeAddressTests = []struct {
+	name         string
+	addrs        []tables.DeviceAddress // Addresses to add to the "test" device
+	wantLocal    []net.IP               // e.g. LocalAddresses()
+	wantNodePort []net.IP               // e.g. LoadBalancerNodeAddresses()
+}{
+	{
+		name: "ipv4 simple",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("10.0.0.1"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+		},
+		wantLocal: []net.IP{
+			ciliumHostIP,
+			net.ParseIP("10.0.0.1"),
+		},
+		wantNodePort: []net.IP{
+			net.ParseIP("10.0.0.1"),
+		},
+	},
+	{
+		name: "ipv6 simple",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("2001:db8::1"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+		},
+		wantLocal: []net.IP{
+			ciliumHostIP,
+			net.ParseIP("2001:db8::1"),
+		},
+		wantNodePort: []net.IP{
+			net.ParseIP("2001:db8::1"),
+		},
+	},
+	{
+		name: "v4/v6 mix",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("10.0.0.1"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+			{
+				Addr:  netip.MustParseAddr("2001:db8::1"),
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+		},
+
+		wantLocal: []net.IP{
+			ciliumHostIP,
+			net.ParseIP("2001:db8::1"),
+			net.ParseIP("10.0.0.1"),
+		},
+		wantNodePort: []net.IP{
+			net.ParseIP("10.0.0.1"),
+			net.ParseIP("2001:db8::1"),
+		},
+	},
+	{
+
+		name: "skip-out-of-scope-addrs",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("10.0.1.1"),
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+			{
+				Addr:  netip.MustParseAddr("10.0.2.2"),
+				Scope: unix.RT_SCOPE_LINK,
+			},
+			{
+				Addr:      netip.MustParseAddr("10.0.3.3"),
+				Secondary: true,
+				Scope:     unix.RT_SCOPE_HOST,
+			},
+		},
+
+		// The default AddressMaxScope is set to LINK-1, so addresses with
+		// scope LINK or above are ignored
+		wantLocal: []net.IP{
+			ciliumHostIP,
+			net.ParseIP("10.0.1.1"),
+		},
+
+		wantNodePort: []net.IP{
+			net.ParseIP("10.0.1.1"),
+		},
+	},
+
+	{
+		name: "multiple",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("10.0.0.1"),
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+			{
+				Addr:      netip.MustParseAddr("10.0.0.2"),
+				Scope:     unix.RT_SCOPE_UNIVERSE,
+				Secondary: true,
+			},
+		},
+
+		wantLocal: []net.IP{
+			ciliumHostIP,
+			net.ParseIP("10.0.0.1"),
+			net.ParseIP("10.0.0.2"),
+		},
+
+		wantNodePort: []net.IP{
+			net.ParseIP("10.0.0.1"),
+		},
+	},
+	{
+		name: "ipv6 multiple",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("2600:beef::2"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+			{
+				Addr:  netip.MustParseAddr("2001:db8::1"),
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+		},
+
+		wantLocal: []net.IP{
+			ciliumHostIP,
+			net.ParseIP("2001:db8::1"),
+			net.ParseIP("2600:beef::2"),
+		},
+
+		wantNodePort: []net.IP{
+			net.ParseIP("2001:db8::1"),
+		},
+	},
+}
+
+func TestNodeAddress(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range nodeAddressTests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				db        *statedb.DB
+				devices   statedb.RWTable[*tables.Device]
+				nodeAddrs statedb.Table[tables.NodeAddress]
+			)
+			h := hive.New(
+				job.Cell,
+				statedb.Cell,
+				tables.NodeAddressCell,
+				tables.DeviceTableCell,
+				cell.Provide(func(t statedb.RWTable[*tables.Device]) statedb.Table[*tables.Device] { return t }),
+				cell.Invoke(func(db_ *statedb.DB, d statedb.RWTable[*tables.Device], na statedb.Table[tables.NodeAddress]) {
+					db = db_
+					devices = d
+					nodeAddrs = na
+				}),
+
+				// option.DaemonConfig needed for AddressMaxScope. This flag will move into NodeAddressConfig
+				// in a follow-up PR.
+				cell.Provide(func() *option.DaemonConfig {
+					return &option.DaemonConfig{
+						AddressScopeMax: defaults.AddressScopeMax,
+					}
+				}),
+			)
+
+			if !assert.NoError(t, h.Start(context.TODO()), "Start") {
+				return
+			}
+
+			txn := db.WriteTxn(devices)
+			_, watch := nodeAddrs.All(txn)
+
+			devices.Insert(txn, &tables.Device{
+				Index: 1,
+				Name:  "cilium_host",
+				Flags: net.FlagUp,
+				Addrs: []tables.DeviceAddress{
+					{Addr: ip.MustAddrFromIP(ciliumHostIP), Scope: unix.RT_SCOPE_UNIVERSE},
+				},
+				Selected: false,
+			})
+
+			shuffleSlice(tt.addrs) // For extra bit of randomness
+			devices.Insert(txn,
+				&tables.Device{
+					Index:    2,
+					Name:     "test",
+					Selected: true,
+					Flags:    net.FlagUp,
+					Addrs:    tt.addrs,
+				})
+
+			txn.Commit()
+			<-watch // wait for propagation
+
+			iter, _ := nodeAddrs.All(db.ReadTxn())
+			local := []string{}
+			nodePort := []string{}
+			for addr, _, ok := iter.Next(); ok; addr, _, ok = iter.Next() {
+				local = append(local, addr.Addr.String())
+				if addr.NodePort {
+					nodePort = append(nodePort, addr.Addr.String())
+				}
+			}
+			assert.ElementsMatch(t, local, ipStrings(tt.wantLocal), "LocalAddresses do not match")
+			assert.ElementsMatch(t, nodePort, ipStrings(tt.wantNodePort), "LoadBalancerNodeAddresses do not match")
+			assert.NoError(t, h.Stop(context.TODO()), "Stop")
+		})
+	}
+
+}
+
+var nodeAddressWhitelistTests = []struct {
+	name         string
+	cidrs        string                 // --nodeport-addresses
+	addrs        []tables.DeviceAddress // Addresses to add to the "test" device
+	wantLocal    []net.IP               // e.g. LocalAddresses()
+	wantNodePort []net.IP               // e.g. LoadBalancerNodeAddresses()
+}{
+	{
+		name:  "ipv4",
+		cidrs: "10.0.0.0/8",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("10.0.0.1"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+			{
+				Addr:  netip.MustParseAddr("11.0.0.1"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+		},
+		wantLocal: []net.IP{
+			ciliumHostIP,
+			net.ParseIP("10.0.0.1"),
+			net.ParseIP("11.0.0.1"),
+		},
+		wantNodePort: []net.IP{
+			net.ParseIP("10.0.0.1"),
+		},
+	},
+	{
+		name:  "ipv6",
+		cidrs: "2001::/16",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("2001:db8::1"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+			{
+				Addr:  netip.MustParseAddr("2600:beef::2"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+		},
+		wantLocal: []net.IP{
+			ciliumHostIP,
+			net.ParseIP("2001:db8::1"),
+			net.ParseIP("2600:beef::2"),
+		},
+		wantNodePort: []net.IP{
+			net.ParseIP("2001:db8::1"),
+		},
+	},
+	{
+		name:  "v4-v6 mix",
+		cidrs: "2001::/16,10.0.0.0/8",
+		addrs: []tables.DeviceAddress{
+			{
+				Addr:  netip.MustParseAddr("10.0.0.1"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+			{
+				Addr:  netip.MustParseAddr("11.0.0.1"),
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+			{
+				Addr:  netip.MustParseAddr("2001:db8::1"),
+				Scope: unix.RT_SCOPE_UNIVERSE,
+			},
+			{
+				Addr:  netip.MustParseAddr("2600:beef::2"),
+				Scope: unix.RT_SCOPE_SITE,
+			},
+		},
+
+		wantLocal: []net.IP{
+			ciliumHostIP,
+			net.ParseIP("10.0.0.1"),
+			net.ParseIP("11.0.0.1"),
+			net.ParseIP("2001:db8::1"),
+			net.ParseIP("2600:beef::2"),
+		},
+		wantNodePort: []net.IP{
+			net.ParseIP("10.0.0.1"),
+			net.ParseIP("2001:db8::1"),
+		},
+	},
+}
+
+func TestNodeAddressWhitelist(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range nodeAddressWhitelistTests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			var (
+				db        *statedb.DB
+				devices   statedb.RWTable[*tables.Device]
+				nodeAddrs statedb.Table[tables.NodeAddress]
+			)
+			h := hive.New(
+				job.Cell,
+				statedb.Cell,
+				tables.NodeAddressCell,
+				tables.DeviceTableCell,
+				cell.Provide(func(t statedb.RWTable[*tables.Device]) statedb.Table[*tables.Device] { return t }),
+				cell.Invoke(func(db_ *statedb.DB, d statedb.RWTable[*tables.Device], na statedb.Table[tables.NodeAddress]) {
+					db = db_
+					devices = d
+					nodeAddrs = na
+				}),
+
+				// option.DaemonConfig needed for AddressMaxScope. This flag will move into NodeAddressConfig
+				// in a follow-up PR.
+				cell.Provide(func() *option.DaemonConfig {
+					return &option.DaemonConfig{
+						AddressScopeMax: defaults.AddressScopeMax,
+					}
+				}),
+			)
+			h.Viper().Set("nodeport-addresses", tt.cidrs)
+
+			if !assert.NoError(t, h.Start(context.TODO()), "Start") {
+				return
+			}
+
+			txn := db.WriteTxn(devices)
+			_, watch := nodeAddrs.All(txn)
+
+			devices.Insert(txn, &tables.Device{
+				Index: 1,
+				Name:  "cilium_host",
+				Flags: net.FlagUp,
+				Addrs: []tables.DeviceAddress{
+					{Addr: ip.MustAddrFromIP(ciliumHostIP), Scope: unix.RT_SCOPE_UNIVERSE},
+				},
+				Selected: false,
+			})
+
+			shuffleSlice(tt.addrs) // For extra bit of randomness
+			devices.Insert(txn,
+				&tables.Device{
+					Index:    2,
+					Name:     "test",
+					Selected: true,
+					Flags:    net.FlagUp,
+					Addrs:    tt.addrs,
+				})
+
+			txn.Commit()
+			<-watch // wait for propagation
+
+			iter, _ := nodeAddrs.All(db.ReadTxn())
+			local := []string{}
+			nodePort := []string{}
+			for addr, _, ok := iter.Next(); ok; addr, _, ok = iter.Next() {
+				local = append(local, addr.Addr.String())
+				if addr.NodePort {
+					nodePort = append(nodePort, addr.Addr.String())
+				}
+			}
+			assert.ElementsMatch(t, local, ipStrings(tt.wantLocal), "LocalAddresses do not match")
+			assert.ElementsMatch(t, nodePort, ipStrings(tt.wantNodePort), "LoadBalancerNodeAddresses do not match")
+			assert.NoError(t, h.Stop(context.TODO()), "Stop")
+		})
+	}
+
+}
+
+// ipStrings converts net.IP to a string. Used to assert equalence without having to deal
+// with e.g. IPv4-mapped IPv6 presentation etc.
+func ipStrings(ips []net.IP) (ss []string) {
+	for i := range ips {
+		ss = append(ss, ips[i].String())
+	}
+	sort.Strings(ss)
+	return
+}
+
+func shuffleSlice[T any](xs []T) {
+	rand.Shuffle(
+		len(xs),
+		func(i, j int) {
+			xs[i], xs[j] = xs[j], xs[i]
+		})
+}

--- a/pkg/statedb/iterator.go
+++ b/pkg/statedb/iterator.go
@@ -3,12 +3,28 @@
 
 package statedb
 
-import "fmt"
+import (
+	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Collect creates a slice of objects out of the iterator.
+// The iterator is consumed in the process.
 func Collect[Obj any](iter Iterator[Obj]) []Obj {
 	objs := []Obj{}
 	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
 		objs = append(objs, obj)
+	}
+	return objs
+}
+
+// CollectSet creates a set of objects out of the iterator.
+// The iterator is consumed in the process.
+func CollectSet[Obj comparable](iter Iterator[Obj]) sets.Set[Obj] {
+	objs := sets.New[Obj]()
+	for obj, _, ok := iter.Next(); ok; obj, _, ok = iter.Next() {
+		objs.Insert(obj)
 	}
 	return objs
 }


### PR DESCRIPTION
To provide modules access to the evolving set of local node's addresses,                                                                                                                       
add Table[NodeAddress] that derives from the low-level Table[*Device] and                                                                                                                      
applies the Cilium-specific heuristics to pick which addresses are considered                                                                                                                  
host IPs and which are used for NodePort and BPF masquerading.                                                                                                                                 
                                                                                                                                                                                                
To allow user to expand the set of addresses used for NodePort, add the                                                                                                                        
configuration flag "--nodeport-addresses" for specifying from which CIDRs                                                                                                                      
the NodePort addresses are allowed. This mirrors exactly the same kube-proxy                                                                                                                   
flag. If user does not specify this, then the default behavior remains, which                                                                                                                  
is to pick the first IPv4 and IPv6 address of each native device.                                                                                                                              

```
// NodeAddress is an IP address assigned to a network interface on a Cilium node                                                                                                               
 // that is considered a "host" IP address.                                                                                                                                                     
 type NodeAddress struct {                                                                                                                                                                      
         Addr netip.Addr                                                                                                                                                                        
                                                                                                                                                                                                
         // NodePort is true if this address is to be used for NodePort.                                                                                                                        
         // If --nodeport-addresses is set, then all addresses on native                                                                                                                        
         // devices that are contained within the specified CIDRs are chosen.                                                                                                                   
         // If it is not set, then only the primary IPv4 and/or IPv6 address                                                                                                                    
         // of each native device is used.                                                                                                                                                      
         NodePort bool                                                                                                                                                                          
                                                                                                                                                                                                
         // Primary is true if this is the primary IPv4 or IPv6 address of this device.                                                                                                         
         // This is mainly used to pick the address for BPF masquerading.                                                                                                                       
         Primary bool                                                                                                                                                                           
                                                                                                                                                                                                
         // DeviceName is the name of the network device from which this address                                                                                                                
         // is derived from.                                                                                                                                                                    
         DeviceName string                                                                                                                                                                      
 } 
```

This PR is one of several that aims to replace the global maps in `pkg/node/address.go` containing the NodePort and BPF masquerade addresses with a table that can be watched for changes and allow dynamic reconfiguration when the addresses
change. The next PR will adapt `NodeAddressing` to access `Table[NodeAddress]` and removes the global maps from `pkg/node`.
Further PRs down the line will switch from `NodeAddressing` to `Table[NodeAddress]` and start reconciling on changes.
         