### PR TITLE
operator: Fix CES Controller rate limiting

### DIFF
--- a/operator/pkg/ciliumendpointslice/controller.go
+++ b/operator/pkg/ciliumendpointslice/controller.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cilium/workerpool"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/time/rate"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/hive"
@@ -62,10 +63,10 @@ type Controller struct {
 	// CES requests going to api-server, ensures a single CES will not be proccessed
 	// multiple times concurrently, and if CES is added multiple times before it
 	// can be processed, this will only be processed only once.
-	queue           workqueue.RateLimitingInterface
-	queueTerminated chan struct{}
-	writeQPSLimit   float64
-	writeQPSBurst   int
+	queue            workqueue.RateLimitingInterface
+	queueRateLimiter *rate.Limiter
+	writeQPSLimit    float64
+	writeQPSBurst    int
 
 	enqueuedAt     map[CESName]time.Time
 	enqueuedAtLock lock.Mutex

--- a/operator/pkg/ciliumendpointslice/endpointslice.go
+++ b/operator/pkg/ciliumendpointslice/endpointslice.go
@@ -66,13 +66,10 @@ func (c *Controller) initializeQueue() {
 		logfields.WorkQueueSyncBackOff: defaultSyncBackOff,
 	}).Info("CES controller workqueue configuration")
 
-	c.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewMaxOfRateLimiter(
+	c.queue = workqueue.NewRateLimitingQueueWithConfig(
 		workqueue.NewItemExponentialFailureRateLimiter(defaultSyncBackOff, maxSyncBackOff),
-		// 10 qps, 100 bucket size. This is only for retry speed and its
-		// only the overall factor (not per item).
-		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(c.writeQPSLimit), c.writeQPSBurst)},
-	), "cilium_endpoint_slice")
-	c.queueTerminated = make(chan struct{})
+		workqueue.RateLimitingQueueConfig{Name: "cilium_endpoint_slice"})
+	c.queueRateLimiter = rate.NewLimiter(rate.Limit(c.writeQPSLimit), c.writeQPSBurst)
 }
 
 func (c *Controller) onEndpointUpdate(cep *cilium_api_v2.CiliumEndpoint) {
@@ -158,14 +155,9 @@ func (c *Controller) Start(ctx hive.HookContext) error {
 
 func (c *Controller) Stop(ctx hive.HookContext) error {
 	c.wp.Close()
-	c.stopQueueAndWait()
+	c.queue.ShutDown()
 	c.contextCancel()
 	return nil
-}
-
-func (c *Controller) stopQueueAndWait() {
-	c.queue.ShutDown()
-	<-c.queueTerminated
 }
 
 func (c *Controller) runCiliumEndpointsUpdater(ctx context.Context) error {
@@ -223,12 +215,20 @@ func (c *Controller) syncCESsInLocalCache(ctx context.Context) error {
 // worker runs a worker thread that just dequeues items, processes them, and
 // marks them done.
 func (c *Controller) worker() {
-	defer close(c.queueTerminated)
 	for c.processNextWorkItem() {
 	}
 }
 
+func (c *Controller) rateLimitProcessing() {
+	delay := c.queueRateLimiter.Reserve().Delay()
+	select {
+	case <-c.context.Done():
+	case <-time.After(delay):
+	}
+}
+
 func (c *Controller) processNextWorkItem() bool {
+	c.rateLimitProcessing()
 	cKey, quit := c.queue.Get()
 	if quit {
 		return false


### PR DESCRIPTION
Rate limiting work queue has rate limiting only when AddRateLimited method is used. It doesn't accept minimum delay so instead delaying queue with separate rate limitter is used.

<!-- Description of change -->

```release-note
Fixes rate limiting for CES Controller
```
