### PR TITLE
gateway-api: Check for required CRDs upon startup

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -4,15 +4,24 @@
 package gateway_api
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/bombsimon/logrusr/v4"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrlRuntime "sigs.k8s.io/controller-runtime"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/hive/cell"
+	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/logging"
 )
 
@@ -28,6 +37,15 @@ var Cell = cell.Module(
 	cell.Invoke(registerController),
 )
 
+var requiredGVK = []schema.GroupVersionKind{
+	gatewayv1.SchemeGroupVersion.WithKind("gatewayclasses"),
+	gatewayv1.SchemeGroupVersion.WithKind("gateways"),
+	gatewayv1.SchemeGroupVersion.WithKind("httproutes"),
+	gatewayv1beta1.SchemeGroupVersion.WithKind("referencegrants"),
+	gatewayv1alpha2.SchemeGroupVersion.WithKind("grpcroutes"),
+	gatewayv1alpha2.SchemeGroupVersion.WithKind("tlsroutes"),
+}
+
 type gatewayApiConfig struct {
 	EnableGatewayAPISecretsSync bool
 	GatewayAPISecretsNamespace  string
@@ -38,8 +56,21 @@ func (r gatewayApiConfig) Flags(flags *pflag.FlagSet) {
 	flags.String("gateway-api-secrets-namespace", r.GatewayAPISecretsNamespace, "Namespace having tls secrets used by CEC for Gateway API")
 }
 
-func registerController(lc hive.Lifecycle, config gatewayApiConfig) error {
+type params struct {
+	cell.In
+
+	Clientset k8sClient.Clientset
+	Logger    logrus.FieldLogger
+}
+
+func registerController(lc hive.Lifecycle, p params, config gatewayApiConfig) error {
 	if !operatorOption.Config.EnableGatewayAPI {
+		return nil
+	}
+
+	p.Logger.WithField("requiredGVK", requiredGVK).Info("Checking for required GatewayAPI resources")
+	if err := checkRequiredCRDs(context.Background(), p.Clientset); err != nil {
+		p.Logger.WithError(err).Error("Required GatewayAPI resources are not found, please refer to docs for installation instructions")
 		return nil
 	}
 
@@ -63,4 +94,33 @@ func registerController(lc hive.Lifecycle, config gatewayApiConfig) error {
 	})
 
 	return nil
+}
+
+func checkRequiredCRDs(ctx context.Context, clientset k8sClient.Clientset) error {
+	if !clientset.IsEnabled() {
+		return nil
+	}
+
+	var res error
+
+	for _, gvk := range requiredGVK {
+		crd, err := clientset.ApiextensionsV1().CustomResourceDefinitions().Get(ctx, gvk.GroupKind().String(), metav1.GetOptions{})
+		if err != nil {
+			res = errors.Join(res, err)
+			continue
+		}
+
+		found := false
+		for _, v := range crd.Spec.Versions {
+			if v.Name == gvk.Version {
+				found = true
+				break
+			}
+		}
+		if !found {
+			res = errors.Join(res, fmt.Errorf("CRD %q does not have version %q", gvk.GroupKind().String(), gvk.Version))
+		}
+	}
+
+	return res
 }


### PR DESCRIPTION
Currently, if the required CRDs are not installed, Cilium Operator will just crash due to the below error. This commit is to perform pre-flight check, and avoid the crash.

```
2023-11-03T11:53:45.585078169Z level=fatal msg="failed to start: failed to create gateway controller: failed to get API group resources: unable to retrieve the complete list of server APIs: gateway.networking.k8s.io/v1: the server could not find the requested resource" subsys=cilium-operator-generic
```
