### PR TITLE
Change Hubble dashboard name

### DIFF
--- a/install/kubernetes/cilium/files/hubble/dashboards/hubble-dashboard.json
+++ b/install/kubernetes/cilium/files/hubble/dashboards/hubble-dashboard.json
@@ -3226,7 +3226,7 @@
     ]
   },
   "timezone": "",
-  "title": "Hubble",
+  "title": "Hubble Metrics and Monitoring",
   "uid": "5HftnJAWz",
   "version": 24
 }


### PR DESCRIPTION

Fixes issue where Hubble dashboard is not installed when `hubble.dashboards.enabled=true` helm value is used. 

This is because the grafana sidecar cannot install the dashboard

```shell
logger=provisioning.dashboard type=file name=sidecarProvider t=2023-11-03T13:54:15.812999204Z level=error msg="failed to save dashboard" file=/tmp/dashboards/Hubble/hubble-dashboard.json error="Dashboard name cannot be the same as folder"
```

Fixes: #28970

```release-note
Renamed Hubble Dashboard so that it can be installed by Grafana Sidecar.
```
