### PR TITLE
[v1.13] Remove remote-node labels from ipcache on node delete

### DIFF
--- a/pkg/node/manager/manager.go
+++ b/pkg/node/manager/manager.go
@@ -57,6 +57,7 @@ type IPCache interface {
 	Upsert(ip string, hostIP net.IP, hostKey uint8, k8sMeta *ipcache.K8sMetadata, newIdentity ipcache.Identity) (bool, error)
 	Delete(IP string, source source.Source) bool
 	UpsertLabels(prefix netip.Prefix, lbls labels.Labels, src source.Source, rid ipcacheTypes.ResourceID)
+	RemoveLabels(prefix netip.Prefix, lbls labels.Labels, rid ipcacheTypes.ResourceID)
 }
 
 // Configuration is the set of configuration options the node manager depends
@@ -508,6 +509,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		entry.mutex.Lock()
 		m.mutex.Unlock()
 		oldNode := entry.node
+		oldRID := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", oldNode.Name)
 		entry.node = n
 		if dpUpdate {
 			m.Iter(func(nh datapath.NodeHandler) {
@@ -532,7 +534,8 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 			}
 			oldNodeIPAddrs = append(oldNodeIPAddrs, prefix.String())
 		}
-		m.deleteIPCache(oldNode.Source, oldNodeIPAddrs, ipsAdded)
+
+		m.deleteIPCache(oldNode.Source, oldNodeIPAddrs, ipsAdded, remoteHostIdentity, oldRID)
 
 		// Delete the old health IP addresses if they have changed in this node.
 		oldHealthIPs := []string{}
@@ -542,7 +545,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		if oldNode.IPv6HealthIP != nil {
 			oldHealthIPs = append(oldHealthIPs, oldNode.IPv6HealthIP.String())
 		}
-		m.deleteIPCache(oldNode.Source, oldHealthIPs, healthIPsAdded)
+		m.deleteIPCache(oldNode.Source, oldHealthIPs, healthIPsAdded, identity.IdentityUnknown, oldRID)
 
 		// Delete the old ingress IP addresses if they have changed in this node.
 		oldIngressIPs := []string{}
@@ -552,7 +555,7 @@ func (m *Manager) NodeUpdated(n nodeTypes.Node) {
 		if oldNode.IPv6IngressIP != nil {
 			oldIngressIPs = append(oldIngressIPs, oldNode.IPv6IngressIP.String())
 		}
-		m.deleteIPCache(oldNode.Source, oldIngressIPs, ingressIPsAdded)
+		m.deleteIPCache(oldNode.Source, oldIngressIPs, ingressIPsAdded, identity.IdentityUnknown, oldRID)
 
 		entry.mutex.Unlock()
 	} else {
@@ -583,9 +586,17 @@ func (m *Manager) upsertIntoIDMD(prefix netip.Prefix, id identity.NumericIdentit
 	}
 }
 
+func (m *Manager) removeFromIDMD(prefix netip.Prefix, id identity.NumericIdentity, rid ipcacheTypes.ResourceID) {
+	if id == identity.ReservedIdentityHost {
+		m.ipcache.RemoveLabels(prefix, labels.LabelHost, rid)
+	} else {
+		m.ipcache.RemoveLabels(prefix, labels.LabelRemoteNode, rid)
+	}
+}
+
 // deleteIPCache deletes the IP addresses from the IPCache with the 'oldSource'
 // if they are not found in the newIPs slice.
-func (m *Manager) deleteIPCache(oldSource source.Source, oldIPs []string, newIPs []string) {
+func (m *Manager) deleteIPCache(oldSource source.Source, oldIPs []string, newIPs []string, remoteID identity.NumericIdentity, rid ipcacheTypes.ResourceID) {
 	for _, address := range oldIPs {
 		var found bool
 		for _, ipAdded := range newIPs {
@@ -597,6 +608,14 @@ func (m *Manager) deleteIPCache(oldSource source.Source, oldIPs []string, newIPs
 		// Delete from the IPCache if the node's IP addresses was not
 		// added in this update.
 		if !found {
+			if remoteID != identity.IdentityUnknown {
+				prefix, err := netip.ParsePrefix(address)
+				if err != nil {
+					log.WithError(err).WithField("prefix", address).Warn("Failed to parse prefix inside deleteIPCache")
+				} else {
+					m.removeFromIDMD(prefix, remoteID, rid)
+				}
+			}
 			m.ipcache.Delete(address, oldSource)
 		}
 	}
@@ -618,6 +637,16 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 	if !oldNodeExists {
 		m.mutex.Unlock()
 		return
+	}
+
+	remoteHostIdentity := identity.ReservedIdentityHost
+	if m.conf.RemoteNodeIdentitiesEnabled() {
+		nid := identity.NumericIdentity(n.NodeIdentity)
+		if nid != identity.IdentityUnknown && nid != identity.ReservedIdentityHost {
+			remoteHostIdentity = nid
+		} else if !n.IsLocal() {
+			remoteHostIdentity = identity.ReservedIdentityRemoteNode
+		}
 	}
 
 	// If the source is Kubernetes and the node is the node we are running on
@@ -650,6 +679,8 @@ func (m *Manager) NodeDeleted(n nodeTypes.Node) {
 		} else {
 			prefix = ip.IPToNetPrefix(address.IP.To16())
 		}
+		rid := ipcacheTypes.NewResourceID(ipcacheTypes.ResourceKindNode, "", n.Name)
+		m.removeFromIDMD(prefix, remoteHostIdentity, rid)
 		m.ipcache.Delete(prefix.String(), n.Source)
 	}
 

--- a/pkg/node/manager/manager_test.go
+++ b/pkg/node/manager/manager_test.go
@@ -107,6 +107,9 @@ func (i *ipcacheMock) Delete(ip string, source source.Source) bool {
 func (i *ipcacheMock) UpsertLabels(netip.Prefix, labels.Labels, source.Source, ipcacheTypes.ResourceID) {
 }
 
+func (i *ipcacheMock) RemoveLabels(netip.Prefix, labels.Labels, ipcacheTypes.ResourceID) {
+}
+
 type signalNodeHandler struct {
 	EnableNodeAddEvent                    bool
 	NodeAddEvent                          chan nodeTypes.Node


### PR DESCRIPTION
Forward port https://github.com/cilium/cilium/pull/27406 to `v1.13` with several edits (partially following https://github.com/cilium/cilium/pull/27010) without the revert of https://github.com/cilium/cilium/pull/26958, because that was never applied to `v1.13`. Supersedes https://github.com/cilium/cilium/pull/27010.

Passes the first two test cases of the [test script for v1.13](https://gist.github.com/tklauser/4690a06f050116a839ee209f63d37c14) (slightly adjusted from the [v1.12 test script](https://gist.github.com/joestringer/d7f55da5dd2f33be6148dd52a96a4a54) used for https://github.com/cilium/cilium/pull/27406):

```
-- PASSED delete-node-then-associate-svc for kind-worker3 (172.18.0.5) at Fri  3 Nov 14:05:27 UTC 2023
[...]
-- PASSED delete-node-then-associate-kubeapi for kind-worker4 (172.18.0.2) at Fri  3 Nov 14:05:28 UTC 2023
```

See commit message for detailed backporter notes.

Closes https://github.com/cilium/cilium/pull/27010