### PR TITLE
helm: Fix annotation duplication problems

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/serviceaccount.yaml
@@ -4,10 +4,6 @@ kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccounts.cilium.name | quote }}
   namespace: {{ .Release.Namespace }}
-  {{- if .Values.serviceAccounts.cilium.annotations }}
-  annotations:
-    {{- toYaml .Values.serviceAccounts.cilium.annotations | nindent 4 }}
-  {{- end }}
   {{- if or .Values.serviceAccounts.cilium.annotations .Values.annotations }}
   annotations:
     {{- with .Values.annotations }}

--- a/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/service.yaml
@@ -6,13 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   {{- if or (not .Values.envoy.prometheus.serviceMonitor.enabled) .Values.envoy.annotations }}
   annotations:
-    {{- if not .Values.envoy.prometheus.serviceMonitor.enabled }}
-      prometheus.io/scrape: "true"
-      prometheus.io/port: {{ .Values.proxy.prometheus.port | default .Values.envoy.prometheus.port | quote }}
-    {{- end }}
-    {{- with .Values.envoy.annotations }}
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- if not .Values.envoy.prometheus.serviceMonitor.enabled }}
+    prometheus.io/scrape: "true"
+    prometheus.io/port: {{ .Values.proxy.prometheus.port | default .Values.envoy.prometheus.port | quote }}
+  {{- end }}
+  {{- with .Values.envoy.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- end }}
   labels:
     k8s-app: cilium-envoy


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [ ] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [X] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [X] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

Fixes: 44698df

https://github.com/cilium/cilium/pull/27860#discussion_r1378867381

This change fixes duplicate `annotations` that can occur in the cilium-agent ServiceAccount if both `annotations` and `serviceAccounts.cilium.annotations` are defined. While testing the change, I found that the indentation on the `cilium-envoy/service.yaml` needed to be fixed as well. If serviceMonitor was not enabled for envoy, helm would return the error `mapping values are not allowed in this context` due to the indent level in the template.

```release-note
helm: Fix annotation duplication problems for cilium-agent
```
