### PR TITLE
[v1.14] Author Backport of 28382 (Metrics associated with a deleted node should not be reported)

### DIFF
--- a/pkg/metrics/interfaces.go
+++ b/pkg/metrics/interfaces.go
@@ -24,13 +24,14 @@ var (
 	NoOpMetric    prometheus.Metric    = &mockMetric{}
 	NoOpCollector prometheus.Collector = &collector{}
 
-	NoOpCounter     metricpkg.Counter                 = &counter{NoOpMetric, NoOpCollector}
-	NoOpCounterVec  metricpkg.Vec[metricpkg.Counter]  = &counterVec{NoOpCollector}
-	NoOpObserver    metricpkg.Observer                = &observer{}
-	NoOpHistogram   metricpkg.Histogram               = &histogram{NoOpCollector}
-	NoOpObserverVec metricpkg.Vec[metricpkg.Observer] = &observerVec{NoOpCollector}
-	NoOpGauge       metricpkg.Gauge                   = &gauge{NoOpMetric, NoOpCollector}
-	NoOpGaugeVec    metricpkg.Vec[metricpkg.Gauge]    = &gaugeVec{NoOpCollector}
+	NoOpCounter           metricpkg.Counter                       = &counter{NoOpMetric, NoOpCollector}
+	NoOpCounterVec        metricpkg.Vec[metricpkg.Counter]        = &counterVec{NoOpCollector}
+	NoOpObserver          metricpkg.Observer                      = &observer{}
+	NoOpHistogram         metricpkg.Histogram                     = &histogram{NoOpCollector}
+	NoOpObserverVec       metricpkg.Vec[metricpkg.Observer]       = &observerVec{NoOpCollector}
+	NoOpGauge             metricpkg.Gauge                         = &gauge{NoOpMetric, NoOpCollector}
+	NoOpGaugeVec          metricpkg.Vec[metricpkg.Gauge]          = &gaugeVec{NoOpCollector}
+	NoOpGaugeDeletableVec metricpkg.DeletableVec[metricpkg.Gauge] = &gaugeDeletableVec{gaugeVec{NoOpCollector}}
 )
 
 // Metric
@@ -155,6 +156,24 @@ func (g *gauge) SetEnabled(bool)      {}
 func (g *gauge) Opts() metricpkg.Opts { return metricpkg.Opts{} }
 
 // GaugeVec
+
+type gaugeDeletableVec struct {
+	gaugeVec
+}
+
+func (*gaugeDeletableVec) Delete(ll prometheus.Labels) bool {
+	return false
+}
+
+func (*gaugeDeletableVec) DeleteLabelValues(lvs ...string) bool {
+	return false
+}
+
+func (*gaugeDeletableVec) DeletePartialMatch(labels prometheus.Labels) int {
+	return 0
+}
+
+func (*gaugeDeletableVec) Reset() {}
 
 type gaugeVec struct {
 	prometheus.Collector

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -247,11 +247,11 @@ var (
 
 	// NodeConnectivityStatus is the connectivity status between local node to
 	// other node intra or inter cluster.
-	NodeConnectivityStatus = NoOpGaugeVec
+	NodeConnectivityStatus = NoOpGaugeDeletableVec
 
 	// NodeConnectivityLatency is the connectivity latency between local node to
 	// other node intra or inter cluster.
-	NodeConnectivityLatency = NoOpGaugeVec
+	NodeConnectivityLatency = NoOpGaugeDeletableVec
 
 	// Endpoint
 
@@ -574,8 +574,8 @@ var (
 type LegacyMetrics struct {
 	BootstrapTimes                   metric.Vec[metric.Observer]
 	APIInteractions                  metric.Vec[metric.Observer]
-	NodeConnectivityStatus           metric.Vec[metric.Gauge]
-	NodeConnectivityLatency          metric.Vec[metric.Gauge]
+	NodeConnectivityStatus           metric.DeletableVec[metric.Gauge]
+	NodeConnectivityLatency          metric.DeletableVec[metric.Gauge]
 	Endpoint                         metric.GaugeFunc
 	EndpointMaxIfindex               metric.Gauge
 	EndpointRegenerationTotal        metric.Vec[metric.Counter]


### PR DESCRIPTION
- [ ] #28382 -- Metrics associated with a deleted node should not be reported (@derailed)

Once this PR is merged, you can update the PR labels via:
```upstream-prs
$ for pr in 28382; do contrib/backporting/set-labels.py $pr done 1.14; done
```