### PR TITLE
operator: Set correct level for log in ingressClassManager

### DIFF
--- a/operator/pkg/ingress/ingress_class.go
+++ b/operator/pkg/ingress/ingress_class.go
@@ -160,7 +160,7 @@ func (i *ingressClassManager) handleSyncEvent() error {
 // If an error is returned, then the IngressClass contained in the event should be retried at a later
 // point in time.
 func (i *ingressClassManager) handleUpsertEvent(event resource.Event[*slim_networkingv1.IngressClass]) error {
-	log.WithField(logfields.IngressClass, event.Object).Warn("Handling IngressClass Upsert event")
+	log.WithField(logfields.IngressClass, event.Object).Debug("Handling IngressClass Upsert event")
 
 	if event.Object == nil || !isIngressClassCilium(event.Object) {
 		return nil


### PR DESCRIPTION
The ingressClassManager emits a warning log while handling an Upsert event on IngressClasses, however, this log should be at the debug level.

This log was set to the warning level while testing #28663 and never changed back to debug.

```release-note
Set correct log level for log in ingressClassManager
```
