### PR TITLE
build: Declare GO in makefile before first use

### DIFF
--- a/Makefile.defs
+++ b/Makefile.defs
@@ -28,6 +28,7 @@ LOCALSTATEDIR?=/var
 RUNDIR?=/var/run
 CONFDIR?=/etc
 
+export GO ?= go
 NATIVE_ARCH = $(shell GOARCH= $(GO) env GOARCH)
 export GOARCH ?= $(NATIVE_ARCH)
 
@@ -65,7 +66,6 @@ endif
 CONSUL_IMAGE=consul:1.7.2
 
 export CILIUM_CLI ?= cilium
-export GO ?= go
 export KUBECTL ?= kubectl
 
 # go build/test/clean flags


### PR DESCRIPTION
This is to avoid the below warning as $(GO) is not defined before calling GOARCH= $(GO) env GOARCH.

```bash
$ make
env: ‘GOARCH’: No such file or directory
contrib/scripts/check-logging-subsys-field.sh
contrib/scripts/check-fmt.sh
...
```

