### PR TITLE
WG tunneling

### DIFF
--- a/.github/actions/ginkgo/main-focus.yaml
+++ b/.github/actions/ginkgo/main-focus.yaml
@@ -107,7 +107,6 @@ include:
     cliFocus: "K8sDatapathConfig Encapsulation|K8sDatapathConfig Etcd|K8sDatapathConfig Etcd|K8sDatapathConfig MonitorAggregation"
 
   ###
-  # K8sDatapathConfig WireGuard encryption strict mode Pod-to-pod traffic is encrypted in tunneling mode with per-endpoint routes
   # K8sDatapathConfig WireGuard encryption strict mode Pod-to-pod traffic is encrypted in native routing mode with per-endpoint routes
   # K8sDatapathConfig WireGuard encryption strict mode Pod-to-pod traffic is encrypted in native routing mode with per-endpoint routes and overlapping node and pod CIDRs
   # K8sDatapathConfig Check BPF masquerading with ip-masq-agent DirectRouting

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -52,7 +52,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.15.11
+  cilium_cli_version: v0.15.13
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/conformance-ipsec-e2e.yaml
+++ b/.github/workflows/conformance-ipsec-e2e.yaml
@@ -52,7 +52,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=cilium/cilium-cli
-  cilium_cli_version: v0.15.11
+  cilium_cli_version: v0.15.13
   cilium_cli_ci_version:
   check_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -1333,17 +1333,11 @@ skip_host_firewall:
 		return send_drop_notify_error(ctx, 0, ret, CTX_ACT_DROP,
 					      METRIC_EGRESS);
 
-	/* We disable the WireGuard strict mode if the tunnel mode is enabled,
-	 * since we have a check earlier in the datapath before encapsulation.
-	 * We chose this approach so that we don't have to decapsulate the
-	 * packet to check if the packet's original destination is allowed to
-	 * be sent unencrypted.
-	 */
-#if !defined(TUNNEL_MODE) && defined(ENCRYPTION_STRICT_MODE)
+#if defined(ENCRYPTION_STRICT_MODE)
 	if (!strict_allow(ctx))
 		return send_drop_notify_error(ctx, 0, DROP_UNENCRYPTED_TRAFFIC,
 					      CTX_ACT_DROP, METRIC_EGRESS);
-#endif /* !TUNNEL_MODE && ENCRYPTION_STRICT_MODE */
+#endif /* ENCRYPTION_STRICT_MODE */
 #endif /* ENABLE_WIREGUARD */
 
 #ifdef ENABLE_HEALTH_CHECK

--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -672,17 +672,6 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	__u32 cluster_id __maybe_unused = 0;
 	__s8 ext_err = 0;
 
-	/* When WireGuard strict mode is enabled, we have additional information
-	 * regarding to which CIDRs packets must encrypted. We have to check the
-	 * packets against the CIDRs before encapsulation. If the packet is not
-	 * encrypted, we drop it.
-	 */
-	#if defined(TUNNEL_MODE) && defined(ENCRYPTION_STRICT_MODE)
-	if (!strict_allow(ctx))
-		return send_drop_notify_error(ctx, 0, DROP_UNENCRYPTED_TRAFFIC,
-					      CTX_ACT_DROP, METRIC_EGRESS);
-	#endif
-
 #ifdef ENABLE_BANDWIDTH_MANAGER
 	/* In tunneling mode, we should do this as close as possible to the
 	 * phys dev where FQ runs, but the issue is that the aggregate state

--- a/bpf/lib/encap.h
+++ b/bpf/lib/encap.h
@@ -52,21 +52,6 @@ __encap_and_redirect_with_nodeid(struct __ctx_buff *ctx, __u32 src_ip __maybe_un
 	int ifindex;
 	int ret = 0;
 
-#if defined(ENABLE_WIREGUARD) && __ctx_is == __ctx_skb
-	/* Redirect the packet to the WireGuard tunnel device for encryption
-	 * if needed.
-	 *
-	 * A packet which previously was a subject to VXLAN/Geneve
-	 * encapsulation (e.g., pod2pod) is going to be encapsulated only once,
-	 * i.e., by the WireGuard tunnel netdev. This is so just to be
-	 * compatible with < the v1.13 behavior in which the pod2pod bypassed
-	 * VXLAN/Geneve encapsulation when the WG feature was on.
-	 */
-	ret = wg_maybe_redirect_to_encrypt(ctx);
-	if (IS_ERR(ret) || ret == CTX_ACT_REDIRECT)
-		return ret;
-#endif /* defined(ENABLE_WIREGUARD) && __ctx_is == __ctx_skb */
-
 	ret = __encap_with_nodeid(ctx, src_ip, 0, tunnel_endpoint, seclabel, dstid,
 				  vni, trace->reason, trace->monitor,
 				  &ifindex);

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -22,6 +22,7 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	__u16 proto = 0;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
+	bool from_tunnel __maybe_unused = false;
 
 	if (!validate_ethertype(ctx, &proto))
 		return DROP_UNSUPPORTED_L2;
@@ -60,6 +61,31 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	case bpf_htons(ETH_P_IP):
 		if (!revalidate_data(ctx, &data, &data_end, &ip4))
 			return DROP_INVALID;
+# if defined(TUNNEL_MODE)
+		/* A rudimentary check (inspired by is_enap()) whether a pkt
+		 * is coming from tunnel device. In tunneling mode WG needs to
+		 * encrypt such pkts, so that src sec ID can be transferred.
+		 *
+		 * This also handles IPv6, as IPv6 pkts are encapsulated w/
+		 * IPv4 tunneling.
+		 */
+		if (ip4->protocol == IPPROTO_UDP) {
+			int l4_off = ETH_HLEN + ipv4_hdrlen(ip4);
+			__be16 dport;
+
+			if (l4_load_port(ctx, l4_off + UDP_DPORT_OFF, &dport) < 0) {
+				/* IP fragmentation is not expected after the
+				 * encap. So this is non-Cilium's pkt.
+				 */
+				break;
+			}
+
+			if (dport == bpf_htons(TUNNEL_PORT)) {
+				from_tunnel = true;
+				break;
+			}
+		}
+# endif /* TUNNEL_MODE */
 		dst = lookup_ip4_remote_endpoint(ip4->daddr, 0);
 		src = lookup_ip4_remote_endpoint(ip4->saddr, 0);
 		break;
@@ -80,6 +106,11 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	 */
 	if ((ctx->mark & MARK_MAGIC_WG_ENCRYPTED) == MARK_MAGIC_WG_ENCRYPTED)
 		goto out;
+
+#if defined(TUNNEL_MODE)
+	if (from_tunnel)
+		goto encrypt;
+#endif /* TUNNEL_MODE */
 
 	/* Unless node encryption is enabled, we don't want to encrypt
 	 * traffic from the hostns.
@@ -105,8 +136,10 @@ wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
 	/* Redirect to the WireGuard tunnel device if the encryption is
 	 * required.
 	 */
-	if (dst && dst->key)
+	if (dst && dst->key) {
+encrypt: __maybe_unused
 		return ctx_redirect(ctx, WG_IFINDEX, 0);
+	}
 
 out:
 	return CTX_ACT_OK;

--- a/pkg/wireguard/agent/agent_test.go
+++ b/pkg/wireguard/agent/agent_test.go
@@ -210,7 +210,7 @@ func (a *AgentSuite) TestAgent_PeerConfig_WithEncryptNode(c *C) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	wgAgent, ipCache := newTestAgent(ctx)
-	wgAgent.nodeToNodeEncryption = true
+	wgAgent.requireNodesInPeerList = true
 	defer ipCache.Shutdown()
 
 	ipCache.Upsert(pod1IPv4Str, k8s1NodeIPv4, 0, nil, ipcache.Identity{ID: 1, Source: source.Kubernetes})

--- a/test/k8s/datapath_configuration.go
+++ b/test/k8s/datapath_configuration.go
@@ -519,21 +519,6 @@ var _ = Describe("K8sDatapathConfig", func() {
 			checkNoLeakP2RemoteService(srcPod, dstPod, srcPodIP.String(), dsSvcIP.String(), true)
 		}
 
-		It("Pod-to-pod traffic is encrypted in tunneling mode with per-endpoint routes", func() {
-			deploymentManager.DeployCilium(map[string]string{
-				"tunnel":                 "vxlan",
-				"ipv6.enabled":           "false",
-				"endpointRoutes.enabled": "true",
-				"encryption.enabled":     "true",
-				"encryption.type":        "wireguard",
-				"l7Proxy":                "false",
-				"ipam.operator.clusterPoolIPv4PodCIDRList": "10.244.0.0/16",
-				"encryption.strictMode.enabled":            "true",
-				"encryption.strictMode.cidr":               "10.244.0.0/16",
-			}, DeployCiliumOptionsAndDNS)
-
-			testStrictWireguard("cilium_vxlan")
-		})
 		It("Pod-to-pod traffic is encrypted in native routing mode with per-endpoint routes", func() {
 			deploymentManager.DeployCilium(map[string]string{
 				"tunnel":                 "disabled",


### PR DESCRIPTION
Forward port of https://github.com/cilium/cilium/pull/28917 (minus the optional flag and the strict mode removal).

```release-note
When tunneling is enabled, a packet will be encapsulated by Cilium's tunnel netdev before encrypting with WireGuard.
```