### PR TITLE
Prevent concurrent operator execution by removing leases discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ generate-cov: ## Generate HTML coverage report at coverage-all.html.
 integration-tests: start-kvstores ## Run Go tests including ones that are marked as integration tests.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C test/bpf/
 	@$(ECHO_CHECK) running integration tests...
-	INTEGRATION_TESTS=true $(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(TESTPKGS) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) | cat
+	INTEGRATION_TESTS=true $(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(TESTPKGS) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) | $(GOTEST_FORMATTER)
 	$(MAKE) generate-cov
 	$(MAKE) stop-kvstores
 

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ generate-cov: ## Generate HTML coverage report at coverage-all.html.
 integration-tests: start-kvstores ## Run Go tests including ones that are marked as integration tests.
 	$(QUIET) $(MAKE) $(SUBMAKEOPTS) -C test/bpf/
 	@$(ECHO_CHECK) running integration tests...
-	INTEGRATION_TESTS=true $(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(TESTPKGS) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) | $(GOTEST_FORMATTER)
+	INTEGRATION_TESTS=true $(GO_TEST) $(TEST_UNITTEST_LDFLAGS) $(TESTPKGS) $(GOTEST_BASE) $(GOTEST_COVER_OPTS) | cat
 	$(MAKE) generate-cov
 	$(MAKE) stop-kvstores
 

--- a/Makefile.defs
+++ b/Makefile.defs
@@ -85,14 +85,7 @@ GOTEST_COVER_OPTS =
 # By default, just print go test output immediately to the terminal. If tparse
 # is installed, use it to format the output. Use -progress instead of -follow,
 # as the latter is too verbose for most of the test suite.
-GOTEST_FORMATTER ?= cat
-ifneq ($(shell command -v tparse),)
-	GOTEST_COVER_OPTS += -json
-	GOTEST_FORMATTER = tparse
-ifneq ($(V),0)
-	GOTEST_FORMATTER += -progress
-endif
-endif
+GOTEST_FORMATTER := cat
 
 # renovate: datasource=docker depName=golangci/golangci-lint
 GOLANGCILINT_WANT_VERSION = v1.55.2

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -372,18 +372,15 @@ func runOperator(lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner 
 		ns = metav1.NamespaceDefault
 	}
 
-	leResourceLock, err := resourcelock.NewFromKubeconfig(
-		resourcelock.LeasesResourceLock,
-		ns,
-		leaderElectionResourceLockName,
-		resourcelock.ResourceLockConfig{
-			// Identity name of the lock holder
+	leResourceLock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      leaderElectionResourceLockName,
+			Namespace: ns,
+		},
+		Client: clientset.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
 			Identity: operatorID,
 		},
-		clientset.RestConfig(),
-		operatorOption.Config.LeaderElectionRenewDeadline)
-	if err != nil {
-		log.WithError(err).Fatal("Failed to create resource lock for leader election")
 	}
 
 	// Start the leader election for running cilium-operators

--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -357,18 +357,6 @@ func runOperator(lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner 
 		}
 	}
 
-	// We only support Operator in HA mode for Kubernetes Versions having support for
-	// LeasesResourceLock.
-	// See docs on capabilities.LeasesResourceLock for more context.
-	if !k8sversion.Capabilities().LeasesResourceLock {
-		log.Info("Support for coordination.k8s.io/v1 not present, fallback to non HA mode")
-
-		if err := lc.Start(leaderElectionCtx); err != nil {
-			log.WithError(err).Fatal("Failed to start leading")
-		}
-		return
-	}
-
 	// Get hostname for identity name of the lease lock holder.
 	// We identify the leader of the operator cluster using hostname.
 	operatorID, err := os.Hostname()

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -497,15 +497,11 @@ const (
 	// traffic will be encapsulated to carry security identities.
 	EnableHighScaleIPcache = false
 
-	// K8sEnableLeasesFallbackDiscovery enables k8s to fallback to API probing to check
-	// for the support of Leases in Kubernetes when there is an error in discovering
-	// API groups using Discovery API.
-	K8sEnableLeasesFallbackDiscovery = false
-
 	// KubeProxyReplacementHealthzBindAddr is the default kubeproxyReplacement healthz server bind addr
 	KubeProxyReplacementHealthzBindAddr = ""
 
-	// InstallNoConntrackRules instructs Cilium to install Iptables rules to skip netfilter connection tracking on all pod traffic.
+	// InstallNoConntrackIptRules instructs Cilium to install Iptables rules to skip
+	// netfilter connection tracking on all pod traffic.
 	InstallNoConntrackIptRules = false
 
 	// WireguardSubnetV4 is a default WireGuard tunnel subnet

--- a/pkg/k8s/version/version.go
+++ b/pkg/k8s/version/version.go
@@ -36,14 +36,6 @@ type ServerCapabilities struct {
 	// EndpointSliceV1 is the ability of k8s server to support endpoint slices
 	// v1. This version was introduced in K8s v1.21.0.
 	EndpointSliceV1 bool
-
-	// LeasesResourceLock is the ability of K8s server to support Lease type
-	// from coordination.k8s.io/v1 API for leader election purposes(currently only in operator).
-	// https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#lease-v1-coordination-k8s-io
-	//
-	// This capability was introduced in K8s version 1.14, prior to which
-	// we don't support HA mode for the cilium-operator.
-	LeasesResourceLock bool
 }
 
 type cachedVersion struct {
@@ -63,9 +55,7 @@ var (
 
 	discoveryAPIGroupV1beta1 = "discovery.k8s.io/v1beta1"
 	discoveryAPIGroupV1      = "discovery.k8s.io/v1"
-	coordinationV1APIGroup   = "coordination.k8s.io/v1"
 	endpointSliceKind        = "EndpointSlice"
-	leaseKind                = "Lease"
 
 	// Constraint to check support for discovery/v1 types. Support for v1
 	// discovery was introduced in K8s version 1.21.
@@ -96,12 +86,6 @@ func Capabilities() ServerCapabilities {
 	return c
 }
 
-func DisableLeasesResourceLock() {
-	cached.mutex.Lock()
-	defer cached.mutex.Unlock()
-	cached.capabilities.LeasesResourceLock = false
-}
-
 func updateVersion(version semver.Version) {
 	cached.mutex.Lock()
 	defer cached.mutex.Unlock()
@@ -119,7 +103,6 @@ func updateServerGroupsAndResources(apiResourceLists []*metav1.APIResourceList) 
 
 	cached.capabilities.EndpointSlice = false
 	cached.capabilities.EndpointSliceV1 = false
-	cached.capabilities.LeasesResourceLock = false
 	for _, rscList := range apiResourceLists {
 		if rscList.GroupVersion == discoveryAPIGroupV1beta1 {
 			for _, rsc := range rscList.APIResources {
@@ -134,15 +117,6 @@ func updateServerGroupsAndResources(apiResourceLists []*metav1.APIResourceList) 
 				if rsc.Kind == endpointSliceKind {
 					cached.capabilities.EndpointSlice = true
 					cached.capabilities.EndpointSliceV1 = true
-					break
-				}
-			}
-		}
-
-		if rscList.GroupVersion == coordinationV1APIGroup {
-			for _, rsc := range rscList.APIResources {
-				if rsc.Kind == leaseKind {
-					cached.capabilities.LeasesResourceLock = true
 					break
 				}
 			}
@@ -199,39 +173,6 @@ func endpointSlicesFallbackDiscovery(client kubernetes.Interface) error {
 	return fmt.Errorf("unable to validate EndpointSlices support: %s", err)
 }
 
-func leasesFallbackDiscovery(client kubernetes.Interface, apiDiscoveryEnabled bool) error {
-	// apiDiscoveryEnabled is used to fallback leases discovery to directly
-	// probing the API when we cannot discover API groups.
-	// We require to check for Leases capabilities in operator only, which uses Leases
-	// for leader election purposes in HA mode.
-	if !apiDiscoveryEnabled {
-		log.Debugf("Skipping Leases support fallback discovery")
-		return nil
-	}
-
-	// Similar to endpointSlicesFallbackDiscovery here we fallback to probing the Kubernetes
-	// API directly. `kube-controller-manager` creates a lease in the kube-system namespace
-	// and here we try and see if that Lease exists.
-	_, err := client.CoordinationV1().Leases("kube-system").Get(context.TODO(), "kube-controller-manager", metav1.GetOptions{})
-	if err == nil {
-		cached.mutex.Lock()
-		cached.capabilities.LeasesResourceLock = true
-		cached.mutex.Unlock()
-		return nil
-	}
-
-	if errors.IsNotFound(err) {
-		log.WithError(err).Info("Unable to retrieve Leases for kube-controller-manager. Disabling LeasesResourceLock")
-		// StatusNotFound is a safe error, Leases are
-		// disabled and the agent can continue
-		return nil
-	}
-
-	// Unknown error, we can't derive whether to enable or disable
-	// LeasesResourceLock and need to error out
-	return fmt.Errorf("unable to validate LeasesResourceLock support: %s", err)
-}
-
 func updateK8sServerVersion(client kubernetes.Interface) error {
 	var ver semver.Version
 
@@ -271,39 +212,36 @@ func updateK8sServerVersion(client kubernetes.Interface) error {
 func Update(client kubernetes.Interface, apiDiscoveryEnabled bool) error {
 	err := updateK8sServerVersion(client)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to update Kubernetes server version: %w", err)
 	}
 
-	if apiDiscoveryEnabled {
-		// Discovery of API groups requires the API services of the
-		// apiserver to be healthy. Such API services can depend on the
-		// readiness of regular pods which require Cilium to function
-		// correctly. By treating failure to discover API groups as
-		// fatal, a critical loop can be entered in which Cilium cannot
-		// start because the API groups can't be discovered and th API
-		// groups will only become discoverable once Cilium is up.
-		_, apiResourceLists, err := client.Discovery().ServerGroupsAndResources()
-		if err != nil {
-			// It doesn't make sense to retry the retrieval of this
-			// information at a later point because the capabilities are
-			// primiarly used while the agent is starting up. Instead, fall
-			// back to probing API endpoints directly.
-			log.WithError(err).Warning("Unable to discover API groups and resources")
-			if err := endpointSlicesFallbackDiscovery(client); err != nil {
-				return err
-			}
-
-			return leasesFallbackDiscovery(client, apiDiscoveryEnabled)
-		}
-
-		updateServerGroupsAndResources(apiResourceLists)
-	} else {
+	if !apiDiscoveryEnabled {
 		if err := endpointSlicesFallbackDiscovery(client); err != nil {
-			return err
+			return fmt.Errorf("failed to fallback-discover endpoint slices: %w", err)
 		}
-
-		return leasesFallbackDiscovery(client, apiDiscoveryEnabled)
+		return nil
 	}
 
+	// Discovery of API groups requires the API services of the
+	// apiserver to be healthy. Such API services can depend on the
+	// readiness of regular pods which require Cilium to function
+	// correctly. By treating failure to discover API groups as
+	// fatal, a critical loop can be entered in which Cilium cannot
+	// start because the API groups can't be discovered and the API
+	// groups will only become discoverable once Cilium is up.
+	_, apiResourceLists, err := client.Discovery().ServerGroupsAndResources()
+	if err != nil {
+		// It doesn't make sense to retry the retrieval of this
+		// information at a later point because the capabilities are
+		// primarily used while the agent is starting up. Instead, fall
+		// back to probing API endpoints directly.
+		log.WithError(err).Warning("Unable to discover API groups and resources")
+		if err := endpointSlicesFallbackDiscovery(client); err != nil {
+			return fmt.Errorf("failed to fallback-discover endpoint slices after API groups discovery failure: %w", err)
+		}
+		return nil
+	}
+
+	updateServerGroupsAndResources(apiResourceLists)
 	return nil
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -2289,14 +2289,6 @@ type DaemonConfig struct {
 	// map.
 	SizeofSockRevElement int
 
-	// k8sEnableLeasesFallbackDiscovery enables k8s to fallback to API probing to check
-	// for the support of Leases in Kubernetes when there is an error in discovering
-	// API groups using Discovery API.
-	// We require to check for Leases capabilities in operator only, which uses Leases for leader
-	// election purposes in HA mode.
-	// This is only enabled for cilium-operator
-	K8sEnableLeasesFallbackDiscovery bool
-
 	// LBMapEntries is the maximum number of entries allowed in BPF lbmap.
 	LBMapEntries int
 
@@ -2482,8 +2474,6 @@ var (
 		AllocatorListTimeout:            defaults.AllocatorListTimeout,
 		EnableICMPRules:                 defaults.EnableICMPRules,
 		UseCiliumInternalIPForIPsec:     defaults.UseCiliumInternalIPForIPsec,
-
-		K8sEnableLeasesFallbackDiscovery: defaults.K8sEnableLeasesFallbackDiscovery,
 
 		ExternalClusterIP:      defaults.ExternalClusterIP,
 		EnableVTEP:             defaults.EnableVTEP,

--- a/test/controlplane/suite/testcase.go
+++ b/test/controlplane/suite/testcase.go
@@ -161,11 +161,6 @@ func (cpt *ControlPlaneTest) StartOperator(
 
 	h.Viper().Set(apis.SkipCRDCreation, true)
 
-	// Disable support for operator HA. This should be cleaned up
-	// by injecting the capabilities, or by supporting the leader
-	// election machinery in the controlplane tests.
-	version.DisableLeasesResourceLock()
-
 	err := startCiliumOperator(h)
 	if err != nil {
 		cpt.t.Fatalf("Failed to start operator: %s", err)


### PR DESCRIPTION
With Cilium's minimum supported Kubernetes version being 1.19 and support for leases in Kubernetes having been around since 1.14, we can drop the discovery logic to check for the availability of leases. Instead, we will assume that the capability always exists.

The assumption helps with enforcing HA mode in cilium-operator at times when the API server is temporarily unavailable, preventing the case where multiple HA operator may run in leader mode concurrently (and break networking) due to the existing fallback logic that is now removed.

Fixes: #17870

Continuation of #18122

/cc @aanm @christarazi 

```release-note
Remove Kubernetes leases discovery to enforce HA mode in cilium-operator when the API server is unavailable
```
