### PR TITLE
CODEOWNERS: IPsec owns `pkg/common/ipsec`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -398,6 +398,7 @@ Makefile* @cilium/build
 /pkg/client @cilium/api
 /pkg/clustermesh @cilium/sig-clustermesh
 /pkg/command/ @cilium/cli
+/pkg/common/ipsec/ @cilium/ipsec
 /pkg/completion/ @cilium/proxy
 /pkg/components/ @cilium/sig-agent
 /pkg/contexthelpers/ @cilium/kvstore


### PR DESCRIPTION
This directory was introduced in commit 2218611873de ("cmd, common: Move countUniqueIPsecKeys to common/ipsec pkg"), but the CODEOWNERS were not updated.

Fixes: 2218611873de ("cmd, common: Move countUniqueIPsecKeys to common/ipsec pkg")