### PR TITLE
ci: add K8s 1.28 platform testing

### DIFF
--- a/.github/actions/aws/k8s-versions.yaml
+++ b/.github/actions/aws/k8s-versions.yaml
@@ -4,11 +4,13 @@ include:
   - version: "1.23"
     region: eu-central-1
   - version: "1.24"
-    region: ap-northeast-1
+    region: eu-central-1
   - version: "1.25"
-    region: us-east-2
+    region: ap-northeast-1
   - version: "1.26"
-    region: ca-central-1
+    region: us-east-2
   - version: "1.27"
+    region: ca-central-1
+  - version: "1.28"
     region: eu-north-1
     default: true

--- a/.github/actions/azure/k8s-versions.yaml
+++ b/.github/actions/azure/k8s-versions.yaml
@@ -10,4 +10,7 @@ include:
   - version: "1.27"
     location: eastasia
     index: 3
+  - version: "1.28"
+    location: eastus
+    index: 4
     default: true

--- a/.github/actions/gke/k8s-versions.yaml
+++ b/.github/actions/gke/k8s-versions.yaml
@@ -2,15 +2,18 @@
 ---
 k8s:
   - version: "1.24"
-    zone: us-west2-a
+    zone: europe-west6-b
     vmIndex: 1
   - version: "1.25"
-    zone: asia-northeast1-c
+    zone: us-west2-a
     vmIndex: 2
   - version: "1.26"
-    zone: europe-north1-b
+    zone: asia-northeast1-c
     vmIndex: 3
   - version: "1.27"
-    zone: us-east5-a
+    zone: europe-north1-b
     vmIndex: 4
+  - version: "1.28"
+    zone: us-east5-a
+    vmIndex: 5
     default: true


### PR DESCRIPTION
Cilium itself officially supports K8s 1.28 since
6a70af21c3b6985096fca3f8240139b548ac4760, however platforms did not have a compatible 1.28 version available for managed clusters until recently.