### PR TITLE
[v1.12] Use pull_request_target in Update Backport Label workflow

### DIFF
--- a/.github/workflows/call-backport-label-updater.yaml
+++ b/.github/workflows/call-backport-label-updater.yaml
@@ -1,7 +1,7 @@
 ---
     name: Call Backport Label Updater
     on:
-      pull_request:
+      pull_request_target:
         types:
           - closed
         branches:


### PR DESCRIPTION
When the workflow is triggered from a PR opened in a fork, it fails (see [here](https://github.com/cilium/cilium/actions/workflows/call-backport-label-updater.yaml?query=is%3Afailure)) with the following message:

`GraphQL: Resource not accessible by integration (removeLabelsFromLabelable)`

To fix this, we need to run the workflow in the context of the pull request base, so the commit changes the event to be `pull_request_target` instead of `pull_request`.

Suggested by @aanm
