### PR TITLE
gateway-api: improve secret sync resiliency

### DIFF
--- a/operator/pkg/gateway-api/controller.go
+++ b/operator/pkg/gateway-api/controller.go
@@ -52,7 +52,7 @@ func hasMatchingController(ctx context.Context, c client.Client, controllerName 
 	}
 }
 
-func getGatewaysForSecret(ctx context.Context, c client.Client, obj client.Object) []types.NamespacedName {
+func getGatewaysForSecret(ctx context.Context, c client.Client, obj client.Object) []*gatewayv1.Gateway {
 	scopedLog := log.WithFields(logrus.Fields{
 		logfields.Controller: gateway,
 		logfields.Resource:   obj.GetName(),
@@ -64,8 +64,9 @@ func getGatewaysForSecret(ctx context.Context, c client.Client, obj client.Objec
 		return nil
 	}
 
-	var gateways []types.NamespacedName
+	var gateways []*gatewayv1.Gateway
 	for _, gw := range gwList.Items {
+		gwCopy := gw
 		for _, l := range gw.Spec.Listeners {
 			if l.TLS == nil {
 				continue
@@ -76,12 +77,8 @@ func getGatewaysForSecret(ctx context.Context, c client.Client, obj client.Objec
 					continue
 				}
 				ns := helpers.NamespaceDerefOr(cert.Namespace, gw.GetNamespace())
-				if string(cert.Name) == obj.GetName() &&
-					ns == obj.GetNamespace() {
-					gateways = append(gateways, client.ObjectKey{
-						Namespace: ns,
-						Name:      gw.GetName(),
-					})
+				if string(cert.Name) == obj.GetName() && ns == obj.GetNamespace() {
+					gateways = append(gateways, &gwCopy)
 				}
 			}
 		}

--- a/operator/pkg/gateway-api/controller_test.go
+++ b/operator/pkg/gateway-api/controller_test.go
@@ -89,6 +89,26 @@ var controllerTestFixture = []client.Object{
 		},
 	},
 
+	&gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "valid-gateway-2",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Hostname: model.AddressOf[gatewayv1.Hostname]("example2.com"),
+					Port:     443,
+					TLS: &gatewayv1.GatewayTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{},
+					},
+				},
+			},
+		},
+	},
+
 	// Gateway with no TLS listener
 	&gatewayv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/pkg/gateway-api/gateway.go
+++ b/operator/pkg/gateway-api/gateway.go
@@ -245,7 +245,10 @@ func (r *gatewayReconciler) enqueueRequestForTLSSecret() handler.EventHandler {
 		reqs := make([]reconcile.Request, 0, len(gateways))
 		for _, gw := range gateways {
 			reqs = append(reqs, reconcile.Request{
-				NamespacedName: gw,
+				NamespacedName: types.NamespacedName{
+					Namespace: gw.GetNamespace(),
+					Name:      gw.GetName(),
+				},
 			})
 		}
 		return reqs

--- a/operator/pkg/gateway-api/secret.go
+++ b/operator/pkg/gateway-api/secret.go
@@ -49,15 +49,11 @@ func newSecretSyncReconciler(mgr ctrl.Manager, secretsNamespace string) *secretS
 func (r *secretSyncer) SetupWithManager(mgr ctrl.Manager) error {
 	hasMatchingControllerFn := hasMatchingController(context.Background(), r.Client, r.controllerName)
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Secret{}, builder.WithPredicates(predicate.NewPredicateFuncs(r.usedInGateway))).
+		For(&corev1.Secret{}).
 		Watches(&gatewayv1.Gateway{},
 			r.enqueueRequestForGatewayTLS(),
 			builder.WithPredicates(predicate.NewPredicateFuncs(hasMatchingControllerFn))).
 		Complete(r)
-}
-
-func (r *secretSyncer) usedInGateway(obj client.Object) bool {
-	return getGatewaysForSecret(context.Background(), r.Client, obj) != nil
 }
 
 func (r *secretSyncer) enqueueRequestForGatewayTLS() handler.EventHandler {

--- a/operator/pkg/gateway-api/secret.go
+++ b/operator/pkg/gateway-api/secret.go
@@ -30,18 +30,18 @@ const (
 
 // secretSyncer syncs Gateway API secrets to dedicated namespace.
 type secretSyncer struct {
-	client.Client
-	Scheme *runtime.Scheme
+	client client.Client
+	scheme *runtime.Scheme
 
-	SecretsNamespace string
+	secretsNamespace string
 	controllerName   string
 }
 
 func newSecretSyncReconciler(mgr ctrl.Manager, secretsNamespace string) *secretSyncer {
 	return &secretSyncer{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		SecretsNamespace: secretsNamespace,
+		client:           mgr.GetClient(),
+		scheme:           mgr.GetScheme(),
+		secretsNamespace: secretsNamespace,
 		controllerName:   controllerName,
 	}
 }
@@ -60,7 +60,7 @@ func (r *secretSyncer) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *secretSyncer) notInSecretsNamespace() builder.Predicates {
 	return builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
-		return object.GetNamespace() != r.SecretsNamespace
+		return object.GetNamespace() != r.secretsNamespace
 	}))
 }
 
@@ -77,7 +77,7 @@ func (r *secretSyncer) enqueueTLSSecrets() handler.EventHandler {
 		}
 
 		// Check whether Gateway is managed by Cilium
-		if !hasMatchingController(ctx, r.Client, r.controllerName)(gw) {
+		if !hasMatchingController(ctx, r.client, r.controllerName)(gw) {
 			return nil
 		}
 
@@ -130,7 +130,7 @@ func enqueueOwningSecretFromLabels() handler.EventHandler {
 
 func (r *secretSyncer) deletedOrChangedInSecretsNamespace() builder.Predicates {
 	return builder.WithPredicates(&deletedOrChangedInSecretsNamespaceStruct{
-		secretsNamespace: r.SecretsNamespace,
+		secretsNamespace: r.secretsNamespace,
 	})
 }
 

--- a/operator/pkg/gateway-api/secret.go
+++ b/operator/pkg/gateway-api/secret.go
@@ -13,6 +13,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -49,7 +50,10 @@ func newSecretSyncReconciler(mgr ctrl.Manager, secretsNamespace string) *secretS
 func (r *secretSyncer) SetupWithManager(mgr ctrl.Manager) error {
 	hasMatchingControllerFn := hasMatchingController(context.Background(), r.Client, r.controllerName)
 	return ctrl.NewControllerManagedBy(mgr).
+		// Source Secrets outside of the secrets namespace
 		For(&corev1.Secret{}, r.notInSecretsNamespace()).
+		// Synced Secrets in the secrets namespace
+		Watches(&corev1.Secret{}, enqueueOwningSecretFromLabels(), r.deletedOrChangedInSecretsNamespace()).
 		Watches(&gatewayv1.Gateway{}, r.enqueueRequestForGatewayTLS(), builder.WithPredicates(predicate.NewPredicateFuncs(hasMatchingControllerFn))).
 		Complete(r)
 }
@@ -91,4 +95,58 @@ func (r *secretSyncer) enqueueRequestForGatewayTLS() handler.EventHandler {
 		}
 		return reqs
 	})
+}
+
+func enqueueOwningSecretFromLabels() handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(_ context.Context, o client.Object) []reconcile.Request {
+		labels := o.GetLabels()
+
+		if labels == nil {
+			return nil
+		}
+
+		owningSecretNamespace, owningSecretNamespacePresent := labels[owningSecretNamespace]
+		owningSecretName, owningSecretNamePresent := labels[owningSecretName]
+
+		if !owningSecretNamespacePresent || !owningSecretNamePresent {
+			return nil
+		}
+
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: owningSecretNamespace,
+					Name:      owningSecretName,
+				},
+			},
+		}
+	})
+}
+
+func (r *secretSyncer) deletedOrChangedInSecretsNamespace() builder.Predicates {
+	return builder.WithPredicates(&deletedOrChangedInSecretsNamespaceStruct{
+		secretsNamespace: r.SecretsNamespace,
+	})
+}
+
+var _ predicate.Predicate = &deletedOrChangedInSecretsNamespaceStruct{}
+
+type deletedOrChangedInSecretsNamespaceStruct struct {
+	secretsNamespace string
+}
+
+func (r *deletedOrChangedInSecretsNamespaceStruct) Create(event.CreateEvent) bool {
+	return false
+}
+
+func (r *deletedOrChangedInSecretsNamespaceStruct) Update(event event.UpdateEvent) bool {
+	return event.ObjectOld.GetNamespace() == r.secretsNamespace
+}
+
+func (r *deletedOrChangedInSecretsNamespaceStruct) Delete(event event.DeleteEvent) bool {
+	return event.Object.GetNamespace() == r.secretsNamespace
+}
+
+func (r *deletedOrChangedInSecretsNamespaceStruct) Generic(event.GenericEvent) bool {
+	return false
 }

--- a/operator/pkg/gateway-api/secret_reconcile.go
+++ b/operator/pkg/gateway-api/secret_reconcile.go
@@ -28,7 +28,7 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	scopedLog.Info("Syncing secrets")
 
 	original := &corev1.Secret{}
-	if err := r.Client.Get(ctx, req.NamespacedName, original); err != nil {
+	if err := r.client.Get(ctx, req.NamespacedName, original); err != nil {
 		if k8serrors.IsNotFound(err) {
 			// there is nothing to copy, the related gateway is not accepted anyway.
 			// if later the secret is created, the gateway will be reconciled again,
@@ -40,7 +40,7 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 	}
 
 	c := &corev1.Secret{}
-	c.SetNamespace(r.SecretsNamespace)
+	c.SetNamespace(r.secretsNamespace)
 	c.SetName(original.Namespace + "-" + original.Name)
 	c.SetAnnotations(original.GetAnnotations())
 	c.SetLabels(original.GetLabels())
@@ -65,10 +65,10 @@ func (r *secretSyncer) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 
 func (r *secretSyncer) ensureSecret(ctx context.Context, desired *corev1.Secret) error {
 	existing := &corev1.Secret{}
-	err := r.Client.Get(ctx, client.ObjectKeyFromObject(desired), existing)
+	err := r.client.Get(ctx, client.ObjectKeyFromObject(desired), existing)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
-			return r.Client.Create(ctx, desired)
+			return r.client.Create(ctx, desired)
 		}
 		return err
 	}
@@ -81,5 +81,5 @@ func (r *secretSyncer) ensureSecret(ctx context.Context, desired *corev1.Secret)
 	temp.StringData = desired.StringData
 	temp.Type = desired.Type
 
-	return r.Client.Patch(ctx, temp, client.MergeFrom(existing))
+	return r.client.Patch(ctx, temp, client.MergeFrom(existing))
 }

--- a/operator/pkg/gateway-api/secret_reconcile_test.go
+++ b/operator/pkg/gateway-api/secret_reconcile_test.go
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package gateway_api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/cilium/cilium/operator/pkg/model"
+)
+
+var secretsNamespace = "cilium-secrets-test"
+
+var secretFixture = []client.Object{
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretsNamespace,
+			Name:      "test-synced-secret-no-source",
+			Labels: map[string]string{
+				owningSecretNamespace: "test",
+				owningSecretName:      "synced-secret-no-source",
+			},
+		},
+	},
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "synced-secret-no-reference",
+		},
+	},
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretsNamespace,
+			Name:      "test-synced-secret-no-reference",
+			Labels: map[string]string{
+				owningSecretNamespace: "test",
+				owningSecretName:      "syced-secret-no-reference",
+			},
+		},
+	},
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "synced-secret-with-source-and-ref",
+		},
+	},
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: secretsNamespace,
+			Name:      "test-synced-secret-with-source-and-ref",
+			Labels: map[string]string{
+				owningSecretNamespace: "test",
+				owningSecretName:      "synced-secret-with-source-and-ref",
+			},
+		},
+	},
+	&gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cilium",
+		},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "io.cilium/gateway-controller",
+		},
+	},
+	&gatewayv1.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Gateway",
+			APIVersion: gatewayv1.GroupName,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "valid-gateway",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "cilium",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Port:     443,
+					Hostname: model.AddressOf[gatewayv1.Hostname]("*.cilium.io"),
+					Protocol: "HTTPS",
+					TLS: &gatewayv1.GatewayTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{
+								Name: "synced-secret-with-source-and-ref",
+							},
+							{
+								Name: "secret-with-ref-not-synced",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+	&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "secret-with-ref-not-synced",
+		},
+	},
+	&gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "third-party",
+		},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "third-party",
+		},
+	},
+	&gatewayv1.Gateway{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Gateway",
+			APIVersion: gatewayv1.GroupName,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test",
+			Name:      "valid-gateway-non-cilium",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "third-party",
+			Listeners: []gatewayv1.Listener{
+				{
+					Name:     "https",
+					Port:     443,
+					Hostname: model.AddressOf[gatewayv1.Hostname]("*.acme.io"),
+					Protocol: "HTTPS",
+					TLS: &gatewayv1.GatewayTLSConfig{
+						CertificateRefs: []gatewayv1.SecretObjectReference{
+							{
+								Name: "secret-with-non-cilium-ref",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func Test_SecretSync_Reconcile(t *testing.T) {
+	c := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(secretFixture...).
+		Build()
+	r := &secretSyncer{
+		client:           c,
+		secretsNamespace: secretsNamespace,
+		controllerName:   controllerName,
+	}
+
+	t.Run("delete synced secret if source secret doesn't exist", func(t *testing.T) {
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "synced-secret-no-source",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		secret := &corev1.Secret{}
+		err = r.client.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-no-source"}, secret)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "secrets \"test-synced-secret-no-source\" not found")
+	})
+
+	t.Run("delete synced secret if source secret isn't referenced by a CIlium Gateway resource", func(t *testing.T) {
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "synced-secret-no-reference",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		secret := &corev1.Secret{}
+		err = r.client.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-no-reference"}, secret)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "secrets \"test-synced-secret-no-reference\" not found")
+	})
+
+	t.Run("keep synced secret if source secret exists and is referenced by a Gateway resource", func(t *testing.T) {
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "synced-secret-with-source-and-ref",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		secret := &corev1.Secret{}
+		err = r.client.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-with-source-and-ref"}, secret)
+		require.NoError(t, err)
+	})
+
+	t.Run("don't create synced secret for source secret that is referenced by a non Cilium Gateway resource", func(t *testing.T) {
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "secret-with-non-cilium-ref",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		secret := &corev1.Secret{}
+		err = r.client.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-synced-secret-non-cilium-ref"}, secret)
+
+		require.Error(t, err)
+		require.ErrorContains(t, err, "secrets \"test-synced-secret-non-cilium-ref\" not found")
+	})
+
+	t.Run("create synced secret for source secret that is referenced by a Cilium Gateway resource", func(t *testing.T) {
+		result, err := r.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "test",
+				Name:      "secret-with-ref-not-synced",
+			},
+		})
+		require.NoError(t, err)
+		require.Equal(t, ctrl.Result{}, result)
+
+		secret := &corev1.Secret{}
+		err = r.client.Get(context.Background(), types.NamespacedName{Namespace: secretsNamespace, Name: "test-secret-with-ref-not-synced"}, secret)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
This PR improves the resiliency of the Gateway API secret sync.

main changes:
* delete synced secret if source secret gets deleted
* delete synced secret if source secret is no longer referenced by a Cilium Gateway
* trigger reconcile when the synced secret gets deleted or updated

Please review the individual commits.

This is a preparation to re-use the secret synchronization for Cilium Ingress (#28911)