### PR TITLE
envoy: Better track updates when qualifying Envoy resource names

### DIFF
--- a/examples/kubernetes/servicemesh/envoy/envoy-admin-listener.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-admin-listener.yaml
@@ -26,7 +26,7 @@ spec:
               - match:
                   prefix: "/"
                 route:
-                  cluster: "envoy-admin"
+                  cluster: "/envoy-admin"
           use_remote_address: true
           skip_xff_append: true
           http_filters:

--- a/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
+++ b/examples/kubernetes/servicemesh/envoy/envoy-prometheus-metrics-listener.yaml
@@ -34,5 +34,5 @@ spec:
       - match:
           path: "/metrics"
         route:
-          cluster: "envoy-admin"
+          cluster: "/envoy-admin"
           prefix_rewrite: "/stats/prometheus"

--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
@@ -36,7 +36,7 @@
                               "prefix": "/metrics"
                             },
                             "route": {
-                              "cluster": "envoy-admin",
+                              "cluster": "/envoy-admin",
                               "prefix_rewrite": "/stats/prometheus"
                             }
                           }
@@ -102,7 +102,7 @@
                               "prefix": "/healthz"
                             },
                             "route": {
-                              "cluster": "envoy-admin",
+                              "cluster": "/envoy-admin",
                               "prefix_rewrite": "/ready"
                             }
                           }
@@ -245,11 +245,11 @@
         }
       },
       {
-        "name": "envoy-admin",
+        "name": "/envoy-admin",
         "type": "STATIC",
         "connectTimeout": "{{ .Values.envoy.connectTimeoutSeconds }}s",
         "loadAssignment": {
-          "clusterName": "envoy-admin",
+          "clusterName": "/envoy-admin",
           "endpoints": [
             {
               "lbEndpoints": [

--- a/pkg/envoy/ciliumenvoyconfig.go
+++ b/pkg/envoy/ciliumenvoyconfig.go
@@ -85,44 +85,61 @@ func qualifyTcpProxyResourceNames(namespace, name string, tcpProxy *envoy_config
 	switch c := tcpProxy.GetClusterSpecifier().(type) {
 	case *envoy_config_tcp.TcpProxy_Cluster:
 		if c != nil {
-			c.Cluster = api.ResourceQualifiedName(namespace, name, c.Cluster)
-			updated = true
+			c.Cluster, updated = api.ResourceQualifiedName(namespace, name, c.Cluster)
 		}
 	case *envoy_config_tcp.TcpProxy_WeightedClusters:
 		if c != nil {
 			for _, wc := range c.WeightedClusters.Clusters {
-				wc.Name = api.ResourceQualifiedName(namespace, name, wc.Name)
-				updated = true
+				var nameUpdated bool
+				wc.Name, nameUpdated = api.ResourceQualifiedName(namespace, name, wc.Name)
+				if nameUpdated {
+					updated = true
+				}
 			}
 		}
 	}
 	return updated
 }
 
-func qualifyRouteConfigurationResourceNames(namespace, name string, routeConfig *envoy_config_route.RouteConfiguration) {
+func qualifyRouteConfigurationResourceNames(namespace, name string, routeConfig *envoy_config_route.RouteConfiguration) (updated bool) {
 	// Strictly not a reference, and may be an empty string
-	routeConfig.Name = api.ResourceQualifiedName(namespace, name, routeConfig.Name, api.ForceNamespace)
+	routeConfig.Name, updated = api.ResourceQualifiedName(namespace, name, routeConfig.Name, api.ForceNamespace)
 
 	for _, vhost := range routeConfig.VirtualHosts {
-		vhost.Name = api.ResourceQualifiedName(namespace, name, vhost.Name, api.ForceNamespace)
+		var nameUpdated bool
+		vhost.Name, nameUpdated = api.ResourceQualifiedName(namespace, name, vhost.Name, api.ForceNamespace)
+		if nameUpdated {
+			updated = true
+		}
 		for _, rt := range vhost.Routes {
 			if action := rt.GetRoute(); action != nil {
 				if clusterName := action.GetCluster(); clusterName != "" {
-					action.GetClusterSpecifier().(*envoy_config_route.RouteAction_Cluster).Cluster = api.ResourceQualifiedName(namespace, name, clusterName)
+					action.GetClusterSpecifier().(*envoy_config_route.RouteAction_Cluster).Cluster, nameUpdated =
+						api.ResourceQualifiedName(namespace, name, clusterName)
+					if nameUpdated {
+						updated = true
+					}
 				}
 				for _, r := range action.GetRequestMirrorPolicies() {
 					if clusterName := r.GetCluster(); clusterName != "" {
-						r.Cluster = api.ResourceQualifiedName(namespace, name, clusterName)
+						r.Cluster, nameUpdated = api.ResourceQualifiedName(namespace, name, clusterName)
+						if nameUpdated {
+							updated = true
+						}
 					}
 				}
 				if weightedClusters := action.GetWeightedClusters(); weightedClusters != nil {
 					for _, cluster := range weightedClusters.GetClusters() {
-						cluster.Name = api.ResourceQualifiedName(namespace, name, cluster.Name)
+						cluster.Name, nameUpdated = api.ResourceQualifiedName(namespace, name, cluster.Name)
+						if nameUpdated {
+							updated = true
+						}
 					}
 				}
 			}
 		}
 	}
+	return updated
 }
 
 // ParseResources parses all supported Envoy resource types from CiliumEnvoyConfig CRD to Resources
@@ -210,8 +227,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 							// Since we are prepending CEC namespace and name to Routes name,
 							// we must do the same here to point to the correct Route resource.
 							if rds.RouteConfigName != "" {
-								rds.RouteConfigName = api.ResourceQualifiedName(cecNamespace, cecName, rds.RouteConfigName, api.ForceNamespace)
-								updated = true
+								rds.RouteConfigName, updated = api.ResourceQualifiedName(cecNamespace, cecName, rds.RouteConfigName, api.ForceNamespace)
 							}
 							if rds.ConfigSource == nil {
 								rds.ConfigSource = ciliumXDS
@@ -219,7 +235,9 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 							}
 						}
 						if routeConfig := hcmConfig.GetRouteConfig(); routeConfig != nil {
-							qualifyRouteConfigurationResourceNames(cecNamespace, cecName, routeConfig)
+							if qualifyRouteConfigurationResourceNames(cecNamespace, cecName, routeConfig) {
+								updated = true
+							}
 						}
 						if injectCiliumFilters {
 							foundCiliumL7Filter := false
@@ -279,7 +297,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 			}
 
 			name := listener.Name
-			listener.Name = api.ResourceQualifiedName(cecNamespace, cecName, listener.Name, api.ForceNamespace)
+			listener.Name, _ = api.ResourceQualifiedName(cecNamespace, cecName, listener.Name, api.ForceNamespace)
 
 			if validate {
 				if err := listener.Validate(); err != nil {
@@ -308,7 +326,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 			qualifyRouteConfigurationResourceNames(cecNamespace, cecName, route)
 
 			name := route.Name
-			route.Name = api.ResourceQualifiedName(cecNamespace, cecName, name, api.ForceNamespace)
+			route.Name, _ = api.ResourceQualifiedName(cecNamespace, cecName, name, api.ForceNamespace)
 
 			if validate {
 				if err := route.Validate(); err != nil {
@@ -347,11 +365,11 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 			}
 
 			if cluster.LoadAssignment != nil {
-				cluster.LoadAssignment.ClusterName = api.ResourceQualifiedName(cecNamespace, cecName, cluster.LoadAssignment.ClusterName)
+				cluster.LoadAssignment.ClusterName, _ = api.ResourceQualifiedName(cecNamespace, cecName, cluster.LoadAssignment.ClusterName)
 			}
 
 			name := cluster.Name
-			cluster.Name = api.ResourceQualifiedName(cecNamespace, cecName, name)
+			cluster.Name, _ = api.ResourceQualifiedName(cecNamespace, cecName, name)
 
 			if validate {
 				if err := cluster.Validate(); err != nil {
@@ -378,7 +396,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 			}
 
 			name := endpoints.ClusterName
-			endpoints.ClusterName = api.ResourceQualifiedName(cecNamespace, cecName, name)
+			endpoints.ClusterName, _ = api.ResourceQualifiedName(cecNamespace, cecName, name)
 
 			if validate {
 				if err := endpoints.Validate(); err != nil {
@@ -405,7 +423,7 @@ func ParseResources(cecNamespace string, cecName string, anySlice []cilium_v2.XD
 			}
 
 			name := secret.Name
-			secret.Name = api.ResourceQualifiedName(cecNamespace, cecName, name)
+			secret.Name, _ = api.ResourceQualifiedName(cecNamespace, cecName, name)
 
 			if validate {
 				if err := secret.Validate(); err != nil {
@@ -880,17 +898,15 @@ func getEndpointsForLBBackends(serviceName lb.ServiceName, backendMap map[string
 	return endpoints
 }
 
-func fillInTlsContextXDS(cecNamespace string, cecName string, tls *envoy_config_tls.CommonTlsContext) bool {
-	updated := false
-
+func fillInTlsContextXDS(cecNamespace string, cecName string, tls *envoy_config_tls.CommonTlsContext) (updated bool) {
 	qualify := func(sc *envoy_config_tls.SdsSecretConfig) {
 		if sc.SdsConfig == nil {
 			sc.SdsConfig = ciliumXDS
 			updated = true
 		}
-		name := sc.Name
-		sc.Name = api.ResourceQualifiedName(cecNamespace, cecName, sc.Name)
-		if sc.Name != name {
+		var nameUpdated bool
+		sc.Name, nameUpdated = api.ResourceQualifiedName(cecNamespace, cecName, sc.Name)
+		if nameUpdated {
 			updated = true
 		}
 	}

--- a/pkg/envoy/xds_server.go
+++ b/pkg/envoy/xds_server.go
@@ -67,7 +67,7 @@ var (
 const (
 	CiliumXDSClusterName = "xds-grpc-cilium"
 
-	adminClusterName      = "envoy-admin"
+	adminClusterName      = "/envoy-admin"
 	egressClusterName     = "egress-cluster"
 	egressTLSClusterName  = "egress-cluster-tls"
 	ingressClusterName    = "ingress-cluster"

--- a/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
+++ b/pkg/k8s/apis/cilium.io/v2/cec_types_test.go
@@ -36,7 +36,7 @@ var (
             - match:
                 path: "/metrics"
               route:
-                cluster: "envoy-admin"
+                cluster: "/envoy-admin"
                 prefix_rewrite: "/stats/prometheus"
         use_remote_address: true
         skip_xff_append: true

--- a/pkg/k8s/watchers/cilium_envoy_config.go
+++ b/pkg/k8s/watchers/cilium_envoy_config.go
@@ -167,7 +167,7 @@ func (k *K8sWatcher) addK8sServiceRedirects(resourceName loadbalancer.ServiceNam
 		svcListener := ""
 		if svc.Listener != "" {
 			// Listener names are qualified after parsing, so qualify the listener reference as well for it to match
-			svcListener = api.ResourceQualifiedName(resourceName.Namespace, resourceName.Name, svc.Listener, api.ForceNamespace)
+			svcListener, _ = api.ResourceQualifiedName(resourceName.Namespace, resourceName.Name, svc.Listener, api.ForceNamespace)
 		}
 		// Find the listener the service is to be redirected to
 		var proxyPort uint16

--- a/pkg/policy/api/utils.go
+++ b/pkg/policy/api/utils.go
@@ -146,7 +146,7 @@ const (
 	ForceNamespace Option = iota
 )
 
-func ResourceQualifiedName(namespace, cecName, resourceName string, options ...Option) string {
+func ResourceQualifiedName(namespace, cecName, resourceName string, options ...Option) (name string, updated bool) {
 	forceNamespace := false
 	for _, option := range options {
 		switch option {
@@ -157,7 +157,7 @@ func ResourceQualifiedName(namespace, cecName, resourceName string, options ...O
 
 	idx := strings.IndexRune(resourceName, '/')
 	if resourceName == "" || idx >= 0 && (!forceNamespace || (idx == len(namespace) && strings.HasPrefix(resourceName, namespace))) {
-		return resourceName
+		return resourceName, false
 	}
 
 	var sb strings.Builder
@@ -168,5 +168,5 @@ func ResourceQualifiedName(namespace, cecName, resourceName string, options ...O
 	sb.WriteRune('/')
 	sb.WriteString(resourceName)
 
-	return sb.String()
+	return sb.String(), true
 }

--- a/pkg/policy/api/utils_test.go
+++ b/pkg/policy/api/utils_test.go
@@ -114,41 +114,109 @@ func (s *PolicyAPITestSuite) TestParseL4Proto(c *C) {
 
 func (s *PolicyAPITestSuite) TestResourceQualifiedName(c *C) {
 	// Empty resource name is passed through
-	c.Assert(ResourceQualifiedName("", "", ""), Equals, "")
-	c.Assert(ResourceQualifiedName("a", "", ""), Equals, "")
-	c.Assert(ResourceQualifiedName("", "b", ""), Equals, "")
-	c.Assert(ResourceQualifiedName("", "", "", ForceNamespace), Equals, "")
-	c.Assert(ResourceQualifiedName("a", "", "", ForceNamespace), Equals, "")
-	c.Assert(ResourceQualifiedName("", "b", "", ForceNamespace), Equals, "")
+	name, updated := ResourceQualifiedName("", "", "")
+	c.Assert(name, Equals, "")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("a", "", "")
+	c.Assert(name, Equals, "")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("a", "", "")
+	c.Assert(name, Equals, "")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("a", "", "")
+	c.Assert(name, Equals, "")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("", "b", "")
+	c.Assert(name, Equals, "")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("", "", "", ForceNamespace)
+	c.Assert(name, Equals, "")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("a", "", "", ForceNamespace)
+	c.Assert(name, Equals, "")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("", "b", "", ForceNamespace)
+	c.Assert(name, Equals, "")
+	c.Assert(updated, Equals, false)
 
 	// Cluster-scope resources have no namespace
-	c.Assert(ResourceQualifiedName("", "", "test-resource"), Equals, "//test-resource")
+	name, updated = ResourceQualifiedName("", "", "test-resource")
+	c.Assert(name, Equals, "//test-resource")
+	c.Assert(updated, Equals, true)
 
 	// Every resource has a name of a CEC they originate from
-	c.Assert(ResourceQualifiedName("", "test-name", "test-resource"), Equals, "/test-name/test-resource")
+	name, updated = ResourceQualifiedName("", "test-name", "test-resource")
+	c.Assert(name, Equals, "/test-name/test-resource")
+	c.Assert(updated, Equals, true)
 
 	// namespaced resources have a namespace
-	c.Assert(ResourceQualifiedName("test-namespace", "", "test-resource"), Equals, "test-namespace//test-resource")
-	c.Assert(ResourceQualifiedName("test-namespace", "test-name", "test-resource"), Equals, "test-namespace/test-name/test-resource")
+	name, updated = ResourceQualifiedName("test-namespace", "", "test-resource")
+	c.Assert(name, Equals, "test-namespace//test-resource")
+	c.Assert(updated, Equals, true)
+
+	name, updated = ResourceQualifiedName("test-namespace", "test-name", "test-resource")
+	c.Assert(name, Equals, "test-namespace/test-name/test-resource")
+	c.Assert(updated, Equals, true)
 
 	// resource names with slashes is considered to already be qualified, and will not be prepended with namespace/cec-name
-	c.Assert(ResourceQualifiedName("test-namespace", "test-name", "test/resource"), Equals, "test/resource")
-	c.Assert(ResourceQualifiedName("test-namespace", "test-name", "/resource"), Equals, "/resource")
-	c.Assert(ResourceQualifiedName("", "test-name", "test/resource"), Equals, "test/resource")
-	c.Assert(ResourceQualifiedName("", "test-name", "/resource"), Equals, "/resource")
+	name, updated = ResourceQualifiedName("test-namespace", "test-name", "test/resource")
+	c.Assert(name, Equals, "test/resource")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("test-namespace", "test-name", "/resource")
+	c.Assert(name, Equals, "/resource")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("", "test-name", "test/resource")
+	c.Assert(name, Equals, "test/resource")
+	c.Assert(updated, Equals, false)
+
+	name, updated = ResourceQualifiedName("", "test-name", "/resource")
+	c.Assert(name, Equals, "/resource")
+	c.Assert(updated, Equals, false)
 
 	// forceNamespacing has no effect when the resource name is non-qualified
-	c.Assert(ResourceQualifiedName("", "", "test-resource", ForceNamespace), Equals, "//test-resource")
-	c.Assert(ResourceQualifiedName("", "test-name", "test-resource", ForceNamespace), Equals, "/test-name/test-resource")
-	c.Assert(ResourceQualifiedName("test-namespace", "", "test-resource", ForceNamespace), Equals, "test-namespace//test-resource")
-	c.Assert(ResourceQualifiedName("test-namespace", "test-name", "test-resource", ForceNamespace), Equals, "test-namespace/test-name/test-resource")
+	name, updated = ResourceQualifiedName("", "", "test-resource", ForceNamespace)
+	c.Assert(name, Equals, "//test-resource")
+	c.Assert(updated, Equals, true)
+
+	name, updated = ResourceQualifiedName("", "test-name", "test-resource", ForceNamespace)
+	c.Assert(name, Equals, "/test-name/test-resource")
+	c.Assert(updated, Equals, true)
+
+	name, updated = ResourceQualifiedName("test-namespace", "", "test-resource", ForceNamespace)
+	c.Assert(name, Equals, "test-namespace//test-resource")
+	c.Assert(updated, Equals, true)
+
+	name, updated = ResourceQualifiedName("test-namespace", "test-name", "test-resource", ForceNamespace)
+	c.Assert(name, Equals, "test-namespace/test-name/test-resource")
+	c.Assert(updated, Equals, true)
 
 	// forceNamespacing qualifies names in foreign namespaces
-	c.Assert(ResourceQualifiedName("test-namespace", "test-name", "test/resource", ForceNamespace), Equals, "test-namespace/test-name/test/resource")
-	c.Assert(ResourceQualifiedName("test-namespace", "test-name", "/resource", ForceNamespace), Equals, "test-namespace/test-name//resource")
-	c.Assert(ResourceQualifiedName("", "test-name", "test/resource", ForceNamespace), Equals, "/test-name/test/resource")
+	name, updated = ResourceQualifiedName("test-namespace", "test-name", "test/resource", ForceNamespace)
+	c.Assert(name, Equals, "test-namespace/test-name/test/resource")
+	c.Assert(updated, Equals, true)
+
+	name, updated = ResourceQualifiedName("test-namespace", "test-name", "/resource", ForceNamespace)
+	c.Assert(name, Equals, "test-namespace/test-name//resource")
+	c.Assert(updated, Equals, true)
+
+	name, updated = ResourceQualifiedName("", "test-name", "test/resource", ForceNamespace)
+	c.Assert(name, Equals, "/test-name/test/resource")
+	c.Assert(updated, Equals, true)
 
 	// forceNamespacing skips prepending if namespace matches
-	c.Assert(ResourceQualifiedName("test-namespace", "test-name", "test-namespace/resource", ForceNamespace), Equals, "test-namespace/resource")
-	c.Assert(ResourceQualifiedName("", "test-name", "/resource", ForceNamespace), Equals, "/resource")
+	name, updated = ResourceQualifiedName("test-namespace", "test-name", "test-namespace/resource", ForceNamespace)
+	c.Assert(name, Equals, "test-namespace/resource")
+	c.Assert(updated, Equals, false)
+	name, updated = ResourceQualifiedName("", "test-name", "/resource", ForceNamespace)
+	c.Assert(name, Equals, "/resource")
+	c.Assert(updated, Equals, false)
 }

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -826,7 +826,7 @@ func createL4Filter(policyCtx PolicyContext, peerEndpoints api.EndpointSelectorS
 				ns = ""
 			default:
 			}
-			l4.Listener = api.ResourceQualifiedName(ns, resource.Name, pr.Listener.Name, api.ForceNamespace)
+			l4.Listener, _ = api.ResourceQualifiedName(ns, resource.Name, pr.Listener.Name, api.ForceNamespace)
 			forceRedirect = true
 		}
 	}


### PR DESCRIPTION
Pass a boolean "updated" pointer to api.ResourceQualifiedName() in order to better track if updates were done or not.

In the case of Http Connection Manager RouteConfig the need for the update was ignored, so this is a bug fix for that.

Factor out the TCP proxy qualification logic to
qualifyTcpProxyResourceNames() which is similar to qualifyRouteConfigurationResourceNames() to keep the main logic simpler.

Fixes: #26037

```release-note
"envoy-admin" cluster is renamed as "/envoy-admin", requiring all references in CEC/CCEC to be updated.
```