### PR TITLE
policy: Return a real nil rather than a non-nil interface

### DIFF
--- a/pkg/policy/distillery.go
+++ b/pkg/policy/distillery.go
@@ -55,7 +55,10 @@ func (cache *PolicyCache) lookupOrCreate(identity *identityPkg.Identity, create 
 	cache.Lock()
 	defer cache.Unlock()
 	cip, ok := cache.policies[identity.ID]
-	if create && !ok {
+	if !ok {
+		if !create {
+			return nil
+		}
 		cip = newCachedSelectorPolicy(identity, cache.repo.GetSelectorCache())
 		cache.policies[identity.ID] = cip
 	}


### PR DESCRIPTION
Callers of lookupOrCreate() test the return value for nilness, but for that to succeed it needs to return nil rather than a nil pointer cast to the SelectorPolicy interface.

This came up in an integration test development, there are no know cases of this being a problem in production.
