### PR TITLE
Resolve named ports for DNS policies

### DIFF
--- a/pkg/endpoint/bpf.go
+++ b/pkg/endpoint/bpf.go
@@ -171,6 +171,25 @@ func (e *Endpoint) writeHeaderfile(prefix string) error {
 	return f.CloseAtomicallyReplace()
 }
 
+// proxyPolicy implements policy.ProxyPolicy interface, and passes most of the calls
+// to policy.L4Filter, but re-implements GetPort() to return the resolved named port,
+// instead of returning a 0 port number.
+type proxyPolicy struct {
+	*policy.L4Filter
+	port uint16
+}
+
+// newProxyPolicy returns a new instance of proxyPolicy by value
+func (e *Endpoint) newProxyPolicy(l4 *policy.L4Filter, port uint16) proxyPolicy {
+	return proxyPolicy{L4Filter: l4, port: port}
+}
+
+// GetPort returns the destination port number on which the proxy policy applies
+// This version properly returns the port resolved from a named port, if any.
+func (p *proxyPolicy) GetPort() uint16 {
+	return p.port
+}
+
 // addNewRedirectsFromDesiredPolicy must be called while holding the endpoint lock for
 // writing. On success, returns nil; otherwise, returns an error indicating the
 // problem that occurred while adding an l7 redirect for the specified policy.
@@ -202,7 +221,9 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 				var finalizeFunc revert.FinalizeFunc
 				var revertFunc revert.RevertFunc
 
-				proxyID := e.proxyID(l4)
+				// proxyID() returns also the destination port for the policy,
+				// which may be resolved from a named port
+				proxyID, dstPort := e.proxyID(l4)
 				if proxyID == "" {
 					// Skip redirects for which a proxyID cannot be created.
 					// This may happen due to the named port mapping not
@@ -213,8 +234,9 @@ func (e *Endpoint) addNewRedirectsFromDesiredPolicy(ingress bool, desiredRedirec
 					return 0, false
 				}
 
+				pp := e.newProxyPolicy(l4, dstPort)
 				var err error
-				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(e.aliveCtx, l4, proxyID, e, proxyWaitGroup)
+				redirectPort, err, finalizeFunc, revertFunc = e.proxy.CreateOrUpdateRedirect(e.aliveCtx, &pp, proxyID, e, proxyWaitGroup)
 				if err != nil {
 					// Skip redirects that can not be created or updated.  This
 					// can happen when a listener is missing, for example when

--- a/pkg/endpoint/endpoint_test.go
+++ b/pkg/endpoint/endpoint_test.go
@@ -534,15 +534,23 @@ func (s *EndpointSuite) TestWaitForPolicyRevision(c *C) {
 
 func (s *EndpointSuite) TestProxyID(c *C) {
 	e := &Endpoint{ID: 123, policyRevision: 0}
+	e.UpdateLogger(nil)
 
-	id := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true})
+	id, port := e.proxyID(&policy.L4Filter{Port: 8080, Protocol: api.ProtoTCP, Ingress: true})
 	c.Assert(id, Not(Equals), "")
+	c.Assert(port, Equals, uint16(8080))
+
 	endpointID, ingress, protocol, port, err := policy.ParseProxyID(id)
 	c.Assert(endpointID, Equals, uint16(123))
 	c.Assert(ingress, Equals, true)
 	c.Assert(protocol, Equals, "TCP")
 	c.Assert(port, Equals, uint16(8080))
 	c.Assert(err, IsNil)
+
+	// Undefined named port
+	id, port = e.proxyID(&policy.L4Filter{PortName: "foobar", Protocol: api.ProtoTCP, Ingress: true})
+	c.Assert(id, Equals, "")
+	c.Assert(port, Equals, uint16(0))
 }
 
 func TestEndpoint_GetK8sPodLabels(t *testing.T) {

--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -89,17 +89,18 @@ func (e *Endpoint) getNamedPortEgress(npMap types.NamedPortMultiMap, name string
 	return port
 }
 
-// proxyID returns a unique string to identify a proxy mapping.
+// proxyID returns a unique string to identify a proxy mapping,
+// and the resolved destination port number, if any.
 // Must be called with e.mutex held.
-func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
+func (e *Endpoint) proxyID(l4 *policy.L4Filter) (string, uint16) {
 	port := uint16(l4.Port)
 	if port == 0 && l4.PortName != "" {
 		port = e.GetNamedPort(l4.Ingress, l4.PortName, uint8(l4.U8Proto))
 		if port == 0 {
-			return ""
+			return "", 0
 		}
 	}
-	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port)
+	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port), port
 }
 
 // lookupRedirectPort returns the redirect L4 proxy port for the given L4


### PR DESCRIPTION
Implement `l4Policy` wrapper with resolved named port so that proxy package can get the actual resolved named port number when calling `GetPort`. Previously, if policy used a named port, `GetPort` returned `0`.

`GetPort` is only used for DNS proxy function `UpdateAllowed`. This means that using a named port for a DNS policy destination port likely has not functioned as intended. Since DNS port is typically `53`, it seems likely that named ports would not be used in DNS policies in practice.

Fixes: #11092

```release-note
Named ports in DNS policies are now resolved correctly.
```
