### PR TITLE
endpoint: Clarify policy locking requirements

### DIFF
--- a/pkg/endpoint/policy.go
+++ b/pkg/endpoint/policy.go
@@ -102,11 +102,11 @@ func (e *Endpoint) proxyID(l4 *policy.L4Filter) string {
 	return policy.ProxyID(e.ID, l4.Ingress, string(l4.Protocol), port)
 }
 
-// lookupRedirectPort returns the redirect L4 proxy port for the given L4
+// LookupRedirectPortBuildLocked returns the redirect L4 proxy port for the given L4
 // policy map key, in host byte order. Returns 0 if not found or the
 // filter doesn't require a redirect.
 // Must be called with either Endpoint.mutex or Endpoint.buildMutex held for reading.
-func (e *Endpoint) LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16 {
+func (e *Endpoint) LookupRedirectPortBuildLocked(ingress bool, protocol string, port uint16) uint16 {
 	return e.realizedRedirects[policy.ProxyID(e.ID, ingress, protocol, port)]
 }
 

--- a/pkg/policy/l4.go
+++ b/pkg/policy/l4.go
@@ -487,7 +487,7 @@ type ChangeState struct {
 // AuthType, and L7 redirection (e.g., for visibility purposes), the mapstate entries are added to
 // 'p.PolicyMapState' using denyPreferredInsertWithChanges().
 // Keys and old values of any added or deleted entries are added to 'changes'.
-// The implementation of 'identities' is also in a locked state.
+// SelectorCache is also in read-locked state during this call.
 func (l4Filter *L4Filter) toMapState(p *EndpointPolicy, features policyFeatures, entryCb entryCallback, changes ChangeState) {
 	port := uint16(l4Filter.Port)
 	proto := uint8(l4Filter.U8Proto)

--- a/pkg/policy/resolve.go
+++ b/pkg/policy/resolve.go
@@ -64,7 +64,7 @@ type EndpointPolicy struct {
 // PolicyOwner is anything which consumes a EndpointPolicy.
 type PolicyOwner interface {
 	GetID() uint64
-	LookupRedirectPortLocked(ingress bool, protocol string, port uint16) uint16
+	LookupRedirectPortBuildLocked(ingress bool, protocol string, port uint16) uint16
 	HasBPFPolicyMap() bool
 	GetNamedPort(ingress bool, name string, proto uint8) uint16
 	PolicyDebug(fields logrus.Fields, msg string)
@@ -102,8 +102,9 @@ func (p *selectorPolicy) Detach() {
 // upon selectors) into a set of concrete map entries based on the
 // SelectorCache. These can subsequently be plumbed into the datapath.
 //
-// Must be performed while holding the Repository lock.
-// PolicyOwner (aka Endpoint) is also locked during this call.
+// Called without holding the Selector cache or Repository locks.
+// PolicyOwner (aka Endpoint) is also unlocked during this call,
+// but the Endpoint's build mutex is held.
 func (p *selectorPolicy) DistillPolicy(policyOwner PolicyOwner, isHost bool) *EndpointPolicy {
 	calculatedPolicy := &EndpointPolicy{
 		selectorPolicy: p,
@@ -165,15 +166,23 @@ func (p *EndpointPolicy) Detach() {
 	p.selectorPolicy.removeUser(p)
 }
 
-// computeDesiredL4PolicyMapEntries transforms the EndpointPolicy.L4Policy into
+// toMapState transforms the EndpointPolicy.L4Policy into
 // the datapath-friendly format inside EndpointPolicy.PolicyMapState.
-// Called with selectorcache locked for reading
+// Called with selectorcache locked for reading.
+// Called without holding the Repository lock.
+// PolicyOwner (aka Endpoint) is also unlocked during this call,
+// but the Endpoint's build mutex is held.
 func (p *EndpointPolicy) toMapState() {
 	p.L4Policy.Ingress.toMapState(p)
 	p.L4Policy.Egress.toMapState(p)
 }
 
-// Called with selectorcache locked for reading
+// toMapState transforms the L4DirectionPolicy into
+// the datapath-friendly format inside EndpointPolicy.PolicyMapState.
+// Called with selectorcache locked for reading.
+// Called without holding the Repository lock.
+// PolicyOwner (aka Endpoint) is also unlocked during this call,
+// but the Endpoint's build mutex is held.
 func (l4policy L4DirectionPolicy) toMapState(p *EndpointPolicy) {
 	for _, l4 := range l4policy.PortRules {
 		lookupDone := false
@@ -185,7 +194,7 @@ func (l4policy L4DirectionPolicy) toMapState(p *EndpointPolicy) {
 					// only lookup once for each filter
 					// Use 'destPort' from the key as it is already resolved
 					// from a named port if needed.
-					proxyport = p.PolicyOwner.LookupRedirectPortLocked(l4.Ingress, string(l4.Protocol), keyFromFilter.DestPort)
+					proxyport = p.PolicyOwner.LookupRedirectPortBuildLocked(l4.Ingress, string(l4.Protocol), keyFromFilter.DestPort)
 					lookupDone = true
 				}
 				entry.ProxyPort = proxyport

--- a/pkg/policy/resolve_test.go
+++ b/pkg/policy/resolve_test.go
@@ -175,7 +175,7 @@ func GenerateCIDRRules(numRules int) api.Rules {
 
 type DummyOwner struct{}
 
-func (d DummyOwner) LookupRedirectPortLocked(bool, string, uint16) uint16 {
+func (d DummyOwner) LookupRedirectPortBuildLocked(bool, string, uint16) uint16 {
 	return 4242
 }
 


### PR DESCRIPTION
Add commentary and rename 'LookupRedirectPortLocked' as 'LookupRedirectPortBuildLocked' to signify that the endpoint's build mutex must be held, while the endpoint mutex is not held during this call.
