### PR TITLE
policy: Simplify AccumulateMapChanges prototypes

### DIFF
--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -76,7 +76,10 @@ func FuzzAccumulateMapChange(f *testing.F) {
 		if err != nil {
 			t.Skip()
 		}
+
+		key := Key{DestPort: port, Nexthdr: proto, TrafficDirection: dir.Uint8()}
+		value := NewMapStateEntry(csFoo, nil, redirect, deny, DefaultAuthType, AuthTypeDisabled)
 		policyMaps := MapChanges{}
-		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, port, proto, dir, redirect, deny, DefaultAuthType, AuthTypeDisabled, nil)
+		policyMaps.AccumulateMapChanges(csFoo, adds, deletes, key, value)
 	})
 }

--- a/pkg/policy/mapstate.go
+++ b/pkg/policy/mapstate.go
@@ -1390,37 +1390,7 @@ type MapChange struct {
 //
 // The caller is responsible for making sure the same identity is not
 // present in both 'adds' and 'deletes'.
-func (mc *MapChanges) AccumulateMapChanges(cs CachedSelector, adds, deletes []identity.NumericIdentity,
-	port uint16, proto uint8, direction trafficdirection.TrafficDirection,
-	redirect, isDeny bool, hasAuth HasAuthType, authType AuthType, derivedFrom labels.LabelArrayList) {
-	key := Key{
-		// The actual identity is set in the loops below
-		Identity: 0,
-		// NOTE: Port is in host byte-order!
-		DestPort:         port,
-		Nexthdr:          proto,
-		TrafficDirection: direction.Uint8(),
-	}
-
-	value := NewMapStateEntry(cs, derivedFrom, redirect, isDeny, hasAuth, authType)
-
-	if option.Config.Debug {
-		authString := "default"
-		if hasAuth {
-			authString = authType.String()
-		}
-		log.WithFields(logrus.Fields{
-			logfields.EndpointSelector: cs,
-			logfields.AddedPolicyID:    adds,
-			logfields.DeletedPolicyID:  deletes,
-			logfields.Port:             port,
-			logfields.Protocol:         proto,
-			logfields.TrafficDirection: direction,
-			logfields.IsRedirect:       redirect,
-			logfields.AuthType:         authString,
-		}).Debug("AccumulateMapChanges")
-	}
-
+func (mc *MapChanges) AccumulateMapChanges(cs CachedSelector, adds, deletes []identity.NumericIdentity, key Key, value MapStateEntry) {
 	mc.mutex.Lock()
 	for _, id := range adds {
 		key.Identity = id.Uint32()

--- a/pkg/policy/mapstate_test.go
+++ b/pkg/policy/mapstate_test.go
@@ -1469,7 +1469,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesDeny(c *check.C) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, DefaultAuthType, AuthTypeDisabled, nil)
+			key := Key{DestPort: x.port, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
+			value := NewMapStateEntry(cs, nil, x.redirect, x.deny, DefaultAuthType, AuthTypeDisabled)
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, key, value)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(policyMapState, denyRules, nil)
 		policyMapState.validatePortProto(c)
@@ -1684,7 +1686,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChanges(c *check.C) {
 			if x.cs != nil {
 				cs = x.cs
 			}
-			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, x.hasAuth, x.authType, nil)
+			key := Key{DestPort: x.port, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
+			value := NewMapStateEntry(cs, nil, x.redirect, x.deny, x.hasAuth, x.authType)
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, key, value)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(policyMapState, policyFeatures(0), nil)
 		policyMapState.validatePortProto(c)
@@ -2244,7 +2248,9 @@ func (ds *PolicyTestSuite) TestMapState_AccumulateMapChangesOnVisibilityKeys(c *
 			if x.cs != nil {
 				cs = x.cs
 			}
-			policyMaps.AccumulateMapChanges(cs, adds, deletes, x.port, x.proto, dir, x.redirect, x.deny, DefaultAuthType, AuthTypeDisabled, nil)
+			key := Key{DestPort: x.port, Nexthdr: x.proto, TrafficDirection: dir.Uint8()}
+			value := NewMapStateEntry(cs, nil, x.redirect, x.deny, DefaultAuthType, AuthTypeDisabled)
+			policyMaps.AccumulateMapChanges(cs, adds, deletes, key, value)
 		}
 		adds, deletes := policyMaps.consumeMapChanges(policyMapState, denyRules, nil)
 		changes = ChangeState{


### PR DESCRIPTION
Simplify AccumulateMapChanges prototypes by moving stuff around. No functional changes.
