### PR TITLE
envoy: Support internal listeners in CiliumEnvoyConfig CRDs

### DIFF
--- a/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
+++ b/install/kubernetes/cilium/files/cilium-envoy/configmap/bootstrap-config.json
@@ -301,6 +301,14 @@
       "resourceApiVersion": "V3"
     }
   },
+  "bootstrapExtensions": [
+    {
+      "name": "envoy.bootstrap.internal_listener",
+      "typed_config": {
+        "@type": "type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener"
+      }
+    }
+  ],
   "layeredRuntime": {
     "layers": [
       {

--- a/pkg/envoy/embedded_envoy.go
+++ b/pkg/envoy/embedded_envoy.go
@@ -20,7 +20,9 @@ import (
 	envoy_config_cluster "github.com/cilium/proxy/go/envoy/config/cluster/v3"
 	envoy_config_core "github.com/cilium/proxy/go/envoy/config/core/v3"
 	envoy_config_endpoint "github.com/cilium/proxy/go/envoy/config/endpoint/v3"
+	envoy_extensions_bootstrap_internal_listener_v3 "github.com/cilium/proxy/go/envoy/extensions/bootstrap/internal_listener/v3"
 	envoy_config_upstream "github.com/cilium/proxy/go/envoy/extensions/upstreams/http/v3"
+
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -432,6 +434,12 @@ func createBootstrap(filePath string, nodeId, cluster string, xdsSock, egressClu
 				Address: &envoy_config_core.Address_Pipe{
 					Pipe: &envoy_config_core.Pipe{Path: adminPath},
 				},
+			},
+		},
+		BootstrapExtensions: []*envoy_config_core.TypedExtensionConfig{
+			{
+				Name:        "envoy.bootstrap.internal_listener",
+				TypedConfig: toAny(&envoy_extensions_bootstrap_internal_listener_v3.InternalListener{}),
 			},
 		},
 		LayeredRuntime: &envoy_config_bootstrap.LayeredRuntime{


### PR DESCRIPTION
Envoy Internal listeners do not have a real listening socket, nor is the downstream connection backed by a socket, so socket options can not be applied on them. Allow use of Envoy internal listeners by refraining from injecting Cilium filters on internal listeners, so that socket options are not applied. This also means that Cilium policy enforcement is not performed on internal listeners, so they must be used with caution.

This should be addressed in a future commit to propagate Cilium metadata to the internal listener from the previous, real listener.

Note that as of now Envoy Internal listeners is not a stable feature, so Envoy emits the following warning during bootstrap:

    [misc] [external/envoy/source/common/protobuf/message_validator_impl.cc:35]
    message 'envoy.extensions.bootstrap.internal_listener.v3.InternalListener'
    is contained in proto file
    'envoy/extensions/bootstrap/internal_listener/v3/internal_listener.proto'
    marked as work-in-progress. API features marked as work-in-progress are not
    considered stable, are not covered by the threat model, are not supported
    by the security team, and are subject to breaking changes. Do not use this
    feature without understanding each of the previous points.
