### PR TITLE
gateway-api: fail Operator startup if Gateway API CRDs are missing

### DIFF
--- a/operator/pkg/gateway-api/cell.go
+++ b/operator/pkg/gateway-api/cell.go
@@ -76,8 +76,7 @@ func initGatewayAPIController(params gatewayAPIParams) error {
 
 	params.Logger.WithField("requiredGVK", requiredGVK).Info("Checking for required GatewayAPI resources")
 	if err := checkRequiredCRDs(context.Background(), params.K8sClient); err != nil {
-		params.Logger.WithError(err).Error("Required GatewayAPI resources are not found, please refer to docs for installation instructions")
-		return nil
+		return fmt.Errorf("required GatewayAPI resources are not found, please refer to docs for installation instructions: %w", err)
 	}
 
 	if err := registerGatewayAPITypesToScheme(params.Scheme); err != nil {


### PR DESCRIPTION
PR #28982 introduced a check for Gateway API CRDs at the startup of the Cilium Operator. If the CRDs aren't present - Gateway API controllers aren't registered the error is logged.

This behaviour might be irritating for the user as the operator doesn't behave as expected. It's only obvious AFTER analysing the logs.

Therefore, this commit lets the Operator initialization fail - but still with a meaningful error message.