### PR TITLE
cmd/watchdogs: add health reporter to watchdog controller.

### DIFF
--- a/daemon/cmd/watchdogs.go
+++ b/daemon/cmd/watchdogs.go
@@ -37,6 +37,7 @@ type epBPFProgWatchdogParams struct {
 	Logger        logrus.FieldLogger
 	Lifecycle     hive.Lifecycle
 	DaemonPromise promise.Promise[*Daemon]
+	Scope         cell.Scope
 }
 
 var (
@@ -68,7 +69,8 @@ func registerEndpointBPFProgWatchdog(p epBPFProgWatchdogParams) {
 			mgr.UpdateController(
 				epBPFProgWatchdog,
 				controller.ControllerParams{
-					Group: controller.NewGroup(epBPFProgWatchdog),
+					Group:          controller.NewGroup(epBPFProgWatchdog),
+					HealthReporter: cell.GetHealthReporter(p.Scope, epBPFProgWatchdog),
 					DoFunc: func(ctx context.Context) error {
 						d, err := p.DaemonPromise.Await(ctx)
 						if err != nil {

--- a/pkg/health/client/modules.go
+++ b/pkg/health/client/modules.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -43,6 +44,9 @@ func GetAndFormatModulesHealth(w io.Writer, clt ModulesHealth, verbose bool) {
 	}
 	if verbose {
 		r := newRoot(rootNode)
+		sort.Slice(resp.Payload.Modules, func(i, j int) bool {
+			return resp.Payload.Modules[i].ModuleID < resp.Payload.Modules[j].ModuleID
+		})
 		for _, m := range resp.Payload.Modules {
 			if m.Level == string(cell.StatusUnknown) {
 				continue

--- a/pkg/health/client/modules_test.go
+++ b/pkg/health/client/modules_test.go
@@ -37,13 +37,13 @@ func TestGetAndFormatModulesHealth(t *testing.T) {
 			h: newTestMHappy(),
 			e: `Modules Health:
 agent
-├── m1                                                      [OK] status nominal (2s, x0)
-└── a
-    └── b
-        └── c
-            ├── fred                                        [OK] yo (20s, x1)
-            │   └── blee                                    [OK] doh (20s, x1)
-            └── dork                                        [DEGRADED] bozo -- BOOM! (20s, x1)`,
+├── a
+│   └── b
+│       └── c
+│           ├── fred                                        [OK] yo (20s, x1)
+│           │   └── blee                                    [OK] doh (20s, x1)
+│           └── dork                                        [DEGRADED] bozo -- BOOM! (20s, x1)
+└── m1                                                      [OK] status nominal (2s, x0)`,
 			v: true,
 		},
 	}


### PR DESCRIPTION
Watchdog already runs in a module, so we should add a health reporter so it appears in modular health status.


