### PR TITLE
labels: further optimize IPStringToLabel for single IP case

### DIFF
--- a/pkg/labels/cidr.go
+++ b/pkg/labels/cidr.go
@@ -21,9 +21,7 @@ import (
 //
 // For IPv6 addresses, it converts ":" into "-" as EndpointSelectors don't
 // support colons inside the name section of a label.
-func maskedIPToLabel(ip netip.Addr, prefix int) Label {
-	ipStr := ip.String()
-
+func maskedIPToLabel(ipStr string, prefix int) Label {
 	var str strings.Builder
 	str.Grow(
 		1 /* preZero */ +
@@ -70,13 +68,13 @@ func IPStringToLabel(ip string) (Label, error) {
 		if err != nil {
 			return Label{}, fmt.Errorf("%q is not an IP address: %w", ip, err)
 		}
-		return maskedIPToLabel(parsedIP, parsedIP.BitLen()), nil
+		return maskedIPToLabel(ip, parsedIP.BitLen()), nil
 	} else {
 		parsedPrefix, err := netip.ParsePrefix(ip)
 		if err != nil {
 			return Label{}, fmt.Errorf("%q is not a CIDR: %w", ip, err)
 		}
-		return maskedIPToLabel(parsedPrefix.Masked().Addr(), parsedPrefix.Bits()), nil
+		return maskedIPToLabel(parsedPrefix.Masked().Addr().String(), parsedPrefix.Bits()), nil
 	}
 }
 
@@ -176,7 +174,7 @@ func computeCIDRLabels(cache *simplelru.LRU[netip.Prefix, []Label], lbls Labels,
 	}
 
 	// Compute the label for this prefix (e.g. "cidr:10.0.0.0/8")
-	prefixLabel := maskedIPToLabel(prefix.Addr(), ones)
+	prefixLabel := maskedIPToLabel(prefix.Addr().String(), ones)
 	lbls[prefixLabel.Key] = prefixLabel
 
 	// Keep computing the rest (e.g. "cidr:10.0.0.0/7", ...).


### PR DESCRIPTION
Pass the IP as a string to `maskedIPToLabel`. When called from `IPStringToLabel` in case of a single IP we already have the IP string and can avoid the additional allocation caused by `ip.String()`. For the call in the prefix case and in `computeCIDRLabels` there is no effect, the `netip.Addr.String()` call is just moved out.

    name                               old time/op    new time/op    delta
    IPStringToLabel/0.0.0.0/0-8          69.6ns ± 1%    71.0ns ± 2%   +1.91%  (p=0.001 n=9+10)
    IPStringToLabel/192.0.2.3-8          70.9ns ± 0%    50.6ns ± 0%  -28.65%  (p=0.000 n=10+9)
    IPStringToLabel/192.0.2.3/32-8       77.7ns ± 1%    78.1ns ± 1%   +0.50%  (p=0.003 n=10+10)
    IPStringToLabel/192.0.2.3/24-8       77.5ns ± 0%    79.9ns ±12%   +3.02%  (p=0.000 n=10+9)
    IPStringToLabel/192.0.2.0/24-8       77.5ns ± 0%    78.1ns ± 0%   +0.67%  (p=0.000 n=10+9)
    IPStringToLabel/::/0-8                108ns ± 0%     109ns ± 0%     ~     (p=0.137 n=10+10)
    IPStringToLabel/fdff::ff-8            136ns ± 0%      74ns ± 0%  -45.61%  (p=0.000 n=10+10)
    IPStringToLabel/f00d:42::ff/128-8     155ns ± 0%     155ns ± 0%   -0.28%  (p=0.000 n=10+9)
    IPStringToLabel/f00d:42::ff/96-8      145ns ± 1%     144ns ± 0%   -0.56%  (p=0.007 n=10+10)

    name                               old alloc/op   new alloc/op   delta
    IPStringToLabel/0.0.0.0/0-8           24.0B ± 0%     24.0B ± 0%     ~     (all equal)
    IPStringToLabel/192.0.2.3-8           32.0B ± 0%     16.0B ± 0%  -50.00%  (p=0.000 n=10+10)
    IPStringToLabel/192.0.2.3/32-8        32.0B ± 0%     32.0B ± 0%     ~     (all equal)
    IPStringToLabel/192.0.2.3/24-8        32.0B ± 0%     32.0B ± 0%     ~     (all equal)
    IPStringToLabel/192.0.2.0/24-8        32.0B ± 0%     32.0B ± 0%     ~     (all equal)
    IPStringToLabel/::/0-8                16.0B ± 0%     16.0B ± 0%     ~     (all equal)
    IPStringToLabel/fdff::ff-8            32.0B ± 0%     16.0B ± 0%  -50.00%  (p=0.000 n=10+10)
    IPStringToLabel/f00d:42::ff/128-8     32.0B ± 0%     32.0B ± 0%     ~     (all equal)
    IPStringToLabel/f00d:42::ff/96-8      32.0B ± 0%     32.0B ± 0%     ~     (all equal)

    name                               old allocs/op  new allocs/op  delta
    IPStringToLabel/0.0.0.0/0-8            2.00 ± 0%      2.00 ± 0%     ~     (all equal)
    IPStringToLabel/192.0.2.3-8            2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
    IPStringToLabel/192.0.2.3/32-8         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
    IPStringToLabel/192.0.2.3/24-8         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
    IPStringToLabel/192.0.2.0/24-8         2.00 ± 0%      2.00 ± 0%     ~     (all equal)
    IPStringToLabel/::/0-8                 2.00 ± 0%      2.00 ± 0%     ~     (all equal)
    IPStringToLabel/fdff::ff-8             3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=10+10)
    IPStringToLabel/f00d:42::ff/128-8      3.00 ± 0%      3.00 ± 0%     ~     (all equal)
    IPStringToLabel/f00d:42::ff/96-8       2.00 ± 0%      2.00 ± 0%     ~     (all equal)