### PR TITLE
bpf: host: adjust scope of HostFW section in handle_ipv6()

### DIFF
--- a/bpf/bpf_host.c
+++ b/bpf/bpf_host.c
@@ -141,22 +141,22 @@ handle_ipv6(struct __ctx_buff *ctx, __u32 secctx __maybe_unused,
 #ifdef ENABLE_HOST_FIREWALL
 	struct ct_buffer6 ct_buffer = {};
 	bool need_hostfw = false;
+	__u8 nexthdr;
+	int hdrlen;
 #endif /* ENABLE_HOST_FIREWALL */
 	void *data, *data_end;
 	struct ipv6hdr *ip6;
 	int __maybe_unused ret;
-	int hdrlen;
-	__u8 nexthdr;
 
 	if (!revalidate_data(ctx, &data, &data_end, &ip6))
 		return DROP_INVALID;
 
+#ifdef ENABLE_HOST_FIREWALL
 	nexthdr = ip6->nexthdr;
 	hdrlen = ipv6_hdrlen(ctx, &nexthdr);
 	if (hdrlen < 0)
 		return hdrlen;
 
-#ifdef ENABLE_HOST_FIREWALL
 	if (likely(nexthdr == IPPROTO_ICMPV6)) {
 		ret = icmp6_host_handle(ctx, ETH_HLEN + hdrlen);
 		if (ret == SKIP_HOST_FIREWALL)


### PR DESCRIPTION
`nexthdr` and `hdrlen` are only needed by the HostFW code. Pull them into the ENABLE_HOST_FIREWALL section.