### PR TITLE
ci-ipsec-upgrade: Bring back missed-tail-calls check

### DIFF
--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -132,6 +132,7 @@ jobs:
         uses: ./.github/actions/cilium-config
         with:
           chart-dir: './cilium-${{ steps.vars.outputs.downgrade_version }}/install/kubernetes/cilium/'
+          image-tag: ${{ steps.vars.outputs.downgrade_version }}
           tunnel: ${{ matrix.tunnel }}
           endpoint-routes: ${{ matrix.endpoint-routes }}
           ipv6: ${{ matrix.ipv6 }}

--- a/.github/workflows/tests-ipsec-upgrade.yaml
+++ b/.github/workflows/tests-ipsec-upgrade.yaml
@@ -265,9 +265,8 @@ jobs:
         uses: cilium/cilium/.github/actions/conn-disrupt-test@1633d7b7c36e73e9ea45f010bcfc88fe6bc7ddc9
         with:
           job-name: ipsec-upgrade-${{ matrix.name }}
-          # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
           # Disable check-log-errors due to https://github.com/cilium/cilium-cli/issues/1858
-          extra-connectivity-test-flags: --test '!no-missed-tail-calls,!check-log-errors'
+          extra-connectivity-test-flags: --test '!check-log-errors'
           operation-cmd: |
             cd /host/
 
@@ -282,9 +281,8 @@ jobs:
         uses: cilium/cilium/.github/actions/conn-disrupt-test@1633d7b7c36e73e9ea45f010bcfc88fe6bc7ddc9
         with:
           job-name: ipsec-downgrade-${{ matrix.name }}
-          # Disable no-missed-tail-calls due to https://github.com/cilium/cilium/issues/26739
           # Disable check-log-errors due to https://github.com/cilium/cilium-cli/issues/1858
-          extra-connectivity-test-flags: --test '!no-missed-tail-calls,!check-log-errors'
+          extra-connectivity-test-flags: --test '!check-log-errors'
           operation-cmd: |
             cd /host/
 


### PR DESCRIPTION
Since \[1\] got merged, we can re-enable the check.

\[1\]: https://github.com/cilium/cilium/pull/28830.