### PR TITLE
cni: remove unused CILIUM_CNI_CONF variable from install script

### DIFF
--- a/plugins/cilium-cni/install-plugin.sh
+++ b/plugins/cilium-cni/install-plugin.sh
@@ -8,7 +8,6 @@ HOST_PREFIX=${HOST_PREFIX:-/host}
 
 BIN_NAME=cilium-cni
 CNI_DIR=${CNI_DIR:-${HOST_PREFIX}/opt/cni}
-CILIUM_CNI_CONF=${CILIUM_CNI_CONF:-${HOST_PREFIX}/etc/cni/net.d/${CNI_CONF_NAME}}
 
 if [ ! -d "${CNI_DIR}/bin" ]; then
 	mkdir -p "${CNI_DIR}/bin"


### PR DESCRIPTION
The CNI install script used to install both the CNI conflist and the CNI binary, but now it just installs the binary, so the CILIUM_CNI_CONF variable can be removed.