### PR TITLE
[Draft] nodestore: move health updates for node delete/updates to nodestore.

### DIFF
--- a/pkg/node/manager/cell.go
+++ b/pkg/node/manager/cell.go
@@ -48,10 +48,10 @@ type NodeManager interface {
 
 	// NodeUpdated is called when the store detects a change in node
 	// information
-	NodeUpdated(n types.Node)
+	NodeUpdated(n types.Node) error
 
 	// NodeDeleted is called when the store detects a deletion of a node
-	NodeDeleted(n types.Node)
+	NodeDeleted(n types.Node) error
 
 	// ClusterSizeDependantInterval returns a time.Duration that is dependent on
 	// the cluster size, i.e. the number of nodes that have been discovered. This


### PR DESCRIPTION
The nodemanager provides an interface for handling node events. Currently, the periodic sync, node delete and node updates are all health checked inside node manager.

However this may lead to flakey health reports as a degraded status may by overwritten by a ok status.
