### PR TITLE
Revert "startup: improve speed of syncing CRDs"

### DIFF
--- a/pkg/k8s/synced/crd.go
+++ b/pkg/k8s/synced/crd.go
@@ -172,7 +172,7 @@ func SyncCRDs(ctx context.Context, clientset client.Clientset, crdNames []string
 
 	log.Info("Waiting until all Cilium CRDs are available")
 
-	ticker := time.NewTicker(50 * time.Millisecond)
+	ticker := time.NewTicker(1 * time.Second)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
This reverts commit https://github.com/cilium/cilium/pull/28954.

This commit seems to be causing a lot of errors in CI:

    2023-11-09T02:07:05.175239647Z level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/resource/resource.go:725: Failed to watch *v2.CiliumEndpoint: failed to list *v2.CiliumEndpoint: the server could not find the requested resource (get ciliumendpoints.cilium.io)" subsys=k8s
    2023-11-09T02:07:05.175585081Z level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/resource/resource.go:725: Failed to watch *v2.CiliumNode: failed to list *v2.CiliumNode: the server could not find the requested resource (get ciliumnodes.cilium.io)" subsys=k8s
    2023-11-09T02:07:05.176117013Z level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/resource/resource.go:725: Failed to watch *v2.CiliumEgressGatewayPolicy: failed to list *v2.CiliumEgressGatewayPolicy: the server could not find the requested resource (get ciliumegressgatewaypolicies.cilium.io)" subsys=k8s
    2023-11-09T02:07:06.614265449Z level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/resource/resource.go:725: Failed to watch *v2.CiliumEgressGatewayPolicy: failed to list *v2.CiliumEgressGatewayPolicy: the server could not find the requested resource (get ciliumegressgatewaypolicies.cilium.io)" subsys=k8s
    2023-11-09T02:07:06.617144774Z level=error msg=k8sError error="github.com/cilium/cilium/pkg/k8s/resource/resource.go:725: Failed to watch *v2.CiliumEndpoint: failed to list *v2.CiliumEndpoint: the server could not find the requested resource (get ciliumendpoints.cilium.io)" subsys=k8s
    2023-11-09T02:07:06.655788942Z level=error msg=k8sError