### PR TITLE
bpf: ct: fully close CT_SERVICE entries to reduce their lifetime

### DIFF
--- a/bpf/tests/conntrack_test.c
+++ b/bpf/tests/conntrack_test.c
@@ -205,6 +205,79 @@ int bpf_test(__maybe_unused struct __sk_buff *sctx)
 		assert(monitor == TRACE_PAYLOAD_LEN);
 	});
 
+	TEST("ct_lookup_svc", {
+		struct __ctx_buff ctx = {};
+		int res;
+		struct ipv4_ct_tuple tuple = {};
+		struct ct_state ct_state = {};
+		union tcp_flags seen_flags = {0};
+		__u32 monitor;
+
+		tuple.nexthdr = IPPROTO_TCP;
+		tuple.flags = CT_SERVICE;
+
+		struct ct_entry ct_entry_new = {};
+
+		res = map_update_elem(get_ct_map4(&tuple), &tuple, &ct_entry_new, BPF_ANY);
+		if (IS_ERR(res))
+			test_fatal("map_update_elem: %lld", res);
+
+		struct ct_entry *entry = map_lookup_elem(get_ct_map4(&tuple), &tuple);
+
+		if (!entry)
+			test_fatal("ct entry lookup failed");
+
+		seen_flags.value |= TCP_FLAG_SYN;
+
+		/* First packet is monitored */
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_SERVICE,
+				  CT_ENTRY_SVC, &ct_state, true, seen_flags, &monitor);
+		assert(res == CT_ESTABLISHED);
+		assert(monitor == TRACE_PAYLOAD_LEN);
+		assert(timeout_in(entry, CT_SYN_TIMEOUT));
+
+		/* Second packet with the same flags is not monitored; it does reset
+		 * lifetime back to CT_SYN_TIMEOUT.
+		 */
+		advance_time();
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_SERVICE,
+				  CT_ENTRY_SVC, &ct_state, true, seen_flags, &monitor);
+		assert(res == CT_ESTABLISHED);
+		assert(monitor == 0);
+		assert(timeout_in(entry, CT_SYN_TIMEOUT));
+
+		/* Subsequent non-SYN packets result in a default SVC TCP lifetime */
+		advance_time();
+		seen_flags.value &= ~TCP_FLAG_SYN;
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_SERVICE,
+				  CT_ENTRY_SVC, &ct_state, true, seen_flags, &monitor);
+		assert(res == CT_ESTABLISHED);
+		assert(monitor == 0);
+		assert(timeout_in(entry, CT_SERVICE_LIFETIME_TCP));
+
+		/* Monitor & lower lifetime if the connection is closing on just one side */
+		advance_time();
+		seen_flags.value |= TCP_FLAG_FIN;
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_SERVICE,
+				  CT_ENTRY_SVC, &ct_state, true, seen_flags, &monitor);
+		assert(res == CT_ESTABLISHED);
+		assert(monitor == TRACE_PAYLOAD_LEN);
+		assert(timeout_in(entry, CT_CLOSE_TIMEOUT));
+
+		/* Label connection as new if the tuple wasn't previously tracked */
+		tuple.saddr = 456;
+		seen_flags.value = TCP_FLAG_SYN;
+		res = __ct_lookup(get_ct_map4(&tuple), &ctx, &tuple,
+				  ct_tcp_select_action(seen_flags), CT_SERVICE,
+				  CT_ENTRY_SVC, &ct_state, true, seen_flags, &monitor);
+		assert(res == CT_NEW);
+		assert(monitor == TRACE_PAYLOAD_LEN);
+	});
+
 	test_finish();
 }
 


### PR DESCRIPTION
The CT_SERVICE entry only tracks requests in forward direction. So when it sees a {FIN,RST} packet and __ct_lookup() handles it as ACTION_CLOSE, we only set `.tx_closing = 1` and the ct_entry_alive() check below will always return true. Thus we don't reduce the entry's lifetime to CT_CLOSE_TIMEOUT.

Quick-fix this by also setting `.rx_closing = 1` for such entries. This is in similar spirit as the RST handling for normal CT entries in half-open state.

```release-note
Reduce conntrack lifetime for closing service connections.
```
