### PR TITLE
pkg/allocator: store key in variable for error message

### DIFF
--- a/pkg/allocator/allocator.go
+++ b/pkg/allocator/allocator.go
@@ -594,12 +594,15 @@ func (a *Allocator) lockedAllocate(ctx context.Context, key AllocatorKey) (idpoo
 		return 0, false, false, fmt.Errorf("Found master key after proceeding with new allocation for %s", k)
 	}
 
-	key, err = a.backend.AllocateIDIfLocked(ctx, id, key, lock)
+	// Assigned to 'key' from 'key2' since in case of an error, we don't replace
+	// the original 'key' variable with 'nil'.
+	key2 := key
+	key, err = a.backend.AllocateIDIfLocked(ctx, id, key2, lock)
 	if err != nil {
 		// Creation failed. Another agent most likely beat us to allocting this
 		// ID, retry.
 		releaseKeyAndID()
-		return 0, false, false, fmt.Errorf("unable to allocate ID %s for key %s: %s", strID, key, err)
+		return 0, false, false, fmt.Errorf("unable to allocate ID %s for key %s: %s", strID, key2, err)
 	}
 
 	// Notify pool that leased ID is now in-use.


### PR DESCRIPTION
In case of an error, the returned 'key' would have been nil. By storing it in a separate variable we will be able to return the error with a more descriptive message.

Fixes: e39fcaea5721 ("pkg/allocator: Improve 'Key allocation attempt failed' handling for CRD mode")