### PR TITLE
Remove deadlock from AuthMap Endpoint GC

### DIFF
--- a/pkg/auth/authmap_gc.go
+++ b/pkg/auth/authmap_gc.go
@@ -39,7 +39,9 @@ type authMapGarbageCollector struct {
 	ciliumIdentitiesSynced     bool
 	ciliumIdentitiesDeleted    map[identity.NumericIdentity]struct{}
 
-	endpointRepo endpointRepository
+	endpointsCache       map[uint16]*endpoint.Endpoint
+	endpointsCacheSynced bool
+	endpointsCacheMutex  lock.RWMutex
 }
 
 func (r *authMapGarbageCollector) Name() string {
@@ -50,17 +52,12 @@ type policyRepository interface {
 	GetAuthTypes(localID, remoteID identity.NumericIdentity) policy.AuthTypes
 }
 
-type endpointRepository interface {
-	GetEndpoints() []*endpoint.Endpoint
-}
-
-func newAuthMapGC(logger logrus.FieldLogger, authmap authMap, nodeIDHandler datapathTypes.NodeIDHandler, policyRepo policyRepository, endpointRepo endpointRepository) *authMapGarbageCollector {
+func newAuthMapGC(logger logrus.FieldLogger, authmap authMap, nodeIDHandler datapathTypes.NodeIDHandler, policyRepo policyRepository) *authMapGarbageCollector {
 	return &authMapGarbageCollector{
 		logger:        logger,
 		authmap:       authmap,
 		nodeIDHandler: nodeIDHandler,
 		policyRepo:    policyRepo,
-		endpointRepo:  endpointRepo,
 
 		ciliumNodesDiscovered: map[uint16]struct{}{
 			0: {}, // Local node 0 is always available
@@ -404,14 +401,28 @@ func (r *authMapGarbageCollector) cleanupExpiredEntries(_ context.Context) error
 // Endpoints
 
 func (r *authMapGarbageCollector) subscribeToEndpointEvents(endpointManager endpointmanager.EndpointManager) {
+	r.endpointsCacheMutex.Lock()
+	r.endpointsCache = map[uint16]*endpoint.Endpoint{}
+	for _, ep := range endpointManager.GetEndpoints() {
+		r.endpointsCache[ep.GetID16()] = ep
+	}
+	r.endpointsCacheSynced = true
+	r.endpointsCacheMutex.Unlock()
+
 	endpointManager.Subscribe(r)
 }
 
 func (r *authMapGarbageCollector) EndpointCreated(ep *endpoint.Endpoint) {
-	// noop function to satisfy interface
+	r.endpointsCacheMutex.Lock()
+	r.endpointsCache[ep.GetID16()] = ep
+	r.endpointsCacheMutex.Unlock()
 }
 
 func (r *authMapGarbageCollector) EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConfig) {
+	r.endpointsCacheMutex.Lock()
+	delete(r.endpointsCache, ep.GetID16())
+	r.endpointsCacheMutex.Unlock()
+
 	// when an endpoint got removed clean the authmap entries
 	if err := r.cleanupEndpoints(context.Background()); err != nil {
 		r.logger.WithError(err).Warning("failed to cleanup auth map entries related to endpoint entries")
@@ -419,16 +430,18 @@ func (r *authMapGarbageCollector) EndpointDeleted(ep *endpoint.Endpoint, conf en
 }
 
 func (r *authMapGarbageCollector) cleanupEndpoints(_ context.Context) error {
-	if r.ciliumIdentitiesDiscovered == nil || r.endpointRepo == nil || !r.ciliumIdentitiesSynced {
+	if r.ciliumIdentitiesDiscovered == nil || !r.ciliumIdentitiesSynced || !r.endpointsCacheSynced {
 		return nil
 	}
 
+	r.endpointsCacheMutex.RLock()
 	idsInUse := map[identity.NumericIdentity]struct{}{}
-	for _, ep := range r.endpointRepo.GetEndpoints() {
+	for _, ep := range r.endpointsCache {
 		if id, err := ep.GetSecurityIdentity(); err == nil && id != nil {
 			idsInUse[id.ID] = struct{}{}
 		}
 	}
+	r.endpointsCacheMutex.RUnlock()
 
 	for id := range r.ciliumIdentitiesDiscovered {
 		if _, exists := idsInUse[id]; !exists {

--- a/pkg/auth/cell.go
+++ b/pkg/auth/cell.go
@@ -105,7 +105,7 @@ func registerAuthManager(params authManagerParams) (*AuthManager, error) {
 		return nil, fmt.Errorf("failed to create auth manager: %w", err)
 	}
 
-	mapGC := newAuthMapGC(params.Logger, mapCache, params.NodeIDHandler, params.PolicyRepo, params.EndpointManager)
+	mapGC := newAuthMapGC(params.Logger, mapCache, params.NodeIDHandler, params.PolicyRepo)
 
 	// Register auth components to lifecycle hooks & jobs
 

--- a/pkg/endpointmanager/subscribe.go
+++ b/pkg/endpointmanager/subscribe.go
@@ -10,11 +10,15 @@ type Subscriber interface {
 	// EndpointCreated is called at the end of endpoint creation.
 	// Implementations must not attempt write operations on the
 	// EndpointManager from this callback.
+	// This function is being called inside a RLock, so it must not attempt
+	// to acquire a lock on the EndpointManager.
 	EndpointCreated(ep *endpoint.Endpoint)
 
 	// EndpointDeleted is called at the end of endpoint deletion.
 	// Implementations must not attempt write operations on the
 	// EndpointManager from this callback.
+	// This function is being called inside a RLock, so it must not attempt
+	// to acquire a lock on the EndpointManager.
 	EndpointDeleted(ep *endpoint.Endpoint, conf endpoint.DeleteConfig)
 }
 


### PR DESCRIPTION
This changes that a create and delete event from the EndpointManager will also give a "state of the world" update of all current endpoints it has.
This allows the subscribers to check against other endpoints without calling a function that issues a lock when the event was send inside an RLock.

This is then used in the AuthMap GC code instead of doing a call that caused a deadlock.

Fixes: https://github.com/cilium/cilium/issues/29078

```release-note
Fix potential deadlock that results in stale authentication entries in Cilium
```
