### PR TITLE
egressgw: tests: wait for initial sync reconciliation

### DIFF
--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -210,12 +210,13 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 
 	policyMap := k.manager.policyMap
 	egressGatewayManager := k.manager
+	reconciliationEventsCount := egressGatewayManager.reconciliationEventsCount.Load()
 
 	k.policies.sync(c)
 	k.nodes.sync(c)
 	k.endpoints.sync(c)
 
-	reconciliationEventsCount := egressGatewayManager.reconciliationEventsCount.Load()
+	reconciliationEventsCount = waitForReconciliationRun(c, egressGatewayManager, reconciliationEventsCount)
 
 	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
 	k.nodes.process(c, resource.Event[*cilium_api_v2.CiliumNode]{
@@ -310,7 +311,8 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	})
 
 	// Test excluded CIDRs by adding one to policy-1
-	addPolicy(c, k.policies, &policyParams{name: "policy-1",
+	addPolicy(c, k.policies, &policyParams{
+		name:            "policy-1",
 		endpointLabels:  ep1Labels,
 		destinationCIDR: destCIDR,
 		excludedCIDRs:   []string{excludedCIDR1},
@@ -326,7 +328,8 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	})
 
 	// Add a second excluded CIDR to policy-1
-	addPolicy(c, k.policies, &policyParams{name: "policy-1",
+	addPolicy(c, k.policies, &policyParams{
+		name:            "policy-1",
 		endpointLabels:  ep1Labels,
 		destinationCIDR: destCIDR,
 		excludedCIDRs:   []string{excludedCIDR1, excludedCIDR2},
@@ -343,7 +346,8 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	})
 
 	// Remove the first excluded CIDR from policy-1
-	addPolicy(c, k.policies, &policyParams{name: "policy-1",
+	addPolicy(c, k.policies, &policyParams{
+		name:            "policy-1",
 		endpointLabels:  ep1Labels,
 		destinationCIDR: destCIDR,
 		excludedCIDRs:   []string{excludedCIDR2},
@@ -359,7 +363,8 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	})
 
 	// Remove the second excluded CIDR
-	addPolicy(c, k.policies, &policyParams{name: "policy-1",
+	addPolicy(c, k.policies, &policyParams{
+		name:            "policy-1",
 		endpointLabels:  ep1Labels,
 		destinationCIDR: destCIDR,
 		nodeLabels:      nodeGroup1Labels,
@@ -373,7 +378,8 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	})
 
 	// Test matching no gateway
-	addPolicy(c, k.policies, &policyParams{name: "policy-1",
+	addPolicy(c, k.policies, &policyParams{
+		name:            "policy-1",
 		endpointLabels:  ep1Labels,
 		destinationCIDR: destCIDR,
 		nodeLabels:      nodeGroupNotFoundLabels,


### PR DESCRIPTION
make sure we wait for the first reconciliation (i.e. the initial k8s sync) in unit tests, as otherwise we might miss a reconciliation event and all the subsequent calls to waitForReconciliationRun might return before the reconciliation has actually run