### PR TITLE
WIP bpf: extract ethertype just once in to-overlay / to-netdev

### DIFF
--- a/bpf/bpf_overlay.c
+++ b/bpf/bpf_overlay.c
@@ -681,7 +681,10 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	struct trace_ctx __maybe_unused trace;
 	int ret = TC_ACT_OK;
 	__u32 cluster_id __maybe_unused = 0;
+	__be16 __maybe_unused proto = 0;
 	__s8 ext_err = 0;
+
+	validate_ethertype(ctx, &proto);
 
 #ifdef ENABLE_BANDWIDTH_MANAGER
 	/* In tunneling mode, we should do this as close as possible to the
@@ -690,7 +693,7 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 	 * timestamp already here. The tunnel dev has noqueue qdisc, so as
 	 * tradeoff it's close enough.
 	 */
-	ret = edt_sched_departure(ctx);
+	ret = edt_sched_departure(ctx, proto);
 	/* No send_drop_notify_error() here given we're rate-limiting. */
 	if (ret == CTX_ACT_DROP) {
 		update_metrics(ctx_full_len(ctx), METRIC_EGRESS,
@@ -712,7 +715,7 @@ int cil_to_overlay(struct __ctx_buff *ctx)
 #ifdef ENABLE_CLUSTER_AWARE_ADDRESSING
 	cluster_id = ctx_get_cluster_id_mark(ctx);
 #endif
-	ret = handle_nat_fwd(ctx, cluster_id, &trace, &ext_err);
+	ret = handle_nat_fwd(ctx, cluster_id, proto, &trace, &ext_err);
 out:
 #endif
 	if (IS_ERR(ret))

--- a/bpf/lib/common.h
+++ b/bpf/lib/common.h
@@ -12,8 +12,8 @@
 #include <linux/in.h>
 #include <linux/socket.h>
 
-#include "eth.h"
 #include "endian.h"
+#include "eth.h"
 #include "mono.h"
 #include "config.h"
 #include "tunnel.h"
@@ -173,10 +173,8 @@ static __always_inline bool validate_ethertype_l2_off(struct __ctx_buff *ctx,
 	eth = data + l2_off;
 
 	*proto = eth->h_proto;
-	if (bpf_ntohs(*proto) < ETH_P_802_3_MIN)
-		return false; /* non-Ethernet II unsupported */
 
-	return true;
+	return eth_is_supported_ethertype(*proto);
 }
 
 static __always_inline bool validate_ethertype(struct __ctx_buff *ctx,

--- a/bpf/lib/edt.h
+++ b/bpf/lib/edt.h
@@ -33,14 +33,14 @@ static __always_inline __u32 edt_get_aggregate(struct __ctx_buff *ctx)
 	return aggregate;
 }
 
-static __always_inline int edt_sched_departure(struct __ctx_buff *ctx)
+static __always_inline int
+edt_sched_departure(struct __ctx_buff *ctx, __be16 proto)
 {
 	__u64 delay, now, t, t_next;
 	struct edt_id aggregate;
 	struct edt_info *info;
-	__u16 proto;
 
-	if (!validate_ethertype(ctx, &proto))
+	if (!eth_is_supported_ethertype(proto))
 		return CTX_ACT_OK;
 	if (proto != bpf_htons(ETH_P_IP) &&
 	    proto != bpf_htons(ETH_P_IPV6))

--- a/bpf/lib/eth.h
+++ b/bpf/lib/eth.h
@@ -47,6 +47,12 @@ static __always_inline int eth_is_bcast(const union macaddr *a)
 		return 0;
 }
 
+static __always_inline bool eth_is_supported_ethertype(__be16 proto)
+{
+	/* non-Ethernet II unsupported */
+	return bpf_ntohs(proto) >= ETH_P_802_3_MIN;
+}
+
 static __always_inline int eth_load_saddr(struct __ctx_buff *ctx, __u8 *mac,
 					  int off)
 {

--- a/bpf/lib/nodeport.h
+++ b/bpf/lib/nodeport.h
@@ -3193,17 +3193,16 @@ health_encap_v6(struct __ctx_buff *ctx, const union v6addr *tunnel_ep,
 }
 
 static __always_inline int
-lb_handle_health(struct __ctx_buff *ctx __maybe_unused)
+lb_handle_health(struct __ctx_buff *ctx __maybe_unused, __be16 proto)
 {
 	void *data __maybe_unused, *data_end __maybe_unused;
 	__sock_cookie key __maybe_unused;
 	int ret __maybe_unused;
-	__u16 proto = 0;
 
 	if ((ctx->mark & MARK_MAGIC_HEALTH_IPIP_DONE) ==
 	    MARK_MAGIC_HEALTH_IPIP_DONE)
 		return CTX_ACT_OK;
-	validate_ethertype(ctx, &proto);
+
 	switch (proto) {
 #if defined(ENABLE_IPV4) && DSR_ENCAP_MODE == DSR_ENCAP_IPIP
 	case bpf_htons(ETH_P_IP): {
@@ -3242,17 +3241,14 @@ lb_handle_health(struct __ctx_buff *ctx __maybe_unused)
 #endif /* ENABLE_HEALTH_CHECK */
 
 static __always_inline int
-handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_id,
+handle_nat_fwd(struct __ctx_buff *ctx, __u32 cluster_id, __be16 proto,
 	       struct trace_ctx *trace __maybe_unused,
 	       __s8 *ext_err __maybe_unused)
 {
 	int ret = CTX_ACT_OK;
-	__u16 proto;
 
 	ctx_store_meta(ctx, CB_CLUSTER_ID_EGRESS, cluster_id);
 
-	if (!validate_ethertype(ctx, &proto))
-		return CTX_ACT_OK;
 	switch (proto) {
 #ifdef ENABLE_IPV4
 	case bpf_htons(ETH_P_IP):

--- a/bpf/lib/wireguard.h
+++ b/bpf/lib/wireguard.h
@@ -14,17 +14,16 @@
 #include "overloadable.h"
 
 static __always_inline int
-wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx)
+wg_maybe_redirect_to_encrypt(struct __ctx_buff *ctx, __be16 proto)
 {
 	struct remote_endpoint_info *dst;
 	struct remote_endpoint_info __maybe_unused *src = NULL;
 	void *data, *data_end;
-	__u16 proto = 0;
 	struct ipv6hdr __maybe_unused *ip6;
 	struct iphdr __maybe_unused *ip4;
 	bool from_tunnel __maybe_unused = false;
 
-	if (!validate_ethertype(ctx, &proto))
+	if (!eth_is_supported_ethertype(proto))
 		return DROP_UNSUPPORTED_L2;
 
 	switch (proto) {
@@ -149,17 +148,13 @@ out:
 
 /* strict_allow checks whether the packet is allowed to pass through the strict mode. */
 static __always_inline bool
-strict_allow(struct __ctx_buff *ctx) {
+strict_allow(struct __ctx_buff *ctx, __be16 proto) {
 	struct remote_endpoint_info __maybe_unused *dest_info, __maybe_unused *src_info;
 	bool __maybe_unused in_strict_cidr = false;
 	void *data, *data_end;
 #ifdef ENABLE_IPV4
 	struct iphdr *ip4;
 #endif
-	__u16 proto = 0;
-
-	if (!validate_ethertype(ctx, &proto))
-		return true;
 
 	switch (proto) {
 #ifdef ENABLE_IPV4


### PR DESCRIPTION
The to-netdev part is getting a bit silly.