### PR TITLE
Remove usage of global options from iptables cell

### DIFF
--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -65,6 +65,7 @@ cilium-agent hive [flags]
       --pprof                                                     Enable serving pprof debugging API
       --pprof-address string                                      Address that pprof listens on (default "localhost")
       --pprof-port uint16                                         Port that pprof listens on (default 6060)
+      --prepend-iptables-chains                                   Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off) (default ":9962")
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -70,6 +70,7 @@ cilium-agent hive dot-graph [flags]
       --pprof                                                     Enable serving pprof debugging API
       --pprof-address string                                      Address that pprof listens on (default "localhost")
       --pprof-port uint16                                         Port that pprof listens on (default 6060)
+      --prepend-iptables-chains                                   Prepend custom iptables chains instead of appending (default true)
       --prometheus-serve-addr string                              IP:Port on which to serve prometheus metrics (pass ":Port" to bind on all interfaces, "" is off) (default ":9962")
       --read-cni-conf string                                      CNI configuration file to use as a source for --write-cni-conf-when-ready. If not supplied, a suitable one will be generated.
       --tunnel-port uint16                                        Tunnel port (default 8472 for "vxlan" and 6081 for "geneve")

--- a/Documentation/operations/upgrade.rst
+++ b/Documentation/operations/upgrade.rst
@@ -339,6 +339,9 @@ Annotations:
   is configured in native routing mode and :ref:`DSR mode with Geneve` is enabled.
   Explicitly configure ``--tunnel-protocol=geneve`` (or the equivalent
   ``tunnelProtocol=geneve`` helm value) when DSR with Geneve is enabled.
+* The ``CILIUM_PREPEND_IPTABLES_CHAIN`` environment variable has been renamed
+  to ``CILIUM_PREPEND_IPTABLES_CHAINS`` (note the trailing ``S``) to more accurately
+  match the name of the associated command line flag ``--prepend-iptables-chains``.
 
 .. _upgrade_cilium_cli_helm_mode:
 

--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -733,9 +733,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Int(option.RouteMetric, 0, "Overwrite the metric used by cilium when adding routes to its 'cilium_host' device")
 	option.BindEnv(vp, option.RouteMetric)
 
-	flags.Bool(option.PrependIptablesChainsName, true, "Prepend custom iptables chains instead of appending")
-	option.BindEnvWithLegacyEnvFallback(vp, option.PrependIptablesChainsName, "CILIUM_PREPEND_IPTABLES_CHAIN")
-
 	flags.String(option.IPv6NodeAddr, "auto", "IPv6 address of node")
 	option.BindEnv(vp, option.IPv6NodeAddr)
 

--- a/pkg/datapath/iptables/cell.go
+++ b/pkg/datapath/iptables/cell.go
@@ -55,16 +55,21 @@ type Config struct {
 	// IPTablesRandomFully defines the "--random-fully" iptables option when the
 	// iptables CLI is directly invoked from the Cilium agent.
 	IPTablesRandomFully bool
+
+	// PrependIptablesChains, when enabled, prepends custom iptables chains instead of appending.
+	PrependIptablesChains bool
 }
 
 var defaultConfig = Config{
-	IPTablesLockTimeout: 5 * time.Second,
+	IPTablesLockTimeout:   5 * time.Second,
+	PrependIptablesChains: true,
 }
 
 func (def Config) Flags(flags *pflag.FlagSet) {
 	flags.Duration("iptables-lock-timeout", def.IPTablesLockTimeout, "Time to pass to each iptables invocation to wait for xtables lock acquisition")
 	flags.StringSlice("disable-iptables-feeder-rules", def.DisableIptablesFeederRules, "Chains to ignore when installing feeder rules.")
 	flags.Bool("iptables-random-fully", def.IPTablesRandomFully, "Set iptables flag random-fully on masquerading rules")
+	flags.Bool("prepend-iptables-chains", def.PrependIptablesChains, "Prepend custom iptables chains instead of appending")
 }
 
 type SharedConfig struct {

--- a/pkg/datapath/iptables/custom_chain.go
+++ b/pkg/datapath/iptables/custom_chain.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	"github.com/mattn/go-shellwords"
-
-	"github.com/cilium/cilium/pkg/option"
 )
 
 type customChain struct {
@@ -220,9 +218,9 @@ func (c *customChain) remove(ipv4, ipv6 bool) error {
 	return nil
 }
 
-func (c *customChain) doInstallFeeder(prog iptablesInterface, feedArgs string) error {
+func (c *customChain) doInstallFeeder(prog iptablesInterface, feedArgs string, prepend bool) error {
 	installMode := "-A"
-	if option.Config.PrependIptablesChains {
+	if prepend {
 		installMode = "-I"
 	}
 
@@ -246,15 +244,15 @@ func (c *customChain) doInstallFeeder(prog iptablesInterface, feedArgs string) e
 	return nil
 }
 
-func (c *customChain) installFeeder(ipv4, ipv6 bool) error {
+func (c *customChain) installFeeder(ipv4, ipv6, prepend bool) error {
 	for _, feedArgs := range c.feederArgs {
 		if ipv4 {
-			if err := c.doInstallFeeder(ip4tables, feedArgs); err != nil {
+			if err := c.doInstallFeeder(ip4tables, feedArgs, prepend); err != nil {
 				return err
 			}
 		}
 		if ipv6 && c.ipv6 {
-			if err := c.doInstallFeeder(ip6tables, feedArgs); err != nil {
+			if err := c.doInstallFeeder(ip6tables, feedArgs, prepend); err != nil {
 				return err
 			}
 		}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -301,6 +301,11 @@ func newIptablesManager(p params) *Manager {
 
 // Start initializes the iptables manager and checks for iptables kernel modules availability.
 func (m *Manager) Start(ctx hive.HookContext) error {
+	if os.Getenv("CILIUM_PREPEND_IPTABLES_CHAIN") != "" {
+		m.logger.Warning("CILIUM_PREPEND_IPTABLES_CHAIN env var has been deprecated. Please use 'CILIUM_PREPEND_IPTABLES_CHAINS' " +
+			"env var or '--prepend-iptables-chains' command line flag instead")
+	}
+
 	if err := enableIPForwarding(m.sharedCfg.EnableIPv6); err != nil {
 		m.logger.WithError(err).Warning("enabling IP forwarding via sysctl failed")
 	}
@@ -1695,7 +1700,7 @@ func (m *Manager) installRules(ifName string) error {
 			continue
 		}
 
-		if err := c.installFeeder(m.sharedCfg.EnableIPv4, m.sharedCfg.EnableIPv6); err != nil {
+		if err := c.installFeeder(m.sharedCfg.EnableIPv4, m.sharedCfg.EnableIPv6, m.cfg.PrependIptablesChains); err != nil {
 			return fmt.Errorf("cannot install feeder rule: %w", err)
 		}
 	}

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -301,7 +301,7 @@ func newIptablesManager(p params) *Manager {
 
 // Start initializes the iptables manager and checks for iptables kernel modules availability.
 func (m *Manager) Start(ctx hive.HookContext) error {
-	if err := enableIPForwarding(); err != nil {
+	if err := enableIPForwarding(m.sharedCfg.EnableIPv6); err != nil {
 		m.logger.WithError(err).Warning("enabling IP forwarding via sysctl failed")
 	}
 

--- a/pkg/datapath/iptables/iptables.go
+++ b/pkg/datapath/iptables/iptables.go
@@ -289,6 +289,7 @@ func newIptablesManager(p params) *Manager {
 	iptMgr := &Manager{
 		logger:        p.Logger,
 		modulesMgr:    p.ModulesMgr,
+		cfg:           p.Cfg,
 		sharedCfg:     p.SharedCfg,
 		haveIp6tables: true,
 	}

--- a/pkg/datapath/iptables/iptables_test.go
+++ b/pkg/datapath/iptables/iptables_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/blang/semver/v4"
 	check "github.com/cilium/checkmate"
-
-	"github.com/cilium/cilium/pkg/option"
 )
 
 func Test(t *testing.T) {
@@ -91,11 +89,10 @@ var mockManager = &Manager{
 	haveSocketMatch:      true,
 	haveBPFSocketAssign:  false,
 	ipEarlyDemuxDisabled: false,
-}
-
-func init() {
-	option.Config.EnableIPv4 = true
-	option.Config.EnableIPv6 = true
+	sharedCfg: SharedConfig{
+		EnableIPv4: true,
+		EnableIPv6: true,
+	},
 }
 
 func (s *iptablesTestSuite) TestRenameCustomChain(c *check.C) {

--- a/pkg/datapath/iptables/sysctl_darwin.go
+++ b/pkg/datapath/iptables/sysctl_darwin.go
@@ -5,6 +5,6 @@ package iptables
 
 // enableIPForwarding on OS X and Darwin is not doing anything. It just exists
 // to make compilation possible.
-func enableIPForwarding() error {
+func enableIPForwarding(_ bool) error {
 	return nil
 }

--- a/pkg/datapath/iptables/sysctl_linux.go
+++ b/pkg/datapath/iptables/sysctl_linux.go
@@ -4,18 +4,17 @@
 package iptables
 
 import (
-	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/sysctl"
 )
 
-func enableIPForwarding() error {
+func enableIPForwarding(ipv6 bool) error {
 	if err := sysctl.Enable("net.ipv4.ip_forward"); err != nil {
 		return err
 	}
 	if err := sysctl.Enable("net.ipv4.conf.all.forwarding"); err != nil {
 		return err
 	}
-	if option.Config.EnableIPv6 {
+	if ipv6 {
 		if err := sysctl.Enable("net.ipv6.conf.all.forwarding"); err != nil {
 			return err
 		}

--- a/pkg/datapath/iptables/sysctl_linux_test.go
+++ b/pkg/datapath/iptables/sysctl_linux_test.go
@@ -20,6 +20,6 @@ func (s *DaemonPrivilegedSuite) SetUpSuite(c *C) {
 }
 
 func (s *DaemonPrivilegedSuite) TestEnableIPForwarding(c *C) {
-	err := enableIPForwarding()
+	err := enableIPForwarding(false)
 	c.Assert(err, IsNil)
 }

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -650,10 +650,6 @@ const (
 	// load loggging
 	LogSystemLoadConfigName = "log-system-load"
 
-	// PrependIptablesChainsName is the name of the option to enable
-	// prepending iptables chains instead of appending
-	PrependIptablesChainsName = "prepend-iptables-chains"
-
 	// DisableCiliumEndpointCRDName is the name of the option to disable
 	// use of the CEP CRD
 	DisableCiliumEndpointCRDName = "disable-endpoint-crd"
@@ -1641,10 +1637,6 @@ type DaemonConfig struct {
 	EnvoyLogPath string
 
 	ProcFs string
-
-	// PrependIptablesChains is the name of the option to enable prepending
-	// iptables chains instead of appending
-	PrependIptablesChains bool
 
 	// K8sNamespace is the name of the namespace in which Cilium is
 	// deployed in when running in Kubernetes mode
@@ -3136,7 +3128,6 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.MonitorAggregationInterval = vp.GetDuration(MonitorAggregationInterval)
 	c.MTU = vp.GetInt(MTUName)
 	c.PreAllocateMaps = vp.GetBool(PreAllocateMapsName)
-	c.PrependIptablesChains = vp.GetBool(PrependIptablesChainsName)
 	c.ProcFs = vp.GetString(ProcFs)
 	c.ProxyConnectTimeout = vp.GetInt(ProxyConnectTimeout)
 	c.ProxyGID = vp.GetInt(ProxyGID)


### PR DESCRIPTION
Remove usage of `option.Config` in iptables cell. These are just leftover after the cell has been modularized.

The option `prepend-iptables-chains` used to have an env var alias named `CILIUM_PREPEND_IPTABLES_CHAIN`.  It was there to ensure backward compatibility.  ~But the alias is exactly the same string as the usual name for the option (prefix is "CILIUM_" and option name is "PREPEND_IPTABLES_CHAIN"). In other words, there was actually no alias.
Thus it is safe to move the option in the cell.Config(), even if hive package does not support additional aliasies for the same config option.~
`CILIUM_PREPEND_IPTABLES_CHAIN` alias has been deprecated with a warning and a note in the v1.15 Upgrade Notes. Read [this comment](https://github.com/cilium/cilium/pull/29088#issuecomment-1812314672) for more info.

~Depends on: https://github.com/cilium/cilium/pull/28746~