### PR TITLE
docs: update versions and parameters for XDP Acceleration on AKS

### DIFF
--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -819,7 +819,7 @@ enabled. In addition, the Linux kernel on the nodes must also have support for
 native XDP in the ``hv_netvsc`` driver, which is available in kernel >= 5.6 and was backported to
 the Azure Linux kernel in 5.4.0-1022.
 
-On AKS, make sure to use the AKS Ubuntu 18.04 node image with Kubernetes version v1.18 which will
+On AKS, make sure to use the AKS Ubuntu 22.04 node image with Kubernetes version v1.26 which will
 provide a Linux kernel with the necessary backports to the ``hv_netvsc`` driver. Please refer to the
 documentation on `how to configure an AKS cluster
 <https://docs.microsoft.com/en-us/azure/aks/cluster-configuration>`_ for more details.
@@ -867,7 +867,7 @@ will automatically configure your virtual network to route pod traffic correctly
      --set devices=eth0 \\
      --set kubeProxyReplacement=true \\
      --set loadBalancer.acceleration=native \\
-     --set loadBalancer.mode=hybrid \\
+     --set loadBalancer.mode=snat \\
      --set k8sServiceHost=${API_SERVER_IP} \\
      --set k8sServicePort=${API_SERVER_PORT}
 

--- a/Documentation/network/kubernetes/kubeproxy-free.rst
+++ b/Documentation/network/kubernetes/kubeproxy-free.rst
@@ -81,7 +81,7 @@ by using the following commands below.
 
 .. include:: ../../installation/k8s-install-download-release.rst
 
-Next, generate the required YAML files and deploy them. 
+Next, generate the required YAML files and deploy them.
 
 .. important::
 
@@ -832,12 +832,14 @@ with Accelerated Networking using Azure CLI
 for more details.
 
 When *Accelerated Networking* is enabled, ``lspci`` will show a
-Mellanox ConnectX-3 or ConnectX-4 Lx NIC:
+Mellanox ConnectX NIC:
 
 .. code-block:: shell-session
 
     $ lspci | grep Ethernet
     2846:00:02.0 Ethernet controller: Mellanox Technologies MT27710 Family [ConnectX-4 Lx Virtual Function] (rev 80)
+
+XDP acceleration can only be enabled on NICs ConnectX-4 Lx and onwards.
 
 In order to run XDP, large receive offload (LRO) needs to be disabled on the
 ``hv_netvsc`` device. If not the case already, this can be achieved by:
@@ -895,9 +897,9 @@ have Kubernetes InternalIP or ExternalIP assigned. InternalIP is preferred over
 ExternalIP if both exist. To change the devices, set their names in the
 ``devices`` Helm option, e.g. ``devices='{eth0,eth1,eth2}'``. Each
 listed device has to be named the same on all Cilium managed nodes. Alternatively
-if the devices do not match across different nodes, the wildcard option can be 
+if the devices do not match across different nodes, the wildcard option can be
 used, e.g. ``devices=eth+``, which would match any device starting with prefix
-``eth``. If no device can be matched the Cilium agent will try to perform auto 
+``eth``. If no device can be matched the Cilium agent will try to perform auto
 detection.
 
 When multiple devices are used, only one device can be used for direct routing


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [X] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [X] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [X] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [X] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->
Through testing with AKS, I determined that networking with XDP acceleration does not work correctly with the Mellanox ConnectX-3 NIC on Azure. This has also been cross-referenced as a known issue in the NVidia [documentation](https://docs.nvidia.com/networking/display/mlnxofedv494170/known+issues) (ref: 1550266). This PR updates to documentation to be clearer about this.
There are also some version and parameter inaccuracies for setting up a cluster with AKS that are corrected in this PR.

Fixes: #29065, #27289