### PR TITLE
ctmap: consider CT entry's .dsr flag in PurgeOrphanNATEntries()

### DIFF
--- a/pkg/maps/ctmap/ctmap_privileged_test.go
+++ b/pkg/maps/ctmap/ctmap_privileged_test.go
@@ -708,6 +708,29 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(buf), Equals, 0)
 
+	// When a connection is re-opened and switches from DSR to local-backend,
+	// its CT entry gets re-created but uses the same CT tuple as key.
+	//
+	// Validate that we clean up the stale DSR NAT entry in such a case.
+	ctVal.Flags = 0
+
+	err = ctMapTCP.Map.Update(ctKey, ctVal)
+	c.Assert(err, IsNil)
+
+	err = natMap.Map.Update(natKey, natVal)
+	c.Assert(err, IsNil)
+
+	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
+	c.Assert(stats.IngressAlive, Equals, uint32(0))
+	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressAlive, Equals, uint32(0))
+	c.Assert(stats.EgressDeleted, Equals, uint32(1))
+	// Check that the orphan NAT entry has been removed
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+
 	// Test DSR (new, tracked by nodeport.h)
 	//
 	// Create the following entries and check that SNAT entries are NOT GC-ed
@@ -771,6 +794,29 @@ func (k *CTMapPrivilegedTestSuite) TestOrphanNatGC(c *C) {
 	// Now remove the CT entry which should remove the NAT entry
 	err = ctMapTCP.Map.Delete(ctKey)
 	c.Assert(err, IsNil)
+	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
+	c.Assert(stats.IngressAlive, Equals, uint32(0))
+	c.Assert(stats.IngressDeleted, Equals, uint32(0))
+	c.Assert(stats.EgressAlive, Equals, uint32(0))
+	c.Assert(stats.EgressDeleted, Equals, uint32(1))
+	// Check that the orphan NAT entry has been removed
+	buf = make(map[string][]string)
+	err = natMap.Map.Dump(buf)
+	c.Assert(err, IsNil)
+	c.Assert(len(buf), Equals, 0)
+
+	// When a connection is re-opened and switches from DSR to local-backend,
+	// its CT entry gets re-created but uses the same CT tuple as key.
+	//
+	// Validate that we clean up the stale DSR NAT entry in such a case.
+	ctVal.Flags = 0
+
+	err = ctMapTCP.Map.Update(ctKey, ctVal)
+	c.Assert(err, IsNil)
+
+	err = natMap.Map.Update(natKey, natVal)
+	c.Assert(err, IsNil)
+
 	stats = PurgeOrphanNATEntries(ctMapTCP, ctMapTCP)
 	c.Assert(stats.IngressAlive, Equals, uint32(0))
 	c.Assert(stats.IngressDeleted, Equals, uint32(0))

--- a/pkg/maps/ctmap/utils.go
+++ b/pkg/maps/ctmap/utils.go
@@ -172,7 +172,16 @@ func egressCTKeyFromEgressNatKey(k nat.NatKey) bpf.MapKey {
 	}
 }
 
-func ctEntryExist(ctMap *Map, ctKey bpf.MapKey) bool {
-	_, err := ctMap.Lookup(ctKey)
-	return !errors.Is(err, unix.ENOENT)
+func ctEntryExist(ctMap *Map, ctKey bpf.MapKey, f func(*CtEntry) bool) bool {
+	v, err := ctMap.Lookup(ctKey)
+
+	if err != nil {
+		return !errors.Is(err, unix.ENOENT)
+	}
+
+	if f == nil {
+		return true
+	}
+
+	return f(v.(*CtEntry))
 }


### PR DESCRIPTION
```
The BPF datapath potentially re-creates a CT entry, in particular when a
DSR connection gets re-opened as local connection. Such a re-purposed CT
entry then leaves a DSR NAT entry behind.

Currently we wouldn't clean up such NAT entries (as the matching CT entry
still exists). But once we look at the CT entry's .dsr flag, we understand
that the CT entry is actually no longer a match for the NAT entry.
```