### PR TITLE
[1.14] Downgrade XDP attachments from Cilium 1.15

### DIFF
--- a/pkg/datapath/loader/base.go
+++ b/pkg/datapath/loader/base.go
@@ -261,6 +261,7 @@ func (l *Loader) reinitializeOverlay(ctx context.Context, encapProto string) err
 }
 
 func (l *Loader) reinitializeXDPLocked(ctx context.Context, extraCArgs []string) error {
+	maybeRemoveXDPLinks()
 	maybeUnloadObsoleteXDPPrograms(option.Config.GetDevices(), option.Config.XDPMode)
 	if option.Config.XDPMode == option.XDPModeDisabled {
 		return nil

--- a/pkg/datapath/loader/paths.go
+++ b/pkg/datapath/loader/paths.go
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loader
+
+import (
+	"path/filepath"
+
+	"github.com/vishvananda/netlink"
+)
+
+// bpffsDevicesDir returns the path to the 'devices' directory on bpffs, usually
+// /sys/fs/bpf/cilium/devices. It does not ensure the directory exists.
+//
+// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
+// during tests.
+func bpffsDevicesDir(base string) string {
+	return filepath.Join(base, "devices")
+}
+
+// bpffsDeviceLinksDir returns the bpffs path to the per-device links directory,
+// usually /sys/fs/bpf/cilium/devices/<device>/links. It does not ensure the
+// directory exists.
+//
+// base is typically set to /sys/fs/bpf/cilium, but can be a temp directory
+// during tests.
+func bpffsDeviceLinksDir(base string, device netlink.Link) string {
+	return filepath.Join(bpffsDevicesDir(base), device.Attrs().Name, "links")
+}

--- a/pkg/datapath/loader/xdp.go
+++ b/pkg/datapath/loader/xdp.go
@@ -52,7 +52,7 @@ func maybeUnloadObsoleteXDPPrograms(xdpDevs []string, xdpMode string) {
 		used := false
 		for _, xdpDev := range xdpDevs {
 			if link.Attrs().Name == xdpDev &&
-				linkxdp.Flags&xdpModeToFlag(xdpMode) != 0 {
+				linkxdp.AttachMode == xdpModeToFlag(xdpMode) {
 				// XDP mode matches; don't unload, otherwise we might introduce
 				// intermittent connectivity problems
 				used = true

--- a/pkg/datapath/loader/xdp_test.go
+++ b/pkg/datapath/loader/xdp_test.go
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package loader
+
+import (
+	"testing"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/stretchr/testify/require"
+	"github.com/vishvananda/netlink"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/asm"
+
+	"github.com/cilium/cilium/pkg/netns"
+	"github.com/cilium/cilium/pkg/option"
+	"github.com/cilium/cilium/pkg/testutils"
+)
+
+func mustXDPProgram(t *testing.T) *ebpf.Program {
+	p, err := ebpf.NewProgram(&ebpf.ProgramSpec{
+		Type: ebpf.XDP,
+		Instructions: asm.Instructions{
+			asm.Mov.Imm(asm.R0, 0),
+			asm.Return(),
+		},
+		License: "Apache-2.0",
+	})
+	if err != nil {
+		t.Skipf("xdp programs not supported: %s", err)
+	}
+	t.Cleanup(func() {
+		p.Close()
+	})
+	return p
+}
+
+func TestMaybeUnloadObsoleteXDPPrograms(t *testing.T) {
+	testutils.PrivilegedTest(t)
+
+	netnsName := "test-maybe-unload-xdp"
+	netns0, err := netns.ReplaceNetNSWithName(netnsName)
+	require.NoError(t, err)
+	require.NotNil(t, netns0)
+	t.Cleanup(func() {
+		netns0.Close()
+		netns.RemoveNetNSWithName(netnsName)
+	})
+
+	netns0.Do(func(_ ns.NetNS) error {
+		veth0 := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "veth0"},
+			PeerName:  "veth2",
+		}
+		err := netlink.LinkAdd(veth0)
+		require.NoError(t, err)
+
+		veth1 := &netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{Name: "veth1"},
+			PeerName:  "veth3",
+		}
+		err = netlink.LinkAdd(veth1)
+		require.NoError(t, err)
+
+		prog := mustXDPProgram(t)
+
+		err = attachProgram(veth0, prog, "test", 0, xdpModeToFlag(option.XDPModeLinkGeneric))
+		require.NoError(t, err)
+
+		err = attachProgram(veth1, prog, "test", 0, xdpModeToFlag(option.XDPModeLinkGeneric))
+		require.NoError(t, err)
+
+		maybeUnloadObsoleteXDPPrograms([]string{"veth0"}, option.XDPModeLinkGeneric)
+
+		v0, err := netlink.LinkByName("veth0")
+		require.NoError(t, err)
+		require.NotNil(t, v0.Attrs().Xdp)
+		require.True(t, v0.Attrs().Xdp.Attached)
+
+		v1, err := netlink.LinkByName("veth1")
+		require.NoError(t, err)
+		if v1.Attrs().Xdp != nil {
+			require.False(t, v1.Attrs().Xdp.Attached)
+		}
+
+		err = netlink.LinkDel(veth0)
+		require.NoError(t, err)
+
+		err = netlink.LinkDel(veth1)
+		require.NoError(t, err)
+
+		return nil
+	})
+}


### PR DESCRIPTION
Cilium 1.15 will attach XDP programs using bpf_link on supported kernels by default. This patch ensures these attachments can be undone during downgrades so programs can be attached using netlink again.

Also fixes a bug in removing XDP attachments from unused devices.

```release-note
Support downgrade path for XDP attachments from Cilium 1.15
```
