### PR TITLE
fix operator dashboard helm template

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/dashboards-configmap.yaml
@@ -20,7 +20,7 @@ metadata:
     {{- with $.Values.operator.dashboards.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.operator.annotations }}
+    {{- with $.Values.operator.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [x] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

The config maps fail to render if either dashboard or operator annotations are specified, this is due to the operator annotations not being accessed using $.Values.operator.annotations and fixes the following error.

`Error: template: cilium/templates/cilium-operator/dashboards-configmap.yaml:23:20: executing "cilium/templates/cilium-operator/dashboards-configmap.yaml" at <.Values.operator.annotations>: can't evaluate field Values in type []uint8`


```release-note
Fix rendering helm operator-dashboard annotations
```
