### PR TITLE
Make sure runtime device detection works with the Bandwidth Manager

### DIFF
--- a/daemon/cmd/daemon.go
+++ b/daemon/cmd/daemon.go
@@ -1136,6 +1136,10 @@ func (d *Daemon) ReloadOnDeviceChange(devices []string) {
 		}
 	}
 
+	if option.Config.EnableBandwidthManager {
+		bandwidth.UpdateDevices(devices)
+	}
+
 	// Reload the datapath.
 	wg, err := d.TriggerReloadWithoutCompile("devices changed")
 	if err != nil {

--- a/daemon/cmd/status.go
+++ b/daemon/cmd/status.go
@@ -1080,12 +1080,25 @@ func (d *Daemon) startStatusCollector(cleaner *daemonCleanup) {
 				}
 			},
 		},
+		{
+			Name: "bandwidth-manager",
+			Probe: func(ctx context.Context) (interface{}, error) {
+				return d.getBandwidthManagerStatus(), nil
+			},
+			OnStatusUpdate: func(status status.Status) {
+				d.statusCollectMutex.Lock()
+				defer d.statusCollectMutex.Unlock()
+
+				if s, ok := status.Data.(*models.BandwidthManager); ok {
+					d.statusResponse.BandwidthManager = s
+				}
+			},
+		},
 	}
 
 	d.statusResponse.Masquerading = d.getMasqueradingStatus()
 	d.statusResponse.IPV6BigTCP = d.getIPV6BigTCPStatus()
 	d.statusResponse.IPV4BigTCP = d.getIPV4BigTCPStatus()
-	d.statusResponse.BandwidthManager = d.getBandwidthManagerStatus()
 	d.statusResponse.HostFirewall = d.getHostFirewallStatus()
 	d.statusResponse.HostRouting = d.getHostRoutingStatus()
 	d.statusResponse.ClockSource = d.getClockSourceStatus()

--- a/pkg/bandwidth/bandwidth.go
+++ b/pkg/bandwidth/bandwidth.go
@@ -178,7 +178,11 @@ func InitBandwidthManager() {
 		log.WithError(err).Fatal("Failed to set sysctl needed by BPF bandwidth manager.")
 	}
 
-	for _, device := range option.Config.GetDevices() {
+	UpdateDevices(option.Config.GetDevices())
+}
+
+func UpdateDevices(devices []string) {
+	for _, device := range devices {
 		link, err := netlink.LinkByName(device)
 		if err != nil {
 			log.WithError(err).WithField("device", device).Warn("Link does not exist")


### PR DESCRIPTION
# Summary
Follow-up to https://github.com/cilium/cilium/pull/17460.

This PR ensures that the runtime device detection feature properly works with the Bandwidth Manager.

# Testing
## Previous behaviour
### --enable-bandwidth-manager=true and --enable-runtime-device-detection=false
Running the Bandwidth Manager without runtime device detection causes some devices to be missed. For example in our setup in AWS, the `ens6` device is added _after_ the Bandwidth Manager is initialized (similar to https://github.com/cilium/cilium/issues/16790). This results in a state where the Bandwidth Manager BPF code is not properly injected and the `qdisc`s are not updated. 

Example:
When querying the status with the CLI, we can see that `ens6` is missing:
```
# cilium status
[...]
BandwidthManager:        EDT with BPF [CUBIC] [ens5]
[...]
```
On the node, `ens6` doesn't have `fq` set-up and is missing the egress filter:
```
$ sudo tc qdisc show dev ens5
qdisc mq 8002: root
qdisc fq 0: parent 8002:2 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 18030b initial_quantum 90150b low_rate_threshold 550Kbit refill_delay 40ms timer_slack 10us horizon 10s horizon_drop
qdisc fq 0: parent 8002:1 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 18030b initial_quantum 90150b low_rate_threshold 550Kbit refill_delay 40ms timer_slack 10us horizon 10s horizon_drop
qdisc clsact ffff: parent ffff:fff1

$ sudo tc qdisc show dev ens6
qdisc mq 0: root
qdisc fq_codel 0: parent :2 limit 10240p flows 1024 quantum 9015 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc fq_codel 0: parent :1 limit 10240p flows 1024 quantum 9015 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc clsact ffff: parent ffff:fff1

ddeng@ip-10-131-49-125:~$ sudo tc filter show dev ens5 egress
filter protocol all pref 1 bpf chain 0
filter protocol all pref 1 bpf chain 0 handle 0x1 cil_to_netdev-ens5 direct-action not_in_hw id 607 tag 1472cecaa85b923e jited
filter protocol all pref 10 bpf chain 0
filter protocol all pref 10 bpf chain 0 handle 0x1 classifier_egress_security2_4026531840_3204 direct-action not_in_hw id 1124 tag e4e4823f44204689 jited

ddeng@ip-10-131-49-125:~$ sudo tc filter show dev ens6 egress
filter protocol all pref 10 bpf chain 0
filter protocol all pref 10 bpf chain 0 handle 0x1 classifier_egress_security4_4026531840_3204 direct-action not_in_hw id 1128 tag e4e4823f44204689 jited
```

### --enable-bandwidth-manager=true and --enable-runtime-device-detection=true
Enabling runtime device detection still caused an inconsistent state when the Bandwidth Manager was enabled. 
This is because the runtime device detection logic is only doing the datapath update but is not doing any Bandwidth Manager specific updates (this was explicitly stated in https://github.com/cilium/cilium/pull/17460).

Example:
When querying the status with the CLI, the `ens6` device is still missing:
```
# cilium status
[...]
BandwidthManager:        EDT with BPF [CUBIC] [ens5]
[...]
```
On the node, the filters were properly updated but the `qdisc`s are still inconsistent:
```
$ sudo tc qdisc show dev ens5
qdisc mq 8002: root
qdisc fq 0: parent 8002:2 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 18030b initial_quantum 90150b low_rate_threshold 550Kbit refill_delay 40ms timer_slack 10us horizon 10s horizon_drop
qdisc fq 0: parent 8002:1 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 18030b initial_quantum 90150b low_rate_threshold 550Kbit refill_delay 40ms timer_slack 10us horizon 10s horizon_drop
qdisc clsact ffff: parent ffff:fff1

$ sudo tc qdisc show dev ens6
qdisc mq 0: root
qdisc fq_codel 0: parent :2 limit 10240p flows 1024 quantum 9015 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc fq_codel 0: parent :1 limit 10240p flows 1024 quantum 9015 target 5ms interval 100ms memory_limit 32Mb ecn drop_batch 64
qdisc clsact ffff: parent ffff:fff1

$ sudo tc filter show dev ens5 egress
filter protocol all pref 1 bpf chain 0
filter protocol all pref 1 bpf chain 0 handle 0x1 cil_to_netdev-ens5 direct-action not_in_hw id 700 tag 1472cecaa85b923e jited
filter protocol all pref 10 bpf chain 0
filter protocol all pref 10 bpf chain 0 handle 0x1 classifier_egress_security2_4026531840_2649 direct-action not_in_hw id 1201 tag e4e4823f44204689 jited

$ sudo tc filter show dev ens6 egress
filter protocol all pref 1 bpf chain 0
filter protocol all pref 1 bpf chain 0 handle 0x1 cil_to_netdev-ens6 direct-action not_in_hw id 714 tag 1472cecaa85b923e jited
filter protocol all pref 10 bpf chain 0
filter protocol all pref 10 bpf chain 0 handle 0x1 classifier_egress_security4_4026531840_2649 direct-action not_in_hw id 1205 tag e4e4823f44204689 jited
```

## Fixed behaviour 
This PR ensures that when `--enable-bandwidth-manager=true` and `--enable-runtime-device-detection=true`, the `qdisc`s and the status are properly updated when new devices are detected.

Example:
The status is now properly updated:
```
# cilium status
[...]
BandwidthManager:        EDT with BPF [CUBIC] [ens5, ens6]
[...]
```

On the node, the `qdisc`s are now properly set up:
```
$ sudo tc qdisc show dev ens5
qdisc mq 8004: root
qdisc fq 0: parent 8004:2 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 18030b initial_quantum 90150b low_rate_threshold 550Kbit refill_delay 40ms timer_slack 10us horizon 10s horizon_drop
qdisc fq 0: parent 8004:1 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 18030b initial_quantum 90150b low_rate_threshold 550Kbit refill_delay 40ms timer_slack 10us horizon 10s horizon_drop
qdisc clsact ffff: parent ffff:fff1

$ sudo tc qdisc show dev ens6
qdisc mq 8006: root
qdisc fq 0: parent 8006:2 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 18030b initial_quantum 90150b low_rate_threshold 550Kbit refill_delay 40ms timer_slack 10us horizon 10s horizon_drop
qdisc fq 0: parent 8006:1 limit 10000p flow_limit 100p buckets 1024 orphan_mask 1023 quantum 18030b initial_quantum 90150b low_rate_threshold 550Kbit refill_delay 40ms timer_slack 10us horizon 10s horizon_drop
qdisc clsact ffff: parent ffff:fff1

$ sudo tc filter show dev ens5 egress
filter protocol all pref 1 bpf chain 0
filter protocol all pref 1 bpf chain 0 handle 0x1 cil_to_netdev-ens5 direct-action not_in_hw id 1164 tag 1472cecaa85b923e jited
filter protocol all pref 10 bpf chain 0
filter protocol all pref 10 bpf chain 0 handle 0x1 classifier_egress_security2_4026531840_2461 direct-action not_in_hw id 1201 tag e4e4823f44204689 jited

$ sudo tc filter show dev ens6 egress
filter protocol all pref 1 bpf chain 0
filter protocol all pref 1 bpf chain 0 handle 0x1 cil_to_netdev-ens6 direct-action not_in_hw id 1181 tag 1472cecaa85b923e jited
filter protocol all pref 10 bpf chain 0
filter protocol all pref 10 bpf chain 0 handle 0x1 classifier_egress_security4_4026531840_2461 direct-action not_in_hw id 1205 tag e4e4823f44204689 jited
```

In the logs I can see:
```
level=info msg="Detected devices" devices="[ens5]" subsys=linux-datapath
level=info msg="Setting qdisc to mq with fq leafs" device=ens5 subsys=bandwidth-manager
level=info msg="Listening for device changes" subsys=linux-datapath
level=info msg="Devices changed" devices="[ens5 ens6]" subsys=linux-datapath
level=info msg="Setting qdisc to mq with fq leafs" device=ens5 subsys=bandwidth-manager
level=info msg="Setting qdisc to mq with fq leafs" device=ens6 subsys=bandwidth-manager
```