### PR TITLE
Replace etcd init script and bump etcd version

### DIFF
--- a/Documentation/helm-values.rst
+++ b/Documentation/helm-values.rst
@@ -436,10 +436,14 @@
      - Affinity for clustermesh.apiserver
      - object
      - ``{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}``
-   * - :spelling:ignore:`clustermesh.apiserver.etcd.image`
-     - Clustermesh API server etcd image.
-     - object
-     - ``{"digest":"sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3","override":null,"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.5.4","useDigest":true}``
+   * - :spelling:ignore:`clustermesh.apiserver.etcd.init.extraArgs`
+     - Additional arguments to ``clustermesh-apiserver etcdinit``.
+     - list
+     - ``[]``
+   * - :spelling:ignore:`clustermesh.apiserver.etcd.init.extraEnv`
+     - Additional environment variables to ``clustermesh-apiserver etcdinit``.
+     - list
+     - ``[]``
    * - :spelling:ignore:`clustermesh.apiserver.etcd.init.resources`
      - Specifies the resources for etcd init container in the apiserver
      - object

--- a/clustermesh-apiserver/etcdinit/root.go
+++ b/clustermesh-apiserver/etcdinit/root.go
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package etcdinit
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/cilium/cilium/pkg/defaults"
+	kvstoreEtcdInit "github.com/cilium/cilium/pkg/kvstore/etcdinit"
+	"github.com/cilium/cilium/pkg/logging"
+	"github.com/cilium/cilium/pkg/logging/logfields"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// etcdBinaryLocation is hardcoded because we expect this command to be run inside a Cilium container that places the
+// etcd binary in a specific location.
+const etcdBinaryLocation = "/usr/bin/etcd"
+
+var (
+	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "etcdinit")
+	vp  = viper.New()
+)
+
+func NewCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:   "etcdinit",
+		Short: "Initialise an etcd data directory for use by the etcd sidecar of clustermesh-apiserver",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := InitEtcdLocal()
+			// The error has already been handled and logged by InitEtcdLocal. We just use it to determine the exit code
+			if err != nil {
+				os.Exit(-1)
+			}
+		},
+	}
+	rootCmd.Flags().String("etcd-data-dir", "/var/run/etcd", "Etcd data directory. Should have read/write permissions here.")
+	rootCmd.Flags().String("etcd-initial-cluster-token", "clustermesh-apiserver", "Etcd initial cluster token. Used to prevent accidentally joining other etcd clusters that are reachable on the same L2 network domain.")
+	rootCmd.Flags().String("etcd-cluster-name", "clustermesh-apiserver", "Name of the etcd cluster. Must match what etcd is later started with.")
+	rootCmd.Flags().String("cluster-name", defaults.ClusterName, "Name of the Cilium cluster, used to set the username of the admin user in etcd. This is distinct from the etcd cluster's name.")
+	rootCmd.Flags().Duration("timeout", time.Minute*2, "How long to wait for operations before exiting.")
+	rootCmd.Flags().Bool("debug", false, "Debug log output.")
+	// Use Viper for configuration so that we can parse both command line flags and environment variables
+	vp.BindPFlags(rootCmd.Flags())
+	vp.SetEnvPrefix("cilium")
+	vp.AutomaticEnv()
+	vp.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	return rootCmd
+}
+
+func InitEtcdLocal() (returnErr error) {
+	// Get configuration values
+	etcdDataDir := vp.GetString("etcd-data-dir")
+	etcdInitialClusterToken := vp.GetString("etcd-initial-cluster-token")
+	etcdClusterName := vp.GetString("etcd-cluster-name")
+	ciliumClusterName := vp.GetString("cluster-name")
+	debug := vp.GetBool("debug")
+	timeout := vp.GetDuration("timeout")
+	// We have returnErr has a named variable, so we can set it in the deferred cleanup function if needed
+	log.WithFields(logrus.Fields{
+		"timeout":                 timeout,
+		"etcdDataDir":             etcdDataDir,
+		"etcdClusterName":         etcdClusterName,
+		logfields.ClusterName:     ciliumClusterName,
+		"etcdInitialClusterToken": etcdInitialClusterToken,
+	}).
+		Info("Starting first-time initialisation of etcd for Cilium Clustermesh")
+
+	ctx, cancelFn := context.WithTimeout(context.Background(), timeout)
+	defer cancelFn()
+
+	if debug {
+		logging.SetLogLevelToDebug()
+	}
+	log.Debug("Debug logging enabled")
+
+	// When the clustermesh-apiserver is launched we create a new etcd. We don't support persistence, so it is safe to
+	// delete the contents of the data directory before we start. It should be empty as we use a Kubernetes emptyDir for
+	// this purpose, but if the initialization failed Kubernetes may re-run this operation and emptyDir is tied to the
+	// lifecycle of the whole pod. Therefore, it could contain files from a previously failed initialization attempt.
+	log.WithField("etcdDataDir", etcdDataDir).
+		Info("Deleting contents of data directory")
+	// We don't use os.RemoveAll on the etcdDataDirectory because we don't want to remove the directory itself, just
+	// everything inside of it. In most cases that directory will be a mount anyway.
+	dir, err := os.ReadDir(etcdDataDir)
+	if err != nil {
+		log.WithField("etcdDataDir", etcdDataDir).
+			WithError(err).
+			Error("Failed to read from the etcd data directory while attempting to delete existing files")
+		return err
+	}
+	for _, d := range dir {
+		log.WithField("etcdDataDir", etcdDataDir).
+			WithField("path", d.Name()).
+			Debug("Removing file/directory in data dir")
+		err = os.RemoveAll(path.Join(etcdDataDir, d.Name()))
+		if err != nil {
+			log.WithField("etcdDataDir", etcdDataDir).
+				WithField("path", d.Name()).
+				WithError(err).
+				Error("Failed to remove pre-existing file/directory in etcd data directory")
+			return err
+		}
+	}
+
+	// Use "localhost" (instead of "http://127.0.0.1:2379" or "http://[::1]:2379") so it works in both the IPv4 and
+	// IPv6 cases.
+	loopbackEndpoint := "http://localhost:2379"
+	log.WithFields(logrus.Fields{
+		"etcdDataDir":             etcdDataDir,
+		"etcdListenClientUrl":     loopbackEndpoint,
+		"etcdClusterName":         etcdClusterName,
+		"etcdInitialClusterToken": etcdInitialClusterToken,
+	}).
+		Info("Starting localhost-only etcd process")
+	// Specify the full path to the etcd binary to avoid any PATH search binary replacement nonsense
+	etcdCmd := exec.CommandContext(ctx, etcdBinaryLocation,
+		fmt.Sprintf("--data-dir=%s", etcdDataDir),
+		fmt.Sprintf("--name=%s", etcdClusterName),
+		fmt.Sprintf("--listen-client-urls=%s", loopbackEndpoint),
+		fmt.Sprintf("--advertise-client-urls=%s", loopbackEndpoint),
+		fmt.Sprintf("--initial-cluster-token=%s", etcdInitialClusterToken),
+		"--initial-cluster-state=new")
+	log.WithField("etcdBinary", etcdBinaryLocation).
+		WithField("etcdFlags", etcdCmd.Args).
+		Debug("Executing etcd")
+
+	// Exec the etcd binary, which ultimately calls fork(2) under the hood. We don't wait on its completion, because
+	// it'll never complete of course.
+	err = etcdCmd.Start()
+	if err != nil {
+		log.WithField("etcdBinary", etcdBinaryLocation).
+			WithField("etcdFlags", etcdCmd.Args).
+			WithError(err).
+			Error("Failed to launch etcd process")
+		return err
+	}
+	etcdPid := etcdCmd.Process.Pid
+	log.WithField("etcdPID", etcdPid).
+		Info("Local etcd server process started")
+
+	// Defer etcd process cleanup
+	defer func() {
+		log := log.WithField("etcdPID", etcdPid)
+		log.Debug("Cleaning up etcd process")
+		// Send the process a SIGTERM. SIGTERM is the "gentle" shutdown signal, and etcd should close down it's resources
+		// cleanly and then exit.
+		log.Info("Sending SIGTERM signal to etcd process")
+		err := etcdCmd.Process.Signal(syscall.SIGTERM)
+		if err != nil {
+			log.WithError(err).
+				Error("Failed to send SIGTERM signal to etcd process")
+			returnErr = err
+		}
+
+		// Wait for the etcd process to finish, and cleanup resources.
+		log.Info("Waiting for etcd process to exit")
+		err = etcdCmd.Wait()
+		if err != nil {
+			if exitError, ok := err.(*exec.ExitError); ok {
+				if exitError.ExitCode() == -1 {
+					// We SIGTERMed the etcd process, so a nonzero exit code is expected.
+					// Check the context as a last sanity check
+					if ctx.Err() != nil {
+						// Don't log the error itself here, if the context is timed out it'll be cancelled, so the error
+						// will just say "context cancelled" and not be useful — and possibly even misleading. It's
+						// possible that the timeout expires at the moment between etcd exiting normally and this check,
+						// which would report a false error. That's very unlikely, so we don't worry about it here.
+						log.WithField("timeout", timeout).
+							Error("etcd exited, but our context has expired. etcd may have been terminated due to timeout. Consider increasing the value of the timeout using the --timeout flag or CILIUM_TIMEOUT environment variable.")
+						// If we're not already returning an error, return an error here
+						if returnErr == nil {
+							returnErr = ctx.Err()
+						}
+						return
+					}
+					// This is the "good state", the context hasn't expired, the etcd process has exited, and we're
+					// okay with a nonzero exit code because we exited it with a SIGTERM.
+					log.Info("etcd process exited")
+					return
+				}
+				log.WithError(err).
+					WithField("etcdExitCode", exitError.ExitCode()).
+					Error("etcd process exited improperly")
+				// If we're not already returning an error, return an error here
+				if returnErr == nil {
+					returnErr = err
+				}
+				return
+			} else {
+				// Some other kind of error
+				log.WithError(err).
+					Error("Failed to wait on etcd process finishing")
+				// If we're not already returning an error, return an error here
+				if returnErr == nil {
+					returnErr = err
+				}
+				return
+			}
+		}
+		log.Info("etcd process exited")
+	}()
+
+	// With the etcd server process launched, we need to construct an etcd client
+	config := clientv3.Config{
+		Context:   ctx,
+		Endpoints: []string{loopbackEndpoint},
+	}
+	log.WithField("etcdClientConfig", fmt.Sprintf("%+v", config)).
+		Debug("Constructed etcd client config")
+	etcdClient, err := clientv3.New(config)
+	if err != nil {
+		log.WithField("etcdClientConfig", fmt.Sprintf("%+v", config)).
+			WithError(err).
+			Error("Failed to construct etcd client from configuration")
+		return err
+	}
+
+	// Run the init commands
+	log.WithField(logfields.ClusterName, ciliumClusterName).
+		Info("Starting etcd init")
+	err = kvstoreEtcdInit.ClusterMeshEtcdInit(ctx, log, etcdClient, ciliumClusterName)
+	if err != nil {
+		log.WithError(err).
+			WithField(logfields.ClusterName, ciliumClusterName).
+			Error("Failed to initialise etcd")
+		return err
+	}
+	log.Info("Etcd init completed")
+	return nil
+}

--- a/clustermesh-apiserver/main.go
+++ b/clustermesh-apiserver/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cilium/cilium/clustermesh-apiserver/clustermesh"
+	"github.com/cilium/cilium/clustermesh-apiserver/etcdinit"
 	"github.com/cilium/cilium/clustermesh-apiserver/kvstoremesh"
 	"github.com/cilium/cilium/pkg/hive"
 )
@@ -21,6 +22,9 @@ func main() {
 	}
 
 	cmd.AddCommand(
+		// etcd init does not use the Hive framework, because it's a "one and done" process that doesn't spawn a service
+		// or server, or perform any waiting for connections.
+		etcdinit.NewCmd(),
 		clustermesh.NewCmd(hive.New(clustermesh.Cell)),
 		kvstoremesh.NewCmd(hive.New(kvstoremesh.Cell)),
 	)

--- a/images/clustermesh-apiserver/Dockerfile
+++ b/images/clustermesh-apiserver/Dockerfile
@@ -2,8 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG BASE_IMAGE=scratch
+# These SHA256 digests are important for two reasons:
+# 1. They 'pin' the container image to a specific version. Unlike a tag that can be changed at any future point, a
+#    SHA265 hash cannot be modified. This increases the security of the build by protecting against a class of supply
+#    chain attacks where an attacker has write access to our 3rd party dependnecy image registries.
+# 2. These digests must be to the *overall* digest, not the digest for a specific image. This is because the images will
+#    be architecture specific, but the overall digest will contiain all of the architectures.
 ARG GOLANG_IMAGE=docker.io/library/golang:1.21.4@sha256:81cd210ae58a6529d832af2892db822b30d84f817a671b8e1c15cff0b271a3db
 ARG ALPINE_IMAGE=docker.io/library/alpine:3.18.4@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
+# We don't use ETCD_IMAGE because that's used in Makefile.defs to select a ETCD image approrpate for the *host platform*
+# to run tests with.
+ARG ETCD_SERVER_IMAGE=gcr.io/etcd-development/etcd:v3.5.10@sha256:fe1d616ac2740b834c8f57de01272cdeb344427f407c31b01f189bf13d17bb78
 
 # BUILDPLATFORM is an automatic platform ARG enabled by Docker BuildKit.
 # Represents the plataform where the build is happening, do not mix with
@@ -49,6 +58,8 @@ RUN apt-get update && apt-get install -y binutils-aarch64-linux-gnu binutils-x86
 RUN --mount=type=bind,readwrite,target=/go/src/github.com/cilium/cilium --mount=target=/root/.cache,type=cache --mount=target=/go/pkg,type=cache \
     ./build-gops.sh
 
+FROM --platform=${TARGETARCH} ${ETCD_SERVER_IMAGE} as etcd
+
 FROM ${BASE_IMAGE} as release
 # TARGETOS is an automatic platform ARG enabled by Docker BuildKit.
 ARG TARGETOS
@@ -57,6 +68,9 @@ ARG TARGETARCH
 LABEL maintainer="maintainer@cilium.io"
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=gops /out/${TARGETOS}/${TARGETARCH}/bin/gops /bin/gops
+# While the etcd image uses /usr/local/bin, we're moving it to /usr/bin to keep consistency with the rest of our images.
+# We also don't grab the etcdctl or etcdutl binaries, as we don't need them for our application.
+COPY --from=etcd /usr/local/bin/etcd /usr/bin/etcd
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/etcd-config.yaml /var/lib/cilium/etcd-config.yaml
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/usr/bin/clustermesh-apiserver /usr/bin/clustermesh-apiserver
 COPY --from=builder /out/${TARGETOS}/${TARGETARCH}/LICENSE.all /LICENSE.all

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -159,7 +159,8 @@ contributors across the globe, there is almost always someone available to help.
 | cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE. |
 | clustermesh.annotations | object | `{}` | Annotations to be added to all top-level clustermesh objects (resources under templates/clustermesh-apiserver and templates/clustermesh-config) |
 | clustermesh.apiserver.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for clustermesh.apiserver |
-| clustermesh.apiserver.etcd.image | object | `{"digest":"sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3","override":null,"pullPolicy":"Always","repository":"quay.io/coreos/etcd","tag":"v3.5.4","useDigest":true}` | Clustermesh API server etcd image. |
+| clustermesh.apiserver.etcd.init.extraArgs | list | `[]` | Additional arguments to `clustermesh-apiserver etcdinit`. |
+| clustermesh.apiserver.etcd.init.extraEnv | list | `[]` | Additional environment variables to `clustermesh-apiserver etcdinit`. |
 | clustermesh.apiserver.etcd.init.resources | object | `{}` | Specifies the resources for etcd init container in the apiserver |
 | clustermesh.apiserver.etcd.lifecycle | object | `{}` | lifecycle setting for the etcd container |
 | clustermesh.apiserver.etcd.resources | object | `{}` | Specifies the resources for etcd container in the apiserver |

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -48,41 +48,37 @@ spec:
       {{- end }}
       initContainers:
       - name: etcd-init
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
-        imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
-        command: ["/bin/sh", "-c"]
+        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
+        imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
+        command:
+        - /usr/bin/clustermesh-apiserver
         args:
-        - |
-          rm -rf /var/run/etcd/*;
-          /usr/local/bin/etcd --data-dir=/var/run/etcd --name=clustermesh-apiserver --listen-client-urls=http://127.0.0.1:2379 --advertise-client-urls=http://127.0.0.1:2379 --initial-cluster-token=clustermesh-apiserver --initial-cluster-state=new --auto-compaction-retention=1 &
-
-          # The following key needs to be created before that the cilium agents
-          # have the possibility of connecting to etcd.
-          etcdctl put cilium/.has-cluster-config true
-
-          etcdctl user add root --no-password;
-          etcdctl user grant-role root root;
-          etcdctl user add admin-{{ .Values.cluster.name }} --no-password;
-          etcdctl user grant-role admin-{{ .Values.cluster.name }} root;
-          etcdctl user add externalworkload --no-password;
-          etcdctl role add externalworkload;
-          etcdctl role grant-permission externalworkload --from-key read '';
-          etcdctl role grant-permission externalworkload readwrite --prefix cilium/state/noderegister/v1/;
-          etcdctl role grant-permission externalworkload readwrite --prefix cilium/.initlock/;
-          etcdctl user grant-role externalworkload externalworkload;
-          etcdctl user add remote --no-password;
-          etcdctl role add remote;
-          etcdctl role grant-permission remote --from-key read '';
-          etcdctl user grant-role remote remote;
-          etcdctl auth enable;
-          exit
+        - etcdinit
+        {{- if .Values.debug.enabled }}
+        - --debug
+        {{- end }}
+        # These need to match the equivalent arguments to etcd in the main container.
+        - --etcd-cluster-name=clustermesh-apiserver
+        - --etcd-initial-cluster-token=clustermesh-apiserver
+        - --etcd-data-dir=/var/run/etcd
+        {{- with .Values.clustermesh.apiserver.etcd.init.extraArgs }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
         env:
-        - name: ETCDCTL_API
-          value: "3"
-        - name: HOSTNAME_IP
+          # The Cilium cluster name (specified via the `CILIUM_CLUSTER_NAME` environment variable) and the etcd cluster
+          # name (specified via the `--etcd-cluster-name` argument) are very different concepts. The Cilium cluster name
+          # is the name of the overall Cilium cluster, and is used to set the admin account username. The etcd cluster
+          # name is a concept that's only relevant for etcd itself. The etcd cluster name must be the same for both this
+          # command and the actual invocation of etcd in the main containers of this Pod, but it's otherwise not
+          # relevant to Cilium.
+        - name: CILIUM_CLUSTER_NAME
           valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
+            configMapKeyRef:
+              name: cilium-config
+              key: cluster-name
+        {{- with .Values.clustermesh.apiserver.etcd.init.extraEnv }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - name: etcd-data-dir
           mountPath: /var/run/etcd
@@ -93,10 +89,11 @@ spec:
         {{- end }}
       containers:
       - name: etcd
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.etcd.image | quote }}
-        imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
+        # The clustermesh-apiserver container image includes an etcd binary.
+        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
+        imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
-        - /usr/local/bin/etcd
+        - /usr/bin/etcd
         args:
         - --data-dir=/var/run/etcd
         - --name=clustermesh-apiserver

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2866,14 +2866,9 @@ clustermesh:
       pullPolicy: "Always"
 
     etcd:
-      # -- Clustermesh API server etcd image.
-      image:
-        override: ~
-        repository: "quay.io/coreos/etcd"
-        tag: "v3.5.4"
-        digest: "sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"
-        useDigest: true
-        pullPolicy: "Always"
+      # The etcd binary is included in the clustermesh API server image, so the same image from above is reused.
+      # Independent override isn't supported, because clustermesh-apiserver is tested against the etcd version it is
+      # built with.
 
       # -- Specifies the resources for etcd container in the apiserver
       resources: {}
@@ -2899,6 +2894,12 @@ clustermesh:
         #   limits:
         #     cpu: 100m
         #     memory: 100Mi
+
+        # -- Additional arguments to `clustermesh-apiserver etcdinit`.
+        extraArgs: []
+
+        # -- Additional environment variables to `clustermesh-apiserver etcdinit`.
+        extraEnv: []
 
     kvstoremesh:
       # -- Enable KVStoreMesh. KVStoreMesh caches the information retrieved

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2863,14 +2863,9 @@ clustermesh:
       pullPolicy: "${PULL_POLICY}"
 
     etcd:
-      # -- Clustermesh API server etcd image.
-      image:
-        override: ~
-        repository: "${ETCD_REPO}"
-        tag: "${ETCD_VERSION}"
-        digest: "${ETCD_DIGEST}"
-        useDigest: true
-        pullPolicy: "${PULL_POLICY}"
+      # The etcd binary is included in the clustermesh API server image, so the same image from above is reused.
+      # Independent override isn't supported, because clustermesh-apiserver is tested against the etcd version it is
+      # built with.
 
       # -- Specifies the resources for etcd container in the apiserver
       resources: {}
@@ -2896,6 +2891,12 @@ clustermesh:
         #   limits:
         #     cpu: 100m
         #     memory: 100Mi
+
+        # -- Additional arguments to `clustermesh-apiserver etcdinit`.
+        extraArgs: []
+
+        # -- Additional environment variables to `clustermesh-apiserver etcdinit`.
+        extraEnv: []
 
     kvstoremesh:
       # -- Enable KVStoreMesh. KVStoreMesh caches the information retrieved

--- a/pkg/kvstore/etcdinit/init.go
+++ b/pkg/kvstore/etcdinit/init.go
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Authors of Cilium
+
+package init
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"go.etcd.io/etcd/api/v3/authpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/cilium/cilium/pkg/kvstore"
+	"github.com/cilium/cilium/pkg/node/store"
+)
+
+// ClusterMeshEtcdInit initializes etcd for use by Cilium Clustermesh via the provided client. It creates a number of
+// user accounts and roles with permissions, sets a well-known key to indicate config has been done, and enables
+// authentication for the cluster.
+//
+// This function uses log to perform informational and debug logging about operations. This function does not log errors
+// and instead returns an error for handling, as it is assumed that the calling function will log errors. Most errors
+// are wrapped with extra context as to the situation in which the error arose.
+//
+// The ciliumClusterName is used to determine the admin username.
+//
+// The context provided as ctx can be used to implement a timeout on operations, and is passed to all etcd client
+// functions.
+//
+// Note that this function is **not idempotent**. It expects a completely blank etcd server with no non-default users,
+// roles, permissions, or keys.
+func ClusterMeshEtcdInit(ctx context.Context, log *logrus.Entry, client *clientv3.Client, ciliumClusterName string) error {
+	ic := initClient{
+		log:    log,
+		client: client,
+	}
+
+	// This function is largely procedural. The various functions on initClient already perform logging and wrap errors
+	// with additional context. So this function only performs the relevant operations, and is more or less a 1:1
+	// translation of the shell script that this function replaced.
+
+	// Pre setup
+	log.Info("Performing pre-init tasks")
+	err := ic.putHasConfigKey(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Root user
+	rootUsername := username("root")
+	log.WithField("etcdUsername", rootUsername).
+		Info("Configuring root user")
+	err = ic.addNoPasswordUser(ctx, rootUsername)
+	if err != nil {
+		return err
+	}
+	err = ic.grantRoleToUser(ctx, rootRolename, rootUsername)
+	if err != nil {
+		return err
+	}
+
+	// Admin user
+	adminUsername := adminUsernameForClusterName(ciliumClusterName)
+	log.WithField("etcdUsername", adminUsername).
+		Info("Configuring admin user")
+	err = ic.addNoPasswordUser(ctx, adminUsername)
+	if err != nil {
+		return err
+	}
+	err = ic.grantRoleToUser(ctx, rootRolename, adminUsername)
+	if err != nil {
+		return err
+	}
+
+	// External workload user
+	externalWorkloadUsername := username("externalworkload")
+	log.WithField("etcdUsername", externalWorkloadUsername).
+		Info("Configuring external workload user")
+	err = ic.addNoPasswordUser(ctx, externalWorkloadUsername)
+	if err != nil {
+		return err
+	}
+	externalWorkloadRolename := rolename("externalworkload")
+	err = ic.addRole(ctx, externalWorkloadRolename)
+	if err != nil {
+		return err
+	}
+	err = ic.grantRoleToUser(ctx, externalWorkloadRolename, externalWorkloadUsername)
+	if err != nil {
+		return err
+	}
+	err = ic.grantPermissionToRole(ctx, readOnly, allKeysRange, externalWorkloadRolename)
+	if err != nil {
+		return err
+	}
+	err = ic.grantPermissionToRole(ctx, readWrite, rangeForPrefix(store.NodeRegisterStorePrefix), externalWorkloadRolename)
+	if err != nil {
+		return err
+	}
+	err = ic.grantPermissionToRole(ctx, readWrite, rangeForPrefix(kvstore.InitLockPath), externalWorkloadRolename)
+	if err != nil {
+		return err
+	}
+
+	// Remote user
+	remoteUsername := username("remote")
+	log.WithField("etcdUsername", remoteUsername).
+		Info("Configuring remote user")
+	remoteRolename := rolename("remote")
+	err = ic.addNoPasswordUser(ctx, remoteUsername)
+	if err != nil {
+		return err
+	}
+	err = ic.addRole(ctx, remoteRolename)
+	if err != nil {
+		return err
+	}
+	err = ic.grantRoleToUser(ctx, remoteRolename, remoteUsername)
+	if err != nil {
+		return err
+	}
+	err = ic.grantPermissionToRole(ctx, readOnly, allKeysRange, remoteRolename)
+	if err != nil {
+		return err
+	}
+
+	// Post setup
+	log.Info("Performing post-init tasks")
+	err = ic.enableAuth(ctx)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// adminUsernameForClusterName generates the admin account username for a given clusterName. This handles the edge case
+// where the clusterName is blank, ensuring we don't have a username with a trailing hyphen.
+func adminUsernameForClusterName(clusterName string) username {
+	if clusterName == "" {
+		return "admin"
+	}
+	return username(fmt.Sprintf("admin-%s", clusterName))
+}
+
+// initClient is a thin wrapper around the etcd client library that provides functions with more useful error messages,
+// debug logging, and more. It's not intended as an interface for mocking or testing, or to be exposed outside of this
+// package. It's entirely an internal implementation detail.
+type initClient struct {
+	client *clientv3.Client
+	log    *logrus.Entry
+}
+
+// The username and rolename types exist to make it harder to mix up usernames and rolenames, which are both strings
+// and are often the same, in code. Without this there could be subtle bugs where the code still works so long as
+// usernames and role names are the same.
+type username string
+type rolename string
+
+// rootRolename refers to a special "root" role that exists by default in etcd.
+const rootRolename = rolename("root")
+
+// put sets a key to a value. It's a wrapper around the etcd client's put method.
+func (ic initClient) put(ctx context.Context, key, val string) error {
+	ic.log.WithField("etcdKey", key).
+		WithField("etcdValue", val).
+		Debug("Setting key in etcd")
+	_, err := ic.client.Put(ctx, key, val)
+	if err != nil {
+		return fmt.Errorf("setting path '%s' to '%s': %w", key, val, err)
+	}
+	return nil
+}
+
+// putHasConfigKey sets the specialised etcd "has config" key to be true.
+func (ic initClient) putHasConfigKey(ctx context.Context) error {
+	ic.log.Debug("Setting the key to indicate that config has already been set")
+	err := ic.put(ctx, kvstore.HasClusterConfigPath, "true")
+	if err != nil {
+		return fmt.Errorf("setting key to indicate config is already set: %w", err)
+	}
+	return nil
+}
+
+// addNoPasswordUser adds a new user to etcd with no password. This is expected as later on we'll enable auth which will
+// require other forms of authentication. This is a wrapper around the client's UserAddWithOptions method.
+func (ic initClient) addNoPasswordUser(ctx context.Context, username username) error {
+	ic.log.WithField("etcdUsername", username).
+		Debug("Adding etcd user")
+	_, err := ic.client.UserAddWithOptions(ctx, string(username), "", &clientv3.UserAddOptions{NoPassword: true})
+	if err != nil {
+		return fmt.Errorf("adding user '%s': %w", username, err)
+	}
+	return nil
+}
+
+// addRole adds a new role to etcd. This is a wrapper around the client's RoleAdd method.
+func (ic initClient) addRole(ctx context.Context, rolename rolename) error {
+	ic.log.WithField("etcdRolename", rolename).
+		Debug("Adding etcd role")
+	_, err := ic.client.RoleAdd(ctx, string(rolename))
+	if err != nil {
+		return fmt.Errorf("adding role '%s': %w", rolename, err)
+	}
+	return nil
+}
+
+// grantRoleToUser grants a role to a user, enabling that user access to the permissions of that role. This is a wrapper
+// around the client's UserGrantRole method.
+func (ic initClient) grantRoleToUser(ctx context.Context, rolename rolename, username username) error {
+	ic.log.WithField("etcdUsername", username).
+		WithField("etcdRolename", rolename).
+		Debug("Granting role to etcd user")
+	_, err := ic.client.UserGrantRole(ctx, string(username), string(rolename))
+	if err != nil {
+		return fmt.Errorf("granting role '%s' to user '%s': %w", rolename, username, err)
+	}
+	return nil
+}
+
+// keyRange describes a range of keys
+type keyRange struct {
+	start string
+	end   string
+}
+
+// rangeForPrefix generates a keyRange for a given prefix. This is a wrapper around the client's GetPrefixRangeEnd
+// function.
+func rangeForPrefix(prefix string) keyRange {
+	// For a **prefix** range, we need a trailing slash. Without it, the behaviour of clientv3.GetPrefixRangeEnd is
+	// slightly different. For example on `cilium/.initlock` the given range end is `cilium/.initlocl`, while on
+	// `cilium/.initlock/` it's `cilium/.initlock0`.
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	return keyRange{
+		prefix,
+		clientv3.GetPrefixRangeEnd(prefix),
+	}
+}
+
+// allKeysRange is the range over all keys in etcd. Granting permissions on this range is the same as granting global
+// permissions in etcd.
+var allKeysRange = keyRange{"\x00", "\x00"}
+
+// permission is a thin, internal wrapper around etcd's permission types
+type permission clientv3.PermissionType
+
+var readOnly = permission(clientv3.PermRead)
+var readWrite = permission(clientv3.PermReadWrite)
+
+func (p permission) string() string {
+	return authpb.Permission_Type(p).String()
+}
+
+// grantPermissionToRole grants permissions on a range of keys to a role. This is a wrapper around the client's
+// RoleGrantPermission method.
+func (ic initClient) grantPermissionToRole(ctx context.Context, permission permission, keyRange keyRange, rolename rolename) error {
+	ic.log.WithFields(logrus.Fields{
+		"etcdRolename":   rolename,
+		"etcdPermission": permission.string(),
+		"etcdRangeStart": keyRange.start,
+		"etcdRangeEnd":   keyRange.end,
+	}).
+		Debug("Granting permission on a range of keys to an etcd role")
+	_, err := ic.client.RoleGrantPermission(ctx, string(rolename), keyRange.start, keyRange.end, clientv3.PermissionType(permission))
+	if err != nil {
+		return fmt.Errorf("granting role '%s' permission '%s' on range '%s' to '%s': %w", rolename, permission.string(), keyRange.start, keyRange.end, err)
+	}
+	return nil
+}
+
+// enableAuth enables etcd authentication. This is a wrapper around the client's AuthEnable method.
+//
+// It should be noted that this command should be run **last**, as we usually don't have authentication, so turning
+// this on will instantly lock us out.
+func (ic initClient) enableAuth(ctx context.Context) error {
+	ic.log.Debug("Enabling authentication on etcd cluster")
+	_, err := ic.client.AuthEnable(ctx)
+	if err != nil {
+		return fmt.Errorf("enabling authentication on etcd: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [X] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

This is a follow-on PR from https://github.com/cilium/cilium/pull/26352, that rebases much of the work and changes the approach.

This change replaces the etcd init script that is normally executed in the etcd container when starting clustermesh-apiserver. Instead the etcd binary is bundled into the clustermesh-apiserver container image, and a new command is added in Go that will start the server and initalise the data directory.

This is intended as a direct replacement of the current etcd in clustermesh deployments.

Previously, we have been unable to update the etcd image as the script requires sh to be present, which isn't in newer etcd images that have moved to distroless.

Fixes: #23770

```release-note
Replace etcd init script used for clustermesh with a Go equivalent.
Upgrade etcd to v3.5.10.
```
