### PR TITLE
datapath: Add support to delegate routing to other plugins, such as AWS-CNI

### DIFF
--- a/Documentation/cmdref/cilium-agent.md
+++ b/Documentation/cmdref/cilium-agent.md
@@ -67,6 +67,7 @@ cilium-agent [flags]
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations
+      --cni-external-routing                                      Whether the chained CNI plugin handles routing on the node
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --config string                                             Configuration file (default "$HOME/ciliumd.yaml")
       --config-dir string                                         Configuration directory that contains a file for each option

--- a/Documentation/cmdref/cilium-agent_hive.md
+++ b/Documentation/cmdref/cilium-agent_hive.md
@@ -21,6 +21,7 @@ cilium-agent hive [flags]
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations
+      --cni-external-routing                                      Whether the chained CNI plugin handles routing on the node
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.

--- a/Documentation/cmdref/cilium-agent_hive_dot-graph.md
+++ b/Documentation/cmdref/cilium-agent_hive_dot-graph.md
@@ -27,6 +27,7 @@ cilium-agent hive dot-graph [flags]
       --cni-chaining-mode string                                  Enable CNI chaining with the specified plugin (default "none")
       --cni-chaining-target string                                CNI network name into which to insert the Cilium chained configuration. Use '*' to select any network.
       --cni-exclusive                                             Whether to remove other CNI configurations
+      --cni-external-routing                                      Whether the chained CNI plugin handles routing on the node
       --cni-log-file string                                       Path where the CNI plugin should write logs (default "/var/run/cilium/cilium-cni.log")
       --controller-group-metrics strings                          List of controller group names for which to to enable metrics. Accepts 'all' and 'none'. The set of controller group names available is not guaranteed to be stable between Cilium versions.
       --disable-iptables-feeder-rules strings                     Chains to ignore when installing feeder rules.

--- a/daemon/cmd/cni/config.go
+++ b/daemon/cmd/cni/config.go
@@ -59,6 +59,12 @@ func (c *cniConfigManager) GetChainingMode() string {
 	return c.config.CNIChainingMode
 }
 
+// ExternalRoutingEnabled returns true if the chained plugin implements routing
+// for Endpoints (Pods).
+func (c *cniConfigManager) ExternalRoutingEnabled() bool {
+	return c.config.CNIExternalRouting
+}
+
 // GetCustomNetConf returns the parsed custom CNI configuration, if provided
 // (In other words, the value to --read-cni-conf).
 // Otherwise, returns nil.

--- a/daemon/cmd/cni/fake/fakecni.go
+++ b/daemon/cmd/cni/fake/fakecni.go
@@ -18,6 +18,10 @@ func (f *FakeCNIConfigManager) GetChainingMode() string {
 	return "none"
 }
 
+func (c *FakeCNIConfigManager) ExternalRoutingEnabled() bool {
+	return false
+}
+
 func (f *FakeCNIConfigManager) GetCustomNetConf() *cnitypes.NetConf {
 	return nil
 }

--- a/daemon/cmd/endpoint.go
+++ b/daemon/cmd/endpoint.go
@@ -339,6 +339,18 @@ func (d *Daemon) createEndpoint(ctx context.Context, owner regeneration.Owner, e
 		// via cilium_host interface
 		epTemplate.DatapathConfiguration.InstallEndpointRoute = true
 
+		// EndpointRoutes mode enables two features:
+		// - Install one route per endpoint into the route table
+		// - Configure BPF programs at receive to the endpoint rather
+		//   than implementing the receive policy at the transmit point
+		//   for another device.
+		// If an external agent configures the routing table, then we
+		// don't need to configure routes for this endpoint. However,
+		// we *do* need to configure the BPF programs at receive.
+		if d.cniConfigManager.ExternalRoutingEnabled() {
+			epTemplate.DatapathConfiguration.InstallEndpointRoute = false
+		}
+
 		// Since routing occurs via endpoint interface directly, BPF
 		// program is needed on that device at egress as BPF program on
 		// cilium_host interface is bypassed

--- a/install/kubernetes/cilium/templates/cilium-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-configmap.yaml
@@ -807,6 +807,9 @@ data:
 {{- if (not (kindIs "invalid" .Values.cni.chainingTarget)) }}
   cni-chaining-target: {{ .Values.cni.chainingTarget | quote }}
 {{- end}}
+{{- if (not (kindIs "invalid" .Values.cni.externalRouting)) }}
+  cni-external-routing: {{ .Values.cni.externalRouting | quote }}
+{{- end}}
 {{- if .Values.kubeConfigPath }}
   k8s-kubeconfig-path: {{ .Values.kubeConfigPath | quote }}
 {{- end }}

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -1259,6 +1259,9 @@ const (
 	// CNIExclusive tells the agent to remove other CNI configuration files
 	CNIExclusive = "cni-exclusive"
 
+	// CNIExternalRouting delegates endpoint routing to the chained CNI plugin.
+	CNIExternalRouting = "cni-external-routing"
+
 	// CNILogFile is the path to a log file (on the host) for the CNI plugin
 	// binary to use for logging.
 	CNILogFile = "cni-log-file"


### PR DESCRIPTION
AWS uses VLAN interfaces for SG routing, and intentionally avoids upserting a route
so that traffic flows through the VPC and SG rules can be evaluated. Cilium will
upsert the route when an endpoint is created, and this causes traffic to be dropped
due to assymetric routing.

This exposes a wider issue where, when cilium is not in charge of routing traffic,
there is no ability to avoid creating the route (`InstallEndointRoute`) while still
configuring the BPF programs (`RequireEgressProg`). This PR implements a config option
to do just that, meaning we allow the host CNI to configure routing but still enable
network policy for those endpoints (Pods).

This flag is automatically set to True when running with aws-cni, as this is required
due to the issue mentioned above.

I would like this backported to 1.13, however the way to access to cni chaining mode seems to have changed, meaning it may need to be manual.

Fixes: https://github.com/cilium/cilium/issues/27152

Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [x] All code is covered by unit and/or runtime tests where feasible.
- [x] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [x] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [x] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [x] Thanks for contributing!

<!-- Description of change -->

Fixes: https://github.com/cilium/cilium/issues/27152

```release-note
Fix routing delegation to AWS-VPC-CNI when using the security groups feature. 
```
