### PR TITLE
Add cluster ip values for clustermesh API helm

### DIFF
--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/service.yaml
@@ -35,4 +35,11 @@ spec:
   {{- if .Values.clustermesh.apiserver.service.internalTrafficPolicy }}
   internalTrafficPolicy: {{ .Values.clustermesh.apiserver.service.internalTrafficPolicy }}
   {{- end }}
+  {{- with .Values.clustermesh.apiserver.service.clusterIP }}
+  clusterIP: {{ . }}
+  {{- end }}
+  {{- with .Values.clustermesh.apiserver.service.clusterIPs }}
+  clusterIPs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -2954,6 +2954,12 @@ clustermesh:
       # -- The internalTrafficPolicy of service used for apiserver access.
       internalTrafficPolicy:
 
+      # -- Optional cluster IP assigned for apiserver service.
+      clusterIP:
+
+      # -- Optional cluster IPs assigned for apiserver service.
+      clusterIPs:
+
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
 

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -2951,6 +2951,12 @@ clustermesh:
       # -- The internalTrafficPolicy of service used for apiserver access.
       internalTrafficPolicy:
 
+      # -- Optional cluster IP assigned for apiserver service.
+      clusterIP:
+
+      # -- Optional cluster IPs assigned for apiserver service.
+      clusterIPs:
+
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
 


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

- [x] For first time contributors, read [Submitting a pull request](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#submitting-a-pull-request)
- [ ] All code is covered by unit and/or runtime tests where feasible.
- [ ] All commits contain a well written commit description including a title,
      description and a `Fixes: #XXX` line if the commit addresses a particular
      GitHub issue.
- [ ] If your commit description contains a `Fixes: <commit-id>` tag, then
      please add the commit author[s] as reviewer[s] to this issue.
- [x] All commits are signed off. See the section [Developer’s Certificate of Origin](https://docs.cilium.io/en/stable/contributing/development/contributing_guide/#dev-coo)
- [ ] Provide a title or release-note blurb suitable for the release notes.
- [ ] Are you a user of Cilium? Please add yourself to the [Users doc](https://github.com/cilium/cilium/blob/main/USERS.md)
- [ ] Thanks for contributing!

<!-- Description of change -->

When I configured the clustermesh API server with cluster IP mode, without giving explicit IP assigned to the service, a random IP will be assigned. To better control which IP is used and making it easier to automate the deployment process, cilium helm chart should provide a way to assign the cluster IP for clustermesh API server. Kubernetes provide new feature since some point to preserve IPs in a range for static:

https://kubernetes.io/docs/concepts/services-networking/cluster-ip-allocation/

With that combining the clusterip options in Helm, I can then set a fixed value like `10.0.0.10` to cilium clustermesh API server without worrying about which IP it will pick.

```release-note
Add cluster ip values for clustermesh API helm
```


