### PR TITLE
gateway-api: Avoid redirect loop when the same host name is used for http and https listeners

### DIFF
--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -9,15 +9,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/cilium/cilium/operator/pkg/model"
 )
 
 var basicHTTP = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
-	Gateway: gatewayv1beta1.Gateway{
+	GatewayClass: gatewayv1.GatewayClass{},
+	Gateway: gatewayv1.Gateway{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Gateway",
 			APIVersion: "gateway.networking.k8s.io/v1",
@@ -26,8 +26,8 @@ var basicHTTP = Input{
 			Name:      "my-gateway",
 			Namespace: "default",
 		},
-		Spec: gatewayv1beta1.GatewaySpec{
-			Listeners: []gatewayv1beta1.Listener{
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
 				{
 					Name:     "prod-web-gw",
 					Port:     80,
@@ -36,36 +36,36 @@ var basicHTTP = Input{
 			},
 		},
 	},
-	HTTPRoutes: []gatewayv1beta1.HTTPRoute{
+	HTTPRoutes: []gatewayv1.HTTPRoute{
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "http-app-1",
 				Namespace: "default",
 			},
-			Spec: gatewayv1beta1.HTTPRouteSpec{
-				CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayv1beta1.ParentReference{
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
 						{
 							Name: "my-gateway",
 						},
 					},
 				},
-				Rules: []gatewayv1beta1.HTTPRouteRule{
+				Rules: []gatewayv1.HTTPRouteRule{
 					{
-						Matches: []gatewayv1beta1.HTTPRouteMatch{
+						Matches: []gatewayv1.HTTPRouteMatch{
 							{
-								Path: &gatewayv1beta1.HTTPPathMatch{
-									Type:  model.AddressOf[gatewayv1beta1.PathMatchType]("PathPrefix"),
+								Path: &gatewayv1.HTTPPathMatch{
+									Type:  model.AddressOf[gatewayv1.PathMatchType]("PathPrefix"),
 									Value: model.AddressOf("/bar"),
 								},
 							},
 						},
-						BackendRefs: []gatewayv1beta1.HTTPBackendRef{
+						BackendRefs: []gatewayv1.HTTPBackendRef{
 							{
-								BackendRef: gatewayv1beta1.BackendRef{
-									BackendObjectReference: gatewayv1beta1.BackendObjectReference{
+								BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
 										Name: "my-service",
-										Port: model.AddressOf[gatewayv1beta1.PortNumber](8080),
+										Port: model.AddressOf[gatewayv1.PortNumber](8080),
 									},
 								},
 							},
@@ -119,8 +119,8 @@ var basicHTTPListeners = []model.HTTPListener{
 }
 
 var basicTLS = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
-	Gateway: gatewayv1beta1.Gateway{
+	GatewayClass: gatewayv1.GatewayClass{},
+	Gateway: gatewayv1.Gateway{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Gateway",
 			APIVersion: "gateway.networking.k8s.io/v1",
@@ -129,8 +129,8 @@ var basicTLS = Input{
 			Name:      "my-gateway",
 			Namespace: "default",
 		},
-		Spec: gatewayv1beta1.GatewaySpec{
-			Listeners: []gatewayv1beta1.Listener{
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
 				{
 					Name:     "prod-web-gw",
 					Port:     443,
@@ -146,8 +146,8 @@ var basicTLS = Input{
 				Namespace: "default",
 			},
 			Spec: gatewayv1alpha2.TLSRouteSpec{
-				CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-					ParentRefs: []gatewayv1beta1.ParentReference{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{
+					ParentRefs: []gatewayv1.ParentReference{
 						{
 							Name: "my-gateway",
 						},
@@ -158,11 +158,11 @@ var basicTLS = Input{
 				},
 				Rules: []gatewayv1alpha2.TLSRouteRule{
 					{
-						BackendRefs: []gatewayv1beta1.BackendRef{
+						BackendRefs: []gatewayv1.BackendRef{
 							{
 								BackendObjectReference: gatewayv1alpha2.BackendObjectReference{
 									Name: "my-service",
-									Port: model.AddressOf[gatewayv1beta1.PortNumber](443),
+									Port: model.AddressOf[gatewayv1.PortNumber](443),
 								},
 							},
 						},
@@ -250,7 +250,7 @@ var basicTLSListeners = []model.TLSListener{
 }
 
 var simpleSameNamespaceTLS = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceTLSGateway,
 	TLSRoutes: []gatewayv1alpha2.TLSRoute{
 		sameNamespaceTLSRoute,
@@ -259,9 +259,9 @@ var simpleSameNamespaceTLS = Input{
 }
 
 var crossNamespaceHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      backendNamespaceGateway,
-	HTTPRoutes: []gatewayv1beta1.HTTPRoute{
+	HTTPRoutes: []gatewayv1.HTTPRoute{
 		crossNamespaceHTTPRoute,
 	},
 	Services: allServices,
@@ -294,9 +294,9 @@ var crossNamespaceHTTPListeners = []model.HTTPListener{
 }
 
 var exactPathMatchingHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
-	HTTPRoutes: []gatewayv1beta1.HTTPRoute{
+	HTTPRoutes: []gatewayv1.HTTPRoute{
 		exactPathMatchingHTTPRoute,
 	},
 	Services: allServices,
@@ -342,9 +342,9 @@ var exactPathMatchingHTTPListeners = []model.HTTPListener{
 }
 
 var headerMatchingHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
-	HTTPRoutes: []gatewayv1beta1.HTTPRoute{
+	HTTPRoutes: []gatewayv1.HTTPRoute{
 		headerMatchingHTTPRoute,
 	},
 	Services: allServices,
@@ -488,7 +488,7 @@ var headerMatchingHTTPListeners = []model.HTTPListener{
 }
 
 var hostnameIntersectionHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      *hostnameIntersectionGateway,
 	HTTPRoutes:   hostnameIntersectionHTTPRoutes,
 	Services:     allServices,
@@ -583,7 +583,7 @@ var hostnameIntersectionHTTPListeners = []model.HTTPListener{
 }
 
 var listenerHostnameMatchingHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      *listenerHostnameMatchingGateway,
 	HTTPRoutes:   listenerHostnameMatchingHTTPRoutes,
 	Services:     allServices,
@@ -691,7 +691,7 @@ var listenerHostnameMatchingHTTPListeners = []model.HTTPListener{
 }
 
 var matchingAcrossHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   matchingAcrossHTTPRoutes,
 	Services:     allServices,
@@ -746,7 +746,7 @@ var matchingAcrossHTTPListeners = []model.HTTPListener{
 }
 
 var matchingHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   matchingHTTPRoutes,
 	Services:     allServices,
@@ -803,7 +803,7 @@ var matchingHTTPListeners = []model.HTTPListener{
 }
 
 var queryParamMatchingHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   queryParamMatchingHTTPRoutes,
 	Services:     allServices,
@@ -897,7 +897,7 @@ var queryParamMatchingHTTPListeners = []model.HTTPListener{
 }
 
 var requestHeaderModifierHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   requestHeaderModifierHTTPRoutes,
 	Services:     allServices,
@@ -1044,7 +1044,7 @@ var requestHeaderModifierHTTPListeners = []model.HTTPListener{
 }
 
 var simpleSameNamespaceHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   simpleSameNamespaceHTTPRoutes,
 	Services:     allServices,
@@ -1078,7 +1078,7 @@ var simpleSameNamespaceHTTPListeners = []model.HTTPListener{
 }
 
 var methodMatchingHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   methodMatchingHTTPRoutes,
 	Services:     allServices,
@@ -1125,7 +1125,7 @@ var methodMatchingHTTPListeners = []model.HTTPListener{
 }
 
 var requestRedirectHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   requestRedirectHTTPRoutes,
 	Services:     allServices,
@@ -1188,7 +1188,7 @@ var requestRedirectHTTPListeners = []model.HTTPListener{
 }
 
 var responseHeaderModifierHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   responseHeaderModifierHTTPRoutes,
 	Services:     allServices,
@@ -1351,7 +1351,7 @@ var responseHeaderModifierHTTPListeners = []model.HTTPListener{
 }
 
 var rewriteHostHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   rewriteHostHTTPRoutes,
 	Services:     allServices,
@@ -1405,7 +1405,7 @@ var rewriteHostHTTPListeners = []model.HTTPListener{
 }
 
 var rewritePathHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   rewritePathHTTPRoutes,
 	Services:     allServices,
@@ -1534,7 +1534,7 @@ var rewritePathHTTPListeners = []model.HTTPListener{
 }
 
 var mirrorHTTPInput = Input{
-	GatewayClass: gatewayv1beta1.GatewayClass{},
+	GatewayClass: gatewayv1.GatewayClass{},
 	Gateway:      sameNamespaceGateway,
 	HTTPRoutes:   mirrorPathHTTPRoutes,
 	Services:     allServices,
@@ -1581,8 +1581,8 @@ var mirrorHTTPListeners = []model.HTTPListener{
 
 var (
 	basicGRPC = Input{
-		GatewayClass: gatewayv1beta1.GatewayClass{},
-		Gateway: gatewayv1beta1.Gateway{
+		GatewayClass: gatewayv1.GatewayClass{},
+		Gateway: gatewayv1.Gateway{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Gateway",
 				APIVersion: "gateway.networking.k8s.io/v1beta1",
@@ -1591,12 +1591,12 @@ var (
 				Name:      "my-gateway",
 				Namespace: "default",
 			},
-			Spec: gatewayv1beta1.GatewaySpec{
-				Listeners: []gatewayv1beta1.Listener{
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
 					{
 						Name:     "prod-web-gw",
 						Port:     80,
-						Protocol: gatewayv1beta1.HTTPProtocolType,
+						Protocol: gatewayv1.HTTPProtocolType,
 					},
 				},
 			},
@@ -1608,8 +1608,8 @@ var (
 					Namespace: "default",
 				},
 				Spec: gatewayv1alpha2.GRPCRouteSpec{
-					CommonRouteSpec: gatewayv1beta1.CommonRouteSpec{
-						ParentRefs: []gatewayv1beta1.ParentReference{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
 							{
 								Name: "my-gateway",
 							},
@@ -1631,10 +1631,10 @@ var (
 							},
 							BackendRefs: []gatewayv1alpha2.GRPCBackendRef{
 								{
-									BackendRef: gatewayv1beta1.BackendRef{
-										BackendObjectReference: gatewayv1beta1.BackendObjectReference{
+									BackendRef: gatewayv1.BackendRef{
+										BackendObjectReference: gatewayv1.BackendObjectReference{
 											Name: "grp-service",
-											Port: model.AddressOf[gatewayv1beta1.PortNumber](8080),
+											Port: model.AddressOf[gatewayv1.PortNumber](8080),
 										},
 									},
 								},

--- a/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_fixture_test.go
@@ -3364,6 +3364,72 @@ var mirrorHTTPListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 	},
 }
 
+var multipleListenerGatewayListeners = []model.HTTPListener{
+	{
+		Name: "http-example",
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "my-gateway",
+				Namespace: "default",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
+			},
+		},
+		Address:  "",
+		Port:     80,
+		Hostname: "example.com",
+		Routes: []model.HTTPRoute{
+			{
+				Hostnames: []string{"example.com"},
+				DirectResponse: &model.DirectResponse{
+					StatusCode: 500,
+				},
+				RequestRedirect: &model.HTTPRequestRedirectFilter{
+					Scheme:     model.AddressOf("https"),
+					StatusCode: model.AddressOf(301),
+				},
+				Backends: []model.Backend{},
+			},
+		},
+	},
+	{
+		Name: "https-example",
+		Sources: []model.FullyQualifiedResource{
+			{
+				Name:      "my-gateway",
+				Namespace: "default",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Kind:      "Gateway",
+			},
+		},
+		Address:  "",
+		Port:     443,
+		Hostname: "example.com",
+		TLS: []model.TLSSecret{
+			{
+				Name:      "example-cert",
+				Namespace: "default",
+			},
+		},
+		Routes: []model.HTTPRoute{
+			{
+				Hostnames: []string{"example.com"},
+				Backends: []model.Backend{
+					{
+						Name:      "my-service",
+						Namespace: "default",
+						Port: &model.BackendPort{
+							Port: 8080,
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
 func toEnvoyCluster(namespace, name, port string) *envoy_config_cluster_v3.Cluster {
 	return &envoy_config_cluster_v3.Cluster{
 		Name: fmt.Sprintf("%s:%s:%s", namespace, name, port),

--- a/operator/pkg/model/translation/gateway-api/translator_test.go
+++ b/operator/pkg/model/translation/gateway-api/translator_test.go
@@ -6,6 +6,8 @@ package gateway_api
 import (
 	"testing"
 
+	envoy_config_route_v3 "github.com/cilium/proxy/go/envoy/config/route/v3"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/cilium/cilium/operator/pkg/model"
@@ -193,6 +195,109 @@ func Test_translator_Translate(t *testing.T) {
 			cec, _, _, err := trans.Translate(tt.args.m)
 			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
 			require.Equal(t, tt.want, cec, "CiliumEnvoyConfig did not match")
+		})
+	}
+}
+
+func Test_translator_TranslateResource(t *testing.T) {
+	type args struct {
+		m *model.Model
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantErr       bool
+		validateFuncs []func(config *ciliumv2.CiliumEnvoyConfig) bool
+	}{
+		{
+			name: "MultipleListenerGateway",
+			args: args{
+				m: &model.Model{
+					HTTP: multipleListenerGatewayListeners,
+				},
+			},
+			validateFuncs: []func(cec *ciliumv2.CiliumEnvoyConfig) bool{
+				func(cec *ciliumv2.CiliumEnvoyConfig) bool {
+					resource := ciliumv2.XDSResource{
+						Any: toAny(&envoy_config_route_v3.RouteConfiguration{
+							Name: "listener-insecure",
+							VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+								{
+									Name: "example.com",
+									Domains: []string{
+										"example.com",
+										"example.com:*",
+									},
+									Routes: []*envoy_config_route_v3.Route{
+										{
+											Match: &envoy_config_route_v3.RouteMatch{
+												PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+													Prefix: "/",
+												},
+											},
+											Action: &envoy_config_route_v3.Route_Redirect{
+												Redirect: &envoy_config_route_v3.RedirectAction{
+													SchemeRewriteSpecifier: &envoy_config_route_v3.RedirectAction_SchemeRedirect{
+														SchemeRedirect: "https",
+													},
+													PortRedirect: 443,
+												},
+											},
+										},
+									},
+								},
+							},
+						}),
+					}
+
+					expected, _ := resource.MarshalJSON()
+					got, _ := cec.Spec.Resources[1].MarshalJSON()
+					return assert.Equal(t, string(expected), string(got), "Route Configuration mismatch")
+				},
+				func(cec *ciliumv2.CiliumEnvoyConfig) bool {
+					resource := ciliumv2.XDSResource{
+						Any: toAny(&envoy_config_route_v3.RouteConfiguration{
+							Name: "listener-secure",
+							VirtualHosts: []*envoy_config_route_v3.VirtualHost{
+								{
+									Name: "example.com",
+									Domains: []string{
+										"example.com",
+										"example.com:*",
+									},
+									Routes: []*envoy_config_route_v3.Route{
+										{
+											Match: &envoy_config_route_v3.RouteMatch{
+												PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{
+													Prefix: "/",
+												},
+											},
+											Action: toRouteAction("default", "my-service", "8080"),
+										},
+									},
+								},
+							},
+						}),
+					}
+
+					expected, _ := resource.MarshalJSON()
+					got, _ := cec.Spec.Resources[2].MarshalJSON()
+					return assert.Equal(t, string(expected), string(got), "Route Configuration mismatch")
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trans := &translator{
+				idleTimeoutSeconds: 60,
+			}
+			cec, _, _, err := trans.Translate(tt.args.m)
+			require.Equal(t, tt.wantErr, err != nil, "Error mismatch")
+			for _, fn := range tt.validateFuncs {
+				require.True(t, fn(cec), "Validation failed")
+			}
 		})
 	}
 }

--- a/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
+++ b/operator/pkg/model/translation/ingress/dedicated_ingress_fixture_test.go
@@ -108,26 +108,6 @@ func toRouteAction(namespace, name, port string) *envoy_config_route_v3.Route_Ro
 	}
 }
 
-func toWeightedClusterRouteAction(names []string) *envoy_config_route_v3.Route_Route {
-	weightedClusters := make([]*envoy_config_route_v3.WeightedCluster_ClusterWeight, 0, len(names))
-	for _, name := range names {
-		weightedClusters = append(weightedClusters, &envoy_config_route_v3.WeightedCluster_ClusterWeight{
-			Name:   name,
-			Weight: &wrapperspb.UInt32Value{Value: 1},
-		})
-	}
-
-	return &envoy_config_route_v3.Route_Route{
-		Route: &envoy_config_route_v3.RouteAction{
-			ClusterSpecifier: &envoy_config_route_v3.RouteAction_WeightedClusters{
-				WeightedClusters: &envoy_config_route_v3.WeightedCluster{
-					Clusters: weightedClusters,
-				},
-			},
-		},
-	}
-}
-
 func toHTTPSRedirectAction() *envoy_config_route_v3.Route_Redirect {
 	return &envoy_config_route_v3.Route_Redirect{
 		Redirect: &envoy_config_route_v3.RedirectAction{
@@ -549,10 +529,7 @@ var hostRulesListenersCiliumEnvoyConfig = &ciliumv2.CiliumEnvoyConfig{
 											Prefix: "/",
 										},
 									},
-									Action: toWeightedClusterRouteAction([]string{
-										"random-namespace:foo-bar-com:http",
-										"random-namespace:foo-bar-com:http",
-									}),
+									Action: toRouteAction("random-namespace", "foo-bar-com", "http"),
 								},
 							},
 						},


### PR DESCRIPTION
This is to fix the issue in which the wrong list of HTTP routes is used
to construct virtual host for insecure and secure routes. Ideally, only
related HTTP routes for the same listener ports should be considered.

Normally, this should not have any side effect, except using weightage
clusters for the multiple, but the same, backends. However, in case of
redirect filter, this will cause redirect loop as mentioned in the below
issue.

Fixes: #28186
Signed-off-by: Tam Mach <tam.mach@cilium.io>

```release-note
gateway-api: Avoid redirect loop when the same host name is used for http and https listeners
```
