### PR TITLE
gateway-api: Add supported features in GatewayClass status

### DIFF
--- a/operator/pkg/gateway-api/gatewayclass_reconcile.go
+++ b/operator/pkg/gateway-api/gatewayclass_reconcile.go
@@ -46,6 +46,29 @@ func (r *gatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Hence, just set gateway class Accepted condition to true blindly.
 	setGatewayClassAccepted(gwc, true)
 
+	// List of features supported by Cilium.
+	// The same is used in GHA CI .github/workflows/conformance-gateway-api.yaml
+	gwc.Status.SupportedFeatures = []gatewayv1.SupportedFeature{
+		"Gateway",
+		//"GatewayPort8080",
+		//"GatewayStaticAddresses",
+		"HTTPRoute",
+		"HTTPRouteDestinationPortMatching",
+		"HTTPRouteHostRewrite",
+		"HTTPRouteMethodMatching",
+		"HTTPRoutePathRedirect",
+		"HTTPRoutePathRewrite",
+		"HTTPRoutePortRedirect",
+		"HTTPRouteQueryParamMatching",
+		"HTTPRouteRequestMirror",
+		"HTTPRouteRequestMultipleMirrors",
+		"HTTPRouteResponseHeaderModification",
+		"HTTPRouteSchemeRedirect",
+		//"Mesh",
+		"ReferenceGrant",
+		"TLSRoute",
+	}
+
 	if err := r.Client.Status().Update(ctx, gwc); err != nil {
 		scopedLog.WithError(err).Error("Failed to update GatewayClass status")
 		return fail(err)


### PR DESCRIPTION
There is a new status.supportedFeature introduced in Gateway resource, the goal is to make things visible to users about capabilities of implementation.  This commit is to add all the supported features into cilium-managed Gateway. 

Kindly note that the list is hard coded right now, as there is no enum/const defined in upstream main codebase (only available in conformance tests).