### PR TITLE
gateway-api: Add support for gateway.infrastructure attribute

### DIFF
--- a/operator/pkg/model/ingestion/gateway_test.go
+++ b/operator/pkg/model/ingestion/gateway_test.go
@@ -34,6 +34,14 @@ var basicHTTP = Input{
 					Protocol: "HTTP",
 				},
 			},
+			Infrastructure: &gatewayv1beta1.GatewayInfrastructure{
+				Labels: map[gatewayv1beta1.AnnotationKey]gatewayv1beta1.AnnotationValue{
+					"internal-loadbalancer-label": "true",
+				},
+				Annotations: map[gatewayv1beta1.AnnotationKey]gatewayv1beta1.AnnotationValue{
+					"internal-loadbalancer-annotation": "true",
+				},
+			},
 		},
 	},
 	HTTPRoutes: []gatewayv1beta1.HTTPRoute{
@@ -113,6 +121,14 @@ var basicHTTPListeners = []model.HTTPListener{
 						},
 					},
 				},
+			},
+		},
+		Infrastructure: &model.Infrastructure{
+			Labels: map[string]string{
+				"internal-loadbalancer-label": "true",
+			},
+			Annotations: map[string]string{
+				"internal-loadbalancer-annotation": "true",
 			},
 		},
 	},

--- a/operator/pkg/model/model.go
+++ b/operator/pkg/model/model.go
@@ -34,6 +34,8 @@ func (m *Model) GetListeners() []Listener {
 type Listener interface {
 	GetSources() []FullyQualifiedResource
 	GetPort() uint32
+	GetAnnotations() map[string]string
+	GetLabels() map[string]string
 }
 
 // HTTPListener holds configuration for any listener that terminates and proxies HTTP
@@ -65,6 +67,8 @@ type HTTPListener struct {
 	Routes []HTTPRoute `json:"routes,omitempty"`
 	// Service configuration
 	Service *Service `json:"service,omitempty"`
+	// Infrastructure configuration
+	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
 }
 
 func (l *HTTPListener) GetSources() []FullyQualifiedResource {
@@ -73,6 +77,20 @@ func (l *HTTPListener) GetSources() []FullyQualifiedResource {
 
 func (l *HTTPListener) GetPort() uint32 {
 	return l.Port
+}
+
+func (l *HTTPListener) GetAnnotations() map[string]string {
+	if l.Infrastructure != nil {
+		return l.Infrastructure.Annotations
+	}
+	return nil
+}
+
+func (l *HTTPListener) GetLabels() map[string]string {
+	if l.Infrastructure != nil {
+		return l.Infrastructure.Labels
+	}
+	return nil
 }
 
 // TLSListener holds configuration for any listener that proxies TLS
@@ -101,6 +119,22 @@ type TLSListener struct {
 	Routes []TLSRoute `json:"routes,omitempty"`
 	// Service configuration
 	Service *Service `json:"service,omitempty"`
+	// Infrastructure configuration
+	Infrastructure *Infrastructure `json:"infrastructure,omitempty"`
+}
+
+func (l *TLSListener) GetAnnotations() map[string]string {
+	if l.Infrastructure != nil {
+		return l.Infrastructure.Annotations
+	}
+	return nil
+}
+
+func (l *TLSListener) GetLabels() map[string]string {
+	if l.Infrastructure != nil {
+		return l.Infrastructure.Labels
+	}
+	return nil
 }
 
 func (l *TLSListener) GetSources() []FullyQualifiedResource {
@@ -253,6 +287,16 @@ type HTTPRoute struct {
 
 	// Timeout holds the timeout configuration for a route.
 	Timeout Timeout `json:"timeout,omitempty"`
+}
+
+// Infrastructure holds the labels and annotations configuration,
+// which will be propagated to LB service.
+type Infrastructure struct {
+	// Labels is a map of labels to be propagated to LB service.
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Annotations is a map of annotations to be propagated to LB service.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // GetMatchKey returns the key to be used for matching the backend.

--- a/operator/pkg/model/translation/gateway-api/translator.go
+++ b/operator/pkg/model/translation/gateway-api/translator.go
@@ -72,10 +72,18 @@ func (t *translator) Translate(m *model.Model) (*ciliumv2.CiliumEnvoyConfig, *co
 			Controller: model.AddressOf(true),
 		},
 	}
-	return cec, getService(source, ports), getEndpoints(*source), err
+
+	allLabels, allAnnotations := map[string]string{}, map[string]string{}
+	// Merge all the labels and annotations from the listeners.
+	// Normally, the labels and annotations are the same for all the listeners having same gateway.
+	for _, l := range listeners {
+		allAnnotations = mergeMap(allAnnotations, l.GetAnnotations())
+		allLabels = mergeMap(allLabels, l.GetLabels())
+	}
+	return cec, getService(source, ports, allLabels, allAnnotations), getEndpoints(*source), err
 }
 
-func getService(resource *model.FullyQualifiedResource, allPorts []uint32) *corev1.Service {
+func getService(resource *model.FullyQualifiedResource, allPorts []uint32, labels, annotations map[string]string) *corev1.Service {
 	uniquePorts := map[uint32]struct{}{}
 	for _, p := range allPorts {
 		uniquePorts[p] = struct{}{}
@@ -92,9 +100,10 @@ func getService(resource *model.FullyQualifiedResource, allPorts []uint32) *core
 
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      shorten(ciliumGatewayPrefix + resource.Name),
-			Namespace: resource.Namespace,
-			Labels:    map[string]string{owningGatewayLabel: resource.Name},
+			Name:        shorten(ciliumGatewayPrefix + resource.Name),
+			Namespace:   resource.Namespace,
+			Labels:      mergeMap(map[string]string{owningGatewayLabel: resource.Name}, labels),
+			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: gatewayv1beta1.GroupVersion.String(),
@@ -173,4 +182,14 @@ func encodeHash(hex string) string {
 // hash hashes `data` with sha256 and returns the hex string
 func hash(data string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(data)))
+}
+
+func mergeMap(left, right map[string]string) map[string]string {
+	if left == nil {
+		return right
+	}
+	for key, value := range right {
+		left[key] = value
+	}
+	return left
 }


### PR DESCRIPTION
Currently, the only child resource that is related to infra is the load balancer Service. This commit is to make sure that user-specified labels and annotations in Gateway are propagated accordingly. Kindly note that there is no validation right now.
