### PR TITLE
egressgateway: Use UID to identify CiliumEndpoints in epDataStore

### DIFF
--- a/pkg/egressgateway/helpers_test.go
+++ b/pkg/egressgateway/helpers_test.go
@@ -168,3 +168,10 @@ func addEndpoint(tb testing.TB, endpoints fakeResource[*k8sTypes.CiliumEndpoint]
 		Object: ep,
 	})
 }
+
+func deleteEndpoint(tb testing.TB, endpoints fakeResource[*k8sTypes.CiliumEndpoint], ep *k8sTypes.CiliumEndpoint) {
+	endpoints.process(tb, resource.Event[*k8sTypes.CiliumEndpoint]{
+		Kind:   resource.Delete,
+		Object: ep,
+	})
+}

--- a/pkg/egressgateway/manager.go
+++ b/pkg/egressgateway/manager.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/cilium/cilium/pkg/datapath/linux/config/defines"
@@ -452,6 +451,7 @@ func (manager *Manager) addEndpoint(endpoint *k8sTypes.CiliumEndpoint) error {
 	logger := log.WithFields(logrus.Fields{
 		logfields.K8sEndpointName: endpoint.Name,
 		logfields.K8sNamespace:    endpoint.Namespace,
+		logfields.K8sUID:          endpoint.UID,
 	})
 
 	if identityLabels, err = manager.getIdentityLabels(uint32(endpoint.Identity.ID)); err != nil {
@@ -480,17 +480,18 @@ func (manager *Manager) addEndpoint(endpoint *k8sTypes.CiliumEndpoint) error {
 	return nil
 }
 
-func (manager *Manager) deleteEndpoint(id types.NamespacedName) {
+func (manager *Manager) deleteEndpoint(endpoint *k8sTypes.CiliumEndpoint) {
 	manager.Lock()
 	defer manager.Unlock()
 
 	logger := log.WithFields(logrus.Fields{
-		logfields.K8sEndpointName: id.Name,
-		logfields.K8sNamespace:    id.Namespace,
+		logfields.K8sEndpointName: endpoint.Name,
+		logfields.K8sNamespace:    endpoint.Namespace,
+		logfields.K8sUID:          endpoint.UID,
 	})
 
 	logger.Debug("Deleted CiliumEndpoint")
-	delete(manager.epDataStore, id)
+	delete(manager.epDataStore, endpoint.UID)
 
 	manager.setEventBitmap(eventDeleteEndpoint)
 	manager.reconciliationTrigger.TriggerWithReason("endpoint deleted")
@@ -499,15 +500,10 @@ func (manager *Manager) deleteEndpoint(id types.NamespacedName) {
 func (manager *Manager) handleEndpointEvent(event resource.Event[*k8sTypes.CiliumEndpoint]) {
 	endpoint := event.Object
 
-	id := types.NamespacedName{
-		Name:      endpoint.GetName(),
-		Namespace: endpoint.GetNamespace(),
-	}
-
 	if event.Kind == resource.Upsert {
 		event.Done(manager.addEndpoint(endpoint))
 	} else {
-		manager.deleteEndpoint(id)
+		manager.deleteEndpoint(endpoint)
 		event.Done(nil)
 	}
 }

--- a/pkg/egressgateway/manager_privileged_test.go
+++ b/pkg/egressgateway/manager_privileged_test.go
@@ -12,7 +12,9 @@ import (
 
 	. "github.com/cilium/checkmate"
 	"github.com/cilium/ebpf/rlimit"
+	"github.com/google/uuid"
 	"github.com/vishvananda/netlink"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/cilium/cilium/pkg/bpf"
 	"github.com/cilium/cilium/pkg/hive"
@@ -43,6 +45,7 @@ const (
 
 	ep1IP = "10.0.0.1"
 	ep2IP = "10.0.0.2"
+	ep3IP = "10.0.0.3"
 
 	destCIDR        = "1.1.1.0/24"
 	allZeroDestCIDR = "0.0.0.0/0"
@@ -402,6 +405,78 @@ func (k *EgressGatewayTestSuite) TestEgressGatewayManager(c *C) {
 	})
 }
 
+func (k *EgressGatewayTestSuite) TestEndpointDataStore(c *C) {
+	createTestInterface(c, testInterface1, egressCIDR1)
+
+	policyMap := k.manager.policyMap
+	egressGatewayManager := k.manager
+
+	k.policies.sync(c)
+	k.nodes.sync(c)
+	k.endpoints.sync(c)
+
+	reconciliationEventsCount := egressGatewayManager.reconciliationEventsCount.Load()
+
+	node1 := newCiliumNode(node1, node1IP, nodeGroup1Labels)
+	k.nodes.process(c, resource.Event[*cilium_api_v2.CiliumNode]{
+		Kind:   resource.Upsert,
+		Object: node1.ToCiliumNode(),
+	})
+	reconciliationEventsCount = waitForReconciliationRun(c, egressGatewayManager, reconciliationEventsCount)
+
+	// Create a new policy
+	policy1 := policyParams{
+		name:            "policy-1",
+		endpointLabels:  ep1Labels,
+		destinationCIDR: destCIDR,
+		nodeLabels:      nodeGroup1Labels,
+		iface:           testInterface1,
+	}
+
+	addPolicy(c, k.policies, &policy1)
+	reconciliationEventsCount = waitForReconciliationRun(c, egressGatewayManager, reconciliationEventsCount)
+
+	assertEgressRules(c, policyMap, []egressRule{})
+
+	// Add a new endpoint & ID which matches policy-1
+	ep1, _ := newEndpointAndIdentity("ep-1", ep1IP, ep1Labels)
+	addEndpoint(c, k.endpoints, &ep1)
+	reconciliationEventsCount = waitForReconciliationRun(c, egressGatewayManager, reconciliationEventsCount)
+
+	assertEgressRules(c, policyMap, []egressRule{
+		{ep1IP, destCIDR, egressIP1, node1IP},
+	})
+
+	// Simulate statefulset pod migrations to a different node.
+
+	// Produce a new endpoint ep2 similar to ep1 - with the same name & labels, but with a different IP address.
+	// The ep1 will be deleted.
+	ep2, _ := newEndpointAndIdentity(ep1.Name, ep2IP, ep1Labels)
+
+	// Test event order: add new -> delete old
+	addEndpoint(c, k.endpoints, &ep2)
+	reconciliationEventsCount = waitForReconciliationRun(c, egressGatewayManager, reconciliationEventsCount)
+	deleteEndpoint(c, k.endpoints, &ep1)
+	reconciliationEventsCount = waitForReconciliationRun(c, egressGatewayManager, reconciliationEventsCount)
+
+	assertEgressRules(c, policyMap, []egressRule{
+		{ep2IP, destCIDR, egressIP1, node1IP},
+	})
+
+	// Produce a new endpoint ep3 similar to ep2 (and ep1) - with the same name & labels, but with a different IP address.
+	ep3, _ := newEndpointAndIdentity(ep1.Name, ep3IP, ep1Labels)
+
+	// Test event order: delete old -> update new
+	deleteEndpoint(c, k.endpoints, &ep2)
+	reconciliationEventsCount = waitForReconciliationRun(c, egressGatewayManager, reconciliationEventsCount)
+	addEndpoint(c, k.endpoints, &ep3)
+	waitForReconciliationRun(c, egressGatewayManager, reconciliationEventsCount)
+
+	assertEgressRules(c, policyMap, []egressRule{
+		{ep3IP, destCIDR, egressIP1, node1IP},
+	})
+}
+
 func TestCell(t *testing.T) {
 	err := hive.New(Cell).Populate()
 	if err != nil {
@@ -474,6 +549,7 @@ func newEndpointAndIdentity(name, ip string, epLabels map[string]string) (k8sTyp
 	return k8sTypes.CiliumEndpoint{
 		ObjectMeta: slimv1.ObjectMeta{
 			Name: name,
+			UID:  types.UID(uuid.New().String()),
 		},
 		Identity: &cilium_api_v2.EndpointIdentity{
 			ID: int64(id.ID),


### PR DESCRIPTION
To address a potential race condition demonstrated by a unit test added as part of this change, this changes internal type of the `endpointID` used to identify `CiliumEndpoint`s in the EGW Manager's `epDataStore` from `NamespacedName` to `UID`.

The race fixed by this change may be triggered during statefulset pod restart/migration to a different node, when a new endpoint may co-exist with the to-be-deleted endpoint with the same `NamespacedName` for a short period of time. To not break EGW Manager's endpoint event handling, these two need to have unique `endpointID`, which can be satisfied by relying on the `UID`.

The drawback of using `UID` is incompatibility with `CiliumEndpointSlices`, which is however not an issue for the EGW, as it is already incompatible. In the future the EGW will probably move away from relying on `CiliumEndpoint`s altogether, which should remove this limitation.
