### PR TITLE
gha: Enable Ingress Controller tests in conformance-e2e

### DIFF
--- a/.github/actions/cilium-config/action.yml
+++ b/.github/actions/cilium-config/action.yml
@@ -40,6 +40,9 @@ inputs:
   mutual-auth:
     description: 'Enable mTLS-based Mutual Authentication'
     default: true
+  ingress-controller:
+    description: 'Enable ingress controller, required kubeProxyReplacement'
+    default: false
   devices:
     description: 'List of native devices to attach datapath programs'
     default: ''
@@ -142,5 +145,12 @@ runs:
             HOST_FW="--helm-set=hostFirewall.enabled=true"
           fi
 
-          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION}"
+          if [ "${{ inputs.kpr }}" == "true" ]; then
+            if [ "${{ inputs.ingress-controller }}" == "true" ]; then
+              INGRESS_CONTROLLER="--helm-set=ingressController.enabled=true"
+              INGRESS_CONTROLLER+=" --helm-set=ingressController.service.type=NodePort"
+            fi
+          fi
+        
+          CONFIG="${DEFAULTS} ${IMAGE} ${TUNNEL} ${DEVICES} ${LB_MODE} ${ENDPOINT_ROUTES} ${IPV6} ${MASQ} ${EGRESS_GATEWAY} ${ENCRYPT} ${HOST_FW} ${LB_ACCELERATION} ${INGRESS_CONTROLLER}"
           echo "config=${CONFIG}" >> $GITHUB_OUTPUT

--- a/.github/workflows/conformance-e2e.yaml
+++ b/.github/workflows/conformance-e2e.yaml
@@ -135,6 +135,7 @@ jobs:
             egress-gateway: 'true'
             host-fw: 'true'
             lb-acceleration: 'testing-only'
+            ingress-controller: 'true'
 
           - name: '7'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -147,6 +148,7 @@ jobs:
             lb-mode: 'snat'
             egress-gateway: 'true'
             lb-acceleration: 'testing-only'
+            ingress-controller: 'true'
 
           - name: '8'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -196,6 +198,7 @@ jobs:
             encryption-node: 'true'
             lb-mode: 'snat'
             egress-gateway: 'true'
+            ingress-controller: 'true'
 
           - name: '12'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -209,6 +212,7 @@ jobs:
             encryption-node: 'true'
             lb-mode: 'snat'
             egress-gateway: 'true'
+            ingress-controller: 'true'
 
           - name: '13'
             # renovate: datasource=docker depName=quay.io/lvh-images/kind
@@ -257,6 +261,7 @@ jobs:
           encryption-node: ${{ matrix.encryption-node }}
           egress-gateway: ${{ matrix.egress-gateway }}
           host-fw: ${{ matrix.host-fw }}
+          ingress-controller: ${{ matrix.ingress-controller }}
           misc: ${{ matrix.misc }}
 
       # Warning: since this is a privileged workflow, subsequent workflow job


### PR DESCRIPTION
The Ingress related connectivity tests are already available in cilium cli, this commit is to enable the same in conformance e2e tests for any case having kpr=true.

Relates: https://github.com/cilium/cilium-cli/pull/1533
Relates: https://github.com/cilium/cilium-cli/pull/2106